### PR TITLE
fix: align versions with v0.3.0 and make release bumps automatic

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,12 +6,12 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Registry commands: 25
-- Tier 1 commands: 16
-- Tier 2 commands: 9
-- Registry-generated MCP commands: 24
-- REST commands: 25
-- CLI commands: 25
+- Registry commands: 27
+- Tier 1 commands: 17
+- Tier 2 commands: 10
+- Registry-generated MCP commands: 26
+- REST commands: 26
+- CLI commands: 26
 - Hand-registered MCP tools: mint_download_token, mint_upload_token, note
 
 ## Command Registry
@@ -23,6 +23,7 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 | add | 1 | MCP, REST, CLI | write | no | - | content*, source_type*, title*, url, tags, why_captured | Capture raw content as an immutable source page in the Knowledge Base. |
 | audit | 1 | MCP, REST, CLI | read | no | - | categories | Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, stale unprocessed sources, and stale-review candidates. Read-only. |
 | attention | 1 | MCP, REST, CLI | read | no | - | categories, limit | Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only. |
+| overview | 1 | MCP, REST, CLI | read | no | path | path, max_depth, include_hidden, samples | Bounded, read-only structure report of the vault (or a subtree). |
 | evolution | 1 | MCP, REST, CLI | read | no | query | query, limit, scope, projects, tags | How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only. |
 | audit_fix | 1 | MCP, REST, CLI | write | yes | - | dry_run, rebuild_embeddings | Run audit + auto-apply safe fixes; propose-only for risky categories. |
 | reconcile | 1 | MCP, REST, CLI | write | no | - | dry_run | Heal vault drift from out-of-band edits in one pass. |
@@ -43,6 +44,7 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 | list_trash | 2 | MCP, REST, CLI | read | no | - | date | Tier 2: enumerate recoverable trash entries. Read-only. |
 | recover_from_trash | 2 | MCP, REST, CLI | write | no | trash_path | trash_path*, restore_path, allow_curated | Tier 2: undo a delete_file/delete_directory. |
 | list_inbound_links | 2 | MCP, REST, CLI | read | no | target | target* | Tier 2: find files whose wikilinks resolve to `target`. Read-only. |
+| get_video_frames | 2 | MCP | read | no | - | path*, max_frames, start_sec, end_sec | View / analyze / look inside a vault video: sampled keyframes returned INLINE as images — no download round-trip. |
 
 ## Hand-registered MCP Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exomem"
-version = "0.2.1"
+version = "0.3.0" # x-release-please-version
 description = "Local knowledge substrate for owned markdown/Obsidian vaults, exposed through MCP, REST, and CLI with multimodal OCR/ASR/CLIP search"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,9 +35,12 @@
       ],
       "extra-files": [
         {
-          "type": "toml",
-          "path": "pyproject.toml",
-          "jsonpath": "$['project']['version']"
+          "type": "generic",
+          "path": "pyproject.toml"
+        },
+        {
+          "type": "generic",
+          "path": "src/exomem/__init__.py"
         }
       ]
     }

--- a/src/exomem/__init__.py
+++ b/src/exomem/__init__.py
@@ -11,4 +11,4 @@ from .env_compat import promote_legacy as _promote_legacy
 
 _promote_legacy()
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"  # x-release-please-version

--- a/uv.lock
+++ b/uv.lock
@@ -631,6 +631,88 @@ wheels = [
 ]
 
 [[package]]
+name = "exomem"
+version = "0.3.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "numpy" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "python-slugify" },
+    { name = "pyyaml" },
+    { name = "rank-bm25" },
+    { name = "snowballstemmer" },
+    { name = "watchdog" },
+]
+
+[package.optional-dependencies]
+diarization = [
+    { name = "speechbrain" },
+]
+embeddings = [
+    { name = "pillow" },
+    { name = "sentence-transformers" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+media = [
+    { name = "faster-whisper" },
+    { name = "markitdown", extra = ["docx", "pptx", "xlsx"] },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32'" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+    { name = "pytesseract" },
+]
+vision = [
+    { name = "transformers" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "faster-whisper", marker = "extra == 'media'", specifier = ">=1.0" },
+    { name = "fastmcp", specifier = ">=2.10" },
+    { name = "markitdown", extras = ["docx", "xlsx", "pptx"], marker = "extra == 'media'", specifier = ">=0.1.1" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
+    { name = "pillow", marker = "extra == 'embeddings'", specifier = ">=10.0" },
+    { name = "pillow", marker = "extra == 'media'", specifier = ">=10.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
+    { name = "pymupdf", marker = "extra == 'media'", specifier = ">=1.24" },
+    { name = "pytesseract", marker = "extra == 'media'", specifier = ">=0.3.10" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "python-slugify", specifier = ">=8.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rank-bm25", specifier = ">=0.2.2" },
+    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.7" },
+    { name = "snowballstemmer", specifier = ">=2.2" },
+    { name = "speechbrain", marker = "extra == 'diarization'", specifier = ">=1.0" },
+    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'embeddings') or (sys_platform == 'win32' and extra == 'embeddings')", specifier = ">=2.12", index = "https://download.pytorch.org/whl/cu132" },
+    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'embeddings'", specifier = ">=2.12" },
+    { name = "transformers", marker = "extra == 'vision'", specifier = ">=4.40" },
+    { name = "watchdog", specifier = ">=4.0" },
+]
+provides-extras = ["embeddings", "media", "diarization", "vision"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+]
+
+[[package]]
 name = "faster-whisper"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,88 +1091,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "exomem"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "fastmcp" },
-    { name = "numpy" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "python-slugify" },
-    { name = "pyyaml" },
-    { name = "rank-bm25" },
-    { name = "snowballstemmer" },
-    { name = "watchdog" },
-]
-
-[package.optional-dependencies]
-diarization = [
-    { name = "speechbrain" },
-]
-embeddings = [
-    { name = "pillow" },
-    { name = "sentence-transformers" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-media = [
-    { name = "faster-whisper" },
-    { name = "markitdown", extra = ["docx", "pptx", "xlsx"] },
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32'" },
-    { name = "pillow" },
-    { name = "pymupdf" },
-    { name = "pytesseract" },
-]
-vision = [
-    { name = "transformers" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "httpx" },
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "faster-whisper", marker = "extra == 'media'", specifier = ">=1.0" },
-    { name = "fastmcp", specifier = ">=2.10" },
-    { name = "markitdown", extras = ["docx", "xlsx", "pptx"], marker = "extra == 'media'", specifier = ">=0.1.1" },
-    { name = "numpy", specifier = ">=1.26" },
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
-    { name = "pillow", marker = "extra == 'embeddings'", specifier = ">=10.0" },
-    { name = "pillow", marker = "extra == 'media'", specifier = ">=10.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
-    { name = "pymupdf", marker = "extra == 'media'", specifier = ">=1.24" },
-    { name = "pytesseract", marker = "extra == 'media'", specifier = ">=0.3.10" },
-    { name = "python-dotenv", specifier = ">=1.0" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
-    { name = "python-slugify", specifier = ">=8.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rank-bm25", specifier = ">=0.2.2" },
-    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.7" },
-    { name = "snowballstemmer", specifier = ">=2.2" },
-    { name = "speechbrain", marker = "extra == 'diarization'", specifier = ">=1.0" },
-    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'embeddings') or (sys_platform == 'win32' and extra == 'embeddings')", specifier = ">=2.12", index = "https://download.pytorch.org/whl/cu132" },
-    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'embeddings'", specifier = ">=2.12" },
-    { name = "transformers", marker = "extra == 'vision'", specifier = ">=4.40" },
-    { name = "watchdog", specifier = ">=4.0" },
-]
-provides-extras = ["embeddings", "media", "diarization", "vision"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "pytest", specifier = ">=8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Repairs the 0.3.0 release: version fields bumped (the extra-files TOML updater has never fired — 0.2.1's release commit didn't touch pyproject either), switched to the reliable x-release-please-version generic markers for future releases, and regenerated docs/capabilities.md (rename-sweep drift was failing CI). After merge: retag v0.3.0 onto the aligned commit and re-dispatch the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RkfJ1PMgzLnXKWTHBAZNs