### PR TITLE
feat(media): video searchable by sight (keyframe CLIP) + graceful no-audio

### DIFF
--- a/src/kb_mcp/backfill.py
+++ b/src/kb_mcp/backfill.py
@@ -71,7 +71,13 @@ def backfill_media(
         log_fn("no Knowledge Base/Evidence/ directory; nothing to back-fill")
         return stats
     clip_index = embeddings.ClipIndex(vault_root) if do_clip else None
-    files = sorted(p for p in evidence.rglob("*") if p.is_file() and extract.media_type_for(p))
+    # Fast media first (image/pdf OCR is quick) so screenshots/docs are searchable in
+    # minutes; slow A/V transcription (Whisper) runs last instead of starving the queue.
+    _order = {"image": 0, "pdf": 1, "audio": 2, "video": 3}
+    files = sorted(
+        (p for p in evidence.rglob("*") if p.is_file() and extract.media_type_for(p)),
+        key=lambda p: (_order.get(extract.media_type_for(p), 9), p.as_posix()),
+    )
     stats.scanned = len(files)
     log_fn(f"scanning {len(files)} media file(s) under Evidence/ (dry_run={dry_run})")
 
@@ -85,7 +91,8 @@ def backfill_media(
         need_sidecar = not sidecar.exists()
         need_ocr = do_ocr and not _ocr_done(sidecar)
         need_clip = (
-            do_clip and clip_index is not None and media_type == "image" and not clip_index.has(rel)
+            do_clip and clip_index is not None
+            and media_type in ("image", "video") and not clip_index.has(rel)
         )
         if not (need_sidecar or need_ocr or need_clip):
             stats.skipped += 1
@@ -117,7 +124,8 @@ def backfill_media(
                 stats.extract_failed += 1
         if need_clip:
             try:
-                clip_index.upsert(rel, embeddings.embed_image(f), f.stat().st_mtime)
+                vec = embeddings.embed_video(f) if media_type == "video" else embeddings.embed_image(f)
+                clip_index.upsert(rel, vec, f.stat().st_mtime)
                 stats.clip_indexed += 1
             except embeddings.ClipUnavailable as e:
                 log_fn(f"  ! CLIP unavailable ({e}); skipping CLIP for the rest")

--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -195,7 +195,13 @@ def embed_video(path: Path, *, max_frames: int = CLIP_VIDEO_FRAMES) -> np.ndarra
 
 
 def _sample_video_frames(path: Path, max_frames: int) -> list:
-    """Decode up to `max_frames` evenly-spaced frames as PIL images (PyAV)."""
+    """Sample `max_frames` evenly-spaced frames as PIL images, SEEKING to each timestamp.
+
+    Seeking decodes only ~`max_frames` frames total (O(1) in video length) instead of
+    decoding the whole stream to reach evenly-spaced positions — so a 1-hour video costs
+    the same as a 10-second one. Falls back to first-N sequential decode if the duration is
+    unknown or seeks fail.
+    """
     try:
         import av
     except ImportError as e:
@@ -206,10 +212,22 @@ def _sample_video_frames(path: Path, max_frames: int) -> list:
             return frames
         stream = container.streams.video[0]
         stream.thread_type = "AUTO"
-        total = stream.frames or 0
-        step = max(1, total // max_frames) if total else 30  # ~every 30th frame if count unknown
-        for i, frame in enumerate(container.decode(stream)):
-            if i % step == 0:
+        total_secs = 0.0
+        if stream.duration and stream.time_base:
+            total_secs = float(stream.duration * stream.time_base)
+        elif container.duration:
+            total_secs = container.duration / av.time_base
+        if total_secs > 0 and stream.time_base:
+            for k in range(max_frames):
+                t = total_secs * (k + 0.5) / max_frames  # evenly-spaced midpoints
+                try:
+                    container.seek(int(t / float(stream.time_base)), stream=stream, backward=True)
+                    frames.append(next(container.decode(stream)).to_image())
+                except Exception:  # noqa: BLE001 — best-effort sample; skip a bad seek
+                    continue
+        if not frames:  # unknown duration or all seeks failed → first-N sequential
+            container.seek(0)
+            for frame in container.decode(stream):
                 frames.append(frame.to_image())
                 if len(frames) >= max_frames:
                     break

--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -165,6 +165,57 @@ def embed_clip_text(query: str) -> np.ndarray:
     return vec.astype(np.float32, copy=False)
 
 
+CLIP_VIDEO_FRAMES = 8  # evenly-sampled keyframes mean-pooled into one video vector
+
+
+def embed_video(path: Path, *, max_frames: int = CLIP_VIDEO_FRAMES) -> np.ndarray:
+    """Encode a video → one CLIP vector (mean-pooled over evenly-sampled keyframes).
+
+    A video is a sequence of images: we decode up to `max_frames` evenly-spaced frames,
+    CLIP-embed each, and mean-pool (renormalized) into a single 512-d vector — so a video
+    is findable by what it visually SHOWS, including a SILENT video that has no transcript.
+    Raises ClipUnavailable if CLIP/PyAV/Pillow are missing or no frame decodes.
+    """
+    try:
+        from PIL import Image  # noqa: F401 — frame.to_image() returns a PIL image
+    except ImportError as e:
+        raise ClipUnavailable(f"Pillow not installed: {e}") from e
+    try:
+        model = get_clip_model()
+    except ImportError as e:
+        raise ClipUnavailable(f"sentence-transformers not installed: {e}") from e
+    frames = _sample_video_frames(path, max_frames)
+    if not frames:
+        raise ClipUnavailable(f"no decodable video frames in {path.name}")
+    vecs = model.encode(frames, convert_to_numpy=True, normalize_embeddings=True)
+    pooled = vecs.mean(axis=0)
+    norm = float(np.linalg.norm(pooled))
+    pooled = pooled / norm if norm else pooled
+    return pooled.astype(np.float32, copy=False)
+
+
+def _sample_video_frames(path: Path, max_frames: int) -> list:
+    """Decode up to `max_frames` evenly-spaced frames as PIL images (PyAV)."""
+    try:
+        import av
+    except ImportError as e:
+        raise ClipUnavailable(f"PyAV not installed: {e}") from e
+    frames: list = []
+    with av.open(str(path)) as container:
+        if not container.streams.video:
+            return frames
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        total = stream.frames or 0
+        step = max(1, total // max_frames) if total else 30  # ~every 30th frame if count unknown
+        for i, frame in enumerate(container.decode(stream)):
+            if i % step == 0:
+                frames.append(frame.to_image())
+                if len(frames) >= max_frames:
+                    break
+    return frames
+
+
 def rerank_pairs(query: str, passages: list[str]) -> np.ndarray:
     """Score `(query, passage)` pairs with bge-reranker-base. Returns float32 (N,).
 

--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -161,12 +161,29 @@ def _get_whisper():
 
 
 def _transcribe(path: Path, media_type: str) -> ExtractResult:
+    # A silent video (no audio stream) can't be transcribed — that's NOT a failure.
+    # Return an empty transcript cleanly; its visual content is still searchable via
+    # CLIP keyframes (embeddings.embed_video). A video IS a sequence of images.
+    if media_type == "video" and not _has_audio_stream(path):
+        return ExtractResult(text="", media_type=media_type, engine="no-audio")
     model = _get_whisper()
     # faster-whisper decodes the media's audio stream via PyAV (handles video containers
     # too), so a video file can be passed directly — no separate ffmpeg extraction step.
     segments, _info = model.transcribe(str(path))
     text = " ".join(seg.text.strip() for seg in segments).strip()
     return ExtractResult(text=text, media_type=media_type, engine=f"faster-whisper:{WHISPER_MODEL}")
+
+
+def _has_audio_stream(path: Path) -> bool:
+    """True if the container has an audio stream. On any probing error, assume yes
+    (let Whisper try) rather than wrongly skipping a transcribable file."""
+    try:
+        import av
+
+        with av.open(str(path)) as container:
+            return any(s.type == "audio" for s in container.streams)
+    except Exception:  # noqa: BLE001 — can't probe → don't pre-empt Whisper
+        return True
 
 
 _TESSERACT_READY = False

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -125,9 +125,12 @@ class MediaWorker:
         )
 
     def _run_clip(self, job: _Job) -> None:
-        """CLIP-embed an image into the ClipIndex so it's findable by visual content."""
+        """CLIP-embed an image (or video keyframes) so it's findable by visual content."""
         try:
-            vec = embeddings.embed_image(job.binary_path)
+            if job.media_type == "video":
+                vec = embeddings.embed_video(job.binary_path)
+            else:
+                vec = embeddings.embed_image(job.binary_path)
         except embeddings.ClipUnavailable as e:
             log.warning("CLIP unavailable for %s: %s", job.binary_path.name, e)
             return
@@ -188,7 +191,8 @@ class MediaWorker:
             return 0
         n = 0
         for f in evidence.rglob("*"):
-            if not f.is_file() or extract.media_type_for(f) != "image":
+            mt = extract.media_type_for(f) if f.is_file() else None
+            if mt not in ("image", "video"):  # video is CLIP-able too (keyframes)
                 continue
             if not f.with_name(f.name + ".md").exists():
                 continue  # no sidecar → not findable; backfill-media handles these
@@ -201,13 +205,13 @@ class MediaWorker:
             self.enqueue(
                 binary_path=f,
                 sidecar_path=f.with_name(f.name + ".md"),
-                media_type="image",
+                media_type=mt,
                 do_ocr=False,
                 do_clip=True,
             )
             n += 1
         if n:
-            log.info("media worker: CLIP-queued %d un-indexed image(s)", n)
+            log.info("media worker: CLIP-queued %d un-indexed image(s)/video(s)", n)
         return n
 
 

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -526,13 +526,13 @@ def build_server(*, require_auth: bool) -> FastMCP:
             )
         # Off-request-path media processing for the uploaded binary:
         #  - OCR/ASR/PDF text when no `text` was supplied (fills the pending sidecar);
-        #  - CLIP-embed every IMAGE (even one uploaded WITH text) so textless photos
-        #    are findable by visual content. Both run in the worker; the 201 returns now.
+        #  - CLIP-embed every IMAGE and VIDEO (keyframes) so visual content — including a
+        #    silent video with no transcript — is findable. Both run in the worker; 201 now.
         if media_worker is not None and result.sidecar_path:
             media_type = extract.media_type_for(filename)
             if media_type:
                 do_ocr = text is None
-                do_clip = media_type == "image" and not os.environ.get("KB_MCP_DISABLE_CLIP")
+                do_clip = media_type in ("image", "video") and not os.environ.get("KB_MCP_DISABLE_CLIP")
                 if do_ocr or do_clip:
                     media_worker.enqueue(
                         binary_path=vault_root / result.path,

--- a/tests/test_video_visual.py
+++ b/tests/test_video_visual.py
@@ -1,0 +1,73 @@
+"""Video visual search — no-audio handling + CLIP keyframe embedding (engines stubbed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kb_mcp import backfill, embeddings, extract, media_worker, preserve
+
+
+def test_transcribe_silent_video_is_not_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A video with no audio stream → empty transcript, engine "no-audio", never raises,
+    # and Whisper is never even loaded.
+    monkeypatch.setattr(extract, "_has_audio_stream", lambda p: False)
+    monkeypatch.setattr(extract, "_get_whisper", lambda: (_ for _ in ()).throw(AssertionError("loaded whisper")))
+    r = extract._transcribe(Path("clip.mp4"), "video")
+    assert r.text == "" and r.engine == "no-audio" and r.media_type == "video"
+
+
+def test_embed_video_mean_pools_keyframes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "_sample_video_frames", lambda p, n: ["f1", "f2"])
+
+    class _Model:
+        def encode(self, frames, **kw):
+            e0 = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+            e0[0] = 1.0
+            e1 = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+            e1[1] = 1.0
+            return np.stack([e0, e1])
+
+    monkeypatch.setattr(embeddings, "get_clip_model", lambda: _Model())
+    v = embeddings.embed_video(Path("clip.mp4"))
+    assert v.shape == (embeddings.CLIP_DIM,)
+    # mean of two orthogonal unit vectors, renormalized → 1/sqrt(2) on each axis
+    assert abs(v[0] - 0.70710) < 1e-3 and abs(v[1] - 0.70710) < 1e-3
+
+
+def test_embed_video_no_frames_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "_sample_video_frames", lambda p, n: [])
+    monkeypatch.setattr(embeddings, "get_clip_model", lambda: object())
+    with pytest.raises(embeddings.ClipUnavailable):
+        embeddings.embed_video(Path("clip.mp4"))
+
+
+def test_worker_clip_embeds_video_via_keyframes(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_CLIP", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    res = preserve.preserve_bytes(
+        vault, scope="Yolo", category="clips", filename="demo.mp4", data=b"\x00\x00video", text="x",
+    )
+    called = {}
+    monkeypatch.setattr(embeddings, "embed_video", lambda p: called.setdefault("v", np.ones(embeddings.CLIP_DIM, np.float32)))
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: (_ for _ in ()).throw(AssertionError("used embed_image for video")))
+    w = media_worker.MediaWorker(vault)
+    w._process(media_worker._Job(
+        binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
+        media_type="video", do_ocr=False, do_clip=True,
+    ))
+    assert "v" in called  # embed_video was used, not embed_image
+    assert embeddings.ClipIndex(vault).has(res.path)
+
+
+def test_backfill_clip_indexes_video(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_CLIP", raising=False)
+    p = vault / "Knowledge Base/Evidence/Old/clips/legacy.mp4"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00video")
+    monkeypatch.setattr(embeddings, "embed_video", lambda f: np.ones(embeddings.CLIP_DIM, np.float32))
+    stats = backfill.backfill_media(vault, do_ocr=False, log_fn=lambda *a: None)
+    assert stats.clip_indexed == 1
+    assert embeddings.ClipIndex(vault).has("Knowledge Base/Evidence/Old/clips/legacy.mp4")


### PR DESCRIPTION
Prompted by a no-audio demo clip that failed the OCR backfill. A video is a sequence of images — a silent one can't be transcribed, but its frames still carry meaning.

## Changes
- **No-audio handled cleanly** (`extract._transcribe`): probe for an audio stream (PyAV); a silent video returns an empty transcript with engine `no-audio` instead of raising → no spurious `extracted_by: failed:`.
- **Video → CLIP via keyframes** (`embeddings.embed_video`): decode up to 8 evenly-spaced frames, CLIP-embed each, mean-pool (renormalized) → one 512-d vector keyed to the video path. So a video is findable by **what it shows** (incl. silent video), reusing the existing sidecar→`find` path with **no schema change**.
- Wired through worker (`_run_clip`, `_scan_unindexed_images`), `/upload` enqueue, and `backfill.py` — video is treated like image for CLIP everywhere.
- **Backfill fast-media-first ordering**: images/PDFs (quick) before audio/video (slow Whisper), so screenshots index in minutes instead of starving behind an 840 MB video.

## Verified
- Real silent mp4 on the box → `has_audio: False`, `no-audio` transcript (no error), `embed_video` → normalized 512-d vector.
- Engines stubbed in CI. **Full suite 505 passed.** No new deps; no SKILL change (video clip hits surface in `find` automatically).

## Deploy
Pull main → `uv sync` → restart. Then `uv run python -m kb_mcp backfill-media` to visually index existing videos (the 4 already-transcribed ones get a CLIP vector; the 1 silent failure resolves to `no-audio` + visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)