### PR TITLE
feat(attention): compose epistemic queues into one ranked review surface (kb attention)

### DIFF
--- a/openspec/changes/add-attention-queue/design.md
+++ b/openspec/changes/add-attention-queue/design.md
@@ -1,0 +1,97 @@
+# Design — Attention queue (unified review surface)
+
+## Context
+
+Three measurement-only review queues live in `audit.py`, all returning `AuditFinding`
+and orchestrated by `audit(vault_root, *, categories, today)` (one parse pass, then the
+selected `_check_*`):
+
+- `_check_stale_review` — emits findings sorted most-dormant-first (ACT-R `activation`
+  ascending, `-age_days` tiebreak). `meta` carries `age_days`, `activation`, etc.
+- `_check_corpus_contradictions` — emits pairs (`path=A`, `paths=[A,B]`) sorted by
+  `cosine + W·dormancy`, cross-family first, capped at `KB_MCP_CONTRADICTION_TOP_N`
+  with a trailing summary finding (`path="Knowledge Base/"`, `meta.truncated`).
+- `_check_unprocessed_sources` — emits sources with empty `ingested_into`, oldest-first.
+
+The enabling fact: **each check already returns findings in intra-queue rank order**
+(emission order == rank). So a composer never recomputes ranks — it enumerates.
+
+## The composition
+
+`attention()` calls `audit()` once with the three categories, then a pure
+`_rank(findings, …)` does the rest. Reuse over rebuild: never call the `_check_*`
+directly (that would duplicate the parse pass + the ACT-R/env wiring and risk drift).
+
+## Decisions
+
+- **Rank by Reciprocal Rank Fusion over intra-queue position, reusing
+  `fusion.reciprocal_rank_fusion_weighted` (k=60, equal weights).** The three queues'
+  raw signals are genuinely incomparable (ACT-R `activation` is log-odds and can be
+  `-inf`; contradiction `priority ≈ 0.5–1.4`; `age_days` an integer). RRF is
+  unit-agnostic by construction — each queue votes purely by rank, which we already
+  have. It is the literal idiom `find` uses, and it is parameter-light (one constant).
+  - *Rejected — normalize-to-urgency:* requires inventing a per-queue 0–1 transform;
+    min-max is population-unstable and breaks on `-inf`, a sigmoid needs hand-tuned
+    params. Manufacturing a cross-queue comparable magnitude is the closest of the
+    options to *inference* and the hardest to defend on the pure-substrate line.
+  - *Rejected — round-robin/quota:* effectively unweighted RRF minus the one property
+    that makes RRF valuable here (below); quotas are themselves arbitrary policy.
+- **Multi-signal additivity is the decisive property.** A note flagged by two queues
+  (stale AND a contradiction anchor) accumulates `1/(k+r₁) + 1/(k+r₂)`, strictly above
+  any single-membership score in its tier — so doubly-flagged notes rise automatically.
+  That is exactly the "did I conclude this is stale *and* it sits next to a conflicting
+  note?" case the surface most wants on top. It is counting independent deterministic
+  votes — measurement, not judgment.
+- **Dedup by anchor `path` into one item carrying `reasons[]`.** Additivity *requires*
+  dedup to express "flagged twice," and a reviewer thinks per-note. The contradiction
+  pair is not lost: its reason keeps `related_paths=[A,B]` + full `meta`. A pair
+  surfaces under anchor `A` (the sorted-first path the check already emits); `B` is an
+  independent item only if separately flagged — a faithful 1:1 with the contradiction
+  queue (the rejected "explode the pair into two items" would double-count it). Within
+  one category an anchor's score uses its **best** rank (the fusion util's standard
+  per-list dedup), but **all** its reasons are attached — so "A overlaps both B and C"
+  lists two reasons without a prolific anchor dominating the score.
+- **Equal default weights + a fixed tiebreak `corpus_contradictions > stale_review >
+  unprocessed_source`.** With equal weights the order is a clean rank-major,
+  category-minor interleave except multi-flagged anchors jump up; the score stays
+  purely rank-driven (trivial to explain) and the cross-queue preference is a
+  transparent documented tiebreak, not a magic float. Per-category weights remain a
+  code seam (not env-exposed in v1, YAGNI). `k=60` is the `fusion` default.
+- **Drop and fold the contradiction summary finding.** The trailing
+  `corpus_contradictions` finding (`meta.truncated`) is not a reviewable item; filter
+  it out before ranking and fold its count into `upstream_truncated`. The surface
+  reports both its own `truncated` (items beyond `limit`) and `upstream_truncated`
+  (pairs `audit` itself capped) in an explicit `note` — never a silent truncation,
+  mirroring the contradiction queue's own "N more not shown" discipline.
+- **Two params only (YAGNI):** `categories` (optional subset of the three, validated
+  against them with a clear `ValueError`) and `limit` (default 25). `project` scoping is
+  cut for v1 — findings don't carry the note's project field, so it would mean threading
+  a filter through `audit()` and all three checks. `today` is threaded internally for
+  test determinism but not exposed as a command param (matching `op_audit`).
+
+## Pure-substrate justification
+
+Every item's rank is a deterministic arithmetic function of (a) the intra-queue rank
+each measurement-only check already computed and (b) a fixed RRF formula with constant
+`k` and constant weights. At attention time no note content is read, embedded, or
+compared; no cross-item semantic judgment is made. This is the same machinery and the
+same status as `find`'s weighted RRF and the contradiction queue's dormancy sort — both
+already in bounds. The per-item `proposed_fix` states the ranking is "a deterministic
+measurement, not a judgment that anything conflicts or is wrong," enumerates the
+human/Claude actions (keep / `replace` / `reconcile` / `propose_compilation` / archive),
+and says nothing is auto-acted. A server-side LLM reasoning across the surfaced items to
+decide what is actually wrong would be the out-of-bounds step — attention stops short.
+
+## Risks
+
+- **Schema-fidelity fixture must be regenerated.** Adding any command breaks
+  `tests/test_mcp_schema_fidelity.py` until `tests/fixtures/mcp_tool_schemas.json` is
+  regenerated. Mitigated by the new `scripts/dump-tool-schemas.py` (serializes the live
+  schema via the same path the test uses), so the regen is reproducible, not hand-edited.
+- **Two-stage truncation.** `attention`'s `limit` cannot surface contradiction pairs
+  that `audit` already capped upstream; this is reported via `upstream_truncated` + the
+  `note` clause rather than raising the upstream cap. Acceptable: the surface is honest
+  about what it can't show and points at the env knob.
+- **Tool ambiguity vs `audit`.** Both read the KB. The `attention` description leads
+  with "your review queue / front door for daily review" and explicitly defers the full
+  lint/health report to `audit`, so natural-language tool selection routes correctly.

--- a/openspec/changes/add-attention-queue/proposal.md
+++ b/openspec/changes/add-attention-queue/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+kb-mcp ships three **measurement-only epistemic queues** that already work but have
+**no single front door**, so they go unused in day-to-day review:
+
+- `stale_review` — active compiled conclusions that are old AND rarely surfaced in
+  `find` AND low inbound-degree (ACT-R dormancy ordered).
+- `corpus_contradictions` — pairs of active conclusions whose embeddings sit in the
+  `[floor, dup)` band, ordered by `cosine + W·dormancy`, capped at
+  `KB_MCP_CONTRADICTION_TOP_N`.
+- `unprocessed_source` — sources captured but never compiled (`ingested_into` empty),
+  aged oldest-first.
+
+Each is reachable today only by running the full `audit` (a lint/health report) and
+mentally filtering. There is no "what needs my review today?" surface, so the
+differentiated epistemic-hygiene layer doesn't get worked. This change builds that
+front door. It is the completion of the unification line already recorded in the KB
+("stale and conflict are the same phenomenon → one review queue").
+
+## What Changes
+
+- **New `attention` operation** (new module `src/kb_mcp/attention.py`) that calls
+  `audit()` **once** with the three categories and composes their findings into **one
+  ranked list** — "what in the Knowledge Base needs your attention today."
+- **Cross-queue ranking by Reciprocal Rank Fusion** over each finding's intra-queue
+  rank (the queues already emit in rank order), reusing the existing house utility
+  `fusion.reciprocal_rank_fusion_weighted` (k=60, equal default weights). A note flagged
+  by more than one queue accumulates votes and rises (multi-signal additivity).
+- **Dedup by anchor path** into one item carrying a `reasons[]` list; a contradiction
+  pair is preserved intact inside its reason (`related_paths=[A,B]`).
+- **Capped surfacing** at `limit` (default 25) with an explicit omitted count, and it
+  **folds** the contradiction queue's own upstream cap (`KB_MCP_CONTRADICTION_TOP_N`)
+  into a reported `upstream_truncated` — never a silent truncation.
+- **Registry entry** exposes `attention` on MCP + REST (`/api/attention`) + CLI
+  (`kb attention`) from one `_SPEC` line, via the same leaf — no per-surface code.
+- A reusable `scripts/dump-tool-schemas.py` regenerates the MCP schema-fidelity fixture
+  (adding any command requires regenerating it; there is no regen tool today).
+
+It stays **pure-substrate**: the ranking is a deterministic arithmetic fusion of ranks
+the measurement-only checks already computed — the same class as `find`'s weighted RRF
+and the contradiction queue's `cosine + W·dormancy` sort. No note content is read,
+embedded, or compared at attention time; no cross-item judgment is made. The surface is
+strictly read-only — it mutates nothing, never auto-supersedes, and does not touch
+`find` ordering. The brain (Claude/Max) still decides what to do with each item.
+
+Out of scope (future): per-`project`/topic scoping (the findings don't carry the note's
+project field); per-category weight tuning beyond the equal default (kept a code seam);
+any synthesis or judgment across the surfaced items (that is the brain's job).
+
+## Capabilities
+
+### Added Capabilities
+- `attention-queue`: a single ranked review surface composing the three epistemic
+  queues via deterministic RRF, dedup-by-anchor with multi-signal additivity, capped
+  with explicit counts, measurement-only, reachable on every surface.
+
+## Impact
+
+- Code: new `src/kb_mcp/attention.py` (`_rank` pure ranker + `attention()` entry +
+  dataclasses). One `op_attention` leaf + one `_SPEC` entry in `commands.py`. New
+  `scripts/dump-tool-schemas.py`. The MCP schema-fidelity fixture
+  (`tests/fixtures/mcp_tool_schemas.json`) is regenerated to include the new tool.
+- Behavior: purely additive — a new read-only tool. No existing tool, the `audit`
+  report, or `find` ordering changes. Default-on (it is read-only and cheap: one audit
+  pass; `corpus_contradictions` already no-ops when embeddings are disabled).
+- Tests: new `tests/test_attention.py` (torch-free unit tests over synthetic findings)
+  + registry/surface assertions + an end-to-end determinism test.
+- Deploy: a new MCP tool requires reconnecting the claude.ai connector to appear; the
+  REST/CLI surfaces need only a restart. No data migration.

--- a/openspec/changes/add-attention-queue/specs/attention-queue/spec.md
+++ b/openspec/changes/add-attention-queue/specs/attention-queue/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Unified Review Surface Composed From The Epistemic Queues
+
+The system SHALL provide a single `attention` operation that composes the
+`stale_review`, `corpus_contradictions`, and `unprocessed_source` review queues into
+one ranked list of review items, computed from a single `audit` pass over those
+categories. It SHALL accept an optional `categories` subset (each value one of the
+three queue names) and an optional `limit` (default 25), and SHALL reject any category
+outside the three with a clear error. It MUST NOT re-implement the queues — it consumes
+the findings the existing checks already produce.
+
+#### Scenario: All three queues compose into one list
+
+- **WHEN** `attention` is called with no `categories` filter over a vault that has stale,
+  contradiction, and unprocessed findings
+- **THEN** it returns a single `items` list drawn from all three queues, plus a
+  `summary` of the contributing-finding count per category
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+#### Scenario: Category subset and invalid category
+
+- **WHEN** `attention` is called with `categories=["stale_review"]`
+- **THEN** only stale-review items are surfaced
+- **AND** calling it with a category outside {corpus_contradictions, stale_review,
+  unprocessed_source} raises a `ValueError` naming the valid set
+
+### Requirement: Deterministic Cross-Queue Ranking By Reciprocal Rank Fusion
+
+The system SHALL rank the composed items by Reciprocal Rank Fusion over each finding's
+intra-queue position (the queues already emit findings in rank order), reusing the
+shared `reciprocal_rank_fusion_weighted` utility with `k=60` and equal default
+per-category weights. The ranking SHALL be fully deterministic: identical input
+findings SHALL produce a byte-identical ordering, with ties broken by a fixed category
+preference (`corpus_contradictions` > `stale_review` > `unprocessed_source`) then path.
+
+#### Scenario: Rank-major interleave at equal weights
+
+- **WHEN** each queue contributes several findings in its emission order
+- **THEN** with equal weights the surfaced order interleaves rank-major, category-minor
+  (each queue's rank-1 before any rank-2), broken by the fixed category preference
+- **AND** running the ranking twice over the same findings yields identical output
+
+### Requirement: Multi-Signal Additivity With Dedup By Anchor
+
+The system SHALL dedup items by anchor path into one item per path carrying a `reasons`
+list (one reason per contributing finding), and a path flagged by more than one queue
+SHALL receive the sum of its per-queue RRF votes so it ranks above any item flagged by
+only one queue at the same per-queue rank. A `corpus_contradictions` pair SHALL surface
+under its anchor path with the other endpoint preserved in the reason's `related_paths`;
+the second endpoint SHALL NOT become its own item unless independently flagged.
+
+#### Scenario: A doubly-flagged note rises and keeps both reasons
+
+- **WHEN** note `N` appears in both `stale_review` and as a `corpus_contradictions`
+  anchor
+- **THEN** `N` is a single item whose `categories` lists both, whose `reasons` holds both
+  findings, and whose score equals the sum of the two RRF votes
+- **AND** `N` ranks above an otherwise-equivalent item flagged by only one queue
+
+#### Scenario: Contradiction pair preserved under its anchor
+
+- **WHEN** a contradiction finding has `path=A` and `paths=[A,B]`
+- **THEN** the item's path is `A` and its contradiction reason carries
+  `related_paths=[A,B]`
+- **AND** `B` is not surfaced as its own item unless `B` is independently flagged
+
+### Requirement: Capped Surfacing With Explicit Counts
+
+The system SHALL cap the surfaced items at `limit` and SHALL report the number of items
+not shown (`truncated`) plus the number of contradiction pairs the upstream
+`corpus_contradictions` cap (`KB_MCP_CONTRADICTION_TOP_N`) itself omitted
+(`upstream_truncated`), folding the contradiction queue's trailing summary finding into
+that count rather than surfacing it as a review item. It MUST NOT silently truncate:
+whenever either count is non-zero it SHALL include an explanatory `note`. A `limit` of
+`0` or negative SHALL disable the cap and surface all items (mirroring
+`KB_MCP_CONTRADICTION_TOP_N`'s `0 = uncapped`).
+
+#### Scenario: Items beyond the limit are counted
+
+- **WHEN** more eligible items exist than `limit`
+- **THEN** exactly `limit` items are surfaced, `truncated` equals the remainder, and a
+  `note` states how many more are not shown
+- **AND** when `limit` exceeds the eligible count, `truncated` is 0 and no `note` is added
+
+#### Scenario: Non-positive limit surfaces everything
+
+- **WHEN** `limit` is `0` or negative
+- **THEN** every eligible item is surfaced, `truncated` is 0, and no `note` is added for
+  the cap
+
+#### Scenario: Upstream contradiction cap is folded, not shown
+
+- **WHEN** the `corpus_contradictions` queue emits its trailing summary finding
+  reporting upstream-capped pairs
+- **THEN** that finding is not surfaced as a review item, `upstream_truncated` carries
+  its count, and the `note` reports the upstream-capped pairs separately
+
+### Requirement: Measurement-Only Composition
+
+The composition SHALL be measurement-only. The system MUST NOT mutate any note, MUST NOT
+auto-supersede, and MUST NOT change `find` ranking. It MUST NOT read, embed, or compare
+note content at attention time beyond the deterministic rank arithmetic over findings
+the checks already produced, and MUST NOT perform any cross-item synthesis or judgment.
+Each surfaced item SHALL carry review-only guidance that defers the keep / supersede /
+reconcile / compile / archive decision to the reader.
+
+#### Scenario: Attention run leaves the vault and find untouched
+
+- **WHEN** `attention` runs over a vault
+- **THEN** no file under the vault is created, modified, moved, or deleted
+- **AND** `find` ranking is unchanged
+- **AND** each item's guidance states the ranking is a measurement, not a judgment that
+  anything is wrong, and that nothing is auto-acted
+
+### Requirement: Single Front-Door Command On All Surfaces
+
+The `attention` operation SHALL be defined by a single command-registry entry and SHALL
+be reachable as an MCP tool, a REST route (`/api/attention`), and a CLI subcommand
+(`kb attention`) with no per-surface code, with its parameters derived as exactly
+`categories` and `limit`. Its MCP description SHALL position it as the daily review
+front door and SHALL defer the full lint/health report to `audit` so natural-language
+tool selection routes correctly.
+
+#### Scenario: One registry entry exposes attention everywhere
+
+- **WHEN** the registry is built
+- **THEN** an `attention` MCP tool, an `/api/attention` REST route, and a `kb attention`
+  CLI subcommand all exist from the one entry
+- **AND** the tool's derived parameters are exactly `categories` and `limit`

--- a/openspec/changes/add-attention-queue/tasks.md
+++ b/openspec/changes/add-attention-queue/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — Attention queue (unified review surface)
+
+## 1. Pure ranker (TDD: tests before wiring)
+- [x] 1.1 Write `tests/test_attention.py` FIRST over synthetic `AuditFinding` lists feeding
+      `attention._rank` (torch-free, no vault): rank-major interleave at equal weights;
+      multi-signal boost + dedup (one item, both reasons, score == sum, ranks above
+      single-flagged, severity == max); contradiction anchor + pair preserved (`item.path==A`,
+      reason `related_paths==[A,B]`, `B` not independent unless separately flagged);
+      truncation (`limit` cap → `shown/total/truncated` + `note`; large `limit` → no `note`);
+      `limit<=0` uncapped; empty findings; same-category double-anchor (best-rank score);
+      upstream folding (synthetic summary finding → not an item, `upstream_truncated==N`, note
+      clause); categories filter + `ValueError` on bogus; severity precedence + byte-identical
+      determinism on re-run.
+- [x] 1.2 Implement `src/kb_mcp/attention.py`: `ATTENTION_CATEGORIES`, `_CATEGORY_ORDER`,
+      `_SEVERITY_RANK`, default `_WEIGHTS`; `AttentionItem` / `AttentionReport` dataclasses with
+      `as_dict()` (omit-when-empty like `AuditFinding`); pure
+      `_rank(findings, *, categories, limit, weights) -> AttentionReport` reusing
+      `fusion.reciprocal_rank_fusion_weighted`; public
+      `attention(vault_root, *, categories=None, limit=25, today=None) -> AttentionReport`
+      that validates `categories ⊆ ATTENTION_CATEGORIES` and calls `audit()` once.
+- [x] 1.3 `tests/test_attention.py` green (16 tests).
+
+## 2. Registry wiring (all surfaces from one entry)
+- [x] 2.1 Add `op_attention(vault_root, categories=None, limit=25) -> dict` to `commands.py`
+      next to `op_audit`, with the load-bearing Google-style docstring (review-queue framing +
+      defer-to-`audit` line + Args/Returns; documents `limit<=0` = uncapped). Import
+      `from . import attention as attention_module`.
+- [x] 2.2 Add `("attention", op_attention, 1, False, False, None, _MCRC)` to `_SPEC` after
+      `audit`. No `HAND_REGISTERED_EXCEPTIONS` change (registry-generated).
+- [x] 2.3 Assert `attention` on MCP (`test_mcp_schema_fidelity`), REST + OpenAPI params
+      (`test_rest_registry::test_attention_route_and_openapi_params`), CLI
+      (`test_cli_core_ops::test_attention_runs`), and an e2e MCP call
+      (`test_consolidated_tools::test_attention_tool_composes_review_surface`); derived params
+      exactly `{categories, limit}`.
+
+## 3. Schema-fidelity fixture
+- [x] 3.1 Add `scripts/dump-tool-schemas.py` — reusable regenerator that serializes the live MCP
+      tool schemas via the same path `tests/test_mcp_schema_fidelity.py` uses, writing
+      `tests/fixtures/mcp_tool_schemas.json` (top-level keys sorted; nested order preserved).
+- [x] 3.2 Regenerate the fixture to include the `attention` tool; diff adds only `attention`
+      (+29 lines), changes no existing tool's schema/description.
+
+## 4. Verify
+- [x] 4.1 `uv run pytest tests/test_attention.py tests/test_mcp_schema_fidelity.py
+      tests/test_rest_registry.py tests/test_consolidated_tools.py tests/test_cli_core_ops.py -q`
+      green (57 passed).
+- [x] 4.2 Full suite via `pytest -q` — 863 passed, 1 skipped (pre-existing diarizer-sidecar
+      smoke; no regression).
+- [x] 4.3 `ruff check` clean on the changed files.
+- [x] 4.4 CLI smoke (fixture vault): `kb attention --limit 5 --json` and
+      `kb attention --categories stale_review --json` return one ranked envelope; the live-vault
+      smoke is Hugo's at deploy.
+- [x] 4.5 Pure-substrate check: `attention.py` imports only `audit` + `fusion` (no
+      embedding/model module); `_rank` reads only pre-computed `AuditFinding` fields; `find`
+      output unchanged.
+- [x] 4.6 `openspec validate add-attention-queue --strict` passes.
+
+## 5. Deploy (Hugo)
+- [ ] 5.1 `reset --hard origin/main` on the deploy checkout + restart; reconnect the claude.ai
+      connector so the new `attention` MCP tool appears. (Additive, read-only — safe.)

--- a/scripts/dump-tool-schemas.py
+++ b/scripts/dump-tool-schemas.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Regenerate the MCP schema-fidelity baseline (`tests/fixtures/mcp_tool_schemas.json`).
+
+`tests/test_mcp_schema_fidelity.py` pins every MCP tool's `description` + `inputSchema`
+byte-for-byte — that JSON IS what Claude sees. Adding, removing, or renaming a command,
+or editing a tool docstring, intentionally changes that baseline, and there was no tool
+to refresh it. Run this after such a change, then review the diff (it should contain only
+your intended addition/edit):
+
+    PYTHONPATH=src python scripts/dump-tool-schemas.py
+
+It builds the server under the SAME env the test captures the fixture with
+(embeddings/media/CLIP off, tier-2 on, dotenv neutralized, vault = tests/fixtures) so the
+live schemas are deterministic, and writes them in the shape the test reads. It mirrors
+`tests/test_mcp_schema_fidelity.py::_build_server` / `_live_schemas` — keep them in sync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "mcp_tool_schemas.json"
+FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
+
+
+def _build_server():
+    """Build the server exactly as the fidelity test does (deterministic env)."""
+    from kb_mcp import server as server_module
+
+    server_module.load_dotenv = lambda *a, **k: None  # never read a real .env
+    os.environ["KB_MCP_DISABLE_EMBEDDINGS"] = "1"
+    os.environ["KB_MCP_DISABLE_RELEVANCE_CHECK"] = "1"
+    os.environ["KB_MCP_DISABLE_MEDIA_EXTRACTION"] = "1"
+    os.environ["KB_MCP_DISABLE_CLIP"] = "1"
+    os.environ.pop("KB_MCP_DISABLE_TIER2", None)  # tier-2 ON
+    os.environ["KB_MCP_VAULT_PATH"] = str(FIXTURE_VAULT)
+    return server_module.build_server(require_auth=False)
+
+
+def _live_schemas(mcp) -> dict[str, dict]:
+    """The wire-level {name: {description, inputSchema}} for every registered tool."""
+    tools = asyncio.run(mcp.list_tools())
+    out: dict[str, dict] = {}
+    for t in tools:
+        mt = t.to_mcp_tool().model_dump(mode="json")
+        out[t.name] = {"description": mt["description"], "inputSchema": mt["inputSchema"]}
+    return out
+
+
+def main() -> None:
+    schemas = _live_schemas(_build_server())
+    # Top-level tool keys are stored alphabetically (a stable, review-friendly order
+    # independent of registration order). Nested inputSchema property order is
+    # signature-order and load-bearing, so only the outer mapping is sorted.
+    schemas = dict(sorted(schemas.items()))
+    FIXTURE_PATH.write_text(
+        json.dumps(schemas, ensure_ascii=False, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {len(schemas)} tool schemas to {FIXTURE_PATH.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kb_mcp/attention.py
+++ b/src/kb_mcp/attention.py
@@ -1,0 +1,243 @@
+"""The `attention` review surface — one ranked "what needs your review today" list.
+
+Composes the three measurement-only epistemic queues that `audit` already produces —
+`corpus_contradictions`, `stale_review`, `unprocessed_source` — into a single ranked
+list. The composition is pure measurement: each queue already emits its findings in
+intra-queue rank order, and this module fuses those ranks with Reciprocal Rank Fusion
+(the same `fusion` utility `find` uses) and dedups by anchor path. No note content is
+read, embedded, or compared here; nothing is mutated; `find` ordering is untouched. The
+brain (Claude) decides what to do with each surfaced item.
+
+The line: surfacing + deterministic rank arithmetic over already-computed measurements is
+MEASUREMENT (in bounds, like `find`'s weighted RRF and the contradiction queue's dormancy
+sort). Cross-item synthesis/judgment would be the brain's job and is deliberately absent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import audit as audit_module
+from . import fusion
+from .audit import AuditFinding
+
+# The queues this surface composes, in tiebreak-preference order (highest first):
+# a self-contradiction is the most actionable signal, an unprocessed source the least.
+ATTENTION_CATEGORIES: tuple[str, ...] = (
+    "corpus_contradictions",
+    "stale_review",
+    "unprocessed_source",
+)
+_CATEGORY_ORDER: dict[str, int] = {c: i for i, c in enumerate(ATTENTION_CATEGORIES)}
+_SEVERITY_RANK: dict[str, int] = {"info": 0, "warn": 1, "error": 2}
+_SEVERITY_BY_RANK: dict[int, str] = {v: k for k, v in _SEVERITY_RANK.items()}
+# Equal default weights — the order is then a clean rank-major interleave, except a note
+# flagged by >1 queue accumulates votes and rises. Weights are a seam, not env-exposed.
+_DEFAULT_WEIGHTS: dict[str, float] = {c: 1.0 for c in ATTENTION_CATEGORIES}
+_RRF_K: int = 60  # the conventional default `fusion` and `find` use
+
+_PROPOSED_FIX: str = (
+    "Surfaced for REVIEW only — this ranking is a deterministic measurement, not a "
+    "judgment that anything conflicts or is wrong. You decide per reason: keep / "
+    "`replace` (supersede) / `reconcile` / `propose_compilation` / archive. Nothing is "
+    "auto-acted; `find` ordering is unchanged."
+)
+
+
+@dataclass
+class AttentionItem:
+    path: str                 # the anchor note
+    score: float              # fused RRF score (higher = more attention)
+    severity: str             # max severity over the contributing reasons
+    categories: list[str]     # queues that flagged this note, in preference order
+    reasons: list[dict]       # one per contributing finding: {category, rank, detail, related_paths?, meta?}
+    proposed_fix: str
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "score": self.score,
+            "severity": self.severity,
+            "categories": self.categories,
+            "reasons": self.reasons,
+            "proposed_fix": self.proposed_fix,
+        }
+
+
+@dataclass
+class AttentionReport:
+    items: list[AttentionItem]
+    summary: dict[str, int]       # contributing-finding count per category (pre-dedup, pre-cap)
+    shown: int
+    total: int                    # distinct anchors after dedup, before the cap
+    truncated: int                # anchors beyond `limit` not shown
+    upstream_truncated: int       # contradiction pairs the upstream cap omitted (folded in)
+    note: str | None
+
+    def as_dict(self) -> dict:
+        return {
+            "items": [it.as_dict() for it in self.items],
+            "summary": self.summary,
+            "shown": self.shown,
+            "total": self.total,
+            "truncated": self.truncated,
+            "upstream_truncated": self.upstream_truncated,
+            "note": self.note,
+        }
+
+
+def _reason(category: str, rank: int, finding: AuditFinding) -> dict:
+    """Build one reason dict from a contributing finding, preserving its pair + meta."""
+    reason: dict = {"category": category, "rank": rank, "detail": finding.detail}
+    if finding.paths:
+        reason["related_paths"] = list(finding.paths)
+    if finding.meta:
+        reason["meta"] = finding.meta
+    return reason
+
+
+def _build_note(shown: int, total: int, truncated: int, upstream_truncated: int) -> str | None:
+    """Explicit truncation note — never a silent cap (mirrors the contradiction queue)."""
+    if truncated <= 0 and upstream_truncated <= 0:
+        return None
+    parts: list[str] = []
+    if truncated > 0:
+        parts.append(
+            f"Showing top {shown} of {total} review items "
+            f"({truncated} more not shown; raise `limit`)."
+        )
+    else:
+        parts.append(f"Showing all {total} review item(s).")
+    if upstream_truncated > 0:
+        parts.append(
+            f"(+{upstream_truncated} contradiction pair(s) capped upstream by "
+            f"KB_MCP_CONTRADICTION_TOP_N; raise it to surface more.)"
+        )
+    return " ".join(parts)
+
+
+def _rank(
+    findings: list[AuditFinding],
+    *,
+    categories: set[str] | None = None,
+    limit: int = 25,
+    weights: dict[str, float] | None = None,
+) -> AttentionReport:
+    """Compose findings into one ranked, deduped review surface. Pure — no vault access.
+
+    Fuse each finding's intra-queue rank (emission order == rank) via weighted RRF, dedup
+    by anchor path (votes add → multi-flagged notes rise), drop+fold the contradiction
+    queue's trailing summary finding, then cap at `limit` with an explicit count.
+    """
+    selected = set(ATTENTION_CATEGORIES) if categories is None else (
+        set(categories) & set(ATTENTION_CATEGORIES)
+    )
+    weights = _DEFAULT_WEIGHTS if weights is None else weights
+
+    per_cat: dict[str, list[AuditFinding]] = {c: [] for c in ATTENTION_CATEGORIES}
+    upstream_truncated = 0
+    for f in findings:
+        if f.category not in selected:
+            continue
+        # The contradiction queue appends a trailing summary finding for the pairs it
+        # capped upstream — not a reviewable item; fold its count, don't surface it.
+        if f.category == "corpus_contradictions" and f.meta and "truncated" in f.meta:
+            upstream_truncated += int(f.meta["truncated"])
+            continue
+        per_cat[f.category].append(f)
+
+    # One best-first anchor-path list per populated category, plus aligned weights.
+    result_lists: list[list[str]] = []
+    weight_list: list[float] = []
+    for c in ATTENTION_CATEGORIES:
+        if c in selected and per_cat[c]:
+            result_lists.append([f.path for f in per_cat[c]])
+            weight_list.append(float(weights.get(c, 1.0)))
+
+    # Reuse the house RRF for the scores; an anchor's score uses its best rank per list.
+    fused = (
+        fusion.reciprocal_rank_fusion_weighted(result_lists, weight_list, k=_RRF_K)
+        if result_lists else []
+    )
+    scores: dict[str, float] = dict(fused)
+
+    # All reasons (every contributing finding) + max severity per anchor path.
+    reasons_by_path: dict[str, list[dict]] = {}
+    severity_by_path: dict[str, int] = {}
+    for c in ATTENTION_CATEGORIES:
+        if c not in selected:
+            continue
+        for rank, f in enumerate(per_cat[c], start=1):
+            reasons_by_path.setdefault(f.path, []).append(_reason(c, rank, f))
+            severity_by_path[f.path] = max(
+                severity_by_path.get(f.path, 0), _SEVERITY_RANK.get(f.severity, 0)
+            )
+
+    # Order: score desc, then category preference of the item's best reason, then path.
+    ordered = sorted(
+        scores,
+        key=lambda p: (
+            -scores[p],
+            min(_CATEGORY_ORDER[r["category"]] for r in reasons_by_path[p]),
+            p,
+        ),
+    )
+    total = len(ordered)
+    shown_paths = ordered[:limit] if (limit and limit > 0) else ordered
+
+    items: list[AttentionItem] = []
+    for p in shown_paths:
+        reasons = sorted(
+            reasons_by_path[p],
+            key=lambda r: (r["rank"], _CATEGORY_ORDER[r["category"]]),
+        )
+        cats = sorted({r["category"] for r in reasons}, key=lambda c: _CATEGORY_ORDER[c])
+        items.append(AttentionItem(
+            path=p,
+            score=round(scores[p], 6),
+            severity=_SEVERITY_BY_RANK[severity_by_path[p]],
+            categories=cats,
+            reasons=reasons,
+            proposed_fix=_PROPOSED_FIX,
+        ))
+
+    truncated = total - len(items)
+    summary = {
+        c: len(per_cat[c])
+        for c in ATTENTION_CATEGORIES
+        if c in selected and per_cat[c]
+    }
+    note = _build_note(len(items), total, truncated, upstream_truncated)
+    return AttentionReport(
+        items=items,
+        summary=summary,
+        shown=len(items),
+        total=total,
+        truncated=truncated,
+        upstream_truncated=upstream_truncated,
+        note=note,
+    )
+
+
+def attention(
+    vault_root: Path,
+    *,
+    categories: list[str] | None = None,
+    limit: int = 25,
+    today=None,
+) -> AttentionReport:
+    """Compose the three epistemic queues into one ranked review surface. Read-only.
+
+    Runs a single `audit` pass over the selected categories, then ranks/dedups via
+    `_rank`. `today` is threaded through for deterministic ACT-R dormancy in tests.
+    """
+    resolved = set(ATTENTION_CATEGORIES) if not categories else set(categories)
+    invalid = resolved - set(ATTENTION_CATEGORIES)
+    if invalid:
+        raise ValueError(
+            f"unknown attention categories: {sorted(invalid)}. "
+            f"Valid: {list(ATTENTION_CATEGORIES)}"
+        )
+    report = audit_module.audit(vault_root, categories=sorted(resolved), today=today)
+    return _rank(report.findings, categories=resolved, limit=limit)

--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from . import add as add_module
 from . import append_to_file as append_to_file_module
+from . import attention as attention_module
 from . import audit as audit_module
 from . import audit_fix as audit_fix_module
 from . import compile_proposal as compile_proposal_module
@@ -506,6 +507,46 @@ def op_audit(
          summary: {category: count}}.
     """
     report = audit_module.audit(vault_root, categories=categories)
+    return report.as_dict()
+
+
+def op_attention(
+    vault_root: Path,categories: list[str] | None = None, limit: int = 25) -> dict:
+    """Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only.
+
+    Composes the three measurement-only epistemic queues into a single list,
+    ranked by Reciprocal Rank Fusion over each queue's own ordering — a note
+    flagged by more than one queue rises to the top:
+    - `stale_review`: active conclusions that are old AND rarely surfaced in
+      `find` AND low inbound-degree (possibly stale — still true?).
+    - `corpus_contradictions`: pairs of active conclusions whose embeddings sit
+      close enough to restate, refine, or contradict (do they conflict?).
+    - `unprocessed_source`: sources captured but never compiled (nothing
+      distilled from them yet).
+
+    Each item carries its reason(s), the related note(s) for a contradiction
+    pair, and severity. Surfaced for REVIEW only: the ranking is a deterministic
+    measurement, not a judgment that anything is wrong — you decide keep /
+    `replace` (supersede) / `reconcile` / `propose_compilation` / archive.
+    Nothing is auto-acted; `find` ordering is unchanged.
+
+    Front door for daily review. Use `audit` instead for the full lint/health
+    report (broken wikilinks, frontmatter compliance, index drift, embedding
+    drift, etc.).
+
+    Args:
+        categories: Optional subset of {corpus_contradictions, stale_review,
+            unprocessed_source}. Omit to include all three.
+        limit: Max items to surface (default 25; 0 or negative = uncapped,
+            surface all). Lower-priority items beyond the cap are summarized in
+            a "N more not shown" note, never dropped silently.
+
+    Returns:
+        {items: [{path, score, severity, categories, reasons: [{category, rank,
+         detail, related_paths?, meta}], proposed_fix}], summary: {category:
+         count}, shown, total, truncated, upstream_truncated, note}.
+    """
+    report = attention_module.attention(vault_root, categories=categories, limit=limit)
     return report.as_dict()
 
 
@@ -1872,6 +1913,7 @@ _SPEC: tuple[tuple, ...] = (
     ("suggest_links", op_suggest_links, 1, False, False, None, _MCRC),
     ("add", op_add, 1, True, True, None, _MCRC),
     ("audit", op_audit, 1, False, False, None, _MCRC),
+    ("attention", op_attention, 1, False, False, None, _MCRC),
     ("audit_fix", op_audit_fix, 1, True, False, None, _MCRC),
     ("reconcile", op_reconcile, 1, True, False, None, _MCRC),
     ("provenance_report", op_provenance_report, 1, False, False, None, _MCRC),

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -90,6 +90,35 @@
       "type": "object"
     }
   },
+  "attention": {
+    "description": "Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only.\n\nComposes the three measurement-only epistemic queues into a single list,\nranked by Reciprocal Rank Fusion over each queue's own ordering — a note\nflagged by more than one queue rises to the top:\n- `stale_review`: active conclusions that are old AND rarely surfaced in\n  `find` AND low inbound-degree (possibly stale — still true?).\n- `corpus_contradictions`: pairs of active conclusions whose embeddings sit\n  close enough to restate, refine, or contradict (do they conflict?).\n- `unprocessed_source`: sources captured but never compiled (nothing\n  distilled from them yet).\n\nEach item carries its reason(s), the related note(s) for a contradiction\npair, and severity. Surfaced for REVIEW only: the ranking is a deterministic\nmeasurement, not a judgment that anything is wrong — you decide keep /\n`replace` (supersede) / `reconcile` / `propose_compilation` / archive.\nNothing is auto-acted; `find` ordering is unchanged.\n\nFront door for daily review. Use `audit` instead for the full lint/health\nreport (broken wikilinks, frontmatter compliance, index drift, embedding\ndrift, etc.).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "categories": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional subset of {corpus_contradictions, stale_review,\nunprocessed_source}. Omit to include all three."
+        },
+        "limit": {
+          "default": 25,
+          "type": "integer",
+          "description": "Max items to surface (default 25; 0 or negative = uncapped,\nsurface all). Lower-priority items beyond the cap are summarized in\na \"N more not shown\" note, never dropped silently."
+        }
+      },
+      "type": "object"
+    }
+  },
   "audit": {
     "description": "Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, stale unprocessed sources, and stale-review candidates. Read-only.\n\nReturns a structured report Claude can read to propose follow-up\nedits via `note`/`add`. Does NOT modify anything.\n\nCategories (default: all):\n- `broken_wikilink`: `[[X]]` whose target file doesn't exist.\n  Skips wikilinks inside fenced code blocks and inline code spans.\n  Bare names resolve against filename stems AND frontmatter `title:`\n  (so date-prefixed sources with a title match are not flagged).\n- `orphan_entity`: `Entities/...` file with no inbound wikilinks\n- `unprocessed_source`: source with empty `ingested_into:` (no notes\n  have compiled from it yet)\n- `index_drift`: top-level `index.md` Counts disagree with on-disk counts\n- `tag_inconsistency`: case/separator variants of the same tag\n  (`warning_letter_incident` vs `warning-letter-incident` vs\n  `Warning-Letter-Incident`). Mechanical drift only; semantic\n  near-duplicates like `metabolism` vs `metabolic` aren't flagged.\n- `frontmatter_compliance`: per-page-type required-field gaps,\n  a `tenant:` set without the expected project, patterns using singular\n  `project:` instead of plural `projects:`.\n- `unregistered_project_key`: a `project`/`projects` value not in the\n  registry (typo or genuinely new scope).\n- `embedding_drift`: vector sidecar rows out of sync with disk (a file\n  changed/added/removed since it was last embedded).\n- `relevance_pairs_pending`: real-usage (query -> cited_path) labels not\n  yet in the golden retrieval set.\n- `stale_review`: active compiled conclusion that is old AND rarely\n  surfaced in `find` AND low inbound-link degree — a measurement-only\n  review candidate (still true? keep / supersede / archive). Never\n  decays or down-ranks; `find` ordering is unchanged.\n- `corpus_contradictions`: corpus-wide pairs of active read-write\n  compiled conclusions whose embeddings sit just below the near-dup\n  threshold (close enough to restate/refine/contradict). A proximity\n  measurement surfaced for review (reconcile or supersede); never\n  auto-acted. The queue is ordered by review priority (cosine + ACT-R\n  dormancy), same-family `Notes/Research/<X>/` architecture noise is\n  demoted, and the surfaced set is capped at KB_MCP_CONTRADICTION_TOP_N\n  (default 40; 0 = uncapped) with an explicit \"N more not shown\" line.\n  No-ops when embeddings are disabled.",
     "inputSchema": {

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,218 @@
+"""Unit tests for the `attention` review surface — the pure `_rank` composer.
+
+Torch-free: every test builds synthetic `AuditFinding` objects and feeds them to
+`attention._rank` directly (no vault, no embeddings, no audit pass). The end-to-end
+path (audit -> _rank) over the fixture vault is covered by
+`test_consolidated_tools.py::test_attention_tool_composes_review_surface` (MCP),
+`test_rest_registry.py::test_attention_route_and_openapi_params` (REST), and
+`test_cli_core_ops.py::test_attention_runs` (CLI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kb_mcp import attention as attention_module
+from kb_mcp.audit import AuditFinding
+
+C = "corpus_contradictions"
+S = "stale_review"
+U = "unprocessed_source"
+
+
+def _f(category: str, path: str, *, severity: str = "info",
+       paths: list[str] | None = None, meta: dict | None = None) -> AuditFinding:
+    return AuditFinding(
+        category=category,
+        severity=severity,
+        path=path,
+        detail=f"{category} finding for {path}",
+        proposed_fix="orig fix text",
+        paths=paths,
+        meta=meta,
+    )
+
+
+def _paths(report) -> list[str]:
+    return [it.path for it in report.items]
+
+
+def test_rank_major_interleave_equal_weights():
+    """Equal weights → rank-major, category-minor interleave (c-before-s-before-u)."""
+    findings = [
+        _f(C, "c1"), _f(C, "c2"), _f(C, "c3"),
+        _f(S, "s1"), _f(S, "s2"), _f(S, "s3"),
+        _f(U, "u1"), _f(U, "u2"), _f(U, "u3"),
+    ]
+    report = attention_module._rank(findings)
+    assert _paths(report) == ["c1", "s1", "u1", "c2", "s2", "u2", "c3", "s3", "u3"]
+    assert report.summary == {C: 3, S: 3, U: 3}
+    assert report.total == 9
+    assert report.truncated == 0
+    assert report.note is None
+
+
+def test_multi_signal_additivity_and_dedup():
+    """A note flagged by two queues dedups to one item, sums votes, and rises."""
+    findings = [
+        _f(C, "c1"), _f(C, "N"),     # N at contradiction rank 2
+        _f(S, "N"), _f(S, "s2"),     # N at stale rank 1
+    ]
+    report = attention_module._rank(findings)
+
+    # N first (0.0325 > c1 0.0164 > s2 0.0161)
+    assert _paths(report)[0] == "N"
+    n = report.items[0]
+    assert n.categories == [C, S]                 # ordered by category preference
+    assert len(n.reasons) == 2
+    k = attention_module._RRF_K
+    expected = round(1.0 / (k + 2) + 1.0 / (k + 1), 6)   # contradiction r2 + stale r1
+    assert n.score == expected
+    assert n.severity == "info"
+    # ranks above both single-flagged items
+    assert _paths(report).index("N") < _paths(report).index("c1")
+    assert _paths(report).index("N") < _paths(report).index("s2")
+    # dedup: N appears exactly once
+    assert _paths(report).count("N") == 1
+
+
+def test_contradiction_anchor_and_pair_preserved():
+    """A contradiction pair surfaces under its anchor; the partner lives in the reason."""
+    findings = [
+        _f(C, "A", paths=["A", "B"], meta={"cosine": 0.83, "priority": 1.2, "same_family": False}),
+    ]
+    report = attention_module._rank(findings)
+    assert _paths(report) == ["A"]                       # B is not its own item
+    reason = report.items[0].reasons[0]
+    assert reason["category"] == C
+    assert reason["related_paths"] == ["A", "B"]
+    assert reason["meta"]["cosine"] == 0.83
+
+
+def test_contradiction_partner_independent_only_when_flagged():
+    """B becomes an item only if independently flagged by another queue."""
+    findings = [
+        _f(C, "A", paths=["A", "B"]),
+        _f(S, "B"),
+    ]
+    report = attention_module._rank(findings)
+    assert set(_paths(report)) == {"A", "B"}
+
+
+def test_truncation_caps_and_counts():
+    findings = [_f(S, f"s{i}") for i in range(1, 6)]     # 5 items
+    report = attention_module._rank(findings, limit=2)
+    assert report.shown == 2
+    assert report.total == 5
+    assert report.truncated == 3
+    assert len(report.items) == 2
+    assert report.note is not None and "3 more" in report.note
+
+
+def test_no_note_when_within_limit():
+    findings = [_f(S, f"s{i}") for i in range(1, 4)]
+    report = attention_module._rank(findings, limit=25)
+    assert report.truncated == 0
+    assert report.note is None
+
+
+def test_upstream_contradiction_summary_is_folded_not_surfaced():
+    """The contradiction queue's trailing summary finding is folded into upstream_truncated."""
+    findings = [
+        _f(C, "A", paths=["A", "B"]),
+        _f(C, "Knowledge Base/", meta={"truncated": 7, "shown": 40, "total": 47}),
+        _f(S, "s1"),
+    ]
+    report = attention_module._rank(findings)
+    assert "Knowledge Base/" not in _paths(report)        # not a review item
+    assert report.upstream_truncated == 7
+    assert report.summary[C] == 1                          # the real pair only
+    assert report.note is not None and "7" in report.note
+    assert "upstream" in report.note.lower() or "capped upstream" in report.note.lower()
+
+
+def test_categories_filter():
+    findings = [_f(C, "c1"), _f(S, "s1"), _f(U, "u1")]
+    report = attention_module._rank(findings, categories={S})
+    assert _paths(report) == ["s1"]
+    assert set(report.summary) == {S}
+
+
+def test_severity_is_max_over_reasons():
+    findings = [_f(U, "p", severity="warn"), _f(S, "p", severity="info")]
+    report = attention_module._rank(findings)
+    assert report.items[0].severity == "warn"
+
+
+def test_ranking_is_deterministic():
+    findings = [
+        _f(C, "c1"), _f(C, "N"),
+        _f(S, "N"), _f(S, "s2"),
+        _f(U, "u1"),
+    ]
+    a = attention_module._rank(findings).as_dict()
+    b = attention_module._rank(findings).as_dict()
+    assert a == b
+
+
+def test_item_proposed_fix_is_review_only():
+    findings = [_f(S, "s1")]
+    report = attention_module._rank(findings)
+    fix = report.items[0].proposed_fix.lower()
+    assert "review only" in fix
+    assert "auto-acted" in fix or "never auto" in fix
+
+
+def test_invalid_category_raises(tmp_path):
+    """attention() validates categories before touching the vault."""
+    with pytest.raises(ValueError, match="unknown attention categories"):
+        attention_module.attention(tmp_path, categories=["bogus"])
+
+
+def test_as_dict_shape():
+    findings = [_f(C, "A", paths=["A", "B"], meta={"cosine": 0.83}), _f(S, "A")]
+    d = attention_module._rank(findings).as_dict()
+    assert set(d) >= {"items", "summary", "shown", "total", "truncated", "upstream_truncated", "note"}
+    item = d["items"][0]
+    assert set(item) >= {"path", "score", "severity", "categories", "reasons", "proposed_fix"}
+    assert isinstance(item["reasons"], list)
+
+
+def test_empty_findings():
+    report = attention_module._rank([])
+    assert report.items == []
+    assert report.total == 0
+    assert report.shown == 0
+    assert report.summary == {}
+    assert report.truncated == 0
+    assert report.upstream_truncated == 0
+    assert report.note is None
+
+
+def test_limit_zero_or_negative_surfaces_all():
+    """`limit <= 0` is the uncapped convention (mirrors KB_MCP_CONTRADICTION_TOP_N=0)."""
+    findings = [_f(S, f"s{i}") for i in range(1, 6)]
+    for lim in (0, -3):
+        report = attention_module._rank(findings, limit=lim)
+        assert report.shown == 5
+        assert report.total == 5
+        assert report.truncated == 0
+        assert report.note is None
+
+
+def test_same_category_double_anchor_one_item_best_rank_score():
+    """One note anchoring two contradiction pairs → one item, both reasons, best-rank score."""
+    findings = [
+        _f(C, "A", paths=["A", "B"], meta={"cosine": 0.90}),   # rank 1
+        _f(C, "c2"),                                           # rank 2
+        _f(C, "A", paths=["A", "D"], meta={"cosine": 0.85}),   # rank 3, same anchor
+    ]
+    report = attention_module._rank(findings)
+    a = next(it for it in report.items if it.path == "A")
+    assert len(a.reasons) == 2
+    assert sorted(r["related_paths"] for r in a.reasons) == [["A", "B"], ["A", "D"]]
+    # score uses A's BEST rank (1), not the sum of rank 1 + rank 3 — no domination by pair count
+    k = attention_module._RRF_K
+    assert a.score == round(1.0 / (k + 1), 6)
+    assert report.summary[C] == 3            # all three contributing findings counted (pre-dedup)
+    assert _paths(report).count("A") == 1    # deduped to one item

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -52,6 +52,23 @@ def test_get_reads_a_page(vault: Path, capsys) -> None:
     assert payload["data"]["frontmatter"]["type"] == "insight"
 
 
+def test_attention_runs(vault: Path, capsys) -> None:
+    """`kb attention` is the registry-generated CLI surface of the review queue."""
+    code, out, _ = _run(["attention", "--limit", "5", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    data = payload["data"]
+    assert {"items", "summary", "shown", "total", "truncated", "upstream_truncated"} <= set(data)
+    assert data["shown"] == len(data["items"]) <= 5
+    # category subset is accepted on the CLI too (list[str] via repeated/append flag)
+    code2, out2, _ = _run(["attention", "--categories", "stale_review", "--json"], capsys)
+    assert code2 == 0
+    data2 = json.loads(out2.strip().splitlines()[-1])["data"]
+    surfaced = {c for it in data2["items"] for c in it["categories"]}
+    assert surfaced <= {"stale_review"}
+
+
 def test_audit_runs(vault: Path, capsys) -> None:
     code, out, _ = _run(["audit", "--json"], capsys)
     assert code == 0

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -207,3 +207,24 @@ def test_note_project_description_is_dynamic_and_open(vault: Path, monkeypatch) 
     # built-in set, which includes these), not a hand-maintained string.
     assert "project-alpha" in project_desc
     assert "personal" in project_desc
+
+
+def test_attention_tool_composes_review_surface(vault: Path, monkeypatch) -> None:
+    """The `attention` MCP tool returns one ranked review surface, read-only, and
+    honors the `categories` subset filter — driven end-to-end through call_tool."""
+    mcp = _build(monkeypatch)
+    out = _call(mcp, "attention", {"limit": 10})
+
+    # Shape contract (mirrors AttentionReport.as_dict()).
+    assert {"items", "summary", "shown", "total", "truncated", "upstream_truncated"} <= set(out)
+    assert isinstance(out["items"], list)
+    assert out["shown"] == len(out["items"]) <= 10
+    for item in out["items"]:
+        assert {"path", "score", "severity", "categories", "reasons", "proposed_fix"} <= set(item)
+        assert item["categories"], "every item must name at least one queue"
+        assert "review only" in item["proposed_fix"].lower()
+
+    # Category subset is honored: only the requested queue can appear.
+    only_sources = _call(mcp, "attention", {"categories": ["unprocessed_source"]})
+    surfaced = {c for it in only_sources["items"] for c in it["categories"]}
+    assert surfaced <= {"unprocessed_source"}

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -161,6 +161,27 @@ def test_openapi_lists_real_params(vault, monkeypatch: pytest.MonkeyPatch) -> No
     assert "path" in get_schema.get("required", [])
 
 
+def test_attention_route_and_openapi_params(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`attention` is exposed on REST from its single registry entry, with exactly
+    `categories` + `limit` as documented parameters."""
+    client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")
+    r = client.post("/api/attention", json={}, headers=_auth())
+    assert r.status_code != 404, f"/api/attention missing: {r.status_code} {r.text}"
+    body = r.json()
+    assert body["success"] is True
+    assert {"items", "summary", "shown", "total", "truncated", "upstream_truncated"} <= set(
+        body["data"]
+    )
+    doc = client.get("/api/openapi.json").json()
+    assert "/api/attention" in doc["paths"]
+    schema = doc["paths"]["/api/attention"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    assert set(schema["properties"]) == {"categories", "limit"}
+    assert schema["properties"]["limit"]["type"] == "integer"
+    assert schema["properties"]["categories"]["type"] == "array"
+
+
 def test_openapi_has_no_hand_list(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     """OpenAPI is generated from the registry — tier-2 ops appear too (no frozen list)."""
     client = _client(vault, monkeypatch, KB_MCP_REST_API_KEY="sekret")


### PR DESCRIPTION
## What

Adds a read-only **`attention`** operation (MCP + REST + CLI, one registry entry) that composes kb-mcp's three measurement-only epistemic queues into **one ranked "what needs your review today" surface**:

- `stale_review` — old + rarely-surfaced + low-inbound active conclusions (ACT-R dormancy ordered)
- `corpus_contradictions` — active-conclusion pairs whose embeddings sit close enough to restate/refine/contradict
- `unprocessed_source` — sources captured but never compiled

These already ship but have no single front door, so they go unused. This is **Direction 2** of the next-phase roadmap (Direction 1 = #64), and the literal completion of the *"stale and conflict are the same phenomenon → one review queue"* unification line.

## How

- Calls `audit()` **once** over the three categories, then a pure `_rank()` composes the findings.
- **Reciprocal Rank Fusion** over each finding's intra-queue rank (the queues already emit in rank order), reusing the house `fusion.reciprocal_rank_fusion_weighted` (k=60, equal weights) — the same idiom `find` uses.
- **Dedup by anchor path** into one item with a `reasons[]` list: a note flagged by >1 queue accumulates votes and **rises** (multi-signal additivity); a contradiction pair is preserved in `related_paths`.
- **Capped** at `limit` (default 25; `0`/negative = uncapped) with explicit `truncated` + `upstream_truncated` (folds the contradiction queue's own cap) — never a silent truncation.

## Pure-substrate

Holds the line. The ranking is a **deterministic arithmetic fusion of ranks the measurement-only checks already computed** — same class as `find`'s weighted RRF. No note content is read/embedded/compared at attention time, nothing is mutated, and `find` ordering is unchanged. The brain (Claude) still decides keep / `replace` / `reconcile` / `propose_compilation` / archive. `attention.py` imports only `audit` + `fusion`.

## Tool disambiguation

The `attention` MCP description leads with *"your review queue / front door for daily review"* and explicitly defers the full lint/health report to `audit`, so natural-language tool selection routes correctly.

## Tests / verification

- New `tests/test_attention.py` — 16 torch-free unit tests over the ranker (interleave, additivity, pair preservation, truncation + upstream fold, `limit<=0`, empty, same-category double-anchor, `ValueError`, determinism).
- MCP (schema-fidelity), REST + OpenAPI params, CLI (`kb attention`), and an e2e MCP call all assert `attention` is generated from the one registry entry with params exactly `{categories, limit}`.
- Adds `scripts/dump-tool-schemas.py` to regenerate the MCP schema-fidelity fixture reproducibly.
- **Full suite: 863 passed, 1 skipped** (pre-existing diarizer-sidecar smoke). `ruff` clean. `openspec validate add-attention-queue --strict` passes. Separate-pass code review: APPROVE.

## OpenSpec

New capability `attention-queue` (change `add-attention-queue`). Archived after merge.

## Deploy (Hugo)

Additive read-only tool: `reset --hard origin/main` + restart on the deploy box, then reconnect the claude.ai connector so the new `attention` MCP tool appears. Behavior is byte-identical to today until the tool is called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
