### PR TITLE
chore: scrub private vault paths from docs (zero-downside)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ existing capture-only path). Revisit if downtime bites.
 ## Install
 
 ```powershell
-cd C:\Users\hugoa\Desktop\projects\kb-mcp
+cd C:\path\to\kb-mcp
 
 # 1. Install Python deps (creates .venv automatically).
 #    --extra embeddings pulls torch + sentence-transformers for HYBRID search.
@@ -180,7 +180,7 @@ KB_MCP_GITHUB_USERNAME=<your-github-login>
 GITHUB_CLIENT_ID=<from step 3>
 GITHUB_CLIENT_SECRET=<from step 3>
 # Optional: override vault path
-KB_MCP_VAULT_PATH=D:\Archive\Personal Archive\50 Notes\Obsidian
+KB_MCP_VAULT_PATH=<your-Obsidian-vault-root>
 ```
 
 `KB_MCP_BASE_URL` must match the Tailscale Funnel URL exactly — no trailing

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -58,8 +58,8 @@ The Knowledge Base does not replace those curated trees. It is a parallel substr
 ```
 
 `<vault>` resolves to the Obsidian vault root. Path differs by machine. From WSL (where Claude Code runs), use these forms:
-- Desktop: `/mnt/d/Archive/Personal Archive/50 Notes/Obsidian` (Windows `D:\Archive\Personal Archive\50 Notes\Obsidian`)
-- Laptop: `/mnt/c/Users/win-laptop/Documents/Obsidian` (Windows `C:\Users\win-laptop\Documents\Obsidian`)
+- Desktop: `/path/to/your/vault` (Windows `<your-vault>`)
+- Laptop: `/path/to/your/vault` (Windows `<your-vault>`)
 
 Both paths are enrolled in `Q_MNT_ALLOWLIST` in `~/.claude/hooks/user-bash-guard.sh` (yadm-tracked). If the relevant path doesn't resolve on the current machine, you're on the other one — try the alternate. Verify allowed filesystem paths before writing.
 
@@ -174,8 +174,8 @@ Sub-folder indexes are not universal — they exist when categorization is itsel
 8. **Deploy via symlink.** The harness loader at `~/.claude/skills/knowledge-base/` is a directory symlink to the KB canonical `_Schema/` folder on each machine — making the canonical and deployed copy literally the same files. Schema ops write to the canonical path; the harness sees the change immediately because it's the same file.
 
     Per-machine symlink targets:
-    - Desktop: `C:\Users\hugoa\.claude\skills\knowledge-base\` → `D:\Archive\Personal Archive\50 Notes\Obsidian\Knowledge Base\_Schema\`
-    - Laptop: `C:\Users\win-laptop\.claude\skills\knowledge-base\` → `C:\Users\win-laptop\Documents\Obsidian\Knowledge Base\_Schema\`
+    - Desktop: `C:\Users\<you>\.claude\skills\knowledge-base\` → `<your-vault>\Knowledge Base\_Schema\`
+    - Laptop: `C:\Users\<you>\.claude\skills\knowledge-base\` → `<your-vault>\Knowledge Base\_Schema\`
 
     The symlinks are per-machine (different targets) and **must be excluded from yadm tracking** so each machine maintains its own local link. The canonical content is sync'd across machines via Obsidian Sync; each machine's symlink resolves to its local vault path.
 


### PR DESCRIPTION
Public-repo hygiene. Sanitizes real filesystem paths + usernames in **documentation only** to placeholders (matching the scaffold style):
- `README.md` — install `cd` example + `.env` `KB_MCP_VAULT_PATH` example
- `tests/fixtures/.../SKILL.md` — stale v0.8.0 fixture (body isn't parsed; **83 tests pass**)

**Intentionally left (preserve functionality):** `src/kb_mcp/vault.py` `DESKTOP_VAULT`/`LAPTOP_VAULT` and `scripts/rebuild-schema-zip.ps1` — these are the auto-locate fallbacks that let the server/zip find the vault with no env var set. Scrubbing them would mean relying on `KB_MCP_VAULT_PATH`. `pyproject` author email kept (public).

Note: this scrubs the working tree, not git history — the paths remain in prior commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)