### PR TITLE
feat(media): backfill-media — make pre-existing Evidence files searchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ uv sync --extra embeddings --extra media
 #     Verify the GPU media path:  uv run python scripts/verify-media-gpu.py
 #     Lean/CPU-only boxes can skip all of this — set KB_MCP_DISABLE_MEDIA_EXTRACTION;
 #     uploads still work, just without server-side searchable-text extraction.
+#     CPU works too (no GPU needed) — just slower; pick a smaller Whisper model with
+#     KB_MCP_WHISPER_MODEL=base. The CUDA-12 wheels above are Windows+GPU only, unused on CPU.
+
+# 1c. Make EXISTING Evidence files searchable (one-shot back-fill). New uploads are
+#     handled automatically; this pass covers files that predate the feature — it writes
+#     a sidecar if missing, extracts text (OCR/ASR/PDF), and CLIP-embeds images. Idempotent.
+#       uv run python -m kb_mcp backfill-media --dry-run   # preview (writes nothing)
+#       uv run python -m kb_mcp backfill-media             # do it (CPU or GPU)
+#     Flags: --no-ocr (sidecar + CLIP only), --no-clip, --vault <root>.
 
 # 2. Set up a public HTTPS URL (you need this hostname in step 3). Pick ONE:
 #

--- a/scripts/smoke-media-pipeline.py
+++ b/scripts/smoke-media-pipeline.py
@@ -1,0 +1,129 @@
+"""End-to-end smoke of the whole searchable-binaries arc — REAL engines, no claude.ai.
+
+Drives the actual ASGI app (build_server + TestClient) against a throwaway vault:
+  1. /upload an image with text in it  → server OCRs it (Tesseract) → find by that text
+  2. /upload a textless red image       → server CLIP-embeds it    → find "a red square"
+  3. /upload a text PDF                  → server reads it (PyMuPDF) → find by that text
+  4. /download one of them back          → bytes match (scoped token)
+Proves the bytes path (no base64), server-side transduction, first-class media find,
+CLIP visual search, and the /download reverse channel — all wired together.
+
+Run from a box with the [media] extra: uv run python scripts/smoke-media-pipeline.py
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TOKEN = "smoke-token"
+
+
+def _wait(predicate, *, timeout=120.0, what="condition"):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.5)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+def main() -> int:
+    # Real engines on; throwaway vault from the test fixtures.
+    for flag in ("KB_MCP_DISABLE_MEDIA_EXTRACTION", "KB_MCP_DISABLE_CLIP", "KB_MCP_DISABLE_EMBEDDINGS"):
+        os.environ.pop(flag, None)
+    vault = Path(tempfile.mkdtemp()) / "vault"
+    shutil.copytree(REPO / "tests" / "fixtures", vault)
+    os.environ["KB_MCP_VAULT_PATH"] = str(vault)
+    os.environ["KB_MCP_UPLOAD_TOKEN"] = TOKEN
+
+    from PIL import Image, ImageDraw
+    from starlette.testclient import TestClient
+
+    from kb_mcp import embeddings
+    from kb_mcp import find as find_module
+    from kb_mcp import server, upload_tokens
+
+    server.load_dotenv = lambda *a, **k: None  # don't let repo .env clobber the smoke vault
+    print("building server (loads bge + CLIP; first time is slow)…")
+    client = TestClient(server.build_server(require_auth=False).http_app())
+
+    def up_token():
+        return upload_tokens.mint(TOKEN, scope="upload")
+
+    def post(name, data_bytes, mime, scope, cat, text=None):
+        form = {"scope": scope, "category": cat}
+        if text is not None:
+            form["text"] = text
+        r = client.post(
+            "/upload",
+            files={"file": (name, data_bytes, mime)},
+            data=form,
+            headers={"Authorization": f"Bearer {up_token()}"},
+        )
+        assert r.status_code == 201, f"{name}: {r.status_code} {r.text}"
+        return r.json()
+
+    # ---- 1. image OCR ----
+    img = Image.new("RGB", (640, 120), "white")
+    ImageDraw.Draw(img).text((10, 45), "EVICTION NOTICE 14 days Whitechapel flat", fill="black")
+    b = io.BytesIO(); img.save(b, "PNG")
+    post("notice.png", b.getvalue(), "image/png", "Smoke", "01")
+    sidecar = vault / "Knowledge Base/Evidence/Smoke/01/notice.png.md"
+    _wait(lambda: sidecar.exists() and "extracted_by: pending" not in sidecar.read_text("utf-8"),
+          what="OCR of notice.png")
+    body = sidecar.read_text("utf-8")
+    assert "whitechapel" in body.lower() or "eviction" in body.lower(), f"OCR text missing:\n{body[:400]}"
+    find_module.clear_cache()
+    hits = find_module.find(vault, query="eviction whitechapel", mode="keyword")
+    assert any("notice.png.md" in h.path for h in hits), "find did not surface the OCR'd image"
+    print("  [1] image OCR -> searchable by its text          PASS")
+
+    # ---- 2. CLIP textless image ----
+    red = io.BytesIO(); Image.new("RGB", (320, 320), "red").save(red, "PNG")
+    post("red.png", red.getvalue(), "image/png", "Smoke", "02")
+    red_rel = "Knowledge Base/Evidence/Smoke/02/red.png"
+    _wait(lambda: embeddings.ClipIndex(vault).has(red_rel), what="CLIP index of red.png")
+    find_module.clear_cache()
+    hits = find_module.find(vault, query="a solid red square", mode="hybrid")
+    red_hit = [h for h in hits if "red.png.md" in h.path]
+    assert red_hit, "CLIP did not surface the textless red image"
+    assert red_hit[0].as_dict().get("media_type") == "image"
+    print("  [2] textless image -> found by CLIP visual match  PASS")
+
+    # ---- 3. PDF text ----
+    import fitz
+    doc = fitz.open(); page = doc.new_page()
+    page.insert_text((72, 72), "MEDICAL REPORT cardiology consult Dr Avery 2026")
+    pdf_bytes = doc.tobytes(); doc.close()
+    post("report.pdf", pdf_bytes, "application/pdf", "Smoke", "03")
+    pdf_sidecar = vault / "Knowledge Base/Evidence/Smoke/03/report.pdf.md"
+    _wait(lambda: pdf_sidecar.exists() and "extracted_by: pending" not in pdf_sidecar.read_text("utf-8"),
+          what="PDF extraction")
+    assert "cardiology" in pdf_sidecar.read_text("utf-8").lower(), "PDF text not extracted"
+    find_module.clear_cache()
+    hits = find_module.find(vault, query="cardiology consult", mode="keyword")
+    assert any("report.pdf.md" in h.path for h in hits), "find did not surface the PDF"
+    print("  [3] PDF text -> extracted (PyMuPDF) & searchable   PASS")
+
+    # ---- 4. /download reverse channel (scoped token) ----
+    dtok = upload_tokens.mint(TOKEN, scope="download")
+    r = client.get("/download", params={"path": red_rel}, headers={"Authorization": f"Bearer {dtok}"})
+    assert r.status_code == 200 and r.content == red.getvalue(), "download byte mismatch"
+    # scope isolation: an upload-scoped token must NOT download
+    r2 = client.get("/download", params={"path": red_rel}, headers={"Authorization": f"Bearer {up_token()}"})
+    assert r2.status_code == 401, f"upload token wrongly accepted on /download: {r2.status_code}"
+    print("  [4] /download original back + scope isolation     PASS")
+
+    print("\nSMOKE: PASS — full arc works end-to-end on this build.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -5,6 +5,7 @@ Subcommands:
 - `init` — bootstrap a fresh Knowledge Base into a vault
 - `install-skill` — install the knowledge-base skill into Claude Code
 - `install-hook` — wire the KB capture + retrieval hooks into Claude Code
+- `backfill-media` — make pre-existing Evidence binaries searchable (sidecar + OCR/ASR/PDF + CLIP)
 """
 
 from __future__ import annotations
@@ -25,6 +26,8 @@ def main(argv: list[str] | None = None) -> int:
         return _install_skill_main(raw[1:])
     if raw and raw[0] == "install-hook":
         return _install_hook_main(raw[1:])
+    if raw and raw[0] == "backfill-media":
+        return _backfill_media_main(raw[1:])
     return _serve_main(raw)
 
 
@@ -57,6 +60,39 @@ def _serve_main(argv: list[str]) -> int:
     except Exception as e:
         print(f"kb-mcp failed: {e}", file=sys.stderr)
         return 1
+    return 0
+
+
+def _backfill_media_main(argv: list[str]) -> int:
+    import logging
+
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp backfill-media",
+        description="Make pre-existing Evidence binaries searchable: write a sidecar if "
+        "missing, extract text (OCR/ASR/PDF), and CLIP-embed images. Idempotent; CPU or GPU.",
+    )
+    parser.add_argument(
+        "--vault", default=os.environ.get("KB_MCP_VAULT_PATH"),
+        help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="report what would change; write nothing")
+    parser.add_argument("--no-ocr", action="store_true", help="skip text extraction (sidecar + CLIP only)")
+    parser.add_argument("--no-clip", action="store_true", help="skip CLIP image embedding")
+    args = parser.parse_args(argv)
+    if not args.vault:
+        print("backfill-media: set --vault or KB_MCP_VAULT_PATH", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    from . import backfill
+
+    backfill.backfill_media(
+        Path(args.vault).expanduser(),
+        do_ocr=not args.no_ocr,
+        do_clip=not args.no_clip,
+        dry_run=args.dry_run,
+        log_fn=print,
+    )
     return 0
 
 

--- a/src/kb_mcp/backfill.py
+++ b/src/kb_mcp/backfill.py
@@ -1,0 +1,131 @@
+"""Bulk media back-fill — make pre-existing Evidence binaries searchable.
+
+`kb-mcp backfill-media` walks Evidence/, and for every media file (image/audio/video/pdf):
+  1. writes a `.md` sidecar if missing — so `find()` can surface it (a CLIP/text match maps
+     to `<file>.md`, which must exist);
+  2. extracts text (OCR / ASR / PDF) if not already done — text-searchable;
+  3. CLIP-embeds images — searchable by visual content.
+
+Idempotent: re-running only does outstanding work. Runs on CPU or GPU (engines auto-detect).
+The *incremental* path (new uploads) is handled live by the server; this is the deliberate
+one-shot pass over content that predates the feature — or for a friend's existing vault.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from . import embeddings, extract, preserve
+
+log = logging.getLogger(__name__)
+
+_EXTRACTED_BY_RE = re.compile(r"(?m)^extracted_by:\s*(.+?)\s*$")
+_NOT_DONE = {"none", "pending"}
+
+
+def _sidecar_for(binary: Path) -> Path:
+    name = binary.name
+    if name.lower().endswith(".md"):
+        return binary.with_name(name[:-3] + "-notes.md")
+    return binary.with_name(name + ".md")
+
+
+def _ocr_done(sidecar: Path) -> bool:
+    """True if the sidecar already has extracted text (a real engine in extracted_by)."""
+    try:
+        head = sidecar.read_text("utf-8")[:800]
+    except OSError:
+        return False
+    m = _EXTRACTED_BY_RE.search(head)
+    if not m:
+        return False
+    v = m.group(1).strip()
+    return v not in _NOT_DONE and not v.startswith("failed:")
+
+
+@dataclass
+class BackfillStats:
+    scanned: int = 0
+    sidecars_created: int = 0
+    extracted: int = 0
+    extract_failed: int = 0
+    clip_indexed: int = 0
+    skipped: int = 0
+
+
+def backfill_media(
+    vault_root: Path,
+    *,
+    do_ocr: bool = True,
+    do_clip: bool = True,
+    dry_run: bool = False,
+    log_fn=log.info,
+) -> BackfillStats:
+    """Back-fill sidecars + text + CLIP for every media file under Evidence/. Idempotent."""
+    stats = BackfillStats()
+    evidence = vault_root / "Knowledge Base" / "Evidence"
+    if not evidence.is_dir():
+        log_fn("no Knowledge Base/Evidence/ directory; nothing to back-fill")
+        return stats
+    clip_index = embeddings.ClipIndex(vault_root) if do_clip else None
+    files = sorted(p for p in evidence.rglob("*") if p.is_file() and extract.media_type_for(p))
+    stats.scanned = len(files)
+    log_fn(f"scanning {len(files)} media file(s) under Evidence/ (dry_run={dry_run})")
+
+    for i, f in enumerate(files, 1):
+        media_type = extract.media_type_for(f)
+        try:
+            rel = f.resolve().relative_to(vault_root.resolve()).as_posix()
+        except (ValueError, OSError):
+            continue
+        sidecar = _sidecar_for(f)
+        need_sidecar = not sidecar.exists()
+        need_ocr = do_ocr and not _ocr_done(sidecar)
+        need_clip = (
+            do_clip and clip_index is not None and media_type == "image" and not clip_index.has(rel)
+        )
+        if not (need_sidecar or need_ocr or need_clip):
+            stats.skipped += 1
+            continue
+        if dry_run:
+            todo = " ".join(t for t, on in
+                            (("sidecar", need_sidecar), ("ocr", need_ocr), ("clip", need_clip)) if on)
+            log_fn(f"  [{i}/{len(files)}] {rel} -> {todo}")
+            stats.sidecars_created += need_sidecar
+            stats.extracted += need_ocr
+            stats.clip_indexed += need_clip
+            continue
+
+        if need_sidecar:
+            sidecar, created = preserve.ensure_media_sidecar(vault_root, f)
+            stats.sidecars_created += int(created)
+        if need_ocr:
+            try:
+                res = extract.extract_text(f, media_type=media_type)
+                preserve.update_sidecar_extraction(
+                    vault_root, sidecar, text=res.text.strip() or "(no text detected)", engine=res.engine
+                )
+                stats.extracted += 1
+            except extract.ExtractionUnavailable as e:
+                log_fn(f"  ! extraction engine unavailable ({e}); skipping OCR for the rest")
+                do_ocr = False
+            except Exception:  # noqa: BLE001 — one bad file shouldn't abort the pass
+                log.exception("backfill: extraction failed for %s", f.name)
+                stats.extract_failed += 1
+        if need_clip:
+            try:
+                clip_index.upsert(rel, embeddings.embed_image(f), f.stat().st_mtime)
+                stats.clip_indexed += 1
+            except embeddings.ClipUnavailable as e:
+                log_fn(f"  ! CLIP unavailable ({e}); skipping CLIP for the rest")
+                do_clip = False
+            except Exception:  # noqa: BLE001
+                log.exception("backfill: CLIP failed for %s", f.name)
+        if i % 25 == 0:
+            log_fn(f"  …{i}/{len(files)} processed")
+
+    log_fn(f"backfill done: {asdict(stats)}")
+    return stats

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -174,7 +174,13 @@ class MediaWorker:
         return n
 
     def _scan_unindexed_images(self) -> int:
-        """CLIP-queue every Evidence image not yet in the index (mirrors the OCR scan)."""
+        """CLIP-queue Evidence images that have a sidecar but aren't indexed yet.
+
+        Sidecar-LESS images (pre-feature files) are skipped on purpose: `find()` can't
+        surface a CLIP match without a `<image>.md` sidecar, so indexing them here would be
+        wasted work. The deliberate `kb-mcp backfill-media` pass writes their sidecars
+        (+ OCR + CLIP) — this incremental scan only tops up already-sidecar'd images.
+        """
         if not embeddings.clip_enabled():
             return 0
         evidence = self._vault_root / "Knowledge Base" / "Evidence"
@@ -184,6 +190,8 @@ class MediaWorker:
         for f in evidence.rglob("*"):
             if not f.is_file() or extract.media_type_for(f) != "image":
                 continue
+            if not f.with_name(f.name + ".md").exists():
+                continue  # no sidecar → not findable; backfill-media handles these
             try:
                 rel = f.resolve().relative_to(self._vault_root.resolve()).as_posix()
             except (ValueError, OSError):

--- a/src/kb_mcp/preserve.py
+++ b/src/kb_mcp/preserve.py
@@ -487,6 +487,45 @@ def _render_sidecar(
     return "\n".join(lines)
 
 
+def ensure_media_sidecar(
+    vault_root: Path, binary_path: Path, *, today: dt.date | None = None
+) -> tuple[Path, bool]:
+    """Ensure an Evidence media binary has a sidecar — the back-fill of pre-feature files.
+
+    Images/PDFs/audio dropped into Evidence/ before server-side extraction existed have no
+    `.md` sidecar, so `find()` can't surface them (a CLIP/text match maps to `<file>.md`,
+    which doesn't exist). This writes a minimal stub (`media_type` + `evidence_file` pointer,
+    `extracted_by: none`) and embeds it. Idempotent: returns (existing_sidecar, False) if one
+    already exists, else (new_sidecar, True). Used by `kb-mcp backfill-media`.
+    """
+    media_type = extract.media_type_for(binary_path)
+    if media_type is None:
+        raise ValueError(f"not an extractable media file: {binary_path.name!r}")
+    name = binary_path.name
+    if name.lower().endswith(".md"):
+        sidecar = binary_path.with_name(name[:-3] + "-notes.md")
+    else:
+        sidecar = binary_path.with_name(name + ".md")
+    if sidecar.exists():
+        return sidecar, False
+    rel = binary_path.resolve().relative_to(vault_root.resolve()).as_posix()
+    # Derive scope/category from Knowledge Base/Evidence/<scope>/<category>/… for the tags.
+    parts = rel.split("/")
+    scope = parts[2] if len(parts) > 2 else "evidence"
+    category = parts[3] if len(parts) > 3 else "uncategorized"
+    md = _render_sidecar(
+        artifact_name=name,
+        scope=scope,
+        category=category,
+        date_iso=(today or dt.date.today()).isoformat(),
+        media_type=media_type,
+        evidence_file=rel,
+        extracted_by="none",  # not pending → the auto OCR scan ignores it; backfill OCRs it
+    )
+    batch_atomic_write([PlannedWrite(path=sidecar, content=md)], vault_root=vault_root)
+    return sidecar, True
+
+
 _EXTRACTED_HEADING = "## Extracted text"
 
 

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,73 @@
+"""backfill-media — sidecar + OCR + CLIP for pre-existing Evidence files (engines stubbed)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kb_mcp import backfill, embeddings, extract, preserve
+
+REL = "Knowledge Base/Evidence/Old/photos/legacy.jpg"
+
+
+def _drop_image(vault, rel=REL, data=b"\xff\xd8\xffOLD"):
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return p
+
+
+def _quiet(*a, **k):
+    pass
+
+
+def test_ensure_media_sidecar_creates_stub(vault) -> None:
+    img = _drop_image(vault)
+    sidecar, created = preserve.ensure_media_sidecar(vault, img)
+    assert created and sidecar.exists()
+    body = sidecar.read_text("utf-8")
+    assert "media_type: image" in body
+    assert f"evidence_file: {REL}" in body
+    assert "extracted_by: none" in body
+    # idempotent
+    sidecar2, created2 = preserve.ensure_media_sidecar(vault, img)
+    assert sidecar2 == sidecar and created2 is False
+
+
+def test_backfill_dry_run_writes_nothing(vault) -> None:
+    img = _drop_image(vault)
+    stats = backfill.backfill_media(vault, dry_run=True, log_fn=_quiet)
+    assert stats.sidecars_created == 1
+    assert not img.with_name(img.name + ".md").exists()  # nothing actually written
+
+
+def test_backfill_creates_sidecar_ocr_clip(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    img = _drop_image(vault)
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda p, media_type=None: extract.ExtractResult(text="legacy invoice acme", media_type="image", engine="tesseract"),
+    )
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: np.ones(embeddings.CLIP_DIM, dtype=np.float32))
+
+    stats = backfill.backfill_media(vault, log_fn=_quiet)
+    assert (stats.sidecars_created, stats.extracted, stats.clip_indexed) == (1, 1, 1)
+    body = img.with_name(img.name + ".md").read_text("utf-8")
+    assert "legacy invoice acme" in body
+    assert "extracted_by: tesseract" in body
+    assert embeddings.ClipIndex(vault).has(REL)
+
+    # idempotent: a second pass does nothing
+    stats2 = backfill.backfill_media(vault, log_fn=_quiet)
+    assert (stats2.sidecars_created, stats2.extracted, stats2.clip_indexed) == (0, 0, 0)
+    assert stats2.skipped >= 1
+
+
+def test_backfill_no_ocr_skips_extraction(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _drop_image(vault)
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: np.ones(embeddings.CLIP_DIM, dtype=np.float32))
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("OCR ran under --no-ocr")),
+    )
+    stats = backfill.backfill_media(vault, do_ocr=False, log_fn=_quiet)
+    assert (stats.sidecars_created, stats.extracted, stats.clip_indexed) == (1, 0, 1)


### PR DESCRIPTION
Fixes a gap found by **testing the live MCP**: the startup scan CLIP-*indexed* existing images, but `find()` drops a CLIP match whose `<image>.md` sidecar doesn't exist — and pre-feature files have none (**247/248 lacked one**). So visual search was effectively dead for existing evidence (worked only for new uploads). This adds the deliberate back-fill + an explicit, friend-runnable flow.

## What's in it
- **`kb-mcp backfill-media`** (new CLI) — walks `Evidence/`, and per media file: writes a sidecar if missing → extracts text (OCR/ASR/PDF) → CLIP-embeds images. **Idempotent**, `--dry-run`, `--no-ocr`/`--no-clip`, **CPU or GPU**. The one-shot pass for content predating the feature (or a friend's existing vault). `backfill.py` holds the logic.
- **`preserve.ensure_media_sidecar()`** — minimal stub sidecar (`media_type` + `evidence_file`) for a sidecar-less binary, so `find()` can surface it.
- **`media_worker._scan_unindexed_images`** now **skips sidecar-less images** (no more wasted CLIP work; the CLI owns the bulk fix).
- README: backfill usage + CPU note (`KB_MCP_WHISPER_MODEL=base`; the CUDA-12 wheels are Windows+GPU only, unused on CPU).
- `scripts/smoke-media-pipeline.py`: the reusable 4-stage end-to-end smoke (real engines).

## CPU / friend-friendly
Everything auto-detects device and runs on CPU (faster-whisper int8, Tesseract, PyMuPDF, CLIP). `[media]` stays an optional, soft-failing extra. So Yusuke can run `kb-mcp backfill-media` on his own vault, GPU or not.

## Verified
- Dry-run over the **real vault**: 330 media files / 326 needing sidecars, CLIP correctly skipped (already indexed → idempotent), nothing written.
- Full suite **500 passed**. No SKILL change → no version bump.

## Deploy (after merge)
Pull main → `uv sync` → restart. Then run `uv run python -m kb_mcp backfill-media --dry-run` to preview, then without `--dry-run` to make your 326 existing files fully searchable (visual + text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)