### PR TITLE
refactor(scaffold): drop residual personal taxonomy from shipped defaults

### DIFF
--- a/src/kb_mcp/_scaffold/_Schema/SKILL.md
+++ b/src/kb_mcp/_scaffold/_Schema/SKILL.md
@@ -437,7 +437,7 @@ The `project` field on a research note is a slug-shaped key registered in
 most-specific scope first. A typical starter set:
 
 - Products / projects: `project-alpha`, `project-beta` — one key per project.
-- Domains: `work`, plus your own (`health`, `finance`, `creative`, …).
+- Domains: `work`, plus your own (`research`, `ops`, …).
 - Cross-cutting: `personal` — anything not tied to a specific project or domain.
 
 For **patterns** that apply across multiple projects, use `projects:` (plural
@@ -449,8 +449,8 @@ slug-shaped project keys to `_Schema/project-keys.yaml` and create the matching
 `Notes/Research/<Folder>/` directory on first use — no manual YAML edit needed.
 Pass `project_category` to bucket the new key (product / activity / domain /
 cross-cutting); omitted, it lands `uncategorized`. A **typo guard** rejects new
-keys within edit distance ≤2 of an existing key (`helath` → "Did you mean
-'health'?") so the registry stays clean.
+keys within edit distance ≤2 of an existing key (`wrok` → "Did you mean
+'work'?") so the registry stays clean.
 
 ### Experiment vs production-log
 

--- a/src/kb_mcp/_scaffold/_Schema/references/frontmatter.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/frontmatter.md
@@ -52,7 +52,7 @@ These appear on every page type:
 
 | Field | Required | Notes |
 |---|---|---|
-| `domain` | yes | `food`, `health`, `workflow`, etc. — matches the subfolder under `Notes/Experiments/` |
+| `domain` | yes | `workflow`, `research`, `ops`, etc. — matches the subfolder under `Notes/Experiments/` |
 | `started` | yes | ISO date the experiment actually began (may differ from `created` if planning preceded execution) |
 | `duration` | yes | freeform string: `"30 days"`, `"2 weeks"`, `"ongoing"` |
 | `concluded` | optional | ISO date the experiment ended; absent while ongoing |
@@ -65,7 +65,7 @@ These appear on every page type:
 
 | Field | Required | Notes |
 |---|---|---|
-| `medium` | yes | `reels`, `episodes`, `pdfs`, `posts`, etc. — matches the subfolder under `Notes/Productions/` |
+| `medium` | yes | `posts`, `articles`, `pdfs`, `episodes`, etc. — matches the subfolder under `Notes/Productions/` |
 | `status` | yes | one of: `planned`, `recorded`, `edited`, `published`, `reflected`, `dropped`, `archived`. Different from other page types — production-logs have lifecycle states. |
 | `recorded` | optional | ISO date primary capture happened |
 | `published` | optional | ISO date or `null` while still pre-publish |
@@ -159,17 +159,17 @@ tags: [retrieval, agentic-rag, knowledge-graph, governance]
 ```yaml
 ---
 type: experiment
-domain: food
+domain: workflow
 status: active
 created: 2026-05-01
 updated: 2026-05-09
 started: 2026-05-09
 duration: "30 days"
 n: 1
-hypothesis: "Eliminating dairy reduces sinus inflammation"
+hypothesis: "Batching code review into one daily slot cuts context-switching"
 sources:
-  - "[[Knowledge Base/Sources/Books/2026-04-the-elimination-diet]]"
-tags: [diet, elimination, sinus]
+  - "[[Knowledge Base/Sources/Books/2026-04-deep-work]]"
+tags: [workflow, batching, focus]
 ---
 ```
 
@@ -178,20 +178,20 @@ tags: [diet, elimination, sinus]
 ```yaml
 ---
 type: production-log
-medium: reels
+medium: posts
 status: recorded
 created: 2026-05-09
 updated: 2026-05-09
 recorded: 2026-05-09
 published: null
-projects: [example-podcast]
+projects: [project-alpha]
 host: the host
 editor: a teammate
 sources:
-  - "[[Knowledge Base/Sources/Sessions/2026-05-09-curriculum-design]]"
+  - "[[Knowledge Base/Sources/Sessions/2026-05-09-launch-planning]]"
 related:
-  - "[[Knowledge Base/Notes/Research/Health/metabolic-literacy-curriculum]]"
-  - "[[Knowledge Base/Notes/Patterns/conversational-reel-script]]"
-tags: [reels, metabolism, batch-02]
+  - "[[Knowledge Base/Notes/Research/Project Alpha/launch-messaging]]"
+  - "[[Knowledge Base/Notes/Patterns/short-form-post-template]]"
+tags: [posts, launch, batch-01]
 ---
 ```

--- a/src/kb_mcp/_scaffold/_Schema/references/operations.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/operations.md
@@ -122,7 +122,7 @@ to one of six compiled-page types: `research-note`, `insight`, `failure`,
 ### Triggers
 - "create an entity for X," "add a concept page for Y"
 - "this references [[X]]" where X doesn't exist yet (offered as a side-effect of `note`)
-- "add Karpathy to People," "add pgvector to Libraries"
+- "add Ada Lovelace to People," "add pgvector to Libraries"
 
 ### Inputs to gather
 - Entity name (becomes filename — see `page-types.md` § entity naming)

--- a/src/kb_mcp/_scaffold/_Schema/references/page-types.md
+++ b/src/kb_mcp/_scaffold/_Schema/references/page-types.md
@@ -214,8 +214,8 @@ Conditions where it's a regression.
 
 ## experiment
 
-**Location:** `Notes/Experiments/<domain>/` where domain is `Food`, or another
-sub-domain that emerges (`Health`, `Workflow`, etc.). Add a new sub-domain only
+**Location:** `Notes/Experiments/<domain>/` where domain is `Workflow`, or another
+sub-domain that emerges (`Research`, `Ops`, etc.). Add a new sub-domain only
 when the first experiment in that domain is being written.
 **Naming:** `YYYY-MM-<slug>.md` — date-prefixed because experiments are time-bounded events, not evolving notes. Use the **start month**.
 **Mutability:** Editable while ongoing; once concluded, body is read-only except for supersession or follow-up notes that link back.
@@ -226,17 +226,17 @@ when the first experiment in that domain is being written.
 ```markdown
 ---
 type: experiment
-domain: food
+domain: workflow
 status: active
 created: 2026-05-09
 updated: 2026-05-09
 started: 2026-05-09
 duration: "30 days"
 n: 1
-hypothesis: "Eliminating dairy reduces sinus inflammation"
+hypothesis: "Batching code review into one daily slot cuts context-switching"
 sources:
-  - "[[Knowledge Base/Sources/Books/2026-04-the-elimination-diet]]"
-tags: [diet, elimination, sinus]
+  - "[[Knowledge Base/Sources/Books/2026-04-deep-work]]"
+tags: [workflow, batching, focus]
 ---
 
 # <Experiment name>
@@ -282,8 +282,8 @@ about* something and synthesize? First → experiment. Second → research-note.
 
 ## production-log
 
-**Location:** `Notes/Productions/<medium>/` where medium is `Reels`, `Episodes`,
-`PDFs`, `Posts`, or another medium that emerges. Add a new medium subfolder only
+**Location:** `Notes/Productions/<medium>/` where medium is `Posts`, `Articles`,
+`PDFs`, `Episodes`, or another medium that emerges. Add a new medium subfolder only
 when the first production in that medium is being written.
 **Naming:** `YYYY-MM-<slug>.md` — date-prefixed by start month.
 **Mutability:** Editable across the production lifecycle (planned → recorded → edited → published → reflected). Once complete and reflection is logged, treat as read-only except for supersession.
@@ -303,21 +303,21 @@ when the first production in that medium is being written.
 ```markdown
 ---
 type: production-log
-medium: reels
+medium: posts
 status: recorded
 created: 2026-05-09
 updated: 2026-05-09
 recorded: 2026-05-09
 published: null
-projects: [example-podcast]
+projects: [project-alpha]
 host: the host
 editor: a teammate
 sources:
-  - "[[Knowledge Base/Sources/Sessions/2026-05-09-curriculum-design]]"
+  - "[[Knowledge Base/Sources/Sessions/2026-05-09-launch-planning]]"
 related:
-  - "[[Knowledge Base/Notes/Research/Health/metabolic-literacy-curriculum]]"
-  - "[[Knowledge Base/Notes/Patterns/conversational-reel-script]]"
-tags: [reels, metabolism, batch-02]
+  - "[[Knowledge Base/Notes/Research/Project Alpha/launch-messaging]]"
+  - "[[Knowledge Base/Notes/Patterns/short-form-post-template]]"
+tags: [posts, launch, batch-01]
 ---
 
 # <Production batch name>
@@ -392,12 +392,12 @@ entity_type: person
 status: active
 created: 2026-05-09
 updated: 2026-05-09
-affiliation: Tesla / OpenAI alumnus
+affiliation: independent researcher
 relationship: public-figure
-tags: [ml, llm]
+tags: [research, methods]
 ---
 
-# Andrej Karpathy
+# Jordan Lee
 
 ## Summary
 
@@ -466,7 +466,7 @@ What this commits us to and what it forecloses.
 - Sources: date-prefixed, dash-slug, lowercase: `2026-05-09-retrieval-patterns.md`
 - Notes (research, insight, failure, pattern): no date prefix, dash-slug, lowercase: `agentic-rag-retrieval-budget.md`
 - Experiments: date-prefixed (start month), dash-slug, lowercase: `2026-05-30-day-low-carb.md`
-- Production-logs: date-prefixed (start month), dash-slug, lowercase: `2026-05-metabolism-basics.md`
+- Production-logs: date-prefixed (start month), dash-slug, lowercase: `2026-05-launch-recap.md`
 - Entities — People: working short used in daily reference; H1 carries the long form when it differs.
 - Entities — Concepts / Libraries / Decisions: Title Case, canonical name.
 

--- a/src/kb_mcp/note.py
+++ b/src/kb_mcp/note.py
@@ -60,30 +60,6 @@ NOTE_TYPES = (
     "experiment", "production-log",
 )
 
-# NOTE: PROJECT_KEYS and PROJECT_TO_FOLDER are now loaded from
-# `Knowledge Base/_Schema/project-keys.yaml` at validation time. The module-
-# level constants below are kept as references for tests/back-compat but are
-# NOT consulted by the live writer — use `_load_keys(vault_root)` instead.
-# To add a new project: edit project-keys.yaml in the vault, no code change
-# needed. See kb_mcp/project_keys.py for the loader.
-PROJECT_KEYS = (
-    "personal", "work", "project-alpha", "project-beta", "book-club",
-    "health", "finance", "creative", "science", "travel",
-)
-
-PROJECT_TO_FOLDER: dict[str, str] = {
-    "personal": "Personal",
-    "work": "Work",
-    "project-alpha": "Project Alpha",
-    "project-beta": "Project Beta",
-    "book-club": "Book Club",
-    "health": "Health",
-    "finance": "Finance",
-    "creative": "Creative",
-    "science": "Science",
-    "travel": "Travel",
-}
-
 
 def _load_keys(vault_root: Path) -> project_keys_module.ProjectRegistry:
     """Load the live project registry (from `_Schema/project-keys.yaml`)."""
@@ -634,7 +610,7 @@ def _resolve_path(
         assert project is not None  # validated above
         # Use live registry so auto-registered keys resolve to their folder.
         registry = _load_keys(vault_root)
-        folder_name = registry.folder_for(project) or PROJECT_TO_FOLDER.get(project, project.capitalize())
+        folder_name = registry.folder_for(project) or project.capitalize()
         folder = kb / "Notes" / "Research" / folder_name
         stem = slug
     elif note_type == "insight":

--- a/src/kb_mcp/project_keys.py
+++ b/src/kb_mcp/project_keys.py
@@ -7,10 +7,9 @@ insights/failures/patterns/production-logs.
 Adding a key is a YAML edit, not a code change. Validation in `note.py`
 calls into this module to get the current accepted set + folder mapping.
 
-If the YAML is missing or unparseable we fall back to a built-in safe
-default so the writer never refuses every project key. The fallback
-mirrors what was hardcoded before the config existed; a warning lands in
-the service log when it fires.
+If the YAML is missing or unparseable we fall back to a small neutral
+starter set so the writer never refuses every project key; a warning
+lands in the service log when it fires.
 """
 
 from __future__ import annotations
@@ -27,20 +26,15 @@ from .vault import kb_root
 log = logging.getLogger(__name__)
 
 
-# Fallback used when project-keys.yaml is missing or malformed. Matches the
-# pre-config hardcoded set so the writer keeps accepting all historical keys
-# even if the config disappears.
+# Fallback used when project-keys.yaml is missing or malformed. A neutral
+# starter set matching `_scaffold/_Schema/project-keys.yaml`, so a vault whose
+# config disappeared still accepts the shipped defaults. Real scopes live in the
+# vault's project-keys.yaml and auto-register on first write.
 _FALLBACK_PROJECTS: dict[str, str] = {
     "personal": "Personal",
-    "work": "Work",
     "project-alpha": "Project Alpha",
     "project-beta": "Project Beta",
-    "book-club": "Book Club",
-    "health": "Health",
-    "finance": "Finance",
-    "creative": "Creative",
-    "science": "Science",
-    "travel": "Travel",
+    "work": "Work",
 }
 
 

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -965,7 +965,7 @@
             }
           ],
           "default": null,
-          "description": "REQUIRED for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, work, project-alpha, project-beta, book-club, health, finance, creative, science, travel."
+          "description": "REQUIRED for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
         },
         "projects": {
           "anyOf": [
@@ -980,7 +980,7 @@
             }
           ],
           "default": null,
-          "description": "List of project keys (plural). Optional for insight,\nfailure, pattern, production-log. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, work, project-alpha, project-beta, book-club, health, finance, creative, science, travel."
+          "description": "List of project keys (plural). Optional for insight,\nfailure, pattern, production-log. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
         },
         "sources": {
           "anyOf": [

--- a/tests/test_project_keys.py
+++ b/tests/test_project_keys.py
@@ -191,11 +191,11 @@ def test_note_surfaces_typo_as_project_key_typo_error(vault: Path) -> None:
             content="# Note\n\n## Question\n\nbody",
             note_type="research-note",
             title="Typo probe",
-            project="helath",  # missing 't' — distance 1 from "health"
+            project="wrok",  # transposed — distance 2 from "work"
             today=TODAY,
         )
     assert exc_info.value.code == "PROJECT_KEY_TYPO"
-    assert "health" in exc_info.value.reason  # suggestion present
+    assert "work" in exc_info.value.reason  # suggestion present
 
 
 def test_set_frontmatter_field_blocks_project_typo(vault: Path) -> None:
@@ -249,12 +249,12 @@ def test_link_decision_blocks_project_typo(vault: Path) -> None:
             entity_type="decision",
             name="Test Decision",
             summary="testing typo guard via link",
-            project="helath",  # distance 1 from "health"
+            project="wrok",  # distance 2 from "work"
             decision_status="proposed",
             today=TODAY,
         )
     assert exc_info.value.code == "PROJECT_KEY_TYPO"
-    assert "health" in exc_info.value.reason
+    assert "work" in exc_info.value.reason
 
 
 def test_link_decision_autoregisters_new_project(vault: Path) -> None:


### PR DESCRIPTION
## Problem
The shipped *generic* scaffold + source still encoded the author's domain **taxonomy/flavor** (not identity — so `test_scaffold_no_leak.py` passed). A new user inherited "dairy-elimination experiment" / "reels batch-02 podcast" / "Karpathy" as starter examples, and `_FALLBACK_PROJECTS` quietly shipped `health/finance/creative/science/travel/book-club` as defaults. This violates the project's own "ship mechanics, not the personal taxonomy" line.

## Changes
- **`project_keys.py`** — trim `_FALLBACK_PROJECTS` to the 4 neutral keys that match `_scaffold/_Schema/project-keys.yaml` (`personal`, `project-alpha`, `project-beta`, `work`). Used only when a vault's `project-keys.yaml` is missing/broken; real scopes auto-register on first write.
- **`note.py`** — delete the dead `PROJECT_KEYS` / `PROJECT_TO_FOLDER` module constants (documented as not consulted at runtime; imported by zero tests); the folder fallback now uses `project.capitalize()`.
- **`_scaffold/_Schema/references/{frontmatter,page-types,operations}.md` + `SKILL.md`** — genericize flavored examples → a neutral `workflow` experiment, a `posts` production-log, a fictional person entity; typo illustration `helath→health` → `wrok→work`.
- **`tests/test_project_keys.py`** — retarget the two typo probes from `helath/health` to `wrok/work` (a retained key).
- **`tests/fixtures/mcp_tool_schemas.json`** — regenerate; the `note` hint now lists the 4 neutral keys (diff is exactly those two strings).

## Verification
- `pytest`: **822 passed, 7 skipped** (skips are torch/sentence-transformers/PIL/diarizer — lean env, unrelated).
- `git grep` of the scaffold for `food|dairy|sinus|reels|metabolic|Karpathy|...` → empty.
- Fixture diff scoped to the two `note` description strings only.
- `ruff` is advisory in CI; this PR introduces no new violations.

First of three PRs in the config-driven-convergence plan (make kb-mcp genuinely generic for other users; collapse the personal fork into config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)