### PR TITLE
fix(restart): ASCII-ify em-dashes so restart.ps1 parses under PowerShell 5.1

### DIFF
--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -28,7 +28,7 @@ function Wait-ServiceState {
 # --- Self-heal the interpreter ------------------------------------------------
 # Kaspersky periodically quarantines the uv-managed python.exe as a false
 # positive. That leaves the venv (and this service) with no interpreter, so the
-# app can't start and NSSM parks the service in PAUSED — which surfaces as a 502
+# app can't start and NSSM parks the service in PAUSED - which surfaces as a 502
 # at the Tailscale funnel. If the venv interpreter won't run, reinstall it
 # before (re)starting. Add a Kaspersky exclusion for %APPDATA%\uv\python to stop
 # the quarantine at the source; this just makes recovery automatic.
@@ -89,5 +89,5 @@ if (Test-Path $logPath) {
     Write-Host "Log tail:"
     Get-Content $logPath -Tail 8
 } else {
-    Write-Warning "No log file at $logPath yet — service may still be initializing."
+    Write-Warning "No log file at $logPath yet - service may still be initializing."
 }


### PR DESCRIPTION
`restart.ps1` is UTF-8 (no BOM) and had two em-dashes (one in a comment, one in the `Write-Warning` string). Windows PowerShell 5.1 (`powershell`) reads no-BOM files as Windows-1252, mangling the em-dash → `â€"` → *'the string is missing the terminator'* parse error. `pwsh` 7 reads UTF-8 and was unaffected. Replaced both with ASCII `-` so the script parses under both interpreters. Verified: no non-ASCII bytes remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)