### PR TITLE
feat(mcp): annotate tools with readOnly/destructive/open-world hints

### DIFF
--- a/src/kb_mcp/commands.py
+++ b/src/kb_mcp/commands.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from mcp.types import ToolAnnotations
+
 from . import add as add_module
 from . import append_to_file as append_to_file_module
 from . import attention as attention_module
@@ -79,6 +81,33 @@ GUARDED_WRITE_FIELDS: dict[str, tuple[str, ...]] = {
     "preserve": ("content",),
 }
 
+# Write ops whose mutation OVERWRITES or REMOVES existing vault content, as opposed
+# to purely additive writes (add / note / create_file / append_to_file / link /
+# preserve / recover_from_trash / reconcile). Drives the MCP `destructiveHint` so a
+# cautious client (e.g. ChatGPT) doesn't badge an append as destructive. Only
+# consulted for non-read-only tools.
+DESTRUCTIVE_OPS: frozenset[str] = frozenset(
+    {"edit", "replace", "delete", "move_file", "audit_fix"}
+)
+
+
+def mcp_tool_annotations(name: str, *, read_only: bool) -> ToolAnnotations:
+    """MCP behaviour hints for one tool — what cautious clients render as badges.
+
+    kb-mcp operates on a CLOSED local vault and never reaches external systems, so
+    `openWorldHint` is always False. `readOnlyHint` comes from the command's
+    `cli_writes` flag (search/get/list ops are read-only). `destructiveHint` is only
+    meaningful for writes: additive writes are non-destructive; only `DESTRUCTIVE_OPS`
+    overwrite or remove. Absent these hints, clients assume the worst (read-only
+    `find` shown as WRITE / OPEN-WORLD / DESTRUCTIVE).
+    """
+    return ToolAnnotations(
+        title=name,
+        readOnlyHint=read_only,
+        destructiveHint=False if read_only else (name in DESTRUCTIVE_OPS),
+        openWorldHint=False,
+    )
+
 
 # --------------------------------------------------------------------------- #
 # Registry dataclasses
@@ -121,6 +150,17 @@ class Command:
     def guarded_fields(self) -> tuple[str, ...]:
         """Text fields whose value must not be a base64 binary blob."""
         return GUARDED_WRITE_FIELDS.get(self.name, ())
+
+    @property
+    def read_only(self) -> bool:
+        """True for non-mutating ops (search / get / list) — the inverse of
+        `cli_writes`, surfaced to the MCP `readOnlyHint`."""
+        return not self.cli_writes
+
+    @property
+    def mcp_annotations(self) -> ToolAnnotations:
+        """MCP behaviour hints for this command's generated tool."""
+        return mcp_tool_annotations(self.name, read_only=self.read_only)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/kb_mcp/server.py
+++ b/src/kb_mcp/server.py
@@ -861,7 +861,8 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         mcp.tool(
             commands_module.bind_vault(
                 _cmd.leaf, *_injected, name=_cmd.name, description=_cmd.doc
-            )
+            ),
+            annotations=_cmd.mcp_annotations,
         )
 
     # `note` stays a hand-registered MCP exception: its description carries the live
@@ -872,10 +873,15 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             vault_root,
             name="note",
             description=commands_module.note_description(project_keys_hint),
-        )
+        ),
+        annotations=commands_module.mcp_tool_annotations("note", read_only=False),
     )
 
-    @mcp.tool
+    @mcp.tool(
+        annotations=commands_module.mcp_tool_annotations(
+            "mint_upload_token", read_only=False
+        )
+    )
     def mint_upload_token() -> dict:
         """Mint a short-lived bearer token for the HTTP `/upload` endpoint.
 
@@ -911,7 +917,11 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
             upload_token, base_url, large_base_url=large_upload_base
         )
 
-    @mcp.tool
+    @mcp.tool(
+        annotations=commands_module.mcp_tool_annotations(
+            "mint_download_token", read_only=True
+        )
+    )
     def mint_download_token() -> dict:
         """Mint a short-lived bearer token for the HTTP `/download` endpoint.
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,101 @@
+"""Every MCP tool carries explicit behaviour annotations (readOnly / destructive /
+open-world hints) so cautious clients render them correctly.
+
+ChatGPT's tool-call panel badged the read-only `find` as WRITE / OPEN-WORLD /
+DESTRUCTIVE because the tools shipped no MCP annotation hints, so the client
+assumed the worst. The hints are derived from the command registry:
+`readOnlyHint = not cli_writes`, `openWorldHint = False` for every tool (kb-mcp is
+a closed local vault), and `destructiveHint` is True only for the small set of
+overwrite/remove ops (`commands.DESTRUCTIVE_OPS`). This test pins that contract
+against the live server so a new tool can't ship un-annotated or mis-classified.
+
+Built against the repo fixture vault with the same deterministic env as
+`tests/test_mcp_schema_fidelity.py` (embeddings/media/clip off, tier-2 ON).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from kb_mcp import commands as commands_module
+from kb_mcp import server as server_module
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
+
+
+def _build_server(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("KB_MCP_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("KB_MCP_DISABLE_RELEVANCE_CHECK", "1")
+    monkeypatch.setenv("KB_MCP_DISABLE_MEDIA_EXTRACTION", "1")
+    monkeypatch.setenv("KB_MCP_DISABLE_CLIP", "1")
+    monkeypatch.delenv("KB_MCP_DISABLE_TIER2", raising=False)
+    monkeypatch.setenv("KB_MCP_VAULT_PATH", str(FIXTURE_VAULT))
+    return server_module.build_server(require_auth=False)
+
+
+def _live_annotations(mcp) -> dict[str, dict | None]:
+    """The wire-level `annotations` object for every registered tool."""
+    tools = asyncio.run(mcp.list_tools())
+    out: dict[str, dict | None] = {}
+    for t in tools:
+        mt = t.to_mcp_tool().model_dump(mode="json")
+        out[t.name] = mt.get("annotations")
+    return out
+
+
+def test_every_tool_is_annotated(monkeypatch: pytest.MonkeyPatch) -> None:
+    ann = _live_annotations(_build_server(monkeypatch))
+    missing = [name for name, a in ann.items() if not a]
+    assert not missing, f"tools missing MCP annotations: {sorted(missing)}"
+
+
+def test_open_world_hint_false_for_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    # kb-mcp operates on a closed local vault and reaches no external systems.
+    ann = _live_annotations(_build_server(monkeypatch))
+    open_world = [n for n, a in ann.items() if not a or a.get("openWorldHint") is not False]
+    assert not open_world, f"tools not marked closed-world: {sorted(open_world)}"
+
+
+def test_read_only_hint_matches_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    ann = _live_annotations(_build_server(monkeypatch))
+    for cmd in commands_module.COMMANDS:
+        if "mcp" not in cmd.surfaces:
+            continue  # note: hand-registered for MCP, checked below
+        assert ann[cmd.name]["readOnlyHint"] is cmd.read_only, (
+            f"{cmd.name}: readOnlyHint={ann[cmd.name]['readOnlyHint']} "
+            f"but registry cli_writes={cmd.cli_writes}"
+        )
+
+
+def test_destructive_hint_only_for_overwrite_ops(monkeypatch: pytest.MonkeyPatch) -> None:
+    ann = _live_annotations(_build_server(monkeypatch))
+    for cmd in commands_module.COMMANDS:
+        if "mcp" not in cmd.surfaces or cmd.read_only:
+            continue
+        expected = cmd.name in commands_module.DESTRUCTIVE_OPS
+        assert ann[cmd.name]["destructiveHint"] is expected, (
+            f"{cmd.name}: destructiveHint={ann[cmd.name]['destructiveHint']} expected {expected}"
+        )
+
+
+def test_find_is_a_safe_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The exact regression ChatGPT surfaced.
+    a = _live_annotations(_build_server(monkeypatch))["find"]
+    assert a["readOnlyHint"] is True
+    assert a["destructiveHint"] is False
+    assert a["openWorldHint"] is False
+
+
+def test_hand_registered_tools_annotated(monkeypatch: pytest.MonkeyPatch) -> None:
+    ann = _live_annotations(_build_server(monkeypatch))
+    # note is an additive write (creates/updates a note, never overwrites blindly).
+    assert ann["note"]["readOnlyHint"] is False
+    assert ann["note"]["destructiveHint"] is False
+    # mint_upload_token issues a write-capable credential; mint_download_token is read-only.
+    assert ann["mint_upload_token"]["readOnlyHint"] is False
+    assert ann["mint_download_token"]["readOnlyHint"] is True


### PR DESCRIPTION
## Why

When Hugo connected kb-mcp to **ChatGPT** (custom MCP App), ChatGPT's tool-call panel badged the read-only `find` as **WRITE / OPEN-WORLD / DESTRUCTIVE**. Cause: kb-mcp's tools shipped **no MCP annotation hints**, so a cautious client assumes the worst. claude.ai doesn't render these badges, so it went unnoticed until now.

## What

Derive `ToolAnnotations` from the existing command registry at MCP registration — no per-tool hand-maintenance:

- `readOnlyHint = not cli_writes` — search/get/list ops are read-only
- `openWorldHint = False` for **every** tool — kb-mcp is a closed local vault with no external reach
- `destructiveHint` is `True` only for the small `DESTRUCTIVE_OPS` set that overwrites/removes (`edit`, `replace`, `delete`, `move_file`, `audit_fix`); additive writes (`add`, `note`, `create_file`, `append_to_file`, `link`, `preserve`, `recover_from_trash`, `reconcile`) are non-destructive

Hand-registered tools annotated explicitly: `note` (additive write), `mint_upload_token` (issues a write credential), `mint_download_token` (read-only).

## Safety

- Annotations live **outside** `description`/`inputSchema`, so the byte-identical **schema-fidelity baseline is unaffected** — no fixture regen, `test_mcp_schema_fidelity.py` stays green.
- New `tests/test_tool_annotations.py` pins the contract to the registry so a future tool can't ship un-annotated or mis-classified.

## Verification

\`\`\`
8 passed  (6 new annotation tests + 2 schema-fidelity tests)
uvx ruff check ... → All checks passed!
\`\`\`

Live dump confirms `find` → readOnly=True, destructive=False, openWorld=False; `delete`/`edit` → destructive=True; `openWorld=False` across all 27 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)