### PR TITLE
feat(ingress): Cloudflare Tunnel as public ingress (runbook + dual-audience docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
-KB_MCP_BASE_URL=https://<device>.<tailnet>.ts.net
+# kb-mcp config — copy to `.env` and fill in. NEVER commit `.env`.
+# Public ingress hostname for THIS host. Exact match, no trailing slash, no /mcp.
+#   Cloudflare Tunnel (current):  https://kb.substratesystems.io  (laptop: https://kb-laptop.substratesystems.io)
+#   Tailscale Funnel (legacy):    https://<device>.<tailnet>.ts.net
+KB_MCP_BASE_URL=https://kb.substratesystems.io
 KB_MCP_GITHUB_USERNAME=your-github-login
+# GitHub OAuth App (per host — its ONE callback must be {KB_MCP_BASE_URL}/auth/callback).
 GITHUB_CLIENT_ID=ovXXXXXXXXXXXXXXXXXX
 GITHUB_CLIENT_SECRET=replace-with-secret
+# Recommended: pins the OAuth signing key so the connector survives upgrades / secret
+# rotation without re-auth. Generate: python -c "import secrets;print(secrets.token_urlsafe(48))"
+KB_MCP_JWT_SIGNING_KEY=replace-with-long-random-string
 KB_MCP_VAULT_PATH=D:\path\to\your\Obsidian

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ writes), `rename_tag`, `find_replace_in_file`, `get_directory_tree`.
 
 ```
 ┌──────────────────┐   HTTPS    ┌──────────────────────────────┐
-│   claude.ai      │ ─────────▶ │ Tailscale edge              │
-│   (mobile/web    │   bearer   │ <device>.<tailnet>.ts.net   │
-│    backend)      │            │ auto Let's Encrypt cert     │
+│   claude.ai      │ ─────────▶ │ Cloudflare edge             │
+│   (mobile/web    │   bearer   │ kb.substratesystems.io      │
+│    backend)      │            │ TLS terminated at edge      │
 │  160.79.104.0/21 │            └──────────────────────────────┘
 └──────────────────┘                          │
-                                              │ tailscale funnel
+                                              │ cloudflare tunnel
                                               ▼
                             ┌────────────────────────────────────┐
                             │ host: macOS / Linux / Windows      │
@@ -151,12 +151,16 @@ cd C:\path\to\kb-mcp
 #    this remote/GPU deployment wants the extra.
 uv sync --extra embeddings
 
-# 2. Set up the public URL via Tailscale Funnel (you need this URL in step 3).
-# In Tailscale admin console: enable HTTPS for tailnet + enable Funnel for this node.
-# Then:
-tailscale funnel --bg --https=443 http://127.0.0.1:8765
-tailscale funnel status
-# Note the printed URL, e.g. https://<device>.<tailnet>.ts.net
+# 2. Set up the public URL via Cloudflare Tunnel (you need this hostname in step 3).
+#    Prereq: winget install --id Cloudflare.cloudflared
+cloudflared tunnel login                          # one-time browser auth for your zone
+pwsh -File scripts/setup-cloudflared.ps1 -Hostname kb.substratesystems.io -TunnelName kb-mcp-desktop
+#    -> public hostname https://kb.substratesystems.io  (the script creates the tunnel,
+#       the DNS record, and an auto-start cloudflared Windows service). In the Cloudflare
+#       dashboard for this hostname: turn OFF Bot Fight Mode + any WAF managed ruleset
+#       (Security Level low) — claude.ai's gateway is bursty automated traffic and
+#       code-bearing notes can trip WAF rules. Cloudflare's edge caps requests at ~100s
+#       (524); run heavy ops (embedding rebuild) via the local CLI, not the connector.
 ```
 
 ### 3. Create a GitHub OAuth App (one-time, ~3 min)
@@ -166,8 +170,8 @@ At <https://github.com/settings/developers> → **OAuth Apps** → **New OAuth A
 | Field | Value |
 |---|---|
 | Application name | `kb-mcp` |
-| Homepage URL | `https://<device>.<tailnet>.ts.net` |
-| Authorization callback URL | `https://<device>.<tailnet>.ts.net/auth/callback` |
+| Homepage URL | `https://kb.substratesystems.io` |
+| Authorization callback URL | `https://kb.substratesystems.io/auth/callback` |
 
 Save the generated **Client ID** and **Client Secret**.
 
@@ -176,7 +180,7 @@ Save the generated **Client ID** and **Client Secret**.
 Create `.env` in the repo root:
 
 ```
-KB_MCP_BASE_URL=https://<device>.<tailnet>.ts.net
+KB_MCP_BASE_URL=https://kb.substratesystems.io
 KB_MCP_GITHUB_USERNAME=<your-github-login>
 GITHUB_CLIENT_ID=<from step 3>
 GITHUB_CLIENT_SECRET=<from step 3>
@@ -188,7 +192,7 @@ KB_MCP_JWT_SIGNING_KEY=<long-random-string>
 KB_MCP_VAULT_PATH=<your-Obsidian-vault-root>
 ```
 
-`KB_MCP_BASE_URL` must match the Tailscale Funnel URL exactly — no trailing
+`KB_MCP_BASE_URL` must match the Cloudflare Tunnel hostname exactly — no trailing
 slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
 be the *login* (e.g. `Artexis10`), not the display name. `KB_MCP_VAULT_PATH` is
 **required**: claude.ai connects over HTTP and passes no environment, so the
@@ -252,7 +256,7 @@ pwsh -File scripts/install-service.ps1
 
 1. claude.ai → Settings → Connectors → **Add custom connector**
 2. **Name**: `Knowledge Base` (or whatever)
-3. **Server URL**: `https://<device>.<tailnet>.ts.net/mcp`
+3. **Server URL**: `https://kb.substratesystems.io/mcp` (this host's Cloudflare hostname)
 4. Leave **OAuth Client ID** and **OAuth Client Secret** blank — claude.ai
    uses Dynamic Client Registration against your `/register` endpoint.
 5. Save. claude.ai opens a GitHub login window → log in (only the user in
@@ -265,14 +269,16 @@ Each machine is an independent deployment — there is no shared state. To run k
 on a second box (e.g. a laptop alongside the desktop), repeat the install with that
 host's *own* values. The non-obvious parts:
 
-- **Its own Funnel hostname.** Each Tailscale node has a distinct
-  `<node>.<tailnet>.ts.net`, so `KB_MCP_BASE_URL` and the claude.ai connector URL are
-  per-host. `tailscale funnel status` prints this node's name.
+- **Its own Cloudflare hostname.** Give each host a distinct subdomain (desktop
+  `kb.substratesystems.io`, laptop `kb-laptop.substratesystems.io`), so `KB_MCP_BASE_URL`
+  and the claude.ai connector URL are per-host. Run
+  `pwsh -File scripts/setup-cloudflared.ps1 -Hostname <this-host> -TunnelName <unique-name>`
+  on that machine (after `cloudflared tunnel login`).
 - **Its own GitHub OAuth App.** A GitHub OAuth App allows exactly **one**
   Authorization callback URL, so you *cannot* reuse another host's app — its callback
   points at the other host and GitHub rejects the redirect with "The redirect_uri is
   not associated with this application." Create a second app (e.g. `kb-mcp (laptop)`)
-  with callback `https://<this-host>.<tailnet>.ts.net/auth/callback` and put *its*
+  with callback `https://<this-host>.substratesystems.io/auth/callback` and put *its*
   `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` in this machine's `.env`.
 - **Its own `.env` and connector.** Set `KB_MCP_VAULT_PATH` to this machine's vault
   root (the folder that contains `Knowledge Base/`). In claude.ai, add a separate
@@ -729,7 +735,7 @@ sc.exe start kb-mcp
 |---|---|---|
 | claude.ai "Couldn't reach the MCP server" during connector add | OAuth discovery failed | `curl.exe -i https://<funnel-url>/.well-known/oauth-authorization-server` should return JSON. If 404, the OAuthProxy isn't mounted — most likely `KB_MCP_BASE_URL` has a trailing slash or includes `/mcp`. |
 | GitHub redirects to "The redirect_uri MUST match…" error | OAuth App callback URL mismatch | At github.com/settings/developers → kb-mcp, set Authorization callback URL to exactly `https://<funnel-url>/auth/callback` (no trailing slash). |
-| GitHub: "The redirect_uri is not associated with this application" on a *second* machine | Reused another host's OAuth App client ID/secret in this machine's `.env` (the app's one callback points at the other host) | Create a per-host OAuth App with callback `https://<this-host>.<tailnet>.ts.net/auth/callback`, put its client ID/secret in this `.env`, restart the service. See § Deploying on a second machine. |
+| GitHub: "The redirect_uri is not associated with this application" on a *second* machine | Reused another host's OAuth App client ID/secret in this machine's `.env` (the app's one callback points at the other host) | Create a per-host OAuth App with callback `https://<this-host>.substratesystems.io/auth/callback`, put its client ID/secret in this `.env`, restart the service. See § Deploying on a second machine. |
 | claude.ai connector connects but every tool call returns 401 | Wrong GitHub user | `KB_MCP_GITHUB_USERNAME` must equal the login of the GitHub account you authorized with. Check the kb-mcp log for `rejecting token for github login=...`. |
 | claude.ai shows "connector failed" | service down (desktop asleep, service stopped, crash loop) | `Get-Service kb-mcp`; tail `logs/service.err.log` and `logs/kb-mcp.log`. Multiple startup banners within seconds = orphan python processes — kill them and force-restart. |
 | Edits to `.env` not picked up | service didn't restart, or UAC dismissed | Elevated: `Start-Process -Verb RunAs -Wait sc.exe -ArgumentList 'stop','kb-mcp'` then `'start','kb-mcp'`. Confirm with `Get-Process python \| Select-Object StartTime`. |

--- a/README.md
+++ b/README.md
@@ -151,16 +151,23 @@ cd C:\path\to\kb-mcp
 #    this remote/GPU deployment wants the extra.
 uv sync --extra embeddings
 
-# 2. Set up the public URL via Cloudflare Tunnel (you need this hostname in step 3).
-#    Prereq: winget install --id Cloudflare.cloudflared
-cloudflared tunnel login                          # one-time browser auth for your zone
+# 2. Set up a public HTTPS URL (you need this hostname in step 3). Pick ONE:
+#
+#    OPTION A - Tailscale Funnel: NO domain needed, free <device>.<tailnet>.ts.net
+#    host, simplest. Best if you don't own a domain. In the Tailscale admin console
+#    enable HTTPS for the tailnet + Funnel for this node, then:
+tailscale funnel --bg --https=443 http://127.0.0.1:8765
+tailscale funnel status        # note the URL, e.g. https://<device>.<tailnet>.ts.net
+#    (Funnel's shared relay can throttle bursty reconnects under heavy use; if that
+#    bites, restart Tailscale, or switch to Option B.)
+#
+#    OPTION B - Cloudflare Tunnel: needs a domain you own in Cloudflare; more
+#    burst-tolerant under load. Prereq: winget install --id Cloudflare.cloudflared
+cloudflared tunnel login
 pwsh -File scripts/setup-cloudflared.ps1 -Hostname kb.substratesystems.io -TunnelName kb-mcp-desktop
-#    -> public hostname https://kb.substratesystems.io  (the script creates the tunnel,
-#       the DNS record, and an auto-start cloudflared Windows service). In the Cloudflare
-#       dashboard for this hostname: turn OFF Bot Fight Mode + any WAF managed ruleset
-#       (Security Level low) — claude.ai's gateway is bursty automated traffic and
-#       code-bearing notes can trip WAF rules. Cloudflare's edge caps requests at ~100s
-#       (524); run heavy ops (embedding rebuild) via the local CLI, not the connector.
+#    -> https://kb.substratesystems.io (script makes the tunnel + DNS + auto-start
+#    service). In the CF dashboard for this hostname: Bot Fight Mode OFF + no WAF
+#    managed ruleset (Security Level low); the edge caps requests at ~100s.
 ```
 
 ### 3. Create a GitHub OAuth App (one-time, ~3 min)
@@ -192,8 +199,8 @@ KB_MCP_JWT_SIGNING_KEY=<long-random-string>
 KB_MCP_VAULT_PATH=<your-Obsidian-vault-root>
 ```
 
-`KB_MCP_BASE_URL` must match the Cloudflare Tunnel hostname exactly — no trailing
-slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
+`KB_MCP_BASE_URL` must match your public hostname (Tailscale Funnel or Cloudflare
+Tunnel, from step 2) exactly — no trailing slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
 be the *login* (e.g. `Artexis10`), not the display name. `KB_MCP_VAULT_PATH` is
 **required**: claude.ai connects over HTTP and passes no environment, so the
 service resolves the vault solely from this line in `.env` at startup.
@@ -269,11 +276,11 @@ Each machine is an independent deployment — there is no shared state. To run k
 on a second box (e.g. a laptop alongside the desktop), repeat the install with that
 host's *own* values. The non-obvious parts:
 
-- **Its own Cloudflare hostname.** Give each host a distinct subdomain (desktop
-  `kb.substratesystems.io`, laptop `kb-laptop.substratesystems.io`), so `KB_MCP_BASE_URL`
-  and the claude.ai connector URL are per-host. Run
-  `pwsh -File scripts/setup-cloudflared.ps1 -Hostname <this-host> -TunnelName <unique-name>`
-  on that machine (after `cloudflared tunnel login`).
+- **Its own public hostname.** `KB_MCP_BASE_URL` and the connector URL are per-host.
+  Tailscale gives each node a distinct `<node>.<tailnet>.ts.net` automatically
+  (`tailscale funnel status`); for Cloudflare, give each host a distinct subdomain
+  (desktop `kb.substratesystems.io`, laptop `kb-laptop.substratesystems.io`) via
+  `pwsh -File scripts/setup-cloudflared.ps1 -Hostname <this-host> -TunnelName <unique-name>`.
 - **Its own GitHub OAuth App.** A GitHub OAuth App allows exactly **one**
   Authorization callback URL, so you *cannot* reuse another host's app — its callback
   points at the other host and GitHub rejects the redirect with "The redirect_uri is

--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -220,8 +220,11 @@ publicly-reachable, authenticated endpoint:
 
 1. **An always-on host** — your desktop running 24/7, or a cheap VPS. (Local
    stdio dies when you close Claude Code; mobile needs it always up.)
-2. **A public HTTPS endpoint** — Tailscale Funnel (what Hugo uses) or Cloudflare
-   Tunnel. This exposes the server to the internet, so auth becomes mandatory.
+2. **A public HTTPS endpoint** — **Tailscale Funnel** (no domain needed — gives a
+   free `*.ts.net` host; the simplest path if you don't own a domain) or
+   **Cloudflare Tunnel** (needs a domain you own in Cloudflare; more burst-tolerant
+   under heavy use — Hugo's setup). This exposes the server to the internet, so auth
+   becomes mandatory.
 3. **A GitHub OAuth app** (client id + secret) wired into the OAuthProxy —
    claude.ai connectors require OAuth; static tokens aren't accepted.
 4. **Lock it to your GitHub login** (the single-user verifier), then run it as a

--- a/deploy/cloudflared/config.example.yml
+++ b/deploy/cloudflared/config.example.yml
@@ -1,0 +1,18 @@
+# cloudflared ingress config for kb-mcp — REFERENCE TEMPLATE.
+#
+# The live copy must live where the Windows service (running as SYSTEM) reads it:
+#   C:\Windows\System32\config\systemprofile\.cloudflared\config.yml
+# `scripts/setup-cloudflared.ps1` generates it there with the real tunnel UUID and
+# copies the credentials + cert alongside. This file is just a committed reference.
+#
+# <UUID>  = the tunnel id from `cloudflared tunnel create` (see `cloudflared tunnel list`)
+# <HOST>  = kb.substratesystems.io (desktop) / kb-laptop.substratesystems.io (laptop)
+
+tunnel: <UUID>
+credentials-file: C:\Windows\System32\config\systemprofile\.cloudflared\<UUID>.json
+
+# Route the public hostname to the local kb-mcp service; everything else 404s.
+ingress:
+  - hostname: <HOST>
+    service: http://127.0.0.1:8765
+  - service: http_status:404

--- a/scripts/setup-cloudflared.ps1
+++ b/scripts/setup-cloudflared.ps1
@@ -1,0 +1,127 @@
+# Set up a Cloudflare Tunnel as the public ingress for kb-mcp on this machine,
+# replacing Tailscale Funnel. Run ONCE per machine, AFTER `cloudflared tunnel login`.
+#
+# What it does (idempotent):
+#   - creates the named tunnel (or reuses it), resolves its UUID
+#   - routes the DNS CNAME for <Hostname> to the tunnel
+#   - writes config.yml + copies cert.pem/creds into the SYSTEM service location
+#     (C:\Windows\System32\config\systemprofile\.cloudflared) — the gotcha that
+#     bites everyone: the service runs as SYSTEM and reads config from there, NOT
+#     from your %USERPROFILE%\.cloudflared where `tunnel login/create` write.
+#   - installs + starts the cloudflared Windows service (auto-start)
+#
+# Prereqs:
+#   - cloudflared installed + on PATH  (winget install --id Cloudflare.cloudflared)
+#   - `cloudflared tunnel login`  has been run once (writes cert.pem to your profile,
+#     authorizing the substratesystems.io zone). This step is browser-interactive,
+#     so it is intentionally NOT in this script.
+#
+# Usage (desktop):
+#   pwsh -File scripts/setup-cloudflared.ps1 -Hostname kb.substratesystems.io -TunnelName kb-mcp-desktop
+# Usage (laptop):
+#   pwsh -File scripts/setup-cloudflared.ps1 -Hostname kb-laptop.substratesystems.io -TunnelName kb-mcp-laptop
+#
+# After this: set KB_MCP_BASE_URL=https://<Hostname> in .env, update the GitHub OAuth
+# App callback to https://<Hostname>/auth/callback, restart kb-mcp, re-add the connector.
+
+param(
+    [Parameter(Mandatory = $true)][string]$Hostname,
+    [Parameter(Mandatory = $true)][string]$TunnelName,
+    [int]$Port = 8765,
+    [string]$CloudflaredPath = "cloudflared"
+)
+
+$ErrorActionPreference = "Stop"
+
+# cloudflared must be resolvable.
+$cf = (Get-Command $CloudflaredPath -ErrorAction SilentlyContinue)
+if (-not $cf) {
+    throw "cloudflared not found on PATH. Install it (winget install --id Cloudflare.cloudflared) or pass -CloudflaredPath."
+}
+$CloudflaredExe = $cf.Source
+
+# The origin cert from `cloudflared tunnel login` lives in the INVOKING user's profile.
+# Elevation (below) preserves the same user, so this path stays valid after elevation.
+$UserCfDir = Join-Path $env:USERPROFILE ".cloudflared"
+$CertPem   = Join-Path $UserCfDir "cert.pem"
+if (-not (Test-Path $CertPem)) {
+    throw "No cert.pem at $CertPem. Run 'cloudflared tunnel login' first (browser auth for the substratesystems.io zone)."
+}
+
+# Service install + writing under System32 need a full admin token. Self-elevate so the
+# behaviour is identical whether UAC is on (filtered token) or off (mirrors install-service.ps1).
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "Not elevated - relaunching as administrator (approve the UAC prompt)..."
+    $hostExe = (Get-Process -Id $PID).Path; if (-not $hostExe) { $hostExe = "pwsh" }
+    $relaunchArgs = @(
+        "-NoExit", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"",
+        "-Hostname", $Hostname, "-TunnelName", $TunnelName, "-Port", $Port, "-CloudflaredPath", "`"$CloudflaredExe`""
+    )
+    Start-Process -FilePath $hostExe -Verb RunAs -ArgumentList $relaunchArgs
+    exit
+}
+
+# --- 1. Create the tunnel (or reuse an existing one), resolve its UUID ----------------
+$existing = & $CloudflaredExe tunnel list --output json | ConvertFrom-Json
+$tunnel = $existing | Where-Object { $_.name -eq $TunnelName } | Select-Object -First 1
+if ($tunnel) {
+    Write-Host "Tunnel '$TunnelName' already exists (id $($tunnel.id)) - reusing."
+} else {
+    Write-Host "Creating tunnel '$TunnelName'..."
+    & $CloudflaredExe tunnel create $TunnelName | Write-Host
+    $tunnel = (& $CloudflaredExe tunnel list --output json | ConvertFrom-Json) |
+        Where-Object { $_.name -eq $TunnelName } | Select-Object -First 1
+    if (-not $tunnel) { throw "Tunnel '$TunnelName' not found after create." }
+}
+$Uuid = $tunnel.id
+$CredsSrc = Join-Path $UserCfDir "$Uuid.json"
+if (-not (Test-Path $CredsSrc)) { throw "Tunnel credentials not found at $CredsSrc." }
+
+# --- 2. Route the public hostname to this tunnel (idempotent) -------------------------
+Write-Host "Routing DNS $Hostname -> tunnel $Uuid ..."
+try { & $CloudflaredExe tunnel route dns $TunnelName $Hostname | Write-Host }
+catch { Write-Warning "route dns returned: $_  (usually 'record already exists' - safe to ignore)" }
+
+# --- 3. Stage config + creds where the SYSTEM service reads them ----------------------
+$SysCfDir = "C:\Windows\System32\config\systemprofile\.cloudflared"
+New-Item -ItemType Directory -Path $SysCfDir -Force | Out-Null
+Copy-Item $CertPem  (Join-Path $SysCfDir "cert.pem")     -Force
+Copy-Item $CredsSrc (Join-Path $SysCfDir "$Uuid.json")   -Force
+
+$CredsDst = Join-Path $SysCfDir "$Uuid.json"
+$ConfigPath = Join-Path $SysCfDir "config.yml"
+@"
+tunnel: $Uuid
+credentials-file: $CredsDst
+ingress:
+  - hostname: $Hostname
+    service: http://127.0.0.1:$Port
+  - service: http_status:404
+"@ | Set-Content -Path $ConfigPath -Encoding ascii
+Write-Host "Wrote $ConfigPath"
+
+# --- 4. Install (or refresh) + start the Windows service -----------------------------
+$svc = Get-Service -Name "cloudflared" -ErrorAction SilentlyContinue
+if ($svc) {
+    Write-Host "cloudflared service exists - reinstalling to pick up config..."
+    try { & $CloudflaredExe service uninstall | Write-Host } catch { Write-Warning "service uninstall: $_" }
+    Start-Sleep -Seconds 2
+}
+Write-Host "Installing cloudflared service..."
+& $CloudflaredExe service install | Write-Host
+Set-Service -Name "cloudflared" -StartupType Automatic
+Start-Service -Name "cloudflared"
+Start-Sleep -Seconds 2
+
+Write-Host ""
+Write-Host "Tunnel '$TunnelName' ($Uuid) -> https://$Hostname -> http://127.0.0.1:$Port"
+Write-Host "Service status: $((Get-Service cloudflared).Status)"
+Write-Host ""
+Write-Host "NEXT (not automated):"
+Write-Host "  1. .env:  KB_MCP_BASE_URL=https://$Hostname"
+Write-Host "  2. GitHub OAuth App: Homepage https://$Hostname ; callback https://$Hostname/auth/callback"
+Write-Host "  3. Restart kb-mcp:  pwsh -File scripts/restart.ps1"
+Write-Host "  4. claude.ai: re-add the connector at https://$Hostname/mcp (redo GitHub OAuth)"
+Write-Host "  5. Cloudflare dashboard: for $Hostname turn OFF Bot Fight Mode + any WAF managed ruleset, Security Level low"
+Write-Host "  6. Verify:  cloudflared tunnel info $TunnelName   and   curl.exe -i https://$Hostname/mcp  (expect 401)"

--- a/scripts/setup-cloudflared.ps1
+++ b/scripts/setup-cloudflared.ps1
@@ -110,9 +110,24 @@ if ($svc) {
 }
 Write-Host "Installing cloudflared service..."
 & $CloudflaredExe service install | Write-Host
+Start-Sleep -Seconds 1
+
+# `cloudflared service install` (no token) registers a BARE ImagePath (just the exe, no
+# `tunnel run`/`--config`), so the service launches cloudflared with no command and dies
+# with exit 1067. Point the service at our config explicitly — the documented Windows fix.
+$svcKey = "HKLM:\SYSTEM\CurrentControlSet\Services\cloudflared"
+$imagePath = '"{0}" --config "{1}" tunnel run' -f $CloudflaredExe, $ConfigPath
+Set-ItemProperty -Path $svcKey -Name ImagePath -Value $imagePath
+Write-Host "Service command: $imagePath"
+
 Set-Service -Name "cloudflared" -StartupType Automatic
-Start-Service -Name "cloudflared"
-Start-Sleep -Seconds 2
+try { Restart-Service -Name "cloudflared" -ErrorAction Stop }
+catch { Start-Service -Name "cloudflared" -ErrorAction SilentlyContinue }
+Start-Sleep -Seconds 3
+if ((Get-Service cloudflared).Status -ne 'Running') {
+    Write-Warning "cloudflared is not Running. See the real error by running it foreground:"
+    Write-Warning "  & `"$CloudflaredExe`" --config `"$ConfigPath`" tunnel run"
+}
 
 Write-Host ""
 Write-Host "Tunnel '$TunnelName' ($Uuid) -> https://$Hostname -> http://127.0.0.1:$Port"


### PR DESCRIPTION
## Summary
Migrate kb-mcp's public ingress from **Tailscale Funnel** to **Cloudflare Tunnel** to end the recurring "connector down" caused by Funnel relay burst-throttling. The server is unchanged — the public URL is env-driven (`KB_MCP_BASE_URL`), so this is ingress + `.env` + GitHub OAuth + connector only.

## Included
- `scripts/setup-cloudflared.ps1` — per-machine tunnel + DNS + auto-start Windows service. Handles the cloudflared bare-ImagePath / exit-1067 fix and the SYSTEM-profile config location.
- `deploy/cloudflared/config.example.yml` + `RUNBOOK.md` — reference config + one consolidated setup / cutover / rollback / gotchas playbook.
- README ingress section: **both** options first-class — Tailscale Funnel (no domain) and Cloudflare Tunnel (needs a domain) — chosen by domain ownership, so the friend/local-stdio path is preserved.
- `.env.example` updated.

## Verified
Desktop cut over live: connector connected at `https://kb.substratesystems.io/mcp`, 23 tools, GitHub OAuth handshake confirmed in the logs. No `server.py` change. Tailscale Funnel kept as documented fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
