### PR TITLE
fix(install-hook): machine-agnostic bash-wrapper command (multi-machine/yadm + portable)

### DIFF
--- a/src/kb_mcp/_hooks/kb-capture-nudge.sh
+++ b/src/kb_mcp/_hooks/kb-capture-nudge.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Stop-hook wrapper for kb_capture_nudge.py. Resolves the interpreter per machine
+# (python3 on Linux/WSL/macOS, python on Windows Git Bash) and runs the sibling
+# script, so the SAME yadm-synced ~/.claude/hooks works across machines. Registered
+# in settings.json as `bash ~/.claude/hooks/kb-capture-nudge.sh` — machine-agnostic,
+# unlike an absolute interpreter path. Exit 0 always: a hook must never break the session.
+here="$(cd "$(dirname "$0")" && pwd)"
+py="$here/kb_capture_nudge.py"
+if command -v python3 >/dev/null 2>&1; then exec python3 "$py"; fi
+command -v python >/dev/null 2>&1 && exec python "$py"
+exit 0

--- a/src/kb_mcp/_hooks/kb-retrieve-nudge.sh
+++ b/src/kb_mcp/_hooks/kb-retrieve-nudge.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# UserPromptSubmit-hook wrapper for kb_retrieve_nudge.py. Resolves the interpreter
+# per machine (python3 on Linux/WSL/macOS, python on Windows Git Bash) and runs the
+# sibling script, so the SAME yadm-synced ~/.claude/hooks works across machines.
+# Registered as `bash ~/.claude/hooks/kb-retrieve-nudge.sh` — machine-agnostic.
+# Exit 0 always: a hook must never break the session.
+here="$(cd "$(dirname "$0")" && pwd)"
+py="$here/kb_retrieve_nudge.py"
+if command -v python3 >/dev/null 2>&1; then exec python3 "$py"; fi
+command -v python >/dev/null 2>&1 && exec python "$py"
+exit 0

--- a/src/kb_mcp/install_hook.py
+++ b/src/kb_mcp/install_hook.py
@@ -1,44 +1,52 @@
 """install-hook: wire the KB capture + retrieval hooks into Claude Code.
 
-Ships two bundled hooks and registers them in `~/.claude/settings.json`, so a
-friend gets the full reliable KB loop with one command:
+Ships two bundled hooks (each a Python script + a bash wrapper) and registers them
+in `~/.claude/settings.json`, so a friend gets the full reliable KB loop with one
+command:
 
-- `_hooks/kb_capture_nudge.py`  → a `Stop` hook (WRITE side): captures durable
-  conclusions at stepping-stones instead of waiting to be told.
-- `_hooks/kb_retrieve_nudge.py` → a `UserPromptSubmit` hook (READ side): reminds
-  Claude to consult the KB before answering, so it functions as the source of
-  truth.
+- `_hooks/kb_capture_nudge.py`  (via `kb-capture-nudge.sh`)  → a `Stop` hook (WRITE):
+  captures durable conclusions at stepping-stones instead of waiting to be told.
+- `_hooks/kb_retrieve_nudge.py` (via `kb-retrieve-nudge.sh`) → a `UserPromptSubmit`
+  hook (READ): reminds Claude to consult the KB before answering.
 
-Both are language-agnostic (structural gate + cooldown, no English keywords). By
-default this copies the scripts AND merges settings.json. `wire=False`
-(`--print-only`) copies the scripts and returns the snippet to paste instead.
+The registered command is **machine-agnostic** — `bash ~/.claude/hooks/<name>.sh`,
+matching the convention of other hooks — so the same `~/.claude` works across
+machines (Windows Git Bash, WSL, Linux, macOS) and survives yadm/dotfile sync. The
+wrapper resolves python per machine; an absolute interpreter path would break the
+moment `~/.claude` is shared between a Windows box and WSL.
+
+Both gates are language-agnostic (structural + cooldown, no English keywords). By
+default this copies the scripts AND merges settings.json; `wire=False`
+(`--print-only`) copies them and returns the snippet to paste instead.
 """
 
 from __future__ import annotations
 
 import json
 import shutil
-import sys
 from pathlib import Path
 
 _HOOK_DIR_SRC = Path(__file__).parent / "_hooks"
-# (script filename, Claude Code event) — the hooks this installs.
+# (python script, bash wrapper, Claude Code event) — the hooks this installs.
 _HOOK_SPECS = (
-    ("kb_capture_nudge.py", "Stop"),
-    ("kb_retrieve_nudge.py", "UserPromptSubmit"),
+    ("kb_capture_nudge.py", "kb-capture-nudge.sh", "Stop"),
+    ("kb_retrieve_nudge.py", "kb-retrieve-nudge.sh", "UserPromptSubmit"),
 )
 DEFAULT_HOOK_DIR = Path.home() / ".claude" / "hooks"
 DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
 
 # Substrings identifying a previously-installed kb nudge entry, so re-running is
-# idempotent and supersedes older hand-wired wrappers.
+# idempotent and supersedes older entries (incl. the absolute-python-path form).
 _MARKERS = ("kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge")
 
 
-def _command_for(script: Path) -> str:
-    """Invoke via the interpreter that ran install-hook (absolute path), so the
-    hook doesn't depend on `python` being on PATH later. Quoted for spaces."""
-    return f'"{sys.executable}" "{script}"'
+def _command_for(wrapper: str, hook_dir: Path) -> str:
+    """Machine-agnostic `bash` invocation of the wrapper. For the default location
+    use the `~`-relative form so the SAME settings.json works on every machine
+    (yadm-synced); for a custom dir (tests) use a POSIX absolute path."""
+    if hook_dir == DEFAULT_HOOK_DIR:
+        return f"bash ~/.claude/hooks/{wrapper}"
+    return f'bash "{(hook_dir / wrapper).as_posix()}"'
 
 
 def snippet(installed: list[dict], timeout: int = 10) -> str:
@@ -59,24 +67,30 @@ def install_hook(
     timeout: int = 10,
     specs: tuple = _HOOK_SPECS,
 ) -> dict:
-    """Install the bundled hook scripts and (optionally) wire settings.json.
+    """Install the bundled hook scripts + wrappers and (optionally) wire settings.json.
 
-    Returns {"installed": [{event, script, command}], "wired", "settings"}.
-    Raises FileNotFoundError if a bundled hook is missing.
+    Returns {"installed": [{event, script, wrapper, command}], "wired", "settings"}.
+    Raises FileNotFoundError if a bundled hook file is missing.
     """
-    for name, _event in specs:
-        if not (_HOOK_DIR_SRC / name).exists():
-            raise FileNotFoundError(
-                f"bundled hook missing at {_HOOK_DIR_SRC / name} — is the kb-mcp install intact?"
-            )
+    for py_name, sh_name, _event in specs:
+        for name in (py_name, sh_name):
+            if not (_HOOK_DIR_SRC / name).exists():
+                raise FileNotFoundError(
+                    f"bundled hook file missing at {_HOOK_DIR_SRC / name} — is the kb-mcp install intact?"
+                )
     hook_dir = (Path(hook_dir).expanduser() if hook_dir else DEFAULT_HOOK_DIR)
     hook_dir.mkdir(parents=True, exist_ok=True)
 
     installed: list[dict] = []
-    for name, event in specs:
-        dest = hook_dir / name
-        shutil.copy2(_HOOK_DIR_SRC / name, dest)
-        installed.append({"event": event, "script": str(dest), "command": _command_for(dest)})
+    for py_name, sh_name, event in specs:
+        shutil.copy2(_HOOK_DIR_SRC / py_name, hook_dir / py_name)
+        shutil.copy2(_HOOK_DIR_SRC / sh_name, hook_dir / sh_name)
+        installed.append({
+            "event": event,
+            "script": str(hook_dir / py_name),
+            "wrapper": str(hook_dir / sh_name),
+            "command": _command_for(sh_name, hook_dir),
+        })
 
     result = {"installed": installed, "wired": False, "settings": None}
     if wire:
@@ -88,10 +102,9 @@ def install_hook(
 
 
 def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> None:
-    """Add each hook to its event in settings.json, preserving every other key
-    and hook. Idempotent: strips any prior kb nudge entry from the target event
-    first (so re-running, or superseding an older hand-wired wrapper, never
-    duplicates)."""
+    """Add each hook to its event in settings.json, preserving every other key and
+    hook. Idempotent: strips any prior kb nudge entry from the target event first
+    (so re-running, or superseding the old absolute-path command, never duplicates)."""
     data: dict = {}
     if path.exists():
         try:

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -1,10 +1,11 @@
 """install-hook (installer) + the capture (Stop) and retrieval (UserPromptSubmit)
 nudge hooks.
 
-The hooks are the reliability fix for the KB loop: skill prose is passive, so
-Stop re-arms "capture this stepping-stone" (write) and UserPromptSubmit re-arms
-"consult the KB first" (read). Both are language-agnostic (structural gate +
-cooldown, no English keywords) so they work on Japanese and every other language.
+The hooks are the reliability fix for the KB loop: skill prose is passive, so Stop
+re-arms "capture this stepping-stone" (write) and UserPromptSubmit re-arms "consult
+the KB first" (read). Both are language-agnostic (structural gate + cooldown). The
+registered command is machine-agnostic (`bash ~/.claude/hooks/<name>.sh`) so a
+yadm-synced ~/.claude works across Windows / WSL / Linux / macOS.
 """
 
 from __future__ import annotations
@@ -31,17 +32,28 @@ def _ups_cmds(data: dict) -> list[str]:
     return [h["command"] for g in data["hooks"].get("UserPromptSubmit", []) for h in g["hooks"]]
 
 
-# --- install_hook: the installer (both hooks) -----------------------------------
+# --- install_hook: the installer (both hooks, py + wrapper) ----------------------
 
-def test_install_hook_copies_and_wires_both(tmp_path: Path) -> None:
+def test_install_hook_copies_scripts_and_wrappers_and_wires_both(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp)
-    assert (hd / "kb_capture_nudge.py").exists()
-    assert (hd / "kb_retrieve_nudge.py").exists()
+    for f in ("kb_capture_nudge.py", "kb-capture-nudge.sh", "kb_retrieve_nudge.py", "kb-retrieve-nudge.sh"):
+        assert (hd / f).exists(), f
     assert r["wired"] is True
     data = json.loads(sp.read_text(encoding="utf-8"))
-    assert any("kb_capture_nudge.py" in c for c in _stop_cmds(data))      # write side -> Stop
-    assert any("kb_retrieve_nudge.py" in c for c in _ups_cmds(data))      # read side -> UserPromptSubmit
+    assert any("kb-capture-nudge.sh" in c for c in _stop_cmds(data))     # write -> Stop, via wrapper
+    assert any("kb-retrieve-nudge.sh" in c for c in _ups_cmds(data))     # read -> UserPromptSubmit
+
+
+def test_command_is_machine_agnostic(tmp_path: Path) -> None:
+    # Default location -> ~-relative bash command (no abs path / interpreter / backslash),
+    # so the same settings.json works on every machine after a yadm sync.
+    cmd = hook_module._command_for("kb-capture-nudge.sh", hook_module.DEFAULT_HOOK_DIR)
+    assert cmd == "bash ~/.claude/hooks/kb-capture-nudge.sh"
+    assert "\\" not in cmd and "python" not in cmd.lower() and ":" not in cmd
+    # Custom dir -> POSIX (forward-slash) bash command, never Windows backslashes.
+    custom = hook_module._command_for("kb-capture-nudge.sh", tmp_path / "hooks")
+    assert custom.startswith('bash "') and custom.endswith('.sh"') and "\\" not in custom
 
 
 def test_install_hook_idempotent(tmp_path: Path) -> None:
@@ -49,8 +61,25 @@ def test_install_hook_idempotent(tmp_path: Path) -> None:
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     data = json.loads(sp.read_text(encoding="utf-8"))
-    assert sum("kb_capture_nudge" in c for c in _stop_cmds(data)) == 1
-    assert sum("kb_retrieve_nudge" in c for c in _ups_cmds(data)) == 1
+    assert sum("kb-capture-nudge" in c for c in _stop_cmds(data)) == 1
+    assert sum("kb-retrieve-nudge" in c for c in _ups_cmds(data)) == 1
+
+
+def test_install_hook_supersedes_prior_absolute_path_entry(tmp_path: Path) -> None:
+    # The old (buggy) form baked an absolute Windows python path; re-running must
+    # replace it with the machine-agnostic wrapper command, exactly once.
+    sp = tmp_path / "settings.json"
+    sp.write_text(
+        json.dumps({"hooks": {"Stop": [
+            {"hooks": [{"type": "command", "command": '"C:\\Python\\python.exe" "C:\\Users\\x\\.claude\\hooks\\kb_capture_nudge.py"'}]}
+        ]}}),
+        encoding="utf-8",
+    )
+    hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    stop = _stop_cmds(data)
+    assert not any("python.exe" in c for c in stop)            # absolute-path form gone
+    assert sum("kb-capture-nudge" in c for c in stop) == 1     # exactly one, the wrapper
 
 
 def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
@@ -69,30 +98,15 @@ def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
     data = json.loads(sp.read_text(encoding="utf-8"))
     assert data["theme"] == "dark"
     assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "bash guard.sh"
-    assert "bash other-stop.sh" in _stop_cmds(data)                # unrelated Stop hook kept
-    assert any("kb_capture_nudge" in c for c in _stop_cmds(data))  # ours added
-    assert any("kb_retrieve_nudge" in c for c in _ups_cmds(data))
-
-
-def test_install_hook_supersedes_old_wrapper(tmp_path: Path) -> None:
-    sp = tmp_path / "settings.json"
-    sp.write_text(
-        json.dumps({"hooks": {"Stop": [
-            {"hooks": [{"type": "command", "command": "bash ~/.claude/hooks/kb-capture-nudge.sh"}]}
-        ]}}),
-        encoding="utf-8",
-    )
-    hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
-    data = json.loads(sp.read_text(encoding="utf-8"))
-    assert not any("kb-capture-nudge.sh" in c for c in _stop_cmds(data))   # old wrapper superseded
-    assert sum("kb_capture_nudge" in c for c in _stop_cmds(data)) == 1
+    assert "bash other-stop.sh" in _stop_cmds(data)                 # unrelated Stop hook kept
+    assert any("kb-capture-nudge" in c for c in _stop_cmds(data))   # ours added
+    assert any("kb-retrieve-nudge" in c for c in _ups_cmds(data))
 
 
 def test_install_hook_print_only_leaves_settings(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp, wire=False)
-    assert (hd / "kb_capture_nudge.py").exists()
-    assert (hd / "kb_retrieve_nudge.py").exists()
+    assert (hd / "kb_capture_nudge.py").exists() and (hd / "kb-capture-nudge.sh").exists()
     assert r["wired"] is False
     assert not sp.exists()
     snip = hook_module.snippet(r["installed"])
@@ -104,8 +118,7 @@ def test_install_hook_via_cli(tmp_path: Path) -> None:
 
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     assert main(["install-hook", "--hook-dir", str(hd), "--settings", str(sp)]) == 0
-    assert (hd / "kb_capture_nudge.py").exists()
-    assert (hd / "kb_retrieve_nudge.py").exists()
+    assert (hd / "kb_capture_nudge.py").exists() and (hd / "kb-retrieve-nudge.sh").exists()
     data = json.loads(sp.read_text(encoding="utf-8"))
     assert data["hooks"]["Stop"] and data["hooks"]["UserPromptSubmit"]
 
@@ -147,7 +160,7 @@ def test_capture_fires_on_substantial_turn(tmp_path: Path) -> None:
 
 def test_capture_fires_language_agnostic_japanese(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
-    jp = "これは重要な結論です。" * 40  # ~400 chars, zero English keywords
+    jp = "これは重要な結論です。" * 40
     t = _transcript(tmp_path, "質問", jp)
     r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "jp"}, home)
     assert '"decision": "block"' in r.stdout
@@ -195,7 +208,7 @@ def test_retrieve_fires_on_substantial_prompt(tmp_path: Path) -> None:
 
 def test_retrieve_fires_language_agnostic_japanese(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
-    jp = "去年このプロジェクトについて何を結論づけましたか？詳しく教えてください。"  # >20 chars, no English
+    jp = "去年このプロジェクトについて何を結論づけましたか？詳しく教えてください。"
     r = _run(RETRIEVE_SCRIPT, {"prompt": jp, "session_id": "rjp"}, home)
     assert "additionalContext" in r.stdout
 


### PR DESCRIPTION
install-hook baked an absolute python path into settings.json, so a yadm-synced ~/.claude carried a Windows path dead on WSL (and non-portable on macOS/Linux). Now ships a bash wrapper per hook and registers `bash ~/.claude/hooks/<name>.sh` (resolves python3||python per machine), matching the existing hook convention. Same settings.json works across Windows Git Bash / WSL / Linux / macOS. 393 tests pass.