### PR TITLE
feat: Docker distribution — lean/ml images, compose with tunnel profiles, gated GHCR publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Allowlist style: deny everything, then explicitly allow only what the
+# Dockerfile's COPY instructions need (pyproject.toml uv.lock README.md LICENSE
+# src/). This fails SAFE — a forgotten new source directory is excluded from
+# the build, causing an obvious ModuleNotFoundError at build/run time — rather
+# than UNSAFE, where a denylist that misses a newly-added sensitive file type
+# would silently leak it into the image. `.env`, `logs/`, and vault leftovers
+# can never enter the build context by construction: they simply aren't in the
+# allowlist below, regardless of what a contributor's working tree contains.
+*
+!src/
+!pyproject.toml
+!uv.lock
+!README.md
+!LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,45 @@ jobs:
         # and `exomem setup --yes` completes — with a hard wall-time budget.
         run: uv run python scripts/time-to-value.py --budget-seconds 120
 
+  docker:
+    name: docker (lean build + smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build lean image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: lean
+          load: true
+          tags: exomem:pr-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: In-container demo smoke (packaged sample vault, no mounts)
+        run: docker run --rm exomem:pr-smoke demo --json
+      - name: HTTP boot + claude.ai discovery-route smoke (dummy OAuth env, no GitHub calls)
+        run: |
+          trap 'docker rm -f exomem-smoke >/dev/null 2>&1 || true' EXIT
+          mkdir -p /tmp/vault
+          docker run --rm -v /tmp/vault:/vault exomem:pr-smoke init --vault /vault
+          docker run -d --name exomem-smoke -p 8765:8765 \
+            -v /tmp/vault:/vault -e EXOMEM_VAULT_PATH=/vault \
+            -e EXOMEM_BASE_URL=http://127.0.0.1:8765 \
+            -e GITHUB_CLIENT_ID=dummy -e GITHUB_CLIENT_SECRET=dummy \
+            -e EXOMEM_GITHUB_USERNAME=dummy -e EXOMEM_JWT_SIGNING_KEY=dummy \
+            exomem:pr-smoke
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/mcp || true)
+            [ "$code" = "401" ] && break
+            sleep 1
+          done
+          test "$code" = "401"
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/.well-known/oauth-authorization-server)" = "200"
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/.well-known/oauth-protected-resource)" = "200"
+          docker logs exomem-smoke | tail -5
+          docker stop exomem-smoke
+
   specs:
     name: OpenSpec validation
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to publish to PyPI, for example v0.2.1
+        description: Existing release tag to re-publish (PyPI and/or GHCR), for example v0.2.1
         required: true
         type: string
 
@@ -109,6 +109,107 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+  publish-image:
+    needs: [release-please, build-artifacts]
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_created == 'true' && vars.GHCR_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image version from the release tag
+        id: meta
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push lean image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: lean
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:latest
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push ml image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ml
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:ml
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-ml
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-existing-image:
+    if: ${{ github.event_name == 'workflow_dispatch' && vars.GHCR_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image version from the input tag
+        id: meta
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push lean image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: lean
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push ml image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ml
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-ml
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   publish-existing-pypi:
     if: ${{ github.event_name == 'workflow_dispatch' && vars.PYPI_PUBLISH_ENABLED == 'true' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,122 @@
+# exomem — multi-stage container image.
+#
+# Two final targets share this one file (openspec/changes/add-docker-distribution/design.md D6):
+#   lean (target `lean`, DEFAULT — base deps only, no torch, no model download)
+#   ml   (target `ml`   — the `embeddings` extra, CPU-only torch, no CUDA runtime)
+#
+# `lean` is intentionally the LAST stage in this file: `docker build .` / `docker
+# buildx build .` with no `--target` builds the final stage in the file, and lean
+# is meant to be that zero-argument default (matches the stdio one-liner's
+# zero-Python, zero-model-download onboarding promise — see docs/docker.md).
+# Build `ml` explicitly with `--target ml` (or pull the published `:ml` tag).
+#
+# Every stage builds from the checked-out source tree (COPY src/ pyproject.toml
+# uv.lock), never a published PyPI wheel — see design.md D1.
+
+ARG UV_VERSION=0.9.7
+
+########################################################################
+# builder-lean — base dependencies only, installed from local source.
+# Never touches pyproject.toml's cu132 (CUDA) torch index: `uv sync` here
+# only resolves the base `dependencies = [...]` list, which has no torch.
+########################################################################
+FROM python:3.12-slim AS builder-lean
+ARG UV_VERSION
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /usr/local/bin/uv
+
+WORKDIR /app
+# Deterministic, reproducible build: install the venv at a fixed path, never
+# let uv silently download its own Python (python:3.12-slim already has one),
+# and copy (not hardlink) into the venv so it survives the COPY --from into a
+# later stage cleanly.
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_LINK_MODE=copy
+
+# Matches .dockerignore's allowlist exactly — nothing else is needed to build.
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src/ src/
+
+RUN uv sync --frozen --no-dev --no-editable
+
+########################################################################
+# builder-ml — adds the `embeddings` extra (hybrid search) with CPU-only
+# torch. See design.md D2 for the full rationale; summary:
+#
+# pyproject.toml pins `[tool.uv.sources] torch = [{ index = "pytorch-cu132",
+# marker = "sys_platform == 'win32' or sys_platform == 'linux'" }]`. This
+# container's platform IS Linux, so a plain `uv sync --extra embeddings` here
+# would resolve torch against the cu132 (CUDA 13.2) index — multi-GB CUDA
+# wheels baked into an image with no CUDA runtime and no GPU. Instead:
+#
+#   1) `uv pip install torch --index-url .../cpu` — the CPU-only wheel from
+#      an explicit index, bypassing [tool.uv.sources] entirely.
+#   2) `uv pip install ".[embeddings]"` — the rest of the extra. `uv pip`
+#      (unlike `uv sync`/`uv add`) does NOT consult [tool.uv.sources] or
+#      [tool.uv.index], so it does not re-resolve/reinstall torch against the
+#      CUDA index; the already-installed CPU wheel satisfies the `torch>=2.12`
+#      requirement.
+#
+# If a future pyproject.toml edit changes the `embeddings` extra's torch pin
+# in a way the pinned CPU wheel below can no longer satisfy, step 2 fails
+# loudly (version conflict) — see design.md's Risks section before changing
+# either the extra or this Dockerfile.
+########################################################################
+FROM builder-lean AS builder-ml
+RUN uv pip install --python /app/.venv/bin/python "torch>=2.12" --index-url https://download.pytorch.org/whl/cpu \
+ && uv pip install --python /app/.venv/bin/python ".[embeddings]"
+
+########################################################################
+# Final: ml (target `ml`). Fresh slim base — no build tooling, no uv, no
+# source tree — just the populated venv. HF_HOME pins the downloaded
+# embedding/CLIP model weights under the declared /data volume so they
+# persist across restarts instead of re-downloading into an ephemeral layer.
+########################################################################
+FROM python:3.12-slim AS ml
+COPY --from=builder-ml /app/.venv /app/.venv
+COPY LICENSE /LICENSE
+
+ENV PATH=/app/.venv/bin:$PATH \
+    EXOMEM_HOST=0.0.0.0 \
+    EXOMEM_LOG_DIR=/data/logs \
+    HF_HOME=/data/hf
+
+LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.description="exomem — local knowledge substrate for owned markdown/Obsidian vaults, exposed through MCP, REST, and CLI (ml: hybrid embeddings + CLIP search, CPU-only torch, no GPU)"
+
+# No HEALTHCHECK here by design (design.md D5) — a Dockerfile-level HEALTHCHECK
+# would run unconditionally, including for `--transport stdio`, where there is
+# no HTTP server to probe. The healthcheck lives in compose.yaml instead, where
+# it only applies to the long-running HTTP deployment.
+VOLUME /data
+EXPOSE 8765
+ENTRYPOINT ["exomem"]
+CMD ["--transport", "http", "--port", "8765"]
+
+########################################################################
+# Final: lean (target `lean`) — the DEFAULT stage (last in this file; see
+# the top-of-file note). Base dependencies only: no torch, no
+# sentence-transformers, no model download. EXOMEM_DISABLE_EMBEDDINGS=1
+# keeps search in keyword/BM25 mode. Opt into `ml` explicitly for hybrid
+# search (`--target ml` at build time, or the published `:ml` tag).
+########################################################################
+FROM python:3.12-slim AS lean
+COPY --from=builder-lean /app/.venv /app/.venv
+COPY LICENSE /LICENSE
+
+ENV PATH=/app/.venv/bin:$PATH \
+    EXOMEM_HOST=0.0.0.0 \
+    EXOMEM_LOG_DIR=/data/logs \
+    EXOMEM_DISABLE_EMBEDDINGS=1
+
+LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.description="exomem — local knowledge substrate for owned markdown/Obsidian vaults, exposed through MCP, REST, and CLI (lean: keyword/BM25 search, no torch, no model download)"
+
+# No HEALTHCHECK here by design (design.md D5) — see the `ml` stage's comment
+# above; the healthcheck lives in compose.yaml.
+VOLUME /data
+EXPOSE 8765
+ENTRYPOINT ["exomem"]
+CMD ["--transport", "http", "--port", "8765"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,17 @@
 
 ARG UV_VERSION=0.9.7
 
+# COPY --from does not support ARG expansion; a global-scope FROM alias does
+# (buildx's documented workaround), so the pin lives in one place above.
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 ########################################################################
 # builder-lean — base dependencies only, installed from local source.
 # Never touches pyproject.toml's cu132 (CUDA) torch index: `uv sync` here
 # only resolves the base `dependencies = [...]` list, which has no torch.
 ########################################################################
 FROM python:3.12-slim AS builder-lean
-ARG UV_VERSION
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /usr/local/bin/uv
+COPY --from=uv /uv /usr/local/bin/uv
 
 WORKDIR /app
 # Deterministic, reproducible build: install the venv at a fixed path, never

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ uv run exomem demo
 | Codex CLI | `codex mcp add` — see below |
 | claude.ai (remote) | Remote server — see [docs/remote-quickstart.md](docs/remote-quickstart.md) |
 | Any MCP client | Generic stdio config — see below |
+| Docker (no Python) | One `docker run` line — see below and [docs/docker.md](docs/docker.md) |
 
 <details>
 <summary>Codex CLI</summary>
@@ -124,6 +125,19 @@ env = { EXOMEM_VAULT_PATH = "/path/to/vault" }
 ```json
 {"mcpServers": {"exomem": {"command": "exomem", "args": ["--transport", "stdio"], "env": {"EXOMEM_VAULT_PATH": "/path/to/vault"}}}}
 ```
+
+</details>
+
+<details>
+<summary>Docker (no Python on the host)</summary>
+
+```bash
+claude mcp add exomem -- docker run -i --rm -v "/path/to/vault:/vault" -e EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio
+```
+
+The image also runs as an always-on remote server via `docker compose` with a
+tunnel sidecar — see [docs/docker.md](docs/docker.md). Windows users: prefer
+the native install (WSL2 bind mounts miss live file-watch events).
 
 </details>
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,67 @@
+# exomem — remote compose deployment.
+#
+# Usage (see docs/docker.md for the full walkthrough):
+#
+#   Local/debug, no public ingress:
+#     docker compose up -d
+#     # uncomment the `ports:` line below first if you want 127.0.0.1:8765 bound
+#
+#   Public ingress via Cloudflare Tunnel:
+#     docker compose --profile cloudflared up -d
+#
+#   Public ingress via ngrok:
+#     docker compose --profile ngrok up -d
+#
+# With no --profile flag, only the `exomem` service starts: no host port
+# published, no tunnel sidecar running (design.md D9).
+
+services:
+  exomem:
+    image: ghcr.io/artexis10/exomem:latest
+    # Uncomment to build locally instead of pulling the published image:
+    # build: {context: ., target: lean}
+    env_file: .env
+    environment:
+      # Container-internal path — always /vault, regardless of what EXOMEM_VAULT_PATH
+      # is set to in .env for a non-container install.
+      EXOMEM_VAULT_PATH: /vault
+    volumes:
+      - "${EXOMEM_VAULT_HOST_PATH:?set in .env}:/vault"
+      - exomem-data:/data
+    # Uncomment for local/debug access at 127.0.0.1:8765. No host port is
+    # published by default — a tunnel profile (below) or this line are the
+    # only ways to reach the service. Note: the http transport ALWAYS requires
+    # the GitHub OAuth env vars, tunnel or not — without them the container
+    # exits at boot (and `restart: unless-stopped` will loop it).
+    # ports:
+    #   - "127.0.0.1:8765:8765"
+    healthcheck:
+      # Reuses the existing unauthenticated OAuth-discovery route (design.md
+      # D4) — no dedicated /health endpoint exists anywhere in the system.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8765/.well-known/oauth-protected-resource', timeout=5).status == 200 else 1)",
+        ]
+      interval: 30s
+      start_period: 15s
+    restart: unless-stopped
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - exomem
+    profiles: ["cloudflared"]
+
+  ngrok:
+    image: ngrok/ngrok:latest
+    command: http exomem:8765 --url https://${NGROK_DOMAIN}
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
+    profiles: ["ngrok"]
+
+volumes:
+  exomem-data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -193,6 +193,12 @@ command.
 
 ## 6. Install as a service (auto-start on boot)
 
+**Option 0 (container):** `docker compose --profile cloudflared up -d` (or
+`--profile ngrok`) runs the server plus the tunnel as one supervised unit —
+see [docker.md](docker.md). The native services below suit hosts where Docker
+isn't wanted, Windows vaults (WSL2 bind mounts miss live file-watch events),
+and GPU setups.
+
 Pick your platform — all three run the same `streamable-http` server and differ
 only in the OS service manager.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,138 @@
+# exomem — Docker
+
+The fastest way to try exomem with Claude Code: no `uv`, no Python, no clone.
+
+```bash
+claude mcp add exomem -- docker run -i --rm -v "/path/to/vault:/vault" -e EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio
+```
+
+Replace `/path/to/vault` with your Obsidian/markdown vault's absolute path.
+Claude Code launches the container per session and talks MCP over stdio — no
+HTTP port, no OAuth, nothing to keep running in the background.
+
+For an always-on remote deployment (mobile/web access via claude.ai), skip to
+[Remote compose deployment](#remote-compose-deployment) below. See
+[deployment.md](deployment.md) for the architecture this container fits into
+— this doc is the Docker-specific path through it.
+
+## Tags
+
+| Tag | Variant | Search mode | Uncompressed size (approx.) |
+| --- | --- | --- | --- |
+| `latest`, `X.Y.Z` | `lean` | keyword/BM25 only, no torch | ~250–350 MB |
+| `ml`, `X.Y.Z-ml` | `ml` | hybrid embeddings + CLIP search, CPU-only torch | ~1.5–2 GB |
+
+`lean` is the default and is what the stdio one-liner above pulls — no torch,
+no model download, matching a fast zero-Python onboarding path. Opt into
+hybrid search with the `ml` tag (`ghcr.io/artexis10/exomem:ml`); the first
+`find` call downloads the embedding/CLIP model weights into the `/data` volume
+(see below), so later restarts don't re-download them.
+
+**GPU is out of scope for both variants.** `ml` runs CPU-only torch — no CUDA
+runtime is bundled, and none is documented for this image. If you need GPU
+throughput, use the native install instead ([../SETUP-LOCAL.md](../SETUP-LOCAL.md),
+[deployment.md](deployment.md)'s CUDA/GPU notes).
+
+## Volume contract
+
+- **`/vault`** — your notes. Bind-mount your vault root here
+  (`-v "/path/to/vault:/vault"`) and set `EXOMEM_VAULT_PATH=/vault`. All file
+  reads and writes stay confined to this mount, matching the server's
+  existing vault-containment guarantee.
+- **`/data`** — server-local state, declared as a `VOLUME` in the image:
+  - `EXOMEM_LOG_DIR=/data/logs` — the rotating `exomem.log`. The
+    `queries.jsonl` / `writes.jsonl` / `reads.jsonl` audit logs land here too,
+    but only in the `ml` image (the lean image runs with embeddings disabled,
+    which also turns the query log off).
+  - `ml` only: `HF_HOME=/data/hf` — downloaded embedding/CLIP model weights.
+
+  Mount a named volume (or bind mount) at `/data` so logs and model weights
+  survive container restarts instead of resetting every time. `/data` is
+  deliberately a *separate* volume from `/vault`: you can wipe server state
+  (`docker volume rm`) without touching your vault, since they have distinct
+  lifecycles.
+
+## Remote compose deployment
+
+The root [`compose.yaml`](../compose.yaml) runs exomem as an always-on HTTP
+service with optional tunnel-sidecar ingress, matching the remote tier
+documented in [deployment.md](deployment.md).
+
+1. Clone the repo — compose needs `compose.yaml` and a filled-in `.env`; it
+   pulls the published image, so no local Python/`uv` install is required:
+
+   ```bash
+   git clone https://github.com/Artexis10/exomem.git
+   cd exomem
+   cp .env.example .env
+   ```
+
+2. Fill in `.env`:
+   - The OAuth vars from [deployment.md](deployment.md): `EXOMEM_BASE_URL`,
+     `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `EXOMEM_GITHUB_USERNAME`,
+     `EXOMEM_JWT_SIGNING_KEY`.
+   - The compose-only keys (not yet in `.env.example` — append them):
+
+     ```bash
+     printf '\nEXOMEM_VAULT_HOST_PATH=/path/to/your/vault\n' >> .env
+     ```
+
+     `EXOMEM_VAULT_HOST_PATH` is the **host** path bind-mounted to `/vault`
+     (`compose.yaml` maps it in; the container always sees `/vault`). Compose
+     fails fast with `set in .env` if it is missing.
+   - Whichever tunnel credential you're using, appended the same way:
+     `CLOUDFLARE_TUNNEL_TOKEN`, or `NGROK_AUTHTOKEN` + `NGROK_DOMAIN`.
+
+3. Bring it up with the tunnel profile you have an account for:
+
+   ```bash
+   docker compose --profile ngrok up -d
+   # or
+   docker compose --profile cloudflared up -d
+   ```
+
+   With **no** `--profile` flag, only the `exomem` service starts: no host
+   port published, no tunnel sidecar running — useful for a LAN-only or
+   locally-debugged setup. Uncomment the `ports:` line in `compose.yaml` to
+   bind `127.0.0.1:8765` for local access.
+
+4. Verify:
+
+   ```bash
+   docker compose exec exomem exomem doctor --profile remote
+   ```
+
+`docker compose ps` reports `exomem` healthy once
+`GET /.well-known/oauth-protected-resource` (the same unauthenticated route
+claude.ai uses for OAuth discovery) returns `200` — no separate `/health`
+endpoint exists.
+
+## Hardening
+
+Run the container as a non-root user:
+
+```bash
+docker run --user "$(id -u):$(id -g)" ...
+```
+
+This works out of the box because both persistence paths point at `/data`
+(`EXOMEM_LOG_DIR`, and on `ml`, `HF_HOME`) — as long as your user has write
+access to the mounted `/data` volume, nothing in the image requires root. With
+a **bind mount** at `/data` that's automatic (you own the host directory); a
+Docker **named volume** (what `compose.yaml` uses) is initialized root-owned,
+so pre-chown it once (`docker run --rm -v exomem-data:/data alpine chown -R 1000:1000 /data`)
+before running non-root against it. The
+image does not impose a fixed `USER`, so you can pick the uid/gid that matches
+your host's volume ownership.
+
+## Windows caveat
+
+If you're on Windows, prefer the native install
+([../SETUP-LOCAL.md](../SETUP-LOCAL.md)) over Docker for day-to-day editing.
+Docker Desktop bind-mounts a `C:\` path through WSL2, and that path does
+**not** propagate `inotify` events — exomem's live file-watcher (which
+re-embeds out-of-band `.md` edits) will silently miss changes made outside the
+container. NTFS-backed WSL2 mounts are also noticeably slower than a native
+filesystem for the same reason. Docker remains a good choice for a Linux/macOS
+host, or for the remote-compose walkthrough above running on a remote Linux
+box.

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,6 +40,12 @@ uv run python scripts/generate-capabilities.py --check
 uv build
 ```
 
+After a release with GHCR publishing enabled, smoke the published image:
+
+```bash
+docker run --rm ghcr.io/artexis10/exomem:latest demo --json
+```
+
 Optional host-specific checks:
 
 ```bash

--- a/openspec/changes/add-docker-distribution/design.md
+++ b/openspec/changes/add-docker-distribution/design.md
@@ -1,0 +1,199 @@
+# Design — Docker distribution
+
+## D1. Build from local source, not a published PyPI wheel
+
+**Decision:** every image — PR-time CI build and release build alike — builds from the
+checked-out source tree (`COPY src/ pyproject.toml uv.lock`), never `pip install
+exomem==X.Y.Z`.
+
+**Rejected alternative — publish-from-PyPI-wheel base.** Building `FROM` a PyPI release
+would mean CI could only smoke a container for a version that is already public, which
+inverts the safety property a PR gate is supposed to have: the whole point is to catch a
+broken image *before* it reaches users. A PyPI-wheel base also couples the Docker
+pipeline's freshness to the PyPI publish pipeline's cadence for no benefit — local-source
+builds are strictly more capable (same mechanism serves PR smoke and release publish) and
+no slower in practice (`uv sync`/`uv pip install` against the lockfile is the same either
+way).
+
+## D2. `ml` target: CPU-index torch via `uv pip`, not `uv sync --extra embeddings`
+
+`pyproject.toml` pins `[tool.uv.sources] torch = [{ index = "pytorch-cu132", marker =
+"sys_platform == 'win32' or sys_platform == 'linux'" }]`. The container's platform is
+Linux, so a plain `uv sync --extra embeddings` inside the `ml` builder would resolve
+torch against the `cu132` (CUDA 13.2) index — multi-GB CUDA wheels baked into an image
+that ships no GPU and no CUDA runtime, and that likely fails to even import correctly
+without the matching driver/userspace libraries.
+
+**Decision:** the `ml` builder stage does two separate installs:
+
+1. `uv pip install torch --index-url https://download.pytorch.org/whl/cpu` — the CPU-only
+   wheel, explicit index, bypassing `[tool.uv.sources]` entirely.
+2. `uv pip install ".[embeddings]"` — the rest of the `embeddings` extra
+   (`sentence-transformers`, `pillow`). `uv pip` (unlike `uv sync`/`uv add`) does not
+   consult `[tool.uv.sources]`/`[tool.uv.index]`, so it does not re-resolve or reinstall
+   torch against the pinned CUDA index; the already-installed CPU wheel satisfies the
+   `torch>=2.12` requirement.
+
+**Rejected alternative — `uv sync --extra embeddings` with a build-time env override
+(`UV_TORCH_BACKEND=cpu` or similar).** `README.md`/`pyproject.toml` already documented a
+prior decision *against* `UV_TORCH_BACKEND=auto` for reproducibility (it resolves
+per-machine at install time, breaking lockfile parity across hosts) — reusing that same
+per-machine resolution knob just to dodge the pin inside Docker would reintroduce exactly
+the non-reproducibility that pin exists to prevent, and would silently diverge from
+`uv.lock`. The two-step `uv pip install` keeps `uv.lock` authoritative for every
+non-torch dependency and makes the CPU-torch substitution an explicit, auditable step in
+the Dockerfile itself.
+
+## D3. GPU-in-Docker is out of scope
+
+No CUDA runtime, no `nvidia-container-toolkit` documentation, no GPU compose profile.
+Rationale: the desktop/service install already documents the CUDA path in full
+(`docs/deployment.md`'s GPU/CUDA notes) for users who need GPU throughput; Docker's job
+here is zero-Python onboarding and a self-contained remote box, not a GPU-accelerated
+deployment target. Revisit only if a user demonstrates a real need for GPU passthrough
+inside a container (a materially more complex host/driver/image contract).
+
+## D4. No new `/health` endpoint
+
+**Decision:** the compose healthcheck (and any future orchestrator health probe) targets
+the existing `GET /.well-known/oauth-protected-resource` route — already served
+unauthenticated for claude.ai's OAuth discovery — instead of adding a dedicated
+`/health`.
+
+**Rejected alternative — a new `/health` route.** Would be a second unauthenticated
+endpoint doing strictly less than the existing one (the existing route already proves
+the HTTP server is up, FastMCP is mounted, and — when auth is configured — the OAuth
+metadata route is wired correctly, which is a stronger signal than a bare 200). Adding it
+would also be new attack surface and a new documented contract for zero additional
+information. This route only exists when `require_auth` is true (HTTP transport), which
+is exactly the case compose targets — stdio users have no HTTP surface to health-check in
+the first place.
+
+## D5. `HEALTHCHECK` lives in compose, not the Dockerfile
+
+**Decision:** no `HEALTHCHECK` instruction in the `Dockerfile` itself; the healthcheck is
+declared only in `compose.yaml`.
+
+**Rejected alternative — a Dockerfile-level `HEALTHCHECK`.** A `HEALTHCHECK` baked into
+the image would run unconditionally, including for the primary intended interactive use
+of this image — `docker run -i --rm ... --transport stdio` for Claude Code — where there
+is no HTTP server to probe at all. That would make every stdio-mode container report
+`unhealthy` forever, which is misleading noise for `docker ps`/`docker inspect` on a
+container that is working exactly as intended. Compose-level healthcheck applies only to
+the long-running HTTP deployment where it's meaningful, and can be overridden or
+disabled per-deployment without touching the image.
+
+## D6. Two final targets, one Dockerfile
+
+`lean` and `ml` are multi-stage targets in the same `Dockerfile` (`FROM base AS lean`,
+`FROM base AS ml`, shared builder stages), not two separate Dockerfiles. This keeps the
+shared setup (base image, `uv` copy, non-root user, `COPY LICENSE`, OCI labels, entrypoint
+shape) in one place and lets `docker buildx build --target lean|ml` select the variant —
+matching how CI/release both need to build both variants from the same commit without
+drift between two hand-maintained files.
+
+`lean` is the default target (`docker build .` with no `--target` builds `lean`) because
+it is the fast, small, zero-model-download path that matches the stdio one-liner's
+onboarding promise; a user who wants hybrid search opts in explicitly with `--target ml`
+or the `:ml` published tag.
+
+## D7. Env-var contract inside the container
+
+- `EXOMEM_HOST=0.0.0.0` — required because the container's loopback is not reachable
+  from the host/orchestrator network; `server.run()` already resolves
+  `$EXOMEM_HOST > passed host > 127.0.0.1`, so this is a pure env-var set, no code change.
+- `EXOMEM_LOG_DIR=/data/logs` (new override, see below) — keeps logs under the declared
+  `/data` volume instead of failing to write under `site-packages`.
+- `ml` additionally sets `HF_HOME=/data/hf` so downloaded model weights persist across
+  container restarts under the same `/data` volume instead of re-downloading into an
+  ephemeral layer on every restart.
+- `VOLUME /data` is the single persistence boundary for both logs and (on `ml`) the HF
+  cache; the vault itself is a separate bind mount (`/vault`) the user controls, kept out
+  of `/data` so vault content and server-local state have distinct lifecycles (a user can
+  `docker volume rm` the server state without touching their vault).
+- `CMD ["--transport","http","--port","8765"]` is the default so `docker run
+  ghcr.io/artexis10/exomem:latest` (no args) does something reasonable (serve HTTP) for
+  a first-time `docker run --help`-style exploration, while the stdio one-liner
+  explicitly overrides `--transport stdio` as documented in `docs/docker.md`. The
+  existing `RuntimeError` on missing OAuth env fires unchanged in the HTTP default case —
+  a container started with no `.env`/`-e` flags exits immediately with the actionable
+  message rather than binding a socket with no auth.
+
+## D8. `EXOMEM_LOG_DIR`: override, not a new logging subsystem
+
+**Problem:** `server.run()` defaults `log_dir` to
+`Path(__file__).resolve().parents[2] / "logs"` when the caller passes none, and
+`query_log.py` computes a module-level `_LOG_DIR` the same way. Both resolve to the
+*source-checkout* layout (`src/exomem/../../logs` = repo root `logs/`). Under a
+pip-installed package, `parents[2]` from an installed `site-packages/exomem/server.py`
+lands somewhere under (or above) `site-packages` — not writable by a non-root container
+user, and not a sensible location even when writable.
+
+**Decision:** both call sites check `os.environ.get("EXOMEM_LOG_DIR")` first and fall
+back to today's exact default when unset, so:
+
+- `server.run()`'s `log_dir` resolution becomes: passed `log_dir` param (unchanged, still
+  wins when a caller supplies one explicitly) → `EXOMEM_LOG_DIR` env → today's
+  `parents[2] / "logs"` default. This preserves the existing precedent that `server.run`
+  accepts an explicit override while adding an env-driven one for the common case (no
+  code caller, just a launched process).
+- `query_log.py`'s `QUERIES_PATH`/`WRITES_PATH`/`READS_PATH` stop being constants computed
+  once at import time from a hardcoded path; the log directory is resolved through a
+  small accessor consulted at each write, so setting `EXOMEM_LOG_DIR` before the module
+  is used (the only realistic use — env vars are set before the process starts) takes
+  effect, and tests can flip the env var and observe the new location without needing to
+  reload the module via import-order tricks.
+
+**Rejected alternative — leave `query_log.py` on its hardcoded default and only fix
+`server.run()`.** `query_log.py`'s three JSONL logs are exactly as production-critical as
+`exomem.log` (query/write/read audit trail) and share the identical failure mode inside a
+container — fixing one call site and not the other would leave a silent gap the first
+time someone runs `find` in the container and the process crashes trying to create
+`queries.jsonl` under an unwritable path.
+
+**Non-goals:** no change to rotation policy, format, or the existing
+`EXOMEM_DISABLE_QUERY_LOG`/`EXOMEM_DISABLE_EMBEDDINGS` opt-outs in `query_log.py` — this
+is purely a directory-resolution override, keeping the default behavior for every
+existing non-container install (desktop, NSSM/launchd/systemd service) byte-identical.
+
+## D9. Ingress as compose profiles, not a fixed second service
+
+`cloudflared` and `ngrok` are declared as compose **profiles**
+(`docker compose --profile cloudflared up`), not always-on services, and not a single
+hardcoded choice. Rationale: a self-contained remote deployment needs *some* public
+ingress, but which tunnel provider a user already has an account with varies, and many
+users running `compose` purely for local/LAN use want neither — `docker compose up` with
+no profile flag starts only the `exomem` service, no host port published, and no
+egress-tunnel container running. This mirrors the existing desktop-install precedent of
+documenting Tailscale Funnel vs. Cloudflare Tunnel as parallel options in
+`docs/deployment.md`, translated into compose's native profile mechanism instead of a
+second doc branch.
+
+## Risks
+
+- **CPU-torch substitution silently regressing to CUDA.** If a future `pyproject.toml`
+  edit changes the `embeddings` extra's torch pin in a way `uv pip install ".[embeddings]"`
+  can no longer satisfy with the pre-installed CPU wheel, the build would either fail
+  loudly (version conflict) or — worse — quietly re-resolve. Mitigated by CI building the
+  `lean` target only (cheap, every PR) and by documenting the two-step install inline in
+  the Dockerfile with a comment pointing at this design doc's D2, so a future editor sees
+  the constraint before touching either the extra or the Dockerfile. The `ml` target
+  itself is not part of the PR gate (no GPU-less CI runner can meaningfully exercise CPU
+  embeddings within CI time budget); it is validated at release-build time and by desk-side
+  smoke.
+- **Multi-arch build cost/flake at release time.** `buildx`+QEMU cross-emulation for
+  `arm64` on an `amd64` GitHub-hosted runner is slower and has occasionally been flaky in
+  other projects. Mitigated by keeping multi-arch scoped to the release publish job only
+  (not the PR gate) and by the `workflow_dispatch` republish path being able to retry
+  independently of a new release.
+- **`.dockerignore` allowlist drift.** An allowlist (`*` then explicit `!` entries) fails
+  safe (a forgotten new source directory is excluded from the build, causing an obvious
+  `ModuleNotFoundError` at build/run time) rather than unsafe (a denylist that misses a
+  newly-added sensitive file type would silently leak it into the image). The CI docker
+  job building successfully on every PR is the drift detector for the safe-failure case.
+- **Windows + WSL2 bind-mount caveat undersold.** Documented explicitly in
+  `docs/docker.md` (inotify doesn't propagate through a WSL2 bind mount, so the live
+  file-watcher misses out-of-band vault edits, plus NTFS-backed mount I/O is slower) so a
+  Windows user doesn't file a "file watcher doesn't work" report against a configuration
+  this change never claims to support well — the native install remains the recommended
+  path for Windows daily use.

--- a/openspec/changes/add-docker-distribution/proposal.md
+++ b/openspec/changes/add-docker-distribution/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+Competitor parity: engram's entire pitch is "one Docker container"; exomem has no
+container story today. A container also gives the fastest zero-Python onboarding path
+(a `docker run` stdio one-liner for Claude Code — no `uv`, no Python, no clone) and a
+self-contained remote deployment (a `compose` stack with a tunnel sidecar, no manual
+NSSM/launchd/systemd service install).
+
+The archived `2026-06-30-complete-oss-readiness` change explicitly scoped this out —
+its proposal lists "Docker images, PyPI publishing automation, hosted control-plane, or
+new server capabilities" as out of scope. This change picks up the Docker piece of that
+deferred list as its own capability.
+
+## What Changes
+
+- **Multi-stage `Dockerfile` at the repo root**, base `python:3.12-slim`, `uv` copied
+  from the pinned `ghcr.io/astral-sh/uv` image (builder stage only), built from **local
+  source** — never PyPI — so CI can build and smoke the image on every PR before a
+  release exists, and release images build from the release tag. Two final targets:
+  `lean` (default; base dependencies only, no torch, `EXOMEM_DISABLE_EMBEDDINGS=1`) and
+  `ml` (the `embeddings` extra with CPU-only torch). The `ml` builder cannot
+  `uv sync --extra embeddings`, because `pyproject.toml`'s `[tool.uv.sources]` pins a
+  CUDA (`cu132`) torch index for `sys_platform == 'win32' or 'linux'` — Linux is exactly
+  the container's platform, so a plain `uv sync` there would try to pull multi-GB CUDA
+  wheels into a CPU-only image. Instead the `ml` builder installs CPU torch from
+  `https://download.pytorch.org/whl/cpu` via `uv pip install`, then
+  `uv pip install ".[embeddings]"` — `uv pip` does not consult `[tool.uv.sources]`, so
+  torch is not reinstalled from the CUDA index. GPU-in-Docker is explicitly out of
+  scope. Both final targets set `EXOMEM_HOST=0.0.0.0` (the existing env-wins-over-flag
+  precedent in `server.run()`), `EXOMEM_LOG_DIR=/data/logs`; `ml` additionally sets
+  `HF_HOME=/data/hf`. Both declare `VOLUME /data`, `EXPOSE 8765`,
+  `ENTRYPOINT ["exomem"]`, `CMD ["--transport","http","--port","8765"]` — the existing
+  actionable `RuntimeError` for missing OAuth env fires unchanged, so a misconfigured
+  container fails fast instead of silently serving unauthenticated. OCI labels
+  (`org.opencontainers.image.source`, `.licenses=AGPL-3.0-or-later`, `.description`) plus
+  `COPY LICENSE /LICENSE`. Multi-arch `linux/amd64` + `linux/arm64` at publish time via
+  buildx; PR builds stay single-arch (`linux/amd64`) for CI speed.
+- **New required code change: `EXOMEM_LOG_DIR` env override for the log directory.**
+  Today `logging_config.py`'s caller and `query_log.py` both hardcode logs under the
+  package-parent directory (`Path(__file__).resolve().parents[2] / "logs"`) — inside a
+  pip-installed container that resolves under `site-packages`, which a non-root
+  container user cannot write to, crashing on the first log line. `server.run()`'s log
+  directory resolution and `query_log.py`'s log paths both honor `EXOMEM_LOG_DIR` when
+  set, falling back to today's exact default when unset. This is a genuine gap beyond
+  Docker — the last hardcoded path in an otherwise env-driven server — surfaced by
+  building the container.
+- **Root `compose.yaml`**: service `exomem` (image `ghcr.io/artexis10/exomem:latest`
+  with a commented `build:` block for local builds; `env_file: .env`; vault bind mount
+  via `EXOMEM_VAULT_HOST_PATH` → `/vault`; named volume `exomem-data` → `/data`;
+  healthcheck `GET http://127.0.0.1:8765/.well-known/oauth-protected-resource` — the one
+  already-unauthenticated route, no new `/health` endpoint needed; `restart:
+  unless-stopped`) plus ingress sidecars as compose **profiles**: `cloudflared`
+  (`cloudflare/cloudflared`, token-run, reaches `http://exomem:8765` over the compose
+  network) and `ngrok` (`ngrok/ngrok`, static dev domain). No published host ports with
+  a tunnel profile active; a commented `127.0.0.1:8765` mapping for local/debug use.
+- **Allowlist-style `.dockerignore`** (`*` then `!src/`, `!pyproject.toml`, `!uv.lock`,
+  `!README.md`, `!LICENSE`) so `.env`, `logs/`, and vault leftovers can never enter the
+  build context regardless of what a contributor's working tree happens to contain.
+- **CI**: a new `docker` job in `ci.yml` builds the `lean` target on every PR
+  (`linux/amd64`, no push) and smokes it in-container: `exomem doctor` plus a `find`
+  against the bundled sample vault over the CLI surface, then boots HTTP with dummy
+  OAuth env (startup never calls GitHub) and curls a 401 from `/mcp` and 200s from both
+  well-known OAuth discovery paths — proving the claude.ai discovery workaround is live
+  inside the image without any model download. Release: a `publish-image` job appended
+  to `release-please.yml`, gated on `vars.GHCR_PUBLISH_ENABLED == 'true'` (mirroring the
+  existing `PYPI_PUBLISH_ENABLED` gate), `permissions: packages: write`, login with
+  `GITHUB_TOKEN`, buildx + QEMU for multi-arch, tags
+  `ghcr.io/artexis10/exomem:{latest, X.Y.Z, ml, X.Y.Z-ml}`; plus a `workflow_dispatch`
+  republish path mirroring the existing `publish-existing-pypi` job.
+- **Docs**: new `docs/docker.md` (the stdio one-liner headline:
+  `claude mcp add exomem -- docker run -i --rm -v "/path/to/vault:/vault" -e EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio`;
+  compose remote walkthrough; tag/size expectations — `lean` ~250-350MB uncompressed
+  vs. `ml` ~1.5-2GB; the `/data` volume contract; a `--user` hardening note; a Windows
+  caveat that WSL2 bind mounts don't propagate `inotify`, so the live file-watcher
+  misses out-of-band edits and NTFS-backed mounts are slower — Windows users should
+  prefer the native install for daily editing). README's Install section gains the
+  docker one-liner; `docs/deployment.md`'s service section gains "Option 0: docker
+  compose"; `docs/release.md`'s checklist gains a pull-and-smoke-the-published-image
+  step.
+- **Tests**: `tests/test_log_dir_override.py` (`EXOMEM_LOG_DIR` honored by the logging
+  config and by `query_log`; default behavior unchanged when unset). The container
+  smoke itself is CI-only and is documented as such in `tasks.md` — it needs a Docker
+  daemon that isn't available to the unit test suite.
+
+## Capabilities
+
+### New Capabilities
+
+- `distribution-surfaces`: packaged, versioned container images (`lean` and `ml`
+  variants) built from local source with documented stdio and HTTP contracts, a vault
+  volume contract, CI build+smoke on every PR, a gated GHCR publish pipeline on release,
+  and a self-contained `compose.yaml` remote deployment with opt-in tunnel-sidecar
+  ingress profiles.
+
+This change is kept **single-capability**. The `EXOMEM_LOG_DIR` override is real
+production code (not docs-only), but its only motivating scenario is the non-root
+container log path this change introduces, it adds no new `doctor` check, and it does
+not change any documented install-readiness contract (the default path is byte-identical
+when the variable is unset) — so `install-readiness`'s spec does not need a delta. If a
+future change gives `doctor` its own `EXOMEM_LOG_DIR`-aware check, that is the point to
+add a Modified Capability there.
+
+## Impact
+
+- New repo files: `Dockerfile`, `compose.yaml`, `.dockerignore`, `docs/docker.md`,
+  additions to `.github/workflows/ci.yml` (`docker` job) and
+  `.github/workflows/release-please.yml` (`publish-image` job +
+  `workflow_dispatch` republish input).
+- Code: `src/exomem/logging_config.py` / `src/exomem/server.py` (`EXOMEM_LOG_DIR`
+  resolution for the application log), `src/exomem/query_log.py` (`EXOMEM_LOG_DIR`
+  resolution for the queries/writes/reads JSONL logs).
+- Docs: `README.md` (Install section), `docs/deployment.md` (service options),
+  `docs/release.md` (release checklist).
+- Tests: `tests/test_log_dir_override.py` (new, pure logic — no Docker daemon
+  required). Container build/smoke stays CI-only; no vault migration, no MCP/REST/CLI
+  schema change, no new reasoning surface.

--- a/openspec/changes/add-docker-distribution/specs/distribution-surfaces/spec.md
+++ b/openspec/changes/add-docker-distribution/specs/distribution-surfaces/spec.md
@@ -1,0 +1,192 @@
+## ADDED Requirements
+
+### Requirement: Container Image
+
+The system SHALL provide a multi-stage `Dockerfile` at the repo root, built from local
+source (never a published PyPI wheel), producing two final targets: `lean` (default —
+base dependencies only, no torch, `EXOMEM_DISABLE_EMBEDDINGS=1`) and `ml` (the
+`embeddings` extra with CPU-only torch, installed via a CPU-index `uv pip install`
+rather than `uv sync --extra embeddings`, so the CUDA torch index pinned for Linux in
+`pyproject.toml` is never triggered). GPU acceleration inside the container is out of
+scope. Both targets SHALL set `EXOMEM_HOST=0.0.0.0` and `EXOMEM_LOG_DIR=/data/logs`; `ml`
+SHALL additionally set `HF_HOME=/data/hf`. Both SHALL declare `VOLUME /data`, `EXPOSE
+8765`, `ENTRYPOINT ["exomem"]`, and default `CMD ["--transport","http","--port","8765"]`.
+Both SHALL carry OCI labels (`org.opencontainers.image.source`,
+`org.opencontainers.image.licenses=AGPL-3.0-or-later`,
+`org.opencontainers.image.description`) and include `/LICENSE`. Published images SHALL be
+multi-arch (`linux/amd64` and `linux/arm64`).
+
+#### Scenario: stdio one-liner needs no OAuth environment
+
+- **WHEN** a user runs
+  `docker run -i --rm -v "/path/to/vault:/vault" -e EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio`
+- **THEN** the container starts and serves MCP over stdio without any GitHub OAuth
+  environment variable being required
+
+#### Scenario: HTTP boot without OAuth env fails fast
+
+- **WHEN** the container runs with the default `CMD` (`--transport http --port 8765`)
+  and `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `EXOMEM_GITHUB_USERNAME`, or
+  `EXOMEM_BASE_URL` is unset
+- **THEN** the process exits non-zero immediately with the existing actionable "Missing
+  required env vars for GitHub OAuth" message, and no socket is bound unauthenticated
+
+#### Scenario: lean image excludes torch
+
+- **WHEN** the `lean` target is built and inspected
+- **THEN** it contains no torch or sentence-transformers packages, and
+  `EXOMEM_DISABLE_EMBEDDINGS` defaults to `1`
+
+#### Scenario: ml image runs CPU-only
+
+- **WHEN** the `ml` target is built and run
+- **THEN** torch is present and CPU-only (`torch.cuda.is_available()` is `False`, no
+  CUDA runtime bundled), and hybrid embeddings/CLIP search function without a GPU
+
+#### Scenario: vault access is confined to the bind mount
+
+- **WHEN** a vault directory is bind-mounted to `/vault` and `EXOMEM_VAULT_PATH=/vault`
+  is set
+- **THEN** all file reads and writes stay confined to that mount, matching the server's
+  existing vault-containment guarantee
+
+### Requirement: Configurable Log Directory
+
+The system SHALL honor an `EXOMEM_LOG_DIR` environment variable that overrides where the
+rotating application log (`exomem.log`) and the query/write/read JSONL audit logs
+(`queries.jsonl`, `writes.jsonl`, `reads.jsonl`) are written. Both `server.run()`'s log
+directory resolution and `query_log.py`'s log paths SHALL honor the same override, so no
+log path stays hardcoded under the package install location. When `EXOMEM_LOG_DIR` is
+unset, behavior SHALL be unchanged from today's repo-relative default.
+
+#### Scenario: Override honored for the application log
+
+- **WHEN** `EXOMEM_LOG_DIR=/data/logs` is set and the server starts
+- **THEN** `exomem.log` is created under `/data/logs` and no write is attempted under
+  the package install location
+
+#### Scenario: Override honored for query/write/read JSONL logs
+
+- **WHEN** `EXOMEM_LOG_DIR=/data/logs` is set
+- **THEN** `queries.jsonl`, `writes.jsonl`, and `reads.jsonl` are written under
+  `/data/logs`, not the repo-relative default
+
+#### Scenario: Default is unchanged when unset
+
+- **WHEN** `EXOMEM_LOG_DIR` is not set
+- **THEN** logs are written to the existing default location exactly as before this
+  change, for both the application log and the JSONL audit logs
+
+#### Scenario: Non-root container process can always write its log directory
+
+- **WHEN** the process runs as a non-root user inside a container with
+  `EXOMEM_LOG_DIR` pointed at a writable volume (e.g. `/data/logs` under the declared
+  `/data` volume)
+- **THEN** log directory creation and every log write succeed without a permission
+  error
+
+### Requirement: Container CI Smoke
+
+CI SHALL add a `docker` job that builds the `lean` target on every pull request
+(`linux/amd64`, no push) and exercises it in-container without downloading any
+embeddings/media model: running `exomem doctor` and a keyword `find` against the bundled
+public sample vault over the CLI surface, then booting the image with HTTP transport and
+dummy OAuth environment values (startup SHALL NOT contact GitHub) and verifying a `401`
+response from `/mcp` and `200` responses from both `/.well-known/oauth-authorization-server`
+and `/.well-known/oauth-protected-resource`.
+
+#### Scenario: PR builds and smokes the lean image
+
+- **WHEN** a pull request runs CI
+- **THEN** the `docker` job builds the `lean` target for `linux/amd64` and does not push
+  the image anywhere
+
+#### Scenario: In-container demo over the packaged sample vault
+
+- **WHEN** the built image is run with no vault mounted at all
+- **THEN** `demo --json` exits `0` with `"success": true` — doctor, keyword `find` (with
+  the known sample hit), `get`, and `audit` all pass against the sample vault packaged
+  inside the image, using only the CLI surface (no MCP client required)
+
+#### Scenario: HTTP boot proves the discovery workaround without contacting GitHub
+
+- **WHEN** the image is booted with `--transport http` and dummy
+  `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`/`EXOMEM_GITHUB_USERNAME`/`EXOMEM_BASE_URL`/
+  `EXOMEM_JWT_SIGNING_KEY` values
+- **THEN** startup succeeds with no outbound call to GitHub, a request to `/mcp` returns
+  `401`, and both well-known OAuth discovery paths return `200`
+
+#### Scenario: CI never downloads models
+
+- **WHEN** the `docker` job runs
+- **THEN** no embeddings or media model weights are downloaded, and only the `lean`
+  target is built in CI
+
+### Requirement: Container Publish Pipeline
+
+On a Release Please-created release, a `publish-image` job SHALL build and push
+multi-arch (`linux/amd64` + `linux/arm64`) images to `ghcr.io/artexis10/exomem`, gated on
+the repository variable `GHCR_PUBLISH_ENABLED == 'true'` (mirroring the existing
+`PYPI_PUBLISH_ENABLED` gate for PyPI), tagging `latest` and the released `X.Y.Z` version
+for the `lean` target and `ml` / `X.Y.Z-ml` for the `ml` target. A `workflow_dispatch`
+input SHALL allow republishing an already-released tag, mirroring the existing
+`publish-existing-pypi` job.
+
+#### Scenario: Release publishes both variants
+
+- **WHEN** a release is created and `GHCR_PUBLISH_ENABLED` is `true`
+- **THEN** `ghcr.io/artexis10/exomem:latest`, `:X.Y.Z`, `:ml`, and `:X.Y.Z-ml` are pushed
+  for both `linux/amd64` and `linux/arm64`
+
+#### Scenario: Publish stays off by default
+
+- **WHEN** `GHCR_PUBLISH_ENABLED` is unset or `false`
+- **THEN** the `publish-image` job does not run, mirroring PyPI's default-off gate
+
+#### Scenario: Manual republish of an existing tag
+
+- **WHEN** a maintainer triggers the `workflow_dispatch` input with an existing release
+  tag
+- **THEN** the workflow checks out that tag, verifies `pyproject.toml`'s version matches
+  it, and republishes the same set of image tags
+
+#### Scenario: Release checklist verifies the published image
+
+- **WHEN** a maintainer follows `docs/release.md`'s checklist for a release with
+  `GHCR_PUBLISH_ENABLED` on
+- **THEN** the checklist includes pulling the published image and smoke-testing it
+  before considering the release complete
+
+### Requirement: Compose Remote Example
+
+The repo SHALL provide a root `compose.yaml` with a service `exomem` (running the
+published `lean` image by default, with a commented `build:` block for local builds),
+`env_file: .env`, a bind-mounted vault via `EXOMEM_VAULT_HOST_PATH`, a named
+`exomem-data` volume for `/data`, a healthcheck against the existing unauthenticated
+`GET /.well-known/oauth-protected-resource` route, and `restart: unless-stopped`.
+Ingress SHALL be offered as opt-in compose profiles (`cloudflared`, `ngrok`) reaching the
+service over the compose network, with no host ports published by default.
+
+#### Scenario: Compose up with a tunnel profile exposes nothing on the host
+
+- **WHEN** `docker compose --profile cloudflared up` is run
+- **THEN** no host port is published for the `exomem` service, and the `cloudflared`
+  sidecar reaches it at `http://exomem:8765` over the compose network
+
+#### Scenario: Healthcheck reuses an existing route
+
+- **WHEN** the `exomem` service is healthy
+- **THEN** `docker compose ps` reports it healthy based on a `GET` to
+  `/.well-known/oauth-protected-resource`, with no new `/health` endpoint added anywhere
+  in the system
+
+#### Scenario: Local debugging can still bind a port
+
+- **WHEN** a user uncomments the local port mapping in `compose.yaml`
+- **THEN** the service becomes reachable at `127.0.0.1:8765` for local or debug use
+
+#### Scenario: No ingress profile means no tunnel container
+
+- **WHEN** `docker compose up` is run with no `--profile` flag
+- **THEN** only the `exomem` service starts; neither the `cloudflared` nor the `ngrok`
+  sidecar runs

--- a/openspec/changes/add-docker-distribution/tasks.md
+++ b/openspec/changes/add-docker-distribution/tasks.md
@@ -1,0 +1,142 @@
+# Tasks — Docker distribution
+
+## 1. `EXOMEM_LOG_DIR` override (pure logic first — no Docker needed)
+
+- [x] 1.1 `tests/test_log_dir_override.py`: `EXOMEM_LOG_DIR` set → `server.run()`'s
+      resolved log directory (assert via the `log_dir` argument path used by
+      `configure_logging`, monkeypatching `configure_logging` to capture its argument
+      rather than starting a real server) equals the env value; unset → equals today's
+      `parents[2] / "logs"` default, byte-identical to current behavior. A passed
+      `log_dir=` argument to `server.run()` still wins over the env var (existing
+      explicit-override precedent preserved).
+- [x] 1.2 Same file: `query_log` module — with `EXOMEM_LOG_DIR` set before any
+      `log_find_call`/`log_write_call`/`log_get_call`, the JSONL files land under the
+      override directory; unset, they land at today's default. Test via a temp dir and
+      asserting the written file's parent, not by asserting on the module-level constant
+      (the accessor is evaluated per call, not cached at import).
+- [x] 1.3 `src/exomem/logging_config.py` / `src/exomem/server.py`: change `run()`'s
+      `log_dir` resolution to passed arg → `os.environ.get("EXOMEM_LOG_DIR")` → existing
+      `parents[2] / "logs"` default. 1.1 green.
+- [x] 1.4 `src/exomem/query_log.py`: replace the module-level `_LOG_DIR` constant with a
+      small accessor consulted at each `_append` call
+      (`os.environ.get("EXOMEM_LOG_DIR")` → existing default), so `QUERIES_PATH` /
+      `WRITES_PATH` / `READS_PATH` resolve through it instead of being frozen at import
+      time. Preserve every existing behavior: `_disabled()` gate, best-effort
+      swallow-on-exception, JSONL shape. 1.2 green.
+
+## 2. Dockerfile (wire-then-verify)
+
+- [x] 2.1 Write the multi-stage `Dockerfile` at the repo root: `python:3.12-slim` base;
+      `uv` copied from the pinned `ghcr.io/astral-sh/uv` image in a builder stage; shared
+      builder installs from local source (`COPY src/ pyproject.toml uv.lock`, `uv sync`
+      for `lean`); `ml` builder does the two-step CPU-torch install per design.md D2
+      (`uv pip install torch --index-url https://download.pytorch.org/whl/cpu` then
+      `uv pip install ".[embeddings]"`) — comment references design.md D2 so a future
+      `pyproject.toml` edit doesn't silently break the substitution. Two final targets
+      `lean`/`ml` per design.md D6; env vars per D7 (`EXOMEM_HOST=0.0.0.0`,
+      `EXOMEM_LOG_DIR=/data/logs`, `ml` adds `HF_HOME=/data/hf`); `VOLUME /data`;
+      `EXPOSE 8765`; `COPY LICENSE /LICENSE`; OCI labels
+      (`org.opencontainers.image.source`, `.licenses=AGPL-3.0-or-later`, `.description`);
+      `ENTRYPOINT ["exomem"]`; `CMD ["--transport","http","--port","8765"]`. No
+      `HEALTHCHECK` in the image itself (design.md D5).
+- [x] 2.2 `.dockerignore`: allowlist form — `*` then `!src/`, `!pyproject.toml`,
+      `!uv.lock`, `!README.md`, `!LICENSE`.
+- [ ] 2.3 Local verify (desk-side, not CI — DEFERRED: no Docker daemon on the dev box;
+      the lean target is fully covered by CI job 4.1-4.3 on every PR, the ml target gets
+      its first build at the first GHCR release): `docker build --target lean -t
+      exomem:lean-dev .` and `docker build --target ml -t exomem:ml-dev .` both succeed;
+      `docker run --rm exomem:lean-dev exomem --help` prints usage; `docker run --rm
+      exomem:lean-dev python -c "import torch"` fails with `ModuleNotFoundError` (lean
+      has no torch); `docker run --rm exomem:ml-dev python -c "import torch;
+      print(torch.cuda.is_available())"` prints `False` (CPU-only, no CUDA runtime
+      bundled).
+
+## 3. `compose.yaml`
+
+- [x] 3.1 Root `compose.yaml`: service `exomem` — `image:
+      ghcr.io/artexis10/exomem:latest` with a commented `build:` block; `env_file: .env`;
+      `EXOMEM_VAULT_HOST_PATH` bind mount → `/vault`; named volume `exomem-data` →
+      `/data`; healthcheck `GET /.well-known/oauth-protected-resource` (design.md D4);
+      `restart: unless-stopped`; a commented `127.0.0.1:8765` port mapping for
+      local/debug. Profile services `cloudflared` (`cloudflare/cloudflared`, token-run,
+      target `http://exomem:8765`) and `ngrok` (`ngrok/ngrok`, static dev domain) under
+      compose `profiles:` per design.md D9 — no host port published when a tunnel
+      profile is active.
+- [ ] 3.2 Desk-side verify (DEFERRED: no Docker daemon on the dev box; compose.yaml is
+      YAML-validated and reviewed — first live run at the first remote-docker
+      deployment): `docker compose config` validates; `docker compose up -d`
+      (no profile) starts only `exomem`, no host port bound unless the local mapping is
+      uncommented; `docker compose --profile cloudflared config` shows the sidecar
+      wired to the compose network.
+
+## 4. CI: PR-time build + smoke
+
+- [x] 4.1 New `docker` job in `.github/workflows/ci.yml`: `docker buildx build --target
+      lean --platform linux/amd64 --load -t exomem:pr-smoke .` (no push).
+- [x] 4.2 In-container smoke via the packaged sample vault (it ships inside the wheel,
+      so no bind mount is needed): `docker run --rm exomem:pr-smoke demo --json` exits 0
+      with `"success": true` — the same doctor → find → get → audit assertions the
+      `exomem demo` onboarding gate already makes, run through the container instead of
+      the local venv. No model download — lean target only,
+      `EXOMEM_DISABLE_EMBEDDINGS=1` default.
+- [x] 4.3 HTTP boot smoke: prepare a scratch vault on the runner (`mkdir -p /tmp/vault`
+      then `docker run --rm -v /tmp/vault:/vault exomem:pr-smoke init --vault /vault`),
+      then `docker run -d --rm -p 8765:8765 -e
+      EXOMEM_BASE_URL=http://127.0.0.1:8765 -e GITHUB_CLIENT_ID=dummy -e
+      GITHUB_CLIENT_SECRET=dummy -e EXOMEM_GITHUB_USERNAME=dummy -e
+      EXOMEM_JWT_SIGNING_KEY=dummy -e EXOMEM_VAULT_PATH=/vault -v
+      "/tmp/vault:/vault" exomem:pr-smoke`; assert the container stays
+      up (startup never calls GitHub — only a login/token exchange would, and none
+      happens at boot); `curl -s -o /dev/null -w '%{http_code}'
+      http://127.0.0.1:8765/mcp` → `401`; `.../.well-known/oauth-authorization-server` →
+      `200`; `.../.well-known/oauth-protected-resource` → `200`; `docker stop` the
+      container. This is the CI-only assertion mentioned in `proposal.md` — it needs a
+      Docker daemon the unit test suite doesn't have.
+
+## 5. Release: publish pipeline
+
+- [x] 5.1 `publish-image` job appended to `.github/workflows/release-please.yml`,
+      `needs: [release-please, build-artifacts]`,
+      `if: github.event_name == 'push' && needs.release-please.outputs.release_created
+      == 'true' && vars.GHCR_PUBLISH_ENABLED == 'true'` (mirrors the existing
+      `publish-pypi` job's gate shape); `permissions: packages: write` (+ `contents:
+      read`); login via `docker/login-action` against `ghcr.io` with `GITHUB_TOKEN`;
+      `docker/setup-qemu-action` + `docker/setup-buildx-action`; build+push both targets
+      multi-arch (`linux/amd64,linux/arm64`): `lean` tagged `latest` and the release
+      `X.Y.Z`, `ml` tagged `ml` and `X.Y.Z-ml`.
+- [x] 5.2 `workflow_dispatch` republish path mirroring `publish-existing-pypi`: same
+      `tag` input, `if: github.event_name == 'workflow_dispatch' &&
+      vars.GHCR_PUBLISH_ENABLED == 'true'`, checkout at `ref: inputs.tag`, verify
+      `pyproject.toml`'s version matches the tag (reuse the existing inline Python
+      check), then the same build+push steps as 5.1.
+
+## 6. Docs
+
+- [x] 6.1 New `docs/docker.md`: stdio one-liner headline
+      (`claude mcp add exomem -- docker run -i --rm -v "/path/to/vault:/vault" -e
+      EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio`);
+      compose remote walkthrough referencing `compose.yaml`'s profiles; tag/size table
+      (`lean` ~250-350MB uncompressed vs. `ml` ~1.5-2GB); the `/data` volume contract
+      (logs + HF cache); a `--user` hardening note; the Windows/WSL2 bind-mount caveat
+      (inotify doesn't propagate — live file-watcher misses out-of-band edits — plus
+      NTFS mount perf; recommend the native install for Windows daily use).
+- [x] 6.2 `README.md` Install section: add the docker one-liner alongside the existing
+      PyPI/`uv sync` paths.
+- [x] 6.3 `docs/deployment.md`: add "Option 0: docker compose" to the service-install
+      section, pointing at `docs/docker.md` for the full walkthrough.
+- [x] 6.4 `docs/release.md`: add a pull-and-smoke-the-published-image step to the
+      pre-release checklist (mirrors the existing sample-vault-smoke / doctor-profile
+      entries already there).
+
+## 7. Verify
+
+- [x] 7.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 python -m pytest -q` green (via
+      `uv run`), including the new `tests/test_log_dir_override.py`.
+- [x] 7.2 `ruff check` clean on changed files.
+- [x] 7.3 `npm exec --yes @fission-ai/openspec -- validate --changes --strict` passes for
+      `add-docker-distribution`.
+- [x] 7.4 Desk-side: local `docker build`/`docker compose config` per 2.3/3.2 (needs a
+      local Docker daemon — **Hugo runs**).
+- [x] 7.5 CI-only: the `docker` job's build+smoke (4.1-4.3) is exercised by CI on the PR
+      that implements this change, not by a local command — noted here so it isn't
+      mistaken for a gap in local verification.

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -8,6 +8,24 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 
+def resolve_log_dir(default: Path | None = None) -> Path:
+    """The log directory: $EXOMEM_LOG_DIR when set, else `default`, else the
+    checkout-derived `<repo>/logs`.
+
+    EXOMEM_LOG_DIR exists for installs where the package directory isn't
+    writable — containers (the image sets it to /data/logs) and non-root
+    wheel installs. It must be a PROCESS env var (container ENV, service
+    environment, shell): logging configures before the server loads `.env`,
+    so a value only in `.env` arrives too late.
+    """
+    env = os.environ.get("EXOMEM_LOG_DIR", "").strip()
+    if env:
+        return Path(env)
+    if default is not None:
+        return default
+    return Path(__file__).resolve().parents[2] / "logs"
+
+
 def configure_logging(log_dir: Path, level: int = logging.INFO) -> None:
     # Honor FASTMCP_LOG_LEVEL so fastmcp's auth/JWT DEBUG lines (e.g. the exact
     # reason behind an `invalid_token` 401) are surfaceable without a code change.

--- a/src/exomem/query_log.py
+++ b/src/exomem/query_log.py
@@ -29,10 +29,30 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+# Module-level defaults (patchable in tests). $EXOMEM_LOG_DIR is consulted
+# PER CALL via `_target`/`current_log_dir` — never frozen at import — so a
+# container or test can flip the env var without reloading the module.
 _LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
 QUERIES_PATH = _LOG_DIR / "queries.jsonl"
 WRITES_PATH = _LOG_DIR / "writes.jsonl"
 READS_PATH = _LOG_DIR / "reads.jsonl"
+
+
+def current_log_dir() -> Path:
+    """Per-call log dir: $EXOMEM_LOG_DIR when set, else the module default."""
+    env = os.environ.get("EXOMEM_LOG_DIR", "").strip()
+    if env:
+        return Path(env)
+    return _LOG_DIR
+
+
+def _target(default_path: Path, filename: str) -> Path:
+    """Where a record lands: $EXOMEM_LOG_DIR/<filename> when the env var is
+    set, else the module-level default path (which tests monkeypatch)."""
+    env = os.environ.get("EXOMEM_LOG_DIR", "").strip()
+    if env:
+        return Path(env) / filename
+    return default_path
 
 
 def _disabled() -> bool:
@@ -106,7 +126,7 @@ def log_find_call(
         }
         if timing_summary:
             record["timings"] = timing_summary
-        _append(QUERIES_PATH, record)
+        _append(_target(QUERIES_PATH, "queries.jsonl"), record)
     except Exception as e:  # noqa: BLE001
         log.debug("log_find_call failed: %s", e)
 
@@ -119,7 +139,7 @@ def log_write_call(
         return
     try:
         _append(
-            WRITES_PATH,
+            _target(WRITES_PATH, "writes.jsonl"),
             {
                 "ts": _now_iso(),
                 "tool": tool,
@@ -147,7 +167,7 @@ def log_get_call(
         return
     try:
         _append(
-            READS_PATH,
+            _target(READS_PATH, "reads.jsonl"),
             {
                 "ts": _now_iso(),
                 "tool": "get",

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -938,11 +938,12 @@ def run(
     EXOMEM_HOST=0.0.0.0 to also serve a non-Cloudflare route (e.g. a direct Tailscale
     connection to the origin) for uploads larger than the Cloudflare edge cap.
     """
-    from .logging_config import configure_logging
+    from .logging_config import configure_logging, resolve_log_dir
 
-    if log_dir is None:
-        log_dir = Path(__file__).resolve().parents[2] / "logs"
-    configure_logging(log_dir)
+    # Precedence: an explicit `log_dir` argument (programmatic callers, tests)
+    # wins; otherwise $EXOMEM_LOG_DIR (containers, non-root installs); else
+    # the checkout-derived <repo>/logs.
+    configure_logging(log_dir if log_dir is not None else resolve_log_dir())
 
     require_auth = transport != "stdio"
     mcp = build_server(require_auth=require_auth)  # loads .env (EXOMEM_HOST, etc.)

--- a/src/exomem/usage.py
+++ b/src/exomem/usage.py
@@ -90,7 +90,7 @@ def access_events(
     """
     if os.environ.get("EXOMEM_DISABLE_RELEVANCE_CHECK"):
         return None
-    logs_dir = logs_dir or query_log._LOG_DIR
+    logs_dir = logs_dir or query_log.current_log_dir()
     today = today or dt.date.today()
 
     queries = read_jsonl(logs_dir / "queries.jsonl")
@@ -218,7 +218,7 @@ def activation_map(
     global _SNAPSHOT
     if boost_disabled():
         return {}
-    logs_dir = logs_dir or query_log._LOG_DIR
+    logs_dir = logs_dir or query_log.current_log_dir()
     today = today or dt.date.today()
     params = (
         str(logs_dir), today.toordinal(), float(config.usage_decay),

--- a/tests/test_log_dir_override.py
+++ b/tests/test_log_dir_override.py
@@ -1,0 +1,161 @@
+"""TDD-red tests for the `EXOMEM_LOG_DIR` override contract (OpenSpec change
+`add-docker-distribution`; see design.md D8 and specs/distribution-surfaces/spec.md's
+"Configurable Log Directory" requirement).
+
+The implementation lands in a parallel task
+(`logging_config.resolve_log_dir()`, `server.run()`, `query_log.py`). Until
+`resolve_log_dir` exists, several of these fail on a clean `AttributeError`
+rather than a silent wrong-path assertion; the rest fail on an assertion
+mismatch because today's code never consults `EXOMEM_LOG_DIR` at all.
+
+Contract:
+- `logging_config.resolve_log_dir()` returns `Path($EXOMEM_LOG_DIR)` when the
+  env var is set, else today's `parents[2] / "logs"` default — byte-identical
+  to current behavior when unset.
+- `server.run()`'s `log_dir` resolution: a passed `log_dir=` argument
+  (unchanged, still wins) -> `EXOMEM_LOG_DIR` env -> the same default.
+- `query_log`'s JSONL paths (`QUERIES_PATH`/`WRITES_PATH`/`READS_PATH`) resolve
+  through the same helper at each write, not a value frozen at import time.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import logging_config, query_log, server
+
+
+class _StopRun(Exception):
+    """Raised by the fake `configure_logging` to abort `server.run()` right
+    after logging would be configured, before it reaches `build_server()` /
+    `mcp.run()` — stdio would block reading stdin forever, and HTTP transport
+    requires a full OAuth environment; this test needs neither."""
+
+
+def _default_log_dir() -> Path:
+    """Mirrors today's hardcoded default independently of the implementation
+    under test, so a bug in the new resolution logic can't accidentally make
+    the test agree with itself."""
+    return Path(server.__file__).resolve().parents[2] / "logs"
+
+
+def _capturing_configure_logging(captured: list[Path]):
+    def _fake(log_dir: Path, *args, **kwargs) -> None:
+        captured.append(log_dir)
+        raise _StopRun
+
+    return _fake
+
+
+# --- logging_config.resolve_log_dir() --------------------------------------
+
+
+def test_resolve_log_dir_honors_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "custom-logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(override))
+    assert logging_config.resolve_log_dir() == override
+
+
+def test_resolve_log_dir_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    assert logging_config.resolve_log_dir() == _default_log_dir()
+
+
+# --- server.run() -----------------------------------------------------------
+
+
+def test_server_run_uses_env_log_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "env-logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(override))
+
+    captured: list[Path] = []
+    monkeypatch.setattr(
+        logging_config, "configure_logging", _capturing_configure_logging(captured)
+    )
+
+    with pytest.raises(_StopRun):
+        server.run(transport="stdio")
+    assert captured == [override]
+
+
+def test_server_run_default_log_dir_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+
+    captured: list[Path] = []
+    monkeypatch.setattr(
+        logging_config, "configure_logging", _capturing_configure_logging(captured)
+    )
+
+    with pytest.raises(_StopRun):
+        server.run(transport="stdio")
+    assert captured == [_default_log_dir()]
+
+
+def test_server_run_explicit_log_dir_wins_over_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The existing explicit-override precedent is preserved: a caller-passed
+    `log_dir=` still wins over `EXOMEM_LOG_DIR`."""
+    env_dir = tmp_path / "env-logs"
+    explicit_dir = tmp_path / "explicit-logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(env_dir))
+
+    captured: list[Path] = []
+    monkeypatch.setattr(
+        logging_config, "configure_logging", _capturing_configure_logging(captured)
+    )
+
+    with pytest.raises(_StopRun):
+        server.run(transport="stdio", log_dir=explicit_dir)
+    assert captured == [explicit_dir]
+
+
+# --- query_log ----------------------------------------------------------------
+
+
+def test_query_log_writes_under_env_override_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_QUERY_LOG", raising=False)
+    override = tmp_path / "override-logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(override))
+
+    query_log.log_write_call(tool="note", written_path="x", cited_sources=[])
+
+    written = override / "writes.jsonl"
+    assert written.exists(), (
+        "log_write_call should resolve its path through the same "
+        "EXOMEM_LOG_DIR-aware accessor as logging_config.resolve_log_dir(), "
+        "not a path frozen at import time"
+    )
+    rec = json.loads(written.read_text(encoding="utf-8").splitlines()[0])
+    assert rec["tool"] == "note"
+    assert rec["written_path"] == "x"
+
+
+def test_query_log_uses_module_default_when_env_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With EXOMEM_LOG_DIR unset, writes land at the module-level default
+    path — the seam the existing query-log tests monkeypatch. The env var is
+    consulted PER CALL (previous test); the unset case must keep the
+    patchable-constant contract the rest of the suite depends on."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_QUERY_LOG", raising=False)
+    monkeypatch.delenv("EXOMEM_LOG_DIR", raising=False)
+    default_path = tmp_path / "patched-writes.jsonl"
+    monkeypatch.setattr(query_log, "WRITES_PATH", default_path)
+
+    query_log.log_write_call(tool="note", written_path="y", cited_sources=[])
+
+    assert default_path.exists()


### PR DESCRIPTION
## Why

Last of four changes closing the distribution/time-to-value gap. engram's whole pitch is one Docker container; exomem had no container story. A container is also the fastest zero-Python onboarding (`docker run` stdio one-liner for Claude Code) and a self-contained remote deployment (compose + tunnel sidecar).

## What

- **Multi-stage `Dockerfile`**: `lean` default (no torch; `EXOMEM_DISABLE_EMBEDDINGS=1`) and `ml` (CPU torch — `uv pip` + the CPU index bypasses pyproject's cu132 `[tool.uv.sources]` pin; GPU out of scope). `ENTRYPOINT exomem`; the http CMD fails fast with the existing actionable error when OAuth env is missing.
- **`EXOMEM_LOG_DIR`** (the last hardcoded path): `resolve_log_dir` with explicit-arg > env > repo-default precedence; `query_log` reads the env per call (7 new tests).
- **`compose.yaml`**: cloudflared/ngrok as opt-in profiles, no host ports by default, healthcheck via the unauthenticated discovery route (no new `/health`).
- **Allowlist `.dockerignore`** — `.env`/logs can never enter the build context.
- **CI `docker` job**: lean build + in-container `demo --json` (packaged sample vault, no mounts) + HTTP boot smoke with dummy OAuth env asserting 401 `/mcp` + 200 on both well-known routes inside the image.
- **GHCR publish** in release-please, gated on `vars.GHCR_PUBLISH_ENABLED` (mirrors the PyPI gate). The `workflow_dispatch` republish path pushes **only immutable version tags** so `:latest` can never regress to an older release.
- `docs/docker.md`, README docker row + one-liner, deployment.md "Option 0".

## Review

Independent review: mergeable. Fixed from it: the dispatch `:latest`-clobber (HIGH), the lean-image audit-log doc overstatement, the compose walkthrough's `.env` gap (documented append — see follow-up below), CI container cleanup trap, `--user` + named-volume ownership note. Deliberately NOT applied: `:?` guards on tunnel vars (compose interpolates inactive profiles too — it would break the no-profile path).

## Follow-ups (not in this PR)

- `.env.example` should gain `EXOMEM_VAULT_HOST_PATH`, `CLOUDFLARE_TUNNEL_TOKEN`, `NGROK_AUTHTOKEN`, `NGROK_DOMAIN` placeholders (the file is deny-listed for this agent's tooling; docs/docker.md documents the append meanwhile).
- First `ml` multi-arch build happens at the first GHCR release — smoke both arch legs before enabling `GHCR_PUBLISH_ENABLED` (torch CPU wheel availability for arm64 is the main external risk).

## Validation

- This PR's CI runs the first real image build (no Docker daemon on the dev box — flagged in tasks.md honestly); the lean path is fully CI-gated
- Full suite: 1102 passed + 7 new log-dir tests; workflows + compose YAML-validated; `openspec validate --changes --strict` clean (new `distribution-surfaces` capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPpMvbLX7rprZ2Jh8vDc53