### PR TITLE
feat: onboarding + reliable auto-capture (install-skill, install-hook, video fixes)

### DIFF
--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -11,6 +11,13 @@ shell; the few Windows (PowerShell) differences are called out inline.
 
 If you're comfortable in Claude Code, this is ~20–30 minutes.
 
+> **kb-mcp is two parts, and you need both.** The **MCP server** (steps 1–5) is
+> the *hands* — the `find`/`add`/`note` tools. The **skill** (step 6) is the
+> *brain* — it's what tells Claude *when* to save, how to file a source, and how
+> to compile a note. Install the server but skip the skill and Claude has the
+> tools but no idea it's meant to use them: it sits silent and feels broken.
+> **This is the #1 "it does nothing" trap — don't skip step 6.**
+
 ---
 
 ## What you need
@@ -78,11 +85,17 @@ export KB_MCP_VAULT_PATH="/path/to/your/Obsidian"   # the vault root, not the KB
 
 - **Lean / keyword-only (default install)** — `pip install -e .` + set
   `KB_MCP_DISABLE_EMBEDDINGS=1`. `find` uses BM25 (stemmed substring + ranking).
-  Instant, no model load, no GPU, works everywhere. The easiest start.
+  Instant, no model load, no GPU, works everywhere. The easiest start. Note it's
+  **silent about it** — there's no error when embeddings are off, so "search
+  works" on a lean install means keyword/BM25, *not* semantic.
 - **Hybrid** — install the extra (`pip install -e ".[embeddings]"`) and leave
   `KB_MCP_DISABLE_EMBEDDINGS` unset. Adds local vector embeddings + graph on top
   of BM25 — best recall on natural-language queries. Ideally an NVIDIA GPU; CPU
-  works but embeds slowly.
+  works but embeds slowly. The vector index builds as you write (each note is
+  embedded on save); to backfill an existing vault, run `audit_fix` with
+  `rebuild_embeddings=True`. Quick check that semantic is live: ask for something
+  using words that *don't* appear in the note — if it still surfaces, embeddings
+  are on.
 
 ---
 
@@ -123,26 +136,34 @@ Restart Claude Code; you should see the `kb-mcp` tools (`find`, `note`, `add`,
 
 ---
 
-## 6. Install + adapt the skill (so Claude knows *how* to use it)
+## 6. Install the skill (REQUIRED — this is the brain)
 
-The `_Schema/SKILL.md` is the operating manual Claude reads. Make Claude Code
-load it as a skill — copy (or symlink) `_Schema/` to your skills folder:
+The server gives Claude the tools; **the skill is what makes Claude actually use
+them** — capture at natural stopping points, file sources to the right folder,
+compile notes under the schema. One command installs it straight from the repo
+into Claude Code's skills folder (no vault path needed — it ships in the package):
 
 ```bash
-# copy:
-cp -r "/path/to/your/Obsidian/Knowledge Base/_Schema" ~/.claude/skills/knowledge-base
-# or symlink (keeps them in sync; needs Developer Mode on Windows for non-admin):
-# ln -s "/path/to/your/Obsidian/Knowledge Base/_Schema" ~/.claude/skills/knowledge-base
+python -m kb_mcp install-skill
 ```
+
+That writes the skill to `~/.claude/skills/knowledge-base/`. **Restart Claude
+Code** so it loads. Useful flags: `--link` symlinks instead of copying so it
+tracks repo updates as you `git pull` (falls back to a copy if your OS refuses
+the symlink); `--force` overwrites an existing install; `--target` picks a
+different folder.
 
 Then **make it yours** — the shipped `SKILL.md` / `project-keys.yaml` are a
 **generic starter** (placeholder projects `personal` / `work`, no machine paths
-or real tenants). Optionally:
+or real tenants). Optionally adapt the **project keys** in your vault's
+`Knowledge Base/_Schema/project-keys.yaml` (the copy the *server* reads) to your
+own — or just start writing; the writer auto-registers new keys as you use them.
 
-- rename the **project keys** in `_Schema/project-keys.yaml` to your own — or
-  just start writing; the writer auto-registers new keys as you use them.
-- if you **symlinked** rather than copied, point rule 8's paths at your machine
-  (skip this if you copied).
+> **What "auto-capture" does and doesn't do.** With the skill loaded, Claude
+> captures on its own *inside a conversation* when it judges you've hit a
+> stepping-stone — a decision, a solved problem, a recognized pattern. There's
+> **no background daemon**: it won't save things while you're away from the chat,
+> and a fresh thread starts fresh. You can always just say *"save that to kb."*
 
 ---
 

--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -167,6 +167,33 @@ own — or just start writing; the writer auto-registers new keys as you use the
 
 ---
 
+## 7. (Recommended) Make auto-save reliable
+
+The skill *tells* Claude to capture at stepping-stones, but that instruction is
+passive — over a long conversation Claude tends to forget it, so auto-save often
+quietly never fires (you'll know: `Knowledge Base/log.md` only shows saves you
+asked for). This optional hook fixes that — it re-checks "is this worth saving?"
+at the end of every turn:
+
+```bash
+python -m kb_mcp install-hook
+```
+
+It writes a small script to `~/.claude/hooks/` and wires it as a Claude Code
+`Stop` hook (restart Claude Code to activate). It's **language-agnostic** (no
+keyword matching — works the same in any language you write in) and cheap (gated
+so it stays quiet on ordinary turns, plus a per-session cooldown). Every time it
+nudges it logs to `~/.claude/kb-capture-nudge.log`, so you can see the real rate.
+Prefer to wire it by hand? `python -m kb_mcp install-hook --print-only` writes the
+script and prints the settings snippet to paste. Tune with
+`KB_CAPTURE_NUDGE_MIN_CHARS` / `KB_CAPTURE_NUDGE_COOLDOWN_SEC`, or turn it off
+with `KB_CAPTURE_NUDGE_DISABLE=1`.
+
+(Hooks are Claude Code only — claude.ai web/mobile can't run them, so there the
+skill stays best-effort: nudge it with *"save that to kb."*)
+
+---
+
 ## You're up
 
 Try it in Claude Code: *"add this as a source and compile an insight from it,"*

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -4,6 +4,7 @@ Subcommands:
 - (default) serve the MCP server — `python -m kb_mcp [--transport ...]`
 - `init` — bootstrap a fresh Knowledge Base into a vault
 - `install-skill` — install the knowledge-base skill into Claude Code
+- `install-hook` — wire the capture-reliability Stop hook into Claude Code
 """
 
 from __future__ import annotations
@@ -22,6 +23,8 @@ def main(argv: list[str] | None = None) -> int:
         return _init_main(raw[1:])
     if raw and raw[0] == "install-skill":
         return _install_skill_main(raw[1:])
+    if raw and raw[0] == "install-hook":
+        return _install_hook_main(raw[1:])
     return _serve_main(raw)
 
 
@@ -130,6 +133,55 @@ def _install_skill_main(argv: list[str]) -> int:
     print(f"  {report['target']}")
     print("Restart Claude Code to load it. Then just talk - it captures at")
     print('natural stopping points, or say "find my notes on X".')
+    return 0
+
+
+def _install_hook_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp install-hook",
+        description=(
+            "Wire the capture-reliability Stop hook into Claude Code so auto-save "
+            "fires on its own at stepping-stones instead of waiting to be told. "
+            "Language-agnostic (no English-keyword gating) and cheap (gated + "
+            "cooldown). Re-running is idempotent."
+        ),
+    )
+    parser.add_argument(
+        "--hook-dir",
+        help="Where to write the hook script (default: ~/.claude/hooks).",
+    )
+    parser.add_argument(
+        "--settings",
+        help="settings.json to wire (default: ~/.claude/settings.json).",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Write the script but don't touch settings.json; print the snippet to add.",
+    )
+    args = parser.parse_args(argv)
+
+    from . import install_hook as hook_module
+
+    try:
+        report = hook_module.install_hook(
+            hook_dir=args.hook_dir,
+            settings_path=args.settings,
+            wire=not args.print_only,
+        )
+    except FileNotFoundError as e:
+        print(f"kb-mcp install-hook: {e}", file=sys.stderr)
+        return 1
+
+    print("Installed the capture-reliability hook script:")
+    print(f"  {report['script']}")
+    if report["wired"]:
+        print(f"Wired into {report['settings']} as a Stop hook.")
+        print("Restart Claude Code to activate it. Triggers log to")
+        print("  ~/.claude/kb-capture-nudge.log")
+    else:
+        print("Add this to your settings.json (merge into hooks.Stop):")
+        print(hook_module.snippet(report["command"]))
     return 0
 
 

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -1,8 +1,9 @@
 """`python -m kb_mcp` entry point.
 
-Two subcommands:
+Subcommands:
 - (default) serve the MCP server — `python -m kb_mcp [--transport ...]`
 - `init` — bootstrap a fresh Knowledge Base into a vault
+- `install-skill` — install the knowledge-base skill into Claude Code
 """
 
 from __future__ import annotations
@@ -19,6 +20,8 @@ def main(argv: list[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] == "init":
         return _init_main(raw[1:])
+    if raw and raw[0] == "install-skill":
+        return _install_skill_main(raw[1:])
     return _serve_main(raw)
 
 
@@ -81,7 +84,52 @@ def _init_main(argv: list[str]) -> int:
     print(f"  {len(report['created'])} files created + the typed folder tree.")
     print("Next:")
     print("  1. Point Claude Code at this vault (see SETUP-FRIEND.md).")
-    print("  2. Adapt Knowledge Base/_Schema/project-keys.yaml to your own projects.")
+    print("  2. Install the skill so Claude knows how to use it: python -m kb_mcp install-skill")
+    print("  3. Adapt Knowledge Base/_Schema/project-keys.yaml to your own projects.")
+    return 0
+
+
+def _install_skill_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp install-skill",
+        description=(
+            "Install the knowledge-base skill into Claude Code's skills folder. "
+            "The MCP server is the hands; the skill is the brain that tells Claude "
+            "when to capture and how to file — without it, the tools sit unused."
+        ),
+    )
+    parser.add_argument(
+        "--target",
+        help="Skill folder to install into (default: ~/.claude/skills/knowledge-base).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing install at the target.",
+    )
+    parser.add_argument(
+        "--link",
+        action="store_true",
+        help="Symlink instead of copy, so the install tracks repo updates "
+        "(falls back to copy if the OS refuses the symlink).",
+    )
+    args = parser.parse_args(argv)
+
+    from . import install_skill as install_module
+
+    target = Path(args.target) if args.target else None
+    try:
+        report = install_module.install_skill(target, force=args.force, link=args.link)
+    except (FileExistsError, FileNotFoundError) as e:
+        print(f"kb-mcp install-skill: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"Installed the knowledge-base skill ({report['mode']}, "
+        f"{report['files']} files):"
+    )
+    print(f"  {report['target']}")
+    print("Restart Claude Code to load it. Then just talk - it captures at")
+    print('natural stopping points, or say "find my notes on X".')
     return 0
 
 

--- a/src/kb_mcp/_hooks/kb_capture_nudge.py
+++ b/src/kb_mcp/_hooks/kb_capture_nudge.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Stop hook: nudge a Knowledge Base capture when a turn looks like a landing.
+
+The KB skill already says to auto-capture at stepping-stones, but skill prose is
+*passive* — over a long thread the model forgets to check, so "auto-save" quietly
+never fires. This hook re-arms the check: when Claude finishes a substantial turn
+that hasn't already written to the KB, it blocks the stop with a one-line reminder
+so Claude evaluates a capture before ending.
+
+LANGUAGE-AGNOSTIC by design. It does NOT gate on English keywords — that would
+miss Japanese and every other language. The gate is structural: a turn is a
+candidate if the assistant's reply is substantial (>= a char threshold) and the
+KB wasn't already written this turn. A per-session cooldown bounds how often it
+can fire, so cost stays low while Claude — which judges "is this really a
+stepping-stone?" well in any language — makes the actual call (the reminder tells
+it to do nothing if it isn't one).
+
+Cheap and safe: the script itself is free (stdlib only); the only token cost is a
+real capture (the feature). Self-disarms via `stop_hook_active` (no loops); the
+cooldown caps frequency; every trigger is logged to ~/.claude/kb-capture-nudge.log
+for tuning.
+
+Tunables (env): KB_CAPTURE_NUDGE_DISABLE=1 (off), KB_CAPTURE_NUDGE_MIN_CHARS
+(default 400), KB_CAPTURE_NUDGE_COOLDOWN_SEC (default 300).
+
+Contract (Claude Code Stop hook): read the event JSON on stdin; print
+`{"decision":"block","reason":...}` and exit 0 to block the stop and feed the
+reminder to Claude; exit 0 with no output to allow the stop. Never raises — a hook
+crash must not break the session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# KB write tools — if one ran this turn, the capture already happened.
+_KB_WRITE = re.compile(r"knowledge_base.*(note|add|edit|append|create_file|replace)", re.I)
+
+REMINDER = (
+    "[KB capture check] This turn did substantial work. If your Knowledge Base "
+    "skill is available and the turn reached a durable conclusion — a decision, a "
+    "solved problem, a diagnosed failure, or a recognized pattern, in whatever "
+    "language you were working in — capture it now as a *compiled note* (the "
+    "distilled conclusion plus links, NOT a transcript) under the standing waiver, "
+    "then report one line (Saved -> path). Ask only if the note's type/scope is "
+    "genuinely ambiguous. If it is NOT a stepping-stone, or no Knowledge Base is "
+    "configured here, do nothing and stop — that is the common case, and skipping "
+    "is correct and free."
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name) or default)
+    except (ValueError, TypeError):
+        return default
+
+
+def _content_blocks(msg: dict) -> list[dict]:
+    if not isinstance(msg, dict):
+        return []
+    c = msg.get("content")
+    if isinstance(c, str):
+        return [{"type": "text", "text": c}]
+    if isinstance(c, list):
+        out: list[dict] = []
+        for b in c:
+            if isinstance(b, dict):
+                out.append(b)
+            elif isinstance(b, str):
+                out.append({"type": "text", "text": b})
+        return out
+    return []
+
+
+def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[str]]:
+    """Return (assistant_text, tool_names) for the latest turn from the JSONL
+    transcript. Walks backward, stopping at the human message that began the turn
+    (a user message with real text and no tool_result block)."""
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+                f.readline()  # drop a partial first line
+            raw = f.read().decode("utf-8", "replace")
+    except OSError:
+        return "", []
+    chunks: list[str] = []
+    tools: list[str] = []
+    for line in reversed([ln for ln in raw.splitlines() if ln.strip()]):
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
+        role = msg.get("role") if isinstance(msg, dict) else None
+        typ = obj.get("type")
+        if role == "assistant" or typ == "assistant":
+            for b in _content_blocks(msg):
+                if b.get("type") == "text":
+                    chunks.append(b.get("text", ""))
+                elif b.get("type") == "tool_use":
+                    tools.append(b.get("name", ""))
+        elif role == "user" or typ == "user":
+            blocks = _content_blocks(msg)
+            if any(b.get("type") == "text" for b in blocks) and not any(
+                b.get("type") == "tool_result" for b in blocks
+            ):
+                break  # reached the human prompt that began this turn
+    return "".join(reversed(chunks)), tools
+
+
+def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
+    """Per-session timestamp file (mtime-based, so we never parse content)."""
+    state_dir = Path.home() / ".claude" / ".cache" / "kb-nudge"
+    key = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:128]
+    stamp = state_dir / key
+    try:
+        if stamp.exists() and (time.time() - stamp.stat().st_mtime) < cooldown:
+            return False, stamp
+    except OSError:
+        pass
+    return True, stamp
+
+
+def _touch(stamp: Path) -> None:
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(str(time.time()), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _log(text: str) -> None:
+    try:
+        logp = Path.home() / ".claude" / "kb-capture-nudge.log"
+        logp.parent.mkdir(parents=True, exist_ok=True)
+        snippet = re.sub(r"\s+", " ", text)[-160:]
+        with open(logp, "a", encoding="utf-8") as f:
+            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | {snippet}\n")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    if os.environ.get("KB_CAPTURE_NUDGE_DISABLE"):
+        return 0
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return 0
+
+    if data.get("stop_hook_active"):  # we already blocked once — stand down
+        return 0
+    tpath = data.get("transcript_path")
+    if not tpath:
+        return 0
+
+    min_chars = _env_int("KB_CAPTURE_NUDGE_MIN_CHARS", 400)
+    cooldown = _env_int("KB_CAPTURE_NUDGE_COOLDOWN_SEC", 300)
+
+    assistant_text, tools = _latest_turn(tpath)
+    if any(_KB_WRITE.search(t) for t in tools):  # already captured this turn
+        return 0
+    if re.search(r"Saved\s*(?:->|→|:)", assistant_text):
+        return 0
+    if len(assistant_text.strip()) < min_chars:  # trivial turn, not a landing
+        return 0
+
+    ok, stamp = _cooldown_ok(data.get("session_id", ""), cooldown)
+    if not ok:  # fired recently this session — keep cost bounded
+        return 0
+
+    _touch(stamp)
+    _log(assistant_text)
+    print(json.dumps({"decision": "block", "reason": REMINDER}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -53,7 +53,10 @@ Not a stepping-stone: mid-thought exploration, brainstorm tangents, unresolved q
 ├── Sources/
 │   ├── Articles/                 Captured web/PDF content
 │   ├── Sessions/                 Conversation transcripts OR Claude-written session captures
-│   └── Books/                    Book notes/excerpts
+│   ├── Books/                    Book notes/excerpts
+│   ├── Papers/                   Academic papers
+│   ├── Videos/                   Video transcripts/notes (e.g. a pasted YouTube transcript)
+│   └── Other/                    Miscellaneous captures
 ├── Notes/
 │   ├── Research/{Substrate, Q, Endstate, Sift, Together Unprocessed,
 │   │            Health, Finance, Creative, Science, Travel,
@@ -385,7 +388,8 @@ Easy to confuse (both time-bounded, date-prefixed, with outcomes). **Experiment*
 ## Workflow: typical add-then-compile session
 
 1. **User pastes raw material or asks to log something.**
-2. **Skill creates a `source` file.** Picks `Sources/Articles/`, `Sources/Sessions/`, or `Sources/Books/` based on the input shape. Filename: ISO-date + slug. Frontmatter per `references/frontmatter.md`. Updates `Sources/index.md`.
+2. **Skill creates a `source` file.** Picks the subfolder from the input shape — `Sources/Articles/` (web/PDF), `Sources/Sessions/` (a pasted conversation), `Sources/Books/`, `Sources/Papers/`, `Sources/Videos/`, or `Sources/Other/`. Filename: ISO-date + slug. Frontmatter per `references/frontmatter.md`. Updates `Sources/index.md`.
+   - **Videos are capturable** — file the *transcript* under `Sources/Videos/` (`source_type: video`, `url` required). YouTube usually exposes a transcript/captions panel, so it's a paste, no ASR needed. kb-mcp does not download or transcribe media itself; only a video with no available transcript would need an external ASR step first.
 3. **Skill asks: "Compile a note from this? If yes, what type — research, insight, failure, pattern, experiment, production-log? And what scope (for research) / domain (for experiment) / medium (for production)?"** Skip if the user already specified.
 4. **Skill drafts the compiled page** with frontmatter, sources block (linking back to the source file), wikilinks to existing entities/concepts where they obviously match, and a "Connections" section listing the wikilinks. **Run `suggest_links` on the draft (title + body) first** — it surfaces related existing pages (hub-preferring) you'd otherwise miss; fold the relevant ones into Connections.
 5. **Skill shows the draft, waits for confirmation.** User can revise inline.

--- a/src/kb_mcp/_scaffold/_Schema/references/operations.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/operations.md
@@ -31,7 +31,7 @@ These two updates are non-negotiable for every operation below. The per-operatio
 
 ### Inputs to gather
 - The raw content (pasted text, URL, file reference, conversation excerpt)
-- Source type — usually inferable: pasted Claude transcript → `Sessions/`; URL or article body → `Articles/`; book excerpt → `Books/`. Ask only if ambiguous.
+- Source type — usually inferable: pasted Claude transcript → `Sessions/`; URL or article body → `Articles/`; book excerpt → `Books/`; academic paper → `Papers/`; a video transcript (e.g. a pasted YouTube transcript) → `Videos/` with `url` set. Ask only if ambiguous.
 - Optional: tags, why-captured one-liner
 
 ### Procedure

--- a/src/kb_mcp/install_hook.py
+++ b/src/kb_mcp/install_hook.py
@@ -1,0 +1,113 @@
+"""install-hook: wire the KB capture-reliability Stop hook into Claude Code.
+
+Ships the bundled hook (`_hooks/kb_capture_nudge.py`) into `~/.claude/hooks` and
+registers it as a `Stop` hook in `~/.claude/settings.json`, so a friend gets
+reliable auto-capture with one command. The hook is language-agnostic (structural
+gate + cooldown), so it works regardless of the language you write in.
+
+By default it copies the script AND merges settings.json. `wire=False`
+(`--print-only`) copies the script and returns the snippet to paste instead, for
+anyone who'd rather edit their config by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+_HOOK_SRC = Path(__file__).parent / "_hooks" / "kb_capture_nudge.py"
+_HOOK_NAME = "kb_capture_nudge.py"
+DEFAULT_HOOK_DIR = Path.home() / ".claude" / "hooks"
+DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
+
+# Substrings identifying a previously-installed kb capture-nudge Stop entry, so
+# re-running is idempotent and supersedes an older hand-wired wrapper.
+_MARKERS = ("kb_capture_nudge", "kb-capture-nudge")
+
+
+def _command_for(script: Path) -> str:
+    """Invoke via the interpreter that ran install-hook (absolute path), so the
+    hook doesn't depend on `python` being on PATH later. Quoted for spaces."""
+    return f'"{sys.executable}" "{script}"'
+
+
+def snippet(command: str, timeout: int = 10) -> str:
+    """The settings.json fragment to merge into `hooks.Stop` (for --print-only)."""
+    return json.dumps(
+        {"hooks": {"Stop": [{"hooks": [
+            {"type": "command", "command": command, "timeout": timeout}
+        ]}]}},
+        indent=2,
+    )
+
+
+def install_hook(
+    *,
+    hook_dir: Path | None = None,
+    settings_path: Path | None = None,
+    wire: bool = True,
+    timeout: int = 10,
+) -> dict:
+    """Install the capture-nudge hook script and (optionally) wire settings.json.
+
+    Returns {"script", "command", "wired", "settings"}.
+    Raises FileNotFoundError if the bundled hook is missing.
+    """
+    if not _HOOK_SRC.exists():
+        raise FileNotFoundError(
+            f"bundled hook missing at {_HOOK_SRC} — is the kb-mcp install intact?"
+        )
+    hook_dir = (Path(hook_dir).expanduser() if hook_dir else DEFAULT_HOOK_DIR)
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    script = hook_dir / _HOOK_NAME
+    shutil.copy2(_HOOK_SRC, script)
+    command = _command_for(script)
+
+    result = {"script": str(script), "command": command, "wired": False, "settings": None}
+    if wire:
+        sp = (Path(settings_path).expanduser() if settings_path else DEFAULT_SETTINGS)
+        _merge_stop_hook(sp, command, timeout)
+        result["wired"] = True
+        result["settings"] = str(sp)
+    return result
+
+
+def _merge_stop_hook(path: Path, command: str, timeout: int) -> None:
+    """Add our Stop hook to settings.json, preserving every other key and hook.
+
+    Idempotent: strips any prior kb capture-nudge entry first (so re-running, or
+    superseding an older hand-wired wrapper, never duplicates)."""
+    data: dict = {}
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = data["hooks"] = {}
+    stop = hooks.get("Stop") if isinstance(hooks.get("Stop"), list) else []
+
+    kept: list = []
+    for group in stop:
+        if not isinstance(group, dict):
+            kept.append(group)
+            continue
+        ghooks = [
+            h for h in group.get("hooks", [])
+            if not any(m in str(h.get("command", "")) for m in _MARKERS)
+        ]
+        if ghooks:  # group still has non-ours hooks — keep it, minus ours
+            kept.append({**group, "hooks": ghooks})
+        # a group whose only hook was ours is dropped entirely
+
+    kept.append({"hooks": [{"type": "command", "command": command, "timeout": timeout}]})
+    hooks["Stop"] = kept
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/src/kb_mcp/install_skill.py
+++ b/src/kb_mcp/install_skill.py
@@ -1,0 +1,105 @@
+"""install-skill: copy the bundled knowledge-base skill into Claude Code.
+
+The MCP server is only the *hands* — the `find`/`add`/`note`/`edit` tools. The
+*brain* that tells Claude when to capture, how to file a source, and how to
+compile a note under the schema is the **skill**: `_scaffold/_Schema/SKILL.md`
+plus its `references/`. Claude Code discovers skills at
+`~/.claude/skills/<name>/SKILL.md`, so until the skill is installed the tools
+just sit there and nothing captures on its own — the #1 "it does nothing" trap.
+
+This makes that install a first-class, one-command operation straight from the
+package (no Obsidian-vault round-trip), so a friend who only cloned the repo can
+install the skill without access to anyone's vault.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+# The skill ships inside the package, the same `_Schema/` that `init` lays into a
+# vault. Resolving from `__file__` works for an installed wheel too, not just a
+# git checkout — same pattern as init.py's _SCAFFOLD.
+_SKILL_SRC = Path(__file__).parent / "_scaffold" / "_Schema"
+
+# Claude Code loads `~/.claude/skills/<name>/SKILL.md`; the folder name must match
+# the skill's `name:` frontmatter (`knowledge-base`).
+DEFAULT_TARGET = Path.home() / ".claude" / "skills" / "knowledge-base"
+
+
+def install_skill(
+    target: Path | None = None,
+    *,
+    force: bool = False,
+    link: bool = False,
+) -> dict:
+    """Install the bundled knowledge-base skill into a Claude Code skills folder.
+
+    Copies (or, with ``link=True``, symlinks) the canonical `_Schema/` — SKILL.md,
+    references/, project-keys.yaml — to ``target`` (default
+    ``~/.claude/skills/knowledge-base``). Claude Code picks it up as the
+    `knowledge-base` skill on next start.
+
+    Args:
+        target: Destination skill folder. Defaults to DEFAULT_TARGET.
+        force: Overwrite an existing, non-empty target. Without it we refuse
+            rather than clobber.
+        link: Best-effort symlink instead of copy (keeps the install in sync as
+            the skill evolves). Falls back to a copy if the OS refuses the
+            symlink — e.g. Windows without Developer Mode.
+
+    Returns:
+        {"target": str, "mode": "copy"|"symlink", "files": int}.
+
+    Raises:
+        FileNotFoundError: the bundled skill is missing (broken install).
+        FileExistsError: target exists and is non-empty and ``force`` is False.
+    """
+    if not (_SKILL_SRC / "SKILL.md").exists():
+        raise FileNotFoundError(
+            f"bundled skill missing at {_SKILL_SRC} (SKILL.md not found) — "
+            "is the kb-mcp install intact?"
+        )
+
+    target = (Path(target) if target is not None else DEFAULT_TARGET).expanduser()
+
+    # Refuse to clobber a real install. An empty dir is safe to fill (parent
+    # mkdir often leaves one); a symlink or any non-empty content needs --force.
+    if target.exists() and not force:
+        empty_dir = (
+            target.is_dir() and not target.is_symlink() and not any(target.iterdir())
+        )
+        if not empty_dir:
+            raise FileExistsError(
+                f"{target} already exists. Pass force=True to overwrite it, or "
+                "choose a different target."
+            )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    # Start from clean ground so the install is a faithful mirror, never a
+    # half-merge of old and new files. Order matters: a symlink-to-dir reports
+    # is_dir() True, so test is_symlink() first and only unlink the link.
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.is_dir():
+        shutil.rmtree(target)
+
+    if link:
+        try:
+            target.symlink_to(_SKILL_SRC, target_is_directory=True)
+            return {
+                "target": str(target),
+                "mode": "symlink",
+                "files": _count_files(_SKILL_SRC),
+            }
+        except OSError:
+            # Restricted FS / no symlink privilege — fall through to a copy.
+            pass
+
+    shutil.copytree(_SKILL_SRC, target)
+    return {"target": str(target), "mode": "copy", "files": _count_files(target)}
+
+
+def _count_files(root: Path) -> int:
+    return sum(1 for p in root.rglob("*") if p.is_file())

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -1,0 +1,172 @@
+"""install-hook (the installer) + the capture-nudge Stop hook (the gate).
+
+The hook is the reliability fix for auto-capture: skill prose is passive, so a
+Stop hook re-arms the "is this a stepping-stone? capture it" check each turn. It's
+language-agnostic (structural gate + cooldown, no English keywords) so it works on
+Japanese and every other language.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import kb_mcp
+from kb_mcp import install_hook as hook_module
+
+HOOK_SCRIPT = Path(kb_mcp.__file__).parent / "_hooks" / "kb_capture_nudge.py"
+
+
+# --- install_hook: the installer ------------------------------------------------
+
+def test_install_hook_copies_and_wires(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    r = hook_module.install_hook(hook_dir=hd, settings_path=sp)
+    assert (hd / "kb_capture_nudge.py").exists()
+    assert r["wired"] is True
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    cmds = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
+    assert any("kb_capture_nudge.py" in c for c in cmds)
+
+
+def test_install_hook_idempotent(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp)
+    hook_module.install_hook(hook_dir=hd, settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    ours = [
+        h["command"]
+        for g in data["hooks"]["Stop"]
+        for h in g["hooks"]
+        if "kb_capture_nudge" in h["command"]
+    ]
+    assert len(ours) == 1  # re-running must not duplicate
+
+
+def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
+    sp = tmp_path / "settings.json"
+    sp.write_text(
+        json.dumps({
+            "theme": "dark",
+            "hooks": {
+                "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "bash guard.sh"}]}],
+                "Stop": [{"hooks": [{"type": "command", "command": "bash other-stop.sh"}]}],
+            },
+        }),
+        encoding="utf-8",
+    )
+    hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    assert data["theme"] == "dark"
+    assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "bash guard.sh"
+    stop = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
+    assert "bash other-stop.sh" in stop  # unrelated Stop hook kept
+    assert any("kb_capture_nudge" in c for c in stop)  # ours added
+
+
+def test_install_hook_supersedes_old_wrapper(tmp_path: Path) -> None:
+    sp = tmp_path / "settings.json"
+    sp.write_text(
+        json.dumps({"hooks": {"Stop": [
+            {"hooks": [{"type": "command", "command": "bash ~/.claude/hooks/kb-capture-nudge.sh"}]}
+        ]}}),
+        encoding="utf-8",
+    )
+    hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    stop = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
+    assert not any("kb-capture-nudge.sh" in c for c in stop)  # old wrapper superseded
+    assert sum("kb_capture_nudge" in c for c in stop) == 1
+
+
+def test_install_hook_print_only_leaves_settings(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    r = hook_module.install_hook(hook_dir=hd, settings_path=sp, wire=False)
+    assert (hd / "kb_capture_nudge.py").exists()
+    assert r["wired"] is False
+    assert not sp.exists()
+
+
+def test_install_hook_via_cli(tmp_path: Path) -> None:
+    from kb_mcp.__main__ import main
+
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    assert main(["install-hook", "--hook-dir", str(hd), "--settings", str(sp)]) == 0
+    assert (hd / "kb_capture_nudge.py").exists()
+    assert sp.exists()
+
+
+# --- the hook gate: real Stop-hook contract via subprocess ----------------------
+
+def _transcript(tmp_path: Path, user_text: str, assistant_text: str | None = None,
+                assistant_tool: str | None = None) -> Path:
+    content: list[dict] = []
+    if assistant_tool:
+        content.append({"type": "tool_use", "name": assistant_tool})
+    if assistant_text is not None:
+        content.append({"type": "text", "text": assistant_text})
+    lines = [
+        {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": user_text}]}},
+        {"type": "assistant", "message": {"role": "assistant", "content": content}},
+    ]
+    p = tmp_path / "t.jsonl"
+    p.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    return p
+
+
+def _run(event: dict, home: Path):
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}  # redirect Path.home()
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(event), capture_output=True, text=True, env=env,
+    )
+
+
+def test_hook_fires_on_substantial_turn(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "We landed on a clear decision. " + "x" * 450)
+    r = _run({"transcript_path": str(t), "session_id": "s1"}, home)
+    assert '"decision": "block"' in r.stdout
+
+
+def test_hook_fires_language_agnostic_japanese(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    jp = "これは重要な結論です。" * 40  # >400 chars, zero English keywords
+    t = _transcript(tmp_path, "質問", jp)
+    r = _run({"transcript_path": str(t), "session_id": "jp"}, home)
+    assert '"decision": "block"' in r.stdout
+
+
+def test_hook_silent_on_trivial_turn(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "Done.")
+    r = _run({"transcript_path": str(t), "session_id": "s2"}, home)
+    assert r.stdout.strip() == ""
+
+
+def test_hook_silent_when_already_saved(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450,
+                    assistant_tool="mcp__claude_ai_Knowledge_Base__note")
+    r = _run({"transcript_path": str(t), "session_id": "s3"}, home)
+    assert r.stdout.strip() == ""
+
+
+def test_hook_silent_when_stop_hook_active(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450)
+    r = _run({"transcript_path": str(t), "session_id": "s4", "stop_hook_active": True}, home)
+    assert r.stdout.strip() == ""
+
+
+def test_hook_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450)
+    ev = {"transcript_path": str(t), "session_id": "cd"}
+    first = _run(ev, home)
+    second = _run(ev, home)
+    assert '"decision": "block"' in first.stdout
+    assert second.stdout.strip() == ""  # cooldown bounds cost

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,71 @@
+"""install-skill — copy the bundled knowledge-base skill into Claude Code.
+
+The MCP server is only the hands (find/add/note); the skill is the brain that
+tells Claude when to capture and how to file. Until it's installed at
+`~/.claude/skills/knowledge-base/SKILL.md`, the tools sit unused — so installing
+it straight from the package (no vault round-trip) is a first-class operation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import install_skill as install_module
+
+
+def test_install_skill_copies_into_target(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge-base"
+    report = install_module.install_skill(target)
+
+    # SKILL.md + references/ land at the target root — Claude Code discovers a
+    # skill by <target>/SKILL.md.
+    assert (target / "SKILL.md").exists()
+    assert (target / "references").is_dir()
+    assert (target / "references" / "operations.md").exists()
+
+    assert report["target"] == str(target)
+    assert report["mode"] == "copy"
+    assert report["files"] > 0
+
+
+def test_install_skill_populates_empty_dir(tmp_path: Path) -> None:
+    """An empty target dir (common — a parent mkdir often leaves one) is safe to
+    fill without --force."""
+    target = tmp_path / "knowledge-base"
+    target.mkdir()
+    install_module.install_skill(target)
+    assert (target / "SKILL.md").exists()
+
+
+def test_install_skill_refuses_existing_without_force(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge-base"
+    target.mkdir()
+    (target / "SKILL.md").write_text("stale", encoding="utf-8")  # non-empty
+    with pytest.raises(FileExistsError):
+        install_module.install_skill(target)
+
+
+def test_install_skill_force_overwrites_cleanly(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge-base"
+    target.mkdir()
+    (target / "stale.md").write_text("old", encoding="utf-8")
+
+    install_module.install_skill(target, force=True)
+
+    # A faithful mirror: canonical SKILL.md present, stale leftovers gone.
+    assert (target / "SKILL.md").exists()
+    assert not (target / "stale.md").exists()
+
+
+def test_install_skill_via_cli(tmp_path: Path) -> None:
+    """`python -m kb_mcp install-skill --target <path>` installs and returns 0;
+    a second run refuses (1) without --force, then succeeds (0) with it."""
+    from kb_mcp.__main__ import main
+
+    target = tmp_path / "knowledge-base"
+    assert main(["install-skill", "--target", str(target)]) == 0
+    assert (target / "SKILL.md").exists()
+    assert main(["install-skill", "--target", str(target)]) == 1
+    assert main(["install-skill", "--target", str(target), "--force"]) == 0


### PR DESCRIPTION
## Why

A friend running kb-mcp in Claude Code hit two things: (1) auto-capture "did nothing" — it's 100% skill-driven and the old skill install routed through a vault path the friend hadn't populated; and even once the skill was installed, (2) it still rarely fires, because skill prose is *passive* (Claude forgets it over a long thread, so it silently never saves). He also thought videos "can't be saved."

## What

**Onboarding**
- `python -m kb_mcp install-skill` — installs the skill from the package into `~/.claude/skills` (no vault round-trip). `--target` / `--force` / `--link`.
- SETUP-FRIEND.md: "two parts (server + skill), you need both" callout; lean = keyword-only-silently note.
- SKILL.md + operations.md: videos **are** capturable via transcript (YouTube has one; no ASR); folder tree lists `Videos`/`Papers`/`Other`.

**Reliable auto-capture (the real fix)**
- `_hooks/kb_capture_nudge.py` — a Claude Code `Stop` hook that re-arms the "is this a stepping-stone? capture it" check every turn. **Language-agnostic** (structural gate + per-session cooldown, no English keywords — works on Japanese). Self-disarms via `stop_hook_active`; logs to `~/.claude/kb-capture-nudge.log`; env-tunable.
- `python -m kb_mcp install-hook` — copies the script and merges the `Stop` hook into `settings.json` (idempotent; `--print-only` fallback prints the snippet).
- SETUP-FRIEND.md step 7 (Claude Code only — claude.ai has no hooks).

## Tests

`pytest`: **380 passed** (incl. install-skill, install-hook, language-agnostic firing, cooldown, idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)