### PR TITLE
feat: publish reproducible retrieval benchmark report

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ store. exomem works the other way around: agents come to your vault.
 For a deeper point-in-time comparison, see
 [docs/comparison-engraph.md](docs/comparison-engraph.md).
 
+**Measured retrieval quality.** Retrieval is graded by a reproducible golden-set
+eval harness, not asserted — methodology and numbers in
+[docs/benchmarks.md](docs/benchmarks.md).
+
 ## Core tools
 
 exomem exposes typed MCP tools for common knowledge-base work:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,93 @@
+# Measured retrieval quality
+
+exomem ships a golden-set eval harness, so retrieval quality is a number you can
+re-derive, not a claim. This page documents the methodology and the measured
+results. It is deliberately transparent about what the numbers are and are not:
+a small, single-vault, self-graded benchmark — strictly more evidence than "no
+published results" or "no harness at all", but not an independent third-party
+benchmark.
+
+> The results table below is filled by a desk-side run against a real vault (it
+> needs the downloaded embedding + reranker models, which CI does not have). The
+> `TODO(real-vault-run)` cells are placeholders, not measurements — see
+> [Reproduction](#reproduction) to generate your own.
+
+## Methodology
+
+- **Harness.** `scripts/eval_retrieval.py --report markdown` runs the golden set
+  once per retrieval mode and emits an aggregate-only markdown report: per-mode
+  ranking-quality metrics, per-mode `find()` latency percentiles, and rounded
+  corpus counts. The report contains no query text, no vault-relative paths, no
+  excerpts, and no per-query rows — only aggregates.
+- **Modes.** Three, at the shipped default ranking config:
+  - `keyword` — lexical (BM25) only.
+  - `hybrid` — lexical + vector fusion (the default).
+  - `hybrid+rerank` — `hybrid` with the cross-encoder reranker on (`rerank=True`;
+    reranking is orthogonal to mode, not a fourth mode).
+- **Metrics.** The four the harness already computes per query and mean-aggregates
+  (`src/exomem/eval_metrics.py`): **NDCG@5**, **NDCG@10**, **MRR**, **recall@10**.
+- **Latency.** Wall-clock `find()` time is sampled by repeating the golden set
+  `--repeat N` times (default 3) per mode and timing each call with
+  `time.perf_counter()`. The report shows the **median** and **p90** (nearest-rank
+  percentile) over that flat sample.
+- **Golden set.** `tests/golden/queries.yaml` — a seed set of **9** hand-authored
+  natural-language queries, each with one or more relevant target pages
+  (`expect_any_of`, or `graded` 0–3 for NDCG). It is designed to grow:
+  `scripts/derive_relevance_pairs.py` proposes additions mined from real
+  (query → cited path) usage, which a human confirms.
+- **Vault scale (rounded).** Reported as counts rounded DOWN to the nearest 10
+  (privacy floor): markdown files (whole vault), KB notes (the pages `find()`
+  indexes), and media artifacts (audio/video/image/pdf).
+- **exomem version / models.** exomem `TODO(real-vault-run)`, embedding model
+  `BAAI/bge-base-en-v1.5`, reranker `BAAI/bge-reranker-base`.
+- **Hardware.** `TODO(real-vault-run)` — CPU / GPU / RAM the published numbers
+  were measured on.
+
+## Results
+
+<!-- Replace every TODO(real-vault-run) cell with a desk-side run's output. -->
+
+- Corpus scale: `TODO(real-vault-run)` markdown files, `TODO(real-vault-run)` KB
+  notes, `TODO(real-vault-run)` media artifacts (rounded down to the nearest 10).
+- Golden set: 9 queries.
+
+| Mode | NDCG@5 | NDCG@10 | MRR | recall@10 | latency median (ms) | latency p90 (ms) |
+|---|---|---|---|---|---|---|
+| keyword | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) |
+| hybrid | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) |
+| hybrid+rerank | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) | TODO(real-vault-run) |
+
+## Reproduction
+
+The report reproduces in the same shape against any vault + golden set that
+follow the harness contract. It needs live vectors (the embedding/reranker
+models), so it is a desk-side command, not a CI step.
+
+Against your own vault and golden queries:
+
+```
+EXOMEM_VAULT_PATH=/path/to/your/Obsidian \
+  python scripts/eval_retrieval.py --report markdown --golden tests/golden/queries.yaml
+```
+
+As a deterministic, smoke-scale run against the bundled sample vault (no private
+vault required — same report shape, tiny corpus):
+
+```
+EXOMEM_VAULT_PATH=tests/fixtures \
+  python scripts/eval_retrieval.py --report markdown
+```
+
+Set `EXOMEM_BENCH_HARDWARE` to record the host in the report's methodology line.
+
+## Limitations
+
+- **Small.** n = 9 golden queries. Individual metric moves are noisy at this size.
+- **Single vault.** Measured against one private vault; results do not
+  generalize to arbitrary corpora.
+- **Self-graded.** Relevance labels are chosen by the vault owner, not by
+  independent annotators — this is a self-measurement, not a third-party
+  benchmark.
+- **Hardware-dependent latency.** The median/p90 numbers reflect one host's
+  CPU/GPU. A third party's latency will differ; the published p90 is not a
+  portable guarantee.

--- a/openspec/changes/publish-retrieval-benchmark/design.md
+++ b/openspec/changes/publish-retrieval-benchmark/design.md
@@ -1,0 +1,177 @@
+# Design - publish retrieval benchmark
+
+## Context
+
+`scripts/eval_retrieval.py` already runs the golden set (`tests/golden/queries.yaml`) against a
+resolved vault (`exomem.vault.resolve_vault()`) with live embeddings forced on, computing
+NDCG@5/NDCG@10/MRR/recall@10 per query via `src/exomem/eval_metrics.py` and mean-aggregating them
+in `_evaluate()`. It already supports `--sweep` (grid search over `RankingConfig` knobs) and a
+`--markdown` flag that prints one table for whichever single run just happened. There is no
+existing multi-mode aggregate table, no latency measurement, and no corpus-stats output anywhere
+in the script.
+
+`find()` (`src/exomem/find.py`) exposes `mode: "keyword" | "hybrid" | "vector"` and an orthogonal
+`rerank: bool | None`, plus an optional `timings: FindTimings | None` recorder populated in place
+(stage spans via `time.perf_counter()`, exposing `total_ms` and per-stage entries) — added by the
+already-implemented `improve-find-latency-token-cost` change. That recorder is designed for a
+single `find()` call's stage breakdown, not for aggregating a latency distribution across many
+calls.
+
+`eval_metrics.py`'s docstring is explicit about staying "pure ranking-quality metrics... No torch,
+no exomem imports" so it's importable in the fast, embeddings-free test suite. That precedent is
+the model for how this change keeps its new reporting logic testable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit one reproducible markdown artifact per harness run: per-mode (keyword/hybrid/hybrid+rerank)
+  aggregate ranking-quality metrics (the four the harness already computes), per-mode latency
+  percentiles, and rounded corpus counts.
+- Keep the published artifact aggregate-only: no golden query text, no vault-relative paths, no
+  excerpts, no per-query rows.
+- Keep the new reporting logic unit-testable on fixture data without a real vault, models, or
+  torch, matching the `eval_metrics.py` precedent.
+- Keep CI's role limited to the ordinary fixture-data unit tests; do not make CI depend on a real
+  vault or downloaded models, and do not gate PRs on retrieval-quality numbers.
+
+**Non-Goals:**
+
+- No change to `find()`'s ranking, default behavior, timing diagnostics, caching, or freshness
+  contracts — this change only adds a reporting mode on top of the existing harness.
+- No adoption of a third-party benchmark harness (e.g. LongMemEval) in this change.
+- No per-query or per-path publication, ever, from `--report markdown`.
+- No new MCP/REST/CLI command-registry surface; `scripts/eval_retrieval.py` stays a standalone
+  dev/eval tool, as it is today.
+
+## Decisions
+
+### The report is a new, additive `--report markdown` mode, not a replacement for `--markdown`
+
+`--report markdown` runs the golden set once per mode in `["keyword", "hybrid", "hybrid+rerank"]`
+(the third being `mode="hybrid", rerank=True`), reusing `_evaluate()` per mode for the four
+existing metrics, and separately samples latency by repeating the golden set `--repeat N` times
+(default small N, e.g. 3) per mode and recording each call's wall-clock time. Existing `--sweep`
+and the current single-run `--markdown` table are untouched — a reader who wants the ranking-knob
+grid search still gets it exactly as today.
+
+Alternative considered: fold benchmark reporting into `--sweep`. Rejected because `--sweep` is a
+ranking-config search tool (rrf_k x compiled_boost x rerank), while the published benchmark is
+about mode comparison at the shipped default config — conflating the two would make `--sweep`'s
+output ambiguous about which config produced the published numbers.
+
+### Latency is measured by direct wall-clock sampling in the harness, not by threading `FindTimings` through
+
+The report only needs an end-to-end latency distribution (median/p90) per mode, not a per-stage
+breakdown. `_evaluate()`/`rank_queries()` wrap each `find_module.find(...)` call with
+`time.perf_counter()` before/after (the same lightweight-span pattern `find.py` itself already
+uses internally for `FindTimings`), collecting a flat list of per-call latencies per mode across
+the `--repeat` runs, then compute median and p90 from that list.
+
+Alternative considered: pass a `FindTimings()` instance into every call and read `.total_ms` off
+it. Rejected because it couples the benchmark script to `FindTimings`' internal per-stage key
+names for a value (`total_ms`) that a bare `time.perf_counter()` delta already gives directly,
+without needing to construct or discard a recorder object per call.
+
+### Corpus counting and report rendering live in a new pure module, not in `eval_retrieval.py` or `eval_metrics.py`
+
+New `src/exomem/eval_report.py`: no torch import, no live-vault network/model access. It exposes:
+
+- `count_corpus_stats(vault_root: Path) -> dict`: a plain filesystem walk that buckets markdown
+  files into rounded counts (e.g. rounded down to the nearest 10) for files/notes/media, so the
+  function's *output* is privacy-safe by construction rather than relying on every caller to round
+  before publishing.
+- `render_benchmark_report(*, corpus: dict, per_mode: dict, golden_n: int, meta: dict) -> str`: a
+  plain-data-in, markdown-string-out function with no vault or query access at all — it cannot
+  leak what it was never given.
+
+`scripts/eval_retrieval.py` calls both from its new `--report markdown` branch; it still owns
+driving `find()` and the golden set (unchanged responsibility).
+
+Alternative considered: add these functions to `eval_metrics.py`. Rejected because that module's
+scope is ranking-quality math (DCG/NDCG/MRR/recall) reused by both the harness and the auto-tuner;
+folding in corpus counting and markdown presentation would blur that module's single concern and
+make its "pure metrics" docstring inaccurate. A sibling module keeps both scopes clean and keeps
+`eval_metrics.py`'s existing tests and callers untouched.
+
+Alternative considered: test `scripts/eval_retrieval.py` directly (via `importlib.util`, the
+pattern `tests/test_scaffold_no_leak.py` already uses for `scripts/genericize-schema.py`).
+Rejected because `eval_retrieval.py`'s module top level currently pops
+`EXOMEM_DISABLE_EMBEDDINGS` and imports `exomem.find`/`exomem.embeddings` unconditionally, as a
+deliberate "this script MUST run with live vectors" guarantee; importing that module from a test
+process would mutate the embeddings-disable env var for the rest of the pytest session and is not
+worth restructuring the script's carefully-ordered head-of-file setup just to make it importable.
+A new pure sibling module sidesteps the problem entirely instead of touching that contract.
+
+### Aggregate-only publication is enforced by giving the pure function no leak-capable inputs, backed by a regression test
+
+`render_benchmark_report()` never receives query strings or paths — its `per_mode` argument is
+`{mode: {"ndcg5": float, "ndcg10": float, "mrr": float, "recall10": float, "latency_median_ms":
+float, "latency_p90_ms": float}}`, and `corpus` is `{"files": int, "notes": int, "media": int}`
+(already rounded). This makes the "no per-query rows, no query text, no paths" contract structural,
+not just a code-review convention. A test still greps the rendered output for every golden query
+string and every golden target path from `tests/golden/queries.yaml` as a regression backstop —
+mirroring `tests/test_scaffold_no_leak.py`'s pattern-denylist posture — in case a future edit
+widens `meta` or `per_mode` to include something leak-capable.
+
+### Golden-set self-eval is published as honest-enough, with limitations stated prominently
+
+The golden set is 9 hand-authored queries against a single private vault, self-graded (the author
+picks the relevant path(s)), and designed to grow via `scripts/derive_relevance_pairs.py` mining +
+human confirmation. `docs/benchmarks.md` states this directly in a Limitations section (n of
+queries, single-vault, self-graded relevance) rather than presenting the numbers as if they came
+from an independent benchmark. This is still strictly more transparent than either comparison
+point in `## Why`: a harness that reports no results, or no harness at all.
+
+Alternative considered: adopt LongMemEval so results are comparable to whichever other project
+publishes against it. Rejected — LongMemEval targets long-horizon conversational memory QA and
+session summarization, a different task shape from exomem's single-shot retrieval over an owned
+markdown vault (typed sources/notes/entities/evidence with provenance and multimodal extraction).
+Bolting on an unrelated benchmark harness for comparability would cost real implementation effort
+for a comparison that doesn't map cleanly onto what exomem's `find()` actually ranks, when the
+existing golden-set harness already measures the retrieval behavior exomem ships today.
+
+Alternative considered: publish per-query rows so a reader can audit individual results. Rejected
+per the Aggregate-Only Publication requirement — per-query rows are 1:1 with golden query text
+and, once the golden set grows from real mined usage, would risk surfacing what a private vault
+actually contains.
+
+### CI runs the new tests but does not gate on retrieval quality
+
+The new `eval_report.py` unit tests (corpus counting against `tests/fixtures/`, rendering against
+synthetic aggregate data, and the privacy-guard grep) are ordinary fast, model-free tests and run
+in the existing lean `pytest -q` CI job like any other test — no new CI job is added. Running
+`--report markdown` against a real vault stays a desk-side command, matching the
+`add-docker-distribution` change's precedent of marking steps that need resources CI doesn't have
+(there: a local Docker daemon; here: a real vault + downloaded embedding/reranker models) as
+explicitly desk-side rather than silently skipped or falsely claimed as covered.
+
+## Risks / Trade-offs
+
+- Latency numbers are host/GPU-dependent and will look different on every machine that reproduces
+  them -> `docs/benchmarks.md`'s methodology states the hardware/versions the published numbers
+  were measured on, and the Limitations section says explicitly that a third party's numbers will
+  differ by hardware, not that the published p90 is a portable guarantee.
+- A future edit to `per_mode`/`meta` could widen `render_benchmark_report()`'s inputs to include
+  something leak-capable (e.g. an excerpt or a path) -> the privacy-guard regression test greps
+  rendered output against every golden query string and target path, so a leak-capable addition
+  fails a fast, already-passing test rather than surfacing only in the published doc.
+- `docs/benchmarks.md`'s results table cannot be filled with real numbers as part of this OpenSpec
+  authoring pass (no vault/model access here) -> `tasks.md` marks that step explicitly as a
+  desk-side, real-vault task to complete at implementation time, not silently left inconsistent
+  with the skeleton.
+- Corpus-count rounding could still be inferred/narrowed across repeated publications over time if
+  the vault grows slowly -> out of scope for this change; noted as a residual risk rather than
+  solved, since the rounding-only contract is materially better than exact counts and no vault
+  content is ever included.
+
+## Migration Plan
+
+No data or schema migration. This is additive dev/eval tooling and documentation; no existing
+`find()` caller, MCP tool, REST route, or CLI command changes shape or behavior. Existing usage of
+`scripts/eval_retrieval.py` without `--report markdown` is unaffected.
+
+## Open Questions
+
+None for implementation. The real-vault run that fills in `docs/benchmarks.md`'s results table is
+explicitly deferred to implementation time (see `tasks.md`), not resolved by this design.

--- a/openspec/changes/publish-retrieval-benchmark/proposal.md
+++ b/openspec/changes/publish-retrieval-benchmark/proposal.md
@@ -1,0 +1,93 @@
+## Why
+
+Neither comparable project publishes retrieval-quality numbers today: a LongMemEval-style
+harness with zero published results is not evidence, and a competitor with no eval harness at
+all is not evidence either. exomem already has a working golden-set eval harness
+(`scripts/eval_retrieval.py`, `tests/golden/queries.yaml`, `src/exomem/eval_metrics.py`) and a
+production-scale vault to run it against. A published, reproducible benchmark artifact —
+methodology plus aggregate metrics — is a low-cost credibility differentiator versus doc-chat/RAG
+apps and other MCP note servers: it turns "we think retrieval is good" into a number a reader can
+re-derive.
+
+This also rides along cheaply with the timing/observability work already landed in
+`improve-find-latency-token-cost`: `find()` already accepts an optional `FindTimings` recorder and
+the harness already drives `find()` directly, so wall-clock latency percentiles per mode are a
+small addition to a harness that already runs the full golden set.
+
+Corrected against code reality (the harness, read in full, wins over any earlier sketch):
+
+- `scripts/eval_retrieval.py` runs `find()` against the **real vault** (it force-enables
+  embeddings by popping `EXOMEM_DISABLE_EMBEDDINGS` before importing `exomem`), scoped
+  `scope="kb-only"` so it never triggers the wider vault auto-widen scan. It writes nothing to the
+  vault.
+- It already computes exactly four metrics per query, via `src/exomem/eval_metrics.py`: NDCG@5,
+  NDCG@10, MRR, and recall@10 (mean-aggregated in `_evaluate()`). There is no fifth metric hiding
+  anywhere; the published table is these four, not an invented set.
+- It already has a `--markdown` flag, but today that only prints a single-config table (baseline
+  run, or one row per `--sweep` grid point) — there is no multi-mode (keyword/hybrid/hybrid+rerank)
+  aggregate table, no latency numbers, and no corpus stats anywhere in the script.
+- The golden set (`tests/golden/queries.yaml`) is a **seed set of 9 queries**, hand-authored against
+  the bundled fixture KB (`tests/fixtures/`), explicitly designed to grow over time via
+  `scripts/derive_relevance_pairs.py` mining real (query -> cited path) usage for human
+  confirmation. Any published benchmark must say so plainly — this is a small, single-vault,
+  self-graded golden set, not a third-party benchmark.
+- `mode` on `find()` is one of `"keyword" | "hybrid" | "vector"`; reranking is an orthogonal
+  boolean (`rerank=True/False`) rather than a fourth mode. "hybrid+rerank" in this proposal means
+  `mode="hybrid", rerank=True`.
+
+## What Changes
+
+- `scripts/eval_retrieval.py` gains an additive `--report markdown` mode: runs the existing golden
+  set once per retrieval mode (keyword, hybrid, hybrid+rerank), reusing the harness's existing
+  `_evaluate()` aggregation for NDCG@5/NDCG@10/MRR/recall@10 per mode, plus median/p90 `find()`
+  wall-clock latency per mode sampled over repeated golden-set runs, plus rounded corpus counts
+  (markdown files, notes, media) computed by a pure, model-free filesystem walk. The emitted
+  artifact is aggregate-only: no query text, no vault-relative paths, no excerpts, no per-query
+  rows. Existing `--sweep`/baseline `--markdown` behavior is unchanged.
+- A new pure module, `src/exomem/eval_report.py` (no torch, no live-vault access), holds the
+  corpus-counting and markdown-rendering logic as plain-data functions — mirroring
+  `eval_metrics.py`'s existing "pure, torch-free, unit-testable" precedent — so the reporting
+  logic is testable on fixture data without a real vault or models.
+- New `docs/benchmarks.md` (skeleton in this change; real numbers filled at implementation time
+  by an actual desk-side run against the private vault): methodology (golden-set construction,
+  vault scale as rounded counts, hardware line, model/version line), the results table, reproduction
+  instructions for a third party (their own vault + golden queries, or the bundled
+  `tests/fixtures` sample vault as a deterministic smoke), and an explicit limitations section (n
+  of queries, single-vault, self-graded golden set).
+- `README.md` gains a short "Measured retrieval quality" note near the existing comparison table,
+  linking to `docs/benchmarks.md`.
+- Tests: fixture-data unit tests for `eval_report.py`'s corpus counting (against
+  `tests/fixtures/`, deterministic, no models) and markdown rendering (synthetic aggregate
+  inputs), plus a privacy-guard test asserting the rendered report contains none of the golden
+  set's query strings or target paths — mirroring this repo's existing leak-guard posture
+  (`tests/test_scaffold_no_leak.py`).
+- CI is **not** a gate on retrieval-quality numbers: no real vault or downloaded models are
+  available in CI, so `--report markdown` against a live vault stays a desk-side command. The new
+  fixture-data unit tests are ordinary, fast, model-free tests and run in the existing lean pytest
+  job like any other test.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: adds a reproducible benchmark-report mode for the existing retrieval
+  eval harness and an aggregate-only publication contract for that report. No change to `find()`
+  behavior, ranking, timing diagnostics, caching, or freshness requirements already specified for
+  this capability.
+
+### New Capabilities
+
+- None.
+
+## Impact
+
+- Code: `scripts/eval_retrieval.py` (new `--report markdown` mode, latency sampling loop), new
+  `src/exomem/eval_report.py` (pure corpus-counting + markdown-rendering module).
+- Docs: new `docs/benchmarks.md`; `README.md` gains a short linking note.
+- Tests: new fixture-data unit tests for `eval_report.py` (corpus counting, report rendering) and a
+  privacy-guard test for the rendered report.
+- No MCP/REST/CLI command-registry change, no schema change, and no change to `find()`'s
+  production ranking/return behavior — this change only adds dev/eval tooling and documentation
+  around the existing harness.
+- Dependencies: none expected. No optional model becomes mandatory; `--report markdown` still
+  requires the same live-vector environment the harness already requires today.

--- a/openspec/changes/publish-retrieval-benchmark/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/publish-retrieval-benchmark/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Reproducible Benchmark Report
+
+The retrieval eval harness (`scripts/eval_retrieval.py`) SHALL provide a `--report markdown` mode
+that runs the existing golden query set once per retrieval mode — keyword, hybrid, and hybrid with
+reranking — and emits a single markdown artifact containing, per mode, the harness's existing
+aggregate ranking-quality metrics (NDCG@5, NDCG@10, MRR, recall@10) and median/p90 `find()`
+wall-clock latency measured over repeated runs of the golden set. The report generation MUST be
+reproducible: re-running the command against any vault and golden set that follow the documented
+harness contract (a `tests/golden/queries.yaml`-shaped golden set and a resolvable vault) MUST
+produce a report in the same shape, including against the bundled `tests/fixtures` sample vault as
+a deterministic smoke path.
+
+#### Scenario: Report includes per-mode metrics and latency
+
+- **WHEN** `scripts/eval_retrieval.py --report markdown` is run
+- **THEN** the emitted markdown includes one row for each of keyword, hybrid, and hybrid-with-rerank
+- **AND** each row includes NDCG@5, NDCG@10, MRR, and recall@10
+- **AND** each row includes median and p90 `find()` latency measured over the run
+
+#### Scenario: Report is reproducible against the bundled sample vault
+
+- **WHEN** `scripts/eval_retrieval.py --report markdown` is run against the bundled
+  `tests/fixtures` sample vault instead of a private vault
+- **THEN** the harness produces a report in the same shape as against any other vault
+- **AND** no private-vault content is required to produce a smoke-scale report
+
+#### Scenario: Existing sweep and baseline markdown modes are unchanged
+
+- **WHEN** `scripts/eval_retrieval.py` is run with `--sweep` or the existing baseline `--markdown`
+  flag without `--report markdown`
+- **THEN** the output matches the harness's existing behavior before this requirement existed
+
+### Requirement: Aggregate-Only Publication
+
+The markdown report produced by `--report markdown` SHALL contain only aggregate values: per-mode
+mean metrics, per-mode latency percentiles, and rounded corpus counts (files, notes, media). It
+MUST NOT contain per-query rows, golden query text, vault-relative paths, excerpts, or any other
+content that could reveal what a private vault contains. The report-rendering logic MUST accept
+only plain aggregate data as input (no vault path, no query text argument) so this constraint is
+structural rather than a formatting convention.
+
+#### Scenario: No golden query text appears in the report
+
+- **WHEN** `--report markdown` is generated from the golden set in `tests/golden/queries.yaml`
+- **THEN** none of the golden set's query strings appear anywhere in the emitted markdown
+
+#### Scenario: No vault-relative path appears in the report
+
+- **WHEN** `--report markdown` is generated from the golden set in `tests/golden/queries.yaml`
+- **THEN** none of the golden set's `expect_any_of` or `graded` target paths appear anywhere in the
+  emitted markdown
+
+#### Scenario: Corpus stats are rounded counts only
+
+- **WHEN** the report includes corpus statistics
+- **THEN** the statistics are rounded integer counts of files, notes, and media
+- **AND** no exact file name, path, or content excerpt is included
+
+#### Scenario: Report has one row per mode, not one row per query
+
+- **WHEN** the report is rendered for N modes over a golden set of any size
+- **THEN** the report contains exactly N result rows, one per mode
+- **AND** the row count does not scale with the number of golden queries

--- a/openspec/changes/publish-retrieval-benchmark/tasks.md
+++ b/openspec/changes/publish-retrieval-benchmark/tasks.md
@@ -1,0 +1,97 @@
+# Tasks — publish retrieval benchmark
+
+## 1. Tests First (pure logic, no torch, no live vault)
+
+- [x] 1.1 `tests/test_eval_report.py::test_count_corpus_stats_against_fixtures`: run
+      `eval_report.count_corpus_stats(Path("tests/fixtures"))` and assert it returns rounded
+      `files`/`notes`/`media` integer counts (bucketed, e.g. rounded down to the nearest 10) that
+      are internally consistent with the known small fixture tree, without asserting on exact
+      filenames.
+- [x] 1.2 `tests/test_eval_report.py::test_render_benchmark_report_shape`: call
+      `eval_report.render_benchmark_report(...)` with synthetic `per_mode` (keyword/hybrid/
+      hybrid+rerank, made-up metric and latency numbers), synthetic `corpus` counts, a golden `n`,
+      and a `meta` dict; assert the returned markdown contains a row per mode with all four
+      existing metrics (NDCG@5, NDCG@10, MRR, recall@10) plus latency median/p90, the corpus
+      counts, and a limitations note — using only invented numbers, never real query/path data.
+- [x] 1.3 `tests/test_eval_report.py::test_report_has_no_leaked_golden_content` (privacy guard):
+      load `tests/golden/queries.yaml`, collect every `query` string and every `expect_any_of`/
+      `graded` target path; render a report via 1.2's synthetic inputs plus a second render that
+      exercises whatever code path is closest to production use; assert none of the golden
+      query strings or target paths appear anywhere in the rendered markdown. Mirrors
+      `tests/test_scaffold_no_leak.py`'s pattern-denylist posture.
+- [x] 1.4 `tests/test_eval_report.py::test_render_benchmark_report_omits_per_query_rows`: assert
+      the rendered markdown has exactly one row per mode (not one row per query) — i.e. row count
+      scales with `len(per_mode)`, not with `golden_n`.
+
+## 2. `src/exomem/eval_report.py` (new pure module)
+
+- [x] 2.1 Add module docstring mirroring `eval_metrics.py`'s "no torch, no live-vault access"
+      framing; implement `count_corpus_stats(vault_root: Path) -> dict[str, int]` as a plain
+      `Path.rglob` walk bucketing by known type folders/extensions (Sources/Articles, Sources/
+      Books, Sources/Sessions, Notes/*, media file extensions), rounding every returned count
+      before returning it so the function's output is privacy-safe by construction. 1.1 green.
+- [x] 2.2 Implement `render_benchmark_report(*, corpus, per_mode, golden_n, meta) -> str`: plain
+      dict/int/str inputs only (no `Path`, no vault, no query text parameter at all) producing a
+      markdown string — header (title, `meta` fields such as exomem version, model names,
+      hardware line), corpus-counts line, one metrics+latency row per mode, golden-set size, and a
+      limitations paragraph. 1.2, 1.4 green.
+- [x] 2.3 Confirm 1.3 (privacy guard) passes given 2.1/2.2's signatures accept no leak-capable
+      input; add a short comment at each function noting the no-path/no-query-text contract so a
+      future edit sees the constraint before widening the signature.
+
+## 3. `scripts/eval_retrieval.py`: `--report markdown` mode
+
+- [x] 3.1 Add `--report {markdown}` and `--repeat N` (default e.g. 3) CLI args, additive to the
+      existing `--sweep`/`--markdown`/`--rerank`/`--include-rerank` args (no existing flag
+      behavior changes).
+- [x] 3.2 When `--report markdown` is set: for each mode in `["keyword", "hybrid",
+      "hybrid+rerank"]` (the third being `mode="hybrid", rerank=True`), call the existing
+      `_evaluate()` once for the four aggregate metrics, then separately time `--repeat` full
+      passes over the golden set with `time.perf_counter()` around each `find_module.find(...)`
+      call (reusing `rank_queries()`'s per-query loop shape, not `FindTimings`), collecting a flat
+      per-mode latency list and computing median/p90 from it.
+- [x] 3.3 Call `eval_report.count_corpus_stats(vault_root)` once (same resolved vault root the
+      harness already uses) and `eval_report.render_benchmark_report(...)` with the three modes'
+      results, corpus counts, `len(golden)`, and a `meta` dict (exomem version, `BAAI/
+      bge-base-en-v1.5` / `BAAI/bge-reranker-base` model names, a hardware-line placeholder field
+      the runner fills at invocation or leaves generic). Print the rendered markdown to stdout
+      (matching the existing `--markdown` precedent of printing rather than writing a file).
+- [x] 3.4 Verify existing `--sweep`, baseline `--markdown`, and `--rerank` flags are byte-identical
+      in behavior to before this change (no regression in the existing dev workflow).
+
+## 4. Docs skeleton
+
+- [x] 4.1 New `docs/benchmarks.md`: Methodology section (golden-set construction and size,
+      `tests/golden/queries.yaml` provenance and growth process via
+      `scripts/derive_relevance_pairs.py`, vault scale as rounded counts, hardware line, exomem
+      version + model/version line), a Results section with the table structure from
+      `render_benchmark_report()`'s shape but **placeholder values** clearly marked
+      `TODO(real-vault-run)`, a Reproduction section (run against your own vault + golden queries,
+      or `EXOMEM_VAULT_PATH=tests/fixtures` as a deterministic smoke), and a Limitations section
+      (n of queries, single-vault, self-graded golden set, hardware-dependent latency).
+- [ ] 4.2 **STILL DESK-SIDE — intentionally left unchecked.** Requires the private vault and
+      downloaded embedding/reranker models, neither available in this implementation environment
+      (torch / sentence_transformers are not installed here; those suite tests skip). The
+      `--report markdown` mode is implemented and wired (tasks 3.1–3.4 done), but the real-vault
+      measurement pass has NOT been run. To complete: run
+      `EXOMEM_VAULT_PATH=/path/to/vault python scripts/eval_retrieval.py --report markdown`
+      against the real vault and replace `docs/benchmarks.md`'s `TODO(real-vault-run)` placeholders
+      with the measured table. (Use the repo's own invocation; do not run `uv run`.)
+- [x] 4.3 `README.md`: add a short "Measured retrieval quality" note near the existing comparison
+      table (the `Compared with` table / the `docs/comparison-engraph.md` link), pointing at
+      `docs/benchmarks.md`.
+
+## 5. Validation
+
+- [x] 5.1 `.venv/Scripts/python.exe -m pytest -q` green — full suite 1268 passed, 11 skipped
+      (pre-existing torch/sentence_transformers/PIL/av/diarizer skips), including the new
+      `tests/test_eval_report.py` (4 tests, all model-free and passing under the lean default).
+- [x] 5.2 `ruff check` clean on changed files (`src/exomem/eval_report.py`,
+      `tests/test_eval_report.py`, `scripts/eval_retrieval.py`) — "All checks passed!".
+- [x] 5.3 `npm exec --yes @fission-ai/openspec -- validate publish-retrieval-benchmark --strict`
+      passes.
+- [x] 5.4 No MCP/REST/CLI command-registry file changed and no `tests/fixtures/
+      mcp_tool_schemas.json` drift — this change touches only dev/eval tooling (`eval_report.py`,
+      `eval_retrieval.py`), docs, tests, and this change's own tasks.
+- [x] 5.5 CI gained no new job — the new tests run inside the existing lean `pytest -q` job; the
+      real-vault `--report markdown` run stays desk-side (task 4.2), not a CI step.

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -18,9 +18,13 @@ This is a dev/eval tool: it imports exomem directly and needs the bge model
 from __future__ import annotations
 
 import argparse
+import math
 import os
+import statistics
 import sys
+import time
 from dataclasses import replace
+from datetime import date
 from pathlib import Path
 
 import yaml
@@ -33,9 +37,15 @@ if str(SRC) not in sys.path:
 # The eval MUST run with live vectors — undo any inherited test/service disable.
 os.environ.pop("EXOMEM_DISABLE_EMBEDDINGS", None)
 
+from exomem import __version__ as EXOMEM_VERSION  # noqa: E402
 from exomem import eval_metrics as metrics  # noqa: E402
+from exomem import eval_report  # noqa: E402
 from exomem import find as find_module  # noqa: E402
 from exomem.vault import resolve_vault  # noqa: E402
+
+# Model names the harness runs against (the shipped default vector stack).
+EMBEDDING_MODEL = "BAAI/bge-base-en-v1.5"
+RERANKER_MODEL = "BAAI/bge-reranker-base"
 
 DEFAULT_GOLDEN = HERE.parent / "tests" / "golden" / "queries.yaml"
 
@@ -74,16 +84,21 @@ def _evaluate(
     config: find_module.RankingConfig,
     *,
     rerank: bool,
+    mode: str = "hybrid",
     k_max: int = 10,
 ) -> dict:
-    """Run every golden query under `config`; return mean metrics + per-query rows."""
+    """Run every golden query under `config`; return mean metrics + per-query rows.
+
+    `mode` defaults to "hybrid" so every existing caller (sweep, baseline) is
+    byte-identical; the `--report markdown` path passes "keyword"/"hybrid".
+    """
     rows: list[dict] = []
     for g in golden:
         hits = find_module.find(
             vault_root,
             query=g["query"],
             limit=k_max,
-            mode="hybrid",
+            mode=mode,
             # The golden targets are all KB paths, so evaluate KB-only: this skips
             # the scope="kb" auto-widen scan over the ~20-folder wider vault, which
             # dominates eval wall-time per query (the tuner makes hundreds of calls).
@@ -186,13 +201,102 @@ def _sweep(
 
     if markdown:
         print("\n=== markdown (file via note(note_type='pattern', pattern_type='governance')) ===\n")
-        print(f"| config | NDCG@5 | NDCG@10 | MRR | recall@10 |")
-        print(f"|---|---|---|---|---|")
+        print("| config | NDCG@5 | NDCG@10 | MRR | recall@10 |")
+        print("|---|---|---|---|---|")
         for label, res, _cfg, _rr in results:
             print(
                 f"| {label} | {res['ndcg5']:.4f} | {res['ndcg10']:.4f} | "
                 f"{res['mrr']:.4f} | {res['recall10']:.4f} |"
             )
+
+
+# Modes for the published benchmark: (label, find mode, rerank flag). The third
+# is mode="hybrid" with rerank on — reranking is orthogonal to mode, not a mode.
+_REPORT_MODES: tuple[tuple[str, str, bool], ...] = (
+    ("keyword", "keyword", False),
+    ("hybrid", "hybrid", False),
+    ("hybrid+rerank", "hybrid", True),
+)
+
+
+def _percentile(sorted_vals: list[float], pct: float) -> float:
+    """Nearest-rank percentile of an already-sorted list (dependency-free).
+
+    Nearest-rank: the value at ceil(pct/100 * N), 1-based, clamped into range.
+    Cheap and adequate for a p90 over a few dozen latency samples; no interpolation.
+    """
+    if not sorted_vals:
+        return 0.0
+    rank = math.ceil(pct / 100.0 * len(sorted_vals))
+    idx = min(max(rank, 1), len(sorted_vals)) - 1
+    return sorted_vals[idx]
+
+
+def _sample_latencies(
+    vault_root: Path,
+    golden: list[dict],
+    config: find_module.RankingConfig,
+    *,
+    mode: str,
+    rerank: bool,
+    repeat: int,
+    k: int = 10,
+) -> list[float]:
+    """Time every find() call over `repeat` passes of the golden set (ms each).
+
+    Wraps each find() in time.perf_counter() — the same lightweight span pattern
+    find.py uses internally — and returns a flat list of per-call latencies. No
+    FindTimings recorder: the report needs end-to-end latency, not a per-stage
+    breakdown, which a bare perf_counter delta already gives.
+    """
+    latencies: list[float] = []
+    for _ in range(max(repeat, 1)):
+        for g in golden:
+            t0 = time.perf_counter()
+            find_module.find(
+                vault_root, query=g["query"], limit=k, mode=mode,
+                scope="kb-only", rerank=rerank, config=config,
+            )
+            latencies.append((time.perf_counter() - t0) * 1000.0)
+    return latencies
+
+
+def _report_markdown(vault_root: Path, golden: list[dict], *, repeat: int) -> None:
+    """Emit the aggregate-only benchmark report markdown to stdout."""
+    per_mode: dict[str, dict] = {}
+    for label, mode, rerank in _REPORT_MODES:
+        res = _evaluate(
+            vault_root, golden, find_module.DEFAULT_RANKING, rerank=rerank, mode=mode
+        )
+        lat = sorted(_sample_latencies(
+            vault_root, golden, find_module.DEFAULT_RANKING,
+            mode=mode, rerank=rerank, repeat=repeat,
+        ))
+        per_mode[label] = {
+            "ndcg5": res["ndcg5"],
+            "ndcg10": res["ndcg10"],
+            "mrr": res["mrr"],
+            "recall10": res["recall10"],
+            "latency_median_ms": statistics.median(lat) if lat else 0.0,
+            "latency_p90_ms": _percentile(lat, 90),
+        }
+
+    corpus = eval_report.count_corpus_stats(vault_root)
+    meta = {
+        "exomem_version": EXOMEM_VERSION,
+        "embedding_model": EMBEDDING_MODEL,
+        "reranker_model": RERANKER_MODEL,
+        # Fill via EXOMEM_BENCH_HARDWARE at invocation; generic placeholder otherwise.
+        "hardware": os.environ.get(
+            "EXOMEM_BENCH_HARDWARE", "(fill in: CPU / GPU / RAM)"
+        ),
+        # Script-side date so the pure renderer never calls datetime.now().
+        "date": date.today().isoformat(),
+    }
+    print()
+    print(eval_report.render_benchmark_report(
+        corpus=corpus, per_mode=per_mode, golden_n=len(golden), meta=meta
+    ))
 
 
 def main() -> int:
@@ -202,6 +306,15 @@ def main() -> int:
     ap.add_argument("--include-rerank", action="store_true", help="add the rerank axis to --sweep (slow)")
     ap.add_argument("--rerank", action="store_true", help="baseline run with rerank on")
     ap.add_argument("--markdown", action="store_true", help="emit a markdown results table")
+    ap.add_argument(
+        "--report", choices=["markdown"], default=None,
+        help="emit the aggregate-only per-mode benchmark report (keyword/hybrid/"
+             "hybrid+rerank) with latency percentiles and rounded corpus counts",
+    )
+    ap.add_argument(
+        "--repeat", type=int, default=3,
+        help="golden-set passes per mode for latency sampling under --report (default 3)",
+    )
     args = ap.parse_args()
 
     vault_root = resolve_vault()
@@ -212,7 +325,9 @@ def main() -> int:
     print(f"vault={vault_root}")
     print(f"golden set: {len(golden)} queries from {args.golden}")
 
-    if args.sweep:
+    if args.report == "markdown":
+        _report_markdown(vault_root, golden, repeat=args.repeat)
+    elif args.sweep:
         _sweep(vault_root, golden, include_rerank=args.include_rerank, markdown=args.markdown)
     else:
         result = _evaluate(

--- a/src/exomem/eval_report.py
+++ b/src/exomem/eval_report.py
@@ -1,0 +1,217 @@
+"""Pure corpus-counting + benchmark-report rendering for the retrieval eval.
+
+No torch, no live model/network access, and — deliberately — no per-query or
+per-path inputs. This mirrors `eval_metrics.py`'s "pure, torch-free, unit-
+testable" precedent so the reporting logic is exercised on fixture data without
+a real vault or downloaded models, and runs in the lean (embedding-free) test
+suite.
+
+Two responsibilities live here:
+
+- `count_corpus_stats(vault_root)` — a plain filesystem walk that returns rounded
+  `{"files", "notes", "media"}` counts. Every count is rounded DOWN to the
+  nearest 10 before it is returned, so the function's *output* is privacy-safe
+  by construction (a caller can never publish an exact vault size through it).
+- `render_benchmark_report(...)` — plain aggregate data in, markdown string out.
+  It accepts NO vault path and NO query text (see the contract note on the
+  function): it renders only per-mode aggregate metrics/latency, rounded corpus
+  counts, and methodology `meta` lines, so it is structurally incapable of
+  leaking golden query text or vault-relative paths — it is never given them.
+
+Scoping conventions (chosen to match how the rest of the codebase already scopes
+markdown vs. media, not invented here):
+
+- "files"  = total markdown pages across the WHOLE vault — the full-vault `.md`
+             walk `vault.walk_vault_md` uses (skips `vault.VAULT_SCAN_SKIP_DIRS`,
+             `.md`-only, Obsidian `.sync-conflict-` duplicates excluded).
+- "notes"  = markdown pages in the KB scope — the KB walk `find()` indexes over
+             (`find._walk_md` under `Knowledge Base/`, skipping
+             `find.EXCLUDED_DIR_NAMES` such as `_Schema`; `.md`-only, sync-
+             conflict excluded). Always a subset of "files".
+- "media"  = binary artifacts (audio / video / image / pdf) anywhere in the
+             vault outside the skip dirs. Extensions mirror `extract.py`'s
+             `_AUDIO_EXTS | _VIDEO_EXTS | _IMAGE_EXTS | _PDF_EXTS`; they are
+             inlined here (not imported) because `extract.py` pulls the GPU
+             extraction stack, which would break this module's torch-free
+             contract.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+from .find import EXCLUDED_DIR_NAMES
+from .vault import VAULT_SCAN_SKIP_DIRS, kb_root
+
+# Media extensions — mirrors extract.py's audio/video/image/pdf buckets. Inlined
+# rather than imported: extract.py imports the extraction/accel stack (torch),
+# and this module must stay pure. Keep in sync with extract.py by hand.
+_MEDIA_EXTS = frozenset({
+    # audio
+    ".mp3", ".wav", ".m4a", ".flac", ".ogg", ".oga", ".aac", ".wma", ".opus",
+    # video
+    ".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v", ".wmv", ".flv", ".mpeg", ".mpg",
+    # image
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".tif", ".webp", ".heic",
+    # pdf
+    ".pdf",
+})
+
+_ROUND_TO = 10
+
+
+def _round_down(n: int) -> int:
+    """Round a count DOWN to the nearest 10 (privacy floor: exact size never leaks)."""
+    return (n // _ROUND_TO) * _ROUND_TO
+
+
+def _iter_files(root: Path, skip_dirs: frozenset[str]) -> Iterable[Path]:
+    """Yield every file under `root`, pruning any directory named in `skip_dirs`."""
+    if not root.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place so os.walk does not descend into skipped subtrees.
+        dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+        for name in filenames:
+            yield Path(dirpath) / name
+
+
+def count_corpus_stats(vault_root: Path) -> dict[str, int]:
+    """Return rounded `{"files", "notes", "media"}` counts for `vault_root`.
+
+    Privacy contract: every returned count is rounded DOWN to the nearest 10, so
+    this function's output can be published as-is without revealing an exact
+    vault size. It takes only a vault root and returns only integers — no path,
+    filename, or content ever escapes it.
+
+    Definitions (see the module docstring for the matching codebase conventions):
+    - files: all `.md` across the whole vault (skips VAULT_SCAN_SKIP_DIRS).
+    - notes: `.md` in the KB scope find() indexes (skips EXCLUDED_DIR_NAMES).
+    - media: audio/video/image/pdf binaries anywhere outside the skip dirs.
+    """
+    files = 0
+    media = 0
+    for path in _iter_files(vault_root, VAULT_SCAN_SKIP_DIRS):
+        ext = path.suffix.lower()
+        if ext == ".md":
+            if ".sync-conflict-" not in path.name:
+                files += 1
+        elif ext in _MEDIA_EXTS:
+            media += 1
+
+    notes = 0
+    for path in _iter_files(kb_root(vault_root), EXCLUDED_DIR_NAMES):
+        if path.suffix.lower() == ".md" and ".sync-conflict-" not in path.name:
+            notes += 1
+
+    return {
+        "files": _round_down(files),
+        "notes": _round_down(notes),
+        "media": _round_down(media),
+    }
+
+
+# Ordered so the published table always lists the same columns in the same order.
+_METRIC_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("NDCG@5", "ndcg5"),
+    ("NDCG@10", "ndcg10"),
+    ("MRR", "mrr"),
+    ("recall@10", "recall10"),
+)
+_LATENCY_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("latency median (ms)", "latency_median_ms"),
+    ("latency p90 (ms)", "latency_p90_ms"),
+)
+
+# Rendered in this order when present in `meta`; unknown extra keys are appended.
+_META_FIELDS: tuple[tuple[str, str], ...] = (
+    ("exomem version", "exomem_version"),
+    ("Embedding model", "embedding_model"),
+    ("Reranker model", "reranker_model"),
+    ("Hardware", "hardware"),
+    ("Measured", "date"),
+)
+
+
+def render_benchmark_report(
+    *,
+    corpus: dict,
+    per_mode: dict,
+    golden_n: int,
+    meta: dict,
+) -> str:
+    """Render an aggregate-only benchmark report as a markdown string.
+
+    Contract — NO leak-capable inputs: this function accepts no vault path and
+    no query text. `per_mode` is
+    `{mode: {"ndcg5", "ndcg10", "mrr", "recall10",
+             "latency_median_ms", "latency_p90_ms"}}` (aggregate floats only),
+    `corpus` is `{"files", "notes", "media"}` (already rounded by
+    `count_corpus_stats`), and `meta` carries methodology strings only (version,
+    model names, hardware, date). Do NOT widen this signature to accept paths,
+    per-query rows, or excerpts — the aggregate-only publication guarantee is
+    structural precisely because leak-capable data is never passed in. A privacy
+    regression test greps rendered output against every golden query and path.
+
+    The date is passed in via `meta["date"]` — this function never calls
+    `datetime.now()`, so rendering is deterministic for a given input.
+    """
+    lines: list[str] = []
+    lines.append("## Retrieval benchmark")
+    lines.append("")
+
+    meta_lines = _render_meta(meta)
+    if meta_lines:
+        lines.extend(meta_lines)
+        lines.append("")
+
+    files = corpus.get("files", 0)
+    notes = corpus.get("notes", 0)
+    media = corpus.get("media", 0)
+    lines.append(
+        f"- Corpus scale: {files} markdown files, {notes} KB notes, "
+        f"{media} media artifacts (counts rounded down to the nearest 10 for privacy)."
+    )
+    lines.append(f"- Golden set: {golden_n} queries.")
+    lines.append("")
+
+    header = ["Mode", *(h for h, _ in _METRIC_COLUMNS), *(h for h, _ in _LATENCY_COLUMNS)]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("|" + "|".join(["---"] * len(header)) + "|")
+    for mode, row in per_mode.items():
+        cells = [str(mode)]
+        for _, key in _METRIC_COLUMNS:
+            cells.append(f"{float(row.get(key, 0.0)):.4f}")
+        for _, key in _LATENCY_COLUMNS:
+            cells.append(f"{float(row.get(key, 0.0)):.1f}")
+        lines.append("| " + " | ".join(cells) + " |")
+    lines.append("")
+
+    lines.append("### Limitations")
+    lines.append("")
+    lines.append(
+        f"These figures come from a small, single-vault, self-graded golden set "
+        f"({golden_n} queries, one private vault, relevance labels chosen by the "
+        f"vault owner) — not an independent third-party benchmark. Latency is host- "
+        f"and GPU-dependent and will differ on other hardware; treat it as a "
+        f"reproducible self-measurement, not a portable guarantee."
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _render_meta(meta: dict) -> list[str]:
+    """Render known `meta` fields in a stable order, then any extra string keys."""
+    out: list[str] = []
+    shown: set[str] = set()
+    for label, key in _META_FIELDS:
+        if key in meta and meta[key] is not None:
+            out.append(f"- {label}: {meta[key]}")
+            shown.add(key)
+    for key, value in meta.items():
+        if key not in shown and value is not None:
+            out.append(f"- {key}: {value}")
+    return out

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -1,0 +1,183 @@
+"""Fixture-data unit tests for `exomem.eval_report` — model-free and fast.
+
+These run in the lean (embedding-free) pytest job like any other test: the
+module under test is pure (no torch, no live vault/model access), so the corpus
+walk runs against the committed `tests/fixtures/` tree and the renderer runs on
+synthetic aggregate inputs. The privacy-guard test mirrors
+`tests/test_scaffold_no_leak.py`'s denylist posture: it asserts none of the
+golden set's query strings or target paths appear in the rendered report.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from exomem import eval_report
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+GOLDEN = Path(__file__).resolve().parent / "golden" / "queries.yaml"
+
+
+# Synthetic aggregate inputs — invented numbers only, never real query/path data.
+_SYNTH_PER_MODE = {
+    "keyword": {
+        "ndcg5": 0.4211, "ndcg10": 0.4567, "mrr": 0.5123, "recall10": 0.6001,
+        "latency_median_ms": 12.3, "latency_p90_ms": 25.7,
+    },
+    "hybrid": {
+        "ndcg5": 0.7012, "ndcg10": 0.7333, "mrr": 0.8001, "recall10": 0.8888,
+        "latency_median_ms": 41.9, "latency_p90_ms": 88.2,
+    },
+    "hybrid+rerank": {
+        "ndcg5": 0.7810, "ndcg10": 0.8004, "mrr": 0.8502, "recall10": 0.9101,
+        "latency_median_ms": 130.5, "latency_p90_ms": 260.4,
+    },
+}
+_SYNTH_CORPUS = {"files": 1200, "notes": 900, "media": 300}
+_SYNTH_GOLDEN_N = 9
+_SYNTH_META = {
+    "exomem_version": "9.9.9-test",
+    "embedding_model": "BAAI/bge-base-en-v1.5",
+    "reranker_model": "BAAI/bge-reranker-base",
+    "hardware": "synthetic test host",
+    "date": "2026-07-03",
+}
+
+
+def _render_synthetic() -> str:
+    return eval_report.render_benchmark_report(
+        corpus=_SYNTH_CORPUS,
+        per_mode=_SYNTH_PER_MODE,
+        golden_n=_SYNTH_GOLDEN_N,
+        meta=_SYNTH_META,
+    )
+
+
+def _golden_strings() -> tuple[list[str], list[str]]:
+    """Return (query strings, target paths) from the golden set."""
+    raw = yaml.safe_load(GOLDEN.read_text(encoding="utf-8")) or []
+    queries: list[str] = []
+    paths: list[str] = []
+    for entry in raw:
+        q = entry.get("query")
+        if q:
+            queries.append(q)
+        for p in entry.get("expect_any_of", []) or []:
+            paths.append(p)
+        for p in (entry.get("graded") or {}):
+            paths.append(p)
+    return queries, paths
+
+
+def test_count_corpus_stats_against_fixtures() -> None:
+    """Corpus walk over tests/fixtures returns rounded, internally-consistent counts.
+
+    The fixture tree currently holds 15 markdown files vault-wide (14 KB notes
+    outside `_Schema` + 1 read-only `Reference/` page) and no media binaries.
+    Rounded DOWN to the nearest 10 that is files=10, notes=10, media=0. We assert
+    the rounding contract and the bucket definitions, not exact filenames.
+    """
+    stats = eval_report.count_corpus_stats(FIXTURES)
+
+    assert set(stats) == {"files", "notes", "media"}
+    for key, value in stats.items():
+        assert isinstance(value, int), key
+        assert value >= 0, key
+        assert value % 10 == 0, f"{key} must be rounded to the nearest 10, got {value}"
+
+    # No binary media in the fixture tree.
+    assert stats["media"] == 0
+    # "files" (whole-vault markdown) is a superset of "notes" (KB-scoped markdown).
+    assert stats["files"] >= stats["notes"]
+    # Current fixture tree: 15 files / 14 notes -> both floor to 10.
+    assert stats["files"] == 10
+    assert stats["notes"] == 10
+
+
+def test_render_benchmark_report_shape() -> None:
+    """Rendered markdown carries every metric + latency per mode, corpus, limits."""
+    md = _render_synthetic()
+
+    # A row per mode, each with all four metrics + both latency percentiles.
+    for mode, row in _SYNTH_PER_MODE.items():
+        assert mode in md
+        assert f"{row['ndcg5']:.4f}" in md
+        assert f"{row['ndcg10']:.4f}" in md
+        assert f"{row['mrr']:.4f}" in md
+        assert f"{row['recall10']:.4f}" in md
+        assert f"{row['latency_median_ms']:.1f}" in md
+        assert f"{row['latency_p90_ms']:.1f}" in md
+
+    # Column headers present.
+    for header in ("NDCG@5", "NDCG@10", "MRR", "recall@10"):
+        assert header in md
+
+    # Corpus counts and golden-set size present.
+    assert str(_SYNTH_CORPUS["files"]) in md
+    assert str(_SYNTH_CORPUS["notes"]) in md
+    assert str(_SYNTH_CORPUS["media"]) in md
+    assert str(_SYNTH_GOLDEN_N) in md
+
+    # Meta methodology lines present.
+    assert _SYNTH_META["embedding_model"] in md
+    assert _SYNTH_META["reranker_model"] in md
+
+    # A limitations note is present.
+    assert "Limitations" in md
+
+
+def test_render_benchmark_report_omits_per_query_rows() -> None:
+    """Exactly one result row per mode — row count scales with modes, not queries."""
+    md = _render_synthetic()
+    data_rows = [
+        line for line in md.splitlines()
+        if line.startswith("|")
+        and "Mode" not in line          # skip the header row
+        and set(line.replace("|", "").strip()) - {"-", " "}  # skip the |---| separator
+    ]
+    assert len(data_rows) == len(_SYNTH_PER_MODE)
+
+    # Sanity: a golden set far larger than the mode count must not add rows.
+    md_big_golden = eval_report.render_benchmark_report(
+        corpus=_SYNTH_CORPUS,
+        per_mode=_SYNTH_PER_MODE,
+        golden_n=9999,
+        meta=_SYNTH_META,
+    )
+    big_rows = [
+        line for line in md_big_golden.splitlines()
+        if line.startswith("|")
+        and "Mode" not in line
+        and set(line.replace("|", "").strip()) - {"-", " "}
+    ]
+    assert len(big_rows) == len(_SYNTH_PER_MODE)
+
+
+def test_report_has_no_leaked_golden_content() -> None:
+    """Privacy guard: no golden query string or target path leaks into the report.
+
+    Renders both the synthetic report and a report that reads the real golden
+    file's size (the closest-to-production shape available without a live vault),
+    then asserts none of the golden query strings or `expect_any_of` / `graded`
+    target paths appear anywhere in the rendered markdown.
+    """
+    queries, paths = _golden_strings()
+    assert queries, "golden set produced no query strings — wrong path?"
+    assert paths, "golden set produced no target paths — wrong path?"
+
+    renders = [
+        _render_synthetic(),
+        eval_report.render_benchmark_report(
+            corpus=eval_report.count_corpus_stats(FIXTURES),
+            per_mode=_SYNTH_PER_MODE,
+            golden_n=len(queries),
+            meta=_SYNTH_META,
+        ),
+    ]
+    for md in renders:
+        for q in queries:
+            assert q not in md, f"leaked golden query text: {q!r}"
+        for p in paths:
+            assert p not in md, f"leaked golden target path: {p!r}"


### PR DESCRIPTION
## What

Turns "we think retrieval is good" into a number a reader can re-derive: an **aggregate-only, reproducible retrieval-quality benchmark** built on the existing golden-set eval harness. A low-cost credibility differentiator versus RAG/doc-chat apps and other MCP note servers — neither comparable project publishes retrieval numbers.

## How

- **New pure module `src/exomem/eval_report.py`** (no torch, no live-vault/model access — mirrors `eval_metrics.py`'s precedent so it runs in the lean test job):
  - `count_corpus_stats(vault_root)` — a filesystem walk returning `{files, notes, media}`, every count **rounded DOWN to the nearest 10** so the output is privacy-safe by construction. Scoping matches the codebase: `files` = whole-vault `.md` (`VAULT_SCAN_SKIP_DIRS`), `notes` = KB-scoped `.md` (`EXCLUDED_DIR_NAMES`), `media` = audio/video/image/pdf.
  - `render_benchmark_report(*, corpus, per_mode, golden_n, meta)` — plain-data-in, markdown-out. Accepts **no vault path and no query text**, so it is structurally incapable of leaking per-query rows/paths/excerpts.
- **`scripts/eval_retrieval.py` gains additive `--report markdown` (+ `--repeat N`, default 3):** runs the golden set once per mode (`keyword` / `hybrid` / `hybrid+rerank`), reuses `_evaluate()` for NDCG@5/NDCG@10/MRR/recall@10, and samples `find()` wall-clock latency (median + nearest-rank p90) via `time.perf_counter()` — no `FindTimings` coupling. Existing `--sweep` / `--markdown` paths are byte-identical (the new `_evaluate` `mode` kwarg defaults to `"hybrid"`).
- **`docs/benchmarks.md`** — methodology, results table, third-party reproduction steps, and a prominent Limitations section (n=9, single private vault, self-graded, host-dependent latency). Real numbers are marked `TODO(real-vault-run)` — a **desk-side** run (needs downloaded embedding/reranker models CI lacks) fills them; nothing is fabricated.
- **`README.md`** — one "Measured retrieval quality" line by the comparison table, linking the doc.

## Tests

`tests/test_eval_report.py` (4, model-free): corpus counting against `tests/fixtures/` (asserts the round-to-10 contract + `files ⊇ notes`), report-shape rendering, one-row-per-mode (row count scales with modes, not queries), and a **privacy-guard** that renders a report and asserts none of the golden set's query strings or `expect_any_of`/`graded` target paths appear in the output.

- Full suite: **1268 passed, 11 skipped** (pre-existing env-only skips); `import exomem.eval_report` pulls in no torch.
- OpenSpec `publish-retrieval-benchmark` validates `--strict`.

## Deferred (honest)

`openspec/.../tasks.md` 4.2 (the real-vault measurement pass) is left **unchecked** — it requires the private vault + models, not available in CI. No numbers were invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)