### PR TITLE
feat: derive the generic skill scaffold from canonical (fix personal-data leak + drift)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ analysis/
 dist/
 build/
 *.egg-info/
+
+# Local-only genericize inputs for genericize-schema.py (real personal tokens).
+scripts/generic/leakguard.txt
+scripts/generic/substitutions.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Maintainer notes
+
+## The skill scaffold is generated — don't hand-edit it
+
+`src/kb_mcp/_scaffold/_Schema/` (the skill shipped to friends via `init` /
+`install-skill`) is a **derived, genericized copy** of the canonical skill that
+lives in the maintainer's Obsidian vault at `<vault>/Knowledge Base/_Schema/`. It
+is produced by `scripts/genericize-schema.py` — the sibling of
+`scripts/rebuild-schema-zip.*`, which derives the claude.ai `.skill` zip from the
+same canonical. One canonical, derive the rest.
+
+**Never edit `_scaffold/_Schema/` by hand.** Your change will be overwritten on
+the next regeneration, and hand-editing is how personal data once leaked into the
+shipped scaffold (a friend's clone contained the maintainer's machine paths and
+sensitive `Evidence/` examples).
+
+### To change the skill
+1. Edit the canonical in the vault (`<vault>/Knowledge Base/_Schema/`).
+2. Regenerate: `python scripts/genericize-schema.py --vault <vault-root>`
+   (or set `KB_MCP_VAULT_PATH`). `--check` does a dry run (guard only, no write).
+3. Commit the regenerated `_scaffold/_Schema/`.
+
+### How genericization works
+- **Block markers** in the canonical — `<!-- GENERIC-START … GENERIC-REPLACE --> … <!-- GENERIC-END -->`
+  (invisible in rendered Obsidian) for multi-line personal regions; the text
+  between START and REPLACE is what ships, the text after it is kept in the
+  canonical but dropped from the output. Empty replacement = omit the block.
+- **Substitutions** — `scripts/generic/substitutions.txt` (gitignored, `real => generic`
+  per line) for scattered personal tokens (e.g. a real tenant key).
+- `project-keys.yaml` is replaced wholesale by `scripts/generic/project-keys.yaml`.
+
+### Leak-guard
+The script aborts before writing if personal data would ship: a committed
+**pattern guard** (machine-path shapes etc., `LEAK_PATTERNS` in
+`genericize-schema.py`) plus an optional local denylist
+(`scripts/generic/leakguard.txt`, gitignored) and the left side of every
+substitution. `tests/test_scaffold_no_leak.py` runs the pattern guard against the
+committed scaffold (no vault needed), so the leak class can't regress in CI.

--- a/scripts/generic/project-keys.yaml
+++ b/scripts/generic/project-keys.yaml
@@ -1,0 +1,24 @@
+# Project keys for research-notes (`project:`) and cross-cutting notes
+# (`projects:` list on insights/failures/patterns/production-logs).
+#
+# Single source of truth. kb-mcp loads this at startup; adding a key here
+# makes it immediately accepted by `note`/`replace`/`audit`. New keys also
+# auto-register here the first time you use them, so you can just start
+# writing and let this grow.
+#
+# Format: `key: { folder: <Folder Name>, category: <bucket> }`. Category is
+# informational (umbrella / product / activity / domain / cross-cutting) — it
+# groups keys in `Notes/index.md` and isn't enforced by validation.
+#
+# These are starter examples — rename or replace them with your own.
+
+projects:
+  # Cross-cutting — anything not tied to a specific project or domain.
+  personal:
+    folder: Personal
+    category: cross-cutting
+
+  # Example domain (rename/delete; the writer adds new keys as you use them).
+  work:
+    folder: Work
+    category: domain

--- a/scripts/genericize-schema.py
+++ b/scripts/genericize-schema.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Generate the shipped generic skill scaffold from the vault canonical.
+
+`src/kb_mcp/_scaffold/_Schema/` is a DERIVED artifact — the genericized, shippable
+copy of the skill whose canonical source lives in the vault's `_Schema/`. This
+script is its build step, the sibling of `scripts/rebuild-schema-zip.*` (which
+derives the claude.ai zip from the same canonical). NEVER hand-edit the scaffold;
+edit the vault canonical and re-run this.
+
+Genericization, in order:
+1. Block markers — strip personal *regions* the author wants to keep in the
+   canonical but not ship. In the canonical:
+
+      <!-- GENERIC-START
+      <generic replacement lines — shipped in the generated output>
+      GENERIC-REPLACE -->
+      <real personal lines — kept in the canonical, dropped from output>
+      <!-- GENERIC-END -->
+
+   The replacement sits inside the opening comment, so it is invisible in Obsidian
+   while the real content renders normally. An empty replacement omits the block.
+2. Substitutions — swap scattered personal *tokens* (e.g. a real tenant key) for
+   generic ones, from scripts/generic/substitutions.txt (gitignored), one
+   `real => generic` per line. Keeps the real token in the canonical.
+3. project-keys.yaml — replaced wholesale by the generic template (scripts/generic/).
+
+Leak-guard (aborts before writing on any hit), two layers:
+- Committed pattern guard: machine-path shapes etc. — catches the common leak in
+  CI/tests without committing sensitive literals.
+- Optional local denylist (scripts/generic/leakguard.txt, gitignored) plus the
+  left-hand side of every substitution — exact personal tokens that must not
+  survive into the output.
+
+Usage: python scripts/genericize-schema.py [--vault <root>] [--check]
+  --vault   vault root containing "Knowledge Base/" (default: $KB_MCP_VAULT_PATH)
+  --check   dry run: run the guard, report, write nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCAFFOLD = REPO / "src" / "kb_mcp" / "_scaffold" / "_Schema"
+GENERIC_KEYS = REPO / "scripts" / "generic" / "project-keys.yaml"
+LOCAL_DENYLIST = REPO / "scripts" / "generic" / "leakguard.txt"
+LOCAL_SUBS = REPO / "scripts" / "generic" / "substitutions.txt"
+
+# Committed pattern guard — structural personal data that must never ship.
+# Patterns, NOT sensitive literals, so this file itself stays clean. Keep in sync
+# with tests/test_scaffold_no_leak.py (it imports this list).
+LEAK_PATTERNS = [
+    r"/mnt/[a-z]/",                                              # WSL drive mounts
+    r"[A-Za-z]:\\Users\\(?!<)",                                  # Windows user paths (real, not <placeholder>)
+    r"[A-Za-z]:\\[A-Za-z0-9 _-]+\\(?:Personal|Archive|Documents)",  # Windows abs paths
+    r"/Users/(?!<)[^/\s<]+/",                                    # macOS home (real, not <placeholder>)
+    r"/home/(?!<)[^/\s<]+/",                                     # Linux home (real, not <placeholder>)
+    r"~/\.claude/hooks/",                                        # author's hook wiring
+    r"\bQ_MNT_ALLOWLIST\b",                                      # author's allowlist env
+]
+
+
+def strip_markers(text: str) -> str:
+    """Replace each GENERIC-marked personal region with its generic replacement."""
+    out: list[str] = []
+    repl: list[str] = []
+    state = "normal"
+    for line in text.splitlines(keepends=True):
+        s = line.strip()
+        if state == "normal":
+            if s.startswith("<!-- GENERIC-START"):
+                state, repl = "repl", []
+            else:
+                out.append(line)
+        elif state == "repl":
+            if s.endswith("GENERIC-REPLACE -->"):
+                out.extend(repl)
+                state = "real"
+            else:
+                repl.append(line)
+        elif state == "real":
+            if s.startswith("<!-- GENERIC-END"):
+                state = "normal"
+            # else: drop the real personal line
+    if state != "normal":
+        raise SystemExit(f"genericize: unbalanced GENERIC markers (ended in state '{state}')")
+    return "".join(out)
+
+
+def load_subs() -> list[tuple[str, str]]:
+    if not LOCAL_SUBS.exists():
+        return []
+    subs = []
+    for ln in LOCAL_SUBS.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#") or "=>" not in ln:
+            continue
+        real, generic = ln.split("=>", 1)
+        subs.append((real.strip(), generic.strip()))
+    return subs
+
+
+def apply_subs(text: str, subs: list[tuple[str, str]]) -> str:
+    for real, generic in subs:
+        text = text.replace(real, generic)
+    return text
+
+
+def load_denylist() -> list[str]:
+    if not LOCAL_DENYLIST.exists():
+        return []
+    toks = []
+    for ln in LOCAL_DENYLIST.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if ln and not ln.startswith("#"):
+            toks.append(ln)
+    return toks
+
+
+def leak_scan(files: dict[str, str], denylist: list[str]) -> list[str]:
+    pats = [re.compile(p) for p in LEAK_PATTERNS]
+    hits: list[str] = []
+    for name, content in files.items():
+        for i, line in enumerate(content.splitlines(), 1):
+            for p in pats:
+                if p.search(line):
+                    hits.append(f"{name}:{i}: pattern /{p.pattern}/ -> {line.strip()[:80]}")
+            for tok in denylist:
+                if tok and tok in line:
+                    hits.append(f"{name}:{i}: token '{tok}' -> {line.strip()[:80]}")
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="genericize-schema")
+    ap.add_argument("--vault", help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)")
+    ap.add_argument("--check", action="store_true", help="dry run: guard only, write nothing")
+    args = ap.parse_args()
+
+    vault = args.vault or os.environ.get("KB_MCP_VAULT_PATH")
+    if not vault:
+        print("genericize: set --vault or KB_MCP_VAULT_PATH (vault root containing 'Knowledge Base/').", file=sys.stderr)
+        return 2
+    canon = Path(vault).expanduser() / "Knowledge Base" / "_Schema"
+    if not (canon / "SKILL.md").exists():
+        print(f"genericize: {canon / 'SKILL.md'} not found.", file=sys.stderr)
+        return 2
+    if not GENERIC_KEYS.exists():
+        print(f"genericize: missing generic template {GENERIC_KEYS}.", file=sys.stderr)
+        return 2
+
+    subs = load_subs()
+
+    def generic(text: str) -> str:
+        return apply_subs(strip_markers(text), subs)
+
+    outputs: dict[str, str] = {"SKILL.md": generic((canon / "SKILL.md").read_text(encoding="utf-8"))}
+    for ref in sorted((canon / "references").glob("*.md")):
+        outputs[f"references/{ref.name}"] = generic(ref.read_text(encoding="utf-8"))
+    outputs["project-keys.yaml"] = GENERIC_KEYS.read_text(encoding="utf-8")
+
+    # Leak-guard BEFORE writing. Denylist = explicit tokens + every substitution's
+    # real side (so an un-substituted variant can't slip through).
+    denylist = load_denylist() + [real for real, _ in subs]
+    hits = leak_scan(outputs, denylist)
+    if hits:
+        print("genericize: LEAK-GUARD FAILED — personal data would ship:", file=sys.stderr)
+        for h in hits:
+            print(f"  {h}", file=sys.stderr)
+        print("Fix: wrap in <!-- GENERIC-START ... --> markers in the canonical, add a "
+              "substitution to scripts/generic/substitutions.txt, or genericize in place.", file=sys.stderr)
+        return 1
+
+    if args.check:
+        print(f"genericize --check: leak-guard passed; {len(outputs)} files ready (nothing written).")
+        return 0
+
+    # Write the scaffold as a clean mirror of the canonical structure.
+    shutil.rmtree(SCAFFOLD / "references", ignore_errors=True)
+    for name, content in outputs.items():
+        dest = SCAFFOLD / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+    print(f"genericize: wrote {len(outputs)} files to {SCAFFOLD} (leak-guard passed).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -73,14 +73,10 @@ Not a stepping-stone: mid-thought exploration, brainstorm tangents, unresolved q
 │   └── Decisions/
 └── Evidence/
     └── <scope>/                  Per-incident binary/document/factual preservation
-                                  (e.g., Evidence/Yolo/, Evidence/Mother Cancer/)
+                                  (e.g., Evidence/Legal/, Evidence/Medical/)
 ```
 
-`<vault>` resolves to the Obsidian vault root. Path differs by machine. From WSL (where Claude Code runs), use these forms:
-- Desktop: `/path/to/your/vault` (Windows `<your-vault>`)
-- Laptop: `/path/to/your/vault` (Windows `<your-vault>`)
-
-Both paths are enrolled in `Q_MNT_ALLOWLIST` in `~/.claude/hooks/user-bash-guard.sh` (yadm-tracked). If the relevant path doesn't resolve on the current machine, you're on the other one — try the alternate. Verify allowed filesystem paths before writing.
+`<vault>` resolves to your Obsidian vault root — the folder that contains `Knowledge Base/`, set via `KB_MCP_VAULT_PATH`. Verify allowed filesystem paths before writing.
 
 ## Loading the tools
 
@@ -281,6 +277,8 @@ The KB serves two complementary purposes:
 
 Both are first-class. When orienting a new project area, descriptive hubs typically come first; patterns and insights extract from the descriptive substrate as second-order knowledge.
 
+**Boundary with the repo (code projects).** For a software project the repository is the source of truth for code, design, and decisions — especially one with governance (OpenSpec, CLAUDE.md/AGENTS.md, ADRs, `design.md`). KB coverage of it is the cross-session/cross-project layer the repo can't hold — strategy, roadmap, orientation, hard-won empirical findings — **never** a condensed changelog or a restatement of what specs/conventions/commits already capture. Litmus test before writing: if the content belongs in a spec, an ADR, a commit message, or CLAUDE.md, write it *there*; and if that home doesn't exist yet, the fix is usually to create it in the repo, not to let the KB become a shadow spec.
+
 Descriptive hubs naturally drift — the system evolves; the hub becomes stale. Acceptable for snapshots (refresh when the question warrants it); for architecture hubs, refresh on major capability ships.
 
 ## Write discipline
@@ -368,18 +366,9 @@ If you find yourself wanting a scope that isn't on this list, the writer auto-re
 
 **Auto-registration of new project keys.** The `note`, `replace`, `edit` (frontmatter-patch mode), and `link` (for decision entities) writers auto-append unknown slug-shaped project keys to `_Schema/project-keys.yaml` and create the matching `Notes/Research/<Folder>/` directory on first use — no manual YAML edit needed. The registration surfaces as a warning in the write response (`"Auto-registered project key 'X' (folder: 'Y')"`). Pass `project_category` on the call to land the new key under the right bucket (umbrella / product / activity / domain / situation / cross-cutting); when omitted, the key lands as `uncategorized` and Hugo can hand-edit later. A **typo guard** rejects new keys within Levenshtein distance ≤2 of any existing registered key — `helath` raises `PROJECT_KEY_TYPO` with `"Did you mean 'health'?"` so the agent can self-correct instead of polluting the registry with typos.
 
-### Q tenants
+### Tenants (multi-tenant projects)
 
-Q is a multi-tenant platform. When research is about a specific Q tenant, set `project: q` and add `tenant: <key>`. Current tenants:
-
-- `example-tenant` — an example client's knowledge platform
-- `tu` — Together, Unprocessed (the TU podcast also runs on Q)
-
-**Disambiguating `tu`:** the same key `tu` is used both as a top-level project (when research is about the podcast as content/activity — episodes, guests, audience, narrative) and as a Q tenant key (when research is about TU's deployment on the Q platform — infrastructure, configuration, integrations). Disambiguate by the `project` field:
-- `project: tu` → about the podcast as activity
-- `project: q, tenant: tu` → about TU as a Q tenant deployment
-
-If a tenant isn't on this list, surface it before assuming.
+If a project is a multi-tenant platform, set `project: <key>` and add `tenant: <tenant-key>` to scope research to one tenant. Surface an unknown tenant before assuming.
 
 ### Experiment vs production-log
 

--- a/src/kb_mcp/_scaffold/_Schema/references/write-scope.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/write-scope.md
@@ -27,10 +27,9 @@ Is the artifact something you reason from (input to your thinking)?
 
 **Worked examples:**
 
-- A PDF you found about EGCG dosing that informs the cancer experiment → `Sources/Articles/_attachments/` with a markdown capture in `Sources/Articles/`. You reason from it.
-- The clinical protocol document you authored and shared with the oncology team → `Notes/Experiments/Health/_attachments/`. Your experiment produced it.
-- The Estonian consilium document received from the medical board → `Evidence/Mother Cancer/01 - Clinical Documentation/`. Third party, preserve as-received.
-- A formal warning letter from your employer → `Evidence/Yolo/01 - Warning Letter .../`. Third party, preserve as-received.
+- An article or PDF you found that informs a project → `Sources/Articles/_attachments/` with a markdown capture in `Sources/Articles/`. You reason from it.
+- A protocol or document you authored and shared with a collaborator → `Notes/<...>/_attachments/`. Your work produced it.
+- An official document received from a third party (a board, an agency, an employer) → `Evidence/<scope>/`. Third party, preserve as-received.
 - A Sources/Sessions transcript of a Claude conversation → not a binary case; lives as markdown in `Sources/Sessions/` directly.
 
 **Why this matters:** mixing layers dilutes their epistemic discipline. Evidence binaries reasoned over become "sources we lightly analysed," losing the as-received guarantee. Source binaries treated as outputs lose the audit trail of what you read. Note outputs dropped in Evidence pretend to come from outside when they came from you. Keep the layers honest and the categories stay useful.

--- a/tests/test_scaffold_no_leak.py
+++ b/tests/test_scaffold_no_leak.py
@@ -1,0 +1,47 @@
+"""Regression backstop: the shipped generic scaffold must not contain personal data.
+
+`src/kb_mcp/_scaffold/_Schema/` is a derived artifact (built by
+scripts/genericize-schema.py from the vault canonical). This test scans the
+COMMITTED scaffold for the same machine-path/personal patterns the genericize
+script guards against — so the leak class (which once shipped `Evidence/Mother
+Cancer/` and the author's machine paths to a friend) can't recur on a hand-edit.
+Runs without the vault, so it works in CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import kb_mcp
+
+SCAFFOLD = Path(kb_mcp.__file__).resolve().parent / "_scaffold" / "_Schema"
+REPO = Path(kb_mcp.__file__).resolve().parent.parent.parent  # src/kb_mcp -> repo root
+
+
+def _leak_patterns() -> list[str]:
+    """Import the pattern list from the (hyphenated) genericize script by path,
+    so the test and the generator never drift."""
+    spec = importlib.util.spec_from_file_location(
+        "genericize_schema", REPO / "scripts" / "genericize-schema.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.LEAK_PATTERNS
+
+
+def test_scaffold_ships_no_personal_data() -> None:
+    patterns = [re.compile(p) for p in _leak_patterns()]
+    offenders: list[str] = []
+    for f in sorted(SCAFFOLD.rglob("*")):
+        if not f.is_file():
+            continue
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for p in patterns:
+                if p.search(line):
+                    offenders.append(f"{f.relative_to(SCAFFOLD)}:{i}: /{p.pattern}/ -> {line.strip()[:80]}")
+    assert not offenders, (
+        "personal-data patterns found in the shipped scaffold (regenerate via "
+        "scripts/genericize-schema.py; never hand-edit _scaffold/_Schema):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Why

`src/kb_mcp/_scaffold/_Schema/` (the skill shipped to friends via `init`/`install-skill`) was a **hand-synced** generic copy of the vault canonical. Hand-sync failed two ways:

1. **It leaked real personal data into friends' clones** — machine paths, `Q_MNT_ALLOWLIST`, and sensitive `Evidence/` examples (clinical documentation, an employer warning). The hand-genericization caught some spots and missed others.
2. **Bidirectional drift** — vault improvements (e.g. the "Boundary with the repo" paragraph) never reached the scaffold; today's video fix had to be applied twice.

Fix: make the scaffold a **derived artifact**, the sibling of `scripts/rebuild-schema-zip.*` (which already derives the claude.ai zip from the same canonical). One canonical, derive the rest.

## What

- **`scripts/genericize-schema.py`** — builds `_scaffold/_Schema/` from the vault canonical (`--vault` / `$KB_MCP_VAULT_PATH`, `--check` dry-run). Pure stdlib, cross-platform.
  - **Block markers** in the canonical (`<!-- GENERIC-START … GENERIC-REPLACE --> … <!-- GENERIC-END -->`, invisible in Obsidian) strip multi-line personal regions.
  - **Substitutions** (`scripts/generic/substitutions.txt`, gitignored) swap scattered tokens (e.g. a real tenant key).
  - `project-keys.yaml` replaced by `scripts/generic/project-keys.yaml`.
  - **Leak-guard** aborts before writing: committed machine-path patterns (Windows/WSL + macOS/Linux) + a local denylist + every substitution's real side.
- **Regenerated scaffold** — personal data removed (`SKILL.md`, `references/write-scope.md`); the drifted improvement propagated. Idempotent.
- **`tests/test_scaffold_no_leak.py`** — runs the pattern guard over the committed scaffold (no vault, CI-safe) so the leak class can't regress.
- **`CONTRIBUTING.md`** — "the scaffold is generated, don't hand-edit; edit the canonical and run the script."

Maintainer-local inputs (GENERIC markers in the vault, `substitutions.txt`, `leakguard.txt`) live outside this repo / gitignored — no real tokens committed.

## Cross-platform
Everything friends install/run is OS-agnostic (stdlib Python, `sys.executable`, `Path.home()`, native symlinks). The genericize maintainer tool is pure Python too; the leak-guard now covers Windows/WSL **and** macOS/Linux home-path shapes.

## Tests
`pytest`: **385 passed** (incl. the new scaffold leak-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)