### PR TITLE
perf(bm25): incremental per-doc token cache so a write re-tokenizes only the changed doc

### DIFF
--- a/src/kb_mcp/bm25.py
+++ b/src/kb_mcp/bm25.py
@@ -1,8 +1,16 @@
-"""BM25Okapi over compiled KB pages, with mtime-based per-process cache.
+"""BM25Okapi over compiled KB pages, with mtime-based per-process caches.
 
-Cheap to rebuild for a 600-file vault (<1s), so we don't bother with
-incremental updates — on every `search()` call we scan the tree once for
-the max observed mtime and rebuild if it advanced.
+On every `search()` call we scan the tree once for the max observed mtime and
+rebuild the index if it advanced. The rebuild is *incremental at the document
+level*: a per-doc token cache (keyed by path + mtime, mirroring
+`find.FrontmatterCache`) means only the documents that actually changed get
+re-tokenized. So one large doc, a big corpus, or a write-heavy session no
+longer forces an O(corpus) Snowball re-tokenize on the next `find` — which was
+the failure behind the "uncapped large doc poisoned find" incident (the 512 KB
+extract cap is the complementary, orthogonal fix). The `BM25Okapi` object
+itself is still reconstructed from the cached token lists each rebuild
+(`rank_bm25` has no incremental add/remove API), but that step is cheap
+relative to the stemming it now avoids.
 
 Tokens are stemmed with Snowball (English) so morphologically related
 words score together — "regulation" matches a page with "regulator",
@@ -65,6 +73,29 @@ class BM25Index:
 
     def __init__(self) -> None:
         self._cache: dict[tuple[Path, str], tuple[float, object, list[str]]] = {}
+        # Per-doc token cache, shared across scopes (a file's tokens don't depend
+        # on scope; KB ⊆ vault). Mirrors find.FrontmatterCache's mtime
+        # invalidation: a doc is Snowball-tokenized once and reused until its
+        # mtime advances, so a rebuild only re-stems the docs that changed.
+        # Stale entries for deleted files linger harmlessly — the corpus is
+        # assembled only from currently-walked paths; clear() flushes them.
+        self._tokens: dict[Path, tuple[float, list[str]]] = {}
+        # Diagnostics for the most recent _build(): how many docs were actually
+        # (re)tokenized vs reused from cache. Lets tests assert incrementality
+        # without timing the wall clock.
+        self.last_tokenized: int = 0
+        self.last_reused: int = 0
+
+    def _doc_tokens(self, path: Path, page) -> list[str]:
+        """Tokens for `page`, reusing the cache while the file's mtime is unchanged."""
+        cached = self._tokens.get(path)
+        if cached is not None and cached[0] == page.mtime:
+            self.last_reused += 1
+            return cached[1]
+        tokens = _tokenize(page.title + " " + page.body)
+        self._tokens[path] = (page.mtime, tokens)
+        self.last_tokenized += 1
+        return tokens
 
     def _build(
         self, vault_root: Path, scope: str
@@ -72,7 +103,8 @@ class BM25Index:
         """Walk the KB (or full vault), tokenize each file, build BM25Okapi.
 
         Returns (max_mtime, bm25, paths) where `paths` is parallel to the
-        BM25 document index.
+        BM25 document index. Reuses cached per-doc tokens for unchanged files
+        (see `_doc_tokens`), so only changed docs are re-tokenized.
         """
         # Lazy import — rank_bm25 isn't on the keyword-only hot path.
         from rank_bm25 import BM25Okapi
@@ -84,6 +116,8 @@ class BM25Index:
             kb = vault_root / "Knowledge Base"
             walk = find_module._walk_md(kb)
 
+        self.last_tokenized = 0
+        self.last_reused = 0
         paths: list[str] = []
         corpus: list[list[str]] = []
         max_mtime = 0.0
@@ -91,7 +125,7 @@ class BM25Index:
             page = find_module._CACHE.get(md, vault_root)
             if page is None:
                 continue
-            tokens = _tokenize(page.title + " " + page.body)
+            tokens = self._doc_tokens(md, page)
             if not tokens:
                 continue
             paths.append(page.rel_path)
@@ -132,6 +166,9 @@ class BM25Index:
 
     def clear(self) -> None:
         self._cache.clear()
+        self._tokens.clear()
+        self.last_tokenized = 0
+        self.last_reused = 0
 
 
 def _current_max_mtime(vault_root: Path, scope: str) -> float:

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -193,6 +193,113 @@ def test_bm25_corpus_is_stemmed(vault) -> None:
     )
 
 
+def _write_md(path, body: str) -> None:
+    """Drop a minimal compiled note straight onto disk (no writer side effects
+    like index refresh), so token-count assertions see exactly one new file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-06-27\n"
+        f"updated: 2026-06-27\ntags: []\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_bm25_incremental_build_only_tokenizes_changed_doc(vault) -> None:
+    """After a single new write, the rebuild re-tokenizes ONLY the new doc.
+
+    The whole point of the per-doc token cache: a write (which advances the
+    vault's max mtime and so forces the next search to rebuild) must not
+    re-stem the entire corpus — only the document that changed.
+    """
+    import os
+    import time
+
+    bm25.clear_cache()
+    find_module.clear_cache()
+    # Cold build over the whole fixture corpus.
+    bm25.search(vault, "insulin", k=5)
+    cold = bm25._INDEX.last_tokenized
+    assert cold > 1, f"cold build should tokenize the whole corpus; got {cold}"
+    assert bm25._INDEX.last_reused == 0, "nothing to reuse on a cold build"
+
+    # Add ONE new note. Force its mtime past every fixture file so the next
+    # search() definitely rebuilds (avoids any filesystem-resolution ambiguity).
+    probe = vault / "Knowledge Base" / "Notes" / "Insights" / "probe-incremental-one.md"
+    _write_md(probe, "# Probe incremental one\n\nA brand new note about insulin and glucose.")
+    future = time.time() + 10_000
+    os.utime(probe, (future, future))
+
+    bm25.search(vault, "insulin", k=5)
+    assert bm25._INDEX.last_tokenized == 1, (
+        f"rebuild after one write should re-tokenize only the new doc; "
+        f"got {bm25._INDEX.last_tokenized}"
+    )
+    # Every original doc came from the token cache instead of being re-stemmed.
+    assert bm25._INDEX.last_reused == cold, (
+        f"all {cold} original docs should be reused; got {bm25._INDEX.last_reused}"
+    )
+
+
+def test_bm25_edit_retokenizes_only_changed_file(vault) -> None:
+    """Editing one existing file re-tokenizes only that file, not the corpus.
+
+    Bumps the file's mtime explicitly via os.utime so the assertion doesn't
+    depend on the filesystem's mtime resolution (a real edit advances mtime
+    too — that's the cache key).
+    """
+    import os
+    import time
+
+    bm25.clear_cache()
+    find_module.clear_cache()
+    bm25.search(vault, "insulin", k=5)  # cold build
+
+    kb = vault / "Knowledge Base"
+    target = next(find_module._walk_md(kb))  # any indexed file
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+
+    bm25.search(vault, "insulin", k=5)
+    assert bm25._INDEX.last_tokenized == 1, (
+        f"editing one file should re-tokenize only it; "
+        f"got {bm25._INDEX.last_tokenized}"
+    )
+
+
+def test_bm25_cached_tokens_match_fresh_tokenization(vault) -> None:
+    """Ranking parity: cached-token scores equal cold-rebuild scores exactly.
+
+    Cached tokens are byte-identical to freshly stemmed tokens, so the BM25
+    corpus — and therefore every score — must be identical whether a doc was
+    reused from cache or re-tokenized from scratch. This is the deterministic
+    parity proof the handoff asks for (stronger than NDCG drift on a golden set).
+    """
+    import os
+    import time
+
+    bm25.clear_cache()
+    find_module.clear_cache()
+    bm25.search(vault, "insulin", k=50)  # cold over the original corpus
+
+    probe = vault / "Knowledge Base" / "Notes" / "Insights" / "probe-parity.md"
+    _write_md(probe, "# Probe parity\n\nGlucose metabolism and insulin sensitivity.")
+    future = time.time() + 10_000
+    os.utime(probe, (future, future))
+
+    # Incremental path: originals reused from cache, only the new doc stemmed.
+    incremental = bm25.search(vault, "insulin", k=50)
+    assert bm25._INDEX.last_tokenized == 1
+
+    # Cold path: same file set, but every doc tokenized fresh.
+    bm25.clear_cache()
+    cold = bm25.search(vault, "insulin", k=50)
+    assert bm25._INDEX.last_tokenized > 1
+
+    assert incremental == cold, (
+        "cached-token ranking must equal fresh-token ranking exactly"
+    )
+
+
 def test_stem_aware_gate_recovers_morphological_match(vault) -> None:
     """A page that uses 'regulator' should be reachable via 'regulation'.
 


### PR DESCRIPTION
## Why

BM25 fully re-tokenized (Snowball-stemmed) the **entire corpus** whenever any file's mtime advanced. At ~1900 files, every `note`/`add`/`edit`/`reconcile`/embedding-refresh forced the next `find` to re-stem everything. With multi-MB extracted sidecars present this drove `find` 44s → 538s — getting worse with each write in a session — and looked like "KB down".

This is the scaling fix; it complements (does not replace) the 512 KB extract cap shipped in #46. Handoff: KB note `kb-mcp-incremental-bm25-index-handoff-...`. Option 1 (in-memory token cache) only — Option 2 (sqlite persistence) intentionally skipped (only speeds the one-time cold start; no GPU forcing function like embeddings).

## What

- Add a per-process, scope-independent **per-doc token cache** to `BM25Index`, keyed by `path + mtime` (mirrors `find.FrontmatterCache`).
- `_build` reuses cached tokens for unchanged docs and re-tokenizes **only changed docs**. `BM25Okapi` is still reconstructed from the cached token lists (`rank_bm25` has no incremental add/remove API) — cheap relative to the stemming now avoided.
- `last_tokenized` / `last_reused` counters so incrementality is asserted directly (no wall-clock timing). `clear()` flushes tokens + counters.
- Public signatures (`search`/`clear_cache`/`tokenize`/`stem_word`) unchanged → `find.py` and other callers untouched.

## Tests / verification

- New tests: only-changed-doc tokenized (`last_tokenized == 1`), edit re-tokenizes only that file, and **ranking parity** (cached-token scores == cold-rebuild scores, exactly — deterministic since cached tokens are byte-identical to fresh ones).
- All **87** BM25-touching tests pass (`test_hybrid_search`, `test_find`, `test_corpus_aware`, `test_ranking_config`, `test_supersession_surface`, `test_query_log`). `ruff` clean.

## Acceptance criteria (from handoff)

- [x] A large doc present in the vault does not slow `find` (tokenized once, reused thereafter).
- [x] A single write re-tokenizes only the changed doc (asserted via counter).
- [x] Ranking parity vs the full-rebuild baseline (parity test).
- [x] 512 KB extract cap untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)