### PR TITLE
feat(upload): raise cap to 100 MB + KB_MCP_HOST bind for off-Cloudflare uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ GITHUB_CLIENT_SECRET=replace-with-secret
 # rotation without re-auth. Generate: python -c "import secrets;print(secrets.token_urlsafe(48))"
 KB_MCP_JWT_SIGNING_KEY=replace-with-long-random-string
 KB_MCP_VAULT_PATH=D:\path\to\your\Obsidian
+KB_MCP_UPLOAD_MAX_BYTES=104857600
+KB_MCP_HOST=127.0.0.1

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -38,8 +38,9 @@ def _serve_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--host",
-        default="127.0.0.1",
-        help="Bind address for HTTP transports (default: 127.0.0.1; fronted by Tailscale Funnel).",
+        default=None,
+        help="Bind address for HTTP transports (default: $KB_MCP_HOST, else 127.0.0.1; "
+        "fronted by Cloudflare Tunnel). Set 0.0.0.0 to also serve a direct Tailscale/LAN route.",
     )
     parser.add_argument(
         "--port",

--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-base
 description: Operates on Hugo's personal Obsidian Knowledge Base — raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts. Triggers when the user wants to save, file, log, compile, distill, search, audit, supersede, or preserve anything in their KB, vault, Obsidian, or notes — including oblique phrasings ("interesting, save it," "I want to remember this"). Also engages proactively, without being told — it consults the KB for prior conclusions when a turn touches a project, domain, decision, or topic it likely covers, and captures durable conclusions when the conversation reaches a stepping-stone (agreement, decision, solved problem, diagnosed failure, or recognized pattern). Do NOT trigger for writes outside the Knowledge Base folder — Cognitive Core, Domains, Prompt Bank, Products, and Personal Context are read-only inputs.
-version: 0.21.0
+version: 0.22.0
 ---
 
 # Knowledge Base

--- a/src/kb_mcp/_scaffold/_Schema/references/operations.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/operations.md
@@ -186,7 +186,8 @@ tool takes text only). Pick the channel by where the file actually is:
   `Authorization: Bearer $KB_MCP_UPLOAD_TOKEN` (the token is **always** required;
   Cloudflare Access may sit in front as an extra network gate but the server does
   not trust its headers). Lands straight in `Evidence/<scope>/<category>/`, zero
-  token cost, ≤25 MB.
+  token cost. The public link is capped near **100 MB** by the Cloudflare edge;
+  larger originals go desk-side (below) rather than over the public URL.
 - **Claude Code / desk-side:** the file is already on local disk — write it straight
   into `Evidence/<scope>/<category>/`, or drop it via Obsidian Sync; the note links it.
 - **`preserve`** is text-only; binaries always go via the channels above. Every write

--- a/src/kb_mcp/preserve.py
+++ b/src/kb_mcp/preserve.py
@@ -20,10 +20,12 @@ from __future__ import annotations
 
 import base64
 import datetime as dt
+import io
 import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 
 from . import indexes
 from .vault import PlannedWrite, batch_atomic_write, escape_wikilinks_for_log, kb_root
@@ -70,9 +72,11 @@ def preserve(
     filename: str,
     content_base64: str | None = None,
     content: str | None = None,
+    content_stream: BinaryIO | None = None,
     description: str | None = None,
     today: dt.date | None = None,
     max_decoded_bytes: int = MAX_DECODED_BYTES,
+    max_stream_bytes: int = MAX_UPLOAD_BYTES,
 ) -> PreserveResult:
     """Capture an artifact to Evidence/<scope>/<category>/<filename>."""
     missing: list[str] = []
@@ -91,11 +95,12 @@ def preserve(
         missing.append("filename")
         reasons.append("filename is empty or only invalid characters")
 
-    if (content_base64 is None) == (content is None):
+    if sum(x is not None for x in (content_base64, content, content_stream)) != 1:
         return _raise(
             "INVALID_PRESERVE",
-            ["content_base64" if content is None else "content"],
-            "Exactly one of `content_base64` or `content` must be supplied.",
+            ["content"],
+            "Exactly one of `content_base64`, `content`, or `content_stream` "
+            "must be supplied.",
         )
 
     if missing:
@@ -140,6 +145,11 @@ def preserve(
             )
         artifact_bytes = decoded
         artifact_text = None
+    elif content_stream is not None:
+        # Large binary: streamed straight to disk in the write block below, so the
+        # file never materializes fully in RAM. Size is enforced during the copy.
+        artifact_bytes = None
+        artifact_text = None
     else:
         # content is UTF-8 text; write as-is.
         artifact_bytes = None
@@ -152,7 +162,13 @@ def preserve(
     sidecar_rel: str | None = None
 
     try:
-        if artifact_bytes is not None:
+        if content_stream is not None:
+            # Stream the upload to disk in chunks — peak memory is one chunk, not
+            # the whole file. Enforces the byte cap mid-copy (defense in depth; the
+            # HTTP layer's max_part_size already bounds the part during parsing).
+            _copy_stream_to_file(content_stream, artifact_path, limit=max_stream_bytes)
+            written_artifact = True
+        elif artifact_bytes is not None:
             # Binary: write directly, no atomic batch (batch_atomic_write is text-only).
             artifact_path.write_bytes(artifact_bytes)
             written_artifact = True
@@ -253,6 +269,37 @@ def preserve(
     )
 
 
+def preserve_stream(
+    vault_root: Path,
+    *,
+    scope: str,
+    category: str,
+    filename: str,
+    stream: BinaryIO,
+    description: str | None = None,
+    today: dt.date | None = None,
+    max_bytes: int = MAX_UPLOAD_BYTES,
+) -> PreserveResult:
+    """Capture a binary STREAM to Evidence/ — the entrypoint for HTTP /upload.
+
+    The bytes arrive out-of-band (multipart over HTTP) and are copied to disk in
+    chunks, so a multi-hundred-MB upload never materializes fully in RAM — peak
+    memory is one chunk. Funnels through `preserve()` so there is exactly ONE write
+    path with identical sanitization, append-only overwrite refusal, sidecar, and
+    index/log behavior. The byte cap is enforced during the copy.
+    """
+    return preserve(
+        vault_root,
+        scope=scope,
+        category=category,
+        filename=filename,
+        content_stream=stream,
+        description=description,
+        today=today,
+        max_stream_bytes=max_bytes,
+    )
+
+
 def preserve_bytes(
     vault_root: Path,
     *,
@@ -264,28 +311,56 @@ def preserve_bytes(
     today: dt.date | None = None,
     max_bytes: int = MAX_UPLOAD_BYTES,
 ) -> PreserveResult:
-    """Capture raw bytes to Evidence/ — the entrypoint for the HTTP /upload route.
+    """Capture an in-memory `bytes` artifact to Evidence/ (back-compat wrapper).
 
-    The bytes arrive out-of-band (multipart over HTTP), never through the model's
-    token stream, so the size budget is generous (`MAX_UPLOAD_BYTES`, not the
-    base64-via-model `MAX_DECODED_BYTES`). We funnel through `preserve()` so there
-    is exactly ONE write path with identical sanitization, append-only overwrite
-    refusal, sidecar, and index/log behavior. The local re-encode is server-side
-    CPU only (no tokens) and negligible relative to a 25 MB upload.
+    Routes through the streaming path (no base64 round-trip) by wrapping the bytes
+    in a BytesIO. Prefer `preserve_stream` when the source is already a file-like
+    (e.g. an HTTP upload's spooled temp file) so nothing is buffered whole.
     """
-    return preserve(
+    return preserve_stream(
         vault_root,
         scope=scope,
         category=category,
         filename=filename,
-        content_base64=base64.b64encode(data).decode("ascii"),
+        stream=io.BytesIO(data),
         description=description,
         today=today,
-        max_decoded_bytes=max_bytes,
+        max_bytes=max_bytes,
     )
 
 
 # ---------------- helpers ----------------
+
+
+_STREAM_CHUNK = 1024 * 1024  # 1 MiB copy buffer
+
+
+def _copy_stream_to_file(stream: BinaryIO, dest: Path, *, limit: int) -> int:
+    """Copy a binary file-like to `dest` in chunks, enforcing `limit` bytes.
+
+    Peak memory is one chunk regardless of file size. On overflow the partial
+    file is removed and TOO_LARGE is raised. Returns the bytes written.
+    """
+    try:
+        stream.seek(0)
+    except (OSError, AttributeError, ValueError):
+        pass  # non-seekable stream: copy from the current position
+    written = 0
+    overflow = False
+    with dest.open("wb") as out:
+        while True:
+            buf = stream.read(_STREAM_CHUNK)
+            if not buf:
+                break
+            written += len(buf)
+            if written > limit:
+                overflow = True
+                break
+            out.write(buf)
+    if overflow:
+        dest.unlink(missing_ok=True)
+        _raise("TOO_LARGE", ["file"], f"upload exceeds the {limit:,}-byte limit")
+    return written
 
 
 _INVALID_PATH_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')

--- a/src/kb_mcp/preserve.py
+++ b/src/kb_mcp/preserve.py
@@ -32,7 +32,10 @@ from .vault import PlannedWrite, batch_atomic_write, escape_wikilinks_for_log, k
 log = logging.getLogger(__name__)
 
 MAX_DECODED_BYTES = 5 * 1024 * 1024  # 5 MB — base64-via-model path (tokens cost real money)
-MAX_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB — HTTP /upload path (raw bytes, no token cost)
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB — HTTP /upload path (raw bytes, no token cost).
+# Aligns with the Cloudflare free-plan ~100 MB edge cap, so the public path and this app cap
+# agree. A deployment that wants larger uploads over a non-Cloudflare route (LAN/Tailscale
+# direct to the origin) raises KB_MCP_UPLOAD_MAX_BYTES in its .env.
 
 
 @dataclass

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -515,7 +515,7 @@ label{{display:block;margin:.75rem 0 .2rem}}input{{width:100%;padding:.5rem;font
 button{{margin-top:1rem;padding:.6rem 1rem;font:inherit}}#out{{margin-top:1rem;white-space:pre-wrap}}</style>
 <h1>Add evidence to the KB</h1>
 <form id=f>
-<label>File</label><input type=file name=file required>
+<label>File <small>(max {upload_max_bytes // (1024 * 1024)} MB; a public link may be capped lower by the proxy)</small></label><input type=file name=file required>
 <label>Scope</label><input name=scope value="{_attr('scope')}" placeholder="e.g. Yolo" required>
 <label>Category</label><input name=category value="{_attr('category')}" placeholder="e.g. 01 - Check-in" required>
 <label>Filename (optional)</label><input name=filename value="{_attr('filename')}">
@@ -2045,13 +2045,19 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
 def run(
     *,
     transport: str = "stdio",
-    host: str = "127.0.0.1",
+    host: str | None = None,
     port: int = 8765,
     log_dir: Path | None = None,
 ) -> None:
     """CLI entry: configure logging, build the server, run it.
 
     Auth is required for HTTP transports; stdio runs auth-free.
+
+    Bind host precedence: $KB_MCP_HOST > the passed `host` > 127.0.0.1. The env var
+    wins (and is resolved AFTER build_server() loads .env) so the deployment can flip
+    the bind from .env without changing the service's launch args. Set
+    KB_MCP_HOST=0.0.0.0 to also serve a non-Cloudflare route (e.g. a direct Tailscale
+    connection to the origin) for uploads larger than the Cloudflare edge cap.
     """
     from .logging_config import configure_logging
 
@@ -2060,11 +2066,12 @@ def run(
     configure_logging(log_dir)
 
     require_auth = transport != "stdio"
-    mcp = build_server(require_auth=require_auth)
+    mcp = build_server(require_auth=require_auth)  # loads .env (KB_MCP_HOST, etc.)
 
     if transport == "stdio":
         log.info("kb-mcp starting on stdio")
         mcp.run(transport="stdio")
     else:
+        host = os.environ.get("KB_MCP_HOST") or host or "127.0.0.1"
         log.info("kb-mcp starting on %s host=%s port=%s", transport, host, port)
         mcp.run(transport=transport, host=host, port=port)

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -30,6 +30,7 @@ from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.github import GitHubTokenVerifier
 from fastmcp.server.middleware.middleware import Middleware, MiddlewareContext
+from starlette.concurrency import run_in_threadpool
 from starlette.formparsers import MultiPartException
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
@@ -465,23 +466,18 @@ def build_server(*, require_auth: bool) -> FastMCP:
         filename = str(form.get("filename") or "").strip() or (
             getattr(upload, "filename", "") or ""
         )
-        data = await upload.read()
-        if len(data) > upload_max_bytes:
-            return JSONResponse(
-                {
-                    "code": "TOO_LARGE",
-                    "reason": f"{len(data):,} bytes exceeds the "
-                    f"{upload_max_bytes:,}-byte upload limit",
-                },
-                status_code=413,
-            )
+        # Stream the spooled upload straight to Evidence/, off the event loop. The
+        # part size is already bounded by max_part_size above; preserve_stream copies
+        # in chunks, so even a multi-hundred-MB file never lands in RAM (no read() of
+        # the whole body, no base64 round-trip).
         try:
-            result = preserve_module.preserve_bytes(
+            result = await run_in_threadpool(
+                preserve_module.preserve_stream,
                 vault_root,
                 scope=scope,
                 category=category,
                 filename=filename,
-                data=data,
+                stream=upload.file,
                 description=description,
                 max_bytes=upload_max_bytes,
             )

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import io
 
 import pytest
 
@@ -89,6 +90,50 @@ def test_preserve_bytes_honors_max_bytes(vault) -> None:
             category="y",
             filename="big.bin",
             data=b"x" * 2048,
+            max_bytes=1024,
+        )
+    assert exc.value.code == "TOO_LARGE"
+
+
+# ---------------- preserve_stream (the streaming /upload write path) ----------------
+
+
+def test_preserve_stream_writes_exact_bytes(vault) -> None:
+    payload = b"\x00\x01\x02binary-stream" * 1000
+    result = preserve_module.preserve_stream(
+        vault,
+        scope="Yolo",
+        category="01 - Check-in",
+        filename="clip.bin",
+        stream=io.BytesIO(payload),
+    )
+    assert (vault / result.path).read_bytes() == payload
+
+
+def test_preserve_stream_handles_file_larger_than_base64_cap(vault) -> None:
+    # 6 MB — above the 5 MB base64-via-model cap. Proves /upload uses the streaming
+    # path (chunked to disk), not the token-budget base64 path that MAX_DECODED_BYTES
+    # guards.
+    payload = b"x" * (6 * 1024 * 1024)
+    result = preserve_module.preserve_stream(
+        vault,
+        scope="x",
+        category="y",
+        filename="big.bin",
+        stream=io.BytesIO(payload),
+        max_bytes=10 * 1024 * 1024,
+    )
+    assert (vault / result.path).stat().st_size == len(payload)
+
+
+def test_preserve_stream_honors_max_bytes(vault) -> None:
+    with pytest.raises(preserve_module.PreserveError) as exc:
+        preserve_module.preserve_stream(
+            vault,
+            scope="x",
+            category="y",
+            filename="big.bin",
+            stream=io.BytesIO(b"x" * 2048),
             max_bytes=1024,
         )
     assert exc.value.code == "TOO_LARGE"


### PR DESCRIPTION
## Why

The `/upload` endpoint capped at **25 MB** (`MAX_UPLOAD_BYTES`, PR #25). Uploading a 164 MB original failed — and the public Cloudflare Tunnel adds its **own ~100 MB edge cap** before the request even reaches the origin. Two stacked limits, one of which (ours) was needlessly low.

## What

- **Raise the app cap 25 MB → 100 MB** (`preserve.py`), aligning the shipped default with the Cloudflare free-plan edge ceiling so the two limits agree. Deployments override via `KB_MCP_UPLOAD_MAX_BYTES`.
- **Env-driven bind host** (`server.py` `run()` + `__main__.py`): precedence `$KB_MCP_HOST` > passed `--host` > `127.0.0.1`, resolved **after** `.env` loads. Setting `KB_MCP_HOST=0.0.0.0` lets the server also serve a **direct, non-Cloudflare route** (e.g. a Tailscale connection straight to the origin), which bypasses the 100 MB edge cap — bounded only by `KB_MCP_UPLOAD_MAX_BYTES`. The public Cloudflare path stays naturally capped at ~100 MB.
- **`GET /upload` form** now shows the size limit.
- **Skill 0.21.0 → 0.22.0**: `operations.md` documents the ~100 MB public cap and points larger originals at the desk-side path; scaffold re-derived (generic, leak-guarded).

## Deploy (not in this PR — applied on the laptop)

`KB_MCP_UPLOAD_MAX_BYTES` (headroom for the bypass) and `KB_MCP_HOST=0.0.0.0` go in `.env`; a Windows Firewall rule scopes TCP 8765 to the Tailscale range so binding `0.0.0.0` doesn't expose it on the LAN. `/upload` stays token-gated; `/mcp` stays OAuth-gated.

## Test

`pytest` — 448 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)