### PR TITLE
feat(discovery): keyword-rich tool descriptions + opt-out Tier 2 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ The routing encodes the discipline.
 express what you need: new folder structures (`Identity/`, `Templates/`),
 files outside the typed-note set, or surgical edits.
 
+> **Lean surface (`KB_MCP_DISABLE_TIER2`).** Set `KB_MCP_DISABLE_TIER2=1` (in
+> `.env` or the service environment) to drop all 12 Tier 2 tools from
+> registration; the 16 Tier 1 ops still load. Use it when the client *defers*
+> MCP tools behind a keyword search — a smaller surface means an agent reaches
+> `find`/`get`/`note` without first wading past a dozen escape hatches (and,
+> with two connectors registered, the surface is doubled). Default is unset:
+> all tools register, preserving current behaviour.
+
 - `create_file` — write a file at an arbitrary vault path, optional
   frontmatter dict. Refuses Sources/Evidence; curated trees require
   `allow_curated=true`.

--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -2,7 +2,7 @@
 name: knowledge-base
 description: Operates on Hugo's personal Obsidian Knowledge Base — raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts. Triggers when the user wants to save, file, log, compile, distill, search, audit, supersede, or preserve anything in their knowledge base, vault, KB, Obsidian, notes, or "my docs," including oblique phrasings ("interesting, save it," "I want to remember this") when context implies a KB operation. Do NOT trigger for operations on parts of the vault outside the Knowledge Base folder — Cognitive Core, Domains, Prompt Bank, Products, and Personal Context are read-only inputs to this skill, never write targets.
 metadata:
-  version: 0.13.0
+  version: 0.13.1
 ---
 
 # Knowledge Base
@@ -62,6 +62,34 @@ The Knowledge Base does not replace those curated trees. It is a parallel substr
 - Laptop: `/path/to/your/vault` (Windows `<your-vault>`)
 
 Both paths are enrolled in `Q_MNT_ALLOWLIST` in `~/.claude/hooks/user-bash-guard.sh` (yadm-tracked). If the relevant path doesn't resolve on the current machine, you're on the other one — try the alternate. Verify allowed filesystem paths before writing.
+
+## Loading the tools
+
+The KB tools may be **deferred** — the client lists them by name and you load a
+tool's schema before you can call it. Two habits keep that from costing extra
+round-trips:
+
+1. **Load the core set up front, in one shot.** You'll almost always need
+   `find` (search), `get` (read a page), and one or more of `note`, `add`,
+   `link`, `suggest_links`, `edit`, `audit`. In Claude Code, load them by exact
+   name in a single call — this skips relevance ranking entirely:
+
+   `ToolSearch("select:find,get,note,add,link,suggest_links,edit,audit")`
+
+   On clients without a `select:` syntax (e.g. claude.ai), search by capability
+   — "search the knowledge base", "read a KB page", "compile a note" — and each
+   resolves to the right tool. Don't keep re-searching for `find`; it's the
+   read-only hybrid (semantic + keyword) search and your default entry point.
+
+2. **Pick one server, not both.** This KB is exposed by two identical
+   connectors — **Knowledge Base** (desktop) and **Knowledge Base (Laptop)**.
+   They front the same vault per machine. Use the one whose vault path resolves
+   on the current machine (see the machine note above); don't fan the same call
+   out to both.
+
+Reach for the Tier 2 filesystem ops only when no Tier 1 op fits — and note they
+may be turned off on lean deployments (`KB_MCP_DISABLE_TIER2`), in which case
+only the Tier 1 ops below are registered.
 
 ## Operations
 

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -315,7 +315,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
         rerank: bool = False,
         prefer_compiled: bool = True,
     ) -> list[dict]:
-        """Search the vault. Filters are AND'd; tag/project lists are OR'd within.
+        """Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.
 
         Args:
             query: Free-text search string. In "hybrid"/"vector" mode it's
@@ -408,8 +408,8 @@ def build_server(*, require_auth: bool) -> FastMCP:
 
         Closes the corpus-blind-write gap: surfaces the related prior work a
         draft (or an existing page) should connect to, so the graph gets denser
-        with every write instead of just bigger. Pure retrieval — it reuses the
-        same hybrid ranker as `find`, prefers well-connected hubs, and excludes
+        with every write instead of just bigger. For link suggestions only — it
+        reuses the same hybrid ranker as `find`, prefers well-connected hubs, and excludes
         the page itself plus anything it already links. Suggestions are
         non-binding: YOU decide which to wire in (e.g. via a follow-up `edit`).
 
@@ -659,7 +659,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
 
     @mcp.tool
     def audit(categories: list[str] | None = None) -> dict:
-        """Read-only health check across the Knowledge Base.
+        """Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, and stale unprocessed sources. Read-only.
 
         Returns a structured report Claude can read to propose follow-up
         edits via `note`/`add`. Does NOT modify anything.
@@ -793,7 +793,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
         value: str | None = None,
         path: str | None = None,
     ) -> dict:
-        """Scan note bodies for `<!-- key:value -->` provenance tags. Read-only.
+        """Trace provenance: scan note bodies for `<!-- key:value -->` tags — where an opinion/take/flag came from. Read-only.
 
         On-demand scan over markdown bodies — no index, no sidecar. Use it to
         answer "show all conv:-derived takes" or "what's flagged add-to-imdb"
@@ -827,7 +827,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
         sources: list[str],
         suggested_title: str | None = None,
     ) -> dict:
-        """Draft a compiled-note scaffold from unprocessed source(s). Read-only.
+        """Draft / scaffold a compiled note from unprocessed source(s) — what to compile next, drain the source backlog. Read-only.
 
         The backlog-drain companion to `audit`'s `unprocessed_source` findings:
         point it at one or more raw sources and it hands back a ready-to-fill
@@ -863,7 +863,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
 
     @mcp.tool
     def get(path: str) -> dict:
-        """Read a full vault file by path. Returns frontmatter + body + raw content.
+        """Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body + raw content.
 
         Reads anywhere under the vault root — not just `Knowledge Base/`.
         This lets you cite from Hugo's curated trees (`Cognitive Core/`,
@@ -1374,8 +1374,17 @@ def build_server(*, require_auth: bool) -> FastMCP:
     # - Cognitive Core/, Domains/, Prompt Bank/, Products/, Personal Context/
     #   are write-protected by default; pass `allow_curated=true` to override.
     # - Every write logs to Knowledge Base/log.md.
+    #
+    # Tier 2 is opt-out: setting KB_MCP_DISABLE_TIER2 drops these 12 escape-hatch
+    # tools from the registered surface, shrinking the deferred-tool list a client
+    # must keyword-search to reach the Tier 1 read/write ops. The functions are
+    # still defined either way; `tier2_tool` only decides whether to register.
+    _expose_tier2 = not os.environ.get("KB_MCP_DISABLE_TIER2")
 
-    @mcp.tool
+    def tier2_tool(fn):
+        return mcp.tool(fn) if _expose_tier2 else fn
+
+    @tier2_tool
     def create_file(
         path: str,
         content: str,
@@ -1426,7 +1435,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def list_directory(
         path: str = "",
         recursive: bool = False,
@@ -1461,7 +1470,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def create_directory(
         path: str,
         parents: bool = True,
@@ -1493,7 +1502,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def move_file(
         old_path: str,
         new_path: str,
@@ -1533,7 +1542,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def delete_file(
         path: str,
         confirm: bool,
@@ -1595,7 +1604,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def delete_directory(
         path: str,
         confirm: bool,
@@ -1646,7 +1655,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def append_to_file(
         path: str,
         content: str,
@@ -1679,7 +1688,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def get_frontmatter(path: str) -> dict:
         """Tier 2: read only the frontmatter of a file. Read-only.
 
@@ -1701,7 +1710,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def set_frontmatter_field(
         path: str,
         field: str,
@@ -1743,7 +1752,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def list_trash(date: str | None = None) -> dict:
         """Tier 2: enumerate recoverable trash entries. Read-only.
 
@@ -1764,7 +1773,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
         result = list_trash_module.list_trash(vault_root, date=date)
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def recover_from_trash(
         trash_path: str,
         restore_path: str | None = None,
@@ -1805,7 +1814,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             raise ValueError(f"{e.code}: {e.reason}") from e
         return result.as_dict()
 
-    @mcp.tool
+    @tier2_tool
     def list_inbound_links(target: str) -> dict:
         """Tier 2: find files whose wikilinks resolve to `target`. Read-only.
 

--- a/tests/test_tier2.py
+++ b/tests/test_tier2.py
@@ -793,3 +793,50 @@ def test_list_inbound_links_returns_empty_for_unreferenced(vault: Path) -> None:
         target="Knowledge Base/Notes/Insights/totally-orphan-xyz123.md",
     )
     assert result.count == 0
+
+
+# ---------------- Tier 2 registration gating (KB_MCP_DISABLE_TIER2) ----------------
+
+TIER2_TOOLS = {
+    "create_file", "create_directory", "list_directory", "move_file",
+    "delete_file", "delete_directory", "append_to_file", "get_frontmatter",
+    "set_frontmatter_field", "list_trash", "recover_from_trash",
+    "list_inbound_links",
+}
+
+
+def _registered_tool_names(monkeypatch: pytest.MonkeyPatch) -> set[str]:
+    """Build the FastMCP server and return the set of registered tool names.
+
+    build_server() calls load_dotenv(override=True); neutralize it so the repo
+    `.env` can't clobber the test's KB_MCP_VAULT_PATH / KB_MCP_DISABLE_TIER2.
+    """
+    import asyncio
+
+    from kb_mcp import server as server_module
+
+    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
+    mcp = server_module.build_server(require_auth=False)
+    tools = asyncio.run(mcp.list_tools(run_middleware=False))
+    return {t.name for t in tools}
+
+
+def test_tier2_registered_by_default(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_TIER2", raising=False)
+    names = _registered_tool_names(monkeypatch)
+    # Tier 1 read/write ops are always present...
+    assert {"find", "get", "note", "add", "edit", "audit"} <= names
+    # ...and so are the Tier 2 escape hatches when the flag is unset.
+    assert TIER2_TOOLS <= names
+
+
+def test_tier2_dropped_when_disabled(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KB_MCP_DISABLE_TIER2", "1")
+    names = _registered_tool_names(monkeypatch)
+    # Tier 1 stays fully registered — only the escape hatches drop.
+    assert {"find", "get", "note", "add", "edit", "audit", "link"} <= names
+    assert names.isdisjoint(TIER2_TOOLS)


### PR DESCRIPTION
## Why
An agent over the claude.ai connector burned several `ToolSearch` round-trips before it could find the `find` tool. Reproduced against the live deferred tools: `find`'s matchable summary was just `"Search the vault."`, so it ranked **only** when the literal word "find" was in the query — "search the knowledge base", "query", "look up", "retrieve" all lost to `note`/`audit`/`get`. Compounded by 28 tools per server, doubled across two connectors.

## What
- **Keyword-rich summaries** — front-load retrieval verbs into the first docstring line of `find`, `get`, `suggest_links`, `audit`, `provenance_report`, `propose_compilation` (the line ToolSearch actually weights; the rich text buried in `Args:` doesn't help discovery).
- **`KB_MCP_DISABLE_TIER2`** — opt-out flag (mirrors existing `KB_MCP_DISABLE_*`) that drops the 12 Tier 2 filesystem escape hatches via a `tier2_tool` wrapper, shrinking the deferred surface 28 → 16. Default unchanged (backward compatible).
- **SKILL.md** — "Loading the tools" bootstrap (one-shot `ToolSearch("select:…")`, pick one connector) + version bump 0.13.0 → 0.13.1.
- **README** — documents the flag.

## Tests
Two new tests in `test_tier2.py` assert Tier 2 presence/absence by the flag. Full suite green (341 passed).

## Notes
- `select:` bootstrap is Claude-Code-specific; on claude.ai the description fixes are what help.
- Live vault `SKILL.md` already synced; laptop service restarted on this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)