### PR TITLE
fix(extract): cap extracted sidecar text (512KB) so one oversized doc can't poison find

### DIFF
--- a/src/kb_mcp/preserve.py
+++ b/src/kb_mcp/preserve.py
@@ -26,6 +26,7 @@ import base64
 import datetime as dt
 import io
 import logging
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,33 @@ from .vault import PlannedWrite, batch_atomic_write, escape_wikilinks_for_log, k
 
 
 log = logging.getLogger(__name__)
+
+# Cap extracted text written into a sidecar. `find` rebuilds BM25 over the whole
+# corpus per query, so one oversized document (e.g. a 7 MB HTML export rendered to
+# markdown) re-tokenizes on every search and degrades ALL lookups. 512 KB sits well
+# above any real document yet kills pathological machine-dumps. The original binary
+# is always preserved — pull the full content via /download. Env-overridable.
+_MAX_EXTRACT_BYTES = int(os.environ.get("KB_MCP_MAX_EXTRACT_BYTES", 512 * 1024))
+
+
+def _cap_extracted_text(text: str) -> str:
+    """Truncate extracted text to `_MAX_EXTRACT_BYTES` (UTF-8), keeping the start.
+
+    No-op for normal documents. A truncated doc stays findable by its start + title;
+    only content past the cap isn't text-indexed (the binary still holds it all).
+    """
+    raw = text.encode("utf-8")
+    if len(raw) <= _MAX_EXTRACT_BYTES:
+        return text
+    kept = raw[:_MAX_EXTRACT_BYTES].decode("utf-8", errors="ignore").rstrip()
+    log.warning(
+        "extracted text %d bytes exceeds cap %d — truncated; full content stays in the binary",
+        len(raw), _MAX_EXTRACT_BYTES,
+    )
+    return (
+        f"{kept}\n\n[... truncated: kept first {_MAX_EXTRACT_BYTES // 1024} KB of "
+        f"{len(raw) // 1024} KB; full content is in the original binary — pull it via /download ...]"
+    )
 
 MAX_DECODED_BYTES = 5 * 1024 * 1024  # 5 MB — base64-via-model path (tokens cost real money)
 MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB — HTTP /upload path (raw bytes, no token cost).
@@ -482,7 +510,7 @@ def _render_sidecar(
         lines.append("## Extracted text")
         lines.append("")
         if text:
-            lines.append(text)
+            lines.append(_cap_extracted_text(text))
             lines.append("")
     return "\n".join(lines)
 
@@ -542,7 +570,7 @@ def update_sidecar_extraction(
     """
     content = sidecar_path.read_text(encoding="utf-8")
     content = _set_frontmatter_field(content, "extracted_by", engine)
-    content = _set_extracted_text(content, text)
+    content = _set_extracted_text(content, _cap_extracted_text(text))
     batch_atomic_write([PlannedWrite(path=sidecar_path, content=content)], vault_root=vault_root)
 
 

--- a/tests/test_preserve.py
+++ b/tests/test_preserve.py
@@ -33,6 +33,33 @@ def test_preserve_text_artifact_writes_file(vault: Path) -> None:
     assert result.sidecar_path is None  # no description supplied
 
 
+def test_cap_extracted_text_passthrough_under_limit() -> None:
+    assert preserve_module._cap_extracted_text("short content") == "short content"
+
+
+def test_cap_extracted_text_truncates_over_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(preserve_module, "_MAX_EXTRACT_BYTES", 1000)
+    out = preserve_module._cap_extracted_text("A" * 5000)
+    assert len(out.encode("utf-8")) < 5000           # genuinely shrunk
+    assert out.startswith("A" * 200)                 # kept the (most-relevant) start
+    assert "truncated" in out and "/download" in out  # marker + pointer to the binary
+
+
+def test_capped_sidecar_keeps_corpus_small(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The worker/backfill write path must cap, so one oversized doc can't poison find.
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    monkeypatch.setattr(preserve_module, "_MAX_EXTRACT_BYTES", 500)
+    res = preserve_module.preserve_bytes(
+        vault, scope="Test", category="docs", filename="huge.docx", data=b"BINARY"
+    )
+    sidecar = vault / res.sidecar_path
+    preserve_module.update_sidecar_extraction(vault, sidecar, text="Z" * 20000, engine="markitdown")
+    body = _read(sidecar)
+    assert "truncated" in body
+    assert body.count("Z") < 20000           # capped, not the full 20k chars
+    assert len(body.encode("utf-8")) < 5000  # sidecar stays small → corpus protected
+
+
 def test_preserve_binary_artifact_decodes_base64(vault: Path) -> None:
     payload = b"\x89PNG\r\n\x1a\nfakepng"
     result = preserve_module.preserve(


### PR DESCRIPTION
## Why

A backfill of two large HTML jira-exports produced **7.8 MB + 7.0 MB markdown sidecars**. `find` rebuilds BM25 over the whole corpus per query, so those re-tokenized on **every** search → find latency climbed **44s → 538s** → the Cloudflare funnel 502'd and the KB looked **down** (the service was RUNNING and serving the whole time). Root cause: **extraction had no size cap**, so one oversized input degraded *all* search. Diagnosed in `Notes/Failures/uncapped-large-doc-extraction-poisons-find-…`.

## What

- New `preserve._cap_extracted_text()` truncates extracted text to **512 KB** (env `KB_MCP_MAX_EXTRACT_BYTES`), on a UTF-8 boundary, keeping the start + a marker pointing at the original binary.
- Applied at **both** write paths — the initial `preserve_bytes` sidecar build *and* `update_sidecar_extraction` (worker + backfill) — so no route can poison the corpus.

## Searchability / trade-offs

- **Real documents are untouched** — the largest legit doc was 137 KB, far under the cap; fully searchable, no change.
- A truncated doc stays **findable** (its start + title are indexed, text *and* vector); only content *past* the cap isn't text-indexed.
- **Nothing is lost** — only the extracted-text sidecar is capped; the **original binary is always preserved** and pullable via `/download`.
- Downside: a genuinely-huge *legitimate* doc (>512 KB text) is only partially text-searchable. Rare; mitigated by the env override + the preserved binary. (Deeper future option: cached/incremental BM25 so corpus size never costs per-query.)

## Verification

**54 passed** (preserve + media_worker + extract). New tests: passthrough under limit, truncation + marker over limit, and the worker write-path keeps the sidecar small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019RvTTZiEtDVTqLiKP2WMnP