### PR TITLE
feat(audit): ACT-R dormancy ordering for stale_review + get read-logging

### DIFF
--- a/src/kb_mcp/audit.py
+++ b/src/kb_mcp/audit.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import logging
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -1065,6 +1066,108 @@ def _stale_access_counts(logs_dir: Path | None = None) -> dict[str, int] | None:
     return counts
 
 
+def _stale_activation_params() -> tuple[float, float, float, float]:
+    """(decay d, w_surfaced, w_read, w_cited) for the ACT-R dormancy sort.
+
+    Env-overridable via KB_MCP_STALE_DECAY / _W_SURFACED / _W_READ / _W_CITED;
+    bad values fall back. ACT-R canonical decay d=0.5; access weights order
+    citation > read > surfacing. These weight the review-queue SORT only — they
+    never touch the stale_review gate or `find` ranking.
+    """
+    def _float_env(name: str, default: float) -> float:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            log.warning("invalid %s=%r; using %s", name, raw, default)
+            return default
+
+    return (
+        _float_env("KB_MCP_STALE_DECAY", 0.5),
+        _float_env("KB_MCP_STALE_W_SURFACED", 1.0),
+        _float_env("KB_MCP_STALE_W_READ", 2.0),
+        _float_env("KB_MCP_STALE_W_CITED", 3.0),
+    )
+
+
+def _stale_access_events(
+    logs_dir: Path | None = None, today: dt.date | None = None
+) -> dict[str, list[tuple[float, float]]] | None:
+    """Per-path weighted access events `(delta_days, weight)` for the ACT-R sort.
+
+    Parallel to `_stale_access_counts`, but instead of a surfacing COUNT it
+    returns, per canonicalised KB path, the access events feeding the base-level
+    activation B = ln(Σ wⱼ·Δtⱼ^(−d)): find-surfacings (queries.jsonl top_k,
+    weight w_surfaced), get-reads (reads.jsonl, w_read), and citations
+    (writes.jsonl cited_sources, w_cited). delta_days = max((today - ts).days, 1)
+    (floored at 1 to dodge the t^−d singularity).
+
+    Returns None when the signal is UNAVAILABLE — gated for tests
+    (`KB_MCP_DISABLE_RELEVANCE_CHECK`, set by the suite) or all three logs
+    empty — so the caller FALLS BACK to the age-based sort rather than fabricate
+    activation. Reuses the relevance-log reader.
+    """
+    if os.environ.get("KB_MCP_DISABLE_RELEVANCE_CHECK"):
+        return None
+    logs_dir = logs_dir or _RELEVANCE_LOGS_DIR
+    today = today or dt.date.today()
+    _, w_surfaced, w_read, w_cited = _stale_activation_params()
+
+    queries = _relevance_read_jsonl(logs_dir / "queries.jsonl")
+    reads = _relevance_read_jsonl(logs_dir / "reads.jsonl")
+    writes = _relevance_read_jsonl(logs_dir / "writes.jsonl")
+    if not queries and not reads and not writes:
+        return None
+
+    events: dict[str, list[tuple[float, float]]] = {}
+
+    def _delta(ts_raw: object) -> float | None:
+        try:
+            ts = dt.datetime.fromisoformat(str(ts_raw))
+        except (ValueError, TypeError):
+            return None
+        return float(max((today - ts.date()).days, 1))
+
+    for q in queries:
+        delta = _delta(q.get("ts"))
+        if delta is None:
+            continue
+        for t in q.get("top_k") or []:
+            p = t.get("path")
+            if p:
+                events.setdefault(_relevance_canon(p), []).append((delta, w_surfaced))
+
+    for r in reads:
+        delta = _delta(r.get("ts"))
+        if delta is None:
+            continue
+        p = r.get("read_path")
+        if p:
+            events.setdefault(_relevance_canon(p), []).append((delta, w_read))
+
+    for w in writes:
+        delta = _delta(w.get("ts"))
+        if delta is None:
+            continue
+        for c in w.get("cited_sources") or []:
+            if c:
+                events.setdefault(_relevance_canon(c), []).append((delta, w_cited))
+
+    return events
+
+
+def _activation(events: list[tuple[float, float]] | None, d: float) -> float | None:
+    """ACT-R base-level activation B = ln(Σ wⱼ·Δtⱼ^(−d)) over weighted access
+    events. Higher B = more recently/often accessed = LESS dormant. Returns None
+    when there are no events (never accessed) — the caller sorts those to the TOP
+    (most dormant)."""
+    if not events:
+        return None
+    return math.log(sum(w * (dt_days ** (-d)) for dt_days, w in events))
+
+
 def _check_stale_review(
     vault_root: Path,
     pages: list[find_module.ParsedPage],
@@ -1085,13 +1188,20 @@ def _check_stale_review(
     type, so it spans the whole writeable KB, not a fixed folder list, and auto-
     excludes the readonly curated trees, append-only Sources/Evidence, hubs/
     snapshots (expected to drift), superseded/archived, and index files.
+
+    Ordering is most-dormant first via ACT-R base-level activation
+    (B = ln(Σ wⱼ·Δtⱼ^(−d)) over weighted access events, ascending; never-accessed
+    sorts to the top); falls back to oldest-first when the access signal is
+    gated/absent. Activation is SORT-ONLY — it never changes who is flagged.
     """
     today = today or dt.date.today()
     min_age_days, max_inbound, max_access = _stale_thresholds()
     degree = _inbound_degree(pages)
     access_counts = _stale_access_counts()  # None when unavailable/gated
+    events_map = _stale_access_events(today=today)  # None when unavailable/gated
+    d, *_ = _stale_activation_params()
 
-    rows: list[tuple[int, AuditFinding]] = []
+    rows: list[tuple[float, int, AuditFinding]] = []
     for page in pages:
         if page.page_type not in _STALE_REVIEW_TYPES:
             continue
@@ -1129,33 +1239,40 @@ def _check_stale_review(
         access_phrase = (
             "" if access_count is None else f", surfaced {access_count}x in find"
         )
-        rows.append((
-            age_days,
-            AuditFinding(
-                category="stale_review",
-                severity="info",
-                path=page.rel_path,
-                detail=(
-                    f"Possibly stale — {age_days}d since updated, "
-                    f"{inbound} inbound link(s){access_phrase}. Still true?"
-                ),
-                proposed_fix=(
-                    "Surfaced for REVIEW only — not auto-decayed or down-ranked; "
-                    "`find` ordering is unchanged. Confirm still true (keep), "
-                    "`replace` (supersede) if newer understanding replaces it, or "
-                    "archive into a `_archive/` subfolder."
-                ),
-                meta={
-                    "age_days": age_days,
-                    "age_bucket": bucket,
-                    "inbound_count": inbound,
-                    "access_count": access_count,  # null when the signal is gated/absent
-                },
+        acts = _activation(events_map.get(page_key) if events_map else None, d)
+        finding = AuditFinding(
+            category="stale_review",
+            severity="info",
+            path=page.rel_path,
+            detail=(
+                f"Possibly stale — {age_days}d since updated, "
+                f"{inbound} inbound link(s){access_phrase}. Still true?"
             ),
-        ))
+            proposed_fix=(
+                "Surfaced for REVIEW only — not auto-decayed or down-ranked; "
+                "`find` ordering is unchanged. Confirm still true (keep), "
+                "`replace` (supersede) if newer understanding replaces it, or "
+                "archive into a `_archive/` subfolder."
+            ),
+            meta={
+                "age_days": age_days,
+                "age_bucket": bucket,
+                "inbound_count": inbound,
+                "access_count": access_count,  # null when the signal is gated/absent
+                "activation": round(acts, 4) if acts is not None else None,
+                "access_observations": (
+                    len(events_map.get(page_key, [])) if events_map else None
+                ),
+            },
+        )
+        # Most-dormant first: activation ASCENDING (never-accessed → -inf at the
+        # top), age DESCENDING on ties (older first). Sort-only — the gate above
+        # already decided who is flagged.
+        sort_act = acts if acts is not None else float("-inf")
+        rows.append((sort_act, age_days, finding))
 
-    rows.sort(key=lambda t: t[0], reverse=True)  # oldest first
-    return [f for _, f in rows]
+    rows.sort(key=lambda r: (r[0], -r[1]))
+    return [f for _, _, f in rows]
 
 
 # ---------------- helpers ----------------

--- a/src/kb_mcp/query_log.py
+++ b/src/kb_mcp/query_log.py
@@ -32,6 +32,7 @@ log = logging.getLogger(__name__)
 _LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
 QUERIES_PATH = _LOG_DIR / "queries.jsonl"
 WRITES_PATH = _LOG_DIR / "writes.jsonl"
+READS_PATH = _LOG_DIR / "reads.jsonl"
 
 
 def _disabled() -> bool:
@@ -120,3 +121,32 @@ def log_write_call(
         )
     except Exception as e:  # noqa: BLE001
         log.debug("log_write_call failed: %s", e)
+
+
+def log_get_call(
+    *,
+    read_path: str,
+    frontmatter_only: bool = False,
+    include_history: bool = False,
+) -> None:
+    """Append one structured record for a get() read. Best-effort.
+
+    Feeds the ACT-R dormancy signal in the stale_review audit (a read is a
+    stronger recency signal than a find-surfacing). Logs ONLY the canonical
+    path, never the body.
+    """
+    if _disabled():
+        return
+    try:
+        _append(
+            READS_PATH,
+            {
+                "ts": _now_iso(),
+                "tool": "get",
+                "read_path": read_path,
+                "frontmatter_only": frontmatter_only,
+                "include_history": include_history,
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        log.debug("log_get_call failed: %s", e)

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -1303,6 +1303,11 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             except get_page_module.GetError as e:
                 raise ValueError(f"{e.code}: {e.reason}") from e
             out = result.as_dict()
+        query_log.log_get_call(
+            read_path=out["path"],
+            frontmatter_only=frontmatter_only,
+            include_history=include_history,
+        )
         if include_history:
             out["history"] = vault.read_log_entries(vault_root, out["path"])
         return out

--- a/tests/test_audit_stale_review.py
+++ b/tests/test_audit_stale_review.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -233,6 +234,98 @@ def test_no_date_note_skipped(vault: Path) -> None:
     )
     find_module.clear_cache()
     assert not [x for x in _stale_findings(vault) if "undated" in x.path]
+
+
+# ---------------- ACT-R dormancy ordering ----------------
+
+
+def test_activation_formula() -> None:
+    d = 0.5
+    # No events → None (never accessed).
+    assert audit_module._activation(None, d) is None
+    assert audit_module._activation([], d) is None
+    # Single event → ln(w · Δt^−d).
+    assert audit_module._activation([(10.0, 1.0)], d) == math.log(1.0 * 10.0 ** -d)
+    # Recent (small Δt) is MORE active (higher B) than an old (large Δt) event.
+    assert (
+        audit_module._activation([(1.0, 1.0)], d)
+        > audit_module._activation([(100.0, 1.0)], d)
+    )
+    # A citation (w=3) is more active than a surfacing (w=1) at the same Δt.
+    assert (
+        audit_module._activation([(10.0, 3.0)], d)
+        > audit_module._activation([(10.0, 1.0)], d)
+    )
+
+
+def test_dormancy_sort_most_dormant_first(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Three old, zero-inbound conclusions. With the access signal enabled, the
+    # review queue reorders them most-dormant first:
+    # never-accessed → surfaced-long-ago → surfaced-recently.
+    _seed_note(vault, "Notes/Insights/never.md", type_="insight", updated="2024-01-01")
+    _seed_note(vault, "Notes/Insights/longago.md", type_="insight", updated="2024-01-01")
+    _seed_note(vault, "Notes/Insights/recent.md", type_="insight", updated="2024-01-01")
+    find_module.clear_cache()
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "queries.jsonl").write_text(
+        "\n".join([
+            json.dumps({
+                "ts": "2025-01-01T10:00:00",
+                "query": "q-longago",
+                "top_k": [{"path": "Knowledge Base/Notes/Insights/longago"}],
+            }),
+            json.dumps({
+                "ts": "2026-06-20T10:00:00",
+                "query": "q-recent",
+                "top_k": [{"path": "Knowledge Base/Notes/Insights/recent"}],
+            }),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("KB_MCP_DISABLE_RELEVANCE_CHECK", raising=False)
+    monkeypatch.setattr(audit_module, "_RELEVANCE_LOGS_DIR", logs)
+
+    findings = [
+        x for x in _stale_findings(vault)
+        if x.path.rsplit("/", 1)[-1] in ("never.md", "longago.md", "recent.md")
+    ]
+    order = [x.path.rsplit("/", 1)[-1] for x in findings]
+    assert order == ["never.md", "longago.md", "recent.md"], order
+
+    by = {x.path.rsplit("/", 1)[-1]: x for x in findings}
+    # never-accessed → activation None, zero observations, sorts to the top.
+    assert by["never.md"].meta["activation"] is None
+    assert by["never.md"].meta["access_observations"] == 0
+    # Both surfaced notes have a populated activation; recent is LESS dormant.
+    assert by["longago.md"].meta["activation"] is not None
+    assert by["recent.md"].meta["activation"] is not None
+    assert by["recent.md"].meta["activation"] > by["longago.md"].meta["activation"]
+    assert by["longago.md"].meta["access_observations"] == 1
+
+
+def test_gated_fallback_activation_none_and_oldest_first(vault: Path) -> None:
+    # Suite default has KB_MCP_DISABLE_RELEVANCE_CHECK set → no access signal.
+    # activation/observations are None for all, and findings fall back to the
+    # age-based oldest-first sort (no crash).
+    _seed_note(vault, "Notes/Insights/g-older.md", type_="insight", updated="2023-01-01")
+    _seed_note(vault, "Notes/Insights/g-newer.md", type_="insight", updated="2024-06-01")
+    find_module.clear_cache()
+    findings = [
+        x for x in _stale_findings(vault)
+        if x.path.endswith(("g-older.md", "g-newer.md"))
+    ]
+    by_path = {x.path.rsplit("/", 1)[-1]: x for x in findings}
+    assert set(by_path) == {"g-older.md", "g-newer.md"}
+    for x in by_path.values():
+        assert x.meta["activation"] is None
+        assert x.meta["access_observations"] is None
+    paths = [x.path for x in findings]
+    assert paths.index(by_path["g-older.md"].path) < paths.index(
+        by_path["g-newer.md"].path
+    )
 
 
 # ---------------- docs guard ----------------

--- a/tests/test_query_log.py
+++ b/tests/test_query_log.py
@@ -90,3 +90,34 @@ def test_explicit_query_log_disable(
     monkeypatch.setattr(query_log, "WRITES_PATH", wpath)
     query_log.log_write_call(tool="note", written_path="x", cited_sources=[])
     assert not wpath.exists()
+
+
+def test_logs_get_call_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_QUERY_LOG", raising=False)
+    rpath = tmp_path / "reads.jsonl"
+    monkeypatch.setattr(query_log, "READS_PATH", rpath)
+
+    query_log.log_get_call(
+        read_path="Knowledge Base/Notes/Insights/a.md",
+        frontmatter_only=False,
+        include_history=True,
+    )
+    rec = json.loads(rpath.read_text(encoding="utf-8").splitlines()[0])
+    assert rec["tool"] == "get"
+    assert rec["read_path"] == "Knowledge Base/Notes/Insights/a.md"
+    assert rec["frontmatter_only"] is False
+    assert rec["include_history"] is True
+
+
+def test_get_call_noop_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("KB_MCP_DISABLE_QUERY_LOG", "1")
+    rpath = tmp_path / "reads.jsonl"
+    monkeypatch.setattr(query_log, "READS_PATH", rpath)
+    query_log.log_get_call(read_path="Knowledge Base/Notes/Insights/a.md")
+    assert not rpath.exists()


### PR DESCRIPTION
Orders the stale_review review queue by ACT-R base-level activation (most-dormant first) instead of plain oldest-first, and logs get-by-path reads so the access signal stops being find-only.

- Activation is SORT-ONLY: the boolean gate is unchanged; never touches find ranking. Gated/absent logs fall back to oldest-first.
- B = ln(Σ w·max(Δt,1)^−d), d=0.5; weights cite>read>surface. All env-tunable.
- New get-read logging (reads.jsonl) feeds the signal going forward.
- 593 tests green (588 baseline + 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)