### PR TITLE
feat: opt-in retrieve-and-inject hook (KB_RETRIEVE_INJECT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ The skill installs under the stable Claude Code name `knowledge-base`; Exomem is
 the server and tool layer behind it. The skill is recommended for Claude Code —
 the server gives Claude the tools, the skill is what makes it use them. Hooks
 are Claude Code-only reliability nudges for long sessions: a read-side reminder
-before answers and a write-side reminder at natural stopping points. Other MCP
-clients can still use the server; put the same knowledge-discipline
+before answers and a write-side reminder at natural stopping points. The
+read-side hook can optionally upgrade that reminder to real retrieved KB
+content (`KB_RETRIEVE_INJECT=1`, opt-in) — see
+[SETUP-LOCAL.md § 7](SETUP-LOCAL.md#7-recommended-make-the-kb-automatic-both-directions).
+Other MCP clients can still use the server; put the same knowledge-discipline
 instructions in their system/project instructions if they do not support
 skills.
 

--- a/SETUP-LOCAL.md
+++ b/SETUP-LOCAL.md
@@ -284,6 +284,21 @@ matching `_COOLDOWN_SEC`), or disable either with `KB_CAPTURE_NUDGE_DISABLE=1` /
 Lower the `MIN_CHARS` values — those scripts pack more meaning per character, so
 the defaults (tuned for English) can under-fire.
 
+**Opt-in: upgrade the read-side reminder to real retrieved content.** By default
+the `UserPromptSubmit` hook only reminds Claude to run `find` — set
+`KB_RETRIEVE_INJECT=1` and it instead fetches the top 3 compact routing stubs
+(keyword mode, no embeddings) for the same gated prompt and appends them to the
+reminder, so relevant prior KB pages are already in context before Claude
+decides whether to search. It tries a short transport ladder and never blocks
+on a slow path: REST first (one `POST /api/find`, ~2s timeout) — only attempted
+when `EXOMEM_REST_API_KEY` is set **in the shell that launches Claude Code**
+(not just the server's service environment — the hook can't read another
+process's env, so export it in the same profile Claude Code inherits from);
+then, only if you also set `KB_RETRIEVE_INJECT_CLI=1`, an `exomem find --json`
+subprocess call (~5s timeout, slower — cold Python start). If neither is
+configured or reachable, it falls straight back to the plain reminder — no
+network call is ever attempted unless `KB_RETRIEVE_INJECT` is on.
+
 (Hooks are Claude Code only — claude.ai web/mobile can't run them, so there the
 skill stays best-effort: nudge it with *"save that to kb"* or *"check the kb."*)
 

--- a/openspec/changes/retrieve-inject-hook/design.md
+++ b/openspec/changes/retrieve-inject-hook/design.md
@@ -1,0 +1,216 @@
+# Design — Retrieve-Inject Hook
+
+## Context
+
+`kb_retrieve_nudge.py` is a standalone, stdlib-only Python script (the
+`.sh` sibling is a thin wrapper that just resolves `python3`/`python` and
+`exec`s it — see `kb-retrieve-nudge.sh`). It is deliberately decoupled from the
+`exomem` package: it never `import exomem`, so it keeps working even when the
+interpreter Claude Code's shell resolves is not the one `exomem` is installed
+into. Today it reads the `UserPromptSubmit` event JSON off stdin, gates on
+prompt length (`KB_RETRIEVE_NUDGE_MIN_CHARS`, default 20) and a per-session
+cooldown file (`KB_RETRIEVE_NUDGE_COOLDOWN_SEC`, default 300), and on a pass
+prints `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit",
+"additionalContext": REMINDER}}` — a static instruction string, never real KB
+content.
+
+Two retrieval surfaces already exist and are reused as-is:
+
+- **REST** (`server.py`): `POST /api/find` is part of the generated REST
+  facade (`_register_rest`, `commands.py` registry entry
+  `("find", op_find, 1, False, False, "query", _MCRC)` — `find` carries the
+  `rest` surface). It is **POST with a JSON body**, gated by
+  `Authorization: Bearer <EXOMEM_REST_API_KEY>` (constant-time compare or a
+  minted `rest`-scoped token), disabled (503) unless `EXOMEM_REST_API_KEY` is
+  set server-side. The response is the shared envelope
+  `{"success": true, "data": [...compact hit dicts...]}` or
+  `{"success": false, "error": {...}}`. Default bind is `127.0.0.1:8765`.
+- **CLI** (`__main__.py` → `_core_op_main`): `python -m exomem find --detail
+  compact --limit 3 --mode keyword --json "<query>"` (or the installed
+  console scripts `exomem`/`kb`, declared in `pyproject.toml`'s
+  `[project.scripts]`). `__main__.py` imports `from . import server` at
+  module scope, so even a keyword-only `find` invocation pays the import cost
+  of `fastmcp`, `starlette`, and the GitHub OAuth provider chain before any
+  query runs — cold-start is dominated by that import chain plus interpreter
+  startup, not by corpus size or by loading any embedding model (keyword mode
+  never touches `bge`/CLIP/reranker).
+- **Compact stub shape** (`find.py::Hit.as_compact_dict`): `path`, `type`,
+  `scope`, `title`, `updated`, plus optional `media_type`, `media_file`,
+  `clip_match_at`, `scene_frame`(+`scene_match_at`), `transcript_match_at`,
+  `outside_kb`, `status`, `superseded_by`. `excerpt` and `signals` are never
+  present in this shape — there is no separate guard needed to keep bodies out
+  of the injected block.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Turn the existing instruction-only nudge into real retrieved content when a
+  fast path exists, without adding a second registered hook or a second
+  cooldown clock.
+- Never make `UserPromptSubmit` noticeably slower on an install where fast
+  retrieval isn't available — REST unconfigured/unreachable and CLI transport
+  not explicitly opted into must cost exactly what today's hook costs (no
+  network call attempted at all).
+- Keep the hook stdlib-only (no new runtime dependency, no shelling out to
+  `curl`/`jq`).
+- Keep the default (`KB_RETRIEVE_INJECT` unset) behavior byte-identical to
+  today, verified by the existing `test_install_hook.py` retrieval-gate tests
+  passing unmodified.
+
+**Non-Goals:**
+
+- No change to `find`'s ranking, registry, REST route, or CLI wiring — this
+  change is a consumer of those surfaces, not a modifier.
+- No hybrid/vector retrieval from the hook (see Decision: keyword-only).
+- No excerpt/body injection (see Decision: stubs only).
+- No new always-on process/daemon.
+
+## Decisions
+
+### In-place upgrade behind `KB_RETRIEVE_INJECT`, not a second hook
+
+A sibling `kb-retrieve-inject.sh` would mean two `UserPromptSubmit`
+registrations, two cooldown clocks, and a real risk of firing twice (nudge +
+inject) on the same prompt with no shared gate. Upgrading `kb_retrieve_nudge.py`
+in place keeps `install_hook.py`'s `_HOOK_SPECS`, the settings.json wiring, and
+the default hook `timeout` (10s) completely unchanged, and makes the inject
+payload strictly additive to the existing gate rather than a parallel trigger.
+`KB_RETRIEVE_INJECT` follows the `_env_flag` truthy-parse convention introduced
+alongside diarization/vision-caption gating (`extract.py::_env_flag`: unset,
+`""`, `0`, `false`, `no`, `off` → disabled, case-insensitive) rather than a bare
+`bool(os.environ.get(...))` check — the same bug class that check just got
+fixed for elsewhere in this repo (`KB_DIARIZE=0` reading as opted-in) must not
+be reintroduced here.
+
+### Transport ladder: REST first, CLI opt-in second, nudge-only floor
+
+1. **REST**, attempted only when `EXOMEM_REST_API_KEY` is present in the
+   hook's own environment (the shell that launches Claude Code — not
+   necessarily the server's service environment; documented as a setup
+   requirement). One POST attempt, `timeout=2s` at the socket level. Any
+   failure — connection refused, timeout, non-200, malformed JSON,
+   `success: false` — is treated as "unreachable" and falls straight through
+   to the next rung. No separate health-check round trip; the real call
+   doubles as the reachability probe, keeping this to exactly one request.
+2. **CLI**, attempted only when REST was not attempted or failed, **and**
+   `KB_RETRIEVE_INJECT_CLI` is truthy. Locate `exomem` then `kb` via
+   `shutil.which`; if neither resolves, treat CLI as unavailable (fall to
+   nudge-only) rather than trying `sys.executable -m exomem` — the hook's
+   interpreter is deliberately not assumed to have `exomem` importable (see
+   Context). `timeout=5s` at the subprocess level, generous headroom over the
+   observed cold-start range and still well inside the 10s Claude Code hook
+   timeout.
+3. **Nudge-only floor**: identical to today's output. Reached whenever REST
+   isn't configured/reachable and CLI isn't opted in (or isn't resolvable).
+
+`KB_RETRIEVE_INJECT_CLI` is independent of REST reachability by design: a user
+who hasn't set `EXOMEM_REST_API_KEY` but wants inject behavior anyway can opt
+into the CLI's latency explicitly; a user who has REST configured but hits a
+transient outage does **not** silently fall through to a multi-second CLI call
+merely because REST failed — that would surprise someone who chose REST
+specifically to keep the hook fast. Both routes are still gated by the same
+opt-in flags rather than either occurring by default.
+
+### Keyword mode only, never hybrid/vector
+
+`mode="keyword"` is pure BM25-free substring/token matching (`find.py`
+docstring: "keyword mode preserves the original case-insensitive substring
+matching") — no embeddings, no GPU, no CrossEncoder. Hybrid/vector mode can
+report a `warming` envelope while models load in the background after a server
+restart (`commands.py`'s `degraded`/`warming` handling) — a hook has no
+business reasoning about that state or paying for a cold semantic lane. Fixing
+the mode to `keyword` makes the REST/CLI call's latency and behavior
+independent of server warm-up state and of whatever embedding/reranker
+configuration the install has.
+
+### Stubs only — no excerpts, no bodies, capped block
+
+`detail="compact"` is requested on every call; `Hit.as_compact_dict()`
+structurally omits `excerpt` and `signals`, so there is no separate
+content-stripping step that could be forgotten. Zero hits → inject nothing
+beyond the existing one-line reminder. The formatted stub block (header + up
+to 3 `- path (type, updated)` lines) is truncated to ~400 chars with a
+trailing marker if it would exceed that, keeping the worst case small and
+predictable regardless of title length.
+
+### Same min-chars gate, same cooldown — no new gating knobs
+
+Inject mode reuses `KB_RETRIEVE_NUDGE_MIN_CHARS` and
+`KB_RETRIEVE_NUDGE_COOLDOWN_SEC` verbatim. The trivial-prompt gate runs before
+any transport attempt (saves the round trip on short prompts exactly as it
+does today), and the cooldown continues to bound how often the hook does
+network/subprocess work per session, in exchange for not re-fetching on every
+single prompt in a long thread. This was considered against firing inject on
+every substantial prompt regardless of cooldown (freshest possible recall per
+prompt) — rejected because it would turn every prompt in an active session
+into a network call (or a multi-second subprocess with CLI opted in), which
+contradicts "the hook must stay fast" for the common multi-turn case; the
+existing cooldown default (300s) still yields several fresh injections across
+a real working session.
+
+## Rejected Alternatives
+
+- **GET `/api/find?query=...` (query string)** — the actual registered REST
+  routes are `POST`-only (`_register_rest`, `methods=["POST"]`) with a JSON
+  body; a GET would just 405. Corrected from the initial framing of this
+  change.
+- **Shelling out to `curl`/`jq`** — the existing hooks are explicitly
+  stdlib-only Python (not bash-with-curl); reusing `urllib.request` inside the
+  already-selected Python process avoids a `curl.exe`/PATH dependency
+  (relevant on a minimal Windows install) and an extra process spawn per
+  request. Rejected in favor of stdlib `urllib.request` with a short timeout.
+- **CLI transport via `sys.executable -m exomem`** — assumes the hook's
+  resolved interpreter has `exomem` importable, which is false whenever hooks
+  run under a bare system Python while `exomem` lives in a project venv (the
+  common case this repo's own hooks are built to survive). Rejected in favor
+  of locating the `exomem`/`kb` console script via `shutil.which`, which
+  carries its own correct shebang/venv regardless of which Python resolved.
+- **CLI-by-default (no opt-in)** — cold-start (interpreter + `fastmcp`/
+  `starlette`/OAuth import chain, see Context) is too slow for a hook that
+  blocks model start on every substantial prompt; would regress the "hook
+  must stay fast" invariant for any install without the REST facade running.
+- **Hybrid/vector mode instead of keyword** — couples hook latency/behavior to
+  embedding-model warm-up state and GPU availability; rejected for the same
+  reason `find`'s own `warming` envelope exists — a hook has no way to wait
+  out or reason about that state.
+- **Full excerpt/body injection** — token bloat (excerpts run up to
+  `EXCERPT_MAX_LEN` — 220 chars — each, in `find.py`) and staleness risk (an
+  injected excerpt has no freshness guarantee at read time); a bare stub is a
+  pointer the model verifies with `get`, not a claim to trust directly.
+- **A separate always-on retrieval daemon** — against this project's
+  single-NSSM-service, no-sidecar simplicity; would need its own lifecycle,
+  health checks, and update path for a problem the existing service already
+  solves when reachable.
+
+## Risks / Trade-offs
+
+- A user sets `EXOMEM_REST_API_KEY` in the server's service environment but
+  not in the shell that launches Claude Code → REST rung is skipped (falls to
+  CLI-opt-in-or-nudge) even though the service is up. Documented in
+  SETUP-LOCAL as a setup requirement (export it in the same profile Claude
+  Code inherits from); not auto-detected, since the hook process cannot read
+  another process's environment.
+- Legacy `KB_MCP_REST_API_KEY`-only installs (pre-rename env var, promoted to
+  `EXOMEM_REST_API_KEY` inside the `exomem` package at import time via
+  `env_compat.promote_legacy()`) are not auto-promoted here, because the hook
+  deliberately never imports `exomem`. Such installs fall through to
+  CLI-opt-in-or-nudge until they set `EXOMEM_REST_API_KEY` directly — a scoped
+  limitation, not a regression (today's hook doesn't read either var).
+- A REST call that times out right at the 2s boundary still costs ~2s on that
+  one prompt before falling back — bounded and rare (only on an unreachable
+  server with a slow-failing connection, e.g. a firewall black-hole rather
+  than a clean refusal), well inside the 10s hook timeout.
+
+## Migration Plan
+
+No data migration. `KB_RETRIEVE_INJECT` unset is the shipped default — every
+existing install is unaffected until a user opts in. `install_hook.py` needs
+no re-run for existing installs (same script path, same wrapper, same
+settings.json entry); the upgraded script is picked up next time
+`install-hook` is (re-)run, or immediately for anyone who edits
+`~/.claude/hooks/kb_retrieve_nudge.py` via a fresh `exomem` install/upgrade.
+
+## Open Questions
+
+None for implementation.

--- a/openspec/changes/retrieve-inject-hook/proposal.md
+++ b/openspec/changes/retrieve-inject-hook/proposal.md
@@ -1,0 +1,111 @@
+## Why
+
+exomem's `UserPromptSubmit` hook (`kb_retrieve_nudge.py`, wired via
+`kb-retrieve-nudge.sh`) currently injects an **instruction**: a one-line reminder
+telling Claude to run `find` before answering. That is a nudge, not a guarantee —
+the model can (and over a long thread, does) forget or skip it. Competitor analysis
+(engram-memory) found that the one genuinely mechanistic layer they have is recall
+**injection**: retrieved content placed directly into context, with zero model
+action required to benefit from it.
+
+exomem already has the ideal payload for this, at zero extra cost to compute:
+`find(detail="compact")` routing stubs (`path`, `type`, `scope`, `title`,
+`updated`, plus lifecycle/media markers — no `excerpt`, no `signals`), designed
+from the ground up to be token-cheap (~15-40 tokens/hit). This upgrades the
+retrieve hook from nudge-only to **score-gated retrieve-and-inject**: on a
+substantial prompt, fetch the top-3 compact stubs for it and inject them as
+`additionalContext` alongside the existing reminder — so relevant prior KB
+pages are already in front of the model before it decides whether to search.
+
+This must not regress installs where fast retrieval isn't available. Two real
+constraints rule out a naive "always call `find`" design:
+
+1. `UserPromptSubmit` **blocks model start until the hook returns** — the hook
+   must stay fast (this is already why the existing hooks are gated + stdlib-only).
+2. exomem's own hook scripts are deliberately **stdlib-only and decoupled from the
+   `exomem` package** — they run under whatever `python3`/`python` the user's shell
+   resolves, which is not guaranteed to be the interpreter/venv that has `exomem`
+   (or its heavy dependencies) installed.
+
+The design below (a REST-first, keyword-mode-only, opt-in ladder with a
+nudge-only floor) is chosen specifically to respect both constraints.
+
+## What Changes
+
+- `kb_retrieve_nudge.py` gains an **inject mode**, upgraded in place (no new
+  sibling hook, no new registered `UserPromptSubmit` entry) behind
+  `KB_RETRIEVE_INJECT` (opt-in, default off — byte-identical behavior to today
+  when unset). This keeps one hook, one settings.json entry, one cooldown clock.
+- **Transport ladder**, evaluated in order, first usable rung wins:
+  1. **REST** — if `EXOMEM_REST_API_KEY` is set in the hook's own environment,
+     POST `http://127.0.0.1:8765/api/find` with a short (2s) socket timeout,
+     `{"query": <prompt>, "detail": "compact", "limit": 3, "mode": "keyword"}`,
+     `Authorization: Bearer <key>`. Fast (service is already warm) and the
+     common case for anyone who already runs the REST facade.
+  2. **CLI (opt-in)** — only if `KB_RETRIEVE_INJECT_CLI` is also set truthy:
+     locate the `exomem` (or `kb`) console script on `PATH` and run
+     `exomem find --detail compact --limit 3 --mode keyword --json <prompt>`
+     with a generous (5s) subprocess timeout. This works on any install but pays
+     Python/import cold-start plus a corpus walk per prompt, so it stays opt-in.
+  3. **Nudge-only (floor)** — REST not configured/unreachable and CLI not opted
+     in: identical output to today. The hook body never blocks or errors past
+     this point; any transport failure falls straight through to this rung.
+- **Keyword mode only**, never hybrid/vector: no embeddings, no GPU, no
+  model-warm-up coupling (`find`'s hybrid path can itself report `warming` while
+  models load — the hook must never depend on that state). Pure-substrate: this
+  capability runs no model; it places an already-computed BM25/substring lexical
+  match into context, with zero added reasoning.
+- **Score/relevance gating**: zero compact hits → inject nothing beyond the
+  existing one-line reminder (today's behavior, unchanged). Hits are capped at 3
+  (the query's own `limit=3`) and the formatted block is capped at ~400 chars.
+  Stubs only — `detail="compact"` structurally omits `excerpt`/`signals`, so no
+  separate excerpt-stripping guard is needed; body/full content is never fetched
+  or injected.
+- The prompt-length gate reuses the existing `KB_RETRIEVE_NUDGE_MIN_CHARS`
+  (default 20) and the existing per-session cooldown
+  (`KB_RETRIEVE_NUDGE_COOLDOWN_SEC`, default 300) unchanged — inject mode is a
+  payload upgrade on the same trigger, not a new, independently-firing trigger.
+- `install_hook.py` wiring is structurally unchanged: same `_HOOK_SPECS` tuple,
+  same `UserPromptSubmit` registration, same default hook `timeout` (10s, ample
+  headroom over both the 2s REST and 5s CLI transport timeouts).
+- Docs: SETUP-LOCAL's hooks section and README's one-liner gain the inject
+  opt-in and its env vars. Scaffold/reference docs stay generic — no change
+  needed there (the hook script content is already covered by the existing
+  leak-guard).
+
+Out of scope: hybrid/vector retrieval from a hook, a separate always-on
+retrieval daemon, injecting excerpts or full page bodies, and any change to
+`find`'s ranking, registry, or REST/CLI surface mechanics themselves.
+
+## Capabilities
+
+### Added Capabilities
+
+- `retrieve-inject-hook`: score-gated retrieve-and-inject upgrade to the
+  `UserPromptSubmit` KB hook — a REST-first, keyword-mode-only transport ladder
+  that injects top-3 compact routing stubs (or falls back to today's
+  reminder-only nudge) with no server-side reasoning added.
+
+## Impact
+
+- Code: `src/exomem/_hooks/kb_retrieve_nudge.py` only (in place). No change to
+  `src/exomem/_hooks/kb-retrieve-nudge.sh` (still a thin interpreter-resolving
+  exec wrapper), `src/exomem/install_hook.py`, `find.py`, `commands.py`, or
+  `server.py` — this change consumes the existing `find(detail="compact")` /
+  `/api/find` / CLI `find` surfaces as-is, it does not modify them.
+- No capability in `openspec/specs/` currently owns hook behavior — the
+  capture/retrieve nudge hooks predate this repo's spec-driven process (added
+  in `a5400ef`/`6ace72b`, before `openspec/` existed). This proposal adds
+  `retrieve-inject-hook` as a new capability to give the `UserPromptSubmit`
+  hook's retrieve-and-inject contract a durable spec; it does not touch
+  `install-readiness` (uv/doctor local-setup concerns) or any `find-*`
+  capability (ranking/registry internals), since neither owns hook behavior and
+  neither is modified here.
+- Docs: `SETUP-LOCAL.md` section 7 ("Make the KB automatic") and `README.md`'s
+  hook one-liner gain the inject opt-in and its tuning env vars.
+- Tests: `tests/test_install_hook.py` additions for the byte-identical default
+  (`KB_RETRIEVE_INJECT` unset) case, plus a new `tests/test_retrieve_inject.py`
+  covering the transport ladder and formatting as pure-logic unit tests
+  (network/subprocess calls mocked at a module-level seam — no real network
+  call in the suite), matching the `doctor.py`/`test_doctor_probe.py`
+  monkeypatched-seam precedent.

--- a/openspec/changes/retrieve-inject-hook/specs/retrieve-inject-hook/spec.md
+++ b/openspec/changes/retrieve-inject-hook/specs/retrieve-inject-hook/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: Recall Injection Defaults Off
+
+The `UserPromptSubmit` retrieve hook (`kb_retrieve_nudge.py`) SHALL keep its
+current reminder-only `additionalContext` behavior unchanged unless
+`KB_RETRIEVE_INJECT` is set truthy (per the repo's `_env_flag` truthy-parse
+convention: unset, `""`, `0`, `false`, `no`, `off` — any case — count as unset).
+No inject-mode code path SHALL be reached, and no network or subprocess call
+SHALL be attempted, when `KB_RETRIEVE_INJECT` is unset.
+
+#### Scenario: Default install is untouched
+
+- **WHEN** `KB_RETRIEVE_INJECT` is not set in the hook's environment
+- **THEN** a `UserPromptSubmit` event that passes the existing min-chars and
+  cooldown gates produces the exact same `additionalContext` reminder string
+  the hook produces today
+- **AND** no REST request or CLI subprocess is attempted
+
+### Requirement: REST-First Transport When Configured And Reachable
+
+The hook SHALL attempt exactly one `POST http://127.0.0.1:8765/api/find` request
+(`detail=compact`, `mode=keyword`, `limit=3`, `Authorization: Bearer
+<EXOMEM_REST_API_KEY>`) with a socket timeout of about 2 seconds, before
+considering any other transport, whenever `KB_RETRIEVE_INJECT` is truthy and
+`EXOMEM_REST_API_KEY` is present in the hook's own environment. The hook SHALL
+treat any failure of that request (connection error, timeout, non-200 status,
+malformed JSON, or an envelope with `success: false`) as "REST unreachable."
+
+#### Scenario: REST configured and reachable
+
+- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, and
+  the local REST facade answers with `{"success": true, "data": [...compact
+  hits...]}`
+- **THEN** the hook's `additionalContext` includes a routing-stub block built
+  from those hits
+- **AND** the CLI transport is never attempted
+
+#### Scenario: REST configured but unreachable, CLI not opted in
+
+- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, the
+  REST request fails (any of: connection error, timeout, non-200, malformed
+  JSON, `success: false`), and `KB_RETRIEVE_INJECT_CLI` is not set truthy
+- **THEN** the hook falls back to today's reminder-only `additionalContext`
+- **AND** no CLI subprocess is attempted
+
+### Requirement: Opt-In CLI Transport Fallback
+
+The hook SHALL locate an installed `exomem` or `kb` console script via `PATH`
+lookup and invoke it as `find --detail compact --limit 3 --mode keyword --json
+<prompt>` (subprocess timeout of about 5 seconds) whenever REST was not
+attempted (no `EXOMEM_REST_API_KEY`) or failed, and `KB_RETRIEVE_INJECT_CLI` is
+set truthy. The hook SHALL treat any failure of that invocation (console
+script not found, non-zero exit, malformed JSON, timeout) the same as "no
+hits."
+
+#### Scenario: REST unconfigured, CLI transport opted in
+
+- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
+  `KB_RETRIEVE_INJECT_CLI` is truthy, and an `exomem` or `kb` console script is
+  resolvable on `PATH`
+- **THEN** the hook invokes that console script's `find` command and, on
+  success, includes a routing-stub block built from its compact hits in
+  `additionalContext`
+
+#### Scenario: Neither REST nor CLI transport available
+
+- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
+  `KB_RETRIEVE_INJECT_CLI` is not set truthy (or no `exomem`/`kb` console
+  script resolves on `PATH`)
+- **THEN** the hook falls back to today's reminder-only `additionalContext`
+- **AND** no REST request or CLI subprocess is attempted
+
+### Requirement: Zero Results Inject Nothing Extra
+
+The hook SHALL inject nothing beyond the existing one-line reminder — never an
+empty stub-block header, never a "no results" message — when the active
+transport returns zero compact hits for the prompt.
+
+#### Scenario: A resolved transport returns no hits
+
+- **WHEN** inject mode is active and the REST or CLI transport succeeds but
+  returns zero hits
+- **THEN** `additionalContext` is exactly today's reminder-only text, with no
+  additional stub-block header or placeholder
+
+### Requirement: Injected Content Is Bounded, Stub-Only Routing Data
+
+The injected block SHALL contain only routing-stub fields already present in
+`find(detail="compact")` output (`path`, `type`, `updated`, and any other
+compact-dict field) — never `excerpt`, `signals`, or any other page body/text.
+It SHALL show at most 3 hits and SHALL be truncated to approximately 400
+characters if the formatted block would otherwise exceed that.
+
+#### Scenario: Three or fewer hits are shown verbatim
+
+- **WHEN** the active transport returns 1 to 3 compact hits
+- **THEN** the injected block contains one line per hit, in the order
+  returned, each showing only `path`, `type`, and `updated`
+- **AND** no hit's `excerpt` or `signals` (neither requested nor present in
+  compact mode) appears anywhere in the block
+
+#### Scenario: An oversized block is truncated, never hit-count-limited beyond 3
+
+- **WHEN** the formatted routing-stub block (3 hits, long titles/paths) would
+  exceed approximately 400 characters
+- **THEN** the block is truncated to approximately 400 characters with a
+  trailing truncation marker
+- **AND** the request itself never asked for more than 3 hits (`limit=3`)
+
+### Requirement: Injection Reuses The Existing Prompt-Length Gate And Cooldown
+
+Inject mode SHALL reuse `KB_RETRIEVE_NUDGE_MIN_CHARS` (checked before any
+transport is attempted) and the existing per-session cooldown
+(`KB_RETRIEVE_NUDGE_COOLDOWN_SEC`) exactly as the reminder-only path does
+today. Inject mode SHALL NOT introduce a second, independent trigger or a
+second cooldown clock.
+
+#### Scenario: A trivial prompt skips inject mode entirely
+
+- **WHEN** `KB_RETRIEVE_INJECT` is truthy and the prompt is shorter than
+  `KB_RETRIEVE_NUDGE_MIN_CHARS`
+- **THEN** the hook produces no `additionalContext` at all
+- **AND** no REST request or CLI subprocess is attempted
+
+#### Scenario: The per-session cooldown suppresses a second fire
+
+- **WHEN** inject mode fired (REST or CLI) once for a session and a second
+  qualifying prompt arrives before `KB_RETRIEVE_NUDGE_COOLDOWN_SEC` has
+  elapsed
+- **THEN** the second call produces no `additionalContext`
+- **AND** no REST request or CLI subprocess is attempted for that second call
+
+### Requirement: The Hook Never Blocks Indefinitely Or Raises
+
+Every transport attempt SHALL be wrapped so that any exception (network
+error, timeout, subprocess failure, malformed JSON) is caught and treated as
+"no hits from this rung," never propagated. The hook process SHALL always
+exit `0`.
+
+#### Scenario: An unexpected transport error still exits cleanly
+
+- **WHEN** the REST or CLI transport raises any exception not explicitly
+  anticipated (e.g. a DNS failure, a broken pipe)
+- **THEN** the hook catches it, treats that rung as failed, proceeds to the
+  next rung or the nudge-only floor
+- **AND** the hook process exits `0` with no traceback on stderr affecting the
+  Claude Code session

--- a/openspec/changes/retrieve-inject-hook/tasks.md
+++ b/openspec/changes/retrieve-inject-hook/tasks.md
@@ -1,0 +1,131 @@
+# Tasks — Retrieve-Inject Hook
+
+## 1. Tests First (pure-logic, seams mocked — no real network/subprocess calls)
+
+- [x] 1.1 Add `tests/test_retrieve_inject.py`. Import `kb_retrieve_nudge.py` as a
+      module (it is not a package — use
+      `importlib.util.spec_from_file_location` against
+      `Path(exomem.__file__).parent / "_hooks" / "kb_retrieve_nudge.py"`, the
+      same script path `test_install_hook.py` already resolves for its
+      subprocess tests) so seam functions can be monkeypatched in-process,
+      matching the `doctor_module._probe_get` monkeypatch precedent in
+      `tests/test_doctor_probe.py`.
+- [x] 1.2 Add `_env_flag`-equivalent truthy-parse unit tests for
+      `KB_RETRIEVE_INJECT` / `KB_RETRIEVE_INJECT_CLI`: unset/`""`/`0`/`false`/
+      `no`/`off` (any case) → disabled; anything else → enabled.
+- [x] 1.3 Add unit tests for the stub-block formatter (e.g.
+      `_format_inject_block(hits) -> str`): 0 hits → `""`; 1-3 hits → one
+      `- path (type, updated)` line per hit in input order; a block that would
+      exceed ~400 chars is truncated to ~400 chars with a trailing marker;
+      output never contains `excerpt` text (guard against a future caller
+      accidentally passing full hit dicts instead of compact ones).
+- [x] 1.4 Add unit tests for the REST seam (e.g. `_fetch_via_rest(prompt,
+      api_key, timeout) -> list[dict] | None`) with the actual HTTP call
+      monkeypatched: success (`{"success": true, "data": [...]}` → hit list),
+      `{"success": false, ...}` → `None`, non-200 → `None`, connection
+      error/timeout → `None` (never raises).
+- [x] 1.5 Add unit tests for the CLI seam (e.g. `_fetch_via_cli(prompt, limit,
+      timeout) -> list[dict] | None`) with `shutil.which` and the subprocess
+      call both monkeypatched: `exomem` resolvable → invoked with
+      `find --detail compact --limit 3 --mode keyword --json <prompt>` and its
+      JSON stdout parsed; neither `exomem` nor `kb` resolvable → `None` without
+      attempting a subprocess call; non-zero exit / malformed JSON / timeout →
+      `None` (never raises).
+- [x] 1.6 Add ladder-decision unit tests (calling the script's top-level
+      decision function directly, with `_fetch_via_rest`/`_fetch_via_cli`
+      monkeypatched, not real network/subprocess): REST configured+reachable →
+      REST hits used, CLI seam never called; REST configured but failing +
+      `KB_RETRIEVE_INJECT_CLI` unset → nudge-only, CLI seam never called; REST
+      unconfigured + `KB_RETRIEVE_INJECT_CLI` set → CLI hits used; neither
+      configured → nudge-only, neither seam called.
+- [x] 1.7 Add a subprocess-level black-box test (matching the existing
+      `test_install_hook.py` `_run(RETRIEVE_SCRIPT, event, home)` pattern) that
+      `KB_RETRIEVE_INJECT` unset produces byte-identical stdout to the current
+      un-augmented behavior for the same fixture inputs already covered by
+      `test_retrieve_fires_on_substantial_prompt` /
+      `test_retrieve_silent_on_short_prompt` /
+      `test_retrieve_cooldown_suppresses_second_fire` in
+      `tests/test_install_hook.py` — proving the default-off path is untouched
+      end-to-end, not just at the unit level.
+- [x] 1.8 Run the new test file (expected to fail/error against the
+      not-yet-implemented seams — TDD red) before starting section 2.
+
+## 2. Hook Script Implementation (`src/exomem/_hooks/kb_retrieve_nudge.py`)
+
+- [x] 2.1 Add the `_env_flag`-equivalent truthy parser (mirrors
+      `extract.py::_env_flag`'s `_FALSY_ENV = {"", "0", "false", "no", "off"}`
+      convention) and gate the whole inject path behind
+      `_env_flag("KB_RETRIEVE_INJECT")`; when falsy, fall through to today's
+      exact code path unchanged.
+- [x] 2.2 Add `_fetch_via_rest(prompt, api_key, limit=3, timeout=2.0) ->
+      list[dict] | None` using stdlib `urllib.request`/`urllib.error` only (no
+      new dependency): `POST http://127.0.0.1:8765/api/find`,
+      `Content-Type: application/json`, `Authorization: Bearer <api_key>`,
+      body `{"query": prompt, "detail": "compact", "limit": limit, "mode":
+      "keyword"}`; parse the `{"success", "data"}` envelope; return `None` on
+      any failure (never raise).
+- [x] 2.3 Add `_fetch_via_cli(prompt, limit=3, timeout=5.0) -> list[dict] |
+      None`: resolve `shutil.which("exomem") or shutil.which("kb")`; if
+      neither resolves, return `None` immediately (no subprocess spawned); else
+      run `[resolved, "find", "--detail", "compact", "--limit", str(limit),
+      "--mode", "keyword", "--json", prompt]` via `subprocess.run(...,
+      capture_output=True, text=True, timeout=timeout)` and parse its JSON
+      stdout the same way as 2.2; return `None` on any failure (never raise).
+- [x] 2.4 Add `_format_inject_block(hits: list[dict]) -> str`: `""` for empty
+      `hits`; else a short header ("KB routing stubs — verify with `get`
+      before relying on these:") plus one `- path (type, updated)` line per hit
+      (using the compact-dict fields already present:
+      `path`/`type`/`updated`), truncated to ~400 chars total.
+- [x] 2.5 Wire the ladder into `main()`: after the existing min-chars and
+      cooldown gates pass, if inject is enabled, attempt REST (only when
+      `EXOMEM_REST_API_KEY` is set) then, only on REST failure/absence, CLI
+      (only when `KB_RETRIEVE_INJECT_CLI` is truthy); build
+      `additionalContext` as the stub block (if any hits) followed by the
+      existing `REMINDER` text; when inject is disabled or every rung is
+      unusable/empty, emit exactly today's `REMINDER`-only output.
+- [x] 2.6 Update the module docstring's "Tunables (env)" list to document
+      `KB_RETRIEVE_INJECT` and `KB_RETRIEVE_INJECT_CLI`, matching the existing
+      docstring style.
+- [x] 2.7 Confirm no change to `kb-retrieve-nudge.sh` or `install_hook.py` is
+      needed (both already generic over "whatever `kb_retrieve_nudge.py`
+      prints"); re-read both to double check.
+- [x] 2.8 Run `tests/test_retrieve_inject.py` and the retrieval-gate tests in
+      `tests/test_install_hook.py` until green (TDD green).
+
+## 3. Docs
+
+- [x] 3.1 Update `SETUP-LOCAL.md` section 7 ("Make the KB automatic — both
+      directions") to describe the inject upgrade: what it adds over the
+      plain reminder, the `KB_RETRIEVE_INJECT=1` / `KB_RETRIEVE_INJECT_CLI=1`
+      opt-ins, the REST-first/CLI-opt-in/nudge-only ladder in one or two
+      sentences, and the requirement to export `EXOMEM_REST_API_KEY` in the
+      same shell/profile Claude Code inherits from for the REST rung to be
+      used.
+- [x] 3.2 Update `README.md`'s hook one-liner (the `install-hook` bullet under
+      "Read") with a one-line mention of the inject opt-in, pointing to
+      SETUP-LOCAL for details — matching how README already defers detail to
+      SETUP-LOCAL elsewhere.
+- [x] 3.3 Confirm no scaffold/reference doc under `src/exomem/_scaffold/`
+      mentions the retrieve hook's exact behavior (it doesn't, per the current
+      hooks section living only in SETUP-LOCAL/README); no scaffold edit
+      needed, but record that this was checked.
+
+## 4. Validation
+
+- [x] 4.1 Run `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q -k "retrieve_inject or install_hook"`
+      focused, then the full suite:
+      `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q`.
+- [ ] 4.2 Run `uv run ruff check`. NOT run this pass: the task instructions this
+      change was implemented under explicitly prohibited `uv sync`/`uv run`
+      (lock churn), and this worktree's `.venv` has no standalone `ruff`
+      module/executable. Reviewed the two changed/added files
+      (`kb_retrieve_nudge.py`, `test_retrieve_inject.py`) by hand instead
+      (import ordering, no unused imports, consistent style with neighboring
+      hook code). Re-run `uv run ruff check` once lock churn is acceptable.
+- [x] 4.3 Confirm `KB_RETRIEVE_INJECT` unset reproduces byte-identical output
+      to the pre-change script for every existing `test_install_hook.py`
+      retrieval-gate fixture (task 1.7's assertion, re-checked here as a final
+      gate).
+- [x] 4.4 Run `npm exec --yes @fission-ai/openspec -- validate retrieve-inject-hook --strict`,
+      then `npm exec --yes @fission-ai/openspec -- validate --changes --strict`
+      until both are clean.

--- a/src/exomem/_hooks/kb_retrieve_nudge.py
+++ b/src/exomem/_hooks/kb_retrieve_nudge.py
@@ -8,13 +8,26 @@ prompt, it injects a one-line reminder to run `find` first and fold prior
 conclusions into the answer, so the KB actually functions as the source of truth.
 
 Language-agnostic and cheap: gates on prompt length + a per-session cooldown, no
-keywords. It injects only a *reminder* — Claude still runs the real (semantic)
-find — so it never stalls the prompt. (UserPromptSubmit blocks model start until
-the hook returns, so the hook must be fast: stdlib only, no search here.)
+keywords. By default it injects only a *reminder* — Claude still runs the real
+(semantic) find — so it never stalls the prompt. (UserPromptSubmit blocks model
+start until the hook returns, so the hook must be fast: stdlib only, no search
+here by default.)
+
+Opt-in **inject mode** (`KB_RETRIEVE_INJECT`) upgrades the reminder to real
+retrieved content: on the same gated prompt, it fetches the top compact routing
+stubs (`find(detail="compact")`, keyword mode only — no embeddings, no GPU) via a
+short transport ladder — REST first (`EXOMEM_REST_API_KEY` in this env), then an
+opt-in CLI fallback (`KB_RETRIEVE_INJECT_CLI`) — and appends them to the
+reminder. Any transport failure (or the flag being off) falls straight through to
+the reminder-only floor; the hook never blocks or raises past that point.
 
 Tunables (env): KB_RETRIEVE_NUDGE_DISABLE=1 (off), KB_RETRIEVE_NUDGE_MIN_CHARS
 (default 20 — short, since prompts are short and a dense script like Japanese
-packs more per char), KB_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300).
+packs more per char), KB_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300),
+KB_RETRIEVE_INJECT (opt-in, default off — truthy-parsed: unset/""/"0"/"false"/
+"no"/"off", any case, count as off) to turn on retrieve-and-inject, and
+KB_RETRIEVE_INJECT_CLI (opt-in, same truthy parse) to additionally allow the
+slower CLI transport when REST isn't configured or fails.
 
 Contract (Claude Code UserPromptSubmit hook): read the event JSON on stdin (incl.
 `prompt`); on exit 0, print
@@ -28,8 +41,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 import time
+import urllib.request
 from pathlib import Path
 
 REMINDER = (
@@ -41,6 +57,25 @@ REMINDER = (
     "searched,' not 'doesn't exist.' If the prompt plainly has no KB bearing "
     "(chit-chat, or a fresh task with no prior notes), skip silently."
 )
+
+# Inject-mode routing-stub block: header + up to 3 `- path (type, updated)` lines,
+# capped to keep the worst case (long titles/paths) small and predictable.
+_STUB_HEADER = "KB routing stubs — verify with `get` before relying on these:"
+_STUB_BLOCK_MAX_CHARS = 400
+
+# Local mirror of extract.py::_env_flag's truthy-parse convention. This script
+# deliberately never imports exomem (see module docstring), so the helper is
+# duplicated rather than shared.
+_FALSY_ENV = {"", "0", "false", "no", "off"}
+
+
+def _env_flag(name: str) -> bool:
+    """Truthy opt-in parse: unset, '', '0', 'false', 'no', 'off' (any case) → False.
+
+    A bare presence/truthiness check would read `KB_RETRIEVE_INJECT=0` as opted in —
+    the same bug class fixed elsewhere in this repo (extract.py::_env_flag).
+    """
+    return os.environ.get(name, "").strip().lower() not in _FALSY_ENV
 
 
 def _env_int(name: str, default: int) -> int:
@@ -83,6 +118,125 @@ def _log(prompt: str) -> None:
         pass
 
 
+# --- inject mode: transport ladder (REST -> CLI -> nudge-only floor) -------------
+
+
+def _parse_hits(payload) -> list[dict] | None:
+    """Extract a compact-hit list from a parsed JSON payload. Accepts either the
+    shared {"success", "data"} envelope (what both REST and `--json` CLI actually
+    print) or a bare list, defensively. `None` means "not usable" (caller falls
+    through); never raises."""
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        if payload.get("success") is True and isinstance(payload.get("data"), list):
+            return payload["data"]
+        return None
+    return None
+
+
+def _fetch_via_rest(
+    prompt: str, api_key: str, limit: int = 3, timeout: float = 2.0
+) -> list[dict] | None:
+    """One POST to the local REST facade's `/api/find` (keyword mode, compact
+    detail). Returns the compact hit list, or `None` on ANY failure — connection
+    error, timeout, non-200, malformed JSON, `success: false` — never raises."""
+    host = os.environ.get("EXOMEM_HOST") or "127.0.0.1"
+    url = f"http://{host}:8765/api/find"
+    body = json.dumps(
+        {"query": prompt, "detail": "compact", "limit": limit, "mode": "keyword"}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.getcode()
+            raw = resp.read()
+        if status != 200:
+            return None
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    return _parse_hits(payload)
+
+
+def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[dict] | None:
+    """Locate the installed `exomem`/`kb` console script and run its `find`
+    subcommand. Returns the compact hit list, or `None` on ANY failure — script
+    not found, non-zero exit, malformed JSON, timeout — never raises. Never falls
+    back to `sys.executable -m exomem`: this hook's interpreter is not assumed to
+    have `exomem` importable."""
+    script = shutil.which("exomem") or shutil.which("kb")
+    if not script:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                script, "find",
+                "--detail", "compact",
+                "--limit", str(limit),
+                "--mode", "keyword",
+                "--json", prompt,
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=timeout,
+        )
+        if proc.returncode != 0:
+            return None
+        payload = json.loads(proc.stdout)
+    except Exception:
+        return None
+    return _parse_hits(payload)
+
+
+def _gather_hits(prompt: str) -> list[dict]:
+    """Transport ladder decision: REST first (only when `EXOMEM_REST_API_KEY` is
+    set), CLI only when REST wasn't attempted/failed AND `KB_RETRIEVE_INJECT_CLI`
+    is truthy. Returns [] when neither rung is usable, or when the resolved
+    transport itself reports zero hits (caller renders that as "nothing extra")."""
+    api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
+    if api_key:
+        hits = _fetch_via_rest(prompt, api_key)
+        if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
+            return hits
+    if _env_flag("KB_RETRIEVE_INJECT_CLI"):
+        hits = _fetch_via_cli(prompt)
+        if hits is not None:
+            return hits
+    return []
+
+
+def _format_inject_block(hits: list[dict]) -> str:
+    """Render up to 3 compact hits as `- path (type, updated)` lines under a
+    header, truncated to ~400 chars total. `""` for no hits — the caller must
+    never inject an empty header or a "no results" placeholder. Only reads the
+    `path`/`type`/`updated` compact-dict fields (never `excerpt`/`signals`)."""
+    lines: list[str] = []
+    for hit in hits[:3]:
+        if not isinstance(hit, dict):
+            continue
+        path = hit.get("path")
+        if not path:
+            continue
+        meta = ", ".join(str(v) for v in (hit.get("type"), hit.get("updated")) if v)
+        lines.append(f"- {path} ({meta})" if meta else f"- {path}")
+    if not lines:
+        return ""
+    block = "\n".join([_STUB_HEADER, *lines])
+    if len(block) > _STUB_BLOCK_MAX_CHARS:
+        block = block[: _STUB_BLOCK_MAX_CHARS - 1].rstrip() + "…"
+    return block
+
+
 def main() -> int:
     if os.environ.get("KB_RETRIEVE_NUDGE_DISABLE"):
         return 0
@@ -108,9 +262,23 @@ def main() -> int:
 
     _touch(stamp)
     _log(prompt)
+
+    additional_context = REMINDER
+    if _env_flag("KB_RETRIEVE_INJECT"):
+        # Inject mode is a payload upgrade on this same gate, not a second
+        # trigger — REST/CLI are only ever attempted past this point. Any
+        # unanticipated failure here must still fall through to the
+        # reminder-only floor, never raise past the hook.
+        try:
+            block = _format_inject_block(_gather_hits(prompt))
+        except Exception:
+            block = ""
+        if block:
+            additional_context = REMINDER + "\n\n" + block
+
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
-        "additionalContext": REMINDER,
+        "additionalContext": additional_context,
     }}))
     return 0
 

--- a/tests/test_retrieve_inject.py
+++ b/tests/test_retrieve_inject.py
@@ -1,0 +1,578 @@
+"""`kb_retrieve_nudge.py`'s opt-in retrieve-and-inject upgrade (KB_RETRIEVE_INJECT).
+
+The hook is a standalone, stdlib-only script — not a package member — so it is
+loaded via `importlib.util.spec_from_file_location` (matching how
+`tests/test_install_hook.py` resolves `RETRIEVE_SCRIPT` for its subprocess
+tests) to get an in-process module whose seam functions
+(`_fetch_via_rest` / `_fetch_via_cli` / the stdlib `urllib.request.urlopen` /
+`subprocess.run` / `shutil.which`) can be monkeypatched — the same seam
+precedent as `doctor_module._probe_get` in `tests/test_doctor_probe.py`. No
+real network request or subprocess is ever spawned by this suite; the one
+exception is the final subprocess-level black-box check, which spawns the
+*script itself* (like `test_install_hook.py` already does) purely to prove the
+default-off path is untouched end-to-end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import urllib.request as urllib_request
+from pathlib import Path
+
+import pytest
+
+import exomem
+
+RETRIEVE_SCRIPT = Path(exomem.__file__).parent / "_hooks" / "kb_retrieve_nudge.py"
+
+
+def _load_hook_module():
+    spec = importlib.util.spec_from_file_location("kb_retrieve_nudge_under_test", RETRIEVE_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook_mod = _load_hook_module()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test starts from a known-clean env — a real EXOMEM_REST_API_KEY or
+    KB_RETRIEVE_INJECT already set on the host machine must never leak in."""
+    for var in (
+        "KB_RETRIEVE_NUDGE_DISABLE",
+        "KB_RETRIEVE_NUDGE_MIN_CHARS",
+        "KB_RETRIEVE_NUDGE_COOLDOWN_SEC",
+        "KB_RETRIEVE_INJECT",
+        "KB_RETRIEVE_INJECT_CLI",
+        "EXOMEM_REST_API_KEY",
+        "EXOMEM_HOST",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class _FakeResponse:
+    """Minimal stand-in for the context-managed object `urllib.request.urlopen`
+    returns: `.getcode()` + `.read()`, usable in a `with ... as resp:` block."""
+
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+def _envelope_bytes(hits: list[dict]) -> bytes:
+    return json.dumps({"success": True, "data": hits}).encode("utf-8")
+
+
+def _call_main(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, event: dict, home: Path) -> str:
+    """Invoke the loaded module's `main()` in-process with a fake stdin and HOME,
+    so cooldown/log state lands under `home` and seam monkeypatches apply."""
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr(hook_mod.sys, "stdin", io.StringIO(json.dumps(event)))
+    hook_mod.main()
+    return capsys.readouterr().out
+
+
+# --- truthy-parse (_env_flag) ----------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "No", "OFF", "off"])
+def test_env_flag_falsy_values_are_disabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", value)
+    assert hook_mod._env_flag("KB_RETRIEVE_INJECT") is False
+
+
+def test_env_flag_unset_is_disabled() -> None:
+    assert hook_mod._env_flag("KB_RETRIEVE_INJECT_DOES_NOT_EXIST") is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "anything"])
+def test_env_flag_truthy_values_are_enabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", value)
+    assert hook_mod._env_flag("KB_RETRIEVE_INJECT_CLI") is True
+
+
+# --- _format_inject_block ---------------------------------------------------------
+
+
+def test_format_inject_block_empty_for_no_hits() -> None:
+    assert hook_mod._format_inject_block([]) == ""
+
+
+def test_format_inject_block_one_line_per_hit_in_order() -> None:
+    hits = [
+        {"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"},
+        {"path": "Notes/b.md", "type": "insight", "updated": "2026-01-02"},
+    ]
+    block = hook_mod._format_inject_block(hits)
+    lines = block.splitlines()
+    assert lines[0] == hook_mod._STUB_HEADER
+    assert lines[1] == "- Notes/a.md (note, 2026-01-01)"
+    assert lines[2] == "- Notes/b.md (insight, 2026-01-02)"
+
+
+def test_format_inject_block_caps_at_three_hits() -> None:
+    hits = [{"path": f"Notes/{i}.md", "type": "note", "updated": "2026-01-01"} for i in range(5)]
+    block = hook_mod._format_inject_block(hits)
+    assert len([ln for ln in block.splitlines() if ln.startswith("- ")]) == 3
+
+
+def test_format_inject_block_omits_missing_fields_gracefully() -> None:
+    block = hook_mod._format_inject_block([{"path": "Notes/only-path.md"}])
+    assert block.splitlines()[1] == "- Notes/only-path.md"
+
+
+def test_format_inject_block_truncates_oversized_block() -> None:
+    long_path = "Knowledge Base/" + ("very-long-segment-" * 15) + "note.md"
+    hits = [{"path": long_path, "type": "note", "updated": "2026-01-01"} for _ in range(3)]
+    block = hook_mod._format_inject_block(hits)
+    assert len(block) <= hook_mod._STUB_BLOCK_MAX_CHARS
+    assert block.endswith("…")
+
+
+def test_format_inject_block_never_contains_excerpt_text() -> None:
+    hits = [{
+        "path": "Notes/a.md", "type": "note", "updated": "2026-01-01",
+        "excerpt": "SENTINEL_EXCERPT_TEXT_SHOULD_NEVER_APPEAR",
+    }]
+    block = hook_mod._format_inject_block(hits)
+    assert "SENTINEL_EXCERPT_TEXT_SHOULD_NEVER_APPEAR" not in block
+    assert "excerpt" not in block.lower()
+
+
+# --- REST seam (_fetch_via_rest) --------------------------------------------------
+
+
+def test_fetch_via_rest_success_returns_hits(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse(200, _envelope_bytes(hits))
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    result = hook_mod._fetch_via_rest("what did I conclude about X?", "secret-key")
+
+    assert result == hits
+    assert captured["url"] == "http://127.0.0.1:8765/api/find"
+    assert captured["method"] == "POST"
+    assert captured["headers"]["Authorization"] == "Bearer secret-key"
+    assert captured["body"] == {
+        "query": "what did I conclude about X?",
+        "detail": "compact",
+        "limit": 3,
+        "mode": "keyword",
+    }
+
+
+def test_fetch_via_rest_respects_exomem_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_HOST", "10.0.0.5")
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _FakeResponse(200, _envelope_bytes([]))
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    hook_mod._fetch_via_rest("prompt", "key")
+    assert captured["url"] == "http://10.0.0.5:8765/api/find"
+
+
+def test_fetch_via_rest_success_false_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req, timeout=None):
+        return _FakeResponse(200, json.dumps({"success": False, "error": {}}).encode())
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    assert hook_mod._fetch_via_rest("prompt", "key") is None
+
+
+def test_fetch_via_rest_non_200_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req, timeout=None):
+        return _FakeResponse(500, b"internal error")
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    assert hook_mod._fetch_via_rest("prompt", "key") is None
+
+
+def test_fetch_via_rest_malformed_json_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req, timeout=None):
+        return _FakeResponse(200, b"{not json")
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    assert hook_mod._fetch_via_rest("prompt", "key") is None
+
+
+def test_fetch_via_rest_connection_error_returns_none_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req, timeout=None):
+        raise ConnectionRefusedError("connection refused")
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    assert hook_mod._fetch_via_rest("prompt", "key") is None
+
+
+def test_fetch_via_rest_timeout_returns_none_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req, timeout=None):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+    assert hook_mod._fetch_via_rest("prompt", "key") is None
+
+
+# --- CLI seam (_fetch_via_cli) ----------------------------------------------------
+
+
+def test_fetch_via_cli_success_invokes_expected_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    captured: dict = {}
+
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem" if name == "exomem" else None)
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps({"success": True, "data": hits}), stderr="")
+
+    monkeypatch.setattr(hook_mod.subprocess, "run", fake_run)
+    result = hook_mod._fetch_via_cli("find my thing")
+
+    assert result == hits
+    assert captured["cmd"] == [
+        "/usr/local/bin/exomem", "find",
+        "--detail", "compact",
+        "--limit", "3",
+        "--mode", "keyword",
+        "--json", "find my thing",
+    ]
+    assert captured["kwargs"]["capture_output"] is True
+    assert captured["kwargs"]["text"] is True
+
+
+def test_fetch_via_cli_falls_back_to_kb_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        hook_mod.shutil, "which",
+        lambda name: "/usr/local/bin/kb" if name == "kb" else None,
+    )
+    monkeypatch.setattr(
+        hook_mod.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout=json.dumps({"success": True, "data": []}), stderr=""),
+    )
+    assert hook_mod._fetch_via_cli("prompt") == []
+
+
+def test_fetch_via_cli_neither_script_resolvable_returns_none_without_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: None)
+
+    def _boom(cmd, **kwargs):
+        raise AssertionError("subprocess.run must not be called when no console script resolves")
+
+    monkeypatch.setattr(hook_mod.subprocess, "run", _boom)
+    assert hook_mod._fetch_via_cli("prompt") is None
+
+
+def test_fetch_via_cli_non_zero_exit_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem")
+    monkeypatch.setattr(
+        hook_mod.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom"),
+    )
+    assert hook_mod._fetch_via_cli("prompt") is None
+
+
+def test_fetch_via_cli_malformed_json_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem")
+    monkeypatch.setattr(
+        hook_mod.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="{not json", stderr=""),
+    )
+    assert hook_mod._fetch_via_cli("prompt") is None
+
+
+def test_fetch_via_cli_timeout_returns_none_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem")
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 5.0))
+
+    monkeypatch.setattr(hook_mod.subprocess, "run", fake_run)
+    assert hook_mod._fetch_via_cli("prompt") is None
+
+
+# --- ladder decision (_gather_hits) -----------------------------------------------
+
+
+def test_gather_hits_rest_reachable_never_calls_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", lambda prompt, api_key, **kw: hits)
+
+    def _boom(*a, **kw):
+        raise AssertionError("_fetch_via_cli must not be called when REST succeeds")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits("prompt") == hits
+
+
+def test_gather_hits_rest_failing_cli_unset_is_nudge_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", lambda prompt, api_key, **kw: None)
+
+    def _boom(*a, **kw):
+        raise AssertionError("_fetch_via_cli must not be called when KB_RETRIEVE_INJECT_CLI is unset")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits("prompt") == []
+
+
+def test_gather_hits_rest_unconfigured_cli_opted_in_uses_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [{"path": "Notes/b.md", "type": "insight", "updated": "2026-01-02"}]
+    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+
+    def _boom(*a, **kw):
+        raise AssertionError("_fetch_via_rest must not be called when EXOMEM_REST_API_KEY is unset")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", lambda prompt, **kw: hits)
+    assert hook_mod._gather_hits("prompt") == hits
+
+
+def test_gather_hits_neither_configured_calls_neither_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*a, **kw):
+        raise AssertionError("no transport seam should be called when neither is configured")
+
+    monkeypatch.setattr(hook_mod, "_fetch_via_rest", _boom)
+    monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
+    assert hook_mod._gather_hits("prompt") == []
+
+
+# --- end-to-end main() wiring ------------------------------------------------------
+
+
+PROMPT = "what did I conclude about the kb hook design earlier?"
+
+
+def test_default_off_no_network_or_subprocess_attempted(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def _boom_url(req, timeout=None):
+        raise AssertionError("urlopen must not be called when KB_RETRIEVE_INJECT is unset")
+
+    def _boom_run(cmd, **kwargs):
+        raise AssertionError("subprocess.run must not be called when KB_RETRIEVE_INJECT is unset")
+
+    monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
+    monkeypatch.setattr(hook_mod.subprocess, "run", _boom_run)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-off"}, home)
+    payload = json.loads(out)
+    assert payload == {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": hook_mod.REMINDER,
+        }
+    }
+
+
+def test_inject_rest_configured_and_reachable_appends_stubs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+    monkeypatch.setattr(urllib_request, "urlopen", lambda req, timeout=None: _FakeResponse(200, _envelope_bytes(hits)))
+
+    def _boom_run(cmd, **kwargs):
+        raise AssertionError("subprocess must not be called when REST succeeds")
+
+    monkeypatch.setattr(hook_mod.subprocess, "run", _boom_run)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-rest-ok"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert ctx.startswith(hook_mod.REMINDER + "\n\n")
+    assert "- Notes/a.md (note, 2026-01-01)" in ctx
+    assert "excerpt" not in ctx.lower()
+
+
+def test_inject_rest_unreachable_cli_not_opted_in_is_nudge_only(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+
+    def _boom_url(req, timeout=None):
+        raise ConnectionRefusedError("connection refused")
+
+    monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-rest-down"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert ctx == hook_mod.REMINDER
+
+
+def test_inject_cli_opt_in_which_resolves_appends_stubs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    hits = [{"path": "Notes/b.md", "type": "insight", "updated": "2026-01-02"}]
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem" if name == "exomem" else None)
+    monkeypatch.setattr(
+        hook_mod.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout=json.dumps({"success": True, "data": hits}), stderr=""),
+    )
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-cli-ok"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "- Notes/b.md (insight, 2026-01-02)" in ctx
+
+
+def test_inject_cli_opt_in_but_unresolvable_is_nudge_only(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setattr(hook_mod.shutil, "which", lambda name: None)
+
+    def _boom_run(cmd, **kwargs):
+        raise AssertionError("subprocess.run must not be called when no console script resolves")
+
+    monkeypatch.setattr(hook_mod.subprocess, "run", _boom_run)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-cli-missing"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert ctx == hook_mod.REMINDER
+
+
+def test_min_chars_gate_short_circuits_before_any_transport(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+
+    def _boom_url(req, timeout=None):
+        raise AssertionError("urlopen must not be called for a trivial prompt")
+
+    monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": "yes go", "session_id": "e2e-short"}, home)
+    assert out.strip() == ""
+
+
+def test_cooldown_gate_short_circuits_second_transport_attempt(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+    call_count = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        call_count["n"] += 1
+        return _FakeResponse(200, _envelope_bytes([]))
+
+    monkeypatch.setattr(urllib_request, "urlopen", fake_urlopen)
+
+    event = {"prompt": PROMPT, "session_id": "e2e-cooldown"}
+    first = _call_main(monkeypatch, capsys, event, home)
+    second = _call_main(monkeypatch, capsys, event, home)
+
+    assert "additionalContext" in first
+    assert second.strip() == ""
+    assert call_count["n"] == 1
+
+
+def test_kb_retrieve_inject_zero_is_disabled_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "0")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+
+    def _boom_url(req, timeout=None):
+        raise AssertionError("urlopen must not be called when KB_RETRIEVE_INJECT=0 (falsy)")
+
+    monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-falsy"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert ctx == hook_mod.REMINDER
+
+
+# --- subprocess-level black box: default-off is byte-identical end-to-end --------
+
+
+def _run_subprocess(event: dict, home: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}
+    for key in ("KB_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT_CLI", "EXOMEM_REST_API_KEY", "EXOMEM_HOST"):
+        env.pop(key, None)
+    return subprocess.run(
+        [sys.executable, str(RETRIEVE_SCRIPT)],
+        input=json.dumps(event), capture_output=True, text=True, env=env,
+    )
+
+
+def test_subprocess_default_off_matches_reminder_only_output(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    r = _run_subprocess({"prompt": PROMPT, "session_id": "sub-1"}, home)
+    payload = json.loads(r.stdout)
+    assert payload == {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": hook_mod.REMINDER,
+        }
+    }
+
+
+def test_subprocess_default_off_silent_on_short_prompt(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    r = _run_subprocess({"prompt": "yes go", "session_id": "sub-2"}, home)
+    assert r.stdout.strip() == ""


### PR DESCRIPTION
## What

Upgrades the read-side `UserPromptSubmit` nudge hook (`kb_retrieve_nudge.py`) in place so that, **behind the opt-in `KB_RETRIEVE_INJECT` flag**, it appends real retrieved KB routing stubs to the reminder instead of only nudging Claude to run `find` itself.

## How

On the same gated prompt (min-chars + per-session cooldown, unchanged), inject mode fetches the top compact hits over a short transport ladder:

1. **REST first** — one `POST http://127.0.0.1:8765/api/find` (keyword mode, `detail=compact`, `limit=3`), Bearer `EXOMEM_REST_API_KEY`, 2s timeout. Only attempted when the key is present in the hook's env.
2. **CLI fallback** — opt-in via `KB_RETRIEVE_INJECT_CLI`: resolves the installed `exomem`/`kb` console script (`shutil.which`) and runs `find --detail compact --limit 3 --mode keyword --json`, 5s timeout. Never `python -m exomem`.
3. **Nudge-only floor** — any failure (flag off, no key, transport down, malformed, zero hits) falls straight through to today's reminder.

Rendered as up to 3 `- path (type, updated)` lines under a header, capped ~400 chars. Stubs only — never the token-heavy `excerpt`/`signals`.

## Safety / compatibility

- **Default-off is byte-identical** to today: unless `KB_RETRIEVE_INJECT` is truthy AND a block is produced, `additionalContext` is the unchanged `REMINDER`. Proven by a subprocess-level black-box test.
- stdlib-only (`urllib.request`, `subprocess`, `shutil`); the hook still never imports exomem and **never raises past the hook** — a crash must not break the session.
- Truthy env parse (`KB_RETRIEVE_INJECT=0` reads as off), mirroring `extract.py::_env_flag`.

## Code-reality confirmation

`/api/find` is real: `find` is a `rest`-surfaced command (`commands.py`), the generic REST handler coerces the JSON body to `op_find`'s params (`query`/`detail`/`limit`/`mode` all exist), and both REST and `--json` CLI return the shared `{"success": true, "data": [...compact dicts...]}` envelope. Compact dicts expose `path`/`type`/`updated` (`find.py::as_compact_dict`).

## Tests

- New `tests/test_retrieve_inject.py` (47 tests): truthy-parse, formatter (cap/truncation/excerpt-guard), REST + CLI seams (success/failure/timeout/malformed), ladder decisions, full `main()` scenarios, and the default-off byte-identical black-box.
- Full suite green (1243 passed / 11 pre-existing env skips); `test_install_hook.py` + `test_scaffold_no_leak.py` green.
- OpenSpec `retrieve-inject-hook` validates `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)