### PR TITLE
feat(server): live file-watcher + personal REST facade + heading edits + get link-summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "rank-bm25>=0.2.2",
     "numpy>=1.26",
     "snowballstemmer>=2.2",
+    "watchdog>=4.0",            # live file-watcher: re-embed out-of-band .md edits (lazy import; soft-fails if absent)
 ]
 
 # Hybrid semantic search (local vector embeddings). Optional so a lean install

--- a/src/kb_mcp/edit.py
+++ b/src/kb_mcp/edit.py
@@ -104,13 +104,15 @@ def edit(
     old_string: str | None = None,
     new_string: str | None = None,
     replace_all: bool = False,
+    heading: str | None = None,
+    section_position: str = "append",
     expected_hash: str | None = None,
     validate_only: bool = False,
     today: dt.date | None = None,
 ) -> EditResult | EditValidation:
     """Edit a compiled page in place. Bumps `updated:`.
 
-    Three (composable) modes:
+    Four (composable) modes:
     - `new_body` — replace the whole body. The heavyweight mode.
     - `tags` — replace the `tags:` frontmatter list.
     - `old_string`/`new_string` — **surgical** string-replace inside the body.
@@ -120,6 +122,12 @@ def edit(
       `replace_all=True` to replace every occurrence. Surgical mode cannot be
       combined with `new_body` (they both rewrite the body), but may be paired
       with `tags`.
+    - `heading` + `section_position` — **section-targeted**. Locate the
+      `## Heading` (or its bare text), take its section (from the heading line
+      to the next heading of equal-or-higher level, or EOF), and
+      replace/prepend/append `new_string` within it. Token-cheap: you don't
+      re-send the page or quote the exact snippet. Mutually exclusive with
+      `new_body`/`old_string`; may be paired with `tags`.
 
     `why` is required — it lands in the log entry so the change is auditable.
     """
@@ -127,6 +135,28 @@ def edit(
     reasons: list[str] = []
 
     surgical = old_string is not None
+    heading_mode = heading is not None
+
+    if heading_mode and new_body is not None:
+        missing.append("heading/new_body")
+        reasons.append(
+            "section mode (`heading`) and whole-body mode (`new_body`) both rewrite "
+            "the body — supply one or the other, not both"
+        )
+    if heading_mode and surgical:
+        missing.append("heading/old_string")
+        reasons.append(
+            "section mode (`heading`) and surgical mode (`old_string`) are mutually "
+            "exclusive — supply one or the other"
+        )
+    if heading_mode and new_string is None:
+        missing.append("new_string")
+        reasons.append("`new_string` (the section content) is required in heading mode")
+    if heading_mode and section_position not in ("replace", "prepend", "append"):
+        missing.append("section_position")
+        reasons.append(
+            f"section_position must be replace|prepend|append, got {section_position!r}"
+        )
 
     if surgical and new_body is not None:
         missing.append("old_string/new_body")
@@ -140,13 +170,13 @@ def edit(
     if surgical and new_string is not None and new_string == old_string:
         missing.append("new_string")
         reasons.append("`new_string` equals `old_string` — that's a no-op edit")
-    if not surgical and new_string is not None:
+    if not surgical and not heading_mode and new_string is not None:
         missing.append("old_string")
         reasons.append("`new_string` given without `old_string` — nothing to match")
-    if new_body is None and tags is None and not surgical:
-        missing.append("new_body, tags, or old_string")
+    if new_body is None and tags is None and not surgical and not heading_mode:
+        missing.append("new_body, tags, heading, or old_string")
         reasons.append(
-            "must supply at least one of `new_body`, `tags`, or "
+            "must supply at least one of `new_body`, `tags`, `heading`, or "
             "`old_string`/`new_string`; otherwise there's nothing to edit"
         )
     if not why or not why.strip():
@@ -210,6 +240,17 @@ def edit(
             rel_path=rel_path,
         )
         body_changed = True
+    elif heading_mode:
+        # new_string is not None here (validated above).
+        new_body_final, body_warnings = apply_section_edit(
+            body,
+            heading,  # type: ignore[arg-type]
+            section_position,
+            new_string,  # type: ignore[arg-type]
+            vault_root,
+            rel_path=rel_path,
+        )
+        body_changed = True
     elif new_body is not None:
         # Normalize wikilinks to canonical full form. Existing body is left
         # alone to preserve user-intended legacy forms in untouched files.
@@ -244,7 +285,12 @@ def edit(
 
     changed: list[str] = []
     if body_changed:
-        changed.append("body (surgical)" if surgical else "body")
+        if surgical:
+            changed.append("body (surgical)")
+        elif heading_mode:
+            changed.append(f"body (section: {heading})")
+        else:
+            changed.append("body")
     if tags is not None:
         changed.append("tags")
 
@@ -437,6 +483,88 @@ def apply_surgical_replace(
     )
     n = -1 if replace_all else 1
     return body.replace(old_string, new_string_norm, n), warnings
+
+
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.*?)[ \t]*$")
+
+
+def _normalize_heading(h: str) -> str:
+    """Drop leading `#` markers + surrounding whitespace so `## Foo` == `Foo`."""
+    return h.lstrip("#").strip()
+
+
+def apply_section_edit(
+    body: str,
+    heading: str,
+    position: str,
+    content: str,
+    vault_root: Path,
+    *,
+    rel_path: str = "",
+    resolver: WikilinkResolver | None = None,
+) -> tuple[str, list[str]]:
+    """Replace/prepend/append `content` within the section under `heading`.
+
+    The section runs from the matched `## Heading` line to the next heading of
+    EQUAL-OR-HIGHER level (or EOF). The heading line itself is preserved; only
+    its body is rewritten. Returns `(new_body, warnings)`.
+
+    Raises EditError(code="HEADING_NOT_FOUND") if the heading is absent. Only
+    the inserted `content` is wikilink-normalized — the rest of the body is left
+    byte-for-byte untouched (matching `apply_surgical_replace`).
+    """
+    where = f" in {rel_path}" if rel_path else ""
+    want = _normalize_heading(heading)
+    lines = body.split("\n")
+
+    h_idx = -1
+    h_level = 0
+    for i, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m and m.group(2).strip() == want:
+            h_idx = i
+            h_level = len(m.group(1))
+            break
+    if h_idx == -1:
+        raise EditError(
+            code="HEADING_NOT_FOUND",
+            missing=["heading"],
+            reason=(
+                f"heading {heading!r} not found{where}. Match an existing `## Heading` "
+                "(the `#` markers are optional in the arg); read the page first."
+            ),
+        )
+
+    end = len(lines)
+    for j in range(h_idx + 1, len(lines)):
+        m = _HEADING_RE.match(lines[j])
+        if m and len(m.group(1)) <= h_level:
+            end = j
+            break
+
+    if resolver is None:
+        resolver = WikilinkResolver(vault_root)
+    content_norm, warnings = normalize_body_wikilinks(
+        content, vault_root, resolver=resolver
+    )
+    content_lines = content_norm.split("\n")
+
+    before = lines[:h_idx]
+    head_line = lines[h_idx]
+    section_lines = lines[h_idx + 1 : end]
+    after = lines[end:]
+
+    if position == "replace":
+        new_section = content_lines
+    elif position == "prepend":
+        new_section = content_lines + section_lines
+    else:  # append — after the section's existing content, before the next heading
+        trimmed = list(section_lines)
+        while trimmed and trimmed[-1].strip() == "":
+            trimmed.pop()
+        new_section = trimmed + content_lines
+
+    return "\n".join(before + [head_line] + new_section + after), warnings
 
 
 def commit_edit(

--- a/src/kb_mcp/file_watcher.py
+++ b/src/kb_mcp/file_watcher.py
@@ -1,0 +1,204 @@
+"""Live file-watcher — re-embed out-of-band edits in ~1s instead of waiting for `reconcile`.
+
+The vault is edited *around* the server — directly in Obsidian, on mobile, or via a
+filesystem write (Obsidian Sync, a git pull). Those bypass the writer hooks, so the
+embedding sidecar drifts until someone runs `reconcile`. This watcher closes that gap:
+it watches `<vault>/Knowledge Base/` for `.md` changes and re-embeds them through the
+SAME `embeddings.upsert_after_write` path the writers (and `reconcile`) use — deletes
+go through `embeddings.delete_after_remove`.
+
+Mirrors `MediaWorker`'s thread+queue shape: a single daemon dispatch thread coalesces
+rapid events behind a ~500ms debounce (a single Obsidian save fires several FS events;
+a `git pull` rewrites a batch at once) and then dispatches one batched upsert/delete.
+
+Lazy + soft-fail: `watchdog` is imported only in `start()`. If it isn't installed the
+watcher is a no-op and the server runs normally (mirrors how `media_worker`/`embeddings`
+soft-fail on missing optional deps).
+
+Self-write echo: the server's own writers already call `upsert_after_write`, so the
+watcher ALSO sees those file changes and re-embeds them a second time. That's wasteful
+but idempotent and harmless (the same content embeds to the same vectors); the debounce
+mitigates it. We deliberately do NOT build write-tracking to suppress the echo — the
+complexity isn't worth it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+
+from . import embeddings
+
+log = logging.getLogger(__name__)
+
+DEBOUNCE_SECONDS = 0.5
+
+
+def _import_watchdog():
+    """Import watchdog lazily. Returns (Observer, FileSystemEventHandler).
+
+    Isolated into a tiny function so `start()` can catch a missing dep and so tests
+    can patch it to simulate watchdog being absent.
+    """
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    return Observer, FileSystemEventHandler
+
+
+class FileWatcher:
+    """Watch Knowledge Base/ for `.md` changes and re-embed them, debounced."""
+
+    def __init__(self, vault_root: Path, *, debounce_seconds: float = DEBOUNCE_SECONDS) -> None:
+        self._vault_root = vault_root
+        self._kb_root = vault_root / "Knowledge Base"
+        self._debounce = debounce_seconds
+        self._lock = threading.Lock()
+        self._pending_upsert: set[Path] = set()
+        self._pending_delete: set[Path] = set()
+        self._last_change = 0.0
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._observer = None
+
+    # ---- change recording (called by the watchdog handler AND by tests) ----
+
+    def _record(self, path: Path, *, deleted: bool) -> None:
+        """Record a `.md` change. Coalesces rapid events for the same path."""
+        if path.suffix.lower() != ".md":
+            return  # only markdown is embedded; ignore attachments / sidecars-of-binaries churn
+        with self._lock:
+            if deleted:
+                self._pending_upsert.discard(path)
+                self._pending_delete.add(path)
+            else:
+                # A re-create after a delete in the same window is a modify.
+                self._pending_delete.discard(path)
+                self._pending_upsert.add(path)
+            self._last_change = time.monotonic()
+        self._wake.set()
+
+    def _rel(self, path: Path) -> str | None:
+        """Vault-relative POSIX path (no resolve()-on-missing surprises for deletes)."""
+        try:
+            return path.resolve().relative_to(self._vault_root.resolve()).as_posix()
+        except (ValueError, OSError):
+            try:
+                return path.relative_to(self._vault_root).as_posix()
+            except ValueError:
+                return None
+
+    def _drain(self) -> tuple[list[Path], list[str]]:
+        with self._lock:
+            ups = sorted(self._pending_upsert)
+            dels = sorted(self._pending_delete)
+            self._pending_upsert.clear()
+            self._pending_delete.clear()
+        del_rels = [r for r in (self._rel(p) for p in dels) if r]
+        return ups, del_rels
+
+    def _flush(self) -> None:
+        """Dispatch the coalesced batch through the SAME paths the writers use."""
+        ups, del_rels = self._drain()
+        if ups:
+            try:
+                embeddings.upsert_after_write(self._vault_root, ups)
+            except Exception:  # noqa: BLE001 — a bad batch must never kill the watcher
+                log.exception("file watcher: upsert_after_write failed for %d file(s)", len(ups))
+        if del_rels:
+            try:
+                embeddings.delete_after_remove(self._vault_root, del_rels)
+            except Exception:  # noqa: BLE001
+                log.exception("file watcher: delete_after_remove failed for %d file(s)", len(del_rels))
+
+    # ---- debounce loop ----
+
+    def _run_dispatch(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait()
+            if self._stop.is_set():
+                break
+            # Wait for a quiet window so a burst of saves (or a git pull) coalesces
+            # into one batch instead of one upsert per FS event.
+            while not self._stop.is_set():
+                time.sleep(self._debounce)
+                with self._lock:
+                    quiet = (time.monotonic() - self._last_change) >= self._debounce
+                if quiet:
+                    break
+            self._wake.clear()
+            self._flush()
+        # Final drain so nothing pending is lost on shutdown.
+        self._flush()
+
+    # ---- lifecycle ----
+
+    def start(self) -> bool:
+        """Start watching. Returns False (no-op) when watchdog is unavailable.
+
+        Soft-fail: a missing `watchdog` dep leaves the server fully functional — edits
+        just won't be live-re-embedded until the next `reconcile`.
+        """
+        try:
+            Observer, FileSystemEventHandler = _import_watchdog()
+        except Exception as e:  # noqa: BLE001 — optional dep
+            log.info(
+                "file watcher: watchdog not available (%s); live re-embed disabled (no-op). "
+                "Out-of-band edits re-embed on the next reconcile.",
+                e,
+            )
+            return False
+        if not self._kb_root.is_dir():
+            log.info("file watcher: %s not found; not watching", self._kb_root)
+            return False
+
+        watcher = self
+
+        class _Handler(FileSystemEventHandler):
+            def on_created(self, event):  # noqa: ANN001
+                if not event.is_directory:
+                    watcher._record(Path(event.src_path), deleted=False)
+
+            def on_modified(self, event):  # noqa: ANN001
+                if not event.is_directory:
+                    watcher._record(Path(event.src_path), deleted=False)
+
+            def on_deleted(self, event):  # noqa: ANN001
+                if not event.is_directory:
+                    watcher._record(Path(event.src_path), deleted=True)
+
+            def on_moved(self, event):  # noqa: ANN001
+                if not event.is_directory:
+                    watcher._record(Path(event.src_path), deleted=True)
+                    watcher._record(Path(event.dest_path), deleted=False)
+
+        self._thread = threading.Thread(
+            target=self._run_dispatch, name="kb-file-watcher", daemon=True
+        )
+        self._thread.start()
+        try:
+            self._observer = Observer()
+            self._observer.schedule(_Handler(), str(self._kb_root), recursive=True)
+            self._observer.start()
+        except Exception as e:  # noqa: BLE001 — watcher must never break the server
+            log.warning("file watcher: observer failed to start (%s); live re-embed disabled", e)
+            self._stop.set()
+            self._wake.set()
+            return False
+        log.info("file watcher started on %s", self._kb_root)
+        return True
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._wake.set()
+        if self._observer is not None:
+            try:
+                self._observer.stop()
+                self._observer.join(timeout=2)
+            except Exception:  # noqa: BLE001
+                log.debug("file watcher: observer stop failed", exc_info=True)
+        if self._thread is not None:
+            self._thread.join(timeout=2)

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -22,6 +22,7 @@ Transports:
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 import secrets
@@ -217,6 +218,42 @@ def _find_call_summary(message) -> str:
     return f' query="{q}" mode={mode} scope={scope}'
 
 
+class _RestJSONResponse(JSONResponse):
+    """JSONResponse that renders frontmatter dates (datetime.date) as ISO strings.
+
+    YAML parses `created: 2026-01-01` to a `datetime.date`, which Starlette's default
+    json.dumps can't serialize. The MCP transport sidesteps this via pydantic; the
+    REST facade needs its own `default=str` fallback.
+    """
+
+    def render(self, content) -> bytes:  # noqa: ANN001
+        return json.dumps(
+            content, ensure_ascii=False, allow_nan=False, default=str
+        ).encode("utf-8")
+
+
+def _link_summary(vault_root: Path, rel_path: str, body: str) -> dict:
+    """Inbound + outbound wikilink summary for the `get(links=True)` option.
+
+    Inbound reuses `vault.find_inbound_wikilinks` (the same matcher
+    `list_inbound_links` uses); outbound scans the body's wikilinks (code spans
+    skipped), de-duped and order-preserved.
+    """
+    inbound = (
+        [m.as_dict() for m in vault.find_inbound_wikilinks(vault_root, rel_path)]
+        if rel_path
+        else []
+    )
+    outbound: list[str] = []
+    seen: set[str] = set()
+    for m in find_body_wikilinks(body):
+        target = m.group(0)[2:-2].split("|", 1)[0].split("#", 1)[0].strip()
+        if target and target not in seen:
+            seen.add(target)
+            outbound.append(target)
+    return {"inbound": inbound, "outbound": outbound}
+
+
 def _server_icons() -> list[mcp.types.Icon]:
     """Load icon.svg from the package dir and return an mcp.types.Icon list.
 
@@ -330,6 +367,22 @@ def build_server(*, require_auth: bool) -> FastMCP:
             media_worker.scan_pending()  # re-enqueue anything a prior run left pending
         except Exception as e:  # noqa: BLE001 — startup scan is best-effort
             log.warning("media worker startup scan failed: %s", e)
+
+    # Live file-watcher: re-embed out-of-band Obsidian/mobile/filesystem `.md` edits in
+    # ~1s instead of waiting for a manual `reconcile`. Off when KB_MCP_DISABLE_FILE_WATCHER
+    # is set, and also when embeddings are disabled (no point watching if we can't embed —
+    # the test suite sets KB_MCP_DISABLE_EMBEDDINGS, so the watcher never starts in tests).
+    file_watcher = None
+    if not os.environ.get("KB_MCP_DISABLE_FILE_WATCHER") and not os.environ.get(
+        "KB_MCP_DISABLE_EMBEDDINGS"
+    ):
+        from . import file_watcher as file_watcher_module
+
+        file_watcher = file_watcher_module.FileWatcher(vault_root)
+        try:
+            file_watcher.start()  # soft no-op if watchdog isn't installed
+        except Exception as e:  # noqa: BLE001 — the watcher must never break startup
+            log.warning("file watcher start failed: %s", e)
 
     # Public base URL (e.g. https://kb.example.com). Used by the OAuth
     # discovery route AND the mint_upload_token tool, so define it unconditionally.
@@ -637,6 +690,379 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             status = 404 if e.code == "NOT_FOUND" else 400
             return JSONResponse({"code": e.code, "reason": e.reason}, status_code=status)
         return FileResponse(abs_path, filename=abs_path.name)
+
+    # ---- Personal REST facade: /api/<tool> JSON wrappers over the SAME leaves ----
+    #
+    # A token-gated HTTP/JSON surface for scripting the KB from your own tools
+    # (a cron job, a shell script, a phone shortcut) WITHOUT the MCP/OAuth dance.
+    # This is NOT a public/ChatGPT plugin surface: single long-lived API key
+    # (KB_MCP_REST_API_KEY), no /.well-known/ai-plugin.json. Disabled (503) unless
+    # the key is set — opt-in only. Each handler calls the exact same leaf function
+    # the matching MCP tool calls (no duplicated business logic) and maps the JSON
+    # body to kwargs, returning the leaf's structured error as 400 {error, reason}.
+    rest_api_key = os.environ.get("KB_MCP_REST_API_KEY", "").strip() or None
+    rest_enabled = rest_api_key is not None
+
+    def _rest_authorized(request: Request) -> bool:
+        # Same non-spoofable model as /upload: the long-lived REST key (constant-time
+        # compared), a short-lived `rest`-scoped minted token, or a verified CF Access
+        # JWT. Never the plaintext cf-access-* email header.
+        if rest_api_key is not None:
+            header = request.headers.get("authorization", "")
+            if header.startswith("Bearer "):
+                presented = header[len("Bearer ") :].strip()
+                if secrets.compare_digest(presented, rest_api_key):
+                    return True
+                if upload_tokens.verify(presented, rest_api_key, scope="rest"):
+                    return True
+        if cf_jwks is not None:
+            if cf_access.verify(
+                request.headers.get("cf-access-jwt-assertion"),
+                jwks_client=cf_jwks,
+                team_domain=cf_team,
+                audience=cf_aud,
+            ):
+                return True
+        return False
+
+    def _rest_err(code: str, reason: str, status: int) -> JSONResponse:
+        return JSONResponse({"error": code, "reason": reason}, status_code=status)
+
+    def _rest_gate(request: Request) -> JSONResponse | None:
+        """503 when the facade is off, 401 when unauthorized, else None (proceed)."""
+        if not rest_enabled:
+            return _rest_err(
+                "REST_DISABLED",
+                "REST API is off: set KB_MCP_REST_API_KEY to enable the /api/* facade",
+                503,
+            )
+        if not _rest_authorized(request):
+            return _rest_err("UNAUTHORIZED", "missing or invalid REST API key", 401)
+        return None
+
+    async def _rest_body(request: Request) -> dict | None:
+        """Parse the JSON request body to a dict. `{}` for empty; None if malformed."""
+        try:
+            raw = await request.body()
+        except Exception:  # noqa: BLE001
+            return {}
+        if not raw or not raw.strip():
+            return {}
+        try:
+            data = json.loads(raw)
+        except Exception:  # noqa: BLE001
+            return None
+        return data if isinstance(data, dict) else None
+
+    @mcp.custom_route("/api/find", methods=["POST"])
+    async def _api_find(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            hits = await run_in_threadpool(
+                find_module.find,
+                vault_root,
+                query=body.get("query", ""),
+                types=body.get("types"),
+                projects=body.get("projects"),
+                tags=body.get("tags"),
+                file_types=body.get("file_types"),
+                exclude_file_types=body.get("exclude_file_types"),
+                limit=body.get("limit", 15),
+                scope=body.get("scope", "kb"),
+                mode=body.get("mode", "hybrid"),
+                graph=body.get("graph", True),
+                rerank=body.get("rerank", False),
+                prefer_compiled=body.get("prefer_compiled", True),
+                prefer_active=body.get("prefer_active", True),
+            )
+        except (ValueError, TypeError) as e:
+            return _rest_err("INVALID_FIND", str(e), 400)
+        query_log.log_find_call(
+            query=body.get("query", ""), mode=body.get("mode", "hybrid"),
+            scope=body.get("scope", "kb"), types=body.get("types"),
+            projects=body.get("projects"), tags=body.get("tags"),
+            limit=body.get("limit", 15), rerank=body.get("rerank", False),
+            prefer_compiled=body.get("prefer_compiled", True),
+            graph=body.get("graph", True), hits=hits,
+        )
+        # Same shape as the MCP `find` tool: a bare list of hit dicts.
+        return _RestJSONResponse([h.as_dict() for h in hits])
+
+    @mcp.custom_route("/api/get", methods=["POST"])
+    async def _api_get(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            result = await run_in_threadpool(
+                get_page_module.get_page, vault_root, path=body.get("path", "")
+            )
+        except get_page_module.GetError as e:
+            status = 404 if e.code == "NOT_FOUND" else 400
+            return _rest_err(e.code, e.reason, status)
+        out = result.as_dict()
+        if body.get("include_history"):
+            out["history"] = vault.read_log_entries(vault_root, out["path"])
+        if body.get("links"):
+            out["links"] = _link_summary(vault_root, out["path"], out["body"])
+        query_log.log_get_call(
+            read_path=out["path"], include_history=bool(body.get("include_history"))
+        )
+        return _RestJSONResponse(out)
+
+    @mcp.custom_route("/api/note", methods=["POST"])
+    async def _api_note(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            result = await run_in_threadpool(
+                lambda: note_module.note(
+                    vault_root,
+                    content=body.get("content", ""),
+                    note_type=body.get("note_type", ""),
+                    title=body.get("title", ""),
+                    project=body.get("project"),
+                    projects=body.get("projects"),
+                    sources=body.get("sources"),
+                    tags=body.get("tags"),
+                    status=body.get("status"),
+                    severity=body.get("severity"),
+                    pattern_type=body.get("pattern_type"),
+                    domain=body.get("domain"),
+                    started=body.get("started"),
+                    duration=body.get("duration"),
+                    hypothesis=body.get("hypothesis"),
+                    n=body.get("n"),
+                    concluded=body.get("concluded"),
+                    medium=body.get("medium"),
+                    recorded=body.get("recorded"),
+                    published=body.get("published"),
+                    host=body.get("host"),
+                    editor=body.get("editor"),
+                    project_category=body.get("project_category"),
+                )
+            )
+        except note_module.NoteError as e:
+            return _rest_err(e.code, f"{e.reason} (missing: {e.missing})", 400)
+        query_log.log_write_call(
+            tool="note", written_path=result.path, cited_sources=body.get("sources")
+        )
+        return _RestJSONResponse(result.as_dict())
+
+    @mcp.custom_route("/api/add", methods=["POST"])
+    async def _api_add(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            result = await run_in_threadpool(
+                lambda: add_module.add(
+                    vault_root,
+                    source_schema,
+                    content=body.get("content", ""),
+                    source_type=body.get("source_type", ""),
+                    title=body.get("title", ""),
+                    url=body.get("url"),
+                    tags=body.get("tags"),
+                    why_captured=body.get("why_captured"),
+                )
+            )
+        except add_module.AddError as e:
+            return _rest_err(e.code, f"{e.reason} (missing: {e.missing})", 400)
+        query_log.log_write_call(tool="add", written_path=result.path, cited_sources=[])
+        return _RestJSONResponse(result.as_dict())
+
+    @mcp.custom_route("/api/edit", methods=["POST"])
+    async def _api_edit(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            result = await run_in_threadpool(
+                lambda: edit_module.edit(
+                    vault_root,
+                    path=body.get("path", ""),
+                    why=body.get("why", ""),
+                    new_body=body.get("new_body"),
+                    tags=body.get("tags"),
+                    old_string=body.get("old_string"),
+                    new_string=body.get("new_string"),
+                    replace_all=body.get("replace_all", False),
+                    heading=body.get("heading"),
+                    section_position=body.get("section_position", "append"),
+                    expected_hash=body.get("expected_hash"),
+                    validate_only=body.get("validate_only", False),
+                )
+            )
+        except edit_module.EditError as e:
+            return _rest_err(e.code, f"{e.reason} (missing: {e.missing})", 400)
+        return _RestJSONResponse(result.as_dict())
+
+    @mcp.custom_route("/api/audit", methods=["POST"])
+    async def _api_audit(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            report = await run_in_threadpool(
+                audit_module.audit, vault_root, categories=body.get("categories")
+            )
+        except (ValueError, TypeError) as e:
+            return _rest_err("INVALID_AUDIT", str(e), 400)
+        return _RestJSONResponse(report.as_dict())
+
+    @mcp.custom_route("/api/reconcile", methods=["POST"])
+    async def _api_reconcile(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        report = await run_in_threadpool(
+            reconcile_module.reconcile, vault_root, dry_run=body.get("dry_run", False)
+        )
+        return _RestJSONResponse(report.as_dict())
+
+    @mcp.custom_route("/api/list_directory", methods=["POST"])
+    async def _api_list_directory(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        try:
+            result = await run_in_threadpool(
+                list_directory_module.list_directory,
+                vault_root,
+                path=body.get("path", ""),
+                recursive=body.get("recursive", False),
+                include_hidden=body.get("include_hidden", False),
+            )
+        except list_directory_module.ListDirectoryError as e:
+            status = 404 if e.code == "NOT_FOUND" else 400
+            return _rest_err(e.code, e.reason, status)
+        return _RestJSONResponse(result.as_dict())
+
+    @mcp.custom_route("/api/suggest_links", methods=["POST"])
+    async def _api_suggest_links(request: Request) -> JSONResponse:
+        gate = _rest_gate(request)
+        if gate is not None:
+            return gate
+        body = await _rest_body(request)
+        if body is None:
+            return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+        path = body.get("path")
+        draft_title = body.get("draft_title")
+        draft_body = body.get("draft_body")
+        limit = body.get("limit", 8)
+        scope = body.get("scope", "kb")
+        try:
+            if path:
+                gp = await run_in_threadpool(
+                    get_page_module.get_page, vault_root, path=path
+                )
+                page = find_module._CACHE.get(vault_root / gp.path, vault_root)
+                if page is None:
+                    return _rest_err("UNREADABLE", f"could not parse {gp.path}", 400)
+                existing_links = set(
+                    find_module._outbound_wikilink_paths(page, vault_root)
+                )
+                suggestions = await run_in_threadpool(
+                    lambda: corpus_aware_module.suggest_related(
+                        vault_root, title=page.title, body=page.body,
+                        self_path=page.rel_path, existing_links=existing_links,
+                        limit=limit, scope=scope,
+                    )
+                )
+            elif draft_title or draft_body:
+                body_md = draft_body or ""
+                existing_links = set()
+                for m in find_body_wikilinks(body_md):
+                    inner = m.group(0)[2:-2].split("|", 1)[0].split("#", 1)[0].strip()
+                    if inner:
+                        existing_links.add(inner)
+                suggestions = await run_in_threadpool(
+                    lambda: corpus_aware_module.suggest_related(
+                        vault_root, title=draft_title or "", body=body_md,
+                        self_path=None, existing_links=existing_links,
+                        limit=limit, scope=scope,
+                    )
+                )
+            else:
+                return _rest_err(
+                    "INVALID_SUGGEST",
+                    "provide either `path` or `draft_title`/`draft_body`",
+                    400,
+                )
+        except get_page_module.GetError as e:
+            status = 404 if e.code == "NOT_FOUND" else 400
+            return _rest_err(e.code, e.reason, status)
+        return _RestJSONResponse([s.as_dict() for s in suggestions])
+
+    @mcp.custom_route("/api/openapi.json", methods=["GET"])
+    async def _api_openapi(request: Request) -> JSONResponse:
+        # Self-documentation only — minimal, hand-built OpenAPI 3.1 of the /api/*
+        # surface. NOT a public plugin manifest (no /.well-known/ai-plugin.json).
+        if not rest_enabled:
+            return _rest_err("REST_DISABLED", "set KB_MCP_REST_API_KEY to enable", 503)
+        post_tools = [
+            "find", "get", "note", "add", "edit",
+            "audit", "reconcile", "list_directory", "suggest_links",
+        ]
+        paths = {
+            f"/api/{name}": {
+                "post": {
+                    "operationId": name,
+                    "summary": f"JSON wrapper over the `{name}` KB tool",
+                    "security": [{"bearerAuth": []}],
+                    "requestBody": {
+                        "content": {"application/json": {"schema": {"type": "object"}}}
+                    },
+                    "responses": {
+                        "200": {"description": "tool result (JSON)"},
+                        "400": {"description": "{error, reason}"},
+                        "401": {"description": "missing/invalid API key"},
+                        "503": {"description": "REST API disabled"},
+                    },
+                }
+            }
+            for name in post_tools
+        }
+        return JSONResponse(
+            {
+                "openapi": "3.1.0",
+                "info": {"title": "kb-mcp personal REST facade", "version": "1.0.0"},
+                "components": {
+                    "securitySchemes": {
+                        "bearerAuth": {"type": "http", "scheme": "bearer"}
+                    }
+                },
+                "paths": paths,
+            }
+        )
 
     @mcp.tool
     def find(
@@ -1245,7 +1671,10 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
 
     @mcp.tool
     def get(
-        path: str, frontmatter_only: bool = False, include_history: bool = False
+        path: str,
+        frontmatter_only: bool = False,
+        include_history: bool = False,
+        links: bool = False,
     ) -> dict:
         """Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body + raw content.
 
@@ -1275,6 +1704,13 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 this note changed / what was the old version / show its history"
                 and to verify an edit's rationale. `[]` when the page has no
                 recorded edits.
+            links: If true, attach a `links` summary —
+                `{inbound: [...], outbound: [...]}`. `inbound` lists files whose
+                wikilinks resolve to this page (each
+                `{path, line_number, context, raw_target}`); `outbound` lists
+                the distinct wikilink targets in this page's body. Use it to
+                see a note's graph neighbourhood in one call. Default off (no
+                behaviour change).
 
         Returns:
             {path, frontmatter, body, content, content_hash, mtime}.
@@ -1310,6 +1746,10 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         )
         if include_history:
             out["history"] = vault.read_log_entries(vault_root, out["path"])
+        if links:
+            out["links"] = _link_summary(
+                vault_root, out.get("path", ""), out.get("body", "")
+            )
         return out
 
     @mcp.tool
@@ -1321,6 +1761,8 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         old_string: str | None = None,
         new_string: str | None = None,
         replace_all: bool = False,
+        heading: str | None = None,
+        section_position: str = "append",
         edits: list[dict] | None = None,
         row_key: str | None = None,
         take: str | None = None,
@@ -1396,6 +1838,13 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 differ from it).
             replace_all: Replace every occurrence instead of requiring a
                 unique match. Default False.
+            heading: Section-targeted mode — the `## Heading` (the `#` markers
+                are optional) under which to place `new_string`. The section
+                spans from that heading to the next heading of equal-or-higher
+                level (or EOF). Mutually exclusive with new_body/old_string.
+                Raises HEADING_NOT_FOUND if absent.
+            section_position: With `heading`, where to put `new_string`:
+                "append" (default), "prepend", or "replace" the section body.
             edits: Batch-surgical mode — list of {old_string, new_string,
                 replace_all?} applied sequentially in one atomic commit.
             row_key: Take-row mode — natural leading text of the row to fill
@@ -1461,8 +1910,9 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
                 result = edit_module.edit(
                     vault_root, path=path, why=why, new_body=new_body,
                     tags=tags, old_string=old_string, new_string=new_string,
-                    replace_all=replace_all, expected_hash=expected_hash,
-                    validate_only=validate_only,
+                    replace_all=replace_all, heading=heading,
+                    section_position=section_position,
+                    expected_hash=expected_hash, validate_only=validate_only,
                 )
         except (
             edit_module.EditError,

--- a/tests/test_edit_heading.py
+++ b/tests/test_edit_heading.py
@@ -1,0 +1,150 @@
+"""edit() heading/section-targeted mode (the 4th edit mode)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import edit as edit_module
+from kb_mcp import find as find_module
+
+NOTE_REL = "Knowledge Base/Notes/Insights/heading-test.md"
+
+BODY = """\
+---
+type: insight
+status: active
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Heading Test
+
+## Overview
+
+Intro line.
+
+## Details
+
+Detail line.
+
+## Connections
+"""
+
+
+def _seed(vault: Path) -> Path:
+    p = vault / NOTE_REL
+    p.write_text(BODY, encoding="utf-8")
+    find_module.clear_cache()
+    return p
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def test_append_lands_at_end_of_section(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="add a point",
+        heading="Overview", section_position="append", new_string="Appended line.",
+    )
+    text = _read(p)
+    assert "Appended line." in text
+    # Stays inside Overview — before the next heading.
+    assert text.index("Appended line.") < text.index("## Details")
+    assert text.index("Intro line.") < text.index("Appended line.")
+
+
+def test_prepend_lands_right_after_heading(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="lead with this",
+        heading="Overview", section_position="prepend", new_string="Prepended line.",
+    )
+    text = _read(p)
+    assert text.index("## Overview") < text.index("Prepended line.") < text.index("Intro line.")
+
+
+def test_replace_swaps_section_body(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="rewrite",
+        heading="Overview", section_position="replace", new_string="Brand new overview.",
+    )
+    text = _read(p)
+    assert "Brand new overview." in text
+    assert "Intro line." not in text
+    assert "Detail line." in text  # other sections untouched
+
+
+def test_hash_prefixed_heading_arg_matches(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="markers ok",
+        heading="## Overview", section_position="append", new_string="With markers.",
+    )
+    assert "With markers." in _read(p)
+
+
+def test_heading_not_found_raises(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(
+            vault, path=NOTE_REL, why="x",
+            heading="Nonexistent", section_position="append", new_string="y",
+        )
+    assert ei.value.code == "HEADING_NOT_FOUND"
+
+
+def test_heading_mutually_exclusive_with_new_body(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(
+            vault, path=NOTE_REL, why="x",
+            heading="Overview", new_string="y", new_body="whole new body",
+        )
+    assert ei.value.code == "INVALID_EDIT"
+
+
+def test_heading_mutually_exclusive_with_old_string(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(
+            vault, path=NOTE_REL, why="x",
+            heading="Overview", new_string="y", old_string="Intro line.",
+        )
+    assert ei.value.code == "INVALID_EDIT"
+
+
+def test_heading_requires_new_string(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(vault, path=NOTE_REL, why="x", heading="Overview")
+    assert ei.value.code == "INVALID_EDIT"
+
+
+def test_bad_section_position_rejected(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(
+            vault, path=NOTE_REL, why="x",
+            heading="Overview", section_position="sideways", new_string="y",
+        )
+    assert ei.value.code == "INVALID_EDIT"
+
+
+def test_bumps_updated_and_writes_log(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _seed(vault)
+    today = dt.date.today().isoformat()
+    edit_module.edit(
+        vault, path=NOTE_REL, why="section edit auditable",
+        heading="Overview", section_position="append", new_string="Logged line.",
+    )
+    text = _read(p)
+    assert f"updated: {today}" in text
+    log_md = (vault / "Knowledge Base" / "log.md").read_text(encoding="utf-8")
+    assert "section edit auditable" in log_md
+    assert "heading-test" in log_md

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,0 +1,120 @@
+"""file_watcher — debounce/dispatch LOGIC tested directly (no real watchdog observer).
+
+We stub embeddings.upsert_after_write / delete_after_remove and feed change events,
+asserting the watcher coalesces them into one batched dispatch with the right paths.
+The soft-fail path (watchdog import fails → start() is a no-op) is tested by patching
+the lazy import.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import embeddings, file_watcher
+
+
+def _stub_embeddings(monkeypatch: pytest.MonkeyPatch):
+    ups: list[list[Path]] = []
+    dels: list[list[str]] = []
+    monkeypatch.setattr(embeddings, "upsert_after_write", lambda root, paths: ups.append(list(paths)))
+    monkeypatch.setattr(embeddings, "delete_after_remove", lambda root, rels: dels.append(list(rels)))
+    return ups, dels
+
+
+def test_flush_batches_upserts_and_dedupes(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    a = vault / "Knowledge Base" / "Notes" / "a.md"
+    b = vault / "Knowledge Base" / "Notes" / "b.md"
+    w._record(a, deleted=False)
+    w._record(a, deleted=False)  # duplicate save coalesces
+    w._record(b, deleted=False)
+    w._flush()
+    assert len(ups) == 1, "one batched upsert call for the whole window"
+    assert sorted(ups[0]) == sorted([a, b])
+    assert dels == []
+    # Pending cleared after flush — a second flush dispatches nothing.
+    w._flush()
+    assert len(ups) == 1
+
+
+def test_non_markdown_is_ignored(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    w._record(vault / "Knowledge Base" / "Evidence" / "scan.png", deleted=False)
+    w._flush()
+    assert ups == [] and dels == []
+
+
+def test_delete_routes_to_delete_after_remove(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    gone = vault / "Knowledge Base" / "Notes" / "gone.md"
+    w._record(gone, deleted=True)
+    w._flush()
+    assert ups == []
+    assert dels == [["Knowledge Base/Notes/gone.md"]]
+
+
+def test_modify_then_delete_only_deletes(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "x.md"
+    w._record(p, deleted=False)
+    w._record(p, deleted=True)  # deleted within the same window wins
+    w._flush()
+    assert ups == []
+    assert dels == [["Knowledge Base/Notes/x.md"]]
+
+
+def test_delete_then_recreate_only_upserts(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "y.md"
+    w._record(p, deleted=True)
+    w._record(p, deleted=False)  # recreated → modify
+    w._flush()
+    assert dels == []
+    assert ups == [[p]]
+
+
+def test_dispatch_thread_coalesces_within_debounce(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    ups, _dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault, debounce_seconds=0.05)
+    t = threading.Thread(target=w._run_dispatch, daemon=True)
+    t.start()
+    try:
+        a = vault / "Knowledge Base" / "Notes" / "a.md"
+        b = vault / "Knowledge Base" / "Notes" / "b.md"
+        w._record(a, deleted=False)
+        w._record(b, deleted=False)
+        deadline = time.monotonic() + 2.0
+        while not ups and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ups, "dispatch thread should flush after the debounce window"
+        assert sorted(ups[0]) == sorted([a, b]), "rapid saves coalesce into one batch"
+    finally:
+        w._stop.set()
+        w._wake.set()
+        t.join(timeout=2)
+
+
+def test_start_soft_fails_when_watchdog_missing(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom():
+        raise ImportError("No module named 'watchdog'")
+
+    monkeypatch.setattr(file_watcher, "_import_watchdog", _boom)
+    w = file_watcher.FileWatcher(vault)
+    assert w.start() is False  # no-op, server keeps running
+    assert w._thread is None and w._observer is None
+
+
+def test_start_no_op_when_kb_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # watchdog "available" but no Knowledge Base/ dir → don't watch.
+    monkeypatch.setattr(file_watcher, "_import_watchdog", lambda: (object, object))
+    w = file_watcher.FileWatcher(tmp_path)
+    assert w.start() is False

--- a/tests/test_get_links.py
+++ b/tests/test_get_links.py
@@ -1,0 +1,109 @@
+"""get(links=True) inbound/outbound link summary — via the REST /api/get path
+(which calls the same `_link_summary` the MCP `get` tool uses) and the helper directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from kb_mcp import find as find_module
+from kb_mcp import server
+
+TARGET_REL = "Knowledge Base/Notes/Insights/link-target.md"
+SOURCE_REL = "Knowledge Base/Notes/Insights/link-source.md"
+
+TARGET = """\
+---
+type: insight
+status: active
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Link Target
+
+## Claim
+
+The target of an inbound link.
+"""
+
+SOURCE = """\
+---
+type: insight
+status: active
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Link Source
+
+## Claim
+
+This builds on [[Knowledge Base/Notes/Insights/link-target]].
+"""
+
+
+def _seed(vault: Path) -> None:
+    (vault / TARGET_REL).write_text(TARGET, encoding="utf-8")
+    (vault / SOURCE_REL).write_text(SOURCE, encoding="utf-8")
+    find_module.clear_cache()
+
+
+def _client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    for leaky in ("KB_MCP_REST_API_KEY", "KB_MCP_UPLOAD_TOKEN"):
+        monkeypatch.delenv(leaky, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    mcp = server.build_server(require_auth=False)
+    return TestClient(mcp.http_app())
+
+
+def test_outbound_links_populated(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/get",
+        json={"path": SOURCE_REL, "links": True},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    links = r.json()["links"]
+    assert "Knowledge Base/Notes/Insights/link-target" in links["outbound"]
+
+
+def test_inbound_links_populated(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/get",
+        json={"path": TARGET_REL, "links": True},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    inbound = r.json()["links"]["inbound"]
+    assert any("link-source" in m["path"] for m in inbound), inbound
+
+
+def test_links_absent_when_flag_off(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/get",
+        json={"path": SOURCE_REL},  # links defaults False
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    assert "links" not in r.json()
+
+
+def test_link_summary_helper_direct(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed(vault)
+    body = (vault / SOURCE_REL).read_text(encoding="utf-8").split("---\n", 2)[-1]
+    out = server._link_summary(vault, SOURCE_REL, body)
+    assert out["outbound"] == ["Knowledge Base/Notes/Insights/link-target"]
+    # Source has no inbound links of its own in this seed.
+    assert out["inbound"] == []

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,0 +1,172 @@
+"""Personal REST facade (/api/*) — auth matrix + leaf round-trips.
+
+Drives the real FastMCP ASGI app via Starlette's sync TestClient (no live server,
+no torch: find runs in keyword mode). `load_dotenv` is neutralized and ambient env
+is cleared so the repo `.env` / dev shell can't clobber the per-test fixture vault.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from kb_mcp import find as find_module
+from kb_mcp import server
+
+
+def _client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    for leaky in (
+        "KB_MCP_REST_API_KEY", "KB_MCP_UPLOAD_TOKEN",
+        "KB_MCP_CF_ACCESS_TEAM_DOMAIN", "KB_MCP_CF_ACCESS_AUD",
+    ):
+        monkeypatch.delenv(leaky, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    mcp = server.build_server(require_auth=False)
+    return TestClient(mcp.http_app())
+
+
+def test_rest_disabled_without_key(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch)  # no KB_MCP_REST_API_KEY
+    r = client.post("/api/find", json={"query": "metabolism", "mode": "keyword"})
+    assert r.status_code == 503, r.text
+    assert r.json()["error"] == "REST_DISABLED"
+
+
+def test_rest_wrong_key_unauthorized(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/find",
+        json={"query": "metabolism", "mode": "keyword"},
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_rest_missing_key_unauthorized(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post("/api/find", json={"query": "metabolism", "mode": "keyword"})
+    assert r.status_code == 401, r.text
+
+
+def test_rest_find_roundtrip_matches_mcp_shape(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/find",
+        json={"query": "metabolism", "mode": "keyword"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert isinstance(payload, list)
+    # Same shape as the MCP `find` tool: a bare list of hit dicts.
+    find_module.clear_cache()
+    expected = [h.as_dict() for h in find_module.find(vault, query="metabolism", mode="keyword")]
+    assert payload == expected
+    assert payload, "keyword find for 'metabolism' should surface fixture notes"
+    assert {"path", "title", "type"} <= set(payload[0].keys())
+
+
+def test_rest_minted_rest_scoped_token_authorizes(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kb_mcp import upload_tokens
+
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    token = upload_tokens.mint("sekret", scope="rest")
+    r = client.post(
+        "/api/find",
+        json={"query": "metabolism", "mode": "keyword"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_rest_upload_scoped_token_does_not_authorize_rest(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kb_mcp import upload_tokens
+
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    token = upload_tokens.mint("sekret", scope="upload")  # wrong scope
+    r = client.post(
+        "/api/find",
+        json={"query": "x", "mode": "keyword"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_rest_get_roundtrip(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/get",
+        json={"path": "Notes/Insights/progressive-disclosure-without-mode-fragmentation"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["frontmatter"]["type"] == "insight"
+    assert "Progressive disclosure" in body["body"]
+    assert "links" not in body  # links default off
+
+
+def test_rest_get_not_found(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/get",
+        json={"path": "Notes/Insights/does-not-exist"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_rest_note_write_roundtrip(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/note",
+        json={
+            "note_type": "insight",
+            "title": "REST facade is scriptable",
+            "content": "# REST facade is scriptable\n\n## Claim\n\nScripts can write to the KB over HTTP.\n",
+        },
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    written = vault / r.json()["path"]
+    assert written.exists()
+    assert "scriptable" in written.read_text(encoding="utf-8")
+
+
+def test_rest_note_validation_error_is_400(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/note",
+        json={"note_type": "research-note", "title": "no project", "content": "x"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 400, r.text
+    assert "error" in r.json() and "reason" in r.json()
+
+
+def test_rest_malformed_body_is_400(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/find",
+        content=b"[1, 2, 3]",  # valid JSON but not an object
+        headers={"Authorization": "Bearer sekret", "Content-Type": "application/json"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"] == "INVALID_BODY"
+
+
+def test_rest_openapi_self_doc(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.get("/api/openapi.json")
+    assert r.status_code == 200, r.text
+    doc = r.json()
+    assert doc["openapi"].startswith("3.1")
+    assert "/api/find" in doc["paths"] and "/api/note" in doc["paths"]
+
+
+def test_rest_openapi_disabled_without_key(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch)
+    r = client.get("/api/openapi.json")
+    assert r.status_code == 503, r.text


### PR DESCRIPTION
Wave 2: reach parity. Disjoint from Wave 1 (server.py/edit.py/file_watcher.py vs find.py/fusion.py).

- Live file-watcher (watchdog, ~500ms debounce) → real-time re-embed of out-of-band Obsidian edits; soft-fails if watchdog absent; off in tests.
- Personal REST facade: /api/{find,get,note,add,edit,audit,reconcile,list_directory,suggest_links} + /api/openapi.json. Single API key (KB_MCP_REST_API_KEY), constant-time auth + scoped minted tokens + CF-Access; 503 until key set; calls the same leaf functions (no dup).
- Heading/section-targeted edits (heading + section_position) via apply_section_edit.
- get(links=true) inbound/outbound summary.
- watchdog>=4.0 added to deps (run uv sync in the service venv to activate the watcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)