### PR TITLE
fix(media): re-index legacy single-vector videos per-keyframe (has_frames gate)

### DIFF
--- a/src/kb_mcp/backfill.py
+++ b/src/kb_mcp/backfill.py
@@ -90,9 +90,12 @@ def backfill_media(
         sidecar = _sidecar_for(f)
         need_sidecar = not sidecar.exists()
         need_ocr = do_ocr and not _ocr_done(sidecar)
+        # Video idempotency keys on per-keyframe rows (has_frames), so a legacy
+        # single-vector video (frame_ts NULL) is re-indexed per-keyframe, not skipped.
+        # Images stay on has() (one row = done).
         need_clip = (
-            do_clip and clip_index is not None
-            and media_type in ("image", "video") and not clip_index.has(rel)
+            do_clip and clip_index is not None and media_type in ("image", "video")
+            and not (clip_index.has_frames(rel) if media_type == "video" else clip_index.has(rel))
         )
         if not (need_sidecar or need_ocr or need_clip):
             stats.skipped += 1

--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -668,13 +668,35 @@ class ClipIndex:
         self._cache = None
 
     def has(self, rel_path: str) -> bool:
-        """True if this image already has a vector (used by the startup scan)."""
+        """True if this file has ANY vector row (image or video). Correct idempotency
+        for IMAGES (one row); for VIDEOS use `has_frames` — a video with only a stale
+        single-vector (frame_ts NULL) row from the old path returns True here but still
+        needs per-keyframe re-indexing."""
         if not self.path.exists():
             return False
         conn = self._connect()
         try:
             row = conn.execute(
                 "SELECT 1 FROM images WHERE file_path = ?", (rel_path,)
+            ).fetchone()
+        finally:
+            conn.close()
+        return row is not None
+
+    def has_frames(self, rel_path: str) -> bool:
+        """True if this file has at least one PER-KEYFRAME vector (frame_ts NOT NULL).
+
+        The correct idempotency check for VIDEO: a video carrying only a legacy
+        single-vector row (frame_ts NULL, from the pre-multi-vector path) returns
+        False here, so backfill/worker re-index it per-keyframe instead of skipping it.
+        """
+        if not self.path.exists():
+            return False
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM images WHERE file_path = ? AND frame_ts IS NOT NULL",
+                (rel_path,),
             ).fetchone()
         finally:
             conn.close()

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -206,7 +206,9 @@ class MediaWorker:
                 rel = f.resolve().relative_to(self._vault_root.resolve()).as_posix()
             except (ValueError, OSError):
                 continue
-            if self._clip_index.has(rel):
+            # Video keys on per-keyframe rows so a legacy single-vector video
+            # (frame_ts NULL) is re-queued for per-keyframe indexing; image = any row.
+            if (self._clip_index.has_frames(rel) if mt == "video" else self._clip_index.has(rel)):
                 continue
             self.enqueue(
                 binary_path=f,

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -96,6 +96,48 @@ def test_find_clip_surfaces_textless_image(vault, monkeypatch: pytest.MonkeyPatc
     assert "clip_frame_ts" not in d["signals"]
 
 
+def test_has_frames_distinguishes_legacy_single_vector_video(vault) -> None:
+    """A video carrying only a legacy single-vector row (frame_ts NULL) must read as
+    NOT per-keyframe-indexed, so backfill/worker re-index it instead of skipping."""
+    idx = embeddings.ClipIndex(vault)
+    img = "Knowledge Base/Evidence/Yolo/photos/a.jpg"
+    vid = "Knowledge Base/Evidence/Yolo/vids/legacy.mp4"
+
+    idx.upsert(img, _unit(0), 1.0)            # normal image
+    idx.upsert(vid, _unit(1), 1.0)            # STALE single-vector video (frame_ts NULL)
+
+    # has() = any row (true for both); has_frames() = per-keyframe row only.
+    assert idx.has(img) and not idx.has_frames(img)
+    assert idx.has(vid)                       # the bug: looks "done" to has()
+    assert not idx.has_frames(vid)            # the fix: still needs per-keyframe indexing
+
+    idx.upsert_frames(vid, [(10.0, _unit(2)), (20.0, _unit(3))], 2.0)
+    assert idx.has_frames(vid)                # now genuinely per-keyframe indexed
+    paths, frame_ts, _ = idx.all_vectors()
+    assert paths.count(vid) == 2 and None not in [t for p, t in zip(paths, frame_ts) if p == vid]
+
+
+def test_backfill_reindexes_legacy_single_vector_video(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """backfill must NOT skip a video that only has a stale single-vector row."""
+    monkeypatch.delenv("KB_MCP_DISABLE_CLIP", raising=False)
+    from kb_mcp import backfill
+    p = vault / "Knowledge Base/Evidence/Old/clips/legacy.mp4"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00video")
+    rel = "Knowledge Base/Evidence/Old/clips/legacy.mp4"
+    embeddings.ClipIndex(vault).upsert(rel, _unit(7), 1.0)  # pre-existing single-vector row
+    monkeypatch.setattr(
+        embeddings, "embed_video_frames",
+        lambda f: [(1.0, _unit(0)), (2.0, _unit(1)), (3.0, _unit(2))],
+    )
+    stats = backfill.backfill_media(vault, do_ocr=False, log_fn=lambda *a: None)
+    assert stats.clip_indexed == 1  # re-indexed, not skipped
+    idx = embeddings.ClipIndex(vault)
+    assert idx.has_frames(rel)
+    paths, _, _ = idx.all_vectors()
+    assert paths.count(rel) == 3  # stale NULL row replaced by 3 keyframes
+
+
 def test_find_clip_skipped_when_disabled(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KB_MCP_DISABLE_CLIP", "1")
     res = preserve.preserve_bytes(


### PR DESCRIPTION
## What

Follow-up bugfix to #34, **found in production during deploy**. A video that was CLIP-indexed by the *pre*-multi-vector path carries one row with `frame_ts NULL`. `ClipIndex.has()` returns True for **any** row, so `backfill-media` and the worker's startup scan treated such a video as "already indexed" and **skipped** the per-keyframe upgrade — leaving long videos stuck at a single mean-pooled vector.

Symptom: after deploying #34, 5 Evidence videos (single-vector indexed by a parallel `feat/video-visual-search` service run) caused `backfill-media` to report `clip_indexed=0`.

## Fix

- Add **`ClipIndex.has_frames(rel)`** — EXISTS a row with `frame_ts NOT NULL`.
- Use it as the **video** idempotency check in `backfill` and `media_worker._scan_unindexed_images`; **images** stay on `has()` (one row = done).
- `upsert_frames` already deletes the stale NULL row first, so re-indexing is clean.

## Verified live

After clearing the stale rows and re-running backfill on the real vault: **`clip_indexed=5` → 90 keyframe rows across 5 videos** (840 MB/68-min → 15 kf after static-screen dedup; 717 MB/56-min → 26; a busy 18-min → 40 at the cap). This PR makes that automatic — no manual row-clearing needed next time.

## Tests

`uv run pytest tests/test_clip.py` → 15 passed; ruff clean. New: `has_frames` distinguishes a legacy single-vector video from a per-keyframe one; backfill re-indexes a stale single-vector video instead of skipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)