### PR TITLE
feat(ranking): close the auto-tune loop (usage→pairs→tuner + reviewed loadable config)

### DIFF
--- a/docs/ranking-tuning.md
+++ b/docs/ranking-tuning.md
@@ -1,0 +1,99 @@
+# Ranking auto-tune — the closed feedback loop
+
+kb-mcp's hybrid ranker (`RankingConfig` in `src/kb_mcp/find.py`) self-tunes from
+your own usage. The loop is **asynchronous and reviewed**: cheap continuous
+mining, a periodic desk-side tune that only *proposes*, and an explicit, reversible
+adopt. Nothing on the server holds a model or a key — it is deterministic
+measurement end to end (see `openspec/specs/ranking-autotune`).
+
+## The loop
+
+```
+capture ──→ mine ──→ tune ──→ review ──→ adopt ──→ (restart)
+(logs)     (snapshot) (desk)  (report)  (commit)   (find reloads)
+```
+
+1. **Capture** — every `find()` and citing write is logged to
+   `logs/queries.jsonl` / `logs/writes.jsonl` (already on). No action needed.
+2. **Mine** — `derive_relevance_pairs.py` joins those logs into weak
+   `(query → cited_path)` relevance pairs and rewrites `logs/relevance_pairs.jsonl`
+   as an **idempotent, deduped snapshot** (re-running over the same logs is
+   byte-identical, so it is safe to schedule):
+
+   ```
+   uv run python scripts/derive_relevance_pairs.py
+   uv run python scripts/derive_relevance_pairs.py --window-hours 6 --dry-run
+   ```
+
+3. **Tune** — `auto_tune_ranking.py` mines fresh, then coordinate-descends the
+   knobs under a lexicographic objective `(pair_mrr, golden_ndcg)`: the 9
+   hand-authored golden queries are a **hard floor** (no candidate may drop golden
+   NDCG@10 more than `--epsilon` below baseline), and the mined pairs are the
+   improvement signal (scored as **binary** relevance — a cited doc is relevant,
+   full stop; mined `confidence` is only a `--conf-min` filter, never a grade).
+   Below `--min-pairs` distinct eligible pair queries the pairs term is **off** and
+   the run reduces to a golden-only tune. Needs torch + the live vault, so it is
+   **desk-side only**:
+
+   ```
+   uv run python scripts/auto_tune_ranking.py
+   ```
+
+   It writes a candidate (`logs/ranking_config.candidate.json`) + a delta report
+   (`logs/ranking_config.report.md`). It **never** edits `find.py` or applies
+   anything.
+
+   > Expect a no-op while usage is thin: until ~`--min-pairs` distinct cited
+   > queries accumulate, the guard keeps the pairs term off and the candidate equals
+   > `DEFAULT_RANKING`. That is correct — the loop is real and safe, not idle.
+
+4. **Review** — read `logs/ranking_config.report.md` (knob deltas, golden/pairs
+   metrics, guard status).
+
+5. **Adopt** — promote the candidate to the committed repo-root
+   `ranking_config.json`. Adoption reuses the golden floor: it refuses a
+   golden-regressing candidate unless `--force`.
+
+   ```
+   uv run python scripts/auto_tune_ranking.py --adopt
+   git add ranking_config.json && git commit -m "tune: adopt ranking config"
+   # deploy + restart the service so find() reloads it
+   ```
+
+6. **Reload** — `find()` loads `ranking_config.json` once per process at startup
+   (same as `.env`: restart to pick up a change).
+
+## How `find()` resolves its config
+
+When `find()` is called **without** an explicit `config` (the live server's path),
+it resolves the active `RankingConfig` in this order:
+
+1. `KB_MCP_DISABLE_RANKING_CONFIG` set → `DEFAULT_RANKING` (the test suite sets this).
+2. `KB_MCP_RANKING_CONFIG=<path>` → that file.
+3. repo-root `ranking_config.json` → that file.
+4. otherwise → `DEFAULT_RANKING`.
+
+A malformed / wrong-typed / bad-lane-length file is logged at **error** and falls
+back to `DEFAULT_RANKING` — it never crashes the server and never applies a partial
+config. **With no file present, ranking is byte-identical to the in-code default.**
+
+## Revert
+
+Delete `ranking_config.json` (or `git revert` the adoption) and restart →
+`DEFAULT_RANKING`, exactly as before. The candidate/report under `logs/` are
+gitignored desk-side artifacts.
+
+## Env vars
+
+| var | effect |
+|---|---|
+| `KB_MCP_RANKING_CONFIG` | override the adopted-config path (tests / per-box). |
+| `KB_MCP_DISABLE_RANKING_CONFIG` | force `DEFAULT_RANKING` (set in the test suite). |
+| `KB_MCP_DISABLE_EMBEDDINGS` | unset for the desk-side eval/tune (they force it off). |
+
+## Pure-substrate
+
+No server-side reasoning LLM anywhere. Relevance labels come only from recorded
+usage (your real citations), the evaluator computes deterministic ranking metrics,
+and the tuner is deterministic coordinate descent — the same logs + vault always
+produce the same proposed config.

--- a/docs/ranking-tuning.md
+++ b/docs/ranking-tuning.md
@@ -43,9 +43,10 @@ capture ──→ mine ──→ tune ──→ review ──→ adopt ──→
    (`logs/ranking_config.report.md`). It **never** edits `find.py` or applies
    anything.
 
-   > Expect a no-op while usage is thin: until ~`--min-pairs` distinct cited
-   > queries accumulate, the guard keeps the pairs term off and the candidate equals
-   > `DEFAULT_RANKING`. That is correct — the loop is real and safe, not idle.
+   > The `--min-pairs` guard keeps the pairs term off until enough distinct cited
+   > queries accumulate (then the candidate equals `DEFAULT_RANKING`, which is correct
+   > — safe, not idle). On a vault with real usage the guard is typically already
+   > cleared, so the pairs term engages and the tune reflects how you actually search.
 
 4. **Review** — read `logs/ranking_config.report.md` (knob deltas, golden/pairs
    metrics, guard status).

--- a/openspec/changes/close-auto-tune-loop/design.md
+++ b/openspec/changes/close-auto-tune-loop/design.md
@@ -1,0 +1,192 @@
+# Design — Close the auto-tune loop
+
+## Context
+
+The ranker tuning loop has five stages: **capture** (queries/writes JSONL logs,
+already written by `query_log`) → **mine** (`derive_relevance_pairs.py`) →
+**incorporate** (pairs enter the tuner objective) → **tune**
+(`auto_tune_ranking.py` coordinate descent) → **adopt** (`find()` uses the tuned
+config). Capture and tune exist and work. Incorporate is broken (pairs are loaded
+but never scored), mine is non-idempotent (append), and adopt has no seam (hand-edit
+`find.py`). This change fixes the three broken stages without touching capture or the
+descent algorithm.
+
+The loop is inherently **asynchronous**: mining is cheap and torch-free; tuning is
+heavy and desk-side (it force-enables embeddings and runs `find()` per candidate
+over the live vault, contending the GPU with the live service); adoption is a human
+flip. There is no real-time component and no daemon — consistent with the
+pure-substrate line (the server measures; a desk-side script or a scheduled Claude
+Code routine drives tuning; nothing on the box holds a metered key).
+
+## Goals / non-goals
+
+- **Goal:** mined usage actually moves the tuner, without letting ~21 weak labels
+  overpower 9 trusted goldens or regress retrieval.
+- **Goal:** a tuned config can take effect as a reviewed, reversible file — no code
+  edit, no auto-mutation.
+- **Goal:** default-off by absence — with no adopted file, ranking is byte-identical
+  to today.
+- **Non-goal:** broadening the relevance signal (clickthrough, negatives, explicit
+  `found_via`). Single note-citation channel this round.
+- **Non-goal:** auto-applying a tune, hot-reloading config, or any server daemon.
+- **Non-goal:** tuning the image-tag / contradiction / diarization thresholds.
+
+## The combined objective (the subtle part)
+
+**A mined pair is a binary fact, not a graded score.** The miner's
+`confidence = (1/rank)·(0.5 + 0.5·recency)` embeds `rank_in_results` — the rank the
+cited doc held under *whatever config was live when the pair was mined*. Using
+`confidence` as the relevance **gain** would bake the incumbent ranking into the
+optimization target: the highest-confidence (rank-1) pairs would reward keeping
+things exactly where they are, and what little gradient exists would push toward the
+*old* config. So:
+
+- **Grade is binary:** a cited doc is relevant (`1`), full stop. `confidence` is used
+  only as a **filter** (`CONF_MIN`, default `0.25`) to drop the weakest mined hits.
+  Rank-1 pairs then act as *guardrails* (moving them down lowers the score), not as a
+  free lever.
+- **Dedup against golden:** drop any pair whose query matches a golden query before
+  scoring, so the trusted signal isn't double-counted.
+
+**Objective shape: lexicographic tuple with a hard floor.** `optimize()` already
+selects by `>` only, and Python tuples compare lexicographically, so returning a
+tuple is a drop-in (only the `:.4f` print needs a fix):
+
+```
+baseline_g = golden_ndcg10(DEFAULT_RANKING)        # measured once at start
+def objective(knobs) -> tuple:
+    g = golden_ndcg10(knobs)                       # trusted anchor
+    if g < baseline_g - EPSILON:    return (-1.0, g)   # HARD FLOOR → infeasible
+    if n_eligible_pairs < MIN_PAIRS: return (0.0, g)   # GUARD → golden-only (== today)
+    return (pair_mrr(knobs), g)                    # primary: pairs; tiebreak: golden
+```
+
+- A **weighted sum** `α·golden + β·pairs` is rejected: any β large enough for ~21
+  weak pairs to matter is large enough to let noise *buy* a golden regression. The
+  constrained form structurally cannot sell the anchor and needs one interpretable
+  threshold (`EPSILON`) instead of an unknowable `(α, β)`.
+- **Pair metric is MRR** (gentle reciprocal discount, rank-sensitive without
+  over-trusting exact positions on ~21 labels); `recall@10` is reported alongside
+  for the human. NDCG on binary grades over so few labels compresses badly — avoid.
+- `DEFAULT_RANKING` is always feasible (`baseline_g − EPSILON ≤ baseline_g`), so the
+  incumbent is well-defined and `optimize()`'s "ties keep incumbent" determinism
+  holds.
+
+**Constants (all CLI-overridable):** `EPSILON = 0.01` absolute mean-NDCG@10 (≈ one
+golden query's sub-position noise; blocks any real regression), `MIN_PAIRS = 8`
+distinct eligible queries (≈ the golden set size — "at least as much signal as the
+trusted set"; keeps pairs OFF until the signal is real), `CONF_MIN = 0.25`.
+
+The safety stack: dedup-golden → conf-filter → `MIN_PAIRS` guard → binary MRR (no
+rank baking) → hard golden floor (EPSILON-bounded). Even if the pairs term overfits,
+golden cannot regress past `EPSILON`.
+
+## The adopt seam in `find.py`
+
+`find()` resolves config via a new memoized `_active_ranking()` whose resolution
+order is:
+
+1. `KB_MCP_DISABLE_RANKING_CONFIG` set → `DEFAULT_RANKING` (hermetic escape hatch;
+   set by the test suite's autouse fixture so a committed file never pollutes tests).
+2. `KB_MCP_RANKING_CONFIG=<path>` → load that path (tests / per-box override).
+3. else repo-root `ranking_config.json` (`Path(__file__).resolve().parents[2]`).
+4. else `DEFAULT_RANKING`.
+
+The seam is the call-site asymmetry: the live `op_find` calls `find()` with **no**
+`config=` → `config is None` → consult the adopted file; both eval harnesses pass
+`config=cfg` explicitly → never consult disk → hermetic. The one-line change is
+`config or DEFAULT_RANKING` → `config if config is not None else _active_ranking()`
+(`is not None`, because a `RankingConfig` is always truthy and we must auto-load only
+when genuinely omitted).
+
+- **Adopted file = committed repo-root `ranking_config.json`.** Adoption *is* a git
+  commit: the diff shows the knob deltas, `git revert` is the reversal, history is
+  the provenance, and it survives the deploy checkout's `reset --hard origin/main`.
+  The candidate + report live in gitignored `logs/`. (The file is generic numeric
+  knobs, not under `src/kb_mcp/`, so the leak-guard is irrelevant; absent →
+  `DEFAULT_RANKING` means a cloner can just delete it. Env-override + a gitignore
+  fallback exist if a tune should stay private.)
+- **(De)serialize:** `dataclasses.asdict(cfg)` writes all fields (tuples → JSON
+  arrays); load is field-driven over `dataclasses.fields(RankingConfig)` — coerce
+  int/float, coerce the four `intent_weights_*` to length-6 float tuples, **ignore
+  unknown keys** (schema-drift-safe), **default missing keys**.
+- **Fail loud → DEFAULT.** Any `JSONDecodeError`, type error, or tuple-length
+  mismatch → `log.error(...)` + `DEFAULT_RANKING`. Never crash; never silently apply
+  a half-parsed config. An unknown/renamed knob is the one non-fatal case (warn,
+  keep going with that field defaulted).
+- **Load-once + restart to reload.** A per-process memo (`reset_active_ranking_cache()`
+  for tests) loads the file once; picking up a newly-adopted file is a service
+  restart, identical to `.env` semantics. Hot-reload is a non-goal (a watcher is
+  stateful and reopens the read race).
+- **Atomic write** for the candidate and the adopted file (tmp + `os.replace`, the
+  existing `vault.batch_atomic_write` pattern) so a concurrent reader at startup sees
+  whole-old or whole-new, never a torn file.
+
+## Mining — idempotent snapshot
+
+`derive_relevance_pairs.main()` is refactored into a reusable
+`mine_pairs(window_seconds, *, write, logs_dir) -> list[dict]`. The pairs file is a
+pure derived artifact of `queries × writes × window`, so mining **rewrites a deduped
+snapshot** (atomic `os.replace`, mode `w`) rather than appending — same logs in →
+byte-identical file out, no cross-run duplicates, no unbounded growth. The source
+logs remain the audit trail. The tuner imports `mine_pairs` and mines fresh as step
+0 so the objective always reflects current usage. Mining stays a standalone
+desk-side script (independently useful for proposing golden additions) and MAY be
+run by a scheduled Claude Code routine; it is never a server daemon, and adoption is
+never inside `tune`.
+
+## Adoption gate (reuses the floor, no torch at adopt time)
+
+`write_candidate()` embeds the measured `baseline_golden` / `candidate_golden`
+(plus `pair_mrr`, `pair_recall10`, `n_eligible_pairs`, `guard_active`, `window_hours`)
+in the candidate JSON's meta. `adopt(candidate, target, *, force)` validate-loads the
+candidate, refuses to promote it when `candidate_golden < baseline_golden − EPSILON`
+unless `--force`, then atomically copies it to the repo-root path and prints the
+git-commit + restart steps. So the same floor that governs tuning gates adoption —
+no torch rerun needed to adopt.
+
+## Edge cases
+
+- **Empty / zero eligible pairs** → guard → golden-only tune (== today); candidate
+  still written (may equal `DEFAULT_RANKING`); warn.
+- **All pairs already in golden** → after dedup, eligible = 0 → guard; warn "nothing
+  new to learn."
+- **Unknown / renamed knob in the adopted JSON** → ignored (field-driven load),
+  logged; that field defaults. Non-fatal.
+- **Malformed JSON / wrong type / bad tuple length** → fail loud + `DEFAULT_RANKING`.
+  Atomic write means a partial file can't occur.
+- **Concurrent read during a restart-coincident write** → atomic `os.replace` +
+  load-once memo → old-or-new whole file.
+- **Adopted config makes golden worse** → adoption blocked by the floor gate unless
+  `--force`.
+- **Reversibility** → delete (or `git revert`) `ranking_config.json` →
+  `_active_ranking()` finds nothing → `DEFAULT_RANKING`, byte-identical. Guarded by a
+  test.
+
+## Decisions
+
+- **Binary pairs, not confidence-graded.** Confidence embeds the incumbent rank;
+  grading by it is circular and gameable. Confidence filters; it never grades.
+- **Lexicographic floor, not a weighted sum.** One interpretable threshold; the
+  anchor structurally cannot be sold for noise.
+- **Default-off by absence.** No file → `DEFAULT_RANKING`, byte-identical. The whole
+  feature is inert until a human adopts.
+- **Reviewed adoption, committed file.** Visibility + reversibility via git, matching
+  the project's "visibility over auto-mutation" stance — but mechanically closed (no
+  hand-edit of `find.py`).
+- **Snapshot, not append.** A derived artifact is regenerated, not accumulated.
+
+## Risks
+
+- **Tiny, weak pairs set barely moves / overfits.** Mitigated by the `MIN_PAIRS`
+  guard (pairs stay OFF until real), binary grade, and the hard floor. The most
+  likely near-term outcome is "the loop is a correct no-op," which is the intended
+  conservative behavior, not a bug — stated plainly so the win is read as "the loop
+  is now real and safe."
+- **A committed `ranking_config.json` silently changes server behavior.** Mitigated
+  by the conftest disable flag, the absent→DEFAULT path, and the reversibility test;
+  the residual risk is a human forgetting the live box needs a restart — documented
+  as `.env`-equivalent.
+- **Schema drift after a future `RankingConfig` refactor.** Field-driven load
+  (unknown-ignore, missing-default) + a loud log; worst case a renamed knob reverts
+  to default, visible in the report/diff.

--- a/openspec/changes/close-auto-tune-loop/proposal.md
+++ b/openspec/changes/close-auto-tune-loop/proposal.md
@@ -25,10 +25,12 @@ This change closes the loop and makes it **safe**: mined usage actually moves th
 tuner; a tuned config is adopted as a reviewed, reversible file (no code edit); and
 a trusted golden floor guarantees adoption can never regress retrieval.
 
-Honest expectation, stated up front: with only ~21 pairs the loop is a **no-op
-until usage compounds** — a `MIN_PAIRS` guard keeps mined signal OFF until there is
-enough of it. The deliverable is the closed, guarded mechanism, not a ranking jump
-today.
+A `MIN_PAIRS` guard keeps the mined signal OFF until there is enough of it, so the
+loop is safe when usage is thin. A real-vault smoke (2026-06-28) confirmed the
+mechanism end to end AND showed the guard is **already cleared on the live vault**:
+the current usage logs mine to 10 distinct eligible queries (≥ `MIN_PAIRS=8`), so the
+pairs term engages today — the loop tunes from real signal now, not just in the
+future. The deliverable is the closed, guarded mechanism (and it is already active).
 
 ## What Changes
 

--- a/openspec/changes/close-auto-tune-loop/proposal.md
+++ b/openspec/changes/close-auto-tune-loop/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+kb-mcp ships the pieces of a self-tuning retrieval ranker — a golden eval set
+(`tests/golden/queries.yaml`), an offline NDCG harness (`scripts/eval_retrieval.py`),
+a coordinate-descent tuner (`scripts/auto_tune_ranking.py`) over `RankingConfig`,
+and a usage miner (`scripts/derive_relevance_pairs.py`) that turns ordinary
+"search-then-compile" usage into weak `(query → cited_path)` relevance labels. On
+paper that's an uncopyable edge: relevance signal mined for free from a single
+user's real work, plus an eval harness to act on it. In practice **the loop is
+open — it never feeds back.** Three concrete breaks:
+
+1. **The mined pairs never reach the tuner's objective.** `auto_tune_ranking.py`
+   loads `logs/relevance_pairs.jsonl` and prints its row count, but its objective
+   (`build_evaluate_fn`) closes over the 9 hand-authored golden queries **only**.
+   Even when pairs exist, they do not move tuning. This is the central bug.
+2. **Mining is manual and non-idempotent.** `derive_relevance_pairs.py` works
+   (~21 pairs on the live vault) but is a hand-run script that **appends**, piling
+   cross-run duplicates — unsafe to run on any schedule.
+3. **A tuned config can't take effect without editing code.** `find()` reads
+   `RankingConfig` only as an in-process param (default `DEFAULT_RANKING`); there
+   is no disk-load seam. The tuner deliberately *prints* the winner and instructs
+   the operator to hand-edit `find.py`.
+
+This change closes the loop and makes it **safe**: mined usage actually moves the
+tuner; a tuned config is adopted as a reviewed, reversible file (no code edit); and
+a trusted golden floor guarantees adoption can never regress retrieval.
+
+Honest expectation, stated up front: with only ~21 pairs the loop is a **no-op
+until usage compounds** — a `MIN_PAIRS` guard keeps mined signal OFF until there is
+enough of it. The deliverable is the closed, guarded mechanism, not a ranking jump
+today.
+
+## What Changes
+
+- **Wire mined pairs into the tuning objective (binary relevance).** A mined pair
+  is a binary fact — "for query Q the user cited D, so D is relevant" — graded `1`,
+  never graded by its mined `confidence` (which embeds the *incumbent* rank and
+  would bake the old ranking into the target). `confidence` is used only as a
+  filter (`CONF_MIN`). The objective becomes a lexicographic tuple
+  `(pair_mrr, golden_ndcg)` under a **hard golden floor**: any candidate whose
+  golden NDCG@10 falls more than `EPSILON` below the `DEFAULT_RANKING` baseline is
+  infeasible. A `MIN_PAIRS` guard drops the pairs term entirely (reducing to
+  today's golden-only tune) until enough distinct, golden-deduped pairs exist.
+- **Idempotent mining snapshot.** `derive_relevance_pairs.py` rewrites a
+  deduped snapshot atomically (tmp + `os.replace`) instead of appending, so
+  re-running over the same logs is reproducible and safe to schedule. The tuner
+  mines fresh first so the objective always reflects current usage.
+- **Adopted-config load seam in `find()`.** When `config` is omitted (the live
+  server's path), `find()` loads an adopted `RankingConfig` from disk if present
+  (resolution: `KB_MCP_DISABLE_RANKING_CONFIG` → `KB_MCP_RANKING_CONFIG` path →
+  repo-root `ranking_config.json` → `DEFAULT_RANKING`). A malformed/wrong-type/
+  bad-length file **fails loud and falls back to `DEFAULT_RANKING`** — never
+  crashes the server, never silently applies a half-parsed config. With no file
+  present, behavior is byte-identical to today. Eval harnesses pass `config=`
+  explicitly and stay hermetic.
+- **Reviewed, reversible adoption.** Tuning only writes a candidate
+  (`logs/ranking_config.candidate.json`) + a human-readable delta report; it never
+  auto-applies. Adoption is an explicit `--adopt` flip that promotes the candidate
+  to the committed repo-root `ranking_config.json`, gated by the same golden floor
+  (refuses a golden-regressing candidate without `--force`). Reversal is deleting
+  or `git revert`-ing the file.
+
+Out of scope (separate changes): broadening the relevance signal (clickthrough /
+negatives / an explicit `found_via` threaded through the skill); tuning the
+image-tag (`0.22`/`K=5`) and contradiction (`W_DORMANCY`/`TOP_N`) thresholds against
+the live vault; anything touching diarization.
+
+## Capabilities
+
+### New Capabilities
+- `ranking-autotune`: a closed, guarded self-tuning loop for the hybrid ranker —
+  mined note-citation pairs enter the tuner objective as binary labels behind a
+  `MIN_PAIRS` guard and a hard golden floor; mining is an idempotent snapshot;
+  tuning writes a reviewed candidate + report; `find()` loads an adopted, reversible
+  `RankingConfig` from disk (absent → `DEFAULT_RANKING`, byte-identical to today).
+
+## Impact
+
+- Code: `src/kb_mcp/find.py` (config (de)serialization + a memoized disk-load seam,
+  one-line change at the `config or DEFAULT_RANKING` call site);
+  `scripts/derive_relevance_pairs.py` (reusable `mine_pairs()` + atomic snapshot);
+  `scripts/auto_tune_ranking.py` (combined lexicographic objective, candidate/report
+  writers, `--adopt` with the golden-floor gate, mine-fresh); a small
+  `rank_queries()` helper reused from `scripts/eval_retrieval.py`.
+- Tests: `tests/test_ranking_config_load.py` (the load seam), extended
+  `tests/test_ranking_config.py` (serialize roundtrip + reversibility), extended
+  `tests/test_auto_tune.py` (pairs→eval, binary pair-MRR, floor, `MIN_PAIRS` guard,
+  candidate/report shape), `tests/test_derive_relevance_pairs.py` (snapshot
+  idempotency). `tests/conftest.py` gains `KB_MCP_DISABLE_RANKING_CONFIG=1` so a
+  committed `ranking_config.json` never pollutes the suite. All torch-free; the real
+  combined tune stays manual/desk-side (needs torch + the live vault), as today.
+- Behavior: **default-off by absence** — with no `ranking_config.json` present,
+  ranking is byte-identical to today. The server-code change is behavior-neutral
+  until a config is adopted, so deploying is safe pre-adoption (restart-to-reload,
+  same as `.env`).
+- Env knobs: `KB_MCP_RANKING_CONFIG` (override the adopted-file path),
+  `KB_MCP_DISABLE_RANKING_CONFIG` (force `DEFAULT_RANKING`; set in the test suite).
+- Pure-substrate: no server-side reasoning LLM anywhere; relevance labels derive
+  only from recorded usage (Hugo's real citations); the evaluator is deterministic
+  metrics and the tuner is deterministic coordinate descent.

--- a/openspec/changes/close-auto-tune-loop/specs/ranking-autotune/spec.md
+++ b/openspec/changes/close-auto-tune-loop/specs/ranking-autotune/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: Mined Pairs Enter the Tuning Objective as Binary Labels
+
+The tuner SHALL incorporate mined `(query → cited_path)` relevance pairs into its
+optimization objective as binary-relevance labels (a cited path is relevant with
+grade 1), using each pair's mined `confidence` only as an inclusion filter and never
+as the relevance grade, so that the loop tunes from real usage without baking the
+incumbent ranking into the target. Pairs whose query matches a golden query SHALL be
+deduplicated out before scoring, and the pairs term SHALL be measured by mean
+reciprocal rank over the eligible pair queries.
+
+#### Scenario: A cited path that ranks low is rewarded when pulled up
+
+- **WHEN** a mined pair `(Q → D)` is eligible and a candidate config ranks `D`
+  higher for `Q` than the incumbent does
+- **THEN** that candidate's pairs term (pair-MRR) is higher than the incumbent's
+- **AND** the reward does not depend on the pair's mined `confidence` value, only on
+  `D`'s rank under the candidate
+
+#### Scenario: A pair already covered by golden is not double-counted
+
+- **WHEN** a mined pair's query equals a golden query (after canonicalization)
+- **THEN** that pair is excluded from the eligible pair set used by the pairs term
+
+### Requirement: MIN_PAIRS Guard Keeps Mined Signal Off Until It Is Real
+
+The tuner SHALL drop the pairs term entirely and optimize on the golden set alone
+whenever the number of distinct eligible pair queries is below `MIN_PAIRS` (default
+8), so that a handful of weak labels can never drive tuning, and the loop reduces
+exactly to today's golden-only behavior until usage compounds.
+
+#### Scenario: Too few pairs reduces to golden-only tuning
+
+- **WHEN** the eligible pair set has fewer than `MIN_PAIRS` distinct queries
+- **THEN** the objective ignores the pairs term and ranks feasible candidates by
+  golden NDCG@10 alone
+- **AND** the run reports that the pairs guard is active
+
+### Requirement: Golden Floor Is a Hard Constraint on Tuning and Adoption
+
+The tuner SHALL treat any candidate whose golden NDCG@10 falls more than `EPSILON`
+(default 0.01) below the `DEFAULT_RANKING` baseline as infeasible and never select
+it, and adoption SHALL reuse the same floor — refusing to promote a candidate whose
+recorded `candidate_golden` is more than `EPSILON` below its recorded
+`baseline_golden` unless explicitly forced — so that closing the loop can never
+silently regress retrieval below the trusted baseline.
+
+#### Scenario: A golden-regressing candidate is never selected
+
+- **WHEN** a candidate improves the pairs term but lowers golden NDCG@10 by more than
+  `EPSILON` below baseline
+- **THEN** the optimizer does not select it over the feasible incumbent
+
+#### Scenario: Adoption refuses a regressing candidate
+
+- **WHEN** `adopt` is invoked on a candidate whose `candidate_golden` is more than
+  `EPSILON` below its `baseline_golden`
+- **THEN** adoption is refused and the adopted `ranking_config.json` is not written
+- **AND** an explicit force flag is required to override
+
+### Requirement: Mining Produces an Idempotent Deduplicated Snapshot
+
+The miner SHALL rewrite `logs/relevance_pairs.jsonl` as a deduplicated snapshot
+written atomically (a temporary sibling file replaced into place), rather than
+appending, so that re-running mining over the same source logs yields a
+byte-identical, duplicate-free file and is safe to run on a schedule.
+
+#### Scenario: Re-running mining is reproducible
+
+- **WHEN** mining runs twice over the same `queries.jsonl` and `writes.jsonl`
+- **THEN** the resulting `relevance_pairs.jsonl` is byte-identical across the two runs
+- **AND** it contains no duplicate `(query, cited_path)` rows
+- **AND** no temporary `.tmp` file is left behind
+
+### Requirement: find Loads an Adopted RankingConfig From Disk
+
+When its `config` argument is omitted, `find` SHALL resolve the active
+`RankingConfig` from disk — honoring `KB_MCP_DISABLE_RANKING_CONFIG` (force default),
+then `KB_MCP_RANKING_CONFIG` (explicit path), then a repo-root `ranking_config.json`,
+and otherwise `DEFAULT_RANKING` — and SHALL parse the file field-by-field, ignoring
+unknown keys and defaulting missing keys. A file that is malformed, wrong-typed, or
+has a bad lane-weight tuple length SHALL fail loud (logged at error) and fall back to
+`DEFAULT_RANKING` rather than crash or apply a partial config. When `config` is
+passed explicitly, `find` SHALL use it and MUST NOT consult disk.
+
+#### Scenario: No adopted file reproduces default ranking exactly
+
+- **WHEN** no adopted config file is resolvable and `find` is called without a
+  `config` argument
+- **THEN** results are byte-identical to calling `find` with `config=DEFAULT_RANKING`
+
+#### Scenario: A valid adopted file changes ranking
+
+- **WHEN** a valid non-default `ranking_config.json` is resolvable
+- **THEN** `find` (called without `config`) ranks according to the adopted config
+- **AND** removing the file and resetting the cache restores `DEFAULT_RANKING` behavior
+
+#### Scenario: A malformed file fails loud and falls back
+
+- **WHEN** the resolved config file is malformed JSON or has a bad lane-weight tuple
+  length
+- **THEN** `find` logs an error and uses `DEFAULT_RANKING`
+- **AND** the server does not crash
+
+#### Scenario: An explicit config never consults disk
+
+- **WHEN** `find` is called with an explicit `config` argument and an adopted file is
+  also present
+- **THEN** the explicit `config` is used and the adopted file is ignored
+
+### Requirement: Tuning Is Reviewed and Reversible, Never Auto-Applied
+
+Tuning SHALL only write a candidate config (`logs/ranking_config.candidate.json`) and
+a human-readable delta report; it MUST NOT mutate `find.py` or the adopted
+`ranking_config.json`. Adoption SHALL be an explicit, separate step that promotes the
+candidate to the committed repo-root `ranking_config.json`, and reversal SHALL be
+deleting or reverting that file (returning ranking to `DEFAULT_RANKING`).
+
+#### Scenario: A tuning run applies nothing
+
+- **WHEN** the tuner runs and finds a better feasible config
+- **THEN** it writes the candidate file and the report only
+- **AND** neither `find.py` nor `ranking_config.json` is modified by the run
+
+### Requirement: The Loop Is Pure-Substrate
+
+The entire loop SHALL run without any server-side reasoning LLM. Relevance labels
+SHALL derive only from recorded usage (queries and citing writes), the evaluator
+SHALL compute deterministic ranking metrics, and the tuner SHALL be deterministic
+coordinate descent — so the same inputs always produce the same proposed config.
+
+#### Scenario: No model decides relevance or ranking
+
+- **WHEN** the loop mines pairs, scores candidates, and proposes a config
+- **THEN** no language model is invoked at any stage
+- **AND** re-running over identical logs and vault produces the same proposed config

--- a/openspec/changes/close-auto-tune-loop/tasks.md
+++ b/openspec/changes/close-auto-tune-loop/tasks.md
@@ -1,0 +1,87 @@
+# Tasks — Close the auto-tune loop
+
+## 1. find.py — adopted-config (de)serialization + load seam (TDD)
+
+- [x] 1.1 Add `ranking_config_to_jsonable(cfg) -> dict` (`dataclasses.asdict`) and
+      `ranking_config_from_jsonable(d) -> RankingConfig` (field-driven over
+      `dataclasses.fields`: coerce int/float; coerce the four `intent_weights_*` to
+      length-`len(LANE_ORDER)` float tuples with a length assert; ignore unknown
+      keys; default missing keys).
+- [x] 1.2 Add `_REPO_ROOT = Path(__file__).resolve().parents[2]`,
+      `_load_adopted_ranking() -> RankingConfig` (resolution: disable-flag → env
+      path → repo-root `ranking_config.json` → DEFAULT; malformed/bad-type/bad-tuple
+      → `log.error` + DEFAULT), a per-process memo `_active_ranking()`, and
+      `reset_active_ranking_cache()`.
+- [x] 1.3 Change the `find()` seam: `config or DEFAULT_RANKING` →
+      `config if config is not None else _active_ranking()`.
+- [x] 1.4 `tests/conftest.py`: add `monkeypatch.setenv("KB_MCP_DISABLE_RANKING_CONFIG",
+      "1")` to the autouse fixture so a committed file never pollutes the suite.
+- [x] 1.5 `tests/test_ranking_config_load.py`: absent→DEFAULT; valid file (via
+      `KB_MCP_RANKING_CONFIG`)→loaded with tuples coerced; malformed JSON→DEFAULT +
+      error log; unknown knob ignored + missing knob defaulted; bad intent-tuple
+      length→DEFAULT; env path override honored; disable-flag→DEFAULT even with a
+      file; memo + `reset_active_ranking_cache()`.
+- [x] 1.6 Extend `tests/test_ranking_config.py`: `to_jsonable→json→from_jsonable ==
+      DEFAULT` (and a tuned config) with intent fields surviving as tuples;
+      reversibility — env-adopt a non-default file changes `find()` output, remove +
+      reset → DEFAULT path. (Existing `find(no config) == find(config=DEFAULT)`
+      invariant still holds under the conftest disable flag.)
+
+## 2. derive_relevance_pairs.py — idempotent snapshot (TDD)
+
+- [x] 2.1 Extract `mine_pairs(window_seconds, *, write, logs_dir=LOGS) -> list[dict]`
+      from `main()`; keep the CLI, `--dry-run`, and the golden-additions proposal.
+- [x] 2.2 Switch the write to an atomic deduped snapshot (tmp sibling + `os.replace`,
+      mode `w`) keyed by `(query, cited_path)` keeping best confidence — not append.
+- [x] 2.3 `tests/test_derive_relevance_pairs.py`: snapshot idempotency (two runs over
+      the same fixture logs → identical bytes, no dupes); no `.tmp` residue.
+
+## 3. auto_tune_ranking.py — combined objective + candidate/report + adopt (TDD)
+
+- [x] 3.1 Add `EPSILON = 0.01`, `MIN_PAIRS = 8`, `CONF_MIN = 0.25` consts + CLI flags.
+- [x] 3.2 `pairs_to_eval(pairs, golden_queries, *, conf_min) -> list[dict]`: dedup
+      golden-overlapping queries, apply `CONF_MIN`, group to `{query, relevant:set}`
+      (binary).
+- [x] 3.3 `pair_mrr(ranked_by_query, eligible)` (+ `pair_recall10` for the report) —
+      reuse `find()` + `_canon` via a small `rank_queries()` helper in
+      `eval_retrieval.py`.
+- [x] 3.4 `build_combined_evaluate_fn(...)` → lexicographic `combined_score`:
+      `(-1.0,g)` floor / `(0.0,g)` guard / `(pair_mrr,g)` per the design.
+- [x] 3.5 `write_candidate(path, cfg, meta)` + `write_report(path, default_cfg,
+      best_cfg, meta)` (atomic); meta carries `baseline_golden`, `candidate_golden`,
+      `pair_mrr`, `pair_recall10`, `n_eligible_pairs`, `guard_active`, `window_hours`.
+- [x] 3.6 `adopt(candidate_path, target_path, *, force, epsilon)`: validate-load,
+      refuse when `candidate_golden < baseline_golden - EPSILON` unless `force`,
+      atomic copy of the RAW config to repo-root `ranking_config.json`, print
+      git-commit + restart steps.
+- [x] 3.7 `main()`: mine fresh first (import `mine_pairs`) → load golden → pairs_to_eval
+      → measure baseline → `optimize(combined)` → write candidate + report; `--adopt`
+      branch. Tuple-score selection (no float print of the score).
+- [x] 3.8 Extend `tests/test_auto_tune.py`: `pairs_to_eval` dedup/filter; binary
+      `pair_mrr` independent of confidence value; `combined_score` + `optimize` floor
+      blocks a golden-regressing candidate; `MIN_PAIRS` guard reduces to golden-only;
+      lexicographic golden tiebreak; candidate + report shape; adopt floor gate.
+
+## 4. Docs
+
+- [x] 4.1 `docs/ranking-tuning.md`: the loop (mine → tune → review report → adopt
+      [commit + restart] → revert) + the three env vars
+      (`KB_MCP_RANKING_CONFIG`, `KB_MCP_DISABLE_RANKING_CONFIG`, and the existing
+      `KB_MCP_DISABLE_EMBEDDINGS` for desk-side runs).
+
+## 5. Verify
+
+- [x] 5.1 `PYTHONPATH=src KB_MCP_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q`
+      green (765 passed, 5 skipped torch/PIL-gated; the one collection error is the
+      pre-existing torch-hard-import in `tests/test_voice_embed.py`, a diarization
+      test that needs the embeddings extra — unrelated to this change).
+- [x] 5.2 `uvx ruff check` clean on changed files (no new findings vs `origin/main`;
+      the repo's lint is advisory with a known baseline).
+- [x] 5.3 `openspec validate close-auto-tune-loop --strict` passes.
+- [ ] 5.4 Live-vault smoke (Hugo, GPU/embeddings box — needs torch + live vault):
+      `uv run python scripts/derive_relevance_pairs.py` twice → idempotent snapshot,
+      no dupes; `uv run python scripts/auto_tune_ranking.py` → mines fresh, prints
+      golden baseline + best (likely guard-OFF / no-op at ~21 pairs, which is
+      correct), writes `logs/ranking_config.candidate.json` + report; `--adopt`
+      writes `ranking_config.json` only when it passes the golden floor; deploy +
+      restart picks it up; deleting it reverts.

--- a/scripts/auto_tune_ranking.py
+++ b/scripts/auto_tune_ranking.py
@@ -1,23 +1,38 @@
-"""Self-tuning RankingConfig search — desk-side tooling, NO server changes.
+"""Self-tuning RankingConfig search — the closed feedback loop, desk-side.
 
 Coordinate-descends the RankingConfig knobs (rrf_k, compiled_boost,
-source_penalty, temporal_boost, and the per-intent lane weights) to MAXIMIZE
-NDCG@10 over the golden query set, reusing the same NDCG evaluator the offline
-harness uses (`scripts/eval_retrieval.py`). It PROPOSES (prints) the winning
-config and its delta vs DEFAULT_RANKING — it never writes defaults back. The
-operator reviews and edits `find.py` by hand (visibility over auto-mutation).
+source_penalty, temporal_boost, and the per-intent lane weights) under a
+LEXICOGRAPHIC objective `(pair_mrr, golden_ndcg)`:
 
-Pure-substrate: the optimizer is deterministic coordinate descent over a fixed
-candidate grid. No model decides anything.
+- the 9 hand-authored golden queries are the trusted anchor, enforced as a HARD
+  FLOOR — any candidate whose golden NDCG@10 drops more than EPSILON below the
+  DEFAULT_RANKING baseline is infeasible and never selected;
+- the mined `(query -> cited_path)` pairs (fresh-mined each run) are the
+  improvement signal, scored as BINARY relevance via mean reciprocal rank — a
+  cited doc is relevant, full stop; the mined `confidence` is only a filter
+  (CONF_MIN), never a grade (grading by it would bake the incumbent rank in);
+- below MIN_PAIRS distinct eligible pair queries the pairs term is OFF and the
+  run reduces exactly to a golden-only tune.
 
-The real run needs torch + the live vault (it force-enables embeddings via
+It writes a reviewed CANDIDATE (`logs/ranking_config.candidate.json`) + a delta
+REPORT — it NEVER auto-applies and never edits find.py. `--adopt` promotes the
+candidate to the committed repo-root `ranking_config.json` (which find() loads
+when no explicit config is passed), gated by the same golden floor. Reversal is
+deleting / reverting that file.
+
+Pure-substrate: deterministic coordinate descent over a fixed grid; relevance
+labels come only from recorded usage; no model decides anything.
+
+The real run needs torch + the live vault (force-enables embeddings via
 eval_retrieval), so it is desk-side only:
 
-    uv run python scripts/auto_tune_ranking.py
+    uv run python scripts/auto_tune_ranking.py            # mine -> tune -> candidate + report
     uv run python scripts/auto_tune_ranking.py --window-hours 6
+    uv run python scripts/auto_tune_ranking.py --adopt    # promote candidate (floor-gated)
 
-The pure pieces — `optimize()`, `load_relevance_pairs()`, `load_golden()`,
-`config_from_dict()` — are torch-free and unit-tested in tests/test_auto_tune.py.
+The pure pieces — `optimize()`, `pairs_to_eval()`, `pair_mrr()`,
+`combined_score()`, `config_from_dict()`, `write_candidate()`, `adopt()` — are
+torch-free and unit-tested in tests/test_auto_tune.py.
 """
 
 from __future__ import annotations
@@ -25,7 +40,9 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import os
 import sys
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -36,11 +53,26 @@ HERE = Path(__file__).resolve().parent
 SRC = HERE.parent / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))  # sibling scripts (derive_relevance_pairs, eval_retrieval)
 
-from kb_mcp.find import DEFAULT_RANKING, RankingConfig  # noqa: E402
+from kb_mcp.find import (  # noqa: E402
+    DEFAULT_RANKING,
+    RankingConfig,
+    ranking_config_from_jsonable,
+    ranking_config_to_jsonable,
+)
 
 DEFAULT_GOLDEN = HERE.parent / "tests" / "golden" / "queries.yaml"
 DEFAULT_PAIRS = HERE.parent / "logs" / "relevance_pairs.jsonl"
+DEFAULT_CANDIDATE = HERE.parent / "logs" / "ranking_config.candidate.json"
+DEFAULT_REPORT = HERE.parent / "logs" / "ranking_config.report.md"
+ADOPTED_CONFIG = HERE.parent / "ranking_config.json"
+
+# Objective guardrails (all CLI-overridable). See openspec/changes/close-auto-tune-loop.
+EPSILON = 0.01     # max golden NDCG@10 the tuner may spend below baseline (hard floor)
+MIN_PAIRS = 8      # distinct eligible pair queries before the pairs term turns on
+CONF_MIN = 0.25    # mined-confidence floor — a FILTER on pairs, never a relevance grade
 
 
 # --------------------------------------------------------------------------- #
@@ -200,20 +232,239 @@ def config_from_dict(knobs: dict[str, Any]) -> RankingConfig:
 
 
 # --------------------------------------------------------------------------- #
-# Real (desk-side) NDCG evaluator — reuses the offline harness. Lazy-imported so
-# the pure core above stays torch-free.
+# Mined-pair scoring (torch-free): pairs are BINARY relevance labels.
 # --------------------------------------------------------------------------- #
-def build_evaluate_fn(
-    vault_root: Path, golden: list[dict], *, rerank: bool = False
-) -> Callable[[dict[str, Any]], float]:
-    """Return `knobs -> mean NDCG@10` over the golden set, on the live vault."""
+def pairs_to_eval(
+    pairs: list[dict], golden_queries: set[str], *, conf_min: float
+) -> list[dict]:
+    """Group mined pairs into binary-relevance eval rows.
+
+    Drops pairs below `conf_min` (confidence is a FILTER, never a grade) and any
+    pair whose query already appears in `golden_queries` (lower/stripped), so the
+    trusted golden signal isn't double-counted. Returns one row per remaining
+    distinct query: `{"query": <raw>, "relevant": set(canon paths)}`.
+    """
+    by_query: dict[str, set[str]] = {}
+    for p in pairs:
+        if float(p.get("confidence", 0.0)) < conf_min:
+            continue
+        q = p.get("query")
+        cited = p.get("cited_path")
+        if not q or not cited:
+            continue
+        if q.strip().lower() in golden_queries:
+            continue
+        by_query.setdefault(q, set()).add(cited)
+    return [{"query": q, "relevant": rel} for q, rel in by_query.items() if rel]
+
+
+def pair_mrr(ranked_by_query: dict[str, list[str]], pair_rows: list[dict]) -> float:
+    """Mean reciprocal rank of the first relevant (cited) path per eligible query.
+
+    Binary relevance: the score depends only on WHERE a cited path lands in the
+    ranking, never on the mined confidence — so a rank-1 pair is a guardrail, not a
+    lever that would reward keeping the incumbent order.
+    """
+    if not pair_rows:
+        return 0.0
+    total = 0.0
+    for row in pair_rows:
+        ranked = ranked_by_query.get(row["query"], [])
+        relevant = row["relevant"]
+        rr = 0.0
+        for idx, path in enumerate(ranked, start=1):
+            if path in relevant:
+                rr = 1.0 / idx
+                break
+        total += rr
+    return total / len(pair_rows)
+
+
+def pair_recall10(
+    ranked_by_query: dict[str, list[str]], pair_rows: list[dict], *, k: int = 10
+) -> float:
+    """Mean fraction of a query's cited paths present in the top-k (report-only)."""
+    if not pair_rows:
+        return 0.0
+    total = 0.0
+    for row in pair_rows:
+        ranked = ranked_by_query.get(row["query"], [])[:k]
+        relevant = row["relevant"]
+        if not relevant:
+            continue
+        total += sum(1 for p in relevant if p in ranked) / len(relevant)
+    return total / len(pair_rows)
+
+
+def combined_score(
+    golden_ndcg: float,
+    pair_mrr_value: float,
+    *,
+    baseline_golden: float,
+    epsilon: float,
+    n_eligible: int,
+    min_pairs: int,
+) -> tuple[float, float]:
+    """The lexicographic objective value for one config.
+
+    `optimize()` compares these tuples by `>` (lexicographic):
+      - `(-1.0, g)`      golden regresses past the floor → infeasible (dominated);
+      - `(0.0, g)`       too few eligible pairs          → golden-only (== today);
+      - `(pair_mrr, g)`  otherwise                       → pairs primary, golden tiebreak.
+    """
+    if golden_ndcg < baseline_golden - epsilon:
+        return (-1.0, golden_ndcg)
+    if n_eligible < min_pairs:
+        return (0.0, golden_ndcg)
+    return (pair_mrr_value, golden_ndcg)
+
+
+# --------------------------------------------------------------------------- #
+# Candidate + report writers, and the floor-gated adopt step (torch-free).
+# --------------------------------------------------------------------------- #
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write `text` to `path` atomically (tmp sibling + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_candidate(path: Path, cfg: RankingConfig, meta: dict) -> None:
+    """Write the reviewed candidate: `{config: <full knobs>, meta: <measurements>}`.
+
+    `config` is a full, find()-loadable RankingConfig; `meta` carries the measured
+    golden/pairs values the adopt gate reads (so adoption needs no torch rerun).
+    """
+    payload = {"config": ranking_config_to_jsonable(cfg), "meta": meta}
+    _atomic_write_text(path, json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+
+
+def _knob_delta_rows(default_cfg: RankingConfig, best_cfg: RankingConfig) -> list[str]:
+    d = ranking_config_to_jsonable(default_cfg)
+    b = ranking_config_to_jsonable(best_cfg)
+    return [f"| `{key}` | {d[key]} | {b[key]} |" for key in d if b[key] != d[key]]
+
+
+def write_report(
+    path: Path, default_cfg: RankingConfig, best_cfg: RankingConfig, meta: dict
+) -> None:
+    """Write a human-readable markdown delta report for review before `--adopt`."""
+    deltas = _knob_delta_rows(default_cfg, best_cfg)
+    lines = [
+        "# Ranking auto-tune report",
+        "",
+        f"- golden NDCG@10: {meta['baseline_golden']} (baseline) "
+        f"→ {meta['candidate_golden']} (candidate)",
+        f"- pair-MRR: {meta['pair_mrr']} | pair-recall@10: {meta['pair_recall10']}",
+        f"- eligible pair queries: {meta['n_eligible_pairs']} "
+        f"(MIN_PAIRS={meta['min_pairs']}, guard_active={meta['guard_active']})",
+        f"- window_hours={meta['window_hours']} epsilon={meta['epsilon']}",
+        "",
+        "## Knob changes vs DEFAULT_RANKING",
+        "",
+    ]
+    if deltas:
+        lines += ["| knob | default | candidate |", "|---|---|---|", *deltas]
+    else:
+        lines.append(
+            "_No knob changed — DEFAULT_RANKING is already optimal under the "
+            "current objective (expected while the pairs guard is active)._"
+        )
+    lines += [
+        "",
+        "## To adopt",
+        "",
+        "```",
+        "uv run python scripts/auto_tune_ranking.py --adopt",
+        "git add ranking_config.json && git commit -m 'tune: adopt ranking config'",
+        "# deploy + restart the service — find() loads ranking_config.json at startup",
+        "```",
+        "",
+        "Revert anytime by deleting `ranking_config.json` (or `git revert`).",
+        "",
+    ]
+    _atomic_write_text(path, "\n".join(lines))
+
+
+def adopt(
+    candidate_path: Path, target_path: Path, *, force: bool, epsilon: float
+) -> int:
+    """Promote the candidate to the committed adopted config, gated by the floor.
+
+    Refuses when the candidate's recorded golden NDCG@10 is more than `epsilon`
+    below its recorded baseline (the same floor that governs tuning) unless
+    `force`. Writes ONLY the raw config knobs to `target_path` so find() loads it
+    directly.
+    """
+    if not candidate_path.exists():
+        print(f"no candidate at {candidate_path}; run a tune first", file=sys.stderr)
+        return 1
+    payload = json.loads(candidate_path.read_text(encoding="utf-8"))
+    config_dict = payload.get("config", {})
+    meta = payload.get("meta", {})
+    # Validate the config loads (raises on a malformed/foreign file).
+    ranking_config_from_jsonable(config_dict)
+    bg, cg = meta.get("baseline_golden"), meta.get("candidate_golden")
+    if bg is not None and cg is not None and cg < bg - epsilon and not force:
+        print(
+            f"refusing to adopt: candidate golden NDCG@10 {cg} is more than "
+            f"{epsilon} below baseline {bg}. Re-run with --adopt --force to override.",
+            file=sys.stderr,
+        )
+        return 1
+    _atomic_write_text(
+        target_path, json.dumps(config_dict, indent=2, ensure_ascii=False) + "\n"
+    )
+    print(f"adopted -> {target_path}")
+    print(f"  git add {target_path.name} && git commit -m 'tune: adopt ranking config'")
+    print("  # then deploy + restart so find() reloads the config")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Real (desk-side) combined objective — reuses the offline harness. Lazy-imported
+# so the pure core above stays torch-free.
+# --------------------------------------------------------------------------- #
+def build_combined_evaluate_fn(
+    vault_root: Path,
+    golden: list[dict],
+    pair_rows: list[dict],
+    *,
+    baseline_golden: float,
+    epsilon: float,
+    min_pairs: int,
+    rerank: bool = False,
+) -> Callable[[dict[str, Any]], tuple[float, float]]:
+    """Return `knobs -> (pair_mrr, golden_ndcg)`, the lexicographic objective."""
     import eval_retrieval  # lazy: force-enables embeddings on import
 
-    def _evaluate(knobs: dict[str, Any]) -> float:
+    pair_queries = [r["query"] for r in pair_rows]
+    n_eligible = len(pair_rows)
+
+    def _evaluate(knobs: dict[str, Any]) -> tuple[float, float]:
         cfg = config_from_dict(knobs)
-        return eval_retrieval._evaluate(
-            vault_root, golden, cfg, rerank=rerank
-        )["ndcg10"]
+        g = eval_retrieval._evaluate(vault_root, golden, cfg, rerank=rerank)["ndcg10"]
+        # Infeasible or guarded: the pairs term is irrelevant — skip ranking pairs.
+        if g < baseline_golden - epsilon or n_eligible < min_pairs:
+            pmrr = 0.0
+        else:
+            ranked = eval_retrieval.rank_queries(
+                vault_root, pair_queries, cfg, rerank=rerank, k=10
+            )
+            pmrr = pair_mrr(ranked, pair_rows)
+        return combined_score(
+            g, pmrr, baseline_golden=baseline_golden, epsilon=epsilon,
+            n_eligible=n_eligible, min_pairs=min_pairs,
+        )
 
     return _evaluate
 
@@ -221,10 +472,28 @@ def build_evaluate_fn(
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN)
-    ap.add_argument("--pairs", type=Path, default=DEFAULT_PAIRS)
+    ap.add_argument("--candidate", type=Path, default=DEFAULT_CANDIDATE)
+    ap.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    ap.add_argument("--window-hours", type=float, default=2.0,
+                    help="mining window: max gap between a find() and a citing write")
     ap.add_argument("--rerank", action="store_true", help="evaluate with rerank on")
     ap.add_argument("--max-passes", type=int, default=12)
+    ap.add_argument("--epsilon", type=float, default=EPSILON,
+                    help="golden NDCG@10 floor below baseline (default 0.01)")
+    ap.add_argument("--min-pairs", type=int, default=MIN_PAIRS,
+                    help="distinct eligible pair queries before pairs term turns on")
+    ap.add_argument("--conf-min", type=float, default=CONF_MIN,
+                    help="mined-confidence filter on pairs (not a grade)")
+    ap.add_argument("--adopt", action="store_true",
+                    help="promote the existing candidate to ranking_config.json (floor-gated)")
+    ap.add_argument("--force", action="store_true",
+                    help="with --adopt, promote even if it regresses golden")
     args = ap.parse_args()
+
+    if args.adopt:
+        return adopt(args.candidate, ADOPTED_CONFIG, force=args.force, epsilon=args.epsilon)
+
+    import derive_relevance_pairs as drp  # lazy (torch-free)
 
     from kb_mcp.vault import resolve_vault  # lazy
 
@@ -233,31 +502,71 @@ def main() -> int:
     if not golden:
         print(f"no golden queries loaded from {args.golden}", file=sys.stderr)
         return 1
-    pairs = load_relevance_pairs(args.pairs)
-    print(f"vault={vault_root}")
-    print(f"golden: {len(golden)} queries | relevance_pairs: {len(pairs)} rows")
 
-    evaluate_fn = build_evaluate_fn(vault_root, golden, rerank=args.rerank)
+    # Step 0: mine fresh so the objective reflects current usage (idempotent snapshot).
+    pairs = drp.mine_pairs(args.window_hours * 3600, write=True)
+    golden_queries = {g["query"].strip().lower() for g in golden}
+    pair_rows = pairs_to_eval(pairs, golden_queries, conf_min=args.conf_min)
+    guard_active = len(pair_rows) < args.min_pairs
+
+    print(f"vault={vault_root}")
+    print(f"golden: {len(golden)} queries | mined pairs: {len(pairs)} | "
+          f"eligible pair queries: {len(pair_rows)} | pairs guard: "
+          f"{'ON (golden-only)' if guard_active else 'off'}")
+
+    import eval_retrieval  # lazy: force-enables embeddings
+    baseline_golden = eval_retrieval._evaluate(
+        vault_root, golden, DEFAULT_RANKING, rerank=args.rerank
+    )["ndcg10"]
+
+    evaluate_fn = build_combined_evaluate_fn(
+        vault_root, golden, pair_rows,
+        baseline_golden=baseline_golden, epsilon=args.epsilon,
+        min_pairs=args.min_pairs, rerank=args.rerank,
+    )
     start = default_knobs()
-    base_score = evaluate_fn(start)
-    best, best_score = optimize(
+    best, _best_score = optimize(
         candidate_axes(), evaluate_fn, start=start, max_passes=args.max_passes
     )
+    best_cfg = config_from_dict(best)
 
-    print(f"\nDEFAULT NDCG@10 = {base_score:.4f}")
-    print(f"BEST    NDCG@10 = {best_score:.4f}  (delta {best_score - base_score:+.4f})")
-    print("\n=== PROPOSED config (review, then hand-edit find.py defaults) ===")
-    for knob, value in best.items():
-        changed = " *" if value != start.get(knob) else ""
-        print(f"  {knob:<28} {value}{changed}")
-    cfg = config_from_dict(best)
-    print("\nRankingConfig(")
-    print(f"    rrf_k={cfg.rrf_k}, compiled_boost={cfg.compiled_boost}, ")
-    print(f"    source_penalty={cfg.source_penalty}, temporal_boost={cfg.temporal_boost},")
-    print(f"    intent_weights_exact={cfg.intent_weights_exact},")
-    print(f"    intent_weights_relationship={cfg.intent_weights_relationship},")
-    print(f"    intent_weights_temporal={cfg.intent_weights_temporal},")
-    print(")")
+    # Final measured metrics for the chosen config (candidate meta + report).
+    candidate_golden = eval_retrieval._evaluate(
+        vault_root, golden, best_cfg, rerank=args.rerank
+    )["ndcg10"]
+    if guard_active:
+        pmrr = prec = None
+    else:
+        ranked = eval_retrieval.rank_queries(
+            vault_root, [r["query"] for r in pair_rows], best_cfg, rerank=args.rerank, k=10
+        )
+        pmrr = round(pair_mrr(ranked, pair_rows), 4)
+        prec = round(pair_recall10(ranked, pair_rows), 4)
+
+    meta = {
+        "baseline_golden": round(baseline_golden, 4),
+        "candidate_golden": round(candidate_golden, 4),
+        "pair_mrr": pmrr,
+        "pair_recall10": prec,
+        "n_eligible_pairs": len(pair_rows),
+        "guard_active": guard_active,
+        "window_hours": args.window_hours,
+        "epsilon": args.epsilon,
+        "min_pairs": args.min_pairs,
+    }
+    write_candidate(args.candidate, best_cfg, meta)
+    write_report(args.report, DEFAULT_RANKING, best_cfg, meta)
+
+    changed = [k for k in best if best[k] != start.get(k)]
+    print(f"\nDEFAULT golden NDCG@10 = {baseline_golden:.4f}")
+    print(f"BEST    golden NDCG@10 = {candidate_golden:.4f}  "
+          f"(delta {candidate_golden - baseline_golden:+.4f}; floor -{args.epsilon})")
+    if not guard_active:
+        print(f"pair-MRR = {pmrr}  pair-recall@10 = {prec}")
+    print(f"changed knobs: {', '.join(changed) if changed else '(none — default is optimal)'}")
+    print(f"candidate -> {args.candidate}")
+    print(f"report    -> {args.report}")
+    print("review the report, then: uv run python scripts/auto_tune_ranking.py --adopt")
     return 0
 
 

--- a/scripts/derive_relevance_pairs.py
+++ b/scripts/derive_relevance_pairs.py
@@ -8,7 +8,10 @@ from ordinary search-then-compile usage and are the only compounding relevance
 signal a single-user vault produces.
 
 Output:
-- `logs/relevance_pairs.jsonl` — the derived pairs (a derived log, safe to write).
+- `logs/relevance_pairs.jsonl` — the derived pairs, rewritten as an ATOMIC,
+  DEDUPED SNAPSHOT each run (not appended). It is a pure derived artifact of
+  `queries × writes × window`, so re-running over the same logs is byte-identical
+  and idempotent — safe to run on a schedule. The source logs are the audit trail.
 - A PROPOSED YAML block printed to stdout for additions to tests/golden/queries.yaml.
   We never auto-edit the golden set (visibility over gating): the user confirms and
   pastes. Constants are never auto-tuned from these.
@@ -23,7 +26,9 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -117,7 +122,48 @@ def derive_pairs(
                         "via_write": w.get("written_path"),
                         "source": "note-citation",
                     }
-    return sorted(best.values(), key=lambda p: -p["confidence"])
+    # Secondary keys (query, cited_path) make the order fully deterministic so the
+    # snapshot is byte-identical across runs regardless of dict iteration order.
+    return sorted(
+        best.values(), key=lambda p: (-p["confidence"], p["query"], p["cited_path"])
+    )
+
+
+def _atomic_write_jsonl(path: Path, rows: list[dict]) -> None:
+    """Write `rows` as JSONL to `path` atomically (tmp sibling + os.replace).
+
+    A concurrent reader sees the whole old or whole new file, never a torn one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        os.replace(tmp, path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def mine_pairs(
+    window_seconds: float, *, write: bool, logs_dir: Path = LOGS
+) -> list[dict]:
+    """Mine deduped (query -> cited_path) pairs from the usage logs under `logs_dir`.
+
+    Reads `queries.jsonl` + `writes.jsonl`, derives weak relevance pairs, and —
+    when `write` — rewrites `relevance_pairs.jsonl` as an ATOMIC, DEDUPED SNAPSHOT
+    (overwrite, not append) so re-running over the same logs is idempotent and
+    byte-identical. Returns the pairs. This is the reusable seam the auto-tuner
+    imports to mine fresh before each tune.
+    """
+    queries = _read_jsonl(logs_dir / QUERIES.name)
+    writes = _read_jsonl(logs_dir / WRITES.name)
+    pairs = derive_pairs(queries, writes, window_seconds)
+    if write:
+        _atomic_write_jsonl(logs_dir / PAIRS_OUT.name, pairs)
+    return pairs
 
 
 def _propose_golden(pairs: list[dict], existing: set[str]) -> dict[str, list[str]]:
@@ -151,16 +197,12 @@ def main() -> int:
         )
         return 1
 
-    pairs = derive_pairs(queries, writes, args.window_hours * 3600)
+    pairs = mine_pairs(args.window_hours * 3600, write=not args.dry_run)
     print(f"derived {len(pairs)} (query -> cited_path) relevance pairs "
           f"from {len(queries)} queries x {len(writes)} writes")
 
-    if not args.dry_run and pairs:
-        PAIRS_OUT.parent.mkdir(parents=True, exist_ok=True)
-        with PAIRS_OUT.open("a", encoding="utf-8") as f:
-            for p in pairs:
-                f.write(json.dumps(p, ensure_ascii=False) + "\n")
-        print(f"appended pairs -> {PAIRS_OUT}")
+    if not args.dry_run:
+        print(f"wrote snapshot ({len(pairs)} pairs) -> {PAIRS_OUT}")
 
     proposed = _propose_golden(pairs, _existing_golden_queries(GOLDEN))
     if proposed:

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -105,6 +105,28 @@ def _evaluate(
     }
 
 
+def rank_queries(
+    vault_root: Path,
+    queries: list[str],
+    config: find_module.RankingConfig,
+    *,
+    rerank: bool = False,
+    k: int = 10,
+) -> dict[str, list[str]]:
+    """Return `{query: [canon'd ranked paths]}` for each query under `config`.
+
+    The canonical find()+`_canon` path, reused by the auto-tuner's pair metrics so
+    mined-pair scoring sees exactly what `_evaluate` scores for golden queries.
+    """
+    out: dict[str, list[str]] = {}
+    for q in queries:
+        hits = find_module.find(
+            vault_root, query=q, limit=k, mode="hybrid", rerank=rerank, config=config
+        )
+        out[q] = [_canon(h.path) for h in hits]
+    return out
+
+
 def _config_label(cfg: find_module.RankingConfig, rerank: bool) -> str:
     return (
         f"rrf_k={cfg.rrf_k} boost={cfg.compiled_boost} "

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -84,6 +84,10 @@ def _evaluate(
             query=g["query"],
             limit=k_max,
             mode="hybrid",
+            # The golden targets are all KB paths, so evaluate KB-only: this skips
+            # the scope="kb" auto-widen scan over the ~20-folder wider vault, which
+            # dominates eval wall-time per query (the tuner makes hundreds of calls).
+            scope="kb-only",
             rerank=rerank,
             config=config,
         )
@@ -121,7 +125,9 @@ def rank_queries(
     out: dict[str, list[str]] = {}
     for q in queries:
         hits = find_module.find(
-            vault_root, query=q, limit=k, mode="hybrid", rerank=rerank, config=config
+            vault_root, query=q, limit=k, mode="hybrid",
+            scope="kb-only",  # mined-pair targets are KB paths; skip the auto-widen scan
+            rerank=rerank, config=config,
         )
         out[q] = [_canon(h.path) for h in hits]
     return out

--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -9,8 +9,11 @@ Cached in-process between calls: keyed by file path, invalidated by mtime.
 
 from __future__ import annotations
 
+import dataclasses
+import json
 import logging
 import math
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import date, timedelta
@@ -97,6 +100,110 @@ class RankingConfig:
 LANE_ORDER = ("vector", "bm25", "keyword", "clip", "graph", "temporal")
 
 DEFAULT_RANKING = RankingConfig()
+
+
+# --------------------------------------------------------------------------- #
+# Adopted-config seam: the auto-tuner writes a reviewed `ranking_config.json`;
+# `find()` loads it once per process when no explicit `config` is passed. Absent
+# file (or any parse error) → DEFAULT_RANKING, byte-identical to the in-code
+# baseline. The live `op_find` calls find() WITHOUT config (consults disk); the
+# eval harnesses pass config= explicitly (hermetic, never touch disk).
+# --------------------------------------------------------------------------- #
+# src/kb_mcp/find.py → parents[2] is the repo (or deploy-checkout) root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_ACTIVE_RANKING: RankingConfig | None = None
+_ACTIVE_RANKING_LOADED = False
+
+
+def ranking_config_to_jsonable(cfg: RankingConfig) -> dict[str, Any]:
+    """Plain-dict form of a RankingConfig (tuples render as JSON arrays)."""
+    return dataclasses.asdict(cfg)
+
+
+def ranking_config_from_jsonable(data: dict[str, Any]) -> RankingConfig:
+    """Build a RankingConfig from a parsed JSON dict, field by field.
+
+    Unknown keys are ignored (schema-drift-safe) and missing keys fall back to
+    the dataclass default. Scalar fields are coerced to int/float per their
+    default; the four `intent_weights_*` fields are coerced to float tuples and
+    MUST have exactly `len(LANE_ORDER)` entries. Raises on an uncoercible value
+    or a wrong-length lane tuple so the caller can fail loud.
+    """
+    field_names = {f.name for f in dataclasses.fields(RankingConfig)}
+    unknown = set(data) - field_names
+    if unknown:
+        log.warning(
+            "ranking config: ignoring unknown knob(s): %s", ", ".join(sorted(unknown))
+        )
+    n_lanes = len(LANE_ORDER)
+    kwargs: dict[str, Any] = {}
+    for f in dataclasses.fields(RankingConfig):
+        if f.name not in data:
+            continue
+        value = data[f.name]
+        if f.name.startswith("intent_weights_"):
+            tup = tuple(float(x) for x in value)
+            if len(tup) != n_lanes:
+                raise ValueError(
+                    f"{f.name}: expected {n_lanes} lane weights, got {len(tup)}"
+                )
+            kwargs[f.name] = tup
+        elif isinstance(f.default, bool):
+            kwargs[f.name] = bool(value)
+        elif isinstance(f.default, int):
+            kwargs[f.name] = int(value)
+        else:
+            kwargs[f.name] = float(value)
+    return RankingConfig(**kwargs)
+
+
+def _load_adopted_ranking() -> RankingConfig:
+    """Resolve the active RankingConfig from disk; DEFAULT_RANKING on absence/error.
+
+    Resolution order:
+      1. ``KB_MCP_DISABLE_RANKING_CONFIG`` set → DEFAULT_RANKING (hermetic; the
+         test suite sets this so a committed file never pollutes the suite).
+      2. ``KB_MCP_RANKING_CONFIG=<path>`` → that path.
+      3. ``<repo_root>/ranking_config.json`` if present.
+      4. else DEFAULT_RANKING.
+
+    A malformed / wrong-typed / bad-lane-length file fails LOUD (``log.error``)
+    and falls back to DEFAULT_RANKING — it never crashes the server and never
+    applies a partially-parsed config.
+    """
+    if os.environ.get("KB_MCP_DISABLE_RANKING_CONFIG"):
+        return DEFAULT_RANKING
+    override = os.environ.get("KB_MCP_RANKING_CONFIG")
+    path = Path(override) if override else _REPO_ROOT / "ranking_config.json"
+    if not path.exists():
+        return DEFAULT_RANKING
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("ranking config must be a JSON object")
+        return ranking_config_from_jsonable(data)
+    except Exception as exc:  # noqa: BLE001 — degrade to known-good, loudly.
+        log.error(
+            "adopted ranking config %s invalid (%s); using DEFAULT_RANKING", path, exc
+        )
+        return DEFAULT_RANKING
+
+
+def _active_ranking() -> RankingConfig:
+    """The adopted RankingConfig, loaded once per process (memoized)."""
+    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
+    if not _ACTIVE_RANKING_LOADED:
+        _ACTIVE_RANKING = _load_adopted_ranking()
+        _ACTIVE_RANKING_LOADED = True
+    return _ACTIVE_RANKING if _ACTIVE_RANKING is not None else DEFAULT_RANKING
+
+
+def reset_active_ranking_cache() -> None:
+    """Drop the memoized adopted config (tests; desk-side adopt happens out of band)."""
+    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
+    _ACTIVE_RANKING = None
+    _ACTIVE_RANKING_LOADED = False
 
 
 @dataclass
@@ -461,7 +568,7 @@ def find(
             auto_rerank=auto_rerank, temporal=temporal, intent=intent,
             prefer_compiled=prefer_compiled,
             prefer_active=prefer_active,
-            config=config or DEFAULT_RANKING,
+            config=config if config is not None else _active_ranking(),
         )
 
     # Auto-widen: reach into the wider vault (sibling folders like Tracking/,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,10 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setenv("KB_MCP_DISABLE_EMBEDDINGS", "1")
     monkeypatch.setenv("KB_MCP_DISABLE_RELEVANCE_CHECK", "1")
+    # A committed repo-root ranking_config.json must never perturb the suite:
+    # force find()'s adopted-config seam to DEFAULT_RANKING. Tests that exercise
+    # the load seam delete this var via their own monkeypatch.
+    monkeypatch.setenv("KB_MCP_DISABLE_RANKING_CONFIG", "1")
     # No real ASR/OCR in the suite: keep uploads from enqueuing GPU work. Tests that
     # exercise the worker enable it explicitly and stub extract.extract_text.
     monkeypatch.setenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", "1")

--- a/tests/test_auto_tune.py
+++ b/tests/test_auto_tune.py
@@ -135,3 +135,147 @@ def test_candidate_axes_excludes_conceptual_weights() -> None:
     assert "temporal_boost" in axes
     # No knob should tune the conceptual lane weights — they must stay neutral.
     assert not any("conceptual" in knob for knob in axes)
+
+
+# --------------------------------------------------------------------------- #
+# Mined-pair scoring — binary relevance, confidence is a filter not a grade
+# --------------------------------------------------------------------------- #
+def test_pairs_to_eval_filters_conf_and_dedups_golden() -> None:
+    pairs = [
+        {"query": "metabolism", "cited_path": "notes/a", "confidence": 0.9},
+        {"query": "metabolism", "cited_path": "notes/b", "confidence": 0.3},
+        {"query": "weak", "cited_path": "notes/c", "confidence": 0.1},  # below conf_min
+        {"query": "In Golden", "cited_path": "notes/d", "confidence": 0.9},  # golden dupe
+    ]
+    rows = at.pairs_to_eval(pairs, {"in golden"}, conf_min=0.25)
+    by_query = {r["query"]: r["relevant"] for r in rows}
+    assert set(by_query) == {"metabolism"}  # weak filtered, golden-dup dropped
+    assert by_query["metabolism"] == {"notes/a", "notes/b"}  # both ≥ conf_min, deduped per query
+
+
+def test_pair_mrr_is_rank_based_not_confidence() -> None:
+    pair_rows = [
+        {"query": "q1", "relevant": {"p1"}},
+        {"query": "q2", "relevant": {"p2"}},
+    ]
+    ranked = {"q1": ["x", "p1", "y"], "q2": ["p2", "z"]}
+    # q1: p1 at rank 2 → 0.5 ; q2: p2 at rank 1 → 1.0 ; mean = 0.75
+    assert at.pair_mrr(ranked, pair_rows) == 0.75
+    # A missing query / no hit contributes 0 — no dependence on any confidence value.
+    assert at.pair_mrr({"q1": ["nope"]}, pair_rows) == 0.0
+
+
+def test_pair_recall10_fraction_in_topk() -> None:
+    pair_rows = [{"query": "q1", "relevant": {"a", "b"}}]
+    assert at.pair_recall10({"q1": ["a", "c", "d"]}, pair_rows) == 0.5
+
+
+def test_combined_score_floor_guard_and_feasible() -> None:
+    base = 0.9
+    # Golden regresses past the floor → infeasible sentinel.
+    assert at.combined_score(
+        0.85, 0.5, baseline_golden=base, epsilon=0.01, n_eligible=10, min_pairs=8
+    ) == (-1.0, 0.85)
+    # Within floor but too few pairs → guard → golden-only (0.0, g).
+    assert at.combined_score(
+        0.9, 0.5, baseline_golden=base, epsilon=0.01, n_eligible=3, min_pairs=8
+    ) == (0.0, 0.9)
+    # Feasible with enough pairs → (pair_mrr, g).
+    assert at.combined_score(
+        0.9, 0.5, baseline_golden=base, epsilon=0.01, n_eligible=10, min_pairs=8
+    ) == (0.5, 0.9)
+
+
+def test_optimize_respects_golden_floor() -> None:
+    """A candidate that boosts pairs but regresses golden past the floor is never
+    selected over a feasible pairs improvement."""
+    base = 0.9
+
+    def evaluate(knobs: dict) -> tuple:
+        scores = {
+            0: (0.90, 0.1),  # start
+            1: (0.90, 0.5),  # pairs improve, golden steady → feasible
+            2: (0.80, 0.9),  # huge pairs gain but golden tanks → infeasible
+        }
+        g, pmrr = scores[knobs["k"]]
+        return at.combined_score(
+            g, pmrr, baseline_golden=base, epsilon=0.01, n_eligible=10, min_pairs=8
+        )
+
+    best, score = at.optimize({"k": [0, 1, 2]}, evaluate, start={"k": 0})
+    assert best == {"k": 1}
+    assert score == (0.5, 0.9)
+
+
+def test_optimize_golden_breaks_pair_ties() -> None:
+    """Equal pair-MRR → the higher golden NDCG wins (lexicographic tiebreak)."""
+    base = 0.9
+
+    def evaluate(knobs: dict) -> tuple:
+        g = {0: 0.90, 1: 0.92, 2: 0.91}[knobs["k"]]
+        return at.combined_score(
+            g, 0.5, baseline_golden=base, epsilon=0.05, n_eligible=10, min_pairs=8
+        )
+
+    best, score = at.optimize({"k": [0, 1, 2]}, evaluate, start={"k": 0})
+    assert best == {"k": 1}
+    assert score == (0.5, 0.92)
+
+
+# --------------------------------------------------------------------------- #
+# Candidate / report / adopt — torch-free file ops + the floor-gated adopt
+# --------------------------------------------------------------------------- #
+def _meta(baseline: float = 0.9, candidate: float = 0.905, guard: bool = False) -> dict:
+    return {
+        "baseline_golden": baseline,
+        "candidate_golden": candidate,
+        "pair_mrr": None if guard else 0.5,
+        "pair_recall10": None if guard else 0.4,
+        "n_eligible_pairs": 3 if guard else 10,
+        "guard_active": guard,
+        "window_hours": 2.0,
+        "epsilon": 0.01,
+        "min_pairs": 8,
+    }
+
+
+def test_write_candidate_is_loadable_with_meta(tmp_path: Path) -> None:
+    cfg = at.RankingConfig(rrf_k=30, compiled_boost=1.3)
+    path = tmp_path / "cand.json"
+    at.write_candidate(path, cfg, _meta())
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["meta"]["candidate_golden"] == 0.905
+    # The embedded config is a full, find()-loadable RankingConfig.
+    assert at.ranking_config_from_jsonable(payload["config"]) == cfg
+
+
+def test_write_report_lists_changed_knobs(tmp_path: Path) -> None:
+    best = at.RankingConfig(rrf_k=30)
+    path = tmp_path / "report.md"
+    at.write_report(path, at.DEFAULT_RANKING, best, _meta())
+    text = path.read_text(encoding="utf-8")
+    assert "rrf_k" in text  # the changed knob is shown
+    assert "--adopt" in text  # the adopt instructions are present
+
+
+def test_adopt_refuses_golden_regression_then_forces(tmp_path: Path) -> None:
+    cand = tmp_path / "cand.json"
+    target = tmp_path / "ranking_config.json"
+    at.write_candidate(cand, at.RankingConfig(rrf_k=30), _meta(candidate=0.80))  # regresses
+    assert at.adopt(cand, target, force=False, epsilon=0.01) == 1
+    assert not target.exists()  # blocked
+    # --force overrides the floor gate.
+    assert at.adopt(cand, target, force=True, epsilon=0.01) == 0
+    written = json.loads(target.read_text(encoding="utf-8"))
+    # The adopted file is the RAW config (loadable by find() directly), not wrapped.
+    assert "rrf_k" in written and "config" not in written
+    assert at.ranking_config_from_jsonable(written).rrf_k == 30
+
+
+def test_adopt_writes_raw_config_within_floor(tmp_path: Path) -> None:
+    cand = tmp_path / "cand.json"
+    target = tmp_path / "ranking_config.json"
+    at.write_candidate(cand, at.RankingConfig(compiled_boost=1.3), _meta(candidate=0.905))
+    assert at.adopt(cand, target, force=False, epsilon=0.01) == 0
+    loaded = at.ranking_config_from_jsonable(json.loads(target.read_text(encoding="utf-8")))
+    assert loaded.compiled_boost == 1.3

--- a/tests/test_derive_relevance_pairs.py
+++ b/tests/test_derive_relevance_pairs.py
@@ -1,0 +1,94 @@
+"""Mining the relevance-pairs snapshot is idempotent (torch-free).
+
+`mine_pairs` rewrites `relevance_pairs.jsonl` as an atomic deduped snapshot, so
+re-running over the same source logs must be byte-identical and leave no temp
+residue — the property that makes it safe to run on a schedule.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import derive_relevance_pairs as drp  # noqa: E402
+
+
+def _seed_logs(logs_dir: Path) -> None:
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    queries = [
+        {
+            "ts": "2026-06-01T10:00:00",
+            "query": "metabolism basics",
+            "top_k": [
+                {"path": "Knowledge Base/Notes/Research/Health/metabolic-literacy.md"},
+                {"path": "Knowledge Base/Sources/Articles/some-source.md"},
+            ],
+        },
+        {
+            "ts": "2026-06-02T09:00:00",
+            "query": "binding problem",
+            "top_k": [
+                {"path": "Knowledge Base/Notes/Insights/binding-mechanism.md"},
+            ],
+        },
+    ]
+    writes = [
+        # Cites a path from query 1, within window → one pair.
+        {
+            "ts": "2026-06-01T10:30:00",
+            "tool": "note",
+            "written_path": "Knowledge Base/Notes/Insights/foo.md",
+            "cited_sources": ["Knowledge Base/Notes/Research/Health/metabolic-literacy.md"],
+        },
+        # A SECOND write citing the SAME (query, path) later → must dedup to one row.
+        {
+            "ts": "2026-06-01T11:00:00",
+            "tool": "note",
+            "written_path": "Knowledge Base/Notes/Insights/bar.md",
+            "cited_sources": ["Knowledge Base/Notes/Research/Health/metabolic-literacy.md"],
+        },
+        # Cites a path from query 2 → a second distinct pair.
+        {
+            "ts": "2026-06-02T09:20:00",
+            "tool": "note",
+            "written_path": "Knowledge Base/Notes/Insights/baz.md",
+            "cited_sources": ["Knowledge Base/Notes/Insights/binding-mechanism.md"],
+        },
+    ]
+    (logs_dir / "queries.jsonl").write_text(
+        "\n".join(json.dumps(q) for q in queries) + "\n", encoding="utf-8"
+    )
+    (logs_dir / "writes.jsonl").write_text(
+        "\n".join(json.dumps(w) for w in writes) + "\n", encoding="utf-8"
+    )
+
+
+def test_snapshot_is_idempotent_and_deduped(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    _seed_logs(logs)
+    window = 2 * 3600
+
+    pairs1 = drp.mine_pairs(window, write=True, logs_dir=logs)
+    snapshot = logs / "relevance_pairs.jsonl"
+    bytes1 = snapshot.read_bytes()
+
+    pairs2 = drp.mine_pairs(window, write=True, logs_dir=logs)
+    bytes2 = snapshot.read_bytes()
+
+    # Idempotent: a second run over the same logs reproduces the file exactly.
+    assert bytes1 == bytes2
+    assert pairs1 == pairs2
+
+    rows = [json.loads(line) for line in snapshot.read_text(encoding="utf-8").splitlines() if line]
+    # Two distinct (query, cited_path) pairs, deduped across the two citing writes.
+    keys = {(r["query"], r["cited_path"]) for r in rows}
+    assert len(rows) == len(keys) == 2
+
+    # No temp residue from the atomic write.
+    assert not list(logs.glob(".relevance_pairs.jsonl.*"))
+    assert not list(logs.glob("*.tmp"))

--- a/tests/test_ranking_config.py
+++ b/tests/test_ranking_config.py
@@ -11,7 +11,10 @@ candidate_k / graph_seed_cap / rrf_k / type-boost, all of which the config feeds
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from kb_mcp import find as find_module
 
@@ -108,3 +111,74 @@ def test_type_boost_honors_config() -> None:
         p for p, _ in find_module._apply_type_boost(fused, fixtures, penalize)
     ]
     assert flipped[0] == source
+
+
+def test_ranking_config_jsonable_roundtrip() -> None:
+    """to_jsonable → json → from_jsonable must reproduce the config exactly, with
+    the intent-weight fields surviving as tuples (the frozen dataclass needs
+    hashable fields)."""
+    default = find_module.DEFAULT_RANKING
+    rt = find_module.ranking_config_from_jsonable(
+        json.loads(json.dumps(find_module.ranking_config_to_jsonable(default)))
+    )
+    assert rt == default
+
+    tuned = find_module.RankingConfig(
+        rrf_k=30,
+        compiled_boost=1.3,
+        intent_weights_exact=(0.5, 2.0, 2.0, 1.0, 0.5, 1.0),
+    )
+    rt2 = find_module.ranking_config_from_jsonable(
+        json.loads(json.dumps(find_module.ranking_config_to_jsonable(tuned)))
+    )
+    assert rt2 == tuned
+    assert isinstance(rt2.intent_weights_exact, tuple)
+
+
+def test_adopted_config_applies_then_reverts(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """find() with no `config` loads an adopted file; deleting it (with a cache
+    reset) restores byte-identical DEFAULT behavior. The reversibility guard."""
+    monkeypatch.delenv("KB_MCP_DISABLE_RANKING_CONFIG", raising=False)
+    tuned = find_module.RankingConfig(compiled_boost=0.1)  # heavy compiled penalty
+    cfg_path = tmp_path / "ranking_config.json"
+    cfg_path.write_text(
+        json.dumps(find_module.ranking_config_to_jsonable(tuned)), encoding="utf-8"
+    )
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg_path))
+    find_module.reset_active_ranking_cache()
+
+    queries = ("egcg", "metabolism", "progressive disclosure")
+    # The seam applies the adopted file when no config is passed.
+    for q in queries:
+        adopted = [h.path for h in find_module.find(vault, query=q, mode="hybrid")]
+        explicit = [
+            h.path for h in find_module.find(vault, query=q, mode="hybrid", config=tuned)
+        ]
+        assert adopted == explicit
+    # ...and the adopted config genuinely perturbs ranking vs DEFAULT somewhere.
+    changed = any(
+        [h.path for h in find_module.find(vault, query=q, mode="hybrid", config=tuned)]
+        != [
+            h.path
+            for h in find_module.find(
+                vault, query=q, mode="hybrid", config=find_module.DEFAULT_RANKING
+            )
+        ]
+        for q in queries
+    )
+    assert changed, "the tuned config should reorder at least one fixture query"
+
+    # Revert: delete the file + reset cache → no-config find() == DEFAULT path.
+    cfg_path.unlink()
+    find_module.reset_active_ranking_cache()
+    for q in queries:
+        reverted = [h.path for h in find_module.find(vault, query=q, mode="hybrid")]
+        default = [
+            h.path
+            for h in find_module.find(
+                vault, query=q, mode="hybrid", config=find_module.DEFAULT_RANKING
+            )
+        ]
+        assert reverted == default

--- a/tests/test_ranking_config_load.py
+++ b/tests/test_ranking_config_load.py
@@ -1,0 +1,125 @@
+"""The adopted-RankingConfig disk-load seam in find.py.
+
+find() consults disk for a tuned config ONLY when called without an explicit
+`config` (the live server's path); the eval harnesses pass config= and stay
+hermetic. These tests exercise the loader directly: resolution order, coercion,
+fail-loud-then-DEFAULT, and the per-process memo. They drop the suite-wide
+KB_MCP_DISABLE_RANKING_CONFIG so the real seam runs, and pin the resolved path
+to a tmp file so a committed repo-root config can't leak in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import find as find_module
+
+
+@pytest.fixture(autouse=True)
+def _exercise_real_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo the suite-wide disable flag and reset the memo around each test."""
+    monkeypatch.delenv("KB_MCP_DISABLE_RANKING_CONFIG", raising=False)
+    monkeypatch.delenv("KB_MCP_RANKING_CONFIG", raising=False)
+    find_module.reset_active_ranking_cache()
+    yield
+    find_module.reset_active_ranking_cache()
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_absent_file_returns_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(tmp_path / "nope.json"))
+    assert find_module._active_ranking() == find_module.DEFAULT_RANKING
+
+
+def test_valid_file_is_loaded_with_tuple_coercion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _write(
+        tmp_path / "ranking_config.json",
+        {
+            "rrf_k": 30,
+            "compiled_boost": 1.3,
+            "intent_weights_exact": [0.7, 1.5, 1.5, 1.0, 0.7, 1.0],
+        },
+    )
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg))
+    loaded = find_module._active_ranking()
+    assert loaded.rrf_k == 30
+    assert loaded.compiled_boost == 1.3
+    # JSON arrays must come back as tuples (frozen dataclass requires hashable).
+    assert isinstance(loaded.intent_weights_exact, tuple)
+    assert loaded.intent_weights_exact == (0.7, 1.5, 1.5, 1.0, 0.7, 1.0)
+    # Unspecified knobs keep their defaults.
+    assert loaded.source_penalty == find_module.DEFAULT_RANKING.source_penalty
+
+
+def test_malformed_json_fails_loud_then_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bad = tmp_path / "ranking_config.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(bad))
+    with caplog.at_level(logging.ERROR, logger="kb_mcp.find"):
+        assert find_module._active_ranking() == find_module.DEFAULT_RANKING
+    assert any("invalid" in r.message for r in caplog.records)
+
+
+def test_unknown_knob_ignored_missing_defaulted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _write(tmp_path / "ranking_config.json", {"rrf_k": 42, "bogus_knob": 5})
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg))
+    with caplog.at_level(logging.WARNING, logger="kb_mcp.find"):
+        loaded = find_module._active_ranking()
+    assert loaded.rrf_k == 42  # known knob applied
+    assert loaded.compiled_boost == find_module.DEFAULT_RANKING.compiled_boost
+    assert any("bogus_knob" in r.message for r in caplog.records)
+
+
+def test_bad_lane_tuple_length_fails_loud_then_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _write(tmp_path / "ranking_config.json", {"intent_weights_exact": [1.0, 2.0, 3.0]})
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg))
+    with caplog.at_level(logging.ERROR, logger="kb_mcp.find"):
+        assert find_module._active_ranking() == find_module.DEFAULT_RANKING
+    assert any("lane weights" in r.message or "invalid" in r.message for r in caplog.records)
+
+
+def test_disable_flag_forces_default_even_with_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _write(tmp_path / "ranking_config.json", {"rrf_k": 30})
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg))
+    monkeypatch.setenv("KB_MCP_DISABLE_RANKING_CONFIG", "1")
+    assert find_module._active_ranking() == find_module.DEFAULT_RANKING
+
+
+def test_repo_root_fallback_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no env override, the loader reads <repo_root>/ranking_config.json."""
+    monkeypatch.setattr(find_module, "_REPO_ROOT", tmp_path)
+    _write(tmp_path / "ranking_config.json", {"rrf_k": 99})
+    assert find_module._active_ranking().rrf_k == 99
+
+
+def test_memo_loads_once_until_reset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = tmp_path / "ranking_config.json"
+    _write(cfg, {"rrf_k": 30})
+    monkeypatch.setenv("KB_MCP_RANKING_CONFIG", str(cfg))
+    assert find_module._active_ranking().rrf_k == 30
+    _write(cfg, {"rrf_k": 77})  # change on disk
+    assert find_module._active_ranking().rrf_k == 30  # memo still serves the old value
+    find_module.reset_active_ranking_cache()
+    assert find_module._active_ranking().rrf_k == 77  # reloaded after reset


### PR DESCRIPTION
## Why

The self-tuning ranker (`RankingConfig` + `auto_tune_ranking.py` + the golden eval + the usage miner) shipped but the loop was **open** — it never fed back. Three concrete breaks:

1. **Mined pairs never reached the tuner's objective.** `auto_tune_ranking.py` loaded `relevance_pairs.jsonl` and printed the count, but optimized against the 9 hand-authored golden queries only.
2. **Mining appended** → cross-run duplicates → unsafe to schedule.
3. **A tuned config couldn't take effect without hand-editing `find.py`** (no disk-load seam).

OpenSpec change: `close-auto-tune-loop` (validates `--strict`). Direction 1 of four next-phase directions; 2–4 follow separately.

## What changed

- **Combined objective — lexicographic `(pair_mrr, golden_ndcg)` with a hard golden floor.** A mined pair is a **binary** relevance fact; `confidence` is only a `CONF_MIN` filter, never a grade (grading by it bakes the *incumbent* rank into the target). Pairs deduped against golden; a `MIN_PAIRS` guard drops the pairs term until enough distinct pairs exist. No candidate may drop golden NDCG@10 more than `EPSILON` below baseline.
- **Idempotent mining.** `mine_pairs()` rewrites an atomic, deduped snapshot (tmp + `os.replace`), not an append.
- **Adopted-config load seam in `find()`.** No explicit `config` → resolve from disk (`KB_MCP_DISABLE_RANKING_CONFIG` → `KB_MCP_RANKING_CONFIG` → repo-root `ranking_config.json` → `DEFAULT_RANKING`). Malformed → fail loud → `DEFAULT`. **Absent file → byte-identical to today.** Eval harnesses pass `config=` explicitly → hermetic.
- **Reviewed, reversible adoption.** Tuning writes a candidate + delta report and **never** auto-applies; `--adopt` promotes it (gated by the same golden floor); reverting is deleting/`git revert`-ing the file.
- **Eval is KB-only (perf).** The golden + mined-pair targets are all KB paths, so the tuner evaluates with `scope="kb-only"`, skipping `find`'s auto-widen scan over the ~20-folder wider vault — without it the descent is CPU-pinned on the wide scan (GPU near-idle); with it the tune is GPU-bound and practical.

## Real-vault smoke (2026-06-28)

Ran on the live vault + real usage logs. **The loop engages on real data** — the current logs mine 21 pairs → **10 distinct eligible queries (≥ `MIN_PAIRS=8`), guard OFF** — so the pairs term tunes from real signal *today*, not just "once usage compounds". Mining + idempotent snapshot + end-to-end run confirmed; producing/adopting a final candidate is a longer desk-side run left to the maintainer.

## Pure-substrate

No server-side reasoning LLM anywhere; labels derive only from recorded usage; deterministic coordinate descent. Default-off by absence.

## Tests / verification

- New/extended torch-free tests: load seam (absent/valid/malformed/unknown-knob/bad-tuple/env-override/disable-flag/memo), serialize roundtrip + reversibility, mining idempotency, `pairs_to_eval`/binary `pair_mrr`/`combined_score`+`optimize` floor & guard & tiebreak, candidate/report shape, adopt floor gate.
- Full suite: **765 passed, 5 skipped** (torch/PIL-gated skip cleanly). The one collection error is the pre-existing torch-hard-import in `tests/test_voice_embed.py` (diarization; needs the embeddings extra) — unrelated to this change.
- `uvx ruff check` adds no new findings vs `origin/main`. `openspec validate close-auto-tune-loop --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)