### PR TITLE
feat(bench): per-lane latency-vs-scale curve + regression gate + golden set 9→26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
         # lean CI never pays the torch download. EXOMEM_DISABLE_EMBEDDINGS is
         # deliberately unset here — the test lifts it and loads the real model.
         run: uv run --extra embeddings python -m pytest -m embeddings -v
+      - name: Per-lane latency ceiling gate (2000-note synthetic vault, model-free)
+        # The anti-"hidden 14s" gate (tests/test_latency_gate.py): generates a
+        # realistic densely-wikilinked 2000-note vault and asserts NO retrieval
+        # lane exceeds its ceiling (graph rebuild → ~1.9s trips it). Model-free,
+        # so it ALSO runs in the lean matrix; pinned here as the benchmark gate's
+        # home next to the golden quality gate.
+        run: uv run python -m pytest tests/test_latency_gate.py -q
 
   onboarding:
     name: onboarding (wheel path)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -33,10 +33,15 @@ benchmark.
   `--repeat N` times (default 3) per mode and timing each call with
   `time.perf_counter()`. The report shows the **median** and **p90** (nearest-rank
   percentile) over that flat sample.
-- **Golden set.** `tests/golden/queries.yaml` — a seed set of **9** hand-authored
+- **Golden set.** `tests/golden/queries.yaml` — **26** hand-authored
   natural-language queries, each with one or more relevant target pages
-  (`expect_any_of`, or `graded` 0–3 for NDCG). It is designed to grow:
-  `scripts/derive_relevance_pairs.py` proposes additions mined from real
+  (`expect_any_of`, or `graded` 0–3 for NDCG). Several entries each PIN one
+  ranking behavior so a regression points at what it broke: compiled-over-source
+  (`prefer_compiled`), supersession demotion (`prefer_active`), a graph-hop-only
+  target (reachable only through a wikilink), a temporal-recency query, an
+  exact/quoted lookup, and a `scope="kb"` query whose answer lives OUTSIDE
+  `Knowledge Base/` (exercising the auto-widen reserve). The set is designed to
+  grow: `scripts/derive_relevance_pairs.py` proposes additions mined from real
   (query → cited path) usage, which a human confirms.
 - **Vault scale (rounded).** Reported as counts rounded DOWN to the nearest 10
   (privacy floor): markdown files (whole vault), KB notes (the pages `find()`
@@ -57,23 +62,105 @@ benchmark.
 
 Measured 2026-07-03 against the bundled fixture vault (sidecar built first).
 
-- Corpus scale: 10 markdown files, 10 KB notes, 0 media artifacts (rounded down
-  to the nearest 10).
-- Golden set: 9 queries.
+- Corpus scale: 30 markdown files, 20 KB notes, 0 media artifacts (rounded down
+  to the nearest 10); 198 chunk vectors.
+- Golden set: 26 queries.
 
 | Mode | NDCG@5 | NDCG@10 | MRR | recall@10 | latency median (ms) | latency p90 (ms) |
 |---|---|---|---|---|---|---|
-| keyword | 0.2222 | 0.2222 | 0.2222 | 0.2222 | 4.8 | 5.7 |
-| hybrid | 0.9590 | 0.9590 | 0.9444 | 1.0000 | 4.7 | 5.4 |
-| hybrid+rerank | 0.9971 | 0.9971 | 1.0000 | 1.0000 | 6.2 | 6.8 |
+| keyword | 0.3430 | 0.3430 | 0.3462 | 0.3269 | 6.4 | 7.2 |
+| hybrid | 0.9142 | 0.9270 | 0.9154 | 0.9615 | 6.5 | 7.3 |
+| hybrid+rerank | 0.9286 | 0.9397 | 0.9397 | 1.0000 | 6.6 | 7.6 |
 
-The gap is the whole point: on this golden set lexical-only (`keyword`) surfaces
-the intended page for just 2 of 9 queries (NDCG@10 0.2222), while `hybrid` finds
-every target in the top-10 (recall@10 1.0) and ranks it first or second (NDCG@10
-0.9590, MRR 0.9444); the cross-encoder reranker then all but perfects the order
-(NDCG@10 0.9971, MRR 1.0). Latency here is dominated by fixed per-call overhead —
-the corpus is 77 chunk vectors — so treat the absolute ms as a floor, not a
-representative production figure.
+The gap is the whole point: lexical-only (`keyword`) recalls the intended page
+for only about a third of the queries (recall@10 0.3269, NDCG@10 0.3430), while
+`hybrid` finds nearly every target in the top-10 (recall@10 0.9615) and ranks it
+at or near the top (NDCG@10 0.9270, MRR 0.9154); the cross-encoder reranker then
+tightens the order and lifts recall to 1.0 (NDCG@10 0.9397). `hybrid`'s recall is
+below 1.0 by design: two queries deliberately grade a marginal page that
+`prefer_compiled` / `prefer_active` demotes out of the top-10 (the
+compiled-over-source and supersession pins), so their grade-3 ideal is found but
+the marginal is not. Latency here is dominated by fixed per-call overhead — the
+corpus is 198 chunk vectors — so treat the absolute ms as a floor, not a
+representative production figure; the per-lane curve below shows how cost grows
+with corpus size.
+
+## Per-lane latency vs. corpus scale
+
+The aggregate latency in the results table is measured on the ~200-vector fixture
+and is dominated by fixed per-call overhead — it says nothing about how cost grows
+with a real vault. That blind spot has bitten before: a 10-file fixture benchmark
+once reported a whole `find()` at ~5ms and hid a ~14s graph-lane cost on a
+~1700-note vault, because an aggregate over a toy corpus cannot show a single lane
+blowing up. So this section measures latency PER LANE at realistic scale.
+
+`scripts/latency_curve.py` generates a synthetic, densely-wikilinked vault (25
+outbound links per note) at increasing sizes, warms every lane, then times a fixed
+query set with `find(include_timings=True)` and reports median / p90 per stage. The
+default run is **model-free** (the vector/CLIP/rerank lanes are switched off) so it
+needs no GPU or embedding sidecar and reproduces anywhere; it reports the lanes that
+both scale with the corpus and need no model — exactly where the graph regression
+lived.
+
+Model-free, measured 2026-07-03 on the reference host (AMD Ryzen 7 5800X3D / RTX
+5080 / 32 GB / Windows 11), per-lane **median / p90 in ms**:
+
+| Notes | vector | bm25 | keyword | graph | fusion | rerank | total |
+|---|---|---|---|---|---|---|---|
+| 100 | — | 13.4 / 14.1 | 14.2 / 15.7 | 15.6 / 16.7 | 4.5 / 5.1 | — | 53.0 / 59.0 |
+| 500 | — | 63.2 / 75.8 | 73.9 / 82.7 | 63.3 / 70.8 | 19.3 / 32.3 | — | 231.5 / 289.1 |
+| 1000 | — | 128.4 / 139.6 | 140.6 / 160.9 | 124.8 / 133.2 | 24.3 / 60.5 | — | 428.5 / 537.9 |
+| 2000 | — | 243.2 / 270.1 | 267.7 / 303.8 | 225.9 / 238.6 | 27.5 / 122.6 | — | 805.2 / 1041.4 |
+| 5000 | — | 594.5 / 625.8 | 642.2 / 777.9 | 559.5 / 598.8 | 31.8 / 311.9 | — | 1840.1 / 2635.2 |
+
+Reading it:
+
+- Every model-free lane scales roughly linearly with corpus size on this dense
+  corpus. `graph`, `bm25`, and `keyword` are all O(N) full-corpus lanes; `fusion`
+  stays cheap. A dash means the lane was switched off for the model-free run.
+- The **graph** lane is the one that regressed historically. Even warm — with the
+  wikilink resolver NOT rebuilt — it costs ~226ms at 2000 notes here, because the
+  synthetic corpus is deliberately dense (25 links/note), heavier than a typical
+  vault. The regression this guards against — the resolver reverting to a per-query
+  full rebuild (read + YAML-parse every note) — pushes the graph lane to ~1.9s at
+  2000 notes and ~4.7s at 5000: the class of ~14s event a fixture-scale benchmark
+  hid.
+- The synthetic dense corpus is a **stress shape, not a representative vault**: a
+  real vault has fewer links per note and lighter graph cost. These numbers show
+  scaling and relative lane cost, not an absolute production latency.
+
+With a real embedding sidecar and the reranker on (`--embeddings --rerank`), the
+`vector` and `rerank` lanes appear too — the per-call query embed and the
+cross-encoder over the fused candidates. Measured at smaller sizes (sidecar build
+dominates wall-time at large N):
+
+| Notes | vector | bm25 | keyword | graph | fusion | rerank | total |
+|---|---|---|---|---|---|---|---|
+| 100 | 14.0 / 19.2 | 15.2 / 17.5 | 15.4 / 18.4 | 20.2 / 25.0 | 4.4 / 4.9 | 194.2 / 219.1 | 289.3 / 311.1 |
+| 500 | 13.4 / 16.4 | 66.5 / 70.3 | 72.2 / 82.4 | 70.7 / 72.7 | 24.7 / 29.0 | 146.8 / 152.3 | 419.4 / 463.5 |
+| 1000 | 14.0 / 18.7 | 137.6 / 176.0 | 145.5 / 185.6 | 135.8 / 145.7 | 39.2 / 60.7 | 147.8 / 157.2 | 660.8 / 766.9 |
+| 2000 | 13.6 / 17.1 | 250.8 / 260.3 | 279.3 / 352.6 | 244.3 / 285.8 | 50.8 / 129.9 | 146.0 / 149.9 | 1030.5 / 1291.1 |
+
+The vector query-embed and the reranker's per-candidate cost are roughly
+corpus-size-independent (they scale with the query and the fixed candidate count,
+not N), so they add a near-constant offset on top of the O(N) lexical/graph lanes.
+
+### Regression gate
+
+`tests/test_latency_gate.py` turns this curve into a CI gate: it generates the same
+dense 2000-note vault, warms the lanes, and asserts NO lane exceeds a ceiling
+(`graph < 1000ms`, `total < 5000ms`). The ceilings sit in the wide gap between the
+warm baseline (graph ~226ms, total ~805ms) and a resolver-rebuild regression (graph
+~1.9s), so a 14s-style regression fails CI while ordinary CI-speed variance does
+not. It is model-free, so it runs in the lean matrix on every PR and is pinned in
+the `retrieval-eval` job next to the golden quality gate.
+
+Reproduce the curve:
+
+```
+uv run python scripts/latency_curve.py --sizes 100,500,1000,2000,5000
+uv run --extra embeddings python scripts/latency_curve.py --embeddings --rerank --sizes 100,500,1000,2000
+```
 
 ## Reproduction
 
@@ -110,12 +197,14 @@ in the report's methodology line.
 
 ## Limitations
 
-- **Small.** n = 9 golden queries. Individual metric moves are noisy at this size.
-- **Tiny corpus.** The published numbers are measured on the bundled fixture
-  vault — ~10 KB notes, 77 chunk vectors. They show the ranking *works* (hybrid
-  ≫ keyword, every target recalled), not production-scale quality, and do not
-  generalize to larger or different corpora. Point the harness at your own vault
-  for a representative read.
+- **Small.** n = 26 golden queries. Individual metric moves are noisy at this size.
+- **Tiny corpus.** The quality numbers are measured on the bundled fixture
+  vault — ~20 KB notes, 198 chunk vectors. They show the ranking *works* (hybrid
+  ≫ keyword, nearly every target recalled), not production-scale quality, and do
+  not generalize to larger or different corpora. Point the harness at your own
+  vault for a representative read. The per-lane latency curve above uses a
+  *separate*, larger synthetic corpus precisely because this fixture is too small
+  to expose latency scaling.
 - **Self-graded.** Relevance labels are hand-authored (by the maintainer, not
   independent annotators) — a self-measurement, not a third-party benchmark.
 - **Hardware-dependent latency.** The median/p90 numbers reflect one host's

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -74,7 +74,14 @@ def _load_golden(path: Path) -> list[dict]:
         if not relevance:
             continue
         relevant = {p for p, g in relevance.items() if g > 0}
-        out.append({"query": query, "relevance": relevance, "relevant": relevant})
+        # Per-query retrieval scope. Defaults to "kb-only" so every existing entry
+        # scores exactly as before (KB-only, no auto-widen). An entry whose target
+        # lives OUTSIDE Knowledge Base/ sets `scope: kb` to exercise the auto-widen
+        # reserve (the out-of-KB slots find() reserves under the default kb scope).
+        scope = entry.get("scope", "kb-only")
+        out.append({
+            "query": query, "relevance": relevance, "relevant": relevant, "scope": scope,
+        })
     return out
 
 
@@ -99,10 +106,11 @@ def _evaluate(
             query=g["query"],
             limit=k_max,
             mode=mode,
-            # The golden targets are all KB paths, so evaluate KB-only: this skips
-            # the scope="kb" auto-widen scan over the ~20-folder wider vault, which
-            # dominates eval wall-time per query (the tuner makes hundreds of calls).
-            scope="kb-only",
+            # Per-query scope (default "kb-only"): most golden targets are KB paths,
+            # so KB-only skips the auto-widen scan over the wider vault that would
+            # dominate eval wall-time. An entry targeting an out-of-KB page sets
+            # `scope: kb` to deliberately exercise that auto-widen reserve.
+            scope=g.get("scope", "kb-only"),
             rerank=rerank,
             config=config,
         )
@@ -255,7 +263,7 @@ def _sample_latencies(
             t0 = time.perf_counter()
             find_module.find(
                 vault_root, query=g["query"], limit=k, mode=mode,
-                scope="kb-only", rerank=rerank, config=config,
+                scope=g.get("scope", "kb-only"), rerank=rerank, config=config,
             )
             latencies.append((time.perf_counter() - t0) * 1000.0)
     return latencies

--- a/scripts/latency_curve.py
+++ b/scripts/latency_curve.py
@@ -1,0 +1,323 @@
+"""Per-lane retrieval latency vs. corpus size — the anti-"5ms lie" harness.
+
+A fixture-scale (10-file) latency benchmark once reported a whole `find()` at
+~5ms and hid a real ~14s graph-lane cost on the owner's ~1700-note vault. The
+lesson: latency MUST be measured at realistic corpus scale AND broken out PER
+LANE, or a single-lane blow-up disappears into an aggregate that stays small on
+a toy corpus. This harness does exactly that.
+
+For each corpus size it:
+  1. generates a synthetic, densely-wikilinked vault (`scripts/synth_vault.py`),
+  2. seeds the freshness registry the way the file watcher does (so the graph
+     lane's resolver is live and warm, like production),
+  3. warms every lane with one query, then
+  4. times a fixed query set `--repeat` times with `find(include_timings=True)`,
+     recording the PER-STAGE milliseconds `FindTimings` exposes,
+and prints a markdown table of median / p90 PER LANE (vector, bm25, keyword,
+graph, fusion, rerank) plus the end-to-end total, at each size.
+
+Two measurement modes:
+  * model-free (default): the vector/CLIP/rerank lanes are switched off so the
+    run needs no GPU, no model download, and no embedding sidecar. It reports
+    the lanes that scale with corpus AND don't need a model — bm25, keyword,
+    graph, fusion — which is exactly where the ~14s graph regression lived. This
+    mode is deterministic and reproducible on any machine.
+  * `--embeddings`: builds a real embedding sidecar per synthetic vault and adds
+    the vector lane (and `--rerank` the rerank lane). Needs `--extra embeddings`
+    + the model cache; the sidecar build dominates wall-time at large sizes, so
+    keep `--max-embeddings-size` sane.
+
+Usage:
+    uv run python scripts/latency_curve.py
+    uv run python scripts/latency_curve.py --sizes 100,500,1000,2000,5000 --repeat 5
+    uv run --extra embeddings python scripts/latency_curve.py --embeddings --rerank \
+        --sizes 100,500,1000,2000
+
+It writes nothing to any real vault — every corpus lives in a throwaway temp dir
+that is removed after the size is measured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# --- Isolate this benchmark from any host/service config BEFORE importing exomem.
+# Every measured find() must run all lanes (no hot-cache short-circuit) and must
+# not spawn the warm thread / file watcher / load a committed ranking config.
+os.environ.setdefault("EXOMEM_FIND_CACHE_SIZE", "0")  # measure lanes, not the cache
+os.environ.setdefault("EXOMEM_DISABLE_WARMUP", "1")
+os.environ.setdefault("EXOMEM_DISABLE_FILE_WATCHER", "1")
+os.environ.setdefault("EXOMEM_DISABLE_RANKING_CONFIG", "1")
+os.environ.setdefault("EXOMEM_DISABLE_RELEVANCE_CHECK", "1")
+os.environ.setdefault("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
+
+# Emit UTF-8 regardless of the host console codepage, so the em-dash for an
+# absent lane survives redirection into the markdown report on Windows.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+except (AttributeError, ValueError):
+    pass
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from synth_vault import gen_dense_vault  # noqa: E402
+
+from exomem import find as find_module  # noqa: E402
+from exomem import freshness  # noqa: E402
+from exomem.vault import walk_vault_md  # noqa: E402
+
+DEFAULT_SIZES = [100, 500, 1000, 2000, 5000]
+
+# Fixed query set, run identically at every size. A spread of shapes so more than
+# one lane is exercised: a long natural-language query, a short topical one, and
+# a bare multi-term query. They intentionally hit the synthetic corpus's shared
+# vocabulary ("topic", "note", "related") so every lane produces candidates.
+DEFAULT_QUERIES = [
+    "topic prose paragraph related context",
+    "note about synthetic dense graph",
+    "realistically sized body text for ranking",
+    "related links between insight pattern notes",
+    "concept people sources experiments topic",
+]
+
+# The lanes we report, in a fixed column order. Names must match FindTimings'
+# stage keys (see find.FindTimings / the _span(...) call sites).
+LANES = ("vector", "bm25", "keyword", "graph", "fusion", "rerank")
+
+
+class _NoEmbeddingIndex:
+    """Sentinel: make find()'s vector lane take its lean-deployment path.
+
+    find() treats an ImportError from the embedding getter as a DEPLOYMENT SHAPE
+    (no embeddings extra), not a failure — it logs and falls back to BM25/keyword
+    without recording degradation. Raising it here is the cleanest way to switch
+    the vector (and, with CLIP disabled, the CLIP) lane OFF for a model-free run,
+    regardless of whether torch happens to be importable on this machine.
+    """
+
+
+def _install_model_free() -> None:
+    """Force the vector + CLIP lanes off for a model-free measurement."""
+    os.environ["EXOMEM_DISABLE_CLIP"] = "1"  # clip_enabled() -> False, lane skipped
+
+    def _raise(*_a, **_k):
+        raise ImportError("model-free latency_curve run: vector lane disabled")
+
+    # find() does `from . import embeddings` inside its recall function, then
+    # calls embeddings.get_embedding_index(...) first in the vector span; an
+    # ImportError there sends it down the intended lean/BM25 fallback. Patch the
+    # module attribute so that lookup resolves to the raiser.
+    from exomem import embeddings as embeddings_module
+    embeddings_module.get_embedding_index = _raise  # type: ignore[assignment]
+
+
+def _seed_freshness_live(vault: Path) -> None:
+    """Seed the event-maintained freshness registry the way the watcher does,
+    so the graph lane's resolver is live and warm (production shape)."""
+    freshness.seed(
+        vault, "vault",
+        ((str(p), p.stat().st_mtime_ns) for p in walk_vault_md(vault)),
+    )
+    kb = vault / "Knowledge Base"
+    freshness.seed(
+        vault, "kb",
+        ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb)),
+    )
+
+
+def _percentile(sorted_vals: list[float], pct: float) -> float:
+    """Nearest-rank percentile of an already-sorted list (dependency-free)."""
+    if not sorted_vals:
+        return 0.0
+    rank = math.ceil(pct / 100.0 * len(sorted_vals))
+    idx = min(max(rank, 1), len(sorted_vals)) - 1
+    return sorted_vals[idx]
+
+
+def measure_size(
+    n: int,
+    *,
+    queries: list[str],
+    repeat: int,
+    links_per_note: int,
+    limit: int,
+    embeddings_on: bool,
+    rerank: bool,
+) -> dict:
+    """Generate an n-note vault and return per-lane + total latency aggregates.
+
+    Returns `{"n", "chunks", "lanes": {lane: {"median","p90","samples"}},
+    "total": {"median","p90"}}`. Lanes that never produced a timing (skipped /
+    errored, e.g. vector in model-free mode) are absent from `lanes`.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix=f"exomem-latcurve-{n}-"))
+    chunks = 0
+    try:
+        vault = tmp / "vault"
+        gen_dense_vault(vault, n, links_per_note=links_per_note)
+        _seed_freshness_live(vault)
+
+        find_module.clear_cache()
+        if embeddings_on:
+            # Real sidecar so the vector lane searches actual chunks at scale.
+            from exomem import embeddings as embeddings_module
+            embeddings_module.clear_embedding_indexes()
+            chunks = embeddings_module.get_embedding_index(vault).rebuild_all()
+
+        lane_samples: dict[str, list[float]] = {lane: [] for lane in LANES}
+        total_samples: list[float] = []
+
+        # Warm every lane once (bm25 corpus, resolver, model/sidecar) so the
+        # measured passes reflect steady-state, not first-touch build cost.
+        for q in queries:
+            find_module.find(
+                vault, query=q, limit=limit, mode="hybrid",
+                graph=True, rerank=rerank,
+            )
+
+        for _ in range(max(repeat, 1)):
+            for q in queries:
+                t = find_module.FindTimings()
+                find_module.find(
+                    vault, query=q, limit=limit, mode="hybrid",
+                    graph=True, rerank=rerank, timings=t,
+                )
+                d = t.as_dict()
+                total_samples.append(d["total_ms"])
+                for lane in LANES:
+                    stage = d["stages"].get(lane, {})
+                    # A lane's `_span` finally-block records `ms` even when the
+                    # lane body raised (e.g. the model-free vector ImportError),
+                    # so exclude any lane that errored or was skipped — it did not
+                    # actually run to completion and its ~0ms is not a lane cost.
+                    if "ms" in stage and "error" not in stage and "skipped" not in stage:
+                        lane_samples[lane].append(stage["ms"])
+
+        lanes: dict[str, dict] = {}
+        for lane, vals in lane_samples.items():
+            if not vals:
+                continue
+            sv = sorted(vals)
+            lanes[lane] = {
+                "median": statistics.median(sv),
+                "p90": _percentile(sv, 90),
+                "samples": len(sv),
+            }
+        total_sorted = sorted(total_samples)
+        return {
+            "n": n,
+            "chunks": chunks,
+            "lanes": lanes,
+            "total": {
+                "median": statistics.median(total_sorted) if total_sorted else 0.0,
+                "p90": _percentile(total_sorted, 90),
+            },
+        }
+    finally:
+        find_module.clear_cache()
+        freshness.clear()
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _fmt_cell(agg: dict | None) -> str:
+    """A `median / p90` cell in ms, or an em-dash when the lane didn't run."""
+    if not agg:
+        return "—"
+    return f"{agg['median']:.1f} / {agg['p90']:.1f}"
+
+
+def render_markdown(results: list[dict], *, embeddings_on: bool, rerank: bool) -> str:
+    """Render the per-lane latency-vs-size curve as a markdown table (ms, median / p90)."""
+    lines: list[str] = []
+    mode = "hybrid + embeddings" if embeddings_on else "model-free (BM25/keyword/graph/fusion)"
+    if embeddings_on and rerank:
+        mode += " + rerank"
+    lines.append(f"Per-lane latency (ms, median / p90) — mode: {mode}")
+    lines.append("")
+    header = ["Notes", *LANES, "total"]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("|" + "|".join(["---"] * len(header)) + "|")
+    for r in results:
+        cells = [str(r["n"])]
+        for lane in LANES:
+            cells.append(_fmt_cell(r["lanes"].get(lane)))
+        cells.append(_fmt_cell(r["total"]))
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--sizes", type=str, default=",".join(str(s) for s in DEFAULT_SIZES),
+        help="comma-separated note counts (default 100,500,1000,2000,5000)",
+    )
+    ap.add_argument("--repeat", type=int, default=5, help="measured passes of the query set per size")
+    ap.add_argument("--links-per-note", type=int, default=25, help="outbound wikilinks per synthetic note")
+    ap.add_argument("--limit", type=int, default=10, help="find() result limit")
+    ap.add_argument(
+        "--embeddings", action="store_true",
+        help="build a real sidecar per size and measure the vector lane (needs --extra embeddings)",
+    )
+    ap.add_argument("--rerank", action="store_true", help="also measure the rerank lane (implies model use)")
+    ap.add_argument(
+        "--max-embeddings-size", type=int, default=2000,
+        help="skip sizes above this when --embeddings (sidecar build is expensive); default 2000",
+    )
+    args = ap.parse_args()
+
+    sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
+    if args.embeddings:
+        sizes = [s for s in sizes if s <= args.max_embeddings_size]
+        if not sizes:
+            print("no sizes <= --max-embeddings-size; nothing to measure", file=sys.stderr)
+            return 1
+    else:
+        _install_model_free()
+
+    print(
+        f"latency curve: sizes={sizes} repeat={args.repeat} "
+        f"links/note={args.links_per_note} queries={len(DEFAULT_QUERIES)} "
+        f"embeddings={'on' if args.embeddings else 'off'} rerank={'on' if args.rerank else 'off'}",
+        file=sys.stderr,
+    )
+    results: list[dict] = []
+    for n in sizes:
+        t0 = time.perf_counter()
+        r = measure_size(
+            n,
+            queries=DEFAULT_QUERIES,
+            repeat=args.repeat,
+            links_per_note=args.links_per_note,
+            limit=args.limit,
+            embeddings_on=args.embeddings,
+            rerank=args.rerank or args.embeddings,
+        )
+        results.append(r)
+        chunk_note = f" chunks={r['chunks']}" if args.embeddings else ""
+        print(
+            f"  n={n:>5}{chunk_note}  graph={_fmt_cell(r['lanes'].get('graph'))}  "
+            f"total={_fmt_cell(r['total'])}  ({time.perf_counter() - t0:.1f}s)",
+            file=sys.stderr,
+        )
+
+    print()
+    print(render_markdown(results, embeddings_on=args.embeddings, rerank=args.rerank or args.embeddings))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/synth_vault.py
+++ b/scripts/synth_vault.py
@@ -1,0 +1,82 @@
+"""Reusable synthetic, densely-wikilinked vault generator for perf benchmarks.
+
+Extracted from `tests/test_graph_lane_perf.py` (which used to carry its own copy)
+so three callers generate a byte-identical corpus from ONE place:
+
+- `tests/test_graph_lane_perf.py` — the graph-lane event-maintenance regression.
+- `tests/test_latency_gate.py`    — the per-lane latency ceiling gate at scale.
+- `scripts/latency_curve.py`      — the latency-vs-corpus-size curve harness.
+
+The generator is pure stdlib (`random` + `pathlib`) — it does NOT import exomem
+or torch — so importing it is cheap and side-effect-free from both tests and
+scripts. `gen_dense_vault` is deterministic for a fixed `(n, links_per_note,
+seed)`: same names, same folders, same link topology every run, so a benchmark
+number is reproducible and a regression is attributable to code, not corpus jitter.
+
+Why "dense": the graph lane resolves every `[[wikilink]]` on strong candidates
+through the whole-vault `WikilinkResolver`. A realistic cross-linked corpus
+(~25 links/note, a mix of full-path and bare-stem link forms) is what makes a
+resolver-rebuild regression show up as a real per-query cost at scale, instead of
+staying hidden the way a 10-file fixture did.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+# KB sub-folders the synthetic notes are spread across — a realistic slice of the
+# page-type tree so the walk/parse cost resembles a real vault's shape.
+FOLDERS: tuple[str, ...] = (
+    "Notes/Insights", "Notes/Patterns", "Notes/Failures",
+    "Entities/Concepts", "Entities/People", "Sources", "Experiments",
+)
+
+
+def gen_dense_vault(
+    root: Path, n: int, links_per_note: int = 25, seed: int = 7
+) -> list[str]:
+    """Write `n` densely cross-linked KB notes under `root`; return their rels.
+
+    Each note gets `links_per_note` outbound `[[wikilinks]]` to random other
+    notes, alternating between full-path and bare-stem link forms so the resolver
+    exercises both resolution paths. Returns the vault-relative paths (with the
+    leading ``Knowledge Base/`` and trailing ``.md``) in creation order, so a
+    caller can address specific notes (e.g. to edit/rename/delete one).
+
+    Deterministic in `(n, links_per_note, seed)`. Writes only under
+    ``root/Knowledge Base/`` — the caller owns `root` (typically a tmp dir).
+    """
+    rng = random.Random(seed)
+    kb = root / "Knowledge Base"
+    for f in FOLDERS:
+        (kb / f).mkdir(parents=True, exist_ok=True)
+    rels: list[str] = []
+    names: list[str] = []
+    for i in range(n):
+        folder = FOLDERS[i % len(FOLDERS)]
+        name = f"note-{i:05d}-topic-{rng.randint(0, 99999)}"
+        names.append(name)
+        rels.append(f"Knowledge Base/{folder}/{name}.md")
+    for i, rel in enumerate(rels):
+        targets = rng.sample(range(n), min(links_per_note, n))
+        link_lines = []
+        for t in targets:
+            if t % 3 == 0:  # mix full-path and bare-stem link forms
+                link_lines.append(f"- see [[{rels[t][:-3]}]] for context")
+            else:
+                link_lines.append(f"- ref [[{names[t]}]] inline")
+        (root / rel).write_text(
+            "---\n"
+            "type: insight\n"
+            f"title: Note {i} about topic {names[i]}\n"
+            "tags: [synthetic, graph, dense]\n"
+            f"updated: 2026-02-{(i % 28) + 1:02d}\n"
+            "---\n\n"
+            f"# Note {i}\n\n"
+            "Prose paragraph so the note is realistically sized and body text "
+            "gives BM25 something to rank on. topic topic topic.\n\n"
+            "## Related\n\n" + "\n".join(link_lines) + "\n",
+            encoding="utf-8",
+        )
+    return rels

--- a/tests/fixtures/Handbooks/incident-severity-levels.md
+++ b/tests/fixtures/Handbooks/incident-severity-levels.md
@@ -1,0 +1,19 @@
+---
+tags: [operations, incidents, oncall, curated]
+---
+
+# Incident Severity Levels (SEV1–SEV4)
+
+This handbook page lives OUTSIDE Knowledge Base/. It is curated, read-only
+material kept in a sibling folder, used by tests to verify that a `scope="kb"`
+query auto-widens to reach out-of-KB content.
+
+## Severity definitions
+
+- **SEV1** — critical: full outage or data loss, all-hands, immediate paging.
+- **SEV2** — major: a core feature is broken for many users; page the on-call.
+- **SEV3** — minor: degraded or partial impact with a workaround; handle in hours.
+- **SEV4** — low: cosmetic or internal-only; handle in the normal queue.
+
+Declare the severity from customer impact, not from how hard the fix looks. When
+in doubt between two levels, pick the higher one and downgrade later.

--- a/tests/fixtures/Knowledge Base/Entities/Concepts/Idempotency Key.md
+++ b/tests/fixtures/Knowledge Base/Entities/Concepts/Idempotency Key.md
@@ -1,0 +1,23 @@
+---
+type: entity
+entity_type: concept
+status: active
+created: 2026-04-18
+updated: 2026-04-18
+domain: distributed-systems
+tags: [idempotency, api, http]
+---
+
+# Idempotency Key
+
+## Summary
+
+An idempotency key is a client-generated unique token sent with a mutating request so the server can deduplicate retries. The client puts the token in the `Idempotency-Key` header; if the same key arrives twice, the server returns the stored result of the first attempt instead of applying the operation again.
+
+## Why in the KB
+
+Referenced whenever a payment or order API needs exactly-once semantics on top of at-least-once retries. The exact header name `Idempotency-Key` is the interoperable convention.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff]]

--- a/tests/fixtures/Knowledge Base/Entities/Concepts/Write-Ahead Log.md
+++ b/tests/fixtures/Knowledge Base/Entities/Concepts/Write-Ahead Log.md
@@ -1,0 +1,23 @@
+---
+type: entity
+entity_type: concept
+status: active
+created: 2026-03-28
+updated: 2026-03-28
+domain: databases
+tags: [durability, wal, storage]
+---
+
+# Write-Ahead Log
+
+## Summary
+
+A write-ahead log (WAL) is an append-only log a database writes changes to BEFORE applying them to the main data pages. Because the intent is durably recorded first, a crash mid-update is recoverable: on restart the engine replays the log to redo committed changes and roll back incomplete ones. The WAL is what lets a database promise durability without an fsync on every page.
+
+## Why in the KB
+
+The core mechanism behind crash recovery and point-in-time restore in relational databases; referenced whenever durability-versus-latency trade-offs come up.
+
+## Connections
+
+- [[Knowledge Base/Entities/Concepts/Envelope]]

--- a/tests/fixtures/Knowledge Base/Entities/People/Grace Hopper.md
+++ b/tests/fixtures/Knowledge Base/Entities/People/Grace Hopper.md
@@ -1,0 +1,24 @@
+---
+type: entity
+entity_type: person
+status: active
+created: 2026-04-02
+updated: 2026-04-02
+affiliation: US Navy / early computing
+relationship: public-figure
+tags: [computing-history, compilers]
+---
+
+# Grace Hopper
+
+## Summary
+
+Grace Hopper was a computer scientist and US Navy rear admiral who built one of the first compilers and championed machine-independent, high-level programming languages, work that led toward COBOL. She popularized the term "debugging" after a literal moth was found taped into a lab logbook as the cause of a fault.
+
+## Why in the KB
+
+The reference example for the argument that programming should happen in readable, high-level languages rather than raw machine code — and the origin story behind the word "bug".
+
+## Connections
+
+- [[Knowledge Base/Entities/People/Ada Lovelace]]

--- a/tests/fixtures/Knowledge Base/Notes/Failures/cache-stampede-on-cold-start.md
+++ b/tests/fixtures/Knowledge Base/Notes/Failures/cache-stampede-on-cold-start.md
@@ -1,0 +1,31 @@
+---
+type: failure
+status: active
+created: 2026-05-30
+updated: 2026-05-30
+sources: []
+severity: serious
+tags: [caching, thundering-herd, latency]
+---
+
+# Cache stampede when a hot key expires under load
+
+## What happened
+
+A single hot cache key expired during peak traffic. Every concurrent request missed at once and all of them hit the database to recompute the same value — a thundering herd that spiked database load and tail latency until the key was repopulated.
+
+## Mechanism
+
+With no coordination, expiry converts N cache readers into N simultaneous recomputers. The cost is proportional to concurrency at the exact moment of expiry, not to the real rate of change of the data.
+
+## Detection
+
+Database CPU and p99 latency spiked on a sawtooth aligned with the cache TTL boundary.
+
+## Mitigation
+
+Add request coalescing (single-flight) so only one caller recomputes while the rest wait on its result, plus early/probabilistic recomputation before the TTL hard-expires.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/circuit-breaker-for-downstream-failures]]

--- a/tests/fixtures/Knowledge Base/Notes/Insights/autovacuum-thresholds-prevent-table-bloat.md
+++ b/tests/fixtures/Knowledge Base/Notes/Insights/autovacuum-thresholds-prevent-table-bloat.md
@@ -1,0 +1,27 @@
+---
+type: insight
+status: active
+created: 2026-06-03
+updated: 2026-06-03
+sources:
+  - "[[Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning]]"
+tags: [postgres, autovacuum, database, bloat]
+---
+
+# Per-table autovacuum scale factors prevent bloat on write-heavy tables
+
+## Claim
+
+On a large, write-heavy Postgres table, lower the per-table `autovacuum_vacuum_scale_factor` to 0.01–0.05 instead of leaving the 0.2 default. The default lets a fifth of the table rot into dead tuples before a vacuum fires, which is exactly how big tables accumulate bloat and lose index-scan performance.
+
+## Why it holds
+
+The vacuum trigger scales with table size, so the same 0.2 factor that is fine for a 10k-row table means millions of dead tuples on a 100M-row table. A small per-table override keeps the dead-tuple ceiling proportional to churn, not to table size.
+
+## Where it applies
+
+Any high-churn relational table: event logs, queue tables, session stores.
+
+## Connections
+
+- [[Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning]]

--- a/tests/fixtures/Knowledge Base/Notes/Insights/percentage-based-feature-flag-rollout.md
+++ b/tests/fixtures/Knowledge Base/Notes/Insights/percentage-based-feature-flag-rollout.md
@@ -1,0 +1,26 @@
+---
+type: insight
+status: active
+created: 2026-05-22
+updated: 2026-05-22
+sources: []
+tags: [feature-flags, rollout, release-engineering]
+---
+
+# Gradual percentage rollout beats big-bang feature releases
+
+## Claim
+
+Release a risky feature by ramping its feature flag through percentage cohorts — 1%, 5%, 25%, 100% — rather than flipping it on for everyone at once. Each percentage step is a checkpoint where you watch error rates before widening exposure.
+
+## Why it holds
+
+A gradual percentage rollout bounds the blast radius: a regression that only shows under real traffic is caught at 1% of users, not 100%. The flag is the throttle; the cohort percentage is the dial.
+
+## Where it applies
+
+Any user-facing change behind a feature flag where a bad release would degrade many users at once.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases]]

--- a/tests/fixtures/Knowledge Base/Notes/Insights/rrf-fusion-beats-score-normalization.md
+++ b/tests/fixtures/Knowledge Base/Notes/Insights/rrf-fusion-beats-score-normalization.md
@@ -1,0 +1,26 @@
+---
+type: insight
+status: active
+created: 2026-06-14
+updated: 2026-06-14
+sources: []
+tags: [retrieval, fusion, ranking, rrf]
+---
+
+# Reciprocal rank fusion is more robust than normalizing retriever scores
+
+## Claim
+
+To combine a lexical retriever with a vector retriever, fuse by rank with reciprocal rank fusion (RRF) rather than normalizing and adding their raw scores. RRF depends only on the position of a document in each list, so it is immune to the incomparable score scales that break weighted-sum fusion.
+
+## Why it holds
+
+BM25 scores and cosine similarities live on different, non-linear scales; any fixed normalization is a guess that drifts per query. Rank is scale-free: a document ranked first contributes `1 / (k + 1)` from each list regardless of the underlying score magnitude.
+
+## Where it applies
+
+Any hybrid search that blends two or more rankers with unlike score distributions.
+
+## Connections
+
+- [[Knowledge Base/Notes/Research/Project Alpha/engine-architecture]]

--- a/tests/fixtures/Knowledge Base/Notes/Patterns/circuit-breaker-for-downstream-failures.md
+++ b/tests/fixtures/Knowledge Base/Notes/Patterns/circuit-breaker-for-downstream-failures.md
@@ -1,0 +1,31 @@
+---
+type: pattern
+status: active
+created: 2026-05-15
+updated: 2026-05-15
+sources: []
+pattern_type: architectural
+tags: [resilience, circuit-breaker, downstream]
+---
+
+# Circuit breaker for a failing downstream service
+
+## Problem
+
+When a downstream dependency starts failing or timing out, callers that keep hammering it waste threads on doomed calls and can drag the whole caller down with it.
+
+## Solution
+
+Wrap calls in a circuit breaker. After a threshold of failures the breaker trips OPEN and short-circuits calls immediately (failing fast or serving a fallback) instead of waiting on timeouts. After a cool-down it goes HALF-OPEN and lets a trial request through; success closes it, failure re-opens it.
+
+## When to use
+
+Any synchronous call to a remote dependency that can degrade, especially on a hot path where piled-up timeouts would exhaust a thread pool.
+
+## When NOT to use
+
+Cheap in-process calls, or when every request truly must reach the dependency.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff]]

--- a/tests/fixtures/Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md
+++ b/tests/fixtures/Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md
@@ -1,0 +1,31 @@
+---
+type: pattern
+status: active
+created: 2026-05-23
+updated: 2026-05-23
+sources: []
+pattern_type: architectural
+tags: [feature-flags, safety, operations]
+---
+
+# Kill switch for risky releases
+
+## Problem
+
+When a release starts misbehaving in production, the team needs to disable it in seconds, without a redeploy or a rollback that itself takes time.
+
+## Solution
+
+Put every risky change behind a boolean kill switch evaluated at request time. Flipping the switch off — a single config write — instantly returns to the previous safe behavior. The switch is independent of the deploy pipeline, so remediation does not wait on a build.
+
+## When to use
+
+Any change severe enough that "wait for a rollback deploy" is too slow a remediation.
+
+## When NOT to use
+
+Trivial changes where a normal rollback is fast enough; every switch is config surface to maintain.
+
+## Connections
+
+- [[Knowledge Base/Notes/Insights/percentage-based-feature-flag-rollout]]

--- a/tests/fixtures/Knowledge Base/Notes/Patterns/retry-with-fixed-interval.md
+++ b/tests/fixtures/Knowledge Base/Notes/Patterns/retry-with-fixed-interval.md
@@ -1,0 +1,28 @@
+---
+type: pattern
+status: superseded
+created: 2026-01-12
+updated: 2026-06-10
+sources: []
+pattern_type: architectural
+superseded_by: "[[Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff]]"
+tags: [retry, backoff, resilience]
+---
+
+# Retry with a fixed interval
+
+## Problem
+
+A client needs to retry a request that failed transiently.
+
+## Solution
+
+Wait a constant interval (e.g. one second) between attempts, up to a maximum retry count.
+
+## When to use
+
+Superseded — a fixed interval synchronizes callers into retry storms under load. Use exponential backoff with full jitter instead.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff]]

--- a/tests/fixtures/Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff.md
+++ b/tests/fixtures/Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff.md
@@ -1,0 +1,32 @@
+---
+type: pattern
+status: active
+created: 2026-06-10
+updated: 2026-06-10
+sources: []
+pattern_type: architectural
+supersedes: "[[Knowledge Base/Notes/Patterns/retry-with-fixed-interval]]"
+tags: [retry, backoff, jitter, resilience]
+---
+
+# Retry with exponential backoff and full jitter
+
+## Problem
+
+Clients that retry a failed request on a fixed schedule synchronize into retry storms: every caller waits the same interval and hammers the recovering service in lockstep, so it never gets breathing room.
+
+## Solution
+
+Retry with exponential backoff AND full jitter: sleep a random duration in `[0, base * 2**attempt]` before each retry, capped at a ceiling. The randomness spreads retries across the window, so load on the downstream smooths out instead of spiking.
+
+## When to use
+
+Any client calling a remote service that can fail transiently — HTTP calls, queue consumers, database connections.
+
+## When NOT to use
+
+Non-idempotent operations without a dedup key, where a blind retry could double-apply.
+
+## Connections
+
+- [[Knowledge Base/Notes/Patterns/circuit-breaker-for-downstream-failures]]

--- a/tests/fixtures/Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning-revisited.md
+++ b/tests/fixtures/Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning-revisited.md
@@ -1,0 +1,23 @@
+---
+type: research-note
+project: infrastructure
+status: active
+created: 2026-06-25
+updated: 2026-06-25
+sources: []
+tags: [vector-database, indexing, hnsw]
+---
+
+# Tuning vector indexes, revisited with HNSW
+
+## Question
+
+After benchmarking, how should we tune vector database indexes for recall and build cost?
+
+## Findings
+
+The latest read: HNSW beats IVFFlat on recall-at-fixed-latency for our corpus. Tune `m` (graph degree, 16 is a good default) and `ef_construction` (build-time breadth, 64–200) for build cost, and raise `ef_search` at query time to trade latency for recall. This supersedes the earlier IVFFlat list-count guidance as the current recommendation for tuning vector database indexes.
+
+## Connections
+
+- [[Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning]]

--- a/tests/fixtures/Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning.md
+++ b/tests/fixtures/Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning.md
@@ -1,0 +1,23 @@
+---
+type: research-note
+project: infrastructure
+status: active
+created: 2026-03-10
+updated: 2026-03-10
+sources: []
+tags: [vector-database, indexing, ivfflat]
+---
+
+# Tuning IVFFlat vector indexes
+
+## Question
+
+How should the IVFFlat list count be chosen for an approximate nearest-neighbour vector index?
+
+## Findings
+
+IVFFlat partitions vectors into `lists` cells and probes a subset at query time. A common starting point is `lists = rows / 1000` for up to a million rows, with `probes` traded off against recall. This is the earlier reading, before HNSW was benchmarked on the same corpus.
+
+## Connections
+
+- [[Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning-revisited]]

--- a/tests/fixtures/Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning.md
+++ b/tests/fixtures/Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning.md
@@ -1,0 +1,20 @@
+---
+type: source
+source_type: article
+captured: 2026-06-02
+url: https://www.postgresql.org/docs/current/routine-vacuuming.html
+tags: [postgres, autovacuum, database, bloat]
+ingested_into: []
+---
+
+# Source: Tuning PostgreSQL Autovacuum to Control Table Bloat
+
+> Captured while diagnosing slow queries on a write-heavy Postgres table — the raw reference on autovacuum knobs.
+
+## Capture
+
+PostgreSQL reclaims dead tuples with autovacuum. The trigger is governed by `autovacuum_vacuum_scale_factor` (default 0.2) plus `autovacuum_vacuum_threshold` (default 50): a vacuum fires when dead tuples exceed `threshold + scale_factor * reltuples`. On a large, write-heavy table the default 0.2 scale factor means one fifth of the table must turn to dead tuples before a vacuum runs, so bloat accumulates and index scans slow down. Lowering the per-table scale factor to 0.01–0.05 and raising `autovacuum_vacuum_cost_limit` makes vacuum run more often and finish faster.
+
+## Why captured
+
+Primary reference behind the compiled insight on autovacuum thresholds; keep the raw knob defaults here.

--- a/tests/fixtures/Knowledge Base/Sources/index.md
+++ b/tests/fixtures/Knowledge Base/Sources/index.md
@@ -4,12 +4,13 @@ Raw, immutable inputs. Append-only. Never edited after capture.
 
 ## By type
 
-- [[Knowledge Base/Sources/Articles/|Articles]] — captured web/PDF content (1)
+- [[Knowledge Base/Sources/Articles/|Articles]] — captured web/PDF content (2)
 - [[Knowledge Base/Sources/Books/|Books]] — book notes/excerpts (1)
 - [[Knowledge Base/Sources/Sessions/|Sessions]] — pasted Claude/conversation transcripts (1)
 
 ## Recent captures
 
+- 2026-06-02 — [[Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning]]
 - 2026-05-05 — [[Knowledge Base/Sources/Sessions/2026-05-05-metabolism-curriculum-design]]
 - 2026-05-04 — [[Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements]]
 - 2026-05-03 — [[Knowledge Base/Sources/Books/2026-05-03-elimination-diet]]

--- a/tests/fixtures/Knowledge Base/index.md
+++ b/tests/fixtures/Knowledge Base/index.md
@@ -25,11 +25,11 @@ Compiled, structured layer of the Obsidian vault. Governed by [[Knowledge Base/_
 
 <!-- Reconciled against disk. -->
 
-- Sources: 3 (articles: 1, books: 1, sessions: 1)
-- Notes (research): 2
-- Notes (insight): 1
-- Notes (failure): 1
-- Notes (pattern): 1
+- Sources: 4 (articles: 2, books: 1, sessions: 1)
+- Notes (research): 4
+- Notes (insight): 4
+- Notes (failure): 2
+- Notes (pattern): 5
 - Notes (production-log): 1
-- Entities (person): 1
-- Entities (concept): 1
+- Entities (person): 2
+- Entities (concept): 3

--- a/tests/golden/queries.yaml
+++ b/tests/golden/queries.yaml
@@ -1,19 +1,28 @@
 # Golden query set for retrieval eval (scripts/eval_retrieval.py).
 #
-# SEED set — hand-authored against the bundled fixture KB (tests/fixtures/) so
-# the baseline number is meaningful and the example runs out of the box. Point
-# the eval at the fixtures with EXOMEM_VAULT_PATH=tests/fixtures, or replace
-# these with queries against your own vault. The set is meant to GROW:
-# scripts/derive_relevance_pairs.py proposes additions mined from real
-# (query -> cited path) usage, which you confirm.
+# Hand-authored against the bundled fixture KB (tests/fixtures/) so the baseline
+# number is meaningful and the example runs out of the box. Point the eval at the
+# fixtures with EXOMEM_VAULT_PATH=tests/fixtures, or replace these with queries
+# against your own vault. The set is meant to GROW: scripts/derive_relevance_pairs.py
+# proposes additions mined from real (query -> cited path) usage, which you confirm.
 #
 # Each entry:
 #   query:         the search string (natural language, not a title echo)
 #   expect_any_of: [vault paths] treated as binary-relevant (grade 1), OR
 #   graded:        {path: grade 0..3} for NDCG grading (3=ideal, 1=marginal)
+#   scope:         optional retrieval scope, default "kb-only". Set "kb" for an
+#                  entry whose target lives OUTSIDE Knowledge Base/, to exercise
+#                  find()'s auto-widen reserve (see the incident-severity entry).
 #
 # Paths are matched leniently: leading "Knowledge Base/" and ".md" optional,
 # case-insensitive (see _canon in eval_retrieval.py).
+#
+# Beyond breadth, several entries each PIN one specific ranking behavior; those
+# are grouped and labelled below so a regression points at the behavior it broke.
+
+# --------------------------------------------------------------------------- #
+# General natural-language recall (one clear target each).
+# --------------------------------------------------------------------------- #
 
 - query: "do single behavioural modes beat basic/advanced toggles for mixed-skill tools"
   expect_any_of:
@@ -47,8 +56,117 @@
   expect_any_of:
     - "Knowledge Base/Sources/Books/2026-05-03-elimination-diet"
 
+- query: "which internal Go packages and CLI subcommands does the alpha engine binary expose"
+  expect_any_of:
+    - "Knowledge Base/Notes/Research/Project Alpha/engine-architecture"
+
+- query: "the ML educator known for the Software 3.0 framing and minimal-dependency engineering"
+  expect_any_of:
+    - "Knowledge Base/Entities/People/Ada Lovelace"
+
+- query: "EGCG hepatotoxicity risk above 800 mg per day from concentrated extracts"
+  expect_any_of:
+    - "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements"
+
+- query: "single-flight request coalescing so only one caller recomputes an expired cache key"
+  expect_any_of:
+    - "Knowledge Base/Notes/Failures/cache-stampede-on-cold-start"
+
+- query: "thundering herd when a hot cache key expires under peak load"
+  expect_any_of:
+    - "Knowledge Base/Notes/Failures/cache-stampede-on-cold-start"
+
+- query: "why reciprocal rank fusion is more robust than normalizing retriever scores"
+  expect_any_of:
+    - "Knowledge Base/Notes/Insights/rrf-fusion-beats-score-normalization"
+
+- query: "who built one of the first compilers and popularized the term debugging"
+  expect_any_of:
+    - "Knowledge Base/Entities/People/Grace Hopper"
+
+- query: "trip a breaker to stop calling a failing downstream service and fail fast"
+  expect_any_of:
+    - "Knowledge Base/Notes/Patterns/circuit-breaker-for-downstream-failures"
+
+- query: "the append-only log a database writes before applying changes for durability"
+  expect_any_of:
+    - "Knowledge Base/Entities/Concepts/Write-Ahead Log"
+
+- query: "tuning HNSW graph degree and ef_search for recall versus query latency"
+  expect_any_of:
+    - "Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning-revisited"
+
+- query: "what a kill switch gives you that a rollback deploy does not"
+  expect_any_of:
+    - "Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases"
+
+# --------------------------------------------------------------------------- #
+# PIN: compiled-over-source (prefer_compiled). A raw source and the compiled
+# insight distilled from it both answer the query; the compiled note is the ideal
+# hit (grade 3), the source marginal (grade 1). A regression that stops boosting
+# compiled pages lets the source outrank the insight and drops NDCG.
+# --------------------------------------------------------------------------- #
+- query: "how to tune postgres autovacuum to stop table bloat on a write-heavy table"
+  graded:
+    "Knowledge Base/Notes/Insights/autovacuum-thresholds-prevent-table-bloat": 3
+    "Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning": 1
+
+# --------------------------------------------------------------------------- #
+# PIN: supersession demotion (prefer_active). The active pattern is the ideal
+# hit; its superseded predecessor is marginal and must not outrank it. A
+# regression that stops demoting `status: superseded` pages inverts the order.
+# --------------------------------------------------------------------------- #
+- query: "recommended client retry backoff strategy for failed requests under load"
+  graded:
+    "Knowledge Base/Notes/Patterns/retry-with-full-jitter-backoff": 3
+    "Knowledge Base/Notes/Patterns/retry-with-fixed-interval": 1
+
+# --------------------------------------------------------------------------- #
+# PIN: graph-hop target. The direct lexical/vector hit is the rollout insight
+# (grade 3). The kill-switch pattern (grade 1) shares no query vocabulary — it
+# surfaces ONLY because the insight wikilinks to it, via the graph lane. If the
+# graph lane regresses, the kill-switch drops out of top-10 and per-query recall
+# falls from 1.0 to 0.5.
+# --------------------------------------------------------------------------- #
+- query: "gradual percentage rollout of new features behind flags"
+  graded:
+    "Knowledge Base/Notes/Insights/percentage-based-feature-flag-rollout": 3
+    "Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases": 1
+
+# --------------------------------------------------------------------------- #
+# PIN: temporal recency. Two research notes on the same topic; the "latest"
+# query must surface the newer (updated 2026-06-25) above the older
+# (2026-03-10). A regression in the temporal/recency lane inverts them.
+# --------------------------------------------------------------------------- #
+- query: "latest notes on tuning vector database indexes"
+  graded:
+    "Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning-revisited": 3
+    "Knowledge Base/Notes/Research/Infrastructure/vector-index-tuning": 1
+
+# --------------------------------------------------------------------------- #
+# PIN: exact/quoted lookup. The quoted phrase appears verbatim in exactly one
+# page; the exact-intent path must surface it. Quotes in the query signal exact
+# intent to find()'s classifier.
+# --------------------------------------------------------------------------- #
+- query: '"Idempotency-Key header"'
+  expect_any_of:
+    - "Knowledge Base/Entities/Concepts/Idempotency Key"
+
+# --------------------------------------------------------------------------- #
+# PIN: scope="kb" auto-widen reserve. The answer lives OUTSIDE Knowledge Base/
+# (a curated Reference/ handbook). Under the default kb scope, find() reserves a
+# few result slots for out-of-KB lexical matches; this entry protects that
+# reserve. scope: kb (NOT kb-only) is required for the widen to fire.
+# --------------------------------------------------------------------------- #
+- query: "incident severity level definitions sev1 sev2 sev3"
+  scope: kb
+  expect_any_of:
+    - "Handbooks/incident-severity-levels"
+
+# --------------------------------------------------------------------------- #
 # Graded example: the curriculum research-note is the ideal hit; the production
 # log that applies it is marginally relevant to the same query.
+# --------------------------------------------------------------------------- #
 - query: "the metabolism reels batch curriculum and how it was produced"
   graded:
     "Knowledge Base/Notes/Productions/Reels/2026-05-metabolism-basics": 3

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -165,7 +165,7 @@ def test_add_updates_sources_index_count(
 ) -> None:
     sources_index = vault / "Knowledge Base" / "Sources" / "index.md"
     before = _read(sources_index)
-    assert "Articles]] — captured web/PDF content (1)" in before
+    assert "Articles]] — captured web/PDF content (2)" in before
 
     add_module.add(
         vault,
@@ -177,7 +177,7 @@ def test_add_updates_sources_index_count(
         today=TODAY,
     )
     after = _read(sources_index)
-    assert "Articles]] — captured web/PDF content (2)" in after
+    assert "Articles]] — captured web/PDF content (3)" in after
     assert "2026-05-18 — [[Knowledge Base/Sources/Articles/2026-05-18-new-article]]" in after
 
 
@@ -234,9 +234,9 @@ def test_add_updates_top_index_counts(
         today=TODAY,
     )
     text = _read(vault / "Knowledge Base" / "index.md")
-    # Original was: Sources: 3 (articles: 1, books: 1, sessions: 1)
-    # After adding one session: total 4, sessions 2
-    assert "- Sources: 4" in text
+    # Fixture baseline: Sources: 4 (articles: 2, books: 1, sessions: 1)
+    # After adding one session: total 5, sessions 2
+    assert "- Sources: 5" in text
     assert "sessions: 2" in text
 
 

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -74,9 +74,9 @@ def _golden_strings() -> tuple[list[str], list[str]]:
 def test_count_corpus_stats_against_fixtures() -> None:
     """Corpus walk over tests/fixtures returns rounded, internally-consistent counts.
 
-    The fixture tree currently holds 15 markdown files vault-wide (14 KB notes
-    outside `_Schema` + 1 read-only `Reference/` page) and no media binaries.
-    Rounded DOWN to the nearest 10 that is files=10, notes=10, media=0. We assert
+    The fixture tree currently holds 30 markdown files vault-wide (28 KB notes
+    outside `_Schema` + 2 read-only `Reference/` pages) and no media binaries.
+    Rounded DOWN to the nearest 10 that is files=30, notes=20, media=0. We assert
     the rounding contract and the bucket definitions, not exact filenames.
     """
     stats = eval_report.count_corpus_stats(FIXTURES)
@@ -91,9 +91,9 @@ def test_count_corpus_stats_against_fixtures() -> None:
     assert stats["media"] == 0
     # "files" (whole-vault markdown) is a superset of "notes" (KB-scoped markdown).
     assert stats["files"] >= stats["notes"]
-    # Current fixture tree: 15 files / 14 notes -> both floor to 10.
-    assert stats["files"] == 10
-    assert stats["notes"] == 10
+    # Current fixture tree: 30 files / 28 notes -> floor to 30 / 20.
+    assert stats["files"] == 30
+    assert stats["notes"] == 20
 
 
 def test_render_benchmark_report_shape() -> None:

--- a/tests/test_find_transcript_match.py
+++ b/tests/test_find_transcript_match.py
@@ -113,6 +113,9 @@ def test_non_media_page_never_localizes(vault: Path) -> None:
         "tags: [x]\n---\n\n# Timed looking\n\n[0:05] this note quotes a transcript line\n",
         encoding="utf-8",
     )
-    hits = find(vault, query="quotes a transcript", mode="hybrid")
+    # scope="kb-only": this test is about a KB note's (non-)localization, not the
+    # default scope's auto-widen — which can add an out-of-KB lexical match on a
+    # broad query and is exercised elsewhere. kb-only keeps the assertion focused.
+    hits = find(vault, query="quotes a transcript", mode="hybrid", scope="kb-only")
     assert len(hits) == 1
     assert "transcript_match_at" not in hits[0].as_dict()

--- a/tests/test_graph_lane_perf.py
+++ b/tests/test_graph_lane_perf.py
@@ -26,7 +26,7 @@ blows the sub-second graph-stage budget, failing loudly.
 
 from __future__ import annotations
 
-import random
+import sys
 from pathlib import Path
 
 import pytest
@@ -36,51 +36,18 @@ from exomem import freshness
 from exomem import vault as vault_module
 from exomem.vault import WikilinkResolver, normalize_wikilink, walk_vault_md
 
+# The densely-wikilinked corpus generator lives in scripts/synth_vault.py so this
+# regression test, the latency-ceiling gate, and the latency-curve harness all
+# generate a byte-identical vault from one place (see that module's docstring).
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+from synth_vault import gen_dense_vault as _gen_dense_vault  # noqa: E402
+
 # Large enough that a full resolver rebuild (read + YAML-parse every note)
 # clearly overshoots the 1s graph-stage budget by several-fold, so the guard
 # is robust rather than marginal, but small enough to keep the suite quick.
 N_NOTES = 1000
-_FOLDERS = (
-    "Notes/Insights", "Notes/Patterns", "Notes/Failures",
-    "Entities/Concepts", "Entities/People", "Sources", "Experiments",
-)
-
-
-def _gen_dense_vault(root: Path, n: int, links_per_note: int = 25, seed: int = 7) -> list[str]:
-    """Write `n` densely-cross-linked KB notes; return their vault-relative rels."""
-    rng = random.Random(seed)
-    kb = root / "Knowledge Base"
-    for f in _FOLDERS:
-        (kb / f).mkdir(parents=True, exist_ok=True)
-    rels: list[str] = []
-    names: list[str] = []
-    for i in range(n):
-        folder = _FOLDERS[i % len(_FOLDERS)]
-        name = f"note-{i:05d}-topic-{rng.randint(0, 99999)}"
-        names.append(name)
-        rels.append(f"Knowledge Base/{folder}/{name}.md")
-    for i, rel in enumerate(rels):
-        targets = rng.sample(range(n), min(links_per_note, n))
-        link_lines = []
-        for t in targets:
-            if t % 3 == 0:  # mix full-path and bare-stem link forms
-                link_lines.append(f"- see [[{rels[t][:-3]}]] for context")
-            else:
-                link_lines.append(f"- ref [[{names[t]}]] inline")
-        (root / rel).write_text(
-            "---\n"
-            "type: insight\n"
-            f"title: Note {i} about topic {names[i]}\n"
-            "tags: [synthetic, graph, dense]\n"
-            f"updated: 2026-02-{(i % 28) + 1:02d}\n"
-            "---\n\n"
-            f"# Note {i}\n\n"
-            "Prose paragraph so the note is realistically sized and body text "
-            "gives BM25 something to rank on. topic topic topic.\n\n"
-            "## Related\n\n" + "\n".join(link_lines) + "\n",
-            encoding="utf-8",
-        )
-    return rels
 
 
 def _seed_freshness_live(vault: Path) -> None:

--- a/tests/test_latency_gate.py
+++ b/tests/test_latency_gate.py
@@ -1,0 +1,172 @@
+"""Per-lane latency CEILING gate at realistic corpus scale (model-free).
+
+Why this exists: a fixture-scale (10-file) latency benchmark once reported a
+whole `find()` at ~5ms and HID a ~14s graph-lane cost on the owner's ~1700-note
+vault. An aggregate over a toy corpus cannot catch a single-lane blow-up. This
+gate closes that hole: it generates a realistic, densely-wikilinked 2000-note
+vault (the same `scripts/synth_vault.py` generator the latency-curve harness and
+the graph-lane regression test use), warms every lane, then asserts that NO lane
+exceeds a sane per-lane ceiling — so a 14s-style regression fails CI loudly.
+
+It is deliberately MODEL-FREE: the lane that regressed (graph) needs no model,
+and neither do bm25/keyword/fusion. The vector/CLIP lanes are switched off so the
+gate is deterministic and needs no GPU, model download, or embedding sidecar —
+it runs in the lean CI matrix (like test_graph_lane_perf.py) AND is pinned in the
+retrieval-eval job.
+
+BASELINE — measured 2026-07-03 on the maintainer's box (AMD Ryzen 7 5800X3D /
+RTX 5080 / 32 GB, Windows 11), model-free, over the 2000-note dense synthetic
+vault via `scripts/latency_curve.py --sizes 2000` and a direct rebuild probe:
+
+    warm graph lane   median ~222ms   p90 ~239ms
+    warm end-to-end   median ~805ms   p90 ~1041ms
+    bm25 / keyword    median ~243ms / ~268ms   (both O(N) full-corpus lanes)
+    resolver REBUILD  ~1662ms  (a from-scratch WikilinkResolver over 2000 notes)
+
+The regression this guards — the graph resolver reverting to a per-query rebuild
+(read + YAML-parse every note) — would push the graph lane from ~222ms to
+~1.9s+ (rebuild ~1662ms + resolution). The ceilings sit in the wide gap between
+the warm baseline and that regression, with enough margin (~4.5x over the warm
+median) that a slower CI runner does not flake but a rebuild regression cannot
+hide. Re-measure (don't hand-tune) if the corpus generator or lane code changes.
+"""
+
+from __future__ import annotations
+
+import statistics
+import sys
+from pathlib import Path
+
+import pytest
+
+from exomem import find as find_module
+from exomem import freshness
+from exomem.vault import walk_vault_md
+
+# Reuse the ONE synthetic-vault generator (scripts/synth_vault.py).
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+from synth_vault import gen_dense_vault  # noqa: E402
+
+# Corpus scale for the gate. 2000 notes: big enough that a per-query resolver
+# rebuild (~1.7s here) stands clearly apart from the warm graph lane (~0.2s),
+# yet small enough to generate + measure in a few seconds in CI.
+N_NOTES = 2000
+
+# Fixed query set, run over the warm corpus. Graph cost here is corpus-driven,
+# not query-driven (verified: broad vs. selective queries cost the same), so a
+# small spread of queries gives a stable median.
+_QUERIES = (
+    "topic prose paragraph related context",
+    "note about synthetic dense graph",
+    "related links between insight pattern notes",
+)
+_REPEAT = 3  # passes over the query set → ~9 samples per lane for a stable median
+
+# --- Ceilings (see the module docstring for the measured baseline they derive
+# from). Median-based; a rebuild regression trips them with room to spare while
+# CI-speed variance over the warm baseline does not.
+CEIL_GRAPH_MS = 1000.0   # warm ~222ms; a per-query resolver rebuild → ~1.9s trips this
+CEIL_TOTAL_MS = 5000.0   # warm ~805ms; catastrophic-blowup backstop, CI-robust
+
+
+def _seed_freshness_live(vault: Path) -> None:
+    """Seed the event-maintained freshness registry the way the watcher does, so
+    the graph lane's resolver is live and warm (production shape) — not rebuilt."""
+    freshness.seed(
+        vault, "vault",
+        ((str(p), p.stat().st_mtime_ns) for p in walk_vault_md(vault)),
+    )
+    kb = vault / "Knowledge Base"
+    freshness.seed(
+        vault, "kb",
+        ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb)),
+    )
+
+
+@pytest.fixture
+def dense_vault_2k(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A warm, freshness-seeded 2000-note dense vault with model lanes OFF.
+
+    The vector/CLIP lanes are forced off (CLIP via env, vector by making the
+    embedding getter raise ImportError — find() treats that as a lean-deployment
+    shape and falls back to BM25/keyword without recording a failure), so the
+    gate measures the model-free lanes deterministically whether or not torch is
+    installed on the host.
+    """
+    find_module.clear_cache()
+    freshness.clear()
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")  # every call runs all lanes
+
+    from exomem import embeddings as embeddings_module
+
+    def _raise(*_a, **_k):
+        raise ImportError("model-free latency gate: vector lane disabled")
+
+    monkeypatch.setattr(embeddings_module, "get_embedding_index", _raise)
+
+    vault = tmp_path / "vault"
+    gen_dense_vault(vault, N_NOTES)
+    _seed_freshness_live(vault)
+
+    # Warm every lane once so the measured passes reflect steady state, not the
+    # first-touch bm25-corpus / resolver build.
+    for q in _QUERIES:
+        find_module.find(vault, query=q, limit=10, mode="hybrid", graph=True)
+
+    yield vault
+    find_module.clear_cache()
+    freshness.clear()
+
+
+def _measure(vault: Path) -> tuple[dict[str, float], float]:
+    """Return (per-lane median ms, total median ms) over the warm query set."""
+    lane_samples: dict[str, list[float]] = {}
+    total_samples: list[float] = []
+    for _ in range(_REPEAT):
+        for q in _QUERIES:
+            t = find_module.FindTimings()
+            find_module.find(vault, query=q, limit=10, mode="hybrid", graph=True, timings=t)
+            d = t.as_dict()
+            total_samples.append(d["total_ms"])
+            for lane, stage in d["stages"].items():
+                # A lane's span records `ms` even when its body raised (the
+                # model-free vector ImportError), so skip errored/skipped lanes.
+                if "ms" in stage and "error" not in stage and "skipped" not in stage:
+                    lane_samples.setdefault(lane, []).append(stage["ms"])
+    medians = {lane: statistics.median(v) for lane, v in lane_samples.items()}
+    return medians, statistics.median(total_samples)
+
+
+def test_no_lane_exceeds_ceiling_at_scale(dense_vault_2k: Path) -> None:
+    """No lane exceeds its ceiling at 2000 notes — the anti-hidden-14s gate.
+
+    Asserts two things over one warm measurement (the vault is generated once):
+
+    1. The GRAPH lane stays under CEIL_GRAPH_MS. This is the direct guard for the
+       ~14s regression: if the resolver reverts to a per-query full rebuild, the
+       graph lane jumps from ~0.2s to ~1.9s+ and trips the ceiling. The graph
+       stage must also actually run — a silent skip is its own regression.
+    2. End-to-end find() stays under CEIL_TOTAL_MS — a CI-robust backstop for any
+       single lane blowing into the seconds range. The failure message names the
+       dominant lane so triage starts from evidence, not a bisect.
+    """
+    medians, total_ms = _measure(dense_vault_2k)
+    rounded = {k: round(v, 1) for k, v in medians.items()}
+
+    assert "graph" in medians, f"graph lane did not run at {N_NOTES} notes: {rounded}"
+    graph_ms = medians["graph"]
+    assert graph_ms < CEIL_GRAPH_MS, (
+        f"graph lane median {graph_ms:.0f}ms >= ceiling {CEIL_GRAPH_MS:.0f}ms at "
+        f"{N_NOTES} notes — the resolver is likely being rebuilt per query again "
+        f"(warm baseline ~222ms; a full rebuild is ~1.7s). all medians: {rounded}"
+    )
+
+    worst = max(medians.items(), key=lambda kv: kv[1]) if medians else ("<none>", 0.0)
+    assert total_ms < CEIL_TOTAL_MS, (
+        f"total find() median {total_ms:.0f}ms >= ceiling {CEIL_TOTAL_MS:.0f}ms at "
+        f"{N_NOTES} notes (warm baseline ~805ms). Dominant lane: {worst[0]} "
+        f"({worst[1]:.0f}ms). all medians: {rounded}"
+    )

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -26,7 +26,7 @@ def test_reconcile_heals_index_count_drift(vault: Path) -> None:
     """An out-of-band edit that desyncs a count row is detected and restored."""
     top = vault / "Knowledge Base" / "index.md"
     original = top.read_text(encoding="utf-8")
-    drifted = original.replace("- Notes (insight): 1", "- Notes (insight): 9")
+    drifted = original.replace("- Notes (insight): 4", "- Notes (insight): 9")
     assert drifted != original, "fixture index.md changed shape; update the test"
     top.write_text(drifted, encoding="utf-8")
 
@@ -37,7 +37,7 @@ def test_reconcile_heals_index_count_drift(vault: Path) -> None:
     rep = reconcile_module.reconcile(vault)
 
     assert "Knowledge Base/index.md" in rep.indexes_updated, rep.as_dict()
-    assert "- Notes (insight): 1" in top.read_text(encoding="utf-8")
+    assert "- Notes (insight): 4" in top.read_text(encoding="utf-8")
     assert not any(
         f["category"] == "index_drift" for f in rep.remaining_drift
     ), rep.as_dict()

--- a/tests/test_retrieval_golden.py
+++ b/tests/test_retrieval_golden.py
@@ -16,15 +16,18 @@ lean 3-version matrix collects nothing here.
 
 BASELINE — how the floors were produced (do NOT hand-tune; re-measure):
     Model rev BAAI/bge-base-en-v1.5 (frozen), exomem 0.4.1, measured 2026-07-03
-    on a sidecar-built copy of tests/fixtures (77 chunk vectors) via:
+    on a sidecar-built copy of tests/fixtures (198 chunk vectors) via:
         EXOMEM_VAULT_PATH=<tmp copy of tests/fixtures> \
           uv run --extra embeddings python scripts/eval_retrieval.py --report markdown
     (the copy's sidecar built first with get_embedding_index(vault).rebuild_all()).
-    Measured hybrid, rerank OFF (exactly what this test evaluates):
-        NDCG@5=0.9590  NDCG@10=0.9590  MRR=0.9444  recall@10=1.0000
-        per-query recall@10 minimum = 1.0  (every golden target surfaces top-10)
-        vs keyword-only NDCG@10=0.2222 — the gap this gate protects.
-    Floors sit ~0.10-0.14 below the measured means: a genuine ranking regression
+    Measured hybrid, rerank OFF (exactly what this test evaluates), 26 golden queries:
+        NDCG@5=0.9142  NDCG@10=0.9270  MRR=0.9154  recall@10=0.9615
+        per-query recall@10 minimum = 0.5 — two entries deliberately grade a
+        marginal page that prefer_compiled / prefer_active DEMOTES out of top-10
+        (the compiled-over-source and supersession pins); their grade-3 ideal is
+        always found, so no query drops to recall@10 == 0.
+        vs keyword-only NDCG@10=0.3430 — the gap this gate protects.
+    Floors sit ~0.08-0.14 below the measured means: a genuine ranking regression
     trips them, but run-to-run / CPU-vs-GPU fp noise does not.
 """
 
@@ -54,10 +57,10 @@ import eval_retrieval  # noqa: E402
 _GOLDEN = _REPO_ROOT / "tests" / "golden" / "queries.yaml"
 
 # --- Floors, WITH MARGIN. See the module docstring for how these were measured.
-_MEASURED = {"ndcg10": 0.9590, "mrr": 0.9444, "recall10": 1.0000}  # 2026-07-03
+_MEASURED = {"ndcg10": 0.9270, "mrr": 0.9154, "recall10": 0.9615}  # 2026-07-03, 26 queries
 _MEAN_NDCG10_FLOOR = 0.85
 _MEAN_MRR_FLOOR = 0.80
-_MEAN_RECALL10_FLOOR = 0.90
+_MEAN_RECALL10_FLOOR = 0.88
 
 
 @pytest.mark.embeddings

--- a/tests/test_subindex_refresh.py
+++ b/tests/test_subindex_refresh.py
@@ -57,7 +57,7 @@ def test_note_updates_top_index_notes_count(vault: Path) -> None:
     """Writing a new insight bumps `- Notes (insight): N` in the top index."""
     top = vault / "Knowledge Base" / "index.md"
     before = top.read_text(encoding="utf-8")
-    assert "- Notes (insight): 1" in before
+    assert "- Notes (insight): 4" in before
 
     note_module.note(
         vault,
@@ -67,14 +67,14 @@ def test_note_updates_top_index_notes_count(vault: Path) -> None:
         today=TODAY,
     )
     after = top.read_text(encoding="utf-8")
-    assert "- Notes (insight): 2" in after, after
+    assert "- Notes (insight): 5" in after, after
 
 
 def test_link_updates_top_index_entities_count(vault: Path) -> None:
     """Writing a new person bumps `- Entities (person): N` in the top index."""
     top = vault / "Knowledge Base" / "index.md"
     before = top.read_text(encoding="utf-8")
-    assert "- Entities (person): 1" in before
+    assert "- Entities (person): 2" in before
 
     link_module.link(
         vault,
@@ -84,7 +84,7 @@ def test_link_updates_top_index_entities_count(vault: Path) -> None:
         today=TODAY,
     )
     after = top.read_text(encoding="utf-8")
-    assert "- Entities (person): 2" in after, after
+    assert "- Entities (person): 3" in after, after
 
 
 def test_note_updates_notes_subindex_h3_count(vault: Path) -> None:
@@ -99,7 +99,7 @@ def test_note_updates_notes_subindex_h3_count(vault: Path) -> None:
         today=TODAY,
     )
     text = notes_idx.read_text(encoding="utf-8")
-    assert "### Insights — distilled cross-cutting lessons (2)" in text, text
+    assert "### Insights — distilled cross-cutting lessons (5)" in text, text
 
 
 def test_note_updates_notes_subindex_subfolder_count(vault: Path) -> None:
@@ -116,8 +116,9 @@ def test_note_updates_notes_subindex_subfolder_count(vault: Path) -> None:
     )
     text = notes_idx.read_text(encoding="utf-8")
     assert "- [[Knowledge Base/Notes/Research/Project Alpha/|Project Alpha]] (2) — engine stuff" in text, text
-    # The Research H3 header also bumps to (3).
-    assert "### Research — project-or-domain-scoped synthesis (3)" in text, text
+    # The Research H3 header recounts all research notes from disk (4 fixtures +
+    # this new one = 5).
+    assert "### Research — project-or-domain-scoped synthesis (5)" in text, text
 
 
 def test_link_updates_entities_subindex_bullet(vault: Path) -> None:
@@ -132,7 +133,7 @@ def test_link_updates_entities_subindex_bullet(vault: Path) -> None:
         today=TODAY,
     )
     text = entities_idx.read_text(encoding="utf-8")
-    assert "- [[Knowledge Base/Entities/Concepts/|Concepts]] (2)" in text, text
+    assert "- [[Knowledge Base/Entities/Concepts/|Concepts]] (4)" in text, text
 
 
 def test_subindex_preserves_hand_curated_descriptions(vault: Path) -> None:
@@ -171,20 +172,21 @@ def test_subindex_skip_when_missing(vault: Path) -> None:
 def test_count_entities_helper(vault: Path) -> None:
     """`_count_entities` should mirror `_count_sources`'s shape."""
     counts = indexes._count_entities(vault / "Knowledge Base" / "Entities")
-    # Fixture has 1 person + 1 concept; libraries/decisions folders may not exist.
-    assert counts.get("person", 0) == 1
-    assert counts.get("concept", 0) == 1
+    # Fixture has 2 people + 3 concepts; libraries/decisions folders may not exist.
+    assert counts.get("person", 0) == 2
+    assert counts.get("concept", 0) == 3
 
 
 def test_count_notes_by_subfolder_helper(vault: Path) -> None:
     """Nested counts for Research/Experiments/Productions; flat for others."""
     counts = indexes._count_notes_by_subfolder(vault / "Knowledge Base" / "Notes")
-    # Fixture has Research/Project Alpha (1), Research/Health (1).
+    # Fixture has Research/Project Alpha (1), Research/Health (1), Research/Infrastructure (2).
     assert counts.get("Research", {}).get("Project Alpha") == 1
     assert counts.get("Research", {}).get("Health") == 1
+    assert counts.get("Research", {}).get("Infrastructure") == 2
     # Flat types: Insights, Failures, Patterns — single "" key.
     assert "Insights" in counts
-    assert counts["Insights"].get("") == 1
+    assert counts["Insights"].get("") == 4
 
 
 def test_no_obsolete_counts_warning_on_note(vault: Path) -> None:


### PR DESCRIPTION
Makes a 14s-style graph-lane regression impossible to ship, and turns the benchmark into a real diagnostic.

- `scripts/synth_vault.py` + `scripts/latency_curve.py`: per-lane median/p90 (vector/bm25/keyword/graph/fusion/rerank) across 100/500/1k/2k/5k-note dense vaults.
- `tests/test_latency_gate.py`: model-free gate (graph <1s, total <5s at 2000 notes), wired into the `retrieval-eval` CI job.
- Golden set 9→26 queries (compiled-over-source, supersession, graph-hop, temporal, exact, out-of-KB reserve) + 15 fixtures. Re-measured hybrid NDCG@10 0.927 / MRR 0.915 / recall@10 0.962.
- `docs/benchmarks.md`: real per-lane latency tables.

**Finding:** the warm graph/bm25/keyword lanes are O(N) in vault size — the next optimization target as vaults grow (not urgent at ~1700 notes).

Note: branch predates the release + the doctor-test importorskip fix (already on main), so its lean run showed that 1 pre-existing failure — it resolves on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYnqb42jGFNb8ZuMwes3n