### PR TITLE
docs+restart: kb-mcp->exomem service re-register + restart.ps1 legacy fallback

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -236,6 +236,26 @@ pwsh -File scripts/install-service.ps1
 #   Start-Process -Verb RunAs -Wait sc.exe -ArgumentList 'start','exomem'
 ```
 
+### Renaming an existing `kb-mcp` service
+
+Boxes provisioned **before the `kb-mcp` → `exomem` rename** still run the Windows
+service under the old name `kb-mcp`. The code (and `install-service.ps1` /
+`restart.ps1`, which now default to `exomem`) are renamed, but the installed NSSM
+service isn't — it must be re-registered once per box. `restart.ps1` falls back to
+the legacy `kb-mcp` name automatically so it keeps working until you migrate; to
+finish the rename, run these in an **elevated** PowerShell (the old service must be
+removed first or it collides with the new one on port 8765):
+
+```powershell
+sc.exe stop kb-mcp
+nssm remove kb-mcp confirm
+pwsh -File scripts/install-service.ps1   # installs + starts 'exomem', re-grants no-UAC rights
+```
+
+The cloudflared tunnel/funnel targets the **port** (127.0.0.1:8765), not the
+service name, so it keeps working across the rename. Verify with
+`sc.exe query exomem` (RUNNING) and `sc.exe query kb-mcp` (should not exist).
+
 ## 7. Add to claude.ai
 
 1. claude.ai → Settings → Connectors → **Add custom connector**
@@ -424,6 +444,11 @@ Get-Content logs\exomem.log -Tail 6
 If you skipped the grant (or installed from an older version of the script),
 re-run the install script — it's idempotent and will only add the ACE if it's
 missing.
+
+On a box still running the pre-rename `kb-mcp` service, `scripts/restart.ps1`
+auto-falls back to that name; use `sc.exe stop/start kb-mcp` for the manual form,
+and see [Renaming an existing `kb-mcp` service](#renaming-an-existing-kb-mcp-service)
+to migrate it to `exomem`.
 
 For a stuck restart (orphan python processes holding port 8765), force-clean:
 

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -57,6 +57,18 @@ if (-not (Test-VenvInterpreter)) {
     Write-Host "  interpreter restored."
 }
 
+# Back-compat with the kb-mcp -> exomem rename: boxes provisioned before the
+# rename still run the service under the OLD name. If the requested service isn't
+# installed but the legacy 'kb-mcp' is, fall back so restart keeps working until
+# the box is re-registered under the new name (scripts/install-service.ps1). See
+# docs/deployment.md "Renaming an existing kb-mcp service".
+if (-not (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
+    if (Get-Service -Name "kb-mcp" -ErrorAction SilentlyContinue) {
+        Write-Warning "Service '$ServiceName' not found; falling back to legacy 'kb-mcp'. Re-register under the new name with scripts/install-service.ps1 (see docs/deployment.md)."
+        $ServiceName = "kb-mcp"
+    }
+}
+
 Write-Host "Stopping $ServiceName..."
 sc.exe stop $ServiceName | Out-Null
 Wait-ServiceState -Name $ServiceName -Target 'Stopped'


### PR DESCRIPTION
Follow-up from the find-latency deploy: the `kb-mcp` → `exomem` rename never shipped a migration for already-provisioned boxes, so the live service was still registered as `kb-mcp` while `restart.ps1`/`install-service.ps1` defaulted to `exomem` (the restart silently failed until re-run with `-ServiceName kb-mcp`).

- **`scripts/restart.ps1`**: if the requested service isn't installed but legacy `kb-mcp` is, fall back to it with a warning — so restart keeps working until the box is migrated.
- **`docs/deployment.md`**: new "Renaming an existing `kb-mcp` service" section (elevated stop → `nssm remove` → `install-service.ps1`), plus a pointer from the Restarting section. Notes that the tunnel targets the port, not the service name.

Docs + one PowerShell fallback; no Python/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)