### PR TITLE
feat: KB retrieval hook (read side) — completes the auto-KB loop

### DIFF
--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -167,30 +167,41 @@ own — or just start writing; the writer auto-registers new keys as you use the
 
 ---
 
-## 7. (Recommended) Make auto-save reliable
+## 7. (Recommended) Make the KB automatic — both directions
 
-The skill *tells* Claude to capture at stepping-stones, but that instruction is
-passive — over a long conversation Claude tends to forget it, so auto-save often
-quietly never fires (you'll know: `Knowledge Base/log.md` only shows saves you
-asked for). This optional hook fixes that — it re-checks "is this worth saving?"
-at the end of every turn:
+The skill *tells* Claude to capture at stepping-stones and to consult the KB
+before answering, but those instructions are passive — over a long conversation
+Claude tends to forget them, so auto-save quietly never fires (you'll know:
+`Knowledge Base/log.md` only shows saves you asked for) and prior notes don't get
+pulled in. This one command installs two small hooks that fix both directions:
 
 ```bash
 python -m kb_mcp install-hook
 ```
 
-It writes a small script to `~/.claude/hooks/` and wires it as a Claude Code
-`Stop` hook (restart Claude Code to activate). It's **language-agnostic** (no
-keyword matching — works the same in any language you write in) and cheap (gated
-so it stays quiet on ordinary turns, plus a per-session cooldown). Every time it
-nudges it logs to `~/.claude/kb-capture-nudge.log`, so you can see the real rate.
-Prefer to wire it by hand? `python -m kb_mcp install-hook --print-only` writes the
-script and prints the settings snippet to paste. Tune with
-`KB_CAPTURE_NUDGE_MIN_CHARS` / `KB_CAPTURE_NUDGE_COOLDOWN_SEC`, or turn it off
-with `KB_CAPTURE_NUDGE_DISABLE=1`.
+- **Write** — a `Stop` hook that re-checks "is this worth saving?" at the end of
+  each turn, so conclusions get captured on their own.
+- **Read** — a `UserPromptSubmit` hook that reminds Claude to run a `find` first
+  when your message touches something the KB might hold, so it actually behaves as
+  your source of truth.
+
+Both are **language-agnostic** (no keyword matching — they work the same in any
+language you write in) and cheap (gated so they stay quiet on ordinary
+turns/prompts, plus a per-session cooldown). They write scripts to
+`~/.claude/hooks/` and wire the two hooks into your settings.json — restart Claude
+Code to activate. Triggers log to `~/.claude/kb-capture-nudge.log` and
+`~/.claude/kb-retrieve-nudge.log` so you can see the real rate. Prefer to wire it
+by hand? `python -m kb_mcp install-hook --print-only` writes the scripts and
+prints the snippet to paste.
+
+Tune with `KB_CAPTURE_NUDGE_MIN_CHARS` / `KB_RETRIEVE_NUDGE_MIN_CHARS` (and the
+matching `_COOLDOWN_SEC`), or disable either with `KB_CAPTURE_NUDGE_DISABLE=1` /
+`KB_RETRIEVE_NUDGE_DISABLE=1`. **Writing in a dense script (Japanese, Chinese)?**
+Lower the `MIN_CHARS` values — those scripts pack more meaning per character, so
+the defaults (tuned for English) can under-fire.
 
 (Hooks are Claude Code only — claude.ai web/mobile can't run them, so there the
-skill stays best-effort: nudge it with *"save that to kb."*)
+skill stays best-effort: nudge it with *"save that to kb"* or *"check the kb."*)
 
 ---
 

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -4,7 +4,7 @@ Subcommands:
 - (default) serve the MCP server — `python -m kb_mcp [--transport ...]`
 - `init` — bootstrap a fresh Knowledge Base into a vault
 - `install-skill` — install the knowledge-base skill into Claude Code
-- `install-hook` — wire the capture-reliability Stop hook into Claude Code
+- `install-hook` — wire the KB capture + retrieval hooks into Claude Code
 """
 
 from __future__ import annotations
@@ -140,10 +140,11 @@ def _install_hook_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="kb-mcp install-hook",
         description=(
-            "Wire the capture-reliability Stop hook into Claude Code so auto-save "
-            "fires on its own at stepping-stones instead of waiting to be told. "
-            "Language-agnostic (no English-keyword gating) and cheap (gated + "
-            "cooldown). Re-running is idempotent."
+            "Wire the KB capture + retrieval hooks into Claude Code: a Stop hook "
+            "that captures conclusions at stepping-stones (write), and a "
+            "UserPromptSubmit hook that reminds Claude to consult the KB before "
+            "answering (read). Language-agnostic and cheap (gated + cooldown). "
+            "Re-running is idempotent."
         ),
     )
     parser.add_argument(
@@ -173,15 +174,17 @@ def _install_hook_main(argv: list[str]) -> int:
         print(f"kb-mcp install-hook: {e}", file=sys.stderr)
         return 1
 
-    print("Installed the capture-reliability hook script:")
-    print(f"  {report['script']}")
+    print("Installed the KB hook scripts:")
+    for item in report["installed"]:
+        print(f"  {item['event']:<16} {item['script']}")
     if report["wired"]:
-        print(f"Wired into {report['settings']} as a Stop hook.")
-        print("Restart Claude Code to activate it. Triggers log to")
-        print("  ~/.claude/kb-capture-nudge.log")
+        print(f"Wired into {report['settings']}.")
+        print("Restart Claude Code to activate. Triggers log to:")
+        print("  ~/.claude/kb-capture-nudge.log   (write / capture)")
+        print("  ~/.claude/kb-retrieve-nudge.log  (read / retrieval)")
     else:
-        print("Add this to your settings.json (merge into hooks.Stop):")
-        print(hook_module.snippet(report["command"]))
+        print("Add this to your settings.json (merge into hooks):")
+        print(hook_module.snippet(report["installed"]))
     return 0
 
 

--- a/src/kb_mcp/_hooks/kb_capture_nudge.py
+++ b/src/kb_mcp/_hooks/kb_capture_nudge.py
@@ -21,7 +21,8 @@ cooldown caps frequency; every trigger is logged to ~/.claude/kb-capture-nudge.l
 for tuning.
 
 Tunables (env): KB_CAPTURE_NUDGE_DISABLE=1 (off), KB_CAPTURE_NUDGE_MIN_CHARS
-(default 400), KB_CAPTURE_NUDGE_COOLDOWN_SEC (default 300).
+(default 300 — lower it for a dense script like Japanese, which packs more meaning
+per char), KB_CAPTURE_NUDGE_COOLDOWN_SEC (default 300).
 
 Contract (Claude Code Stop hook): read the event JSON on stdin; print
 `{"decision":"block","reason":...}` and exit 0 to block the stop and feed the
@@ -163,7 +164,7 @@ def main() -> int:
     if not tpath:
         return 0
 
-    min_chars = _env_int("KB_CAPTURE_NUDGE_MIN_CHARS", 400)
+    min_chars = _env_int("KB_CAPTURE_NUDGE_MIN_CHARS", 300)
     cooldown = _env_int("KB_CAPTURE_NUDGE_COOLDOWN_SEC", 300)
 
     assistant_text, tools = _latest_turn(tpath)

--- a/src/kb_mcp/_hooks/kb_retrieve_nudge.py
+++ b/src/kb_mcp/_hooks/kb_retrieve_nudge.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: nudge a KB retrieval before Claude answers.
+
+The read-side mirror of the capture hook. The skill says to consult the KB
+proactively, but that prose is passive — Claude forgets, especially at the start
+of a thread. This re-arms the read side: when the user submits a substantial
+prompt, it injects a one-line reminder to run `find` first and fold prior
+conclusions into the answer, so the KB actually functions as the source of truth.
+
+Language-agnostic and cheap: gates on prompt length + a per-session cooldown, no
+keywords. It injects only a *reminder* — Claude still runs the real (semantic)
+find — so it never stalls the prompt. (UserPromptSubmit blocks model start until
+the hook returns, so the hook must be fast: stdlib only, no search here.)
+
+Tunables (env): KB_RETRIEVE_NUDGE_DISABLE=1 (off), KB_RETRIEVE_NUDGE_MIN_CHARS
+(default 20 — short, since prompts are short and a dense script like Japanese
+packs more per char), KB_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300).
+
+Contract (Claude Code UserPromptSubmit hook): read the event JSON on stdin (incl.
+`prompt`); on exit 0, print
+`{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": ...}}`
+to add the reminder to context; print nothing to stay silent. Never raises — a
+hook crash must not break the session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+REMINDER = (
+    "[KB retrieval check] Before answering: if this prompt touches a topic the "
+    "Knowledge Base might hold — a project, a past decision, a domain you've taken "
+    "notes on, or a 'what did I conclude / have I looked at' question — run a quiet "
+    "`find` FIRST and fold any hits into the answer (cite them). The KB is the "
+    "source of truth for prior conclusions; a miss means 'not found in what I "
+    "searched,' not 'doesn't exist.' If the prompt plainly has no KB bearing "
+    "(chit-chat, or a fresh task with no prior notes), skip silently."
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name) or default)
+    except (ValueError, TypeError):
+        return default
+
+
+def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
+    """Per-session timestamp file (mtime-based). Namespaced so it never collides
+    with the capture hook's cooldown stamp for the same session."""
+    state_dir = Path.home() / ".claude" / ".cache" / "kb-nudge"
+    key = "retrieve_" + re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:120]
+    stamp = state_dir / key
+    try:
+        if stamp.exists() and (time.time() - stamp.stat().st_mtime) < cooldown:
+            return False, stamp
+    except OSError:
+        pass
+    return True, stamp
+
+
+def _touch(stamp: Path) -> None:
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(str(time.time()), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _log(prompt: str) -> None:
+    try:
+        logp = Path.home() / ".claude" / "kb-retrieve-nudge.log"
+        logp.parent.mkdir(parents=True, exist_ok=True)
+        snippet = re.sub(r"\s+", " ", prompt)[:160]
+        with open(logp, "a", encoding="utf-8") as f:
+            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} nudge fired | {snippet}\n")
+    except Exception:
+        pass
+
+
+def main() -> int:
+    if os.environ.get("KB_RETRIEVE_NUDGE_DISABLE"):
+        return 0
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return 0
+
+    prompt = data.get("prompt")
+    if not isinstance(prompt, str):
+        return 0
+
+    min_chars = _env_int("KB_RETRIEVE_NUDGE_MIN_CHARS", 20)
+    cooldown = _env_int("KB_RETRIEVE_NUDGE_COOLDOWN_SEC", 300)
+
+    if len(prompt.strip()) < min_chars:  # trivial prompt ("yes", "go", "thanks")
+        return 0
+
+    ok, stamp = _cooldown_ok(data.get("session_id", ""), cooldown)
+    if not ok:  # already nudged recently this session — keep it quiet
+        return 0
+
+    _touch(stamp)
+    _log(prompt)
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": REMINDER,
+    }}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb_mcp/install_hook.py
+++ b/src/kb_mcp/install_hook.py
@@ -1,13 +1,17 @@
-"""install-hook: wire the KB capture-reliability Stop hook into Claude Code.
+"""install-hook: wire the KB capture + retrieval hooks into Claude Code.
 
-Ships the bundled hook (`_hooks/kb_capture_nudge.py`) into `~/.claude/hooks` and
-registers it as a `Stop` hook in `~/.claude/settings.json`, so a friend gets
-reliable auto-capture with one command. The hook is language-agnostic (structural
-gate + cooldown), so it works regardless of the language you write in.
+Ships two bundled hooks and registers them in `~/.claude/settings.json`, so a
+friend gets the full reliable KB loop with one command:
 
-By default it copies the script AND merges settings.json. `wire=False`
-(`--print-only`) copies the script and returns the snippet to paste instead, for
-anyone who'd rather edit their config by hand.
+- `_hooks/kb_capture_nudge.py`  → a `Stop` hook (WRITE side): captures durable
+  conclusions at stepping-stones instead of waiting to be told.
+- `_hooks/kb_retrieve_nudge.py` → a `UserPromptSubmit` hook (READ side): reminds
+  Claude to consult the KB before answering, so it functions as the source of
+  truth.
+
+Both are language-agnostic (structural gate + cooldown, no English keywords). By
+default this copies the scripts AND merges settings.json. `wire=False`
+(`--print-only`) copies the scripts and returns the snippet to paste instead.
 """
 
 from __future__ import annotations
@@ -17,14 +21,18 @@ import shutil
 import sys
 from pathlib import Path
 
-_HOOK_SRC = Path(__file__).parent / "_hooks" / "kb_capture_nudge.py"
-_HOOK_NAME = "kb_capture_nudge.py"
+_HOOK_DIR_SRC = Path(__file__).parent / "_hooks"
+# (script filename, Claude Code event) — the hooks this installs.
+_HOOK_SPECS = (
+    ("kb_capture_nudge.py", "Stop"),
+    ("kb_retrieve_nudge.py", "UserPromptSubmit"),
+)
 DEFAULT_HOOK_DIR = Path.home() / ".claude" / "hooks"
 DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
 
-# Substrings identifying a previously-installed kb capture-nudge Stop entry, so
-# re-running is idempotent and supersedes an older hand-wired wrapper.
-_MARKERS = ("kb_capture_nudge", "kb-capture-nudge")
+# Substrings identifying a previously-installed kb nudge entry, so re-running is
+# idempotent and supersedes older hand-wired wrappers.
+_MARKERS = ("kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge")
 
 
 def _command_for(script: Path) -> str:
@@ -33,14 +41,14 @@ def _command_for(script: Path) -> str:
     return f'"{sys.executable}" "{script}"'
 
 
-def snippet(command: str, timeout: int = 10) -> str:
-    """The settings.json fragment to merge into `hooks.Stop` (for --print-only)."""
-    return json.dumps(
-        {"hooks": {"Stop": [{"hooks": [
-            {"type": "command", "command": command, "timeout": timeout}
-        ]}]}},
-        indent=2,
-    )
+def snippet(installed: list[dict], timeout: int = 10) -> str:
+    """The settings.json fragment to merge by hand (for --print-only)."""
+    hooks: dict[str, list] = {}
+    for item in installed:
+        hooks[item["event"]] = [
+            {"hooks": [{"type": "command", "command": item["command"], "timeout": timeout}]}
+        ]
+    return json.dumps({"hooks": hooks}, indent=2)
 
 
 def install_hook(
@@ -49,36 +57,41 @@ def install_hook(
     settings_path: Path | None = None,
     wire: bool = True,
     timeout: int = 10,
+    specs: tuple = _HOOK_SPECS,
 ) -> dict:
-    """Install the capture-nudge hook script and (optionally) wire settings.json.
+    """Install the bundled hook scripts and (optionally) wire settings.json.
 
-    Returns {"script", "command", "wired", "settings"}.
-    Raises FileNotFoundError if the bundled hook is missing.
+    Returns {"installed": [{event, script, command}], "wired", "settings"}.
+    Raises FileNotFoundError if a bundled hook is missing.
     """
-    if not _HOOK_SRC.exists():
-        raise FileNotFoundError(
-            f"bundled hook missing at {_HOOK_SRC} — is the kb-mcp install intact?"
-        )
+    for name, _event in specs:
+        if not (_HOOK_DIR_SRC / name).exists():
+            raise FileNotFoundError(
+                f"bundled hook missing at {_HOOK_DIR_SRC / name} — is the kb-mcp install intact?"
+            )
     hook_dir = (Path(hook_dir).expanduser() if hook_dir else DEFAULT_HOOK_DIR)
     hook_dir.mkdir(parents=True, exist_ok=True)
-    script = hook_dir / _HOOK_NAME
-    shutil.copy2(_HOOK_SRC, script)
-    command = _command_for(script)
 
-    result = {"script": str(script), "command": command, "wired": False, "settings": None}
+    installed: list[dict] = []
+    for name, event in specs:
+        dest = hook_dir / name
+        shutil.copy2(_HOOK_DIR_SRC / name, dest)
+        installed.append({"event": event, "script": str(dest), "command": _command_for(dest)})
+
+    result = {"installed": installed, "wired": False, "settings": None}
     if wire:
         sp = (Path(settings_path).expanduser() if settings_path else DEFAULT_SETTINGS)
-        _merge_stop_hook(sp, command, timeout)
+        _merge_hooks(sp, installed, timeout)
         result["wired"] = True
         result["settings"] = str(sp)
     return result
 
 
-def _merge_stop_hook(path: Path, command: str, timeout: int) -> None:
-    """Add our Stop hook to settings.json, preserving every other key and hook.
-
-    Idempotent: strips any prior kb capture-nudge entry first (so re-running, or
-    superseding an older hand-wired wrapper, never duplicates)."""
+def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> None:
+    """Add each hook to its event in settings.json, preserving every other key
+    and hook. Idempotent: strips any prior kb nudge entry from the target event
+    first (so re-running, or superseding an older hand-wired wrapper, never
+    duplicates)."""
     data: dict = {}
     if path.exists():
         try:
@@ -91,23 +104,24 @@ def _merge_stop_hook(path: Path, command: str, timeout: int) -> None:
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
         hooks = data["hooks"] = {}
-    stop = hooks.get("Stop") if isinstance(hooks.get("Stop"), list) else []
 
-    kept: list = []
-    for group in stop:
-        if not isinstance(group, dict):
-            kept.append(group)
-            continue
-        ghooks = [
-            h for h in group.get("hooks", [])
-            if not any(m in str(h.get("command", "")) for m in _MARKERS)
-        ]
-        if ghooks:  # group still has non-ours hooks — keep it, minus ours
-            kept.append({**group, "hooks": ghooks})
-        # a group whose only hook was ours is dropped entirely
-
-    kept.append({"hooks": [{"type": "command", "command": command, "timeout": timeout}]})
-    hooks["Stop"] = kept
+    for item in installed:
+        event, command = item["event"], item["command"]
+        arr = hooks.get(event) if isinstance(hooks.get(event), list) else []
+        kept: list = []
+        for group in arr:
+            if not isinstance(group, dict):
+                kept.append(group)
+                continue
+            ghooks = [
+                h for h in group.get("hooks", [])
+                if not any(m in str(h.get("command", "")) for m in _MARKERS)
+            ]
+            if ghooks:  # group still has non-ours hooks — keep it, minus ours
+                kept.append({**group, "hooks": ghooks})
+            # a group whose only hook was ours is dropped entirely
+        kept.append({"hooks": [{"type": "command", "command": command, "timeout": timeout}]})
+        hooks[event] = kept
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -1,9 +1,10 @@
-"""install-hook (the installer) + the capture-nudge Stop hook (the gate).
+"""install-hook (installer) + the capture (Stop) and retrieval (UserPromptSubmit)
+nudge hooks.
 
-The hook is the reliability fix for auto-capture: skill prose is passive, so a
-Stop hook re-arms the "is this a stepping-stone? capture it" check each turn. It's
-language-agnostic (structural gate + cooldown, no English keywords) so it works on
-Japanese and every other language.
+The hooks are the reliability fix for the KB loop: skill prose is passive, so
+Stop re-arms "capture this stepping-stone" (write) and UserPromptSubmit re-arms
+"consult the KB first" (read). Both are language-agnostic (structural gate +
+cooldown, no English keywords) so they work on Japanese and every other language.
 """
 
 from __future__ import annotations
@@ -17,19 +18,30 @@ from pathlib import Path
 import kb_mcp
 from kb_mcp import install_hook as hook_module
 
-HOOK_SCRIPT = Path(kb_mcp.__file__).parent / "_hooks" / "kb_capture_nudge.py"
+_HOOKS = Path(kb_mcp.__file__).parent / "_hooks"
+CAPTURE_SCRIPT = _HOOKS / "kb_capture_nudge.py"
+RETRIEVE_SCRIPT = _HOOKS / "kb_retrieve_nudge.py"
 
 
-# --- install_hook: the installer ------------------------------------------------
+def _stop_cmds(data: dict) -> list[str]:
+    return [h["command"] for g in data["hooks"].get("Stop", []) for h in g["hooks"]]
 
-def test_install_hook_copies_and_wires(tmp_path: Path) -> None:
+
+def _ups_cmds(data: dict) -> list[str]:
+    return [h["command"] for g in data["hooks"].get("UserPromptSubmit", []) for h in g["hooks"]]
+
+
+# --- install_hook: the installer (both hooks) -----------------------------------
+
+def test_install_hook_copies_and_wires_both(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp)
     assert (hd / "kb_capture_nudge.py").exists()
+    assert (hd / "kb_retrieve_nudge.py").exists()
     assert r["wired"] is True
     data = json.loads(sp.read_text(encoding="utf-8"))
-    cmds = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
-    assert any("kb_capture_nudge.py" in c for c in cmds)
+    assert any("kb_capture_nudge.py" in c for c in _stop_cmds(data))      # write side -> Stop
+    assert any("kb_retrieve_nudge.py" in c for c in _ups_cmds(data))      # read side -> UserPromptSubmit
 
 
 def test_install_hook_idempotent(tmp_path: Path) -> None:
@@ -37,13 +49,8 @@ def test_install_hook_idempotent(tmp_path: Path) -> None:
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     data = json.loads(sp.read_text(encoding="utf-8"))
-    ours = [
-        h["command"]
-        for g in data["hooks"]["Stop"]
-        for h in g["hooks"]
-        if "kb_capture_nudge" in h["command"]
-    ]
-    assert len(ours) == 1  # re-running must not duplicate
+    assert sum("kb_capture_nudge" in c for c in _stop_cmds(data)) == 1
+    assert sum("kb_retrieve_nudge" in c for c in _ups_cmds(data)) == 1
 
 
 def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
@@ -62,9 +69,9 @@ def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
     data = json.loads(sp.read_text(encoding="utf-8"))
     assert data["theme"] == "dark"
     assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "bash guard.sh"
-    stop = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
-    assert "bash other-stop.sh" in stop  # unrelated Stop hook kept
-    assert any("kb_capture_nudge" in c for c in stop)  # ours added
+    assert "bash other-stop.sh" in _stop_cmds(data)                # unrelated Stop hook kept
+    assert any("kb_capture_nudge" in c for c in _stop_cmds(data))  # ours added
+    assert any("kb_retrieve_nudge" in c for c in _ups_cmds(data))
 
 
 def test_install_hook_supersedes_old_wrapper(tmp_path: Path) -> None:
@@ -77,17 +84,19 @@ def test_install_hook_supersedes_old_wrapper(tmp_path: Path) -> None:
     )
     hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
     data = json.loads(sp.read_text(encoding="utf-8"))
-    stop = [h["command"] for g in data["hooks"]["Stop"] for h in g["hooks"]]
-    assert not any("kb-capture-nudge.sh" in c for c in stop)  # old wrapper superseded
-    assert sum("kb_capture_nudge" in c for c in stop) == 1
+    assert not any("kb-capture-nudge.sh" in c for c in _stop_cmds(data))   # old wrapper superseded
+    assert sum("kb_capture_nudge" in c for c in _stop_cmds(data)) == 1
 
 
 def test_install_hook_print_only_leaves_settings(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp, wire=False)
     assert (hd / "kb_capture_nudge.py").exists()
+    assert (hd / "kb_retrieve_nudge.py").exists()
     assert r["wired"] is False
     assert not sp.exists()
+    snip = hook_module.snippet(r["installed"])
+    assert "Stop" in snip and "UserPromptSubmit" in snip
 
 
 def test_install_hook_via_cli(tmp_path: Path) -> None:
@@ -96,10 +105,20 @@ def test_install_hook_via_cli(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     assert main(["install-hook", "--hook-dir", str(hd), "--settings", str(sp)]) == 0
     assert (hd / "kb_capture_nudge.py").exists()
-    assert sp.exists()
+    assert (hd / "kb_retrieve_nudge.py").exists()
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    assert data["hooks"]["Stop"] and data["hooks"]["UserPromptSubmit"]
 
 
-# --- the hook gate: real Stop-hook contract via subprocess ----------------------
+# --- shared subprocess helper ---------------------------------------------------
+
+def _run(script: Path, event: dict, home: Path):
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}  # redirect Path.home()
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(event), capture_output=True, text=True, env=env,
+    )
+
 
 def _transcript(tmp_path: Path, user_text: str, assistant_text: str | None = None,
                 assistant_tool: str | None = None) -> Path:
@@ -117,56 +136,80 @@ def _transcript(tmp_path: Path, user_text: str, assistant_text: str | None = Non
     return p
 
 
-def _run(event: dict, home: Path):
-    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}  # redirect Path.home()
-    return subprocess.run(
-        [sys.executable, str(HOOK_SCRIPT)],
-        input=json.dumps(event), capture_output=True, text=True, env=env,
-    )
+# --- capture (Stop) gate --------------------------------------------------------
 
-
-def test_hook_fires_on_substantial_turn(tmp_path: Path) -> None:
+def test_capture_fires_on_substantial_turn(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
     t = _transcript(tmp_path, "q?", "We landed on a clear decision. " + "x" * 450)
-    r = _run({"transcript_path": str(t), "session_id": "s1"}, home)
+    r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "s1"}, home)
     assert '"decision": "block"' in r.stdout
 
 
-def test_hook_fires_language_agnostic_japanese(tmp_path: Path) -> None:
+def test_capture_fires_language_agnostic_japanese(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
-    jp = "これは重要な結論です。" * 40  # >400 chars, zero English keywords
+    jp = "これは重要な結論です。" * 40  # ~400 chars, zero English keywords
     t = _transcript(tmp_path, "質問", jp)
-    r = _run({"transcript_path": str(t), "session_id": "jp"}, home)
+    r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "jp"}, home)
     assert '"decision": "block"' in r.stdout
 
 
-def test_hook_silent_on_trivial_turn(tmp_path: Path) -> None:
+def test_capture_silent_on_trivial_turn(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
     t = _transcript(tmp_path, "q?", "Done.")
-    r = _run({"transcript_path": str(t), "session_id": "s2"}, home)
+    r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "s2"}, home)
     assert r.stdout.strip() == ""
 
 
-def test_hook_silent_when_already_saved(tmp_path: Path) -> None:
+def test_capture_silent_when_already_saved(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
     t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450,
                     assistant_tool="mcp__claude_ai_Knowledge_Base__note")
-    r = _run({"transcript_path": str(t), "session_id": "s3"}, home)
+    r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "s3"}, home)
     assert r.stdout.strip() == ""
 
 
-def test_hook_silent_when_stop_hook_active(tmp_path: Path) -> None:
+def test_capture_silent_when_stop_hook_active(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
     t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450)
-    r = _run({"transcript_path": str(t), "session_id": "s4", "stop_hook_active": True}, home)
+    r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "s4", "stop_hook_active": True}, home)
     assert r.stdout.strip() == ""
 
 
-def test_hook_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
+def test_capture_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
     t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450)
     ev = {"transcript_path": str(t), "session_id": "cd"}
-    first = _run(ev, home)
-    second = _run(ev, home)
+    first = _run(CAPTURE_SCRIPT, ev, home)
+    second = _run(CAPTURE_SCRIPT, ev, home)
     assert '"decision": "block"' in first.stdout
-    assert second.stdout.strip() == ""  # cooldown bounds cost
+    assert second.stdout.strip() == ""
+
+
+# --- retrieval (UserPromptSubmit) gate ------------------------------------------
+
+def test_retrieve_fires_on_substantial_prompt(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    r = _run(RETRIEVE_SCRIPT, {"prompt": "what did I conclude about the kb hook design earlier?", "session_id": "r1"}, home)
+    assert "additionalContext" in r.stdout
+
+
+def test_retrieve_fires_language_agnostic_japanese(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    jp = "去年このプロジェクトについて何を結論づけましたか？詳しく教えてください。"  # >20 chars, no English
+    r = _run(RETRIEVE_SCRIPT, {"prompt": jp, "session_id": "rjp"}, home)
+    assert "additionalContext" in r.stdout
+
+
+def test_retrieve_silent_on_short_prompt(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    r = _run(RETRIEVE_SCRIPT, {"prompt": "yes go", "session_id": "r2"}, home)
+    assert r.stdout.strip() == ""
+
+
+def test_retrieve_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    ev = {"prompt": "what did I conclude about the architecture decisions here?", "session_id": "rc"}
+    first = _run(RETRIEVE_SCRIPT, ev, home)
+    second = _run(RETRIEVE_SCRIPT, ev, home)
+    assert "additionalContext" in first.stdout
+    assert second.stdout.strip() == ""


### PR DESCRIPTION
## Why

#10 made **capture (write)** reliable with a `Stop` hook, but **retrieval (read)** was still passive skill prose — so Claude often didn't consult prior notes before answering. This adds the mirror so the KB is consulted on its own, completing the loop (KB as source of truth, both written to and read from automatically).

## What

- **`_hooks/kb_retrieve_nudge.py`** — a `UserPromptSubmit` hook that, on a substantial prompt, reminds Claude to run a `find` first and fold prior conclusions in. **Language-agnostic** (prompt-length gate + per-session cooldown, no keywords). Injects via `hookSpecificOutput.additionalContext`; it never runs the search itself (UserPromptSubmit blocks prompt start, so the hook must be fast — Claude does the real semantic find). Tunable via `KB_RETRIEVE_NUDGE_MIN_CHARS` / `_COOLDOWN_SEC` / `_DISABLE`.
- **`install-hook` now installs BOTH hooks** (Stop + UserPromptSubmit) and wires both events — idempotent, `--print-only` emits both. One command = full read+write loop.
- **CJK fairness:** lowered default `MIN_CHARS` (capture 400→300, retrieve 20) since dense scripts pack more meaning per character; documented in SETUP-FRIEND step 7 with a "lower it for Japanese/Chinese" note.

## Tests

`pytest`: **384 passed** (two-event installer + retrieval gate incl. Japanese firing and cooldown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)