### PR TITLE
feat(query-data): structured query tool over vault CSV/JSON datasets

### DIFF
--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-base
 description: Operates on Hugo's personal Obsidian Knowledge Base — raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts. Triggers when the user wants to save, file, log, compile, distill, search, audit, supersede, or preserve anything in their KB, vault, Obsidian, or notes — including oblique phrasings ("interesting, save it," "I want to remember this"). Also engages proactively, without being told — it consults the KB for prior conclusions when a turn touches a project, domain, decision, or topic it likely covers, and captures durable conclusions when the conversation reaches a stepping-stone (agreement, decision, solved problem, diagnosed failure, or recognized pattern). Do NOT trigger for writes outside the Knowledge Base folder — Cognitive Core, Domains, Prompt Bank, Products, and Personal Context are read-only inputs.
-version: 0.16.0
+version: 0.17.0
 ---
 
 # Knowledge Base
@@ -152,6 +152,7 @@ Do NOT use Tier 2 when Tier 1 fits. If it's a research-note → `note`. If it's 
 | **recover_from_trash** | Undo a delete: move from `_trash/` back to original (or custom) location, clean sidecar | `_trash/` → restored path |
 | **append_to_file** | Append text to an existing file | the file |
 | **list_inbound_links** | Find all files whose wikilinks resolve to a target. Read-only | — |
+| **query_data** | Structured query over a CSV/JSON **data file** under the vault — filter/sort/paginate, project columns, or aggregate (count/min/max/sum/avg/latest/distinct). Dotted columns reach nested JSON; `record_path` locates a nested array. The retrieval half of the data-search pattern (`find` → dataset card → `query_data`); raw data files aren't `find`-searchable, this queries them by path. Read-only | — |
 
 ### Discipline preserved across BOTH tiers
 
@@ -186,6 +187,7 @@ These constraints apply equally to Tier 1 and Tier 2 ops — no escape hatch aro
 - "create a file at X with this content," "write an Identity/ page" (path doesn't fit a typed-note route) → **create_file** (Tier 2)
 - "rename this page to X," "move this note to Patterns/" → **move_file** (Tier 2; defaults to updating inbound wikilinks)
 - "what's in folder X," "list the files under Y" → **list_directory** (Tier 2)
+- "query my data," "filter the CSV," "what was my X over time," "rows where Y > Z," "sum/avg/latest of a column," "how many entries in <dataset>" → **query_data** (Tier 2)
 - "what links to X" → **list_inbound_links** (Tier 2)
 - "flip the status to archived," "set tenant: tu on this page" (single-field tweak) → **edit** (`field`+`value`)
 - "tack this onto the end of X" → **append_to_file** (Tier 2)

--- a/src/kb_mcp/_scaffold/_Schema/references/operations.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/operations.md
@@ -297,3 +297,31 @@ See `supersession.md`. Summary:
 - One updated old file (frontmatter + banner)
 - Updated subfolder and top-level `index.md`
 - Updated `ingested_into` fields on cited sources for the new page
+
+## query_data
+
+Structured query over a CSV/JSON **data file** under the vault — the retrieval half of the data-search pattern. `find` surfaces a dataset's markdown card; `query_data` reads the raw file the card's `dataset_files:` points at and returns exact rows or an aggregate. Read-only; no writes, no index (reads on demand — KB datasets are small). Raw CSV/JSON are not `find`-searchable; this is how you query their values.
+
+### Triggers
+- "what was my X over time," "filter the CSV," "rows where Y > Z," "sum/avg/latest/distinct of a column," "how many entries in <dataset>."
+- A value the dataset card's summary tables don't pre-answer, or a whole-dataset / ad-hoc query.
+
+### Inputs to gather
+- `path` — vault-relative `.csv`/`.tsv`/`.json` (usually a card's `dataset_files:` entry).
+- For nested JSON: `record_path` (dotted, e.g. `sections.work_incapacity`) — omit for a top-level array or the common keys result/results/data/rows/items/entries.
+- The query: `filters` (`[{column, op, value}]`; op ∈ eq/ne/gt/gte/lt/lte/contains/icontains/startswith/in/nin/exists/missing), `columns` (projection; dotted ok), `sort_by`+`descending`, `limit`/`offset`, OR `aggregate` (`count` | `min|max|sum|avg|latest|distinct:column`), OR `date_from`/`date_to`(/`date_column`).
+
+### Procedure
+1. Resolve + read the file (path-escape-guarded; 25 MB cap; CSV/TSV by header, JSON array or via `record_path`).
+2. Apply filters (+ any date range). Numeric compares coerce tolerantly (comma decimals; lab `<`/`>` operators stripped for the comparison).
+3. If `aggregate`: compute over matched rows and return it. Else: sort → paginate → project columns.
+
+### Output format
+`{path, format, total_rows, total_matched, returned, columns, rows, aggregate, truncated, warnings}`.
+
+### Edge cases
+- Dotted columns reach nested JSON fields (`performer.name`, `id.extension`) in filters/columns/sort/aggregate. Deeply irregular JSON may need a one-time flatten-to-CSV first; flat tables are the sweet spot.
+- `limit` hard-capped at 1000 (default 100); `truncated: true` signals more rows matched than returned.
+
+### Writes performed
+- None (read-only).

--- a/src/kb_mcp/query_data.py
+++ b/src/kb_mcp/query_data.py
@@ -1,0 +1,364 @@
+"""The `query_data` MCP tool: structured queries over vault data files (CSV/JSON).
+
+Read-only. `find` discovers a dataset (via its markdown "dataset card");
+`query_data` pulls exact rows / aggregates from the raw CSV/JSON the card points
+at — filter by column / value / date-range, project columns, sort, paginate, or
+aggregate (count / min / max / sum / avg / latest / distinct). KB datasets are
+small, so the file is read into memory per call — no index, no new infra
+(consistent with the "no vector DB needed at this scale" ethos).
+
+Supports:
+- CSV / TSV (header row → columns).
+- JSON: a top-level array of objects, OR a nested array located via
+  `record_path` (dotted, e.g. "sections.work_incapacity") or common-key
+  auto-detect ("result"/"results"/"data"/"rows"/"items"/"entries").
+- Dotted column names for nested JSON fields (e.g. "performer.name",
+  "id.extension") everywhere a column is named — filters, columns, sort,
+  aggregate.
+
+Numeric comparisons coerce tolerantly (Estonian decimal comma "," → ".";
+leading lab operators like "<0.4"/">75" are stripped for the comparison).
+Date filters (`date_from`/`date_to`) compare ISO date strings lexicographically.
+Deeply irregular JSON may still want a one-time flatten-to-CSV first; flat
+tables are the sweet spot.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .vault import VaultPathError, resolve_under_vault
+
+
+log = logging.getLogger(__name__)
+
+ALLOWED_SUFFIXES = (".csv", ".tsv", ".json")
+MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MB guard — KB datasets are small
+HARD_ROW_CAP = 1000
+DEFAULT_LIMIT = 100
+_COMMON_RECORD_KEYS = ("result", "results", "data", "rows", "items", "entries")
+_OPS = frozenset({
+    "eq", "ne", "gt", "gte", "lt", "lte",
+    "contains", "icontains", "startswith", "in", "nin", "exists", "missing",
+})
+_NUM_PREFIX = re.compile(r"^[<>≤≥=~\s]+")
+_DATE_LIKE = re.compile(r"\d{1,4}[-/]\d")        # 2024-07, 9/2024 → not a number
+_LEADING_NUM = re.compile(r"[+-]?\d+(?:[.,]\d+)?")  # leading number, comma or dot decimal
+
+
+@dataclass
+class QueryDataError(Exception):
+    code: str
+    reason: str
+
+    def as_dict(self) -> dict:
+        return {"code": self.code, "reason": self.reason}
+
+
+@dataclass
+class QueryDataResult:
+    path: str
+    format: str
+    total_rows: int       # rows in the dataset
+    total_matched: int    # rows matching the filters (before limit/offset)
+    returned: int
+    columns: list[str]
+    rows: list[dict]
+    aggregate: Any = None
+    truncated: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "format": self.format,
+            "total_rows": self.total_rows,
+            "total_matched": self.total_matched,
+            "returned": self.returned,
+            "columns": self.columns,
+            "rows": self.rows,
+            "aggregate": self.aggregate,
+            "truncated": self.truncated,
+            "warnings": self.warnings,
+        }
+
+
+def _get_field(row: Any, dotted: str) -> Any:
+    """Nested access via dotted key — dicts by key, lists by integer index."""
+    cur = row
+    for part in str(dotted).split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        elif isinstance(cur, list):
+            try:
+                cur = cur[int(part)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return cur
+
+
+def _coerce_num(v: Any) -> float | None:
+    """Best-effort numeric coercion; tolerant of comma decimals and lab operators."""
+    if isinstance(v, bool):
+        return None
+    if isinstance(v, (int, float)):
+        return float(v)
+    if not isinstance(v, str):
+        return None
+    s = _NUM_PREFIX.sub("", v.strip())
+    if not s or _DATE_LIKE.match(s):
+        return None
+    m = _LEADING_NUM.match(s)
+    if not m:
+        return None
+    try:
+        return float(m.group(0).replace(",", "."))
+    except ValueError:
+        return None
+
+
+def _locate_array(data: Any, record_path: str | None, warnings: list[str]) -> list:
+    if record_path:
+        located = _get_field(data, record_path) if isinstance(data, (dict, list)) else None
+        if not isinstance(located, list):
+            raise QueryDataError(
+                "BAD_RECORD_PATH",
+                f"record_path {record_path!r} did not resolve to a JSON array",
+            )
+        return located
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in _COMMON_RECORD_KEYS:
+            if isinstance(data.get(k), list):
+                warnings.append(f"auto-detected record array at top-level key {k!r}")
+                return data[k]
+        warnings.append("JSON root is an object with no obvious array; treated as a single row")
+        return [data]
+    raise QueryDataError("BAD_JSON", "JSON root is neither an array nor an object")
+
+
+def _infer_columns(rows: list[dict]) -> list[str]:
+    cols: list[str] = []
+    seen: set[str] = set()
+    for r in rows[:500]:
+        if isinstance(r, dict):
+            for k in r:
+                if k not in seen:
+                    seen.add(k)
+                    cols.append(k)
+    return cols
+
+
+def _load_rows(abs_path: Path, record_path: str | None) -> tuple[str, list[dict], list[str], list[str]]:
+    suffix = abs_path.suffix.lower()
+    size = abs_path.stat().st_size
+    if size > MAX_FILE_BYTES:
+        raise QueryDataError(
+            "TOO_LARGE",
+            f"file is {size} bytes (> {MAX_FILE_BYTES} limit); pre-split or filter upstream",
+        )
+    warnings: list[str] = []
+    if suffix in (".csv", ".tsv"):
+        delimiter = "\t" if suffix == ".tsv" else ","
+        with abs_path.open(encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f, delimiter=delimiter)
+            rows = [dict(r) for r in reader]
+            cols = list(reader.fieldnames or [])
+        return ("tsv" if suffix == ".tsv" else "csv"), rows, cols, warnings
+    if suffix == ".json":
+        try:
+            data = json.loads(abs_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise QueryDataError("BAD_JSON", f"could not parse JSON: {e}") from None
+        arr = _locate_array(data, record_path, warnings)
+        rows = [r if isinstance(r, dict) else {"value": r} for r in arr]
+        return "json", rows, _infer_columns(rows), warnings
+    raise QueryDataError("UNSUPPORTED_FORMAT", f"only {list(ALLOWED_SUFFIXES)} supported, got {suffix!r}")
+
+
+def _match(row: dict, filt: dict) -> bool:
+    col = filt["column"]
+    op = filt.get("op", "eq")
+    val = filt.get("value")
+    actual = _get_field(row, col)
+
+    if op == "exists":
+        return actual not in (None, "")
+    if op == "missing":
+        return actual in (None, "")
+    if op in ("in", "nin"):
+        vals = val if isinstance(val, list) else [val]
+        hit = str(actual) in {str(x) for x in vals}
+        return hit if op == "in" else not hit
+    if op in ("contains", "icontains", "startswith"):
+        a = "" if actual is None else str(actual)
+        b = "" if val is None else str(val)
+        if op == "contains":
+            return b in a
+        if op == "icontains":
+            return b.lower() in a.lower()
+        return a.lower().startswith(b.lower())
+
+    # eq / ne / gt / gte / lt / lte — numeric when both coerce; string otherwise.
+    an, bn = _coerce_num(actual), _coerce_num(val)
+    both_num = an is not None and bn is not None
+
+    if op in ("eq", "ne"):
+        if both_num:
+            a, b = an, bn
+        else:
+            a = "" if actual is None else str(actual)
+            b = "" if val is None else str(val)
+        return (a == b) if op == "eq" else (a != b)
+
+    # Ordering (gt/gte/lt/lte): compare numerically when both coerce, or as
+    # strings when NEITHER does (e.g. ISO dates). If exactly one side is
+    # numeric the values aren't comparable — exclude the row rather than fall
+    # back to a misleading lexicographic compare (e.g. "100,2 nmol/l" < 50).
+    if both_num:
+        a, b = an, bn
+    elif an is None and bn is None:
+        a = "" if actual is None else str(actual)
+        b = "" if val is None else str(val)
+    else:
+        return False
+    if op == "gt":
+        return a > b
+    if op == "gte":
+        return a >= b
+    if op == "lt":
+        return a < b
+    if op == "lte":
+        return a <= b
+    raise QueryDataError("BAD_OP", f"unknown filter op {op!r}; allowed: {sorted(_OPS)}")
+
+
+def _aggregate(matched: list[dict], spec: str, date_col: str | None) -> dict:
+    spec = spec.strip()
+    if spec == "count":
+        return {"count": len(matched)}
+    if ":" not in spec:
+        raise QueryDataError(
+            "BAD_AGGREGATE",
+            "aggregate must be 'count' or 'func:column' (func in min,max,sum,avg,latest,distinct)",
+        )
+    func, col = (p.strip() for p in spec.split(":", 1))
+    if func == "distinct":
+        out: list[Any] = []
+        seen: set[str] = set()
+        for r in matched:
+            v = _get_field(r, col)
+            key = json.dumps(v, sort_keys=True, ensure_ascii=False) if isinstance(v, (dict, list)) else str(v)
+            if key not in seen:
+                seen.add(key)
+                out.append(v)
+        return {"distinct": out, "n": len(out)}
+    if func == "latest":
+        order_col = date_col or col
+        best, best_key = None, None
+        for r in matched:
+            k = _get_field(r, order_col)
+            if k is None:
+                continue
+            if best_key is None or str(k) > str(best_key):
+                best_key, best = k, r
+        return {"latest_by": order_col, "row": best}
+    if func in ("min", "max", "sum", "avg"):
+        nums = [n for r in matched if (n := _coerce_num(_get_field(r, col))) is not None]
+        if not nums:
+            return {func: None, "n": 0, "note": f"no numeric values in {col!r}"}
+        value = {
+            "min": min(nums), "max": max(nums),
+            "sum": sum(nums), "avg": sum(nums) / len(nums),
+        }[func]
+        return {func: value, "n": len(nums)}
+    raise QueryDataError("BAD_AGGREGATE", f"unknown aggregate func {func!r}")
+
+
+def query_data(
+    vault_root: Path,
+    *,
+    path: str,
+    record_path: str | None = None,
+    filters: list[dict] | None = None,
+    columns: list[str] | None = None,
+    sort_by: str | None = None,
+    descending: bool = False,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+    aggregate: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    date_column: str | None = None,
+) -> QueryDataResult:
+    """Query a CSV/JSON data file under the vault. See module docstring."""
+    try:
+        abs_path, rel = resolve_under_vault(vault_root, path, must_exist=True, must_be_file=True)
+    except VaultPathError as e:
+        raise QueryDataError(e.code, e.reason) from None
+    if abs_path.suffix.lower() not in ALLOWED_SUFFIXES:
+        raise QueryDataError("UNSUPPORTED_FORMAT", f"only {list(ALLOWED_SUFFIXES)} supported")
+
+    fmt, rows, cols, warnings = _load_rows(abs_path, record_path)
+    total_rows = len(rows)
+
+    flt: list[dict] = []
+    for f0 in filters or []:
+        if not isinstance(f0, dict) or not f0.get("column"):
+            raise QueryDataError("BAD_FILTER", f"each filter needs a 'column': {f0!r}")
+        if f0.get("op", "eq") not in _OPS:
+            raise QueryDataError("BAD_OP", f"unknown op {f0.get('op')!r}; allowed: {sorted(_OPS)}")
+        flt.append(f0)
+
+    date_col = date_column or ("date" if "date" in cols else None)
+    if (date_from or date_to) and not date_col:
+        warnings.append("date_from/date_to ignored: no date column found (pass date_column=)")
+    if date_col and date_from:
+        flt.append({"column": date_col, "op": "gte", "value": date_from})
+    if date_col and date_to:
+        flt.append({"column": date_col, "op": "lte", "value": date_to})
+
+    matched = [r for r in rows if all(_match(r, f) for f in flt)]
+    total_matched = len(matched)
+
+    if aggregate:
+        return QueryDataResult(
+            path=rel, format=fmt, total_rows=total_rows, total_matched=total_matched,
+            returned=0, columns=cols, rows=[],
+            aggregate=_aggregate(matched, aggregate, date_col),
+            truncated=False, warnings=warnings,
+        )
+
+    if sort_by:
+        def _key(r: dict):
+            v = _get_field(r, sort_by)
+            n = _coerce_num(v)
+            return (0, n, "") if n is not None else (1, 0.0, "" if v is None else str(v))
+        matched.sort(key=_key, reverse=descending)
+
+    limit = max(0, min(int(limit), HARD_ROW_CAP))
+    offset = max(0, int(offset))
+    window = matched[offset: offset + limit] if limit else matched[offset:]
+    truncated = (offset + len(window)) < total_matched
+
+    if columns:
+        out_rows = [{c: _get_field(r, c) for c in columns} for r in window]
+        out_cols = list(columns)
+    else:
+        out_rows = window
+        out_cols = cols
+
+    return QueryDataResult(
+        path=rel, format=fmt, total_rows=total_rows, total_matched=total_matched,
+        returned=len(out_rows), columns=out_cols, rows=out_rows,
+        aggregate=None, truncated=truncated, warnings=warnings,
+    )

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -56,6 +56,7 @@ from . import note as note_module
 from . import preserve as preserve_module
 from . import project_keys as project_keys_module
 from . import provenance as provenance_module
+from . import query_data as query_data_module
 from . import query_log
 from . import reconcile as reconcile_module
 from . import recover_from_trash as recover_from_trash_module
@@ -1383,7 +1384,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
     #   are write-protected by default; pass `allow_curated=true` to override.
     # - Every write logs to Knowledge Base/log.md.
     #
-    # Tier 2 is opt-out: setting KB_MCP_DISABLE_TIER2 drops these 12 escape-hatch
+    # Tier 2 is opt-out: setting KB_MCP_DISABLE_TIER2 drops these 13 escape-hatch
     # tools from the registered surface, shrinking the deferred-tool list a client
     # must keyword-search to reach the Tier 1 read/write ops. The functions are
     # still defined either way; `tier2_tool` only decides whether to register.
@@ -1391,6 +1392,78 @@ def build_server(*, require_auth: bool) -> FastMCP:
 
     def tier2_tool(fn):
         return mcp.tool(fn) if _expose_tier2 else fn
+
+    @tier2_tool
+    def query_data(
+        path: str,
+        record_path: str | None = None,
+        filters: list[dict] | None = None,
+        columns: list[str] | None = None,
+        sort_by: str | None = None,
+        descending: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+        aggregate: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        date_column: str | None = None,
+    ) -> dict:
+        """Tier 2: structured query over a CSV/JSON data file under the vault.
+
+        The retrieval half of the data-search pattern — `find` surfaces a
+        dataset's markdown "card"; this reads the raw file the card points at
+        and returns exact rows / aggregates (no whole-file dump). KB datasets
+        are small, so it reads on demand — no index, no new infra.
+
+        Formats: CSV / TSV, and JSON (a top-level array, or a nested array via
+        `record_path` / common-key auto-detect). Column names may be dotted to
+        reach nested JSON fields (e.g. "performer.name", "id.extension")
+        anywhere a column is named (filters / columns / sort / aggregate).
+
+        Args:
+            path: vault-relative path to the `.csv` / `.tsv` / `.json` file.
+            record_path: (JSON) dotted path to the array inside a nested
+                object, e.g. "sections.work_incapacity". Omit for a top-level
+                array or the common keys result/results/data/rows/items/entries.
+            filters: list of `{column, op, value}`. `op` ∈ eq, ne, gt, gte, lt,
+                lte, contains, icontains, startswith, in, nin, exists, missing.
+                Numeric compares coerce tolerantly (comma decimals; lab
+                operators like "<0.4"/">75" are stripped for the comparison).
+            columns: project to these columns (dotted ok). Omit for all.
+            sort_by / descending: sort by a column (numeric-aware).
+            limit / offset: pagination (limit default 100, hard cap 1000).
+            aggregate: instead of rows — "count", or "func:column" where func ∈
+                min, max, sum, avg, latest, distinct.
+            date_from / date_to / date_column: convenience date-range filter on
+                `date_column` (defaults to a "date" column if present); ISO
+                date strings, compared lexicographically.
+
+        Returns:
+            {path, format, total_rows, total_matched, returned, columns, rows,
+             aggregate, truncated, warnings}.
+
+        Errors: INVALID_PATH / NOT_FOUND (path); UNSUPPORTED_FORMAT; TOO_LARGE;
+            BAD_JSON; BAD_RECORD_PATH; BAD_FILTER; BAD_OP; BAD_AGGREGATE.
+        """
+        try:
+            result = query_data_module.query_data(
+                vault_root,
+                path=path,
+                record_path=record_path,
+                filters=filters,
+                columns=columns,
+                sort_by=sort_by,
+                descending=descending,
+                limit=limit,
+                offset=offset,
+                aggregate=aggregate,
+                date_from=date_from,
+                date_to=date_to,
+                date_column=date_column,
+            )
+        except query_data_module.QueryDataError as e:
+            raise ValueError(f"{e.code}: {e.reason}") from e
+        return result.as_dict()
 
     @tier2_tool
     def create_file(

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -1,0 +1,190 @@
+"""query_data: structured queries over CSV/JSON data files under the vault."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import query_data as qd
+
+
+CSV = (
+    "date,analyte,value,unit,ref_range\n"
+    "2016-03,IGF-1,276,ng/ml,111 - 551\n"
+    "2024-07,IGF-1,77,ng/ml,90 - 357\n"
+    '2024-07,CRP,"<0,4",mg/l,<5\n'
+    "2025-05,CRP,0.42,mg/l,<5\n"
+    "2020-09,Hb,151,g/l,134 - 170\n"
+)
+
+
+def _write(vault: Path, rel: str, text: str) -> str:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return rel
+
+
+# ---------------- CSV ----------------
+
+def test_csv_loads_rows_and_columns(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel)
+    assert r.format == "csv"
+    assert r.total_rows == 5
+    assert r.columns == ["date", "analyte", "value", "unit", "ref_range"]
+    assert r.returned == 5
+
+
+def test_csv_filter_eq(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel, filters=[{"column": "analyte", "op": "eq", "value": "IGF-1"}])
+    assert r.total_matched == 2
+    assert {row["value"] for row in r.rows} == {"276", "77"}
+
+
+def test_csv_numeric_gt_with_comma_and_lab_operator(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    # CRP "<0,4" -> 0.4 ; 0.42 -> 0.42. value < 0.41 keeps only the "<0,4" row.
+    r = qd.query_data(vault, path=rel, filters=[
+        {"column": "analyte", "op": "eq", "value": "CRP"},
+        {"column": "value", "op": "lt", "value": 0.41},
+    ])
+    assert r.total_matched == 1
+    assert r.rows[0]["value"] == "<0,4"
+
+
+def test_csv_numeric_gt(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel, filters=[
+        {"column": "analyte", "op": "eq", "value": "IGF-1"},
+        {"column": "value", "op": "gt", "value": 100},
+    ])
+    assert r.total_matched == 1 and r.rows[0]["value"] == "276"
+
+
+def test_csv_date_range(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel, date_from="2024-01", date_to="2024-12")
+    assert r.total_matched == 2
+    assert {row["date"] for row in r.rows} == {"2024-07"}
+
+
+def test_csv_columns_projection(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel, columns=["date", "value"], limit=2)
+    assert r.columns == ["date", "value"]
+    assert all(set(row.keys()) == {"date", "value"} for row in r.rows)
+
+
+def test_csv_sort_numeric_descending(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(
+        vault, path=rel,
+        filters=[{"column": "analyte", "op": "eq", "value": "IGF-1"}],
+        sort_by="value", descending=True,
+    )
+    assert [row["value"] for row in r.rows] == ["276", "77"]
+
+
+def test_csv_limit_offset_truncation(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    r = qd.query_data(vault, path=rel, limit=2, offset=0)
+    assert r.returned == 2 and r.total_matched == 5 and r.truncated is True
+
+
+def test_csv_aggregate_count_max_latest_distinct(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    assert qd.query_data(vault, path=rel, aggregate="count").aggregate == {"count": 5}
+
+    igf = [{"column": "analyte", "op": "eq", "value": "IGF-1"}]
+    assert qd.query_data(vault, path=rel, filters=igf, aggregate="max:value").aggregate["max"] == 276.0
+    latest = qd.query_data(vault, path=rel, filters=igf, aggregate="latest:value").aggregate
+    assert latest["row"]["value"] == "77"  # 2024-07 is later than 2016-03
+
+    distinct = qd.query_data(vault, path=rel, aggregate="distinct:analyte").aggregate
+    assert distinct["n"] == 3 and set(distinct["distinct"]) == {"IGF-1", "CRP", "Hb"}
+
+
+# ---------------- JSON ----------------
+
+def test_json_top_level_array(vault: Path) -> None:
+    data = [{"date": "2024-07-26", "analyte": "IGF-1", "value": 77},
+            {"date": "2025-05-21", "analyte": "B12", "value": 392}]
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.json", json.dumps(data))
+    r = qd.query_data(vault, path=rel, filters=[{"column": "analyte", "op": "eq", "value": "IGF-1"}])
+    assert r.format == "json" and r.total_rows == 2 and r.total_matched == 1
+    assert r.rows[0]["value"] == 77
+
+
+def test_json_nested_record_path_and_dotted_column(vault: Path) -> None:
+    data = {"sections": {"log": [
+        {"performer": {"name": "Confido"}, "dt": "2024"},
+        {"performer": {"name": "Hugo"}, "dt": "2025"},
+    ]}}
+    rel = _write(vault, "Knowledge Base/Evidence/Test/log.json", json.dumps(data))
+    r = qd.query_data(
+        vault, path=rel, record_path="sections.log",
+        filters=[{"column": "performer.name", "op": "eq", "value": "Confido"}],
+        columns=["performer.name", "dt"],
+    )
+    assert r.total_matched == 1
+    assert r.rows[0] == {"performer.name": "Confido", "dt": "2024"}
+
+
+def test_json_common_key_autodetect(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/r.json", json.dumps({"result": [{"a": 1}, {"a": 2}]}))
+    r = qd.query_data(vault, path=rel)
+    assert r.total_rows == 2
+    assert any("auto-detected" in w for w in r.warnings)
+
+
+def test_json_bad_record_path(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/r.json", json.dumps({"result": [{"a": 1}]}))
+    with pytest.raises(qd.QueryDataError) as e:
+        qd.query_data(vault, path=rel, record_path="nope.missing")
+    assert e.value.code == "BAD_RECORD_PATH"
+
+
+# ---------------- errors / safety ----------------
+
+def test_not_found(vault: Path) -> None:
+    with pytest.raises(qd.QueryDataError) as e:
+        qd.query_data(vault, path="Knowledge Base/Evidence/Test/missing.csv")
+    assert e.value.code == "NOT_FOUND"
+
+
+def test_path_escape_rejected(vault: Path) -> None:
+    with pytest.raises(qd.QueryDataError) as e:
+        qd.query_data(vault, path="../../../etc/passwd")
+    assert e.value.code == "INVALID_PATH"
+
+
+def test_unsupported_format(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/x.md", "# not data\n")
+    with pytest.raises(qd.QueryDataError) as e:
+        qd.query_data(vault, path=rel)
+    assert e.value.code == "UNSUPPORTED_FORMAT"
+
+
+def test_bad_op(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Evidence/Test/labs.csv", CSV)
+    with pytest.raises(qd.QueryDataError) as e:
+        qd.query_data(vault, path=rel, filters=[{"column": "value", "op": "between", "value": 1}])
+    assert e.value.code == "BAD_OP"
+
+
+def test_numeric_filter_ignores_appended_units_and_dates(vault: Path) -> None:
+    # Older rows store value+unit together ("100,2 nmol/l"); a `< 50` filter must
+    # parse the leading number, not lexicographically string-compare.
+    csv = (
+        "date,analyte,value\n"
+        '2016-03,VitD,"22,8 nmol/l"\n'
+        '2016-11,VitD,"100,2 nmol/l"\n'
+        "2024-04,VitD,21.1\n"
+    )
+    rel = _write(vault, "Knowledge Base/Evidence/Test/vitd.csv", csv)
+    r = qd.query_data(vault, path=rel, filters=[{"column": "value", "op": "lt", "value": 50}])
+    assert {row["value"] for row in r.rows} == {"22,8 nmol/l", "21.1"}  # 100,2 excluded


### PR DESCRIPTION
Adds the `query_data` tier-2 MCP tool — structured queries (filter / sort / paginate / project / aggregate) over vault CSV/TSV/JSON, with dotted-column access for nested JSON and `record_path` for nested arrays. The retrieval half of the dataset-card pattern: `find` → card → `query_data` pulls exact rows/aggregates from the raw file the card points at.

- New `src/kb_mcp/query_data.py` + tier-2 `@mcp.tool` registration in `server.py`.
- 18 tests (`tests/test_query_data.py`); full suite green.
- Tolerant numeric coercion (appended units, comma decimals, lab `<`/`>` operators); ordering comparisons exclude non-comparable values rather than silently string-comparing.
- Skill docs updated (canonical SKILL v0.17 + operations.md); repo scaffold re-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
