### PR TITLE
fix(cli): first-run polish — entry points target exomem, warm names the missing extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,12 @@ dev = [
 
 [project.scripts]
 # exomem is the public CLI; kb is the short daily-driver alias.
-# python -m kb_mcp remains available for source checkouts.
-kb = "kb_mcp.__main__:main"
-exomem = "kb_mcp.__main__:main"
+# python -m exomem (and the legacy python -m kb_mcp) remain available for
+# source checkouts. Entry points MUST target exomem.__main__ — routing them
+# through the kb_mcp alias made every official CLI invocation print the
+# shim's DeprecationWarning.
+kb = "exomem.__main__:main"
+exomem = "exomem.__main__:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -227,13 +227,20 @@ def _warm_main(argv: list[str]) -> int:
     from . import embeddings
 
     failed = False
+    missing_extra = False
 
     def _step(label: str, fn) -> None:
-        nonlocal failed
+        nonlocal failed, missing_extra
         t0 = time.perf_counter()
         try:
             fn()
             print(f"  {label}: ready ({time.perf_counter() - t0:.1f}s)")
+        except ImportError as e:
+            # A lean install has no ML stack — that's a missing extra, not a
+            # download problem, and the remediation must say so.
+            failed = True
+            missing_extra = True
+            print(f"  {label}: FAILED ({e})", file=sys.stderr)
         except Exception as e:  # noqa: BLE001 — report every model, then exit non-zero
             failed = True
             print(f"  {label}: FAILED ({e})", file=sys.stderr)
@@ -254,6 +261,14 @@ def _warm_main(argv: list[str]) -> int:
         print(f"  lexical caches: warmed ({time.perf_counter() - t0:.1f}s)")
 
     if failed:
+        if missing_extra:
+            print(
+                "warm: the ML stack is not installed — this is a lean install. "
+                "Add it with `uv sync --extra embeddings` (source checkout) or "
+                "`pip install 'exomem[embeddings]'`, then re-run `exomem warm`.",
+                file=sys.stderr,
+            )
+            return 1
         print("warm: one or more models failed — check network/proxy and retry.", file=sys.stderr)
         return 1
     print("warm: done. Server starts will now warm from disk in seconds.")


### PR DESCRIPTION
Two first-impression warts found while exercising every new onboarding command from a fresh `uvx --from git+…` install:

1. **Every official CLI run printed a DeprecationWarning** — `[project.scripts]` routed both `kb` and `exomem` through the `kb_mcp` compat shim. The README's own headline (`uvx exomem demo`) warned at its first line. Entry points now target `exomem.__main__:main`; `python -m kb_mcp` stays available.
2. **`exomem warm` on a lean install said "check network/proxy and retry"** when the real problem is the missing ML extra. It now detects the ImportError case and names the fix (`uv sync --extra embeddings` / `pip install 'exomem[embeddings]'`), still exit 1.

Verified from a rebuilt wheel via uvx: demo runs warning-free; lean `warm` prints the new remediation and exits 1. Full suite: 1109 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPpMvbLX7rprZ2Jh8vDc53