### PR TITLE
feat: build claude.ai zip via cross-platform Python that strips GENERIC markers

### DIFF
--- a/scripts/rebuild-schema-zip.ps1
+++ b/scripts/rebuild-schema-zip.ps1
@@ -1,58 +1,18 @@
 #requires -Version 5.1
 <#
 .SYNOPSIS
-  Rebuild the Knowledge Base/_Schema.zip bundle from the canonical _Schema folder.
-
+  Thin wrapper -> the cross-platform Python builder, scripts/rebuild-schema-zip.py.
 .DESCRIPTION
-  Repacks _Schema/ into _Schema.zip so it can be re-uploaded as a skill to
-  claude.ai whenever SKILL.md / references / project-keys.yaml change.
-
-  Resolves the vault from $env:KB_MCP_VAULT_PATH (the vault root that contains
-  Knowledge Base/).
-
+  Rebuilds Knowledge Base/_Schema.zip (the claude.ai `.skill`) from the canonical,
+  stripping the canonical's GENERIC markers (keeping your real content) so the zip
+  carries no marker comments. Resolves the vault from --vault or
+  $env:KB_MCP_VAULT_PATH. Requires Python (no Compress-Archive needed anymore).
 .EXAMPLE
   pwsh -File scripts/rebuild-schema-zip.ps1
 #>
-
 [CmdletBinding()]
-param()
+param([Parameter(ValueFromRemainingArguments = $true)] $Args)
 
 $ErrorActionPreference = 'Stop'
-
-function Resolve-Vault {
-  if (-not $env:KB_MCP_VAULT_PATH) {
-    throw 'KB_MCP_VAULT_PATH is not set. Point it at your vault root (the folder that contains Knowledge Base/).'
-  }
-  $p = $env:KB_MCP_VAULT_PATH
-  if (Test-Path (Join-Path $p 'Knowledge Base/_Schema/SKILL.md')) { return $p }
-  throw "KB_MCP_VAULT_PATH=$p does not contain Knowledge Base/_Schema/SKILL.md"
-}
-
-$vault     = Resolve-Vault
-$kb        = Join-Path $vault 'Knowledge Base'
-$schemaDir = Join-Path $kb '_Schema'
-$zipPath   = Join-Path $kb '_Schema.zip'
-
-Write-Host "vault:      $vault"
-Write-Host "schema dir: $schemaDir"
-Write-Host "zip target: $zipPath"
-
-# Read the canonical version straight out of SKILL.md frontmatter so the
-# operator sees what's about to ship.
-$skillHead = (Get-Content (Join-Path $schemaDir 'SKILL.md') -TotalCount 8) -join "`n"
-if ($skillHead -match '(?m)^\s*version:\s*([0-9]+\.[0-9]+\.[0-9]+)') {
-  Write-Host "version:    $($matches[1])"
-} else {
-  Write-Warning 'Could not parse version from SKILL.md frontmatter.'
-}
-
-if (Test-Path $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
-
-# Compress-Archive on a folder packages the FOLDER as the top-level entry.
-# To match claude.ai's expectation (SKILL.md at zip root, not under _Schema/),
-# pass the folder's children instead.
-$items = Get-ChildItem -LiteralPath $schemaDir -Force
-Compress-Archive -LiteralPath $items.FullName -DestinationPath $zipPath -CompressionLevel Optimal
-
-$size = (Get-Item -LiteralPath $zipPath).Length
-Write-Host "wrote $zipPath ($([math]::Round($size/1KB,1)) KB)"
+& python "$PSScriptRoot/rebuild-schema-zip.py" @Args
+exit $LASTEXITCODE

--- a/scripts/rebuild-schema-zip.py
+++ b/scripts/rebuild-schema-zip.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Rebuild Knowledge Base/_Schema.zip (the claude.ai `.skill`) from the canonical.
+
+This is the **personal** derivation of the canonical skill (the maintainer's real
+content), for upload to claude.ai — the sibling of scripts/genericize-schema.py
+(which derives the *generic* repo scaffold from the same canonical). Both strip the
+GENERIC markers; this one keeps the REAL side, the genericize script keeps the
+generic side.
+
+So the canonical `_Schema/` stays the single editable source — its inline
+`<!-- GENERIC-START ... GENERIC-REPLACE --> <real> <!-- GENERIC-END -->` regions
+let one file serve both the personal zip (real content, markers removed) and the
+generic scaffold (generic content) without hand-maintaining either.
+
+Cross-platform (pure stdlib; no `zip` CLI / Compress-Archive). SKILL.md lands at the
+archive root, mirroring the on-disk skill layout claude.ai expects.
+
+Usage: python scripts/rebuild-schema-zip.py [--vault <root>]
+  --vault   vault root containing "Knowledge Base/" (default: $KB_MCP_VAULT_PATH)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+
+def strip_markers_keep_real(text: str) -> str:
+    """Drop GENERIC marker scaffolding + the generic replacement, KEEP the real
+    content (the inverse of genericize-schema.strip_markers, which keeps generic)."""
+    out: list[str] = []
+    state = "normal"
+    for line in text.splitlines(keepends=True):
+        s = line.strip()
+        if state == "normal":
+            if s.startswith("<!-- GENERIC-START"):
+                state = "repl"
+            elif s.startswith("<!-- GENERIC-END"):
+                pass  # stray end — drop
+            else:
+                out.append(line)
+        elif state == "repl":
+            if s.endswith("GENERIC-REPLACE -->"):
+                state = "real"
+            # else: drop the generic replacement line
+        elif state == "real":
+            if s.startswith("<!-- GENERIC-END"):
+                state = "normal"
+            else:
+                out.append(line)  # keep the real personal content
+    if state != "normal":
+        raise SystemExit(f"rebuild-schema-zip: unbalanced GENERIC markers (ended in state '{state}')")
+    return "".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="rebuild-schema-zip")
+    ap.add_argument("--vault", help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)")
+    args = ap.parse_args()
+
+    vault = args.vault or os.environ.get("KB_MCP_VAULT_PATH")
+    if not vault:
+        print("rebuild-schema-zip: set --vault or KB_MCP_VAULT_PATH (vault root containing 'Knowledge Base/').", file=sys.stderr)
+        return 2
+    kb = Path(vault).expanduser() / "Knowledge Base"
+    canon = kb / "_Schema"
+    zip_path = kb / "_Schema.zip"
+    if not (canon / "SKILL.md").exists():
+        print(f"rebuild-schema-zip: {canon / 'SKILL.md'} not found.", file=sys.stderr)
+        return 2
+
+    # Build the personal rendering (markers stripped, real content kept).
+    files: dict[str, str] = {"SKILL.md": strip_markers_keep_real((canon / "SKILL.md").read_text(encoding="utf-8"))}
+    for ref in sorted((canon / "references").glob("*.md")):
+        files[f"references/{ref.name}"] = strip_markers_keep_real(ref.read_text(encoding="utf-8"))
+    keys = canon / "project-keys.yaml"
+    if keys.exists():
+        files["project-keys.yaml"] = keys.read_text(encoding="utf-8")  # real keys, verbatim
+
+    version = ""
+    m = re.search(r"(?m)^\s*version:\s*([0-9]+\.[0-9]+\.[0-9]+)", files["SKILL.md"])
+    if m:
+        version = m.group(1)
+
+    print(f"vault:      {vault}")
+    print(f"schema dir: {canon}")
+    print(f"zip target: {zip_path}")
+    print(f"version:    {version}" if version else "warning: could not parse version from SKILL.md frontmatter.")
+
+    if zip_path.exists():
+        zip_path.unlink()
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+        for arcname, content in files.items():
+            z.writestr(arcname, content)
+
+    size_kb = zip_path.stat().st_size // 1024
+    print(f"wrote {zip_path} ({size_kb} KB, {len(files)} files; GENERIC markers stripped).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rebuild-schema-zip.sh
+++ b/scripts/rebuild-schema-zip.sh
@@ -1,41 +1,11 @@
 #!/usr/bin/env bash
-# Rebuild Knowledge Base/_Schema.zip from the canonical _Schema/ folder, so it can
-# be re-uploaded as a skill to claude.ai when SKILL.md / references /
-# project-keys.yaml change. Cross-platform counterpart to
-# scripts/rebuild-schema-zip.ps1 (Windows).
-#
-# Resolves the vault from $KB_MCP_VAULT_PATH (the vault root that contains
-# Knowledge Base/). Requires the `zip` CLI.
-#
-# Usage: KB_MCP_VAULT_PATH=/path/to/Obsidian bash scripts/rebuild-schema-zip.sh
-
+# Thin wrapper -> the cross-platform Python builder, scripts/rebuild-schema-zip.py.
+# It strips the canonical's GENERIC markers (keeping your real content) so the
+# claude.ai zip carries no marker comments. Resolves the vault from --vault or
+# $KB_MCP_VAULT_PATH. Requires Python (no `zip` CLI needed anymore).
 set -euo pipefail
-
-if [[ -z "${KB_MCP_VAULT_PATH:-}" ]]; then
-    echo "KB_MCP_VAULT_PATH is not set. Point it at your vault root (the folder that contains Knowledge Base/)." >&2
-    exit 1
+here="$(cd "$(dirname "$0")" && pwd)"
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$here/rebuild-schema-zip.py" "$@"
 fi
-
-VAULT="$KB_MCP_VAULT_PATH"
-SCHEMA_DIR="$VAULT/Knowledge Base/_Schema"
-ZIP_PATH="$VAULT/Knowledge Base/_Schema.zip"
-
-[[ -f "$SCHEMA_DIR/SKILL.md" ]] || { echo "KB_MCP_VAULT_PATH=$VAULT does not contain Knowledge Base/_Schema/SKILL.md" >&2; exit 1; }
-command -v zip >/dev/null 2>&1 || { echo "the 'zip' CLI is required (macOS ships it; Linux: apt install zip)." >&2; exit 1; }
-
-echo "vault:      $VAULT"
-echo "schema dir: $SCHEMA_DIR"
-echo "zip target: $ZIP_PATH"
-
-# Surface the version from SKILL.md frontmatter so the operator sees what ships.
-version="$(sed -n 's/^[[:space:]]*version:[[:space:]]*\([0-9.]*\).*/\1/p' "$SCHEMA_DIR/SKILL.md" | head -n1)"
-if [[ -n "$version" ]]; then echo "version:    $version"; else echo "warning: could not parse version from SKILL.md frontmatter." >&2; fi
-
-rm -f "$ZIP_PATH"
-
-# zip from inside _Schema/ so SKILL.md lands at the archive root (claude.ai expects
-# SKILL.md at the top level, not nested under _Schema/). -r recurse, -X drop extras.
-( cd "$SCHEMA_DIR" && zip -r -X "$ZIP_PATH" . -x '.DS_Store' )
-
-size_kb=$(( $(wc -c < "$ZIP_PATH") / 1024 ))
-echo "wrote $ZIP_PATH (${size_kb} KB)"
+exec python "$here/rebuild-schema-zip.py" "$@"

--- a/tests/test_schema_markers.py
+++ b/tests/test_schema_markers.py
@@ -1,0 +1,62 @@
+"""The GENERIC marker logic feeds both schema derivations, in opposite directions:
+genericize-schema.py keeps the generic replacement (repo scaffold); rebuild-schema-zip.py
+keeps the real content (claude.ai zip). Both must drop the marker scaffolding.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import kb_mcp
+
+REPO = Path(kb_mcp.__file__).resolve().parent.parent.parent  # src/kb_mcp -> repo root
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO / "scripts" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE = (
+    "before\n"
+    "<!-- GENERIC-START\n"
+    "GENERIC LINE\n"
+    "GENERIC-REPLACE -->\n"
+    "REAL LINE ONE\n"
+    "REAL LINE TWO\n"
+    "<!-- GENERIC-END -->\n"
+    "after\n"
+)
+
+
+def test_generic_side_keeps_replacement_drops_real() -> None:
+    gen = _load("genericize_schema", "genericize-schema.py")
+    out = gen.strip_markers(SAMPLE)
+    assert out == "before\nGENERIC LINE\nafter\n"
+    assert "REAL LINE" not in out
+    assert "GENERIC-START" not in out
+
+
+def test_personal_side_keeps_real_drops_replacement() -> None:
+    zip_mod = _load("rebuild_schema_zip", "rebuild-schema-zip.py")
+    out = zip_mod.strip_markers_keep_real(SAMPLE)
+    assert out == "before\nREAL LINE ONE\nREAL LINE TWO\nafter\n"
+    assert "GENERIC LINE" not in out
+    assert "GENERIC-START" not in out
+
+
+def test_empty_replacement_omits_block_generic() -> None:
+    gen = _load("genericize_schema", "genericize-schema.py")
+    text = "a\n<!-- GENERIC-START\nGENERIC-REPLACE -->\nsecret\n<!-- GENERIC-END -->\nb\n"
+    assert gen.strip_markers(text) == "a\nb\n"
+
+
+def test_unbalanced_markers_raise() -> None:
+    import pytest
+
+    zip_mod = _load("rebuild_schema_zip", "rebuild-schema-zip.py")
+    with pytest.raises(SystemExit):
+        zip_mod.strip_markers_keep_real("x\n<!-- GENERIC-START\nonly start\n")


### PR DESCRIPTION
## Why

The genericize work (#12) added `<!-- GENERIC ... -->` marker regions to the canonical `_Schema/`. The claude.ai zip is the **personal** derivation (your real content, for upload), so its build must strip the markers keeping the *real* side — the inverse of `genericize-schema.py`. Otherwise the uploaded skill carries inert-but-noisy marker comments.

## What

- **`scripts/rebuild-schema-zip.py`** — pure-stdlib, cross-platform zip builder. Renders the canonical keeping real content (`strip_markers_keep_real`), drops the marker scaffolding + generic replacements, zips with `SKILL.md` at the archive root. Resolves the vault from `--vault`/`$KB_MCP_VAULT_PATH`. No `zip` CLI / `Compress-Archive` dependency.
- **`rebuild-schema-zip.sh` / `.ps1`** — now thin wrappers delegating to the `.py`; the same invocation still works.
- **`tests/test_schema_markers.py`** — both marker directions (generic keeps replacement, personal keeps real), empty-replacement omit, unbalanced-marker guard.

Verified against the real vault: rebuilt `_Schema.zip` has SKILL.md at root, **no `GENERIC-*` markers**, and keeps the real content (machine paths, sensitive examples) — exactly what claude.ai should get.

## Tests
`pytest`: **389 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)