### PR TITLE
fix(deps): add Pillow so CLIP image search + OCR can open images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 embeddings = [
     "sentence-transformers>=2.7",
     "torch>=2.12",
+    "pillow>=10.0",  # CLIP image encoding opens images via PIL (sentence-transformers)
 ]
 # Server-side media extraction (transduction, not a brain): ASR for audio/video,
 # OCR for images, text for PDFs. Optional so a lean box runs without it — the code
@@ -39,6 +40,7 @@ embeddings = [
 media = [
     "faster-whisper>=1.0",
     "pytesseract>=0.3.10",
+    "pillow>=10.0",  # pytesseract opens images via PIL for OCR
     "pymupdf>=1.24",
     # CUDA-12 runtime for faster-whisper/ctranslate2 on Windows. torch+cu132 ships
     # cuBLAS *13* (different major), so ctranslate2's CUDA-12 cuBLAS + cudart must be

--- a/uv.lock
+++ b/uv.lock
@@ -879,6 +879,7 @@ dependencies = [
 
 [package.optional-dependencies]
 embeddings = [
+    { name = "pillow" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -888,6 +889,7 @@ media = [
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32'" },
     { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32'" },
+    { name = "pillow" },
     { name = "pymupdf" },
     { name = "pytesseract" },
 ]
@@ -906,6 +908,8 @@ requires-dist = [
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
     { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
+    { name = "pillow", marker = "extra == 'embeddings'", specifier = ">=10.0" },
+    { name = "pillow", marker = "extra == 'media'", specifier = ">=10.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
     { name = "pymupdf", marker = "extra == 'media'", specifier = ">=1.24" },
     { name = "pytesseract", marker = "extra == 'media'", specifier = ">=0.3.10" },


### PR DESCRIPTION
## Why

#31 (CLIP image search) and the media OCR path (`pytesseract`) both open image files via **PIL**, but **Pillow was never declared as a dependency**. At runtime the media worker logs `No module named 'PIL'` and skips every image — observed on the laptop deploy: **248 images queued, 0 indexable**. The code degrades soft (no crash), so it slipped through.

## What

Add `pillow>=10.0` to:
- the **`embeddings`** extra — CLIP image encoding (sentence-transformers opens images via PIL),
- the **`media`** extra — `pytesseract` OCR opens images via PIL.

`uv.lock` updated. No code changes.

## Deploy

`uv sync --extra embeddings --extra media` on the host, then restart — the media worker will then index the queued images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)