### PR TITLE
docs(skill): encode "comprehensive coverage, minimal expression"

### DIFF
--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-base
 description: Operates on your personal Obsidian Knowledge Base — raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts. Triggers when you want to save, file, log, compile, distill, search, audit, supersede, or preserve anything in your KB, vault, Obsidian, or notes — including oblique phrasings ("interesting, save it," "I want to remember this"). Also engages proactively — it consults the KB for prior conclusions when a turn touches a topic it likely covers, and captures durable conclusions when the conversation reaches a stepping-stone (a decision, a solved problem, a diagnosed failure, a recognized pattern). Do NOT write outside the Knowledge Base folder; any sibling folders in the vault are read-only inputs.
-version: 0.30.0
+version: 0.31.0
 ---
 
 # Knowledge Base
@@ -60,6 +60,18 @@ diagnosed, a pattern is recognized — capture it:
 
 Not a stepping-stone: mid-thought exploration, brainstorm tangents, unresolved
 questions. Capture at the landing, not during the flight.
+
+**Comprehensive coverage, minimal expression.** Capturing at the landing is about
+*timing*, not *volume* — it never means keep less. Minimality is a property of
+*expression* — distillation, signal-density, no redundancy — never of *coverage*.
+Don't drop context or detail because it "doesn't seem important": importance is
+usually only legible in hindsight, and nothing here forces the tradeoff (no
+retention decay, hybrid BM25+vector retrieval, append-only `Sources/`, no storage
+limit). Default coverage to comprehensive; reserve concision for *how* a note is
+written, not *what* it keeps. Torn between keeping a detail and dropping it? Keep
+it — an over-kept detail is free to retrieval, a dropped one is unrecoverable.
+Capture more, at the right layer: raw verbatim to `Sources/` liberally; compiled
+notes stay distilled in form but never context-pruned.
 
 ## Vault layout
 
@@ -516,7 +528,11 @@ is in **`references/audit-checks.md`**.
 
 - Touch anything outside `Knowledge Base/`.
 - Auto-compile *blindly* after every capture. Compilation is a deliberate step
-  taken at a stepping-stone; it's always reported, never a silent dump.
+  taken at a stepping-stone; it's always reported, never a silent dump of raw
+  transcripts or every passing remark. "No silent dump" targets *noise* —
+  transcripts, mid-flight tangents — not *signal*: it never licenses pruning
+  context or detail from a note (see *Comprehensive coverage, minimal expression*
+  under Proactive engagement).
 - Assign numeric confidence scores. Use citation count and recency as the trust
   signal.
 - Apply retention decay or "forgetting curves." Old material stays. If superseded,


### PR DESCRIPTION
## Problem

The KB skill's capture guidance is meant to keep notes *expression*-minimal (distilled, signal-dense, no redundancy) while keeping *coverage* comprehensive. But "minimal" conflated two properties at capture time:

- **expression-minimality** — distillation, signal-density, no redundancy — *keep this*
- **coverage-minimality** — dropping context/detail judged "not important" — *the bug*

Importance is usually only legible in hindsight, and nothing in the system forces the tradeoff (no retention decay, hybrid BM25+vector retrieval, append-only `Sources/`, no storage limit). The existing anti-dump language ("never a silent dump," "capture at the landing, not during the flight") targets **noise** (transcripts, mid-flight tangents) but could be misread as license to drop **signal**. This encodes the distinction in the skill loader so the rule is enforced, not just remembered.

## Changes

All in `src/kb_mcp/_scaffold/_Schema/SKILL.md` (the hand-authored canonical scaffold):

1. **New named principle "Comprehensive coverage, minimal expression"** woven into the Proactive engagement → stepping-stone-capture block, right after the existing "capture at the landing" guardrail. It clarifies that capturing at the landing is about *timing*, not *volume*; minimality governs *how* a note is written, never *what* it keeps; default coverage to comprehensive; keep the over-kept detail (free to retrieval) over the dropped one (unrecoverable).
2. **Disambiguated the auto-compile bullet** in "What this skill does NOT do" so "no silent dump" explicitly targets *noise* (transcripts, every passing remark), not *signal*, cross-referencing the new principle.
3. **Version bump** `0.30.0` → `0.31.0` (additive). Changelog recorded in the commit message per the repo's convention (no CHANGELOG file).

## Verification

- `tests/test_scaffold_no_leak.py`: passing (additions are generic — no personal names/products/vault labels).
- Deploy parity: `python -m kb_mcp install-skill --target <tmp> --force` produces a **byte-identical** copy at `version: 0.31.0` (no diff vs canonical).
- Full suite: **800 passed**. The one failure (`test_child_env_cuda_keeps_gpu_and_strips_nvidia_bins`) is a Windows-PATH test that breaks on Linux (`os.pathsep`) — a pre-existing platform quirk unrelated to this docs change.

## Follow-up (maintainer, private vault — not in this repo)

The pattern note `capture-comprehensiveness-minimality-is-expression-not-coverage.md` lives only in the private vault. Its FOLLOW-UP marker should be flipped pending → done citing **v0.31.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ3fdbcMHfqtpQpJhCHdeH)_