### PR TITLE
feat: corpus-wide contradiction sweep + opt-in ASR diarization + opt-in vision captioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,23 @@ media = [
     "nvidia-cudnn-cu12; sys_platform == 'win32'",
     "nvidia-cuda-runtime-cu12; sys_platform == 'win32'",
 ]
+# Opt-in ASR speaker diarization (KB_MCP_DIARIZE). A pretrained pyannote clustering
+# model labels who-spoke-when so transcripts carry `[Speaker A]: …` turns. Heavy +
+# default-OFF + soft-fail, so it's an extra, never a core dep — the base install and
+# the test suite never require it. pyannote gates its weights behind a HF token
+# (HUGGINGFACE_TOKEN). Full install: `uv sync --extra media --extra diarization`.
+diarization = [
+    "pyannote.audio>=3.1",
+]
+# Opt-in vision captioning (KB_MCP_VISION_CAPTION). A FROZEN image-caption model
+# (BLIP/Florence-2 class, run via transformers) prepends a one-line description to an
+# image's OCR text. Default-OFF (it generates text — see extract.py's pure-substrate
+# note) + soft-fail, so it's an extra, never a core dep. transformers/torch come from
+# the `embeddings` extra on a GPU box. Full install:
+# `uv sync --extra media --extra embeddings --extra vision`.
+vision = [
+    "transformers>=4.40",
+]
 
 [dependency-groups]
 dev = [

--- a/src/kb_mcp/audit.py
+++ b/src/kb_mcp/audit.py
@@ -18,6 +18,13 @@ Checks (all read-only; no writes ever):
   `find` AND low inbound-link degree — a measurement-only review candidate.
   Surfaces it for the reader to judge (keep / supersede / archive); never
   decays, down-ranks, or moves anything (`find` ordering is unchanged).
+- `corpus_contradictions`: corpus-wide sweep for pairs of ACTIVE read-write
+  COMPILED conclusions whose embeddings sit in the contradiction band
+  `[floor, dup_threshold)` — close enough to plausibly restate/refine/contradict
+  each other, but not near-duplicates. A PROXIMITY measurement, not a stance
+  judgment (cosine can't tell agreement from contradiction); deduped unordered
+  pairs are surfaced for the reader to reconcile or supersede. Never auto-acts.
+  No-ops cleanly when embeddings are disabled.
 
 Audit is the diagnostic counterpart to the writers. Output is a proposal
 report; nothing is rewritten without explicit confirmation via the
@@ -54,7 +61,7 @@ ALL_CATEGORIES: tuple[str, ...] = (
     "broken_wikilink", "orphan_entity", "unprocessed_source",
     "index_drift", "tag_inconsistency", "frontmatter_compliance",
     "unregistered_project_key", "embedding_drift", "relevance_pairs_pending",
-    "stale_review",
+    "stale_review", "corpus_contradictions",
 )
 
 # Repo-global feedback-loop logs (written by the running service) + the golden
@@ -167,6 +174,8 @@ def audit(
         findings.extend(_check_relevance_pairs_pending())
     if "stale_review" in selected:
         findings.extend(_check_stale_review(vault_root, pages, today=today))
+    if "corpus_contradictions" in selected:
+        findings.extend(_check_corpus_contradictions(vault_root, pages))
 
     summary: dict[str, int] = {}
     for f in findings:
@@ -1273,6 +1282,133 @@ def _check_stale_review(
 
     rows.sort(key=lambda r: (r[0], -r[1]))
     return [f for _, _, f in rows]
+
+
+# ---------------- check: corpus_contradictions ----------------
+
+
+def _is_active_compiled_rw(vault_root: Path, page: find_module.ParsedPage) -> bool:
+    """An active, read-write, COMPILED conclusion — the only pages a contradiction
+    can actually be reconciled against (edit/replace/supersede). Mirrors the scope
+    of `corpus_aware.detect_contradictions` + `_check_stale_review`: a compiled type
+    (`find._COMPILED_TYPES`), not an index/log hub, not superseded/archived/draft,
+    and in a writeable (read-write) tree (auto-excludes readonly curated trees,
+    append-only Sources/Evidence, and excluded subtrees)."""
+    if page.page_type not in find_module._COMPILED_TYPES:
+        return False
+    if page.path.name in ("index.md", "log.md"):
+        return False
+    if page.status in ("superseded", "archived", "draft"):
+        return False
+    if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
+        return False
+    return True
+
+
+def _check_corpus_contradictions(
+    vault_root: Path, pages: list[find_module.ParsedPage]
+) -> list[AuditFinding]:
+    """Corpus-wide contradiction sweep: surface PAIRS of active read-write compiled
+    conclusions whose embeddings sit in the band `[floor, dup_threshold)`.
+
+    The audit-time counterpart to `corpus_aware.detect_contradictions` (which fires
+    on a single write): instead of one draft vs. the corpus, it sweeps every active
+    read-write compiled conclusion against every other and reports the deduped,
+    unordered file pairs whose max chunk-cosine lands just below the near-dup
+    ceiling. That band is close enough to plausibly restate, refine, OR contradict —
+    a PROXIMITY measurement, not a stance judgment (cosine can't separate "X works"
+    from "X doesn't"), so each pair is surfaced for the reader to reconcile or
+    supersede; nothing is ever auto-acted.
+
+    Reuses the existing vector sidecar (`EmbeddingIndex.all_vectors()`, cached by
+    mtime) — it reads the chunk vectors already on disk and never re-encodes, so the
+    sweep is O(eligible_files) matmuls over the sidecar matrix and needs no model
+    (works on a CPU/offline box as long as a sidecar exists). The band edges are the
+    same knobs the write-time check uses: floor = `corpus_aware._contradiction_floor`,
+    ceiling = `corpus_aware._dup_threshold`. An inverted band (floor >= ceiling) is
+    disabled. No-ops cleanly (returns []) when embeddings are disabled, the sidecar
+    is empty, or numpy/embeddings are unimportable — the same gate the write-time
+    check honors, so the fast test suite and torch-less deploys are unaffected.
+    """
+    if os.environ.get("KB_MCP_DISABLE_EMBEDDINGS"):
+        return []
+    from . import corpus_aware
+
+    floor = corpus_aware._contradiction_floor()
+    ceiling = corpus_aware._dup_threshold()
+    if floor >= ceiling:
+        log.warning(
+            "contradiction floor (%s) >= dup ceiling (%s); corpus_contradictions "
+            "sweep disabled this run",
+            floor, ceiling,
+        )
+        return []
+    try:
+        import numpy as np
+
+        from . import embeddings as embeddings_module
+    except ImportError as e:  # numpy is core, but stay defensive
+        log.debug("corpus_contradictions sweep unavailable (%s)", e)
+        return []
+
+    idx = embeddings_module.EmbeddingIndex(vault_root)
+    metadata, matrix = idx.all_vectors()  # cached by sidecar mtime
+    if not metadata or matrix.shape[0] == 0:
+        return []
+
+    # Both endpoints of a flagged pair must be active read-write compiled.
+    eligible: dict[str, find_module.ParsedPage] = {
+        page.rel_path: page
+        for page in pages
+        if _is_active_compiled_rw(vault_root, page)
+    }
+    if len(eligible) < 2:
+        return []
+
+    rows_by_file: dict[str, list[int]] = {}
+    for i, (fp, _cidx, _ctext) in enumerate(metadata):
+        rows_by_file.setdefault(fp, []).append(i)
+
+    # max chunk-cosine per deduped unordered file pair, both endpoints eligible.
+    pair_cos: dict[tuple[str, str], float] = {}
+    for fp, _page in eligible.items():
+        rows = rows_by_file.get(fp)
+        if not rows:
+            continue  # eligible page with no vectors yet (e.g. never embedded)
+        sub = matrix[rows]                       # (m, D) this file's chunk vectors
+        col_max = (sub @ matrix.T).max(axis=0)   # (N,) best cosine file→each chunk
+        in_band = np.nonzero((col_max >= floor) & (col_max < ceiling))[0]
+        for j in in_band:
+            other_fp = metadata[int(j)][0]
+            if other_fp == fp or other_fp not in eligible:
+                continue
+            score = float(col_max[int(j)])
+            a, b = sorted((fp, other_fp))
+            key = (a, b)
+            if key not in pair_cos or score > pair_cos[key]:
+                pair_cos[key] = score
+
+    findings: list[AuditFinding] = []
+    for (a, b), cos in sorted(pair_cos.items(), key=lambda kv: (-kv[1], kv[0])):
+        findings.append(AuditFinding(
+            category="corpus_contradictions",
+            severity="info",
+            path=a,
+            detail=(
+                f"Active conclusion overlaps active conclusion {b!r} "
+                f"(cosine {round(cos, 4)}) — close enough to restate, refine, or "
+                f"contradict. Do they conflict?"
+            ),
+            proposed_fix=(
+                "Surfaced for REVIEW only — a proximity measurement, not an asserted "
+                "contradiction. Read both: if they genuinely conflict, `replace` "
+                "(supersede) the stale one or `reconcile` them; otherwise leave as-is. "
+                "Never auto-acted."
+            ),
+            paths=[a, b],
+            meta={"cosine": round(cos, 4)},
+        ))
+    return findings
 
 
 # ---------------- helpers ----------------

--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -13,6 +13,21 @@ and the caller skips server extraction — the model-driven `/upload` `text` pat
 Engines are swappable behind `extract_text(path, media_type=...) -> ExtractResult`: the
 faster-whisper backend can be replaced with a torch/transformers Whisper if CTranslate2
 lacks Blackwell `sm_120` kernels (the verification gate), without touching callers.
+
+Two OPTIONAL deepen-the-moat transducers ship here, both DEFAULT-OFF + soft-fail:
+
+- ASR speaker diarization (`KB_MCP_DIARIZE`): a pretrained clustering model
+  (pyannote.audio) labels who-spoke-when and prefixes transcript turns with
+  `[Speaker A]: …`. Deterministic (a frozen clustering model, not an LLM), so it is
+  pure-substrate "measure" — but it stays off by default and falls back to the plain
+  transcript when the dep/model isn't present, so existing extraction is unchanged.
+- Vision captioning (`KB_MCP_VISION_CAPTION`): a FROZEN image-caption model
+  (BLIP/Florence-2 class) prepends a one-line description to an image's OCR text so a
+  photo with no text is still findable. A frozen caption model is deterministic
+  transduction — the same class as Tesseract/CLIP/bge — NOT a reasoning LLM. But
+  because it *generates* text it ships OFF by default; flip the flag to opt in once
+  you've confirmed the model is the frozen captioner you intend. Soft-fails to
+  OCR-only when the dep/model/GPU is absent.
 """
 
 from __future__ import annotations
@@ -55,6 +70,11 @@ class ExtractResult:
     media_type: str           # audio|video|image|pdf|docx|xlsx|pptx|html|text|email|calendar
     engine: str               # provenance, e.g. "faster-whisper:large-v3", "tesseract", "pymupdf"
     warnings: list[str] = field(default_factory=list)
+    # Optional speaker-diarized turns from ASR (KB_MCP_DIARIZE). Each entry is
+    # `{"speaker": "Speaker A", "start": float, "end": float, "text": str}`. Default
+    # None so every existing call site and engine is unchanged; only set when
+    # diarization is enabled AND succeeds (else the plain transcript flows through).
+    speakers: list[dict] | None = None
 
 
 class ExtractionUnavailable(Exception):
@@ -230,8 +250,141 @@ def _transcribe(path: Path, media_type: str) -> ExtractResult:
     # faster-whisper decodes the media's audio stream via PyAV (handles video containers
     # too), so a video file can be passed directly — no separate ffmpeg extraction step.
     segments, _info = model.transcribe(str(path))
-    text = " ".join(seg.text.strip() for seg in segments).strip()
-    return ExtractResult(text=text, media_type=media_type, engine=f"faster-whisper:{WHISPER_MODEL}")
+    seg_list = list(segments)  # materialize once: diarization needs per-segment timing
+    engine = f"faster-whisper:{WHISPER_MODEL}"
+
+    # OPTIONAL speaker diarization (KB_MCP_DIARIZE, default OFF). A pretrained
+    # clustering model (deterministic transduction, not an LLM) labels who-spoke-when
+    # and prefixes turns with `[Speaker A]: …`. Soft-fail: if the dep/model is absent
+    # or diarization errors, fall back to the plain transcript below — extraction with
+    # the flag off (or unavailable) is byte-for-byte unchanged.
+    if _diarize_enabled():
+        labeled = _diarize(path, seg_list)
+        if labeled is not None:
+            text, speakers = labeled
+            return ExtractResult(
+                text=text, media_type=media_type, engine=f"{engine}+diarized",
+                speakers=speakers,
+            )
+
+    text = " ".join(seg.text.strip() for seg in seg_list).strip()
+    return ExtractResult(text=text, media_type=media_type, engine=engine)
+
+
+# ---------------- optional: ASR speaker diarization (KB_MCP_DIARIZE, default OFF) ----
+
+
+_DIARIZATION_PIPELINE = None
+_DIARIZATION_LOCK = threading.Lock()
+
+
+def _diarize_enabled() -> bool:
+    """True only when KB_MCP_DIARIZE is set. OFF by default — diarization never
+    changes existing extraction unless explicitly opted in."""
+    return bool(os.environ.get("KB_MCP_DIARIZE"))
+
+
+def _load_diarization_pipeline():
+    """Lazy-import + load the pretrained pyannote speaker-diarization pipeline.
+
+    Soft-import seam (patched in tests): a box without the `[diarization]` extra
+    raises ImportError here, which `_run_diarization` catches → plain transcript.
+    `KB_MCP_DIARIZE_MODEL` overrides the pretrained checkpoint; `HUGGINGFACE_TOKEN`
+    (pyannote gates its weights behind a HF token) is honored if set.
+    """
+    from pyannote.audio import Pipeline  # soft dep — only imported when enabled
+
+    model = os.environ.get("KB_MCP_DIARIZE_MODEL", "pyannote/speaker-diarization-3.1")
+    token = os.environ.get("HUGGINGFACE_TOKEN") or os.environ.get("HF_TOKEN")
+    return Pipeline.from_pretrained(model, use_auth_token=token)
+
+
+def _get_diarization_pipeline():
+    """Lazy singleton for the diarization pipeline (one load per process)."""
+    global _DIARIZATION_PIPELINE
+    if _DIARIZATION_PIPELINE is not None:
+        return _DIARIZATION_PIPELINE
+    with _DIARIZATION_LOCK:
+        if _DIARIZATION_PIPELINE is None:
+            _DIARIZATION_PIPELINE = _load_diarization_pipeline()
+    return _DIARIZATION_PIPELINE
+
+
+def _run_diarization(path: Path) -> list[tuple[float, float, str]] | None:
+    """Run the pretrained diarization pipeline → `[(start, end, raw_label), …]`.
+
+    Soft-fail: returns None when the dep/model is unavailable or anything errors, so
+    `_transcribe` falls back to the plain transcript. Never raises.
+    """
+    try:
+        pipeline = _get_diarization_pipeline()
+    except ImportError as e:
+        log.debug("diarization dep not installed: %s", e)
+        return None
+    except Exception:  # noqa: BLE001 — model/token/GPU issues must soft-fail, not crash
+        log.warning("diarization pipeline load failed; using plain transcript", exc_info=True)
+        return None
+    try:
+        annotation = pipeline(str(path))
+        return [
+            (float(turn.start), float(turn.end), str(label))
+            for turn, _track, label in annotation.itertracks(yield_label=True)
+        ]
+    except Exception:  # noqa: BLE001 — a bad/unsupported file must soft-fail to plain ASR
+        log.warning("diarization run failed for %s; using plain transcript", path.name, exc_info=True)
+        return None
+
+
+def _diarize(
+    path: Path, seg_list: list
+) -> tuple[str, list[dict]] | None:
+    """Label ASR segments with speakers and render `[Speaker A]: …` turns.
+
+    Maps each whisper segment to the diarization speaker whose turn overlaps it most,
+    relabels raw `SPEAKER_00/01/…` to first-appearance `Speaker A/B/…`, and merges
+    consecutive same-speaker segments into one turn. Returns
+    `(labeled_text, speakers)` where `speakers` is the structured turn list, or None
+    on soft-fail (no diarization output / no segments) so the caller uses the plain
+    transcript.
+    """
+    turns = _run_diarization(path)
+    if not turns or not seg_list:
+        return None
+
+    # First-appearance map of raw pyannote labels → "Speaker A", "Speaker B", …
+    label_names: dict[str, str] = {}
+
+    def _name(raw: str) -> str:
+        if raw not in label_names:
+            label_names[raw] = f"Speaker {chr(ord('A') + len(label_names))}"
+        return label_names[raw]
+
+    def _speaker_for(start: float, end: float) -> str | None:
+        best_label, best_overlap = None, 0.0
+        for t_start, t_end, raw in turns:
+            overlap = min(end, t_end) - max(start, t_start)
+            if overlap > best_overlap:
+                best_overlap, best_label = overlap, raw
+        return _name(best_label) if best_label is not None else None
+
+    merged: list[dict] = []
+    for seg in seg_list:
+        seg_text = seg.text.strip()
+        if not seg_text:
+            continue
+        start = float(getattr(seg, "start", 0.0) or 0.0)
+        end = float(getattr(seg, "end", start) or start)
+        speaker = _speaker_for(start, end) or "Speaker A"
+        if merged and merged[-1]["speaker"] == speaker:
+            merged[-1]["text"] += " " + seg_text
+            merged[-1]["end"] = end
+        else:
+            merged.append({"speaker": speaker, "start": start, "end": end, "text": seg_text})
+
+    if not merged:
+        return None
+    labeled_text = "\n".join(f"[{m['speaker']}]: {m['text']}" for m in merged).strip()
+    return labeled_text, merged
 
 
 def _has_audio_stream(path: Path) -> bool:
@@ -289,7 +442,104 @@ def _ocr_image(path: Path) -> ExtractResult:
             text = pytesseract.image_to_string(img).strip()
     except pytesseract.TesseractNotFoundError as e:
         raise ExtractionUnavailable(f"Tesseract binary not on PATH: {e}") from e
-    return ExtractResult(text=text, media_type="image", engine="tesseract")
+    # OPTIONAL frozen-model caption (KB_MCP_VISION_CAPTION, default OFF) prepended so
+    # a photo with no on-image text is still findable. Soft-fails to OCR-only.
+    text, engine = _maybe_caption(text, path)
+    return ExtractResult(text=text, media_type="image", engine=engine)
+
+
+# ---------------- optional: vision captioning (KB_MCP_VISION_CAPTION, default OFF) ----
+#
+# PURE-SUBSTRATE NOTE: a FROZEN image-caption model (BLIP/Florence-2 class) is
+# deterministic transduction — the same category as Tesseract OCR, CLIP, and the bge
+# embedder: it MEASURES the pixels into text, it does not reason. It is NOT a
+# server-side reasoning LLM. But because a caption model *generates* natural-language
+# text (unlike OCR, which only reads text that is already in the image), it ships
+# DEFAULT-OFF: flip KB_MCP_VISION_CAPTION only once you've confirmed the configured
+# model is the frozen captioner you intend. With the flag off (or the dep/model/GPU
+# absent) `_ocr_image` returns byte-for-byte the same OCR-only result as before.
+
+
+_CAPTIONER = None
+_CAPTIONER_LOCK = threading.Lock()
+
+
+def _vision_caption_enabled() -> bool:
+    """True only when KB_MCP_VISION_CAPTION is set. OFF by default (see the
+    pure-substrate note above) — captioning never changes OCR output unless opted in."""
+    return bool(os.environ.get("KB_MCP_VISION_CAPTION"))
+
+
+def _caption_model_name() -> str:
+    """The frozen caption checkpoint; KB_MCP_VISION_CAPTION_MODEL overrides it."""
+    return os.environ.get("KB_MCP_VISION_CAPTION_MODEL", "Salesforce/blip-image-captioning-large")
+
+
+def _load_captioner():
+    """Lazy-import + load the frozen caption pipeline (transformers image-to-text).
+
+    Soft-import seam (patched in tests): a box without the `[vision]` extra raises
+    ImportError here, which `_caption_image` catches → OCR-only.
+    """
+    from transformers import pipeline  # soft dep — only imported when enabled
+
+    device = 0 if _device() == "cuda" else -1
+    return pipeline("image-to-text", model=_caption_model_name(), device=device)
+
+
+def _get_captioner():
+    """Lazy singleton for the caption pipeline (one load per process)."""
+    global _CAPTIONER
+    if _CAPTIONER is not None:
+        return _CAPTIONER
+    with _CAPTIONER_LOCK:
+        if _CAPTIONER is None:
+            _CAPTIONER = _load_captioner()
+    return _CAPTIONER
+
+
+def _caption_image(path: Path) -> str | None:
+    """Frozen caption model → a one-line description, or None on soft-fail.
+
+    Deterministic transduction (a frozen captioner, not an LLM). Never raises: a
+    missing dep/model/GPU or any inference error returns None so the caller keeps the
+    OCR-only text.
+    """
+    try:
+        captioner = _get_captioner()
+    except ImportError as e:
+        log.debug("vision-caption dep not installed: %s", e)
+        return None
+    except Exception:  # noqa: BLE001 — model/GPU load issues must soft-fail, not crash
+        log.warning("vision-caption model load failed; using OCR only", exc_info=True)
+        return None
+    try:
+        out = captioner(str(path))
+        # transformers image-to-text returns [{"generated_text": "..."}].
+        if isinstance(out, list) and out and isinstance(out[0], dict):
+            caption = str(out[0].get("generated_text", "")).strip()
+            return caption or None
+        return None
+    except Exception:  # noqa: BLE001 — a bad image must soft-fail to OCR-only
+        log.warning("vision-caption inference failed for %s; using OCR only", path.name, exc_info=True)
+        return None
+
+
+def _maybe_caption(ocr_text: str, path: Path) -> tuple[str, str]:
+    """Return `(text, engine)` for an OCR'd image, prepending a frozen-model caption
+    when KB_MCP_VISION_CAPTION is enabled and captioning succeeds.
+
+    Flag off, or the captioner soft-fails → the unchanged OCR text + `"tesseract"`.
+    Caption present → `"<caption>\\n\\n<ocr_text>"` + `"tesseract+<model-short>"`.
+    """
+    if not _vision_caption_enabled():
+        return ocr_text, "tesseract"
+    caption = _caption_image(path)
+    if not caption:
+        return ocr_text, "tesseract"
+    text = f"{caption}\n\n{ocr_text}".strip() if ocr_text else caption
+    short = _caption_model_name().rsplit("/", 1)[-1]
+    return text, f"tesseract+{short}"
 
 
 def _extract_pdf(path: Path) -> ExtractResult:

--- a/src/kb_mcp/media_worker.py
+++ b/src/kb_mcp/media_worker.py
@@ -125,7 +125,8 @@ class MediaWorker:
             return
         text = result.text.strip() or "(no text detected)"
         preserve.update_sidecar_extraction(
-            self._vault_root, job.sidecar_path, text=text, engine=result.engine
+            self._vault_root, job.sidecar_path, text=text, engine=result.engine,
+            speakers=result.speakers,
         )
         log.info(
             "extracted %s via %s (%d chars)", job.binary_path.name, result.engine, len(result.text)

--- a/src/kb_mcp/preserve.py
+++ b/src/kb_mcp/preserve.py
@@ -558,7 +558,8 @@ _EXTRACTED_HEADING = "## Extracted text"
 
 
 def update_sidecar_extraction(
-    vault_root: Path, sidecar_path: Path, *, text: str, engine: str
+    vault_root: Path, sidecar_path: Path, *, text: str, engine: str,
+    speakers: list[dict] | None = None,
 ) -> None:
     """Fill a pending media sidecar with extracted text + engine, and re-embed.
 
@@ -567,9 +568,23 @@ def update_sidecar_extraction(
     body, then writes via `batch_atomic_write(vault_root=)` so the sidecar is
     re-embedded and immediately findable by its content. `engine` may be a
     `failed: …` marker so a permanent failure stops the restart re-enqueue loop.
+
+    `speakers` (optional, from opt-in ASR diarization) carries the structured turn
+    list; when present its distinct speaker labels are recorded as a `speakers:`
+    frontmatter list so the transcript's `[Speaker A]: …` turns are also queryable
+    structurally. Omitted (None/empty) leaves the frontmatter unchanged — every
+    existing call site is unaffected.
     """
     content = sidecar_path.read_text(encoding="utf-8")
     content = _set_frontmatter_field(content, "extracted_by", engine)
+    if speakers:
+        labels: list[str] = []
+        for turn in speakers:
+            label = str(turn.get("speaker", "")).strip()
+            if label and label not in labels:
+                labels.append(label)
+        if labels:
+            content = _set_frontmatter_field(content, "speakers", f"[{', '.join(labels)}]")
     content = _set_extracted_text(content, _cap_extracted_text(text))
     batch_atomic_write([PlannedWrite(path=sidecar_path, content=content)], vault_root=vault_root)
 

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -1488,6 +1488,11 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
           surfaced in `find` AND low inbound-link degree — a measurement-only
           review candidate (still true? keep / supersede / archive). Never
           decays or down-ranks; `find` ordering is unchanged.
+        - `corpus_contradictions`: corpus-wide pairs of active read-write
+          compiled conclusions whose embeddings sit just below the near-dup
+          threshold (close enough to restate/refine/contradict). A proximity
+          measurement surfaced for review (reconcile or supersede); never
+          auto-acted. No-ops when embeddings are disabled.
 
         Args:
             categories: Optional filter; only run these checks. Each must be

--- a/tests/test_audit_corpus_contradictions.py
+++ b/tests/test_audit_corpus_contradictions.py
@@ -1,0 +1,173 @@
+"""corpus_contradictions audit: corpus-wide sweep for near-but-not-dup conclusion pairs.
+
+A measurement-only review queue over the existing vector sidecar — it surfaces
+deduped, unordered pairs of ACTIVE read-write COMPILED conclusions whose max
+chunk-cosine lands in the band [floor, dup_threshold); never auto-acts. Gated by
+KB_MCP_DISABLE_EMBEDDINGS (the suite default). The band edges are tunable via
+KB_MCP_CONTRADICTION_FLOOR / KB_MCP_DUP_THRESHOLD, so the semantic tests place a
+near-identical pair in or out of the band deterministically (identical heading+body
+→ cosine 1.0, so a ceiling above 1.0 keeps the pair in band; a ceiling below it makes
+the pair a near-dup that the band excludes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import audit as audit_module
+from kb_mcp import find as find_module
+
+
+# Distinctive nonsense body so the planted pair doesn't collide with fixture notes.
+_SHARED_BODY = "\n\n".join(
+    f"Zylo narwhal quokka substrate measure-not-judge clause number {i}" for i in range(6)
+)
+
+
+def _seed(
+    vault: Path,
+    rel: str,
+    *,
+    type_: str = "insight",
+    status: str = "active",
+    heading: str = "Shared Claim",
+    body: str = _SHARED_BODY,
+) -> str:
+    """Write a minimal compiled page at KB-relative `rel`. Returns the sidecar-form
+    key (vault-relative WITH 'Knowledge Base/' prefix and .md)."""
+    p = vault / "Knowledge Base" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        f"---\ntype: {type_}\nstatus: {status}\n"
+        f"created: 2026-01-01\nupdated: 2026-01-01\n---\n\n# {heading}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return f"Knowledge Base/{rel}"
+
+
+def _cc_findings(vault: Path):
+    return audit_module.audit(vault, categories=["corpus_contradictions"]).findings
+
+
+def _pairs(findings) -> set[tuple[str, str]]:
+    return {tuple(sorted(f.paths)) for f in findings if f.paths}
+
+
+# ---------------- registration / gating (torch-free) ----------------
+
+
+def test_corpus_contradictions_registered() -> None:
+    assert "corpus_contradictions" in audit_module.ALL_CATEGORIES
+
+
+def test_unknown_category_still_rejected(vault: Path) -> None:
+    with pytest.raises(ValueError):
+        audit_module.audit(vault, categories=["does_not_exist"])
+
+
+def test_noop_when_embeddings_disabled(vault: Path) -> None:
+    # Suite-wide KB_MCP_DISABLE_EMBEDDINGS is set → the sweep short-circuits to []
+    # without loading torch or touching a sidecar, even with near-identical pages.
+    _seed(vault, "Notes/Insights/cc-a.md")
+    _seed(vault, "Notes/Insights/cc-b.md")
+    find_module.clear_cache()
+    assert _cc_findings(vault) == []
+
+
+# ---------------- semantic sweep (model-loading) ----------------
+
+pytest.importorskip("sentence_transformers")
+pytest.importorskip("torch")
+
+from kb_mcp import embeddings  # noqa: E402
+
+
+@pytest.fixture
+def embeddings_enabled(monkeypatch):
+    """Lift the conftest-wide KB_MCP_DISABLE_EMBEDDINGS gate for these tests."""
+    monkeypatch.delenv("KB_MCP_DISABLE_EMBEDDINGS", raising=False)
+    embeddings._IMPORT_FAILED = False
+
+
+def _build(vault: Path) -> None:
+    find_module.clear_cache()
+    embeddings.EmbeddingIndex(vault).rebuild_all()
+
+
+def test_flags_deduped_pair_in_band(vault: Path, embeddings_enabled, monkeypatch) -> None:
+    monkeypatch.setenv("KB_MCP_CONTRADICTION_FLOOR", "0.5")
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "1.01")  # ceiling > 1.0 → near-identical lands in band
+    a = _seed(vault, "Notes/Insights/cc-a.md")
+    b = _seed(vault, "Notes/Insights/cc-b.md")
+    _build(vault)
+
+    findings = _cc_findings(vault)
+    mine = [f for f in findings if set(f.paths or []) == {a, b}]
+    assert len(mine) == 1, [f.as_dict() for f in findings]  # deduped: one pair, not A→B AND B→A
+    f = mine[0]
+    assert f.category == "corpus_contradictions"
+    assert f.severity == "info"
+    assert f.path == min(a, b)            # canonical: smaller rel_path
+    assert f.paths == sorted([a, b])
+    assert f.meta["cosine"] >= 0.5
+    assert "review" in (f.proposed_fix or "").lower()
+    assert "never auto" in (f.proposed_fix or "").lower()
+
+
+def test_above_ceiling_dup_excluded(vault: Path, embeddings_enabled, monkeypatch) -> None:
+    # cosine ~1.0 >= ceiling 0.9 → a near-duplicate, NOT a contradiction: excluded.
+    monkeypatch.setenv("KB_MCP_CONTRADICTION_FLOOR", "0.5")
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "0.9")
+    a = _seed(vault, "Notes/Insights/cc-dup-a.md")
+    b = _seed(vault, "Notes/Insights/cc-dup-b.md")
+    _build(vault)
+    assert not [f for f in _cc_findings(vault) if set(f.paths or []) == {a, b}]
+
+
+def test_below_floor_excluded(vault: Path, embeddings_enabled, monkeypatch) -> None:
+    # Unrelated bodies → cosine well below floor 0.999 → not in band: excluded.
+    monkeypatch.setenv("KB_MCP_CONTRADICTION_FLOOR", "0.999")
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "1.01")
+    a = _seed(
+        vault, "Notes/Insights/cc-far-a.md",
+        heading="Alpha", body="Photosynthesis converts sunlight into sugars inside chloroplasts.",
+    )
+    b = _seed(
+        vault, "Notes/Insights/cc-far-b.md",
+        heading="Beta", body="The quarterly invoice was paid by wire transfer last Tuesday.",
+    )
+    _build(vault)
+    assert not [f for f in _cc_findings(vault) if set(f.paths or []) == {a, b}]
+
+
+def test_inverted_band_disabled(vault: Path, embeddings_enabled, monkeypatch) -> None:
+    monkeypatch.setenv("KB_MCP_CONTRADICTION_FLOOR", "0.95")
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "0.90")  # floor >= ceiling → band disabled
+    _seed(vault, "Notes/Insights/cc-inv-a.md")
+    _seed(vault, "Notes/Insights/cc-inv-b.md")
+    _build(vault)
+    assert _cc_findings(vault) == []
+
+
+def test_excludes_non_active_compiled_rw_endpoints(
+    vault: Path, embeddings_enabled, monkeypatch
+) -> None:
+    # Four near-identical pages, but only ONE is an active read-write compiled
+    # conclusion. The superseded / raw-source / readonly twins are never eligible
+    # endpoints, so no surfaced pair includes any of them.
+    monkeypatch.setenv("KB_MCP_CONTRADICTION_FLOOR", "0.5")
+    monkeypatch.setenv("KB_MCP_DUP_THRESHOLD", "1.01")
+    _seed(vault, "Notes/Insights/cc-active.md")
+    superseded = _seed(vault, "Notes/Insights/cc-sup.md", status="superseded")
+    source = _seed(vault, "Sources/Other/cc-src.md", type_="source")
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly:\n  - Products\nexcluded: []\n", encoding="utf-8"
+    )
+    readonly = _seed(vault, "Products/cc-ro.md")
+    _build(vault)
+
+    pairs = _pairs(_cc_findings(vault))
+    for excluded in (superseded, source, readonly):
+        assert not any(excluded in pair for pair in pairs), (excluded, pairs)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from kb_mcp import extract
@@ -141,3 +143,138 @@ def test_extract_document_soft_fails_on_bad_input(tmp_path) -> None:
     # → still ExtractionUnavailable (wrapped). Either way, never a hard crash.
     with pytest.raises(extract.ExtractionUnavailable):
         extract._extract_document(tmp_path / "does-not-exist.docx", "docx")
+
+
+# ---------------- optional: ASR speaker diarization (KB_MCP_DIARIZE, default OFF) ----
+
+
+class _FakeSeg:
+    def __init__(self, text: str, start: float, end: float) -> None:
+        self.text = text
+        self.start = start
+        self.end = end
+
+
+class _FakeWhisper:
+    def __init__(self, segs: list) -> None:
+        self._segs = segs
+
+    def transcribe(self, path):  # faster-whisper returns (segments_generator, info)
+        return iter(self._segs), None
+
+
+def test_diarize_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DIARIZE", raising=False)
+    assert extract._diarize_enabled() is False
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    assert extract._diarize_enabled() is True
+
+
+def test_transcribe_plain_when_diarize_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_DIARIZE", raising=False)
+    segs = [_FakeSeg("hello there", 0.0, 1.0), _FakeSeg("general kenobi", 1.0, 2.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "hello there general kenobi"
+    assert r.speakers is None
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}"
+
+
+def test_transcribe_labels_speakers_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    segs = [_FakeSeg("hello there", 0.0, 1.0), _FakeSeg("general kenobi", 1.0, 2.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    # Stub the raw diarization → two turns mapped to distinct speakers (no real model).
+    monkeypatch.setattr(
+        extract, "_run_diarization",
+        lambda p: [(0.0, 1.0, "SPEAKER_00"), (1.0, 2.0, "SPEAKER_01")],
+    )
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert "[Speaker A]: hello there" in r.text
+    assert "[Speaker B]: general kenobi" in r.text
+    assert r.engine.endswith("+diarized")
+    assert r.speakers is not None
+    assert [t["speaker"] for t in r.speakers] == ["Speaker A", "Speaker B"]
+    assert r.speakers[0]["text"] == "hello there"
+
+
+def test_transcribe_merges_consecutive_same_speaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    segs = [_FakeSeg("part one", 0.0, 1.0), _FakeSeg("part two", 1.0, 2.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    monkeypatch.setattr(
+        extract, "_run_diarization",
+        lambda p: [(0.0, 2.0, "SPEAKER_00")],  # one speaker the whole time
+    )
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "[Speaker A]: part one part two"
+    assert len(r.speakers) == 1
+
+
+def test_transcribe_soft_fails_to_plain_when_diarization_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    monkeypatch.setattr(extract, "_DIARIZATION_PIPELINE", None)
+    segs = [_FakeSeg("solo line", 0.0, 1.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+
+    def _no_dep():
+        raise ImportError("pyannote.audio not installed")
+
+    # Real _run_diarization runs; its pipeline loader raises ImportError → soft-fail.
+    monkeypatch.setattr(extract, "_load_diarization_pipeline", _no_dep)
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "solo line"
+    assert r.speakers is None
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}"
+
+
+# ---------------- optional: vision captioning (KB_MCP_VISION_CAPTION, default OFF) ----
+
+
+def test_vision_caption_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_VISION_CAPTION", raising=False)
+    assert extract._vision_caption_enabled() is False
+    monkeypatch.setenv("KB_MCP_VISION_CAPTION", "1")
+    assert extract._vision_caption_enabled() is True
+
+
+def test_maybe_caption_ocr_only_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_VISION_CAPTION", raising=False)
+    called: list = []
+    monkeypatch.setattr(extract, "_caption_image", lambda p: called.append(p) or "nope")
+    text, engine = extract._maybe_caption("ocr body", Path("x.png"))
+    assert text == "ocr body"
+    assert engine == "tesseract"
+    assert called == []  # flag off → captioner is never invoked
+
+
+def test_maybe_caption_prepends_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_VISION_CAPTION", "1")
+    monkeypatch.setattr(extract, "_caption_image", lambda p: "a cat sitting on a mat")
+    text, engine = extract._maybe_caption("INVOICE 7731", Path("x.png"))
+    assert text == "a cat sitting on a mat\n\nINVOICE 7731"
+    assert engine.startswith("tesseract+")
+
+
+def test_maybe_caption_empty_ocr_returns_caption_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_VISION_CAPTION", "1")
+    monkeypatch.setattr(extract, "_caption_image", lambda p: "a beach at sunset")
+    text, engine = extract._maybe_caption("", Path("x.png"))
+    assert text == "a beach at sunset"
+    assert engine.startswith("tesseract+")
+
+
+def test_maybe_caption_soft_fails_to_ocr_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_VISION_CAPTION", "1")
+    monkeypatch.setattr(extract, "_CAPTIONER", None)
+
+    def _no_dep():
+        raise ImportError("transformers not installed")
+
+    # Real _caption_image runs; its model loader raises ImportError → soft-fail.
+    monkeypatch.setattr(extract, "_load_captioner", _no_dep)
+    text, engine = extract._maybe_caption("ocr body", Path("x.png"))
+    assert text == "ocr body"
+    assert engine == "tesseract"

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -51,6 +51,34 @@ def test_worker_fills_pending_sidecar(vault, monkeypatch: pytest.MonkeyPatch) ->
     assert "extracted_by: pending" not in body
 
 
+def test_worker_writes_speaker_labels_and_field(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Opt-in diarization output round-trips: labeled turns into the sidecar text AND
+    # the distinct speaker labels into a `speakers:` frontmatter list.
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    result = _preserve_media_stub(vault, filename="meeting2.mp3")
+    sidecar = vault / result.sidecar_path
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda p, media_type=None: extract.ExtractResult(
+            text="[Speaker A]: we shipped it\n[Speaker B]: nice work",
+            media_type="audio",
+            engine="faster-whisper:test+diarized",
+            speakers=[
+                {"speaker": "Speaker A", "start": 0.0, "end": 1.0, "text": "we shipped it"},
+                {"speaker": "Speaker B", "start": 1.0, "end": 2.0, "text": "nice work"},
+            ],
+        ),
+    )
+    w = media_worker.MediaWorker(vault)
+    w._process(media_worker._Job(binary_path=vault / result.path, sidecar_path=sidecar, media_type="audio"))
+
+    body = sidecar.read_text(encoding="utf-8")
+    assert "[Speaker A]: we shipped it" in body
+    assert "[Speaker B]: nice work" in body
+    assert "speakers: [Speaker A, Speaker B]" in body
+    assert "extracted_by: faster-whisper:test+diarized" in body
+
+
 def test_worker_marks_failed_on_extraction_error(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
     result = _preserve_media_stub(vault, filename="bad.mp3")


### PR DESCRIPTION
Wave 3: deepen moats.
- audit corpus_contradictions: corpus-wide sweep for active read-write compiled pairs in the contradiction band; all_vectors()+matmul, deduped, surface-for-review, no-op when embeddings disabled.
- ASR diarization (KB_MCP_DIARIZE, default OFF, pyannote extra, soft-fail).
- Vision captioning (KB_MCP_VISION_CAPTION, default OFF, transformers extra, soft-fail) — frozen-model measurement, ships off pending pure-substrate sign-off.
- 709 green (690 + 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)