### PR TITLE
feat: semantic video segments — timed transcripts, fused topic segmentation, transcript_match_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_VIDEO_SCENE_FRAMES` | Set to enable video scene detection + persisted, OCR'd scene-frame JPEGs (default off). |
 | `EXOMEM_VIDEO_SCENE_THRESHOLD` | Scene-boundary hash threshold in bits of 64 (default 10). |
 | `EXOMEM_VIDEO_SCENE_MIN_SECS` | Minimum scene duration in seconds; closer boundaries merge (default 4). |
+| `EXOMEM_SEMANTIC_SEGMENTS` | Set to enable timed transcripts + semantic segment retrieval for audio/video (default off). |
 | `EXOMEM_WHISPER_MODEL` | Whisper model size for ASR, such as `base` or `small`. |
 | `EXOMEM_TESSERACT_CMD` | Path to the `tesseract` binary if not auto-discovered. |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -305,6 +305,18 @@ and `EXOMEM_VIDEO_SCENE_MIN_SECS` (default 4). To upgrade already-indexed videos
 run `exomem backfill-media` with the flag set — idempotent, and it replaces the
 old uniform CLIP rows with scene-aware ones.
 
+**Semantic video segments** (`EXOMEM_SEMANTIC_SEGMENTS`, default off) make the
+moment the retrieval unit for audio/video. Transcripts render as one timed line
+per ASR segment (`[51:20] …`, diarized `[51:20] [Alice]: …`), and the embedding
+chunker segments them at fused topic boundaries — bge similarity valleys plus
+scene-change, speaker-turn, and OCR-change events from the persisted scene
+frames. A transcript match then surfaces `transcript_match_at` on the hit with
+the nearest scene frame attached. Pure measurement, no LLM, no new dependency;
+gate off is byte-identical. The worker re-embeds a video's sidecar once after
+its frame OCRs so segments see all signals (bounded, off the request path).
+Upgrade existing recordings with `exomem backfill-media --retime` (opt-in —
+re-runs ASR; combine with `--rediarize` to gain both markers in one pass).
+
 **Install:** `uv sync --extra media --extra diarization`, then build the isolated
 sidecar with `pwsh -File scripts/setup-diarizer.ps1 -Prewarm` on Windows or
 `uv sync --directory sidecar/diarizer` on Linux/macOS.

--- a/openspec/changes/add-semantic-video-segments/design.md
+++ b/openspec/changes/add-semantic-video-segments/design.md
@@ -1,0 +1,99 @@
+# Design — semantic video segments
+
+## D1. Timed rendering + gate
+
+One gate, `EXOMEM_SEMANTIC_SEGMENTS` (truthy opt-in, legacy `KB_MCP_` promoted),
+covers rendering AND segmentation; the find surface is data-driven, not gated
+(scene-frames precedent). Rendering happens **in `extract`** — `_transcribe` for
+plain, `_diarize` for labeled — because per-segment timings exist only there,
+and every writer inherits the behavior. Format: one line per ASR segment,
+`[m:ss]`/`[h:mm:ss]` prefix (identical semantics to `find._format_timestamp`),
+diarized lines repeat the speaker label per segment (merged turns would span
+minutes and kill both windowing and match localization; the structured
+merged-turn `speakers` list is untouched). Engine marker `+timed` precedes
+`+diarized` (`_needs_rediarize` matches `endswith("+diarized")`). Canonical
+parse regex lives in `semantic_segments.TIMED_LINE_RE`; `find._format_timestamp`
+delegates to the shared formatter. Renderer failure soft-fails to the flat join;
+gate unset is byte-identical (regression-tested for plain AND diarized).
+
+## D2. Segmenter (`semantic_segments.py`)
+
+- `parse_timed_lines` → `[(ts, speaker|None, text)]`; unmatched lines fold into
+  the previous line.
+- Windows of `WINDOW_LINES=4` (stride 1), text-only (markers stripped), embedded
+  in one batch via an **injected `embed_fn`** (defaults to
+  `embeddings.embed_texts` via lazy import — the test seam that lets the whole
+  segmenter run with embeddings disabled).
+- Valley scores: adjacent-window cosine + TextTiling depth
+  `((peak_left - sim) + (peak_right - sim)) / 2`, normalized to `topic ∈ [0,1]`
+  by `depth / 0.4`.
+- Events (`gather_events`): visual = midpoints between consecutive scene-frame
+  `rep_ts` values parsed from `<video>.frames/scene-*-t<ms>ms.jpg` filenames
+  (rep_ts is a scene midpoint, so the boundary lies between reps — ±5 s
+  proximity absorbs the approximation); speaker = label change between adjacent
+  lines; OCR = token-set Jaccard < 0.5 between consecutive frame sidecars with
+  real engines (`(no text detected)` = empty).
+- Fusion per gap: `1.0*topic + 0.5*scene(±5s) + 0.35*speaker + 0.4*ocr(±5s)`,
+  boundary at `>= 0.55` — a deep valley alone passes; a moderate valley plus any
+  corroborating event passes; scene+OCR+speaker together pass without a valley.
+- Constraints: `MIN_SEG_SECS=25` (keep the higher-scoring of two close
+  boundaries), `MAX_SEG_WORDS = MAX_WORDS_PER_CHUNK - 30` (force-split at the
+  best interior gap — nothing silently truncates), `MAX_SEGMENTS=256` (drop
+  weakest first).
+- Chunks: segment lines verbatim (markers included) + standard title prefix;
+  the first line's `[ts]` is what find parses.
+- Fallback ladder (unit-tested): full fusion → events-only on embed failure →
+  `None` (< 8 timed lines or any error) ⇒ caller falls back to `chunk_text`.
+
+## D3. Chunker seam (`embeddings.py`)
+
+`upsert_after_write` calls `_chunks_for_page(vault_root, page)` instead of
+`chunk_text` directly. Semantic path only when gate on ∧ `media_type` audio or
+video ∧ ≥ 8 timed lines in `## Extracted text`; sections before/after the
+transcript still paragraph-chunk in document order. All other pages —
+provably identical output to `chunk_text` (equality tests). The seam is shared
+automatically by every writer, the file watcher, and reconcile.
+
+## D4. find surface
+
+`Hit.transcript_ts` emitted as `transcript_match_at` (same formatter).
+Resolution: vector lane parses the matched chunk's first timed marker;
+BM25/keyword-only hits on timed A/V pages locate the first query-token anchor in
+the body and take the nearest **preceding** marker; title-only matches emit
+nothing. The existing nearest-frame block extends: `clip_frame_ts` first (as
+today), else `transcript_ts` — `scene_match_at` and `transcript_match_at`
+coexist, never suppress each other. `_find_keyword` gets the same helper. One
+video = one hit is already guaranteed (best-chunk-per-file + frame-child
+collapse).
+
+## D5. Worker ordering
+
+Segmentation is a pure function of (sidecar bytes, frames-dir state) — safe to
+re-run. `_Job.do_reembed` + `_process` branch calls `upsert_after_write` on the
+sidecar. `_persist_scene_frames` enqueues the frame-OCR jobs THEN one parent
+re-embed (single-thread FIFO ⇒ runs after all OCRs; no synchronization). First
+upsert at ASR time segments from transcript+speaker signals only (missing
+events contribute zero — soft); the trailing job re-segments with all four.
+Restart: `_scan_pending_ocr` enqueues deduped parent re-embeds after pending
+frame children. The narrow crash window (frames OCR'd, re-embed lost) heals on
+any later sidecar write or backfill.
+
+## D6. Backfill `--retime`
+
+CLI arg mirroring `--rediarize` (help text names the gate; warn-and-disable
+when unset). `_needs_retime`: audio/video ∧ completed real engine ∧
+`"+timed" not in engine`. One `extract_text` call serves retime+rediarize;
+the existing marker-degradation path generalizes to whichever markers were
+requested. Stats gain `retimed`. After `need_scenes` writes+OCRs fresh frames,
+a final parent `upsert_after_write` folds the new events into segments.
+
+## Risks
+
+- Concurrent session in find.py-adjacent code — all edits additive; drop the
+  `_format_timestamp` delegation if it collides.
+- `_chunks_for_page` touches every file's embedding path — the non-timed branch
+  equality tests are the regression guard.
+- Thresholds are educated guesses — deterministic, centralized in one constants
+  block, tuned desk-side on real ASR output.
+- Sidecar size +10–15% vs the 512 KB cap — very long videos truncate slightly
+  earlier; documented, cap unchanged.

--- a/openspec/changes/add-semantic-video-segments/proposal.md
+++ b/openspec/changes/add-semantic-video-segments/proposal.md
@@ -1,0 +1,85 @@
+## Why
+
+A text match on a long recording today returns the whole two-hour sidecar: the
+transcript is one flat blob, so `find` can say *that* a video discusses a topic
+but not *when*. Only visual matches carry timestamps (`clip_match_at` from the
+CLIP lane, `scene_match_at` from persisted scene frames). Meanwhile the two
+ingredients for timed text retrieval already exist and are thrown away: Whisper
+produces per-segment timings (materialized in `_transcribe` for diarization) and
+the scene-frames feature persists visual-change events with timestamps.
+
+This change makes the **semantic segment** the retrieval unit for timed media:
+transcripts persist with human-readable timestamps, segmentation fuses
+transcript-topic boundaries with visual/speaker/OCR events, and a transcript
+match surfaces `transcript_match_at: "51:20"` with the nearest persisted scene
+frame attached — "find where they said X" and "where they showed X" both answer
+with a moment and a picture.
+
+It stays **pure-substrate**: bge window embeddings + cosine similarity valleys +
+fixed thresholds and event fusion are deterministic measurement (the same class
+as CLIP, scene detection, and OCR) — no reasoning LLM. No new dependency.
+
+## What Changes
+
+- **Timed transcript rendering** (gate `EXOMEM_SEMANTIC_SEGMENTS`, default OFF):
+  audio/video `## Extracted text` becomes one line per ASR segment —
+  `[51:20] …` plain, `[51:20] [Alice]: …` diarized — rendered at the source in
+  `extract` so every writer (worker, backfill, upload) inherits it. The engine
+  marker gains `+timed` (before `+diarized` — suffix order is load-bearing for
+  the rediarize idempotency check). The structured merged-turn `speakers` list
+  and frontmatter are unchanged. Gate unset ⇒ byte-identical output.
+- **Semantic segmentation as the chunking unit** (new `semantic_segments.py`):
+  for gated, timed audio/video sidecars, the embedding chunker segments the
+  transcript at fused boundaries — TextTiling-style embedding-valley topic
+  scores combined with visual-change events (scene-frame filename timestamps),
+  speaker-turn changes, and OCR-change events (token-Jaccard between consecutive
+  frame sidecars) — with minimum segment duration, max-words force-splits, and a
+  segment cap. Non-timed pages chunk exactly as today (equality-tested).
+  Soft-fail ladder: embed failure ⇒ events-only boundaries; anything else ⇒
+  paragraph chunking as today.
+- **find surfaces the moment**: hits on timed media gain `transcript_match_at`
+  (parsed from the matched chunk's leading timestamp in the vector lane, or the
+  nearest preceding marker for BM25/keyword matches) and attach the nearest
+  persisted scene frame when no CLIP frame already did. Data-driven, not gated —
+  flat sidecars produce byte-identical responses.
+- **Worker ordering**: after scene-frame OCR jobs, the worker enqueues one
+  trailing re-embed of the parent sidecar so segmentation re-runs with all
+  signals present (single-thread FIFO — no new synchronization). Restart scan
+  re-enqueues deduped parent re-embeds after pending frame children.
+- **Backfill `--retime`** (opt-in — re-ASR is expensive): upgrades existing
+  flat-text audio/video to timed transcripts; idempotent via the `+timed`
+  marker; one re-extract serves `--retime` and `--rediarize` together; warns
+  and disables when the gate is unset.
+
+Out of scope: VLM captions or any server-side reasoning; cross-video inference;
+per-segment vectors in the CLIP index; Q/UnifiedSegment work (the pattern
+transfers later).
+
+## Capabilities
+
+### New Capabilities
+- `semantic-video-segments`: timed transcripts + fused semantic segmentation
+  make moments the retrieval unit for audio/video — default-off, soft-fail,
+  pure-substrate (deterministic embedding/event measurement, no LLM, no new
+  dependency).
+
+### Modified Capabilities
+- `speaker-diarization`: gate carve-out — with `EXOMEM_SEMANTIC_SEGMENTS` set,
+  diarized transcripts render as per-segment timed lines (labels repeated per
+  line) instead of merged turns; the structured merged-turn list is unchanged.
+- `video-scene-frames`: persisted frames additionally serve as segmentation
+  boundary events; the worker enqueues a parent-sidecar re-embed after frame
+  OCRs complete.
+
+## Impact
+
+- Code: `src/exomem/semantic_segments.py` (new — timestamps/parser/renderer,
+  valley+event fusion segmenter); `extract.py` (gated timed rendering);
+  `embeddings.py` (`_chunks_for_page` routing seam); `find.py`
+  (`transcript_match_at` + nearest-frame attach, additive); `media_worker.py`
+  (`do_reembed` trailing job); `backfill.py` + `__main__.py` (`--retime`).
+- Deps: none added. Gate unset ⇒ zero behavior change anywhere.
+- Cost: one extra windows-embedding batch per timed sidecar write and one
+  bounded re-embed per video after frame OCR — off the request path, only when
+  gated on. Sidecar grows ~10–15% from markers (existing 512 KB cap applies).
+- Docs: `EXOMEM_SEMANTIC_SEGMENTS` env row + `--retime` in README/deployment.

--- a/openspec/changes/add-semantic-video-segments/specs/semantic-video-segments/spec.md
+++ b/openspec/changes/add-semantic-video-segments/specs/semantic-video-segments/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Timed Transcript Rendering
+
+The system SHALL, when semantic segments are enabled (`EXOMEM_SEMANTIC_SEGMENTS`), render
+audio/video extracted text as one line per ASR segment prefixed with a human-readable
+timestamp — `[m:ss] …` (or `[h:mm:ss] …` at an hour and beyond), and
+`[m:ss] [Speaker]: …` when diarization is active, repeating the speaker label per segment.
+Rendering SHALL happen at the extraction source so every writer (worker, backfill, upload)
+inherits it. The extraction engine marker SHALL gain `+timed`, ordered before `+diarized`.
+The structured merged-turn `speakers` data and frontmatter SHALL be unchanged. With the flag
+unset, extraction output SHALL be byte-identical to today for both plain and diarized paths.
+
+#### Scenario: Plain transcript gains per-segment timestamps
+
+- **WHEN** an audio/video file is transcribed with `EXOMEM_SEMANTIC_SEGMENTS` set and
+  diarization off
+- **THEN** the extracted text is one `[m:ss] <segment text>` line per ASR segment and the
+  engine carries `+timed`
+
+#### Scenario: Diarized transcript keeps per-segment granularity
+
+- **WHEN** the same file is transcribed with diarization active under the gate
+- **THEN** each line is `[m:ss] [<speaker>]: <segment text>` with the label repeated per
+  segment, the engine ends `+timed+diarized`, and the structured merged-turn `speakers` list
+  is identical to the ungated shape
+
+#### Scenario: Gate unset is byte-identical
+
+- **WHEN** extraction runs with `EXOMEM_SEMANTIC_SEGMENTS` unset
+- **THEN** transcript text and engine strings are exactly today's output
+
+### Requirement: Fused Semantic Segmentation as the Retrieval Unit
+
+For gated, timed audio/video sidecars, the text-embedding chunker SHALL segment the
+transcript at boundaries fused from deterministic signals: transcript-topic scores from
+embedding-similarity valleys over sliding line windows, visual-change events from persisted
+scene-frame timestamps, speaker-turn changes, and OCR-change events between consecutive
+frame sidecars. Segments SHALL respect a minimum duration, a maximum word budget (splitting
+rather than truncating), and a segment cap. Each chunk SHALL begin with its segment's
+timestamp marker. Pages that are not gated timed media SHALL chunk exactly as today.
+
+#### Scenario: Topic shift becomes a chunk boundary
+
+- **WHEN** a timed transcript moves from one topic to a distinctly different one and the
+  sidecar is re-embedded under the gate
+- **THEN** the embedding index holds separate chunks for the two topics, each beginning with
+  its segment's `[timestamp]` marker
+
+#### Scenario: Corroborating events tip a moderate boundary
+
+- **WHEN** a moderate topic valley coincides (within the proximity window) with a
+  visual-change event or a speaker change
+- **THEN** a segment boundary is placed there
+
+#### Scenario: Non-timed pages are unaffected
+
+- **WHEN** any page without timed media lines is embedded, gate set or not
+- **THEN** its chunks are byte-identical to the existing paragraph chunker's output
+
+### Requirement: Transcript Matches Surface the Moment
+
+`find` SHALL surface `transcript_match_at` (human-readable timestamp) on hits whose match
+localizes inside a timed transcript: from the matched chunk's leading timestamp marker in
+the vector lane, or from the nearest preceding marker to the first query-token anchor for
+BM25/keyword matches on timed audio/video pages. When such a hit has no CLIP-resolved frame,
+the nearest persisted scene frame SHALL be attached by transcript timestamp. The surfacing
+SHALL be data-driven — hits on flat (untimed) sidecars are byte-identical to today.
+
+#### Scenario: A said phrase lands at its moment
+
+- **WHEN** a query matches text spoken at 51:20 of a timed video transcript
+- **THEN** the video's single hit carries `transcript_match_at: "51:20"` and, when frames
+  are persisted, a `scene_frame` near that moment
+
+#### Scenario: Flat sidecars unchanged
+
+- **WHEN** a query matches a video sidecar whose transcript has no timestamp markers
+- **THEN** the hit contains no `transcript_match_at` and is otherwise identical to today
+
+### Requirement: Segment Signals Complete After Frame OCR
+
+The media worker SHALL enqueue one re-embed of the parent sidecar after a video's frame-OCR
+jobs — OCR-change events depend on frame sidecars extracted after the transcript is written —
+so segmentation re-runs with all signals present, and the restart scan SHALL re-enqueue
+deduped parent re-embeds after pending frame children. Segmentation SHALL tolerate missing
+signals at any earlier run (absent events contribute nothing).
+
+#### Scenario: Trailing re-embed folds in OCR events
+
+- **WHEN** a gated video finishes ASR, scene frames are written, and their OCR jobs complete
+- **THEN** the parent sidecar is re-embedded once afterwards and its segments reflect
+  visual, speaker, and OCR events
+
+### Requirement: Opt-In Re-Timing Backfill
+
+`backfill-media` SHALL support an explicit opt-in re-ASR pass (`--retime`) that upgrades
+completed flat-text audio/video sidecars to timed transcripts, keyed idempotent on the
+`+timed` engine marker. One re-extraction SHALL serve `--retime` and `--rediarize` together
+when both are requested. The pass SHALL warn and disable itself when the gate is unset.
+
+#### Scenario: Legacy recording upgraded once
+
+- **WHEN** `backfill-media --retime` runs twice over a video whose engine lacks `+timed`
+- **THEN** the first run re-transcribes and writes timed lines (engine gains `+timed`) and
+  the second run skips it
+
+### Requirement: Soft-Fail Ladder and Pure-Substrate Bounds
+
+Segmentation SHALL degrade without failing extraction or embedding: an embedding failure
+falls back to event-only boundaries; fewer than the minimum timed lines, or any error,
+falls back to the existing paragraph chunker. All signals SHALL be deterministic
+measurements (embedding similarity, filename timestamps, label changes, token overlap);
+no reasoning model SHALL be invoked.
+
+#### Scenario: Embedding failure still segments
+
+- **WHEN** window embedding raises while events are available
+- **THEN** boundaries come from events (plus word-budget splits) and embedding of the
+  resulting chunks proceeds
+
+#### Scenario: Too little timed content falls back
+
+- **WHEN** a timed sidecar has fewer than the minimum timed lines
+- **THEN** the page chunks via the existing paragraph chunker unchanged

--- a/openspec/changes/add-semantic-video-segments/specs/speaker-diarization/spec.md
+++ b/openspec/changes/add-semantic-video-segments/specs/speaker-diarization/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Named-Speaker Attribution via Voice Profiles
+
+The system SHALL resolve anonymous diarization clusters to enrolled speaker names when ASR
+diarization is enabled (`EXOMEM_DIARIZE`) and at least one voice profile is enrolled — by
+computing a per-cluster ECAPA voice embedding and matching it against profile centroids by
+cosine similarity. A cluster SHALL be assigned a profile name only when the match clears the
+configured threshold, margin, and standout rules; otherwise it SHALL remain anonymous.
+
+Transcript rendering SHALL depend on the semantic-segments gate: with
+`EXOMEM_SEMANTIC_SEGMENTS` unset, diarized transcripts render as merged same-speaker turns
+(`[Hugo]: …`) exactly as today; with it set, they render as one timed line per ASR segment
+(`[m:ss] [Hugo]: …`) with the label repeated per segment. In both modes the structured
+`speakers` field SHALL carry the merged-turn shape unchanged.
+
+#### Scenario: Enrolled speaker is named in the transcript
+
+- **WHEN** a media file is diarized for a vault with an enrolled profile "Hugo" and a cluster's
+  ECAPA centroid matches the Hugo centroid above threshold and margin
+- **THEN** that cluster's turns are rendered as `[Hugo]: …` in the transcript text (prefixed
+  `[m:ss]` per segment when `EXOMEM_SEMANTIC_SEGMENTS` is set)
+- **AND** the structured `speakers` field carries `speaker: "Hugo"` for those turns
+
+#### Scenario: Unknown voice stays anonymous
+
+- **WHEN** a cluster's centroid does not clear any profile's threshold/margin/standout rules
+- **THEN** the cluster is labeled with a stable anonymous label (`Speaker A`, `Speaker B`, … by
+  first-onset order)
+- **AND** no profile name is applied to it
+
+#### Scenario: Over-split single speaker is merged before attribution
+
+- **WHEN** pyannote splits one speaker into two clusters whose centroids are within the merge
+  threshold
+- **THEN** the two clusters are merged via average-linkage before attribution
+- **AND** a single profile can label the merged group
+
+#### Scenario: Timed rendering keeps merged-turn structure
+
+- **WHEN** a diarized transcript is rendered with `EXOMEM_SEMANTIC_SEGMENTS` set
+- **THEN** the text is per-segment timed lines while the structured `speakers` list remains
+  the merged-turn shape, so the `speakers:` frontmatter and speaker filters are unaffected

--- a/openspec/changes/add-semantic-video-segments/specs/video-scene-frames/spec.md
+++ b/openspec/changes/add-semantic-video-segments/specs/video-scene-frames/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Scene Frames Are OCR'd Through the Image Path
+
+Scene-frame sidecars SHALL enter the existing pending-extraction flow so each frame is OCR'd by
+the existing image path and its on-screen text lands in the sidecar's extracted text, indexed by
+BM25 and the text embedding index. Scene frames SHALL NOT receive their own ClipIndex rows — the
+parent video's per-scene vectors own visual search — and every CLIP-enqueue point SHALL skip
+images whose sidecar carries `parent_media`.
+
+Persisted frames additionally serve as segmentation inputs: their filename timestamps and OCR
+text are boundary-event sources for semantic segmentation. When `EXOMEM_SEMANTIC_SEGMENTS` is
+set, the media worker SHALL enqueue one re-embed of the parent video's sidecar after the
+frame-OCR jobs it created, so segmentation re-runs with visual and OCR events present.
+
+#### Scenario: On-screen text becomes findable
+
+- **WHEN** a scene frame containing legible text (a slide, a stack trace) is OCR'd
+- **THEN** that text is stored in the frame's sidecar and is findable via keyword/BM25 search
+
+#### Scenario: No duplicate visual vectors
+
+- **WHEN** the media worker's startup scan or a backfill pass encounters a scene-frame image
+- **THEN** it is not queued for CLIP indexing and no ClipIndex row is created for the frame file
+
+#### Scenario: Parent re-embed follows frame OCR
+
+- **WHEN** a gated video's scene frames finish their OCR jobs
+- **THEN** exactly one re-embed job for the parent sidecar runs afterwards on the same queue

--- a/openspec/changes/add-semantic-video-segments/tasks.md
+++ b/openspec/changes/add-semantic-video-segments/tasks.md
@@ -1,0 +1,82 @@
+# Tasks — semantic video segments
+
+## 1. Timestamp core (pure, no models)
+- [x] 1.1 `semantic_segments.py`: `format_ts` (m:ss / h:mm:ss, identical to
+      `find._format_timestamp` output), `TIMED_LINE_RE`, `parse_timed_lines`
+      (unmatched lines fold into previous), `render_timed_lines` (plain +
+      per-segment diarized lines).
+- [x] 1.2 `find._format_timestamp` kept as-is (zero collision surface with the
+      concurrent find.py work); output-identity with the shared formatter is
+      asserted by test instead of by delegation.
+- [x] 1.3 Tests `tests/test_semantic_segments.py`: format/parse round-trip incl.
+      hour rollover, diarized/plain groups, folding, renderer shapes.
+
+## 2. Gated timed rendering (extract)
+- [x] 2.1 `_transcribe`: gate on ⇒ `render_timed_lines` + engine `+timed`;
+      gate off byte-identical; renderer failure ⇒ flat join (soft).
+- [x] 2.2 `_diarize`: gate on ⇒ per-segment `[ts] [Speaker]:` lines, engine
+      `…+timed+diarized` (order load-bearing); merged-turn `speakers` list
+      unchanged; gate off byte-identical.
+- [x] 2.3 Tests (extend `tests/test_extract.py`, `_FakeWhisper` pattern):
+      byte-identical off (plain + diarized), timed shapes on, engine markers,
+      diarization soft-fail under gate ⇒ timed plain.
+
+## 3. Segmenter
+- [x] 3.1 Windows/valleys: text-only windows (4, stride 1), injected `embed_fn`,
+      adjacent-window cosine, TextTiling depth → `topic` signal.
+- [x] 3.2 `gather_events`: scene-frame midpoints (filename parse), speaker-change
+      gaps, OCR Jaccard events (real-engine frame sidecars only).
+- [x] 3.3 Fusion + constraints: weights 1.0/0.5/0.35/0.4, threshold 0.55,
+      `MIN_SEG_SECS` 25, `MAX_SEG_WORDS` force-split, `MAX_SEGMENTS` 256.
+- [x] 3.4 Ladder: embed failure ⇒ events-only; <8 timed lines or error ⇒ None.
+- [x] 3.5 Tests: fake `embed_fn` two-topic boundary, uniform ⇒ none, event
+      fixtures on a tmp vault, constraint cases, ladder cases, determinism.
+
+## 4. Chunker seam (embeddings)
+- [x] 4.1 `_chunks_for_page`: route gated timed A/V sidecars to the segmenter
+      (transcript section) + `chunk_text` for surrounding sections in document
+      order; everything else and segmenter-None ⇒ `chunk_text`.
+- [x] 4.2 Tests: equality with `chunk_text` for non-media pages and gate-off;
+      segment chunks + section chunks composition; None fallback.
+
+## 5. find surface
+- [x] 5.1 `Hit.transcript_ts` + `transcript_match_at` in `as_dict`/compact.
+- [x] 5.2 `_transcript_ts_for_hit`: vector-chunk leading marker; BM25/keyword
+      nearest-preceding-marker for timed A/V pages; title-only ⇒ None.
+- [x] 5.3 Nearest-frame attach extension (`clip_frame_ts` first, else
+      `transcript_ts`); `_find_keyword` parity.
+- [x] 5.4 Tests `tests/test_find_transcript_match.py` (embeddings disabled):
+      keyword/BM25 hit on a timed sidecar ⇒ `transcript_match_at` + attached
+      `scene_frame`; chunk-branch unit test; coexistence with `scene_match_at`;
+      flat sidecar ⇒ field absent; compact emission.
+
+## 6. Worker ordering
+- [x] 6.1 `_Job.do_reembed` + `_process` branch (`upsert_after_write`).
+- [x] 6.2 `_persist_scene_frames`: enqueue parent re-embed after frame OCRs
+      (gate on). `_scan_pending_ocr`: deduped parent re-embeds after pending
+      frame children.
+- [x] 6.3 Tests: enqueue-order assertions via stubs; restart-scan dedup.
+
+## 7. Backfill --retime
+- [x] 7.1 `_needs_retime` (a/v ∧ real engine ∧ no `+timed`); one re-extract
+      serves retime+rediarize; generalized marker degradation; `retimed` stat;
+      gate-off warn-and-disable; dry-run tag; post-frames parent re-embed.
+- [x] 7.2 `__main__.py` `--retime` arg (help names the gate).
+- [x] 7.3 Tests: detection matrix, combined retime+rediarize single extract,
+      idempotent second run, gate-off disable, dry-run.
+
+## 8. Docs + verify
+- [x] 8.1 README env row (`EXOMEM_SEMANTIC_SEGMENTS`) + `--retime`;
+      deployment.md note (cost, worker ordering, backfill upgrade path).
+- [x] 8.2 Full suite green; ruff no net-new; leak guard;
+      `openspec validate add-semantic-video-segments --strict`.
+- [ ] 8.3 Desk-side e2e (Hugo/desk, GPU + gate on): upload a talking-head+slides
+      recording → timed sidecar bytes → segment chunks in `.embeddings.sqlite` →
+      `find("<phrase said>")` returns the video with `transcript_match_at` + a
+      `scene_frame` → `backfill-media --retime --dry-run` then real run on one
+      legacy video; tune thresholds if boundaries feel off.
+
+## 9. Follow-ups (non-blocking)
+- [ ] 9.1 Content-type-aware weights (screen-recording vs podcast profiles).
+- [ ] 9.2 Segment-aware context packs / get_video_frames integration.
+- [ ] 9.3 Port the pattern to Q's UnifiedSegment (separate repo).

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -118,6 +118,13 @@ def _backfill_media_main(argv: list[str]) -> int:
         "'+diarized') so they gain speaker turns + a speakers: frontmatter list. Requires "
         "EXOMEM_DIARIZE set in this shell (the CLI does not read .env).",
     )
+    parser.add_argument(
+        "--retime", action="store_true",
+        help="re-extract audio/video transcribed before timed transcripts (extracted_by "
+        "without '+timed') so they gain per-segment [m:ss] lines — the substrate for "
+        "semantic segments. Requires EXOMEM_SEMANTIC_SEGMENTS set in this shell (the CLI "
+        "does not read .env). One re-extraction serves --retime and --rediarize together.",
+    )
     args = parser.parse_args(argv)
     if not args.vault:
         print("backfill-media: set --vault or EXOMEM_VAULT_PATH", file=sys.stderr)
@@ -131,6 +138,7 @@ def _backfill_media_main(argv: list[str]) -> int:
         do_ocr=not args.no_ocr,
         do_clip=not args.no_clip,
         rediarize=args.rediarize,
+        retime=args.retime,
         dry_run=args.dry_run,
         log_fn=print,
     )

--- a/src/exomem/backfill.py
+++ b/src/exomem/backfill.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from . import embeddings, extract, preserve, scene_frames
+from . import embeddings, extract, preserve, scene_frames, semantic_segments
 from .vault import VAULT_SCAN_SKIP_DIRS
 
 log = logging.getLogger(__name__)
@@ -99,6 +99,18 @@ def _needs_rediarize(sidecar: Path, media_type: str | None) -> bool:
     return not v.endswith("+diarized")
 
 
+def _needs_retime(sidecar: Path, media_type: str | None) -> bool:
+    """True for an audio/video sidecar transcribed BEFORE timed transcripts: a
+    completed ASR engine (not pending/failed/no-audio) without the `+timed`
+    marker — that marker is the re-time done-state, keeping the pass idempotent."""
+    if media_type not in ("audio", "video"):
+        return False
+    v = _extracted_engine(sidecar)
+    if v is None or v in _NOT_DONE or v.startswith("failed:") or v == "no-audio":
+        return False
+    return "+timed" not in v
+
+
 def _is_frame_child(sidecar: Path) -> bool:
     """True for a scene-frame child sidecar (`parent_media:` set). Such images never
     get their own ClipIndex rows — the parent video's per-scene vectors own visual
@@ -131,6 +143,7 @@ class BackfillStats:
     extracted: int = 0
     extract_failed: int = 0
     rediarized: int = 0
+    retimed: int = 0
     clip_indexed: int = 0
     scene_frames_written: int = 0
     skipped: int = 0
@@ -142,6 +155,7 @@ def backfill_media(
     do_ocr: bool = True,
     do_clip: bool = True,
     rediarize: bool = False,
+    retime: bool = False,
     dry_run: bool = False,
     log_fn=log.info,
 ) -> BackfillStats:
@@ -149,6 +163,9 @@ def backfill_media(
 
     `rediarize` re-extracts audio/video whose transcript predates diarization (a completed
     ASR engine without `+diarized`) so they gain labeled turns + `speakers:` frontmatter.
+    `retime` re-extracts audio/video whose transcript predates timed transcripts (no
+    `+timed` marker) so they gain per-segment `[m:ss]` lines — the substrate for
+    semantic segmentation. One re-extraction serves both flags when both are requested.
     """
     stats = BackfillStats()
     kb = vault_root / "Knowledge Base"
@@ -161,6 +178,12 @@ def backfill_media(
             "skipping re-diarization (set EXOMEM_DIARIZE=1)"
         )
         rediarize = False
+    if retime and not semantic_segments.semantic_segments_enabled():
+        log_fn(
+            "--retime requested but EXOMEM_SEMANTIC_SEGMENTS is not enabled; "
+            "skipping re-timing (set EXOMEM_SEMANTIC_SEGMENTS=1)"
+        )
+        retime = False
     clip_index = embeddings.ClipIndex(vault_root) if do_clip else None
     # Fast media first (image/pdf OCR is quick) so screenshots/docs are searchable in
     # minutes; slow A/V transcription (Whisper) runs last instead of starving the queue.
@@ -203,46 +226,66 @@ def backfill_media(
         need_rediarize = (
             rediarize and do_ocr and not need_ocr and _needs_rediarize(sidecar, media_type)
         )
-        if not (need_sidecar or need_ocr or need_clip or need_scenes or need_rediarize):
+        need_retime = (
+            retime and do_ocr and not need_ocr and _needs_retime(sidecar, media_type)
+        )
+        if not (need_sidecar or need_ocr or need_clip or need_scenes or need_rediarize
+                or need_retime):
             stats.skipped += 1
             continue
         if dry_run:
             todo = " ".join(t for t, on in
                             (("sidecar", need_sidecar), ("ocr", need_ocr), ("clip", need_clip),
-                             ("scenes", need_scenes), ("rediarize", need_rediarize)) if on)
+                             ("scenes", need_scenes), ("rediarize", need_rediarize),
+                             ("retime", need_retime)) if on)
             log_fn(f"  [{i}/{len(files)}] {rel} -> {todo}")
             stats.sidecars_created += need_sidecar
             stats.extracted += need_ocr
             stats.clip_indexed += need_clip
             stats.rediarized += need_rediarize
+            stats.retimed += need_retime
             continue
 
         if need_sidecar:
             sidecar, created = preserve.ensure_media_sidecar(vault_root, f)
             stats.sidecars_created += int(created)
-        if need_ocr or need_rediarize:
+        if need_ocr or need_rediarize or need_retime:
             try:
                 res = extract.extract_text(f, media_type=media_type)
-                if need_rediarize and not res.engine.endswith("+diarized"):
-                    # Diarization soft-failed (extract's contract) — the result is the
-                    # same plain transcript the sidecar already holds. Leave its bytes
-                    # untouched and stop re-diarizing: every further attempt would fail
-                    # the same way. Mirrors the do_ocr/do_clip degradation pattern.
+                # Each requested upgrade is judged by its engine marker (extract's
+                # soft-fail contract). A failed upgrade disables its pass for the rest
+                # (every further attempt would fail the same way); the sidecar is
+                # written when first-time OCR ran or at least one upgrade materialized
+                # — a fully-failed upgrade leaves bytes it already holds untouched.
+                got_diarized = res.engine.endswith("+diarized")
+                got_timed = "+timed" in res.engine
+                if need_rediarize and not got_diarized:
                     log_fn(
                         f"  ! diarization unavailable (engine {res.engine}); "
                         "skipping re-diarization for the rest"
                     )
                     rediarize = False
-                else:
+                if need_retime and not got_timed:
+                    log_fn(
+                        f"  ! timed rendering unavailable (engine {res.engine}); "
+                        "skipping re-timing for the rest"
+                    )
+                    retime = False
+                upgrade_gained = (need_rediarize and got_diarized) or (
+                    need_retime and got_timed
+                )
+                if need_ocr or upgrade_gained:
                     preserve.update_sidecar_extraction(
                         vault_root, sidecar,
                         text=res.text.strip() or "(no text detected)", engine=res.engine,
                         speakers=res.speakers,
                     )
-                    if need_rediarize:
-                        stats.rediarized += 1
-                    else:
+                    if need_ocr:
                         stats.extracted += 1
+                    if need_rediarize and got_diarized:
+                        stats.rediarized += 1
+                    if need_retime and got_timed:
+                        stats.retimed += 1
             except extract.ExtractionUnavailable as e:
                 log_fn(f"  ! extraction engine unavailable ({e}); skipping OCR for the rest")
                 do_ocr = False
@@ -261,6 +304,10 @@ def backfill_media(
                     stats.scene_frames_written += len(written)
                     if do_ocr and written:
                         do_ocr = _ocr_new_scene_frames(vault_root, written, stats, log_fn)
+                    if written and semantic_segments.semantic_segments_enabled():
+                        # Fold the fresh visual/OCR boundary events into the parent's
+                        # semantic segments (mirrors the worker's trailing re-embed).
+                        embeddings.upsert_after_write(vault_root, [sidecar])
                 elif media_type == "video":
                     clip_index.upsert_frames(rel, embeddings.embed_video_frames(f), mtime)
                     stats.clip_indexed += 1

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -704,6 +704,53 @@ def chunk_text(title: str, body: str) -> list[str]:
     return out
 
 
+def _chunks_for_page(vault_root: Path, page) -> list[str]:
+    """Chunking router — the single seam every writer/rebuild path goes through.
+
+    Gated (`EXOMEM_SEMANTIC_SEGMENTS`) audio/video sidecars whose transcript is
+    timed get SEMANTIC SEGMENT chunks (each starting with its `[timestamp]`
+    marker — what `find` surfaces as `transcript_match_at`), with the sections
+    before/after `## Extracted text` still paragraph-chunked in document order.
+    Every other page — and the gate-off world — returns `chunk_text` output
+    unchanged (equality-tested).
+    """
+    from . import semantic_segments as ss
+
+    if not (
+        ss.semantic_segments_enabled()
+        and getattr(page, "media_type", None) in ("audio", "video")
+    ):
+        return chunk_text(page.title, page.body)
+    body = page.body or ""
+    idx = body.find("## Extracted text")
+    if idx == -1:
+        return chunk_text(page.title, page.body)
+    head = body[:idx]
+    rest = body[idx + len("## Extracted text"):]
+    nxt = rest.find("\n## ")
+    transcript = (rest if nxt == -1 else rest[:nxt]).strip()
+    tail = "" if nxt == -1 else rest[nxt + 1 :]
+    timed_lines = sum(1 for line in transcript.splitlines() if ss.TIMED_LINE_RE.match(line))
+    if timed_lines < ss.MIN_TIMED_LINES:
+        return chunk_text(page.title, page.body)
+    events = (
+        ss.gather_events(vault_root, page.media_file)
+        if getattr(page, "media_file", None)
+        else ss.Events([], [])
+    )
+    segs = ss.segment_transcript(transcript, events=events)
+    if segs is None:
+        return chunk_text(page.title, page.body)
+    title = (page.title or "").strip()
+    out: list[str] = []
+    if head.strip():
+        out.extend(chunk_text(title, head))
+    out.extend(f"{title}\n\n{s}" if title else s for s in segs)
+    if tail.strip():
+        out.extend(chunk_text(title, tail))
+    return out
+
+
 def embed_texts(texts: list[str], *, is_query: bool = False) -> np.ndarray:
     """Batch-encode texts → float32 `(N, 768)`, L2-normalized for cosine."""
     if not texts:
@@ -869,7 +916,7 @@ class EmbeddingIndex:
                 continue
             if not access.is_indexable(self.vault_root, page.rel_path):
                 continue  # excluded tree (_access.yaml) — keep it out of the index
-            chunks = chunk_text(page.title, page.body)
+            chunks = _chunks_for_page(self.vault_root, page)
             if not chunks:
                 continue
             all_chunks.append((page.rel_path, chunks, page.mtime))
@@ -1158,7 +1205,7 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
         page = find_module._CACHE.get(md, vault_root)
         if page is None:
             continue
-        chunks = chunk_text(page.title, page.body)
+        chunks = _chunks_for_page(vault_root, page)
         if not chunks:
             # Page has no embeddable content — drop any stale rows for it.
             index.delete_file(page.rel_path)

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -42,6 +42,8 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from . import semantic_segments
+
 log = logging.getLogger(__name__)
 
 # Media-type buckets by extension. Extension-based is deliberate: no libmagic dep, and
@@ -297,13 +299,49 @@ def _transcribe(path: Path, media_type: str) -> ExtractResult:
         labeled = _diarize(path, seg_list)
         if labeled is not None:
             text, speakers = labeled
+            # `+timed` is detected from the rendered text (not re-checked from the
+            # gate) so a soft-failed timed render can never mislabel the engine —
+            # the marker is backfill's idempotency key. Order matters:
+            # `_needs_rediarize` matches endswith("+diarized").
+            timed = "+timed" if _is_timed_text(text) else ""
             return ExtractResult(
-                text=text, media_type=media_type, engine=f"{engine}+diarized",
+                text=text, media_type=media_type, engine=f"{engine}{timed}+diarized",
                 speakers=speakers,
             )
 
+    # Timed rendering (EXOMEM_SEMANTIC_SEGMENTS, default OFF): one line per ASR
+    # segment with a `[m:ss]` prefix — the substrate for semantic segmentation
+    # and `transcript_match_at`. Soft-fail: any renderer error falls back to the
+    # flat join below; gate unset is byte-identical to it.
+    if semantic_segments.semantic_segments_enabled():
+        try:
+            timed_text = semantic_segments.render_timed_lines(
+                [
+                    (
+                        float(getattr(seg, "start", 0.0) or 0.0),
+                        float(getattr(seg, "end", 0.0) or 0.0),
+                        seg.text,
+                        None,
+                    )
+                    for seg in seg_list
+                ]
+            ).strip()
+            if timed_text:
+                return ExtractResult(
+                    text=timed_text, media_type=media_type, engine=f"{engine}+timed"
+                )
+        except Exception:  # noqa: BLE001 — timed rendering must never block extraction
+            log.warning("timed transcript rendering failed for %s; using flat text", path.name)
+
     text = " ".join(seg.text.strip() for seg in seg_list).strip()
     return ExtractResult(text=text, media_type=media_type, engine=engine)
+
+
+def _is_timed_text(text: str) -> bool:
+    """True when the transcript's first line carries a `[m:ss]` marker."""
+    first = text.split("\n", 1)[0] if text else ""
+    m = semantic_segments.TIMED_LINE_RE.match(first)
+    return bool(m and m.group(2) is not None)
 
 
 # ---------------- optional: ASR speaker diarization (EXOMEM_DIARIZE, default OFF) ----
@@ -552,6 +590,7 @@ def _diarize(
         return _name(raw) if raw is not None else None
 
     merged: list[dict] = []
+    timed_segs: list[tuple[float, float, str, str | None]] = []
     for seg in seg_list:
         seg_text = seg.text.strip()
         if not seg_text:
@@ -559,6 +598,7 @@ def _diarize(
         start = float(getattr(seg, "start", 0.0) or 0.0)
         end = float(getattr(seg, "end", start) or start)
         speaker = _speaker_for(start, end) or "Speaker A"
+        timed_segs.append((start, end, seg_text, speaker))
         if merged and merged[-1]["speaker"] == speaker:
             merged[-1]["text"] += " " + seg_text
             merged[-1]["end"] = end
@@ -567,6 +607,18 @@ def _diarize(
 
     if not merged:
         return None
+    # Timed rendering (EXOMEM_SEMANTIC_SEGMENTS): one line per ASR segment with the
+    # label repeated — merged multi-minute turns would destroy segmentation windows
+    # and match localization. The structured `merged` list keeps the merged-turn
+    # shape either way (speakers: frontmatter + filters are unaffected). Soft-fail
+    # to the merged-turn rendering below.
+    if semantic_segments.semantic_segments_enabled():
+        try:
+            timed_text = semantic_segments.render_timed_lines(timed_segs).strip()
+            if timed_text:
+                return timed_text, merged
+        except Exception:  # noqa: BLE001 — timed rendering must never block diarization
+            log.warning("timed diarized rendering failed for %s; using merged turns", path.name)
     labeled_text = "\n".join(f"[{m['speaker']}]: {m['text']}" for m in merged).strip()
     return labeled_text, merged
 

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -446,6 +446,11 @@ class Hit:
     # visual "why" for the hit. Surfaced as `scene_frame` + `scene_match_at`.
     scene_frame: str | None = None
     scene_frame_ts: float | None = None
+    # Seconds into a TIMED transcript where the text match localizes — the
+    # matched semantic-segment chunk's leading [timestamp] (vector lane) or the
+    # nearest marker preceding the query anchor (BM25/keyword). Surfaced as
+    # `transcript_match_at`. Data-driven: flat sidecars never set it.
+    transcript_ts: float | None = None
     # Lifecycle. `status` is set when a hit is NOT plain `active`, so a reader can
     # tell a superseded tombstone (or draft) from a live conclusion; `superseded_by`
     # carries the forward pointer(s) to the replacement(s). Surfaced in as_dict()
@@ -479,6 +484,8 @@ class Hit:
             out["scene_frame"] = self.scene_frame
             if self.scene_frame_ts is not None:
                 out["scene_match_at"] = _format_timestamp(self.scene_frame_ts)
+        if self.transcript_ts is not None:
+            out["transcript_match_at"] = _format_timestamp(self.transcript_ts)
         if self.outside_kb:
             out["outside_kb"] = True
         if self.status and self.status != "active":
@@ -535,6 +542,8 @@ class Hit:
             out["scene_frame"] = self.scene_frame
             if self.scene_frame_ts is not None:
                 out["scene_match_at"] = _format_timestamp(self.scene_frame_ts)
+        if self.transcript_ts is not None:
+            out["transcript_match_at"] = _format_timestamp(self.transcript_ts)
         if self.outside_kb:
             out["outside_kb"] = True
         if self.status and self.status != "active":
@@ -1004,6 +1013,45 @@ def find(
     return hits
 
 
+def _transcript_ts_for_hit(page: ParsedPage, chunk: str | None, query_norm: str) -> float | None:
+    """Localize a text match inside a TIMED transcript → seconds, or None.
+
+    Vector lane: the matched chunk is a semantic segment whose first timed line
+    carries the segment start. BM25/keyword (no chunk, or a chunk without
+    markers): anchor on the first query token's position in the body and take
+    the nearest PRECEDING timestamp marker. Only timed audio/video sidecars
+    ever return a value — flat pages cost one media_type check.
+    """
+    if page.media_type not in ("audio", "video"):
+        return None
+    from . import semantic_segments as ss
+
+    if chunk:
+        for line in chunk.splitlines():
+            m = ss.TIMED_LINE_RE.match(line)
+            if m and m.group(2) is not None:
+                return ss.ts_from_match(m)
+    tokens = query_norm.split() if query_norm else []
+    if not tokens:
+        return None
+    body = page.body or ""
+    if "[" not in body:
+        return None
+    pos = body.lower().find(tokens[0])
+    if pos == -1:
+        return None
+    offset = 0
+    best: float | None = None
+    for line in body.splitlines(keepends=True):
+        if offset > pos:
+            break
+        m = ss.TIMED_LINE_RE.match(line)
+        if m and m.group(2) is not None:
+            best = ss.ts_from_match(m)
+        offset += len(line)
+    return best
+
+
 def _collapse_frame_children(
     ranking: list[str],
     vault_root: Path,
@@ -1116,6 +1164,12 @@ def _find_keyword(
             scene_frame=scene_frame,
             scene_frame_ts=scene_frame_ts,
         )
+        hit.transcript_ts = _transcript_ts_for_hit(page, None, query_norm)
+        if hit.scene_frame is None and page.media_type == "video" and page.media_file and hit.transcript_ts is not None:
+            from . import scene_frames  # lazy: keyword mode stays import-light
+            nf = scene_frames.nearest_frame(vault_root, page.media_file, hit.transcript_ts)
+            if nf is not None:
+                hit.scene_frame, hit.scene_frame_ts = nf
         by_path[page.rel_path] = hit
         hits.append((page.updated or "0000-00-00", hit))
 
@@ -1549,17 +1603,16 @@ def _find_semantic(
             scene_frame=attr[0] if attr else None,
             scene_frame_ts=attr[1] if attr else None,
         )
-        if (
-            hit.scene_frame is None
-            and hit.clip_frame_ts is not None
-            and page.media_type == "video"
-            and page.media_file
-        ):
-            # A CLIP keyframe match on a video: attach the nearest PERSISTED frame
-            # (if any exist) so the moment is viewable, not just timestamped.
-            nf = scene_frames.nearest_frame(vault_root, page.media_file, hit.clip_frame_ts)
-            if nf is not None:
-                hit.scene_frame, hit.scene_frame_ts = nf
+        hit.transcript_ts = _transcript_ts_for_hit(page, chunk, query_norm)
+        if hit.scene_frame is None and page.media_type == "video" and page.media_file:
+            # A localized match on a video — CLIP keyframe first (existing), else a
+            # timed-transcript match — attaches the nearest PERSISTED frame so the
+            # moment is viewable, not just timestamped.
+            anchor_ts = hit.clip_frame_ts if hit.clip_frame_ts is not None else hit.transcript_ts
+            if anchor_ts is not None:
+                nf = scene_frames.nearest_frame(vault_root, page.media_file, anchor_ts)
+                if nf is not None:
+                    hit.scene_frame, hit.scene_frame_ts = nf
         hits.append(hit)
         if len(hits) >= target_n:
             break

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -20,7 +20,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import embeddings, extract, preserve, scene_frames
+from . import embeddings, extract, preserve, scene_frames, semantic_segments
 from .backfill import iter_kb_files
 
 log = logging.getLogger(__name__)
@@ -38,6 +38,7 @@ class _Job:
     media_type: str
     do_ocr: bool = True    # transcribe/OCR/read → fill the sidecar text
     do_clip: bool = False  # CLIP-embed (images only) → ClipIndex
+    do_reembed: bool = False  # re-embed the sidecar (semantic re-segmentation)
 
 
 class MediaWorker:
@@ -77,6 +78,7 @@ class MediaWorker:
         media_type: str,
         do_ocr: bool = True,
         do_clip: bool = False,
+        do_reembed: bool = False,
     ) -> None:
         self._q.put(
             _Job(
@@ -85,6 +87,7 @@ class MediaWorker:
                 media_type=media_type,
                 do_ocr=do_ocr,
                 do_clip=do_clip,
+                do_reembed=do_reembed,
             )
         )
 
@@ -112,6 +115,21 @@ class MediaWorker:
             self._run_extraction(job)
         if job.do_clip:
             self._run_clip(job)
+        if job.do_reembed:
+            self._run_reembed(job)
+
+    def _run_reembed(self, job: _Job) -> None:
+        """Re-embed a sidecar so semantic segmentation re-runs with late signals.
+
+        Enqueued AFTER a video's frame-OCR jobs (FIFO ⇒ runs once they're done),
+        so segment boundaries can use visual + OCR events. Soft-fails; the
+        earlier embed (transcript+speaker signals only) remains valid.
+        """
+        try:
+            embeddings.upsert_after_write(self._vault_root, [job.sidecar_path])
+            log.info("re-embedded %s (post-frame-OCR segmentation)", job.sidecar_path.name)
+        except Exception:  # noqa: BLE001 — enrichment, never fatal
+            log.exception("re-embed failed for %s", job.sidecar_path.name)
 
     def _run_extraction(self, job: _Job) -> None:
         try:
@@ -192,6 +210,18 @@ class MediaWorker:
                 do_ocr=True,
                 do_clip=False,
             )
+        if written and semantic_segments.semantic_segments_enabled():
+            # Trailing re-embed of the PARENT sidecar: the FIFO queue guarantees it
+            # runs after every frame OCR above, so semantic segmentation sees the
+            # visual + OCR boundary events.
+            self.enqueue(
+                binary_path=job.binary_path,
+                sidecar_path=job.sidecar_path,
+                media_type=job.media_type,
+                do_ocr=False,
+                do_clip=False,
+                do_reembed=True,
+            )
         if written:
             log.info(
                 "scene frames: wrote %d frame(s) for %s", len(written), job.binary_path.name
@@ -207,6 +237,7 @@ class MediaWorker:
         if not kb.is_dir():
             return 0
         n = 0
+        pending_parents: dict[str, bool] = {}  # insertion-ordered dedup
         for sidecar in iter_kb_files(kb):
             if sidecar.suffix.lower() != ".md":
                 continue
@@ -225,6 +256,26 @@ class MediaWorker:
             if media_type and binary.exists():
                 self.enqueue(binary_path=binary, sidecar_path=sidecar, media_type=media_type)
                 n += 1
+                if _PARENT_MEDIA_MARKER in head:
+                    pm = re.search(r"(?m)^parent_media:\s*(.+?)\s*$", head)
+                    if pm:
+                        pending_parents[pm.group(1).strip()] = True
+        # Deduped parent re-embeds AFTER the pending frame children above, so
+        # semantic segmentation re-runs once their OCR completes (gate on only).
+        if pending_parents and semantic_segments.semantic_segments_enabled():
+            for parent_rel in pending_parents:
+                parent_sidecar = self._vault_root / (parent_rel + ".md")
+                parent_binary = self._vault_root / parent_rel
+                if parent_sidecar.exists() and parent_binary.exists():
+                    self.enqueue(
+                        binary_path=parent_binary,
+                        sidecar_path=parent_sidecar,
+                        media_type=extract.media_type_for(parent_binary) or "video",
+                        do_ocr=False,
+                        do_clip=False,
+                        do_reembed=True,
+                    )
+                    n += 1
         if n:
             log.info("media worker: re-enqueued %d pending extraction(s)", n)
         return n

--- a/src/exomem/semantic_segments.py
+++ b/src/exomem/semantic_segments.py
@@ -1,0 +1,369 @@
+"""Semantic video segments (`EXOMEM_SEMANTIC_SEGMENTS`).
+
+Makes the *moment* the retrieval unit for timed media. Three cooperating parts:
+
+1. **Timed transcript codec** — `format_ts`/`TIMED_LINE_RE`/`parse_timed_lines`/
+   `render_timed_lines`. Extraction renders one line per ASR segment
+   (`[51:20] …`, diarized `[51:20] [Alice]: …`); everything downstream parses
+   timestamps straight out of the sidecar text — no side store.
+2. **Segmenter** — transcript-topic boundaries from embedding-similarity valleys
+   over sliding line windows (TextTiling-style depth), FUSED with deterministic
+   events: visual scene changes (persisted frame filenames), speaker-turn
+   changes, and OCR-change events between consecutive frame sidecars. Pure
+   measurement — no reasoning model (the pure-substrate rule).
+3. **Chunking** — each segment becomes one embedding chunk whose first line
+   carries the segment's `[timestamp]`, which `find` surfaces as
+   `transcript_match_at`.
+
+Soft-fail ladder: full fusion → events-only when embedding fails → `None`
+(caller falls back to the ordinary paragraph chunker).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+_FALSY_ENV = {"", "0", "false", "no", "off"}
+
+
+def semantic_segments_enabled() -> bool:
+    """`EXOMEM_SEMANTIC_SEGMENTS` gates timed rendering AND segment chunking.
+
+    Truthy opt-in (same parse as `EXOMEM_DIARIZE`): unset, '', '0', 'false',
+    'no', 'off' → OFF. Default OFF: extraction output and chunking stay
+    byte-identical to the pre-feature behavior.
+    """
+    return os.environ.get("EXOMEM_SEMANTIC_SEGMENTS", "").strip().lower() not in _FALSY_ENV
+
+
+# --- Timestamp codec ----------------------------------------------------------
+
+# `[m:ss]` under an hour, `[h:mm:ss]` from an hour — identical semantics to the
+# find-side formatter so `transcript_match_at` reads like `clip_match_at`.
+TIMED_LINE_RE = re.compile(
+    r"^\[(?:(\d+):)?(\d{1,2}):(\d{2})\](?:\s\[([^\]\n]+)\]:)?\s?(.*)$"
+)
+
+
+def format_ts(seconds: float) -> str:
+    """Seconds → `m:ss` (or `h:mm:ss` past an hour)."""
+    total = int(round(seconds))
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+class TimedLine(NamedTuple):
+    ts: float
+    speaker: str | None
+    text: str
+
+
+def ts_from_match(m: re.Match) -> float:
+    """Seconds from a TIMED_LINE_RE match."""
+    hours, minutes, secs = m.group(1), m.group(2), m.group(3)
+    return float(int(hours or 0) * 3600 + int(minutes) * 60 + int(secs))
+
+
+def parse_timed_lines(block: str) -> list[TimedLine]:
+    """Parse a timed transcript block → `[TimedLine]`.
+
+    Lines without a leading `[ts]` marker fold into the previous line's text
+    (defensive: manual edits, wrapped lines). Leading unmatched lines are
+    skipped.
+    """
+    lines: list[TimedLine] = []
+    for raw in block.splitlines():
+        raw = raw.rstrip()
+        if not raw:
+            continue
+        m = TIMED_LINE_RE.match(raw)
+        if m:
+            lines.append(TimedLine(ts_from_match(m), m.group(4), m.group(5).strip()))
+        elif lines:
+            prev = lines[-1]
+            lines[-1] = TimedLine(prev.ts, prev.speaker, f"{prev.text} {raw.strip()}".strip())
+    return lines
+
+
+def render_timed_lines(segs: list[tuple[float, float, str, str | None]]) -> str:
+    """`[(start, end, text, speaker|None)]` → one timed line per segment.
+
+    Empty/whitespace-only segments are skipped. Diarized lines repeat the
+    speaker label per segment on purpose — merged multi-minute turns would
+    destroy both segmentation windows and match localization.
+    """
+    out: list[str] = []
+    for start, _end, text, speaker in segs:
+        text = (text or "").strip()
+        if not text:
+            continue
+        if speaker:
+            out.append(f"[{format_ts(start)}] [{speaker}]: {text}")
+        else:
+            out.append(f"[{format_ts(start)}] {text}")
+    return "\n".join(out)
+
+
+def _render_line(line: TimedLine) -> str:
+    if line.speaker:
+        return f"[{format_ts(line.ts)}] [{line.speaker}]: {line.text}"
+    return f"[{format_ts(line.ts)}] {line.text}"
+
+
+# --- Segmenter ------------------------------------------------------------------
+#
+# Boundary score per gap g (between line g and g+1, boundary ts = line g+1's ts):
+#   score = topic + 0.5*scene(±5s) + 0.35*speaker_change + 0.4*ocr(±5s)
+# where topic is the TextTiling depth of the embedding-similarity valley,
+# normalized by DEPTH_NORM (unclamped — ranking needs the deepest valley to win
+# over its clamped-equal neighbours). A gap is a boundary at score >= 0.55: a
+# deep valley alone passes; a moderate valley plus any corroborating event
+# passes; scene+OCR+speaker together pass without a valley.
+
+MIN_TIMED_LINES = 8  # fewer → fall back to the paragraph chunker
+WINDOW_LINES = 4  # sliding-window width for topic embeddings
+DEPTH_NORM = 0.4  # valley depth that counts as a full topic signal
+SCENE_WEIGHT = 0.5
+SPEAKER_WEIGHT = 0.35
+OCR_WEIGHT = 0.4
+BOUNDARY_THRESHOLD = 0.55
+EVENT_PROXIMITY_SECS = 5.0
+MIN_SEG_SECS = 25.0  # closer accepted boundaries: keep the higher score
+MAX_SEGMENTS = 256
+OCR_JACCARD_THRESHOLD = 0.5  # below → an OCR-change event
+# Stay under the text chunker's word cap so segment chunks never get truncated.
+MAX_SEG_WORDS_MARGIN = 30
+
+EmbedFn = Callable[[list[str]], "np.ndarray"]
+
+
+class Events(NamedTuple):
+    scene_ts: list[float]
+    ocr_ts: list[float]
+
+
+def _default_embed_fn(texts: list[str]) -> np.ndarray:
+    from . import embeddings  # lazy: keep this module import-light
+
+    return embeddings.embed_texts(texts, is_query=False)
+
+
+def _max_seg_words() -> int:
+    from . import embeddings  # lazy — single source of truth for the chunk cap
+
+    return embeddings.MAX_WORDS_PER_CHUNK - MAX_SEG_WORDS_MARGIN
+
+
+def _topic_scores(lines: list[TimedLine], embed_fn: EmbedFn) -> list[float]:
+    """TextTiling-style valley depth per gap, normalized by DEPTH_NORM (unclamped)."""
+    n_gaps = len(lines) - 1
+    left_texts = [
+        " ".join(li.text for li in lines[max(0, g - WINDOW_LINES + 1) : g + 1])
+        for g in range(n_gaps)
+    ]
+    right_texts = [
+        " ".join(li.text for li in lines[g + 1 : g + 1 + WINDOW_LINES])
+        for g in range(n_gaps)
+    ]
+    unique = sorted(set(left_texts) | set(right_texts))
+    vecs = np.asarray(embed_fn(unique), dtype=np.float32)
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    vecs = vecs / np.maximum(norms, 1e-9)  # defensive: fakes may not normalize
+    by_text = {t: vecs[i] for i, t in enumerate(unique)}
+    sim = np.array(
+        [float(by_text[left_texts[g]] @ by_text[right_texts[g]]) for g in range(n_gaps)]
+    )
+    # Running peaks to each side of every gap.
+    peak_left = np.maximum.accumulate(sim)
+    peak_right = np.maximum.accumulate(sim[::-1])[::-1]
+    depth = ((peak_left - sim) + (peak_right - sim)) / 2.0
+    return [float(d) / DEPTH_NORM for d in depth]
+
+
+def _near(events: list[float], ts: float) -> bool:
+    return any(abs(e - ts) <= EVENT_PROXIMITY_SECS for e in events)
+
+
+def _select_boundaries(scores: list[tuple[int, float, float]]) -> list[int]:
+    """Greedy accept by (score desc, ts asc): threshold + min-distance + cap.
+
+    `scores` is [(gap_index, boundary_ts, score)]. Returns accepted gap indices
+    in ascending order.
+    """
+    candidates = [c for c in scores if c[2] >= BOUNDARY_THRESHOLD]
+    candidates.sort(key=lambda c: (-c[2], c[1]))
+    accepted_ts: list[float] = []
+    accepted: list[int] = []
+    for gap, ts, _score in candidates:
+        if len(accepted) >= MAX_SEGMENTS - 1:
+            break
+        if any(abs(ts - a) < MIN_SEG_SECS for a in accepted_ts):
+            continue
+        accepted.append(gap)
+        accepted_ts.append(ts)
+    return sorted(accepted)
+
+
+def _force_split_by_words(lines: list[TimedLine], gap_scores: list[float]) -> list[list[TimedLine]]:
+    """Split an over-long run of lines at its best interior gap until each part
+    fits the word budget — nothing silently truncates."""
+    words = sum(len(li.text.split()) for li in lines)
+    if words <= _max_seg_words() or len(lines) < 2:
+        return [lines]
+    # Best interior gap by score; ties/no-signal → the gap nearest the word midpoint.
+    cum = np.cumsum([len(li.text.split()) for li in lines])
+    target = words / 2.0
+    best_gap = None
+    best_key = None
+    for g in range(len(lines) - 1):
+        score = gap_scores[g] if g < len(gap_scores) else 0.0
+        key = (-score, abs(float(cum[g]) - target))
+        if best_key is None or key < best_key:
+            best_key = key
+            best_gap = g
+    left, right = lines[: best_gap + 1], lines[best_gap + 1 :]
+    return _force_split_by_words(left, gap_scores[: best_gap + 1]) + _force_split_by_words(
+        right, gap_scores[best_gap + 1 :]
+    )
+
+
+def segment_transcript(
+    block: str,
+    *,
+    events: Events | None = None,
+    embed_fn: EmbedFn | None = None,
+) -> list[str] | None:
+    """Segment a timed transcript block → list of segment strings (timed lines,
+    markers included; the first line's `[ts]` is the segment start).
+
+    Soft-fail ladder: embedding failure ⇒ events-only boundaries; fewer than
+    MIN_TIMED_LINES timed lines, or any other error ⇒ None (the caller falls
+    back to the ordinary paragraph chunker).
+    """
+    try:
+        lines = parse_timed_lines(block)
+        if len(lines) < MIN_TIMED_LINES:
+            return None
+        events = events or Events([], [])
+        n_gaps = len(lines) - 1
+        try:
+            topic = _topic_scores(lines, embed_fn or _default_embed_fn)
+        except Exception as e:  # noqa: BLE001 — ladder step: events-only
+            log.warning("topic embedding failed (%s); segmenting on events only", e)
+            topic = [0.0] * n_gaps
+        start_ts = lines[0].ts
+        scored: list[tuple[int, float, float]] = []
+        gap_scores: list[float] = []
+        for g in range(n_gaps):
+            ts = lines[g + 1].ts
+            speaker_change = (
+                lines[g].speaker is not None
+                and lines[g + 1].speaker is not None
+                and lines[g].speaker != lines[g + 1].speaker
+            )
+            score = (
+                topic[g]
+                + (SCENE_WEIGHT if _near(events.scene_ts, ts) else 0.0)
+                + (SPEAKER_WEIGHT if speaker_change else 0.0)
+                + (OCR_WEIGHT if _near(events.ocr_ts, ts) else 0.0)
+            )
+            gap_scores.append(score)
+            if ts - start_ts >= MIN_SEG_SECS:  # no boundary in the opening seconds
+                scored.append((g, ts, score))
+        boundaries = _select_boundaries(scored)
+        # Cut into line runs, then enforce the word budget per run.
+        runs: list[list[TimedLine]] = []
+        prev = 0
+        for g in boundaries:
+            runs.append(lines[prev : g + 1])
+            prev = g + 1
+        runs.append(lines[prev:])
+        out: list[list[TimedLine]] = []
+        offset = 0
+        for run in runs:
+            out.extend(_force_split_by_words(run, gap_scores[offset : offset + len(run) - 1]))
+            offset += len(run)
+        return ["\n".join(_render_line(li) for li in seg) for seg in out if seg]
+    except Exception as e:  # noqa: BLE001 — ladder floor: paragraph chunker
+        log.warning("semantic segmentation failed (%s); falling back", e)
+        return None
+
+
+# --- Boundary events from persisted scene frames --------------------------------
+
+
+_REAL_ENGINE_BAD = ("none", "pending")
+
+
+def _frame_ocr_tokens(sidecar: Path) -> set[str] | None:
+    """Token set of a frame sidecar's OCR text; None when extraction isn't done."""
+    try:
+        content = sidecar.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r"(?m)^extracted_by:\s*(.+?)\s*$", content[:800])
+    if not m:
+        return None
+    engine = m.group(1).strip()
+    if engine in _REAL_ENGINE_BAD or engine.startswith("failed:"):
+        return None
+    idx = content.find("## Extracted text")
+    if idx == -1:
+        return set()
+    body = content[idx + len("## Extracted text") :]
+    nxt = body.find("\n## ")
+    if nxt != -1:
+        body = body[:nxt]
+    body = body.replace("(no text detected)", "")
+    return set(re.findall(r"[a-z0-9]+", body.lower()))
+
+
+def gather_events(vault_root: Path, media_rel: str) -> Events:
+    """Boundary events for a video from its persisted scene frames.
+
+    Visual events are the MIDPOINTS between consecutive representative-frame
+    timestamps (rep_ts marks a scene's middle, so the change lies between two
+    reps — the ±EVENT_PROXIMITY_SECS window absorbs the approximation). OCR
+    events are those midpoints where consecutive frames' OCR token sets have
+    Jaccard overlap below OCR_JACCARD_THRESHOLD. Soft: any error ⇒ no events.
+    """
+    try:
+        from . import scene_frames  # lazy: avoid import cycles
+
+        frames_dir = vault_root / (media_rel + scene_frames.FRAMES_DIR_SUFFIX)
+        if not frames_dir.is_dir():
+            return Events([], [])
+        frames: list[tuple[float, Path]] = []
+        for f in frames_dir.iterdir():
+            ts = scene_frames.parse_frame_ts(f.name)
+            if ts is not None:
+                frames.append((ts, f))
+        frames.sort()
+        scene_ts: list[float] = []
+        ocr_ts: list[float] = []
+        for (ts_a, f_a), (ts_b, f_b) in zip(frames, frames[1:], strict=False):
+            mid = (ts_a + ts_b) / 2.0
+            scene_ts.append(mid)
+            tok_a = _frame_ocr_tokens(f_a.with_name(f_a.name + ".md"))
+            tok_b = _frame_ocr_tokens(f_b.with_name(f_b.name + ".md"))
+            if tok_a is None or tok_b is None:
+                continue
+            union = tok_a | tok_b
+            jaccard = (len(tok_a & tok_b) / len(union)) if union else 1.0
+            if jaccard < OCR_JACCARD_THRESHOLD:
+                ocr_ts.append(mid)
+        return Events(scene_ts, ocr_ts)
+    except Exception as e:  # noqa: BLE001 — events are an enrichment, never fatal
+        log.warning("gather_events failed for %s: %s", media_rel, e)
+        return Events([], [])

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -253,3 +253,101 @@ def test_rediarize_dry_run_counts_without_writing(vault, monkeypatch: pytest.Mon
     stats = backfill.backfill_media(vault, do_clip=False, rediarize=True, dry_run=True, log_fn=_quiet)
     assert stats.rediarized == 1
     assert sidecar.read_text("utf-8") == before
+
+
+# ---------------- --retime: re-extract pre-timed-transcript A/V sidecars ----------------
+
+
+def _timed_result(*a, **k):
+    return extract.ExtractResult(
+        text="[0:05] hello there\n[0:12] general kenobi",
+        media_type="audio",
+        engine="faster-whisper:large-v3+timed",
+    )
+
+
+def test_retime_reextracts_flat_sidecar(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    _, sidecar = _drop_audio_with_plain_transcript(vault)
+    monkeypatch.setattr(extract, "extract_text", _timed_result)
+    stats = backfill.backfill_media(vault, do_clip=False, retime=True, log_fn=_quiet)
+    assert stats.retimed == 1
+    assert stats.extracted == 0
+    body = sidecar.read_text("utf-8")
+    assert "extracted_by: faster-whisper:large-v3+timed" in body
+    assert "[0:05] hello there" in body
+
+
+def test_retime_second_run_is_noop(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    _drop_audio_with_plain_transcript(vault)
+    monkeypatch.setattr(extract, "extract_text", _timed_result)
+    backfill.backfill_media(vault, do_clip=False, retime=True, log_fn=_quiet)
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("re-extracted a +timed sidecar")),
+    )
+    stats2 = backfill.backfill_media(vault, do_clip=False, retime=True, log_fn=_quiet)
+    assert stats2.retimed == 0
+    assert stats2.skipped >= 1
+
+
+def test_needs_retime_classification(vault) -> None:
+    p = vault / "Knowledge Base/Evidence/x/rec2.wav"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"RIFF")
+    sidecar, _ = preserve.ensure_media_sidecar(vault, p)
+    assert backfill._needs_retime(sidecar, "audio") is False  # not extracted yet
+    preserve.update_sidecar_extraction(vault, sidecar, text="t", engine="faster-whisper:large-v3")
+    assert backfill._needs_retime(sidecar, "audio") is True
+    assert backfill._needs_retime(sidecar, "image") is False
+    preserve.update_sidecar_extraction(vault, sidecar, text="t", engine="faster-whisper:large-v3+timed+diarized")
+    assert backfill._needs_retime(sidecar, "audio") is False  # done-marker anywhere in engine
+    preserve.update_sidecar_extraction(vault, sidecar, text="t", engine="no-audio")
+    assert backfill._needs_retime(sidecar, "video") is False
+
+
+def test_retime_guard_when_gate_disabled(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    _drop_audio_with_plain_transcript(vault)
+    monkeypatch.setattr(
+        extract, "extract_text",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("retime ran with the gate off")),
+    )
+    stats = backfill.backfill_media(vault, do_clip=False, retime=True, log_fn=_quiet)
+    assert stats.retimed == 0
+
+
+def test_retime_and_rediarize_share_one_extraction(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.setenv("EXOMEM_DIARIZE", "1")
+    _, sidecar = _drop_audio_with_plain_transcript(vault)
+    calls = {"n": 0}
+
+    def _both(*a, **k):
+        calls["n"] += 1
+        return extract.ExtractResult(
+            text="[0:05] [Hugo]: hello there",
+            media_type="audio",
+            engine="faster-whisper:large-v3+timed+diarized",
+            speakers=[{"speaker": "Hugo", "start": 0.0, "end": 1.5, "text": "hello there"}],
+        )
+
+    monkeypatch.setattr(extract, "extract_text", _both)
+    stats = backfill.backfill_media(vault, do_clip=False, rediarize=True, retime=True, log_fn=_quiet)
+    assert calls["n"] == 1  # ONE extraction served both upgrades
+    assert stats.retimed == 1 and stats.rediarized == 1
+    body = sidecar.read_text("utf-8")
+    assert "+timed+diarized" in body and "[0:05] [Hugo]:" in body
+
+
+def test_retime_partial_win_writes_timed_disables_rediarize(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.setenv("EXOMEM_DIARIZE", "1")
+    _, sidecar = _drop_audio_with_plain_transcript(vault)
+    monkeypatch.setattr(extract, "extract_text", _timed_result)  # +timed but no +diarized
+    stats = backfill.backfill_media(vault, do_clip=False, rediarize=True, retime=True, log_fn=_quiet)
+    assert stats.retimed == 1 and stats.rediarized == 0
+    assert "+timed" in sidecar.read_text("utf-8")  # partial upgrade still landed

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -229,6 +229,97 @@ def test_transcribe_soft_fails_to_plain_when_diarization_unavailable(
     assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}"
 
 
+# ---------------- optional: timed transcripts (EXOMEM_SEMANTIC_SEGMENTS, default OFF) ----
+
+
+def test_transcribe_gate_off_is_byte_identical_plain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    monkeypatch.delenv("EXOMEM_DIARIZE", raising=False)
+    segs = [_FakeSeg("hello there", 0.0, 1.0), _FakeSeg("general kenobi", 1.0, 2.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "hello there general kenobi"
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}"
+
+
+def test_transcribe_timed_plain_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.delenv("EXOMEM_DIARIZE", raising=False)
+    segs = [_FakeSeg("hello there", 5.0, 8.0), _FakeSeg("general kenobi", 3080.0, 3084.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "[0:05] hello there\n[51:20] general kenobi"
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}+timed"
+    assert r.speakers is None
+
+
+def test_transcribe_timed_diarized_per_segment_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.setenv("EXOMEM_DIARIZE", "1")
+    segs = [
+        _FakeSeg("part one", 0.0, 1.0),
+        _FakeSeg("part two", 1.0, 2.0),
+        _FakeSeg("reply", 2.0, 3.0),
+    ]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    monkeypatch.setattr(
+        extract, "_run_diarization",
+        lambda p: [(0.0, 2.0, "SPEAKER_00"), (2.0, 3.0, "SPEAKER_01")],
+    )
+    r = extract._transcribe(Path("x.wav"), "audio")
+    # Per-segment timed lines with the label repeated — NOT merged turns.
+    assert r.text.splitlines() == [
+        "[0:00] [Speaker A]: part one",
+        "[0:01] [Speaker A]: part two",
+        "[0:02] [Speaker B]: reply",
+    ]
+    # Suffix order is load-bearing: _needs_rediarize matches endswith("+diarized").
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}+timed+diarized"
+    # The structured speakers list keeps the MERGED-turn shape (unchanged surface).
+    assert [t["speaker"] for t in r.speakers] == ["Speaker A", "Speaker B"]
+    assert r.speakers[0]["text"] == "part one part two"
+
+
+def test_transcribe_gate_off_diarized_byte_identical(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    monkeypatch.setenv("EXOMEM_DIARIZE", "1")
+    segs = [_FakeSeg("part one", 0.0, 1.0), _FakeSeg("part two", 1.0, 2.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    monkeypatch.setattr(extract, "_run_diarization", lambda p: [(0.0, 2.0, "SPEAKER_00")])
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "[Speaker A]: part one part two"
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}+diarized"
+
+
+def test_transcribe_timed_survives_diarization_soft_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.setenv("EXOMEM_DIARIZE", "1")
+    segs = [_FakeSeg("solo line", 5.0, 6.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    monkeypatch.setattr(extract, "_diarizer_sidecar_python", lambda: None)
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "[0:05] solo line"  # timed plain, no speaker labels
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}+timed"
+
+
+def test_transcribe_timed_render_failure_falls_back_flat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.delenv("EXOMEM_DIARIZE", raising=False)
+    segs = [_FakeSeg("hello there", 0.0, 1.0)]
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    monkeypatch.setattr(
+        extract.semantic_segments, "render_timed_lines",
+        lambda s: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    r = extract._transcribe(Path("x.wav"), "audio")
+    assert r.text == "hello there"
+    assert r.engine == f"faster-whisper:{extract.WHISPER_MODEL}"  # no lying +timed marker
+
+
 # ---------------- optional: vision captioning (EXOMEM_VISION_CAPTION, default OFF) ----
 
 

--- a/tests/test_find_transcript_match.py
+++ b/tests/test_find_transcript_match.py
@@ -1,0 +1,118 @@
+"""find surfaces transcript_match_at for timed media (embeddings disabled —
+exercised through the BM25/keyword lanes + the chunk-branch unit seam)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import find as find_mod
+from exomem import scene_frames
+from exomem.embeddings import Scene
+from exomem.find import find
+
+VIDEO_REL = "Knowledge Base/Evidence/Test/clips/standup.mp4"
+
+
+class _FakeImg:
+    size = (640, 360)
+
+    def resize(self, size):
+        return self
+
+    def convert(self, mode):
+        return self
+
+    def save(self, path, format=None, quality=None):
+        Path(path).write_bytes(b"\xff\xd8x")
+
+
+TIMED_TRANSCRIPT = "\n".join(
+    [
+        "[0:05] good morning everyone welcome to standup",
+        "[0:40] first up the deployment pipeline status",
+        "[51:20] [Alice]: the flux capacitor migration is unblocked",
+        "[52:10] [Bob]: shipping it after lunch then",
+    ]
+)
+
+
+def _write_video_sidecar(vault: Path, timed: bool = True) -> Path:
+    video = vault / VIDEO_REL
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"\x00video")
+    body = TIMED_TRANSCRIPT if timed else TIMED_TRANSCRIPT.replace("[0:05] ", "").replace(
+        "[0:40] ", ""
+    ).replace("[51:20] ", "").replace("[52:10] ", "")
+    sidecar = vault / (VIDEO_REL + ".md")
+    sidecar.write_text(
+        "---\ntype: source\nsource_type: other\ncaptured: 2026-07-02\n"
+        "media_type: video\n"
+        f"evidence_file: {VIDEO_REL}\n"
+        "extracted_by: faster-whisper:large-v3+timed\ntags: [evidence]\n---\n\n"
+        f"# Evidence: standup.mp4\n\n## Extracted text\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return video
+
+
+def test_hybrid_text_match_carries_transcript_match_at(vault: Path) -> None:
+    video = _write_video_sidecar(vault)
+    scene_frames.write_scene_frames(
+        vault,
+        video,
+        [
+            (Scene(0.0, 60.0, 30.0, 0.0), _FakeImg()),
+            (Scene(3000.0, 3200.0, 3100.0, 0.7), _FakeImg()),
+        ],
+    )
+    hits = find(vault, query="flux capacitor migration", mode="hybrid")
+    assert len(hits) == 1
+    d = hits[0].as_dict()
+    assert d["path"] == VIDEO_REL + ".md"
+    assert d["transcript_match_at"] == "51:20"
+    # Nearest persisted frame (3100s) attached as the visual for the moment.
+    assert d["scene_frame"].endswith("t3100000ms.jpg")
+    assert d["scene_match_at"] == "51:40"
+
+
+def test_flat_sidecar_has_no_transcript_field(vault: Path) -> None:
+    _write_video_sidecar(vault, timed=False)
+    hits = find(vault, query="flux capacitor migration", mode="hybrid")
+    assert len(hits) == 1
+    assert "transcript_match_at" not in hits[0].as_dict()
+
+
+def test_keyword_mode_parity(vault: Path) -> None:
+    _write_video_sidecar(vault)
+    hits = find(vault, query="deployment pipeline", mode="keyword")
+    assert len(hits) == 1
+    d = hits[0].as_dict()
+    assert d["transcript_match_at"] == "0:40"
+
+
+def test_compact_dict_emits_transcript_match_at(vault: Path) -> None:
+    _write_video_sidecar(vault)
+    hits = find(vault, query="welcome to standup", mode="hybrid")
+    assert hits[0].as_compact_dict()["transcript_match_at"] == "0:05"
+
+
+def test_chunk_branch_prefers_segment_marker(vault: Path) -> None:
+    page = find_mod._CACHE.get(vault / (VIDEO_REL + ".md"), vault)
+    if page is None:
+        _write_video_sidecar(vault)
+        page = find_mod._CACHE.get(vault / (VIDEO_REL + ".md"), vault)
+    chunk = "Evidence: standup.mp4\n\n[51:20] [Alice]: the flux capacitor migration is unblocked"
+    assert find_mod._transcript_ts_for_hit(page, chunk, "anything") == 3080.0
+
+
+def test_non_media_page_never_localizes(vault: Path) -> None:
+    note = vault / "Knowledge Base/Notes/Insights/timed-looking.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-07-02\nupdated: 2026-07-02\n"
+        "tags: [x]\n---\n\n# Timed looking\n\n[0:05] this note quotes a transcript line\n",
+        encoding="utf-8",
+    )
+    hits = find(vault, query="quotes a transcript", mode="hybrid")
+    assert len(hits) == 1
+    assert "transcript_match_at" not in hits[0].as_dict()

--- a/tests/test_semantic_segments.py
+++ b/tests/test_semantic_segments.py
@@ -1,0 +1,305 @@
+"""Semantic segments — timestamp codec, timed-line parsing, transcript rendering.
+
+Pure logic: no torch, no whisper, no PyAV. The segmenter's embedding calls are
+covered separately via the injected embed_fn seam.
+"""
+
+from __future__ import annotations
+
+from exomem import find as find_mod
+from exomem import semantic_segments as ss
+
+# --- format_ts ----------------------------------------------------------------
+
+
+def test_format_ts_minutes_and_hours() -> None:
+    assert ss.format_ts(5) == "0:05"
+    assert ss.format_ts(80) == "1:20"
+    assert ss.format_ts(3080) == "51:20"
+    assert ss.format_ts(3785) == "1:03:05"
+    assert ss.format_ts(3785.4) == "1:03:05"  # rounds like the find formatter
+
+
+def test_format_ts_matches_find_formatter() -> None:
+    for secs in (0, 5, 59.6, 61, 3599, 3600, 3785.4, 7322):
+        assert ss.format_ts(secs) == find_mod._format_timestamp(secs)
+
+
+# --- parse_timed_lines ---------------------------------------------------------
+
+
+def test_parse_plain_and_diarized_lines() -> None:
+    block = "\n".join(
+        [
+            "[0:05] welcome to the incident review",
+            "[51:20] [Alice]: we will start using interaction data",
+            "[1:03:05] [Speaker B]: any questions",
+        ]
+    )
+    lines = ss.parse_timed_lines(block)
+    assert [round(line.ts, 2) for line in lines] == [5.0, 3080.0, 3785.0]
+    assert [line.speaker for line in lines] == [None, "Alice", "Speaker B"]
+    assert lines[1].text == "we will start using interaction data"
+
+
+def test_parse_folds_unmatched_lines_into_previous() -> None:
+    block = "\n".join(
+        [
+            "[0:05] first line",
+            "a continuation without a marker",
+            "[0:20] second line",
+        ]
+    )
+    lines = ss.parse_timed_lines(block)
+    assert len(lines) == 2
+    assert lines[0].text == "first line a continuation without a marker"
+    assert lines[1].ts == 20.0
+
+
+def test_parse_skips_leading_unmatched_and_empty() -> None:
+    assert ss.parse_timed_lines("no markers here\nat all") == []
+    assert ss.parse_timed_lines("") == []
+
+
+def test_roundtrip_render_then_parse() -> None:
+    segs = [(5.0, 9.0, "hello there", None), (3080.0, 3085.0, "topic two", "Alice")]
+    block = ss.render_timed_lines(segs)
+    lines = ss.parse_timed_lines(block)
+    assert [line.speaker for line in lines] == [None, "Alice"]
+    assert [line.text for line in lines] == ["hello there", "topic two"]
+    assert [line.ts for line in lines] == [5.0, 3080.0]
+
+
+# --- render_timed_lines ---------------------------------------------------------
+
+
+def test_render_plain_lines() -> None:
+    segs = [(5.2, 9.0, " welcome ", None), (12.0, 15.0, "to the review", None)]
+    assert ss.render_timed_lines(segs) == "[0:05] welcome\n[0:12] to the review"
+
+
+def test_render_diarized_repeats_label_per_segment() -> None:
+    segs = [
+        (5.0, 9.0, "point one", "Alice"),
+        (9.0, 14.0, "point two", "Alice"),
+        (14.0, 20.0, "reply", "Speaker B"),
+    ]
+    out = ss.render_timed_lines(segs)
+    assert out.splitlines() == [
+        "[0:05] [Alice]: point one",
+        "[0:09] [Alice]: point two",
+        "[0:14] [Speaker B]: reply",
+    ]
+
+
+def test_render_skips_empty_segments() -> None:
+    segs = [(1.0, 2.0, "   ", None), (3.0, 4.0, "kept", None)]
+    assert ss.render_timed_lines(segs) == "[0:03] kept"
+
+
+# --- segmenter (embedding calls faked via the injected embed_fn) ----------------
+
+import numpy as np  # noqa: E402
+
+
+def _topic_embed(texts: list[str]) -> np.ndarray:
+    """Deterministic fake: 'alpha' windows → e0, 'beta' → e1, mixed → normalized blend."""
+    out = np.zeros((len(texts), 2), dtype=np.float32)
+    for i, t in enumerate(texts):
+        a = t.count("alpha")
+        b = t.count("beta")
+        v = np.array([a + 1e-6, b + 1e-6], dtype=np.float32)
+        out[i] = v / np.linalg.norm(v)
+    return out
+
+
+def _timed_block(topic_words: list[str], step: float = 10.0, speakers: list | None = None) -> str:
+    lines = []
+    for i, w in enumerate(topic_words):
+        spk = speakers[i] if speakers else None
+        prefix = f"[{ss.format_ts(i * step)}]"
+        body = f"[{spk}]: {w} filler words here" if spk else f"{w} filler words here"
+        lines.append(f"{prefix} {body}")
+    return "\n".join(lines)
+
+
+def test_two_topics_split_at_the_seam() -> None:
+    block = _timed_block(["alpha"] * 8 + ["beta"] * 8)
+    segs = ss.segment_transcript(block, embed_fn=_topic_embed)
+    assert segs is not None and len(segs) == 2
+    assert "alpha" in segs[0] and "beta" not in segs[0]
+    assert segs[1].startswith("[1:20]")  # line 8 at 80s opens segment two
+
+
+def test_uniform_topic_is_one_segment() -> None:
+    block = _timed_block(["alpha"] * 12)
+    segs = ss.segment_transcript(block, embed_fn=_topic_embed)
+    assert segs is not None and len(segs) == 1
+
+
+def test_too_few_lines_returns_none() -> None:
+    block = _timed_block(["alpha"] * 5)
+    assert ss.segment_transcript(block, embed_fn=_topic_embed) is None
+
+
+def test_events_only_when_embed_fails() -> None:
+    def boom(texts):
+        raise RuntimeError("no model")
+
+    # Speaker change + scene event at the same gap: 0.35 + 0.5 >= 0.55 → boundary.
+    speakers = ["A"] * 6 + ["B"] * 6
+    block = _timed_block(["alpha"] * 12, speakers=speakers)
+    events = ss.Events(scene_ts=[60.0], ocr_ts=[])
+    segs = ss.segment_transcript(block, events=events, embed_fn=boom)
+    assert segs is not None and len(segs) == 2
+    assert segs[1].startswith("[1:00]")
+
+
+def test_speaker_change_alone_is_not_enough() -> None:
+    def boom(texts):
+        raise RuntimeError("no model")
+
+    speakers = ["A"] * 6 + ["B"] * 6
+    block = _timed_block(["alpha"] * 12, speakers=speakers)
+    segs = ss.segment_transcript(block, events=ss.Events([], []), embed_fn=boom)
+    assert segs is not None and len(segs) == 1  # 0.35 < 0.55
+
+
+def test_min_seg_secs_keeps_stronger_boundary() -> None:
+    def boom(texts):
+        raise RuntimeError("no model")
+
+    # Two candidate gaps 10s apart (< MIN_SEG_SECS): scene+ocr+speaker at 60s
+    # (score 1.25) vs scene-only at 70s (0.5 — below threshold anyway); use
+    # speaker changes at both to make both viable: A..A|B..B|C..C
+    speakers = ["A"] * 6 + ["B"] * 1 + ["C"] * 5
+    block = _timed_block(["alpha"] * 12, speakers=speakers)
+    events = ss.Events(scene_ts=[60.0, 70.0], ocr_ts=[60.0])
+    segs = ss.segment_transcript(block, events=events, embed_fn=boom)
+    # gap@60s scores 0.5+0.4+0.35=1.25; gap@70s scores 0.5+0.35=0.85 but is
+    # within MIN_SEG_SECS of the stronger accepted boundary → dropped.
+    assert segs is not None and len(segs) == 2
+    assert segs[1].startswith("[1:00]")
+
+
+def test_max_words_force_splits() -> None:
+    long_words = " ".join(["word"] * 60)
+    block = "\n".join(
+        f"[{ss.format_ts(i * 40)}] alpha {long_words}" for i in range(10)
+    )  # ~610 words per line-pairing, far over the chunk cap
+    segs = ss.segment_transcript(block, embed_fn=_topic_embed)
+    assert segs is not None and len(segs) >= 2
+    from exomem.embeddings import MAX_WORDS_PER_CHUNK
+
+    assert all(len(s.split()) <= MAX_WORDS_PER_CHUNK for s in segs)
+
+
+def test_segmenter_is_deterministic() -> None:
+    block = _timed_block(["alpha"] * 8 + ["beta"] * 8)
+    a = ss.segment_transcript(block, embed_fn=_topic_embed)
+    b = ss.segment_transcript(block, embed_fn=_topic_embed)
+    assert a == b
+
+
+# --- gather_events on a real (tmp) vault ---------------------------------------
+
+
+class _FakeImg:
+    size = (640, 360)
+
+    def resize(self, size):
+        return self
+
+    def convert(self, mode):
+        return self
+
+    def save(self, path, format=None, quality=None):
+        from pathlib import Path as _P
+
+        _P(path).write_bytes(b"\xff\xd8x")
+
+
+def test_gather_events_from_frames(vault) -> None:
+
+    from exomem import preserve, scene_frames
+    from exomem.embeddings import Scene
+
+    rel = "Knowledge Base/Evidence/Test/clips/demo.mp4"
+    video = vault / rel
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"\x00video")
+    pairs = scene_frames.write_scene_frames(
+        vault,
+        video,
+        [
+            (Scene(0.0, 100.0, 50.0, 0.0), _FakeImg()),
+            (Scene(100.0, 200.0, 150.0, 0.6), _FakeImg()),
+            (Scene(200.0, 300.0, 250.0, 0.5), _FakeImg()),
+        ],
+    )
+    # OCR: frame 1 and 2 share text (no event); frame 3 differs (event).
+    preserve.update_sidecar_extraction(vault, pairs[0][1], text="quarterly revenue chart", engine="tesseract")
+    preserve.update_sidecar_extraction(vault, pairs[1][1], text="quarterly revenue chart details", engine="tesseract")
+    preserve.update_sidecar_extraction(vault, pairs[2][1], text="incident timeline postmortem", engine="tesseract")
+    ev = ss.gather_events(vault, rel)
+    assert ev.scene_ts == [100.0, 200.0]  # midpoints between rep timestamps
+    assert ev.ocr_ts == [200.0]  # only the low-Jaccard transition
+
+
+def test_gather_events_missing_frames_dir_is_empty(vault) -> None:
+    ev = ss.gather_events(vault, "Knowledge Base/Evidence/nope.mp4")
+    assert ev.scene_ts == [] and ev.ocr_ts == []
+
+
+# --- _chunks_for_page routing seam ----------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from exomem import embeddings  # noqa: E402
+
+
+def _page(title: str, body: str, media_type=None, media_file=None) -> SimpleNamespace:
+    return SimpleNamespace(title=title, body=body, media_type=media_type, media_file=media_file)
+
+
+def test_seam_non_media_page_identical_to_chunk_text(vault, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    page = _page("A note", "First paragraph.\n\nSecond paragraph.")
+    assert embeddings._chunks_for_page(vault, page) == embeddings.chunk_text(
+        page.title, page.body
+    )
+
+
+def test_seam_gate_off_identical_for_timed_media(vault, monkeypatch) -> None:
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    body = "## Extracted text\n\n" + _timed_block(["alpha"] * 10)
+    page = _page("A video", body, media_type="video")
+    assert embeddings._chunks_for_page(vault, page) == embeddings.chunk_text(
+        page.title, page.body
+    )
+
+
+def test_seam_flat_transcript_falls_back(vault, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    body = "## Extracted text\n\njust flat prose with no markers at all"
+    page = _page("A video", body, media_type="video")
+    assert embeddings._chunks_for_page(vault, page) == embeddings.chunk_text(
+        page.title, page.body
+    )
+
+
+def test_seam_timed_video_gets_segment_chunks(vault, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    monkeypatch.setattr(
+        embeddings, "embed_texts", lambda texts, is_query=False: _topic_embed(texts)
+    )
+    transcript = _timed_block(["alpha"] * 8 + ["beta"] * 8)
+    body = f"# Evidence: demo.mp4\n\nPreserved under Evidence.\n\n## Extracted text\n\n{transcript}\n"
+    page = _page("Evidence: demo.mp4", body, media_type="video")
+    chunks = embeddings._chunks_for_page(vault, page)
+    # Head section chunks first, then one chunk per semantic segment.
+    assert any("Preserved under Evidence" in c for c in chunks[:2])
+    seg_chunks = [c for c in chunks if "[0:00]" in c or "[1:20]" in c]
+    assert len(seg_chunks) == 2
+    assert all(c.startswith("Evidence: demo.mp4\n\n") for c in chunks)
+    assert "[1:20]" in seg_chunks[1] and "beta" in seg_chunks[1]

--- a/tests/test_video_visual.py
+++ b/tests/test_video_visual.py
@@ -271,3 +271,102 @@ def test_backfill_gate_off_writes_no_frames(vault, monkeypatch: pytest.MonkeyPat
     stats = backfill.backfill_media(vault, do_ocr=False, log_fn=lambda *a: None)
     assert stats.scene_frames_written == 0
     assert not scene_frames.frames_dir_for(p).exists()
+
+
+# ---------------- semantic segments: trailing re-embed ordering ----------------
+
+
+def test_worker_gate_on_enqueues_parent_reembed_after_ocr(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_CLIP", raising=False)
+    monkeypatch.setenv("EXOMEM_VIDEO_SCENE_FRAMES", "1")
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    res = preserve.preserve_bytes(
+        vault, scope="Yolo", category="clips", filename="demo.mp4", data=b"\x00video", text="x",
+    )
+    monkeypatch.setattr(embeddings, "embed_video_scenes", lambda p: _two_scenes())
+    w = media_worker.MediaWorker(vault)
+    w._process(media_worker._Job(
+        binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
+        media_type="video", do_ocr=False, do_clip=True,
+    ))
+    jobs = []
+    while not w._q.empty():
+        jobs.append(w._q.get_nowait())
+    # FIFO: 2 frame-OCR jobs first, then exactly ONE parent re-embed.
+    assert [j.do_reembed for j in jobs] == [False, False, True]
+    assert jobs[-1].sidecar_path == vault / res.sidecar_path
+    assert not jobs[-1].do_ocr and not jobs[-1].do_clip
+
+
+def test_worker_reembed_gate_off_not_enqueued(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_CLIP", raising=False)
+    monkeypatch.setenv("EXOMEM_VIDEO_SCENE_FRAMES", "1")
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    res = preserve.preserve_bytes(
+        vault, scope="Yolo", category="clips", filename="demo.mp4", data=b"\x00video", text="x",
+    )
+    monkeypatch.setattr(embeddings, "embed_video_scenes", lambda p: _two_scenes())
+    w = media_worker.MediaWorker(vault)
+    w._process(media_worker._Job(
+        binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
+        media_type="video", do_ocr=False, do_clip=True,
+    ))
+    jobs = []
+    while not w._q.empty():
+        jobs.append(w._q.get_nowait())
+    assert [j.do_reembed for j in jobs] == [False, False]
+
+
+def test_process_reembed_calls_upsert(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+    monkeypatch.setattr(
+        media_worker.embeddings, "upsert_after_write",
+        lambda root, paths: called.setdefault("paths", paths),
+    )
+    sidecar = vault / "Knowledge Base/Evidence/T/clips/demo.mp4.md"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text("---\nmedia_type: video\n---\n", encoding="utf-8")
+    w = media_worker.MediaWorker(vault)
+    w._process(media_worker._Job(
+        binary_path=sidecar.with_suffix(""), sidecar_path=sidecar,
+        media_type="video", do_ocr=False, do_clip=False, do_reembed=True,
+    ))
+    assert called["paths"] == [sidecar]
+
+
+def test_scan_pending_enqueues_deduped_parent_reembed(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_SEMANTIC_SEGMENTS", "1")
+    parent_rel = "Knowledge Base/Evidence/T/clips/demo.mp4"
+    parent = vault / parent_rel
+    parent.parent.mkdir(parents=True, exist_ok=True)
+    parent.write_bytes(b"\x00video")
+    (vault / (parent_rel + ".md")).write_text(
+        f"---\nmedia_type: video\nevidence_file: {parent_rel}\nextracted_by: whisper+timed\n---\n",
+        encoding="utf-8",
+    )
+    frames = vault / (parent_rel + ".frames")
+    frames.mkdir()
+    for i, ms in enumerate((5000, 15000)):
+        jpg = frames / f"scene-00{i}-t{ms}ms.jpg"
+        jpg.write_bytes(b"\xff\xd8x")
+        jpg.with_name(jpg.name + ".md").write_text(
+            "---\nmedia_type: image\n"
+            f"evidence_file: {parent_rel}.frames/{jpg.name}\n"
+            "extracted_by: pending\n"
+            f"parent_media: {parent_rel}\n---\n",
+            encoding="utf-8",
+        )
+    w = media_worker.MediaWorker(vault)
+    n = w._scan_pending_ocr()
+    jobs = []
+    while not w._q.empty():
+        jobs.append(w._q.get_nowait())
+    reembeds = [j for j in jobs if j.do_reembed]
+    assert len(reembeds) == 1  # two children, ONE deduped parent re-embed
+    assert reembeds[0].sidecar_path == vault / (parent_rel + ".md")
+    assert jobs.index(reembeds[0]) == len(jobs) - 1  # after the pending children
+    assert n == 3


### PR DESCRIPTION
## What

Phase 2 of the video arc. With `EXOMEM_SEMANTIC_SEGMENTS` set (default **off**, soft-fail), the **moment** becomes the retrieval unit for audio/video: transcripts persist as timed lines, the embedding chunker segments them at fused topic boundaries, and a transcript match surfaces `transcript_match_at: "51:20"` with the nearest persisted scene frame attached — "find where they *said* X" now answers like "where they *showed* X" already does.

OpenSpec change: `openspec/changes/add-semantic-video-segments/` (validated `--strict`; MODIFIED deltas for `speaker-diarization` and `video-scene-frames`).

## How

- **Timed transcripts** render at the extraction source (`[m:ss] …`, diarized `[m:ss] [Alice]: …` per ASR segment — labels repeated so match localization survives; the structured merged-turn `speakers` list is unchanged). Engine gains `+timed` (before `+diarized` — that ordering is load-bearing for backfill idempotency). Gate off ⇒ byte-identical, regression-tested for both plain and diarized paths.
- **Segmenter** (`semantic_segments.py`, pure measurement — no LLM, no new dependency): TextTiling-style embedding-valley depth over 4-line sliding windows, fused with scene-change events (frame filename timestamps), speaker-turn changes, and OCR-change events (token-Jaccard < 0.5 between consecutive frames). Min segment duration, max-words force-splits (never truncates), 256-segment cap. The `embed_fn` is injected, so the whole segmenter is tested without torch. Ladder: embed failure → events-only → paragraph chunker.
- **Chunker seam**: `_chunks_for_page` — the one routing point shared by writers, watcher, reconcile, and full rebuilds. Equality tests prove non-timed pages chunk byte-identically.
- **find**: `transcript_match_at` from the matched chunk's leading marker (vector lane) or the nearest preceding marker to the query anchor (BM25/keyword); nearest-frame attach extends the existing block (`clip_frame_ts` first, else `transcript_ts`); keyword-mode parity. All additive.
- **Worker ordering**: OCR-change events depend on frame OCRs that finish after the transcript embeds — one trailing `do_reembed` job on the existing FIFO queue re-segments with all signals; restart scan enqueues deduped parent re-embeds.
- **`backfill-media --retime`**: opt-in re-ASR upgrade for existing flat transcripts, idempotent via `+timed`; one extraction serves `--retime` + `--rediarize`; a partial upgrade (timed gained, diarize soft-failed) still writes and disables only the failed pass.

## Verification

- **1116 passed, 11 skipped** — including gate-off byte-identical regressions at every layer, segmenter behavior (two-topic seam, events-only, min-distance, force-splits, determinism), find surfacing through keyword/BM25 lanes with embeddings disabled, worker FIFO-order assertions, and the full backfill matrix
- ruff at baseline (zero net-new), leak guard green, `openspec validate --strict`

Desk-side e2e (tasks.md 8.3, Hugo): gate on, upload a talking-head+slides recording, check timed sidecar + `transcript_match_at` + attached frame; then `backfill-media --retime --dry-run` → real run on one legacy recording. Thresholds centralized in one constants block for tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RkfJ1PMgzLnXKWTHBAZNs