### PR TITLE
fix(cli): 4 LOW review follow-ups from unify-command-surface

### DIFF
--- a/src/kb_mcp/__main__.py
+++ b/src/kb_mcp/__main__.py
@@ -41,6 +41,14 @@ def main(argv: list[str] | None = None) -> int:
     # `kb note …`, etc. — every command on the `cli` surface.
     if raw and raw[0] in _core_op_names():
         return _core_op_main(raw)
+    # A real tier-2 op invoked while KB_MCP_DISABLE_TIER2 is set would otherwise fall
+    # through to the serve parser and emit a confusing argparse error — name it instead.
+    if raw and not _expose_tier2() and raw[0] in _core_op_names(expose_tier2=True):
+        print(
+            f"Error [UNAVAILABLE]: operation {raw[0]!r} is unavailable (tier-2 disabled)",
+            file=sys.stderr,
+        )
+        return 2
     return _serve_main(raw)
 
 
@@ -354,11 +362,13 @@ def _expose_tier2() -> bool:
     return not os.environ.get("KB_MCP_DISABLE_TIER2")
 
 
-def _core_op_names() -> frozenset[str]:
+def _core_op_names(*, expose_tier2: bool | None = None) -> frozenset[str]:
     from . import commands as commands_module
 
+    if expose_tier2 is None:
+        expose_tier2 = _expose_tier2()
     return frozenset(
-        c.name for c in commands_module.commands_for("cli", expose_tier2=_expose_tier2())
+        c.name for c in commands_module.commands_for("cli", expose_tier2=expose_tier2)
     )
 
 
@@ -420,7 +430,9 @@ def _add_command_args(sp: argparse.ArgumentParser, cmd) -> None:
         )
 
 
-def _collect_raw_args(cmd, args: argparse.Namespace) -> dict:
+def _collect_raw_args(
+    cmd, args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> dict:
     field_escape = cmd.name in _FIELD_ESCAPE
     raw: dict = {}
     for p in cmd.params:
@@ -433,9 +445,9 @@ def _collect_raw_args(cmd, args: argparse.Namespace) -> dict:
         for item in getattr(args, "field", None) or []:
             key, sep, value = item.partition("=")
             if not sep:
-                raise SystemExit(
-                    f"Error [USAGE]: --field expects KEY=VALUE, got {item!r}"
-                )
+                # Route through argparse's error path → exit 2, consistent with
+                # every other usage error (a bare `raise SystemExit(str)` is exit 1).
+                parser.error(f"--field expects KEY=VALUE, got {item!r}")
             raw[key.strip()] = value
     return raw
 
@@ -485,9 +497,9 @@ def _core_op_main(argv: list[str]) -> int:
 
     try:
         vault_root = resolve_vault()
-        raw = _collect_raw_args(cmd, args)
+        raw = _collect_raw_args(cmd, args, parser)
         kwargs = cli_ops.coerce(
-            cmd.params, raw, guarded_fields=cmd.guarded_fields, tool=cmd.name
+            cmd.params, raw, guarded_fields=cmd.guarded_fields, tool=cmd.name, cli=True
         )
         if cmd.needs_schema:
             injected = (vault_root, schema_module.load_source_schema(vault_root))

--- a/src/kb_mcp/cli_ops.py
+++ b/src/kb_mcp/cli_ops.py
@@ -141,11 +141,16 @@ def _coerce_list(value: Any, name: str) -> list[str]:
     raise OpError("BAD_TYPE", f"`{name}` must be a list, got {value!r}")
 
 
-def _coerce_json(value: Any, name: str) -> Any:
+def _coerce_json(value: Any, name: str, *, cli: bool = False) -> Any:
     if isinstance(value, str):
         try:
             return json.loads(value)
         except json.JSONDecodeError as e:
+            if cli:
+                # CLI convenience: a bare unquoted string for a union/json field is
+                # itself (`kb edit --value hello`), not malformed JSON. REST stays
+                # strict-JSON — this fallback only fires on the CLI surface.
+                return value
             raise OpError("BAD_JSON", f"`{name}` must be valid JSON: {e}") from None
     return value
 
@@ -163,6 +168,7 @@ def coerce(
     *,
     guarded_fields: tuple[str, ...] = (),
     tool: str = "",
+    cli: bool = False,
 ) -> dict:
     """Coerce a raw arg mapping into leaf kwargs using the `Param` specs.
 
@@ -172,6 +178,10 @@ def coerce(
     - Coerces each value by its declared type tag (works for JSON-native values
       from REST and for CLI strings alike).
     - Re-runs the base64 binary-blob guard on the declared text fields.
+
+    `cli=True` relaxes one thing only: a union/`json` field whose raw string isn't
+    valid JSON falls back to that string (so `kb edit --value hello` works without
+    `--value '"hello"'`). REST keeps `cli=False` and stays strict-JSON.
     """
     spec = {p.name: p for p in params}
     unknown = [k for k in raw if k not in spec]
@@ -185,6 +195,15 @@ def coerce(
     for fld in guarded_fields:
         if fld in raw:
             guards.guard_text_content(raw.get(fld), tool=tool, field=fld)
+    # `edit`'s batch mode carries each write payload in edits[].new_string — guard
+    # those too (the top-level guarded_fields only covers new_body/new_string),
+    # mirroring the MCP middleware so no surface lets a blob in through the nest.
+    if tool == "edit" and isinstance(raw.get("edits"), list):
+        for item in raw["edits"]:
+            if isinstance(item, dict):
+                guards.guard_text_content(
+                    item.get("new_string"), tool=tool, field="edits[].new_string"
+                )
 
     kwargs: dict[str, Any] = {}
     for name, value in raw.items():
@@ -200,7 +219,7 @@ def coerce(
         elif p.type == "dict":
             kwargs[name] = _coerce_dict(value, name)
         elif p.type == "json":
-            kwargs[name] = _coerce_json(value, name)
+            kwargs[name] = _coerce_json(value, name, cli=cli)
         else:  # "str"
             kwargs[name] = value if isinstance(value, str) else str(value)
     return kwargs

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from kb_mcp.__main__ import main
+
+_INSIGHT = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
 
 
 def _run(argv: list[str], capsys) -> tuple[int, str, str]:
@@ -92,6 +96,53 @@ def test_note_field_escape(vault: Path, capsys) -> None:
     payload = json.loads(out.strip().splitlines()[-1])
     assert payload["success"] is True
     assert "Project Alpha" in payload["data"]["path"]
+
+
+def test_edit_value_plain_string(vault: Path, capsys) -> None:
+    """`kb edit --field K --value <plain string>` works without quoting as JSON.
+
+    `value` is a genuine union (coercion tag "json"); on the CLI a bare unquoted
+    string must be taken as itself, not rejected as BAD_JSON.
+    """
+    code, out, err = _run(
+        ["edit", _INSIGHT, "--why", "set domain", "--field", "domain",
+         "--value", "retrieval", "--json"],
+        capsys,
+    )
+    assert code == 0, err
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"]["new_value"] == "retrieval"
+    assert "domain: retrieval" in (vault / _INSIGHT).read_text(encoding="utf-8")
+
+
+def test_malformed_field_exits_2(vault: Path, capsys) -> None:
+    """A `--field` token with no `=` is a usage error → exit 2 (not exit 1)."""
+    code, _out, err = _run(
+        [
+            "note",
+            "--note-type", "insight",
+            "--title", "x",
+            "--content", "# x\n\n## Claim\n\ny\n",
+            "--field", "bogus",  # no KEY=VALUE separator
+        ],
+        capsys,
+    )
+    assert code == 2
+    assert "Error [USAGE]" in err
+    assert "KEY=VALUE" in err
+
+
+def test_tier2_op_disabled_emits_unavailable(
+    vault: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`kb <tier2-op>` with KB_MCP_DISABLE_TIER2 set names the gap, exit 2."""
+    monkeypatch.setenv("KB_MCP_DISABLE_TIER2", "1")
+    code, _out, err = _run(["query_data", "some.csv"], capsys)
+    assert code == 2
+    assert "Error [UNAVAILABLE]" in err
+    assert "tier-2 disabled" in err
+    assert "query_data" in err
 
 
 def test_missing_required_arg_exits_2(vault: Path, capsys) -> None:

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -120,3 +120,37 @@ def test_coerce_json_passthrough_for_union() -> None:
     assert out == {"value": {"nested": [1, 2]}}
     out2 = cli_ops.coerce(_PARAMS, {"value": "42"}, tool="edit")
     assert out2 == {"value": 42}  # JSON string parsed
+
+
+def test_coerce_json_rest_rejects_bare_string() -> None:
+    # REST (cli=False) stays strict: a bare unquoted string is NOT valid JSON.
+    with pytest.raises(cli_ops.OpError) as exc:
+        cli_ops.coerce(_PARAMS, {"value": "hello"}, tool="edit")
+    assert exc.value.code == "BAD_JSON"
+
+
+def test_coerce_json_cli_falls_back_to_raw_string() -> None:
+    # CLI (cli=True): `kb edit --value hello` — a bare string is itself, not BAD_JSON.
+    out = cli_ops.coerce(_PARAMS, {"value": "hello"}, tool="edit", cli=True)
+    assert out == {"value": "hello"}
+    # Real JSON still parses under cli=True (the fallback only fires on parse failure).
+    out2 = cli_ops.coerce(_PARAMS, {"value": "42"}, tool="edit", cli=True)
+    assert out2 == {"value": 42}
+    out3 = cli_ops.coerce(_PARAMS, {"value": '{"k": 1}'}, tool="edit", cli=True)
+    assert out3 == {"value": {"k": 1}}
+
+
+def test_coerce_guards_nested_edit_new_string() -> None:
+    # edit's batch mode hides the write payload in edits[].new_string — it must be
+    # blob-guarded too, not just the top-level new_body/new_string.
+    params = (Param("path", "str"), Param("why", "str"), Param("edits", "json"))
+    blob = "data:image/png;base64," + "A" * 40000
+    with pytest.raises(ValueError) as exc:
+        cli_ops.coerce(
+            params,
+            {"path": "x.md", "why": "y", "edits": [{"old_string": "a", "new_string": blob}]},
+            guarded_fields=("new_body", "new_string"),
+            tool="edit",
+        )
+    assert "BINARY_BLOB_REJECTED" in str(exc.value)
+    assert "edits[].new_string" in str(exc.value)

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -120,6 +120,24 @@ def test_blob_guard_preserved(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     assert r.json()["error"]["code"] == "BINARY_BLOB_REJECTED"
 
 
+def test_blob_guard_nested_edits_preserved(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`edit`'s batch mode carries the payload in edits[].new_string — REST must
+    blob-guard each nested item, mirroring the MCP middleware (not only top-level)."""
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    blob = "data:image/png;base64," + "A" * 40000
+    r = client.post(
+        "/api/edit",
+        json={
+            "path": "Knowledge Base/Notes/Insights/x.md",
+            "why": "nested blob",
+            "edits": [{"old_string": "a", "new_string": blob}],
+        },
+        headers=_auth(),
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "BINARY_BLOB_REJECTED"
+
+
 def test_openapi_lists_real_params(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
     doc = client.get("/api/openapi.json").json()


### PR DESCRIPTION
Polish for the 4 LOW code-review findings on the new `kb` CLI / REST facade (tracked in unify-command-surface tasks.md sec 9). REST stays strict-JSON; MCP schemas byte-identical (fidelity green); 792 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)