### PR TITLE
perf(auth): cache GitHub token validation + un-redden lean CI

### DIFF
--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -22,10 +22,12 @@ Transports:
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
 import secrets
+import time
 from pathlib import Path
 
 import mcp.types
@@ -214,13 +216,48 @@ def _server_icons() -> list[mcp.types.Icon]:
 
 
 class SingleUserGitHubVerifier(GitHubTokenVerifier):
-    """Reject any GitHub token whose login isn't the allowed user."""
+    """Reject any GitHub token whose login isn't the allowed user.
+
+    Caches *validated* tokens for a short TTL (``KB_MCP_AUTH_CACHE_TTL`` seconds,
+    default 300). Without it every MCP request — and a single connector operation
+    fires several (ListTools + ListResources + ListPrompts + CallTool) — re-hits the
+    GitHub API to revalidate the same token, adding seconds of `api.github.com`
+    round-trips to the hot path. GitHub OAuth-App tokens carry no time-expiry, so the
+    only invalidation is a deliberate revoke / secret rotation, and a re-authorized
+    client presents a *new* token (a new cache key) that validates immediately — so
+    the TTL only bounds how long a revoked-but-still-presented token keeps working,
+    which doesn't happen for a single user. Only successes are cached (a rejection is
+    re-checked every call, so recovery is instant); set the TTL to 0 to disable.
+    """
+
+    _DEFAULT_TTL = 300.0
+    _MAX_ENTRIES = 64  # single user → tiny; cap guards against unbounded distinct tokens
 
     def __init__(self, *, allowed_login: str, **kwargs):
         super().__init__(**kwargs)
         self._allowed_login = allowed_login.lower()
+        self._cache: dict[str, tuple[float, AccessToken]] = {}
+
+    def _ttl(self) -> float:
+        raw = os.environ.get("KB_MCP_AUTH_CACHE_TTL")
+        if raw is None:
+            return self._DEFAULT_TTL
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            return self._DEFAULT_TTL
 
     async def verify_token(self, token: str) -> AccessToken | None:
+        ttl = self._ttl()
+        key = hashlib.sha256(token.encode("utf-8")).hexdigest() if token else ""
+        if ttl > 0 and key:
+            hit = self._cache.get(key)
+            if hit is not None:
+                ts, cached = hit
+                if time.monotonic() - ts < ttl:
+                    return cached
+                del self._cache[key]  # expired
+
         access = await super().verify_token(token)
         if access is None:
             # GitHub rejected the token (expired / revoked / invalid). This is what
@@ -234,6 +271,15 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
         if login != self._allowed_login:
             log.warning("rejecting token for github login=%r", login)
             return None
+
+        if ttl > 0 and key:
+            now = time.monotonic()
+            if len(self._cache) >= self._MAX_ENTRIES:
+                # Drop expired entries before inserting; cheap, the cache is tiny.
+                self._cache = {
+                    k: v for k, v in self._cache.items() if now - v[0] < ttl
+                }
+            self._cache[key] = (now, access)
         return access
 
 

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -1,0 +1,106 @@
+"""SingleUserGitHubVerifier's TTL cache for validated GitHub tokens.
+
+The real GitHub round-trip (`super().verify_token`) is stubbed with a call-counter so
+these tests assert the *caching contract* without any network: a validated token is
+served from cache within the TTL, distinct tokens validate independently, rejections are
+never cached (instant recovery), and TTL=0 disables caching.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+
+from kb_mcp.server import SingleUserGitHubVerifier
+
+ALLOWED = "artexis10"
+
+
+def _verifier() -> SingleUserGitHubVerifier:
+    return SingleUserGitHubVerifier(allowed_login=ALLOWED)
+
+
+def _stub_super(monkeypatch: pytest.MonkeyPatch, *, login: str | None):
+    """Patch the parent verify_token to count calls; returns the call counter.
+
+    `login=None` simulates GitHub rejecting the token (returns None)."""
+    calls = {"n": 0}
+
+    async def fake(self, token):  # noqa: ANN001 — test stub
+        calls["n"] += 1
+        if login is None:
+            return None
+        return SimpleNamespace(claims={"login": login}, token=token)
+
+    monkeypatch.setattr(GitHubTokenVerifier, "verify_token", fake)
+    return calls
+
+
+def test_validated_token_is_served_from_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch, login=ALLOWED)
+    v = _verifier()
+
+    a1 = asyncio.run(v.verify_token("tok"))
+    a2 = asyncio.run(v.verify_token("tok"))
+
+    assert a1 is not None and a2 is a1  # same cached object
+    assert calls["n"] == 1  # second call hit the cache, not GitHub
+
+
+def test_distinct_tokens_validate_independently(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch, login=ALLOWED)
+    v = _verifier()
+
+    asyncio.run(v.verify_token("tok-a"))
+    asyncio.run(v.verify_token("tok-b"))
+
+    assert calls["n"] == 2  # different cache keys → each validated once
+
+
+def test_expired_entry_revalidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch, login=ALLOWED)
+    v = _verifier()
+
+    asyncio.run(v.verify_token("tok"))
+    # Rewind the cached timestamp well past the TTL to simulate expiry.
+    (key,) = v._cache.keys()
+    ts, access = v._cache[key]
+    v._cache[key] = (ts - 10_000.0, access)
+    asyncio.run(v.verify_token("tok"))
+
+    assert calls["n"] == 2  # expired → re-hit GitHub
+
+
+def test_github_rejection_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch, login=None)  # GitHub says no
+    v = _verifier()
+
+    assert asyncio.run(v.verify_token("tok")) is None
+    assert asyncio.run(v.verify_token("tok")) is None
+    assert calls["n"] == 2  # re-checked each time — recovery is instant after re-auth
+    assert not v._cache
+
+
+def test_wrong_login_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch, login="someone-else")
+    v = _verifier()
+
+    assert asyncio.run(v.verify_token("tok")) is None
+    assert asyncio.run(v.verify_token("tok")) is None
+    assert calls["n"] == 2  # only the *allowed* login is ever cached
+    assert not v._cache
+
+
+def test_ttl_zero_disables_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_MCP_AUTH_CACHE_TTL", "0")
+    calls = _stub_super(monkeypatch, login=ALLOWED)
+    v = _verifier()
+
+    asyncio.run(v.verify_token("tok"))
+    asyncio.run(v.verify_token("tok"))
+
+    assert calls["n"] == 2  # caching off → every call revalidates
+    assert not v._cache

--- a/tests/test_diarizer_sidecar.py
+++ b/tests/test_diarizer_sidecar.py
@@ -142,14 +142,18 @@ def test_child_env_cpu_forces_cuda_off(monkeypatch) -> None:
 
 
 def test_child_env_cuda_keeps_gpu_and_strips_nvidia_bins(monkeypatch) -> None:
+    # Colon-free, pathsep-portable entries: a Windows drive path ("C:\\Windows") contains
+    # `:`, which IS os.pathsep on Linux — joining/splitting it on the CI runner shatters the
+    # drive letter. `_is_nvidia_wheel_bin` normalizes separators, so unix-style paths still
+    # exercise the strip on every platform (mirrors test_child_env_cpu_forces_cuda_off).
     monkeypatch.setenv("KB_MCP_DIARIZE_DEVICE", "cuda")
     monkeypatch.setenv(
-        "PATH", os.pathsep.join(["C:\\Windows", "C:\\v\\nvidia\\cublas\\bin", "C:\\v\\nvidia\\cudnn\\bin"])
+        "PATH", os.pathsep.join(["/usr/bin", "/x/nvidia/cublas/bin", "/x/nvidia/cudnn/bin"])
     )
     env = extract._diarizer_child_env()
     assert env.get("CUDA_VISIBLE_DEVICES", "x") != ""  # GPU stays visible (not blanked)
     parts = env["PATH"].split(os.pathsep)
-    assert "C:\\Windows" in parts  # non-nvidia entries kept
+    assert "/usr/bin" in parts  # non-nvidia entries kept
     assert not any("nvidia" in p.lower() for p in parts)  # cu12 wheel bins stripped → no cuDNN shadow
 
 

--- a/tests/test_voice_embed.py
+++ b/tests/test_voice_embed.py
@@ -8,9 +8,15 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import torch
 
-from kb_mcp import voice_embed
+# The embeddings/voice extra (torch) isn't installed in lean CI — skip the whole module
+# there instead of erroring on collection, which is what reddened the `tests` workflow on
+# every PR. Mirrors the importorskip gate the other model-loading tests already use.
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from kb_mcp import voice_embed  # noqa: E402
 
 
 def test_voice_device_env_and_asr_gating(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Two small, independent wins from the context-packs session.

## 1. Cache validated GitHub tokens (`perf(auth)`)
Every MCP request re-validated the bearer token against the GitHub API, and a single connector operation fires several requests (ListTools + ListResources + ListPrompts + CallTool) — so each one paid repeated `api.github.com/user`(+`/user/repos`) round-trips on the hot path. `SingleUserGitHubVerifier` now caches **validated** tokens in-process for `KB_MCP_AUTH_CACHE_TTL` seconds (default **300**), keyed by `sha256(token)`.

**Threat model (single-user server):** OAuth-App tokens carry no time-expiry, and a re-authorized client presents a **new** token (new cache key) that validates immediately — so the TTL only bounds how long a *revoked-but-still-presented* token would keep working, which doesn't happen for one user. Only **successes** are cached (a rejection or wrong-login is re-checked every call, so recovery is instant); `TTL=0` disables it; a 64-entry cap prunes expired entries.

## 2. Un-redden lean CI (`test(ci)`)
`tests/test_voice_embed.py` hard-imported `torch` at module top, so the lean CI runner (no embeddings extra) **errored during collection** — turning the `tests` workflow red on every PR (#63–#70 all merged over it). Guarded with the same `pytest.importorskip("torch")` gate the other model-loading tests use, so it skips cleanly. **This PR's own CI should now be green**, proving the fix.

## Verify
- New `tests/test_auth_cache.py` (6 tests, network-free): cache hit, distinct tokens, TTL expiry, rejection-not-cached, wrong-login-not-cached, TTL=0 disables.
- Full lean suite: **822 passed, 7 skipped, 0 errors** (was 814/6/**1 collection error**). `ruff` clean.

## Deploy
The auth change is in the live request path — needs a service restart to take effect (no connector reconnect, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8uujJrqb3frA3H581HgT2