### PR TITLE
feat(find): speaker filter — find diarized media by who spoke

### DIFF
--- a/openspec/changes/find-speaker-filter/design.md
+++ b/openspec/changes/find-speaker-filter/design.md
@@ -1,0 +1,22 @@
+# Design — find speaker filter
+
+## Approach
+
+Mirror the existing `tags`/`projects` filters exactly: a `speakers: list[str] | None` param on
+`find`, threaded through every ranker path to `_passes_filters`, which drops a page unless its
+`Page.speakers` (the `speakers:` frontmatter list) intersects the requested speakers
+(case-insensitive). A page with no `speakers:` never matches a speaker filter; an unset filter is a
+no-op (default-allow, like `file_types`).
+
+## Decisions
+
+- **Frontmatter facet, not a new index.** The `speakers:` list already exists on diarized sidecars
+  (written by `preserve.update_sidecar_extraction`); the filter reads it directly — no sidecar, no
+  row-IDs, no migration (consistent with the "no queryable sidecar" rule).
+- **AND with query / OR within the list** — consistent with `tags`/`projects`, so combinations behave
+  predictably (`find(query="thyroid", speakers=["Alice"])`).
+- **Named speakers only in practice.** The point is finding by person; anonymous `Speaker A` labels
+  match only if explicitly requested (harmless, rarely useful).
+- **Unified surface via the registry.** The `find` command gains the param once; MCP/REST/CLI/OpenAPI
+  all inherit it. The byte-identical MCP schema-fidelity baseline was regenerated (only the `find`
+  tool's `speakers` property is added, positioned after `tags`).

--- a/openspec/changes/find-speaker-filter/proposal.md
+++ b/openspec/changes/find-speaker-filter/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Named-speaker diarization writes a `speakers:` frontmatter list (e.g. `[Alice, Speaker B]`) on each
+diarized media sidecar, and the named transcript embeds the names inline. But names are only findable
+as *content* — there's no structured way to ask "what did <person> say", which the original
+diarization change (`add-named-speaker-diarization`) explicitly scoped as future work.
+
+## What Changes
+
+- Add a `speakers` filter to `find`: restrict results to pages whose `speakers:` frontmatter includes
+  any of the named speakers (case-insensitive), AND'd with the query and other filters, OR'd within
+  the list — mirroring the existing `tags`/`projects` filters. Threaded through every search path
+  (keyword/vector/bm25/hybrid) via `_passes_filters`, plus a `Page.speakers` accessor.
+- Exposed on the unified command surface (MCP/REST/CLI/OpenAPI) via the `find` command registry.
+
+Pure-substrate intact: this is a frontmatter filter over already-measured data — no model, no judgment.
+
+## Capabilities
+
+### Modified Capabilities
+- `speaker-diarization`: diarized media is now findable by speaker via a `find(speakers=[…])` filter,
+  not just by name-as-content.
+
+## Impact
+
+- Code: `src/kb_mcp/find.py` (`Page.speakers`, `speakers` param threaded through `find` + helpers +
+  `_passes_filters`), `src/kb_mcp/commands.py` (the `find` command param + docstring), the regenerated
+  MCP schema-fidelity fixture, the scaffold `SKILL.md` find-knobs note.
+- Default `None` ⇒ zero behaviour change when the filter is unset (search never hides a page by default).

--- a/openspec/changes/find-speaker-filter/specs/speaker-diarization/spec.md
+++ b/openspec/changes/find-speaker-filter/specs/speaker-diarization/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Speaker-Scoped Search
+
+The system SHALL support filtering `find` results by speaker: a `speakers` filter restricts results
+to pages whose `speakers:` frontmatter includes any of the requested names (case-insensitive),
+combined with the query and other filters by AND and within the speaker list by OR. When the filter
+is unset the system SHALL NOT scope by speaker (default-allow); a page without a `speakers:` list
+SHALL NOT match a non-empty speaker filter.
+
+#### Scenario: Find what a speaker said
+
+- **WHEN** `find` is called with `speakers=["Alice"]`
+- **THEN** only pages whose `speakers:` frontmatter includes "Alice" (case-insensitive) are returned
+- **AND** the filter is AND'd with the query and any other filters
+
+#### Scenario: Unset speaker filter changes nothing
+
+- **WHEN** `find` is called without a `speakers` filter
+- **THEN** results are unchanged — no page is hidden on the basis of its speakers

--- a/openspec/changes/find-speaker-filter/tasks.md
+++ b/openspec/changes/find-speaker-filter/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — find speaker filter
+
+- [x] 1. `Page.speakers` accessor in `find.py` (reads the `speakers:` frontmatter list; non-list → []).
+- [x] 2. `speakers` param on `find()` threaded through every ranker path to `_passes_filters`
+      (default `None` = no scoping; mirrors `tags`). Case-insensitive intersection match in
+      `_passes_filters`.
+- [x] 3. Expose on the `find` command in `commands.py` (param + docstring); regenerate the MCP
+      schema-fidelity fixture (`tests/fixtures/mcp_tool_schemas.json` — only `find`'s `speakers`
+      property added).
+- [x] 4. Scaffold `SKILL.md` find-knobs note (generic — leak-guarded).
+- [x] 5. Tests in `tests/test_find.py`: `Page.speakers` accessor, `_passes_filters` speaker
+      match/miss, and a find() integration test.
+- [x] 6. Full suite green (851 passed, 1 skipped); leak guard green; `openspec validate --strict`.

--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -292,9 +292,10 @@ Empty queries degrade to filtered-most-recent regardless of mode.
 Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
 `rerank=true` (CrossEncoder re-sort, opt-in), `prefer_compiled=true` (default;
 favours compiled types over raw `source`), `prefer_active=true` (default;
-soft-demotes superseded pages), and `file_types` / `exclude_file_types` (scope to
+soft-demotes superseded pages), `file_types` / `exclude_file_types` (scope to
 or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
-`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`).
+`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`), and `speakers`
+(restrict to diarized media whose `speakers:` frontmatter names a given person).
 
 **Tabular data is card-based.** Raw CSV/JSON/TSV rows are never embedded and raw
 data files aren't `find`-searchable. To make a dataset findable, write a

--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -206,6 +206,7 @@ def op_find(
     types: list[str] | None = None,
     projects: list[str] | None = None,
     tags: list[str] | None = None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
     limit: int = 15,
@@ -228,6 +229,9 @@ def op_find(
         types: Filter to these page types (source, research-note, insight, failure, pattern, experiment, production-log, entity).
         projects: Filter to pages whose `project` or `projects:` includes any of these keys.
         tags: Filter to pages whose `tags:` includes any of these (case-insensitive).
+        speakers: Filter to diarized media whose `speakers:` frontmatter includes any of
+            these named speakers (case-insensitive) — e.g. "what did Alice say about X".
+            AND'd with the query/other filters; OR'd within the list.
         file_types: Scope results to these artifact kinds — note, pdf, image,
             audio, video, csv, json, tsv. A binary surfaces under its media
             kind (pdf/image/...); a data file under its dataset card's format
@@ -305,6 +309,7 @@ def op_find(
         types=types,
         projects=projects,
         tags=tags,
+        speakers=speakers,
         file_types=file_types,
         exclude_file_types=exclude_file_types,
         limit=limit,

--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -274,6 +274,13 @@ class ParsedPage:
         return [str(x).lower() for x in t] if isinstance(t, list) else []
 
     @property
+    def speakers(self) -> list[str]:
+        """Named speakers from a diarized media sidecar's `speakers:` frontmatter
+        (e.g. `[Alice, Speaker B]`). Empty when undiarized or not a media sidecar."""
+        s = self.frontmatter.get("speakers") or []
+        return [str(x) for x in s] if isinstance(s, list) else []
+
+    @property
     def media_type(self) -> str | None:
         """audio/video/image/pdf on an Evidence media sidecar, else None."""
         mt = self.frontmatter.get("media_type")
@@ -445,6 +452,7 @@ def find(
     types: list[str] | None = None,
     projects: list[str] | None = None,
     tags: list[str] | None = None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
     limit: int = 15,
@@ -554,7 +562,7 @@ def find(
         hits = _find_keyword(
             vault_root,
             query_norm=query_norm,
-            types=types, projects=projects, tags=tags,
+            types=types, projects=projects, tags=tags, speakers=speakers,
             file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=walk_scope,
         )
@@ -562,7 +570,7 @@ def find(
         hits = _find_semantic(
             vault_root,
             query=query, query_norm=query_norm,
-            types=types, projects=projects, tags=tags,
+            types=types, projects=projects, tags=tags, speakers=speakers,
             file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=walk_scope, mode=mode, graph=graph, rerank=rerank,
             auto_rerank=auto_rerank, temporal=temporal, intent=intent,
@@ -592,7 +600,7 @@ def find(
                 vault_root,
                 query=query,
                 query_norm=query_norm,
-                types=types, projects=projects, tags=tags,
+                types=types, projects=projects, tags=tags, speakers=speakers,
                 file_types=file_types, exclude_file_types=exclude_file_types,
                 limit=limit,
             )
@@ -632,6 +640,7 @@ def _find_keyword(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
     limit: int,
@@ -655,7 +664,7 @@ def _find_keyword(
         page = _CACHE.get(path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
                                file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         excerpt = _make_excerpt(page, query_norm)
@@ -691,6 +700,7 @@ def _find_semantic(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
     limit: int,
@@ -856,7 +866,7 @@ def _find_semantic(
         return _find_keyword(
             vault_root,
             query_norm=query_norm,
-            types=types, projects=projects, tags=tags,
+            types=types, projects=projects, tags=tags, speakers=speakers,
             file_types=file_types, exclude_file_types=exclude_file_types,
             limit=limit, scope=scope,
         )
@@ -927,7 +937,7 @@ def _find_semantic(
         page = _CACHE.get(abs_path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
                                file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         keyword_excerpt = _make_excerpt(page, query_norm)
@@ -1040,6 +1050,7 @@ def _find_outside_kb(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
     limit: int,
@@ -1087,7 +1098,7 @@ def _find_outside_kb(
         page = _CACHE.get(vault_root / rel_path, vault_root)
         if page is None:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags,
+        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
                                file_types=file_types, exclude_file_types=exclude_file_types):
             continue
         # Relaxed gate: BM25 score>0 already implies a token match, but the
@@ -1688,6 +1699,7 @@ def _passes_filters(
     types: list[str] | None,
     projects: list[str] | None,
     tags: list[str] | None,
+    speakers: list[str] | None = None,
     file_types: list[str] | None = None,
     exclude_file_types: list[str] | None = None,
 ) -> bool:
@@ -1707,6 +1719,10 @@ def _passes_filters(
     if tags:
         page_tags = set(page.tags)
         if not any(t.lower() in page_tags for t in tags):
+            return False
+    if speakers:
+        page_speakers = {s.lower() for s in page.speakers}
+        if not any(s.lower() in page_speakers for s in speakers):
             return False
     # File-type scoping (opt-in; default None/None lets every kind through — a
     # search must never hide an artifact type by default).

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -500,6 +500,21 @@
           "default": null,
           "description": "Filter to pages whose `tags:` includes any of these (case-insensitive)."
         },
+        "speakers": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to diarized media whose `speakers:` frontmatter includes any of\nthese named speakers (case-insensitive) — e.g. \"what did Alice say about X\".\nAND'd with the query/other filters; OR'd within the list."
+        },
         "file_types": {
           "anyOf": [
             {

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -375,3 +375,37 @@ def test_passes_filters_file_types_include_and_exclude() -> None:
     # exclude: listed kinds drop, others pass
     assert not find_module._passes_filters(ds, types=None, projects=None, tags=None, exclude_file_types=["csv"])
     assert find_module._passes_filters(note, types=None, projects=None, tags=None, exclude_file_types=["csv"])
+
+
+# ---------------- speaker filter (diarized media; default = no speaker scoping) ----------------
+
+
+def test_page_speakers_accessor() -> None:
+    assert _mk_page({}).speakers == []
+    assert _mk_page({"speakers": ["Hugo", "Speaker B"]}).speakers == ["Hugo", "Speaker B"]
+    assert _mk_page({"speakers": "Hugo"}).speakers == []  # non-list frontmatter → empty (defensive)
+
+
+def test_passes_filters_speakers_match_and_miss() -> None:
+    diarized = _mk_page({"media_type": "audio", "speakers": ["Hugo", "Speaker B"]})
+    other = _mk_page({"media_type": "audio", "speakers": ["Kim"]})
+    plain = _mk_page({"type": "insight"})
+    # case-insensitive match on any listed speaker
+    assert find_module._passes_filters(diarized, types=None, projects=None, tags=None, speakers=["hugo"])
+    # a recording without that speaker is dropped
+    assert not find_module._passes_filters(other, types=None, projects=None, tags=None, speakers=["Hugo"])
+    # a page with no speakers never matches a speaker filter
+    assert not find_module._passes_filters(plain, types=None, projects=None, tags=None, speakers=["Hugo"])
+    # no speaker filter → speakers ignored (default lets everything through)
+    assert find_module._passes_filters(plain, types=None, projects=None, tags=None)
+
+
+def test_find_speaker_filter_integration(vault: Path) -> None:
+    note = vault / "Knowledge Base" / "Sources" / "Other" / "meeting-xyz.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "---\ntype: source\nmedia_type: audio\nspeakers: [Hugo, Speaker B]\n---\n\n[Hugo]: thyroid talk\n",
+        encoding="utf-8",
+    )
+    assert any("meeting-xyz" in h.path for h in find_module.find(vault, query="", speakers=["Hugo"]))
+    assert not any("meeting-xyz" in h.path for h in find_module.find(vault, query="", speakers=["Nobody"]))


### PR DESCRIPTION
Adds a `speakers` filter to `find`: restrict results to diarized media whose `speakers:` frontmatter includes the named people (case-insensitive), AND'd with the query, OR'd within the list — mirroring `tags`/`projects`. Fulfils the `speaker:` filter the diarization change scoped as future work.

- `Page.speakers` accessor + `speakers` threaded through every ranker path to `_passes_filters`
- exposed on the unified `find` command (MCP/REST/CLI/OpenAPI); schema-fidelity baseline regenerated (only `find`'s `speakers` property added, after `tags`)
- scaffold SKILL.md find-knobs note (generic); OpenSpec change `find-speaker-filter` (validates `--strict`)
- tests: `Page.speakers` accessor, `_passes_filters` match/miss, find() integration

851 passed, 1 skipped; leak guard green. Default `None` = no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnHCrSGB62kFmmptCoMAQn
