### PR TITLE
docs(ingress): give domain-less friends a real escape from the Funnel drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,23 +176,33 @@ uv sync --extra embeddings --extra media
 #       uv run python -m kb_mcp backfill-media             # do it (CPU or GPU)
 #     Flags: --no-ocr (sidecar + CLIP only), --no-clip, --vault <root>.
 
-# 2. Set up a public HTTPS URL (you need this hostname in step 3). Pick ONE:
+# 2. Set up a public HTTPS URL (you need this hostname in step 3). Pick a
+#    BURST-TOLERANT ingress: claude.ai re-auths in bursts and a shared relay that
+#    throttles them shows up as a connector that "keeps dropping."
 #
-#    OPTION A - Tailscale Funnel: NO domain needed, free <device>.<tailnet>.ts.net
-#    host, simplest. Best if you don't own a domain. In the Tailscale admin console
-#    enable HTTPS for the tailnet + Funnel for this node, then:
-tailscale funnel --bg --https=443 http://127.0.0.1:8765
-tailscale funnel status        # note the URL, e.g. https://<device>.<tailnet>.ts.net
-#    (Funnel's shared relay can throttle bursty reconnects under heavy use; if that
-#    bites, restart Tailscale, or switch to Option B.)
-#
-#    OPTION B - Cloudflare Tunnel: needs a domain you own in Cloudflare; more
-#    burst-tolerant under load. Prereq: winget install --id Cloudflare.cloudflared
+#    OPTION A (recommended) - Cloudflare Tunnel: needs a domain you own in Cloudflare;
+#    burst-tolerant, no request caps. Any cheap domain (~$1-12/yr) on Cloudflare's
+#    free plan works. Prereq: winget install --id Cloudflare.cloudflared
 cloudflared tunnel login
 pwsh -File scripts/setup-cloudflared.ps1 -Hostname kb.substratesystems.io -TunnelName kb-mcp-desktop
 #    -> https://kb.substratesystems.io (script makes the tunnel + DNS + auto-start
 #    service). In the CF dashboard for this hostname: Bot Fight Mode OFF + no WAF
 #    managed ruleset (Security Level low); the edge caps requests at ~100s.
+#    Full runbook: deploy/cloudflared/RUNBOOK.md
+#
+#    OPTION B - ngrok: NO domain needed, burst-tolerant, free stable *.ngrok-free.dev
+#    host. Free-tier caveats: a one-time "Visit Site" click on the GitHub-login
+#    redirect + a 20,000 requests/month cap. Best no-purchase path.
+ngrok config add-authtoken <token>   # then reserve a free domain in the dashboard
+ngrok http --url=https://<name>.ngrok-free.dev 8765   # older agents: --domain=<name>.ngrok-free.dev
+#    Full runbook (incl. running it as a service): deploy/ngrok/RUNBOOK.md
+#
+#    OPTION C - Tailscale Funnel: NO domain needed, free <device>.<tailnet>.ts.net
+#    host, BUT its shared relay throttles claude.ai's reconnect bursts -> the connector
+#    "keeps dropping." Workable for light use; `Restart-Service Tailscale` recovers it
+#    when it drops, but prefer Option A/B for a durable fix.
+tailscale funnel --bg --https=443 http://127.0.0.1:8765
+tailscale funnel status        # note the URL, e.g. https://<device>.<tailnet>.ts.net
 ```
 
 ### 3. Create a GitHub OAuth App (one-time, ~3 min)
@@ -224,8 +234,8 @@ KB_MCP_JWT_SIGNING_KEY=<long-random-string>
 KB_MCP_VAULT_PATH=<your-Obsidian-vault-root>
 ```
 
-`KB_MCP_BASE_URL` must match your public hostname (Tailscale Funnel or Cloudflare
-Tunnel, from step 2) exactly — no trailing slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
+`KB_MCP_BASE_URL` must match your public hostname (Cloudflare Tunnel, ngrok, or
+Tailscale Funnel, from step 2) exactly — no trailing slash, no `/mcp` suffix. `KB_MCP_GITHUB_USERNAME` is case-insensitive but must
 be the *login* (e.g. `Artexis10`), not the display name. `KB_MCP_VAULT_PATH` is
 **required**: claude.ai connects over HTTP and passes no environment, so the
 service resolves the vault solely from this line in `.env` at startup.

--- a/SETUP-FRIEND.md
+++ b/SETUP-FRIEND.md
@@ -213,18 +213,17 @@ sync the index counts after your manual `index.md` edit.
 
 ## Optional: mobile / claude.ai-web access
 
-Want the on-the-go experience Hugo has — querying your KB from **Claude
-mobile**? Same engine, just the remote tier. It's not *hard*, but it's
-genuinely more than the local path, because a phone needs an always-on,
-publicly-reachable, authenticated endpoint:
+Want the on-the-go experience Hugo has — querying your KB from **Claude mobile**
+or **claude.ai web**? Same engine, just the remote tier. It's more than the local
+path, because a public client needs an always-on, publicly-reachable,
+authenticated endpoint:
 
 1. **An always-on host** — your desktop running 24/7, or a cheap VPS. (Local
    stdio dies when you close Claude Code; mobile needs it always up.)
-2. **A public HTTPS endpoint** — **Tailscale Funnel** (no domain needed — gives a
-   free `*.ts.net` host; the simplest path if you don't own a domain) or
-   **Cloudflare Tunnel** (needs a domain you own in Cloudflare; more burst-tolerant
-   under heavy use — Hugo's setup). This exposes the server to the internet, so auth
-   becomes mandatory.
+2. **A public HTTPS endpoint** — a tunnel that exposes the local server. **Which
+   tunnel you pick matters** (see the table below) — it's the #1 cause of the
+   "connector keeps dropping" complaint. Exposing the server to the internet makes
+   auth mandatory (next step).
 3. **A GitHub OAuth app** (client id + secret) wired into the OAuthProxy —
    claude.ai connectors require OAuth; static tokens aren't accepted.
 4. **Lock it to your GitHub login** (the single-user verifier), then run it as a
@@ -233,10 +232,49 @@ publicly-reachable, authenticated endpoint:
    [README](README.md) covers all three platforms).
 5. **Add it as a custom connector** in claude.ai.
 
-The main [README](README.md) documents this path end-to-end (it's Hugo's exact
-setup). Rule of thumb: the **local path is ~90% of the value for ~20% of the
-effort**; the mobile tier is the rest — worth it if you genuinely want your KB
+### Which public endpoint? (read this before you pick)
+
+claude.ai's connector re-authenticates in **bursts** — a tight `/.well-known` →
+`register` → `authorize` → `token` sequence. A shared-relay tunnel can throttle
+that burst and silently drop it, which surfaces as a connector that **"keeps
+dropping" and needs constant reconnecting.** Pick a burst-tolerant ingress:
+
+| Your situation | Use | Notes |
+| --- | --- | --- |
+| **You only use Claude Code (desktop)** | **No tunnel at all** — the local stdio path above | Nothing public, nothing to drop. The whole remote tier is *only* for web/mobile — if you don't need your KB on your phone, stop here. |
+| **You own / will buy a domain** (~$1–12/yr) | **Cloudflare Tunnel** — *recommended* | Burst-tolerant, no request caps; Hugo's exact setup. Put any cheap domain on Cloudflare's free plan (switch its nameservers), then follow **[deploy/cloudflared/RUNBOOK.md](deploy/cloudflared/RUNBOOK.md)**. |
+| **No domain, won't buy one** | **ngrok** free dev domain | Burst-tolerant too, a free *stable* `*.ngrok-free.dev` host, no purchase. Caveats below. See **[deploy/ngrok/RUNBOOK.md](deploy/ngrok/RUNBOOK.md)**. |
+| **Already on Tailscale Funnel and it's dropping** | Restart Tailscale to recover *now*, then migrate | `*.ts.net` is free + no-domain, but its **shared relay throttles claude.ai's reconnect bursts** — that's the dropping. `Restart-Service Tailscale` (admin) clears it temporarily; move to Cloudflare or ngrok for a real fix. |
+
+**ngrok caveats (so you're not surprised):** the free tier shows a one-time
+"Visit Site" interstitial on the GitHub-login *browser* redirect (one click, then
+a cookie suppresses it ~7 days; it does **not** affect claude.ai's API/OAuth
+calls, which are exempt as programmatic traffic), and caps you at **20,000
+requests/month** — fine for light personal use, a ceiling under heavy use. It's a
+genuine no-cost path; Cloudflare-with-a-domain is the more bulletproof one.
+
+The main [README](README.md) documents the OAuth-app + service steps end-to-end
+(Hugo's setup). Rule of thumb: the **local path is ~90% of the value for ~20% of
+the effort**; the remote tier is the rest — worth it if you genuinely want your KB
 in your pocket.
+
+### Connector keeps dropping? (quick triage)
+
+Almost always the **path, not the server** — the kb-mcp service is usually fine.
+Before touching it:
+
+1. **Is the service actually up?** `curl.exe -i http://127.0.0.1:8765/mcp`
+   (Windows) / `curl -i http://127.0.0.1:8765/mcp` → a fast **401** means
+   healthy (the 401 is the auth funnel doing its job, not an error). If you get
+   that 401, the break is the tunnel, not kb-mcp — **don't restart the service**
+   (it only wedges any live chats).
+2. **Do you even need the remote tier?** If you mostly use Claude Code on the
+   desktop, drop the public endpoint and use the **local stdio** path above —
+   nothing public means nothing to drop.
+3. **On Tailscale Funnel?** That's the usual culprit (shared-relay burst
+   throttle). `Restart-Service Tailscale` (admin) gets you connected again now;
+   then migrate to **Cloudflare** (with a domain) or **ngrok** (no domain) per the
+   table above for a durable fix.
 
 ### Make the KB proactive in the Claude app (custom instructions)
 

--- a/deploy/cloudflared/RUNBOOK.md
+++ b/deploy/cloudflared/RUNBOOK.md
@@ -5,9 +5,14 @@ setup or **migrating an existing host off Tailscale Funnel**. The server code is
 unchanged (the public URL is env-driven via `KB_MCP_BASE_URL`); this is purely
 ingress + `.env` + GitHub OAuth App + the claude.ai connector.
 
-> **No domain?** Cloudflare Tunnel needs a domain you own in Cloudflare. If you don't
-> have one, use **Tailscale Funnel** instead (free `*.ts.net`, no domain) — see the
-> README "Option A". This runbook is for the Cloudflare path.
+> **No domain?** Cloudflare Tunnel needs a domain you own in Cloudflare — but a cheap
+> one (~$1–12/yr) added to Cloudflare's **free** plan (register anywhere, switch its
+> nameservers to Cloudflare) is enough, and this is the most robust path (no request
+> caps, no interstitial). If you truly won't buy one, use **[ngrok](../ngrok/RUNBOOK.md)**
+> instead (free *stable* `*.ngrok-free.dev`, no domain, also burst-tolerant) — **not**
+> Tailscale Funnel, whose shared relay throttles claude.ai's reconnect bursts (the
+> "keeps dropping" failure this migration exists to fix). This runbook is the
+> Cloudflare path.
 
 Substitute throughout:
 - `<HOST>` = `kb.substratesystems.io` (desktop) / `kb-laptop.substratesystems.io` (laptop)

--- a/deploy/ngrok/RUNBOOK.md
+++ b/deploy/ngrok/RUNBOOK.md
@@ -1,0 +1,128 @@
+# ngrok — kb-mcp ingress setup (no domain needed)
+
+Per-machine playbook for putting kb-mcp behind **ngrok** — the **no-domain**,
+burst-tolerant alternative to [Cloudflare Tunnel](../cloudflared/RUNBOOK.md). Use
+this when you want claude.ai web/mobile access but **don't own (and won't buy) a
+domain**. The server code is unchanged — the public URL is env-driven via
+`KB_MCP_BASE_URL`; this is purely ingress + `.env` + GitHub OAuth App + the
+claude.ai connector.
+
+> **Why ngrok and not Tailscale Funnel?** claude.ai's connector re-authenticates
+> in bursts (`/.well-known` → `register` → `authorize` → `token`). Tailscale
+> Funnel's shared relay throttles that burst and silently drops it — the "connector
+> keeps dropping" complaint. ngrok's free tier allows 4,000 req/min, so the ~5
+> request OAuth burst sails through. The trade is ngrok's free-tier caveats (below),
+> not burst drops.
+>
+> **Want the bulletproof path instead?** Cloudflare Tunnel (own a domain) has no
+> request cap and no interstitial — see [../cloudflared/RUNBOOK.md](../cloudflared/RUNBOOK.md).
+> A domain is ~$1–12/yr; put it on Cloudflare's free plan, switch nameservers, done.
+
+## Caveats — read before you commit (free tier)
+
+- **One-time login interstitial.** On the free tier, the *first* time a browser
+  hits your ngrok host it shows a "Visit Site" warning page. This fires **once** on
+  the GitHub-login redirect (`/authorize` opens in your browser), you click through,
+  and a cookie suppresses it for ~7 days. It does **not** affect claude.ai's own
+  API/OAuth calls — ngrok exempts programmatic traffic from the interstitial.
+- **20,000 requests/month cap** (and 4,000/min). Fine for light personal use; a
+  ceiling under heavy use or connector reconnect churn. If you outgrow it, move to
+  Cloudflare or a paid ngrok plan.
+- **Not yet battle-tested against claude.ai end-to-end by us** (Cloudflare is). The
+  mechanism is sound; if something snags, it'll be the interstitial on the login
+  redirect — fall back to the cloudflared runbook.
+
+Substitute throughout:
+- `<HOST>` = your reserved ngrok domain, e.g. `kb-yourname.ngrok-free.dev`
+  (newer accounts; older accounts get `*.ngrok-free.app` — both work).
+
+## Prereqs
+- An ngrok account (free) — <https://dashboard.ngrok.com>.
+- ngrok agent installed: `winget install --id Ngrok.Ngrok` (Windows) /
+  `brew install ngrok` (macOS) / see <https://ngrok.com/download> (Linux).
+- kb-mcp already installed and running as a service on `127.0.0.1:8765` (see the
+  main [README](../../README.md) for the service install).
+
+## Steps — order matters
+
+1. **Authenticate the agent** (token from dashboard → *Your Authtoken*):
+   ```
+   ngrok config add-authtoken <YOUR_TOKEN>
+   ```
+2. **Reserve your free dev domain.** Dashboard → **Domains** → you get one free
+   static domain like `kb-yourname.ngrok-free.dev`. This is **stable across
+   restarts** (reserved to your account) — which is what makes OAuth work; the
+   ephemeral `ngrok http 8765` URL would change every restart and break the
+   callback. Copy it; that's your `<HOST>`.
+3. **Smoke-test in the foreground** (Ctrl-C when you've confirmed it serves):
+   ```
+   ngrok http --url=https://<HOST> 8765
+   ```
+   > Older agents use `--domain=<HOST>` instead of `--url=https://<HOST>`.
+
+   Then from another machine/phone: `https://<HOST>/mcp` should return **401**
+   (healthy — the auth funnel).
+4. **Run it as a persistent service** so it survives reboots/logout. Create an
+   `ngrok.yml` next to your kb-mcp checkout:
+   ```yaml
+   version: "2"
+   authtoken: <YOUR_TOKEN>
+   tunnels:
+     kb-mcp:
+       proto: http
+       addr: 8765
+       domain: <HOST>
+   ```
+   Install + start the service (cross-platform: Windows service / systemd / launchd):
+   ```
+   ngrok service install --config <full-path-to>/ngrok.yml
+   ngrok service start
+   ```
+   (See <https://ngrok.com/docs/agent/> for per-OS service details.)
+5. **GitHub OAuth App** — edit *this host's* app (the one whose Client ID matches
+   `GITHUB_CLIENT_ID` in this machine's `.env`) at
+   <https://github.com/settings/developers>:
+   - Homepage URL → `https://<HOST>`
+   - Authorization callback URL → `https://<HOST>/auth/callback`
+   - **Update application** (fields aren't saved until you click it).
+6. **Point the server at `<HOST>`** and restart so it reloads:
+   ```
+   (Get-Content .env) -replace '^KB_MCP_BASE_URL=.*','KB_MCP_BASE_URL=https://<HOST>' | Set-Content .env   # Windows
+   pwsh -File scripts/restart.ps1
+   ```
+   (macOS/Linux: set `KB_MCP_BASE_URL=https://<HOST>` in `.env`, then restart the
+   service per the README.)
+   > **CRITICAL:** steps 5 and 6 must *both* point at `<HOST>` before step 7. If the
+   > GitHub app and the server's base URL disagree, GitHub rejects the login with
+   > "The redirect_uri is not associated with this application."
+7. **claude.ai** → Connectors → add at `https://<HOST>/mcp` → complete the GitHub
+   login (click through the one-time ngrok "Visit Site" page if it appears). Remove
+   any old `*.ts.net` connector once verified.
+
+## Verify
+- Local: `curl.exe -i http://127.0.0.1:8765/mcp` → **401**.
+- Public base URL — must now show `<HOST>` (proves the `.env` cutover took). From
+  off-host (another machine/phone, not the server itself):
+  ```
+  curl -s https://<HOST>/.well-known/oauth-protected-resource
+  ```
+  → `{"resource":"https://<HOST>/mcp","authorization_servers":["https://<HOST>/"], ...}`
+- claude.ai: connector connected, tools listed, a `find` returns results.
+- Reboot: the ngrok service and kb-mcp both auto-start and the connector still works.
+
+## Gotchas
+- **Ephemeral vs reserved URL.** Only the *reserved* dev domain (step 2) is stable.
+  If you ever run a bare `ngrok http 8765`, it mints a random URL that won't match
+  your OAuth callback — always pass your `<HOST>`.
+- **Interstitial during login.** If GitHub login stalls on an ngrok warning page,
+  click **Visit Site** once; the cookie suppresses it for ~7 days. If it ever blocks
+  the *API* path (it shouldn't — programmatic traffic is exempt), you've outgrown the
+  free tier; switch to Cloudflare or upgrade ngrok.
+- **Hit the 20k/month cap?** That's the free-tier ceiling, not a kb-mcp bug. Move to
+  the [Cloudflare path](../cloudflared/RUNBOOK.md) or a paid ngrok plan.
+
+## Rollback
+- `.env`: `KB_MCP_BASE_URL` back to the previous public URL; `pwsh -File scripts/restart.ps1`.
+- GitHub OAuth App callback back to the previous `https://<old-host>/auth/callback`.
+- claude.ai connector back to the previous `https://<old-host>/mcp`.
+- `ngrok service stop` (or `ngrok service uninstall`) to retire the tunnel.


### PR DESCRIPTION
## Why

Yusuke (a friend self-hosting kb-mcp) reports the claude.ai connector **keeps dropping** and needs constant reconnecting. That's the already-diagnosed failure: **Tailscale Funnel's shared relay throttles claude.ai's bursty OAuth reconnect handshakes** and silently drops them.

The fix machinery already ships (`deploy/cloudflared/RUNBOOK.md` + `scripts/setup-cloudflared.ps1`). The gap was **the docs**: every path told a domain-less friend *"no domain? → use Tailscale Funnel"* — the exact thing dropping them. A circular dead-end.

## What changed (docs only)

All friend-facing docs now converge on one decision tree:

- **Only use Claude Code (desktop)?** → local stdio, no tunnel — problem gone.
- **Need web/mobile?** → a burst-tolerant ingress:
  - **Cloudflare Tunnel** + a cheap domain (~$1–12/yr on the free plan) — *recommended*, no caps.
  - **ngrok** free dev domain — *no purchase*, burst-tolerant, with honest caveats.
  - **Tailscale Funnel** — last, reframed as the throttle-prone option that causes the dropping.

Files:
- `SETUP-FRIEND.md` — decision tree + ngrok quickstart + a "connector keeps dropping?" triage.
- `deploy/ngrok/RUNBOOK.md` (new) — no-domain runbook mirroring the cloudflared one.
- `deploy/cloudflared/RUNBOOK.md` — "No domain?" callout now points at ngrok (not Funnel) + cheap-domain note.
- `README.md` — Option block reordered: Cloudflare (recommended) / ngrok / Funnel.

## ngrok viability (verified, with caveats)

- ngrok's interstitial is **HTML-browser-only**; claude.ai's API/OAuth calls are exempt (programmatic). The one browser hop (`/authorize` → GitHub) shows a one-time "Visit Site" click, then a cookie suppresses it ~7 days.
- Free rate limit **4,000 req/min** → the ~5-request OAuth burst clears (root cause addressed).
- Free **dev domain is stable across restarts** → OAuth callback stays valid (Quick Tunnels' random URL would break it — rejected).
- **Caveats stated in the docs:** one-time login click, **20,000 req/month** cap, and **not yet battle-tested against claude.ai by us** — Cloudflare-with-a-domain remains the bulletproof path.

## Scope

Ingress is env-driven (`KB_MCP_BASE_URL`) — **no server code change**, and these are deploy/README/setup docs (**not** skill content), so no version bump / scaffold re-derive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)