### PR TITLE
feat(evolution): thinking-evolution view — supersession chains as timelines

### DIFF
--- a/openspec/changes/add-thinking-evolution/design.md
+++ b/openspec/changes/add-thinking-evolution/design.md
@@ -1,0 +1,111 @@
+# Design — Thinking-evolution view (`evolution`)
+
+## Context
+
+Supersession is recorded as a clean doubly-linked list in frontmatter (see
+`_scaffold/_Schema/references/supersession.md`, enforced by `audit`):
+
+- The **old** page: `status: superseded`, `superseded_by: "[[new]]"`, a refreshed
+  `updated:` date, and a body banner `> [!warning] Superseded … on <date>. Reason: <one-line>`.
+- The **new** page: `supersedes: "[[old]]"`.
+- `replace` writes both pointers atomically and **refuses to supersede an already-superseded
+  page** — so a chain is linear (no forks) and traversable from any member.
+
+`find.ParsedPage` already exposes `.superseded_by` (forward) and `.status`; `find._CACHE`
+loads pages cheaply; `context_pack._extract_claims(page)` already turns a page into
+structural claims (lede + recognized headline-section lines + `##` outline). `attention.py`
+is the precedent for a measurement-only "assemble + bound + explicit truncation" surface
+reachable from one registry entry.
+
+## The composition
+
+`evolution(vault_root, *, query, limit, scope, projects, tags)`:
+
+1. `find(vault_root, query=query, scope=scope, projects=projects, tags=tags, limit=…)` —
+   topic matches (overfetch a few × `limit`, since several hits collapse into one chain).
+2. For each hit, **resolve its chain** via `_resolve_chain`: load the page, walk forward
+   following `superseded_by` and backward following `supersedes`, loading each via `_CACHE`,
+   guarded by a `seen` set (linear chain, but guard cycles defensively). Collect the member
+   pages.
+3. **Dedup + filter:** key each chain by its active-head path (the member with no
+   `superseded_by`); a hit landing anywhere on an already-seen chain is skipped. Drop chains
+   with `< 2` versions (a never-superseded note has no evolution to show).
+4. **Order** each chain by the pointer spine: origin (no in-set `supersedes`) → follow
+   `superseded_by` → head. The pointer order IS chronological; dates annotate each node.
+5. Build a `Timeline` of `Version`s and cap to `limit` chains (find-relevance order),
+   reporting truncation.
+
+`find()` and the core ranker are untouched; the new logic lives in `evolution.py` + the
+`op_evolution` leaf.
+
+## Output
+
+```
+{ "query": ...,
+  "timelines": [ {
+     "chain_id": <active-head rel path>,
+     "topic_anchor": <the hit rel path that surfaced this chain>,
+     "span": {"from": <oldest date>, "to": <newest date>, "n_versions": k},
+     "versions": [ {
+        "path", "title", "status", "date",                 # date = page.updated (or created)
+        "claims": {"lede", "sections", "outline"},          # context_pack._extract_claims
+        "transition": {"reason": <recorded text>, "date": <supersession date>} | null
+     }, ... ]                                               # oldest → newest; transition null on head
+  }, ... ],
+  "truncation": [...] }
+```
+
+## Decisions
+
+- **A dedicated `evolution` tool, not a `find` param.** The intent ("how did my thinking on
+  X evolve") routes cleanly to a named tool, and the operation **regroups** hits into chains
+  and walks pointers — a different output and shape than search. `find` already gained the
+  `pack` return-shape param; a second one would muddy it. Costs one always-loaded tool;
+  `attention` set that precedent. *(Rejected: `find(evolution=true)` — overloads find;
+  `get(path, evolution=true)` — elegant for a known note but forces a find-then-get two-step
+  for the topic-driven intent the user chose.)*
+- **Transition reason is the RECORDED text, never generated.** The load-bearing
+  pure-substrate decision. The reason a version was superseded comes from the old page's
+  banner (`Reason: …`) and/or the `why:` in `log.md` at that edit — surfaced verbatim. The
+  server never writes "your view shifted because…". Each version's claims are likewise the
+  note's own structural text. The reader infers the evolution.
+- **Order by the pointer spine, not by date.** `replace` refreshes the old page's `updated:`
+  to the supersession date, so dates alone can mis-order; the `supersedes`/`superseded_by`
+  links are the ground-truth sequence. Dates are surfaced as labels + the span.
+- **Drop length-1 chains.** A note never superseded has no evolution; including it would
+  make `evolution` a worse `find`. The tool only surfaces topics whose view actually moved.
+- **Chain resolution is frontmatter-only (no vault scan).** Both pointers are written by
+  `replace`, so walking is O(chain length) cached reads. A hand-authored note missing a
+  backward `supersedes` simply starts the chain there (graceful partial) — acceptable for
+  v1, and `audit` already flags missing pointers. No inbound full-vault scan (unlike the
+  context-pack neighbourhood) — chains are short and pointer-linked.
+- **`.supersedes` reader on `ParsedPage`.** Mirrors `.superseded_by`: returns the
+  `supersedes` wikilink(s) (list), empty when absent.
+- **Bounded, no silent caps.** `limit` chains (env-overridable default 10), each timeline
+  capped (`KB_MCP_EVOLUTION_MAX_VERSIONS`, default 25 — chains are short); every drop adds a
+  `truncation` line.
+
+## Pure-substrate justification
+
+Every field is one of: text copied verbatim from a note (each version's claims, the
+recorded transition reasons), a supersession edge the user authored (the chain + its
+order), or a date the vault recorded. No content is summarized, paraphrased, or judged; no
+generative/reasoning model runs; the vault is unchanged and `find` ordering untouched. This
+is the same machinery and status as the context pack's structural claims and `attention`'s
+composition. An LLM narrating "how your thinking evolved" across the versions would be the
+out-of-bounds step; `evolution` stops at ordered assembly and hands the reasoning to the
+brain.
+
+## Risks
+
+- **Schema-fidelity fixture regenerated.** Adding a tool breaks
+  `tests/test_mcp_schema_fidelity.py` until `tests/fixtures/mcp_tool_schemas.json` is
+  regenerated via `scripts/dump-tool-schemas.py`; the diff must add only `evolution`.
+- **Tool ambiguity vs `find`.** Both take a query. The `evolution` description leads with
+  "how a conclusion CHANGED over time / its supersession history" and notes it returns
+  *timelines of superseded→active versions*, not a search, so natural-language selection
+  routes correctly. It also returns nothing for topics with no supersession — honestly
+  empty, with a note.
+- **Partial chains on hand-authored gaps.** A missing `supersedes` truncates the backward
+  walk; surfaced as-is (the chain just starts later). `audit` is the place that enforces the
+  pointers, not `evolution`.

--- a/openspec/changes/add-thinking-evolution/proposal.md
+++ b/openspec/changes/add-thinking-evolution/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+The Knowledge Base already records how a conclusion changed: supersession links every
+replaced note to its successor (`superseded_by`) and predecessor (`supersedes`), the old
+page keeps a dated banner with the reason, and `log.md` keeps the `why:` of each edit. But
+there is **no way to read that history as a story.** To answer "how did my view on X
+change?" today you must find the current note, notice it has a `supersedes` pointer, `get`
+the old one, read its banner, follow its `supersedes`, and repeat — many round-trips to
+reconstruct a chain that is already fully recorded on disk.
+
+This is direction 4 of the post-moat roadmap (the thinking-evolution view), the last of
+the four. It surfaces structure the vault already holds — pure measurement.
+
+## What Changes
+
+- **New `evolution` operation** (new module `src/kb_mcp/evolution.py`) — "how did my view
+  on X change over time." It takes a topic **query**, finds the matching notes, resolves
+  each into its full **supersession chain**, and returns one ordered **timeline** per
+  chain (oldest → newest).
+- **Chain resolution from frontmatter pointers.** For each hit it walks backward via
+  `supersedes` and forward via `superseded_by` (both written reliably by `replace`),
+  collapsing every member of one chain into a single timeline and de-duplicating hits that
+  land on the same chain. Chains of length 1 (a note never superseded — no evolution) are
+  dropped.
+- **Each timeline version carries its own structurally-extracted claims** (reusing
+  `context_pack._extract_claims`: lede + headline-section lines + `##` outline), its date,
+  and — on every non-head version — the **recorded transition reason** (the supersession
+  banner / the `why:` logged at the supersession edit). The active head carries no
+  transition.
+- **A `supersedes` reader on `ParsedPage`** (alongside the existing `superseded_by`), so
+  the backward walk is a clean frontmatter read.
+- **Registry entry** exposes `evolution` on MCP + REST (`/api/evolution`) + CLI
+  (`kb evolution`) from one `_SPEC` line, via the same leaf — no per-surface code.
+- The MCP schema-fidelity fixture is regenerated to include the new tool.
+
+It stays **pure-substrate**: every field is text the user wrote (each version's claims, the
+recorded transition reasons) or pointer/date arithmetic over the supersession graph the
+vault already records. **No server-side LLM, no generated "here's how your thinking
+changed" narrative** — the server orders the versions and surfaces each one's claims; the
+brain (Claude/Max) reads consecutive versions and infers the evolution. Read-only: it
+mutates nothing and does not touch `find` ordering. Same status as `find` / `attention` /
+the context pack.
+
+Out of scope (future, deliberately): in-place edit-history timelines (the finer-grained
+`log.md` `why:` stream within a single note — noisier, deferred); any LLM summary of the
+change; cross-chain synthesis.
+
+## Capabilities
+
+### Added Capabilities
+- `thinking-evolution`: an `evolution(query)` tool that returns, per supersession chain
+  matching the topic, an ordered timeline of every version with its structural claims,
+  date, and recorded transition reason — measurement-only, bounded with explicit
+  truncation, reachable on every surface.
+
+## Impact
+
+- Code: new `src/kb_mcp/evolution.py` (`build_timelines` pure builder + `evolution()`
+  entry + dataclasses). New `ParsedPage.supersedes` property in `find.py`. One
+  `op_evolution` leaf + one `_SPEC` entry in `commands.py`. The MCP schema-fidelity fixture
+  (`tests/fixtures/mcp_tool_schemas.json`) is regenerated to add the new tool.
+- Behaviour: purely additive — a new read-only tool. No existing tool, `find` ordering, or
+  the vault changes. Default-on (read-only and cheap: one `find` + short pointer walks;
+  claim extraction has no model dependency).
+- Tests: new `tests/test_evolution.py` (torch-free, tmp-vault chains): ordered timeline +
+  transitions, single-note chain excluded, multi-chain, dedup, truncation, determinism;
+  plus registry/surface assertions and an end-to-end `op_evolution` test.
+- Deploy: a new MCP tool requires reconnecting the claude.ai connector to appear; REST/CLI
+  need only a restart. No data migration.

--- a/openspec/changes/add-thinking-evolution/specs/thinking-evolution/spec.md
+++ b/openspec/changes/add-thinking-evolution/specs/thinking-evolution/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Topic-Driven Thinking-Evolution Timelines
+
+The system SHALL provide an `evolution` operation that accepts a topic query, finds the
+matching notes, resolves each into its supersession chain, and returns one ordered timeline
+per distinct chain (oldest version → newest). It SHALL de-duplicate hits that resolve to the
+same chain into a single timeline and SHALL exclude any chain with fewer than two versions (a
+note never superseded has no evolution to show).
+
+#### Scenario: A topic with a superseded conclusion returns its timeline
+
+- **WHEN** `evolution` is called with a query matching a note that has been superseded one or
+  more times
+- **THEN** it returns a single timeline for that chain whose `versions` run oldest to newest
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+#### Scenario: Hits on the same chain collapse, and unchanged topics are excluded
+
+- **WHEN** the query matches two members of the same supersession chain, and also a note that
+  was never superseded
+- **THEN** the two members yield exactly one timeline (de-duplicated), and the
+  never-superseded note yields no timeline
+
+### Requirement: Chain Resolution And Ordering From Supersession Pointers
+
+The system SHALL resolve a chain by walking the frontmatter supersession pointers — backward
+via `supersedes` and forward via `superseded_by` — and SHALL order the resulting versions by
+the pointer spine (the origin has no in-chain `supersedes`; the head has no `superseded_by`),
+not by date alone. A `supersedes` reader SHALL be available on the parsed page alongside the
+existing `superseded_by`.
+
+#### Scenario: Versions are ordered by the pointer spine
+
+- **WHEN** a chain A → B → C exists (A `superseded_by` B, B `superseded_by` C; C `supersedes`
+  B, B `supersedes` A)
+- **THEN** the timeline's `versions` are ordered exactly [A, B, C] regardless of their
+  `updated` dates
+- **AND** C (no `superseded_by`) is the chain head and A (no `supersedes`) is the origin
+
+### Requirement: Per-Version Structural Claims And Recorded Transition Reasons
+
+The system SHALL attach to each timeline version its structurally-extracted claims (lede,
+recognized headline-section lines, and `##` outline) and, for every non-head version, the
+**recorded** transition reason (from the superseded page's banner and/or the `why:` logged
+at the supersession edit). It MUST NOT generate, summarize, or judge how the view changed —
+the claims and reasons are the notes' own text, surfaced verbatim, and the active head
+carries no transition.
+
+#### Scenario: Each version carries its own claims; transitions carry recorded reasons
+
+- **WHEN** a timeline is built for a multi-version chain
+- **THEN** each version's `claims` are extracted structurally from that version's own body,
+  and each non-head version's `transition.reason` is the recorded text, with the head
+  version's `transition` null
+- **AND** no generative or reasoning model is invoked
+
+### Requirement: Bounded Output With Explicit Truncation
+
+The system SHALL bound the result by a configurable cap on the number of timelines (by find
+relevance) and a configurable cap on versions per timeline, and MUST NOT silently truncate:
+whenever a cap drops content the result SHALL carry an explicit `truncation` entry naming
+what was dropped.
+
+#### Scenario: More chains than the limit are reported, not silently dropped
+
+- **WHEN** more matching chains exist than the timelines cap
+- **THEN** exactly the cap is returned and `truncation` carries an entry stating how many
+  chains were not shown
+
+### Requirement: Measurement-Only Operation On All Surfaces
+
+The `evolution` operation SHALL be measurement-only — reading note content, frontmatter,
+supersession pointers, and recorded edit reasons, applying only deterministic ordering — and
+MUST NOT mutate the vault or change `find` ordering. It SHALL be defined by a single
+command-registry entry and reachable as an MCP tool, a REST route (`/api/evolution`), and a
+CLI subcommand (`kb evolution`) with no per-surface code.
+
+#### Scenario: One registry entry exposes evolution everywhere, read-only
+
+- **WHEN** the registry is built
+- **THEN** an `evolution` MCP tool, an `/api/evolution` REST route, and a `kb evolution` CLI
+  subcommand all exist from the one entry
+- **AND** running it over a vault creates, modifies, moves, or deletes no file and leaves
+  `find` ordering unchanged

--- a/openspec/changes/add-thinking-evolution/tasks.md
+++ b/openspec/changes/add-thinking-evolution/tasks.md
@@ -1,16 +1,16 @@
 # Tasks — Thinking-evolution view (`evolution`)
 
 ## 1. Pointer reader + pure builder (TDD: tests before wiring)
-- [ ] 1.1 Add `ParsedPage.supersedes` to `src/kb_mcp/find.py` (mirrors `.superseded_by`:
+- [x] 1.1 Add `ParsedPage.supersedes` to `src/kb_mcp/find.py` (mirrors `.superseded_by`:
       returns the `supersedes` frontmatter wikilink(s) as a list, empty when absent).
-- [ ] 1.2 Write `tests/test_evolution.py` FIRST over a tmp-vault, torch-free: a 3-version
+- [x] 1.2 Write `tests/test_evolution.py` FIRST over a tmp-vault, torch-free: a 3-version
       chain A→B→C (both pointers set + banners/reasons) → one timeline ordered [A,B,C], each
       with structural claims, transitions A→B and B→C carrying recorded reasons, head C
       transition null, span {from,to,n_versions=3}; a never-superseded note → no timeline;
       two hits on the same chain → one timeline (dedup); two separate chains → two timelines;
       timeline cap → `truncation` entry; ordering by pointer spine even when dates disagree;
       determinism on re-run; empty result when no supersession matches.
-- [ ] 1.3 Implement `src/kb_mcp/evolution.py`: env-resolved caps (`KB_MCP_EVOLUTION_MAX_CHAINS`
+- [x] 1.3 Implement `src/kb_mcp/evolution.py`: env-resolved caps (`KB_MCP_EVOLUTION_MAX_CHAINS`
       default 10, `KB_MCP_EVOLUTION_MAX_VERSIONS` default 25); `Version`/`Timeline` dataclasses
       with `as_dict()`; `_resolve_chain(vault_root, page)` (walk `superseded_by`/`supersedes`
       via `find._CACHE`, `seen`-guarded), `_order_chain` (origin→head spine), `_transition_reason`
@@ -18,38 +18,38 @@
       reusing `context_pack._extract_claims`; public `evolution(vault_root, *, query, limit=10,
       scope="kb", projects=None, tags=None)` that calls `find()` (overfetch) then builds. No
       mutation, no model import.
-- [ ] 1.4 `tests/test_evolution.py` green.
+- [x] 1.4 `tests/test_evolution.py` green.
 
 ## 2. Registry wiring (all surfaces from one entry)
-- [ ] 2.1 Add `op_evolution(vault_root, query="", limit=10, scope="kb", projects=None,
+- [x] 2.1 Add `op_evolution(vault_root, query="", limit=10, scope="kb", projects=None,
       tags=None) -> dict` to `commands.py` with the load-bearing Google-style docstring
       (lead: "how a conclusion CHANGED over time / its supersession history"; defers plain
       lookup to `find`; documents the timelines/versions/transition shape). Import
       `from . import evolution as evolution_module`.
-- [ ] 2.2 Add the `_SPEC` line `("evolution", op_evolution, 1, False, False, "query", _MCRC)`
+- [x] 2.2 Add the `_SPEC` line `("evolution", op_evolution, 1, False, False, "query", _MCRC)`
       after `attention`. No `HAND_REGISTERED_EXCEPTIONS` change (registry-generated).
-- [ ] 2.3 Assert `evolution` on MCP (`test_mcp_schema_fidelity`), REST + OpenAPI params
+- [x] 2.3 Assert `evolution` on MCP (`test_mcp_schema_fidelity`), REST + OpenAPI params
       (`test_rest_registry`), CLI (`test_cli_core_ops`), and an e2e call
       (`test_consolidated_tools`); derived params exactly `{query, limit, scope, projects, tags}`.
 
 ## 3. Schema-fidelity fixture
-- [ ] 3.1 Regenerate `tests/fixtures/mcp_tool_schemas.json` via `scripts/dump-tool-schemas.py`;
+- [x] 3.1 Regenerate `tests/fixtures/mcp_tool_schemas.json` via `scripts/dump-tool-schemas.py`;
       confirm the diff adds only the `evolution` tool and changes no existing tool.
 
 ## 4. Verify
-- [ ] 4.1 `uv run pytest tests/test_evolution.py tests/test_mcp_schema_fidelity.py
+- [x] 4.1 `uv run pytest tests/test_evolution.py tests/test_mcp_schema_fidelity.py
       tests/test_rest_registry.py tests/test_consolidated_tools.py tests/test_cli_core_ops.py -q`
       green.
-- [ ] 4.2 Full suite via `uv run pytest -q` — no regression (expect the suite to collect clean,
-      0 errors, since the torch CI fix is on main).
-- [ ] 4.3 `ruff check` clean on `src/kb_mcp/evolution.py` + `src/kb_mcp/find.py` +
+- [x] 4.2 Full suite via `uv run pytest -q` — 831 passed, 7 skipped, 0 errors (collects clean;
+      the torch CI fix is on main). +9 evolution tests, no regression.
+- [x] 4.3 `ruff check` clean on `src/kb_mcp/evolution.py` + `src/kb_mcp/find.py` +
       `src/kb_mcp/commands.py`.
-- [ ] 4.4 CLI smoke (fixture vault): `kb evolution "<topic>" --json` returns timelines (or an
+- [x] 4.4 CLI smoke (fixture vault): `kb evolution "<topic>" --json` returns timelines (or an
       explicit empty result with a note) — pick a fixture topic with a supersession chain, add
       one to the fixture vault if none exists.
-- [ ] 4.5 Pure-substrate check: `evolution.py` imports no model/embedding module for generation;
+- [x] 4.5 Pure-substrate check: `evolution.py` imports no model/embedding module for generation;
       claims/reasons are verbatim note text; vault + `find` ordering unchanged.
-- [ ] 4.6 `openspec validate add-thinking-evolution --strict` passes.
+- [x] 4.6 `openspec validate add-thinking-evolution --strict` passes.
 
 ## 5. Deploy (Hugo)
 - [ ] 5.1 `reset --hard origin/main` (or ff-pull) on the deploy checkout + restart; reconnect

--- a/openspec/changes/add-thinking-evolution/tasks.md
+++ b/openspec/changes/add-thinking-evolution/tasks.md
@@ -1,0 +1,56 @@
+# Tasks — Thinking-evolution view (`evolution`)
+
+## 1. Pointer reader + pure builder (TDD: tests before wiring)
+- [ ] 1.1 Add `ParsedPage.supersedes` to `src/kb_mcp/find.py` (mirrors `.superseded_by`:
+      returns the `supersedes` frontmatter wikilink(s) as a list, empty when absent).
+- [ ] 1.2 Write `tests/test_evolution.py` FIRST over a tmp-vault, torch-free: a 3-version
+      chain A→B→C (both pointers set + banners/reasons) → one timeline ordered [A,B,C], each
+      with structural claims, transitions A→B and B→C carrying recorded reasons, head C
+      transition null, span {from,to,n_versions=3}; a never-superseded note → no timeline;
+      two hits on the same chain → one timeline (dedup); two separate chains → two timelines;
+      timeline cap → `truncation` entry; ordering by pointer spine even when dates disagree;
+      determinism on re-run; empty result when no supersession matches.
+- [ ] 1.3 Implement `src/kb_mcp/evolution.py`: env-resolved caps (`KB_MCP_EVOLUTION_MAX_CHAINS`
+      default 10, `KB_MCP_EVOLUTION_MAX_VERSIONS` default 25); `Version`/`Timeline` dataclasses
+      with `as_dict()`; `_resolve_chain(vault_root, page)` (walk `superseded_by`/`supersedes`
+      via `find._CACHE`, `seen`-guarded), `_order_chain` (origin→head spine), `_transition_reason`
+      (banner `Reason:` / `get` log `why:`); pure `build_timelines(vault_root, hits, *, …)`
+      reusing `context_pack._extract_claims`; public `evolution(vault_root, *, query, limit=10,
+      scope="kb", projects=None, tags=None)` that calls `find()` (overfetch) then builds. No
+      mutation, no model import.
+- [ ] 1.4 `tests/test_evolution.py` green.
+
+## 2. Registry wiring (all surfaces from one entry)
+- [ ] 2.1 Add `op_evolution(vault_root, query="", limit=10, scope="kb", projects=None,
+      tags=None) -> dict` to `commands.py` with the load-bearing Google-style docstring
+      (lead: "how a conclusion CHANGED over time / its supersession history"; defers plain
+      lookup to `find`; documents the timelines/versions/transition shape). Import
+      `from . import evolution as evolution_module`.
+- [ ] 2.2 Add the `_SPEC` line `("evolution", op_evolution, 1, False, False, "query", _MCRC)`
+      after `attention`. No `HAND_REGISTERED_EXCEPTIONS` change (registry-generated).
+- [ ] 2.3 Assert `evolution` on MCP (`test_mcp_schema_fidelity`), REST + OpenAPI params
+      (`test_rest_registry`), CLI (`test_cli_core_ops`), and an e2e call
+      (`test_consolidated_tools`); derived params exactly `{query, limit, scope, projects, tags}`.
+
+## 3. Schema-fidelity fixture
+- [ ] 3.1 Regenerate `tests/fixtures/mcp_tool_schemas.json` via `scripts/dump-tool-schemas.py`;
+      confirm the diff adds only the `evolution` tool and changes no existing tool.
+
+## 4. Verify
+- [ ] 4.1 `uv run pytest tests/test_evolution.py tests/test_mcp_schema_fidelity.py
+      tests/test_rest_registry.py tests/test_consolidated_tools.py tests/test_cli_core_ops.py -q`
+      green.
+- [ ] 4.2 Full suite via `uv run pytest -q` — no regression (expect the suite to collect clean,
+      0 errors, since the torch CI fix is on main).
+- [ ] 4.3 `ruff check` clean on `src/kb_mcp/evolution.py` + `src/kb_mcp/find.py` +
+      `src/kb_mcp/commands.py`.
+- [ ] 4.4 CLI smoke (fixture vault): `kb evolution "<topic>" --json` returns timelines (or an
+      explicit empty result with a note) — pick a fixture topic with a supersession chain, add
+      one to the fixture vault if none exists.
+- [ ] 4.5 Pure-substrate check: `evolution.py` imports no model/embedding module for generation;
+      claims/reasons are verbatim note text; vault + `find` ordering unchanged.
+- [ ] 4.6 `openspec validate add-thinking-evolution --strict` passes.
+
+## 5. Deploy (Hugo)
+- [ ] 5.1 `reset --hard origin/main` (or ff-pull) on the deploy checkout + restart; reconnect
+      the claude.ai connector so the new `evolution` MCP tool appears. (Additive, read-only.)

--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -616,9 +616,10 @@ def op_evolution(
 
     Returns:
         {query, timelines: [{chain_id, topic_anchor, span: {from, to, n_versions},
-         versions: [{path, title, status, date, claims: {lede, sections, outline},
-         transition: {reason, date} | null}]}], truncation: [...]}. `transition` is
-        null on the active head; `versions` run oldest → newest by supersession order.
+         versions: [{path, title, status, date, claims: {title, type, lede, sections,
+         outline}, transition: {reason, date} | null}]}], truncation: [...]}.
+        `transition` is null on the active head; `versions` run oldest → newest by
+        supersession order; `span`/`n_versions` describe the whole chain.
     """
     return evolution_module.evolution(
         vault_root,

--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -39,6 +39,7 @@ from . import create_file as create_file_module
 from . import delete_directory as delete_directory_module
 from . import delete_file as delete_file_module
 from . import edit as edit_module
+from . import evolution as evolution_module
 from . import find as find_module
 from . import get_frontmatter as get_frontmatter_module
 from . import get_page as get_page_module
@@ -578,6 +579,55 @@ def op_attention(
     """
     report = attention_module.attention(vault_root, categories=categories, limit=limit)
     return report.as_dict()
+
+
+def op_evolution(
+    vault_root: Path,
+    query: str = "",
+    limit: int = 10,
+    scope: str = "kb",
+    projects: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> dict:
+    """How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only.
+
+    For a topic `query`, finds the matching notes, follows each one's supersession
+    chain (the `supersedes`/`superseded_by` links `replace` records), and returns one
+    ordered timeline per chain — oldest version → newest. Each version carries its own
+    structurally-extracted claims, its date, and the RECORDED reason it was superseded
+    (the `why:` logged at that edit). The server only orders and surfaces what you
+    wrote; it does NOT generate a "here's how your thinking changed" summary — you read
+    the consecutive versions and see the shift.
+
+    Use this for "how did my view on X evolve / what did I used to think / why did this
+    change". Use `find` for plain lookup. Notes never superseded are omitted (no
+    evolution to show); a topic with no supersession returns empty `timelines` — an
+    honest "nothing changed here", not an error. Read-only: mutates nothing; `find`
+    ordering is unchanged.
+
+    Args:
+        query: The topic to trace (free text, like `find`).
+        limit: Max chains (timelines) to return, by find relevance (default 10;
+            0 or negative = uncapped). Chains beyond the cap are reported in
+            `truncation`, never dropped silently.
+        scope: Search scope passed to `find` — "kb" (default) / "vault" / "kb-only".
+        projects: Optional project-key filter passed to `find`.
+        tags: Optional tag filter passed to `find`.
+
+    Returns:
+        {query, timelines: [{chain_id, topic_anchor, span: {from, to, n_versions},
+         versions: [{path, title, status, date, claims: {lede, sections, outline},
+         transition: {reason, date} | null}]}], truncation: [...]}. `transition` is
+        null on the active head; `versions` run oldest → newest by supersession order.
+    """
+    return evolution_module.evolution(
+        vault_root,
+        query=query,
+        limit=limit,
+        scope=scope,
+        projects=projects,
+        tags=tags,
+    )
 
 
 def op_audit_fix(
@@ -1944,6 +1994,7 @@ _SPEC: tuple[tuple, ...] = (
     ("add", op_add, 1, True, True, None, _MCRC),
     ("audit", op_audit, 1, False, False, None, _MCRC),
     ("attention", op_attention, 1, False, False, None, _MCRC),
+    ("evolution", op_evolution, 1, False, False, "query", _MCRC),
     ("audit_fix", op_audit_fix, 1, True, False, None, _MCRC),
     ("reconcile", op_reconcile, 1, True, False, None, _MCRC),
     ("provenance_report", op_provenance_report, 1, False, False, None, _MCRC),

--- a/src/kb_mcp/context_pack.py
+++ b/src/kb_mcp/context_pack.py
@@ -50,7 +50,7 @@ _NEIGHBOR_LEDE_CHARS = 160
 RECOGNIZED_SECTIONS: frozenset[str] = frozenset({
     "summary", "problem", "conclusion", "decision", "pattern", "hypothesis",
     "result", "results", "insight", "tl;dr", "tldr", "takeaway", "why",
-    "finding", "findings",
+    "finding", "findings", "claim", "claims",
 })
 
 _FENCE_RE = re.compile(r"^\s*(?:```|~~~)")

--- a/src/kb_mcp/evolution.py
+++ b/src/kb_mcp/evolution.py
@@ -1,0 +1,230 @@
+"""The `evolution` view — "how did my view on X change over time?"
+
+The vault already records how a conclusion moved: `replace` links every superseded note to
+its successor (`superseded_by`) and predecessor (`supersedes`), and logs the reason to
+`log.md`. This module reads that doubly-linked chain and surfaces it as an ordered
+**timeline**: for a topic query, find the matching notes, resolve each into its supersession
+chain, and return one timeline per chain — each version with its own structural claims, its
+date, and the recorded reason it was superseded.
+
+PURE ASSEMBLY (measurement), mirroring `attention.py` / `context_pack.py`:
+- versions are ordered by the supersession POINTER spine (not by date — `replace` bumps the
+  old page's `updated:` to the supersession date, so dates alone mis-order);
+- each version's claims are extracted STRUCTURALLY (reused from `context_pack`);
+- the transition reason is the RECORDED `log.md` `why:` (via `vault.read_log_entries`),
+  surfaced verbatim — the server never generates a "here's how your thinking changed"
+  narrative. The brain reads consecutive versions and infers the evolution.
+
+Nothing is mutated, no generative/reasoning model runs, and `find` ordering is untouched.
+Chains of length 1 (a note never superseded) are dropped — there is no evolution to show.
+Every cap that drops content is reported in `truncation`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from . import context_pack
+from . import find as find_module
+from . import vault as vault_module
+from .find import Hit, ParsedPage
+
+_DEFAULT_MAX_CHAINS = 10
+_DEFAULT_MAX_VERSIONS = 25
+_OVERFETCH = 5  # find more candidates than chains, since members collapse into one chain
+
+
+def _int_env(value: int | None, env: str, default: int) -> int:
+    if value is not None:
+        return value
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _load_link(vault_root: Path, raw_wikilink: str) -> ParsedPage | None:
+    """Resolve a `supersedes`/`superseded_by` wikilink to its parsed page (or None)."""
+    target = context_pack._wikilink_target(raw_wikilink)
+    if not target:
+        return None
+    rel = target if target.endswith(".md") else target + ".md"
+    return find_module._CACHE.get(vault_root / rel, vault_root)
+
+
+def _resolve_chain(vault_root: Path, start: ParsedPage) -> dict[str, ParsedPage]:
+    """Walk the supersession pointers from `start` both ways into the full chain.
+
+    Forward via `superseded_by`, backward via `supersedes`, `seen`-guarded (the chain is
+    linear — `replace` refuses to supersede an already-superseded page — but guard cycles).
+    """
+    members: dict[str, ParsedPage] = {start.rel_path: start}
+    cur: ParsedPage | None = start
+    while cur and cur.superseded_by:
+        nxt = _load_link(vault_root, cur.superseded_by[0])
+        if nxt is None or nxt.rel_path in members:
+            break
+        members[nxt.rel_path] = nxt
+        cur = nxt
+    cur = start
+    while cur and cur.supersedes:
+        prev = _load_link(vault_root, cur.supersedes[0])
+        if prev is None or prev.rel_path in members:
+            break
+        members[prev.rel_path] = prev
+        cur = prev
+    return members
+
+
+def _order_chain(vault_root: Path, members: dict[str, ParsedPage]) -> list[ParsedPage]:
+    """Order chain members oldest→newest along the pointer spine (origin → head)."""
+    def _is_origin(p: ParsedPage) -> bool:
+        if not p.supersedes:
+            return True
+        prev = _load_link(vault_root, p.supersedes[0])
+        return prev is None or prev.rel_path not in members
+
+    origin = next((p for p in members.values() if _is_origin(p)), next(iter(members.values())))
+    ordered: list[ParsedPage] = []
+    seen: set[str] = set()
+    cur: ParsedPage | None = origin
+    while cur is not None and cur.rel_path not in seen:
+        ordered.append(cur)
+        seen.add(cur.rel_path)
+        if not cur.superseded_by:
+            break
+        nxt = _load_link(vault_root, cur.superseded_by[0])
+        cur = nxt if (nxt is not None and nxt.rel_path in members) else None
+    return ordered
+
+
+def _transition_reason(vault_root: Path, new_page: ParsedPage) -> tuple[str | None, str | None]:
+    """The recorded reason `new_page` superseded its predecessor — read verbatim from the
+    `log.md` entry `replace` writes under the new page (returns (reason, date))."""
+    for entry in vault_module.read_log_entries(vault_root, new_page.rel_path):
+        if "supersede" in entry.get("summary", "").lower():
+            return entry["summary"], entry.get("date")
+    return None, None
+
+
+def _build_timeline(
+    vault_root: Path, ordered: list[ParsedPage], *, anchor: str, max_versions: int
+) -> tuple[dict, int]:
+    """Assemble one chain's timeline dict; returns (timeline, dropped_versions)."""
+    dropped = 0
+    shown = ordered
+    if max_versions > 0 and len(ordered) > max_versions:
+        dropped = len(ordered) - max_versions
+        shown = ordered[-max_versions:]  # keep the most recent versions (head matters most)
+
+    versions: list[dict] = []
+    for page in shown:
+        transition = None
+        if page.superseded_by:
+            succ = _load_link(vault_root, page.superseded_by[0])
+            if succ is not None:
+                reason, tdate = _transition_reason(vault_root, succ)
+                transition = {"reason": reason, "date": tdate}
+        versions.append({
+            "path": page.rel_path,
+            "title": page.title,
+            "status": page.status or "active",
+            "date": page.updated,
+            "claims": context_pack._extract_claims(page),
+            "transition": transition,
+        })
+
+    dates = [p.updated for p in shown if p.updated]
+    timeline = {
+        "chain_id": ordered[-1].rel_path,   # the active head
+        "topic_anchor": anchor,
+        "span": {
+            "from": min(dates) if dates else "",
+            "to": max(dates) if dates else "",
+            "n_versions": len(versions),
+        },
+        "versions": versions,
+    }
+    return timeline, dropped
+
+
+def build_timelines(
+    vault_root: Path,
+    hits: list[Hit],
+    *,
+    max_chains: int | None = None,
+    max_versions: int | None = None,
+) -> dict:
+    """Resolve the hits' supersession chains into ordered timelines. Pure measurement.
+
+    Dedups hits that land on the same chain (keyed by active-head path), drops chains of
+    length < 2, orders each by the pointer spine, caps to `max_chains` (find-relevance
+    order) and each timeline to `max_versions`, reporting every drop in `truncation`.
+    """
+    max_chains = _int_env(max_chains, "KB_MCP_EVOLUTION_MAX_CHAINS", _DEFAULT_MAX_CHAINS)
+    max_versions = _int_env(max_versions, "KB_MCP_EVOLUTION_MAX_VERSIONS", _DEFAULT_MAX_VERSIONS)
+
+    truncation: list[str] = []
+    seen_heads: set[str] = set()
+    timelines: list[dict] = []
+    for hit in hits:
+        page = find_module._CACHE.get(vault_root / hit.path, vault_root)
+        if page is None:
+            continue
+        members = _resolve_chain(vault_root, page)
+        if len(members) < 2:
+            continue  # never superseded → no evolution to show
+        ordered = _order_chain(vault_root, members)
+        head = ordered[-1].rel_path
+        if head in seen_heads:
+            continue  # another hit already surfaced this chain
+        seen_heads.add(head)
+        timeline, dropped = _build_timeline(
+            vault_root, ordered, anchor=page.rel_path, max_versions=max_versions
+        )
+        if dropped:
+            truncation.append(
+                f"timeline {head} capped at {max_versions} versions "
+                f"({dropped} older not shown; raise KB_MCP_EVOLUTION_MAX_VERSIONS)"
+            )
+        timelines.append(timeline)
+
+    total = len(timelines)
+    if max_chains > 0 and total > max_chains:
+        timelines = timelines[:max_chains]
+        truncation.append(
+            f"showing {max_chains} of {total} chains "
+            f"({total - max_chains} more not shown; raise KB_MCP_EVOLUTION_MAX_CHAINS)"
+        )
+    return {"timelines": timelines, "truncation": truncation}
+
+
+def evolution(
+    vault_root: Path,
+    *,
+    query: str,
+    limit: int = 10,
+    scope: str = "kb",
+    projects: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> dict:
+    """Timelines of how the topic's conclusions changed, from supersession chains. Read-only.
+
+    Finds the topic, resolves each hit's supersession chain, and returns one ordered
+    timeline per chain. Empty `timelines` means nothing matching the topic has been
+    superseded — honestly empty, not an error.
+    """
+    hits = find_module.find(
+        vault_root,
+        query=query,
+        scope=scope,
+        projects=projects,
+        tags=tags,
+        limit=max(limit * _OVERFETCH, 25),
+    )
+    built = build_timelines(vault_root, hits, max_chains=limit)
+    return {"query": query, **built}

--- a/src/kb_mcp/evolution.py
+++ b/src/kb_mcp/evolution.py
@@ -104,8 +104,17 @@ def _order_chain(vault_root: Path, members: dict[str, ParsedPage]) -> list[Parse
 
 def _transition_reason(vault_root: Path, new_page: ParsedPage) -> tuple[str | None, str | None]:
     """The recorded reason `new_page` superseded its predecessor — read verbatim from the
-    `log.md` entry `replace` writes under the new page (returns (reason, date))."""
-    for entry in vault_module.read_log_entries(vault_root, new_page.rel_path):
+    `log.md` entry `replace` writes under the new page (returns (reason, date)).
+
+    Match the explicit `replace` op first (what supersession records); fall back to a
+    summary mention only if absent, so a later ordinary `edit` whose rationale happens to
+    say "supersede" can't masquerade as the transition reason.
+    """
+    entries = vault_module.read_log_entries(vault_root, new_page.rel_path)
+    for entry in entries:
+        if entry.get("op") == "replace":
+            return entry.get("summary"), entry.get("date")
+    for entry in entries:
         if "supersede" in entry.get("summary", "").lower():
             return entry["summary"], entry.get("date")
     return None, None
@@ -138,14 +147,16 @@ def _build_timeline(
             "transition": transition,
         })
 
-    dates = [p.updated for p in shown if p.updated]
+    # span + n_versions describe the WHOLE chain (`ordered`), not just the shown window —
+    # the truncation note carries the dropped count, so these stay chain-level facts.
+    dates = [p.updated for p in ordered if p.updated]
     timeline = {
         "chain_id": ordered[-1].rel_path,   # the active head
         "topic_anchor": anchor,
         "span": {
             "from": min(dates) if dates else "",
             "to": max(dates) if dates else "",
-            "n_versions": len(versions),
+            "n_versions": len(ordered),
         },
         "versions": versions,
     }
@@ -168,9 +179,8 @@ def build_timelines(
     max_chains = _int_env(max_chains, "KB_MCP_EVOLUTION_MAX_CHAINS", _DEFAULT_MAX_CHAINS)
     max_versions = _int_env(max_versions, "KB_MCP_EVOLUTION_MAX_VERSIONS", _DEFAULT_MAX_VERSIONS)
 
-    truncation: list[str] = []
     seen_heads: set[str] = set()
-    timelines: list[dict] = []
+    built: list[tuple[dict, int]] = []  # (timeline, dropped_versions)
     for hit in hits:
         page = find_module._CACHE.get(vault_root / hit.path, vault_root)
         if page is None:
@@ -183,23 +193,29 @@ def build_timelines(
         if head in seen_heads:
             continue  # another hit already surfaced this chain
         seen_heads.add(head)
-        timeline, dropped = _build_timeline(
+        built.append(_build_timeline(
             vault_root, ordered, anchor=page.rel_path, max_versions=max_versions
+        ))
+
+    # Apply the chains cap FIRST, so per-timeline version-truncation notes below can only
+    # reference chains that are actually returned (never a dropped one).
+    truncation: list[str] = []
+    total = len(built)
+    if max_chains > 0 and total > max_chains:
+        built = built[:max_chains]
+        truncation.append(
+            f"showing {max_chains} of {total} chains "
+            f"({total - max_chains} more not shown; raise `limit`)"
         )
+
+    timelines: list[dict] = []
+    for timeline, dropped in built:
         if dropped:
             truncation.append(
-                f"timeline {head} capped at {max_versions} versions "
+                f"timeline {timeline['chain_id']} capped at {max_versions} versions "
                 f"({dropped} older not shown; raise KB_MCP_EVOLUTION_MAX_VERSIONS)"
             )
         timelines.append(timeline)
-
-    total = len(timelines)
-    if max_chains > 0 and total > max_chains:
-        timelines = timelines[:max_chains]
-        truncation.append(
-            f"showing {max_chains} of {total} chains "
-            f"({total - max_chains} more not shown; raise KB_MCP_EVOLUTION_MAX_CHAINS)"
-        )
     return {"timelines": timelines, "truncation": truncation}
 
 
@@ -216,15 +232,19 @@ def evolution(
 
     Finds the topic, resolves each hit's supersession chain, and returns one ordered
     timeline per chain. Empty `timelines` means nothing matching the topic has been
-    superseded — honestly empty, not an error.
+    superseded — honestly empty, not an error. Results are bounded by `find`'s candidate
+    pool (≤100): a chain whose only matching members fall outside it won't surface.
     """
+    # Overfetch candidates since several hits collapse into one chain; `find` clamps to
+    # 100, so an "uncapped" (limit<=0) call fetches that full pool.
+    overfetch = 100 if limit <= 0 else min(max(limit * _OVERFETCH, 25), 100)
     hits = find_module.find(
         vault_root,
         query=query,
         scope=scope,
         projects=projects,
         tags=tags,
-        limit=max(limit * _OVERFETCH, 25),
+        limit=overfetch,
     )
     built = build_timelines(vault_root, hits, max_chains=limit)
     return {"query": query, **built}

--- a/src/kb_mcp/find.py
+++ b/src/kb_mcp/find.py
@@ -319,6 +319,15 @@ class ParsedPage:
             return []
         return [str(x) for x in sb] if isinstance(sb, list) else [str(sb)]
 
+    @property
+    def supersedes(self) -> list[str]:
+        """Wikilink(s) to the page(s) this one replaced — the backward supersession
+        pointer `replace` writes on a new page (empty when it supersedes nothing)."""
+        sv = self.frontmatter.get("supersedes")
+        if not sv:
+            return []
+        return [str(x) for x in sv] if isinstance(sv, list) else [str(sv)]
+
 
 def _format_timestamp(seconds: float) -> str:
     """Seconds → `mm:ss` (or `h:mm:ss` past an hour) for human-readable video deeplinks."""

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -474,6 +474,60 @@
       "type": "object"
     }
   },
+  "evolution": {
+    "description": "How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only.\n\nFor a topic `query`, finds the matching notes, follows each one's supersession\nchain (the `supersedes`/`superseded_by` links `replace` records), and returns one\nordered timeline per chain — oldest version → newest. Each version carries its own\nstructurally-extracted claims, its date, and the RECORDED reason it was superseded\n(the `why:` logged at that edit). The server only orders and surfaces what you\nwrote; it does NOT generate a \"here's how your thinking changed\" summary — you read\nthe consecutive versions and see the shift.\n\nUse this for \"how did my view on X evolve / what did I used to think / why did this\nchange\". Use `find` for plain lookup. Notes never superseded are omitted (no\nevolution to show); a topic with no supersession returns empty `timelines` — an\nhonest \"nothing changed here\", not an error. Read-only: mutates nothing; `find`\nordering is unchanged.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "default": "",
+          "type": "string",
+          "description": "The topic to trace (free text, like `find`)."
+        },
+        "limit": {
+          "default": 10,
+          "type": "integer",
+          "description": "Max chains (timelines) to return, by find relevance (default 10;\n0 or negative = uncapped). Chains beyond the cap are reported in\n`truncation`, never dropped silently."
+        },
+        "scope": {
+          "default": "kb",
+          "type": "string",
+          "description": "Search scope passed to `find` — \"kb\" (default) / \"vault\" / \"kb-only\"."
+        },
+        "projects": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional project-key filter passed to `find`."
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional tag filter passed to `find`."
+        }
+      },
+      "type": "object"
+    }
+  },
   "find": {
     "description": "Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.",
     "inputSchema": {

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,206 @@
+"""Unit tests for the thinking-evolution view (`evolution`).
+
+Torch-free: builds a tmp vault with two supersession chains + a standalone note, plus a
+`log.md` carrying the recorded transition reasons, and exercises `evolution()` directly.
+Dates are deliberately out of pointer order to prove ordering follows the supersession
+spine, not `updated:`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import evolution
+from kb_mcp import find as find_module
+
+# --- chain 1: widget-cache  A -> B -> C  (A's date is LATER than C's, on purpose) ---
+
+A = """\
+---
+type: insight
+status: superseded
+superseded_by: "[[Knowledge Base/Notes/Insights/widget-cache-v2]]"
+updated: 2026-09-01
+---
+# Widget cache (v1)
+
+We do not cache widget reads; every request hits the store.
+
+## Claim
+No caching keeps it simple and correct.
+"""
+
+B = """\
+---
+type: insight
+status: superseded
+superseded_by: "[[Knowledge Base/Notes/Insights/widget-cache-v3]]"
+supersedes: "[[Knowledge Base/Notes/Insights/widget-cache]]"
+updated: 2026-03-01
+---
+# Widget cache (v2)
+
+We cache widget reads with a 60s TTL after the latency spike.
+
+## Claim
+A short TTL cuts p99 latency without much staleness.
+"""
+
+C = """\
+---
+type: insight
+status: active
+supersedes: "[[Knowledge Base/Notes/Insights/widget-cache-v2]]"
+updated: 2026-03-15
+---
+# Widget cache (v3)
+
+We cache widget reads with an LRU keyed by tenant; TTL was too blunt.
+
+## Claim
+LRU beats TTL on our measured hit-rate.
+"""
+
+# standalone widget note — matches the query but was never superseded
+D = """\
+---
+type: insight
+status: active
+updated: 2026-02-20
+---
+# Widget metrics
+
+Track widget read latency p50/p99.
+"""
+
+# --- chain 2: widget-rollout  E -> F ---
+
+E = """\
+---
+type: insight
+status: superseded
+superseded_by: "[[Knowledge Base/Notes/Insights/widget-rollout-v2]]"
+updated: 2026-02-15
+---
+# Widget rollout (v1)
+
+Big-bang rollout of the widget service.
+"""
+
+F = """\
+---
+type: insight
+status: active
+supersedes: "[[Knowledge Base/Notes/Insights/widget-rollout]]"
+updated: 2026-02-16
+---
+# Widget rollout (v2)
+
+Phased rollout of the widget service, 5% at a time.
+"""
+
+# log.md — supersession reasons recorded under the NEW page (replace's contract)
+LOG = """\
+# Activity log
+
+## [2026-03-15] replace | Notes/Insights/widget-cache-v3
+Supersedes `Notes/Insights/widget-cache-v2` via kb-mcp. LRU beat TTL on the measured hit-rate.
+
+## [2026-03-01] replace | Notes/Insights/widget-cache-v2
+Supersedes `Notes/Insights/widget-cache` via kb-mcp. Switched to a TTL after the latency spike.
+
+## [2026-02-16] replace | Notes/Insights/widget-rollout-v2
+Supersedes `Notes/Insights/widget-rollout` via kb-mcp. Phased rollout replaced big-bang.
+"""
+
+INS = "Knowledge Base/Notes/Insights"
+A_P, B_P, C_P = f"{INS}/widget-cache.md", f"{INS}/widget-cache-v2.md", f"{INS}/widget-cache-v3.md"
+D_P = f"{INS}/widget-metrics.md"
+E_P, F_P = f"{INS}/widget-rollout.md", f"{INS}/widget-rollout-v2.md"
+
+
+def _write(vault: Path, rel: str, body: str) -> None:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def chains(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    _write(vault, A_P, A)
+    _write(vault, B_P, B)
+    _write(vault, C_P, C)
+    _write(vault, D_P, D)
+    _write(vault, E_P, E)
+    _write(vault, F_P, F)
+    _write(vault, "Knowledge Base/log.md", LOG)
+    find_module.clear_cache()
+    return vault
+
+
+def _timeline_for(result: dict, head: str) -> dict:
+    return next(t for t in result["timelines"] if t["chain_id"] == head)
+
+
+def test_chain_is_one_ordered_timeline(chains: Path) -> None:
+    result = evolution.evolution(chains, query="widget cache")
+    tl = _timeline_for(result, C_P)
+    # Ordered by the supersession spine A -> B -> C, NOT by date (A's date is latest).
+    assert [v["path"] for v in tl["versions"]] == [A_P, B_P, C_P]
+    assert tl["span"]["n_versions"] == 3
+
+
+def test_transitions_carry_recorded_reasons_head_is_null(chains: Path) -> None:
+    tl = _timeline_for(evolution.evolution(chains, query="widget cache"), C_P)
+    a, b, c = tl["versions"]
+    assert "TTL after the latency spike" in a["transition"]["reason"]   # A -> B reason (from B's log)
+    assert "LRU beat TTL" in b["transition"]["reason"]                  # B -> C reason (from C's log)
+    assert c["transition"] is None                                      # active head
+
+
+def test_versions_carry_structural_claims(chains: Path) -> None:
+    tl = _timeline_for(evolution.evolution(chains, query="widget cache"), C_P)
+    head = tl["versions"][-1]
+    assert head["claims"]["lede"].startswith("We cache widget reads with an LRU")
+    assert any("Claim:" in s for s in head["claims"]["sections"])
+    assert "Claim" in head["claims"]["outline"]
+
+
+def test_standalone_note_is_excluded(chains: Path) -> None:
+    result = evolution.evolution(chains, query="widget")
+    all_paths = {v["path"] for t in result["timelines"] for v in t["versions"]}
+    assert D_P not in all_paths  # never superseded → no evolution to show
+
+
+def test_separate_chains_each_get_a_timeline(chains: Path) -> None:
+    result = evolution.evolution(chains, query="widget")
+    heads = {t["chain_id"] for t in result["timelines"]}
+    assert C_P in heads and F_P in heads  # both chains surfaced
+    assert len(result["timelines"]) == 2
+
+
+def test_hits_on_same_chain_dedup(chains: Path) -> None:
+    # "cache" matches A, B, and C — all one chain → exactly one timeline.
+    result = evolution.evolution(chains, query="widget cache")
+    cache_timelines = [t for t in result["timelines"] if t["chain_id"] == C_P]
+    assert len(cache_timelines) == 1
+
+
+def test_chains_cap_reports_truncation(chains: Path) -> None:
+    result = evolution.evolution(chains, query="widget", limit=1)
+    assert len(result["timelines"]) == 1
+    assert any("chain" in t.lower() for t in result["truncation"])
+
+
+def test_no_supersession_match_is_empty(chains: Path) -> None:
+    result = evolution.evolution(chains, query="nonexistent-topic-zzz")
+    assert result["timelines"] == []
+
+
+def test_deterministic_on_rerun(chains: Path) -> None:
+    assert evolution.evolution(chains, query="widget") == evolution.evolution(
+        chains, query="widget"
+    )

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -105,6 +105,9 @@ Phased rollout of the widget service, 5% at a time.
 LOG = """\
 # Activity log
 
+## [2026-04-01] edit | Notes/Insights/widget-cache-v3
+Tidied prose; notes that v3 supersedes the TTL approach. No claim change.
+
 ## [2026-03-15] replace | Notes/Insights/widget-cache-v3
 Supersedes `Notes/Insights/widget-cache-v2` via kb-mcp. LRU beat TTL on the measured hit-rate.
 
@@ -158,6 +161,8 @@ def test_transitions_carry_recorded_reasons_head_is_null(chains: Path) -> None:
     a, b, c = tl["versions"]
     assert "TTL after the latency spike" in a["transition"]["reason"]   # A -> B reason (from B's log)
     assert "LRU beat TTL" in b["transition"]["reason"]                  # B -> C reason (from C's log)
+    # The `replace` op is picked, NOT the newer `edit` entry that merely mentions "supersede".
+    assert "Tidied prose" not in b["transition"]["reason"]
     assert c["transition"] is None                                      # active head
 
 


### PR DESCRIPTION
Direction 4 (last roadmap item): **how did my view on X change over time.**

## What
New `evolution(query)` tool. For a topic it finds the matching notes, resolves each into its **supersession chain** (forward via `superseded_by`, backward via `supersedes` — both written by `replace`), and returns one **ordered timeline per chain**, oldest→newest by the **pointer spine** (not by date — `replace` bumps the old page's `updated:`). Each version carries:
- its **structurally-extracted claims** (reused from `context_pack._extract_claims`),
- its date, and
- the **recorded transition reason** — the `why:` logged to `log.md` at the supersession (`vault.read_log_entries`), surfaced verbatim. The active head has no transition.

## Pure-substrate
No server-side LLM, no generated "here's how your thinking changed" narrative — the server orders + surfaces what you wrote; the brain reads consecutive versions and infers the shift. Read-only; `find` ordering unchanged. Length-1 chains (never superseded) are dropped. Bounded (`KB_MCP_EVOLUTION_MAX_CHAINS`/`MAX_VERSIONS`) with explicit `truncation`.

## Shape
New `src/kb_mcp/evolution.py` (mirrors `attention.py`); `ParsedPage.supersedes` reader; `op_evolution` leaf + one `_SPEC` line → MCP/REST/CLI from one entry; schema-fidelity fixture regenerated (**only `evolution` added**). Also adds `claim`/`claims` to `context_pack`'s recognized sections (the insight-note convention).

## Tests / verify
New `tests/test_evolution.py` (9, torch-free tmp-vault): spine-ordering (dates deliberately out of order), recorded transitions + null head, structural claims, standalone-note excluded, two-chain, dedup, truncation, empty result, determinism. Full suite **831 passed / 7 skipped / 0 errors**; new files ruff-clean; `openspec validate` passes. Specced as OpenSpec change `add-thinking-evolution`.

## Deploy
Additive, read-only. New MCP tool → reconnect the claude.ai connector to surface it; REST/CLI need only a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8uujJrqb3frA3H581HgT2