### PR TITLE
test(doctor): skip live embed-probe test on lean installs (fixes CI)

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -187,6 +187,10 @@ def test_sidecar_live_probe_passes_on_built_sidecar(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """End-to-end: build real vectors, then the live embed+search probe passes."""
+    # Skip on lean installs (no `embeddings` extra) — the lean CI `tests` job
+    # runs every test, so the @pytest.mark.embeddings marker alone doesn't
+    # deselect this; the importorskip is what its siblings use to skip cleanly.
+    pytest.importorskip("sentence_transformers")
     from exomem import embeddings as embeddings_module
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)


### PR DESCRIPTION
One-line test fix. `test_sidecar_live_probe_passes_on_built_sidecar` is marked `embeddings` but lacked the `importorskip` guard its siblings use, so it ran (and failed with ModuleNotFoundError) on the lean CI `tests` job across py3.11/3.12/3.13. Now skips cleanly on lean; still runs in the `retrieval-eval` job. Verified locally: 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYnqb42jGFNb8ZuMwes3n