### PR TITLE
feat: zero-shot image tags via CLIP (richer image measurement, default-off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ the repo root). The only required one is the vault path.
 | `KB_MCP_DISABLE_MEDIA_EXTRACTION` | `1` skips server-side OCR/ASR/PDF/office extraction. |
 | `KB_MCP_DISABLE_CLIP` | `1` disables CLIP visual image search. |
 | `KB_MCP_CLIP_DEVICE` | `cpu`/`cuda` override for CLIP (defaults to CPU when ASR is active). |
+| `KB_MCP_IMAGE_TAGS` | Set to append zero-shot CLIP tags (`Tags: invoice, table, …`) to an image's indexed text. Default off; no new dependency (reuses CLIP). |
+| `KB_MCP_IMAGE_TAGS_TOPK` | Max image tags to emit per image (default `5`). |
+| `KB_MCP_IMAGE_TAGS_THRESHOLD` | Raw-cosine floor a tag must clear (default `0.22`). |
 | `KB_MCP_DIARIZE` | Set to enable opt-in ASR speaker diarization (`[Speaker A]: …` turns). |
 | `KB_MCP_VOICE_DEVICE` | `cpu`/`cuda` override for the ECAPA voice embedder (defaults to CPU when ASR is active). |
 | `KB_MCP_VOICE_EMBED_MODEL` | ECAPA checkpoint for named-speaker attribution (default `speechbrain/spkrec-ecapa-voxceleb`). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -275,6 +275,16 @@ CLIP visual search runs CLIP on **CPU when ASR is active** (whisper's cu12 cuDNN
 PATH-prepend otherwise shadows torch's cuDNN and breaks CLIP's Conv2d). Override
 with `KB_MCP_CLIP_DEVICE=cuda`/`cpu` if needed.
 
+Zero-shot **image tags** (`KB_MCP_IMAGE_TAGS`, default off) reuse that same loaded
+CLIP model — no extra dependency. When set, each extracted image is cosine-scored
+against a fixed generic tag vocabulary and the top matches are appended to its
+indexed text as a `Tags: invoice, table, screenshot` line, so a photo is findable
+by what it depicts (not just its OCR text). It is a frozen cosine measurement (no
+LLM), inherits the CLIP device logic above, and soft-fails to no tags when CLIP is
+absent. Tune with `KB_MCP_IMAGE_TAGS_TOPK` (default 5) and
+`KB_MCP_IMAGE_TAGS_THRESHOLD` (raw cosine, default 0.22); only newly-extracted
+images are tagged.
+
 Named-speaker diarization's ECAPA voice embedder (`diarization` extra) runs on
 torch and follows the same precedent: it defaults to **CPU when ASR is active**, with
 a `KB_MCP_VOICE_DEVICE=cuda`/`cpu` override. Enroll voices with

--- a/openspec/changes/image-zero-shot-tags/design.md
+++ b/openspec/changes/image-zero-shot-tags/design.md
@@ -1,0 +1,96 @@
+# Design — Zero-shot image tags
+
+## Context
+
+kb-mcp already loads a CLIP model (`embeddings.get_clip_model()`, `clip-ViT-B-32`) that encodes
+images (`embed_image`) and text queries (`embed_clip_text`) into one shared 512-dim space, used
+today for visual `find`. Image extraction (`extract._ocr_image`) produces the text that the
+sidecar stores and that BM25 + bge index. That text is currently OCR output plus an optional
+default-off caption. The depicted content of a textless photo never reaches the text index.
+
+A zero-shot classifier falls out of CLIP for free: embed a fixed tag vocabulary with the SAME
+model's text encoder, cosine an image vector against it, and the high-scoring tags name what the
+image shows. This change wires that into the extraction seam so the tags are indexed like any
+other extracted text.
+
+## Goals / non-goals
+
+- **Goal:** an image's depicted concepts (`invoice`, `whiteboard`, `screenshot`) become plain
+  words in the indexed sidecar text, BM25-findable and bge-embedded — no special `find` path.
+- **Goal:** reuse the loaded CLIP model + its device logic; add no dependency; stay default-off,
+  soft-fail, and byte-identical when unused.
+- **Non-goal:** video-keyframe tagging, a structured `tags:` field or `tag:` filter, custom/
+  per-vault vocabularies, prompt-templated vocab, re-tagging already-indexed images. (Future.)
+
+## Pure-substrate justification
+
+CLIP image and text encoders are frozen, deterministic functions (pixels→vector, words→vector) —
+the same class as Tesseract OCR, the bge embedder, and the existing CLIP visual search. Tagging is
+a fixed cosine comparison against frozen vocabulary vectors with a fixed threshold: a
+*measurement*, not a judgment, and not a generative or reasoning model. The vocabulary is a fixed
+human-authored list (a one-time brain act); the server only measures "this image is within τ of
+the `invoice` text vector." Unlike captioning (which *generates* language and therefore ships
+off), tagging only SELECTS from a frozen list — but it still ships default-off for parity and so
+the threshold can be tuned on real images before it changes any indexed text. In-bounds.
+
+## Architecture
+
+Per image, when `KB_MCP_IMAGE_TAGS` is set:
+
+1. **Embed the vocabulary once** (new `image_tags._vocab_matrix`, cached per process): the ~190
+   fixed terms in `image_tags.TAG_VOCAB` → `(N, 512)` via a new batched
+   `embeddings.embed_clip_texts()` (CLIP's text encoder, L2-normalized). One encode per process.
+2. **Embed the image** (existing `embeddings.embed_image`): the CLIP image vector (512, normalized).
+3. **Score + select** (`image_tags.compute_tags`): `scores = vocab_matrix @ image_vec`; take the
+   top-K indices by descending cosine whose score ≥ threshold → tag strings.
+4. **Append at the seam** (`extract._maybe_image_tags`, called by `_ocr_image` after
+   `_maybe_caption`): render `Tags: a, b, c` and append it to the extracted text
+   (`<text>\n\nTags: …`, or just the line when OCR/caption text is empty); suffix the engine with
+   `+tags` for provenance. The text then flows through the unchanged sidecar/index path.
+
+Defaults: `top_k=5`, `threshold=0.22` (raw cosine). Both overridable via `KB_MCP_IMAGE_TAGS_TOPK`
+/ `KB_MCP_IMAGE_TAGS_THRESHOLD`.
+
+## Decisions
+
+- **Append (not prepend) one line.** OCR/caption text is the primary signal; tags are secondary
+  metadata, so they go after. A single `Tags:` line keeps the addition obvious and easy to strip
+  if ever undesired, and reads naturally in the sidecar.
+- **Vocabulary is a generic Python constant in `image_tags.TAG_VOCAB`, not a data file.** ~190
+  lowercase single concepts (document/screen kinds, objects, scenes, nature, people, animals,
+  food, vehicles, art). It ships under `src/kb_mcp/` and is leak-guarded
+  (`tests/test_scaffold_no_leak.py` scans all of `src/kb_mcp/`), so it is deliberately brand- and
+  identity-free. A constant keeps it import-time-cheap and unit-testable without resource loading.
+- **Raw-cosine threshold, not softmax.** Multiple independent tags can apply to one image, so an
+  absolute per-tag cosine floor is the right gate (softmax-over-vocab would force a single winner
+  and distort multi-concept images). Raw CLIP cosines are low-magnitude; 0.22 is a sane default,
+  tuned desk-side on real images.
+- **Raw vocab words, no prompt template.** Terms are embedded verbatim ("invoice"), not as
+  "a photo of an invoice". Simpler and deterministic; prompt-templating is a noted desk-side
+  refinement if recall needs it, behind the same threshold knob.
+- **Reuse CLIP device logic.** No new device function: tagging goes through `embed_image` /
+  `embed_clip_texts`, which use `embeddings.get_clip_model()` → `_clip_device()` (CPU when ASR is
+  active, the existing whisper-cuDNN-shadow fix; `KB_MCP_CLIP_DEVICE` override).
+- **Compute at the extraction seam, accept a second image encode.** `_ocr_image` (the do_ocr job)
+  encodes the image for tags; the separate do_clip job encodes it again for `ClipIndex`. Two
+  forward passes through one shared, already-warm ViT-B/32 — sub-second, off the request path.
+  Keeping tagging at the extraction seam (where the indexed text is assembled) is cleaner than
+  threading a cached vector across two independent worker jobs.
+
+## Soft-fail & default-off
+
+`extract._maybe_image_tags` returns the input `(text, engine)` unchanged when the flag is unset —
+so with `KB_MCP_IMAGE_TAGS` off, `image_tags`/`embeddings` aren't even imported and output is
+byte-identical. When on, `image_tags.compute_tags` never raises: a missing dep/Pillow/model
+(`ClipUnavailable`), an unreadable image, or any encode error returns `[]` → no tags appended,
+extraction completes normally. The vocab matrix is not cached on failure, so a transient absence
+can recover on a later image.
+
+## Risks
+
+- Threshold tuning is empirical: too low → noisy/wrong tags pollute the index; too high → no tags.
+  Mitigated by default-off + a desk-side smoke on real images before enabling, and the env knob.
+- A second CLIP image encode per image (tags + ClipIndex) — acceptable (tiny model, off the
+  request path); a shared-vector optimization is a noted follow-up, not done here.
+- Only newly-extracted images get tags; existing indexed images are unchanged until re-extracted.
+  A `backfill-media` re-tag pass is out of scope here.

--- a/openspec/changes/image-zero-shot-tags/proposal.md
+++ b/openspec/changes/image-zero-shot-tags/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Image search today rests on three thin signals: Tesseract OCR (text that is literally on the
+image), an optional one-line BLIP caption (`KB_MCP_VISION_CAPTION`, default-off), and the CLIP
+visual embedding (`find` matches a text query against the image vector). A photo with no
+on-image text and captioning off contributes nothing to BM25 or the bge text index — it is only
+findable via the CLIP vector, which the user must trigger with a visual-style query. The
+high-value, cheap enrichment we are NOT yet extracting: *what the image depicts* as plain words
+("invoice", "whiteboard", "screenshot", "receipt", "chart") that land in the normal text index.
+
+The CLIP model is already loaded and already encodes BOTH images and text in one shared space.
+Scoring an image's CLIP embedding against a fixed tag vocabulary by cosine is a free, frozen
+MEASUREMENT — no new model, no new dependency. This change turns that into per-image tags
+appended to the indexed text, so a depicted concept becomes BM25-findable and bge-embedded.
+
+It stays **pure-substrate**: CLIP zero-shot cosine is deterministic transduction (the same class
+as OCR/CLIP/bge), not a reasoning LLM. The user has signed off this class of enrichment —
+"richer per-image measurement is in-bounds; cross-image inference stays Claude's."
+
+## What Changes
+
+- **Zero-shot image tags from the already-loaded CLIP model.** A fixed, generic visual-concept
+  vocabulary (~190 terms: document/screen kinds, objects, scenes) is embedded ONCE with CLIP's
+  TEXT encoder and cached. For each image, cosine its CLIP image embedding against the vocab and
+  take the **top-K tags above a threshold**.
+- **Tags append to the image's extracted text at the extraction seam** (`extract._ocr_image`):
+  a single `Tags: invoice, table, screenshot` line is appended after OCR (and after any caption),
+  so it flows through the existing sidecar → BM25 + bge indexing path. No `find` changes, no new
+  index, no schema migration.
+- **Reuse, not duplicate:** the existing CLIP model singleton and its device logic (the
+  whisper-cuDNN-shadow CPU fallback in `embeddings._clip_device()`) are reused as-is. The only new
+  embeddings surface is a batched `embed_clip_texts()` text encoder beside `embed_clip_text()`.
+- **Env-gated, default-OFF, soft-fail.** `KB_MCP_IMAGE_TAGS` is unset by default ⇒ extraction
+  output is byte-identical. `KB_MCP_IMAGE_TAGS_TOPK` (default 5) and `KB_MCP_IMAGE_TAGS_THRESHOLD`
+  (default 0.22 raw cosine) tune it. Any failure (CLIP/Pillow/model absent, unreadable image,
+  encode error) yields no tags and unchanged output — extraction never raises.
+- **No new dependency.** Tagging needs only the existing `embeddings` extra (sentence-transformers
+  + Pillow) that already powers CLIP; a box without it soft-fails to no tags.
+
+Out of scope (future changes): tagging video keyframes; a structured `tags:` frontmatter field or
+a `tag:` filter on `find`; per-vault custom vocabularies; prompt-templated vocab ("a photo of X");
+re-tagging already-indexed images (a `backfill-media` pass would carry it — not wired here).
+
+## Capabilities
+
+### New Capabilities
+- `image-tags`: zero-shot CLIP tags enrich an image's indexed text with the concepts it depicts —
+  default-off, soft-fail, pure-substrate (frozen cosine measurement, no LLM, no new dependency).
+
+## Impact
+
+- Code: `src/kb_mcp/image_tags.py` (new — vocabulary + cached vocab matrix + `compute_tags`);
+  `src/kb_mcp/extract.py` (`_maybe_image_tags` seam in `_ocr_image`); `src/kb_mcp/embeddings.py`
+  (new batched `embed_clip_texts`). `find` / sidecar / index code is untouched.
+- Deps: none added — reuses the `embeddings` extra (CLIP via sentence-transformers + Pillow).
+- Default-off ⇒ zero behavior change when `KB_MCP_IMAGE_TAGS` is unset — image extraction output
+  is byte-identical to today.
+- GPU: tagging runs on the existing CLIP model and inherits `embeddings._clip_device()` (CPU when
+  ASR is active, dodging the whisper cuDNN shadow); a tiny ViT-B/32 text+image encode off the
+  request path in the async media worker.
+- Docs: `KB_MCP_IMAGE_TAGS*` env vars in the README env table; brief note in `docs/deployment.md`.
+  (SKILL/scaffold media-doc copy handled separately — scaffold left untouched, leak-guarded.)

--- a/openspec/changes/image-zero-shot-tags/specs/image-tags/spec.md
+++ b/openspec/changes/image-zero-shot-tags/specs/image-tags/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Zero-Shot CLIP Image Tags
+
+The system SHALL, when image tagging is enabled (`KB_MCP_IMAGE_TAGS`), enrich an image's
+extracted text with zero-shot tags computed from the already-loaded CLIP model: it SHALL embed a
+fixed generic tag vocabulary with CLIP's text encoder (once, cached), cosine the image's CLIP
+embedding against that vocabulary, and select the top-K tags whose cosine score clears a
+configured threshold. The selected tags SHALL be appended to the image's extracted text as a
+single `Tags: <a>, <b>, …` line so they are indexed by BM25 and the bge text index.
+
+#### Scenario: Depicted concept becomes findable text
+
+- **WHEN** an image is extracted with `KB_MCP_IMAGE_TAGS` set and its CLIP embedding scores the
+  vocabulary terms `invoice` and `table` above the threshold
+- **THEN** the extracted text gains a `Tags: invoice, table` line (after any OCR/caption text)
+- **AND** that line is stored in the image's sidecar and indexed like any other extracted text
+
+#### Scenario: Tags are ordered and capped
+
+- **WHEN** more vocabulary terms clear the threshold than the configured top-K
+- **THEN** only the top-K highest-cosine tags are emitted, in descending-score order
+
+#### Scenario: Reuse the loaded CLIP model and device logic
+
+- **WHEN** tags are computed
+- **THEN** the existing CLIP model singleton and its device selection (CPU when ASR is active, per
+  `KB_MCP_CLIP_DEVICE`) are reused with no additional model load and no new dependency
+
+### Requirement: Configurable Top-K and Threshold
+
+The number of tags and the cosine threshold SHALL be configurable via `KB_MCP_IMAGE_TAGS_TOPK`
+and `KB_MCP_IMAGE_TAGS_THRESHOLD`, with sane defaults when unset or unparseable. Only tags whose
+score is greater than or equal to the threshold SHALL be emitted.
+
+#### Scenario: Threshold filters weak matches
+
+- **WHEN** a vocabulary term's cosine score is below `KB_MCP_IMAGE_TAGS_THRESHOLD`
+- **THEN** that term is not emitted as a tag
+
+#### Scenario: Top-K override limits output
+
+- **WHEN** `KB_MCP_IMAGE_TAGS_TOPK` is set to 1 and several terms clear the threshold
+- **THEN** exactly one tag — the highest-scoring — is emitted
+
+#### Scenario: Unparseable override falls back to the default
+
+- **WHEN** `KB_MCP_IMAGE_TAGS_TOPK` or `KB_MCP_IMAGE_TAGS_THRESHOLD` is set to a non-numeric value
+- **THEN** the corresponding built-in default is used and tagging still proceeds
+
+### Requirement: Generic Tag Vocabulary
+
+The tag vocabulary SHALL be a fixed, generic set of common visual concepts (objects, scenes,
+document and screen kinds) shipped in the package. It SHALL contain no personal, brand, tenant, or
+vault-structure tokens, so it passes the source leak guard that scans all of `src/kb_mcp/`.
+
+#### Scenario: Vocabulary is generic and leak-safe
+
+- **WHEN** the package source is scanned by the leak guard (`tests/test_scaffold_no_leak.py`)
+- **THEN** the vocabulary introduces no personal or brand token and the scan passes
+
+#### Scenario: Vocabulary terms are clean and unique
+
+- **WHEN** the vocabulary is loaded
+- **THEN** every term is a non-empty lowercase concept and there are no duplicate terms
+
+### Requirement: Default-Off and Byte-Identical When Unset
+
+Image tagging SHALL change no behavior unless `KB_MCP_IMAGE_TAGS` is set. With the flag unset, the
+image extraction output SHALL be byte-identical to the current OCR (plus optional caption) output,
+and no tagging or CLIP-text code path SHALL run.
+
+#### Scenario: Flag unset leaves extraction unchanged
+
+- **WHEN** an image is extracted with `KB_MCP_IMAGE_TAGS` unset
+- **THEN** the extracted text and engine are exactly today's OCR/caption result with no `Tags:` line
+- **AND** no tag computation is performed
+
+### Requirement: Soft-Fail Degradation
+
+The tagging path SHALL soft-fail. Any failure — a missing CLIP/Pillow dependency, an unloadable
+model, a GPU/cuDNN error, an unreadable image, or any encoding error — SHALL be logged and degrade
+to producing no tags. Image extraction MUST still complete successfully; the path MUST NOT raise.
+
+#### Scenario: CLIP dependency absent
+
+- **WHEN** the CLIP model or Pillow is not importable while tagging is enabled
+- **THEN** no tags are appended and the image's OCR/caption text is extracted and stored unchanged
+- **AND** the failure is logged and extraction does not raise
+
+#### Scenario: No vocabulary term clears the threshold
+
+- **WHEN** tagging runs but no vocabulary term's score clears the threshold
+- **THEN** no `Tags:` line is appended and the extraction output is the unchanged OCR/caption text

--- a/openspec/changes/image-zero-shot-tags/tasks.md
+++ b/openspec/changes/image-zero-shot-tags/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — Zero-shot image tags
+
+## 1. CLIP text-encode seam (reuse, no new dep)
+- [x] 1.1 Add `embeddings.embed_clip_texts(texts) -> np.ndarray (N, 512)`: batched CLIP text
+      encoder beside `embed_clip_text`, L2-normalized, raises `ClipUnavailable` when CLIP missing.
+
+## 2. Tag vocabulary + scoring (TDD-able, model stubbed)
+- [x] 2.1 Add `src/kb_mcp/image_tags.py`: fixed generic `TAG_VOCAB` (~190 brand-free concepts),
+      cached `_vocab_matrix()` (vocab embedded once via `embed_clip_texts`), `compute_tags(path)`
+      (cosine image-vs-vocab → top-K above threshold, descending score, soft-fail → `[]`),
+      `image_tags_enabled()`, `_top_k()`/`_threshold()` env knobs, `format_tags_line()`.
+- [x] 2.2 Tests `tests/test_image_tags.py` (CLIP patched — no real model): threshold + top-K +
+      ordering, env overrides + unparseable fallback, soft-fail (ClipUnavailable + unexpected
+      error) → `[]`, vocab generic/unique/sized.
+
+## 3. Wire tags into image extraction (default-off seam)
+- [x] 3.1 In `extract._ocr_image`: after `_maybe_caption`, call new `_maybe_image_tags(text, path,
+      engine)` — gated on `KB_MCP_IMAGE_TAGS`; appends `Tags: a, b, c` to the text and `+tags` to
+      the engine. Flag off OR no tags → unchanged `(text, engine)`, byte-identical output.
+- [x] 3.2 Tests in `tests/test_image_tags.py` for the seam: flag-off unchanged (compute never
+      called), appended when enabled, empty-OCR → tags-only line, caption-engine preserved
+      (`…+tags`), no-tags → unchanged.
+
+## 4. Docs (no dep change — reuses the `embeddings` extra)
+- [x] 4.1 Add `KB_MCP_IMAGE_TAGS` / `KB_MCP_IMAGE_TAGS_TOPK` / `KB_MCP_IMAGE_TAGS_THRESHOLD` rows
+      to the README env table; brief note in `docs/deployment.md`. (Scaffold/SKILL untouched —
+      leak-guarded; handled separately.)
+
+## 5. Verify
+- [x] 5.1 `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 python -m pytest -q` green (full suite, no
+      regression).
+- [x] 5.2 `ruff check .` clean (no new findings).
+- [x] 5.3 `openspec validate image-zero-shot-tags --strict` passes.
+- [ ] 5.4 Desk-side smoke (GPU box, real CLIP): enable `KB_MCP_IMAGE_TAGS`, extract a few real
+      images (an invoice scan, a whiteboard photo, a UI screenshot), confirm sensible `Tags:` lines
+      and that `find` surfaces them by the tag words; tune `KB_MCP_IMAGE_TAGS_THRESHOLD` if needed.
+      **(Hugo runs — needs GPU + the CLIP model on real images.)**
+
+## 6. Follow-ups (post-merge, non-blocking)
+- [ ] 6.1 Share the CLIP image vector between the do_ocr tag pass and the do_clip `ClipIndex` pass
+      so an image is encoded once, not twice (pure perf; off the request path).
+- [ ] 6.2 A `backfill-media` re-tag pass for already-indexed images (this change only tags newly
+      extracted images).
+- [ ] 6.3 Optional structured `tags:` frontmatter field + a `tag:` filter on `find`; per-vault
+      custom vocabularies; prompt-templated vocab ("a photo of X") if recall needs it.

--- a/src/kb_mcp/embeddings.py
+++ b/src/kb_mcp/embeddings.py
@@ -193,6 +193,23 @@ def embed_clip_text(query: str) -> np.ndarray:
     return vec.astype(np.float32, copy=False)
 
 
+def embed_clip_texts(texts: list[str]) -> np.ndarray:
+    """Batch-encode texts into CLIP space → float32 `(N, 512)`, L2-normalized.
+
+    Same shared image+text space as `embed_image`, so a cosine between an image vector
+    and these text vectors is a valid zero-shot match score. Used to embed the fixed
+    image-tag vocabulary once (image_tags). Raises ClipUnavailable when CLIP is missing.
+    """
+    if not texts:
+        return np.zeros((0, CLIP_DIM), dtype=np.float32)
+    try:
+        model = get_clip_model()
+    except ImportError as e:
+        raise ClipUnavailable(f"sentence-transformers not installed: {e}") from e
+    vecs = model.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
+    return vecs.astype(np.float32, copy=False)
+
+
 CLIP_VIDEO_FRAMES = 8  # frame budget for the unknown-duration sequential fallback
 
 

--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -498,6 +498,9 @@ def _ocr_image(path: Path) -> ExtractResult:
     # OPTIONAL frozen-model caption (KB_MCP_VISION_CAPTION, default OFF) prepended so
     # a photo with no on-image text is still findable. Soft-fails to OCR-only.
     text, engine = _maybe_caption(text, path)
+    # OPTIONAL CLIP zero-shot tags (KB_MCP_IMAGE_TAGS, default OFF) appended so the image
+    # is findable by what it depicts ("invoice", "whiteboard"). Soft-fails to no tags.
+    text, engine = _maybe_image_tags(text, path, engine)
     return ExtractResult(text=text, media_type="image", engine=engine)
 
 
@@ -593,6 +596,36 @@ def _maybe_caption(ocr_text: str, path: Path) -> tuple[str, str]:
     text = f"{caption}\n\n{ocr_text}".strip() if ocr_text else caption
     short = _caption_model_name().rsplit("/", 1)[-1]
     return text, f"tesseract+{short}"
+
+
+# ---------------- optional: CLIP zero-shot image tags (KB_MCP_IMAGE_TAGS, default OFF) ----
+#
+# PURE-SUBSTRATE NOTE: scoring an image's CLIP embedding against a fixed text vocabulary is
+# deterministic MEASUREMENT — the same category as Tesseract OCR, CLIP visual search, and the
+# bge embedder. It reads pixels into a fixed cosine score against frozen vectors; it does NOT
+# generate language and is not a reasoning LLM (cross-image inference stays Claude's). The
+# computation + vocabulary live in `image_tags`; this seam just gates it (default-OFF) and
+# appends the tags to the indexed text. With the flag off the OCR text flows through unchanged.
+
+
+def _maybe_image_tags(ocr_text: str, path: Path, engine: str) -> tuple[str, str]:
+    """Append CLIP zero-shot tags (KB_MCP_IMAGE_TAGS, default OFF) to an image's extracted text.
+
+    Flag off, no tag clears the threshold, or CLIP soft-fails → unchanged `(ocr_text, engine)`.
+    Tags present → `<text>\\n\\nTags: a, b, c` with `+tags` appended to the engine for provenance.
+    """
+    # Check the gate BEFORE importing image_tags (which pulls in embeddings/CLIP), so the
+    # default-off path imports nothing and the output is byte-identical — mirrors _maybe_caption.
+    if not os.environ.get("KB_MCP_IMAGE_TAGS"):
+        return ocr_text, engine
+    from . import image_tags  # lazy: defers the CLIP/embeddings import until opted in
+
+    tags = image_tags.compute_tags(path)
+    line = image_tags.format_tags_line(tags)
+    if not line:
+        return ocr_text, engine
+    text = f"{ocr_text}\n\n{line}" if ocr_text else line
+    return text, f"{engine}+tags"
 
 
 def _extract_pdf(path: Path) -> ExtractResult:

--- a/src/kb_mcp/image_tags.py
+++ b/src/kb_mcp/image_tags.py
@@ -1,0 +1,175 @@
+"""Zero-shot image tagging via the already-loaded CLIP model (KB_MCP_IMAGE_TAGS, default OFF).
+
+Enriches an image's per-file MEASUREMENT: score the image's CLIP embedding against a fixed,
+generic tag vocabulary by cosine, take the top-K tags above a threshold, and (at the
+extraction seam) append them to the image's extracted text so they become BM25-findable and
+bge-embedded. This makes a photo discoverable by what it depicts ("invoice", "whiteboard",
+"screenshot") even when it carries no on-image text.
+
+PURE-SUBSTRATE NOTE: CLIP zero-shot scoring is deterministic MEASUREMENT — the same class as
+Tesseract OCR, CLIP visual search, and the bge embedder. It maps pixels to a fixed cosine
+score against frozen text vectors; it does not generate language and is not a reasoning LLM.
+Cross-image inference stays Claude's job.
+
+Reuses `embeddings.get_clip_model()` (one model that encodes BOTH images and text) and its
+device logic (the whisper-cuDNN-shadow CPU fallback in `embeddings._clip_device()`) — no new
+dependency, no second model. The vocabulary is embedded ONCE with CLIP's text encoder and
+cached for the process. Soft-fail everywhere: CLIP/Pillow/model absent, or any error, yields
+no tags and leaves extraction output unchanged. Default-OFF ⇒ byte-identical when unset.
+
+Tunables (env): `KB_MCP_IMAGE_TAGS` (gate), `KB_MCP_IMAGE_TAGS_TOPK` (default 5),
+`KB_MCP_IMAGE_TAGS_THRESHOLD` (raw cosine floor, default 0.22).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+import numpy as np
+
+from . import embeddings
+
+log = logging.getLogger(__name__)
+
+
+# A fixed, GENERIC visual-concept vocabulary (objects, scenes, document/screen kinds). Kept
+# brand- and identity-free on purpose: this ships under src/kb_mcp/ and is leak-guarded
+# (tests/test_scaffold_no_leak.py). Lowercase single concepts; embedded once with CLIP's text
+# encoder. Order is irrelevant — tags are emitted by descending cosine, not vocab position.
+TAG_VOCAB: tuple[str, ...] = (
+    # documents & paperwork
+    "invoice", "receipt", "contract", "form", "spreadsheet", "report", "resume",
+    "letter", "certificate", "ticket", "menu", "label", "business card", "sticky note",
+    "handwriting", "signature", "stamp", "barcode", "qr code", "calendar", "schedule",
+    "map", "blueprint", "sheet music", "newspaper", "magazine", "book", "document",
+    "poster", "flyer", "brochure",
+    # data visualization & diagrams
+    "table", "chart", "graph", "diagram", "flowchart", "infographic", "timeline",
+    "mind map", "whiteboard", "presentation slide",
+    # screens, software & technology
+    "screenshot", "dashboard", "website", "app interface", "login screen",
+    "error message", "terminal", "source code", "email", "chat conversation",
+    "social media post", "video call", "keyboard", "monitor", "laptop", "smartphone",
+    "tablet", "computer", "server rack", "circuit board", "robot", "drone", "camera",
+    "headphones",
+    # buildings & places
+    "cityscape", "skyline", "street", "road", "highway", "bridge", "building",
+    "skyscraper", "house", "apartment", "office", "kitchen", "bathroom", "bedroom",
+    "living room", "classroom", "library", "store", "restaurant", "cafe", "hospital",
+    "church", "museum", "stadium", "airport", "train station", "parking lot",
+    "construction site", "factory", "warehouse", "farm",
+    # nature & landscape
+    "garden", "park", "playground", "beach", "ocean", "lake", "river", "waterfall",
+    "mountain", "valley", "forest", "desert", "field", "cave", "island", "snow",
+    "glacier", "sky", "clouds", "sunset", "sunrise", "rainbow", "storm", "lightning",
+    "rain", "fog", "fire", "smoke", "night sky", "stars", "moon",
+    # people & activities
+    "person", "crowd", "portrait", "selfie", "group photo", "family", "child", "baby",
+    "wedding", "party", "concert", "meeting", "conference", "sports", "running",
+    "cycling", "swimming", "hiking", "dancing", "cooking", "reading", "gaming",
+    "shopping", "traveling", "protest", "parade", "graduation",
+    # animals
+    "dog", "cat", "bird", "horse", "cow", "sheep", "fish", "insect", "butterfly",
+    "wildlife",
+    # food & drink
+    "food", "meal", "breakfast", "coffee", "tea", "cake", "dessert", "fruit",
+    "vegetable", "drink", "wine", "cocktail",
+    # vehicles
+    "car", "truck", "bus", "train", "airplane", "boat", "ship", "bicycle",
+    "motorcycle",
+    # objects
+    "money", "coin", "jewelry", "watch", "clock", "flower", "plant", "tree", "tool",
+    "machine", "furniture", "chair", "bed", "lamp", "sculpture", "statue", "sign",
+    "billboard", "flag", "box", "bottle", "bag", "clothing", "shoes", "hat", "toy",
+    "ball", "guitar", "piano",
+    # art, media & imaging style
+    "photograph", "illustration", "cartoon", "comic", "sketch", "logo", "icon", "meme",
+    "abstract art", "pattern", "texture", "collage", "black and white photo",
+    "aerial view", "close-up", "x-ray", "medical scan", "microscope image",
+)
+
+DEFAULT_TOP_K = 5
+DEFAULT_THRESHOLD = 0.22
+
+_VOCAB_MATRIX: np.ndarray | None = None
+_VOCAB_LOCK = threading.Lock()
+
+
+def image_tags_enabled() -> bool:
+    """True only when KB_MCP_IMAGE_TAGS is set. OFF by default — tagging never changes
+    extraction output unless explicitly opted in (so output is byte-identical when unset)."""
+    return bool(os.environ.get("KB_MCP_IMAGE_TAGS"))
+
+
+def _top_k() -> int:
+    """Max tags to emit (KB_MCP_IMAGE_TAGS_TOPK, default DEFAULT_TOP_K)."""
+    raw = os.environ.get("KB_MCP_IMAGE_TAGS_TOPK")
+    if raw:
+        try:
+            v = int(raw)
+            if v > 0:
+                return v
+        except ValueError:
+            pass
+    return DEFAULT_TOP_K
+
+
+def _threshold() -> float:
+    """Raw-cosine floor a tag must clear (KB_MCP_IMAGE_TAGS_THRESHOLD, default DEFAULT_THRESHOLD)."""
+    raw = os.environ.get("KB_MCP_IMAGE_TAGS_THRESHOLD")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return DEFAULT_THRESHOLD
+
+
+def _vocab_matrix() -> np.ndarray:
+    """Cached CLIP text-embedding matrix of TAG_VOCAB → `(len(TAG_VOCAB), CLIP_DIM)`.
+
+    Embedded once per process via CLIP's text encoder. Not cached on failure: an error
+    propagates so `compute_tags` soft-fails and a later call can retry once CLIP is present.
+    """
+    global _VOCAB_MATRIX
+    if _VOCAB_MATRIX is not None:
+        return _VOCAB_MATRIX
+    with _VOCAB_LOCK:
+        if _VOCAB_MATRIX is None:
+            _VOCAB_MATRIX = embeddings.embed_clip_texts(list(TAG_VOCAB))
+    return _VOCAB_MATRIX
+
+
+def compute_tags(path: str | Path) -> list[str]:
+    """Top-K vocab tags (descending cosine) whose score clears the threshold, or [] on soft-fail.
+
+    Embeds the image with CLIP, cosines it against the cached vocabulary matrix, and returns the
+    matching tags. Never raises: a missing dep/model/Pillow, an unreadable image, or any error
+    returns [] so the caller keeps the unchanged extraction text.
+    """
+    p = Path(path)
+    try:
+        img_vec = embeddings.embed_image(p)
+        mat = _vocab_matrix()
+    except embeddings.ClipUnavailable as e:
+        log.debug("image-tags: CLIP unavailable for %s: %s", p.name, e)
+        return []
+    except Exception:  # noqa: BLE001 — tagging is best-effort; never break extraction
+        log.warning("image-tags: tagging failed for %s; no tags applied", p.name, exc_info=True)
+        return []
+    if mat.size == 0:
+        return []
+    scores = mat @ img_vec.astype(np.float32, copy=False)
+    threshold = _threshold()
+    top_k = _top_k()
+    order = np.argsort(-scores)[:top_k]
+    return [TAG_VOCAB[i] for i in order if scores[i] >= threshold]
+
+
+def format_tags_line(tags: list[str]) -> str:
+    """Render tags as the single indexed line appended to an image's text, e.g.
+    `Tags: invoice, table, screenshot`. Empty string for no tags (caller skips appending)."""
+    return "Tags: " + ", ".join(tags) if tags else ""

--- a/tests/test_image_tags.py
+++ b/tests/test_image_tags.py
@@ -1,0 +1,172 @@
+"""CLIP zero-shot image tagging — vocab scoring + the extraction-seam append (model stubbed).
+
+Mirrors the caption tests' style: the CLIP model is never loaded. `embeddings.embed_image` and
+`embeddings.embed_clip_texts` are patched to return controlled vectors, so scoring/threshold/
+top-K/soft-fail are exercised deterministically. Default-OFF ⇒ extraction output unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kb_mcp import embeddings, extract, image_tags
+
+
+def _unit(i: int) -> np.ndarray:
+    v = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+    v[i] = 1.0
+    return v
+
+
+# A tiny stand-in vocabulary; rows of the patched matrix are the matching basis vectors so
+# `matrix @ image_vec` yields exactly the image_vec's leading components as cosine scores.
+_FAKE_VOCAB = ("invoice", "table", "screenshot", "dog")
+_FAKE_MATRIX = np.stack([_unit(i) for i in range(len(_FAKE_VOCAB))]).astype(np.float32)
+
+
+def _patch_clip(monkeypatch: pytest.MonkeyPatch, image_vec: np.ndarray) -> None:
+    """Stub the CLIP seams: fixed vocab + matrix, a controlled image vector, fresh cache."""
+    monkeypatch.setattr(image_tags, "TAG_VOCAB", _FAKE_VOCAB)
+    monkeypatch.setattr(image_tags, "_VOCAB_MATRIX", None)
+    monkeypatch.setattr(embeddings, "embed_clip_texts", lambda texts: _FAKE_MATRIX)
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: image_vec)
+
+
+def _img_vec(invoice: float, table: float, screenshot: float, dog: float) -> np.ndarray:
+    v = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+    v[0], v[1], v[2], v[3] = invoice, table, screenshot, dog
+    return v
+
+
+# ---- gate -------------------------------------------------------------------
+
+
+def test_image_tags_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS", raising=False)
+    assert image_tags.image_tags_enabled() is False
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS", "1")
+    assert image_tags.image_tags_enabled() is True
+
+
+# ---- scoring: threshold + top-K + ordering ----------------------------------
+
+
+def test_compute_tags_threshold_and_descending_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS_TOPK", raising=False)
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS_THRESHOLD", raising=False)
+    # Scores: invoice=0.9, table=0.5, screenshot=0.1, dog=0.0. Default threshold 0.22 drops
+    # screenshot+dog; result is sorted by descending cosine.
+    _patch_clip(monkeypatch, _img_vec(0.9, 0.5, 0.1, 0.0))
+    assert image_tags.compute_tags(Path("x.png")) == ["invoice", "table"]
+
+
+def test_compute_tags_top_k_caps_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS_TOPK", "1")
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS_THRESHOLD", raising=False)
+    _patch_clip(monkeypatch, _img_vec(0.9, 0.5, 0.3, 0.25))
+    assert image_tags.compute_tags(Path("x.png")) == ["invoice"]  # only the single best
+
+
+def test_compute_tags_threshold_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS_TOPK", raising=False)
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS_THRESHOLD", "0.05")  # lets screenshot (0.1) through
+    _patch_clip(monkeypatch, _img_vec(0.9, 0.5, 0.1, 0.0))
+    assert image_tags.compute_tags(Path("x.png")) == ["invoice", "table", "screenshot"]
+
+
+def test_compute_tags_none_above_threshold_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS_THRESHOLD", raising=False)
+    _patch_clip(monkeypatch, _img_vec(0.1, 0.05, 0.0, 0.0))  # all below 0.22
+    assert image_tags.compute_tags(Path("x.png")) == []
+
+
+# ---- soft-fail --------------------------------------------------------------
+
+
+def test_compute_tags_soft_fails_when_clip_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(image_tags, "_VOCAB_MATRIX", None)
+
+    def _no_clip(_p):
+        raise embeddings.ClipUnavailable("sentence-transformers not installed")
+
+    monkeypatch.setattr(embeddings, "embed_image", _no_clip)
+    assert image_tags.compute_tags(Path("x.png")) == []
+
+
+def test_compute_tags_soft_fails_on_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(image_tags, "TAG_VOCAB", _FAKE_VOCAB)
+    monkeypatch.setattr(image_tags, "_VOCAB_MATRIX", None)
+    monkeypatch.setattr(embeddings, "embed_image", lambda p: _img_vec(0.9, 0.0, 0.0, 0.0))
+
+    def _boom(_texts):
+        raise RuntimeError("vocab encode blew up")
+
+    monkeypatch.setattr(embeddings, "embed_clip_texts", _boom)
+    assert image_tags.compute_tags(Path("x.png")) == []  # error swallowed → no tags
+
+
+# ---- format -----------------------------------------------------------------
+
+
+def test_format_tags_line() -> None:
+    assert image_tags.format_tags_line(["invoice", "table"]) == "Tags: invoice, table"
+    assert image_tags.format_tags_line([]) == ""
+
+
+# ---- extraction seam: _maybe_image_tags -------------------------------------
+
+
+def test_maybe_image_tags_unchanged_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_MCP_IMAGE_TAGS", raising=False)
+    called: list = []
+    monkeypatch.setattr(image_tags, "compute_tags", lambda p: called.append(p) or ["invoice"])
+    text, engine = extract._maybe_image_tags("ocr body", Path("x.png"), "tesseract")
+    assert text == "ocr body"
+    assert engine == "tesseract"
+    assert called == []  # flag off → CLIP path is never invoked (byte-identical output)
+
+
+def test_maybe_image_tags_appends_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS", "1")
+    monkeypatch.setattr(image_tags, "compute_tags", lambda p: ["invoice", "table", "screenshot"])
+    text, engine = extract._maybe_image_tags("INVOICE 7731", Path("x.png"), "tesseract")
+    assert text == "INVOICE 7731\n\nTags: invoice, table, screenshot"
+    assert engine == "tesseract+tags"
+
+
+def test_maybe_image_tags_empty_ocr_returns_tags_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS", "1")
+    monkeypatch.setattr(image_tags, "compute_tags", lambda p: ["beach", "ocean"])
+    text, engine = extract._maybe_image_tags("", Path("x.png"), "tesseract")
+    assert text == "Tags: beach, ocean"
+    assert engine == "tesseract+tags"
+
+
+def test_maybe_image_tags_preserves_caption_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tags stack on top of a caption: engine becomes `<caption-engine>+tags`."""
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS", "1")
+    monkeypatch.setattr(image_tags, "compute_tags", lambda p: ["whiteboard"])
+    text, engine = extract._maybe_image_tags("a meeting room", Path("x.png"), "tesseract+blip-large")
+    assert text == "a meeting room\n\nTags: whiteboard"
+    assert engine == "tesseract+blip-large+tags"
+
+
+def test_maybe_image_tags_unchanged_when_no_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_IMAGE_TAGS", "1")
+    monkeypatch.setattr(image_tags, "compute_tags", lambda p: [])  # soft-fail / nothing clears
+    text, engine = extract._maybe_image_tags("ocr body", Path("x.png"), "tesseract")
+    assert text == "ocr body"
+    assert engine == "tesseract"
+
+
+# ---- vocabulary hygiene -----------------------------------------------------
+
+
+def test_vocab_is_generic_unique_and_sized() -> None:
+    vocab = image_tags.TAG_VOCAB
+    assert len(vocab) >= 150  # a useful zero-shot surface
+    assert len(set(vocab)) == len(vocab)  # no duplicate rows
+    assert all(t == t.lower() and t.strip() == t and t for t in vocab)  # clean lowercase concepts


### PR DESCRIPTION
OpenSpec change `image-zero-shot-tags`. Reuses the already-loaded CLIP model to score each image against a generic vocab and append findable tags. Default-off, soft-fail, pure-substrate. 799 passed; MCP schemas byte-identical; leak guard green. Code-reviewed APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)