### PR TITLE
feat(find,get): surface supersession + edit-why at read time

### DIFF
--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -51,6 +51,7 @@ class RankingConfig:
     rrf_k: int = 60  # Cormack/Clarke/Buettcher 2009 default; fusion.py
     compiled_boost: float = 1.15  # must equal _COMPILED_BOOST
     source_penalty: float = 0.85  # must equal _SOURCE_PENALTY
+    superseded_penalty: float = 0.5  # must equal _SUPERSEDED_PENALTY
     candidate_multiplier: int = 5  # candidate_k = max(limit*mult, floor)
     candidate_floor: int = 50
     graph_seed_cap: int = 20  # per-ranker fanout cap for 1-hop expansion
@@ -138,6 +139,20 @@ class ParsedPage:
         ef = self.frontmatter.get("evidence_file")
         return str(ef) if ef else None
 
+    @property
+    def status(self) -> str | None:
+        """Lifecycle status — draft / active / superseded / archived (None if unset)."""
+        s = self.frontmatter.get("status")
+        return str(s) if s else None
+
+    @property
+    def superseded_by(self) -> list[str]:
+        """Wikilink(s) to the page(s) that replaced this one (empty when not superseded)."""
+        sb = self.frontmatter.get("superseded_by")
+        if not sb:
+            return []
+        return [str(x) for x in sb] if isinstance(sb, list) else [str(sb)]
+
 
 def _format_timestamp(seconds: float) -> str:
     """Seconds → `mm:ss` (or `h:mm:ss` past an hour) for human-readable video deeplinks."""
@@ -185,6 +200,13 @@ class Hit:
     # on video visual hits (multi-vector index); None for images. Surfaced as a
     # human-readable `clip_match_at` ("14:32") so the caller can deep-link the moment.
     clip_frame_ts: float | None = None
+    # Lifecycle. `status` is set when a hit is NOT plain `active`, so a reader can
+    # tell a superseded tombstone (or draft) from a live conclusion; `superseded_by`
+    # carries the forward pointer(s) to the replacement(s). Surfaced in as_dict()
+    # regardless of `prefer_active` — exposure is independent of the ranking
+    # demotion. Omitted when status is active/unset so live hits stay noise-free.
+    status: str | None = None
+    superseded_by: list[str] = field(default_factory=list)
 
     def as_dict(self) -> dict:
         out: dict = {
@@ -203,6 +225,10 @@ class Hit:
             out["clip_match_at"] = _format_timestamp(self.clip_frame_ts)
         if self.outside_kb:
             out["outside_kb"] = True
+        if self.status and self.status != "active":
+            out["status"] = self.status
+        if self.superseded_by:
+            out["superseded_by"] = self.superseded_by
         signals: dict = {}
         if self.bm25_rank is not None:
             signals["bm25_rank"] = self.bm25_rank
@@ -266,6 +292,7 @@ def find(
     graph: bool = True,
     rerank: bool = False,
     prefer_compiled: bool = True,
+    prefer_active: bool = True,
     config: RankingConfig | None = None,
 ) -> list[Hit]:
     """Search the vault. Returns up to `limit` hits.
@@ -308,6 +335,13 @@ def find(
     pages. Reflects the KB's epistemic hierarchy — compiled distillations
     are the intentional output, sources are inputs. Set False to retrieve
     raw source discussion verbatim (e.g. "what did I capture from Dr. X").
+
+    `prefer_active`: when True (default), soft-demotes `status: superseded`
+    pages so a replaced conclusion can't outrank the page that superseded it.
+    The tombstone stays findable (never excluded) and its hit carries `status`
+    + `superseded_by` either way, so the reader sees it's superseded and where
+    it points. Set False to rank superseded pages on their content alone (e.g.
+    "what did I used to think about X").
     """
     if scope not in ("kb", "vault", "kb-only"):
         raise ValueError(
@@ -344,6 +378,7 @@ def find(
             types=types, projects=projects, tags=tags,
             limit=limit, scope=walk_scope, mode=mode, graph=graph, rerank=rerank,
             prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
             config=config or DEFAULT_RANKING,
         )
 
@@ -436,6 +471,8 @@ def _find_keyword(
                     excerpt=excerpt or "",
                     media_type=page.media_type,
                     media_file=page.media_file,
+                    status=page.status,
+                    superseded_by=page.superseded_by,
                 ),
             )
         )
@@ -458,6 +495,7 @@ def _find_semantic(
     graph: bool = True,
     rerank: bool = False,
     prefer_compiled: bool = True,
+    prefer_active: bool = True,
     config: RankingConfig = DEFAULT_RANKING,
 ) -> list[Hit]:
     """Hybrid (BM25+vector) or vector-only mode."""
@@ -621,6 +659,8 @@ def _find_semantic(
     # applied to rerank_score below so it survives the final sort.
     if prefer_compiled:
         fused = _apply_type_boost(fused, vault_root, config)
+    if prefer_active:
+        fused = _apply_status_demotion(fused, vault_root, config)
     vector_paths: set[str] = set(vector_ranking)
 
     # Resolve fused paths back to ParsedPage, filter, build hits in fused order.
@@ -681,6 +721,8 @@ def _find_semantic(
             excerpt=excerpt or "",
             media_type=page.media_type,
             media_file=page.media_file,
+            status=page.status,
+            superseded_by=page.superseded_by,
             bm25_rank=bm25_rank_by_path.get(rel_path),
             vector_rank=vector_rank_by_path.get(rel_path),
             vector_score=vector_score_by_path.get(rel_path),
@@ -721,6 +763,13 @@ def _find_semantic(
                 for h in hits:
                     if h.rerank_score is not None:
                         h.rerank_score *= _type_multiplier(h.type, config)
+            # Re-apply the supersession demotion to rerank scores too, so a
+            # superseded tombstone the reranker liked can't float back above
+            # its successor in the final sort.
+            if prefer_active:
+                for h in hits:
+                    if h.rerank_score is not None:
+                        h.rerank_score *= _status_multiplier(h.status, config)
             hits.sort(key=lambda h: -(h.rerank_score if h.rerank_score is not None else float("-inf")))
         except ImportError as e:
             log.warning("rerank requested but reranker unavailable: %s", e)
@@ -799,6 +848,8 @@ def _find_outside_kb(
             excerpt=excerpt or "",
             media_type=page.media_type,
             media_file=page.media_file,
+            status=page.status,
+            superseded_by=page.superseded_by,
             outside_kb=True,
         ))
         if len(hits) >= limit:
@@ -859,6 +910,11 @@ _COMPILED_TYPES = frozenset(
 _SOURCE_TYPES = frozenset({"source"})
 _COMPILED_BOOST = 1.15
 _SOURCE_PENALTY = 0.85
+# Supersession demotion: a `status: superseded` page stays in place per the
+# supersession protocol (it is NOT moved), so without this it competes head-to-head
+# with — and can outrank — the very page that replaced it. Soft-demote, never
+# exclude: the tombstone must stay findable for "what did I used to think".
+_SUPERSEDED_PENALTY = 0.5
 
 
 def _type_multiplier(
@@ -868,6 +924,19 @@ def _type_multiplier(
         return config.compiled_boost
     if page_type in _SOURCE_TYPES:
         return config.source_penalty
+    return 1.0
+
+
+def _status_multiplier(
+    status: str | None, config: RankingConfig = DEFAULT_RANKING
+) -> float:
+    """Demote `superseded` tombstones; everything else is neutral.
+
+    `archived` pages live in `_archive/` (already dir-excluded), so only
+    `superseded` needs handling here. `active`/`draft`/unset → 1.0.
+    """
+    if status == "superseded":
+        return config.superseded_penalty
     return 1.0
 
 
@@ -890,6 +959,25 @@ def _apply_type_boost(
             mult = 1.0
         else:
             mult = _type_multiplier(page.page_type if page else None, config)
+        adjusted.append((path, score * mult))
+    adjusted.sort(key=lambda t: (-t[1], t[0]))
+    return adjusted
+
+
+def _apply_status_demotion(
+    fused: list[tuple[str, float]],
+    vault_root: Path,
+    config: RankingConfig = DEFAULT_RANKING,
+) -> list[tuple[str, float]]:
+    """Re-sort fused `(path, score)` pairs after demoting superseded pages.
+
+    Mirrors `_apply_type_boost` but gated by `prefer_active` independently of
+    `prefer_compiled`. Pages that can't be loaded keep their original score.
+    """
+    adjusted: list[tuple[str, float]] = []
+    for path, score in fused:
+        page = _CACHE.get(vault_root / path, vault_root)
+        mult = _status_multiplier(page.status if page else None, config)
         adjusted.append((path, score * mult))
     adjusted.sort(key=lambda t: (-t[1], t[0]))
     return adjusted

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -71,6 +71,7 @@ from . import schema
 from . import set_frontmatter_field as set_frontmatter_field_module
 from . import set_take as set_take_module
 from . import upload_tokens
+from . import vault
 from .vault import (
     VaultPathError,
     find_body_wikilinks,
@@ -645,6 +646,7 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         graph: bool = True,
         rerank: bool = False,
         prefer_compiled: bool = True,
+        prefer_active: bool = True,
     ) -> list[dict]:
         """Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.
 
@@ -699,12 +701,22 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 AND rerank. Reflects the KB's epistemic hierarchy. Set
                 false to retrieve raw source discussion verbatim (e.g.
                 "what did I capture from Dr. X").
+            prefer_active: When true (default), soft-demotes `status:
+                superseded` pages so a replaced conclusion can't outrank the
+                page that superseded it. The tombstone stays findable and its
+                hit still carries `status` + `superseded_by` (the forward
+                pointer) so you can see it's superseded. Set false to rank a
+                superseded page on its content alone (e.g. "what did I used to
+                think about X").
 
         Returns:
             List of {path, type, scope, title, updated, excerpt[, outside_kb]
-            [, signals]}. `outside_kb: true` is present only on hits the
-            "kb" auto-widen pulled from beyond Knowledge Base/ (the `path`
-            also shows the sibling folder).
+            [, status][, superseded_by][, signals]}. `outside_kb: true` is
+            present only on hits the "kb" auto-widen pulled from beyond
+            Knowledge Base/ (the `path` also shows the sibling folder).
+            `status` + `superseded_by` appear only when a hit is NOT plain
+            `active` — i.e. a superseded tombstone (or draft) — so you can tell
+            it from a live conclusion and follow `superseded_by` to the replacement.
             In hybrid mode `excerpt` shows the best-matching chunk; in
             keyword mode it's a snippet anchored to the literal query
             match. `signals` (hybrid/vector only) carries per-ranker
@@ -726,6 +738,7 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             graph=graph,
             rerank=rerank,
             prefer_compiled=prefer_compiled,
+            prefer_active=prefer_active,
         )
         # Durable structured log → feeds the offline retrieval feedback loop.
         # Best-effort; never affects the returned result.
@@ -1208,7 +1221,9 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             raise ValueError(f"{e.code}: {e.reason}") from e
 
     @mcp.tool
-    def get(path: str, frontmatter_only: bool = False) -> dict:
+    def get(
+        path: str, frontmatter_only: bool = False, include_history: bool = False
+    ) -> dict:
         """Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body + raw content.
 
         Reads anywhere under the vault root — not just `Knowledge Base/`.
@@ -1230,6 +1245,13 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 cheap for scanning many files by field (folds in the former
                 `get_frontmatter` tool). Returns {path, frontmatter,
                 has_frontmatter} instead of the full page below.
+            include_history: If true, attach a `history` list — the page's
+                change log from the append-only `log.md`, newest-first
+                (`[{date, op, summary}]`, where `summary` is the `why:`
+                rationale recorded at write time). Use this to answer "why was
+                this note changed / what was the old version / show its history"
+                and to verify an edit's rationale. `[]` when the page has no
+                recorded edits.
 
         Returns:
             {path, frontmatter, body, content, content_hash, mtime}.
@@ -1238,6 +1260,7 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             is a sha256 you can echo back to `edit`/`multi_edit` via
             `expected_hash` to refuse a write if the file changed on disk since
             this read (two-writer drift guard); `mtime` is advisory.
+            Adds `history` when `include_history=true`.
 
         Errors:
             INVALID_PATH (path escapes vault root or empty);
@@ -1245,17 +1268,21 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         """
         if frontmatter_only:
             try:
-                result = get_frontmatter_module.get_frontmatter(
+                fm_result = get_frontmatter_module.get_frontmatter(
                     vault_root, path=path
                 )
             except get_frontmatter_module.GetFrontmatterError as e:
                 raise ValueError(f"{e.code}: {e.reason}") from e
-            return result.as_dict()
-        try:
-            result = get_page_module.get_page(vault_root, path=path)
-        except get_page_module.GetError as e:
-            raise ValueError(f"{e.code}: {e.reason}") from e
-        return result.as_dict()
+            out = fm_result.as_dict()
+        else:
+            try:
+                result = get_page_module.get_page(vault_root, path=path)
+            except get_page_module.GetError as e:
+                raise ValueError(f"{e.code}: {e.reason}") from e
+            out = result.as_dict()
+        if include_history:
+            out["history"] = vault.read_log_entries(vault_root, out["path"])
+        return out
 
     @mcp.tool
     def edit(

--- a/src/kb_mcp/vault.py
+++ b/src/kb_mcp/vault.py
@@ -861,3 +861,51 @@ def write_log_entry(
     )
     batch_atomic_write([PlannedWrite(path=log_file, content=new_text)])
     return None
+
+
+# Matches a single log.md entry header: `## [2026-06-23] edit | Notes/Insights/foo`.
+# `op` is a single whitespace-free token; the title runs to end-of-line.
+_LOG_ENTRY_HEADER_RE = re.compile(
+    r"^## \[(\d{4}-\d{2}-\d{2})\] (\S+) \| (.+)$",
+    re.MULTILINE,
+)
+
+
+def read_log_entries(vault_root: Path, rel_path_no_ext: str) -> list[dict[str, str]]:
+    """Return the `log.md` change entries for one page, newest-first.
+
+    The inverse of `prepend_log_entry`: it parses the append-only activity log
+    and returns the `why`/rationale history for a single page so a reader can
+    verify *why* a note changed. Title matching mirrors how writers record the
+    entry (`prepend_log_entry`): a leading `Knowledge Base/` is stripped and the
+    `.md` extension dropped. Entries are stored newest-first (prepended), so file
+    order is preserved.
+
+    Missing `log.md`, or no matching entries, returns `[]` — never an error;
+    surfacing history is best-effort. Each entry is
+    ``{"date": "2026-06-23", "op": "edit", "summary": "<rationale + what changed>"}``.
+    """
+    title = rel_path_no_ext
+    if title.endswith(".md"):
+        title = title[: -len(".md")]
+    if title.startswith("Knowledge Base/"):
+        title = title[len("Knowledge Base/"):]
+
+    log_file = kb_root(vault_root) / "log.md"
+    if not log_file.exists():
+        return []
+    text = log_file.read_text(encoding="utf-8")
+
+    matches = list(_LOG_ENTRY_HEADER_RE.finditer(text))
+    entries: list[dict[str, str]] = []
+    for i, m in enumerate(matches):
+        if m.group(3).strip() != title:
+            continue
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        entries.append({
+            "date": m.group(1),
+            "op": m.group(2),
+            "summary": text[body_start:body_end].strip(),
+        })
+    return entries

--- a/tests/test_ranking_config.py
+++ b/tests/test_ranking_config.py
@@ -23,6 +23,7 @@ def test_default_config_matches_legacy_constants() -> None:
     # canonical source values; this binds them together.
     assert cfg.compiled_boost == find_module._COMPILED_BOOST
     assert cfg.source_penalty == find_module._SOURCE_PENALTY
+    assert cfg.superseded_penalty == find_module._SUPERSEDED_PENALTY
     assert cfg.rrf_k == 60
     assert cfg.candidate_multiplier == 5
     assert cfg.candidate_floor == 50

--- a/tests/test_supersession_surface.py
+++ b/tests/test_supersession_surface.py
@@ -1,0 +1,220 @@
+"""Surface what the substrate already records.
+
+Two pieces, one principle — the server *records* both the supersession
+relationship and each edit's `why`, and these tests pin that it now *surfaces*
+them at read time:
+
+- Piece B: `find` soft-demotes `status: superseded` pages (so a replaced
+  conclusion can't outrank its successor) and flags `status`/`superseded_by`
+  on the hit. Demotion is gated by `prefer_active`; exposure is not.
+- Piece A: `vault.read_log_entries` / `get(include_history=True)` return a
+  page's edit-`why` history from the append-only `log.md`.
+
+Runs under the suite-wide KB_MCP_DISABLE_EMBEDDINGS (see conftest): hybrid
+degrades to BM25 + keyword + graph, which still exercises the fusion + the new
+demotion pass. The conflict-pair notes match a rare token, so the keyword
+contribution carries them even if the BM25 index is stale.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import edit as edit_module
+from kb_mcp import find as find_module
+from kb_mcp import get_page as get_module
+from kb_mcp import server as server_module
+from kb_mcp import vault as vault_module
+
+
+TODAY = dt.date(2026, 6, 23)
+TOKEN = "zqxconflicttoken"  # rare → only the notes we plant here match it
+EXISTING = (
+    "Knowledge Base/Notes/Insights/"
+    "progressive-disclosure-without-mode-fragmentation.md"
+)
+
+
+def _write_insight(vault: Path, name: str, body: str, *, extra_fm: str = "") -> str:
+    rel = f"Knowledge Base/Notes/Insights/{name}"
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\n"
+        "type: insight\n"
+        "created: 2026-06-01\n"
+        "updated: 2026-06-01\n"
+        "tags: []\n"
+        f"{extra_fm}"
+        "---\n" + body,
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+    return rel
+
+
+def _write_conflict_pair(vault: Path) -> tuple[str, str]:
+    """An active conclusion and its superseded predecessor with IDENTICAL bodies.
+
+    Identical content means equal base ranking scores, so the only thing that
+    can separate them is the supersession demotion.
+    """
+    body = f"# Heading\n\nThe {TOKEN} is the distinctive search term here.\n"
+    new_rel = _write_insight(vault, "zqx-current.md", body)
+    old_rel = _write_insight(
+        vault,
+        "zqx-old.md",
+        body,
+        extra_fm=(
+            "status: superseded\n"
+            'superseded_by:\n  - "[[Knowledge Base/Notes/Insights/zqx-current]]"\n'
+        ),
+    )
+    return new_rel, old_rel
+
+
+# ---------------- Piece B: supersession-aware find ----------------
+
+
+def test_status_multiplier_only_demotes_superseded() -> None:
+    cfg = find_module.RankingConfig()
+    assert find_module._status_multiplier("superseded", cfg) == cfg.superseded_penalty
+    assert find_module._status_multiplier("active", cfg) == 1.0
+    assert find_module._status_multiplier("draft", cfg) == 1.0
+    assert find_module._status_multiplier(None, cfg) == 1.0
+
+
+def test_apply_status_demotion_reorders(vault: Path) -> None:
+    """Mirror of test_type_boost_honors_config: equal base scores, the demotion
+    decides order, and the config value (not a constant) drives it."""
+    new_rel, old_rel = _write_conflict_pair(vault)
+    fused = [(old_rel, 1.0), (new_rel, 1.0)]  # superseded listed first
+    order = [p for p, _ in find_module._apply_status_demotion(fused, vault)]
+    assert order[0] == new_rel  # active overtakes the demoted predecessor
+
+    zero = find_module.RankingConfig(superseded_penalty=0.0)
+    order0 = [p for p, _ in find_module._apply_status_demotion(fused, vault, zero)]
+    assert order0[-1] == old_rel
+
+
+def test_find_demotes_and_flags_superseded(vault: Path) -> None:
+    new_rel, old_rel = _write_conflict_pair(vault)
+    hits = find_module.find(vault, query=TOKEN, prefer_active=True)
+    paths = [h.path for h in hits]
+    assert new_rel in paths and old_rel in paths
+    # Equal base scores → demotion makes the successor rank strictly first.
+    assert paths.index(new_rel) < paths.index(old_rel)
+
+    old_hit = next(h for h in hits if h.path == old_rel)
+    od = old_hit.as_dict()
+    assert od["status"] == "superseded"
+    assert od["superseded_by"] == ["[[Knowledge Base/Notes/Insights/zqx-current]]"]
+
+    # The live conclusion carries no status/superseded_by noise.
+    new_hit = next(h for h in hits if h.path == new_rel)
+    nd = new_hit.as_dict()
+    assert "status" not in nd
+    assert "superseded_by" not in nd
+
+
+def test_find_exposure_independent_of_prefer_active(vault: Path) -> None:
+    """status/superseded_by surface even when the demotion is turned off."""
+    _, old_rel = _write_conflict_pair(vault)
+    hits = find_module.find(vault, query=TOKEN, prefer_active=False)
+    old_hit = next(h for h in hits if h.path == old_rel)
+    od = old_hit.as_dict()
+    assert od["status"] == "superseded"
+    assert od["superseded_by"]
+
+
+def test_archived_dir_excluded_from_find(vault: Path) -> None:
+    rel = "Knowledge Base/_archive/zqx-archived.md"
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\ntype: insight\nstatus: archived\ncreated: 2026-06-01\n"
+        "updated: 2026-06-01\ntags: []\n---\n"
+        f"# Archived\n\nThe {TOKEN} is here too but archived.\n",
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+    hits = find_module.find(vault, query=TOKEN, mode="keyword")
+    assert all("/_archive/" not in h.path for h in hits)
+
+
+# ---------------- Piece A: edit-`why` history ----------------
+
+
+def _edit_with_why(vault: Path, why: str, suffix: str) -> None:
+    body = get_module.get_page(vault, path=EXISTING).body
+    edit_module.edit(
+        vault, path=EXISTING, why=why, new_body=body + f"\n{suffix}\n", today=TODAY
+    )
+
+
+def test_read_log_entries_returns_why_newest_first(vault: Path) -> None:
+    _edit_with_why(vault, "WHY_ALPHA_marker", "alpha")
+    _edit_with_why(vault, "WHY_BETA_marker", "beta")
+
+    entries = vault_module.read_log_entries(vault, EXISTING)
+    assert len(entries) >= 2
+    # Entries are prepended → newest first. BETA was the last edit.
+    assert "WHY_BETA_marker" in entries[0]["summary"]
+    assert any("WHY_ALPHA_marker" in e["summary"] for e in entries)
+    assert entries[0]["op"] == "edit"
+    assert entries[0]["date"] == TODAY.isoformat()
+
+
+def test_read_log_entries_empty_for_unlogged(vault: Path) -> None:
+    assert (
+        vault_module.read_log_entries(
+            vault, "Knowledge Base/Notes/Insights/never-logged.md"
+        )
+        == []
+    )
+
+
+def test_read_log_entries_missing_log_returns_empty(tmp_path: Path) -> None:
+    # A vault root with no log.md → [] (best-effort, never an error).
+    assert vault_module.read_log_entries(tmp_path, EXISTING) == []
+
+
+# ---------------- Piece A: get(include_history) server tool ----------------
+
+
+def _build_server(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("KB_MCP_DISABLE_EMBEDDINGS", "1")
+    return server_module.build_server(require_auth=False)
+
+
+def _call(mcp, name: str, args: dict) -> dict:
+    result = asyncio.run(mcp.call_tool(name, args, run_middleware=False))
+    sc = getattr(result, "structured_content", None)
+    if isinstance(sc, dict):
+        return sc
+    for c in getattr(result, "content", []) or []:
+        text = getattr(c, "text", None)
+        if text:
+            return json.loads(text)
+    return {}
+
+
+def test_get_include_history_surfaces_why(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _edit_with_why(vault, "WHY_GET_marker", "x")
+    mcp = _build_server(monkeypatch)
+
+    out = _call(mcp, "get", {"path": EXISTING, "include_history": True})
+    assert "history" in out
+    assert any("WHY_GET_marker" in e["summary"] for e in out["history"])
+
+    # Without the flag, no history key is attached.
+    plain = _call(mcp, "get", {"path": EXISTING})
+    assert "history" not in plain


### PR DESCRIPTION
## Why

Started as "should we model prominence / source authority?" — verified against the KB's own standing conclusions, that's a dead end by design (*evidence weight is contextual, not hierarchical*; the deliberate no-confidence-field divergence) and would cross the substrate/brain line. The real question underneath was **conflict + stale-info handling**, whose answer is **supersession**.

Verifying supersession in the live code turned up the actual gap: it's **first-class in storage but invisible at read time**. The substrate records both the supersession relationship and every edit's `why`, then never surfaces either:

- `find` never reads `status` / `superseded_by`, so a `status: superseded` tombstone (which the protocol keeps in place) can outrank the very page that replaced it — and results don't expose `status`, so a reader can't tell.
- Every edit's `why` lands in the append-only `log.md`, but `find` excludes `log.md` and `provenance_report` reads something else — no tool surfaces a page's change history.

This PR closes both with one principle: **surface what the substrate already records.** No authority/confidence model — pure measurement.

## What

**Piece B — supersession-aware `find`**
- Soft-demote `status: superseded` pages via a new `prefer_active` knob (`_SUPERSEDED_PENALTY = 0.5`), mirroring the existing `prefer_compiled` machinery (`_apply_status_demotion` runs after `_apply_type_boost` in the fused pass, and in the rerank branch).
- Expose `status` + `superseded_by` on hits (omitted when `active`/unset). Exposure is **not** gated by `prefer_active` — a reader sees a tombstone even with demotion off.
- **Never excludes** — the old conclusion stays findable for "what did I used to think".

**Piece A — surface edit-`why` history**
- `get(include_history=true)` attaches a `history` list (date / op / why, newest-first) via the new `vault.read_log_entries`, so an LLM can verify *why* a note changed.
- Extends the existing `get` tool rather than adding a new one (keeps the always-loaded surface flat).

## Tests

`tests/test_supersession_surface.py` covers the demotion (`_status_multiplier`, `_apply_status_demotion`, integration flip), exposure independent of `prefer_active`, `_archive` exclusion, `read_log_entries` (ordering / empty / missing-log), and `get(include_history)` through the server tool. Plus a `RankingConfig` invariant bind.

Full suite: **485 passed, 4 skipped** (embeddings/PIL extras not installed in the CI-less venv; orthogonal to this change). ruff clean on all added code.

## Follow-up (not in this PR)

SKILL.md doesn't *need* changing for the tools to work (the `get`/`find` docstrings the connector surfaces are updated here), but a small SKILL.md note would teach the loose phrasings ("why did this change", "what did I used to think") to route to these. That touches the canonical **vault** `_Schema/SKILL.md` + a `_Schema.zip` rebuild Hugo re-uploads — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
