### PR TITLE
feat(search): vault-wide binary extraction, dataset cards, find file-type filters, access tiers

### DIFF
--- a/docs/vault-consolidation-migration.md
+++ b/docs/vault-consolidation-migration.md
@@ -1,0 +1,173 @@
+# Vault consolidation — gated migration runbook
+
+**Status: STAGED. Nothing here runs automatically.** The code that makes this
+safe (whole-KB extraction, dataset cards, `find` file-type filters, the
+`access.py` tier system + central write-guard) is merged and tested. This
+runbook is the **irreversible** other half: physically folding the vault's
+sibling folders into `Knowledge Base/` so the KB becomes the single coverage
+boundary. Run it deliberately, with a backup, on the primary host (the laptop
+server deploys/syncs separately — do it there afterward or let sync carry it).
+
+> Decision recap (yours): **everything** under `Knowledge Base/`; curated-thinking
+> folders come in but are marked **`readonly`** via `_access.yaml`; keep an
+> archived copy of the old structure marked deprecated. Live data is fine to move
+> in — append-only only governs `Sources/`/`Evidence/`, not the whole KB.
+
+Throughout, `"$VAULT"` = your vault root (the folder that contains
+`Knowledge Base/`). Confirm it before starting:
+`echo $env:KB_MCP_VAULT_PATH` (PowerShell).
+
+---
+
+## Step 0 — Pre-flight (read-only; do this first)
+
+1. **Inventory the siblings.** List the top-level vault folders so you decide
+   exactly what moves in:
+   `Get-ChildItem -Directory "$VAULT" | Select-Object Name`
+   - **Move in:** data folders (`Finance`, `Tracking`, …) and curated-thinking
+     folders (`Cognitive Core`, `Domains`, `Prompt Bank`, `Products`,
+     `Personal Context (Evolving)`, `Systems Thinking`).
+   - **Leave alone:** `Knowledge Base` itself, `.git`, `.obsidian`, any
+     `*-backup-*`.
+
+2. **Find hardcoded references to those folders** before moving them — other
+   skills/tools may reference e.g. `Cognitive Core/...` as a *sibling* path that
+   becomes `Knowledge Base/Cognitive Core/...` after the move:
+   `Select-String -Path "$VAULT\**\*.md" -Pattern '\[\[(Cognitive Core|Domains|Prompt Bank|Products|Personal Context|Systems Thinking|Finance|Tracking)/' -List`
+   Wikilinks usually still resolve (the resolver is KB-prefix-tolerant), but note
+   any **tool/skill configs or code** outside the vault that hardcode these paths
+   (e.g. the cv-build skill) and update them after.
+
+---
+
+## Step 1 — Backup + deprecation marker (the archive you asked for)
+
+1. **Full timestamped copy** (non-destructive; copies to a fresh dir):
+   `robocopy "$VAULT" "$VAULT-backup-20260624" /E /R:1 /W:1 /XD "$VAULT\.git"`
+2. Keep that backup until you've verified the migrated vault for a few days. It
+   *is* the rollback (Step 7).
+3. After the move (Step 3), drop a deprecation note at the vault root recording
+   the old layout — Claude writes this during the supervised run, or:
+   create `"$VAULT\Knowledge Base\DEPRECATED-STRUCTURE.md"` describing the
+   pre-migration sibling layout and the migration date.
+
+---
+
+## Step 2 — SKILL update (vault canonical) + re-derive
+
+The canonical SKILL is the **vault** `_Schema/SKILL.md`, not the repo scaffold
+(never hand-edit the scaffold). Apply these additions there, **bump `version:`**,
+then re-derive both surfaces.
+
+**Edits to `Knowledge Base/_Schema/SKILL.md`:**
+
+- **Searchable binaries are vault-wide now.** Note that *any* binary placed
+  anywhere under `Knowledge Base/` (not only `Evidence/`) is OCR/ASR/PDF-extracted
+  into a `.md` companion and becomes findable — so invoices, receipts, and
+  screenshots filed under a data folder are searchable by content.
+- **Tabular data → dataset card + `query_data`.** Document the flow: call
+  `query_data(path=<csv/json>, aggregate="profile")` to get a content profile
+  (vendors, item names, totals, date span) **and** a ready `dataset` card; write
+  the card into the KB (fill its "What this holds" line); retrieve exact rows via
+  `query_data`. **Raw rows are never embedded** — search the card, retrieve the
+  rows. Salient single records get promoted to notes/entities as usual.
+- **`find` file-type filters.** `file_types` / `exclude_file_types` over
+  `note/pdf/image/audio/video/csv/json`. Default returns **all** kinds — search
+  never hides a type unless asked. Mention `aggregate="profile"` on `query_data`.
+- **Access tiers (`_access.yaml`).** The KB is now the whole vault; per-subtree
+  access is governed by `Knowledge Base/_access.yaml`: `readonly` (findable,
+  never written — the curated-thinking trees), `excluded` (private: not indexed,
+  not written), with `Sources/`/`Evidence/` append-only as before. Reads are
+  unrestricted. Note that curated trees (`Cognitive Core/`, `Domains/`,
+  `Prompt Bank/`, `Products/`, `Personal Context/`, `Systems Thinking/`) are
+  read-only inputs even though they now live inside the KB.
+- **`prefer_compiled=false` for record hunts.** When hunting a specific line
+  item / asset / transaction, pass `prefer_compiled=false` so raw captures aren't
+  down-weighted under compiled notes.
+
+**Then re-derive (repo CLAUDE.md rule):**
+- `python scripts/genericize-schema.py --vault "$VAULT"`  (regenerates the repo scaffold; commit it)
+- `python scripts/rebuild-schema-zip.py --vault "$VAULT"`  (rebuilds `_Schema.zip`; re-upload to claude.ai)
+- Reminder: copy the gitignored `scripts/generic/{substitutions,leakguard}.txt`
+  from the primary checkout first if re-deriving in a fresh worktree (see the
+  "genericize worktree leak" note).
+
+---
+
+## Step 3 — Move the siblings under `Knowledge Base/` (IRREVERSIBLE)
+
+Stop the service first so nothing reads mid-move:
+`scripts/restart.ps1 -Stop`  (or stop the NSSM service).
+
+Then, **one folder per line** (repeat per folder you chose in Step 0):
+`Move-Item "$VAULT\Finance" "$VAULT\Knowledge Base\Finance"`
+`Move-Item "$VAULT\Tracking" "$VAULT\Knowledge Base\Tracking"`
+`Move-Item "$VAULT\Cognitive Core" "$VAULT\Knowledge Base\Cognitive Core"`
+`Move-Item "$VAULT\Domains" "$VAULT\Knowledge Base\Domains"`
+`Move-Item "$VAULT\Prompt Bank" "$VAULT\Knowledge Base\Prompt Bank"`
+`Move-Item "$VAULT\Products" "$VAULT\Knowledge Base\Products"`
+`Move-Item "$VAULT\Personal Context (Evolving)" "$VAULT\Knowledge Base\Personal Context (Evolving)"`
+`Move-Item "$VAULT\Systems Thinking" "$VAULT\Knowledge Base\Systems Thinking"`
+
+Wikilinks stay valid (the resolver matches both `[[Cognitive Core/X]]` and the
+new `[[Knowledge Base/Cognitive Core/X]]`). No bulk rewrite needed.
+
+---
+
+## Step 4 — Seed `_access.yaml` (the off-limits policy)
+
+Create `Knowledge Base/_access.yaml` marking the curated-thinking trees
+`readonly` (Claude writes this during the supervised run). Content:
+
+```yaml
+# Per-subtree access tiers. Folder paths are KB-relative; each entry covers the
+# whole subtree. readonly = findable but never written; excluded = private
+# (not indexed, not written). Sources/ and Evidence/ stay append-only (built-in).
+readonly:
+  - Cognitive Core
+  - Domains
+  - Prompt Bank
+  - Products
+  - Personal Context (Evolving)
+  - Systems Thinking
+excluded: []
+```
+
+Live-loaded — no restart needed for policy changes. Add folders to `excluded`
+later if you want any truly private (hidden from `find`).
+
+---
+
+## Step 5 — Re-index everything
+
+Start the service: `scripts/restart.ps1`. Then, from the repo (GPU host):
+- Rebuild embeddings over the now-larger KB:
+  `uv run kb-mcp audit-fix --rebuild-embeddings`  (or the `rebuild_all` entrypoint)
+- Back-fill media companions for any binaries newly inside the KB
+  (invoices/receipts/screenshots under the moved data folders):
+  `uv run kb-mcp backfill-media`
+- For each CSV/JSON you want findable, create its dataset card (Step 2 flow).
+
+---
+
+## Step 6 — Verify (evidence before declaring done)
+
+- **Invoice is searchable:** in claude.ai, `find "Ugreen Nexode 100W charger"`
+  and `find "USB4 240W cable"` — the invoice surfaces with **no** hand-typed
+  register entry needed.
+- **Curated docs are findable but locked:** `find` a Cognitive Core topic →
+  it appears; then have the skill attempt an `edit`/`create_file` there → refused
+  (`WRITE_REFUSED … readonly`).
+- **Tabular by content:** `find "Mavic battery"` hits the dataset card;
+  `query_data` returns the exact rows.
+- **Connector still healthy:** a fast `401` at the funnel (per the triage note);
+  don't restart reflexively.
+
+---
+
+## Step 7 — Rollback (if anything's wrong)
+
+The migration is just a folder move + a config file + an embedding rebuild. To
+revert: stop the service, delete the migrated `Knowledge Base/<Folder>` copies,
+restore the sibling folders from `"$VAULT-backup-20260624"`, remove
+`_access.yaml`, restart, rebuild embeddings. The backup is the source of truth.

--- a/src/kb_mcp/access.py
+++ b/src/kb_mcp/access.py
@@ -1,0 +1,141 @@
+"""Access tiers — what the skill may DO to a path, decoupled from WHERE it lives.
+
+A path resolves to exactly one tier:
+
+- ``excluded``    — invisible to find/embedding AND unwritable (truly private).
+- ``readonly``    — findable, but every write is refused (no override). The
+                    "off-limits" marker: lets a curated-thinking folder be
+                    folded into ``Knowledge Base/`` and stay write-protected
+                    without moving it back out of the search corpus.
+- ``append-only`` — ``Sources/`` and ``Evidence/`` (add/preserve only).
+- ``read-write``  — the default (Notes/, compiled material, data subtrees).
+
+Tiers come from a live-loaded ``Knowledge Base/_access.yaml`` (folder paths, one
+subtree per entry) layered over built-in defaults. The config is read fresh when
+its mtime changes — edit it desk-side and the next call sees the new policy, no
+restart (mirrors ``project-keys.yaml``). Decoupling *capability* from *location*
+is the same move as decoupling *searchability* from a folder: a single
+``Knowledge Base/`` boundary, with per-subtree access governed by this file.
+
+This layer is ADDITIVE and back-compatible: with no ``_access.yaml`` present,
+only ``Sources/``/``Evidence/`` differ from ``read-write`` — the existing
+curated-tree write guard (``vault.in_curated_tree`` + ``allow_curated``) is
+untouched. The migration that folds the curated trees into the KB seeds
+``_access.yaml`` with them as ``readonly``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+TIER_EXCLUDED = "excluded"
+TIER_READONLY = "readonly"
+TIER_APPEND_ONLY = "append-only"
+TIER_READ_WRITE = "read-write"
+
+# Append-only KB subtrees — kept here (not just vault.py) so access_tier is the
+# single source of truth for the tier of a path.
+_APPEND_ONLY = ("Sources", "Evidence")
+
+# (mtime, parsed_config) per config-file path, so an unchanged file isn't re-read.
+_CACHE: dict[str, tuple[float, dict[str, list[str]]]] = {}
+
+
+def access_config_path(vault_root: Path) -> Path:
+    return vault_root / "Knowledge Base" / "_access.yaml"
+
+
+def _load_config(vault_root: Path) -> dict[str, list[str]]:
+    """Read ``_access.yaml`` → ``{"readonly": [...], "excluded": [...]}``.
+
+    Missing/malformed → empty policy (never raises — a broken config must not
+    take down search). Live-reloaded on mtime change.
+    """
+    p = access_config_path(vault_root)
+    try:
+        mtime = p.stat().st_mtime
+    except OSError:
+        return {"readonly": [], "excluded": []}
+    key = str(p)
+    cached = _CACHE.get(key)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            data = {}
+    except (OSError, yaml.YAMLError) as e:
+        log.warning("could not read %s (%s); treating as no access policy", p.name, e)
+        data = {}
+    cfg = {
+        "readonly": [str(x) for x in (data.get("readonly") or [])],
+        "excluded": [str(x) for x in (data.get("excluded") or [])],
+    }
+    _CACHE[key] = (mtime, cfg)
+    return cfg
+
+
+def _kb_relative(rel_path: str) -> str:
+    """Strip a leading ``Knowledge Base/`` so config entries are KB-relative.
+
+    Callers pass either form (``Knowledge Base/Cognitive Core/x.md`` or
+    ``Cognitive Core/x.md``); both normalize to the same KB-relative key.
+    """
+    rel = rel_path.replace("\\", "/").strip("/")
+    parts = rel.split("/")
+    if parts and parts[0] == "Knowledge Base":
+        return "/".join(parts[1:])
+    return rel
+
+
+def _under(prefix: str, kb_rel: str) -> bool:
+    """True if `kb_rel` is the subtree `prefix` or anything inside it."""
+    p = prefix.replace("\\", "/").strip("/")
+    return bool(p) and (kb_rel == p or kb_rel.startswith(p + "/"))
+
+
+def _matches(prefixes: list[str], kb_rel: str) -> bool:
+    return any(_under(p, kb_rel) for p in prefixes)
+
+
+def access_tier(vault_root: Path, rel_path: str) -> str:
+    """Return the tier governing `rel_path` (vault-relative, either prefix form).
+
+    Resolution order: excluded → readonly (config) → append-only
+    (Sources/Evidence) → read-write.
+    """
+    cfg = _load_config(vault_root)
+    kb_rel = _kb_relative(rel_path)
+    if _matches(cfg["excluded"], kb_rel):
+        return TIER_EXCLUDED
+    if _matches(cfg["readonly"], kb_rel):
+        return TIER_READONLY
+    head = kb_rel.split("/", 1)[0]
+    if head in _APPEND_ONLY:
+        return TIER_APPEND_ONLY
+    return TIER_READ_WRITE
+
+
+def is_indexable(vault_root: Path, rel_path: str) -> bool:
+    """False only for `excluded` paths — everything else is searchable."""
+    return access_tier(vault_root, rel_path) != TIER_EXCLUDED
+
+
+def writable_reason(vault_root: Path, rel_path: str) -> str | None:
+    """None if the path accepts ordinary writes; else a refusal reason.
+
+    `readonly` and `excluded` are HARD refusals (no override). `append-only`
+    is refused here too — those trees are written via `add`/`preserve`, not the
+    general write tools — mirroring the existing append-only guard.
+    """
+    tier = access_tier(vault_root, rel_path)
+    if tier == TIER_EXCLUDED:
+        return "path is in an `excluded` tree (_access.yaml): not writable and not indexed"
+    if tier == TIER_READONLY:
+        return "path is in a `readonly` tree (_access.yaml): findable but write-protected"
+    return None

--- a/src/kb_mcp/backfill.py
+++ b/src/kb_mcp/backfill.py
@@ -1,10 +1,16 @@
-"""Bulk media back-fill — make pre-existing Evidence binaries searchable.
+"""Bulk media back-fill — make pre-existing KB binaries searchable.
 
-`kb-mcp backfill-media` walks Evidence/, and for every media file (image/audio/video/pdf):
+`kb-mcp backfill-media` walks the whole `Knowledge Base/` tree (not just
+`Evidence/`), and for every media file (image/audio/video/pdf):
   1. writes a `.md` sidecar if missing — so `find()` can surface it (a CLIP/text match maps
      to `<file>.md`, which must exist);
   2. extracts text (OCR / ASR / PDF) if not already done — text-searchable;
   3. CLIP-embeds images — searchable by visual content.
+
+Coverage is the whole KB so a binary filed anywhere a note can live (an invoice
+under `Finance/`, a screenshot under `Sources/`) becomes searchable — not only
+the `Evidence/` claim-backing tree. Config/cruft dirs are pruned
+(`vault.VAULT_SCAN_SKIP_DIRS`).
 
 Idempotent: re-running only does outstanding work. Runs on CPU or GPU (engines auto-detect).
 The *incremental* path (new uploads) is handled live by the server; this is the deliberate
@@ -19,11 +25,42 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from . import embeddings, extract, preserve
+from .vault import VAULT_SCAN_SKIP_DIRS
 
 log = logging.getLogger(__name__)
 
 _EXTRACTED_BY_RE = re.compile(r"(?m)^extracted_by:\s*(.+?)\s*$")
 _NOT_DONE = {"none", "pending"}
+
+
+def iter_kb_files(root: Path):
+    """Yield every file under `root`, pruning config/cruft/index dirs.
+
+    Replaces a bare `rglob("*")` so a whole-KB walk never descends into
+    `.git`, the embedding sqlite dir, `_Schema`, etc. (`VAULT_SCAN_SKIP_DIRS`).
+    Shared with the live media worker's KB scans.
+    """
+    stack = [root]
+    while stack:
+        d = stack.pop()
+        try:
+            children = list(d.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if child.is_dir():
+                if child.name not in VAULT_SCAN_SKIP_DIRS:
+                    stack.append(child)
+            elif child.is_file():
+                yield child
+
+
+def _iter_media_files(root: Path):
+    """Yield media files under `root` (pruned walk). `.md` sidecars and other
+    non-media files are filtered out by `extract.media_type_for`."""
+    for f in iter_kb_files(root):
+        if extract.media_type_for(f):
+            yield f
 
 
 def _sidecar_for(binary: Path) -> Path:
@@ -64,22 +101,22 @@ def backfill_media(
     dry_run: bool = False,
     log_fn=log.info,
 ) -> BackfillStats:
-    """Back-fill sidecars + text + CLIP for every media file under Evidence/. Idempotent."""
+    """Back-fill sidecars + text + CLIP for every media file under Knowledge Base/. Idempotent."""
     stats = BackfillStats()
-    evidence = vault_root / "Knowledge Base" / "Evidence"
-    if not evidence.is_dir():
-        log_fn("no Knowledge Base/Evidence/ directory; nothing to back-fill")
+    kb = vault_root / "Knowledge Base"
+    if not kb.is_dir():
+        log_fn("no Knowledge Base/ directory; nothing to back-fill")
         return stats
     clip_index = embeddings.ClipIndex(vault_root) if do_clip else None
     # Fast media first (image/pdf OCR is quick) so screenshots/docs are searchable in
     # minutes; slow A/V transcription (Whisper) runs last instead of starving the queue.
     _order = {"image": 0, "pdf": 1, "audio": 2, "video": 3}
     files = sorted(
-        (p for p in evidence.rglob("*") if p.is_file() and extract.media_type_for(p)),
+        _iter_media_files(kb),
         key=lambda p: (_order.get(extract.media_type_for(p), 9), p.as_posix()),
     )
     stats.scanned = len(files)
-    log_fn(f"scanning {len(files)} media file(s) under Evidence/ (dry_run={dry_run})")
+    log_fn(f"scanning {len(files)} media file(s) under Knowledge Base/ (dry_run={dry_run})")
 
     for i, f in enumerate(files, 1):
         media_type = extract.media_type_for(f)

--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -494,6 +494,7 @@ class EmbeddingIndex:
 
     def rebuild_all(self) -> int:
         """Wipe + re-embed every compiled .md under Knowledge Base/. Returns row count."""
+        from . import access
         from . import find as find_module
 
         kb = self.vault_root / "Knowledge Base"
@@ -515,6 +516,8 @@ class EmbeddingIndex:
             page = find_module._CACHE.get(md, self.vault_root)
             if page is None:
                 continue
+            if not access.is_indexable(self.vault_root, page.rel_path):
+                continue  # excluded tree (_access.yaml) — keep it out of the index
             chunks = chunk_text(page.title, page.body)
             if not chunks:
                 continue

--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -140,6 +140,19 @@ class ParsedPage:
         return str(ef) if ef else None
 
     @property
+    def file_kind(self) -> str:
+        """Coarse artifact kind for file-type filtering: a dataset's underlying
+        format (csv/json/tsv), a binary companion's media_type (pdf/image/audio/
+        video), else 'note' for a plain markdown page. The vocabulary `find`'s
+        `file_types`/`exclude_file_types` scope on."""
+        if self.page_type == "dataset":
+            fmt = self.frontmatter.get("format")
+            return str(fmt).lower() if fmt else "dataset"
+        if self.media_type:
+            return self.media_type.lower()
+        return "note"
+
+    @property
     def status(self) -> str | None:
         """Lifecycle status — draft / active / superseded / archived (None if unset)."""
         s = self.frontmatter.get("status")
@@ -286,6 +299,8 @@ def find(
     types: list[str] | None = None,
     projects: list[str] | None = None,
     tags: list[str] | None = None,
+    file_types: list[str] | None = None,
+    exclude_file_types: list[str] | None = None,
     limit: int = 15,
     scope: str = "kb",
     mode: str = "hybrid",
@@ -369,6 +384,7 @@ def find(
             vault_root,
             query_norm=query_norm,
             types=types, projects=projects, tags=tags,
+            file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=walk_scope,
         )
     else:
@@ -376,6 +392,7 @@ def find(
             vault_root,
             query=query, query_norm=query_norm,
             types=types, projects=projects, tags=tags,
+            file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=walk_scope, mode=mode, graph=graph, rerank=rerank,
             prefer_compiled=prefer_compiled,
             prefer_active=prefer_active,
@@ -404,6 +421,7 @@ def find(
                 query=query,
                 query_norm=query_norm,
                 types=types, projects=projects, tags=tags,
+                file_types=file_types, exclude_file_types=exclude_file_types,
                 limit=limit,
             )
             if h.path not in seen
@@ -433,6 +451,8 @@ def _find_keyword(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    file_types: list[str] | None = None,
+    exclude_file_types: list[str] | None = None,
     limit: int,
     scope: str,
 ) -> list[Hit]:
@@ -454,7 +474,8 @@ def _find_keyword(
         page = _CACHE.get(path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, types=types, projects=projects, tags=tags):
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+                               file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         excerpt = _make_excerpt(page, query_norm)
         if query_norm and excerpt is None:
@@ -489,6 +510,8 @@ def _find_semantic(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    file_types: list[str] | None = None,
+    exclude_file_types: list[str] | None = None,
     limit: int,
     scope: str,
     mode: str,
@@ -650,6 +673,7 @@ def _find_semantic(
             vault_root,
             query_norm=query_norm,
             types=types, projects=projects, tags=tags,
+            file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=scope,
         )
 
@@ -683,7 +707,8 @@ def _find_semantic(
         page = _CACHE.get(abs_path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, types=types, projects=projects, tags=tags):
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+                               file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         keyword_excerpt = _make_excerpt(page, query_norm)
         if (
@@ -787,6 +812,8 @@ def _find_outside_kb(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    file_types: list[str] | None = None,
+    exclude_file_types: list[str] | None = None,
     limit: int,
 ) -> list[Hit]:
     """BM25/keyword recall over the vault, RESTRICTED to paths outside
@@ -832,7 +859,8 @@ def _find_outside_kb(
         page = _CACHE.get(vault_root / rel_path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, types=types, projects=projects, tags=tags):
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+                               file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         # Relaxed gate: BM25 score>0 already implies a token match, but the
         # keyword fallback path needs this explicit check.
@@ -1233,10 +1261,20 @@ def _parse_page(path: Path, mtime: float, vault_root: Path) -> ParsedPage | None
 def _passes_filters(
     page: ParsedPage,
     *,
+    vault_root: Path | None = None,
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    file_types: list[str] | None = None,
+    exclude_file_types: list[str] | None = None,
 ) -> bool:
+    # `excluded` tier (_access.yaml): never surfaced. Checked first — an excluded
+    # page is invisible regardless of how well it matches. (vault_root omitted in
+    # unit tests → skip; real find paths always pass it.)
+    if vault_root is not None:
+        from . import access
+        if not access.is_indexable(vault_root, page.rel_path):
+            return False
     if types and page.page_type not in types:
         return False
     if projects:
@@ -1246,6 +1284,14 @@ def _passes_filters(
     if tags:
         page_tags = set(page.tags)
         if not any(t.lower() in page_tags for t in tags):
+            return False
+    # File-type scoping (opt-in; default None/None lets every kind through — a
+    # search must never hide an artifact type by default).
+    if file_types or exclude_file_types:
+        kind = page.file_kind
+        if file_types and kind not in {ft.lower() for ft in file_types}:
+            return False
+        if exclude_file_types and kind in {ft.lower() for ft in exclude_file_types}:
             return False
     return True
 

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -1,4 +1,4 @@
-"""Background media-extraction worker — fills pending Evidence sidecars off the request path.
+"""Background media-extraction worker — fills pending media sidecars off the request path.
 
 When a media binary is uploaded without text, `preserve()` writes a `pending` stub sidecar
 and the `/upload` route enqueues a job here. A single background thread (the GPU is
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import embeddings, extract, preserve
+from .backfill import iter_kb_files
 
 log = logging.getLogger(__name__)
 
@@ -157,12 +158,14 @@ class MediaWorker:
         return self._scan_pending_ocr() + self._scan_unindexed_images()
 
     def _scan_pending_ocr(self) -> int:
-        """Re-enqueue every `extracted_by: pending` sidecar under Evidence/. Returns count."""
-        evidence = self._vault_root / "Knowledge Base" / "Evidence"
-        if not evidence.is_dir():
+        """Re-enqueue every `extracted_by: pending` sidecar under the KB. Returns count."""
+        kb = self._vault_root / "Knowledge Base"
+        if not kb.is_dir():
             return 0
         n = 0
-        for sidecar in evidence.rglob("*.md"):
+        for sidecar in iter_kb_files(kb):
+            if sidecar.suffix.lower() != ".md":
+                continue
             try:
                 head = sidecar.read_text(encoding="utf-8")[:800]
             except OSError:
@@ -183,7 +186,7 @@ class MediaWorker:
         return n
 
     def _scan_unindexed_images(self) -> int:
-        """CLIP-queue Evidence images that have a sidecar but aren't indexed yet.
+        """CLIP-queue KB images that have a sidecar but aren't indexed yet.
 
         Sidecar-LESS images (pre-feature files) are skipped on purpose: `find()` can't
         surface a CLIP match without a `<image>.md` sidecar, so indexing them here would be
@@ -192,12 +195,12 @@ class MediaWorker:
         """
         if not embeddings.clip_enabled():
             return 0
-        evidence = self._vault_root / "Knowledge Base" / "Evidence"
-        if not evidence.is_dir():
+        kb = self._vault_root / "Knowledge Base"
+        if not kb.is_dir():
             return 0
         n = 0
-        for f in evidence.rglob("*"):
-            mt = extract.media_type_for(f) if f.is_file() else None
+        for f in iter_kb_files(kb):
+            mt = extract.media_type_for(f)
             if mt not in ("image", "video"):  # video is CLIP-able too (keyframes)
                 continue
             if not f.with_name(f.name + ".md").exists():

--- a/src/kb_mcp/query_data.py
+++ b/src/kb_mcp/query_data.py
@@ -42,6 +42,7 @@ ALLOWED_SUFFIXES = (".csv", ".tsv", ".json")
 MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MB guard — KB datasets are small
 HARD_ROW_CAP = 1000
 DEFAULT_LIMIT = 100
+PROFILE_MAX_DISTINCT = 20  # categorical/text columns expose up to this many distinct values
 _COMMON_RECORD_KEYS = ("result", "results", "data", "rows", "items", "entries")
 _OPS = frozenset({
     "eq", "ne", "gt", "gte", "lt", "lte",
@@ -284,6 +285,167 @@ def _aggregate(matched: list[dict], spec: str, date_col: str | None) -> dict:
     raise QueryDataError("BAD_AGGREGATE", f"unknown aggregate func {func!r}")
 
 
+# ---------------- profile (the dataset-card "what it holds" engine) ----------------
+
+
+@dataclass
+class ColumnProfile:
+    """Deterministic per-column summary — the searchable signal of a dataset.
+
+    Pure "measure": numeric → range/sum/avg; date → earliest/latest; otherwise a
+    capped list of distinct values (vendors, item names…). No LLM — Claude writes
+    the prose "what this holds" line; this only stats the raw rows.
+    """
+
+    name: str
+    kind: str            # numeric | date | categorical | text
+    non_null: int
+    distinct: int
+    min: float | None = None
+    max: float | None = None
+    sum: float | None = None
+    avg: float | None = None
+    earliest: str | None = None
+    latest: str | None = None
+    top_values: list[Any] | None = None
+
+    def as_dict(self) -> dict:
+        d: dict[str, Any] = {
+            "name": self.name, "kind": self.kind,
+            "non_null": self.non_null, "distinct": self.distinct,
+        }
+        for k in ("min", "max", "sum", "avg", "earliest", "latest", "top_values"):
+            v = getattr(self, k)
+            if v is not None:
+                d[k] = v
+        return d
+
+
+def _profile_column(name: str, values: list[Any], *, max_distinct: int = PROFILE_MAX_DISTINCT) -> ColumnProfile:
+    non_null = [v for v in values if v not in (None, "")]
+    n = len(non_null)
+    seen: list[Any] = []
+    seen_keys: set[str] = set()
+    for v in non_null:
+        k = str(v)
+        if k not in seen_keys:
+            seen_keys.add(k)
+            seen.append(v)
+    distinct = len(seen)
+
+    nums = [x for v in non_null if (x := _coerce_num(v)) is not None]
+    date_like = sum(1 for v in non_null if _DATE_LIKE.search(str(v)))
+    name_l = name.lower()
+
+    # Date when the name says so or values look date-shaped — but never when the
+    # column is predominantly plain numbers (guards a numeric col named "...date").
+    if n and ("date" in name_l or date_like >= 0.6 * n) and len(nums) < 0.6 * n:
+        svals = [str(v) for v in non_null]
+        return ColumnProfile(name, "date", n, distinct, earliest=min(svals), latest=max(svals))
+    if n and len(nums) >= 0.6 * n:
+        return ColumnProfile(
+            name, "numeric", n, distinct,
+            min=min(nums), max=max(nums), sum=sum(nums), avg=sum(nums) / len(nums),
+        )
+    kind = "categorical" if distinct <= max_distinct else "text"
+    return ColumnProfile(name, kind, n, distinct, top_values=seen[:max_distinct])
+
+
+def profile_data(
+    vault_root: Path,
+    *,
+    path: str,
+    record_path: str | None = None,
+    max_distinct: int = PROFILE_MAX_DISTINCT,
+) -> dict:
+    """Deterministic content profile of a CSV/JSON file — feeds a dataset card.
+
+    Returns `{path, format, total_rows, columns: [ColumnProfile.as_dict()...],
+    warnings}`. The half of the tabular-search pattern that captures *what a
+    dataset holds* without embedding raw rows: a markdown dataset card renders
+    this (vendors, item names, totals, date ranges) and is embedded; the rows
+    stay queryable only via `query_data`.
+    """
+    try:
+        abs_path, rel = resolve_under_vault(vault_root, path, must_exist=True, must_be_file=True)
+    except VaultPathError as e:
+        raise QueryDataError(e.code, e.reason) from None
+    if abs_path.suffix.lower() not in ALLOWED_SUFFIXES:
+        raise QueryDataError("UNSUPPORTED_FORMAT", f"only {list(ALLOWED_SUFFIXES)} supported")
+    fmt, rows, cols, warnings = _load_rows(abs_path, record_path)
+    profiles = [
+        _profile_column(c, [_get_field(r, c) for r in rows], max_distinct=max_distinct).as_dict()
+        for c in cols
+    ]
+    return {
+        "path": rel, "format": fmt, "total_rows": len(rows),
+        "columns": profiles, "warnings": warnings,
+    }
+
+
+def _render_column_line(c: dict) -> str:
+    name, kind = c["name"], c["kind"]
+    if kind == "numeric":
+        return (
+            f"- **{name}** (numeric): min {c.get('min')}, max {c.get('max')}, "
+            f"sum {c.get('sum')}, avg {round(c['avg'], 2) if c.get('avg') is not None else None}"
+        )
+    if kind == "date":
+        return f"- **{name}** (date): {c.get('earliest')} → {c.get('latest')}"
+    vals = ", ".join(str(v) for v in (c.get("top_values") or []))
+    label = "categorical" if kind == "categorical" else "text"
+    suffix = "" if kind == "categorical" else " (sample)"
+    return f"- **{name}** ({label}, {c['distinct']} distinct){suffix}: {vals}"
+
+
+def build_dataset_card(profile: dict, *, title: str | None = None) -> str:
+    """Render a `profile_data` result into a markdown dataset card.
+
+    The card is the embedded, `find`-able surface for a data file: a `dataset`
+    page whose body carries the salient content (vendors, items, ranges) plus a
+    prose placeholder for Claude's "what this holds" summary and a `data_file:`
+    pointer the reader follows into `query_data`. Raw rows are never embedded.
+    """
+    data_file = profile["path"]
+    title = title or Path(data_file).stem
+    cols = profile["columns"]
+    lines = [
+        "---",
+        "type: dataset",
+        f"title: {title}",
+        f"data_file: {data_file}",
+        f"format: {profile['format']}",
+        f"rows: {profile['total_rows']}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "## What this holds",
+        "",
+        "<!-- TODO: one-line prose summary of what this dataset contains (Claude fills this in) -->",
+        "",
+        "## Profile",
+        "",
+        f"_Auto-generated from {data_file} ({profile['total_rows']} rows) — regenerate when the data changes._",
+        "",
+        "Columns: " + ", ".join(c["name"] for c in cols),
+        "",
+    ]
+    lines.extend(_render_column_line(c) for c in cols)
+    return "\n".join(lines) + "\n"
+
+
+def _profile_payload(rows: list[dict], cols: list[str], fmt: str, rel: str) -> dict:
+    """Profile already-loaded rows and render a card — the `aggregate="profile"` result."""
+    profile = {
+        "path": rel, "format": fmt, "total_rows": len(rows),
+        "columns": [
+            _profile_column(c, [_get_field(r, c) for r in rows]).as_dict() for c in cols
+        ],
+    }
+    return {"profile": profile, "dataset_card": build_dataset_card(profile)}
+
+
 def query_data(
     vault_root: Path,
     *,
@@ -331,10 +493,14 @@ def query_data(
     total_matched = len(matched)
 
     if aggregate:
+        if aggregate.strip() == "profile":
+            agg: Any = _profile_payload(matched, cols, fmt, rel)
+        else:
+            agg = _aggregate(matched, aggregate, date_col)
         return QueryDataResult(
             path=rel, format=fmt, total_rows=total_rows, total_matched=total_matched,
             returned=0, columns=cols, rows=[],
-            aggregate=_aggregate(matched, aggregate, date_col),
+            aggregate=agg,
             truncated=False, warnings=warnings,
         )
 

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -640,6 +640,8 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         types: list[str] | None = None,
         projects: list[str] | None = None,
         tags: list[str] | None = None,
+        file_types: list[str] | None = None,
+        exclude_file_types: list[str] | None = None,
         limit: int = 15,
         scope: str = "kb",
         mode: str = "hybrid",
@@ -660,6 +662,12 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             types: Filter to these page types (source, research-note, insight, failure, pattern, experiment, production-log, entity).
             projects: Filter to pages whose `project` or `projects:` includes any of these keys.
             tags: Filter to pages whose `tags:` includes any of these (case-insensitive).
+            file_types: Scope results to these artifact kinds — note, pdf, image,
+                audio, video, csv, json, tsv. A binary surfaces under its media
+                kind (pdf/image/...); a data file under its dataset card's format
+                (csv/json). Omit to return ALL kinds (the default — search never
+                hides a type unless you ask).
+            exclude_file_types: Drop these kinds from results (same vocabulary).
             limit: Max hits to return. Default 15, hard cap 100.
             scope: "kb" (default) searches Knowledge Base/ first and
                 AUTO-WIDENS to the whole vault when the KB doesn't fill
@@ -732,6 +740,8 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             types=types,
             projects=projects,
             tags=tags,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
             limit=limit,
             scope=scope,
             mode=mode,
@@ -1801,8 +1811,14 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             columns: project to these columns (dotted ok). Omit for all.
             sort_by / descending: sort by a column (numeric-aware).
             limit / offset: pagination (limit default 100, hard cap 1000).
-            aggregate: instead of rows — "count", or "func:column" where func ∈
-                min, max, sum, avg, latest, distinct.
+            aggregate: instead of rows — "count"; "func:column" where func ∈
+                min, max, sum, avg, latest, distinct; or "profile" to get a
+                deterministic content profile (per-column kind, distinct values,
+                numeric ranges, date span) under `aggregate.profile` PLUS a
+                ready-to-write markdown dataset card under `aggregate.dataset_card`.
+                Use "profile" to make a CSV/JSON findable — write the card into
+                the KB (fill in its "What this holds" line) so the dataset is
+                discoverable by content without ever embedding its raw rows.
             date_from / date_to / date_column: convenience date-range filter on
                 `date_column` (defaults to a "date" column if present); ISO
                 date strings, compared lexicographically.

--- a/src/kb_mcp/vault.py
+++ b/src/kb_mcp/vault.py
@@ -162,6 +162,23 @@ def batch_atomic_write(
     still works, and `audit_fix(rebuild_embeddings=True)` recovers drift.
     """
     writes = list(writes)
+    # Access-tier backstop: when the caller knows the vault root, refuse any
+    # write that lands in a `readonly`/`excluded` tree (_access.yaml). Central
+    # here so every content writer inherits it without per-tool wiring. No
+    # `_access.yaml` → writable_reason() is always None → no-op (Sources/Evidence
+    # are append-only, not readonly, so add/preserve still write fine).
+    if vault_root is not None:
+        from . import access
+
+        vault_resolved = vault_root.resolve()
+        for w in writes:
+            try:
+                rel = w.path.resolve().relative_to(vault_resolved).as_posix()
+            except (ValueError, OSError):
+                continue  # not under the vault (shouldn't happen) — don't block
+            reason = access.writable_reason(vault_root, rel)
+            if reason is not None:
+                raise ValueError(f"WRITE_REFUSED: {rel}: {reason}")
     staged: list[tuple[Path, Path]] = []  # (final, tmp)
     try:
         for w in writes:

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -1,0 +1,90 @@
+"""access: per-path tiers from _access.yaml layered over built-in defaults."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import access
+
+
+def _write_cfg(vault: Path, text: str) -> Path:
+    p = vault / "Knowledge Base" / "_access.yaml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_default_tiers_without_config(vault: Path) -> None:
+    assert access.access_tier(vault, "Knowledge Base/Notes/Insights/foo.md") == access.TIER_READ_WRITE
+    assert access.access_tier(vault, "Knowledge Base/Sources/Articles/x.md") == access.TIER_APPEND_ONLY
+    assert access.access_tier(vault, "Knowledge Base/Evidence/Legal/x.pdf") == access.TIER_APPEND_ONLY
+    # No config → nothing is excluded, everything (bar excluded) is indexable.
+    assert access.is_indexable(vault, "Knowledge Base/Notes/x.md") is True
+    assert access.writable_reason(vault, "Knowledge Base/Notes/x.md") is None
+
+
+def test_readonly_from_config(vault: Path) -> None:
+    _write_cfg(vault, "readonly:\n  - Cognitive Core\n  - Domains\n")
+    assert access.access_tier(vault, "Knowledge Base/Cognitive Core/Strategy.md") == access.TIER_READONLY
+    # nested + KB-stripped form both resolve to the same tier
+    assert access.access_tier(vault, "Cognitive Core/sub/deep.md") == access.TIER_READONLY
+    assert access.writable_reason(vault, "Knowledge Base/Cognitive Core/Strategy.md") is not None
+    # readonly is still findable
+    assert access.is_indexable(vault, "Knowledge Base/Cognitive Core/Strategy.md") is True
+    # a non-listed folder stays read-write
+    assert access.access_tier(vault, "Knowledge Base/Notes/x.md") == access.TIER_READ_WRITE
+
+
+def test_excluded_hides_and_blocks(vault: Path) -> None:
+    _write_cfg(vault, "excluded:\n  - Private\n")
+    assert access.access_tier(vault, "Knowledge Base/Private/secret.md") == access.TIER_EXCLUDED
+    assert access.is_indexable(vault, "Knowledge Base/Private/secret.md") is False
+    assert access.is_indexable(vault, "Knowledge Base/Notes/x.md") is True
+    assert access.writable_reason(vault, "Knowledge Base/Private/secret.md") is not None
+
+
+def test_excluded_outranks_readonly(vault: Path) -> None:
+    _write_cfg(vault, "readonly:\n  - Shared\nexcluded:\n  - Shared/Private\n")
+    assert access.access_tier(vault, "Shared/notes.md") == access.TIER_READONLY
+    assert access.access_tier(vault, "Shared/Private/secret.md") == access.TIER_EXCLUDED
+
+
+def test_config_live_reloads_on_mtime_change(vault: Path) -> None:
+    p = _write_cfg(vault, "readonly:\n  - Domains\n")
+    assert access.access_tier(vault, "Domains/AI.md") == access.TIER_READONLY
+    future = time.time() + 2
+    p.write_text("readonly: []\n", encoding="utf-8")
+    os.utime(p, (future, future))
+    assert access.access_tier(vault, "Domains/AI.md") == access.TIER_READ_WRITE
+
+
+def test_batch_write_refuses_readonly_tree(vault: Path) -> None:
+    # The central enforcement: a content write into a readonly tree is refused.
+    from kb_mcp.vault import PlannedWrite, batch_atomic_write
+    _write_cfg(vault, "readonly:\n  - Cognitive Core\n")
+    blocked = vault / "Knowledge Base" / "Cognitive Core" / "x.md"
+    blocked.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError, match="WRITE_REFUSED"):
+        batch_atomic_write([PlannedWrite(path=blocked, content="hi")], vault_root=vault)
+    # a normal path still writes fine (no-op guard for read-write tiers)
+    ok = vault / "Knowledge Base" / "Notes" / "ok.md"
+    ok.parent.mkdir(parents=True, exist_ok=True)
+    batch_atomic_write([PlannedWrite(path=ok, content="hi")], vault_root=vault)
+    assert ok.read_text(encoding="utf-8") == "hi"
+
+
+def test_find_hides_excluded_tree(vault: Path) -> None:
+    from kb_mcp import find as find_module
+    secret = vault / "Knowledge Base" / "Private" / "secret.md"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_text("---\ntype: source\n---\nzzqqxx unique marker\n", encoding="utf-8")
+    find_module.clear_cache()
+    # control: surfaced when nothing excludes it
+    assert any("secret" in h.path.lower() for h in find_module.find(vault, query="zzqqxx"))
+    # exclude Private/ → the page disappears from results
+    _write_cfg(vault, "excluded:\n  - Private\n")
+    find_module.clear_cache()
+    assert not any("secret" in h.path.lower() for h in find_module.find(vault, query="zzqqxx"))

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -62,6 +62,42 @@ def test_backfill_creates_sidecar_ocr_clip(vault, monkeypatch: pytest.MonkeyPatc
     assert stats2.skipped >= 1
 
 
+FINANCE_REL = "Knowledge Base/Finance/invoices/inv.jpg"
+
+
+def test_backfill_covers_non_evidence_kb_subtree(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A binary that lives OUTSIDE Evidence/ (e.g. an invoice in Finance/) must
+    # still be picked up — coverage is the whole KB, not just Evidence/.
+    p = vault / FINANCE_REL
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\xff\xd8\xffINV")
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda p, media_type=None: extract.ExtractResult(
+            text="ugreen nexode 100w charger", media_type="image", engine="tesseract"
+        ),
+    )
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: np.ones(embeddings.CLIP_DIM, dtype=np.float32))
+
+    stats = backfill.backfill_media(vault, log_fn=_quiet)
+    assert stats.sidecars_created == 1
+    assert stats.extracted == 1
+    sidecar = p.with_name(p.name + ".md")
+    assert sidecar.exists()
+    body = sidecar.read_text("utf-8")
+    assert "ugreen nexode 100w charger" in body
+    assert f"evidence_file: {FINANCE_REL}" in body
+
+
+def test_backfill_skips_schema_and_index_dirs(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Cruft/config dirs must be pruned so the walk never indexes them.
+    skipped = vault / "Knowledge Base" / "_Schema" / "_attachments" / "logo.png"
+    skipped.parent.mkdir(parents=True, exist_ok=True)
+    skipped.write_bytes(b"\xff\xd8\xffLOGO")
+    stats = backfill.backfill_media(vault, dry_run=True, log_fn=_quiet)
+    assert stats.sidecars_created == 0
+
+
 def test_backfill_no_ocr_skips_extraction(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     _drop_image(vault)
     monkeypatch.setattr(embeddings, "embed_image", lambda p: np.ones(embeddings.CLIP_DIM, dtype=np.float32))

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -338,3 +338,40 @@ def test_cache_invalidation_on_mtime_change(vault: Path) -> None:
     os.utime(p, (future, future))
     post = find_module.find(vault, query=sentinel)
     assert any("progressive-disclosure" in h.path for h in post)
+
+
+# ---------------- file-type filters (scoping; default = allow all) ----------------
+
+
+def _mk_page(fm: dict):
+    return find_module.ParsedPage(
+        path=Path("x.md"), rel_path="Knowledge Base/x.md",
+        frontmatter=fm, body="", title="t", mtime=0.0,
+    )
+
+
+def test_file_kind_classification() -> None:
+    assert _mk_page({}).file_kind == "note"
+    assert _mk_page({"type": "insight"}).file_kind == "note"
+    assert _mk_page({"media_type": "pdf"}).file_kind == "pdf"
+    assert _mk_page({"media_type": "image"}).file_kind == "image"
+    assert _mk_page({"type": "dataset", "format": "csv"}).file_kind == "csv"
+    assert _mk_page({"type": "dataset"}).file_kind == "dataset"
+
+
+def test_passes_filters_default_allows_all_kinds() -> None:
+    # No file-type filter → every kind passes. Search must never hide a type by default.
+    for fm in ({}, {"media_type": "pdf"}, {"type": "dataset", "format": "csv"}):
+        assert find_module._passes_filters(_mk_page(fm), types=None, projects=None, tags=None)
+
+
+def test_passes_filters_file_types_include_and_exclude() -> None:
+    pdf = _mk_page({"media_type": "pdf"})
+    note = _mk_page({"type": "insight"})
+    ds = _mk_page({"type": "dataset", "format": "csv"})
+    # include: only listed kinds pass
+    assert find_module._passes_filters(pdf, types=None, projects=None, tags=None, file_types=["pdf"])
+    assert not find_module._passes_filters(note, types=None, projects=None, tags=None, file_types=["pdf"])
+    # exclude: listed kinds drop, others pass
+    assert not find_module._passes_filters(ds, types=None, projects=None, tags=None, exclude_file_types=["csv"])
+    assert find_module._passes_filters(note, types=None, projects=None, tags=None, exclude_file_types=["csv"])

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -188,3 +188,64 @@ def test_numeric_filter_ignores_appended_units_and_dates(vault: Path) -> None:
     rel = _write(vault, "Knowledge Base/Evidence/Test/vitd.csv", csv)
     r = qd.query_data(vault, path=rel, filters=[{"column": "value", "op": "lt", "value": 50}])
     assert {row["value"] for row in r.rows} == {"22,8 nmol/l", "21.1"}  # 100,2 excluded
+
+
+# ---------------- profile + dataset card ("what it holds") ----------------
+
+FINANCE_CSV = (
+    "date,vendor,item,amount\n"
+    "2025-08-25,Ugreen,Nexode 100W charger,28.56\n"
+    "2025-08-25,Ugreen,USB4 240W cable,12.59\n"
+    "2025-07-01,DJI,Mavic battery,99.00\n"
+)
+
+
+def test_profile_data_summarizes_columns(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Finance/invoices.csv", FINANCE_CSV)
+    prof = qd.profile_data(vault, path=rel)
+    assert prof["total_rows"] == 3
+    cols = {c["name"]: c for c in prof["columns"]}
+    assert cols["amount"]["kind"] == "numeric"
+    assert cols["amount"]["sum"] == pytest.approx(140.15)
+    assert cols["amount"]["min"] == pytest.approx(12.59)
+    assert cols["amount"]["max"] == pytest.approx(99.00)
+    assert cols["vendor"]["kind"] == "categorical"
+    assert set(cols["vendor"]["top_values"]) == {"Ugreen", "DJI"}
+    assert cols["date"]["kind"] == "date"
+    assert cols["date"]["earliest"] == "2025-07-01"
+    assert cols["date"]["latest"] == "2025-08-25"
+
+
+def test_build_dataset_card_carries_frontmatter_and_content(vault: Path) -> None:
+    rel = _write(vault, "Knowledge Base/Finance/invoices.csv", FINANCE_CSV)
+    prof = qd.profile_data(vault, path=rel)
+    card = qd.build_dataset_card(prof, title="Invoice register")
+    assert "type: dataset" in card
+    assert f"data_file: {rel}" in card
+    # Salient content the card must expose so `find` can hit it semantically:
+    assert "Ugreen" in card            # a vendor (categorical top value)
+    assert "Nexode 100W charger" in card  # an item value
+    assert "2025-07-01" in card        # date range floor
+    # A prose placeholder for Claude's "what this holds" summary:
+    assert "what this holds" in card.lower()
+
+
+def test_query_data_profile_aggregate_returns_card(vault: Path) -> None:
+    # `aggregate="profile"` is how Claude gets a server-side profile + a ready
+    # dataset card for a raw file it can't read directly.
+    rel = _write(vault, "Knowledge Base/Finance/invoices.csv", FINANCE_CSV)
+    r = qd.query_data(vault, path=rel, aggregate="profile")
+    assert r.aggregate["profile"]["total_rows"] == 3
+    card = r.aggregate["dataset_card"]
+    assert "type: dataset" in card
+    assert f"data_file: {rel}" in card
+    assert "Ugreen" in card
+
+
+def test_raw_data_files_are_never_embeddable() -> None:
+    # The never-embed-rows invariant: CSV/JSON are NOT part of the embedding
+    # corpus (only the markdown dataset card is). Locks Hugo's noise concern.
+    from kb_mcp import embeddings
+    assert embeddings._is_embeddable_path(Path("Knowledge Base/Finance/x.csv")) is False
+    assert embeddings._is_embeddable_path(Path("Knowledge Base/Finance/x.json")) is False
+    assert embeddings._is_embeddable_path(Path("Knowledge Base/Finance/x.md")) is True


### PR DESCRIPTION
## Why

A filed invoice (PDF in the `Finance/` vault sibling) was unsearchable. Traced in code: the binary-extraction pipeline was hardwired to `Knowledge Base/Evidence/` and the vector index embeds only `.md` under `Knowledge Base/`, so binaries/data anywhere else were invisible to `find`.

## What (all tested; 501 passed, 4 skipped)

- **Extraction = whole KB** — `backfill` + the live media worker walk all of `Knowledge Base/`, not just `Evidence/`. Any binary in the KB gets an OCR/text companion + CLIP.
- **Tabular** — `query_data(aggregate="profile")` returns a deterministic content profile + a ready `dataset` card; raw CSV/JSON rows are **never embedded** (locked by a test). Search the card; retrieve rows via `query_data`.
- **`find` file-type filters** — `file_types` / `exclude_file_types` (`note/pdf/image/audio/video/csv/json`); default allow-all (search never hides a type unless asked).
- **Access tiers** — new `access.py` reads a live-loaded `Knowledge Base/_access.yaml` (`readonly` = findable-but-write-protected, `excluded` = private/not-indexed) over append-only `Sources/`/`Evidence/`; enforced centrally in `batch_atomic_write`; `find` + the embedding index skip `excluded`.

## Gated (NOT in this PR's runtime effect)

`docs/vault-consolidation-migration.md` is the **irreversible** runbook to fold the vault siblings under `Knowledge Base/` and seed `_access.yaml`. It has **not** been run — existing `Finance/` invoices stay dark until it is.

## Follow-up before the migration

Run the embedding-path tests on the GPU host (extras not in CI venv):
`uv run --extra embeddings pytest tests/test_hybrid_search.py tests/test_clip.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
