### PR TITLE
feat: first-class macOS GPU acceleration — MPS embeddings + mlx-whisper ASR

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_VIDEO_SCENE_THRESHOLD` | Scene-boundary hash threshold in bits of 64 (default 10). |
 | `EXOMEM_VIDEO_SCENE_MIN_SECS` | Minimum scene duration in seconds; closer boundaries merge (default 4). |
 | `EXOMEM_SEMANTIC_SEGMENTS` | Set to enable timed transcripts + semantic segment retrieval for audio/video (default off). |
-| `EXOMEM_WHISPER_MODEL` | Whisper model size for ASR, such as `base` or `small`. |
+| `EXOMEM_WHISPER_MODEL` | faster-whisper model size for ASR, such as `base` or `small`. |
+| `EXOMEM_ASR_BACKEND` | ASR engine: `mlx` (Apple Silicon Metal GPU, needs the `media-mlx` extra) or `faster-whisper` (CUDA/CPU). Default auto-selects MLX on Apple Silicon, else faster-whisper. |
+| `EXOMEM_MLX_WHISPER_MODEL` | HF repo for the MLX ASR model (default `mlx-community/whisper-large-v3-mlx`; use `mlx-community/whisper-large-v3-turbo` for speed). |
 | `EXOMEM_TESSERACT_CMD` | Path to the `tesseract` binary if not auto-discovered. |
 
 Legacy `EXOMEM_*` names (from the project's former working name, exomem) remain

--- a/README.md
+++ b/README.md
@@ -248,9 +248,11 @@ System tools: Tesseract is required for image OCR. On Windows:
 winget install --id UB-Mannheim.TesseractOCR -e
 ```
 
-GPU acceleration is useful but not required. See
-[docs/deployment.md](docs/deployment.md) for CUDA, Blackwell, diarization, and
-remote-service details.
+GPU acceleration is useful but not required, and cross-platform: NVIDIA **CUDA**
+(Linux/Windows) and Apple Silicon **MPS/Metal** (macOS) are both auto-detected for
+the torch models (bge embeddings, reranker, CLIP), with CPU as the fallback. See
+[docs/deployment.md](docs/deployment.md) for CUDA, Blackwell, Apple Silicon,
+diarization, and remote-service details.
 
 ## Configuration
 
@@ -264,6 +266,7 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_REST_API_KEY` | Enables authenticated REST routes. |
 | `EXOMEM_DISABLE_MEDIA_EXTRACTION` | `1` skips server-side OCR/ASR/PDF/Office extraction. |
 | `EXOMEM_DISABLE_CLIP` | `1` disables CLIP image search. |
+| `EXOMEM_TORCH_DEVICE` | Force the device for all torch models: `cuda`, `mps`, or `cpu` (default: auto-detect CUDA → MPS → CPU). Pin `cpu` to avoid thermal throttling on a fanless Mac. |
 | `EXOMEM_VIDEO_SCENE_FRAMES` | Set to enable video scene detection + persisted, OCR'd scene-frame JPEGs (default off). |
 | `EXOMEM_VIDEO_SCENE_THRESHOLD` | Scene-boundary hash threshold in bits of 64 (default 10). |
 | `EXOMEM_VIDEO_SCENE_MIN_SECS` | Minimum scene duration in seconds; closer boundaries merge (default 4). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -302,15 +302,26 @@ Apple Silicon gets GPU acceleration for the torch models with **no extra wheels*
 text embedder, bge reranker, and CLIP — auto-select the Metal GPU when no CUDA is
 present, so interactive `find`, note-write embedding, and CLIP image search run on
 the GPU on an M-series Mac. `PYTORCH_ENABLE_MPS_FALLBACK=1` is set automatically so
-any op MPS lacks degrades to CPU instead of raising. Two caveats: (1) **ASR**
-(faster-whisper / ctranslate2) has **no Metal backend**, so audio/video
-transcription stays on CPU — pick a smaller `EXOMEM_WHISPER_MODEL` (e.g. `base`)
-to cut cost; a Metal `mlx-whisper` backend slots in behind `extract.get_transcriber`
-as a planned follow-up. (2) **Voiceprints** (ECAPA) and **diarization** stay on CPU
-by default for cross-machine numeric parity — opt in per model with
-`EXOMEM_VOICE_DEVICE=mps` / `EXOMEM_DIARIZE_DEVICE=mps`. Force every torch model to a
-device with `EXOMEM_TORCH_DEVICE=cpu|mps|cuda` (handy to dodge thermal throttling on
-a fanless MacBook Air during a large `backfill-media`).
+any op MPS lacks degrades to CPU instead of raising.
+
+**ASR on the Metal GPU (`media-mlx` extra).** faster-whisper/ctranslate2 has no Metal
+backend, but ASR runs behind a `TranscriptionBackend` seam (`extract.get_transcriber`)
+with two implementations: `FasterWhisperBackend` (CUDA/CPU) and `MlxWhisperBackend`
+(**mlx-whisper**, Metal GPU). Install the extra — `uv sync --extra media --extra
+media-mlx` — and `get_transcriber()` **auto-selects MLX on Apple Silicon**, putting
+transcription on the GPU too. `EXOMEM_ASR_BACKEND=mlx|faster-whisper` forces the choice;
+`EXOMEM_MLX_WHISPER_MODEL` picks the HF repo (default `mlx-community/whisper-large-v3-mlx`;
+use `mlx-community/whisper-large-v3-turbo` for a lighter, faster run on a fanless Air).
+Without the extra, transcription falls back to CPU faster-whisper — pick a smaller
+`EXOMEM_WHISPER_MODEL` (e.g. `base`) there to cut cost. Audio is decoded via PyAV (the
+shared 16 kHz whisper timebase) when the `media` extra is present, else mlx-whisper
+decodes the file itself (needs `ffmpeg` on PATH).
+
+Two more notes: **Voiceprints** (ECAPA) and **diarization** stay on CPU by default for
+cross-machine numeric parity — opt in per model with `EXOMEM_VOICE_DEVICE=mps` /
+`EXOMEM_DIARIZE_DEVICE=mps`. And you can force every torch model to a device with
+`EXOMEM_TORCH_DEVICE=cpu|mps|cuda` (handy to dodge thermal throttling on a fanless
+MacBook Air during a large `backfill-media`).
 
 The `media` extra adds a wrinkle: `faster-whisper` runs on **ctranslate2**, which
 wants **CUDA-12** cuBLAS/cuDNN/cudart, while torch's `cu132` build ships cuBLAS

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -286,14 +286,31 @@ The deployments coexist — claude.ai talks to whichever host's connector you in
 and only that host needs to be awake. After editing `.env`, restart the service so
 it reloads.
 
-## GPU / CUDA notes (Blackwell, sm_120)
+## GPU notes (CUDA / Blackwell / Apple Silicon MPS)
 
 Blackwell GPUs (RTX 50-series, compute capability 12.0 / `sm_120`) need CUDA
 wheels. Default PyPI torch on Windows is **still CPU-only**, so `pyproject.toml`
 pins an explicit CUDA index (`pytorch-cu132`, CUDA 13.2) whose wheel ships
 `sm_120` — `torch.cuda.get_arch_list()` includes it, so any RTX 50-series GPU
 works. The index is scoped to win32/linux via a platform marker; macOS falls back
-to default PyPI.
+to default PyPI — whose arm64 torch wheel **includes the MPS (Metal) backend**, so
+Apple Silicon gets GPU acceleration for the torch models with **no extra wheels**
+(see "Apple Silicon" below).
+
+**Apple Silicon (MPS / Metal).** Device selection is centralized in
+`exomem.accel.select_device` (priority CUDA → MPS → CPU). The torch models — bge
+text embedder, bge reranker, and CLIP — auto-select the Metal GPU when no CUDA is
+present, so interactive `find`, note-write embedding, and CLIP image search run on
+the GPU on an M-series Mac. `PYTORCH_ENABLE_MPS_FALLBACK=1` is set automatically so
+any op MPS lacks degrades to CPU instead of raising. Two caveats: (1) **ASR**
+(faster-whisper / ctranslate2) has **no Metal backend**, so audio/video
+transcription stays on CPU — pick a smaller `EXOMEM_WHISPER_MODEL` (e.g. `base`)
+to cut cost; a Metal `mlx-whisper` backend slots in behind `extract.get_transcriber`
+as a planned follow-up. (2) **Voiceprints** (ECAPA) and **diarization** stay on CPU
+by default for cross-machine numeric parity — opt in per model with
+`EXOMEM_VOICE_DEVICE=mps` / `EXOMEM_DIARIZE_DEVICE=mps`. Force every torch model to a
+device with `EXOMEM_TORCH_DEVICE=cpu|mps|cuda` (handy to dodge thermal throttling on
+a fanless MacBook Air during a large `backfill-media`).
 
 The `media` extra adds a wrinkle: `faster-whisper` runs on **ctranslate2**, which
 wants **CUDA-12** cuBLAS/cuDNN/cudart, while torch's `cu132` build ships cuBLAS
@@ -304,9 +321,10 @@ server prepends their `bin` directories to PATH before load (see
 Verify with `uv run python scripts/verify-media-gpu.py`. On Linux, ctranslate2
 resolves CUDA via the wheels' RPATH.
 
-CLIP visual search runs CLIP on **CPU when ASR is active** (whisper's cu12 cuDNN
-PATH-prepend otherwise shadows torch's cuDNN and breaks CLIP's Conv2d). Override
-with `EXOMEM_CLIP_DEVICE=cuda`/`cpu` if needed.
+CLIP visual search runs CLIP on **CPU when ASR is active on CUDA** (whisper's cu12
+cuDNN PATH-prepend otherwise shadows torch's cuDNN and breaks CLIP's Conv2d). This
+clash is CUDA-only, so on Apple Silicon CLIP keeps the **MPS** GPU even with ASR
+running. Override with `EXOMEM_CLIP_DEVICE=cuda`/`mps`/`cpu` if needed.
 
 Zero-shot **image tags** (`EXOMEM_IMAGE_TAGS`, default off) reuse that same loaded
 CLIP model — no extra dependency. When set, each extracted image is cosine-scored
@@ -351,8 +369,9 @@ sidecar with `pwsh -File scripts/setup-diarizer.ps1 -Prewarm` on Windows or
 `uv sync --directory sidecar/diarizer` on Linux/macOS.
 
 Named-speaker diarization's ECAPA voice embedder (`diarization` extra) runs on
-torch and follows the same precedent: it defaults to **CPU when ASR is active**, with
-a `EXOMEM_VOICE_DEVICE=cuda`/`cpu` override. Enroll voices with
+torch and follows the same precedent: it defaults to **CPU when ASR is active** (and
+to CPU on Apple Silicon for cross-machine voiceprint parity), with a
+`EXOMEM_VOICE_DEVICE=cuda`/`mps`/`cpu` override. Enroll voices with
 `exomem enroll-speaker --name <name> [--self] <sample.wav>` (profiles live in a local
 `.voice_profiles.json` beside the embedding sidecar; `list-speakers` / `remove-speaker`
 manage them). With ≥1 profile enrolled and `EXOMEM_DIARIZE` set, matched clusters render

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,16 @@ media = [
     "nvidia-cudnn-cu12; sys_platform == 'win32'",
     "nvidia-cuda-runtime-cu12; sys_platform == 'win32'",
 ]
+# Apple-Silicon (Metal) ASR backend: mlx-whisper runs Whisper on the Mac GPU via MLX,
+# which faster-whisper/CTranslate2 cannot (no Metal). extract.get_transcriber() auto-selects
+# it on macOS arm64 when installed; EXOMEM_ASR_BACKEND=mlx|faster-whisper forces the choice,
+# EXOMEM_MLX_WHISPER_MODEL picks the HF repo (default mlx-community/whisper-large-v3-mlx). The
+# marker makes the extra a no-op off Apple Silicon, so `--extra media-mlx` is harmless on any
+# host. Pair with `--extra media` (PyAV decode + OCR/PDF). Full Mac install:
+# `uv sync --extra embeddings --extra media --extra media-mlx`.
+media-mlx = [
+  "mlx-whisper>=0.4; sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
 # Opt-in ASR speaker diarization (KB_MCP_DIARIZE). The pyannote who-spoke-when pipeline does NOT
 # live here: it runs in an ISOLATED CPU-torch sidecar venv (sidecar/diarizer/, built via
 # scripts/setup-diarizer.ps1) as a subprocess, because pyannote/torchaudio are fundamentally

--- a/scripts/verify-mlx.py
+++ b/scripts/verify-mlx.py
@@ -1,0 +1,91 @@
+"""Apple Silicon (Metal) acceleration gate for exomem.
+
+Confirms the GPU paths work on this Mac:
+- torch sees the MPS (Metal) backend, and accel.select_device() picks it for bge/CLIP
+- get_transcriber() selects the mlx-whisper backend (needs the `media-mlx` extra)
+- mlx-whisper transcribes a generated silent clip on the Metal GPU
+
+Run: uv run python scripts/verify-mlx.py
+Exit 0 = PASS (MPS embeddings + MLX ASR both work); non-zero = something fell back to CPU.
+Not meaningful off Apple Silicon (MLX is macOS-arm64 only) — use verify-media-gpu.py on CUDA hosts.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+import tempfile
+import wave
+
+# Use a tiny model for the gate (fast download) unless the caller pinned one — this
+# validates the Metal ASR *path*, not a specific model. Set before importing extract,
+# which reads EXOMEM_MLX_WHISPER_MODEL at import.
+os.environ.setdefault("EXOMEM_MLX_WHISPER_MODEL", "mlx-community/whisper-tiny")
+
+
+def main() -> int:
+    ok = True
+
+    # --- torch / MPS + the device accel will pick for bge/CLIP ---
+    try:
+        import torch
+
+        from exomem import accel
+
+        mps = getattr(torch.backends, "mps", None)
+        mps_ok = bool(mps and mps.is_available() and mps.is_built())
+        device = accel.select_device()
+        print(f"torch {torch.__version__} | mps_available={mps_ok} | select_device()={device}")
+        if not mps_ok:
+            ok = False
+            print("  WARN: MPS unavailable — bge/CLIP will run on CPU. Need an arm64 torch wheel.")
+        elif device != "mps":
+            print(f"  NOTE: select_device()={device} — an override (EXOMEM_TORCH_DEVICE?) is forcing it.")
+    except Exception as e:  # noqa: BLE001
+        ok = False
+        print(f"torch/MPS check FAILED: {e}")
+
+    # --- which ASR backend is active ---
+    try:
+        from exomem import extract
+
+        backend = type(extract.get_transcriber()).__name__
+        print(f"ASR backend: {backend}")
+        if backend != "MlxWhisperBackend":
+            ok = False
+            print("  WARN: not MLX — install the extra: uv sync --extra media --extra media-mlx")
+            print("        (or set EXOMEM_ASR_BACKEND=mlx). ASR would run on CPU faster-whisper.")
+    except Exception as e:  # noqa: BLE001
+        ok = False
+        print(f"ASR backend check FAILED: {e}")
+
+    # --- mlx-whisper transcribes a silent clip on the Metal GPU (the gate that matters) ---
+    try:
+        from pathlib import Path
+
+        from exomem import extract
+
+        tmp = os.path.join(tempfile.gettempdir(), "exomem_mlx_gate_silence.wav")
+        with wave.open(tmp, "w") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(16000)
+            w.writeframes(struct.pack("<" + "h" * 16000, *([0] * 16000)))
+
+        segments, engine = extract.get_transcriber().transcribe(Path(tmp))
+        list(segments)  # force the decode so the Metal kernels actually run
+        print(f"transcription OK — engine={engine}")
+        if not engine.startswith("mlx-whisper:"):
+            ok = False
+            print("  NOTE: engine is not mlx-whisper — transcription did not use the Metal GPU.")
+    except Exception as e:  # noqa: BLE001
+        ok = False
+        print(f"MLX transcription check FAILED: {e}")
+
+    print("GATE:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sidecar/diarizer/worker.py
+++ b/sidecar/diarizer/worker.py
@@ -44,11 +44,27 @@ def _decode(path: str):
 
 
 def _device() -> str:
-    """Resolve the run device. KB_MCP_DIARIZE_DEVICE = cpu | cuda | auto (default auto)."""
+    """Resolve the run device. EXOMEM_DIARIZE_DEVICE (or legacy KB_MCP_DIARIZE_DEVICE)
+    = cpu | cuda | mps | auto (default auto → cuda if available, else cpu).
+
+    `auto` never picks MPS: pyannote on this pinned sidecar stack is validated on
+    CUDA/CPU, and diarization feeds cross-machine voiceprint attribution, so Apple
+    Silicon Metal is an explicit opt-in (`=mps`) rather than an automatic choice.
+    """
     import torch
 
-    pref = os.environ.get("KB_MCP_DIARIZE_DEVICE", "auto").lower()
+    pref = (
+        os.environ.get("EXOMEM_DIARIZE_DEVICE")
+        or os.environ.get("KB_MCP_DIARIZE_DEVICE")
+        or "auto"
+    ).lower()
     if pref == "cpu":
+        return "cpu"
+    if pref == "mps":
+        backend = getattr(torch.backends, "mps", None)
+        if backend is not None and backend.is_available():
+            os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+            return "mps"
         return "cpu"
     if pref in ("cuda", "gpu", "auto"):
         return "cuda" if torch.cuda.is_available() else "cpu"
@@ -109,8 +125,8 @@ def _diarize(audio_path: str) -> list[dict]:
             "and accepted conditions for speaker-diarization-3.1 + segmentation-3.0"
         )
     dev = _device()
-    if dev == "cuda":
-        pipeline.to(torch.device("cuda"))
+    if dev in ("cuda", "mps"):
+        pipeline.to(torch.device(dev))
     print(f"[worker] device={dev}", file=sys.stderr)
     annotation = _annotation(pipeline({"waveform": waveform, "sample_rate": 16000}))
     return [

--- a/src/exomem/accel.py
+++ b/src/exomem/accel.py
@@ -1,0 +1,136 @@
+"""Compute-backend selection for torch models: CUDA > MPS > CPU.
+
+One place decides where torch models run so macOS (Apple Silicon / Metal via the
+MPS backend), Linux + Windows NVIDIA (CUDA), and CPU-only boxes all follow the
+same rules. Torch is imported lazily inside `select_device` — keyword-mode and a
+lean install without the `[embeddings]` extra must never pay the import cost.
+
+Scope — this governs **torch** models only: the bge text embedder, bge reranker,
+CLIP, ECAPA voiceprints, and the optional caption pipeline. The ASR engine is
+faster-whisper (CTranslate2), which has **no Metal backend** and owns its own
+cuda/cpu choice in `extract`; it does NOT route through here. On Apple Silicon,
+transcription therefore still runs on CPU until a Metal-capable backend (e.g.
+mlx-whisper) is added behind the `extract` transcription seam.
+
+Overrides are checked first, in order: a per-model env var (e.g.
+`EXOMEM_CLIP_DEVICE`, `EXOMEM_VOICE_DEVICE`), then the global
+`EXOMEM_TORCH_DEVICE`. An override value is returned verbatim, so
+`EXOMEM_TORCH_DEVICE=cpu` forces every torch model to CPU (a handy escape hatch
+for debugging or thermal control on a fanless Mac).
+
+Linux note: AMD ROCm builds of torch report `torch.cuda.is_available() == True`
+(HIP masquerades as CUDA), so the existing `"cuda"` path already covers ROCm —
+enabling it is a wheel/index packaging matter, not a code branch. The only
+genuinely new hardware path here is macOS MPS.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+# Global torch-device override, consulted after any per-model override.
+GLOBAL_OVERRIDE_ENV = "EXOMEM_TORCH_DEVICE"
+# Lets ops the MPS backend hasn't implemented fall back to CPU instead of raising.
+_MPS_FALLBACK_ENV = "PYTORCH_ENABLE_MPS_FALLBACK"
+
+
+def _mps_available(torch) -> bool:
+    """True when torch exposes a usable Apple-Silicon MPS (Metal) backend.
+
+    Guarded with getattr so an older torch without `backends.mps` is simply
+    treated as MPS-absent, and any probe error degrades to unavailable.
+    """
+    backend = getattr(torch.backends, "mps", None)
+    if backend is None:
+        return False
+    try:
+        return bool(backend.is_available() and backend.is_built())
+    except Exception:  # noqa: BLE001 — any probe failure → treat as unavailable
+        return False
+
+
+def _asr_active() -> bool:
+    """Mirror `extract.extraction_enabled()` via env alone (no heavy import edge).
+
+    Media extraction (ASR) being active is the signal for the CUDA-only
+    cuDNN-shadow workaround; see `select_device(avoid_cuda_when_asr=...)`.
+    """
+    return not os.environ.get("EXOMEM_DISABLE_MEDIA_EXTRACTION")
+
+
+def _enable_mps_fallback() -> None:
+    """Set PYTORCH_ENABLE_MPS_FALLBACK=1 before any model runs its first op.
+
+    Setting it here (before a model is constructed or run) is sufficient — torch
+    reads it at op-dispatch time. `setdefault` respects an explicit operator
+    choice (e.g. someone who set it to 0 on purpose).
+    """
+    os.environ.setdefault(_MPS_FALLBACK_ENV, "1")
+
+
+def select_device(
+    *,
+    override_env: str | None = None,
+    avoid_cuda_when_asr: bool = False,
+    auto_mps: bool = True,
+) -> str:
+    """Pick a torch device string: ``"cuda"`` | ``"mps"`` | ``"cpu"``.
+
+    Priority: explicit override (``override_env`` then ``EXOMEM_TORCH_DEVICE``)
+    → CUDA → MPS → CPU.
+
+    Args:
+        override_env: name of a per-model device override checked first. An
+            override is returned verbatim (e.g. ``"cuda"``, ``"cpu"``, ``"mps"``,
+            ``"cuda:1"``).
+        avoid_cuda_when_asr: when the auto-pick would be CUDA *and* media
+            extraction (ASR) is active in this process, return CPU instead. This
+            is the faster-whisper cuDNN-shadow workaround and is **CUDA-only** —
+            it never forces CPU on an MPS host, so CLIP/ECAPA keep the Apple GPU
+            even with ASR running (an improvement over the previous
+            unconditional force-to-CPU). See `embeddings._clip_device`.
+        auto_mps: whether auto-detection may select MPS. False keeps the default
+            on CPU (e.g. ECAPA voiceprints, for cross-machine numeric parity)
+            while an explicit override to ``"mps"`` is still honored.
+    """
+    for env in (override_env, GLOBAL_OVERRIDE_ENV):
+        if not env:
+            continue
+        value = os.environ.get(env)
+        if value:
+            value = value.strip()
+            if value == "mps":
+                _enable_mps_fallback()
+            return value
+
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
+        return "cpu"
+
+    if torch.cuda.is_available():
+        if avoid_cuda_when_asr and _asr_active():
+            return "cpu"
+        return "cuda"
+    if auto_mps and _mps_available(torch):
+        _enable_mps_fallback()
+        return "mps"
+    return "cpu"
+
+
+def pipeline_device(**kwargs):
+    """`transformers.pipeline(device=...)` value for the selected torch device.
+
+    HF's pipeline takes an int GPU index or a device string: ``0`` for the first
+    CUDA GPU, ``"mps"`` for Apple Silicon, ``-1`` for CPU. Accepts the same
+    keyword policy as `select_device`.
+    """
+    device = select_device(**kwargs)
+    if device == "cuda":
+        return 0
+    if device == "cpu":
+        return -1
+    return device  # "mps", or an explicit override like "cuda:1"

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -239,29 +239,37 @@ def _check_torch_cuda() -> DoctorCheck:
         return _check(
             "torch.cuda",
             "fail",
-            "torch is not installed, so CUDA availability cannot be checked.",
+            "torch is not installed, so GPU acceleration cannot be checked.",
             "Install embeddings with `uv sync --extra embeddings`.",
         )
     try:
         import torch
 
-        available = bool(torch.cuda.is_available())
-        if available:
+        if torch.cuda.is_available():
             name = torch.cuda.get_device_name(0)
             arches = ", ".join(torch.cuda.get_arch_list())
             return _check("torch.cuda", "pass", f"CUDA visible to torch: {name} ({arches}).")
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available() and mps.is_built():
+            return _check(
+                "torch.cuda",
+                "pass",
+                "Apple Silicon MPS (Metal) backend available — bge/CLIP embeddings will "
+                "use the GPU. Note: faster-whisper (ASR) has no Metal path and stays on CPU.",
+            )
         return _check(
             "torch.cuda",
             "warn",
-            "torch imports but CUDA is not available; embeddings/media will run on CPU.",
-            "This is supported. On NVIDIA GPU hosts, verify the uv torch source and driver.",
+            "torch imports but no GPU (CUDA or MPS) is available; embeddings/media run on CPU.",
+            "This is supported. On NVIDIA hosts verify the uv torch source and driver; on "
+            "Apple Silicon ensure a recent arm64 torch wheel (default PyPI ships MPS).",
         )
     except Exception as e:  # noqa: BLE001
         return _check(
             "torch.cuda",
             "warn",
-            f"torch imports failed during CUDA probe: {e}",
-            "Re-run `uv sync --extra embeddings`; on GPU hosts, verify the CUDA wheel/driver.",
+            f"torch imports failed during GPU probe: {e}",
+            "Re-run `uv sync --extra embeddings`; on GPU hosts, verify the CUDA/torch wheel.",
         )
 
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -273,6 +273,41 @@ def _check_torch_cuda() -> DoctorCheck:
         )
 
 
+def _check_torch_device() -> DoctorCheck:
+    """Report the device the torch models (bge/CLIP) will actually select — read-only,
+    loads no model."""
+    if not _module_available("torch"):
+        return _check(
+            "torch.device",
+            "warn",
+            "torch not installed; embeddings fall back to lexical/CPU.",
+            "Install with `uv sync --extra embeddings`.",
+        )
+    try:
+        from . import accel
+
+        return _check("torch.device", "pass", f"bge/CLIP embeddings will run on: {accel.select_device()}.")
+    except Exception as e:  # noqa: BLE001
+        return _check("torch.device", "warn", f"torch device probe failed: {e}")
+
+
+def _check_asr_backend() -> DoctorCheck:
+    """Report which ASR backend get_transcriber() selects — read-only, loads no model."""
+    try:
+        from . import extract
+
+        backend = type(extract.get_transcriber()).__name__
+    except Exception as e:  # noqa: BLE001
+        return _check("asr.backend", "warn", f"ASR backend probe failed: {e}")
+    if backend == "MlxWhisperBackend":
+        return _check("asr.backend", "pass", "ASR: mlx-whisper (Apple Silicon Metal GPU).")
+    return _check(
+        "asr.backend",
+        "pass",
+        "ASR: faster-whisper (CUDA/CPU). On Apple Silicon, add `--extra media-mlx` for Metal.",
+    )
+
+
 def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
     if vault_root is None:
         return None
@@ -530,6 +565,7 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
             _check_dependency("torch", "embeddings"),
             _check_dependency("pillow", "embeddings", import_name="PIL"),
             _check_torch_cuda(),
+            _check_torch_device(),
             _check_models_cache(),
         ])
         sidecar = _check_embedding_sidecar(vault_root)
@@ -543,6 +579,7 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
             _check_dependency("pymupdf", "media", import_name="fitz"),
             _check_dependency("markitdown", "media"),
             _check_tesseract(),
+            _check_asr_backend(),
         ])
 
     if profile == "remote":

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import numpy as np
 
+from . import accel
 
 log = logging.getLogger(__name__)
 
@@ -83,36 +84,34 @@ def _is_embeddable_path(path: Path) -> bool:
 
 
 def get_model():
-    """Lazy singleton. Picks CUDA when available, falls back to CPU."""
+    """Lazy singleton. Device via `accel.select_device` (CUDA > MPS > CPU)."""
     global _MODEL
     if _MODEL is not None:
         return _MODEL
     with _MODEL_LOCK:
         if _MODEL is not None:
             return _MODEL
-        # Heavy imports stay local — keyword-mode and existing tests must not
+        # Heavy import stays local — keyword-mode and existing tests must not
         # pay this cost.
-        import torch
         from sentence_transformers import SentenceTransformer
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = accel.select_device()
         log.info("loading embedding model %s on %s", MODEL_NAME, device)
         _MODEL = SentenceTransformer(MODEL_NAME, device=device)
     return _MODEL
 
 
 def get_reranker():
-    """Lazy singleton for the cross-encoder reranker. CUDA when available."""
+    """Lazy singleton for the cross-encoder reranker. Device via `accel.select_device`."""
     global _RERANKER
     if _RERANKER is not None:
         return _RERANKER
     with _RERANKER_LOCK:
         if _RERANKER is not None:
             return _RERANKER
-        import torch
         from sentence_transformers import CrossEncoder
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = accel.select_device()
         log.info("loading reranker %s on %s", RERANKER_NAME, device)
         _RERANKER = CrossEncoder(RERANKER_NAME, device=device)
     return _RERANKER
@@ -123,31 +122,22 @@ class ClipUnavailable(Exception):
 
 
 def _clip_device() -> str:
-    """Device for CLIP. Honors EXOMEM_CLIP_DEVICE; otherwise GPU only when ASR is NOT
-    running in this process, else CPU.
+    """Device for CLIP. Honors EXOMEM_CLIP_DEVICE; otherwise CUDA > MPS > CPU via
+    `accel.select_device`, but avoids CUDA when ASR is active in this process.
 
-    Why not always GPU: faster-whisper's CUDA-12 cuDNN/cuBLAS wheels get PATH-prepended
-    (extract._ensure_cuda_dll_path) so ctranslate2 can load — which then shadows
-    torch-cu132's bundled cuDNN 13 and makes CLIP's ViT Conv2d die with
+    Why avoid CUDA under ASR: faster-whisper's CUDA-12 cuDNN/cuBLAS wheels get
+    PATH-prepended (extract._ensure_cuda_dll_path) so ctranslate2 can load — which
+    then shadows torch-cu132's bundled cuDNN 13 and makes CLIP's ViT Conv2d die with
     CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH. bge survives (pure transformer, no conv);
     CLIP's vision tower doesn't. Since the media worker prewarms ASR at startup, having
-    extraction enabled means PATH is already poisoned, so CLIP must run on CPU — a tiny
-    ViT-B/32, off the request path, embeds in well under a second. A CLIP-only box
-    (EXOMEM_DISABLE_MEDIA_EXTRACTION set) has no conflict and keeps the GPU.
-    """
-    override = os.environ.get("EXOMEM_CLIP_DEVICE")
-    if override:
-        return override
-    # Mirror extract.extraction_enabled() without importing it (avoids a new module edge).
-    asr_active = not os.environ.get("EXOMEM_DISABLE_MEDIA_EXTRACTION")
-    if asr_active:
-        return "cpu"
-    try:
-        import torch
+    extraction enabled means PATH is already poisoned, so CLIP falls to CPU there — a
+    tiny ViT-B/32, off the request path, embeds in well under a second.
 
-        return "cuda" if torch.cuda.is_available() else "cpu"
-    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
-        return "cpu"
+    This clash is **CUDA-only**: `avoid_cuda_when_asr` fires only when the auto-pick
+    would be CUDA, so on Apple Silicon CLIP keeps the MPS (Metal) GPU even with ASR
+    running. A CLIP-only box (EXOMEM_DISABLE_MEDIA_EXTRACTION set) also keeps the GPU.
+    """
+    return accel.select_device(override_env="EXOMEM_CLIP_DEVICE", avoid_cuda_when_asr=True)
 
 
 def get_clip_model():

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -10,9 +10,10 @@ Each engine is **soft-imported** and lazily loaded: a lean box without the `[med
 extra (or with `EXOMEM_DISABLE_MEDIA_EXTRACTION` set) simply raises `ExtractionUnavailable`,
 and the caller skips server extraction — the model-driven `/upload` `text` path still works.
 
-Engines are swappable behind `extract_text(path, media_type=...) -> ExtractResult`: the
-faster-whisper backend can be replaced with a torch/transformers Whisper if CTranslate2
-lacks Blackwell `sm_120` kernels (the verification gate), without touching callers.
+Engines are swappable behind `extract_text(path, media_type=...) -> ExtractResult`. ASR
+specifically runs behind a `TranscriptionBackend` seam (see `get_transcriber`): faster-
+whisper (CTranslate2, CUDA/CPU) or mlx-whisper (Apple Silicon Metal GPU), selected by
+platform, without touching callers.
 
 Two OPTIONAL deepen-the-moat transducers ship here, both DEFAULT-OFF + soft-fail:
 
@@ -247,7 +248,7 @@ def prewarm() -> None:
     if not extraction_enabled():
         return
     try:
-        _get_whisper()
+        get_transcriber().prewarm()
     except ExtractionUnavailable as e:
         log.info("ASR prewarm skipped (engine unavailable): %s", e)
     except Exception:  # noqa: BLE001 — prewarm must never crash startup
@@ -257,12 +258,18 @@ def prewarm() -> None:
 # ---------------- ASR backend seam ----------------
 #
 # Transcription runs behind a swappable backend so the engine can vary by platform
-# without touching `_transcribe`. faster-whisper (CTranslate2) is the only shipped
-# backend; it supports CUDA + CPU but has NO Metal path, so on Apple Silicon ASR runs
-# on CPU. An `MlxWhisperBackend` (mlx-whisper) would slot in at `get_transcriber` to put
-# transcription on the Mac GPU — a bounded follow-up (new optional dep + segment-format
-# normalization), deliberately not built here. This realizes the swap-without-touching-
-# callers intent stated in the module docstring.
+# without touching `_transcribe`. Two backends ship:
+#   - FasterWhisperBackend (CTranslate2): CUDA or CPU. No Metal path.
+#   - MlxWhisperBackend (mlx-whisper): Apple Silicon Metal GPU, from the optional
+#     `[media-mlx]` extra.
+# `get_transcriber()` auto-selects MLX on Apple Silicon when it's installed, else
+# faster-whisper; `EXOMEM_ASR_BACKEND=mlx|faster-whisper` forces the choice.
+
+# Default MLX model repo (HF). large-v3 for quality parity with faster-whisper's default;
+# override to e.g. `mlx-community/whisper-large-v3-turbo` for a lighter, faster run on a Mac.
+MLX_WHISPER_MODEL = os.environ.get(
+    "EXOMEM_MLX_WHISPER_MODEL", "mlx-community/whisper-large-v3-mlx"
+)
 
 
 class TranscriptionSegment(Protocol):
@@ -283,6 +290,10 @@ class TranscriptionBackend(Protocol):
         """
         ...
 
+    def prewarm(self) -> None:
+        """Eagerly load the model so the first real job isn't a cold start."""
+        ...
+
 
 class FasterWhisperBackend:
     """CTranslate2 faster-whisper — CUDA or CPU (never Metal). Device and compute_type
@@ -295,10 +306,89 @@ class FasterWhisperBackend:
         segments, _info = model.transcribe(str(path))
         return segments, f"faster-whisper:{WHISPER_MODEL}"
 
+    def prewarm(self) -> None:
+        _get_whisper()
+
+
+class _MlxSegment:
+    """Adapts an mlx-whisper segment dict to the ``.text``/``.start``/``.end`` attribute
+    shape the extractor consumes (faster-whisper yields objects; MLX yields dicts)."""
+
+    __slots__ = ("text", "start", "end")
+
+    def __init__(self, seg: dict):
+        self.text = seg.get("text", "")
+        self.start = float(seg.get("start", 0.0) or 0.0)
+        self.end = float(seg.get("end", self.start) or self.start)
+
+
+class MlxWhisperBackend:
+    """mlx-whisper on Apple Silicon (Metal GPU) — what accelerates ASR on a Mac, since
+    faster-whisper/CTranslate2 has no Metal path. Audio is decoded via PyAV (the shared
+    16 kHz whisper timebase) when faster-whisper is present, else the file path is handed
+    to mlx-whisper's own loader. MLX caches the model in memory after the first load."""
+
+    @staticmethod
+    def _require_mlx():
+        try:
+            import mlx_whisper
+        except ImportError as e:  # the optional [media-mlx] extra isn't installed
+            raise ExtractionUnavailable(f"mlx-whisper not installed: {e}") from e
+        return mlx_whisper
+
+    @staticmethod
+    def _load_audio(path: Path):
+        """16 kHz mono float32 array via PyAV when available (no ffmpeg, shared timebase);
+        else the path string, which mlx-whisper decodes itself (via ffmpeg)."""
+        try:
+            from faster_whisper.audio import decode_audio
+        except ImportError:
+            return str(path)
+        return decode_audio(str(path), sampling_rate=16000)
+
+    def transcribe(self, path: Path) -> tuple[Iterable[TranscriptionSegment], str]:
+        mlx_whisper = self._require_mlx()
+        result = mlx_whisper.transcribe(
+            self._load_audio(path), path_or_hf_repo=MLX_WHISPER_MODEL
+        )
+        segments = [_MlxSegment(s) for s in result.get("segments", [])]
+        return segments, f"mlx-whisper:{MLX_WHISPER_MODEL}"
+
+    def prewarm(self) -> None:
+        import numpy as np
+
+        mlx_whisper = self._require_mlx()
+        # A 1 s silent buffer forces the download + model load into MLX's in-memory cache
+        # (public API only — no reliance on mlx-whisper internals), so the first real job
+        # isn't a cold start.
+        mlx_whisper.transcribe(
+            np.zeros(16000, dtype=np.float32), path_or_hf_repo=MLX_WHISPER_MODEL
+        )
+
+
+def _mlx_available() -> bool:
+    """True on Apple Silicon with mlx-whisper importable (the [media-mlx] extra)."""
+    import platform
+    import sys
+
+    if sys.platform != "darwin" or platform.machine() != "arm64":
+        return False
+    import importlib.util
+
+    return importlib.util.find_spec("mlx_whisper") is not None
+
 
 def get_transcriber() -> TranscriptionBackend:
-    """The active ASR backend. faster-whisper today; an Apple-Silicon Metal backend
-    (mlx-whisper) would be selected here on macOS — see the seam note above."""
+    """The active ASR backend: mlx-whisper on Apple Silicon (Metal GPU) when available,
+    else faster-whisper (CUDA/CPU). Force the choice with
+    ``EXOMEM_ASR_BACKEND=mlx|faster-whisper``."""
+    pref = (os.environ.get("EXOMEM_ASR_BACKEND") or "auto").strip().lower()
+    if pref == "mlx":
+        return MlxWhisperBackend()
+    if pref in ("faster-whisper", "faster_whisper", "ctranslate2"):
+        return FasterWhisperBackend()
+    if _mlx_available():  # auto
+        return MlxWhisperBackend()
     return FasterWhisperBackend()
 
 

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -39,10 +39,12 @@ import re
 import subprocess
 import tempfile
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Protocol
 
-from . import semantic_segments
+from . import accel, semantic_segments
 
 log = logging.getLogger(__name__)
 
@@ -252,6 +254,54 @@ def prewarm() -> None:
         log.warning("ASR prewarm failed; will retry lazily on first job", exc_info=True)
 
 
+# ---------------- ASR backend seam ----------------
+#
+# Transcription runs behind a swappable backend so the engine can vary by platform
+# without touching `_transcribe`. faster-whisper (CTranslate2) is the only shipped
+# backend; it supports CUDA + CPU but has NO Metal path, so on Apple Silicon ASR runs
+# on CPU. An `MlxWhisperBackend` (mlx-whisper) would slot in at `get_transcriber` to put
+# transcription on the Mac GPU — a bounded follow-up (new optional dep + segment-format
+# normalization), deliberately not built here. This realizes the swap-without-touching-
+# callers intent stated in the module docstring.
+
+
+class TranscriptionSegment(Protocol):
+    """The per-segment fields `_transcribe` consumes (text + timing)."""
+
+    text: str
+    start: float
+    end: float
+
+
+class TranscriptionBackend(Protocol):
+    def transcribe(self, path: Path) -> tuple[Iterable[TranscriptionSegment], str]:
+        """Transcribe `path` → ``(segments, engine_label)``.
+
+        ``segments`` yields objects exposing ``.text`` / ``.start`` / ``.end``;
+        ``engine_label`` is the provenance string stored on the sidecar (e.g.
+        ``faster-whisper:large-v3``).
+        """
+        ...
+
+
+class FasterWhisperBackend:
+    """CTranslate2 faster-whisper — CUDA or CPU (never Metal). Device and compute_type
+    live in `_get_whisper`; this wrapper keeps the loader seam that tests patch."""
+
+    def transcribe(self, path: Path) -> tuple[Iterable[TranscriptionSegment], str]:
+        model = _get_whisper()
+        # faster-whisper decodes the media's audio stream via PyAV (handles video
+        # containers too), so a video file can be passed directly — no ffmpeg step.
+        segments, _info = model.transcribe(str(path))
+        return segments, f"faster-whisper:{WHISPER_MODEL}"
+
+
+def get_transcriber() -> TranscriptionBackend:
+    """The active ASR backend. faster-whisper today; an Apple-Silicon Metal backend
+    (mlx-whisper) would be selected here on macOS — see the seam note above."""
+    return FasterWhisperBackend()
+
+
 def log_diarization_readiness(vault_root: Path | None = None) -> None:
     """One boot-time log line saying whether diarization can actually run.
 
@@ -290,12 +340,8 @@ def _transcribe(path: Path, media_type: str, vault_root: Path | None = None) -> 
     # per-keyframe CLIP (embeddings.embed_video_frames). A video IS a sequence of images.
     if media_type == "video" and not _has_audio_stream(path):
         return ExtractResult(text="", media_type=media_type, engine="no-audio")
-    model = _get_whisper()
-    # faster-whisper decodes the media's audio stream via PyAV (handles video containers
-    # too), so a video file can be passed directly — no separate ffmpeg extraction step.
-    segments, _info = model.transcribe(str(path))
+    segments, engine = get_transcriber().transcribe(path)
     seg_list = list(segments)  # materialize once: diarization needs per-segment timing
-    engine = f"faster-whisper:{WHISPER_MODEL}"
 
     # OPTIONAL speaker diarization (EXOMEM_DIARIZE, default OFF). A pretrained
     # clustering model (deterministic transduction, not an LLM) labels who-spoke-when
@@ -744,7 +790,9 @@ def _load_captioner():
     """
     from transformers import pipeline  # soft dep — only imported when enabled
 
-    device = 0 if _device() == "cuda" else -1
+    # This captioner IS a torch model, so it can use MPS on Apple Silicon (unlike
+    # the CTranslate2 ASR engine); device via the shared torch-device selector.
+    device = accel.pipeline_device()
     return pipeline("image-to-text", model=_caption_model_name(), device=device)
 
 

--- a/src/exomem/voice_embed.py
+++ b/src/exomem/voice_embed.py
@@ -26,6 +26,8 @@ import threading
 
 import numpy as np
 
+from . import accel
+
 log = logging.getLogger(__name__)
 
 # Frozen ECAPA speaker-embedding checkpoint; override for a pinned/local copy.
@@ -42,30 +44,24 @@ _VOICE_LOCK = threading.Lock()
 
 
 def _voice_device() -> str:
-    """Device for ECAPA. Honors EXOMEM_VOICE_DEVICE; otherwise GPU only when ASR is NOT
-    running in this process, else CPU.
+    """Device for ECAPA. Honors EXOMEM_VOICE_DEVICE; otherwise CUDA when available
+    (never under active ASR — the cuDNN-shadow clash), else CPU.
 
-    Same rationale as `embeddings._clip_device()`: faster-whisper's CUDA-12 cuDNN wheels get
-    PATH-prepended (extract._ensure_cuda_dll_path) so ctranslate2 can load, which then shadows
-    torch-cu132's bundled cuDNN 13 and makes torch conv/inference die with
-    CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH. Since the media worker prewarms ASR at startup,
-    having extraction enabled means PATH is already poisoned, so ECAPA must run on CPU — a small
-    model, off the request path. A box with media extraction disabled has no conflict and keeps
-    the GPU.
+    Same CUDA rationale as `embeddings._clip_device()`: faster-whisper's CUDA-12 cuDNN
+    wheels get PATH-prepended (extract._ensure_cuda_dll_path) so ctranslate2 can load,
+    which then shadows torch-cu132's bundled cuDNN 13 and makes torch conv/inference die
+    with CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH. So `avoid_cuda_when_asr` keeps ECAPA
+    off CUDA while ASR is active.
+
+    Unlike CLIP, ECAPA does **not** auto-select MPS (`auto_mps=False`): a voiceprint is
+    matched by cosine against profiles that may have been computed on another machine,
+    and MPS float32 kernels differ numerically from CPU — so the parity-safe default is
+    CPU, mirroring `_disable_tf32`. Set `EXOMEM_VOICE_DEVICE=mps` to opt into the Apple
+    GPU on a single-machine setup where parity across hosts doesn't matter.
     """
-    override = os.environ.get("EXOMEM_VOICE_DEVICE")
-    if override:
-        return override
-    # Mirror extract.extraction_enabled() without importing it (avoids a new module edge).
-    asr_active = not os.environ.get("EXOMEM_DISABLE_MEDIA_EXTRACTION")
-    if asr_active:
-        return "cpu"
-    try:
-        import torch
-
-        return "cuda" if torch.cuda.is_available() else "cpu"
-    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
-        return "cpu"
+    return accel.select_device(
+        override_env="EXOMEM_VOICE_DEVICE", avoid_cuda_when_asr=True, auto_mps=False
+    )
 
 
 def _disable_tf32() -> None:

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -21,6 +21,8 @@ _ENV_KEYS = (
     "EXOMEM_VOICE_DEVICE",
     "EXOMEM_DISABLE_MEDIA_EXTRACTION",
     "PYTORCH_ENABLE_MPS_FALLBACK",
+    "EXOMEM_ASR_BACKEND",
+    "EXOMEM_MLX_WHISPER_MODEL",
 )
 
 
@@ -164,3 +166,95 @@ def test_get_transcriber_is_faster_whisper_and_keeps_engine_label(
     segments, engine = backend.transcribe(Path("clip.wav"))
     assert engine == f"faster-whisper:{extract.WHISPER_MODEL}"
     assert [s.text for s in segments] == ["hi"]
+
+
+# ---- MLX (Apple Silicon Metal) ASR backend ----
+
+def _fake_mlx(monkeypatch: pytest.MonkeyPatch, segments: list[dict], capture: dict | None = None):
+    """Inject a fake `mlx_whisper` module so the backend runs off Apple Silicon."""
+    mlx = types.ModuleType("mlx_whisper")
+
+    def transcribe(audio, path_or_hf_repo=None):
+        if capture is not None:
+            capture["audio"] = audio
+            capture["repo"] = path_or_hf_repo
+        return {"segments": segments, "text": "", "language": "en"}
+
+    mlx.transcribe = transcribe
+    monkeypatch.setitem(sys.modules, "mlx_whisper", mlx)
+
+
+def _fake_fw_decode(monkeypatch: pytest.MonkeyPatch, array) -> None:
+    """Inject a fake `faster_whisper.audio.decode_audio` returning a canned array."""
+    fw = types.ModuleType("faster_whisper")
+    fw_audio = types.ModuleType("faster_whisper.audio")
+    fw_audio.decode_audio = lambda _p, sampling_rate=16000: array
+    fw.audio = fw_audio
+    monkeypatch.setitem(sys.modules, "faster_whisper", fw)
+    monkeypatch.setitem(sys.modules, "faster_whisper.audio", fw_audio)
+
+
+def test_mlx_backend_normalizes_segments_and_engine_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MLX yields segment *dicts*; the backend adapts them to the .text/.start/.end objects
+    the extractor consumes, and stamps an `mlx-whisper:<model>` provenance label."""
+    from pathlib import Path
+
+    from exomem import extract
+
+    capture: dict = {}
+    _fake_fw_decode(monkeypatch, [0.0, 0.0, 0.0])
+    _fake_mlx(
+        monkeypatch,
+        [{"start": 0.0, "end": 1.5, "text": " hello"}, {"start": 1.5, "end": 2.0, "text": " world"}],
+        capture,
+    )
+    segments, engine = extract.MlxWhisperBackend().transcribe(Path("clip.wav"))
+    assert engine == f"mlx-whisper:{extract.MLX_WHISPER_MODEL}"
+    assert [(round(s.start, 2), round(s.end, 2), s.text.strip()) for s in segments] == [
+        (0.0, 1.5, "hello"),
+        (1.5, 2.0, "world"),
+    ]
+    # PyAV-decoded array is passed to MLX (not the raw path) when faster-whisper is present.
+    assert capture["audio"] == [0.0, 0.0, 0.0]
+    assert capture["repo"] == extract.MLX_WHISPER_MODEL
+
+
+def test_mlx_load_audio_falls_back_to_path_without_faster_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    from exomem import extract
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", None)
+    monkeypatch.setitem(sys.modules, "faster_whisper.audio", None)
+    assert extract.MlxWhisperBackend._load_audio(Path("a.wav")) == str(Path("a.wav"))
+
+
+def test_mlx_backend_missing_dep_raises_extraction_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pathlib import Path
+
+    from exomem import extract
+
+    monkeypatch.setitem(sys.modules, "mlx_whisper", None)  # import mlx_whisper → ImportError
+    with pytest.raises(extract.ExtractionUnavailable):
+        extract.MlxWhisperBackend().transcribe(Path("x.wav"))
+
+
+def test_get_transcriber_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import extract
+
+    # Explicit override wins over auto-detection.
+    monkeypatch.setenv("EXOMEM_ASR_BACKEND", "mlx")
+    assert isinstance(extract.get_transcriber(), extract.MlxWhisperBackend)
+    monkeypatch.setenv("EXOMEM_ASR_BACKEND", "faster-whisper")
+    assert isinstance(extract.get_transcriber(), extract.FasterWhisperBackend)
+
+    # Auto: MLX on Apple Silicon (mlx-whisper importable), else faster-whisper.
+    monkeypatch.delenv("EXOMEM_ASR_BACKEND", raising=False)
+    monkeypatch.setattr(extract, "_mlx_available", lambda: True)
+    assert isinstance(extract.get_transcriber(), extract.MlxWhisperBackend)
+    monkeypatch.setattr(extract, "_mlx_available", lambda: False)
+    assert isinstance(extract.get_transcriber(), extract.FasterWhisperBackend)

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -1,0 +1,166 @@
+"""Device-selection matrix for `exomem.accel` — CUDA > MPS > CPU with per-model policy.
+
+Hardware-independent: `torch.cuda.is_available` and `accel._mps_available` are
+monkeypatched so every branch (CUDA / MPS / CPU / overrides / ASR-avoidance) is
+exercised deterministically on any host, including CI boxes with no GPU.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+from exomem import accel
+
+_ENV_KEYS = (
+    "EXOMEM_TORCH_DEVICE",
+    "EXOMEM_CLIP_DEVICE",
+    "EXOMEM_VOICE_DEVICE",
+    "EXOMEM_DISABLE_MEDIA_EXTRACTION",
+    "PYTORCH_ENABLE_MPS_FALLBACK",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate every test from ambient device/env config."""
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _set_hw(monkeypatch: pytest.MonkeyPatch, *, cuda: bool, mps: bool) -> None:
+    """Advertise a fake `torch` with the given accelerators — no real torch needed, so the
+    matrix runs on lean CI too (matching the suite's torch-optional design)."""
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: cuda)
+    torch.backends = types.SimpleNamespace()  # MPS is probed via accel._mps_available (patched)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setattr(accel, "_mps_available", lambda _torch: mps)
+
+
+# ---- auto-detection priority: CUDA > MPS > CPU ----
+
+def test_cuda_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=True)
+    assert accel.select_device() == "cuda"
+
+
+def test_mps_when_no_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=True)
+    assert accel.select_device() == "mps"
+    # Selecting MPS must arm the op-fallback so unimplemented ops don't crash.
+    assert os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
+
+
+def test_cpu_when_no_accelerator(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=False)
+    assert accel.select_device() == "cpu"
+
+
+def test_no_torch_is_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `import torch` with None in sys.modules raises ImportError → CPU.
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert accel.select_device() == "cpu"
+
+
+# ---- auto_mps=False (ECAPA voiceprint parity default) ----
+
+def test_auto_mps_false_skips_mps(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=True)
+    assert accel.select_device(auto_mps=False) == "cpu"
+
+
+def test_auto_mps_false_still_honors_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=True)
+    monkeypatch.setenv("EXOMEM_VOICE_DEVICE", "mps")
+    assert accel.select_device(override_env="EXOMEM_VOICE_DEVICE", auto_mps=False) == "mps"
+
+
+# ---- overrides ----
+
+def test_per_model_override_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)  # would auto-pick cuda
+    monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cpu")
+    assert accel.select_device(override_env="EXOMEM_CLIP_DEVICE") == "cpu"
+
+
+def test_global_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)
+    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "cpu")
+    assert accel.select_device() == "cpu"
+
+
+def test_per_model_override_beats_global(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=False)
+    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "cpu")
+    monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cuda")
+    assert accel.select_device(override_env="EXOMEM_CLIP_DEVICE") == "cuda"
+
+
+def test_explicit_mps_override_arms_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)
+    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "mps")
+    assert accel.select_device() == "mps"
+    assert os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
+
+
+# ---- avoid_cuda_when_asr: the cuDNN-shadow workaround is CUDA-only ----
+
+def test_avoid_cuda_when_asr_active_falls_to_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)
+    # ASR active = EXOMEM_DISABLE_MEDIA_EXTRACTION unset (cleared by the fixture).
+    assert accel.select_device(avoid_cuda_when_asr=True) == "cpu"
+
+
+def test_avoid_cuda_when_asr_disabled_keeps_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)
+    monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
+    assert accel.select_device(avoid_cuda_when_asr=True) == "cuda"
+
+
+def test_avoid_cuda_when_asr_does_not_penalize_mps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The key Apple-Silicon win: CLIP/ECAPA keep MPS even with ASR active, because the
+    cuDNN clash only exists on CUDA."""
+    _set_hw(monkeypatch, cuda=False, mps=True)  # a Mac: MPS, no CUDA
+    # ASR active. On the old code this returned "cpu"; now it stays on the GPU.
+    assert accel.select_device(avoid_cuda_when_asr=True) == "mps"
+
+
+# ---- pipeline_device (HF transformers device form) ----
+
+@pytest.mark.parametrize(
+    "cuda, mps, expected",
+    [(True, False, 0), (False, True, "mps"), (False, False, -1)],
+)
+def test_pipeline_device(monkeypatch: pytest.MonkeyPatch, cuda, mps, expected) -> None:
+    _set_hw(monkeypatch, cuda=cuda, mps=mps)
+    assert accel.pipeline_device() == expected
+
+
+# ---- ASR transcription backend seam (Phase 2) ----
+
+def test_get_transcriber_is_faster_whisper_and_keeps_engine_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The seam ships one backend today; it must preserve the `faster-whisper:<model>`
+    provenance label that sidecars and tests depend on."""
+    from exomem import extract
+
+    class _Seg:
+        text, start, end = "hi", 0.0, 1.0
+
+    class _FakeWhisper:
+        def transcribe(self, _path):  # faster-whisper returns (segments, info)
+            return [_Seg()], object()
+
+    monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper())
+    backend = extract.get_transcriber()
+    assert isinstance(backend, extract.FasterWhisperBackend)
+    from pathlib import Path
+
+    segments, engine = backend.transcribe(Path("clip.wav"))
+    assert engine == f"faster-whisper:{extract.WHISPER_MODEL}"
+    assert [s.text for s in segments] == ["hi"]

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -38,20 +38,42 @@ class _FakeClip:
 
 
 def test_clip_device_env_and_asr_gating(monkeypatch) -> None:
-    """GPU CLIP shares a process with faster-whisper, whose cu12 cuDNN PATH-prepend
-    breaks CLIP's ViT Conv2d on torch-cu132. So CLIP must run on CPU whenever ASR
-    (media extraction) is enabled; an explicit EXOMEM_CLIP_DEVICE override always wins."""
-    # Explicit override wins regardless of ASR state.
+    """CLIP device policy via `accel`: an explicit EXOMEM_CLIP_DEVICE override always wins;
+    otherwise CUDA is avoided while ASR is active (the faster-whisper cuDNN-shadow clash that
+    breaks CLIP's ViT Conv2d on torch-cu132) — but MPS is not, since the clash is CUDA-only, so
+    on Apple Silicon CLIP keeps the Metal GPU even with ASR running."""
+    import sys
+    import types
+
+    from exomem import accel
+
+    def set_hw(*, cuda: bool, mps: bool) -> None:
+        # Fake torch so this runs torch-free (test_clip has no module-level torch gate).
+        torch = types.ModuleType("torch")
+        torch.cuda = types.SimpleNamespace(is_available=lambda: cuda)
+        torch.backends = types.SimpleNamespace()
+        monkeypatch.setitem(sys.modules, "torch", torch)
+        monkeypatch.setattr(accel, "_mps_available", lambda _t: mps)
+
+    # Explicit override wins regardless of hardware / ASR state.
     monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cuda")
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
     assert embeddings._clip_device() == "cuda"
     monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cpu")
     monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
     assert embeddings._clip_device() == "cpu"
-    # No override + ASR enabled (the live default) → CPU, dodging the whisper cuDNN clash.
+
     monkeypatch.delenv("EXOMEM_CLIP_DEVICE", raising=False)
+    monkeypatch.delenv("EXOMEM_TORCH_DEVICE", raising=False)
+
+    # CUDA box + ASR active → CPU (dodges the whisper cuDNN clash).
+    set_hw(cuda=True, mps=False)
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
     assert embeddings._clip_device() == "cpu"
+
+    # Apple Silicon (MPS, no CUDA) + ASR active → MPS: the clash is CUDA-only.
+    set_hw(cuda=False, mps=True)
+    assert embeddings._clip_device() == "mps"
 
 
 def test_clip_index_upsert_search_has_delete(vault) -> None:

--- a/tests/test_voice_embed.py
+++ b/tests/test_voice_embed.py
@@ -20,19 +20,39 @@ from exomem import voice_embed  # noqa: E402
 
 
 def test_voice_device_env_and_asr_gating(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mirrors embeddings._clip_device: GPU only when ASR (media extraction) is disabled;
-    an explicit EXOMEM_VOICE_DEVICE override always wins."""
-    # Explicit override wins regardless of ASR state.
+    """ECAPA device policy via `accel`: an explicit EXOMEM_VOICE_DEVICE override always wins;
+    CUDA is avoided while ASR is active (the cuDNN-shadow clash); and MPS is never
+    auto-selected — voiceprints are matched by cosine against profiles from other machines and
+    MPS float32 kernels drift from CPU, so Apple Silicon is opt-in only."""
+    import torch
+
+    from exomem import accel
+
+    # Explicit override wins regardless of hardware / ASR state.
     monkeypatch.setenv("EXOMEM_VOICE_DEVICE", "cuda")
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
     assert voice_embed._voice_device() == "cuda"
     monkeypatch.setenv("EXOMEM_VOICE_DEVICE", "cpu")
     monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
     assert voice_embed._voice_device() == "cpu"
-    # No override + ASR enabled (the live default) → CPU, dodging the whisper cuDNN clash.
+
     monkeypatch.delenv("EXOMEM_VOICE_DEVICE", raising=False)
+    monkeypatch.delenv("EXOMEM_TORCH_DEVICE", raising=False)
+
+    # CUDA box + ASR active → CPU (dodges the whisper cuDNN clash).
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(accel, "_mps_available", lambda _t: False)
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
     assert voice_embed._voice_device() == "cpu"
+
+    # Apple Silicon (MPS, no CUDA): NOT auto-selected → CPU for cross-machine parity.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(accel, "_mps_available", lambda _t: True)
+    assert voice_embed._voice_device() == "cpu"
+
+    # …but an explicit opt-in is honored.
+    monkeypatch.setenv("EXOMEM_VOICE_DEVICE", "mps")
+    assert voice_embed._voice_device() == "mps"
 
 
 def test_disable_tf32_turns_tf32_off() -> None:


### PR DESCRIPTION
## Why

Yusuke runs exomem on a 2026 MacBook Air (Apple Silicon) and **everything ran on
CPU**: every model picked its device with `"cuda" if torch.cuda.is_available() else
"cpu"` — no MPS/Metal branch anywhere. This makes macOS a **first-class GPU platform**
for the whole pipeline.

## What

A proper cross-platform device/backend abstraction (priority **CUDA > MPS > CPU**),
plus a Metal ASR backend — a reusable pattern, not scattered `mps` branches.

### Part 1 — device abstraction (embeddings/CLIP/reranker)
- New `exomem.accel.select_device()`: lazy torch import, arms
  `PYTORCH_ENABLE_MPS_FALLBACK`, global `EXOMEM_TORCH_DEVICE` + per-model overrides.
  Wires the bge text embedder, bge reranker, CLIP, ECAPA, and the caption pipeline
  through one place.
- The cuDNN-shadow **"avoid CUDA under active ASR"** workaround is now **CUDA-only**,
  so on Apple Silicon CLIP/ECAPA keep the GPU even with media extraction running.
- **Voiceprints (ECAPA) + diarization default to CPU** for cross-machine numeric
  parity; opt in with `EXOMEM_VOICE_DEVICE=mps` / `EXOMEM_DIARIZE_DEVICE=mps`.
- `doctor` reports MPS availability.

### Part 2 — ASR on the Metal GPU (mlx-whisper)
faster-whisper/CTranslate2 has **no Metal path**, so ASR runs behind a
`TranscriptionBackend` seam with two implementations:
- `FasterWhisperBackend` (CUDA/CPU) — unchanged.
- `MlxWhisperBackend` (**mlx-whisper**, Metal GPU) — new, from the optional
  **`media-mlx`** extra (macOS-arm64-gated marker → no-op elsewhere).

`get_transcriber()` **auto-selects MLX on Apple Silicon** when installed, else
faster-whisper. `EXOMEM_ASR_BACKEND=mlx|faster-whisper` forces it;
`EXOMEM_MLX_WHISPER_MODEL` picks the HF repo (default `whisper-large-v3-mlx`, or
`…-turbo` for a lighter run on a fanless Air). Audio decodes via PyAV (shared 16 kHz
whisper timebase) when `media` is present, else mlx-whisper decodes the file itself.

### Linux
The abstraction unifies Linux too: `select_device` returns `cuda` on NVIDIA
(unchanged) and `cpu` otherwise; ASR uses faster-whisper CUDA as before. AMD ROCm
rides the `cuda` path (HIP masquerades as CUDA) — a wheel/packaging matter, not new
code. The only genuinely new **code** paths are macOS MPS + the MLX ASR backend.

## Verification
- Full suite green on this Windows/CPU box: **1172 passed, 11 skipped** (skips are
  torch/PIL/av/sentence-transformers gated — expected on a lean box).
- New `tests/test_accel.py` covers the device matrix **and** the ASR backend
  (segment normalization, PyAV-vs-path decode fallback, missing-dep soft-fail,
  factory selection) — all **torch-free/mlx-free** via fake modules, so it runs on
  lean CI. mlx-whisper API confirmed against the ml-explore source.
- Ruff clean on added/edited code.

⚠️ **Real GPU execution can only be exercised on Apple Silicon** — please test on the
Air: `exomem doctor` should report MPS; a `find` should log `loading embedding model
… on mps`; and with `uv sync --extra media --extra media-mlx`, transcribing audio
should use `mlx-whisper:…` (check the sidecar's `extracted_by`). See
`docs/deployment.md` → "GPU notes … Apple Silicon".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
