### PR TITLE
fix(auth): stop SingleUserGitHubVerifier shadowing the parent's _cache (fixes connector 401)

### DIFF
--- a/src/kb_mcp/logging_config.py
+++ b/src/kb_mcp/logging_config.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 
 def configure_logging(log_dir: Path, level: int = logging.INFO) -> None:
+    # Honor FASTMCP_LOG_LEVEL so fastmcp's auth/JWT DEBUG lines (e.g. the exact
+    # reason behind an `invalid_token` 401) are surfaceable without a code change.
+    env_level = os.environ.get("FASTMCP_LOG_LEVEL", "").upper()
+    if env_level:
+        level = getattr(logging, env_level, level)
     log_dir.mkdir(parents=True, exist_ok=True)
     handler = RotatingFileHandler(
         log_dir / "kb-mcp.log",

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -236,7 +236,12 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
     def __init__(self, *, allowed_login: str, **kwargs):
         super().__init__(**kwargs)
         self._allowed_login = allowed_login.lower()
-        self._cache: dict[str, tuple[float, AccessToken]] = {}
+        # NOTE: this MUST NOT be named ``_cache`` — the parent GitHubTokenVerifier
+        # owns ``self._cache`` (a fastmcp ``TokenCache``) and unpacks its
+        # ``.get()`` as a 2-tuple inside ``super().verify_token``. Shadowing it
+        # with a plain dict made that line raise "cannot unpack non-iterable
+        # NoneType object", failing the OAuth token-swap → 401 on every request.
+        self._login_cache: dict[str, tuple[float, AccessToken]] = {}
 
     def _ttl(self) -> float:
         raw = os.environ.get("KB_MCP_AUTH_CACHE_TTL")
@@ -251,12 +256,12 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
         ttl = self._ttl()
         key = hashlib.sha256(token.encode("utf-8")).hexdigest() if token else ""
         if ttl > 0 and key:
-            hit = self._cache.get(key)
+            hit = self._login_cache.get(key)
             if hit is not None:
                 ts, cached = hit
                 if time.monotonic() - ts < ttl:
                     return cached
-                del self._cache[key]  # expired
+                del self._login_cache[key]  # expired
 
         access = await super().verify_token(token)
         if access is None:
@@ -274,12 +279,12 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
 
         if ttl > 0 and key:
             now = time.monotonic()
-            if len(self._cache) >= self._MAX_ENTRIES:
+            if len(self._login_cache) >= self._MAX_ENTRIES:
                 # Drop expired entries before inserting; cheap, the cache is tiny.
-                self._cache = {
-                    k: v for k, v in self._cache.items() if now - v[0] < ttl
+                self._login_cache = {
+                    k: v for k, v in self._login_cache.items() if now - v[0] < ttl
                 }
-            self._cache[key] = (now, access)
+            self._login_cache[key] = (now, access)
         return access
 
 

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -1,9 +1,11 @@
 """SingleUserGitHubVerifier's TTL cache for validated GitHub tokens.
 
-The real GitHub round-trip (`super().verify_token`) is stubbed with a call-counter so
-these tests assert the *caching contract* without any network: a validated token is
-served from cache within the TTL, distinct tokens validate independently, rejections are
-never cached (instant recovery), and TTL=0 disables caching.
+Most tests stub the real GitHub round-trip (`super().verify_token`) with a call-counter
+so they assert the *caching contract* without any network: a validated token is served
+from cache within the TTL, distinct tokens validate independently, rejections are never
+cached (instant recovery), and TTL=0 disables caching. The final test deliberately does
+*not* stub `super().verify_token` (only the HTTP call) so the real parent code path runs
+— a regression guard for the `_cache` attribute-shadowing bug those stubbed tests missed.
 """
 
 from __future__ import annotations
@@ -11,8 +13,10 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+from fastmcp.utilities.token_cache import TokenCache
 
 from kb_mcp.server import SingleUserGitHubVerifier
 
@@ -66,9 +70,9 @@ def test_expired_entry_revalidates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     asyncio.run(v.verify_token("tok"))
     # Rewind the cached timestamp well past the TTL to simulate expiry.
-    (key,) = v._cache.keys()
-    ts, access = v._cache[key]
-    v._cache[key] = (ts - 10_000.0, access)
+    (key,) = v._login_cache.keys()
+    ts, access = v._login_cache[key]
+    v._login_cache[key] = (ts - 10_000.0, access)
     asyncio.run(v.verify_token("tok"))
 
     assert calls["n"] == 2  # expired → re-hit GitHub
@@ -81,7 +85,7 @@ def test_github_rejection_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None
     assert asyncio.run(v.verify_token("tok")) is None
     assert asyncio.run(v.verify_token("tok")) is None
     assert calls["n"] == 2  # re-checked each time — recovery is instant after re-auth
-    assert not v._cache
+    assert not v._login_cache
 
 
 def test_wrong_login_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,7 +95,7 @@ def test_wrong_login_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     assert asyncio.run(v.verify_token("tok")) is None
     assert asyncio.run(v.verify_token("tok")) is None
     assert calls["n"] == 2  # only the *allowed* login is ever cached
-    assert not v._cache
+    assert not v._login_cache
 
 
 def test_ttl_zero_disables_cache(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,4 +107,41 @@ def test_ttl_zero_disables_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     asyncio.run(v.verify_token("tok"))
 
     assert calls["n"] == 2  # caching off → every call revalidates
-    assert not v._cache
+    assert not v._login_cache
+
+
+def test_real_super_verify_does_not_crash_on_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: do NOT shadow the parent GitHubTokenVerifier's ``_cache``.
+
+    Every other test in this file replaces ``GitHubTokenVerifier.verify_token``
+    wholesale, so none of them exercise the parent's first line —
+    ``is_cached, cached_result = self._cache.get(token)``. When kb-mcp's verifier
+    overwrote ``self._cache`` with a plain ``dict``, that line unpacked
+    ``dict.get(token)``'s ``None`` return → ``TypeError: cannot unpack
+    non-iterable NoneType object`` → the OAuth token-swap failed → every
+    authenticated ``/mcp`` request returned 401. This test runs the REAL
+    ``super().verify_token`` (only the GitHub HTTP call is stubbed) so the
+    regression is caught locally.
+    """
+
+    class _FakeResp:
+        status_code = 401
+        text = "unauthorized"
+        headers: dict[str, str] = {}
+
+        def json(self) -> dict[str, object]:  # pragma: no cover — 401 path returns early
+            return {}
+
+    async def _fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
+        return _FakeResp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+
+    v = _verifier()
+    # A GitHub-rejected token must resolve to None, not raise the unpack TypeError
+    # the parent's `self._cache.get(token)` throws when `_cache` is a plain dict.
+    assert asyncio.run(v.verify_token("tok")) is None
+    # And the parent class must still own ``_cache`` as its TokenCache.
+    assert isinstance(v._cache, TokenCache)


### PR DESCRIPTION
## Problem

The claude.ai web connector returned `invalid_token (401)` on every authenticated `POST /mcp`. stdio worked; OAuth did not. A prior investigation pinned it on FastMCP (`subject=None`, "switch to `GitHubProvider`") — that lead was a dead end (see below).

## Root cause (kb-mcp-side, not FastMCP)

`SingleUserGitHubVerifier.__init__` calls `super().__init__()` — which sets `self._cache` to a fastmcp `TokenCache` — and **then overwrites `self._cache` with a plain `dict`**. On a cache miss, `verify_token` calls `super().verify_token()`, whose first line is:

```python
is_cached, cached_result = self._cache.get(token)
```

On the clobbered dict, `dict.get(token)` returns `None`, so the unpack raises `TypeError: cannot unpack non-iterable NoneType object`. That crashed `OAuthProxy.load_access_token`'s token-swap **before any `api.github.com/user` call**, so every request 401'd.

The fastmcp `3.3.1 → 3.4.2` upgrade exposed it: 3.4.2's `GitHubTokenVerifier` added the `TokenCache` + that unpack line. The full suite stayed green because `test_auth_cache.py` monkeypatches `GitHubTokenVerifier.verify_token` away entirely, so the crashing line never ran under test.

### Why the prior leads were red herrings
- `subject=None` is cosmetic — FastMCP proxy JWTs never carry `sub`; that log line prints on every request, working or not.
- `GitHubProvider` is literally `OAuthProxy(..., token_verifier=GitHubTokenVerifier(...))` — the same construction kb-mcp already uses. Switching to it would not change the swap path.

## Fix

- Rename kb-mcp's attribute to `self._login_cache` so it no longer shadows the parent's `TokenCache` (whose disabled-by-default `.get()` safely returns `(False, None)`). kb-mcp's own login-cache behaviour is unchanged.
- Add a regression test that runs the **real** `super().verify_token` (only the GitHub HTTP call is stubbed), so the parent cache path is exercised — the gap the existing stubbed tests left open.
- Honor `FASTMCP_LOG_LEVEL` in `logging_config.py` (quiet by default) so the auth/JWT DEBUG trail is surfaceable without a code change.

Pairs with `FASTMCP_HOME` (a separate, real store-writability fix already set in `.env`); both are required for the connector to work. fastmcp stays at 3.4.2 (no revert — the bug was kb-mcp-side).

## Verification

- Local: `uv run python -m pytest -q` → **832 passed, 7 skipped** (skips are optional embeddings/torch/PIL/diarizer extras). The new regression test fails (the production `TypeError`) before the rename and passes after. `ruff` clean on changed files.
- Production (maintainer): `nssm restart kb-mcp` → remove + re-add the connector in claude.ai → confirm `POST /mcp → 200` in `logs/service.out.log`, no new `Token swap validation failed` in `logs/service.err.log`, and that an `api.github.com/user` call now occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zcy8LuPnEfzP56N3pn2Ub
