### PR TITLE
fix(reconcile): embed never-embedded files, not just mtime-stale rows

### DIFF
--- a/src/kb_mcp/audit.py
+++ b/src/kb_mcp/audit.py
@@ -746,11 +746,16 @@ def _check_unregistered_project_keys(
 
 
 def _check_embedding_drift(vault_root: Path) -> list[AuditFinding]:
-    """Flag sidecar rows whose on-disk file mtime is newer than the row's mtime.
+    """Flag embedding drift in three forms: (1) sidecar rows whose on-disk file
+    mtime is newer than the row (external edit), (2) rows whose file is gone from
+    disk, and (3) on-disk embeddable files with NO sidecar row at all — never
+    embedded, e.g. created out-of-band in Obsidian / mobile / a filesystem write,
+    which bypass the writer's embed hook.
 
-    External Obsidian edits don't trigger the writer hooks, so the vector
-    sidecar drifts silently. `audit_fix(rebuild_embeddings=True)` resolves
-    all of them in one rebuild — but you want to know it's needed.
+    External edits/creates don't trigger the writer hooks, so the vector sidecar
+    drifts silently. `reconcile` heals all three incrementally (it re-embeds
+    whatever this flags); `audit_fix(rebuild_embeddings=True)` resolves them in
+    one wipe-and-rebuild.
     """
     findings: list[AuditFinding] = []
     sidecar = vault_root / "Knowledge Base" / ".embeddings.sqlite"
@@ -800,8 +805,37 @@ def _check_embedding_drift(vault_root: Path) -> list[AuditFinding]:
                     f"({(row_mtime or 0):.0f}) — likely external edit."
                 ),
                 proposed_fix=(
-                    "Run `audit_fix(rebuild_embeddings=true)` to refresh."
+                    "Run `reconcile` (or `audit_fix(rebuild_embeddings=true)`) to refresh."
                 ),
+            ))
+
+    # Files on disk that were NEVER embedded — no sidecar row at all. The scan
+    # above only compares existing rows, so out-of-band *creates* (Obsidian /
+    # mobile / filesystem writes that bypass the writer's embed hook) stay
+    # vector-invisible until caught here. Mirror the embedder's selection
+    # (_walk_md + _is_embeddable_path + non-empty chunks) so we never flag a
+    # file the rebuild itself would skip — that would be perpetual drift.
+    from . import embeddings as embeddings_module
+    kb = vault_root / "Knowledge Base"
+    if kb.is_dir():
+        for md in find_module._walk_md(kb):
+            if not embeddings_module._is_embeddable_path(md):
+                continue
+            try:
+                rel = md.resolve().relative_to(vault_root.resolve()).as_posix()
+            except (ValueError, OSError):
+                continue
+            if rel in seen:
+                continue
+            page = find_module._CACHE.get(md, vault_root)
+            if page is None or not embeddings_module.chunk_text(page.title, page.body):
+                continue  # empty / no-chunk file — the embedder skips it too
+            findings.append(AuditFinding(
+                category="embedding_drift",
+                severity="info",
+                path=rel,
+                detail="file has no sidecar row — never embedded (out-of-band create).",
+                proposed_fix="Run `reconcile` to embed it incrementally.",
             ))
     return findings
 

--- a/src/kb_mcp/reconcile.py
+++ b/src/kb_mcp/reconcile.py
@@ -12,10 +12,12 @@ counts drift silently (surfaced by audit's `embedding_drift` / `index_drift`).
    on-disk reality (reusing `indexes.compute_subindex_writes`) and rewrite any
    that drifted. Hand-curated descriptions and Recent-activity are preserved —
    only count tokens move.
-2. **Embeddings (incremental)** — re-embed only the *stale* files (the ones
-   `embedding_drift` flags: on-disk mtime newer than the sidecar row), via the
-   same `upsert_after_write` path the writers use. Cheaper than a full
-   `audit_fix(rebuild_embeddings=True)` wipe-and-rebuild.
+2. **Embeddings (incremental)** — re-embed the files `embedding_drift` flags:
+   *stale* rows (on-disk mtime newer than the sidecar row) AND files with no
+   sidecar row at all (never embedded — out-of-band creates in Obsidian /
+   mobile / a filesystem write), via the same `upsert_after_write` path the
+   writers use. Cheaper than a full `audit_fix(rebuild_embeddings=True)`
+   wipe-and-rebuild.
 3. **Drift report** — re-run `index_drift` + `embedding_drift` and return what
    remains.
 
@@ -100,7 +102,7 @@ def reconcile(vault_root: Path, *, dry_run: bool = False) -> ReconcileReport:
     if writes and not dry_run:
         batch_atomic_write(writes, vault_root=vault_root)
 
-    # ---- 2. Embeddings (incremental refresh of stale rows only) ----
+    # ---- 2. Embeddings (incremental refresh of stale + never-embedded files) ----
     if os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
         report.embeddings_status = "disabled"
     else:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -170,3 +170,43 @@ def test_broken_link_in_editable_file_stays_warn(vault: Path) -> None:
     assert hits, "expected the broken link to be flagged"
     assert hits[0].severity == "warn", hits[0].as_dict()
     assert not (hits[0].meta or {}).get("immutable"), hits[0].as_dict()
+
+
+def test_embedding_drift_flags_never_embedded_file(vault: Path) -> None:
+    """A file with NO sidecar row (out-of-band create) is flagged as drift —
+    not just files whose existing row is mtime-stale. Regression for reconcile
+    silently skipping never-embedded files."""
+    import sqlite3
+
+    kb = vault / "Knowledge Base"
+    sidecar = kb / ".embeddings.sqlite"
+    embedded = kb / "Notes" / "Insights" / "progressive-disclosure-without-mode-fragmentation.md"
+    embedded_rel = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
+
+    # Seed a sidecar with one already-embedded note; row mtime ahead of disk so
+    # it is NOT mtime-stale.
+    conn = sqlite3.connect(sidecar)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS chunks (file_path TEXT NOT NULL, "
+        "chunk_idx INTEGER NOT NULL, chunk_text TEXT NOT NULL, vector BLOB NOT NULL, "
+        "file_mtime REAL NOT NULL, PRIMARY KEY (file_path, chunk_idx))"
+    )
+    conn.execute(
+        "INSERT INTO chunks VALUES (?,?,?,?,?)",
+        (embedded_rel, 0, "x", b"\x00", embedded.stat().st_mtime + 60),
+    )
+    conn.commit()
+    conn.close()
+
+    # A brand-new note written out-of-band — no sidecar row at all.
+    new = kb / "Notes" / "Insights" / "brand-new-out-of-band.md"
+    new.write_text(
+        "---\ntype: insight\nstatus: active\n---\n\n# Brand new\n\nSome body to chunk.\n",
+        encoding="utf-8",
+    )
+
+    findings = audit_module._check_embedding_drift(vault)
+    flagged = {f.path for f in findings}
+    assert "Knowledge Base/Notes/Insights/brand-new-out-of-band.md" in flagged, flagged
+    assert embedded_rel not in flagged  # already embedded + fresh → not flagged
+    assert all(f.category == "embedding_drift" for f in findings)


### PR DESCRIPTION
Fixes `reconcile` silently skipping never-embedded files. `audit._check_embedding_drift` only compared existing sidecar rows by mtime, so files created out-of-band (Obsidian / mobile / filesystem writes that bypass the writer's embed hook) had no row at all and were never flagged — staying vector-invisible (BM25-findable but absent from semantic recall) until a full `audit_fix(rebuild_embeddings=true)`.

Now it also walks on-disk embeddable files (mirroring the embedder's `_walk_md` + `_is_embeddable_path` + non-empty-chunks selection) and flags any with no sidecar row, so `reconcile` embeds them incrementally — and never flags a file the rebuild itself would skip (no perpetual drift). Model-free regression test added; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
