### PR TITLE
fix: re-promote legacy KB_MCP_* env vars after server-side load_dotenv

### DIFF
--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -42,7 +42,7 @@ from starlette.formparsers import MultiPartException
 from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 
-from . import cf_access, cli_ops, extract, guards, schema, upload_tokens
+from . import cf_access, cli_ops, env_compat, extract, guards, schema, upload_tokens
 from . import commands as commands_module
 from . import preserve as preserve_module
 from . import project_keys as project_keys_module
@@ -295,6 +295,10 @@ def build_server(*, require_auth: bool) -> FastMCP:
     True for HTTP transports; False for stdio.
     """
     load_dotenv(override=True)
+    # A .env written before the exomem rename supplies KB_MCP_* names, and it
+    # loads AFTER the import-time promotion — re-promote so legacy configs keep
+    # working (explicitly set EXOMEM_* values still win).
+    env_compat.promote_legacy()
 
     vault_root = resolve_vault()
     source_schema = schema.load_source_schema(vault_root)

--- a/tests/test_rename_compat.py
+++ b/tests/test_rename_compat.py
@@ -67,6 +67,27 @@ def test_promote_legacy_never_clobbers_explicit_new_name(monkeypatch) -> None:
     assert os.environ["EXOMEM_RENAME_PROBE2"] == "new-wins"
 
 
+def test_dotenv_legacy_vars_promoted_at_server_build(vault, monkeypatch) -> None:
+    """A pre-rename .env (KB_MCP_* keys) loads inside build_server, after the
+    import-time promotion — the post-dotenv re-promotion must cover it."""
+    from exomem import server as server_mod
+
+    monkeypatch.delenv("EXOMEM_VAULT_PATH", raising=False)
+    monkeypatch.delenv("KB_MCP_VAULT_PATH", raising=False)
+
+    def fake_load_dotenv(*args, **kwargs):
+        os.environ["KB_MCP_VAULT_PATH"] = str(vault)  # what an old .env supplies
+
+    monkeypatch.setattr(server_mod, "load_dotenv", fake_load_dotenv)
+    try:
+        srv = server_mod.build_server(require_auth=False)
+        assert srv is not None
+        assert os.environ["EXOMEM_VAULT_PATH"] == str(vault)
+    finally:
+        os.environ.pop("EXOMEM_VAULT_PATH", None)
+        os.environ.pop("KB_MCP_VAULT_PATH", None)
+
+
 def test_legacy_env_reaches_a_real_reader(monkeypatch) -> None:
     from exomem import embeddings
 


### PR DESCRIPTION
Hotfix for the #81 rename: build_server() loads .env after the import-time promotion, so a pre-rename .env (KB_MCP_* keys only) left EXOMEM_VAULT_PATH unset and the service crash-looped on boot. One-line fix at the designed-for seam + regression test through build_server. Full suite green (1021 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RkfJ1PMgzLnXKWTHBAZNs