### PR TITLE
feat(find): reasoning-ready context packs via find(pack=true)

### DIFF
--- a/openspec/changes/add-context-packs/design.md
+++ b/openspec/changes/add-context-packs/design.md
@@ -1,0 +1,127 @@
+# Design — Reasoning-ready context packs from `find`
+
+## Context
+
+`find_module.find(vault_root, *, query, ..., limit, ...) -> list[Hit]` is the read path.
+A `Hit` carries `path, type, scope, title, updated, excerpt` + ranking signals — an
+*excerpt*, not the note. The leaf `op_find` (in `commands.py`) wraps it, logs the call,
+and returns `[h.as_dict() for h in hits]`; the registry derives the tool's params from
+`op_find`'s signature + Google-style docstring and exposes it on MCP/REST/CLI.
+
+The assembly primitives already exist and are all measurement-only:
+
+- `find._parse_page` / `find._CACHE.get(path, vault_root)` → `ParsedPage` (frontmatter +
+  body + `.title`/`.page_type`/`.status`/`.superseded_by`).
+- `find._outbound_wikilink_paths(page, vault_root)` → resolved outbound wikilink targets
+  (KB-scoped, `.md`, code-fence-aware).
+- `vault.find_inbound_wikilinks(vault_root, rel_path)` → `InboundLink[]` (who links here).
+- `corpus_aware._best_cosine_per_file(vault_root, *, title, body, k)` →
+  `{file_path: best_cosine}` over the sidecar; `_canon()` for path comparison; band edges
+  `_contradiction_floor()` / `_dup_threshold()` (env-overridable, default `[0.82, 0.90)`).
+  All no-op to `{}`/`[]` when `KB_MCP_DISABLE_EMBEDDINGS` is set.
+- `attention.py` is the precedent for "assemble measurement sources into one bounded,
+  explicitly-truncated response."
+
+## The composition
+
+`assemble_pack(vault_root, hits, *, max_hits=None, max_neighbors=None, max_tension=None)`
+in a new `context_pack.py`, called by `op_find` only when `pack=true`:
+
+1. Take the top `min(len(hits), PACK_MAX_HITS)` hits as `packed`; load each `ParsedPage`
+   once via `_CACHE` (reused across all four parts).
+2. **claims** — `{rel_path: {title, type, lede, sections[], outline[]}}` via
+   `_extract_claims(page)`.
+3. **neighborhood** — union of inbound + outbound 1-hop neighbours of the packed notes,
+   minus the packed set, ranked by co-citation, capped.
+4. **contradictions** — `{superseded: [...], tension: [...]}`.
+5. Assemble `{packed_paths, claims, neighborhood, contradictions, embeddings_available,
+   truncation}`.
+
+`find()` itself is **not** modified — the `pack` param and the `{"hits","pack"}` return
+live in `op_find`, so the ranker contract and its tests are untouched and the list↔dict
+polymorphism is confined to the tool boundary (REST returns JSON; the CLI already
+pretty-prints a dict result via its `json.dumps` branch).
+
+## Decisions
+
+- **`pack` is a `find` parameter, not a new tool.** Claude flips it on the `find` it was
+  already going to make — no extra always-loaded tool on the MCP surface (the surface-
+  token cost is real and "consolidate over cut" is the standing principle), and it routes
+  by natural language without Claude having to name a second tool. The cost is a
+  polymorphic return; contained at the leaf, it is cheaper than a 23rd tool.
+  - *Rejected — dedicated `context_pack` tool:* cleaner typing, but adds a tool to the
+    always-loaded list and forces a tool-selection decision for what is "find, but with
+    its context."
+- **Key claims are extracted STRUCTURALLY, never generated.** This is the load-bearing
+  pure-substrate decision. The lede is the note's own first paragraph; `sections` are the
+  first line / leading bullets under recognized headline headings; `outline` is the `##`
+  skeleton. The KB's compiled notes already carry this structure (Problem / Summary /
+  Connections …), so structural extraction is high-signal **and** defensible — the server
+  never decides what a note "means," it only quotes what the note says.
+  - *Rejected — LLM/extractive summarization:* a server-side model picking salient
+    sentences is exactly the brain's job and the out-of-bounds step.
+- **Heading + lede scanning is code-fence aware.** A `#` or `[[...]]` inside a fenced
+  code block is not a heading/link; the scanner tracks fence state (mirroring
+  `find_body_wikilinks`) so code samples don't pollute claims.
+- **Neighbourhood ranks by co-citation, not raw degree.** A neighbour linked by *2 of
+  the packed notes* is more central to *this* result set than one linked by 1, so the
+  primary sort key is `len(referenced_by)` (distinct packed notes connected), then total
+  link richness ("both" directions > one), then path. Direction (`in`/`out`/`both`) is
+  recorded. Packed notes are excluded from their own neighbourhood. Each neighbour
+  carries only a one-sentence lede (token bound) — the pack points at neighbours, it does
+  not inline them whole.
+- **Contradictions are two measured kinds.** *Recorded supersession* edges (one note in
+  the set whose `superseded_by`/`status:superseded` points at another note in the set)
+  are definite, read straight from frontmatter. *Proximity tension* pairs are computed by
+  embedding each packed note once (`_best_cosine_per_file`), keeping only pairs **among
+  the packed set** whose cosine lands in the existing `[floor, dup)` band, and are framed
+  verbatim as the contradiction queue frames them — "proximity, not polarity — reader
+  decides." Reusing the same band + helper keeps one definition of "tension" in the
+  codebase. The top-k of `_best_cosine_per_file` is ample for the band (band membership
+  requires high similarity, so a band-neighbour is always in the top results).
+- **`embeddings_available` is honest.** It is `true` iff at least one
+  `_best_cosine_per_file` pass returned a non-empty map (a packed note always retrieves
+  at least itself when the sidecar works). When embeddings are disabled/unimportable it
+  is `false`, `tension` is empty, and the claims + neighbourhood + supersession parts
+  still produce a useful pack — the same soft-fail contract `detect_contradictions` has.
+- **Bounded with explicit truncation, env-overridable.** `KB_MCP_PACK_MAX_HITS` (5),
+  `KB_MCP_PACK_MAX_NEIGHBORS` (10), `KB_MCP_PACK_MAX_TENSION` (10),
+  `KB_MCP_PACK_CLAIM_CHARS` (280) — resolved at call time (so tests can monkeypatch),
+  overridable per call via kwargs. Every cap that drops content appends a line to
+  `truncation`; nothing is silently dropped (the `attention` / "no silent caps"
+  discipline).
+
+## Pure-substrate justification
+
+Every field of the pack is one of: text copied verbatim from a note (lede, section
+lines, outline headings, neighbour ledes), a wikilink edge the user authored
+(neighbourhood, supersession), or rank/band arithmetic over cosines the sidecar already
+computed (co-citation order, tension membership). No note content is summarized,
+paraphrased, classified, or judged; no generative or reasoning model runs at pack time;
+the vault is not mutated and `find` ordering is unchanged. This is the same status as
+`find`'s RRF, the contradiction queue's band, and the `attention` surface — all in
+bounds. A server-side LLM deciding which notes "really" conflict, or writing a synthesis
+across them, would be the out-of-bounds step; the pack stops at assembly and hands the
+reasoning to the brain.
+
+## Risks
+
+- **Schema-fidelity fixture must be regenerated.** Adding `find`'s `pack` param breaks
+  `tests/test_mcp_schema_fidelity.py` until `tests/fixtures/mcp_tool_schemas.json` is
+  regenerated via the existing `scripts/dump-tool-schemas.py`; the diff must add only the
+  `pack` property to `find` and change no other tool.
+- **Polymorphic `find` return.** `pack=true` returns a dict, not a list. Confined to
+  `op_find`; default-off keeps every existing caller on the list path; REST/CLI already
+  handle a dict result. Documented in the `find` docstring `Returns:` so Claude expects it.
+- **Pack size.** An unbounded pack would defeat the one-shot goal; the caps + explicit
+  `truncation` keep it bounded and honest. Defaults are conservative (top-5 hits).
+- **Tool ambiguity.** `pack` is one boolean on an existing tool with a tight docstring
+  ("assemble a reasoning-ready context pack from the top hits"), so it does not create a
+  second tool to disambiguate.
+- **Inbound-link cost (known follow-up).** The neighbourhood calls
+  `vault.find_inbound_wikilinks` once per packed note, and each call walks the whole vault
+  (twice — basename-uniqueness + a text read of every md). Bounded by `PACK_MAX_HITS`
+  (default 5) and only on the opt-in `pack=true` path, but on a ~500-file vault that is
+  several full walks of added latency. Accepted for v1; the follow-up is a single batched
+  vault walk that resolves inbound links for all packed notes at once (or an mtime-keyed
+  memo like the outbound `WikilinkResolver` cache already uses). Outbound is already cached.

--- a/openspec/changes/add-context-packs/proposal.md
+++ b/openspec/changes/add-context-packs/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+When Claude calls `find`, it gets a ranked list of hit **excerpts**. To actually reason
+over the matches it must then fire several follow-up `get` calls to read the full notes,
+chase wikilinks by hand to find context, and it has **no view of whether the surfaced
+notes contradict each other**. That is many round-trips, and Claude still "only sees a
+subset" of the relevant graph.
+
+The vault already records everything needed to assemble that context deterministically:
+each note's structure (lede, headline sections, heading outline), its wikilink
+neighbours (inbound + outbound), recorded supersession edges, and — via the embedding
+sidecar — pairwise proximity. Nothing here needs a model; it needs **assembly**.
+
+This is direction 3 of the post-moat roadmap ("reasoning-ready context packs"), the
+read-path companion to the just-shipped `attention` review surface.
+
+## What Changes
+
+- **New optional `pack` parameter on `find`** (default `false`). With `pack=false`,
+  `find` returns today's byte-identical hit list — no contract change. With `pack=true`,
+  `find` returns `{"hits": [...], "pack": {...}}`: the same hits plus one assembled
+  **context pack** over the top hits.
+- **New module `src/kb_mcp/context_pack.py`** with a pure `assemble_pack(vault_root,
+  hits, ...)` that composes four measurement-only parts:
+  - **Key claims** — per packed note, extracted **structurally**: the lede (first
+    paragraph), the first line/bullets of recognized headline sections
+    (Summary/Problem/Conclusion/Decision/Pattern/Hypothesis/Result/Insight/TL;DR), and
+    the `##` heading outline. No generation.
+  - **1-hop neighbourhood** — the inbound + outbound wikilink neighbours of the packed
+    notes (reusing `find._outbound_wikilink_paths` + `vault.find_inbound_wikilinks`),
+    excluding notes already packed, ranked by **co-citation** (how many packed notes
+    link it), each carrying a one-sentence lede.
+  - **Contradictions among the set** — (a) recorded **supersession** edges between
+    notes in the set (from `status`/`superseded_by` frontmatter), and (b) **proximity
+    "tension"** pairs among the packed notes whose pairwise cosine sits in the existing
+    `[CONTRADICTION_FLOOR, DUP_THRESHOLD)` band (reusing
+    `corpus_aware._best_cosine_per_file`), framed exactly as the contradiction queue
+    does — proximity, not polarity; the reader decides.
+  - **Bounds + explicit truncation** — env-overridable caps on packed hits, neighbours,
+    and tension pairs; every drop is reported in a `truncation` list — never silent.
+- **The polymorphic return lives only in the `op_find` leaf** (`commands.py`); the core
+  `find_module.find()` keeps its exact signature and `list[Hit]` return, so the ranker
+  and its 100+ tests are untouched. The registry derives the new `pack` param
+  automatically from the leaf signature + docstring — no `_SPEC` edit.
+
+It stays **pure-substrate**: the pack is deterministic extraction and graph-walking over
+markdown the user already wrote, plus rank/band arithmetic over embeddings the sidecar
+already computed. **No server-side LLM, no relevance judging, no
+summarization-by-generation.** Assembly mutates nothing and does not touch `find`
+ordering. The brain (Claude/Max) does the reasoning over the assembled context.
+
+**Default-off + soft-fail:** `pack` defaults to `false` (existing behaviour). The
+`tension` part depends on the embedding sidecar and **soft-fails to empty** when
+embeddings are disabled or unimportable (`embeddings_available: false`); the claims,
+neighbourhood, and recorded-supersession parts work with no embeddings, so the fast test
+suite and torch-less deploys still produce a useful pack.
+
+## Capabilities
+
+### Added Capabilities
+- `context-packs`: an optional `find(pack=true)` mode that returns an assembled,
+  reasoning-ready context pack — structural key claims, the 1-hop co-citation
+  neighbourhood, and recorded-supersession + proximity-tension among the top hits —
+  measurement-only, bounded with explicit truncation, reachable on every surface.
+
+## Impact
+
+- Code: new `src/kb_mcp/context_pack.py` (`assemble_pack` + `_extract_claims`,
+  `_neighborhood`, `_contradictions` helpers + constants). `op_find` in `commands.py`
+  gains a `pack: bool = False` param + the `{"hits","pack"}` branch and imports the new
+  module. The MCP schema-fidelity fixture (`tests/fixtures/mcp_tool_schemas.json`) is
+  regenerated to include `find`'s new `pack` property.
+- Behaviour: purely additive. `pack=false` (default) is byte-identical to today;
+  `find()`'s core signature/return and ordering are unchanged. No other tool changes.
+- Tests: new `tests/test_context_pack.py` (mostly torch-free unit tests over a synthetic
+  cluster — claims, co-citation neighbourhood, supersession edges, truncation,
+  embeddings-off degradation; tension-band logic with injected cosines) + an
+  `op_find(pack=true)` integration test + the schema-fidelity regen.
+- Deploy: the changed `find` schema requires reconnecting the claude.ai connector to pick
+  up the `pack` param; REST/CLI need only a restart. No data migration.

--- a/openspec/changes/add-context-packs/specs/context-packs/spec.md
+++ b/openspec/changes/add-context-packs/specs/context-packs/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Optional Context Pack Assembly From `find`
+
+The system SHALL provide an optional `pack` parameter on `find` (default `false`) that,
+when `false`, returns the existing hit list **unchanged** and, when `true`, returns an
+object `{"hits": [...], "pack": {...}}` where `pack` is an assembled context pack over
+the top hits carrying `packed_paths`, `claims`, `neighborhood`, `contradictions`,
+`embeddings_available`, and `truncation`. The assembly SHALL NOT alter the hits, their
+order, or any existing `find` behaviour, and the core `find` ranker signature and return
+type SHALL be unchanged (the parameter and the object return are confined to the command
+leaf).
+
+#### Scenario: Pack off is byte-identical to today
+
+- **WHEN** `find` is called with `pack` omitted or `false`
+- **THEN** it returns the same hit list it returns today, with no `pack` object and no
+  change to ordering or fields
+
+#### Scenario: Pack on returns hits plus an assembled pack
+
+- **WHEN** `find` is called with `pack=true` over a vault with matching notes
+- **THEN** it returns `{"hits", "pack"}` where `hits` is the usual list and `pack`
+  carries `packed_paths` (the top notes covered), `claims`, `neighborhood`,
+  `contradictions`, `embeddings_available`, and `truncation`
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+### Requirement: Structural Key-Claim Extraction Without Generation
+
+The system SHALL extract each packed note's `claims` **structurally** from the note's own
+text — a `lede` (its first content paragraph), `sections` (the first line or leading
+bullets under recognized headline sections), and an `outline` (its `##` headings in
+order) — and MUST NOT invoke any generative or summarizing model to produce them. Heading
+and lede detection SHALL ignore content inside fenced code blocks.
+
+#### Scenario: Claims are the note's own structure
+
+- **WHEN** a packed note has a lede paragraph, a `## Summary` section, and several `##`
+  headings
+- **THEN** its `claims` carry the lede text, a `Summary:` entry drawn from that section,
+  and the `##` headings as `outline`
+- **AND** no generative/reasoning model is invoked to produce them
+
+### Requirement: One-Hop Wikilink Neighbourhood Ranked By Co-Citation
+
+The system SHALL assemble the `neighborhood` as the 1-hop inbound and outbound wikilink
+neighbours of the packed notes — reusing the existing outbound-link and inbound-link
+resolution — excluding any note already in `packed_paths`, recording each neighbour's
+link `direction` (`in`/`out`/`both`) and the packed notes it is linked with
+(`referenced_by`), and ranking neighbours by co-citation (the count of distinct packed
+notes that link them) before capping. Each neighbour SHALL carry at most a one-sentence
+lede.
+
+#### Scenario: A co-cited neighbour outranks a singly-cited one
+
+- **WHEN** neighbour `X` is linked by two packed notes and neighbour `Y` by one
+- **THEN** `X` is ranked above `Y` in `neighborhood`, each with its `direction` and
+  `referenced_by`
+- **AND** no note already present in `packed_paths` appears in `neighborhood`
+
+### Requirement: Contradictions And Supersession Among The Packed Set
+
+The system SHALL surface, within the pack's `contradictions`, two measured relations
+among the notes in the set: recorded `superseded` edges read from `status` /
+`superseded_by` frontmatter, and proximity `tension` pairs whose pairwise cosine sits in
+the existing contradiction band `[CONTRADICTION_FLOOR, DUP_THRESHOLD)`. Tension SHALL be
+labelled as proximity, not polarity, deferring the judgment to the reader, and SHALL be
+computed only among the packed notes. When the embedding sidecar is unavailable
+(embeddings disabled or unimportable), `tension` SHALL be empty and `embeddings_available`
+SHALL be `false`, while `superseded` edges (which need no embeddings) SHALL still be
+surfaced.
+
+#### Scenario: A recorded supersession edge is surfaced
+
+- **WHEN** a packed note's `superseded_by` points at another note in the set
+- **THEN** `contradictions.superseded` carries that `{from, to}` edge, read from
+  frontmatter without embeddings
+
+#### Scenario: Embeddings-off still yields a useful pack
+
+- **WHEN** `find(pack=true)` runs with embeddings disabled
+- **THEN** `embeddings_available` is `false`, `tension` is empty, and `claims`,
+  `neighborhood`, and `contradictions.superseded` are still populated
+
+### Requirement: Bounded Assembly With Explicit Truncation
+
+The system SHALL bound the pack by configurable, env-overridable caps on the number of
+packed hits, neighbours, and tension pairs, and MUST NOT silently truncate: whenever a
+cap drops content the pack's `truncation` list SHALL carry an explicit entry naming what
+was capped and by how much.
+
+#### Scenario: A capped neighbourhood is reported
+
+- **WHEN** more 1-hop neighbours exist than the neighbour cap
+- **THEN** exactly the cap is surfaced and `truncation` carries an entry stating how many
+  neighbours were not shown
+
+### Requirement: Measurement-Only Assembly On All Surfaces
+
+The pack assembly SHALL be measurement-only — reading note content, frontmatter,
+wikilinks, and precomputed sidecar embeddings, applying only deterministic extraction and
+rank/band arithmetic — and MUST NOT invoke a generative or reasoning model, MUST NOT
+mutate the vault, and MUST NOT change `find` ordering. The `pack` parameter SHALL be
+exposed from the single `find` registry entry across the MCP, REST, and CLI surfaces with
+no per-surface code.
+
+#### Scenario: Pack assembly leaves the vault and find untouched
+
+- **WHEN** `find(pack=true)` runs over a vault
+- **THEN** no file under the vault is created, modified, moved, or deleted, and `find`
+  ordering is unchanged
+- **AND** the `pack` parameter is reachable on the MCP tool, the `/api/find` REST route,
+  and the `kb find` CLI from the one registry entry

--- a/openspec/changes/add-context-packs/tasks.md
+++ b/openspec/changes/add-context-packs/tasks.md
@@ -1,0 +1,62 @@
+# Tasks — Reasoning-ready context packs from `find`
+
+## 1. Pure assembler (TDD: tests before wiring)
+- [x] 1.1 Write `tests/test_context_pack.py` FIRST over a small synthetic vault cluster
+      (inter-linked notes + one supersession pair), torch-free (embeddings disabled):
+      claim extraction (lede skips H1, recognized `## Summary`/`## Problem` section lines,
+      `##` outline, code-fence `#`/`[[...]]` ignored, claim chars capped); neighbourhood
+      (inbound+outbound union, packed notes excluded, `direction` in/out/both, co-citation
+      order — 2-cited above 1-cited, neighbour cap → `truncation` entry, one-sentence
+      ledes); supersession edges read from frontmatter among the set; embeddings-off
+      degradation (`embeddings_available==false`, `tension==[]`, other parts populated);
+      tension-band membership via injected cosines (a stub/monkeypatched
+      `_best_cosine_per_file` returning band/above-band/below-band scores → only band
+      pairs surface, framed proximity-not-polarity); bounded hits (`packed_paths` ==
+      top-N); determinism on re-run.
+- [x] 1.2 Implement `src/kb_mcp/context_pack.py`: env-resolved caps
+      (`KB_MCP_PACK_MAX_HITS=5`, `KB_MCP_PACK_MAX_NEIGHBORS=10`, `KB_MCP_PACK_MAX_TENSION=10`,
+      `KB_MCP_PACK_CLAIM_CHARS=280`), `RECOGNIZED_SECTIONS` set; helpers `_extract_claims`,
+      `_neighborhood`, `_contradictions`, fence-aware heading/lede scan; pure
+      `assemble_pack(vault_root, hits, *, max_hits=None, max_neighbors=None,
+      max_tension=None) -> dict` reusing `find._CACHE`/`_outbound_wikilink_paths`,
+      `vault.find_inbound_wikilinks`, `corpus_aware._best_cosine_per_file` +
+      `_contradiction_floor`/`_dup_threshold` + `_canon`. No mutation, no model import.
+- [x] 1.3 `tests/test_context_pack.py` green.
+
+## 2. Wire `pack` into `find` (leaf only)
+- [x] 2.1 Add `pack: bool = False` to `op_find` in `commands.py` with an Args docstring
+      entry (assemble a reasoning-ready context pack from the top hits; measurement-only;
+      list-vs-`{hits,pack}` return) and a `Returns:` note for the pack shape. Import
+      `from . import context_pack as context_pack_module`.
+- [x] 2.2 Branch the return: `pack=false` → `[h.as_dict() for h in hits]` (unchanged);
+      `pack=true` → `{"hits": [...], "pack": context_pack.assemble_pack(vault_root, hits)}`.
+      No `_SPEC` edit (param auto-derived); no `HAND_REGISTERED_EXCEPTIONS` change.
+- [x] 2.3 Integration test: `op_find(vault, query=..., pack=true)` returns the
+      `{"hits","pack"}` shape with a sane pack; `pack` absent/false returns the bare list
+      byte-identical to before (add to `tests/test_find.py` or `tests/test_consolidated_tools.py`).
+
+## 3. Schema-fidelity fixture
+- [x] 3.1 Regenerate `tests/fixtures/mcp_tool_schemas.json` via
+      `scripts/dump-tool-schemas.py`; confirm the diff adds only `find`'s `pack` boolean
+      property (+ its description) and changes no other tool's schema/description.
+
+## 4. Verify
+- [x] 4.1 `uv run pytest tests/test_context_pack.py tests/test_find.py
+      tests/test_mcp_schema_fidelity.py tests/test_consolidated_tools.py
+      tests/test_rest_registry.py tests/test_cli_core_ops.py -q` green.
+- [x] 4.2 Full suite via `uv run pytest -q` — 814 passed, 6 skipped, no regression. (1
+      pre-existing collection error: `tests/test_voice_embed.py` bare `import torch`, the
+      worktree venv lacks the embeddings/torch extra; unrelated — this change is torch-free.)
+- [x] 4.3 `ruff check` clean on `src/kb_mcp/context_pack.py` + `src/kb_mcp/commands.py`.
+- [x] 4.4 CLI smoke (fixture vault): `kb find "<term>" --pack --json` returns an envelope
+      whose `data` has `hits` + `pack`; `kb find "<term>" --json` still returns the list.
+- [x] 4.5 Pure-substrate check: `context_pack.py` imports no embedding/model module for
+      generation (only `corpus_aware`'s precomputed-cosine helper); assembly reads content
+      + frontmatter + wikilinks only; vault and `find` ordering unchanged.
+- [x] 4.6 `openspec validate add-context-packs --strict` passes.
+
+## 5. Deploy (Hugo)
+- [ ] 5.1 `reset --hard origin/main` on the deploy checkout + restart; reconnect the
+      claude.ai connector so `find`'s new `pack` param appears. Live smoke: one real
+      `find(pack=true)` confirms `tension` pairs populate from the band and the pack is
+      token-bounded. (Additive, read-only — safe.)

--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -32,6 +32,7 @@ from . import attention as attention_module
 from . import audit as audit_module
 from . import audit_fix as audit_fix_module
 from . import compile_proposal as compile_proposal_module
+from . import context_pack as context_pack_module
 from . import corpus_aware as corpus_aware_module
 from . import create_directory as create_directory_module
 from . import create_file as create_file_module
@@ -217,7 +218,8 @@ def op_find(
     rerank: bool = False,
     prefer_compiled: bool = True,
     prefer_active: bool = True,
-) -> list[dict]:
+    pack: bool = False,
+) -> list[dict] | dict:
     """Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.
 
     Args:
@@ -286,9 +288,23 @@ def op_find(
             pointer) so you can see it's superseded. Set false to rank a
             superseded page on its content alone (e.g. "what did I used to
             think about X").
+        pack: When true (off by default), ALSO assemble a reasoning-ready
+            context pack from the top hits and change the return to
+            {"hits": [...], "pack": {...}} (with pack off, the return is the
+            usual hit list, unchanged). The pack is PURE MEASUREMENT over the
+            notes you already wrote — no server-side reasoning: each top note's
+            structurally-extracted key claims (lede + headline-section lines +
+            heading outline), the 1-hop wikilink neighbourhood of those notes
+            ranked by co-citation, and the contradictions among them (recorded
+            supersession edges + proximity "tension" pairs in the embedding
+            band, surfaced for you to judge — proximity, not polarity). Lets you
+            reason over the matches in one shot instead of fanning out `get`
+            calls. Bounded with explicit `truncation`; the tension part needs
+            the embedding sidecar and reports `embeddings_available`.
 
     Returns:
-        List of {path, type, scope, title, updated, excerpt[, outside_kb]
+        With pack off (default): a list of {path, type, scope, title, updated,
+        excerpt[, outside_kb]
         [, status][, superseded_by][, signals]}. `outside_kb: true` is
         present only on hits the "kb" auto-widen pulled from beyond
         Knowledge Base/ (the `path` also shows the sibling folder).
@@ -303,6 +319,9 @@ def op_find(
         number of top-N seeds whose body wikilinks to this hit —
         independent of graph_hop, which only fires for graph-only
         results.
+        With pack on: {"hits": [...the same list...], "pack": {packed_paths,
+        claims, neighborhood, contradictions: {superseded, tension},
+        embeddings_available, truncation}}.
     """
     hits = find_module.find(
         vault_root,
@@ -329,7 +348,13 @@ def op_find(
         limit=limit, rerank=rerank, prefer_compiled=prefer_compiled,
         graph=graph, hits=hits,
     )
-    return [h.as_dict() for h in hits]
+    hit_dicts = [h.as_dict() for h in hits]
+    if not pack:
+        return hit_dicts
+    return {
+        "hits": hit_dicts,
+        "pack": context_pack_module.assemble_pack(vault_root, hits),
+    }
 
 
 def op_suggest_links(

--- a/src/kb_mcp/context_pack.py
+++ b/src/kb_mcp/context_pack.py
@@ -1,0 +1,386 @@
+"""Reasoning-ready context packs — the optional assembled return of `find(pack=true)`.
+
+`find` normally returns ranked hit *excerpts*; to reason over them a caller then fans out
+`get` calls, chases wikilinks by hand, and has no view of contradictions among the hits.
+This module assembles, in one pass over the top hits, a **context pack**: each note's key
+claims, the 1-hop wikilink neighbourhood of those notes, and the contradictions /
+supersessions among them.
+
+It is PURE ASSEMBLY (measurement), mirroring `attention.py`:
+- "Key claims" are extracted STRUCTURALLY from the note's own markdown (lede, recognized
+  headline-section lines, the `##` outline) — never generated or summarized by a model.
+- The neighbourhood reuses `find`'s outbound-link resolution + `vault`'s inbound search.
+- Contradictions are recorded supersession edges (frontmatter) plus proximity "tension"
+  pairs whose cosine sits in the existing `[floor, dup)` band (reusing
+  `corpus_aware._best_cosine_per_file`) — proximity, not polarity; the reader decides.
+
+Nothing is mutated, no generative/reasoning model runs, and `find` ordering is untouched.
+The tension part soft-fails to empty (`embeddings_available: false`) when the embedding
+sidecar is disabled or unimportable, so the rest of the pack still assembles. Every cap
+that drops content is reported in `truncation` — never a silent truncation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from . import corpus_aware
+from . import find as find_module
+from . import vault as vault_module
+from .find import Hit, ParsedPage
+
+# --- bounds (env-overridable at call time so tests can monkeypatch) ---
+_DEFAULT_MAX_HITS = 5
+_DEFAULT_MAX_NEIGHBORS = 10
+_DEFAULT_MAX_TENSION = 10
+_DEFAULT_CLAIM_CHARS = 280
+
+# Per-note claim shaping — small, fixed (claims are inherently bounded by note structure).
+_SECTION_MAX_LINES = 3
+_SECTION_CHARS = 200
+_MAX_SECTIONS = 8
+_MAX_OUTLINE = 16
+_NEIGHBOR_LEDE_CHARS = 160
+
+# Headline sections whose lead line is a high-signal "claim". Matched case-insensitively
+# against the heading text (trailing colon stripped). Connections/See-also are links, not
+# claims, so they are deliberately absent.
+RECOGNIZED_SECTIONS: frozenset[str] = frozenset({
+    "summary", "problem", "conclusion", "decision", "pattern", "hypothesis",
+    "result", "results", "insight", "tl;dr", "tldr", "takeaway", "why",
+    "finding", "findings",
+})
+
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+_H1_RE = re.compile(r"^#\s+")               # level-1 (the title line in body)
+_H2_RE = re.compile(r"^##\s+(.*)$")         # level-2 only (the outline skeleton)
+_HEADING_RE = re.compile(r"^(#{2,6})\s+(.*)$")  # level 2-6 (recognized-section scan)
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s")
+
+
+# ----------------------------- small text utils -----------------------------
+
+def _resolve_cap(value: int | None, env: str, default: int) -> int:
+    if value is not None:
+        return value
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _collapse(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _cap(text: str, n: int) -> str:
+    text = text.strip()
+    if len(text) <= n:
+        return text
+    return text[:n].rstrip() + "…"
+
+
+def _strip_fences(body: str) -> list[str]:
+    """Body lines with fenced code blocks removed (a `#`/`[[ ]]` inside a fence is not a
+    heading/link). Mirrors the fence-awareness of `vault.find_body_wikilinks`."""
+    out: list[str] = []
+    in_fence = False
+    for line in body.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return out
+
+
+def _first_sentence(text: str) -> str:
+    text = _collapse(text)
+    if not text:
+        return ""
+    return _SENTENCE_SPLIT.split(text, maxsplit=1)[0]
+
+
+# ----------------------------- claim extraction -----------------------------
+
+def _lede(lines: list[str]) -> str:
+    """The first content paragraph (collapsed), skipping leading blanks + the H1 title."""
+    i, n = 0, len(lines)
+    while i < n and not lines[i].strip():
+        i += 1
+    if i < n and _H1_RE.match(lines[i].lstrip()):
+        i += 1
+        while i < n and not lines[i].strip():
+            i += 1
+    buf: list[str] = []
+    while i < n:
+        stripped = lines[i].lstrip()
+        if not stripped.strip():
+            break
+        if _HEADING_RE.match(stripped) or _H1_RE.match(stripped):
+            break
+        buf.append(stripped.lstrip("-*+ ").strip())
+        i += 1
+    return _collapse(" ".join(buf))
+
+
+def _sections(lines: list[str]) -> list[str]:
+    """`"Heading: lead text"` for each recognized headline section, in document order."""
+    out: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        m = _HEADING_RE.match(lines[i].lstrip())
+        if not m:
+            i += 1
+            continue
+        heading = m.group(2).strip()
+        key = heading.lower().strip().rstrip(":").strip()
+        i += 1
+        if key not in RECOGNIZED_SECTIONS:
+            continue
+        while i < n and not lines[i].strip():
+            i += 1
+        buf: list[str] = []
+        while i < n and len(buf) < _SECTION_MAX_LINES:
+            stripped = lines[i].lstrip()
+            if not stripped.strip() or _HEADING_RE.match(stripped):
+                break
+            buf.append(stripped.lstrip("-*+ ").strip())
+            i += 1
+        text = _cap(_collapse(" ".join(buf)), _SECTION_CHARS)
+        if text:
+            out.append(f"{heading}: {text}")
+        if len(out) >= _MAX_SECTIONS:
+            break
+    return out
+
+
+def _outline(lines: list[str]) -> list[str]:
+    out: list[str] = []
+    for line in lines:
+        m = _H2_RE.match(line.lstrip())
+        if m:
+            out.append(m.group(1).strip())
+            if len(out) >= _MAX_OUTLINE:
+                break
+    return out
+
+
+def _extract_claims(page: ParsedPage, *, claim_chars: int = _DEFAULT_CLAIM_CHARS) -> dict:
+    lines = _strip_fences(page.body)
+    return {
+        "title": page.title,
+        "type": page.page_type,
+        "lede": _cap(_lede(lines), claim_chars),
+        "sections": _sections(lines),
+        "outline": _outline(lines),
+    }
+
+
+# ----------------------------- neighbourhood -----------------------------
+
+def _neighborhood(
+    vault_root: Path, packed_pages: list[ParsedPage], max_neighbors: int
+) -> tuple[list[dict], int]:
+    """1-hop inbound+outbound wikilink neighbours of the packed notes, packed notes
+    excluded, ranked by co-citation (distinct packed notes linked), capped."""
+    packed_canon = {corpus_aware._canon(p.rel_path) for p in packed_pages}
+    # canon -> {"path", "directions": set, "referenced_by": set}
+    neigh: dict[str, dict] = {}
+
+    def _touch(target_path: str, packed_rel: str, direction: str) -> None:
+        canon = corpus_aware._canon(target_path)
+        if canon in packed_canon:
+            return
+        entry = neigh.setdefault(
+            canon, {"path": target_path, "directions": set(), "referenced_by": set()}
+        )
+        entry["directions"].add(direction)
+        entry["referenced_by"].add(packed_rel)
+
+    for page in packed_pages:
+        for target in find_module._outbound_wikilink_paths(page, vault_root):
+            _touch(target, page.rel_path, "out")
+        for link in vault_module.find_inbound_wikilinks(vault_root, page.rel_path):
+            _touch(link.path, page.rel_path, "in")
+
+    items = sorted(
+        neigh.values(),
+        key=lambda e: (-len(e["referenced_by"]), -len(e["directions"]), e["path"]),
+    )
+    shown = items[:max_neighbors] if max_neighbors > 0 else items
+    dropped = len(items) - len(shown)
+
+    out: list[dict] = []
+    for entry in shown:
+        page = find_module._CACHE.get(vault_root / entry["path"], vault_root)
+        directions = entry["directions"]
+        direction = "both" if len(directions) > 1 else next(iter(directions))
+        lede = _cap(_first_sentence(_lede(_strip_fences(page.body))), _NEIGHBOR_LEDE_CHARS) if page else ""
+        out.append({
+            "path": entry["path"],
+            "title": page.title if page else entry["path"].rsplit("/", 1)[-1].removesuffix(".md"),
+            "type": page.page_type if page else None,
+            "direction": direction,
+            "referenced_by": sorted(entry["referenced_by"]),
+            "lede": lede,
+        })
+    return out, dropped
+
+
+# ----------------------------- contradictions -----------------------------
+
+def _wikilink_target(raw: str) -> str:
+    t = raw.strip()
+    if t.startswith("[[") and t.endswith("]]"):
+        t = t[2:-2]
+    return t.split("|", 1)[0].split("#", 1)[0].strip()
+
+
+def _supersession_edges(packed_pages: list[ParsedPage]) -> list[dict]:
+    """Recorded supersession edges among the set, read straight from frontmatter."""
+    by_canon = {corpus_aware._canon(p.rel_path): p.rel_path for p in packed_pages}
+    edges: list[dict] = []
+    for page in packed_pages:
+        for raw in page.superseded_by:
+            canon = corpus_aware._canon(_wikilink_target(raw))
+            if canon in by_canon and by_canon[canon] != page.rel_path:
+                edges.append(
+                    {"from": page.rel_path, "to": by_canon[canon], "kind": "supersession"}
+                )
+    return edges
+
+
+def _tension_pairs(
+    vault_root: Path, packed_pages: list[ParsedPage], max_tension: int
+) -> tuple[list[dict], int, bool]:
+    """Proximity-tension pairs AMONG the packed notes whose pairwise cosine lands in the
+    contradiction band. Reuses the embedding sidecar; soft-fails to empty when off.
+
+    `embeddings_available` is True iff a cosine pass returned scores AND the band is
+    active; an inverted/disabled band (floor >= ceiling) reports it False — the band is
+    off, so no tension can be measured regardless of the sidecar."""
+    floor = corpus_aware._contradiction_floor()
+    ceiling = corpus_aware._dup_threshold()
+    by_canon = {corpus_aware._canon(p.rel_path): p.rel_path for p in packed_pages}
+    pair_best: dict[frozenset[str], float] = {}
+    embeddings_available = False
+
+    if floor < ceiling:
+        for page in packed_pages:
+            cmap = corpus_aware._best_cosine_per_file(
+                vault_root, title=page.title, body=page.body
+            )
+            if cmap:
+                embeddings_available = True
+            self_canon = corpus_aware._canon(page.rel_path)
+            for fp, score in cmap.items():
+                canon = corpus_aware._canon(fp)
+                if canon == self_canon or canon not in by_canon:
+                    continue
+                if not (floor <= score < ceiling):
+                    continue
+                key = frozenset((self_canon, canon))
+                if key not in pair_best or score > pair_best[key]:
+                    pair_best[key] = score
+
+    pairs: list[dict] = []
+    for key, score in pair_best.items():
+        a, b = sorted(key)
+        pairs.append({
+            "a": by_canon[a],
+            "b": by_canon[b],
+            "cosine": round(float(score), 4),
+            "note": "proximity, not polarity — reader decides",
+        })
+    pairs.sort(key=lambda d: (-d["cosine"], d["a"], d["b"]))
+    shown = pairs[:max_tension] if max_tension > 0 else pairs
+    dropped = len(pairs) - len(shown)
+    return shown, dropped, embeddings_available
+
+
+# ----------------------------- assembly -----------------------------
+
+def assemble_pack(
+    vault_root: Path,
+    hits: list[Hit],
+    *,
+    max_hits: int | None = None,
+    max_neighbors: int | None = None,
+    max_tension: int | None = None,
+) -> dict:
+    """Assemble a reasoning-ready context pack over the top `hits`. Pure measurement.
+
+    Returns ``{packed_paths, claims, neighborhood, contradictions, embeddings_available,
+    truncation}``. Reads note content, frontmatter, wikilinks, and precomputed sidecar
+    embeddings only — no mutation, no generative model, `find` ordering untouched.
+    """
+    max_hits = _resolve_cap(max_hits, "KB_MCP_PACK_MAX_HITS", _DEFAULT_MAX_HITS)
+    max_neighbors = _resolve_cap(max_neighbors, "KB_MCP_PACK_MAX_NEIGHBORS", _DEFAULT_MAX_NEIGHBORS)
+    max_tension = _resolve_cap(max_tension, "KB_MCP_PACK_MAX_TENSION", _DEFAULT_MAX_TENSION)
+    claim_chars = _resolve_cap(None, "KB_MCP_PACK_CLAIM_CHARS", _DEFAULT_CLAIM_CHARS)
+
+    truncation: list[str] = []
+    # De-dupe by canonical path up front: `find` rarely emits the same path twice, but a
+    # duplicate would otherwise double-count in `packed_paths` and the supersession edges.
+    seen: set[str] = set()
+    unique_hits: list[Hit] = []
+    for hit in hits:
+        canon = corpus_aware._canon(hit.path)
+        if canon in seen:
+            continue
+        seen.add(canon)
+        unique_hits.append(hit)
+
+    total = len(unique_hits)
+    packed_hits = unique_hits[:max_hits] if max_hits > 0 else unique_hits
+    if total > len(packed_hits):
+        truncation.append(
+            f"packed {len(packed_hits)} of {total} hits "
+            f"({total - len(packed_hits)} more not packed; raise KB_MCP_PACK_MAX_HITS)"
+        )
+
+    packed_pages: list[ParsedPage] = []
+    missing = 0
+    for hit in packed_hits:
+        page = find_module._CACHE.get(vault_root / hit.path, vault_root)
+        if page is None:
+            missing += 1  # a packed hit whose file is gone/unreadable — surface it.
+            continue
+        packed_pages.append(page)
+    if missing:
+        truncation.append(f"{missing} packed hit(s) unreadable or missing, not packed")
+
+    claims = {
+        p.rel_path: _extract_claims(p, claim_chars=claim_chars) for p in packed_pages
+    }
+    neighborhood, n_dropped = _neighborhood(vault_root, packed_pages, max_neighbors)
+    if n_dropped > 0:
+        truncation.append(
+            f"neighborhood capped at {max_neighbors} "
+            f"({n_dropped} more not shown; raise KB_MCP_PACK_MAX_NEIGHBORS)"
+        )
+
+    superseded = _supersession_edges(packed_pages)
+    tension, t_dropped, embeddings_available = _tension_pairs(
+        vault_root, packed_pages, max_tension
+    )
+    if t_dropped > 0:
+        truncation.append(
+            f"tension pairs capped at {max_tension} "
+            f"({t_dropped} more not shown; raise KB_MCP_PACK_MAX_TENSION)"
+        )
+
+    return {
+        "packed_paths": [p.rel_path for p in packed_pages],
+        "claims": claims,
+        "neighborhood": neighborhood,
+        "contradictions": {"superseded": superseded, "tension": tension},
+        "embeddings_available": embeddings_available,
+        "truncation": truncation,
+    }

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -608,6 +608,11 @@
           "default": true,
           "type": "boolean",
           "description": "When true (default), soft-demotes `status:\nsuperseded` pages so a replaced conclusion can't outrank the\npage that superseded it. The tombstone stays findable and its\nhit still carries `status` + `superseded_by` (the forward\npointer) so you can see it's superseded. Set false to rank a\nsuperseded page on its content alone (e.g. \"what did I used to\nthink about X\")."
+        },
+        "pack": {
+          "default": false,
+          "type": "boolean",
+          "description": "When true (off by default), ALSO assemble a reasoning-ready\ncontext pack from the top hits and change the return to\n{\"hits\": [...], \"pack\": {...}} (with pack off, the return is the\nusual hit list, unchanged). The pack is PURE MEASUREMENT over the\nnotes you already wrote — no server-side reasoning: each top note's\nstructurally-extracted key claims (lede + headline-section lines +\nheading outline), the 1-hop wikilink neighbourhood of those notes\nranked by co-citation, and the contradictions among them (recorded\nsupersession edges + proximity \"tension\" pairs in the embedding\nband, surfaced for you to judge — proximity, not polarity). Lets you\nreason over the matches in one shot instead of fanning out `get`\ncalls. Bounded with explicit `truncation`; the tension part needs\nthe embedding sidecar and reports `embeddings_available`."
         }
       },
       "type": "object"

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -1,0 +1,320 @@
+"""Unit tests for the reasoning-ready context pack (`find(pack=true)`).
+
+Torch-free: builds its own tiny inter-linked vault per test (so it never perturbs
+the shared fixture vault), and exercises `context_pack.assemble_pack` directly. The
+embedding-dependent `tension` path is tested by monkeypatching
+`corpus_aware._best_cosine_per_file` with injected cosines — no model load.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import context_pack, corpus_aware
+from kb_mcp import find as find_module
+from kb_mcp.find import Hit
+
+# --- a small cluster: Alpha + Beta packed; Hub (co-cited), Charlie, Delta neighbours ---
+
+ALPHA = """\
+---
+type: insight
+---
+# Alpha Insight
+
+Alpha is the lede paragraph that states the core claim plainly.
+
+## Summary
+- Alpha summarizes the key finding succinctly.
+
+## Problem
+The problem Alpha addresses is stated right here.
+
+## Detail
+
+```python
+# not-a-heading inside a fenced code block
+x = "[[Knowledge Base/Notes/NotALink]]"
+```
+
+## Connections
+- [[Knowledge Base/Notes/Charlie]] — related leaf
+- [[Knowledge Base/Notes/Hub]] — the hub
+"""
+
+BETA = """\
+---
+type: pattern
+---
+# Beta Pattern
+
+Beta lede paragraph describing the pattern.
+
+## Pattern
+Beta's pattern body, linking to [[Knowledge Base/Notes/Hub]].
+"""
+
+CHARLIE = """\
+---
+type: insight
+---
+# Charlie
+
+Charlie lede sentence. A second sentence that should not appear in a one-liner.
+"""
+
+HUB = """\
+---
+type: insight
+---
+# Hub
+
+Hub lede paragraph describing the central hub note.
+"""
+
+DELTA = """\
+---
+type: note
+---
+# Delta
+
+Delta references [[Knowledge Base/Notes/Alpha]] from outside the packed set.
+"""
+
+OLD = """\
+---
+type: insight
+status: superseded
+superseded_by: "[[Knowledge Base/Notes/NewView]]"
+---
+# Old View
+
+The old lede that has since been replaced.
+"""
+
+NEW = """\
+---
+type: insight
+---
+# New View
+
+The current lede that supersedes the old one.
+"""
+
+
+def _write(vault: Path, rel: str, body: str) -> None:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def _hit(rel: str) -> Hit:
+    return Hit(path=rel, type=None, scope=None, title="", updated="", excerpt="")
+
+
+ALPHA_P = "Knowledge Base/Notes/Alpha.md"
+BETA_P = "Knowledge Base/Notes/Beta.md"
+CHARLIE_P = "Knowledge Base/Notes/Charlie.md"
+HUB_P = "Knowledge Base/Notes/Hub.md"
+DELTA_P = "Knowledge Base/Notes/Delta.md"
+OLD_P = "Knowledge Base/Notes/Old.md"
+NEW_P = "Knowledge Base/Notes/NewView.md"
+
+
+@pytest.fixture
+def cluster(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    _write(vault, ALPHA_P, ALPHA)
+    _write(vault, BETA_P, BETA)
+    _write(vault, CHARLIE_P, CHARLIE)
+    _write(vault, HUB_P, HUB)
+    _write(vault, DELTA_P, DELTA)
+    _write(vault, OLD_P, OLD)
+    _write(vault, NEW_P, NEW)
+    find_module.clear_cache()
+    return vault
+
+
+# ----------------------------- claims -----------------------------
+
+def test_claims_are_structural_lede_sections_outline(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P), _hit(BETA_P)])
+    claims = pack["claims"][ALPHA_P]
+
+    assert claims["type"] == "insight"
+    # lede is the first content paragraph, NOT the H1 title.
+    assert claims["lede"].startswith("Alpha is the lede paragraph")
+    assert "Alpha Insight" not in claims["lede"]
+    # recognized headline sections are captured with their heading label.
+    joined = " | ".join(claims["sections"])
+    assert "Summary:" in joined and "Alpha summarizes" in joined
+    assert "Problem:" in joined and "problem Alpha addresses" in joined
+    # outline is the ## skeleton, in order.
+    assert claims["outline"] == ["Summary", "Problem", "Detail", "Connections"]
+
+
+def test_claims_ignore_fenced_code(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P)])
+    claims = pack["claims"][ALPHA_P]
+    # The `# not-a-heading` inside the code fence is not a heading.
+    assert "not-a-heading" not in " ".join(claims["outline"])
+    assert all("not-a-heading" not in s for s in claims["sections"])
+    # The `[[...NotALink]]` inside the fence is not an outbound neighbour.
+    assert all("NotALink" not in n["path"] for n in pack["neighborhood"])
+
+
+def test_claim_lede_capped(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P)], )
+    # Force a tiny cap and confirm an ellipsis marks the truncation (not silent).
+    pack_small = context_pack.assemble_pack(cluster, [_hit(ALPHA_P)], max_hits=1)
+    # default claim chars is generous; explicitly cap via env-independent kwarg path:
+    capped = context_pack._extract_claims(
+        find_module._CACHE.get(cluster / ALPHA_P, cluster), claim_chars=20
+    )
+    assert len(capped["lede"]) <= 21  # 20 chars + ellipsis
+    assert capped["lede"].endswith("…")
+    assert pack["claims"][ALPHA_P]["lede"]  # sanity: default not truncated
+    assert pack_small["packed_paths"] == [ALPHA_P]
+
+
+# -------------------------- neighbourhood --------------------------
+
+def test_neighbourhood_co_citation_order_and_exclusion(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P), _hit(BETA_P)])
+    neigh = pack["neighborhood"]
+    paths = [n["path"] for n in neigh]
+
+    # Hub is linked by BOTH Alpha and Beta → co-citation 2 → ranks first.
+    assert paths[0] == HUB_P
+    hub = neigh[0]
+    assert set(hub["referenced_by"]) == {ALPHA_P, BETA_P}
+    assert hub["direction"] == "out"
+    # Charlie and Delta are each linked by one packed note.
+    assert CHARLIE_P in paths and DELTA_P in paths
+    # Packed notes never appear in their own neighbourhood.
+    assert ALPHA_P not in paths and BETA_P not in paths
+    # Inbound link (Delta → Alpha) is tagged direction "in".
+    delta = next(n for n in neigh if n["path"] == DELTA_P)
+    assert delta["direction"] == "in"
+    assert delta["referenced_by"] == [ALPHA_P]
+    # one-sentence lede only.
+    charlie = next(n for n in neigh if n["path"] == CHARLIE_P)
+    assert "second sentence" not in charlie["lede"]
+
+
+def test_neighbourhood_cap_reports_truncation(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(
+        cluster, [_hit(ALPHA_P), _hit(BETA_P)], max_neighbors=1
+    )
+    assert len(pack["neighborhood"]) == 1
+    assert pack["neighborhood"][0]["path"] == HUB_P
+    assert any("neighborhood" in t for t in pack["truncation"])
+
+
+# ---------------------- contradictions / supersession ----------------------
+
+def test_supersession_edge_from_frontmatter(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(OLD_P), _hit(NEW_P)])
+    edges = pack["contradictions"]["superseded"]
+    assert {"from": OLD_P, "to": NEW_P, "kind": "supersession"} in edges
+    # supersession needs no embeddings.
+    assert pack["embeddings_available"] is False
+
+
+def test_embeddings_off_degrades_gracefully(cluster: Path) -> None:
+    # Default suite env has embeddings disabled (conftest autouse).
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P), _hit(BETA_P)])
+    assert pack["embeddings_available"] is False
+    assert pack["contradictions"]["tension"] == []
+    # The non-embedding parts are still populated.
+    assert pack["claims"] and pack["neighborhood"]
+
+
+def test_tension_pairs_only_in_band(cluster: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_bcpf(vault_root, *, title, body, k: int = 15):
+        if title.startswith("Alpha"):
+            # Beta in band [0.82,0.90); Charlie above (a near-dup, excluded).
+            return {BETA_P: 0.85, CHARLIE_P: 0.95}
+        if title.startswith("Beta"):
+            return {ALPHA_P: 0.85}
+        return {}
+
+    monkeypatch.setattr(corpus_aware, "_best_cosine_per_file", fake_bcpf)
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P), _hit(BETA_P)])
+
+    tension = pack["contradictions"]["tension"]
+    assert pack["embeddings_available"] is True
+    assert len(tension) == 1
+    pair = tension[0]
+    assert {pair["a"], pair["b"]} == {ALPHA_P, BETA_P}
+    assert pair["cosine"] == 0.85
+    assert "polarity" in pair["note"]
+
+
+# ------------------------------ bounds / determinism ------------------------------
+
+def test_packed_paths_bounded_by_max_hits(cluster: Path) -> None:
+    hits = [_hit(ALPHA_P), _hit(BETA_P), _hit(HUB_P)]
+    pack = context_pack.assemble_pack(cluster, hits, max_hits=2)
+    assert pack["packed_paths"] == [ALPHA_P, BETA_P]
+    assert any("hits" in t for t in pack["truncation"])
+
+
+def test_deterministic_on_rerun(cluster: Path) -> None:
+    hits = [_hit(ALPHA_P), _hit(BETA_P)]
+    assert context_pack.assemble_pack(cluster, hits) == context_pack.assemble_pack(
+        cluster, hits
+    )
+
+
+def test_empty_hits_yield_empty_pack(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [])
+    assert pack["packed_paths"] == []
+    assert pack["claims"] == {}
+    assert pack["neighborhood"] == []
+    assert pack["contradictions"] == {"superseded": [], "tension": []}
+
+
+def test_duplicate_hits_are_deduped(cluster: Path) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(OLD_P), _hit(OLD_P), _hit(NEW_P)])
+    assert pack["packed_paths"] == [OLD_P, NEW_P]
+    # the supersession edge is not double-counted.
+    assert pack["contradictions"]["superseded"] == [
+        {"from": OLD_P, "to": NEW_P, "kind": "supersession"}
+    ]
+
+
+def test_missing_hit_file_is_reported_not_silent(cluster: Path) -> None:
+    gone = "Knowledge Base/Notes/DoesNotExist.md"
+    pack = context_pack.assemble_pack(cluster, [_hit(ALPHA_P), _hit(gone)])
+    assert pack["packed_paths"] == [ALPHA_P]
+    assert any("unreadable or missing" in t for t in pack["truncation"])
+
+
+# ------------------------------ integration via op_find ------------------------------
+
+def test_op_find_pack_false_returns_bare_list(vault: Path) -> None:
+    from kb_mcp import commands
+
+    result = commands.op_find(vault, query="insulin", pack=False)
+    assert isinstance(result, list)
+
+
+def test_op_find_pack_true_returns_hits_and_pack(vault: Path) -> None:
+    from kb_mcp import commands
+
+    result = commands.op_find(vault, query="insulin", pack=True)
+    assert isinstance(result, dict)
+    assert set(result) == {"hits", "pack"}
+    assert isinstance(result["hits"], list)
+    pack = result["pack"]
+    assert set(pack) >= {
+        "packed_paths",
+        "claims",
+        "neighborhood",
+        "contradictions",
+        "embeddings_available",
+        "truncation",
+    }


### PR DESCRIPTION
## What

Direction 3 of the post-moat roadmap: **reasoning-ready context packs from `find`.**

`find` gains an optional `pack` parameter (default off — byte-identical to today). With
`pack=true`, the `op_find` leaf returns `{"hits": [...], "pack": {...}}` where the pack is
an assembled, reasoning-ready context over the top hits, so Claude reasons in one shot
instead of fanning out `get` calls and chasing wikilinks by hand:

- **key claims**, extracted **structurally** (lede + recognized headline-section lines +
  the `##` heading outline) — never generated by a model;
- the **1-hop wikilink neighbourhood** of the packed notes (inbound + outbound), packed
  notes excluded, ranked by **co-citation**;
- **contradictions among the set**: recorded **supersession** edges (frontmatter) + proximity
  **tension** pairs whose cosine sits in the existing `[floor, dup)` band (proximity, not
  polarity — the reader decides).

## Pure-substrate line

Pure measurement: no server-side LLM, no vault mutation, `find` ordering unchanged. The
tension part soft-fails to empty (`embeddings_available: false`) when the embedding sidecar
is off, so the rest of the pack still assembles. Every cap (hits / neighbours / tension,
all env-overridable) is reported in `truncation` — no silent drops.

## Shape of the change

- New `src/kb_mcp/context_pack.py` (mirrors `attention.py`), reusing `find`'s
  outbound-link resolution + `_CACHE`, `vault.find_inbound_wikilinks`, and
  `corpus_aware._best_cosine_per_file` + the contradiction band.
- The list↔dict polymorphism is confined to the `op_find` leaf; `find()`'s core
  signature/return and its 100+ tests are untouched.
- MCP schema-fidelity fixture regenerated — the **only** delta is `find`'s new `pack`
  boolean property.
- Specced as OpenSpec change `add-context-packs` (proposal / design / specs / tasks).

## Tests / verification

- New `tests/test_context_pack.py` (torch-free): structural claims (fence-aware), co-citation
  neighbourhood + exclusion + direction, supersession edges, truncation, embeddings-off
  degradation, tension band via injected cosines, dedupe + missing-file reporting, determinism;
  plus an `op_find(pack=true)` integration test.
- Full suite: **814 passed, 6 skipped** (1 pre-existing `import torch` collection error in an
  unrelated diarization test — the worktree venv lacks the torch/embeddings extra; this change
  is torch-free). `ruff check` clean. `openspec validate add-context-packs --strict` passes.
  CLI smoke confirms `kb find --pack --json` returns `{hits, pack}` and the no-pack form is
  still a list.
- A separate code-review pass approved with no blockers; its cheap, clearly-correct findings
  (duplicate-hit dedupe, missing-file reporting, `max_tension<=0` sentinel, lede bullet-strip,
  `embeddings_available` honesty under an inverted band) are folded in. The one perf note
  (per-call inbound full-vault rescans on the opt-in path) is documented as a follow-up in
  `design.md`.

## Deploy

Additive + read-only. The changed `find` schema needs the claude.ai connector reconnected to
pick up the `pack` param; REST/CLI need only a restart. A live `find(pack=true)` on the deploy
box (embeddings on) will confirm `tension` pairs populate from the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8uujJrqb3frA3H581HgT2
