### PR TITLE
feat(kb): compounding knowledge engine — measured retrieval + corpus-aware writes + active distillation

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,62 @@ Tests run against a fixture vault under `tests/fixtures/`. The **real
 vault is never touched** during testing — `conftest.py` copies fixtures
 to a per-test tmp dir and sets `KB_MCP_VAULT_PATH` to the copy.
 
+## Retrieval evaluation & feedback loop
+
+Ranking is **measured, not guessed**. The tunable knobs (`RRF k`, the
+compiled/source boosts, `candidate_k`, the graph seed cap) live in one place —
+`find.RankingConfig` — so an offline harness can sweep them against a golden set
+and pick winners by NDCG/MRR. `RankingConfig` is internal; it's not exposed on the
+`find` MCP tool (claude.ai needs no knobs API).
+
+```powershell
+# Baseline NDCG@5/@10, MRR, recall@10 over the real vault (embeddings ON):
+uv run python scripts/eval_retrieval.py
+# Grid-search the ranking knobs; --markdown emits a table to file as a pattern note:
+uv run python scripts/eval_retrieval.py --sweep --markdown
+#   add --include-rerank to add the (slow) cross-encoder axis
+```
+
+The golden set is `tests/golden/queries.yaml` — hand-seeded against real paths and
+designed to **grow from your own usage**:
+
+- Every `find()` is logged to `logs/queries.jsonl` (query + per-hit ranking
+  signals — no bodies/excerpts) and every `note`/`add`/`replace` to
+  `logs/writes.jsonl` (path + cited sources). Both via `kb_mcp.query_log`,
+  best-effort, gitignored, never Obsidian-synced. No-op under
+  `KB_MCP_DISABLE_EMBEDDINGS` or `KB_MCP_DISABLE_QUERY_LOG`.
+- `scripts/derive_relevance_pairs.py` joins the two: when a write cites a path
+  shortly after a `find()` for some query, that `(query → cited_path)` pair is a
+  weak relevance label. It writes `logs/relevance_pairs.jsonl` and **proposes**
+  (never auto-writes) golden-set additions for you to confirm.
+
+Metric math (`kb_mcp.eval_metrics`) is pure and unit-tested in the fast suite;
+the live-vault eval is a manual `scripts/` run (it needs the bge model).
+
+## Corpus-aware writes
+
+Writes consult the corpus instead of being blind to it — so each new entry makes
+the existing ones more discoverable, not just adds to the pile. Pure retrieval
+(`kb_mcp.corpus_aware`), reusing `find()` + the embedding sidecar; no new
+dependency, no server-side LLM. Suggestions are **surfaced, never auto-applied** —
+the client decides what to wire in.
+
+- **`suggest_links`** (MCP tool, read-only): given an existing `path` OR a
+  `draft_title`+`draft_body`, returns ranked existing pages to link
+  `{path, title, type, why, excerpt}`, preferring graph hubs and excluding the
+  page itself + anything already linked. Run it on a draft before `note`, or on
+  any existing page to densify the graph retroactively.
+- **`note` suggestions**: `note()` returns an optional `suggestions` block (the
+  related pages you didn't cite). Best-effort, computed pre-write, fully guarded —
+  a suggestion failure can never roll back the write.
+- **Near-duplicate warnings**: `note`/`add` surface a `warnings` entry like
+  `possible near-duplicate of [[X]] (cosine 0.91)` when a draft closely matches an
+  existing page (doc-doc cosine over the sidecar). A warning, never a block —
+  append-only + supersession invariants mean the client chooses edit/replace/append.
+
+All of it no-ops under `KB_MCP_DISABLE_EMBEDDINGS`, so the fast test suite and
+the write path's existing behaviour are unchanged when embeddings are off.
+
 ## Logs
 
 - `logs/kb-mcp.log` — application log (rotated, 5 MB × 5 files)

--- a/README.md
+++ b/README.md
@@ -607,6 +607,26 @@ the client decides what to wire in.
 All of it no-ops under `KB_MCP_DISABLE_EMBEDDINGS`, so the fast test suite and
 the write path's existing behaviour are unchanged when embeddings are off.
 
+## Active distillation
+
+The KB grows in raw captures faster than it grows in compiled knowledge (a large
+share of sources never get distilled). Two read-only additions turn that backlog
+from an undifferentiated pile into a worked queue — without any server-side LLM:
+
+- **Aged `unprocessed_source` audit**: each finding now carries `meta`
+  (`age_days`, `age_bucket` ∈ fresh/aging/stale, `captured`), is sorted
+  **oldest-first**, and escalates to `warn` once stale. You drain the worst rot
+  first instead of guessing.
+- **`propose_compilation`** (MCP tool): point it at one or more sources and it
+  returns a ready-to-fill note scaffold — inferred `note_type`, a sectioned
+  outline (`Question/Findings/Connections` or `Claim/…`), the `sources[]` to
+  cite, and adjacent compiled pages to link (via the same retrieval as
+  `suggest_links`). It **never writes** — you fill the prose and call `note()`.
+
+Grouping (which sources belong in one note) is left to the client — that's a
+judgment call Claude makes better than a cosine threshold. Audit surfaces the
+aged list; you pick a coherent set and pass it to `propose_compilation`.
+
 ## Logs
 
 - `logs/kb-mcp.log` — application log (rotated, 5 MB × 5 files)

--- a/scripts/derive_relevance_pairs.py
+++ b/scripts/derive_relevance_pairs.py
@@ -1,0 +1,179 @@
+"""Mine weak (query -> relevant path) labels from real usage — the feedback loop.
+
+Joins `logs/queries.jsonl` x `logs/writes.jsonl`: when a note/replace write cites
+a path shortly AFTER a find() for some query, and that cited path appeared in the
+query's results, then `(query -> cited_path)` is a weak-but-real relevance label —
+the search surfaced something Hugo then actually used. These accumulate for free
+from ordinary search-then-compile usage and are the only compounding relevance
+signal a single-user vault produces.
+
+Output:
+- `logs/relevance_pairs.jsonl` — the derived pairs (a derived log, safe to write).
+- A PROPOSED YAML block printed to stdout for additions to tests/golden/queries.yaml.
+  We never auto-edit the golden set (visibility over gating): Hugo confirms and
+  pastes. Constants are never auto-tuned from these.
+
+Usage:
+    uv run python scripts/derive_relevance_pairs.py
+    uv run python scripts/derive_relevance_pairs.py --window-hours 6 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+LOGS = HERE.parent / "logs"
+QUERIES = LOGS / "queries.jsonl"
+WRITES = LOGS / "writes.jsonl"
+PAIRS_OUT = LOGS / "relevance_pairs.jsonl"
+GOLDEN = HERE.parent / "tests" / "golden" / "queries.yaml"
+
+
+def _canon(path: str) -> str:
+    p = (path or "").strip().replace("\\", "/")
+    if p.lower().endswith(".md"):
+        p = p[:-3]
+    if p.startswith("Knowledge Base/"):
+        p = p[len("Knowledge Base/"):]
+    return p.lower()
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _parse_ts(ts: str) -> dt.datetime | None:
+    try:
+        return dt.datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+def _existing_golden_queries(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    return {e["query"].strip().lower() for e in raw if e.get("query")}
+
+
+def derive_pairs(
+    queries: list[dict], writes: list[dict], window_seconds: float
+) -> list[dict]:
+    """Return deduped (query, cited_path) pairs with a confidence score."""
+    best: dict[tuple[str, str], dict] = {}
+    for w in writes:
+        if w.get("tool") not in ("note", "replace"):
+            continue
+        w_ts = _parse_ts(w.get("ts", ""))
+        cited = {_canon(c) for c in (w.get("cited_sources") or []) if c}
+        if not (w_ts and cited):
+            continue
+        for q in queries:
+            q_ts = _parse_ts(q.get("ts", ""))
+            if q_ts is None:
+                continue
+            delta = (w_ts - q_ts).total_seconds()
+            if not (0 <= delta <= window_seconds):
+                continue  # query must precede the write, within the window
+            ranks = {
+                _canon(t.get("path", "")): rank
+                for rank, t in enumerate(q.get("top_k") or [], start=1)
+                if t.get("path")
+            }
+            for c in cited:
+                rank = ranks.get(c)
+                if rank is None:
+                    continue  # cited path wasn't in this query's results
+                # Confidence: rank position (1/rank) decayed by time distance.
+                recency = max(0.0, 1.0 - delta / window_seconds)
+                conf = round((1.0 / rank) * (0.5 + 0.5 * recency), 4)
+                key = (q["query"], c)
+                prev = best.get(key)
+                if prev is None or conf > prev["confidence"]:
+                    best[key] = {
+                        "query": q["query"],
+                        "cited_path": c,
+                        "confidence": conf,
+                        "rank_in_results": rank,
+                        "delta_seconds": round(delta, 1),
+                        "via_write": w.get("written_path"),
+                        "source": "note-citation",
+                    }
+    return sorted(best.values(), key=lambda p: -p["confidence"])
+
+
+def _propose_golden(pairs: list[dict], existing: set[str]) -> dict[str, list[str]]:
+    """Group new (not-yet-in-golden) queries -> their relevant paths."""
+    proposed: dict[str, list[str]] = {}
+    for p in pairs:
+        if p["query"].strip().lower() in existing:
+            continue
+        proposed.setdefault(p["query"], [])
+        full = "Knowledge Base/" + p["cited_path"]
+        if full not in proposed[p["query"]]:
+            proposed[p["query"]].append(full)
+    return proposed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--window-hours", type=float, default=2.0,
+                    help="max gap between a find() and a citing write (default 2h)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="don't write relevance_pairs.jsonl; just print")
+    args = ap.parse_args()
+
+    queries = _read_jsonl(QUERIES)
+    writes = _read_jsonl(WRITES)
+    if not queries or not writes:
+        print(
+            f"need both logs with data: queries.jsonl={len(queries)} rows, "
+            f"writes.jsonl={len(writes)} rows. Use the connector a bit first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pairs = derive_pairs(queries, writes, args.window_hours * 3600)
+    print(f"derived {len(pairs)} (query -> cited_path) relevance pairs "
+          f"from {len(queries)} queries x {len(writes)} writes")
+
+    if not args.dry_run and pairs:
+        PAIRS_OUT.parent.mkdir(parents=True, exist_ok=True)
+        with PAIRS_OUT.open("a", encoding="utf-8") as f:
+            for p in pairs:
+                f.write(json.dumps(p, ensure_ascii=False) + "\n")
+        print(f"appended pairs -> {PAIRS_OUT}")
+
+    proposed = _propose_golden(pairs, _existing_golden_queries(GOLDEN))
+    if proposed:
+        print(f"\n=== PROPOSED golden additions ({len(proposed)} new queries) ===")
+        print("# Review, then paste confirmed entries into tests/golden/queries.yaml:\n")
+        block = [
+            {"query": q, "expect_any_of": paths} for q, paths in proposed.items()
+        ]
+        print(yaml.safe_dump(block, sort_keys=False, allow_unicode=True))
+    else:
+        print("\nno new golden queries to propose (all already covered).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -1,0 +1,202 @@
+"""Offline retrieval-quality eval harness for kb-mcp.
+
+Runs `find()` against the REAL vault (embeddings ENABLED) over a golden query
+set and reports NDCG@5/@10, MRR, recall@10 — so every ranking change becomes a
+number that goes up or down instead of a vibe. `--sweep` walks the RankingConfig
+knobs and prints a ranked comparison plus a markdown table you can file as a
+governance pattern note.
+
+Usage:
+    uv run python scripts/eval_retrieval.py                  # baseline (DEFAULT config)
+    uv run python scripts/eval_retrieval.py --sweep          # rrf_k x compiled_boost grid
+    uv run python scripts/eval_retrieval.py --sweep --include-rerank --markdown
+
+This is a dev/eval tool: it imports kb_mcp directly and needs the bge model
+(it force-enables embeddings). It writes nothing to the vault.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# The eval MUST run with live vectors — undo any inherited test/service disable.
+os.environ.pop("KB_MCP_DISABLE_EMBEDDINGS", None)
+
+from kb_mcp import eval_metrics as metrics  # noqa: E402
+from kb_mcp import find as find_module  # noqa: E402
+from kb_mcp.vault import resolve_vault  # noqa: E402
+
+DEFAULT_GOLDEN = HERE.parent / "tests" / "golden" / "queries.yaml"
+
+
+def _canon(path: str) -> str:
+    """Normalize a path so golden entries and find() results compare equal."""
+    p = path.strip().replace("\\", "/")
+    if p.lower().endswith(".md"):
+        p = p[:-3]
+    if p.startswith("Knowledge Base/"):
+        p = p[len("Knowledge Base/"):]
+    return p.lower()
+
+
+def _load_golden(path: Path) -> list[dict]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    out: list[dict] = []
+    for entry in raw:
+        query = entry.get("query")
+        if not query:
+            continue
+        if "graded" in entry and entry["graded"]:
+            relevance = {_canon(p): float(g) for p, g in entry["graded"].items()}
+        else:
+            relevance = {_canon(p): 1.0 for p in entry.get("expect_any_of", [])}
+        if not relevance:
+            continue
+        relevant = {p for p, g in relevance.items() if g > 0}
+        out.append({"query": query, "relevance": relevance, "relevant": relevant})
+    return out
+
+
+def _evaluate(
+    vault_root: Path,
+    golden: list[dict],
+    config: find_module.RankingConfig,
+    *,
+    rerank: bool,
+    k_max: int = 10,
+) -> dict:
+    """Run every golden query under `config`; return mean metrics + per-query rows."""
+    rows: list[dict] = []
+    for g in golden:
+        hits = find_module.find(
+            vault_root,
+            query=g["query"],
+            limit=k_max,
+            mode="hybrid",
+            rerank=rerank,
+            config=config,
+        )
+        ranked = [_canon(h.path) for h in hits]
+        rows.append({
+            "query": g["query"],
+            "ndcg5": metrics.ndcg_at_k(ranked, g["relevance"], 5),
+            "ndcg10": metrics.ndcg_at_k(ranked, g["relevance"], 10),
+            "mrr": metrics.mrr(ranked, g["relevant"]),
+            "recall10": metrics.recall_at_k(ranked, g["relevant"], 10),
+        })
+    return {
+        "ndcg5": metrics.mean(r["ndcg5"] for r in rows),
+        "ndcg10": metrics.mean(r["ndcg10"] for r in rows),
+        "mrr": metrics.mean(r["mrr"] for r in rows),
+        "recall10": metrics.mean(r["recall10"] for r in rows),
+        "n": len(rows),
+        "rows": rows,
+    }
+
+
+def _config_label(cfg: find_module.RankingConfig, rerank: bool) -> str:
+    return (
+        f"rrf_k={cfg.rrf_k} boost={cfg.compiled_boost} "
+        f"penalty={cfg.source_penalty} rerank={'on' if rerank else 'off'}"
+    )
+
+
+def _print_baseline(result: dict) -> None:
+    print(f"\nPer-query (n={result['n']}):")
+    print(f"  {'ndcg@5':>7} {'ndcg@10':>8} {'mrr':>6} {'rec@10':>7}  query")
+    for r in result["rows"]:
+        print(
+            f"  {r['ndcg5']:7.3f} {r['ndcg10']:8.3f} {r['mrr']:6.3f} "
+            f"{r['recall10']:7.3f}  {r['query'][:70]}"
+        )
+    print("\nMEANS:")
+    print(
+        f"  NDCG@5={result['ndcg5']:.4f}  NDCG@10={result['ndcg10']:.4f}  "
+        f"MRR={result['mrr']:.4f}  recall@10={result['recall10']:.4f}"
+    )
+
+
+def _sweep(
+    vault_root: Path, golden: list[dict], *, include_rerank: bool, markdown: bool
+) -> None:
+    rrf_ks = [30, 60, 100]
+    boosts = [1.0, 1.15, 1.3]
+    rerank_axis = [False, True] if include_rerank else [False]
+
+    results: list[tuple[str, dict, find_module.RankingConfig, bool]] = []
+    base = find_module.DEFAULT_RANKING
+    for rerank in rerank_axis:
+        for k in rrf_ks:
+            for b in boosts:
+                cfg = replace(base, rrf_k=k, compiled_boost=b)
+                res = _evaluate(vault_root, golden, cfg, rerank=rerank)
+                results.append((_config_label(cfg, rerank), res, cfg, rerank))
+                print(
+                    f"  {_config_label(cfg, rerank):<52} "
+                    f"NDCG@10={res['ndcg10']:.4f} MRR={res['mrr']:.4f} "
+                    f"rec@10={res['recall10']:.4f}"
+                )
+
+    results.sort(key=lambda t: -t[1]["ndcg10"])
+    print("\n=== ranked by NDCG@10 ===")
+    for label, res, _cfg, _rr in results:
+        print(f"  NDCG@10={res['ndcg10']:.4f}  {label}")
+    for metric in ("ndcg10", "mrr", "recall10"):
+        winner = max(results, key=lambda t: t[1][metric])
+        print(f"best {metric}: {winner[1][metric]:.4f}  [{winner[0]}]")
+
+    if markdown:
+        print("\n=== markdown (file via note(note_type='pattern', pattern_type='governance')) ===\n")
+        print(f"| config | NDCG@5 | NDCG@10 | MRR | recall@10 |")
+        print(f"|---|---|---|---|---|")
+        for label, res, _cfg, _rr in results:
+            print(
+                f"| {label} | {res['ndcg5']:.4f} | {res['ndcg10']:.4f} | "
+                f"{res['mrr']:.4f} | {res['recall10']:.4f} |"
+            )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN)
+    ap.add_argument("--sweep", action="store_true", help="grid-search the ranking knobs")
+    ap.add_argument("--include-rerank", action="store_true", help="add the rerank axis to --sweep (slow)")
+    ap.add_argument("--rerank", action="store_true", help="baseline run with rerank on")
+    ap.add_argument("--markdown", action="store_true", help="emit a markdown results table")
+    args = ap.parse_args()
+
+    vault_root = resolve_vault()
+    golden = _load_golden(args.golden)
+    if not golden:
+        print(f"no golden queries loaded from {args.golden}", file=sys.stderr)
+        return 1
+    print(f"vault={vault_root}")
+    print(f"golden set: {len(golden)} queries from {args.golden}")
+
+    if args.sweep:
+        _sweep(vault_root, golden, include_rerank=args.include_rerank, markdown=args.markdown)
+    else:
+        result = _evaluate(
+            vault_root, golden, find_module.DEFAULT_RANKING, rerank=args.rerank
+        )
+        _print_baseline(result)
+        if args.markdown:
+            print("\n| metric | value |\n|---|---|")
+            for m in ("ndcg5", "ndcg10", "mrr", "recall10"):
+                print(f"| {m} | {result[m]:.4f} |")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kb_mcp/add.py
+++ b/src/kb_mcp/add.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import indexes, schema
+from . import corpus_aware, indexes, schema
 from .vault import (
     PlannedWrite,
     batch_atomic_write,
@@ -96,6 +97,22 @@ def add(
     )
     if err is not None:
         raise AddError(code=err.code, missing=list(err.missing), reason=err.reason)
+
+    # Corpus-aware near-duplicate check (best-effort; warns, never blocks — the
+    # 57% unprocessed-source backlog implies real dupes). Skipped when embeddings
+    # are disabled so the fast suite and existing add() tests are unaffected.
+    dup_warnings: list[str] = []
+    if not os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
+        try:
+            dup_warnings = [
+                corpus_aware.dup_warning(c)
+                for c in corpus_aware.detect_duplicates(
+                    vault_root, title=title, body=content,
+                    self_path=None, types_filter=["source"],
+                )
+            ]
+        except Exception as e:  # noqa: BLE001 — never break a capture
+            log.debug("corpus-aware dup check failed (non-fatal): %s", e)
 
     today = today or dt.date.today()
     date_iso = today.isoformat()
@@ -178,7 +195,7 @@ def add(
     ]
     writes.extend(sub_writes)
 
-    warnings: list[str] = []
+    warnings: list[str] = list(dup_warnings)
     if slug_warning:
         warnings.append(slug_warning)
     # Cap-50 trim is recorded in log.md per SKILL.md trim discipline; no need

--- a/src/kb_mcp/audit.py
+++ b/src/kb_mcp/audit.py
@@ -22,6 +22,7 @@ existing write tools (no auto-fix).
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import re
 from dataclasses import dataclass
@@ -66,15 +67,26 @@ class AuditFinding:
     path: str           # vault-relative path of the affected page (or "index.md")
     detail: str         # one-line human description
     proposed_fix: str | None = None
+    # Optional cluster/aging context, surfaced only when set (mirrors
+    # find.Hit.signals' omit-when-empty convention so existing findings and
+    # the test suite see no shape change). `paths` carries a multi-file group;
+    # `meta` carries structured extras like age_days / age_bucket.
+    paths: list[str] | None = None
+    meta: dict | None = None
 
     def as_dict(self) -> dict:
-        return {
+        out: dict = {
             "category": self.category,
             "severity": self.severity,
             "path": self.path,
             "detail": self.detail,
             "proposed_fix": self.proposed_fix,
         }
+        if self.paths:
+            out["paths"] = self.paths
+        if self.meta:
+            out["meta"] = self.meta
+        return out
 
 
 @dataclass
@@ -90,11 +102,15 @@ class AuditReport:
 
 
 def audit(
-    vault_root: Path, *, categories: list[str] | None = None
+    vault_root: Path,
+    *,
+    categories: list[str] | None = None,
+    today: dt.date | None = None,
 ) -> AuditReport:
     """Scan the KB and return a structured findings report.
 
     `categories` filters which checks to run (default: all). Read-only.
+    `today` is dependency-injectable for tests (used by unprocessed-source aging).
     """
     selected = set(categories) if categories else set(ALL_CATEGORIES)
     invalid = selected - set(ALL_CATEGORIES)
@@ -113,7 +129,7 @@ def audit(
     if "orphan_entity" in selected:
         findings.extend(_check_orphan_entities(vault_root, pages))
     if "unprocessed_source" in selected:
-        findings.extend(_check_unprocessed_sources(vault_root, pages))
+        findings.extend(_check_unprocessed_sources(vault_root, pages, today=today))
     if "index_drift" in selected:
         findings.extend(_check_index_drift(vault_root))
     if "tag_inconsistency" in selected:
@@ -317,26 +333,82 @@ def _extract_wikilinks_from_value(value) -> list[str]:
 
 
 def _check_unprocessed_sources(
-    vault_root: Path, pages: list[find_module.ParsedPage]
+    vault_root: Path,
+    pages: list[find_module.ParsedPage],
+    *,
+    today: dt.date | None = None,
 ) -> list[AuditFinding]:
-    findings: list[AuditFinding] = []
+    """Flag sources with empty ingested_into, aged + triaged oldest-first.
+
+    Adds age signal so the backlog can be drained by priority rather than
+    treated as an undifferentiated pile: bucket fresh (<30d) / aging (30-90d) /
+    stale (>90d), bump severity to `warn` once stale, sort oldest-first, and
+    surface age in `meta` so a client can `propose_compilation` the worst rot
+    first.
+    """
+    today = today or dt.date.today()
+    rows: list[tuple[int, AuditFinding]] = []  # (age_days for sort, finding)
     for page in pages:
         if page.frontmatter.get("type") != "source":
             continue
         ingested = page.frontmatter.get("ingested_into")
-        if ingested is None or (isinstance(ingested, list) and len(ingested) == 0):
-            findings.append(AuditFinding(
+        if not (ingested is None or (isinstance(ingested, list) and len(ingested) == 0)):
+            continue
+
+        captured = _parse_fm_date(
+            page.frontmatter.get("captured") or page.frontmatter.get("created")
+        )
+        meta: dict = {}
+        age_days: int | None = None
+        if captured is not None:
+            age_days = max(0, (today - captured).days)
+            bucket = (
+                "fresh" if age_days < 30 else "aging" if age_days < 90 else "stale"
+            )
+            meta = {"age_days": age_days, "age_bucket": bucket, "captured": captured.isoformat()}
+            severity = "warn" if bucket == "stale" else "info"
+            age_phrase = f" ({age_days}d old, {bucket})"
+        else:
+            bucket = "unknown"
+            severity = "info"
+            age_phrase = " (capture date unknown)"
+
+        rows.append((
+            age_days if age_days is not None else -1,
+            AuditFinding(
                 category="unprocessed_source",
-                severity="info",
+                severity=severity,
                 path=page.rel_path,
-                detail="Source has no ingested_into entries — nothing compiled from it yet",
-                proposed_fix=(
-                    "If still relevant, compile a research-note/insight that cites this "
-                    "source (the back-ref will update automatically). Otherwise mark as "
-                    "archived or delete."
+                detail=(
+                    f"Source has no ingested_into entries — nothing compiled "
+                    f"from it yet{age_phrase}"
                 ),
-            ))
-    return findings
+                proposed_fix=(
+                    "Call `propose_compilation(sources=[this])` for a draft note "
+                    "skeleton, then compile via `note` (the back-ref updates "
+                    "automatically). Otherwise mark archived or delete."
+                ),
+                meta=meta or None,
+            ),
+        ))
+
+    # Oldest first — drain the worst rot first. Capture-unknown (-1) sinks last.
+    rows.sort(key=lambda t: t[0], reverse=True)
+    return [f for _, f in rows]
+
+
+def _parse_fm_date(value) -> dt.date | None:
+    """Coerce a frontmatter date value (yaml date, datetime, or ISO str) to date."""
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return dt.date.fromisoformat(value.strip()[:10])
+        except ValueError:
+            return None
+    return None
 
 
 # ---------------- check: index_drift ----------------

--- a/src/kb_mcp/compile_proposal.py
+++ b/src/kb_mcp/compile_proposal.py
@@ -1,0 +1,151 @@
+"""propose_compilation: turn unprocessed source(s) into a draft note skeleton.
+
+Pure retrieval. Reads the cited source(s), infers a likely note_type, finds the
+adjacent compiled notes worth connecting to (reusing corpus_aware.suggest_related),
+and returns a sectioned outline with `sources[]` and wikilink connections
+pre-filled. It NEVER writes — the client (Claude) fills the prose and calls
+`note()`. Generation stays client-side per the pure-substrate principle; the
+server just hands over the scaffolding and the connections it can compute.
+
+Grouping (which sources belong together) is deliberately NOT done here — that's a
+judgment call the client is better at. The audit unprocessed_source check surfaces
+the aged backlog; the client picks a coherent set and passes it here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import corpus_aware
+from . import find as find_module
+from .vault import WikilinkResolver, normalize_wikilink
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ProposeError(Exception):
+    code: str
+    reason: str
+
+    def as_dict(self) -> dict:
+        return {"code": self.code, "reason": self.reason}
+
+
+def propose_compilation(
+    vault_root: Path,
+    *,
+    sources: list[str],
+    suggested_title: str | None = None,
+) -> dict:
+    """Return a draft compilation scaffold for `sources`. Never writes."""
+    if not sources:
+        raise ProposeError("INVALID_PROPOSE", "provide at least one source path")
+
+    resolver = WikilinkResolver(vault_root)
+    resolved: list[str] = []          # canonical "Knowledge Base/..." (no .md)
+    source_types: list[str] = []
+    titles: list[str] = []
+    body_parts: list[str] = []
+    warnings: list[str] = []
+
+    for s in sources:
+        canonical, _w = normalize_wikilink(s, vault_root, resolver=resolver, strict=False)
+        abs_path = vault_root / f"{canonical}.md"
+        page = find_module._CACHE.get(abs_path, vault_root)
+        if page is None:
+            warnings.append(f"source not found, skipped: {s}")
+            continue
+        resolved.append(canonical)
+        st = page.frontmatter.get("source_type")
+        if isinstance(st, str):
+            source_types.append(st)
+        titles.append(page.title)
+        body_parts.append(page.body)
+
+    if not resolved:
+        raise ProposeError(
+            "SOURCES_NOT_FOUND", f"none of the provided sources resolved: {sources}"
+        )
+
+    combined_body = "\n\n".join(body_parts)
+    title = suggested_title or _suggest_title(titles)
+    note_type = _suggest_note_type(source_types)
+
+    # Adjacent compiled notes to connect to — exclude the sources themselves.
+    suggestions = corpus_aware.suggest_related(
+        vault_root,
+        title=title,
+        body=combined_body,
+        self_path=None,
+        existing_links=set(resolved),
+        limit=6,
+        scope="kb",
+    )
+    connections = [s.path for s in suggestions if s.type != "source"][:5]
+
+    return {
+        "suggested_note_type": note_type,
+        "suggested_title": title,
+        "suggested_sources": resolved,
+        "suggested_connections": connections,
+        "outline_markdown": _render_outline(note_type, title, connections),
+        "warnings": warnings,
+    }
+
+
+def _suggest_title(titles: list[str]) -> str:
+    clean = [t.removeprefix("Source: ").strip() for t in titles if t]
+    if not clean:
+        return "Untitled compilation"
+    if len(clean) == 1:
+        return clean[0]
+    head = "; ".join(clean[:2])
+    return f"Synthesis: {head}" + (" + more" if len(clean) > 2 else "")
+
+
+def _suggest_note_type(source_types: list[str]) -> str:
+    """Heuristic only — the client picks the final type. Session-heavy captures
+    tend to be project work (research-note); mixed/article captures tend to be
+    cross-cutting (insight)."""
+    if source_types and source_types.count("session") >= (len(source_types) + 1) // 2:
+        return "research-note"
+    return "insight"
+
+
+_SECTIONS: dict[str, list[str]] = {
+    "research-note": ["Question", "Findings", "Connections"],
+    "insight": ["Claim", "Why it holds", "Connections"],
+    "failure": ["What happened", "Mechanism", "Detection", "Mitigation", "Connections"],
+    "pattern": ["Problem", "Solution", "When to use", "When NOT to use", "Connections"],
+}
+
+
+def _render_outline(note_type: str, title: str, connections: list[str]) -> str:
+    sections = _SECTIONS.get(note_type, _SECTIONS["insight"])
+    lines = [f"# {title}", ""]
+    if note_type == "research-note":
+        lines += [
+            "> Draft scaffold from propose_compilation. research-note requires a "
+            "`project:` — pass it to note(). Fill the prose, then call note() with "
+            "the suggested_sources/connections.",
+            "",
+        ]
+    else:
+        lines += [
+            "> Draft scaffold from propose_compilation. Fill the prose, then call "
+            "note() with the suggested_sources + connections.",
+            "",
+        ]
+    for sec in sections:
+        lines.append(f"## {sec}")
+        lines.append("")
+        if sec == "Connections" and connections:
+            for c in connections:
+                lines.append(f"- [[{c}]]")
+        else:
+            lines.append(f"<!-- {sec.lower()}: distilled from the cited source(s) -->")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/kb_mcp/corpus_aware.py
+++ b/src/kb_mcp/corpus_aware.py
@@ -1,0 +1,222 @@
+"""Corpus-aware writes: let the existing graph + embeddings inform authoring.
+
+Today the write path is corpus-blind — every wikilink and source is caller-
+supplied, so the dense link graph and the embedding sidecar contribute nothing
+at authoring time. This module closes that loop using ONLY the existing retrieval
+stack (find() + EmbeddingIndex), no new dependency and no server-side LLM:
+
+- `suggest_related()` — given a draft (title + body), return ranked EXISTING
+  pages it should probably link to, preferring graph hubs, excluding itself and
+  anything already linked. Reuses find() wholesale, so it inherits graceful
+  BM25/keyword degradation when embeddings are unavailable.
+- `detect_duplicates()` — flag existing pages whose content is near-identical to
+  a draft (cosine over the sidecar), so a new entry doesn't silently duplicate an
+  old one. A WARNING, never a block — append-only + supersession invariants mean
+  the client decides (edit/replace/append), we just make the overlap visible.
+
+ALTITUDE: everything here is *surfaced* (returned as structured suggestions /
+warnings) for the client LLM to act on — never auto-injected into a body. Hugo
+rubber-stamps approvals, so visibility beats silent graph mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Tunable knobs — intuition-seeded like find.RankingConfig; revisit against the
+# eval harness (scripts/eval_retrieval.py) once a golden set exists. Kept here
+# as named constants so they're one-line greppable.
+HUB_WEIGHT = 0.15  # weight on log1p(graph_in_degree) when re-ranking suggestions
+DUP_THRESHOLD = 0.86  # min doc-doc cosine to call something a near-duplicate
+RELATED_OVERFETCH = 3  # fetch limit * this from find(), then re-rank + trim
+
+# Lead-body word budget for the synthesized "what is this about" query.
+_QUERY_LEAD_WORDS = 400
+
+
+@dataclass
+class RelatedSuggestion:
+    path: str
+    title: str
+    type: str | None
+    why: str
+    excerpt: str
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "title": self.title,
+            "type": self.type,
+            "why": self.why,
+            "excerpt": self.excerpt,
+        }
+
+
+@dataclass
+class DupCandidate:
+    path: str
+    title: str
+    cosine: float
+
+    def as_dict(self) -> dict:
+        return {"path": self.path, "title": self.title, "cosine": self.cosine}
+
+
+def _canon(path: str) -> str:
+    """Comparable key across find paths (with .md), sources (no .md), wikilinks."""
+    p = (path or "").strip().replace("\\", "/").split("#", 1)[0].strip()
+    if p.lower().endswith(".md"):
+        p = p[:-3]
+    if p.startswith("Knowledge Base/"):
+        p = p[len("Knowledge Base/"):]
+    return p.lower()
+
+
+def _why(hit) -> str:
+    """One-line rationale assembled from the hit's ranking signals."""
+    bits: list[str] = []
+    if hit.vector_rank:
+        bits.append(f"semantic #{hit.vector_rank}")
+    if hit.bm25_rank:
+        bits.append(f"keyword #{hit.bm25_rank}")
+    if hit.graph_in_degree:
+        hub = " (hub)" if hit.graph_in_degree >= 3 else ""
+        bits.append(f"{hit.graph_in_degree} shared link(s){hub}")
+    return ", ".join(bits) or "related"
+
+
+def suggest_related(
+    vault_root: Path,
+    *,
+    title: str,
+    body: str,
+    self_path: str | None = None,
+    existing_links: set[str] | None = None,
+    limit: int = 8,
+    scope: str = "kb",
+) -> list[RelatedSuggestion]:
+    """Rank existing pages a draft should link to. Reuses find(); never writes.
+
+    Excludes the draft itself (`self_path`) and anything in `existing_links`
+    (cited sources + wikilinks already in the body). Re-ranks find()'s order
+    with a small log-scaled graph-in-degree bonus so well-connected hubs float
+    up — linking a hub compounds more than linking a leaf.
+    """
+    from . import find as find_module
+
+    lead = " ".join((body or "").split()[:_QUERY_LEAD_WORDS])
+    query = f"{title}\n\n{lead}".strip() or (title or "").strip()
+    if not query:
+        return []
+
+    self_canon = _canon(self_path) if self_path else None
+    excluded = {_canon(e) for e in (existing_links or set())}
+
+    try:
+        hits = find_module.find(
+            vault_root,
+            query=query,
+            limit=limit * RELATED_OVERFETCH,
+            mode="hybrid",
+            graph=True,
+            scope=scope,
+            prefer_compiled=True,
+        )
+    except Exception as e:  # noqa: BLE001 — suggestions are best-effort
+        log.debug("suggest_related find() failed: %s", e)
+        return []
+
+    eligible = []
+    for h in hits:
+        hc = _canon(h.path)
+        if self_canon and hc == self_canon:
+            continue
+        if hc in excluded:
+            continue
+        eligible.append(h)
+
+    # Re-rank: find's fused position (1/(i+1)) + hub bonus on graph_in_degree.
+    def _score(i_h: tuple[int, object]) -> float:
+        i, h = i_h
+        return 1.0 / (i + 1) + HUB_WEIGHT * math.log1p(getattr(h, "graph_in_degree", 0) or 0)
+
+    ranked = sorted(enumerate(eligible), key=_score, reverse=True)
+    return [
+        RelatedSuggestion(
+            path=h.path, title=h.title, type=h.type, why=_why(h), excerpt=h.excerpt
+        )
+        for _, h in ranked[:limit]
+    ]
+
+
+def detect_duplicates(
+    vault_root: Path,
+    *,
+    title: str,
+    body: str,
+    self_path: str | None = None,
+    types_filter: list[str] | None = None,
+    threshold: float = DUP_THRESHOLD,
+    top_n: int = 3,
+) -> list[DupCandidate]:
+    """Flag existing pages whose content is near-identical to a draft.
+
+    Embeds the draft as PASSAGES (is_query=False — this is doc-to-doc, not a
+    query) and cosine-matches against the existing sidecar. Returns at most
+    `top_n` candidates at/above `threshold`, optionally restricted to
+    `types_filter` page types. No-ops (returns []) when embeddings are disabled
+    or the sidecar is empty, so the fast test suite and torch-less deploys are
+    unaffected.
+    """
+    if os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
+        return []
+    try:
+        from . import embeddings, find as find_module
+
+        chunks = embeddings.chunk_text(title, body)
+        if not chunks:
+            return []
+        vecs = embeddings.embed_texts(chunks, is_query=False)
+        idx = embeddings.EmbeddingIndex(vault_root)
+        best_per_file: dict[str, float] = {}
+        for v in vecs:
+            for fp, _cidx, _ctext, score in idx.search(v, k=top_n * 5):
+                if fp not in best_per_file or score > best_per_file[fp]:
+                    best_per_file[fp] = score
+    except ImportError as e:
+        log.debug("detect_duplicates unavailable (%s)", e)
+        return []
+    except Exception as e:  # noqa: BLE001 — best-effort
+        log.debug("detect_duplicates failed: %s", e)
+        return []
+
+    self_canon = _canon(self_path) if self_path else None
+    out: list[DupCandidate] = []
+    for fp, score in sorted(best_per_file.items(), key=lambda t: -t[1]):
+        if score < threshold:
+            break  # sorted desc — nothing below threshold remains
+        if self_canon and _canon(fp) == self_canon:
+            continue
+        page = find_module._CACHE.get(vault_root / fp, vault_root)
+        if page is None:
+            continue
+        if types_filter and page.page_type not in types_filter:
+            continue
+        out.append(DupCandidate(path=fp, title=page.title, cosine=round(float(score), 4)))
+        if len(out) >= top_n:
+            break
+    return out
+
+
+def dup_warning(candidate: DupCandidate) -> str:
+    """Render a near-duplicate as a single warning string for a write result."""
+    return (
+        f"possible near-duplicate of [[{candidate.path}]] (cosine "
+        f"{candidate.cosine}) — consider edit/replace/append instead of a new page"
+    )

--- a/src/kb_mcp/eval_metrics.py
+++ b/src/kb_mcp/eval_metrics.py
@@ -1,0 +1,57 @@
+"""Pure ranking-quality metrics for the retrieval eval harness.
+
+No torch, no kb_mcp imports — these operate on already-normalized path strings
+so they're importable in the fast (embedding-free) test suite and reusable by
+`scripts/eval_retrieval.py`. The harness is responsible for canonicalizing
+both the golden-set paths and find()'s returned paths into the same form
+before calling these (see `scripts/eval_retrieval.py:_canon`).
+
+Conventions:
+- `ranked`: list[str] of retrieved paths, best-first (what find() returned).
+- `relevance`: dict[str, float] mapping a path to its graded relevance
+  (0..3 typical). Absent paths are treated as grade 0.
+- `relevant`: set[str] of paths with grade > 0 (binary relevance), used by
+  MRR and recall where grade magnitude doesn't matter.
+
+NDCG uses the standard exponential gain (2**g - 1), so a grade-3 "ideal" hit is
+worth far more than a grade-1 "marginal" one.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+
+
+def dcg(gains: Iterable[float]) -> float:
+    """Discounted cumulative gain. gains[i] is the gain at rank i+1."""
+    return sum(g / math.log2(i + 2) for i, g in enumerate(gains))
+
+
+def ndcg_at_k(ranked: list[str], relevance: Mapping[str, float], k: int) -> float:
+    """Normalized DCG@k with exponential gain. Returns 0.0 when no ideal gain."""
+    actual = dcg(2.0 ** relevance.get(p, 0.0) - 1.0 for p in ranked[:k])
+    ideal_grades = sorted(relevance.values(), reverse=True)[:k]
+    ideal = dcg(2.0 ** g - 1.0 for g in ideal_grades)
+    return actual / ideal if ideal > 0 else 0.0
+
+
+def mrr(ranked: list[str], relevant: set[str]) -> float:
+    """Reciprocal rank of the first relevant hit; 0.0 if none in `ranked`."""
+    for i, p in enumerate(ranked, start=1):
+        if p in relevant:
+            return 1.0 / i
+    return 0.0
+
+
+def recall_at_k(ranked: list[str], relevant: set[str], k: int) -> float:
+    """Fraction of the relevant set that appears in the top-k. 0.0 if none relevant."""
+    if not relevant:
+        return 0.0
+    top = set(ranked[:k])
+    return len(top & relevant) / len(relevant)
+
+
+def mean(values: Iterable[float]) -> float:
+    vals = list(values)
+    return sum(vals) / len(vals) if vals else 0.0

--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -33,6 +33,32 @@ EXCERPT_RADIUS = 100  # chars on each side of the match
 EXCERPT_MAX_LEN = 220
 
 
+@dataclass(frozen=True)
+class RankingConfig:
+    """The tunable knobs of the hybrid ranker, in one place.
+
+    Every value here was historically a hardcoded literal scattered through
+    `_find_semantic`/`fusion`/`_type_multiplier`. Bundling them lets the
+    offline eval harness (`scripts/eval_retrieval.py`) sweep them against a
+    golden set and pick winners by NDCG/MRR instead of intuition. The
+    field defaults reproduce the pre-refactor behaviour byte-for-byte — see
+    `tests/test_ranking_config.py`, which guards that invariant.
+
+    Intentionally NOT exposed on the MCP `find` tool signature: claude.ai
+    needs no knobs API. It's an internal seam for measurement + tuning.
+    """
+
+    rrf_k: int = 60  # Cormack/Clarke/Buettcher 2009 default; fusion.py
+    compiled_boost: float = 1.15  # must equal _COMPILED_BOOST
+    source_penalty: float = 0.85  # must equal _SOURCE_PENALTY
+    candidate_multiplier: int = 5  # candidate_k = max(limit*mult, floor)
+    candidate_floor: int = 50
+    graph_seed_cap: int = 20  # per-ranker fanout cap for 1-hop expansion
+
+
+DEFAULT_RANKING = RankingConfig()
+
+
 @dataclass
 class ParsedPage:
     path: Path  # absolute
@@ -189,6 +215,7 @@ def find(
     graph: bool = True,
     rerank: bool = False,
     prefer_compiled: bool = True,
+    config: RankingConfig | None = None,
 ) -> list[Hit]:
     """Search the vault. Returns up to `limit` hits.
 
@@ -260,6 +287,7 @@ def find(
         types=types, projects=projects, tags=tags,
         limit=limit, scope=scope, mode=mode, graph=graph, rerank=rerank,
         prefer_compiled=prefer_compiled,
+        config=config or DEFAULT_RANKING,
     )
 
 
@@ -328,13 +356,14 @@ def _find_semantic(
     graph: bool = True,
     rerank: bool = False,
     prefer_compiled: bool = True,
+    config: RankingConfig = DEFAULT_RANKING,
 ) -> list[Hit]:
     """Hybrid (BM25+vector) or vector-only mode."""
     # Lazy imports — keep keyword-mode users out of the torch import path.
     from . import bm25, embeddings, fusion
 
     # Pull more than we need so post-filter losses don't starve the result.
-    candidate_k = max(limit * 5, 50)
+    candidate_k = max(limit * config.candidate_multiplier, config.candidate_floor)
 
     # ---- Vector contribution ----
     vector_ranking: list[str] = []
@@ -402,7 +431,7 @@ def _find_semantic(
         graph_seeds: list[str] = []
         seen_seed: set[str] = set()
         for r in (vector_ranking, bm25_ranking):
-            for p in r[:20]:  # cap fanout
+            for p in r[:config.graph_seed_cap]:  # cap fanout
                 if p in seen_seed:
                     continue
                 seen_seed.add(p)
@@ -454,12 +483,12 @@ def _find_semantic(
             limit=limit, scope=scope,
         )
 
-    fused = fusion.reciprocal_rank_fusion(rankings, k=60)
+    fused = fusion.reciprocal_rank_fusion(rankings, k=config.rrf_k)
     # Apply type-weight boost before iterating fused candidates — affects the
     # iteration order for non-rerank flows. For rerank, the boost is also
     # applied to rerank_score below so it survives the final sort.
     if prefer_compiled:
-        fused = _apply_type_boost(fused, vault_root)
+        fused = _apply_type_boost(fused, vault_root, config)
     vector_paths: set[str] = set(vector_ranking)
 
     # Resolve fused paths back to ParsedPage, filter, build hits in fused order.
@@ -553,7 +582,7 @@ def _find_semantic(
             if prefer_compiled:
                 for h in hits:
                     if h.rerank_score is not None:
-                        h.rerank_score *= _type_multiplier(h.type)
+                        h.rerank_score *= _type_multiplier(h.type, config)
             hits.sort(key=lambda h: -(h.rerank_score if h.rerank_score is not None else float("-inf")))
         except ImportError as e:
             log.warning("rerank requested but reranker unavailable: %s", e)
@@ -581,16 +610,20 @@ _COMPILED_BOOST = 1.15
 _SOURCE_PENALTY = 0.85
 
 
-def _type_multiplier(page_type: str | None) -> float:
+def _type_multiplier(
+    page_type: str | None, config: RankingConfig = DEFAULT_RANKING
+) -> float:
     if page_type in _COMPILED_TYPES:
-        return _COMPILED_BOOST
+        return config.compiled_boost
     if page_type in _SOURCE_TYPES:
-        return _SOURCE_PENALTY
+        return config.source_penalty
     return 1.0
 
 
 def _apply_type_boost(
-    fused: list[tuple[str, float]], vault_root: Path
+    fused: list[tuple[str, float]],
+    vault_root: Path,
+    config: RankingConfig = DEFAULT_RANKING,
 ) -> list[tuple[str, float]]:
     """Re-sort fused `(path, score)` pairs after applying per-type multipliers.
 
@@ -600,7 +633,7 @@ def _apply_type_boost(
     adjusted: list[tuple[str, float]] = []
     for path, score in fused:
         page = _CACHE.get(vault_root / path, vault_root)
-        mult = _type_multiplier(page.page_type if page else None)
+        mult = _type_multiplier(page.page_type if page else None, config)
         adjusted.append((path, score * mult))
     adjusted.sort(key=lambda t: (-t[1], t[0]))
     return adjusted

--- a/src/kb_mcp/note.py
+++ b/src/kb_mcp/note.py
@@ -30,16 +30,19 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
+from . import corpus_aware
 from . import indexes
 from . import project_keys as project_keys_module
 from .vault import (
     PlannedWrite,
     WikilinkResolver,
     batch_atomic_write,
+    find_body_wikilinks,
     kb_root,
     normalize_body_wikilinks,
     normalize_wikilink,
@@ -107,9 +110,16 @@ STATUS_PRODUCTION = (
 class NoteResult:
     path: str  # vault-relative
     warnings: list[str]
+    # Corpus-aware "you might want to link these" hints. Non-binding — the
+    # client decides. Omitted from as_dict() when empty so existing callers
+    # (and the ~256 tests) see no shape change unless a suggestion fires.
+    suggestions: list[dict] = field(default_factory=list)
 
     def as_dict(self) -> dict:
-        return {"path": self.path, "warnings": self.warnings}
+        out: dict = {"path": self.path, "warnings": self.warnings}
+        if self.suggestions:
+            out["suggestions"] = self.suggestions
+        return out
 
 
 @dataclass
@@ -260,6 +270,37 @@ def note(
         content, vault_root, resolver=resolver
     )
 
+    # Corpus-aware nudges — best-effort, must NEVER block or roll back the write.
+    # Computed PRE-write so the new note isn't in the sidecar yet (no self-match,
+    # no 70MB matrix reload). Skipped entirely when embeddings are disabled, so
+    # the fast test suite and existing note() tests see no behaviour change.
+    corpus_suggestions: list[dict] = []
+    dup_warnings: list[str] = []
+    if not os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
+        try:
+            existing_links: set[str] = set(sources_norm)
+            for m in find_body_wikilinks(body_clean):
+                inner = m.group(0)[2:-2].split("|", 1)[0].split("#", 1)[0].strip()
+                if inner:
+                    existing_links.add(inner)
+            corpus_suggestions = [
+                s.as_dict()
+                for s in corpus_aware.suggest_related(
+                    vault_root, title=title, body=body_clean,
+                    self_path=rel_note_no_ext, existing_links=existing_links,
+                    limit=6,
+                )
+            ]
+            dup_warnings = [
+                corpus_aware.dup_warning(c)
+                for c in corpus_aware.detect_duplicates(
+                    vault_root, title=title, body=body_clean,
+                    self_path=rel_note_no_ext, types_filter=[note_type],
+                )
+            ]
+        except Exception as e:  # noqa: BLE001 — nudges never break a write
+            log.debug("corpus-aware nudges failed (non-fatal): %s", e)
+
     note_md = _render_note(
         note_type=note_type,
         title=title,
@@ -287,7 +328,12 @@ def note(
 
     kb = kb_root(vault_root)
     writes: list[PlannedWrite] = [PlannedWrite(path=note_path, content=note_md)]
-    warnings: list[str] = list(autoregister_warnings) + list(source_warnings) + list(body_warnings)
+    warnings: list[str] = (
+        list(autoregister_warnings)
+        + list(source_warnings)
+        + list(body_warnings)
+        + list(dup_warnings)
+    )
     if slug_warning:
         warnings.append(slug_warning)
 
@@ -387,6 +433,7 @@ def note(
     return NoteResult(
         path=note_path.relative_to(vault_root).as_posix(),
         warnings=warnings,
+        suggestions=corpus_suggestions,
     )
 
 

--- a/src/kb_mcp/query_log.py
+++ b/src/kb_mcp/query_log.py
@@ -1,0 +1,122 @@
+"""Durable structured logs of find() queries and write events.
+
+Two JSONL files under the repo `logs/` dir (already gitignored via `logs/*`,
+NSSM-rotated neighborhood, NEVER Obsidian-synced — query text can name sensitive
+Evidence scopes, so it stays on the box at the same trust boundary as
+`logs/kb-mcp.log`):
+
+- `logs/queries.jsonl` : one object per find() call (query + ranking signals)
+- `logs/writes.jsonl`  : one object per note/add/replace write (path + citations)
+
+These feed the offline feedback loop (`scripts/derive_relevance_pairs.py`), which
+mines weak `(query -> cited_path)` relevance labels to grow the eval golden set.
+We log ONLY paths + the per-hit `signals` dict, never excerpts or bodies — that's
+the bloat trap.
+
+Everything here is best-effort: any failure is swallowed so logging can NEVER
+break a tool call. No-op when `KB_MCP_DISABLE_EMBEDDINGS` (so the test suite stays
+clean) or `KB_MCP_DISABLE_QUERY_LOG` (an explicit ops opt-out) is set.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
+QUERIES_PATH = _LOG_DIR / "queries.jsonl"
+WRITES_PATH = _LOG_DIR / "writes.jsonl"
+
+
+def _disabled() -> bool:
+    return bool(
+        os.environ.get("KB_MCP_DISABLE_EMBEDDINGS")
+        or os.environ.get("KB_MCP_DISABLE_QUERY_LOG")
+    )
+
+
+def _append(path: Path, obj: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    except Exception as e:  # noqa: BLE001 — logging must never raise
+        log.debug("query_log append to %s failed: %s", path.name, e)
+
+
+def _now_iso() -> str:
+    return dt.datetime.now().isoformat(timespec="seconds")
+
+
+def log_find_call(
+    *,
+    query: str,
+    mode: str,
+    scope: str,
+    types: list[str] | None,
+    projects: list[str] | None,
+    tags: list[str] | None,
+    limit: int,
+    rerank: bool,
+    prefer_compiled: bool,
+    graph: bool,
+    hits: list[Any],
+) -> None:
+    """Append one structured record for a find() call. Best-effort."""
+    if _disabled():
+        return
+    try:
+        top_k = []
+        for h in hits:
+            d = h.as_dict()
+            top_k.append(
+                {
+                    "path": d.get("path"),
+                    "type": d.get("type"),
+                    "signals": d.get("signals", {}),
+                }
+            )
+        _append(
+            QUERIES_PATH,
+            {
+                "ts": _now_iso(),
+                "query": query,
+                "mode": mode,
+                "scope": scope,
+                "filters": {"types": types, "projects": projects, "tags": tags},
+                "limit": limit,
+                "rerank": rerank,
+                "prefer_compiled": prefer_compiled,
+                "graph": graph,
+                "n_results": len(hits),
+                "top_k": top_k,
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        log.debug("log_find_call failed: %s", e)
+
+
+def log_write_call(
+    *, tool: str, written_path: str | None, cited_sources: list[str] | None
+) -> None:
+    """Append one structured record for a note/add/replace write. Best-effort."""
+    if _disabled():
+        return
+    try:
+        _append(
+            WRITES_PATH,
+            {
+                "ts": _now_iso(),
+                "tool": tool,
+                "written_path": written_path,
+                "cited_sources": list(cited_sources or []),
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        log.debug("log_write_call failed: %s", e)

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -36,6 +36,7 @@ from . import add as add_module
 from . import append_to_file as append_to_file_module
 from . import audit as audit_module
 from . import audit_fix as audit_fix_module
+from . import compile_proposal as compile_proposal_module
 from . import corpus_aware as corpus_aware_module
 from . import create_directory as create_directory_module
 from . import create_file as create_file_module
@@ -742,6 +743,45 @@ def build_server(*, require_auth: bool) -> FastMCP:
             rebuild_embeddings=rebuild_embeddings,
         )
         return report.as_dict()
+
+    @mcp.tool
+    def propose_compilation(
+        sources: list[str],
+        suggested_title: str | None = None,
+    ) -> dict:
+        """Draft a compiled-note scaffold from unprocessed source(s). Read-only.
+
+        The backlog-drain companion to `audit`'s `unprocessed_source` findings:
+        point it at one or more raw sources and it hands back a ready-to-fill
+        note skeleton — inferred note_type, a Question/Findings/Connections (or
+        Claim/…) outline, the `sources[]` to cite, and adjacent compiled pages to
+        link (computed via the same hybrid retrieval as `suggest_links`). It
+        does NOT write anything: you fill the prose and call `note()` with the
+        returned `suggested_sources` + `suggested_connections`.
+
+        Group sources yourself before calling — pass a set that genuinely belongs
+        in one note (the audit list is aged oldest-first to help you triage).
+
+        Args:
+            sources: Vault-relative paths/wikilinks to the source(s) to compile.
+                Same path conventions as `note.sources` (brackets and the
+                leading `Knowledge Base/` are tolerated).
+            suggested_title: Optional title override; otherwise one is derived
+                from the source titles.
+
+        Returns:
+            {suggested_note_type, suggested_title, suggested_sources,
+             suggested_connections, outline_markdown, warnings}.
+
+        Errors:
+            INVALID_PROPOSE (no sources); SOURCES_NOT_FOUND (none resolved).
+        """
+        try:
+            return compile_proposal_module.propose_compilation(
+                vault_root, sources=sources, suggested_title=suggested_title
+            )
+        except compile_proposal_module.ProposeError as e:
+            raise ValueError(f"{e.code}: {e.reason}") from e
 
     @mcp.tool
     def get(path: str) -> dict:

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -36,6 +36,7 @@ from . import add as add_module
 from . import append_to_file as append_to_file_module
 from . import audit as audit_module
 from . import audit_fix as audit_fix_module
+from . import corpus_aware as corpus_aware_module
 from . import create_directory as create_directory_module
 from . import create_file as create_file_module
 from . import delete_directory as delete_directory_module
@@ -51,11 +52,12 @@ from . import list_trash as list_trash_module
 from . import move_file as move_file_module
 from . import note as note_module
 from . import preserve as preserve_module
+from . import query_log
 from . import recover_from_trash as recover_from_trash_module
 from . import replace as replace_module
 from . import schema
 from . import set_frontmatter_field as set_frontmatter_field_module
-from .vault import resolve_vault
+from .vault import find_body_wikilinks, resolve_vault
 
 
 log = logging.getLogger(__name__)
@@ -379,7 +381,91 @@ def build_server(*, require_auth: bool) -> FastMCP:
             rerank=rerank,
             prefer_compiled=prefer_compiled,
         )
+        # Durable structured log → feeds the offline retrieval feedback loop.
+        # Best-effort; never affects the returned result.
+        query_log.log_find_call(
+            query=query, mode=mode, scope=scope,
+            types=types, projects=projects, tags=tags,
+            limit=limit, rerank=rerank, prefer_compiled=prefer_compiled,
+            graph=graph, hits=hits,
+        )
         return [h.as_dict() for h in hits]
+
+    @mcp.tool
+    def suggest_links(
+        path: str | None = None,
+        draft_title: str | None = None,
+        draft_body: str | None = None,
+        limit: int = 8,
+        scope: str = "kb",
+    ) -> list[dict]:
+        """Suggest existing KB pages a note should link to. Read-only.
+
+        Closes the corpus-blind-write gap: surfaces the related prior work a
+        draft (or an existing page) should connect to, so the graph gets denser
+        with every write instead of just bigger. Pure retrieval — it reuses the
+        same hybrid ranker as `find`, prefers well-connected hubs, and excludes
+        the page itself plus anything it already links. Suggestions are
+        non-binding: YOU decide which to wire in (e.g. via a follow-up `edit`).
+
+        Two call shapes:
+        - `path`: suggest links for an EXISTING page (densify it retroactively).
+          Same path conventions as `get`/`find`.
+        - `draft_title` + `draft_body`: suggest links for a note you're about to
+          create, BEFORE calling `note` — so you can cite/connect on first write.
+
+        Args:
+            path: Existing page to suggest links for. Mutually exclusive with
+                the draft_* args.
+            draft_title: Title of a not-yet-written note.
+            draft_body: Body (markdown) of a not-yet-written note. Wikilinks
+                already present in it are treated as "already linked" and excluded.
+            limit: Max suggestions (default 8).
+            scope: "kb" (default) or "vault" — same meaning as `find`.
+
+        Returns:
+            List of {path, title, type, why, excerpt}, best-first. `why`
+            explains the match (e.g. "semantic #2, 4 shared link(s) (hub)").
+            Empty list if nothing relevant or the draft/page is empty.
+
+        Errors:
+            INVALID_SUGGEST (neither path nor draft supplied); plus get-style
+            path errors (NOT_FOUND, INVALID_PATH) when `path` doesn't resolve.
+        """
+        if path:
+            try:
+                gp = get_page_module.get_page(vault_root, path=path)
+            except get_page_module.GetError as e:
+                raise ValueError(f"{e.code}: {e.reason}") from e
+            page = find_module._CACHE.get(vault_root / gp.path, vault_root)
+            if page is None:
+                raise ValueError(f"UNREADABLE: could not parse {gp.path}")
+            existing_links = set(
+                find_module._outbound_wikilink_paths(page, vault_root)
+            )
+            suggestions = corpus_aware_module.suggest_related(
+                vault_root, title=page.title, body=page.body,
+                self_path=page.rel_path, existing_links=existing_links,
+                limit=limit, scope=scope,
+            )
+        elif draft_title or draft_body:
+            body = draft_body or ""
+            existing_links = set()
+            for m in find_body_wikilinks(body):
+                inner = m.group(0)[2:-2].split("|", 1)[0].split("#", 1)[0].strip()
+                if inner:
+                    existing_links.add(inner)
+            suggestions = corpus_aware_module.suggest_related(
+                vault_root, title=draft_title or "", body=body,
+                self_path=None, existing_links=existing_links,
+                limit=limit, scope=scope,
+            )
+        else:
+            raise ValueError(
+                "INVALID_SUGGEST: provide either `path` (existing page) or "
+                "`draft_title`/`draft_body` (a note you're about to write)"
+            )
+        return [s.as_dict() for s in suggestions]
 
     @mcp.tool
     def add(
@@ -426,6 +512,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(
                 f"{e.code}: {e.reason} (missing: {e.missing})"
             ) from e
+        query_log.log_write_call(tool="add", written_path=result.path, cited_sources=[])
         return result.as_dict()
 
     @mcp.tool
@@ -560,6 +647,9 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(
                 f"{e.code}: {e.reason} (missing: {e.missing})"
             ) from e
+        query_log.log_write_call(
+            tool="note", written_path=result.path, cited_sources=sources
+        )
         return result.as_dict()
 
     @mcp.tool
@@ -849,6 +939,9 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(
                 f"{e.code}: {e.reason} (missing: {e.missing})"
             ) from e
+        query_log.log_write_call(
+            tool="replace", written_path=result.new_path, cited_sources=sources
+        )
         return result.as_dict()
 
     @mcp.tool

--- a/tests/golden/queries.yaml
+++ b/tests/golden/queries.yaml
@@ -1,0 +1,76 @@
+# Golden query set for retrieval eval (scripts/eval_retrieval.py).
+#
+# SEED set — hand-authored against real vault paths so the baseline number is
+# meaningful. It is meant to GROW: scripts/derive_relevance_pairs.py proposes
+# additions mined from real (query -> cited path) usage, which Hugo confirms.
+#
+# Each entry:
+#   query:         the search string (natural language, not a title echo)
+#   expect_any_of: [vault paths] treated as binary-relevant (grade 1), OR
+#   graded:        {path: grade 0..3} for NDCG grading (3=ideal, 1=marginal)
+#
+# Paths are matched leniently: leading "Knowledge Base/" and ".md" optional,
+# case-insensitive (see _canon in eval_retrieval.py).
+
+- query: "what actually triggers defensiveness when receiving criticism"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/asymmetric-criticism-as-trigger"
+
+- query: "how should creators frame their analytics — what to make next"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/audience-as-data-frame-creator-analytics-as-what-to-make-next-not-what-already-happened"
+
+- query: "the universal binding problem in large language models"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/binding-mechanism-is-the-universal-llm-problem"
+
+- query: "migrating infrastructure from coolify to k3s, the IaC origin story"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/coolify-to-k3s-migration-the-iac-origin-story"
+
+- query: "does informal coaching feedback satisfy a formal warning precondition"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/coaching-feedback-does-not-satisfy-the-formal-warning-precondition"
+
+- query: "friendly UI labels for non-technical creators"
+  expect_any_of:
+    - "Knowledge Base/Notes/Patterns/2026-05-10-friendly-ui-labels-for-non-technical-creators"
+
+- query: "deprecation window protocol for shipping breaking changes"
+  expect_any_of:
+    - "Knowledge Base/Notes/Patterns/breaking-change-deprecation-window-protocol"
+
+- query: "should I paste multi-line shell into Claude Code or materialise a script"
+  expect_any_of:
+    - "Knowledge Base/Notes/Patterns/claude-code-scripts-not-multiline-pastes"
+
+- query: "map of AI infrastructure job opportunities for May 2026"
+  expect_any_of:
+    - "Knowledge Base/Notes/Research/Career/ai-infra-opportunity-map-may-2026-tranche-1"
+
+- query: "the operating plan for exiting Yolo via tranche 1"
+  expect_any_of:
+    - "Knowledge Base/Notes/Research/Career/primary-goal-yolo-exit-via-tranche-1-operating-plan-may-july-2026"
+
+- query: "field workflow for shooting aurora and night photography"
+  expect_any_of:
+    - "Knowledge Base/Notes/Research/Creative/aurora-night-photography-field-workflow"
+
+- query: "backup script uploaded garbage to B2 after pg_dump failed"
+  expect_any_of:
+    - "Knowledge Base/Notes/Failures/backup-script-uploads-garbage-on-pg-dump-failure"
+
+- query: "why a 404 on the bare oauth protected resource broke the claude.ai connector"
+  expect_any_of:
+    - "Knowledge Base/Notes/Failures/bare-oauth-protected-resource-404-breaks-claude-ai-mcp-registration"
+
+- query: "are AI coding agents just code editors"
+  expect_any_of:
+    - "Knowledge Base/Notes/Failures/ai-coding-agents-are-not-code-editors"
+
+# Graded example: the live canonical career record should rank above its
+# superseded predecessor, which is still marginally relevant.
+- query: "Hugo's canonical career and skillset record"
+  graded:
+    "Knowledge Base/Notes/Research/Career/hugo-ander-kivi-canonical-career-and-skillset-record": 3
+    "Knowledge Base/Notes/Research/Career/hugo-ander-kivi-canonical-career-and-skillset-record-superseded": 1

--- a/tests/test_audit_distillation.py
+++ b/tests/test_audit_distillation.py
@@ -1,0 +1,68 @@
+"""Aging/triage on the unprocessed_source audit check (Pillar 3)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from kb_mcp import add as add_module
+from kb_mcp import audit as audit_module
+from kb_mcp import schema as schema_module
+
+
+def test_parse_fm_date_coerces_forms() -> None:
+    assert audit_module._parse_fm_date("2026-05-04") == dt.date(2026, 5, 4)
+    assert audit_module._parse_fm_date(dt.date(2026, 5, 4)) == dt.date(2026, 5, 4)
+    assert audit_module._parse_fm_date(dt.datetime(2026, 5, 4, 9, 0)) == dt.date(2026, 5, 4)
+    assert audit_module._parse_fm_date(None) is None
+    assert audit_module._parse_fm_date("not-a-date") is None
+
+
+def test_unprocessed_sources_aged_bucketed_and_oldest_first(
+    vault: Path, source_schema: schema_module.SourceSchema
+) -> None:
+    # Two fresh-off-add sources (ingested_into: []), with controlled capture dates.
+    add_module.add(
+        vault, source_schema, content="old capture body", source_type="other",
+        title="Aging Old One", today=dt.date(2026, 1, 1),
+    )
+    add_module.add(
+        vault, source_schema, content="recent capture body", source_type="other",
+        title="Aging Recent One", today=dt.date(2026, 5, 20),
+    )
+
+    report = audit_module.audit(
+        vault, categories=["unprocessed_source"], today=dt.date(2026, 5, 29)
+    )
+    findings = report.findings
+    old_f = next(f for f in findings if "aging-old-one" in f.path)
+    rec_f = next(f for f in findings if "aging-recent-one" in f.path)
+
+    # Aging meta.
+    assert old_f.meta["age_days"] == (dt.date(2026, 5, 29) - dt.date(2026, 1, 1)).days
+    assert old_f.meta["age_bucket"] == "stale"
+    assert old_f.severity == "warn"
+    assert old_f.meta["captured"] == "2026-01-01"
+
+    assert rec_f.meta["age_days"] == 9
+    assert rec_f.meta["age_bucket"] == "fresh"
+    assert rec_f.severity == "info"
+
+    # Oldest first.
+    paths = [f.path for f in findings]
+    assert paths.index(old_f.path) < paths.index(rec_f.path)
+
+    # proposed_fix points at the new drain path.
+    assert "propose_compilation" in old_f.proposed_fix
+
+
+def test_unprocessed_source_finding_omits_meta_when_no_date(
+    vault: Path, source_schema: schema_module.SourceSchema
+) -> None:
+    # as_dict should not carry a meta key when capture date is unknown.
+    # (add always sets captured, so synthesize a finding directly.)
+    f = audit_module.AuditFinding(
+        category="unprocessed_source", severity="info", path="x", detail="d",
+    )
+    assert "meta" not in f.as_dict()
+    assert "paths" not in f.as_dict()

--- a/tests/test_compile_proposal.py
+++ b/tests/test_compile_proposal.py
@@ -1,0 +1,64 @@
+"""Tests for propose_compilation — the backlog-drain scaffold (Pillar 3).
+
+suggest_related (which calls find/hybrid → torch) is monkeypatched so these stay
+fast, torch-free, and deterministic. The point under test is the scaffold: type
+heuristic, source resolution, connection filtering, outline shape, no writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import compile_proposal as cp
+from kb_mcp import corpus_aware
+
+_ARTICLE = "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements"
+_SESSION = "Knowledge Base/Sources/Sessions/2026-05-05-metabolism-curriculum-design"
+
+
+def test_proposal_structure_and_no_write(vault: Path, monkeypatch) -> None:
+    monkeypatch.setattr(corpus_aware, "suggest_related", lambda *a, **k: [])
+    res = cp.propose_compilation(vault, sources=[_ARTICLE])
+    assert res["suggested_sources"] == [_ARTICLE]
+    assert res["suggested_note_type"] in ("insight", "research-note")
+    out = res["outline_markdown"]
+    assert out.startswith("# ")
+    assert "## Connections" in out
+    # It must not have written anything — the source's ingested_into stays empty.
+    src = (vault / f"{_ARTICLE}.md").read_text(encoding="utf-8")
+    assert "ingested_into: []" in src
+
+
+def test_proposal_filters_source_connections(vault: Path, monkeypatch) -> None:
+    fake = [
+        corpus_aware.RelatedSuggestion(
+            path="Knowledge Base/Notes/Insights/keep.md", title="Keep",
+            type="insight", why="", excerpt="",
+        ),
+        corpus_aware.RelatedSuggestion(
+            path="Knowledge Base/Sources/Articles/drop.md", title="Drop",
+            type="source", why="", excerpt="",
+        ),
+    ]
+    monkeypatch.setattr(corpus_aware, "suggest_related", lambda *a, **k: fake)
+    res = cp.propose_compilation(vault, sources=[_ARTICLE])
+    assert res["suggested_connections"] == ["Knowledge Base/Notes/Insights/keep.md"]
+    assert "[[Knowledge Base/Notes/Insights/keep.md]]" in res["outline_markdown"]
+
+
+def test_session_source_suggests_research_note(vault: Path, monkeypatch) -> None:
+    monkeypatch.setattr(corpus_aware, "suggest_related", lambda *a, **k: [])
+    res = cp.propose_compilation(vault, sources=[_SESSION])
+    assert res["suggested_note_type"] == "research-note"
+    assert "project:" in res["outline_markdown"]  # reminder that research-note needs it
+
+
+def test_errors(vault: Path) -> None:
+    with pytest.raises(cp.ProposeError):
+        cp.propose_compilation(vault, sources=[])
+    with pytest.raises(cp.ProposeError):
+        cp.propose_compilation(
+            vault, sources=["Knowledge Base/Sources/Articles/does-not-exist-xyz"]
+        )

--- a/tests/test_corpus_aware.py
+++ b/tests/test_corpus_aware.py
@@ -1,0 +1,137 @@
+"""Tests for corpus-aware writes (suggest_related + detect_duplicates).
+
+Logic tests (path canon, self/already-linked exclusion, hub re-rank) monkeypatch
+find() and run torch-free. Semantic tests build the real sidecar over the fixture
+vault and exercise dedup + note()'s suggestion block; they import-skip without
+torch and lift the suite-wide embeddings gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import corpus_aware, find as find_module
+
+
+# ---------------- pure / torch-free logic ----------------
+
+
+def test_canon_normalizes_equivalent_forms() -> None:
+    a = corpus_aware._canon("Knowledge Base/Notes/Insights/x.md")
+    b = corpus_aware._canon("Notes/Insights/x")
+    c = corpus_aware._canon("Knowledge Base/Notes/Insights/x.md#a-heading")
+    assert a == b == c == "notes/insights/x"
+
+
+def _hit(path: str, *, gid: int = 0, vr: int | None = None, br: int | None = None):
+    return find_module.Hit(
+        path=path, type="insight", scope=None, title=path.rsplit("/", 1)[-1],
+        updated="", excerpt="ex", bm25_rank=br, vector_rank=vr, graph_in_degree=gid,
+    )
+
+
+def test_suggest_related_excludes_self_and_already_linked(monkeypatch) -> None:
+    fake = [
+        _hit("Knowledge Base/Notes/Insights/self.md"),
+        _hit("Knowledge Base/Notes/Insights/linked.md"),
+        _hit("Knowledge Base/Notes/Insights/fresh1.md"),
+        _hit("Knowledge Base/Notes/Insights/fresh2.md"),
+    ]
+    monkeypatch.setattr(find_module, "find", lambda *a, **k: fake)
+    out = corpus_aware.suggest_related(
+        Path("/unused"), title="t", body="b",
+        self_path="Knowledge Base/Notes/Insights/self",
+        existing_links={"Knowledge Base/Notes/Insights/linked"},
+        limit=8,
+    )
+    paths = {corpus_aware._canon(s.path) for s in out}
+    assert "notes/insights/self" not in paths      # never suggest itself
+    assert "notes/insights/linked" not in paths     # already linked
+    assert {"notes/insights/fresh1", "notes/insights/fresh2"} <= paths
+
+
+def test_suggest_related_prefers_hubs(monkeypatch) -> None:
+    # find ranks the leaf first; a strongly-connected hub sits just below it.
+    # The hub bonus must lift the hub to the top.
+    fake = [
+        _hit("Knowledge Base/Notes/Insights/leaf.md", gid=0),
+        _hit("Knowledge Base/Notes/Insights/hub.md", gid=100),
+    ]
+    monkeypatch.setattr(find_module, "find", lambda *a, **k: fake)
+    out = corpus_aware.suggest_related(Path("/unused"), title="t", body="b", limit=8)
+    assert corpus_aware._canon(out[0].path) == "notes/insights/hub"
+
+
+def test_suggest_related_why_mentions_signals(monkeypatch) -> None:
+    fake = [_hit("Knowledge Base/Notes/Insights/x.md", gid=5, vr=2)]
+    monkeypatch.setattr(find_module, "find", lambda *a, **k: fake)
+    out = corpus_aware.suggest_related(Path("/unused"), title="t", body="b")
+    assert "semantic #2" in out[0].why
+    assert "hub" in out[0].why  # gid >= 3
+
+
+def test_detect_duplicates_noop_when_embeddings_disabled(vault: Path) -> None:
+    # Runs under the suite-wide KB_MCP_DISABLE_EMBEDDINGS — must short-circuit to
+    # [] without loading torch or touching a sidecar.
+    assert corpus_aware.detect_duplicates(
+        vault, title="anything", body="some body", types_filter=["insight"]
+    ) == []
+
+
+# ---------------- semantic (model-loading) ----------------
+
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("torch")
+
+from kb_mcp import embeddings, note as note_module  # noqa: E402
+
+_INSIGHT = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
+
+
+@pytest.fixture
+def embeddings_enabled(monkeypatch):
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    embeddings._IMPORT_FAILED = False
+
+
+def test_detect_duplicates_flags_near_identical(vault: Path, embeddings_enabled) -> None:
+    embeddings.EmbeddingIndex(vault).rebuild_all()
+    page = find_module._CACHE.get(vault / _INSIGHT, vault)
+    assert page is not None
+    # Feed an existing page's own content back as a "draft" → near-perfect cosine.
+    dups = corpus_aware.detect_duplicates(
+        vault, title=page.title, body=page.body, types_filter=["insight"]
+    )
+    match = next((d for d in dups if "progressive-disclosure" in d.path), None)
+    assert match is not None, f"expected the twin insight flagged; got {dups}"
+    assert match.cosine >= corpus_aware.DUP_THRESHOLD
+
+
+def test_detect_duplicates_respects_type_filter(vault: Path, embeddings_enabled) -> None:
+    embeddings.EmbeddingIndex(vault).rebuild_all()
+    page = find_module._CACHE.get(vault / _INSIGHT, vault)
+    # Filtering to a type the twin isn't → it must not be returned.
+    dups = corpus_aware.detect_duplicates(
+        vault, title=page.title, body=page.body, types_filter=["pattern"]
+    )
+    assert not any("progressive-disclosure" in d.path for d in dups)
+
+
+def test_note_attaches_suggestions_for_near_twin(vault: Path, embeddings_enabled) -> None:
+    embeddings.EmbeddingIndex(vault).rebuild_all()
+    twin = find_module._CACHE.get(vault / _INSIGHT, vault)
+    res = note_module.note(
+        vault,
+        content=twin.body,
+        note_type="insight",
+        title="Near twin of progressive disclosure",
+        tags=["ux"],
+    )
+    d = res.as_dict()
+    assert d["path"]
+    # The original insight should surface as a related-link suggestion.
+    assert d.get("suggestions"), "expected suggestions for a near-twin insight"
+    sugg = {corpus_aware._canon(s["path"]) for s in d["suggestions"]}
+    assert "notes/insights/progressive-disclosure-without-mode-fragmentation" in sugg

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,61 @@
+"""Unit tests for the pure ranking metrics. No embeddings / torch needed."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kb_mcp import eval_metrics as m
+
+
+def test_dcg_known_values() -> None:
+    # rank1 discount = 1/log2(2) = 1; rank2 = 1/log2(3); rank3 = 1/log2(4)=0.5
+    assert m.dcg([1.0]) == pytest.approx(1.0)
+    assert m.dcg([0.0, 1.0]) == pytest.approx(1.0 / math.log2(3))
+    assert m.dcg([3.0, 0.0, 1.0]) == pytest.approx(3.0 + 0.0 + 1.0 / 2.0)
+
+
+def test_ndcg_perfect_ranking_is_one() -> None:
+    rel = {"a": 3.0, "b": 1.0}
+    assert m.ndcg_at_k(["a", "b"], rel, 2) == pytest.approx(1.0)
+
+
+def test_ndcg_reversed_ranking_below_one() -> None:
+    rel = {"a": 3.0, "b": 1.0}
+    score = m.ndcg_at_k(["b", "a"], rel, 2)
+    assert 0.0 < score < 1.0
+    # exponential gain: actual = (2^1-1) + (2^3-1)/log2(3) = 1 + 7/1.585
+    actual = 1.0 + 7.0 / math.log2(3)
+    ideal = 7.0 + 1.0 / math.log2(3)
+    assert score == pytest.approx(actual / ideal)
+
+
+def test_ndcg_no_relevant_is_zero() -> None:
+    assert m.ndcg_at_k(["x", "y"], {}, 10) == pytest.approx(0.0)
+
+
+def test_ndcg_truncates_at_k() -> None:
+    # The ideal is also truncated at k, so a relevant doc beyond k can't lift it.
+    rel = {"a": 3.0, "b": 3.0, "c": 3.0}
+    # only "a" in top-1, ideal@1 is one grade-3 doc → perfect
+    assert m.ndcg_at_k(["a", "b", "c"], rel, 1) == pytest.approx(1.0)
+
+
+def test_mrr_first_relevant_rank() -> None:
+    assert m.mrr(["x", "a", "b"], {"a", "b"}) == pytest.approx(0.5)
+    assert m.mrr(["a"], {"a"}) == pytest.approx(1.0)
+    assert m.mrr(["x", "y"], {"a"}) == pytest.approx(0.0)
+
+
+def test_recall_at_k() -> None:
+    ranked = ["a", "x", "b", "y"]
+    relevant = {"a", "b", "c"}
+    assert m.recall_at_k(ranked, relevant, 2) == pytest.approx(1.0 / 3)  # only "a" in top-2
+    assert m.recall_at_k(ranked, relevant, 4) == pytest.approx(2.0 / 3)  # a,b in top-4
+    assert m.recall_at_k(ranked, set(), 4) == pytest.approx(0.0)
+
+
+def test_mean() -> None:
+    assert m.mean([1.0, 2.0, 3.0]) == pytest.approx(2.0)
+    assert m.mean([]) == pytest.approx(0.0)

--- a/tests/test_query_log.py
+++ b/tests/test_query_log.py
@@ -1,0 +1,92 @@
+"""query_log is best-effort structured logging for the retrieval feedback loop.
+
+The suite-wide conftest sets KB_MCP_DISABLE_EMBEDDINGS, which also disables
+query_log — so these tests both (a) confirm the no-op-when-disabled contract and
+(b) explicitly re-enable + redirect the JSONL paths to tmp to exercise writes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import query_log
+
+
+class _FakeHit:
+    def __init__(self, path: str, type_: str, signals: dict) -> None:
+        self._d = {"path": path, "type": type_, "signals": signals}
+
+    def as_dict(self) -> dict:
+        return dict(self._d)
+
+
+def test_noop_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setattr(query_log, "WRITES_PATH", tmp_path / "writes.jsonl")
+    query_log.log_write_call(tool="note", written_path="x", cited_sources=[])
+    assert not (tmp_path / "writes.jsonl").exists()
+
+
+def test_logs_find_call_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_QUERY_LOG", raising=False)
+    qpath = tmp_path / "queries.jsonl"
+    monkeypatch.setattr(query_log, "QUERIES_PATH", qpath)
+
+    hits = [
+        _FakeHit("Knowledge Base/Notes/Insights/a.md", "insight", {"vector_rank": 1}),
+        _FakeHit("Knowledge Base/Sources/Articles/b.md", "source", {"bm25_rank": 2}),
+    ]
+    query_log.log_find_call(
+        query="metabolism", mode="hybrid", scope="kb",
+        types=None, projects=["health"], tags=None,
+        limit=10, rerank=False, prefer_compiled=True, graph=True, hits=hits,
+    )
+    lines = qpath.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["query"] == "metabolism"
+    assert rec["n_results"] == 2
+    assert rec["filters"]["projects"] == ["health"]
+    assert rec["top_k"][0] == {
+        "path": "Knowledge Base/Notes/Insights/a.md",
+        "type": "insight",
+        "signals": {"vector_rank": 1},
+    }
+    # No bodies/excerpts leak into the log.
+    assert "excerpt" not in rec["top_k"][0]
+
+
+def test_logs_write_call_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_QUERY_LOG", raising=False)
+    wpath = tmp_path / "writes.jsonl"
+    monkeypatch.setattr(query_log, "WRITES_PATH", wpath)
+
+    query_log.log_write_call(
+        tool="note",
+        written_path="Knowledge Base/Notes/Insights/new.md",
+        cited_sources=["Knowledge Base/Sources/Articles/src"],
+    )
+    rec = json.loads(wpath.read_text(encoding="utf-8").splitlines()[0])
+    assert rec["tool"] == "note"
+    assert rec["written_path"] == "Knowledge Base/Notes/Insights/new.md"
+    assert rec["cited_sources"] == ["Knowledge Base/Sources/Articles/src"]
+
+
+def test_explicit_query_log_disable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("KB_MCP_DISABLE_QUERY_LOG", "1")
+    wpath = tmp_path / "writes.jsonl"
+    monkeypatch.setattr(query_log, "WRITES_PATH", wpath)
+    query_log.log_write_call(tool="note", written_path="x", cited_sources=[])
+    assert not wpath.exists()

--- a/tests/test_ranking_config.py
+++ b/tests/test_ranking_config.py
@@ -1,0 +1,63 @@
+"""RankingConfig is the tuning seam for the eval harness.
+
+These guard the one invariant that makes the seam safe to add: the DEFAULT
+config must reproduce the pre-refactor ranking exactly, while a non-default
+config must actually change ranking (proving the knobs are wired, not ignored).
+
+Runs under the suite-wide KB_MCP_DISABLE_EMBEDDINGS — hybrid mode degrades to
+BM25 + keyword + graph (the fixture vault has no sidecar), which still exercises
+candidate_k / graph_seed_cap / rrf_k / type-boost, all of which the config feeds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kb_mcp import find as find_module
+
+
+def test_default_config_matches_legacy_constants() -> None:
+    cfg = find_module.RankingConfig()
+    # The field defaults must equal the historical literals so DEFAULT is a
+    # faithful no-op. _COMPILED_BOOST / _SOURCE_PENALTY are kept as the
+    # canonical source values; this binds them together.
+    assert cfg.compiled_boost == find_module._COMPILED_BOOST
+    assert cfg.source_penalty == find_module._SOURCE_PENALTY
+    assert cfg.rrf_k == 60
+    assert cfg.candidate_multiplier == 5
+    assert cfg.candidate_floor == 50
+    assert cfg.graph_seed_cap == 20
+    assert find_module.DEFAULT_RANKING == cfg
+
+
+def test_default_config_reproduces_no_config(vault: Path) -> None:
+    """Passing config=DEFAULT_RANKING must be identical to passing nothing."""
+    for query in ("metabolism", "progressive disclosure", "EGCG"):
+        baseline = find_module.find(vault, query=query, mode="hybrid")
+        explicit = find_module.find(
+            vault, query=query, mode="hybrid",
+            config=find_module.DEFAULT_RANKING,
+        )
+        assert [h.path for h in baseline] == [h.path for h in explicit]
+        assert [h.as_dict() for h in baseline] == [h.as_dict() for h in explicit]
+
+
+def test_type_boost_honors_config() -> None:
+    """_apply_type_boost must read multipliers from the passed config."""
+    # Two repo-fixture paths at equal base score: a compiled insight + a raw source.
+    insight = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
+    source = "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements.md"
+    fixtures = Path(__file__).resolve().parents[0] / "fixtures"  # read-only
+    fused = [(insight, 1.0), (source, 1.0)]
+
+    # DEFAULT: compiled x1.15 > source x0.85 → insight ranks first.
+    default_order = [p for p, _ in find_module._apply_type_boost(fused, fixtures)]
+    assert default_order[0] == insight
+
+    # Penalize compiled heavily → source overtakes the insight, proving the
+    # config value (not the module constant) drives the multiplier.
+    penalize = find_module.RankingConfig(compiled_boost=0.1)
+    flipped = [
+        p for p, _ in find_module._apply_type_boost(fused, fixtures, penalize)
+    ]
+    assert flipped[0] == source

--- a/tests/test_relevance_pairs.py
+++ b/tests/test_relevance_pairs.py
@@ -1,0 +1,83 @@
+"""Unit tests for the query->citation feedback-loop join (pure, no torch)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import derive_relevance_pairs as drp  # noqa: E402
+
+
+def _q(ts: str, query: str, paths: list[str]) -> dict:
+    return {"ts": ts, "query": query, "top_k": [{"path": p} for p in paths]}
+
+
+def _w(ts: str, written: str, cited: list[str], tool: str = "note") -> dict:
+    return {"ts": ts, "tool": tool, "written_path": written, "cited_sources": cited}
+
+
+def test_pair_when_query_precedes_write_in_window() -> None:
+    queries = [_q(
+        "2026-05-29T10:00:00", "binding problem in llms",
+        ["Knowledge Base/Notes/Insights/binding.md",
+         "Knowledge Base/Sources/Articles/src-a.md"],
+    )]
+    writes = [_w(
+        "2026-05-29T10:05:00", "Knowledge Base/Notes/Insights/new.md",
+        ["Knowledge Base/Sources/Articles/src-a"],
+    )]
+    pairs = drp.derive_pairs(queries, writes, window_seconds=2 * 3600)
+    assert len(pairs) == 1
+    p = pairs[0]
+    assert p["query"] == "binding problem in llms"
+    assert p["cited_path"] == "sources/articles/src-a"
+    assert p["rank_in_results"] == 2
+    assert 0.0 < p["confidence"] <= 0.5  # rank-2 cap
+
+
+def test_no_pair_when_write_precedes_query() -> None:
+    queries = [_q("2026-05-29T11:00:00", "q", ["Knowledge Base/Sources/Articles/s.md"])]
+    writes = [_w("2026-05-29T10:00:00", "n", ["Knowledge Base/Sources/Articles/s"])]
+    assert drp.derive_pairs(queries, writes, window_seconds=2 * 3600) == []
+
+
+def test_no_pair_outside_window() -> None:
+    queries = [_q("2026-05-29T06:00:00", "q", ["Knowledge Base/Sources/Articles/s.md"])]
+    writes = [_w("2026-05-29T10:00:00", "n", ["Knowledge Base/Sources/Articles/s"])]
+    assert drp.derive_pairs(queries, writes, window_seconds=2 * 3600) == []  # 4h > 2h
+
+
+def test_no_pair_when_cited_not_in_results() -> None:
+    queries = [_q("2026-05-29T10:00:00", "q", ["Knowledge Base/Notes/Insights/other.md"])]
+    writes = [_w("2026-05-29T10:01:00", "n", ["Knowledge Base/Sources/Articles/s"])]
+    assert drp.derive_pairs(queries, writes, window_seconds=2 * 3600) == []
+
+
+def test_rank1_beats_rank2_confidence() -> None:
+    queries = [_q(
+        "2026-05-29T10:00:00", "q",
+        ["Knowledge Base/Sources/Articles/top.md",
+         "Knowledge Base/Sources/Articles/second.md"],
+    )]
+    writes = [_w(
+        "2026-05-29T10:01:00", "n",
+        ["Knowledge Base/Sources/Articles/top",
+         "Knowledge Base/Sources/Articles/second"],
+    )]
+    pairs = {p["cited_path"]: p for p in drp.derive_pairs(queries, writes, 2 * 3600)}
+    assert pairs["sources/articles/top"]["confidence"] > pairs["sources/articles/second"]["confidence"]
+
+
+def test_propose_golden_skips_existing() -> None:
+    pairs = [
+        {"query": "new query", "cited_path": "notes/insights/x"},
+        {"query": "old query", "cited_path": "notes/insights/y"},
+    ]
+    proposed = drp._propose_golden(pairs, existing={"old query"})
+    assert "new query" in proposed
+    assert "old query" not in proposed
+    assert proposed["new query"] == ["Knowledge Base/notes/insights/x"]


### PR DESCRIPTION
## What & why

Transforms the KB from a passive library into a **compounding engine**: every entry and every search makes the whole more valuable. Three pillars, governed by one principle — **kb-mcp stays a pure retrieval + file-ops substrate; Claude (Max) is the brain.** No server-side LLM.

### Pillar 1 — Measured retrieval + feedback loop
- `find.RankingConfig`: the ranking knobs (rrf_k, type boosts, candidate_k, graph seed cap) in one tunable seam; DEFAULT is byte-identical to prior behaviour (regression-tested).
- `scripts/eval_retrieval.py` + `tests/golden/queries.yaml`: NDCG@5/@10, MRR, recall@10 over the real vault; `--sweep` grid-searches the knobs. Baseline **NDCG@10 ≈ 0.95**.
- `kb_mcp.eval_metrics`: pure metric math, unit-tested.
- `query_log`: every find → `logs/queries.jsonl`, every write → `logs/writes.jsonl` (paths + signals, no bodies; best-effort; gitignored).
- `scripts/derive_relevance_pairs.py`: joins the two logs into weak `(query → cited_path)` labels and **proposes** golden-set additions — the eval set grows from real usage.

### Pillar 2 — Corpus-aware writes
- `kb_mcp.corpus_aware`: `suggest_related()` (reuse find(), hub-aware re-rank, drop self/already-linked) + `detect_duplicates()` (doc-doc cosine over the existing sidecar). No new dependency.
- `suggest_links` MCP tool (existing path OR draft).
- `note()` returns a non-binding `suggestions` block; `note()`/`add()` surface near-duplicate warnings. Pre-write, guarded — never rolls back a write.

### Pillar 3 — Active distillation
- `audit` `unprocessed_source`: aged + triaged oldest-first (`meta.age_days`/`age_bucket`, escalates to warn once stale). AuditFinding gains optional `paths[]`/`meta`.
- `propose_compilation` MCP tool + `compile_proposal.py`: turns source(s) into a ready-to-fill note scaffold (inferred type, outline, sources, adjacent connections). Never writes — the client fills prose and calls `note()`.

## Invariants & safety
All corpus-aware/logging behaviour no-ops under `KB_MCP_DISABLE_EMBEDDINGS`, so the write path and the fast suite are unchanged when embeddings are off. Append-only Sources/Evidence, supersession-not-deletion, and propose-before-write all preserved. **271 tests pass** (was ~235).

## Post-merge deploy (claude.ai web, manual)
1. Reconnect the connector so `suggest_links` + `propose_compilation` appear.
2. Re-upload `_Schema.zip` (knowledge-base skill bumped to **v0.11.0** with the corpus-aware + backlog-drain discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
