### PR TITLE
feat(media): prewarm ASR (large-v3) at startup so the first transcription isn't a ~6-min cold-start

### DIFF
--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -143,21 +144,49 @@ def _device() -> str:
         return "cpu"
 
 
+_WHISPER_LOCK = threading.Lock()
+
+
 def _get_whisper():
     global _WHISPER
     if _WHISPER is not None:
         return _WHISPER
-    _ensure_cuda_dll_path()
-    try:
-        from faster_whisper import WhisperModel
-    except ImportError as e:
-        raise ExtractionUnavailable(f"faster-whisper not installed: {e}") from e
-    device = _device()
-    # int8_float16 on GPU keeps large-v3 light without accuracy loss; int8 on CPU.
-    compute_type = "int8_float16" if device == "cuda" else "int8"
-    log.info("loading faster-whisper %s on %s (%s)", WHISPER_MODEL, device, compute_type)
-    _WHISPER = WhisperModel(WHISPER_MODEL, device=device, compute_type=compute_type)
+    # Serialize the load so a prewarm thread and a real job can't double-load the model
+    # (two ~3 GB WhisperModels briefly in VRAM). Double-checked: skip the lock once warm.
+    with _WHISPER_LOCK:
+        if _WHISPER is not None:
+            return _WHISPER
+        _ensure_cuda_dll_path()
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError as e:
+            raise ExtractionUnavailable(f"faster-whisper not installed: {e}") from e
+        device = _device()
+        # int8_float16 on GPU keeps large-v3 light without accuracy loss; int8 on CPU.
+        compute_type = "int8_float16" if device == "cuda" else "int8"
+        log.info("loading faster-whisper %s on %s (%s)", WHISPER_MODEL, device, compute_type)
+        _WHISPER = WhisperModel(WHISPER_MODEL, device=device, compute_type=compute_type)
     return _WHISPER
+
+
+def prewarm() -> None:
+    """Eagerly load the ASR model so the first real transcription isn't a cold-start.
+
+    `WHISPER_MODEL` (default large-v3, ~3 GB) loads lazily on first use; with a single
+    GPU-serialized media worker that first job otherwise blocks for minutes while the
+    model reads in. The server calls this off the request path at start (a background
+    thread) so the model warms during boot/idle, not on the user's first audio/video
+    upload. Soft-fail: a box without the engine (or with media extraction disabled)
+    just stays lazy and transcribes nothing until configured.
+    """
+    if not extraction_enabled():
+        return
+    try:
+        _get_whisper()
+    except ExtractionUnavailable as e:
+        log.info("ASR prewarm skipped (engine unavailable): %s", e)
+    except Exception:  # noqa: BLE001 — prewarm must never crash startup
+        log.warning("ASR prewarm failed; will retry lazily on first job", exc_info=True)
 
 
 def _transcribe(path: Path, media_type: str) -> ExtractResult:

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -58,6 +58,12 @@ class MediaWorker:
             )
             self._thread.start()
             log.info("media extraction worker started")
+            # Warm the ASR model off the request path so the first audio/video upload
+            # isn't a multi-minute cold-start (large-v3 ~3 GB loads lazily on first use).
+            # Separate daemon thread so image/PDF/CLIP jobs aren't blocked while it loads.
+            threading.Thread(
+                target=extract.prewarm, name="kb-asr-prewarm", daemon=True
+            ).start()
 
     def enqueue(
         self,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -38,6 +38,32 @@ def test_extraction_enabled_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert extract.extraction_enabled() is True
 
 
+def test_prewarm_loads_the_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    called: list[bool] = []
+    monkeypatch.setattr(extract, "_get_whisper", lambda: called.append(True))
+    extract.prewarm()
+    assert called == [True]  # warmed eagerly
+
+
+def test_prewarm_soft_fails_when_engine_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+
+    def unavailable():
+        raise extract.ExtractionUnavailable("faster-whisper not installed")
+
+    monkeypatch.setattr(extract, "_get_whisper", unavailable)
+    extract.prewarm()  # must not raise — a lean box just stays lazy
+
+
+def test_prewarm_skipped_when_extraction_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", "1")
+    called: list[bool] = []
+    monkeypatch.setattr(extract, "_get_whisper", lambda: called.append(True))
+    extract.prewarm()
+    assert called == []  # disabled → never touches the model
+
+
 def test_extract_text_routes_by_media_type(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(extract, "_transcribe", lambda p, mt: extract.ExtractResult("T", mt, "whisper"))
     monkeypatch.setattr(extract, "_ocr_image", lambda p: extract.ExtractResult("O", "image", "tesseract"))

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -68,6 +68,19 @@ def test_worker_marks_failed_on_extraction_error(vault, monkeypatch: pytest.Monk
     assert "extracted_by: pending" not in body  # won't re-loop on restart scan
 
 
+def test_start_prewarms_asr_off_the_request_path(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    import threading
+
+    warmed = threading.Event()
+    monkeypatch.setattr(extract, "prewarm", warmed.set)
+    w = media_worker.MediaWorker(vault)
+    w.start()
+    try:
+        assert warmed.wait(timeout=5.0), "start() should warm ASR in a background thread"
+    finally:
+        w.stop()
+
+
 def test_worker_unavailable_leaves_pending(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
     result = _preserve_media_stub(vault, filename="later.mp3")


### PR DESCRIPTION
## Why

`WHISPER_MODEL` (default `large-v3`, ~3 GB) loads **lazily on first use**. With the single GPU-serialized media worker, the **first audio/video upload after a restart blocks ~6 min** while the model reads in — the sidecar sits `extracted_by: pending` the whole time, and anything queued behind it stalls. Observed live in `logs/kb-mcp.log` (model-resolve 18:17 → first transcription 18:24). Diagnosed in `Notes/Research/Substrate/kb-mcp-full-e2e-modality-verification-2026-06-26-…`.

## What

- `MediaWorker.start()` warms the model in a **background daemon thread** (`extract.prewarm`) so the load happens at boot/idle, **off the request path**. A separate thread (not the worker queue) means image/PDF/CLIP jobs aren't blocked while ASR loads.
- `_get_whisper()` gets **double-checked locking** so the prewarm thread and a real job can't double-load the model (two ~3 GB instances briefly in VRAM).
- `extract.prewarm()` **soft-fails**: returns early when media extraction is disabled, swallows `ExtractionUnavailable`, and never crashes startup.

## Why keep large-v3 (not distil)

`distil-large-v3` is faster and ~1-2% WER behind on English — but it's **English-only**, and the vault has **Estonian** content (medical/work). Prewarming keeps full multilingual `large-v3` *and* removes the cold-start — no quality tradeoff. (`KB_MCP_WHISPER_MODEL` still overrides for anyone who wants a smaller model.)

## Verification

`27 passed` — full `test_extract.py` + `test_media_worker.py` including 4 new tests: prewarm loads the model, soft-fails when the engine is unavailable, is skipped when extraction is disabled, and `start()` warms ASR off the request path (monkeypatched — no GPU/model load in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019RvTTZiEtDVTqLiKP2WMnP