### PR TITLE
docs: Claude-app custom-instruction snippet to make the KB proactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,9 +660,11 @@ the client decides what to wire in.
   related pages you didn't cite). Best-effort, computed pre-write, fully guarded —
   a suggestion failure can never roll back the write.
 - **Near-duplicate warnings**: `note`/`add` surface a `warnings` entry like
-  `possible near-duplicate of [[X]] (cosine 0.91)` when a draft closely matches an
-  existing page (doc-doc cosine over the sidecar). A warning, never a block —
-  append-only + supersession invariants mean the client chooses edit/replace/append.
+  `possible near-duplicate of [[X]] (cosine 0.91)` when a draft's best doc-doc
+  cosine against an existing page meets the threshold (default `0.90`). A warning,
+  never a block — append-only + supersession invariants mean the client chooses
+  edit/replace/append. Tune the noise with **`KB_MCP_DUP_THRESHOLD`** (lower = more
+  warnings, e.g. `0.86`; higher = stricter, e.g. `0.93`).
 
 All of it no-ops under `KB_MCP_DISABLE_EMBEDDINGS`, so the fast test suite and
 the write path's existing behaviour are unchanged when embeddings are off.

--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -234,3 +234,21 @@ The main [README](README.md) documents this path end-to-end (it's Hugo's exact
 setup). Rule of thumb: the **local path is ~90% of the value for ~20% of the
 effort**; the mobile tier is the rest — worth it if you genuinely want your KB
 in your pocket.
+
+### Make the KB proactive in the Claude app (custom instructions)
+
+claude.ai (web/mobile) can't run hooks — those are Claude Code only — so the
+skill's proactive find/capture is best-effort there. To nudge it reliably across
+*all* your chats, paste this into the Claude app at **Settings → Profile → "What
+personal preferences should Claude consider in responses?"**:
+
+```
+Precise and non-performative: no hype, fluff, or motivational tone; clarity and correctness over filler. Use lists/structure only when they genuinely help; plain prose is fine. Match length to the substance, terse when simple and fuller when it's not.
+
+I keep a personal Knowledge Base, connected as the "Knowledge Base" connector (kb-mcp). Use it proactively: search it first when a turn touches my projects, notes, decisions, or domains (cite what you find; an empty search means a gap, not a dead end). Capture durable conclusions on your own (a decision, solved problem, diagnosed failure, or recognized pattern) as a short compiled note, not a transcript, whether or not the topic exists yet, then report one line: "Saved -> <path>". Ask before saving only if type/scope is genuinely ambiguous. Stay quiet on chit-chat and don't narrate empty searches.
+```
+
+The first paragraph is general response style (trim to taste); the second is the KB
+nudge. Account-level custom instructions are always in context, so they make Claude
+reach for the connected KB on its own — the app-side equivalent of the Claude Code
+hooks. The "stay quiet on chit-chat" line keeps it from firing on unrelated chats.

--- a/src/kb_mcp/corpus_aware.py
+++ b/src/kb_mcp/corpus_aware.py
@@ -33,11 +33,28 @@ log = logging.getLogger(__name__)
 # eval harness (scripts/eval_retrieval.py) once a golden set exists. Kept here
 # as named constants so they're one-line greppable.
 HUB_WEIGHT = 0.15  # weight on log1p(graph_in_degree) when re-ranking suggestions
-DUP_THRESHOLD = 0.86  # min doc-doc cosine to call something a near-duplicate
+DUP_THRESHOLD = 0.90  # default min doc-doc cosine for a near-dup; override via KB_MCP_DUP_THRESHOLD
 RELATED_OVERFETCH = 3  # fetch limit * this from find(), then re-rank + trim
 
 # Lead-body word budget for the synthesized "what is this about" query.
 _QUERY_LEAD_WORDS = 400
+
+
+def _dup_threshold() -> float:
+    """DUP_THRESHOLD, overridable at runtime via KB_MCP_DUP_THRESHOLD.
+
+    Lower = more near-dup warnings (0.86 was the old, looser default); higher =
+    stricter (e.g. 0.93). Resolved per call so the env is read live, not frozen
+    at import. Bad values fall back to the default with a logged warning.
+    """
+    raw = os.environ.get("KB_MCP_DUP_THRESHOLD")
+    if raw is None:
+        return DUP_THRESHOLD
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("invalid KB_MCP_DUP_THRESHOLD=%r; using %s", raw, DUP_THRESHOLD)
+        return DUP_THRESHOLD
 
 
 @dataclass
@@ -162,20 +179,23 @@ def detect_duplicates(
     body: str,
     self_path: str | None = None,
     types_filter: list[str] | None = None,
-    threshold: float = DUP_THRESHOLD,
+    threshold: float | None = None,
     top_n: int = 3,
 ) -> list[DupCandidate]:
     """Flag existing pages whose content is near-identical to a draft.
 
     Embeds the draft as PASSAGES (is_query=False — this is doc-to-doc, not a
     query) and cosine-matches against the existing sidecar. Returns at most
-    `top_n` candidates at/above `threshold`, optionally restricted to
+    `top_n` candidates at/above `threshold` (default resolved from
+    `KB_MCP_DUP_THRESHOLD`, else `DUP_THRESHOLD`), optionally restricted to
     `types_filter` page types. No-ops (returns []) when embeddings are disabled
     or the sidecar is empty, so the fast test suite and torch-less deploys are
     unaffected.
     """
     if os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
         return []
+    if threshold is None:
+        threshold = _dup_threshold()
     try:
         from . import embeddings, find as find_module
 

--- a/tests/test_corpus_aware.py
+++ b/tests/test_corpus_aware.py
@@ -80,6 +80,21 @@ def test_detect_duplicates_noop_when_embeddings_disabled(vault: Path) -> None:
     ) == []
 
 
+def test_dup_threshold_defaults_when_env_unset(monkeypatch) -> None:
+    monkeypatch.delenv("KB_MCP_DUP_THRESHOLD", raising=False)
+    assert corpus_aware._dup_threshold() == corpus_aware.DUP_THRESHOLD
+
+
+def test_dup_threshold_honors_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "0.93")
+    assert corpus_aware._dup_threshold() == 0.93
+
+
+def test_dup_threshold_falls_back_on_garbage(monkeypatch) -> None:
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "loose")
+    assert corpus_aware._dup_threshold() == corpus_aware.DUP_THRESHOLD
+
+
 # ---------------- semantic (model-loading) ----------------
 
 pytest.importorskip("sentence_transformers")


### PR DESCRIPTION
claude.ai (web/mobile) can't run the Claude Code hooks, so the skill's proactive find/capture is best-effort there. Adds a paste-in account-level custom instruction (trimmed style line + KB nudge) to SETUP-FRIEND so friends can make Claude reach for the KB on its own across all chats. Coverage-agnostic (empty search = gap to fill).