### PR TITLE
fix(auth): issue 30-day fallback access tokens to cut OAuth re-auth churn

### DIFF
--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -309,6 +309,13 @@ def build_server(*, require_auth: bool) -> FastMCP:
             token_verifier=SingleUserGitHubVerifier(allowed_login=gh_username),
             base_url=base_url,
             jwt_signing_key=jwt_signing_key,
+            # GitHub OAuth-App tokens carry no expiry, so FastMCP falls back to a
+            # 1-hour access token by default. For a single-user KB reached from a
+            # phone over the Funnel, that short TTL forces re-auth churn whenever a
+            # client (mobile app especially) can't silently refresh in time. Issue
+            # 30-day access tokens instead; the refresh token already never expires,
+            # and access is still gated to one GitHub login.
+            fallback_access_token_expiry_seconds=30 * 24 * 60 * 60,  # 30 days
         )
 
     mcp = FastMCP("kb-mcp", auth=auth, icons=_server_icons())


### PR DESCRIPTION
## What

`OAuthProxy` now passes `fallback_access_token_expiry_seconds=30*24*60*60` (30 days). GitHub OAuth-App tokens carry no `expires_in`, so FastMCP otherwise falls back to a **1-hour** access token, forcing re-auth churn whenever a client (mobile especially) can't silently refresh in time.

## Why this is separate from `jwt_signing_key`

This **stacks on** the existing `jwt_signing_key` pin rather than replacing it — they fix different churn causes:

- `jwt_signing_key` → keeps the token **store** stable across secret rotation / FastMCP upgrade (no store-orphaning).
- `fallback_access_token_expiry_seconds=30d` → access tokens live **30 days** instead of 1 hour (matches the observed "intermittent access-token expiry, session not silently refreshed" symptom).

The refresh token already never expires, and access stays gated to a single GitHub login.

## Notes

- This change has been running on the laptop deployment (editable install + service restart) and verified healthy (`/mcp` → 401 locally and through the Cloudflare tunnel).
- Should be ported to the desktop deployment after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)