### PR TITLE
perf: warm an encode at boot so the first query doesn't pay kernel compile

### DIFF
--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -115,6 +115,24 @@ def warm_all(vault_root: Path) -> dict[str, float]:
         finally:
             durations[name] = round((time.perf_counter() - t0) * 1000.0, 1)
 
+    def _preload(step: str, loader, warm) -> bool:
+        """Preload a model (readiness gates on this) then run a best-effort throwaway
+        encode on the loaded object. Loading the weights isn't enough: the backend compiles
+        its compute kernels on the FIRST forward pass (most visibly the Metal/MPS graph on
+        Apple Silicon; CUDA/CPU pay a smaller first-call cost too), so warming a dummy input
+        here moves that one-time compile onto the boot/idle path instead of the user's first
+        query. The warm runs on the already-loaded model (loader is called exactly once) and
+        is never load-bearing — readiness gates on the preload, and a warm failure (e.g. an
+        MPS op gap) is swallowed. Cross-platform, not a Mac-only tweak."""
+        box: dict = {}
+        if not _model_step(step, lambda: box.update(m=loader())):
+            return False
+        try:
+            warm(box["m"])
+        except Exception:  # noqa: BLE001 — a warm-encode is a latency nicety, never a gate
+            log.debug("%s warm-encode skipped", step, exc_info=True)
+        return True
+
     if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
         # Lexical-only install: there are no models to wait for, so mark the
         # model components ready immediately — otherwise finds during the
@@ -127,7 +145,7 @@ def warm_all(vault_root: Path) -> dict[str, float]:
         from . import embeddings
 
         log.info("preloading embedding model %s", embeddings.MODEL_NAME)
-        if _model_step("model_bge", embeddings.get_model):
+        if _preload("model_bge", embeddings.get_model, lambda m: m.encode(["warm"])):
             log.info("embedding model ready")
             drained = readiness.mark_ready("embeddings")
             for item_vault, paths in drained:
@@ -139,13 +157,13 @@ def warm_all(vault_root: Path) -> dict[str, float]:
                 log.info("drained %d deferred write-embed batch(es)", len(drained))
 
         log.info("preloading reranker %s", embeddings.RERANKER_NAME)
-        if _model_step("model_reranker", embeddings.get_reranker):
+        if _preload("model_reranker", embeddings.get_reranker, lambda m: m.predict([("warm", "warm")])):
             log.info("reranker model ready")
             readiness.mark_ready("reranker")
 
         if embeddings.clip_enabled():
             log.info("preloading CLIP model %s", embeddings.CLIP_MODEL_NAME)
-            if _model_step("model_clip", embeddings.get_clip_model):
+            if _preload("model_clip", embeddings.get_clip_model, lambda m: m.encode(["warm"])):
                 log.info("CLIP model ready")
                 readiness.mark_ready("clip")
 

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -304,6 +304,61 @@ def test_warm_all_drains_deferred_write_embeds_after_embeddings_ready(
     assert drained_calls == [(tmp_path, list(some_paths))]
 
 
+def test_warm_all_runs_a_throwaway_encode_after_each_preload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loading weights isn't enough — the backend compiles its kernels on the first
+    forward pass (Metal/MPS especially), so warm_all runs one throwaway encode/predict on
+    each loaded model, moving that one-time compile off the user's first query. The loader
+    is called exactly once — the warm runs on the returned model object."""
+    warmed: list[str] = []
+
+    class _FakeST:  # SentenceTransformer-like (bge + CLIP)
+        def encode(self, texts, *a, **kw):
+            warmed.append("encode")
+
+    class _FakeCE:  # CrossEncoder-like (reranker)
+        def predict(self, pairs, *a, **kw):
+            warmed.append("predict")
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(embeddings, "get_model", _FakeST)
+    monkeypatch.setattr(embeddings, "get_reranker", _FakeCE)
+    monkeypatch.setattr(embeddings, "get_clip_model", _FakeST)
+    monkeypatch.setattr(embeddings, "clip_enabled", lambda: True)
+
+    warmup.warm_all(tmp_path)
+
+    assert warmed == ["encode", "predict", "encode"]  # bge, reranker, CLIP
+
+
+def test_warm_encode_failure_is_swallowed_and_does_not_block_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A warm-encode is a latency nicety, never a gate: if the dummy encode raises (e.g. an
+    unimplemented MPS op with fallback off), the component still marks ready because the
+    preload itself succeeded."""
+
+    class _Boom:
+        def encode(self, *a, **kw):
+            raise RuntimeError("mps kernel compile failed")
+
+        def predict(self, *a, **kw):
+            raise RuntimeError("mps kernel compile failed")
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(embeddings, "get_model", _Boom)
+    monkeypatch.setattr(embeddings, "get_reranker", _Boom)
+    monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
+
+    warmup.warm_all(tmp_path)
+
+    assert readiness.is_ready("embeddings") is True
+    assert readiness.is_ready("reranker") is True
+
+
 # ============================================================================
 # exomem.warmup.start_background — the daemon-thread wrapper
 # ============================================================================


### PR DESCRIPTION
## Why

`warm_all` preloaded model **weights** but never ran a forward pass. Backends compile their
compute kernels on the **first forward pass** — most visibly the Metal/MPS graph on Apple
Silicon (a few hundred ms–1s), but CUDA/CPU pay a first-call cost too. So the user's first
`find` after every restart ate that one-time compile.

## What

Each preload now runs one throwaway `encode`/`predict` on the loaded model, moving the compile
onto the boot/idle warm path. A new `_preload(step, loader, warm)` helper:
- calls the loader **exactly once** (readiness still gates on the preload — no behavior change),
- runs the warm on the returned model object,
- swallows any warm failure (e.g. an unimplemented MPS op) — the warm is a latency nicety, never a gate.

Cross-platform — **not** a Mac-only tweak (this was the balance concern; it helps CUDA/CPU too).

## Verification
- New tests: the throwaway encode/predict runs once per loaded model; a failing warm-encode
  doesn't block readiness. The existing preload-order / soft-fail / drain tests still pass
  (loader-call semantics preserved).
- Note: this repo's local dev env currently has partial heavy deps installed, so a few
  integration tests (`test_video_visual`, a torch-import-isolation test) fail **locally** and
  reproduce on the untouched base — unrelated to this change. `main`'s CI is green; relying on
  this PR's CI as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
