### PR TITLE
fix(diarization): decode via PyAV, bypass broken torchcodec on cu132

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -285,6 +285,11 @@ absent. Tune with `KB_MCP_IMAGE_TAGS_TOPK` (default 5) and
 `KB_MCP_IMAGE_TAGS_THRESHOLD` (raw cosine, default 0.22); only newly-extracted
 images are tagged.
 
+**Install:** `uv sync --extra media --extra diarization`, then **`uv pip uninstall torchcodec`**
+— the extra pulls `torchcodec` transitively, but its native lib won't load against the torch-cu132
+build and importing it breaks `sentence-transformers` (the embedding stack); it's unused here
+(audio decode goes through faster-whisper's PyAV path), so it must be removed.
+
 Named-speaker diarization's ECAPA voice embedder (`diarization` extra) runs on
 torch and follows the same precedent: it defaults to **CPU when ASR is active**, with
 a `KB_MCP_VOICE_DEVICE=cuda`/`cpu` override. Enroll voices with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ media = [
 # Heavy + default-OFF + soft-fail, so it's an extra, never a core dep — the base install and
 # the test suite never require it. Both pyannote and the ECAPA checkpoint gate their weights
 # behind a HF token (HUGGINGFACE_TOKEN). Full install: `uv sync --extra media --extra diarization`.
+# WARNING (diagnosed 2026-06-28): the extra transitively pulls `torchcodec`, whose native lib
+# won't load against the torch-cu132 build AND breaks `sentence-transformers` (the embedding
+# stack) on import. It is UNUSED here — audio decode goes through faster-whisper's PyAV path —
+# so REMOVE it after installing: `uv pip uninstall torchcodec`.
 diarization = [
     "pyannote.audio>=3.1",
     "speechbrain>=1.0",  # ECAPA-TDNN speaker embeddings for named-speaker attribution

--- a/src/kb_mcp/extract.py
+++ b/src/kb_mcp/extract.py
@@ -325,7 +325,15 @@ def _run_diarization(path: Path) -> list[tuple[float, float, str]] | None:
         log.warning("diarization pipeline load failed; using plain transcript", exc_info=True)
         return None
     try:
-        annotation = pipeline(str(path))
+        # Decode via faster-whisper's PyAV path and hand pyannote a pre-decoded waveform dict,
+        # bypassing pyannote 4.x / torchaudio's torchcodec decoder (its native lib won't load
+        # against torch-cu132 — the diarization blocker diagnosed 2026-06-28).
+        import torch
+        from faster_whisper.audio import decode_audio
+
+        samples = decode_audio(str(path), sampling_rate=16000)
+        waveform = torch.as_tensor(samples, dtype=torch.float32).unsqueeze(0)
+        annotation = pipeline({"waveform": waveform, "sample_rate": 16000})
         return [
             (float(turn.start), float(turn.end), str(label))
             for turn, _track, label in annotation.itertracks(yield_label=True)

--- a/src/kb_mcp/voice_embed.py
+++ b/src/kb_mcp/voice_embed.py
@@ -109,19 +109,18 @@ def _get_voice_model():
 def _load_audio(audio_path):
     """Load `audio_path` as a mono 16 kHz float waveform `(1, N)` torch tensor + sample rate.
 
-    Uses torchaudio (pulled in by speechbrain); absent/undecodable → the caller catches and
-    returns None. Multi-channel audio is downmixed to mono; non-16 kHz is resampled so spans
-    align with ECAPA's training rate.
+    Decodes via faster-whisper's PyAV-based `decode_audio` (handles wav/mp3/m4a/video; already a
+    media dep, present whenever ASR/diarization runs) — NOT torchaudio, whose 2.x decode routes
+    through `torchcodec`, whose native lib fails to load against torch-cu132 (the diarization
+    blocker diagnosed 2026-06-28). `decode_audio` returns a mono float32 array already resampled
+    to the target rate. absent/undecodable → the caller catches and returns None.
     """
-    import torchaudio
+    import torch
+    from faster_whisper.audio import decode_audio  # soft dep — bundles PyAV/ffmpeg, no torchcodec
 
-    waveform, sr = torchaudio.load(str(audio_path))
-    if waveform.shape[0] > 1:
-        waveform = waveform.mean(dim=0, keepdim=True)
-    if sr != _TARGET_SR:
-        waveform = torchaudio.functional.resample(waveform, sr, _TARGET_SR)
-        sr = _TARGET_SR
-    return waveform, sr
+    samples = decode_audio(str(audio_path), sampling_rate=_TARGET_SR)
+    waveform = torch.from_numpy(np.ascontiguousarray(samples, dtype=np.float32)).unsqueeze(0)
+    return waveform, _TARGET_SR
 
 
 def embed_spans(audio_path, spans) -> np.ndarray | None:


### PR DESCRIPTION
Installing the diarization extra pulled `torchcodec`, whose native lib won't load against torch-cu132 and breaks `sentence-transformers` (the embedding stack). Fix: decode audio via faster-whisper's PyAV path (no torchaudio/torchcodec), feed pyannote a pre-decoded waveform dict, and document `uv pip uninstall torchcodec` (unused). Enroll smoke passes on the real ECAPA stack; full suite 813 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)