### PR TITLE
perf(find): decouple vector-lane latency from sidecar write churn

### DIFF
--- a/openspec/changes/incremental-embedding-matrix-cache/design.md
+++ b/openspec/changes/incremental-embedding-matrix-cache/design.md
@@ -1,0 +1,84 @@
+# Design — incremental-embedding-matrix-cache
+
+## 1. Why the cache never worked, and the two-part fix
+
+The `EmbeddingIndex` docstring claimed the matrix was "cached per-process," but
+nothing memoized the instance — `find._find_semantic` (and warm-up, and every
+writer) constructed a fresh `EmbeddingIndex(vault_root)` whose `_cache` began
+`None`. So `search()` → `all_vectors()` always missed and did the full O(vault)
+load. Two things are therefore needed, and neither suffices alone:
+
+1. **A process-lifetime shared instance** so the matrix outlives a single call.
+2. **Incremental patching** so that, while the sidecar is being written, keeping
+   the cache current costs the size of the *delta*, not the *vault* — otherwise a
+   full-tilt writer bumps the sidecar mtime constantly and every find reloads.
+
+## 2. Concurrency model
+
+MCP sync tool handlers run on an anyio worker-thread pool; the file watcher and
+media worker are their own daemon threads. Sharing one index across them is
+genuinely concurrent, so:
+
+- **Per-index `threading.RLock`** guards *only* in-memory cache mutation. It is
+  never held across a SQLite write (that would re-couple find latency to the slow,
+  contended write). Reentrant so any nested cache touch can't self-deadlock.
+- **Copy-on-write, atomic swap.** A writer builds fresh `metadata`/`matrix` arrays
+  and replaces `self._cache` in one assignment; it never mutates arrays a reader
+  may be holding. Readers take the fast path with **no lock**: they snapshot
+  `self._cache` into a local once (the reader-snapshot fix) and use it. A snapshot
+  is either the pre- or post-swap tuple, never a torn mix.
+- **Double-checked load.** On a miss the reader takes the lock and re-checks before
+  loading, so a splice that landed while it waited is picked up without a reload.
+- **Per-call `sqlite3.connect`** stays as-is (connections are not shared across
+  threads).
+
+## 3. Splice mechanics
+
+Rows for one file are contiguous under the load ordering (`ORDER BY file_path,
+chunk_idx`). `_file_block(keys, rel_path)` returns that block's `[lo, hi)`, or the
+sorted insertion point when the file is new. The splice is
+`np.concatenate([matrix[:lo], new_vecs?, matrix[hi:]])` + the parallel metadata
+slice — which naturally handles a changed chunk count, a new file, and a delete
+(empty new block; zero-row shape restored if the matrix empties). An
+`len(metadata) == matrix.shape[0]` invariant guards every swap.
+
+**Self-heal.** The whole splice is best-effort: any exception (or invariant
+violation) drops `self._cache` to `None`, so the next `all_vectors()` does a
+correct full reload. A splice bug can never surface a wrong or torn result — only,
+at worst, one extra reload.
+
+**Freshness gate stays authoritative.** `all_vectors()` still keys on the sidecar
+file mtime. An in-process splice sets the cache mtime to the post-write stat, so a
+subsequent read hits without reloading. An out-of-process / out-of-instance write
+(a CLI `audit_fix --rebuild-embeddings`) advances the on-disk mtime past the cache
+mtime, so the shared instance detects it and reloads exactly once — correctness
+before speed.
+
+**CLIP twin.** `ClipIndex` mirrors the same shape. Its `upsert()` does a *partial*
+delete (image/NULL-ts rows only), so its splice keeps existing video-keyframe rows
+and replaces only the image row (`images_only=True`); `upsert_frames`/`delete`
+block-replace the whole file.
+
+**`rebuild_all`.** Routing it through per-file `upsert_file` would now cost O(N²)
+splices plus N transactions, so it is special-cased: build every row, wipe +
+`executemany` in one transaction, leave the cache cold for one clean reload.
+
+## 4. WAL
+
+`journal_mode=WAL` decouples readers from the writer (the direct cause of the 13s
+read spikes) and, with `synchronous=NORMAL`, collapses the writer fsync cost behind
+the 37-42s note-writes. Applied in both `_connect`s via `_apply_sidecar_pragmas`,
+which soft-fails to the default journal if WAL is unavailable. Safe because the
+sidecar is a local per-machine dotfile (Sync-ignored, never on a network FS).
+SQLite's automatic checkpoint bounds the `-wal` file under a long backfill.
+
+## 5. Scope boundary
+
+In-scope: the in-process write-churn incident (file watcher / media worker / tool
+writes on the worker-thread pool) — fully covered. Out-of-scope, deferred as
+measured follow-ups: a metadata-diff delta reload for out-of-process CLI writers
+(WAL already degrades that case to the ~289ms baseline), and a monotonic `rev`
+column for the same-source-mtime re-embed detection hole. Consistent with the
+capability's "retrieval architecture changes are deferred until measured"
+requirement — this change adds no ANN/LSH, only cache reuse and freshness-safe
+invalidation.

--- a/openspec/changes/incremental-embedding-matrix-cache/proposal.md
+++ b/openspec/changes/incremental-embedding-matrix-cache/proposal.md
@@ -1,0 +1,83 @@
+# incremental-embedding-matrix-cache
+
+## Why
+
+Under a concurrent sidecar writer (a backfill re-embedding the vault), `find`'s
+vector lane degrades from ~1s to 10-25s and note-writes to 37-42s — observed live
+on 2026-07-02, isolated with `find(include_timings=true)`: two identical smoke
+finds ~30s apart, the first 13.9s with the **vector lane alone at 13.0s**, the
+second 1.14s (vector 289ms), everything else healthy in both.
+
+Root cause: the vector-matrix cache was never actually process-lifetime. Every
+call site built a throwaway `EmbeddingIndex`, whose mtime-keyed `_cache` starts
+empty, so `all_vectors()` did a full `SELECT … FROM chunks` + per-row
+`np.frombuffer` + `np.stack` of the whole `(N, 768)` matrix on **every** find —
+O(vault) each call. Quiescent + warm OS page cache that's ~289ms; contending with
+a concurrent SQLite writer (rollback journal → readers block the writer) it's the
+13s spike. Warm-up even populated a throwaway instance's cache and discarded it,
+so it helped find nothing. The 37-42s note-writes are a separate, adjacent
+mechanism: `rebuild_all` committed one transaction per file (N fsyncs) and a
+concurrent note-write queued behind it — writer↔writer contention a read cache
+can't touch.
+
+## What Changes
+
+- **Process-lifetime shared index.** A per-vault memo returns ONE shared
+  `EmbeddingIndex`/`ClipIndex`; all production call sites (find, warm-up, writers,
+  audit, backfill, media worker) go through `get_embedding_index()` /
+  `get_clip_index()`. The in-memory matrix now survives across finds and warm-up
+  finally primes it — the first find pays the load, the rest reuse it.
+- **Incremental in-place cache updates.** `upsert_file`/`delete_file` (and the
+  CLIP `upsert`/`upsert_frames`/`delete`) patch the changed file's rows into the
+  cached matrix copy-on-write instead of nulling the whole cache, so an in-process
+  write keeps the shared matrix current and a concurrent find pays **no** reload.
+- **WAL on the sidecar.** `journal_mode=WAL`, `synchronous=NORMAL`,
+  `busy_timeout=5000`: readers stop blocking the writer (and vice-versa), and the
+  per-write fsync cost that produced the 37-42s note-writes collapses.
+- **Reader-snapshot fix.** `all_vectors()` now snapshots `self._cache` once — a
+  latent torn read (`TypeError` on a mid-flight `None`) that only becomes reachable
+  once the instance is shared across threads.
+- **`rebuild_all` single-transaction.** Wipe + one `executemany` (was N
+  transactions + would now be N O(vault) splices); leaves the cache cold for one
+  clean reload.
+
+Default-on and lean-safe. Soft-fail everywhere: a splice inconsistency drops the
+cache to `None` so the next read does a correct full reload (never a wrong result);
+the WAL pragmas soft-fail to the default journal on an odd filesystem. WAL is safe
+because the sidecar is a **local, per-machine dotfile Obsidian Sync ignores** — its
+`-wal`/`-shm` siblings inherit the leading dot and stay ignored too; WAL's
+shared-memory requirement rules out the network filesystems this sidecar is
+designed never to live on. No model and no retrieval-architecture change — this is
+cache reuse + freshness-safe invalidation only, inside the existing
+`find-recall-efficiency` "defer architecture until measured" guardrail (pure
+substrate: measurement, not reasoning).
+
+Out of scope (deferred, measured follow-ups): a delta-reload path for
+**out-of-process** CLI writers against a live server (under WAL those degrade
+gracefully to the ~289ms baseline, not the 13s spike), and a monotonic `rev`
+column to close the same-source-mtime re-embed detection hole.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: adds a process-lifetime, incrementally-patched vector
+  matrix cache and WAL sidecar concurrency, making `find` latency independent of
+  concurrent in-process sidecar writes.
+
+## Impact
+
+- `src/exomem/embeddings.py`: shared memo + `get_embedding_index`/`get_clip_index`/
+  `clear_embedding_indexes`; per-index `RLock`; COW splice in the writers;
+  `all_vectors` reader-snapshot + `_load_all_rows` extraction; `_apply_sidecar_pragmas`
+  (WAL) in both `_connect`s; single-transaction `rebuild_all`.
+- Construction sites routed through the getters: `find.py`, `warmup.py`,
+  `audit.py`, `audit_fix.py`, `corpus_aware.py`, `media_worker.py`, `backfill.py`.
+- Tests: new `tests/test_embedding_matrix_cache.py` (reload-count, in-place patch,
+  splice correctness, external-write gate, WAL, thread-safety); `tests/conftest.py`
+  clears the memo in the `vault` fixture. No API/dependency changes; the hot-find
+  cache freshness key (`find._freshness_key`) is untouched.

--- a/openspec/changes/incremental-embedding-matrix-cache/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/incremental-embedding-matrix-cache/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Process-Lifetime Embedding Matrix Cache
+
+The system SHALL load the embedding (and CLIP) vector matrix from its sidecar at
+most once per unchanged sidecar state and reuse it across `find` calls, via a
+process-shared per-vault index instance. A brand-new call site MUST NOT construct
+an index whose in-memory matrix starts empty and forces a full reload. Startup
+warm-up of the matrix MUST prime the same shared instance that `find` reads.
+
+#### Scenario: Repeated finds reuse a single matrix load
+
+- **WHEN** two or more `find` requests run against a vault whose embedding sidecar
+  has not changed between them
+- **THEN** the vector matrix is loaded from the sidecar at most once for that
+  unchanged state
+- **AND** the later requests reuse the already-loaded matrix rather than
+  re-reading and re-stacking every row
+
+#### Scenario: Warm-up primes the matrix find actually uses
+
+- **WHEN** startup warm-up loads the embedding matrix and a subsequent `find` runs
+  with the sidecar unchanged
+- **THEN** that `find` reuses the warmed matrix without a fresh full load
+
+### Requirement: Write-Independent Find Latency
+
+An in-process embedding write (upsert or delete) SHALL update the shared in-memory
+matrix incrementally so that a concurrent `find` does not pay a full vault-sized
+matrix reload per call while the sidecar is being written. A change to the sidecar
+made outside the shared instance (for example an out-of-process writer) MUST still
+be detected and reflected by the next `find`. An incremental update that cannot be
+applied consistently MUST fall back to a correct full reload rather than return a
+wrong or partial result.
+
+#### Scenario: In-process write does not force a reload
+
+- **WHEN** a file's rows are upserted or deleted through the shared index while the
+  matrix is already loaded
+- **THEN** the change is reflected on the next read without a full matrix reload
+- **AND** the number of full reloads does not grow with the number of in-process
+  writes
+
+#### Scenario: A changed file's search results stay correct after an incremental update
+
+- **WHEN** a file is upserted (including a change to its chunk count) or deleted and
+  the matrix is patched in place
+- **THEN** a search reflects the new content — the upserted file is findable, a
+  deleted file's rows are gone — with the same ranking a full reload would produce
+
+#### Scenario: Out-of-instance sidecar change is still reflected
+
+- **WHEN** the embedding sidecar is modified by a writer that did not go through the
+  shared index, advancing the sidecar's freshness
+- **THEN** the next `find` detects the change and reflects the new sidecar contents
+
+#### Scenario: An inconsistent incremental update falls back to a full reload
+
+- **WHEN** an incremental matrix update cannot be applied consistently
+- **THEN** the cache is invalidated and the next read performs a full reload
+- **AND** no `find` returns a torn, partial, or incorrect matrix as a result
+
+### Requirement: Sidecar Concurrency Mode
+
+The embedding and CLIP sidecar connections SHALL use a journaling mode that lets a
+reader proceed without blocking a concurrent writer and a writer without blocking
+concurrent readers, so `find` latency does not track sidecar write churn. Enabling
+this mode MUST soft-fail to the default journal without failing the operation when
+the mode is unavailable.
+
+#### Scenario: Reads are not blocked by a concurrent sidecar write
+
+- **WHEN** a `find` reads the sidecar while a backfill is writing it
+- **THEN** the read is not serialized behind the writer by the sidecar's journaling
+  mode
+
+#### Scenario: Concurrency mode failure is non-fatal
+
+- **WHEN** the concurrency journaling mode cannot be enabled on a sidecar connection
+- **THEN** the connection falls back to the default journal
+- **AND** the operation still succeeds

--- a/openspec/changes/incremental-embedding-matrix-cache/tasks.md
+++ b/openspec/changes/incremental-embedding-matrix-cache/tasks.md
@@ -6,7 +6,9 @@
       torch): matrix loads once and is reused; in-process writes never force a
       reload (new file, chunk-count up/down, delete); spliced result equals a full
       reload; external write triggers exactly one reload; delete-to-empty keeps the
-      zero-row shape; WAL is on; concurrent readers+writer stay correct.
+      zero-row shape; WAL is on; concurrent readers+writer stay correct; and an
+      END-TO-END `find(mode="vector")` test (stubbed embedder) that asserts the
+      vector lane actually ran and three distinct finds share one matrix load.
 - [x] 1.2 `all_vectors()` reader-snapshot fix + extract the full load into
       `_load_all_rows()` (both `EmbeddingIndex` and `ClipIndex`).
 - [x] 1.3 Per-index `RLock`; `upsert_file`/`delete_file` (and CLIP

--- a/openspec/changes/incremental-embedding-matrix-cache/tasks.md
+++ b/openspec/changes/incremental-embedding-matrix-cache/tasks.md
@@ -1,0 +1,40 @@
+# incremental-embedding-matrix-cache — tasks
+
+## 1. Cache engine (test-first)
+
+- [x] 1.1 Write `tests/test_embedding_matrix_cache.py` (fabricated vectors, no
+      torch): matrix loads once and is reused; in-process writes never force a
+      reload (new file, chunk-count up/down, delete); spliced result equals a full
+      reload; external write triggers exactly one reload; delete-to-empty keeps the
+      zero-row shape; WAL is on; concurrent readers+writer stay correct.
+- [x] 1.2 `all_vectors()` reader-snapshot fix + extract the full load into
+      `_load_all_rows()` (both `EmbeddingIndex` and `ClipIndex`).
+- [x] 1.3 Per-index `RLock`; `upsert_file`/`delete_file` (and CLIP
+      `upsert`/`upsert_frames`/`delete`) copy-on-write splice via `_patch_cache`
+      instead of nulling; `len == shape[0]` invariant; self-heal to full reload on
+      any splice exception.
+- [x] 1.4 `_apply_sidecar_pragmas` (WAL / synchronous=NORMAL / busy_timeout) in
+      both `_connect`s; soft-fail to default journal.
+- [x] 1.5 `rebuild_all`: single wipe + `executemany` transaction, cache left cold.
+
+## 2. Sharing / wiring
+
+- [x] 2.1 Module memo + `get_embedding_index`/`get_clip_index` +
+      `clear_embedding_indexes()` reset hook.
+- [x] 2.2 Route every production construction site through the getters: `find.py`,
+      `warmup.py`, `audit.py`, `audit_fix.py`, `corpus_aware.py`, `media_worker.py`,
+      `backfill.py`, and the in-module writers.
+- [x] 2.3 Clear the memo in `tests/conftest.py`'s `vault` fixture (beside
+      `find.clear_cache()`).
+
+## 3. Verification
+
+- [x] 3.1 `uv run pytest -q` green (1162 passed, 11 skipped — optional-dep gated);
+      `find._freshness_key` and the hot-find-cache suite untouched; scaffold leak
+      guard green.
+- [x] 3.2 `ruff check` introduces no new findings (only pre-existing advisory
+      I001/BLE001 remain, matching the committed baseline).
+- [x] 3.3 `openspec validate incremental-embedding-matrix-cache --strict` — valid.
+- [ ] 3.4 Desk-side live smoke (torch env): `find(include_timings=true)` twice
+      ~30s apart while a backfill writes the sidecar — the `vector` lane stays flat
+      (no 13s spike).

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -1400,7 +1400,7 @@ def _check_corpus_contradictions(
         log.debug("corpus_contradictions sweep unavailable (%s)", e)
         return []
 
-    idx = embeddings_module.EmbeddingIndex(vault_root)
+    idx = embeddings_module.get_embedding_index(vault_root)
     metadata, matrix = idx.all_vectors()  # cached by sidecar mtime
     if not metadata or matrix.shape[0] == 0:
         return []

--- a/src/exomem/audit_fix.py
+++ b/src/exomem/audit_fix.py
@@ -413,7 +413,7 @@ def audit_fix(
     if rebuild_embeddings and not dry_run:
         try:
             from . import embeddings
-            count = embeddings.EmbeddingIndex(vault_root).rebuild_all()
+            count = embeddings.get_embedding_index(vault_root).rebuild_all()
             report.summary["embeddings_chunks"] = count
             log.info("audit_fix: rebuilt embedding sidecar (%d chunks)", count)
         except ImportError as e:

--- a/src/exomem/backfill.py
+++ b/src/exomem/backfill.py
@@ -184,7 +184,7 @@ def backfill_media(
             "skipping re-timing (set EXOMEM_SEMANTIC_SEGMENTS=1)"
         )
         retime = False
-    clip_index = embeddings.ClipIndex(vault_root) if do_clip else None
+    clip_index = embeddings.get_clip_index(vault_root) if do_clip else None
     # Fast media first (image/pdf OCR is quick) so screenshots/docs are searchable in
     # minutes; slow A/V transcription (Whisper) runs last instead of starving the queue.
     _order = {"image": 0, "pdf": 1, "audio": 2, "video": 3}

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -230,7 +230,7 @@ def _best_cosine_per_file(
         if not chunks:
             return {}
         vecs = embeddings.embed_texts(chunks, is_query=False)
-        idx = embeddings.EmbeddingIndex(vault_root)
+        idx = embeddings.get_embedding_index(vault_root)
         best_per_file: dict[str, float] = {}
         for v in vecs:
             for fp, _cidx, _ctext, score in idx.search(v, k=k):

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -54,6 +54,16 @@ _CLIP_LOCK = threading.Lock()
 _IMPORT_FAILED = False  # one-time soft-fail flag for upsert_after_write
 _CLIP_IMPORT_FAILED = False
 
+# Process-lifetime memo of the per-vault index objects. Sharing ONE instance per
+# vault is what makes the in-memory matrix cache survive across find() calls (and
+# lets warm-up actually prime it) — previously every call site built a throwaway
+# instance whose cache started empty, so all_vectors() paid a full O(vault) reload
+# on every find. Keyed by the resolved vault path; guarded for the worker-thread
+# pool + file-watcher/media-worker threads that touch these concurrently.
+_INDEX_CACHE: dict[str, EmbeddingIndex] = {}
+_CLIP_INDEX_CACHE: dict[str, ClipIndex] = {}
+_INDEX_CACHE_LOCK = threading.Lock()
+
 
 def sidecar_path(vault_root: Path) -> Path:
     return vault_root / "Knowledge Base" / ".embeddings.sqlite"
@@ -768,6 +778,53 @@ def embed_texts(texts: list[str], *, is_query: bool = False) -> np.ndarray:
     return vecs.astype(np.float32, copy=False)
 
 
+def _apply_sidecar_pragmas(conn: sqlite3.Connection) -> None:
+    """WAL + relaxed sync on a sidecar connection.
+
+    WAL lets a find (reader) proceed WITHOUT blocking a concurrent backfill
+    (writer) and vice-versa — the whole point of this change: find latency stops
+    tracking sidecar write churn. `synchronous=NORMAL` collapses the per-write
+    fsync cost (the 37-42s note-writes were writer↔writer fsync contention).
+    Safe here because the sidecar is a LOCAL, per-machine dotfile Obsidian Sync
+    ignores (WAL's shared-memory requirement rules out network filesystems, which
+    this sidecar is designed never to live on). The `-wal`/`-shm` siblings inherit
+    the leading dot, so Sync ignores them too. SQLite's automatic checkpoint
+    (wal_autocheckpoint, ~1000 pages) bounds the WAL under a long backfill.
+    """
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+    except sqlite3.Error as e:  # pragma: no cover — WAL unavailable (e.g. odd FS)
+        log.warning("sidecar WAL pragmas failed (%s); continuing on default journal", e)
+
+
+def _file_block(keys: list[str], rel_path: str) -> tuple[int, int]:
+    """Locate `rel_path`'s rows in a `(file_path, …)`-sorted key list.
+
+    Returns `(lo, hi)` for the contiguous block of rows whose file_path equals
+    `rel_path` (rows for one file are always contiguous under the load ordering).
+    When the file is absent, returns `(ins, ins)` — the sorted insertion point —
+    so a splice keeps the array ordered the same way a full reload would.
+    """
+    lo = hi = None
+    for i, k in enumerate(keys):
+        if k == rel_path:
+            if lo is None:
+                lo = i
+            hi = i + 1
+        elif hi is not None:
+            break  # block ended — rows for one file are contiguous
+    if lo is not None:
+        return lo, hi
+    ins = len(keys)
+    for i, k in enumerate(keys):
+        if k > rel_path:
+            ins = i
+            break
+    return ins, ins
+
+
 class EmbeddingIndex:
     """Per-vault sqlite sidecar holding chunk-level vectors.
 
@@ -780,10 +837,14 @@ class EmbeddingIndex:
         self.vault_root = vault_root
         self.path = sidecar_path(vault_root)
         self._cache: tuple[float, list[tuple[str, int, str]], np.ndarray] | None = None
+        # Guards in-memory cache mutation only (never held across a sqlite write).
+        # Reentrant so rebuild_all()-style nesting can't self-deadlock.
+        self._lock = threading.RLock()
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(self.path)
+        _apply_sidecar_pragmas(conn)
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS chunks (
@@ -828,7 +889,11 @@ class EmbeddingIndex:
                     )
         finally:
             conn.close()
-        self._cache = None  # invalidate in-memory matrix
+        # Patch the shared in-memory matrix in place instead of nulling it, so a
+        # concurrent find() doesn't pay a full O(vault) reload for this one write.
+        new_meta = [(rel_path, i, chunks[i]) for i in range(len(chunks))]
+        new_vecs = np.asarray(vectors, dtype=np.float32) if chunks else None
+        self._patch_cache(rel_path, new_meta, new_vecs)
 
     def delete_file(self, rel_path: str) -> None:
         conn = self._connect()
@@ -837,7 +902,53 @@ class EmbeddingIndex:
                 conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
         finally:
             conn.close()
-        self._cache = None
+        self._patch_cache(rel_path, [], None)
+
+    def _patch_cache(
+        self,
+        rel_path: str,
+        new_meta: list[tuple[str, int, str]],
+        new_vecs: np.ndarray | None,
+    ) -> None:
+        """Splice one file's rows into the cached matrix (copy-on-write).
+
+        Builds fresh `metadata`/`matrix` and atomically swaps `self._cache`; never
+        mutates the arrays a concurrent reader may be holding. Best-effort: any
+        inconsistency drops the cache to None so the next `all_vectors()` does a
+        safe full reload. Leaves a cold (`None`) cache cold — the next read loads.
+        """
+        with self._lock:
+            c = self._cache
+            if c is None:
+                return
+            try:
+                new_mtime = self.path.stat().st_mtime
+            except OSError:
+                self._cache = None
+                return
+            try:
+                _, metadata, matrix = c
+                lo, hi = _file_block([m[0] for m in metadata], rel_path)
+                new_metadata = metadata[:lo] + list(new_meta) + metadata[hi:]
+                parts = [matrix[:lo]]
+                if new_vecs is not None and new_vecs.shape[0]:
+                    parts.append(new_vecs)
+                parts.append(matrix[hi:])
+                parts = [p for p in parts if p.shape[0]]
+                new_matrix = (
+                    np.concatenate(parts, axis=0)
+                    if parts
+                    else np.zeros((0, VECTOR_DIM), dtype=np.float32)
+                )
+                if len(new_metadata) != new_matrix.shape[0]:
+                    raise ValueError(
+                        f"splice invariant broken for {rel_path}: "
+                        f"{len(new_metadata)} meta rows vs {new_matrix.shape[0]} vectors"
+                    )
+                self._cache = (new_mtime, new_metadata, new_matrix)
+            except Exception as e:  # noqa: BLE001 — self-heal, never break a write
+                log.warning("embedding matrix splice failed (%s); dropping cache", e)
+                self._cache = None
 
     def all_vectors(self) -> tuple[list[tuple[str, int, str]], np.ndarray]:
         """Return `(metadata, matrix)` cached until the sidecar mtime advances.
@@ -848,8 +959,27 @@ class EmbeddingIndex:
             sidecar_mtime = self.path.stat().st_mtime
         except FileNotFoundError:
             return [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
-        if self._cache and self._cache[0] == sidecar_mtime:
-            return self._cache[1], self._cache[2]
+        # Snapshot the cache tuple ONCE: another thread may swap or null it between
+        # reads, and `self._cache[0]` then `self._cache[1]` would race (TypeError on
+        # a mid-flight None). This fast path takes no lock — the common case.
+        c = self._cache
+        if c is not None and c[0] == sidecar_mtime:
+            return c[1], c[2]
+        with self._lock:
+            c = self._cache  # re-check under the lock; another thread may have loaded
+            if c is not None and c[0] == sidecar_mtime:
+                return c[1], c[2]
+            metadata, matrix = self._load_all_rows()
+            self._cache = (sidecar_mtime, metadata, matrix)
+            return metadata, matrix
+
+    def _load_all_rows(self) -> tuple[list[tuple[str, int, str]], np.ndarray]:
+        """Full reload of every row from the sidecar → `(metadata, matrix)`.
+
+        This is the O(vault) `SELECT` + `np.stack` the incremental cache exists to
+        avoid paying per find. Isolated as a named method so tests can count how
+        often a genuine full reload happens.
+        """
         conn = self._connect()
         try:
             rows = conn.execute(
@@ -859,16 +989,13 @@ class EmbeddingIndex:
         finally:
             conn.close()
         if not rows:
-            self._cache = (sidecar_mtime, [], np.zeros((0, VECTOR_DIM), dtype=np.float32))
-            return self._cache[1], self._cache[2]
+            return [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
         metadata: list[tuple[str, int, str]] = []
         vectors: list[np.ndarray] = []
         for fp, idx, txt, blob in rows:
             metadata.append((fp, idx, txt))
             vectors.append(np.frombuffer(blob, dtype=np.float32))
-        matrix = np.stack(vectors, axis=0)
-        self._cache = (sidecar_mtime, metadata, matrix)
-        return metadata, matrix
+        return metadata, np.stack(vectors, axis=0)
 
     def search(
         self, query_vec: np.ndarray, k: int
@@ -932,14 +1059,34 @@ class EmbeddingIndex:
                  len(flat_texts), len(all_chunks))
         vectors = embed_texts(flat_texts, is_query=False)
 
-        # Slice back per-file and write.
+        # Bulk write in ONE transaction. Per-file upsert_file() calls would each
+        # open a connection, fsync, and splice the in-memory matrix — O(N²) copies
+        # plus N fsyncs. Build every row, wipe + executemany once, then leave the
+        # cache null (set at the top) so the next all_vectors() does ONE full load.
+        insert_rows: list[tuple[str, int, str, bytes, float]] = []
         offset = 0
         total = 0
         for rel_path, chunks, mtime in all_chunks:
-            n = len(chunks)
-            self.upsert_file(rel_path, chunks, vectors[offset:offset + n], mtime)
-            offset += n
-            total += n
+            for i, ch in enumerate(chunks):
+                insert_rows.append(
+                    (rel_path, i, ch, vectors[offset + i].astype(np.float32).tobytes(), mtime)
+                )
+            offset += len(chunks)
+            total += len(chunks)
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute("DELETE FROM chunks")
+                conn.executemany(
+                    "INSERT INTO chunks "
+                    "(file_path, chunk_idx, chunk_text, vector, file_mtime) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    insert_rows,
+                )
+        finally:
+            conn.close()
+        with self._lock:
+            self._cache = None
         return total
 
 
@@ -956,10 +1103,12 @@ class ClipIndex:
         self.path = clip_sidecar_path(vault_root)
         # (sidecar_mtime, file_paths, frame_ts_list, matrix) — frame_ts is None for images.
         self._cache: tuple[float, list[str], list[float | None], np.ndarray] | None = None
+        self._lock = threading.RLock()
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(self.path)
+        _apply_sidecar_pragmas(conn)
         # Multi-vector schema: one row per image (frame_ts NULL) OR one row per
         # video keyframe (frame_ts = seconds). Composite PK keys frames within a
         # file. NOTE: SQLite treats NULL as DISTINCT in a PRIMARY KEY/UNIQUE index,
@@ -1030,7 +1179,15 @@ class ClipIndex:
                 )
         finally:
             conn.close()
-        self._cache = None
+        # Mirror the partial DELETE: replace only the image (NULL-ts) row, keep any
+        # existing video keyframe rows for this file.
+        self._patch_cache(
+            rel_path,
+            [rel_path],
+            [None],
+            np.asarray(vector, dtype=np.float32).reshape(1, -1),
+            images_only=True,
+        )
 
     def upsert_frames(
         self, rel_path: str, frames: list[tuple[float, np.ndarray]], mtime: float
@@ -1057,7 +1214,15 @@ class ClipIndex:
                 )
         finally:
             conn.close()
-        self._cache = None
+        # Whole-file DELETE + re-insert → block-replace with the frames, ordered by
+        # timestamp to match the load's `ORDER BY file_path, frame_ts`.
+        ordered = sorted(frames, key=lambda f: f[0])
+        self._patch_cache(
+            rel_path,
+            [rel_path] * len(ordered),
+            [float(ts) for ts, _ in ordered],
+            np.stack([np.asarray(vec, dtype=np.float32) for _, vec in ordered], axis=0),
+        )
 
     def delete(self, rel_path: str) -> None:
         conn = self._connect()
@@ -1066,7 +1231,70 @@ class ClipIndex:
                 conn.execute("DELETE FROM images WHERE file_path = ?", (rel_path,))
         finally:
             conn.close()
-        self._cache = None
+        self._patch_cache(rel_path, [], [], None)
+
+    def _patch_cache(
+        self,
+        rel_path: str,
+        new_paths: list[str],
+        new_frame_ts: list[float | None],
+        new_vecs: np.ndarray | None,
+        *,
+        images_only: bool = False,
+    ) -> None:
+        """Splice one file's CLIP rows into the cached matrix (copy-on-write).
+
+        `images_only=True` keeps existing video keyframe rows (frame_ts NOT NULL)
+        and replaces only the image (NULL-ts) row, mirroring `upsert()`'s partial
+        DELETE. Otherwise the file's whole block is replaced. Best-effort: any
+        inconsistency drops the cache to None for a safe full reload next read.
+        """
+        with self._lock:
+            c = self._cache
+            if c is None:
+                return
+            try:
+                new_mtime = self.path.stat().st_mtime
+            except OSError:
+                self._cache = None
+                return
+            try:
+                _, paths, frame_ts, matrix = c
+                lo, hi = _file_block(paths, rel_path)
+                if images_only and hi > lo:
+                    keep = [j for j in range(lo, hi) if frame_ts[j] is not None]
+                    block_paths = [paths[j] for j in keep] + list(new_paths)
+                    block_ts = [frame_ts[j] for j in keep] + list(new_frame_ts)
+                    keep_mat = (
+                        matrix[keep] if keep else np.zeros((0, CLIP_DIM), dtype=np.float32)
+                    )
+                    block_parts = [keep_mat]
+                    if new_vecs is not None and new_vecs.shape[0]:
+                        block_parts.append(new_vecs)
+                else:
+                    block_paths = list(new_paths)
+                    block_ts = list(new_frame_ts)
+                    block_parts = (
+                        [new_vecs] if (new_vecs is not None and new_vecs.shape[0]) else []
+                    )
+                out_paths = paths[:lo] + block_paths + paths[hi:]
+                out_ts = frame_ts[:lo] + block_ts + frame_ts[hi:]
+                parts = [matrix[:lo], *block_parts, matrix[hi:]]
+                parts = [p for p in parts if p.shape[0]]
+                out_matrix = (
+                    np.concatenate(parts, axis=0)
+                    if parts
+                    else np.zeros((0, CLIP_DIM), dtype=np.float32)
+                )
+                if not (len(out_paths) == len(out_ts) == out_matrix.shape[0]):
+                    raise ValueError(
+                        f"CLIP splice invariant broken for {rel_path}: "
+                        f"{len(out_paths)} paths / {len(out_ts)} ts / {out_matrix.shape[0]} vecs"
+                    )
+                self._cache = (new_mtime, out_paths, out_ts, out_matrix)
+            except Exception as e:  # noqa: BLE001 — self-heal, never break a write
+                log.warning("CLIP matrix splice failed (%s); dropping cache", e)
+                self._cache = None
 
     def has(self, rel_path: str) -> bool:
         """True if this file has ANY vector row (image or video). Correct idempotency
@@ -1110,8 +1338,19 @@ class ClipIndex:
             sidecar_mtime = self.path.stat().st_mtime
         except FileNotFoundError:
             return [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
-        if self._cache and self._cache[0] == sidecar_mtime:
-            return self._cache[1], self._cache[2], self._cache[3]
+        c = self._cache  # snapshot once — a concurrent writer may swap/null it
+        if c is not None and c[0] == sidecar_mtime:
+            return c[1], c[2], c[3]
+        with self._lock:
+            c = self._cache
+            if c is not None and c[0] == sidecar_mtime:
+                return c[1], c[2], c[3]
+            paths, frame_ts, matrix = self._load_all_rows()
+            self._cache = (sidecar_mtime, paths, frame_ts, matrix)
+            return paths, frame_ts, matrix
+
+    def _load_all_rows(self) -> tuple[list[str], list[float | None], np.ndarray]:
+        """Full reload of every CLIP row from the sidecar (the O(vault) path)."""
         conn = self._connect()
         try:
             rows = conn.execute(
@@ -1120,12 +1359,10 @@ class ClipIndex:
         finally:
             conn.close()
         if not rows:
-            self._cache = (sidecar_mtime, [], [], np.zeros((0, CLIP_DIM), dtype=np.float32))
-            return self._cache[1], self._cache[2], self._cache[3]
+            return [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
         paths = [r[0] for r in rows]
         frame_ts = [r[1] for r in rows]
         matrix = np.stack([np.frombuffer(r[2], dtype=np.float32) for r in rows], axis=0)
-        self._cache = (sidecar_mtime, paths, frame_ts, matrix)
         return paths, frame_ts, matrix
 
     def search(self, query_vec: np.ndarray, k: int) -> list[tuple[str, float | None, float]]:
@@ -1143,6 +1380,42 @@ class ClipIndex:
         top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
         top_idx = top_idx[np.argsort(-scores[top_idx])]
         return [(paths[i], frame_ts[i], float(scores[i])) for i in top_idx]
+
+
+def get_embedding_index(vault_root: Path) -> EmbeddingIndex:
+    """Return the process-shared `EmbeddingIndex` for this vault.
+
+    ALL production call sites (find, warm-up, writers, audit) must go through this
+    so the in-memory matrix cache is shared and survives across calls — the whole
+    reason find() stops paying a full reload per query. Tests may still construct
+    `EmbeddingIndex` directly to exercise the class in isolation.
+    """
+    key = str(Path(vault_root).resolve())
+    with _INDEX_CACHE_LOCK:
+        idx = _INDEX_CACHE.get(key)
+        if idx is None:
+            idx = EmbeddingIndex(vault_root)
+            _INDEX_CACHE[key] = idx
+        return idx
+
+
+def get_clip_index(vault_root: Path) -> ClipIndex:
+    """Return the process-shared `ClipIndex` for this vault (see get_embedding_index)."""
+    key = str(Path(vault_root).resolve())
+    with _INDEX_CACHE_LOCK:
+        idx = _CLIP_INDEX_CACHE.get(key)
+        if idx is None:
+            idx = ClipIndex(vault_root)
+            _CLIP_INDEX_CACHE[key] = idx
+        return idx
+
+
+def clear_embedding_indexes() -> None:
+    """Drop the shared index memo (and its in-memory matrices). Test hook — the
+    per-test tmp vault would otherwise leave a stale instance keyed by its path."""
+    with _INDEX_CACHE_LOCK:
+        _INDEX_CACHE.clear()
+        _CLIP_INDEX_CACHE.clear()
 
 
 def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
@@ -1189,7 +1462,7 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
 
     from . import find as find_module
 
-    index = EmbeddingIndex(vault_root)
+    index = get_embedding_index(vault_root)
     per_file: list[tuple[str, list[str], float]] = []
     for md in md_paths:
         try:
@@ -1241,7 +1514,7 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
     if not removed_rel_paths:
         return
     try:
-        index = EmbeddingIndex(vault_root)
+        index = get_embedding_index(vault_root)
     except Exception as e:
         log.warning("could not open embedding sidecar for delete: %s", e)
         return

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -1249,7 +1249,7 @@ def _find_semantic(
     else:
         try:
             with _span(timings, "vector"):
-                idx = embeddings.EmbeddingIndex(vault_root)
+                idx = embeddings.get_embedding_index(vault_root)
                 query_vec = embeddings.embed_texts([query], is_query=True)[0]
                 chunk_hits = idx.search(query_vec, k=candidate_k * 3)  # over-fetch chunks
                 # Collapse chunks → file-level: keep the best-scoring chunk per file.
@@ -1295,7 +1295,7 @@ def _find_semantic(
     elif embeddings.clip_enabled() and query.strip():
         try:
             with _span(timings, "clip"):
-                clip_idx = embeddings.ClipIndex(vault_root)
+                clip_idx = embeddings.get_clip_index(vault_root)
                 clip_qvec = embeddings.embed_clip_text(query)
                 # A video contributes N keyframe rows; over-fetch so distinct videos
                 # aren't crowded out, then dedup to best-per-file (rows are score-desc,

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -49,7 +49,7 @@ class MediaWorker:
         self._q: queue.Queue[_Job | None] = queue.Queue()
         self._thread: threading.Thread | None = None
         self._lock = threading.Lock()
-        self._clip_index = embeddings.ClipIndex(vault_root)
+        self._clip_index = embeddings.get_clip_index(vault_root)
 
     def start(self) -> None:
         with self._lock:

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -76,13 +76,13 @@ def warm_caches(vault_root: Path) -> dict[str, float]:
         def _warm_matrix() -> None:
             from . import embeddings
 
-            embeddings.EmbeddingIndex(vault_root).all_vectors()
+            embeddings.get_embedding_index(vault_root).all_vectors()
 
         def _warm_clip() -> None:
             from . import embeddings
 
             if embeddings.clip_enabled():
-                embeddings.ClipIndex(vault_root).all_vectors()
+                embeddings.get_clip_index(vault_root).all_vectors()
 
         _step("embedding_matrix", _warm_matrix)
         _step("clip_matrix", _warm_clip)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from exomem import embeddings as embeddings_module
 from exomem import find as find_module
 from exomem import schema as schema_module
 
@@ -47,6 +48,9 @@ def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("EXOMEM_VAULT_PATH", str(dest))
     # Clear find's in-process cache so previous test runs don't bleed in.
     find_module.clear_cache()
+    # Drop the process-shared embedding index memo — a stale instance keyed by a
+    # prior tmp vault's path would otherwise persist across tests.
+    embeddings_module.clear_embedding_indexes()
     return dest
 
 

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -272,6 +272,59 @@ def test_concurrent_readers_and_writer_stay_correct(tmp_path):
     assert sorted({m[0] for m in meta}) == [f"f{i:02d}.md" for i in range(20)]
 
 
+def test_find_vector_lane_reuses_shared_matrix(tmp_path, monkeypatch):
+    """End-to-end through the REAL `find()` entry point (deterministic fake
+    embedder, no torch): three distinct finds share ONE matrix load, and the
+    vector lane genuinely ran — guarding against a silent BM25 fallback that
+    would make the reuse assertion pass for the wrong reason."""
+    from exomem import find as find_module
+    from exomem import readiness
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")  # bypass the hot result cache
+    readiness.reset()
+
+    vault = _fresh_vault(tmp_path)
+    rel_a = "Knowledge Base/Notes/Insights/alpha.md"
+    rel_b = "Knowledge Base/Notes/Insights/beta.md"
+    for rel, title in ((rel_a, "Alpha"), (rel_b, "Beta")):
+        p = vault / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: 2026-01-01\n"
+            f"updated: 2026-01-01\n---\n\n# {title}\n\nbody text {title}\n",
+            encoding="utf-8",
+        )
+
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file(rel_a, ["alpha chunk"], _mat([1, 0]), 1.0)
+    idx.upsert_file(rel_b, ["beta chunk"], _mat([0, 1]), 2.0)
+
+    # Query embedder → deterministic vector aligned to note A (no model needed).
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, is_query=False: np.stack([_pad([1, 0]) for _ in texts]),
+    )
+
+    find_module.clear_cache()
+    count = _count_loads(monkeypatch, idx)
+
+    first_hits = None
+    for q in ("first query", "second query", "third query"):
+        timings = find_module.FindTimings()
+        hits = find_module.find(vault, query=q, mode="vector", limit=5, timings=timings)
+        stage = timings.as_dict()["stages"].get("vector", {})
+        assert stage and not stage.get("skipped") and not stage.get("error"), (
+            f"vector lane did not run cleanly: {stage!r}"
+        )
+        if first_hits is None:
+            first_hits = hits
+
+    assert first_hits and first_hits[0].path == rel_a  # query-aligned note ranks first
+    assert count["n"] == 1  # one sqlite load served all three distinct finds
+
+
 # --------------------------------------------------------------------------- #
 # ClipIndex (visual matrix) — structural twin
 # --------------------------------------------------------------------------- #

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -1,0 +1,328 @@
+"""Process-lifetime, incremental embedding-matrix cache.
+
+OpenSpec: incremental-embedding-matrix-cache (capability find-recall-efficiency).
+
+These lock the behavior that decouples find latency from sidecar write churn:
+the shared per-vault index loads the matrix ONCE and reuses it across calls, and
+an in-process write patches the in-memory matrix in place instead of forcing a
+full O(vault) reload. Assertions count genuine full reloads (`_load_all_rows`),
+never wall-clock — deterministic in CI. All fabricated vectors: no torch/model.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import embeddings
+
+
+@pytest.fixture(autouse=True)
+def _clean_memo() -> None:
+    """Each test starts with an empty shared-index memo."""
+    embeddings.clear_embedding_indexes()
+    yield
+    embeddings.clear_embedding_indexes()
+
+
+def _fresh_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    return vault
+
+
+def _pad(vals: list[float]) -> np.ndarray:
+    out = np.zeros(embeddings.VECTOR_DIM, dtype=np.float32)
+    out[: len(vals)] = vals
+    return out
+
+
+def _mat(*rows: list[float]) -> np.ndarray:
+    return np.stack([_pad(r) for r in rows], axis=0)
+
+
+def _cpad(vals: list[float]) -> np.ndarray:
+    out = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+    out[: len(vals)] = vals
+    return out
+
+
+def _count_loads(monkeypatch: pytest.MonkeyPatch, idx) -> dict[str, int]:
+    """Wrap idx._load_all_rows to count genuine full reloads."""
+    calls = {"n": 0}
+    orig = idx._load_all_rows
+
+    def wrapped():
+        calls["n"] += 1
+        return orig()
+
+    monkeypatch.setattr(idx, "_load_all_rows", wrapped)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# EmbeddingIndex (bge text matrix)
+# --------------------------------------------------------------------------- #
+
+
+def test_matrix_loads_once_and_is_reused(tmp_path, monkeypatch):
+    """A quiescent vault loads the matrix once, then every find reuses it."""
+    vault = _fresh_vault(tmp_path)
+    seed = embeddings.EmbeddingIndex(vault)
+    seed.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    seed.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+
+    idx = embeddings.get_embedding_index(vault)
+    assert idx is embeddings.get_embedding_index(vault)  # shared instance
+    count = _count_loads(monkeypatch, idx)
+
+    metadata = matrix = None
+    for _ in range(5):
+        metadata, matrix = idx.all_vectors()
+
+    assert count["n"] == 1  # loaded once, not per call
+    assert matrix.shape[0] == 2
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+
+
+def test_in_process_writes_never_force_reload(tmp_path, monkeypatch):
+    """Warm cache + a stream of in-process writes → reads reload zero times.
+
+    This is the core write-churn fix: an upsert/delete through the shared index
+    patches the in-memory matrix, so a concurrent find pays no O(vault) reload.
+    """
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+
+    # New file (2 chunks) → spliced in.
+    idx.upsert_file("b.md", ["b1", "b2"], _mat([0, 1], [1, 1]), 2.0)
+    metadata, matrix = idx.all_vectors()
+    assert matrix.shape[0] == 3
+    assert [m[0] for m in metadata] == ["a.md", "b.md", "b.md"]
+
+    # Grow a.md to 3 chunks, then shrink to 1 — block length tracks.
+    idx.upsert_file("a.md", ["a1", "a2", "a3"], _mat([1, 0], [2, 0], [3, 0]), 3.0)
+    assert idx.all_vectors()[1].shape[0] == 5
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 4.0)
+    assert idx.all_vectors()[1].shape[0] == 3
+
+    # Delete b.md → its rows vanish, a.md intact.
+    idx.delete_file("b.md")
+    metadata, matrix = idx.all_vectors()
+    assert [m[0] for m in metadata] == ["a.md"]
+    assert matrix.shape[0] == 1
+
+    assert count["n"] == 0  # not one full reload across all of it
+
+
+def test_spliced_matrix_is_searchable_and_correct(tmp_path):
+    """After an in-place splice, search returns the freshly-written file."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+    idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+
+    hits = idx.search(_pad([0, 1]), k=1)
+    assert hits[0][0] == "b.md"
+    hits = idx.search(_pad([1, 0]), k=1)
+    assert hits[0][0] == "a.md"
+
+
+def test_delete_to_empty_keeps_zero_row_shape(tmp_path):
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+    idx.delete_file("a.md")
+    metadata, matrix = idx.all_vectors()
+    assert metadata == []
+    assert matrix.shape == (0, embeddings.VECTOR_DIM)
+    assert idx.search(_pad([1, 0]), k=3) == []
+
+
+def test_incremental_matches_full_reload(tmp_path, monkeypatch):
+    """The spliced cache is byte-identical to a from-scratch reload."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+    idx.upsert_file("c.md", ["c"], _mat([0, 0, 1]), 3.0)
+    idx.upsert_file("b.md", ["b1", "b2"], _mat([0, 1], [1, 1]), 2.0)
+    spliced_meta, spliced_matrix = idx.all_vectors()
+
+    # Force a genuine full reload and compare.
+    with idx._lock:
+        idx._cache = None
+    reload_meta, reload_matrix = idx.all_vectors()
+
+    assert spliced_meta == reload_meta  # same order (sorted by file_path)
+    assert np.array_equal(spliced_matrix, reload_matrix)
+
+
+def test_external_writer_triggers_exactly_one_reload(tmp_path, monkeypatch):
+    """An out-of-band sidecar change (a writer that bypassed the shared instance)
+    is caught by the mtime gate: exactly one reload, reflecting the new content."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+
+    # A separate instance writes the sidecar; the shared idx never saw it.
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+    _bump_mtime(idx.path)  # guarantee a distinct mtime for the gate
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+    # A second read reuses; no further reload.
+    idx.all_vectors()
+    assert count["n"] == 1
+
+
+def test_rebuild_all_does_not_splice_per_file(tmp_path, monkeypatch):
+    """rebuild_all writes in one transaction and leaves a cold cache (one reload
+    on next read) — never O(N) per-file splices."""
+    vault = _fresh_vault(tmp_path)
+    kb = vault / "Knowledge Base"
+    (kb / "one.md").write_text("---\ntype: note\n---\n# One\nalpha beta\n", encoding="utf-8")
+    (kb / "two.md").write_text("---\ntype: note\n---\n# Two\ngamma delta\n", encoding="utf-8")
+
+    # Stub the model so rebuild_all embeds without torch.
+    def fake_embed(texts, *, is_query=False):
+        return np.stack([_pad([float(len(t))]) for t in texts], axis=0)
+
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+
+    idx = embeddings.get_embedding_index(vault)
+    total = idx.rebuild_all()
+    assert total >= 2
+    with idx._lock:
+        assert idx._cache is None  # left cold; next read does one full load
+    _, matrix = idx.all_vectors()
+    assert matrix.shape[0] == total
+
+
+def test_sidecar_uses_wal(tmp_path):
+    """WAL is what lets a reader proceed without blocking a concurrent writer."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.EmbeddingIndex(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)  # creates the sidecar
+    conn = sqlite3.connect(idx.path)
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+    assert mode.lower() == "wal"
+
+
+def test_concurrent_readers_and_writer_stay_correct(tmp_path):
+    """Stress the RLock + copy-on-write swap: readers never see a torn cache and
+    the final state is correct. (Reload COUNT is racy under threads, so this
+    asserts correctness, not the counter — the deterministic count claims live in
+    the single-threaded tests above.)"""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    for i in range(20):
+        idx.upsert_file(f"f{i:02d}.md", ["c"], _mat([i, 0]), float(i))
+    idx.all_vectors()  # warm
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def reader():
+        try:
+            while not stop.is_set():
+                meta, matrix = idx.all_vectors()
+                assert len(meta) == matrix.shape[0]  # never torn
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    def writer():
+        try:
+            for j in range(200):
+                idx.upsert_file("f00.md", ["c"], _mat([j % 7, 1]), float(100 + j))
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    readers = [threading.Thread(target=reader) for _ in range(3)]
+    w = threading.Thread(target=writer)
+    for t in readers:
+        t.start()
+    w.start()
+    w.join()
+    stop.set()
+    for t in readers:
+        t.join()
+
+    assert not errors
+    meta, matrix = idx.all_vectors()
+    assert len(meta) == matrix.shape[0] == 20  # same file set, no leaks/dupes
+    assert sorted({m[0] for m in meta}) == [f"f{i:02d}.md" for i in range(20)]
+
+
+# --------------------------------------------------------------------------- #
+# ClipIndex (visual matrix) — structural twin
+# --------------------------------------------------------------------------- #
+
+
+def test_clip_index_patches_in_place(tmp_path, monkeypatch):
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_clip_index(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)
+    paths, ts, matrix = idx.all_vectors()
+    assert paths == ["a.png"] and ts == [None] and matrix.shape[0] == 1
+
+    count = _count_loads(monkeypatch, idx)
+
+    # A video → per-keyframe rows, block-replaced and timestamp-ordered.
+    idx.upsert_frames("v.mp4", [(5.0, _cpad([1, 1])), (0.0, _cpad([0, 1]))], 2.0)
+    paths, ts, matrix = idx.all_vectors()
+    assert paths == ["a.png", "v.mp4", "v.mp4"]
+    assert ts == [None, 0.0, 5.0]
+    assert matrix.shape[0] == 3
+
+    # Re-upserting the image keeps the video keyframes (partial-delete mirror).
+    idx.upsert("a.png", _cpad([2, 0]), 3.0)
+    paths, ts, matrix = idx.all_vectors()
+    assert paths == ["a.png", "v.mp4", "v.mp4"]
+    assert matrix.shape[0] == 3
+
+    # Delete the video → back to just the image.
+    idx.delete("v.mp4")
+    paths, ts, matrix = idx.all_vectors()
+    assert paths == ["a.png"] and matrix.shape[0] == 1
+
+    assert count["n"] == 0  # every step patched in place
+
+
+def test_clip_sidecar_uses_wal(tmp_path):
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.ClipIndex(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)
+    conn = sqlite3.connect(idx.path)
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+    assert mode.lower() == "wal"
+
+
+def _bump_mtime(path: Path) -> None:
+    """Push a sidecar's mtime clearly forward so the mtime gate can't miss it
+    (Windows st_mtime resolution is coarse). Mirrors tests/test_find_hot_cache.py."""
+    st = path.stat()
+    import os
+
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))


### PR DESCRIPTION
## Why

Under a concurrent sidecar writer (a backfill re-embedding the vault), `find`'s vector lane degraded from ~1s to **10-25s** and note-writes to **37-42s** — observed live on 2026-07-02 and isolated with `find(include_timings=true)`: the slow finds were **entirely the vector lane** (13.0s), everything else healthy.

**Root cause:** the vector-matrix cache was never actually process-lifetime. Every call site built a throwaway `EmbeddingIndex`, whose mtime-keyed `_cache` starts empty, so `all_vectors()` did a full `SELECT … FROM chunks` + `np.stack` of the whole `(N,768)` matrix on **every** find. Quiescent that's ~289ms; contending with a concurrent SQLite writer (rollback journal → readers block the writer) it's the 13s spike. Warm-up even primed a throwaway instance and discarded it.

## What changed (capability `find-recall-efficiency`)

- **Process-lifetime shared index** — one `EmbeddingIndex`/`ClipIndex` per vault via `get_embedding_index`/`get_clip_index`, routed through find, warm-up, writers, audit, backfill, media worker. The matrix survives across finds; warm-up finally primes it.
- **Incremental in-place cache updates** — `upsert_file`/`delete_file` (and CLIP `upsert`/`upsert_frames`/`delete`) splice the changed file's rows copy-on-write instead of nulling, so an in-process write keeps the matrix current and a concurrent find pays **no** reload.
- **WAL** (`journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout`) — readers stop blocking the writer; also collapses the writer↔writer fsync contention behind the 37-42s note-writes. Safe: the sidecar is a local per-machine dotfile Sync ignores.
- **Reader-snapshot fix** — `all_vectors()` snapshots `self._cache` once, closing a latent torn read that only becomes reachable once the instance is shared.
- **`rebuild_all` single-transaction** — avoids O(N²) splices + N fsyncs.

Splices self-heal to a full reload on any inconsistency; the sidecar-mtime gate stays authoritative so out-of-instance writes still reflect. No model, no retrieval-architecture change — cache reuse + freshness-safe invalidation only, inside the capability's "defer architecture until measured" guardrail.

**Deferred (measured follow-ups):** an out-of-process delta-reload path (WAL already degrades that case to the ~289ms baseline) and a monotonic `rev` column for the same-source-mtime re-embed hole.

## Tests

New `tests/test_embedding_matrix_cache.py`: matrix loads once & reuses; in-process writes never force a reload (new file / chunk-count up-down / delete); **spliced result byte-identical to a full reload**; external write triggers exactly one reload; WAL on; concurrent readers+writer stay correct. Full suite **1162 passed, 11 skipped** (optional-dep gated); `openspec validate --strict` clean; hot-find-cache freshness key untouched.

OpenSpec change: `incremental-embedding-matrix-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)