### PR TITLE
fix(media): CLIP on CPU when ASR active — visual search was silently dead on GPU (whisper cuDNN clash)

### DIFF
--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -121,18 +121,45 @@ class ClipUnavailable(Exception):
     """CLIP (sentence-transformers/Pillow) isn't importable — soft-fail signal."""
 
 
+def _clip_device() -> str:
+    """Device for CLIP. Honors KB_MCP_CLIP_DEVICE; otherwise GPU only when ASR is NOT
+    running in this process, else CPU.
+
+    Why not always GPU: faster-whisper's CUDA-12 cuDNN/cuBLAS wheels get PATH-prepended
+    (extract._ensure_cuda_dll_path) so ctranslate2 can load — which then shadows
+    torch-cu132's bundled cuDNN 13 and makes CLIP's ViT Conv2d die with
+    CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH. bge survives (pure transformer, no conv);
+    CLIP's vision tower doesn't. Since the media worker prewarms ASR at startup, having
+    extraction enabled means PATH is already poisoned, so CLIP must run on CPU — a tiny
+    ViT-B/32, off the request path, embeds in well under a second. A CLIP-only box
+    (KB_MCP_DISABLE_MEDIA_EXTRACTION set) has no conflict and keeps the GPU.
+    """
+    override = os.environ.get("KB_MCP_CLIP_DEVICE")
+    if override:
+        return override
+    # Mirror extract.extraction_enabled() without importing it (avoids a new module edge).
+    asr_active = not os.environ.get("KB_MCP_DISABLE_MEDIA_EXTRACTION")
+    if asr_active:
+        return "cpu"
+    try:
+        import torch
+
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
+        return "cpu"
+
+
 def get_clip_model():
-    """Lazy CLIP singleton (encodes BOTH images and text). CUDA when available."""
+    """Lazy CLIP singleton (encodes BOTH images and text). Device via _clip_device()."""
     global _CLIP_MODEL
     if _CLIP_MODEL is not None:
         return _CLIP_MODEL
     with _CLIP_LOCK:
         if _CLIP_MODEL is not None:
             return _CLIP_MODEL
-        import torch
         from sentence_transformers import SentenceTransformer
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = _clip_device()
         log.info("loading CLIP model %s on %s", CLIP_MODEL_NAME, device)
         _CLIP_MODEL = SentenceTransformer(CLIP_MODEL_NAME, device=device)
     return _CLIP_MODEL

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -37,6 +37,23 @@ class _FakeClip:
         )
 
 
+def test_clip_device_env_and_asr_gating(monkeypatch) -> None:
+    """GPU CLIP shares a process with faster-whisper, whose cu12 cuDNN PATH-prepend
+    breaks CLIP's ViT Conv2d on torch-cu132. So CLIP must run on CPU whenever ASR
+    (media extraction) is enabled; an explicit KB_MCP_CLIP_DEVICE override always wins."""
+    # Explicit override wins regardless of ASR state.
+    monkeypatch.setenv("KB_MCP_CLIP_DEVICE", "cuda")
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    assert embeddings._clip_device() == "cuda"
+    monkeypatch.setenv("KB_MCP_CLIP_DEVICE", "cpu")
+    monkeypatch.setenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", "1")
+    assert embeddings._clip_device() == "cpu"
+    # No override + ASR enabled (the live default) → CPU, dodging the whisper cuDNN clash.
+    monkeypatch.delenv("KB_MCP_CLIP_DEVICE", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    assert embeddings._clip_device() == "cpu"
+
+
 def test_clip_index_upsert_search_has_delete(vault) -> None:
     idx = embeddings.ClipIndex(vault)
     a_path = "Knowledge Base/Evidence/Yolo/photos/a.jpg"


### PR DESCRIPTION
## Problem

Smoke (`scripts/smoke-media-pipeline.py`) caught that **CLIP visual search was silently failing on the GPU**: textless-image match died with

```
RuntimeError: CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH
```

in CLIP's ViT `patch_embedding` Conv2d.

## Root cause (verified)

- CPU CLIP works; clean-process GPU CLIP works.
- GPU CLIP only breaks **after** the media worker's `extract.prewarm()` loads faster-whisper, whose `_ensure_cuda_dll_path()` PATH-prepends the `nvidia-cudnn-cu12` / `nvidia-cublas-cu12` wheel dirs (needed for ctranslate2 on Blackwell).
- torch is `2.12.0+cu132` and wants its **own** cuDNN 13; the prepended **cu12** cuDNN 9.23 shadows it → sublibrary mismatch. bge survives because it's a pure transformer (no conv → never touches cuDNN); CLIP's vision tower has a Conv2d, so it's the casualty.
- Since whisper + CLIP share **one process** in the media worker and prewarm runs at startup, **every new image/video upload was getting an OCR sidecar but no CLIP vector** on the live box. OCR / PDF / ASR / bge retrieval were all fine — only visual search was down.

The same PATH-prepend that fixes ASR on Blackwell is what breaks CLIP — cu12 (ctranslate2) vs cu13 (torch) cuDNN can't coexist on PATH in one process.

## Fix

`embeddings._clip_device()` chooses CLIP's device:
- `KB_MCP_CLIP_DEVICE` override wins;
- else **CPU when media extraction (ASR) is enabled** — the live default, where PATH is poisoned;
- else GPU (a CLIP-only box with `KB_MCP_DISABLE_MEDIA_EXTRACTION` set has no conflict).

CLIP ViT-B/32 is tiny and runs off the request path, so CPU costs ~sub-second/image — bge (request-path) and whisper (heavy) stay on GPU.

## Verification

- `scripts/smoke-media-pipeline.py`: **all 4 steps green** (OCR, **CLIP visual match**, PDF, /download) under whisper prewarm — the exact condition that failed before.
- `test_clip.py` / `test_extract.py` / `test_media_worker.py` / `test_video_visual.py`: 55 passed; +1 new regression test for `_clip_device()` gating.

## Deploy

After merge: `scripts/restart.ps1` on the live box so the worker picks it up. Existing images uploaded while this was broken have no CLIP vector — a `kb-mcp backfill-media` pass (now on CPU) will index them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)