### PR TITLE
perf: run bge/CLIP in fp16 on Apple Silicon (MPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_DISABLE_MEDIA_EXTRACTION` | `1` skips server-side OCR/ASR/PDF/Office extraction. |
 | `EXOMEM_DISABLE_CLIP` | `1` disables CLIP image search. |
 | `EXOMEM_TORCH_DEVICE` | Force the device for all torch models: `cuda`, `mps`, or `cpu` (default: auto-detect CUDA → MPS → CPU). Pin `cpu` to avoid thermal throttling on a fanless Mac. |
+| `EXOMEM_MPS_FP16` | On Apple Silicon, run bge/CLIP in fp16 on the Metal GPU — ~half the memory, faster encodes (default on; set `0` to keep fp32). |
 | `EXOMEM_VIDEO_SCENE_FRAMES` | Set to enable video scene detection + persisted, OCR'd scene-frame JPEGs (default off). |
 | `EXOMEM_VIDEO_SCENE_THRESHOLD` | Scene-boundary hash threshold in bits of 64 (default 10). |
 | `EXOMEM_VIDEO_SCENE_MIN_SECS` | Minimum scene duration in seconds; closer boundaries merge (default 4). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -337,6 +337,12 @@ Without the extra, transcription falls back to CPU faster-whisper — pick a sma
 shared 16 kHz whisper timebase) when the `media` extra is present, else mlx-whisper
 decodes the file itself (needs `ffmpeg` on PATH).
 
+On MPS, bge/CLIP also run in **fp16** by default (`EXOMEM_MPS_FP16`, set `0` to keep
+fp32) — roughly half the memory and faster encodes, which these retrieval models
+tolerate well. Storage is unchanged (vectors are upcast to float32 before the sqlite
+blob); existing fp32 vectors differ from new fp16 ones by ~1e-3, harmless for ranking,
+and `audit_fix(rebuild_embeddings=True)` re-embeds for exact consistency if wanted.
+
 Two more notes: **Voiceprints** (ECAPA) and **diarization** stay on CPU by default for
 cross-machine numeric parity — opt in per model with `EXOMEM_VOICE_DEVICE=mps` /
 `EXOMEM_DIARIZE_DEVICE=mps`. And you can force every torch model to a device with

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -107,7 +107,7 @@ def get_model():
 
         device = accel.select_device()
         log.info("loading embedding model %s on %s", MODEL_NAME, device)
-        _MODEL = SentenceTransformer(MODEL_NAME, device=device)
+        _MODEL = _maybe_half(SentenceTransformer(MODEL_NAME, device=device), device)
     return _MODEL
 
 
@@ -125,6 +125,26 @@ def get_reranker():
         log.info("loading reranker %s on %s", RERANKER_NAME, device)
         _RERANKER = CrossEncoder(RERANKER_NAME, device=device)
     return _RERANKER
+
+
+def _maybe_half(model, device: str):
+    """Run bge/CLIP in fp16 on Apple Silicon (MPS): ~half the memory and faster encodes,
+    and these retrieval models tolerate half precision well. Gated to MPS only — CPU fp16
+    is emulated (slower) and the CUDA path stays fp32 for cross-run/voiceprint parity.
+    Disable with EXOMEM_MPS_FP16=0.
+
+    Storage is unaffected: every vector is upcast to float32 before it hits the sqlite blob
+    (the astype(np.float32) guards in embed_*/upsert_*), so the on-disk format is identical —
+    only the computed precision changes. Existing fp32 vectors differ from new fp16 ones by
+    ~1e-3 (harmless for ranking); `audit_fix(rebuild_embeddings=True)` re-embeds for exact
+    consistency if wanted."""
+    if device != "mps" or os.environ.get("EXOMEM_MPS_FP16", "1") == "0":
+        return model
+    try:
+        return model.half()
+    except Exception:  # noqa: BLE001 — a precision tweak must never break model load
+        log.warning("fp16 (MPS) conversion failed; staying fp32", exc_info=True)
+        return model
 
 
 class ClipUnavailable(Exception):
@@ -162,7 +182,7 @@ def get_clip_model():
 
         device = _clip_device()
         log.info("loading CLIP model %s on %s", CLIP_MODEL_NAME, device)
-        _CLIP_MODEL = SentenceTransformer(CLIP_MODEL_NAME, device=device)
+        _CLIP_MODEL = _maybe_half(SentenceTransformer(CLIP_MODEL_NAME, device=device), device)
     return _CLIP_MODEL
 
 

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -23,6 +23,7 @@ _ENV_KEYS = (
     "PYTORCH_ENABLE_MPS_FALLBACK",
     "EXOMEM_ASR_BACKEND",
     "EXOMEM_MLX_WHISPER_MODEL",
+    "EXOMEM_MPS_FP16",
 )
 
 
@@ -258,3 +259,40 @@ def test_get_transcriber_selection(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(extract.get_transcriber(), extract.MlxWhisperBackend)
     monkeypatch.setattr(extract, "_mlx_available", lambda: False)
     assert isinstance(extract.get_transcriber(), extract.FasterWhisperBackend)
+
+
+# ---- fp16 on MPS (embeddings._maybe_half) ----
+
+def test_maybe_half_only_on_mps_and_respects_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bge/CLIP run fp16 on MPS only (CPU fp16 is emulated; CUDA keeps fp32 for parity),
+    and EXOMEM_MPS_FP16=0 opts out."""
+    from exomem import embeddings
+
+    class _Model:
+        def __init__(self):
+            self.halved = False
+
+        def half(self):
+            self.halved = True
+            return self
+
+    monkeypatch.delenv("EXOMEM_MPS_FP16", raising=False)
+    assert embeddings._maybe_half(_Model(), "mps").halved is True
+    assert embeddings._maybe_half(_Model(), "cpu").halved is False
+    assert embeddings._maybe_half(_Model(), "cuda").halved is False
+
+    monkeypatch.setenv("EXOMEM_MPS_FP16", "0")
+    assert embeddings._maybe_half(_Model(), "mps").halved is False
+
+
+def test_maybe_half_swallows_conversion_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing .half() must never break model load — return the original model, fp32."""
+    from exomem import embeddings
+
+    class _Boom:
+        def half(self):
+            raise RuntimeError("mps fp16 unsupported for this op")
+
+    monkeypatch.delenv("EXOMEM_MPS_FP16", raising=False)
+    m = _Boom()
+    assert embeddings._maybe_half(m, "mps") is m  # original returned, no raise


### PR DESCRIPTION
## Why

On the Metal GPU, fp16 roughly halves memory and speeds up encodes, and bge/CLIP tolerate
half precision well for retrieval — a real win on the fanless Air (less heat, faster `find`).

## What

A small `_maybe_half(model, device)` gate applied to the bge text embedder and CLIP:
- **MPS only.** CPU fp16 is emulated (slower); the CUDA path stays fp32 for cross-run and
  voiceprint parity. The reranker stays fp32 (opt-in, low value).
- **Default on**, `EXOMEM_MPS_FP16=0` to keep fp32. A failing `.half()` falls back to fp32 —
  never breaks model load.
- **Storage unchanged.** Every vector is already upcast to float32 before the sqlite blob
  (existing `astype(np.float32)` guards in `embed_*`/`upsert_*`), so the on-disk format is
  identical — only the *computed* precision changes. No migration needed.

Existing fp32 vectors differ from new fp16 ones by ~1e-3 (harmless for ranking, and new
writes/queries are both fp16 so they're mutually consistent); `audit_fix(rebuild_embeddings=True)`
re-embeds for exact consistency if wanted.

## Verification
- New tests (torch-free): `_maybe_half` halves only on MPS, respects `EXOMEM_MPS_FP16=0`,
  and swallows a failing `.half()`. Full local accel/clip suite green; ruff clean on the new
  code. CI is the gate (this box's dev env has partial deps that redden unrelated integration
  tests locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
