### PR TITLE
feat: named-speaker diarization (OpenSpec change #1) — voice-profile attribution, default-off + soft-fail

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,155 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,160 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/bulk-archive.md
+++ b/.claude/commands/opsx/bulk-archive.md
@@ -1,0 +1,244 @@
+---
+name: "OPSX: Bulk Archive"
+description: Archive multiple completed changes at once
+category: Workflow
+tags: [workflow, archive, experimental, bulk]
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName`, `artifacts`, `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`
+      - Note which artifacts are `done` vs other states
+
+      If any selected change reports `actionContext.mode: "workspace-planning"`, explain that workspace bulk archive is not supported in this slice and STOP before syncing specs or moving changes. Do not fall back to repo-local paths or edit linked repos.
+
+   b. **Task completion** - Read `artifactPaths.tasks.existingOutputPaths` from status JSON
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `artifactPaths.specs.existingOutputPaths` from status JSON
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p "<planningHome.changesDir>/archive"
+      mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Create a new change to get started.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.claude/commands/opsx/continue.md
+++ b/.claude/commands/opsx/continue.md
@@ -1,0 +1,115 @@
+---
+name: "OPSX: Continue"
+description: Continue working on a change - create the next artifact (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name after `/opsx:continue` (e.g., `/opsx:continue add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change with `/opsx:apply` or archive it with `/opsx:archive`."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the `resolvedOutputPath` specified in instructions. If it is a glob pattern, choose the concrete file path using the schema instruction and workspace planning context
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Run `/opsx:continue` to create the next artifact"
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,172 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/ff.md
+++ b/.claude/commands/opsx/ff.md
@@ -1,0 +1,98 @@
+---
+name: "OPSX: Fast Forward"
+description: Create a change and generate all artifacts needed for implementation in one go
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation.
+
+**Input**: The argument after `/opsx:ff` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/new.md
+++ b/.claude/commands/opsx/new.md
@@ -1,0 +1,69 @@
+---
+name: "OPSX: New"
+description: Start a new change using the experimental artifact workflow (OPSX)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The argument after `/opsx:new` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change in the planning home resolved by the CLI.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Use the returned `planningHome`, `changeRoot`, `artifactPaths`, and `nextSteps` instead of assuming repo-local paths.
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Run `/opsx:continue` or just describe what this change is about and I'll draft it."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest using `/opsx:continue` instead
+- Pass --schema if using a non-default workflow

--- a/.claude/commands/opsx/onboard.md
+++ b/.claude/commands/opsx/onboard.md
@@ -1,0 +1,548 @@
+---
+name: "OPSX: Onboard"
+description: Guided onboarding - walk through a complete OpenSpec workflow cycle with narration
+category: Workflow
+tags: [workflow, onboarding, tutorial, learning]
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if the OpenSpec CLI is installed:
+
+```bash
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
+```
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
+
+Stop here if not installed.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+# Unix/macOS
+git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives at the `changeRoot` reported by `openspec status --change "<name>" --json` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: <changeRoot from status JSON>
+
+The folder structure:
+```
+<changeRoot>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to the `resolvedOutputPath` from `openspec instructions proposal --change "<name>" --json`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Resolve where the spec file should be created:
+```bash
+openspec instructions specs --change "<name>" --json
+# Use resolvedOutputPath from the JSON. If it is a glob, choose the concrete file path using the schema instruction and workspace planning context.
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to the concrete file path chosen from `resolvedOutputPath`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to the `resolvedOutputPath` from `openspec instructions design --change "<name>" --json`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to the `resolvedOutputPath` from `openspec instructions tasks --change "<name>" --json`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. The archive path is derived from `planningHome.changesDir` and the date.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `<planningHome.changesDir>/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
+
+---
+
+## What's Next?
+
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at the `changeRoot` reported by `openspec status --change "<name>" --json`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+**Core workflow:**
+
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,143 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/commands/opsx/verify.md
+++ b/.claude/commands/opsx/verify.md
@@ -1,0 +1,167 @@
+---
+name: "OPSX: Verify"
+description: Verify implementation matches change artifacts before archiving
+category: Workflow
+tags: [workflow, verify, experimental]
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name after `/opsx:verify` (e.g., `/opsx:verify add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - Which artifacts exist for this change
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that full workspace implementation verification is not supported in this slice and STOP. Do not infer repo-local implementation ownership or edit linked repos.
+
+3. **Get planning context and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If `contextFiles.tasks` exists, read every file path in it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `contextFiles.specs`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If `contextFiles.design` exists:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,8 @@ scripts/generic/substitutions.txt
 # session transcripts, and project memory). Untracked but present in working
 # checkouts; ignored so a stray `git add` can't leak them into the public repo.
 .omc/
-.claude/
+# Ignore everything under .claude/ EXCEPT shared tooling that should travel with
+# the repo (OpenSpec's /opsx: commands). settings.local.json, skills/, and
+# worktrees/ (machine paths) stay ignored.
+.claude/*
+!.claude/commands/

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ the repo root). The only required one is the vault path.
 | `KB_MCP_DISABLE_MEDIA_EXTRACTION` | `1` skips server-side OCR/ASR/PDF/office extraction. |
 | `KB_MCP_DISABLE_CLIP` | `1` disables CLIP visual image search. |
 | `KB_MCP_CLIP_DEVICE` | `cpu`/`cuda` override for CLIP (defaults to CPU when ASR is active). |
+| `KB_MCP_DIARIZE` | Set to enable opt-in ASR speaker diarization (`[Speaker A]: …` turns). |
+| `KB_MCP_VOICE_DEVICE` | `cpu`/`cuda` override for the ECAPA voice embedder (defaults to CPU when ASR is active). |
+| `KB_MCP_VOICE_EMBED_MODEL` | ECAPA checkpoint for named-speaker attribution (default `speechbrain/spkrec-ecapa-voxceleb`). |
 | `KB_MCP_WHISPER_MODEL` | Whisper model size for ASR (e.g. `base`, `small`, `large-v3`). |
 | `KB_MCP_TESSERACT_CMD` | Path to the `tesseract` binary if not auto-discovered. |
 | `KB_MCP_DUP_THRESHOLD` | Near-duplicate cosine-warning threshold (default `0.90`). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -275,6 +275,20 @@ CLIP visual search runs CLIP on **CPU when ASR is active** (whisper's cu12 cuDNN
 PATH-prepend otherwise shadows torch's cuDNN and breaks CLIP's Conv2d). Override
 with `KB_MCP_CLIP_DEVICE=cuda`/`cpu` if needed.
 
+Named-speaker diarization's ECAPA voice embedder (`diarization` extra) runs on
+torch and follows the same precedent: it defaults to **CPU when ASR is active**, with
+a `KB_MCP_VOICE_DEVICE=cuda`/`cpu` override. Enroll voices with
+`kb-mcp enroll-speaker --name <name> [--self] <sample.wav>` (profiles live in a local
+`.voice_profiles.json` beside the embedding sidecar; `list-speakers` / `remove-speaker`
+manage them). With ≥1 profile enrolled and `KB_MCP_DIARIZE` set, matched clusters render
+as `[<name>]: …`; unknown voices stay anonymous. The ECAPA checkpoint
+(`speechbrain/spkrec-ecapa-voxceleb`, override `KB_MCP_VOICE_EMBED_MODEL`) is gated like
+pyannote's — set `HUGGINGFACE_TOKEN`. Attribution thresholds are tunable via
+`KB_MCP_VOICE_MARGIN`, `KB_MCP_VOICE_MERGE_THRESHOLD`, `KB_MCP_VOICE_CONFIDENT_DELTA`, and
+`KB_MCP_VOICE_REL_GAP` (defaults match the shipped evidence-based values). The whole path is
+default-off + soft-fail: with no profiles or the dep absent it degrades to today's anonymous
+`[Speaker A]: …` output.
+
 ## Revoke access
 
 Pick the strongest option that fits the situation:

--- a/openspec/changes/add-named-speaker-diarization/design.md
+++ b/openspec/changes/add-named-speaker-diarization/design.md
@@ -1,0 +1,88 @@
+# Design — Named-speaker diarization
+
+## Context
+
+kb-mcp already has anonymous diarization (`extract._diarize`: pyannote
+`speaker-diarization-3.1` → per-segment max-overlap label → `[Speaker A]:` turns,
+gated by `KB_MCP_DIARIZE`, soft-fail to plain transcript). What it lacks is the step
+from `SPEAKER_00` to **a name**. Q solves exactly this in production; this change ports
+Q's portable core and adapts its storage to a vault.
+
+## Goals / non-goals
+
+- **Goal:** diarized transcripts carry enrolled names (`[Hugo]: …`) and stay anonymous
+  (`[Speaker A]: …`) for unknown voices; names are BM25-findable in the transcript + the
+  structured `speakers:` field.
+- **Goal:** stay pure-substrate; default-off; soft-fail; zero change when unused.
+- **Non-goal:** Q's full eval harness, cross-corpus clustering, a `find` speaker filter,
+  MCP-tool enrollment. (Future changes.)
+
+## Pure-substrate justification
+
+ECAPA voice embedding is a frozen, deterministic function audio→vector (same class as
+bge/CLIP/Whisper). Attribution is a fixed cosine comparison against an enrolled centroid
+with deterministic thresholds — a *measurement*, not a judgment, and not an LLM. The human
+decides who to enroll (a brain act, done once via CLI); the server only measures "this
+cluster's voiceprint is within τ of the Hugo centroid." In-bounds.
+
+## Architecture (port-from-Q, adapted)
+
+Pipeline per media file when `KB_MCP_DIARIZE` is set AND ≥1 profile is enrolled:
+
+1. **Diarize** (existing): pyannote → anonymous `Turn(start, end, speaker)` list.
+2. **Embed clusters** (new): for each anonymous cluster, sample its spans and compute a
+   speechbrain **ECAPA** (192-dim) centroid via `voice_embed.embed_spans(audio, spans)`.
+   TF32 disabled for parity (`torch.backends.cuda.matmul.allow_tf32 = False`).
+3. **Merge over-split** (new, ported): average-linkage agglomerative merge of clusters
+   whose centroids are within `merge_threshold` (0.50 cosine) — recovers true speaker
+   count when pyannote over-splits one voice.
+4. **Attribute** (new, ported `speaker_attribution.attribute_clusters`): cosine each merged
+   centroid against each profile; assign the profile name iff
+   `score ≥ profile.threshold` AND `score − second_best ≥ margin` AND
+   (`score ≥ threshold + confident_delta` OR `score − other_groups_best ≥ rel_gap`).
+   Unmatched → stable `Speaker A/B…` by first-onset order.
+5. **Assign + render** (existing + ported `speaker_assignment.assign_span` max-overlap):
+   relabel each ASR segment with its turn's resolved label; collapse consecutive
+   same-label segments → `[<label>]: text` turns + structured `speakers:` field.
+
+Threshold defaults (from Q's evidence): `merge_threshold=0.50`, `margin=0.05`,
+`confident_delta=0.15`, `rel_gap=0.10`, default per-profile `threshold=0.40`. All overridable
+via `KB_MCP_VOICE_*` env vars.
+
+## Decisions
+
+- **Profile store = local JSON, not sqlite, not the vault content.** Few speakers (owner +
+  a handful), human-inspectable, trivially backed up. Path: `<embeddings-sidecar-dir>/
+  voice_profiles.json` (operational infra beside the embedding sidecar — NOT under the
+  vault's note trees, NOT a queryable markdown sidecar; consistent with the "no sidecar on
+  notes" rule which is about *note metadata*, not server infra). Schema:
+  `{ "<name>": {"centroid": [192 floats], "threshold": 0.40, "samples": int, "is_self": bool,
+  "updated": iso8601} }`.
+- **Enrollment = CLI, not MCP tool.** Enrolling a voice is a desk-side admin act on a local
+  audio file, not a vault-content write — it fits the `python -m kb_mcp` CLI (beside
+  `install-hook`/`install-skill`), not the connector tool surface. A profile can be enrolled
+  from multiple samples (averaged centroid; `samples` counts them). `--self` sets `is_self`.
+- **Ported logic is pure-NumPy + unit-tested first.** `speaker_attribution.py` and
+  `speaker_assignment.py` carry no torch and are the TDD anchor (deterministic thresholds,
+  overlap math) — mirrors Q's torch-free `backend/scripts/common/` modules.
+- **GPU device follows the CLIP precedent.** ECAPA via speechbrain uses torch's cuDNN; when
+  whisper's cuDNN-12 PATH-prepend is active it can shadow torch's cuDNN-13 (the bug that
+  broke CLIP). So ECAPA gets a `_voice_device()` that returns CPU when ASR/whisper is active,
+  with `KB_MCP_VOICE_DEVICE` override — exactly the CLIP fix.
+- **Soft-fail everywhere.** Missing `speechbrain`/model/GPU, an embedding error, or zero
+  profiles → fall through to today's anonymous diarization (or plain transcript). Never raises.
+
+## Data flow through the sidecar
+
+`extract._diarize` already returns `(labeled_text, speakers)`; `speakers` entries gain a
+resolved `speaker` name where matched. `media_worker._run_extraction` →
+`preserve.update_sidecar_*` persist the named turns unchanged in shape — names just become
+real strings instead of `Speaker A`. No sidecar schema migration.
+
+## Risks
+
+- Gated HF models (pyannote, and speechbrain's ECAPA if gated) need `HUGGINGFACE_TOKEN` on
+  the box — same as existing diarization; documented.
+- Short/cross-talk clusters embed poorly → low confidence → stays anonymous (correct
+  failure mode: never *mis*-name, prefer `Speaker A`).
+- First-run ECAPA download adds startup latency on first diarized file only (lazy singleton).

--- a/openspec/changes/add-named-speaker-diarization/proposal.md
+++ b/openspec/changes/add-named-speaker-diarization/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+kb-mcp's opt-in ASR diarization (`KB_MCP_DIARIZE`) labels who-spoke-when but only
+*anonymously*: `[Speaker A]: …`, `[Speaker B]: …`. For a personal vault the high-value
+question is "what did **I** say in that meeting?" vs the other person — which anonymous
+labels can't answer and `find` can't target. Q already runs a production speaker pipeline
+that resolves anonymous clusters to **named** speakers via voice-embedding profiles. This
+change ports that approach into kb-mcp — adapted to a vault (no DB; a small local profile
+store) — so diarized transcripts carry real names and become findable by speaker.
+
+It stays **pure-substrate**: voice-embedding speaker-ID is deterministic *measurement*
+(ECAPA embedding + cosine match against an enrolled centroid), the same class as ASR/OCR/
+CLIP — not a reasoning LLM, no judgment.
+
+## What Changes
+
+- **Voice-embedding speaker attribution** on top of the existing pyannote diarization:
+  per anonymous cluster, compute a speechbrain **ECAPA** (192-dim) centroid, match it
+  against enrolled **voice profiles** by cosine with margin/threshold rules (ported from
+  Q), and relabel matched clusters with the profile name. Unmatched clusters keep stable
+  anonymous labels (`Speaker A/B…`).
+- A small local **voice-profile store** (JSON; operational infra — NOT note metadata, NOT
+  a queryable markdown sidecar) mapping `name → {centroid, threshold, samples, is_self}`.
+- A **CLI enrollment** path: `python -m kb_mcp enroll-speaker --name <N> [--self] <audio>`
+  — extract an ECAPA centroid from a voice sample and persist a profile. `--self` marks the
+  vault owner (the "what did I say" primary case). Companion `list-speakers` / `remove-speaker`.
+- Bake in Q's hard-won correctness lessons: **TF32-disabled** ECAPA inference for embedding
+  parity, **average-linkage** over-split cluster merge, **max-overlap** segment→turn
+  assignment (port the pure-NumPy `speaker_attribution` + `speaker_assignment` modules).
+- New dependency `speechbrain` added to the existing `diarization` extra. Gated pyannote
+  weights continue to honor `HUGGINGFACE_TOKEN`.
+
+Out of scope (future changes): a `speaker:` filter on `find`; a full cpWER/DER eval harness
+(Q-grade); auto-enrollment / cross-corpus speaker clustering; MCP-tool enrollment (CLI only
+for now); the broader engraph-style CLI/REST surface standardization (its own change).
+
+## Capabilities
+
+### New Capabilities
+- `speaker-diarization`: named-speaker attribution for diarized media via local
+  voice-embedding profiles — default-off, soft-fail, pure-substrate (measurement only).
+
+## Impact
+
+- Code: `src/kb_mcp/extract.py` (attribution hook in `_diarize`); new
+  `src/kb_mcp/voice_profiles.py` (store), `src/kb_mcp/speaker_attribution.py` +
+  `src/kb_mcp/speaker_assignment.py` (ported pure-NumPy logic), `src/kb_mcp/enroll_speaker.py`
+  + a subcommand in `src/kb_mcp/__main__.py`; `media_worker.py` + `preserve.py` carry names
+  through the extracted sidecar.
+- Deps: `speechbrain` in the `diarization` extra; ECAPA model (~80–150 MB) downloads from HF
+  at first use on the GPU box (same pattern as bge/whisper/CLIP).
+- Default-off ⇒ zero behavior change when `KB_MCP_DIARIZE` is unset OR no profiles are
+  enrolled — output is byte-identical to today's anonymous diarization.
+- GPU: ECAPA runs on GPU but is subject to the same whisper-cuDNN-shadow gotcha as CLIP —
+  it falls back to CPU under that condition (`KB_MCP_VOICE_DEVICE` override), soft-fail.

--- a/openspec/changes/add-named-speaker-diarization/specs/speaker-diarization/spec.md
+++ b/openspec/changes/add-named-speaker-diarization/specs/speaker-diarization/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Named-Speaker Attribution via Voice Profiles
+
+The system SHALL resolve anonymous diarization clusters to enrolled speaker names when ASR
+diarization is enabled (`KB_MCP_DIARIZE`) and at least one voice profile is enrolled — by
+computing a per-cluster ECAPA voice embedding and matching it against profile centroids by
+cosine similarity. A cluster SHALL be assigned a profile name only when the match clears the
+configured threshold, margin, and standout rules; otherwise it SHALL remain anonymous.
+
+#### Scenario: Enrolled speaker is named in the transcript
+
+- **WHEN** a media file is diarized for a vault with an enrolled profile "Hugo" and a cluster's
+  ECAPA centroid matches the Hugo centroid above threshold and margin
+- **THEN** that cluster's turns are rendered as `[Hugo]: …` in the transcript text
+- **AND** the structured `speakers` field carries `speaker: "Hugo"` for those turns
+
+#### Scenario: Unknown voice stays anonymous
+
+- **WHEN** a cluster's centroid does not clear any profile's threshold/margin/standout rules
+- **THEN** the cluster is labeled with a stable anonymous label (`Speaker A`, `Speaker B`, … by
+  first-onset order)
+- **AND** no profile name is applied to it
+
+#### Scenario: Over-split single speaker is merged before attribution
+
+- **WHEN** pyannote splits one speaker into two clusters whose centroids are within the merge
+  threshold
+- **THEN** the two clusters are merged via average-linkage before attribution
+- **AND** a single profile can label the merged group
+
+### Requirement: Default-Off and Anonymous Fallback
+
+The capability SHALL change no behavior unless `KB_MCP_DIARIZE` is set AND at least one profile
+is enrolled. With diarization disabled, or enabled with zero enrolled profiles, the system
+SHALL produce output byte-identical to the current anonymous diarization (or plain transcript).
+
+#### Scenario: No profiles enrolled
+
+- **WHEN** `KB_MCP_DIARIZE` is set but no voice profiles are enrolled
+- **THEN** diarization runs exactly as today, emitting anonymous `[Speaker A]: …` turns
+- **AND** no voice-embedding model is loaded
+
+#### Scenario: Diarization disabled
+
+- **WHEN** `KB_MCP_DIARIZE` is unset
+- **THEN** extraction emits the plain transcript with no diarization and no profile lookup
+
+### Requirement: Soft-Fail Degradation
+
+The named-attribution path SHALL soft-fail. Any failure — a missing `speechbrain`
+dependency, an unloadable ECAPA model, a GPU/cuDNN error, or an inference exception — SHALL
+be logged and degrade to the existing anonymous diarization (or plain transcript). The
+transcript extraction MUST still complete successfully; the path MUST NOT raise.
+
+#### Scenario: Voice-embedding dependency absent
+
+- **WHEN** the `[diarization]` extra's `speechbrain` is not importable
+- **THEN** the failure is logged once and diarization proceeds anonymously
+- **AND** transcript extraction completes normally
+
+#### Scenario: Embedding inference fails on GPU
+
+- **WHEN** ECAPA inference raises (e.g. a cuDNN shadow or OOM)
+- **THEN** the error is logged and the file's clusters stay anonymous
+- **AND** the transcript and its other extracted fields are persisted unchanged
+
+### Requirement: Local Voice-Profile Store
+
+Voice profiles SHALL be persisted in a single local JSON store that is operational
+infrastructure beside the embedding sidecar — NOT under the vault's note trees, NOT a
+queryable markdown sidecar, and never indexed by `find`. Each profile SHALL record its name,
+a 192-dim ECAPA centroid, a per-profile threshold, a sample count, and an `is_self` flag.
+
+#### Scenario: Profile persisted outside vault content
+
+- **WHEN** a speaker is enrolled
+- **THEN** the profile is written to the JSON store in the operational sidecar directory
+- **AND** no file under the vault's `Knowledge Base/` note trees is created or modified
+
+#### Scenario: Multi-sample enrollment averages the centroid
+
+- **WHEN** the same name is enrolled from an additional audio sample
+- **THEN** the stored centroid is the running average over all samples
+- **AND** the `samples` count reflects the number of samples enrolled
+
+### Requirement: CLI Speaker Enrollment
+
+The system SHALL expose enrollment via the `python -m kb_mcp` CLI: `enroll-speaker`
+(extract an ECAPA centroid from an audio sample and persist a profile, with a `--self` flag
+for the vault owner), `list-speakers`, and `remove-speaker`. Enrollment SHALL NOT be exposed
+as an MCP connector tool.
+
+#### Scenario: Enroll the vault owner
+
+- **WHEN** `python -m kb_mcp enroll-speaker --name Hugo --self <sample.wav>` is run
+- **THEN** a profile "Hugo" with `is_self: true` and a 192-dim centroid is stored
+- **AND** `list-speakers` reports it
+
+#### Scenario: Remove a profile
+
+- **WHEN** `python -m kb_mcp remove-speaker --name Hugo` is run
+- **THEN** the "Hugo" profile is deleted from the store
+- **AND** subsequent diarization labels that voice anonymously again
+
+### Requirement: Deterministic Pure-Substrate Measurement
+
+Speaker attribution SHALL be a deterministic measurement: a frozen ECAPA embedding plus fixed
+cosine thresholds, with no generative or reasoning model in the path. To preserve embedding
+parity the implementation SHALL disable TF32 for voice-embedding inference. The system SHALL
+prefer leaving a cluster anonymous over assigning an uncertain name (never mis-name).
+
+#### Scenario: Deterministic labeling
+
+- **WHEN** the same audio and the same profile store are processed twice
+- **THEN** the resolved speaker labels are identical across runs
+
+#### Scenario: Ambiguous match prefers anonymity
+
+- **WHEN** a cluster is near two profiles' centroids within the margin (ambiguous)
+- **THEN** no name is assigned and the cluster stays anonymous

--- a/openspec/changes/add-named-speaker-diarization/tasks.md
+++ b/openspec/changes/add-named-speaker-diarization/tasks.md
@@ -20,39 +20,48 @@
       store location is NOT under the vault note trees, corrupt/missing file → empty store.
 
 ## 3. Voice embedding (soft-fail seam)
-- [ ] 3.1 Add `src/kb_mcp/voice_embed.py`: lazy speechbrain ECAPA singleton;
+- [x] 3.1 Add `src/kb_mcp/voice_embed.py`: lazy speechbrain ECAPA singleton;
       `embed_spans(audio_path, spans) -> np.ndarray (192,)`; TF32 disabled; `_voice_device()`
       returns CPU when ASR/whisper active (CLIP precedent) with `KB_MCP_VOICE_DEVICE` override;
       soft-import seam so a box without `speechbrain` raises ImportError caught upstream.
-- [ ] 3.2 Tests with the model patched: device selection, TF32 disabled, ImportError → None.
+- [x] 3.2 Tests with the model patched: device selection, TF32 disabled, ImportError → None.
 
 ## 4. Wire attribution into extraction
-- [ ] 4.1 In `extract._diarize`: after anonymous turns, when ≥1 profile enrolled, embed clusters
+- [x] 4.1 In `extract._diarize`: after anonymous turns, when ≥1 profile enrolled, embed clusters
       → merge → `attribute_clusters` → relabel via `assign_span`; render `[<name>]: …` +
       structured `speakers` names. Guard: no profiles OR soft-fail → today's anonymous output.
-- [ ] 4.2 Ensure `media_worker._run_extraction` + `preserve.update_sidecar_*` carry resolved
+- [x] 4.2 Ensure `media_worker._run_extraction` + `preserve.update_sidecar_*` carry resolved
       names through unchanged (no sidecar schema change).
-- [ ] 4.3 Tests `tests/test_diarize_named.py` (pyannote + ECAPA patched): enrolled→named,
+- [x] 4.3 Tests `tests/test_diarize_named.py` (pyannote + ECAPA patched): enrolled→named,
       unknown→anonymous, no-profiles→byte-identical to anonymous, soft-fail→anonymous.
 
 ## 5. CLI enrollment
-- [ ] 5.1 Add `src/kb_mcp/enroll_speaker.py` + register `enroll-speaker`/`list-speakers`/
+- [x] 5.1 Add `src/kb_mcp/enroll_speaker.py` + register `enroll-speaker`/`list-speakers`/
       `remove-speaker` subcommands in `src/kb_mcp/__main__.py` (beside install-hook/skill).
       `--self` sets is_self; enroll averages across repeated `--name`.
-- [ ] 5.2 Tests `tests/test_enroll_speaker_cli.py` (embedder patched): enroll writes a profile,
+- [x] 5.2 Tests `tests/test_enroll_speaker_cli.py` (embedder patched): enroll writes a profile,
       `--self` flag, list/remove round-trip.
 
 ## 6. Deps + docs
-- [ ] 6.1 Add `speechbrain>=1.0` to the `diarization` extra in `pyproject.toml`; note the ECAPA
+- [x] 6.1 Add `speechbrain>=1.0` to the `diarization` extra in `pyproject.toml`; note the ECAPA
       model + `HUGGINGFACE_TOKEN` in the extra's comment.
-- [ ] 6.2 Update the SKILL/scaffold media docs to mention named speakers (generic; leak-guard
-      green) and `KB_MCP_VOICE_*` env vars in the deployment/README notes. Keep scaffold generic.
+- [x] 6.2 `KB_MCP_VOICE_*` env vars + enrollment documented in `docs/deployment.md` + the README
+      env table. (SKILL/scaffold media-doc copy is handled separately — scaffold left untouched.)
 
 ## 7. Verify
-- [ ] 7.1 `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q` green
+- [x] 7.1 `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 python -m pytest -q` green — 748 passed
       (full suite, no regression).
-- [ ] 7.2 `ruff check` clean.
+- [x] 7.2 `ruff check` clean (no new errors; pre-existing advisory baseline untouched).
 - [ ] 7.3 Desk-side smoke (GPU box): enroll own voice from a sample, diarize a 2-speaker
       recording, confirm `[<name>]:` for the enrolled voice + anonymous for the other, and
-      that the transcript is findable by the enrolled name.
-- [ ] 7.4 `openspec validate add-named-speaker-diarization --strict` passes.
+      that the transcript is findable by the enrolled name. **(Hugo runs — needs GPU + models.)**
+- [x] 7.4 `openspec validate add-named-speaker-diarization --strict` passes.
+
+## 8. Follow-ups (post-merge, non-blocking)
+- [ ] 8.1 `voice_embed.embed_clusters(audio_path, spans_by_cluster)` that decodes the audio ONCE
+      and slices per cluster (today `_resolve_named_labels` calls `embed_spans` per cluster →
+      one decode per speaker). Pure perf; off the request path. (code-review MEDIUM #2.)
+- [ ] 8.2 Wire diarization's `assign_span` was done in review; the `speaker_assignment` module is
+      now load-bearing. (Resolved — code-review MEDIUM #1.)
+- [ ] 8.3 Mirror the named-speaker capability into the canonical `_Schema/` SKILL + scaffold media
+      docs (kept generic; leak-guard) — deferred per the scaffold-edit policy.

--- a/openspec/changes/add-named-speaker-diarization/tasks.md
+++ b/openspec/changes/add-named-speaker-diarization/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — Named-speaker diarization
+
+## 1. Ported pure-NumPy core (TDD first — no torch)
+- [ ] 1.1 Add `src/kb_mcp/speaker_attribution.py`: `attribute_clusters(cluster_embeddings,
+      first_onset, profiles, *, margin=0.05, merge_threshold=0.50, confident_delta=0.15,
+      rel_gap=0.10) -> dict[cluster_id, Attribution]` (port from Q; cosine + margin/standout
+      rules; unmatched → stable `Speaker A/B…` by first-onset order).
+- [ ] 1.2 Add `src/kb_mcp/speaker_assignment.py`: `assign_span(start, end, turns) -> label|None`
+      (max-overlap, earliest-turn tiebreak) + average-linkage cluster merge helper.
+- [ ] 1.3 Unit tests `tests/test_speaker_attribution.py` + `tests/test_speaker_assignment.py`:
+      threshold/margin/standout table, ambiguous→anonymous, over-split merge, max-overlap +
+      tiebreak, determinism. All torch-free, run under the default test env.
+
+## 2. Voice-profile store
+- [ ] 2.1 Add `src/kb_mcp/voice_profiles.py`: JSON store at the operational sidecar dir
+      (`load_profiles()`, `save_profile(name, centroid, *, threshold, is_self)`,
+      `remove_profile(name)`, `list_profiles()`); multi-sample running-average centroid;
+      schema `{name: {centroid, threshold, samples, is_self, updated}}`.
+- [ ] 2.2 Tests `tests/test_voice_profiles.py`: create/list/remove, multi-sample averaging,
+      store location is NOT under the vault note trees, corrupt/missing file → empty store.
+
+## 3. Voice embedding (soft-fail seam)
+- [ ] 3.1 Add `src/kb_mcp/voice_embed.py`: lazy speechbrain ECAPA singleton;
+      `embed_spans(audio_path, spans) -> np.ndarray (192,)`; TF32 disabled; `_voice_device()`
+      returns CPU when ASR/whisper active (CLIP precedent) with `KB_MCP_VOICE_DEVICE` override;
+      soft-import seam so a box without `speechbrain` raises ImportError caught upstream.
+- [ ] 3.2 Tests with the model patched: device selection, TF32 disabled, ImportError → None.
+
+## 4. Wire attribution into extraction
+- [ ] 4.1 In `extract._diarize`: after anonymous turns, when ≥1 profile enrolled, embed clusters
+      → merge → `attribute_clusters` → relabel via `assign_span`; render `[<name>]: …` +
+      structured `speakers` names. Guard: no profiles OR soft-fail → today's anonymous output.
+- [ ] 4.2 Ensure `media_worker._run_extraction` + `preserve.update_sidecar_*` carry resolved
+      names through unchanged (no sidecar schema change).
+- [ ] 4.3 Tests `tests/test_diarize_named.py` (pyannote + ECAPA patched): enrolled→named,
+      unknown→anonymous, no-profiles→byte-identical to anonymous, soft-fail→anonymous.
+
+## 5. CLI enrollment
+- [ ] 5.1 Add `src/kb_mcp/enroll_speaker.py` + register `enroll-speaker`/`list-speakers`/
+      `remove-speaker` subcommands in `src/kb_mcp/__main__.py` (beside install-hook/skill).
+      `--self` sets is_self; enroll averages across repeated `--name`.
+- [ ] 5.2 Tests `tests/test_enroll_speaker_cli.py` (embedder patched): enroll writes a profile,
+      `--self` flag, list/remove round-trip.
+
+## 6. Deps + docs
+- [ ] 6.1 Add `speechbrain>=1.0` to the `diarization` extra in `pyproject.toml`; note the ECAPA
+      model + `HUGGINGFACE_TOKEN` in the extra's comment.
+- [ ] 6.2 Update the SKILL/scaffold media docs to mention named speakers (generic; leak-guard
+      green) and `KB_MCP_VOICE_*` env vars in the deployment/README notes. Keep scaffold generic.
+
+## 7. Verify
+- [ ] 7.1 `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q` green
+      (full suite, no regression).
+- [ ] 7.2 `ruff check` clean.
+- [ ] 7.3 Desk-side smoke (GPU box): enroll own voice from a sample, diarize a 2-speaker
+      recording, confirm `[<name>]:` for the enrolled voice + anonymous for the other, and
+      that the transcript is findable by the enrolled name.
+- [ ] 7.4 `openspec validate add-named-speaker-diarization --strict` passes.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,36 @@
+schema: spec-driven
+
+context: |
+  kb-mcp — a Model Context Protocol server over an Obsidian/markdown vault. It turns the
+  vault you already own into a multimodal, hybrid-search knowledge base for Claude.
+
+  Tech stack: Python 3.11+, FastMCP, sqlite (embeddings sidecar). Hybrid retrieval =
+  BM25 + bge-base-en-v1.5 (768d, GPU) + wikilink graph + bge-reranker, fused via RRF.
+  Multimodal extraction is server-side: Tesseract OCR, faster-whisper ASR, CLIP visual
+  search, MarkItDown for office docs. Optional extras: embeddings, media, diarization,
+  vision. NSSM-managed Windows service; GitHub OAuth proxy; cloudflared tunnel.
+
+  THE CORE CONSTRAINT — "pure substrate": the server MEASURES, the brain (Claude/Max)
+  REASONS. Deterministic transduction (ASR, OCR, embeddings, CLIP, frozen captioners,
+  voice-embedding speaker-ID) is "measurement" and is IN bounds. A server-side reasoning
+  LLM is NEVER added. No confidence/authority floats on notes. Epistemic surfaces
+  (conflict, staleness) MEASURE and SURFACE for review; they never auto-decay or rank.
+
+  Surface consistency (engraph/Endstate-style): every core operation should be reachable
+  consistently across the MCP tools, the CLI (`python -m kb_mcp <cmd>`), and the personal
+  REST facade (`/api/<tool>`), all over the SAME leaf functions — one documented contract,
+  zero logic duplication.
+
+  Test: `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 python -m pytest -q` (run via `uv run`).
+  Lint: `ruff check`. Keep the suite green; torch-backed semantic tests run desk-side.
+
+  The skill scaffold under `src/kb_mcp/_scaffold/` is hand-authored + leak-guarded
+  (tests/test_scaffold_no_leak.py) — keep it generic; no personal/brand tokens anywhere
+  under `src/kb_mcp/`.
+
+rules:
+  proposal:
+    - State default-off + soft-fail behavior explicitly for any optional/heavy capability.
+    - Name the pure-substrate justification when a capability runs a model.
+  tasks:
+    - TDD order: pure-logic unit tests before wiring; torch/model paths behind soft-fail seams.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,16 @@ media = [
     "nvidia-cuda-runtime-cu12; sys_platform == 'win32'",
 ]
 # Opt-in ASR speaker diarization (KB_MCP_DIARIZE). A pretrained pyannote clustering
-# model labels who-spoke-when so transcripts carry `[Speaker A]: …` turns. Heavy +
-# default-OFF + soft-fail, so it's an extra, never a core dep — the base install and
-# the test suite never require it. pyannote gates its weights behind a HF token
-# (HUGGINGFACE_TOKEN). Full install: `uv sync --extra media --extra diarization`.
+# model labels who-spoke-when so transcripts carry `[Speaker A]: …` turns; with voice
+# profiles enrolled (`kb-mcp enroll-speaker`), a frozen speechbrain ECAPA voiceprint
+# (`speechbrain/spkrec-ecapa-voxceleb`, override KB_MCP_VOICE_EMBED_MODEL) resolves matched
+# clusters to enrolled names (`[Alice]: …`) by deterministic cosine — measurement, not a brain.
+# Heavy + default-OFF + soft-fail, so it's an extra, never a core dep — the base install and
+# the test suite never require it. Both pyannote and the ECAPA checkpoint gate their weights
+# behind a HF token (HUGGINGFACE_TOKEN). Full install: `uv sync --extra media --extra diarization`.
 diarization = [
     "pyannote.audio>=3.1",
+    "speechbrain>=1.0",  # ECAPA-TDNN speaker embeddings for named-speaker attribution
 ]
 # Opt-in vision captioning (KB_MCP_VISION_CAPTION). A FROZEN image-caption model
 # (BLIP/Florence-2 class, run via transformers) prepends a one-line description to an

--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -6,6 +6,8 @@ Subcommands:
 - `install-skill` — install the knowledge-base skill into Claude Code
 - `install-hook` — wire the KB capture + retrieval hooks into Claude Code
 - `backfill-media` — make pre-existing Evidence binaries searchable (sidecar + OCR/ASR/PDF + CLIP)
+- `enroll-speaker` / `list-speakers` / `remove-speaker` — manage named-speaker voice profiles
+  for opt-in diarization (desk-side admin; never an MCP tool)
 """
 
 from __future__ import annotations
@@ -28,6 +30,12 @@ def main(argv: list[str] | None = None) -> int:
         return _install_hook_main(raw[1:])
     if raw and raw[0] == "backfill-media":
         return _backfill_media_main(raw[1:])
+    if raw and raw[0] == "enroll-speaker":
+        return _enroll_speaker_main(raw[1:])
+    if raw and raw[0] == "list-speakers":
+        return _list_speakers_main(raw[1:])
+    if raw and raw[0] == "remove-speaker":
+        return _remove_speaker_main(raw[1:])
     return _serve_main(raw)
 
 
@@ -93,6 +101,109 @@ def _backfill_media_main(argv: list[str]) -> int:
         dry_run=args.dry_run,
         log_fn=print,
     )
+    return 0
+
+
+def _speaker_vault(args) -> Path | None:
+    """Vault root for the voice-profile store: --vault, else $KB_MCP_VAULT_PATH, else resolve."""
+    if args.vault:
+        return Path(args.vault).expanduser()
+    return None  # enroll_speaker resolves via KB_MCP_VAULT_PATH
+
+
+def _enroll_speaker_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp enroll-speaker",
+        description=(
+            "Enroll (or extend) a named voice profile from an audio sample for opt-in "
+            "diarization. The sample is embedded into a 192-dim ECAPA voiceprint and stored in "
+            "the per-machine profile store beside the embedding sidecar — desk-side admin, never "
+            "an MCP tool. Re-enrolling the same name running-averages the centroid over samples. "
+            'Example: kb-mcp enroll-speaker --name Alice --self alice-sample.wav'
+        ),
+    )
+    parser.add_argument("audio", help="path to an audio sample of the speaker's voice")
+    parser.add_argument("--name", required=True, help="speaker name to attach to matched clusters")
+    parser.add_argument(
+        "--self", dest="is_self", action="store_true",
+        help="mark this profile as the vault owner's own voice (is_self).",
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=None,
+        help="per-profile cosine match threshold (default 0.40). Raise for confusable voices.",
+    )
+    parser.add_argument(
+        "--vault", default=os.environ.get("KB_MCP_VAULT_PATH"),
+        help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)",
+    )
+    args = parser.parse_args(argv)
+
+    from . import enroll_speaker as enroll_module
+    from .voice_profiles import DEFAULT_THRESHOLD
+
+    try:
+        rec = enroll_module.enroll_speaker(
+            args.audio, args.name, is_self=args.is_self,
+            threshold=args.threshold if args.threshold is not None else DEFAULT_THRESHOLD,
+            vault_root=_speaker_vault(args),
+        )
+    except (enroll_module.EnrollmentError, RuntimeError) as e:
+        print(f"kb-mcp enroll-speaker: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"Enrolled {args.name!r} ({rec['samples']} sample(s), "
+        f"threshold {rec['threshold']}, is_self={rec['is_self']})."
+    )
+    return 0
+
+
+def _list_speakers_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp list-speakers",
+        description="List the enrolled voice profiles used for named diarization.",
+    )
+    parser.add_argument(
+        "--vault", default=os.environ.get("KB_MCP_VAULT_PATH"),
+        help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)",
+    )
+    args = parser.parse_args(argv)
+
+    from . import enroll_speaker as enroll_module
+
+    try:
+        profiles = enroll_module.list_speakers(_speaker_vault(args))
+    except RuntimeError as e:
+        print(f"kb-mcp list-speakers: {e}", file=sys.stderr)
+        return 1
+    if not profiles:
+        print("No voice profiles enrolled.")
+        return 0
+    for p in profiles:
+        flag = " (self)" if p["is_self"] else ""
+        print(f"  {p['name']}{flag}: {p['samples']} sample(s), threshold {p['threshold']}")
+    return 0
+
+
+def _remove_speaker_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="kb-mcp remove-speaker",
+        description="Delete an enrolled voice profile; that voice then labels anonymously again.",
+    )
+    parser.add_argument("--name", required=True, help="profile name to remove")
+    parser.add_argument(
+        "--vault", default=os.environ.get("KB_MCP_VAULT_PATH"),
+        help="vault root containing 'Knowledge Base/' (default: $KB_MCP_VAULT_PATH)",
+    )
+    args = parser.parse_args(argv)
+
+    from . import enroll_speaker as enroll_module
+
+    try:
+        removed = enroll_module.remove_speaker(args.name, _speaker_vault(args))
+    except RuntimeError as e:
+        print(f"kb-mcp remove-speaker: {e}", file=sys.stderr)
+        return 1
+    print(f"Removed {args.name!r}." if removed else f"No profile named {args.name!r}.")
     return 0
 
 

--- a/src/kb_mcp/enroll_speaker.py
+++ b/src/kb_mcp/enroll_speaker.py
@@ -1,0 +1,73 @@
+"""CLI speaker enrollment — desk-side admin, not an MCP connector tool.
+
+Enrolling a voice is a one-time local act on an audio sample (a *brain* decision about who to
+name), so it lives in `python -m kb_mcp` beside `install-hook`/`install-skill`, never on the
+tool surface a remote client sees. Each command resolves the per-machine voice-profile store
+(`voice_profiles.voice_profiles_path`) and delegates to the pure store + the ECAPA embedder:
+
+- `enroll_speaker(sample, name)` ECAPA-embeds the whole sample into a 192-dim voiceprint and
+  folds it into the profile (a repeat name running-averages the centroid; `--self` marks the
+  vault owner).
+- `list_speakers()` / `remove_speaker(name)` round-trip the store.
+
+The embedding is a frozen audio→vector measurement (no generation, no reasoning) — pure
+substrate. A model/dep failure raises `EnrollmentError` so the CLI reports it (unlike the
+server diarization path, which soft-fails to anonymous).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import voice_embed, voice_profiles
+from .vault import resolve_vault
+from .voice_profiles import DEFAULT_THRESHOLD
+
+# Single span covering the entire sample: voice_embed.embed_spans clamps the end to the audio's
+# true length, so this embeds the whole file without a separate duration probe.
+_WHOLE_SAMPLE_SPANS = [(0.0, 10 * 3600.0)]
+
+
+class EnrollmentError(RuntimeError):
+    """Enrollment could not produce a voiceprint (missing dep/model, or unreadable audio)."""
+
+
+def _store_path(vault_root: Path | None) -> Path:
+    return voice_profiles.voice_profiles_path(vault_root or resolve_vault())
+
+
+def enroll_speaker(
+    audio_path: str | Path,
+    name: str,
+    *,
+    is_self: bool = False,
+    threshold: float = DEFAULT_THRESHOLD,
+    vault_root: Path | None = None,
+) -> dict[str, Any]:
+    """Embed `audio_path` into a voiceprint and persist/extend the `name` profile.
+
+    Raises `EnrollmentError` when the sample can't be embedded (no `speechbrain`/model, or
+    undecodable audio). Returns the stored record.
+    """
+    path = Path(audio_path).expanduser()
+    if not path.is_file():
+        raise EnrollmentError(f"audio sample not found: {path}")
+    centroid = voice_embed.embed_spans(path, _WHOLE_SAMPLE_SPANS)
+    if centroid is None:
+        raise EnrollmentError(
+            f"could not compute a voiceprint for {path.name} — is the [diarization] extra "
+            f"(speechbrain) installed and the audio readable?"
+        )
+    return voice_profiles.save_profile(
+        _store_path(vault_root), name, centroid, threshold=threshold, is_self=is_self
+    )
+
+
+def list_speakers(vault_root: Path | None = None) -> list[dict[str, Any]]:
+    """Enrolled-profile summaries (no centroid), sorted by name."""
+    return voice_profiles.list_profiles(_store_path(vault_root))
+
+
+def remove_speaker(name: str, vault_root: Path | None = None) -> bool:
+    """Delete the `name` profile. Returns True if it existed."""
+    return voice_profiles.remove_profile(_store_path(vault_root), name)

--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -335,37 +335,90 @@ def _run_diarization(path: Path) -> list[tuple[float, float, str]] | None:
         return None
 
 
+def _resolve_named_labels(
+    path: Path, turns: list[tuple[float, float, str]]
+) -> dict[str, str] | None:
+    """Resolve raw diarization labels → enrolled speaker names, or None to stay anonymous.
+
+    Optional named-attribution layer over the anonymous turns (default-OFF, soft-fail). When
+    ≥1 voice profile is enrolled AND voice embedding is available, each raw cluster's spans are
+    ECAPA-embedded into a centroid and matched against the profiles by cosine
+    (`speaker_attribution.attribute_clusters`). Returns `{raw_label: display_label}` where a
+    matched cluster gets the profile name and the rest get stable `Speaker A/B…` (by first
+    onset). Returns None — falling through to today's anonymous output — when there are no
+    profiles, the embedder is unavailable, or anything fails. Never raises.
+    """
+    try:
+        from . import vault, voice_embed, voice_profiles
+        from .speaker_attribution import attribute_clusters
+
+        store_path = voice_profiles.voice_profiles_path(vault.resolve_vault())
+        profiles = voice_profiles.load_profiles(store_path)
+        if not profiles:
+            return None  # nobody enrolled → anonymous, no embedding model loaded
+
+        spans_by_label: dict[str, list[tuple[float, float]]] = {}
+        first_onset: dict[str, float] = {}
+        for t_start, t_end, raw in turns:
+            spans_by_label.setdefault(raw, []).append((t_start, t_end))
+            first_onset[raw] = min(first_onset.get(raw, float("inf")), t_start)
+
+        # NOTE: embeds per cluster (each call decodes the file once). A load-once
+        # embed_clusters() is a tracked follow-up — acceptable here since diarization is
+        # opt-in and runs off the request path in the async media worker.
+        centroids: dict[str, object] = {}
+        for raw, spans in spans_by_label.items():
+            vec = voice_embed.embed_spans(path, spans)
+            if vec is None:
+                return None  # embed soft-fail → wholly anonymous (never partially name)
+            centroids[raw] = vec
+
+        attributions = attribute_clusters(centroids, first_onset, profiles)
+        return {raw: attr.label for raw, attr in attributions.items()}
+    except Exception:  # noqa: BLE001 — attribution must never break extraction
+        log.warning("named speaker attribution failed; using anonymous diarization", exc_info=True)
+        return None
+
+
 def _diarize(
     path: Path, seg_list: list
 ) -> tuple[str, list[dict]] | None:
-    """Label ASR segments with speakers and render `[Speaker A]: …` turns.
+    """Label ASR segments with speakers and render `[Speaker A]: …` (or `[<name>]: …`) turns.
 
-    Maps each whisper segment to the diarization speaker whose turn overlaps it most,
-    relabels raw `SPEAKER_00/01/…` to first-appearance `Speaker A/B/…`, and merges
-    consecutive same-speaker segments into one turn. Returns
-    `(labeled_text, speakers)` where `speakers` is the structured turn list, or None
-    on soft-fail (no diarization output / no segments) so the caller uses the plain
-    transcript.
+    Maps each whisper segment to the diarization speaker whose turn overlaps it most, relabels
+    raw `SPEAKER_00/01/…` to first-appearance `Speaker A/B/…`, and merges consecutive
+    same-speaker segments into one turn. When voice profiles are enrolled and embedding succeeds
+    (`_resolve_named_labels`), matched clusters render with the enrolled name instead; everything
+    else (no profiles / soft-fail) is byte-identical to the anonymous output. Returns
+    `(labeled_text, speakers)` where `speakers` is the structured turn list, or None on soft-fail
+    (no diarization output / no segments) so the caller uses the plain transcript.
     """
     turns = _run_diarization(path)
     if not turns or not seg_list:
         return None
 
+    # Optional named layer: raw cluster label → enrolled name (or None → stay anonymous).
+    resolved = _resolve_named_labels(path, turns)
+
     # First-appearance map of raw pyannote labels → "Speaker A", "Speaker B", …
     label_names: dict[str, str] = {}
 
     def _name(raw: str) -> str:
+        if resolved is not None and raw in resolved:
+            return resolved[raw]
         if raw not in label_names:
             label_names[raw] = f"Speaker {chr(ord('A') + len(label_names))}"
         return label_names[raw]
 
+    # Max-overlap segment→turn assignment (earliest-start tiebreak) via the shared, unit-tested
+    # helper — keeps assignment logic in one place for both the anonymous and named paths.
+    from .speaker_assignment import Turn, assign_span
+
+    turn_objs = [Turn(t_start, t_end, raw) for t_start, t_end, raw in turns]
+
     def _speaker_for(start: float, end: float) -> str | None:
-        best_label, best_overlap = None, 0.0
-        for t_start, t_end, raw in turns:
-            overlap = min(end, t_end) - max(start, t_start)
-            if overlap > best_overlap:
-                best_overlap, best_label = overlap, raw
-        return _name(best_label) if best_label is not None else None
+        raw = assign_span(start, end, turn_objs)
+        return _name(raw) if raw is not None else None
 
     merged: list[dict] = []
     for seg in seg_list:

--- a/src/kb_mcp/speaker_assignment.py
+++ b/src/kb_mcp/speaker_assignment.py
@@ -4,7 +4,7 @@ Each transcript unit (a Whisper segment) is assigned to the turn it overlaps mos
 the earliest turn for determinism. Replaces naive midpoint assignment, which loses short turns
 and mis-attributes boundary-straddling units.
 
-Pure / torch-free (stdlib only) so it unit-tests without a GPU. Ported from Q's production
+Pure / torch-free (stdlib only) so it unit-tests without a GPU. Ported from a production
 `speaker_assignment` module; consumed by `extract._diarize` to map ASR segments → resolved
 speaker labels.
 """

--- a/src/kb_mcp/speaker_assignment.py
+++ b/src/kb_mcp/speaker_assignment.py
@@ -1,0 +1,51 @@
+"""Max-overlap assignment of transcript segments to diarization turns.
+
+Each transcript unit (a Whisper segment) is assigned to the turn it overlaps most; ties go to
+the earliest turn for determinism. Replaces naive midpoint assignment, which loses short turns
+and mis-attributes boundary-straddling units.
+
+Pure / torch-free (stdlib only) so it unit-tests without a GPU. Ported from Q's production
+`speaker_assignment` module; consumed by `extract._diarize` to map ASR segments → resolved
+speaker labels.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+
+@dataclass(frozen=True)
+class Turn:
+    start: float
+    end: float
+    label: str  # diarization cluster id or resolved speaker label
+
+
+def overlap(a0: float, a1: float, b0: float, b1: float) -> float:
+    """Length of the temporal intersection of [a0,a1] and [b0,b1] (0 if disjoint)."""
+    return max(0.0, min(a1, b1) - max(a0, b0))
+
+
+def assign_span(start: float, end: float, turns: Sequence[Turn]) -> Optional[str]:
+    """Label of the turn with the greatest overlap with [start, end]; None if none overlaps.
+
+    Ties (equal overlap) are broken toward the earliest-starting turn for determinism.
+    """
+    best_key: Optional[tuple[float, float]] = None
+    best_label: Optional[str] = None
+    for t in turns:
+        ov = overlap(start, end, t.start, t.end)
+        if ov <= 0.0:
+            continue
+        key = (ov, -t.start)  # maximize overlap, then prefer the earliest-starting turn
+        if best_key is None or key > best_key:
+            best_key = key
+            best_label = t.label
+    return best_label
+
+
+def assign_spans(
+    spans: Sequence[tuple[float, float]], turns: Sequence[Turn]
+) -> list[Optional[str]]:
+    """Assign a label to each (start, end) span by max overlap."""
+    return [assign_span(s, e, turns) for (s, e) in spans]

--- a/src/kb_mcp/speaker_attribution.py
+++ b/src/kb_mcp/speaker_attribution.py
@@ -6,8 +6,8 @@ either confidently high OR clearly standing out from other clusters) wins the na
 profile may label more than one cluster-group if a speaker is split across non-merging groups.
 Unmatched clusters become stable anonymous `Speaker A/B/…` labels by first-onset order.
 
-Pure / torch-free (numpy only) so it unit-tests without a GPU. Ported from Q's production
-`speaker_attribution` module (single-host "Chaffee vs Guest" → multi-profile), adapted to
+Pure / torch-free (numpy only) so it unit-tests without a GPU. Ported from a production
+`speaker_attribution` module (single-host host-vs-guest → multi-profile), adapted to
 kb-mcp's anonymous `Speaker A` labelling and `KB_MCP_VOICE_*` env overrides.
 
 The attribution is a deterministic *measurement* — a frozen cosine comparison against an

--- a/src/kb_mcp/speaker_attribution.py
+++ b/src/kb_mcp/speaker_attribution.py
@@ -1,0 +1,203 @@
+"""Speaker attribution: map diarized clusters → enrolled voice profiles.
+
+Each anonymous diarization cluster is matched against the set of enrolled voice profiles. The
+best match above a profile's threshold (by a margin over the cluster's second-best profile, and
+either confidently high OR clearly standing out from other clusters) wins the named label; each
+profile may label more than one cluster-group if a speaker is split across non-merging groups.
+Unmatched clusters become stable anonymous `Speaker A/B/…` labels by first-onset order.
+
+Pure / torch-free (numpy only) so it unit-tests without a GPU. Ported from Q's production
+`speaker_attribution` module (single-host "Chaffee vs Guest" → multi-profile), adapted to
+kb-mcp's anonymous `Speaker A` labelling and `KB_MCP_VOICE_*` env overrides.
+
+The attribution is a deterministic *measurement* — a frozen cosine comparison against an
+enrolled centroid with fixed thresholds — not a judgment and not an LLM. It prefers leaving a
+cluster anonymous over assigning an uncertain name (never mis-names).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Hashable, Mapping, Optional
+
+import numpy as np
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# A group's best profile must beat its second-best by at least this to be named (guards against
+# confusable enrolled speakers, e.g. two household members).
+DEFAULT_MARGIN = _env_float("KB_MCP_VOICE_MARGIN", 0.05)
+# Two clusters whose mutual cosine >= this are the SAME speaker and are merged (undoes diarizer
+# over-splitting). ECAPA cross-speaker cosine tops out ~0.4, within-speaker ~0.6+, so 0.5 keeps
+# distinct speakers apart while re-merging over-split fragments.
+DEFAULT_MERGE_THRESHOLD = _env_float("KB_MCP_VOICE_MERGE_THRESHOLD", 0.50)
+# A group is named only if it clears its profile threshold (floor) AND either scores confidently
+# (threshold + CONFIDENT_DELTA) OR clearly out-scores every other group for that profile (REL_GAP).
+DEFAULT_CONFIDENT_DELTA = _env_float("KB_MCP_VOICE_CONFIDENT_DELTA", 0.15)
+DEFAULT_REL_GAP = _env_float("KB_MCP_VOICE_REL_GAP", 0.10)
+
+
+def _anon_label(i: int) -> str:
+    """0-indexed guest order → 'Speaker A', 'Speaker B', … (matches kb-mcp's anonymous scheme)."""
+    return f"Speaker {chr(ord('A') + i)}" if i < 26 else f"Speaker {i + 1}"
+
+
+@dataclass(frozen=True)
+class Profile:
+    """An enrolled speaker: a name, a voice-embedding centroid, and a match threshold."""
+
+    name: str
+    centroid: np.ndarray
+    # Evidence-based default (from Q): named speakers scored ~0.44–0.62, others <=0.19, so 0.40
+    # cleanly separates them. Per-profile overridable.
+    threshold: float = 0.40
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """Result for one cluster: the resolved label, a confidence, and the matched profile (or None)."""
+
+    label: str
+    confidence: float
+    matched_profile: Optional[str]
+
+
+def cosine(a, b) -> float:
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    na = float(np.linalg.norm(a))
+    nb = float(np.linalg.norm(b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return float(np.dot(a.ravel(), b.ravel()) / (na * nb))
+
+
+def _group_clusters(
+    cluster_ids: list, embeddings: Mapping[Hashable, np.ndarray], merge_threshold: float
+) -> list[list]:
+    """Merge clusters that are the same speaker into groups via **average-linkage** (UPGMA).
+
+    Undoes diarizer over-splitting so attribution decides per *speaker*, not per fragment. Groups
+    merge only when their *average* pairwise cosine clears ``merge_threshold``. Average-linkage
+    (not single-linkage) prevents a weak near-threshold bridge fragment from chaining two genuinely
+    distinct speakers into one. Returns a deterministic partition of every input cluster_id.
+    """
+    n = len(cluster_ids)
+    if n == 0:
+        return []
+    if n == 1:
+        return [list(cluster_ids)]
+
+    mat = np.stack([np.asarray(embeddings[c], dtype=float).ravel() for c in cluster_ids])
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    unit = mat / np.where(norms == 0.0, 1.0, norms)
+    dist = 1.0 - np.clip(unit @ unit.T, -1.0, 1.0)
+
+    cutoff = 1.0 - merge_threshold
+    members: dict[int, list[int]] = {i: [i] for i in range(n)}
+    sizes: dict[int, int] = {i: 1 for i in range(n)}
+    gdist = dist.astype(float).copy()
+    np.fill_diagonal(gdist, np.inf)
+    live = list(range(n))  # ascending, so the lower-index slot always survives a merge
+
+    while len(live) > 1:
+        best_d, lo, hi = np.inf, -1, -1
+        for x in range(len(live)):
+            for y in range(x + 1, len(live)):
+                a, b = live[x], live[y]
+                if gdist[a, b] < best_d:
+                    best_d, lo, hi = gdist[a, b], a, b
+        if best_d > cutoff:
+            break
+        na, nb = sizes[lo], sizes[hi]
+        for c in live:
+            if c == lo or c == hi:
+                continue
+            gdist[lo, c] = gdist[c, lo] = (na * gdist[lo, c] + nb * gdist[hi, c]) / (na + nb)
+        sizes[lo] = na + nb
+        members[lo].extend(members[hi])
+        live.remove(hi)
+
+    return [
+        [cluster_ids[i] for i in sorted(members[slot])]
+        for slot in sorted(live, key=lambda s: min(members[s]))
+    ]
+
+
+def attribute_clusters(
+    cluster_embeddings: Mapping[Hashable, np.ndarray],
+    first_onset: Mapping[Hashable, float],
+    profiles: Mapping[str, Profile],
+    *,
+    margin: float = DEFAULT_MARGIN,
+    merge_threshold: float = DEFAULT_MERGE_THRESHOLD,
+    confident_delta: float = DEFAULT_CONFIDENT_DELTA,
+    rel_gap: float = DEFAULT_REL_GAP,
+) -> dict[Hashable, Attribution]:
+    """Attribute each diarized cluster to a named profile or a stable anonymous `Speaker #` label.
+
+    Clusters are first grouped into *speakers* (``merge_threshold`` on mutual cosine), then the
+    named-vs-anonymous decision is made on each group's MEAN embedding — so one unlucky high-scoring
+    fragment can't flip the call. A group is named its best profile only if it clears the floor +
+    cross-profile margin AND (scores confidently OR clearly out-scores every other group for that
+    profile). Every input cluster maps to its group's resolved label.
+    """
+    cluster_ids = list(cluster_embeddings)
+    profile_list = list(profiles.values())
+    groups = _group_clusters(cluster_ids, cluster_embeddings, merge_threshold)
+
+    # Pass 1: each speaker-group's mean embedding, per-profile cosines, and first onset.
+    group_info: list[tuple[list, dict[str, float], float]] = []
+    for members in groups:
+        gcent = np.mean(
+            np.stack([np.asarray(cluster_embeddings[c], dtype=float).ravel() for c in members]),
+            axis=0,
+        )
+        scores = {p.name: cosine(gcent, p.centroid) for p in profile_list}
+        g_onset = min((first_onset.get(c, float("inf")) for c in members), default=float("inf"))
+        group_info.append((members, scores, g_onset))
+
+    # Pass 2: decide each group RELATIVE to the others.
+    result: dict[Hashable, Attribution] = {}
+    anon_groups: list[tuple[float, list, float]] = []
+    for idx, (members, scores, g_onset) in enumerate(group_info):
+        named: Optional[tuple[str, float]] = None
+        ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+        if ranked:
+            best_name, best_score = ranked[0]
+            second_score = ranked[1][1] if len(ranked) > 1 else float("-inf")
+            threshold = profiles[best_name].threshold
+            other_best = max(
+                (group_info[j][1][best_name] for j in range(len(group_info)) if j != idx),
+                default=float("-inf"),
+            )
+            clears_floor = best_score >= threshold
+            beats_other_profiles = (best_score - second_score) >= margin
+            confident = best_score >= threshold + confident_delta
+            stands_out = (best_score - other_best) >= rel_gap
+            if clears_floor and beats_other_profiles and (confident or stands_out):
+                named = (best_name, round(best_score, 4))
+        if named is not None:
+            for c in members:
+                result[c] = Attribution(named[0], named[1], named[0])
+        else:
+            nearest = round(max(scores.values()), 4) if scores else 0.0
+            anon_groups.append((g_onset, members, nearest))
+
+    # Unmatched groups → anonymous Speaker A/B/…, enumerated by each group's first onset.
+    anon_groups.sort(key=lambda t: (t[0], str(t[1])))
+    for i, (_onset, members, nearest) in enumerate(anon_groups):
+        for c in members:
+            result[c] = Attribution(label=_anon_label(i), confidence=nearest, matched_profile=None)
+
+    return result
+
+
+def count_distinct_speakers(attributions: Mapping[Hashable, Attribution]) -> int:
+    return len({a.label for a in attributions.values()})

--- a/src/kb_mcp/voice_embed.py
+++ b/src/kb_mcp/voice_embed.py
@@ -1,0 +1,167 @@
+"""Voice embedding — speechbrain ECAPA voiceprints (deterministic transduction, not a brain).
+
+A frozen ECAPA-TDNN model (`speechbrain/spkrec-ecapa-voxceleb`) turns an audio span into a
+192-dim speaker-embedding vector — the same category of measurement as bge/CLIP/Whisper: a
+fixed audio→vector function, no reasoning, no generation. `extract._diarize` uses it to embed
+each anonymous diarization cluster so `speaker_attribution` can match it against enrolled
+profiles by cosine. Pure-substrate "measure," not "judge."
+
+Soft-import seam (mirrors `extract._load_diarization_pipeline`): a box without the
+`[diarization]` extra's `speechbrain` raises ImportError inside the lazy loader, which
+`embed_spans` catches → returns None. Every failure (missing dep, unloadable model, GPU/cuDNN
+error, inference exception, undecodable audio) degrades to None — the caller then stays
+anonymous. Never raises.
+
+Device follows the CLIP precedent (`embeddings._clip_device`): ECAPA runs on torch, whose
+cuDNN can be shadowed by faster-whisper's PATH-prepended CUDA-12 cuDNN when ASR is active —
+the bug that broke CLIP's ViT. So `_voice_device()` returns CPU whenever ASR/media extraction
+is enabled in this process, with a `KB_MCP_VOICE_DEVICE` override. TF32 is disabled before
+inference so a voiceprint computed here matches one computed elsewhere (embedding parity).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Frozen ECAPA speaker-embedding checkpoint; override for a pinned/local copy.
+VOICE_EMBED_MODEL = os.environ.get(
+    "KB_MCP_VOICE_EMBED_MODEL", "speechbrain/spkrec-ecapa-voxceleb"
+)
+# ECAPA produces 192-dim speaker embeddings.
+VOICE_EMBED_DIM = 192
+# ECAPA was trained on 16 kHz mono audio; spans are resampled to this before inference.
+_TARGET_SR = 16000
+
+_VOICE_MODEL = None  # speechbrain EncoderClassifier singleton
+_VOICE_LOCK = threading.Lock()
+
+
+def _voice_device() -> str:
+    """Device for ECAPA. Honors KB_MCP_VOICE_DEVICE; otherwise GPU only when ASR is NOT
+    running in this process, else CPU.
+
+    Same rationale as `embeddings._clip_device()`: faster-whisper's CUDA-12 cuDNN wheels get
+    PATH-prepended (extract._ensure_cuda_dll_path) so ctranslate2 can load, which then shadows
+    torch-cu132's bundled cuDNN 13 and makes torch conv/inference die with
+    CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH. Since the media worker prewarms ASR at startup,
+    having extraction enabled means PATH is already poisoned, so ECAPA must run on CPU — a small
+    model, off the request path. A box with media extraction disabled has no conflict and keeps
+    the GPU.
+    """
+    override = os.environ.get("KB_MCP_VOICE_DEVICE")
+    if override:
+        return override
+    # Mirror extract.extraction_enabled() without importing it (avoids a new module edge).
+    asr_active = not os.environ.get("KB_MCP_DISABLE_MEDIA_EXTRACTION")
+    if asr_active:
+        return "cpu"
+    try:
+        import torch
+
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
+        return "cpu"
+
+
+def _disable_tf32() -> None:
+    """Disable TF32 matmul before inference so voiceprints are bit-stable across machines.
+
+    TF32 trades mantissa bits for speed on Ampere+ GPUs; with it on, the same audio + model can
+    yield slightly different embeddings on different hardware, drifting the cosine scores that
+    attribution thresholds depend on. Embedding parity matters more than the marginal speed.
+    """
+    import torch
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.set_float32_matmul_precision("highest")
+
+
+def _load_voice_model():
+    """Lazy-import + load the pretrained ECAPA speaker-embedding model.
+
+    Soft-import seam (patched in tests): a box without the `[diarization]` extra's `speechbrain`
+    raises ImportError here, which `embed_spans` catches → None. The checkpoint is gated like
+    pyannote's, so `HUGGINGFACE_TOKEN`/`HF_TOKEN` is honored if set.
+    """
+    from speechbrain.inference.speaker import EncoderClassifier  # soft dep — only when used
+
+    device = _voice_device()
+    log.info("loading voice-embedding model %s on %s", VOICE_EMBED_MODEL, device)
+    return EncoderClassifier.from_hparams(source=VOICE_EMBED_MODEL, run_opts={"device": device})
+
+
+def _get_voice_model():
+    """Lazy singleton for the ECAPA model (one load per process)."""
+    global _VOICE_MODEL
+    if _VOICE_MODEL is not None:
+        return _VOICE_MODEL
+    with _VOICE_LOCK:
+        if _VOICE_MODEL is None:
+            _VOICE_MODEL = _load_voice_model()
+    return _VOICE_MODEL
+
+
+def _load_audio(audio_path):
+    """Load `audio_path` as a mono 16 kHz float waveform `(1, N)` torch tensor + sample rate.
+
+    Uses torchaudio (pulled in by speechbrain); absent/undecodable → the caller catches and
+    returns None. Multi-channel audio is downmixed to mono; non-16 kHz is resampled so spans
+    align with ECAPA's training rate.
+    """
+    import torchaudio
+
+    waveform, sr = torchaudio.load(str(audio_path))
+    if waveform.shape[0] > 1:
+        waveform = waveform.mean(dim=0, keepdim=True)
+    if sr != _TARGET_SR:
+        waveform = torchaudio.functional.resample(waveform, sr, _TARGET_SR)
+        sr = _TARGET_SR
+    return waveform, sr
+
+
+def embed_spans(audio_path, spans) -> np.ndarray | None:
+    """Embed the given `(start, end)` second-spans of `audio_path` → a mean 192-dim voiceprint.
+
+    Loads the audio once, slices each span, ECAPA-embeds it, and returns the mean vector over all
+    non-empty spans (float32, shape `(VOICE_EMBED_DIM,)`). Used to compute one centroid per
+    anonymous diarization cluster.
+
+    Soft-fail: returns None on ANY failure — missing `speechbrain`/torchaudio, an unloadable or
+    gated model, a GPU/cuDNN error, an inference exception, undecodable audio, or no usable
+    spans. Never raises; the caller then keeps the cluster anonymous.
+    """
+    if not spans:
+        return None
+    try:
+        model = _get_voice_model()
+    except Exception:  # noqa: BLE001 — missing dep / unloadable model → anonymous
+        log.warning("voice-embedding model unavailable; clusters stay anonymous", exc_info=True)
+        return None
+    try:
+        waveform, sr = _load_audio(audio_path)
+    except Exception:  # noqa: BLE001 — undecodable audio / torchaudio absent → anonymous
+        log.warning("voice-embedding audio load failed for %s", audio_path, exc_info=True)
+        return None
+    try:
+        _disable_tf32()
+        vectors: list[np.ndarray] = []
+        total = waveform.shape[-1]
+        for start, end in spans:
+            a = max(0, int(float(start) * sr))
+            b = min(total, int(float(end) * sr))
+            if b <= a:
+                continue
+            emb = model.encode_batch(waveform[:, a:b])
+            arr = emb.detach().cpu().numpy() if hasattr(emb, "detach") else np.asarray(emb)
+            vectors.append(np.asarray(arr, dtype=np.float32).reshape(-1))
+        if not vectors:
+            return None
+        return np.mean(np.stack(vectors), axis=0).astype(np.float32)
+    except Exception:  # noqa: BLE001 — inference / cuDNN / OOM error → anonymous
+        log.warning("voice-embedding inference failed for %s", audio_path, exc_info=True)
+        return None

--- a/src/kb_mcp/voice_profiles.py
+++ b/src/kb_mcp/voice_profiles.py
@@ -1,0 +1,124 @@
+"""Local voice-profile store — operational infra, NOT note content.
+
+Persists enrolled speaker voiceprints in a single JSON file beside the embedding sidecar
+(`<vault>/Knowledge Base/.voice_profiles.json`, dot-prefixed like `.embeddings.sqlite` /
+`.clip.sqlite`, excluded from `find`/`audit`). It is NOT a queryable markdown sidecar and is
+never indexed — it is server state, the same class as the embedding sidecar.
+
+Schema: `{ "<name>": {"centroid": [floats], "threshold": float, "samples": int,
+"is_self": bool, "updated": iso8601} }`. Enrolling the same name again folds the new sample
+into a running-average centroid.
+
+Pure (numpy + stdlib). Soft: a missing or corrupt store reads as empty (never raises on read).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from kb_mcp.speaker_attribution import Profile
+
+DEFAULT_THRESHOLD = 0.40
+
+
+def voice_profiles_path(vault_root: Path) -> Path:
+    """Per-machine voice-profile store, beside the embedding sidecars (operational infra)."""
+    return vault_root / "Knowledge Base" / ".voice_profiles.json"
+
+
+def load_store(path: Path) -> dict[str, dict[str, Any]]:
+    """Raw store dict. Missing or corrupt/unreadable file → empty dict (never raises)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return {}
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_profiles(path: Path) -> dict[str, Profile]:
+    """Store → `{name: Profile}` for `attribute_clusters`. Skips malformed entries."""
+    profiles: dict[str, Profile] = {}
+    for name, rec in load_store(path).items():
+        if not isinstance(rec, dict):
+            continue
+        centroid = rec.get("centroid")
+        if not centroid:
+            continue
+        threshold = float(rec.get("threshold", DEFAULT_THRESHOLD))
+        profiles[name] = Profile(name=name, centroid=np.asarray(centroid, dtype=float),
+                                 threshold=threshold)
+    return profiles
+
+
+def _write_store(path: Path, store: dict[str, dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def save_profile(
+    path: Path,
+    name: str,
+    centroid: np.ndarray,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    is_self: bool = False,
+) -> dict[str, Any]:
+    """Enroll/extend a profile. A repeat name folds `centroid` into the running-average centroid
+    and increments `samples`. Returns the stored record."""
+    centroid = np.asarray(centroid, dtype=float).ravel()
+    store = load_store(path)
+    existing = store.get(name)
+    if isinstance(existing, dict) and existing.get("centroid"):
+        prev = np.asarray(existing["centroid"], dtype=float).ravel()
+        n = int(existing.get("samples", 1))
+        merged = (prev * n + centroid) / (n + 1)
+        samples = n + 1
+        is_self = bool(existing.get("is_self", False) or is_self)
+        threshold = float(existing.get("threshold", threshold))
+    else:
+        merged = centroid
+        samples = 1
+    rec = {
+        "centroid": [float(x) for x in merged],
+        "threshold": float(threshold),
+        "samples": samples,
+        "is_self": bool(is_self),
+        "updated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    store[name] = rec
+    _write_store(path, store)
+    return rec
+
+
+def remove_profile(path: Path, name: str) -> bool:
+    """Delete a profile. Returns True if it existed."""
+    store = load_store(path)
+    if name in store:
+        del store[name]
+        _write_store(path, store)
+        return True
+    return False
+
+
+def list_profiles(path: Path) -> list[dict[str, Any]]:
+    """Summaries (no centroid) for the CLI, sorted by name."""
+    out = []
+    for name, rec in load_store(path).items():
+        if not isinstance(rec, dict):
+            continue
+        out.append({
+            "name": name,
+            "samples": int(rec.get("samples", 0)),
+            "is_self": bool(rec.get("is_self", False)),
+            "threshold": float(rec.get("threshold", DEFAULT_THRESHOLD)),
+            "updated": rec.get("updated"),
+        })
+    return sorted(out, key=lambda r: r["name"])

--- a/tests/test_diarize_named.py
+++ b/tests/test_diarize_named.py
@@ -1,0 +1,116 @@
+"""Named-speaker attribution wired into extract._diarize (pyannote + ECAPA patched).
+
+No real models run: `_run_diarization` is stubbed to fixed turns, `voice_embed.embed_spans` to
+fixed vectors, and the profile store / vault resolution are patched. Covers the four contract
+cases — enrolled→named, unknown→anonymous, no-profiles→byte-identical, embed-soft-fail→anonymous
+— plus that the resolved name reaches the structured `speakers` field that flows to the sidecar.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kb_mcp import extract, vault, voice_embed, voice_profiles
+from kb_mcp.speaker_attribution import Profile
+
+
+class _FakeSeg:
+    def __init__(self, text: str, start: float, end: float) -> None:
+        self.text = text
+        self.start = start
+        self.end = end
+
+
+class _FakeWhisper:
+    def __init__(self, segs: list) -> None:
+        self._segs = segs
+
+    def transcribe(self, path):  # faster-whisper returns (segments_generator, info)
+        return iter(self._segs), None
+
+
+# Orthogonal unit "voiceprints": the enrolled owner vs. two distinct unknown voices (cosine ~0,
+# so the two strangers don't merge into one anonymous cluster either).
+_OWNER = np.array([1.0, 0.0, 0.0])
+_STRANGER = np.array([0.0, 1.0, 0.0])
+_STRANGER2 = np.array([0.0, 0.0, 1.0])
+
+# Two segments diarized into two distinct raw clusters, one per second.
+_SEGS = [_FakeSeg("hello there", 0.0, 1.0), _FakeSeg("general kenobi", 1.0, 2.0)]
+_TURNS = [(0.0, 1.0, "SPEAKER_00"), (1.0, 2.0, "SPEAKER_01")]
+
+
+def _wire(monkeypatch, *, profiles, embed):
+    """Enable diarization and patch the whisper, pyannote, profile-store, and embedder seams."""
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(list(_SEGS)))
+    monkeypatch.setattr(extract, "_run_diarization", lambda p: list(_TURNS))
+    monkeypatch.setattr(vault, "resolve_vault", lambda: Path("/vault"))
+    monkeypatch.setattr(voice_profiles, "load_profiles", lambda path: dict(profiles))
+    monkeypatch.setattr(voice_embed, "embed_spans", embed)
+
+
+def test_enrolled_voice_is_named(monkeypatch: pytest.MonkeyPatch) -> None:
+    # SPEAKER_00 (starts at 0.0) is the owner; SPEAKER_01 is unknown.
+    def embed(_path, spans):
+        return _OWNER if spans[0][0] < 1.0 else _STRANGER
+
+    _wire(monkeypatch, profiles={"Alex": Profile("Alex", _OWNER)}, embed=embed)
+    r = extract._transcribe(Path("x.wav"), "audio")
+
+    assert "[Alex]: hello there" in r.text
+    assert "[Speaker A]: general kenobi" in r.text  # the unknown cluster stays anonymous
+    assert r.engine.endswith("+diarized")
+    # The resolved name reaches the structured field that media_worker → preserve persist.
+    assert [t["speaker"] for t in r.speakers] == ["Alex", "Speaker A"]
+
+
+def test_unknown_voice_stays_anonymous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Both clusters embed far from the only profile (and from each other) → two anonymous voices.
+    def embed(_path, spans):
+        return _STRANGER if spans[0][0] < 1.0 else _STRANGER2
+
+    _wire(monkeypatch, profiles={"Alex": Profile("Alex", _OWNER)}, embed=embed)
+    r = extract._transcribe(Path("x.wav"), "audio")
+
+    assert "Alex" not in r.text
+    assert "[Speaker A]: hello there" in r.text
+    assert "[Speaker B]: general kenobi" in r.text
+    assert all(t["speaker"].startswith("Speaker ") for t in r.speakers)
+
+
+def test_no_profiles_is_byte_identical_to_anonymous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Zero profiles → the named layer returns None and never loads the embedder.
+    def _must_not_embed(_p, _s):
+        raise AssertionError("embed_spans must not be called when no profiles are enrolled")
+
+    _wire(monkeypatch, profiles={}, embed=_must_not_embed)
+    r = extract._transcribe(Path("x.wav"), "audio")
+
+    assert r.text == "[Speaker A]: hello there\n[Speaker B]: general kenobi"
+    assert [t["speaker"] for t in r.speakers] == ["Speaker A", "Speaker B"]
+
+
+def test_embed_soft_fail_falls_back_to_anonymous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Embedder unavailable / errors → None → wholly anonymous (never partially named).
+    _wire(monkeypatch, profiles={"Alex": Profile("Alex", _OWNER)}, embed=lambda _p, _s: None)
+    r = extract._transcribe(Path("x.wav"), "audio")
+
+    assert r.text == "[Speaker A]: hello there\n[Speaker B]: general kenobi"
+    assert [t["speaker"] for t in r.speakers] == ["Speaker A", "Speaker B"]
+
+
+def test_resolution_failure_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # resolve_vault blowing up (e.g. KB_MCP_VAULT_PATH unset) must degrade, not crash.
+    def _boom():
+        raise RuntimeError("KB_MCP_VAULT_PATH is not set")
+
+    monkeypatch.setenv("KB_MCP_DIARIZE", "1")
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(list(_SEGS)))
+    monkeypatch.setattr(extract, "_run_diarization", lambda p: list(_TURNS))
+    monkeypatch.setattr(vault, "resolve_vault", _boom)
+    r = extract._transcribe(Path("x.wav"), "audio")
+
+    assert r.text == "[Speaker A]: hello there\n[Speaker B]: general kenobi"

--- a/tests/test_enroll_speaker_cli.py
+++ b/tests/test_enroll_speaker_cli.py
@@ -1,0 +1,81 @@
+"""CLI speaker enrollment (embedder patched) — enroll writes a profile, --self, list/remove.
+
+The ECAPA embedder is stubbed so no model loads; we drive the public functions and the
+`python -m kb_mcp` subcommand dispatch against a tmp profile store.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kb_mcp import __main__ as cli
+from kb_mcp import enroll_speaker, voice_embed, voice_profiles
+
+
+@pytest.fixture
+def sample(tmp_path):
+    p = tmp_path / "voice.wav"
+    p.write_bytes(b"RIFF....")  # contents are never read — embed_spans is patched
+    return p
+
+
+def test_enroll_writes_a_profile(tmp_path, sample, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: np.array([1.0, 0.0, 0.0]))
+    rec = enroll_speaker.enroll_speaker(sample, "Alice", vault_root=tmp_path)
+
+    assert rec["samples"] == 1
+    assert rec["is_self"] is False
+    store = voice_profiles.voice_profiles_path(tmp_path)
+    assert "Alice" in voice_profiles.load_profiles(store)
+
+
+def test_enroll_self_flag_and_running_average(tmp_path, sample, monkeypatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: np.array([0.0, 0.0, 0.0]))
+    enroll_speaker.enroll_speaker(sample, "Alice", is_self=True, vault_root=tmp_path)
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: np.array([2.0, 4.0, 6.0]))
+    rec = enroll_speaker.enroll_speaker(sample, "Alice", vault_root=tmp_path)
+
+    assert rec["samples"] == 2
+    assert rec["is_self"] is True  # sticks once set
+    np.testing.assert_allclose(rec["centroid"], [1.0, 2.0, 3.0])  # running average
+
+
+def test_enroll_soft_fail_raises(tmp_path, sample, monkeypatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: None)
+    with pytest.raises(enroll_speaker.EnrollmentError):
+        enroll_speaker.enroll_speaker(sample, "Alice", vault_root=tmp_path)
+
+
+def test_enroll_missing_sample_raises(tmp_path) -> None:
+    with pytest.raises(enroll_speaker.EnrollmentError):
+        enroll_speaker.enroll_speaker(tmp_path / "nope.wav", "Alice", vault_root=tmp_path)
+
+
+def test_list_and_remove_round_trip(tmp_path, sample, monkeypatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: np.array([1.0, 0.0, 0.0]))
+    enroll_speaker.enroll_speaker(sample, "Alice", is_self=True, vault_root=tmp_path)
+
+    listed = enroll_speaker.list_speakers(tmp_path)
+    assert [r["name"] for r in listed] == ["Alice"]
+    assert listed[0]["is_self"] is True
+
+    assert enroll_speaker.remove_speaker("Alice", tmp_path) is True
+    assert enroll_speaker.list_speakers(tmp_path) == []
+    assert enroll_speaker.remove_speaker("Alice", tmp_path) is False
+
+
+def test_cli_dispatch_enroll_list_remove(tmp_path, sample, monkeypatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: np.array([1.0, 0.0, 0.0]))
+    v = str(tmp_path)
+
+    assert cli.main(["enroll-speaker", "--name", "Alice", "--self", "--vault", v, str(sample)]) == 0
+    assert cli.main(["list-speakers", "--vault", v]) == 0
+    assert cli.main(["remove-speaker", "--name", "Alice", "--vault", v]) == 0
+    # Removing again reports "no profile" but still exits 0 (idempotent CLI).
+    assert cli.main(["remove-speaker", "--name", "Alice", "--vault", v]) == 0
+
+
+def test_cli_enroll_soft_fail_returns_nonzero(tmp_path, sample, monkeypatch) -> None:
+    monkeypatch.setattr(voice_embed, "embed_spans", lambda p, spans: None)
+    rc = cli.main(["enroll-speaker", "--name", "Alice", "--vault", str(tmp_path), str(sample)])
+    assert rc == 1

--- a/tests/test_speaker_assignment.py
+++ b/tests/test_speaker_assignment.py
@@ -1,0 +1,37 @@
+"""Unit tests for max-overlap segment→turn assignment (pure, torch-free)."""
+from __future__ import annotations
+
+from kb_mcp.speaker_assignment import Turn, assign_span, assign_spans, overlap
+
+
+def test_overlap_basic_and_disjoint():
+    assert overlap(0.0, 10.0, 5.0, 15.0) == 5.0
+    assert overlap(0.0, 5.0, 10.0, 15.0) == 0.0  # disjoint
+    assert overlap(0.0, 5.0, 5.0, 10.0) == 0.0  # touching, not overlapping
+
+
+def test_assign_span_picks_max_overlap():
+    turns = [Turn(0.0, 4.0, "A"), Turn(3.0, 10.0, "B")]
+    # [2,6] overlaps A by 2.0 and B by 3.0 → B
+    assert assign_span(2.0, 6.0, turns) == "B"
+    # [0,3.5] overlaps A by 3.5, B by 0.5 → A
+    assert assign_span(0.0, 3.5, turns) == "A"
+
+
+def test_assign_span_no_overlap_returns_none():
+    turns = [Turn(0.0, 1.0, "A")]
+    assert assign_span(5.0, 6.0, turns) is None
+    assert assign_span(0.0, 1.0, []) is None
+
+
+def test_assign_span_tie_breaks_to_earliest_turn():
+    # Equal overlap (1.0 each) → earliest-starting turn wins.
+    turns = [Turn(0.0, 2.0, "EARLY"), Turn(2.0, 5.0, "LATE")]
+    # [1,3]: overlaps EARLY by 1.0 (1→2) and LATE by 1.0 (2→3) → EARLY
+    assert assign_span(1.0, 3.0, turns) == "EARLY"
+
+
+def test_assign_spans_maps_each():
+    turns = [Turn(0.0, 5.0, "A"), Turn(5.0, 10.0, "B")]
+    out = assign_spans([(1.0, 2.0), (6.0, 7.0), (20.0, 21.0)], turns)
+    assert out == ["A", "B", None]

--- a/tests/test_speaker_attribution.py
+++ b/tests/test_speaker_attribution.py
@@ -1,0 +1,117 @@
+"""Unit tests for voice-profile speaker attribution (pure, numpy-only)."""
+from __future__ import annotations
+
+import numpy as np
+
+from kb_mcp.speaker_attribution import (
+    Attribution,
+    Profile,
+    _group_clusters,
+    attribute_clusters,
+    cosine,
+    count_distinct_speakers,
+)
+
+
+def _unit(*vals: float) -> np.ndarray:
+    v = np.array(vals, dtype=float)
+    return v / np.linalg.norm(v)
+
+
+# Two near-orthogonal "voiceprints" — distinct speakers; cosine ~0.
+HUGO = _unit(1.0, 0.0, 0.0)
+KIM = _unit(0.0, 1.0, 0.0)
+STRANGER = _unit(0.0, 0.0, 1.0)
+
+
+def test_cosine_basic():
+    assert cosine([1, 0], [1, 0]) == 1.0
+    assert abs(cosine([1, 0], [0, 1])) < 1e-9
+    assert cosine([0, 0], [1, 1]) == 0.0  # zero vector → 0, no div error
+
+
+def test_clear_match_is_named():
+    profiles = {"Hugo": Profile("Hugo", HUGO)}
+    # cluster c0 is essentially Hugo's voiceprint
+    attrs = attribute_clusters({"c0": HUGO}, {"c0": 0.0}, profiles)
+    assert attrs["c0"].label == "Hugo"
+    assert attrs["c0"].matched_profile == "Hugo"
+    assert attrs["c0"].confidence >= 0.99
+
+
+def test_below_threshold_stays_anonymous():
+    # STRANGER is orthogonal to Hugo (cosine ~0) → far below the 0.40 floor.
+    profiles = {"Hugo": Profile("Hugo", HUGO)}
+    attrs = attribute_clusters({"c0": STRANGER}, {"c0": 0.0}, profiles)
+    assert attrs["c0"].label == "Speaker A"
+    assert attrs["c0"].matched_profile is None
+
+
+def test_no_profiles_all_anonymous_by_onset():
+    attrs = attribute_clusters(
+        {"c0": HUGO, "c1": KIM},
+        {"c0": 10.0, "c1": 2.0},  # c1 starts earlier → Speaker A
+        {},
+    )
+    assert attrs["c1"].label == "Speaker A"
+    assert attrs["c0"].label == "Speaker B"
+    assert all(a.matched_profile is None for a in attrs.values())
+
+
+def test_two_speakers_named_and_anonymous_mix():
+    profiles = {"Hugo": Profile("Hugo", HUGO)}
+    attrs = attribute_clusters(
+        {"c0": HUGO, "c1": STRANGER},
+        {"c0": 0.0, "c1": 5.0},
+        profiles,
+    )
+    assert attrs["c0"].label == "Hugo"
+    assert attrs["c1"].label == "Speaker A"  # the lone unmatched group
+    assert count_distinct_speakers(attrs) == 2
+
+
+def test_ambiguous_within_margin_prefers_anonymous():
+    # A cluster equally close to Hugo and Kim (the average direction) — within-margin → anonymous.
+    blended = _unit(1.0, 1.0, 0.0)  # cosine ~0.707 to both Hugo and Kim
+    profiles = {"Hugo": Profile("Hugo", HUGO), "Kim": Profile("Kim", KIM)}
+    attrs = attribute_clusters({"c0": blended}, {"c0": 0.0}, profiles)
+    # best - second_best ≈ 0 < margin(0.05) → not named.
+    assert attrs["c0"].matched_profile is None
+    assert attrs["c0"].label == "Speaker A"
+
+
+def test_over_split_speaker_is_merged_then_named():
+    # Two clusters that are the SAME speaker (mutual cosine ~1.0, above 0.50 merge) — should merge
+    # into one group, and a single profile labels both.
+    hugo_a = _unit(1.0, 0.02, 0.0)
+    hugo_b = _unit(1.0, 0.0, 0.02)
+    groups = _group_clusters(["a", "b"], {"a": hugo_a, "b": hugo_b}, 0.50)
+    assert len(groups) == 1  # merged
+
+    profiles = {"Hugo": Profile("Hugo", HUGO)}
+    attrs = attribute_clusters({"a": hugo_a, "b": hugo_b}, {"a": 0.0, "b": 3.0}, profiles)
+    assert attrs["a"].label == "Hugo"
+    assert attrs["b"].label == "Hugo"
+    assert count_distinct_speakers(attrs) == 1
+
+
+def test_distinct_speakers_not_merged():
+    # Hugo and Kim are orthogonal (cosine ~0 < 0.50) → stay separate groups.
+    groups = _group_clusters(["a", "b"], {"a": HUGO, "b": KIM}, 0.50)
+    assert len(groups) == 2
+
+
+def test_determinism():
+    profiles = {"Hugo": Profile("Hugo", HUGO), "Kim": Profile("Kim", KIM)}
+    emb = {"c0": HUGO, "c1": KIM, "c2": STRANGER}
+    onset = {"c0": 0.0, "c1": 1.0, "c2": 2.0}
+    a1 = attribute_clusters(emb, onset, profiles)
+    a2 = attribute_clusters(emb, onset, profiles)
+    assert {k: (v.label, v.matched_profile) for k, v in a1.items()} == {
+        k: (v.label, v.matched_profile) for k, v in a2.items()
+    }
+
+
+def test_attribution_is_a_frozen_dataclass():
+    a = Attribution("Hugo", 0.9, "Hugo")
+    assert (a.label, a.confidence, a.matched_profile) == ("Hugo", 0.9, "Hugo")

--- a/tests/test_voice_embed.py
+++ b/tests/test_voice_embed.py
@@ -1,0 +1,95 @@
+"""voice_embed.py — device selection, TF32 parity, and soft-fail seams (model patched).
+
+The real ECAPA model is never loaded here: a box without `speechbrain`/`torchaudio` must still
+run the suite. We patch the lazy loader + audio loader and exercise the soft-fail contract
+(every failure → None, never raises) plus the CLIP-precedent device gating.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from kb_mcp import voice_embed
+
+
+def test_voice_device_env_and_asr_gating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors embeddings._clip_device: GPU only when ASR (media extraction) is disabled;
+    an explicit KB_MCP_VOICE_DEVICE override always wins."""
+    # Explicit override wins regardless of ASR state.
+    monkeypatch.setenv("KB_MCP_VOICE_DEVICE", "cuda")
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    assert voice_embed._voice_device() == "cuda"
+    monkeypatch.setenv("KB_MCP_VOICE_DEVICE", "cpu")
+    monkeypatch.setenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", "1")
+    assert voice_embed._voice_device() == "cpu"
+    # No override + ASR enabled (the live default) → CPU, dodging the whisper cuDNN clash.
+    monkeypatch.delenv("KB_MCP_VOICE_DEVICE", raising=False)
+    monkeypatch.delenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", raising=False)
+    assert voice_embed._voice_device() == "cpu"
+
+
+def test_disable_tf32_turns_tf32_off() -> None:
+    torch.backends.cuda.matmul.allow_tf32 = True
+    voice_embed._disable_tf32()
+    assert torch.backends.cuda.matmul.allow_tf32 is False
+
+
+class _FakeModel:
+    """Stand-in for the ECAPA EncoderClassifier: returns a fixed (1,1,192) embedding."""
+
+    def __init__(self, vector: np.ndarray) -> None:
+        self._vec = vector
+
+    def encode_batch(self, _waveform):
+        return torch.tensor(self._vec).reshape(1, 1, -1)
+
+
+def test_embed_spans_mean_over_spans_and_disables_tf32(monkeypatch: pytest.MonkeyPatch) -> None:
+    vec = np.arange(voice_embed.VOICE_EMBED_DIM, dtype=np.float32)
+    monkeypatch.setattr(voice_embed, "_get_voice_model", lambda: _FakeModel(vec))
+    monkeypatch.setattr(voice_embed, "_load_audio", lambda p: (torch.zeros(1, 32000), 16000))
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    out = voice_embed.embed_spans("x.wav", [(0.0, 1.0), (1.0, 2.0)])
+
+    assert out is not None
+    assert out.shape == (voice_embed.VOICE_EMBED_DIM,)
+    # Two spans of the same fixed embedding → the mean is that embedding.
+    np.testing.assert_allclose(out, vec)
+    # TF32 was disabled before inference (embedding parity).
+    assert torch.backends.cuda.matmul.allow_tf32 is False
+
+
+def test_embed_spans_empty_spans_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(voice_embed, "_get_voice_model", lambda: pytest.fail("should not load"))
+    assert voice_embed.embed_spans("x.wav", []) is None
+
+
+def test_embed_spans_import_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _no_dep():
+        raise ImportError("speechbrain not installed")
+
+    # The lazy loader raises ImportError (no [diarization] extra) → soft-fail to None.
+    monkeypatch.setattr(voice_embed, "_load_voice_model", _no_dep)
+    monkeypatch.setattr(voice_embed, "_VOICE_MODEL", None)
+    assert voice_embed.embed_spans("x.wav", [(0.0, 1.0)]) is None
+
+
+def test_embed_spans_inference_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        def encode_batch(self, _waveform):
+            raise RuntimeError("cuDNN shadow / OOM")
+
+    monkeypatch.setattr(voice_embed, "_get_voice_model", lambda: _Boom())
+    monkeypatch.setattr(voice_embed, "_load_audio", lambda p: (torch.zeros(1, 32000), 16000))
+    assert voice_embed.embed_spans("x.wav", [(0.0, 1.0)]) is None
+
+
+def test_embed_spans_audio_load_failure_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _bad_audio(_p):
+        raise RuntimeError("undecodable / torchaudio absent")
+
+    monkeypatch.setattr(voice_embed, "_get_voice_model", lambda: _FakeModel(np.zeros(192)))
+    monkeypatch.setattr(voice_embed, "_load_audio", _bad_audio)
+    assert voice_embed.embed_spans("x.wav", [(0.0, 1.0)]) is None

--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -1,0 +1,71 @@
+"""Unit tests for the local voice-profile JSON store (pure, numpy + stdlib)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from kb_mcp import voice_profiles as vp
+
+
+def test_store_path_is_operational_infra_not_a_note_tree():
+    p = vp.voice_profiles_path(Path("/vault"))
+    # Dot-prefixed file in the KB root, beside the embedding sidecars — never under a note tree.
+    assert p.name == ".voice_profiles.json"
+    assert p.name.startswith(".")
+    assert "Knowledge Base" in p.parts
+    assert not any(seg in ("Notes", "Entities", "Sources", "Evidence") for seg in p.parts)
+
+
+def test_missing_and_corrupt_store_reads_empty(tmp_path):
+    missing = tmp_path / "nope.json"
+    assert vp.load_store(missing) == {}
+    assert vp.load_profiles(missing) == {}
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert vp.load_store(corrupt) == {}
+    assert vp.load_profiles(corrupt) == {}
+
+
+def test_save_list_remove_round_trip(tmp_path):
+    path = tmp_path / ".voice_profiles.json"
+    vp.save_profile(path, "Hugo", np.array([1.0, 0.0, 0.0]), is_self=True)
+    listed = vp.list_profiles(path)
+    assert len(listed) == 1
+    assert listed[0]["name"] == "Hugo"
+    assert listed[0]["is_self"] is True
+    assert listed[0]["samples"] == 1
+
+    profiles = vp.load_profiles(path)
+    assert "Hugo" in profiles
+    assert profiles["Hugo"].name == "Hugo"
+    assert profiles["Hugo"].centroid.shape == (3,)
+
+    assert vp.remove_profile(path, "Hugo") is True
+    assert vp.list_profiles(path) == []
+    assert vp.remove_profile(path, "Hugo") is False  # already gone
+
+
+def test_multi_sample_running_average(tmp_path):
+    path = tmp_path / ".voice_profiles.json"
+    vp.save_profile(path, "Hugo", np.array([0.0, 0.0, 0.0]))
+    rec = vp.save_profile(path, "Hugo", np.array([3.0, 6.0, 9.0]))
+    # running average of [0,0,0] and [3,6,9] over 2 samples → [1.5, 3, 4.5]
+    assert rec["samples"] == 2
+    np.testing.assert_allclose(rec["centroid"], [1.5, 3.0, 4.5])
+    # is_self sticks once set, even if a later sample omits it
+    vp.save_profile(path, "Hugo", np.array([0.0, 0.0, 0.0]), is_self=True)
+    rec2 = vp.save_profile(path, "Hugo", np.array([0.0, 0.0, 0.0]))
+    assert rec2["is_self"] is True
+    assert rec2["samples"] == 4
+
+
+def test_load_profiles_skips_malformed_entries(tmp_path):
+    path = tmp_path / ".voice_profiles.json"
+    path.write_text(
+        '{"Good": {"centroid": [1,0,0], "threshold": 0.4, "samples": 1},'
+        ' "NoCentroid": {"threshold": 0.4}, "Junk": 5}',
+        encoding="utf-8",
+    )
+    profiles = vp.load_profiles(path)
+    assert set(profiles) == {"Good"}


### PR DESCRIPTION
## Summary

First **OpenSpec** change for kb-mcp. Initializes OpenSpec (1.4.1, spec-driven) and lands change #1: **named-speaker diarization** — ports Q's production voice-profile attribution so diarized media transcripts carry real names (`[Name]: …`) instead of anonymous `[Speaker A]:`, findable by speaker. Default-OFF, soft-fail, pure-substrate (frozen ECAPA voiceprint + cosine = measurement, no LLM).

Spec: `openspec/changes/add-named-speaker-diarization/` (proposal/design/specs/tasks, validates `--strict`).

## What's in it

- `speaker_attribution.py` + `speaker_assignment.py` — ported pure-NumPy core (average-linkage over-split merge, relative margin/threshold attribution, max-overlap assignment). 20 unit tests.
- `voice_profiles.py` — local JSON profile store (operational infra beside the embedding sidecar; not note content, excluded from find/audit).
- `voice_embed.py` — speechbrain ECAPA voiceprints; soft-fail seam; `_voice_device()` mirrors the CLIP cuDNN-shadow fix (PR #47); TF32 off for embedding parity.
- `extract._diarize` — optional named layer over anonymous turns; **byte-identical** anonymous output when off/soft-fail; wired to the unit-tested `assign_span`.
- CLI: `python -m kb_mcp enroll-speaker --name <N> [--self] <audio>`, `list-speakers`, `remove-speaker`.
- `speechbrain>=1.0` in the `diarization` extra.

## Safety

- **Default-off**: no behavior change unless `KB_MCP_DIARIZE` set AND >=1 profile enrolled.
- **Soft-fail**: missing dep/model/GPU or any error degrades to byte-identical anonymous diarization; the voice path cannot raise into extraction (verified by review, traced every path).
- Code-reviewed (APPROVE, 0 blockers); full suite **748 passed**; leak guard green.

## Activation (post-merge, GPU box)

1. `uv sync --extra media --extra diarization --extra embeddings`
2. `python -m kb_mcp enroll-speaker --name <you> --self <voice-sample>`
3. set `KB_MCP_DIARIZE=1` + `HUGGINGFACE_TOKEN`, restart.
4. Smoke (task 7.3): diarize a 2-speaker recording, confirm `[<name>]:` for you + anonymous for the other.

Follow-ups tracked in `tasks.md` §8 (decode-once perf; SKILL/scaffold doc mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
