### PR TITLE
feat: cross-platform setup for macOS and Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize line endings so cross-platform scripts work regardless of a
+# contributor's core.autocrlf. A CRLF in a shell shebang breaks the script on
+# macOS/Linux ("bad interpreter: /usr/bin/env bash^M"), so these must stay LF.
+*.sh        text eol=lf
+*.service   text eol=lf
+*.plist     text eol=lf
+
+# PowerShell runs on Windows; CRLF is the native, expected ending there.
+*.ps1       text eol=crlf

--- a/README.md
+++ b/README.md
@@ -180,13 +180,15 @@ KB_MCP_BASE_URL=https://<device>.<tailnet>.ts.net
 KB_MCP_GITHUB_USERNAME=<your-github-login>
 GITHUB_CLIENT_ID=<from step 3>
 GITHUB_CLIENT_SECRET=<from step 3>
-# Optional: override vault path
+# Required: vault root — the folder that contains Knowledge Base/
 KB_MCP_VAULT_PATH=<your-Obsidian-vault-root>
 ```
 
 `KB_MCP_BASE_URL` must match the Tailscale Funnel URL exactly — no trailing
 slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
-be the *login* (e.g. `Artexis10`), not the display name.
+be the *login* (e.g. `Artexis10`), not the display name. `KB_MCP_VAULT_PATH` is
+**required**: claude.ai connects over HTTP and passes no environment, so the
+service resolves the vault solely from this line in `.env` at startup.
 
 ### 5. Sanity-test locally
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ every write logs to `Knowledge Base/log.md`.
 - `logs/kb-mcp.log` — service log. Every call (reads + writes) is
   surfaced via a per-call middleware as `tool=<name> duration_ms=<n>
   event=tool_success|tool_error`. Operational layer (debug "did the
-  call reach the server", spot slow ops, etc.). Rotated by NSSM.
+  call reach the server", spot slow ops, etc.). Rotated in-process
+  (`RotatingFileHandler`, 5 MB × 5) — same on every platform.
 
 Deferred to desk-side: `schema` (KB governance — intentionally non-parity).
 
@@ -112,14 +113,14 @@ writes), `rename_tag`, `find_replace_in_file`, `get_directory_tree`.
                                               │ tailscale funnel
                                               ▼
                             ┌────────────────────────────────────┐
-                            │ Windows desktop                    │
+                            │ host: macOS / Linux / Windows      │
                             │                                    │
                             │   FastMCP @ 127.0.0.1:8765         │
                             │   bearer-token auth                │
                             │   ↓                                │
                             │   tools: find, add                 │
                             │   ↓                                │
-                            │   D:\Archive\...\Knowledge Base    │
+                            │   <vault>/Knowledge Base           │
                             └────────────────────────────────────┘
 ```
 
@@ -202,7 +203,30 @@ uv run python -m kb_mcp --transport streamable-http --host 127.0.0.1 --port 8765
 #                                                              → expect JSON metadata
 ```
 
-### 6. Install as Windows service (auto-start on boot)
+### 6. Install as a service (auto-start on boot)
+
+Pick your platform — all three run the same `streamable-http` server and differ
+only in the OS service manager.
+
+**macOS (launchd):**
+
+```bash
+bash scripts/install-service.sh
+# Restart after .env edits:  bash scripts/restart.sh
+# Uninstall:                 launchctl bootout gui/$(id -u)/com.kb-mcp && rm ~/Library/LaunchAgents/com.kb-mcp.plist
+```
+
+**Linux (systemd --user):**
+
+```bash
+mkdir -p ~/.config/systemd/user
+sed -e "s|__REPO_ROOT__|$PWD|g" -e "s|__VENV_PYTHON__|$PWD/.venv/bin/python|g" scripts/kb-mcp.service > ~/.config/systemd/user/kb-mcp.service
+systemctl --user daemon-reload && systemctl --user enable --now kb-mcp
+loginctl enable-linger "$USER"   # keep it running without an active login session
+# Restart after .env edits:  systemctl --user restart kb-mcp   (or: bash scripts/restart.sh)
+```
+
+**Windows (NSSM):**
 
 ```powershell
 # Prereq: NSSM must be installed and on PATH. Easiest:
@@ -244,9 +268,9 @@ host's *own* values. The non-obvious parts:
   not associated with this application." Create a second app (e.g. `kb-mcp (laptop)`)
   with callback `https://<this-host>.<tailnet>.ts.net/auth/callback` and put *its*
   `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` in this machine's `.env`.
-- **Its own `.env` and connector.** The vault path auto-resolves per machine (see the
-  desktop/laptop constants in `src/kb_mcp/vault.py`); override with `KB_MCP_VAULT_PATH`
-  if needed. In claude.ai, add a separate connector pointing at this host's `/mcp` URL
+- **Its own `.env` and connector.** Set `KB_MCP_VAULT_PATH` to this machine's vault
+  root (the folder that contains `Knowledge Base/`). In claude.ai, add a separate
+  connector pointing at this host's `/mcp` URL
   (the URL usually isn't editable in place, so delete + re-add to repoint).
 - **Its own embedding stack (GPU).** Hybrid `find` needs `torch` + `sentence-transformers`
   (the optional `embeddings` extra) in the host's `.venv` — `uv sync --extra embeddings`
@@ -659,12 +683,18 @@ aged list; you pick a coherent set and pass it to `propose_compilation`.
 
 ## Logs
 
-- `logs/kb-mcp.log` — application log (rotated, 5 MB × 5 files)
-- `logs/service.out.log`, `logs/service.err.log` — NSSM stdout/stderr (rotated by NSSM)
+- `logs/kb-mcp.log` — application log (rotated in-process, 5 MB × 5 files; same on every platform)
+- `logs/service.out.log`, `logs/service.err.log` — service stdout/stderr. On Windows
+  NSSM writes and rotates these; launchd/systemd write them but do **not** rotate them
+  (the app's own `kb-mcp.log` above is the durable, self-rotating record). On Linux,
+  `journalctl --user -u kb-mcp` is the primary stdout/stderr view.
 
 ## Restarting the service
 
-`install-service.ps1` grants your user account start/stop rights on the
+**macOS / Linux:** `bash scripts/restart.sh` — launchd `kickstart -k` on macOS,
+`systemctl --user restart` on Linux. It truncates `logs/kb-mcp.log` and tails it.
+
+**Windows:** `install-service.ps1` grants your user account start/stop rights on the
 service, so day-to-day restarts don't need UAC:
 
 ```powershell

--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -6,13 +6,17 @@ Windows service — none of the remote/mobile machinery in the main
 [README](README.md). Everything stays on your machine; the only thing that ever
 leaves is the query Claude sends to Anthropic to answer you.
 
+**Works on macOS, Linux, and Windows.** The commands below use a macOS/Linux
+shell; the few Windows (PowerShell) differences are called out inline.
+
 If you're comfortable in Claude Code, this is ~20–30 minutes.
 
 ---
 
 ## What you need
 
-- **Python 3.12+**
+- **Python 3.11+** — check with `python3 --version`. On macOS, `brew install
+  python` if you don't have it (or use the [python.org](https://www.python.org/downloads/) installer).
 - **Claude Code** (you already have this)
 - An **Obsidian vault** — or just any folder you want to use as one. It needs a
   `Knowledge Base/` subfolder (we create a minimal one below).
@@ -25,8 +29,8 @@ If you're comfortable in Claude Code, this is ~20–30 minutes.
 ```bash
 git clone <repo-url> kb-mcp
 cd kb-mcp
-python -m venv .venv && . .venv/Scripts/activate   # Windows
-# (macOS/Linux: source .venv/bin/activate)
+python3 -m venv .venv && source .venv/bin/activate   # macOS/Linux
+# (Windows PowerShell: python -m venv .venv ; .venv\Scripts\Activate.ps1)
 pip install -e .                 # lean: keyword/BM25 search, no heavy deps
 # for hybrid semantic search, add the extra (~1-2 GB torch + sentence-transformers):
 # pip install -e ".[embeddings]"
@@ -162,7 +166,9 @@ publicly-reachable, authenticated endpoint:
 3. **A GitHub OAuth app** (client id + secret) wired into the OAuthProxy —
    claude.ai connectors require OAuth; static tokens aren't accepted.
 4. **Lock it to your GitHub login** (the single-user verifier), then run it as a
-   service with `--transport streamable-http`.
+   background service with `--transport streamable-http` — `scripts/install-service.sh`
+   sets this up via **launchd** on macOS or **systemd** on Linux (the main
+   [README](README.md) covers all three platforms).
 5. **Add it as a custom connector** in claude.ai.
 
 The main [README](README.md) documents this path end-to-end (it's Hugo's exact

--- a/scripts/com.kb-mcp.plist
+++ b/scripts/com.kb-mcp.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd user-agent for kb-mcp (macOS). This is a TEMPLATE: the placeholders
+  __VENV_PYTHON__, __REPO_ROOT__, __BIND_HOST__ and __PORT__ are substituted by
+  scripts/install-service.sh, which writes the rendered copy to
+  ~/Library/LaunchAgents/com.kb-mcp.plist. Cross-platform counterpart to the
+  Windows NSSM service in scripts/install-service.ps1.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.kb-mcp</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__VENV_PYTHON__</string>
+        <string>-m</string>
+        <string>kb_mcp</string>
+        <string>--transport</string>
+        <string>streamable-http</string>
+        <string>--host</string>
+        <string>__BIND_HOST__</string>
+        <string>--port</string>
+        <string>__PORT__</string>
+    </array>
+
+    <!-- Run from the repo root so the app's load_dotenv() picks up ./.env. -->
+    <key>WorkingDirectory</key>
+    <string>__REPO_ROOT__</string>
+
+    <!-- Start at login and keep it alive (≈ NSSM SERVICE_AUTO_START + restart). -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Don't respawn faster than every 10s in a crash loop (≈ NSSM AppThrottle). -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__REPO_ROOT__/logs/service.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__REPO_ROOT__/logs/service.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Install kb-mcp as an always-on background service on macOS (launchd user agent).
+#
+# This is the cross-platform counterpart to scripts/install-service.ps1
+# (Windows/NSSM). On Linux, use the systemd unit instead: scripts/kb-mcp.service
+# (its header has the install steps). No sudo needed here — it's a per-user agent.
+#
+# Prereqs:
+#   - .venv exists with kb-mcp installed, e.g.
+#       python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[embeddings]"
+#     (or `uv sync --extra embeddings`).
+#   - .env in the repo root with the GitHub OAuth vars (KB_MCP_BASE_URL,
+#     KB_MCP_GITHUB_USERNAME, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET) and
+#     KB_MCP_VAULT_PATH. See the Install section of README.md.
+#
+# Usage:     bash scripts/install-service.sh
+# Override:  KB_MCP_BIND_HOST=127.0.0.1 KB_MCP_PORT=8765 bash scripts/install-service.sh
+# Restart:   bash scripts/restart.sh            # after .env edits
+# Uninstall: launchctl bootout gui/$(id -u)/com.kb-mcp && rm ~/Library/LaunchAgents/com.kb-mcp.plist
+
+set -euo pipefail
+
+LABEL="com.kb-mcp"
+BIND_HOST="${KB_MCP_BIND_HOST:-127.0.0.1}"
+PORT="${KB_MCP_PORT:-8765}"
+
+# Resolve repo root from this script's own location (scripts/..), so it works
+# regardless of the caller's working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "This installer targets macOS (launchd)." >&2
+    echo "On Linux, use the systemd unit: scripts/kb-mcp.service" >&2
+    echo "  (see the 'Install as a service' section of README.md)." >&2
+    exit 1
+fi
+
+VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+LOG_DIR="$REPO_ROOT/logs"
+PLIST_SRC="$SCRIPT_DIR/com.kb-mcp.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+[[ -x "$VENV_PYTHON" ]] || { echo "venv python not found at $VENV_PYTHON — create the venv and install kb-mcp first (see README)." >&2; exit 1; }
+[[ -f "$REPO_ROOT/.env" ]] || { echo ".env missing in $REPO_ROOT — add the GitHub OAuth vars (see README Install)." >&2; exit 1; }
+[[ -f "$PLIST_SRC" ]] || { echo "plist template missing at $PLIST_SRC" >&2; exit 1; }
+mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+
+# Render the template: substitute absolute paths + bind host/port.
+sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__REPO_ROOT__|$REPO_ROOT|g" \
+    -e "s|__BIND_HOST__|$BIND_HOST|g" \
+    -e "s|__PORT__|$PORT|g" \
+    "$PLIST_SRC" > "$PLIST_DEST"
+
+# Reload cleanly: bootout any prior instance (ignore if absent), then bootstrap.
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+launchctl kickstart -k "gui/$(id -u)/$LABEL"
+
+echo "Installed and started '$LABEL' bound to ${BIND_HOST}:${PORT}."
+echo "  plist:   $PLIST_DEST"
+echo "  logs:    $LOG_DIR/service.out.log (stdout), service.err.log (stderr), kb-mcp.log (app)"
+echo "  status:  launchctl print gui/$(id -u)/$LABEL | grep -i state"
+echo "  restart: bash scripts/restart.sh   (after .env edits)"
+echo "  remove:  launchctl bootout gui/$(id -u)/$LABEL && rm \"$PLIST_DEST\""

--- a/scripts/kb-mcp.service
+++ b/scripts/kb-mcp.service
@@ -1,0 +1,32 @@
+# systemd --user unit for kb-mcp (Linux). Cross-platform counterpart to the
+# macOS launchd agent (scripts/com.kb-mcp.plist) and the Windows NSSM service
+# (scripts/install-service.ps1).
+#
+# This is a TEMPLATE: __REPO_ROOT__ and __VENV_PYTHON__ must be substituted with
+# absolute paths before installing. From the repo root:
+#
+#   mkdir -p ~/.config/systemd/user
+#   sed -e "s|__REPO_ROOT__|$PWD|g" -e "s|__VENV_PYTHON__|$PWD/.venv/bin/python|g" \
+#       scripts/kb-mcp.service > ~/.config/systemd/user/kb-mcp.service
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now kb-mcp
+#   loginctl enable-linger "$USER"     # so it runs without an active login session
+#
+# Restart after .env edits:  systemctl --user restart kb-mcp   (or: bash scripts/restart.sh)
+# Logs:                       journalctl --user -u kb-mcp -f   (plus logs/kb-mcp.log)
+# Uninstall:                  systemctl --user disable --now kb-mcp && rm ~/.config/systemd/user/kb-mcp.service
+
+[Unit]
+Description=kb-mcp: Obsidian Knowledge Base MCP server for mobile claude.ai
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=__REPO_ROOT__
+ExecStart=__VENV_PYTHON__ -m kb_mcp --transport streamable-http --host 127.0.0.1 --port 8765
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/normalize_vault_wikilinks.py
+++ b/scripts/normalize_vault_wikilinks.py
@@ -10,7 +10,7 @@ Usage:
     python scripts/normalize_vault_wikilinks.py [--dry-run] [--vault PATH]
 
 By default runs against the vault resolved via `kb_mcp.vault.resolve_vault()`
-(KB_MCP_VAULT_PATH env or desktop/laptop defaults). Use --vault to override.
+(the `KB_MCP_VAULT_PATH` env var). Use --vault to override.
 
 The script:
 1. Builds a WikilinkResolver against the vault (one walk; includes

--- a/scripts/rebuild-schema-zip.ps1
+++ b/scripts/rebuild-schema-zip.ps1
@@ -7,8 +7,8 @@
   Repacks _Schema/ into _Schema.zip so it can be re-uploaded as a skill to
   claude.ai whenever SKILL.md / references / project-keys.yaml change.
 
-  Resolves the vault automatically: desktop first, then laptop. Honors
-  $env:KB_MCP_VAULT_PATH when set.
+  Resolves the vault from $env:KB_MCP_VAULT_PATH (the vault root that contains
+  Knowledge Base/).
 
 .EXAMPLE
   pwsh -File scripts/rebuild-schema-zip.ps1
@@ -20,18 +20,12 @@ param()
 $ErrorActionPreference = 'Stop'
 
 function Resolve-Vault {
-  if ($env:KB_MCP_VAULT_PATH) {
-    $p = $env:KB_MCP_VAULT_PATH
-    if (Test-Path (Join-Path $p 'Knowledge Base/_Schema/SKILL.md')) { return $p }
-    throw "KB_MCP_VAULT_PATH=$p does not contain Knowledge Base/_Schema/SKILL.md"
+  if (-not $env:KB_MCP_VAULT_PATH) {
+    throw 'KB_MCP_VAULT_PATH is not set. Point it at your vault root (the folder that contains Knowledge Base/).'
   }
-  foreach ($candidate in @(
-    'D:\Archive\Personal Archive\50 Notes\Obsidian',
-    'C:\Users\win-laptop\Documents\Obsidian'
-  )) {
-    if (Test-Path (Join-Path $candidate 'Knowledge Base/_Schema/SKILL.md')) { return $candidate }
-  }
-  throw 'Could not locate Obsidian vault on this machine. Set $env:KB_MCP_VAULT_PATH.'
+  $p = $env:KB_MCP_VAULT_PATH
+  if (Test-Path (Join-Path $p 'Knowledge Base/_Schema/SKILL.md')) { return $p }
+  throw "KB_MCP_VAULT_PATH=$p does not contain Knowledge Base/_Schema/SKILL.md"
 }
 
 $vault     = Resolve-Vault

--- a/scripts/rebuild-schema-zip.sh
+++ b/scripts/rebuild-schema-zip.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Rebuild Knowledge Base/_Schema.zip from the canonical _Schema/ folder, so it can
+# be re-uploaded as a skill to claude.ai when SKILL.md / references /
+# project-keys.yaml change. Cross-platform counterpart to
+# scripts/rebuild-schema-zip.ps1 (Windows).
+#
+# Resolves the vault from $KB_MCP_VAULT_PATH (the vault root that contains
+# Knowledge Base/). Requires the `zip` CLI.
+#
+# Usage: KB_MCP_VAULT_PATH=/path/to/Obsidian bash scripts/rebuild-schema-zip.sh
+
+set -euo pipefail
+
+if [[ -z "${KB_MCP_VAULT_PATH:-}" ]]; then
+    echo "KB_MCP_VAULT_PATH is not set. Point it at your vault root (the folder that contains Knowledge Base/)." >&2
+    exit 1
+fi
+
+VAULT="$KB_MCP_VAULT_PATH"
+SCHEMA_DIR="$VAULT/Knowledge Base/_Schema"
+ZIP_PATH="$VAULT/Knowledge Base/_Schema.zip"
+
+[[ -f "$SCHEMA_DIR/SKILL.md" ]] || { echo "KB_MCP_VAULT_PATH=$VAULT does not contain Knowledge Base/_Schema/SKILL.md" >&2; exit 1; }
+command -v zip >/dev/null 2>&1 || { echo "the 'zip' CLI is required (macOS ships it; Linux: apt install zip)." >&2; exit 1; }
+
+echo "vault:      $VAULT"
+echo "schema dir: $SCHEMA_DIR"
+echo "zip target: $ZIP_PATH"
+
+# Surface the version from SKILL.md frontmatter so the operator sees what ships.
+version="$(sed -n 's/^[[:space:]]*version:[[:space:]]*\([0-9.]*\).*/\1/p' "$SCHEMA_DIR/SKILL.md" | head -n1)"
+if [[ -n "$version" ]]; then echo "version:    $version"; else echo "warning: could not parse version from SKILL.md frontmatter." >&2; fi
+
+rm -f "$ZIP_PATH"
+
+# zip from inside _Schema/ so SKILL.md lands at the archive root (claude.ai expects
+# SKILL.md at the top level, not nested under _Schema/). -r recurse, -X drop extras.
+( cd "$SCHEMA_DIR" && zip -r -X "$ZIP_PATH" . -x '.DS_Store' )
+
+size_kb=$(( $(wc -c < "$ZIP_PATH") / 1024 ))
+echo "wrote $ZIP_PATH (${size_kb} KB)"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Restart the kb-mcp background service after a .env edit.
+#   macOS -> launchd agent (com.kb-mcp);  Linux -> systemd --user service (kb-mcp).
+# Truncates logs/kb-mcp.log so the post-restart tail shows only this session,
+# then tails it. Cross-platform counterpart to scripts/restart.ps1 (Windows).
+#
+# Usage: bash scripts/restart.sh
+
+set -euo pipefail
+
+LABEL="com.kb-mcp"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG="$REPO_ROOT/logs/kb-mcp.log"
+
+# Truncate the app log (keep the file, just empty it).
+: > "$LOG" 2>/dev/null || true
+
+case "$(uname -s)" in
+    Darwin)
+        launchctl kickstart -k "gui/$(id -u)/$LABEL"
+        echo "Restarted launchd agent '$LABEL'."
+        ;;
+    Linux)
+        systemctl --user restart kb-mcp
+        echo "Restarted systemd user service 'kb-mcp'."
+        ;;
+    *)
+        echo "Unsupported platform $(uname -s). On Windows use scripts/restart.ps1." >&2
+        exit 1
+        ;;
+esac
+
+# Give the app a beat to write its startup banner, then tail.
+sleep 2
+if [[ -s "$LOG" ]]; then
+    echo
+    echo "Log tail:"
+    tail -n 8 "$LOG"
+else
+    echo "No log output at $LOG yet — service may still be initializing." >&2
+fi

--- a/src/kb_mcp/vault.py
+++ b/src/kb_mcp/vault.py
@@ -22,9 +22,6 @@ import yaml
 from slugify import slugify as _slugify
 
 
-DESKTOP_VAULT = Path(r"D:\Archive\Personal Archive\50 Notes\Obsidian")
-LAPTOP_VAULT = Path(r"C:\Users\win-laptop\Documents\Obsidian")
-
 SLUG_MAX_LENGTH = 100
 
 # Curated trees are desk-managed; Tier 2 writes refuse by default and
@@ -62,24 +59,26 @@ _FM_PATTERN = re.compile(r"^---\n(.*?)\n---\n?(.*)", re.DOTALL)
 def resolve_vault(env_var: str = "KB_MCP_VAULT_PATH") -> Path:
     """Return the Obsidian vault root that contains Knowledge Base/.
 
-    Priority: env override → desktop → laptop. Raises if none resolve.
+    Resolved from the ``{env_var}`` environment variable — the vault *root*, i.e.
+    the folder that contains ``Knowledge Base/``. Raises if it is unset or does
+    not point at a vault. (This is cross-platform: there are no machine-specific
+    fallback paths — every host sets the env var to its own vault.)
     """
     override = os.environ.get(env_var)
-    if override:
-        path = Path(override)
-        if not _is_vault(path):
-            raise RuntimeError(
-                f"{env_var}={override!r} does not look like a vault "
-                f"(no Knowledge Base/_Schema/SKILL.md found)"
-            )
-        return path
-    for candidate in (DESKTOP_VAULT, LAPTOP_VAULT):
-        if _is_vault(candidate):
-            return candidate
-    raise RuntimeError(
-        "Knowledge Base vault not found at the desktop or laptop path. "
-        f"Set {env_var} to override."
-    )
+    if not override:
+        raise RuntimeError(
+            f"{env_var} is not set. Point it at your vault root — the folder "
+            f"that contains 'Knowledge Base/'. For example:\n"
+            f'  macOS/Linux:  export {env_var}="/path/to/your/Obsidian"\n'
+            f'  Windows:      setx {env_var} "C:\\path\\to\\your\\Obsidian"'
+        )
+    path = Path(override)
+    if not _is_vault(path):
+        raise RuntimeError(
+            f"{env_var}={override!r} does not look like a vault "
+            f"(no Knowledge Base/_Schema/SKILL.md found)"
+        )
+    return path
 
 
 def _is_vault(path: Path) -> bool:


### PR DESCRIPTION
## Why

A friend (on a MacBook) couldn't tell whether kb-mcp runs on macOS — Claude Code warned that "some features might only work on Windows." This makes the repo genuinely cross-platform: macOS and Linux, not just Windows.

## What was actually Windows-only

Almost nothing in the server. The code already uses `pathlib`, normalizes path separators, forces UTF-8, and has no `win32`/`pywin32`/`ctypes.windll` imports or `sys.platform` branches. `pyproject.toml` already scopes the CUDA torch index to Windows/Linux so macOS falls back to CPU torch.

The only genuine gaps were the **hardcoded vault paths** and the always-on **service tier** (PowerShell + NSSM).

## Changes

- **`vault.py`** — removed hardcoded `D:\…` / `C:\Users\win-laptop\…` fallbacks; `resolve_vault()` now reads `KB_MCP_VAULT_PATH` only, with a clear cross-platform error.
- **Service tier ported off Windows-only PowerShell/NSSM:**
  - macOS: `scripts/com.kb-mcp.plist` + `scripts/install-service.sh` (launchd user agent)
  - Linux: `scripts/kb-mcp.service` (systemd `--user` unit)
  - `scripts/restart.sh` (launchd/systemd)
- **Docs:** `SETUP-FRIEND.md` is now macOS-first (the file a new user feeds to Claude Code); README service/logs/restart sections + architecture diagram generalized across macOS/Linux/Windows.
- **`scripts/rebuild-schema-zip.sh`** — parity with the `.ps1`.
- **`.gitattributes`** — pins LF on `*.sh`/`*.service`/`*.plist` so shebangs never get CRLF and break on Unix.

## Verification

- `pytest`: **363 passed**.
- `resolve_vault()`: verified unset → clear error, set → returns path.
- launchd plist renders (installer substitution) and parses via `plistlib`.
- **Not exercisable on Windows:** actual launchd/systemd run + a real Claude Code session on macOS — needs a Mac/Linux host.

## Heads-up

With the hardcoded fallbacks gone, existing Windows hosts must set `KB_MCP_VAULT_PATH` explicitly (the service `.env` already does; confirm local stdio config does too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)