### PR TITLE
docs: CLAUDE.md skill-deploy discipline (bump version on skill change)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# kb-mcp — instructions for Claude
+
+## Editing the skill — BUMP THE VERSION (this keeps getting missed)
+
+The knowledge-base skill's canonical source is the **vault** `_Schema/`
+(`$KB_MCP_VAULT_PATH/Knowledge Base/_Schema/`), **not** the repo. The repo's
+`src/kb_mcp/_scaffold/_Schema/` (generic, for friends) and the claude.ai
+`_Schema.zip` (personal) are **derived** from it.
+
+Whenever you change skill content (SKILL.md or any `references/*.md`), in the SAME change:
+
+1. **Bump `version:` in the canonical SKILL.md frontmatter** (semver). A content
+   edit without a version bump is a bug — do not skip it.
+2. **Re-derive both surfaces:**
+   - `python scripts/genericize-schema.py --vault <root>` → regenerates the repo
+     scaffold (generic, leak-guarded). Commit the result.
+   - `python scripts/rebuild-schema-zip.py --vault <root>` → rebuilds the vault
+     `_Schema.zip` (real content, markers stripped). Hugo re-uploads it to claude.ai.
+3. **Never hand-edit `src/kb_mcp/_scaffold/_Schema/`** — it's generated (see CONTRIBUTING.md).
+
+## Connector triage ("MCP not working" / forced reconnect)
+
+claude.ai connector problems are almost always **connection-side, not the service**.
+A healthy service returns a fast `401` at the funnel. The most common cause is the
+**Tailscale Funnel relay throttling the connector's request burst** — the connector
+looks disconnected but the kb-mcp service is RUNNING and fine. **Diagnose from the
+access log before touching the server** (look for the claude.ai gateway IPs); don't
+restart the service reflexively. Full triage table: KB note "kb-mcp connector triage
+— read the access log before blaming the server".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,13 @@ sensitive `Evidence/` examples).
 
 ### To change the skill
 1. Edit the canonical in the vault (`<vault>/Knowledge Base/_Schema/`).
-2. Regenerate: `python scripts/genericize-schema.py --vault <vault-root>`
-   (or set `KB_MCP_VAULT_PATH`). `--check` does a dry run (guard only, no write).
-3. Commit the regenerated `_scaffold/_Schema/`.
+2. **Bump `version:` in SKILL.md frontmatter** (semver). A content change without a
+   version bump is a bug — do it in the same change.
+3. Regenerate the repo scaffold: `python scripts/genericize-schema.py --vault <vault-root>`
+   (or set `KB_MCP_VAULT_PATH`; `--check` dry-runs the guard). Commit the regenerated
+   `_scaffold/_Schema/`.
+4. Rebuild the claude.ai zip: `python scripts/rebuild-schema-zip.py --vault <vault-root>`,
+   then re-upload `<vault>/Knowledge Base/_Schema.zip` to claude.ai.
 
 ### How genericization works
 - **Block markers** in the canonical — `<!-- GENERIC-START … GENERIC-REPLACE --> … <!-- GENERIC-END -->`


### PR DESCRIPTION
Adds repo CLAUDE.md so the bump-version-on-skill-change rule is loaded every kb-mcp session (it kept getting missed), plus connector-triage guidance (funnel throttle vs service). Extends CONTRIBUTING's checklist with version-bump + zip-rebuild.