### PR TITLE
feat: sqlite-vec vec0 vector backend inside the embedding sidecars (OpenSpec: add-sqlite-vec-backend)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -162,6 +162,70 @@ uv run python scripts/latency_curve.py --sizes 100,500,1000,2000,5000
 uv run --extra embeddings python scripts/latency_curve.py --embeddings --rerank --sizes 100,500,1000,2000
 ```
 
+## Vector backend at scale (10k–50k notes, sqlite-vec vs in-memory scan)
+
+The `add-sqlite-vec-backend` change moved the vector lane's default onto vec0
+virtual tables inside the embedding sidecar (`EXOMEM_VEC_BACKEND=auto`), with the
+in-memory numpy scan as kill switch and fallback. That swap was gated on measured
+evidence, per the find-recall-efficiency spec. This section is that evidence and
+the decision record.
+
+Method: same dense synthetic generator as the curve above, with a REAL bge
+sidecar per size (`--embeddings`), measured once per backend over the same built
+corpus via `--vec-backend numpy,sqlite-vec,binary` and reused across runs via
+`--corpus-cache` (embed once, measure many). `binary` is `sqlite-vec` with
+`EXOMEM_VEC_QUANT=binary`. Measured 2026-07-03 on the reference host (AMD Ryzen 7
+5800X3D / RTX 5080 / 32 GB / Windows 11); 10k tier `--repeat 3`, 50k tier
+`--repeat 2`. Vector lane only (ms, median / p90); `overlap@10` is the mean
+top-10 overlap of end-to-end `find()` results against the numpy pass; RSS is the
+process resident set after the pass (psutil; not captured for the 10k run).
+
+| Notes | chunk vectors | vector numpy | vector vec0-f32 | overlap@10 f32 | vector vec0-binary | overlap@10 binary | RSS numpy / f32 / binary (MB) |
+|---|---|---|---|---|---|---|---|
+| 10000 | 40,000 | 17.5 / 21.8 | 130.5 / 137.2 | 1.00 | 59.7 / 74.3 | 0.86 | — |
+| 50000 | 200,000 | 31.2 / 36.8 | 544.5 / 550.0 | 1.00 | 253.3 / 357.6 | 0.68 | 3491 / 1707 / 1234 |
+
+Reading it honestly:
+
+- **The warm lane race goes to numpy, 7–17×.** BLAS over a RAM-resident
+  contiguous matrix runs at memory bandwidth; the vec0 f32 scan re-reads every
+  vector byte per query through SQLite's page layer (~614 MB at 200k chunks →
+  ~545 ms). Both are brute force — neither is sub-linear — so the gap grows
+  with N.
+- **What numpy pays for that speed is the point of the swap:** at 200k chunks
+  the numpy pass holds ~1.8 GB more resident (the float32 matrix plus every
+  chunk's text in the metadata cache), and any out-of-process sidecar change
+  costs it a full O(N) reload. The vec0 backend holds essentially nothing
+  between queries.
+- **vec0-f32 is exact.** overlap@10 = 1.00 at both tiers, end-to-end through
+  `find()` — matching the unit-level parity tests. The default-backend swap
+  changes no ranking.
+- **Binary quantization diverges at scale.** overlap@10 fell from 0.86 (10k) to
+  0.68 (50k) on this corpus. It stays strictly opt-in
+  (`EXOMEM_VEC_QUANT=binary`, default off); the golden retrieval floors are its
+  promotion gate (it clears them on the fixture corpus — both parametrized
+  passes of `tests/test_retrieval_golden.py`).
+- **The loudest finding is about a different lane entirely:** at 50k notes the
+  whole `find()` costs ~25 s under EVERY backend, because bm25 / keyword / graph
+  are each ~8 s of O(N) work. The vector lane is under 2.2% of the total in its
+  slowest configuration. "Sub-second search at 100k notes" is gated on the
+  lexical/graph lanes, not on vector search — that is the next scaling build.
+
+**Decision record.** `auto` defaults to vec0-f32: the lane-latency delta is
+invisible end-to-end today, while the residency and reload wins are large and
+grow with corpus size. `EXOMEM_VEC_BACKEND=numpy` restores the previous behavior
+wholesale. If a future build makes the vector lane the visible bottleneck (e.g.
+after the lexical lanes are fixed), the recorded next step is a real ANN index —
+hnswlib, or sqlite-vec's ANN once it leaves alpha — behind the same `vecstore`
+seam, recall-gated by the same golden floors.
+
+The 100k-note tier (400k chunk vectors) is generated, embedded, and cached; its
+measurement pass is pending. Complete it desk-side with:
+
+```
+uv run python scripts/latency_curve.py --embeddings --sizes 100000 --max-embeddings-size 100000 --repeat 1 --vec-backend numpy,sqlite-vec,binary --corpus-cache <cache-dir>
+```
+
 ## Reproduction
 
 The report reproduces in the same shape against any vault + golden set that

--- a/openspec/changes/add-sqlite-vec-backend/.openspec.yaml
+++ b/openspec/changes/add-sqlite-vec-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/add-sqlite-vec-backend/design.md
+++ b/openspec/changes/add-sqlite-vec-backend/design.md
@@ -1,0 +1,173 @@
+# Design - sqlite-vec vector backend
+
+## Context
+
+`EmbeddingIndex.search()` (`src/exomem/embeddings.py`) computes `matrix @ query_vec` over a
+process-cached (N, 768) float32 matrix loaded from the `chunks` table of
+`.embeddings.sqlite`; `ClipIndex.search()` is a near-duplicate over `images` in
+`.clip.sqlite` (512-dim). The matrix cache is mtime-invalidated and incrementally spliced by
+`_patch_cache()` after in-process writes. `audit.py`'s corpus-contradiction sweep reuses the
+same matrix via `all_vectors()`. Fusion (`fusion.py`) consumes ranked path lists only, so
+the vector backend can change beneath `search()` without touching `find.py` or fusion.
+
+Two facts anchor the design, verified against sqlite-vec's own documentation:
+
+1. Stable sqlite-vec (v0.1.x) is a SIMD-optimized brute-force scan, NOT an ANN index — its
+   scale levers are quantization (`bit[N]` columns, `vec_quantize_binary`) and keeping the
+   scan in C over on-disk pages instead of a Python-resident matrix. Its ANN work
+   (DiskANN/IVF) is alpha-only and not depended on here.
+2. Raw `np.float32.tobytes()` blobs — exactly what `chunks.vector`/`images.vector` already
+   store — are sqlite-vec's native float32 input format, so vec0 tables can be populated
+   and rebuilt from the existing blobs with pure SQL, no model in the loop.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove the Python-resident O(N) matrix (memory + cold-load) from the default vector
+  search path at scale, keeping results exact.
+- Keep the sidecar-file model: vec0 tables live inside the existing sidecars; blob tables
+  stay the source of truth.
+- Keep every freshness seam intact: writer hooks, file watcher, reconcile, and the
+  find-cache sidecar-mtime key all continue to work unchanged.
+- Provide an opt-in quantized mode whose recall is gated by the golden retrieval floors.
+- Measure, before and after, at 10k/50k/100k-note scale with real embeddings.
+
+**Non-Goals:**
+
+- No ANN index (HNSW/IVF/DiskANN) in this change — sqlite-vec's stable release has none.
+- No change to `find` ranking, request/response shapes, fusion, or the command surface.
+- No removal of the numpy path: it remains the fallback, the kill-switch target, and the
+  substrate for `audit.py`'s all-pairs sweep.
+- No re-embedding: migration and rebuild never invoke the embedding model.
+
+## Decisions
+
+### One shared vec0 helper, composed into both index classes
+
+`EmbeddingIndex` and `ClipIndex` are duplicated implementations; a base-class refactor is
+riskier than the feature. A new `src/exomem/vecstore.py` module owns everything vec0:
+extension loading (with a process-global load-failure memo mirroring `_IMPORT_FAILED`),
+schema creation, count-sync/rebuild-from-blobs, dual-write SQL, and KNN (float and
+binary+rescore). Each index class holds a `SqliteVecStore` instance parameterized by
+(source table, vector column, dim, vec-table name). The module is import-safe without
+`sqlite_vec` installed — the import is lazy inside the load probe.
+
+Alternative considered: extract a shared base class for both indexes first. Rejected —
+it rewrites the two most correctness-sensitive classes in the codebase to save ~50 lines,
+and the composition seam gives CLIP the same backend with no inheritance risk.
+
+### vec0 rowid == blob-table rowid; join back for metadata
+
+Both `chunks` and `images` are ordinary rowid tables (composite TEXT PKs, not WITHOUT
+ROWID), so every row has a stable implicit rowid within a transaction's lifetime. vec0
+rows are inserted with the blob row's rowid (`INSERT INTO vec_chunks(rowid, embedding)
+SELECT rowid, vector FROM chunks WHERE file_path = ?`) and KNN results join back to the
+blob table for metadata. No metadata/auxiliary columns in vec0 — deleting by rowid is the
+dependable primitive, and duplicating `file_path` per vec row buys nothing.
+
+Caveat (documented, not defended in schema): VACUUM can renumber rowids of tables without
+an INTEGER PRIMARY KEY. Nothing in the codebase VACUUMs sidecars; if anything ever does,
+the count-sync check cannot detect a pure renumbering, so a VACUUM of a sidecar must be
+followed by a vec rebuild (`audit_fix(rebuild_embeddings=True)` does this implicitly).
+
+Alternative considered: an explicit `id INTEGER PRIMARY KEY` on the blob tables. That is a
+schema migration of every existing sidecar for a hazard no current code path can trigger.
+
+### Same-transaction dual-write; vec deletes precede blob deletes
+
+Every mutator already wraps its work in `with conn:`. The vec delete must run BEFORE the
+blob delete (`DELETE FROM vec_chunks WHERE rowid IN (SELECT rowid FROM chunks WHERE
+file_path = ?)`) because the subquery needs the blob rows; the vec insert runs after the
+blob insert, selecting the fresh rowids. `ClipIndex.upsert`'s image-only replace carries
+the same `AND frame_ts IS NULL` predicate into the vec-delete subquery. `rebuild_all`
+wipes vec tables alongside `chunks` and repopulates with one whole-table
+`INSERT ... SELECT` after the bulk blob insert. Dual-writes are skipped entirely when the
+extension is unavailable on the writing process — the sync check heals later.
+
+Alternative considered: SQLite triggers on the blob tables. Triggers fire for every writer
+including ones without the extension loaded (they would hard-fail lean writers), and they
+hide write behavior from the code that owns it.
+
+### Count-mismatch sync-on-first-use is both migration and drift healer
+
+On an index instance's first vec use per process (memoized), after ensuring the tables
+exist: compare `count(chunks)` to `count(vec_chunks)`; on mismatch, wipe and repopulate
+vec rows from blobs in one transaction, logged at INFO. A pre-existing sidecar (vec count
+0 ≠ N) is thereby migrated on first open with no model and no user action — the same
+idempotent-on-connect pattern as `ClipIndex._migrate_add_frame_ts`. A sidecar advanced by
+a non-vec-aware writer (old version, lean CLI) is healed the same way. Because dual-writes
+are same-transaction, counts cannot diverge under normal operation; a runtime KNN failure
+additionally drops that call to the numpy path and marks the instance unavailable for the
+process.
+
+Alternative considered: a schema-version table with explicit migrations. Heavier than the
+one invariant we need (vec rows ≡ blob rows), and count-compare self-heals cases a version
+number cannot see (partial manual surgery).
+
+### Backend ladder with explicit env surface; quantization strictly opt-in
+
+`EXOMEM_VEC_BACKEND` = `auto` (default) | `sqlite-vec` | `numpy` (kill switch).
+`EXOMEM_VEC_QUANT` = `off` (default) | `binary`. In `auto`, availability alone decides —
+no corpus-size threshold, because the f32 scan is exact at every N (the per-query
+difference at small N is milliseconds against a ~800 ms find budget) and one fork fewer is
+one fork tested. Binary mode runs Hamming KNN over `bit[N]` with `k * 8` candidates, then
+rescores those candidates against their f32 blobs in numpy and returns true cosine scores,
+so downstream consumers see the same score semantics in every mode.
+
+`distance_metric=cosine` on the float vec0 column keeps `score = 1.0 - distance` on the
+existing cosine scale (vectors are L2-normalized at embed time).
+
+Alternative considered: auto-enable binary above a corpus-size threshold. Rejected — a
+recall-affecting mode flipping implicitly as a vault grows makes results non-reproducible
+across time; the golden gate can bless the mode, but turning it on stays a user decision.
+
+### The numpy matrix stays; it just stops being loaded when vec0 serves search
+
+`all_vectors()` / `_load_all_rows()` / `_patch_cache()` are untouched: `audit.py`'s
+all-pairs sweep and the fallback ladder need them. When vec0 serves search, `search()`
+never touches the matrix cache, so it stays cold and `_patch_cache()` early-returns on
+writes — the memory win requires no cache surgery. `warmup.warm_caches()` branches: when
+the vec backend is active it runs the sync check plus one dummy KNN (faulting in the vec0
+pages); otherwise it primes the matrix as today.
+
+### Fallback substrate if measurement disappoints: hnswlib
+
+If the 10k–100k tier curves show vec0-f32 not beating the numpy scan and binary
+quantization unable to close the gap within the golden floors, the documented fallback is
+a true ANN library (hnswlib) behind the same `vecstore` seam — a separate index file
+beside the sidecar, real `M`/`ef_search` tuning against the golden gate. Not implemented
+in this change; recorded so the decision point is explicit in `docs/benchmarks.md`.
+
+## Risks / Trade-offs
+
+- f32 mode doubles vector bytes on disk (~3 KB/chunk duplicated into vec0 shadow tables)
+  -> accepted: sidecars are local per-machine dotfiles; binary mode adds only ~96 B/chunk,
+  and at the scale where storage matters binary is the mode you run.
+- Python built without loadable-extension support (`enable_load_extension` missing) ->
+  process-global soft-fail memo catches `AttributeError`/`OperationalError`; numpy path
+  serves; `doctor` surfaces loadability as a warn.
+- Binary quantization recall loss -> default-off; rescore-at-full-precision; golden floors
+  (NDCG@10 ≥ 0.85, MRR ≥ 0.80, recall@10 ≥ 0.90, per-query zero-recall cliff guard) run in
+  the quantized configuration as its promotion gate.
+- Mixed-version writers (a process without the extension writes blobs only) -> count
+  drift, healed by sync-on-first-use in the next vec-aware process.
+- Windows is not CI'd; the extension loads or it doesn't per machine -> verified working
+  on the maintainer's Windows box (vec_version v0.1.9); every failure mode soft-fails to
+  numpy; lean CI matrix exercises the genuinely-absent path on every run.
+- Float32 dtype discipline: a float64 array's `.tobytes()` is read as 2× the dimensions
+  and vec0 rejects it -> all writes go through the existing `.astype(np.float32)` sites;
+  vecstore asserts dtype at its boundary.
+
+## Migration Plan
+
+No user action. Existing sidecars gain vec0 tables on first use by a vec-aware process
+(rebuild-from-blobs, seconds even for large sidecars, no model). Rolling BACK is equally
+safe: older code ignores the extra vec0 tables entirely (SQLite only errors when a virtual
+table is queried without its module), and blob tables never stopped being the source of
+truth. `audit_fix(rebuild_embeddings=True)` rebuilds both table families.
+
+## Open Questions
+
+None for implementation. The hnswlib decision is deferred to the measured curve in
+`docs/benchmarks.md`.

--- a/openspec/changes/add-sqlite-vec-backend/proposal.md
+++ b/openspec/changes/add-sqlite-vec-backend/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+The vector lane is an O(N) in-memory scan: `EmbeddingIndex.search()` loads the entire
+(N, 768) float32 matrix into Python RAM (~3 KB per chunk resident — roughly 1 GB at a
+100k-note corpus) and re-stacks it from the sidecar whenever the sidecar changes out of
+process. The `find-recall-efficiency` spec deliberately deferred any retrieval-architecture
+change "until the timing diagnostics justify it"; that measurement now exists — the per-lane
+timing diagnostics and the latency-vs-scale curve harness (`scripts/latency_curve.py`) show
+the vector lane and its matrix load are the lanes whose cost grows linearly with corpus
+size. exomem is OSS: strangers will point it at corpora far larger than the maintainer's
+vault, and "search visibly degrades at scale" is a weak scale story.
+
+## What Changes
+
+- Add `sqlite-vec` (vec0 virtual tables) INSIDE the existing `.embeddings.sqlite` and
+  `.clip.sqlite` sidecars — no new files, preserving the "just your local sidecar" model.
+  The blob tables (`chunks`, `images`) remain the source of truth; vec0 rows are always
+  rebuildable from stored blobs with pure SQL (no model, no re-embedding).
+- Sidecar writers dual-write vec0 rows in the same transaction as blob rows; a
+  count-mismatch check on first use rebuilds vec0 from blobs — one mechanism serving as
+  both the migration for pre-existing sidecars and the drift healer.
+- `search()` gains a backend ladder: vec0 full-precision scan (exact — rank-identical to
+  the in-memory scan) → opt-in binary-quantized scan with exact full-precision rescore →
+  the existing numpy scan.
+- Extend `scripts/latency_curve.py` with per-backend vector-lane measurement
+  (`--vec-backend`) and a reusable corpus cache (`--corpus-cache`) so 10k/50k/100k-note
+  tiers with real embeddings are runnable desk-side; publish the resulting scale story in
+  `docs/benchmarks.md`. These tiers are opt-in desk-side runs, never CI.
+- `doctor` reports sqlite-vec presence and extension loadability.
+
+Defaults and soft-fail, stated explicitly: `EXOMEM_VEC_BACKEND` defaults to `auto` — the
+vec0 full-precision backend serves vector search when the extension is importable and
+loadable, and it is exact (result-identical to the numpy path), so `auto` changes no
+ranking. Every vec failure mode — package missing (lean install), Python's sqlite3 built
+without loadable-extension support, or a runtime error — soft-fails to the numpy path with
+zero behavior change; `EXOMEM_VEC_BACKEND=numpy` is the kill switch.
+`EXOMEM_VEC_QUANT` (binary quantization) is default-OFF and strictly opt-in because it can
+affect recall; the golden retrieval floors are its promotion gate.
+
+Pure-substrate note: sqlite-vec is a distance calculator over vectors the server already
+measured — no model runs, nothing is generated or judged. This is the same measurement,
+computed in SQL instead of numpy.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: the vector lane gains a SQL-native KNN backend (exact
+  full-precision default, opt-in quantized mode gated by the golden floors, kill switch,
+  soft-fail to the in-memory scan); the "architecture changes are deferred until measured"
+  requirement is updated to record that the measurement justified this backend; the
+  matrix-cache and warm-up requirements are scoped to whichever backend serves search.
+- `live-index-freshness`: sidecar writes now keep vec0 tables transactionally in sync with
+  the blob tables, with a rebuild-from-blobs self-heal for sidecars written by
+  non-vec-aware processes.
+
+## Impact
+
+- Code: `src/exomem/vecstore.py` (new shared vec0 helper), `src/exomem/embeddings.py`
+  (both index classes: connect hook, dual-writes, search ladder), `src/exomem/warmup.py`,
+  `src/exomem/doctor.py`, `scripts/latency_curve.py`, `docs/benchmarks.md`.
+- Surfaces: none — no command-registry, MCP, REST, or CLI parameter changes; `find`'s
+  request/response shapes and ranking are unchanged.
+- Tests: new vecstore unit suite (schema, sync, migration, drift heal, f32 parity vs the
+  numpy scan, binary rescore, dual-write lockstep); lean-suite fallback coverage (kill
+  switch, forced-unavailable); a quantized-mode pass of the golden retrieval gate.
+- Dependencies: `sqlite-vec>=0.1.6` added to the `embeddings` extra (plain PyPI wheel).
+  The base install is unaffected; lean deployments never import it.

--- a/openspec/changes/add-sqlite-vec-backend/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/add-sqlite-vec-backend/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: SQL-Native Vector Search Backend
+
+The system SHALL be able to serve vector KNN search from vec0 virtual tables co-located in
+the existing embedding and CLIP sidecars, selected by `EXOMEM_VEC_BACKEND` (`auto` |
+`sqlite-vec` | `numpy`, default `auto`). In full-precision mode the vec0 backend MUST be
+exact: the ranked (path, chunk) results and cosine scores MUST match what the in-memory
+scan returns for the same sidecar state, within floating-point tolerance. When the backend
+is unavailable in any way — the package is not installed, the Python build cannot load
+SQLite extensions, or a runtime error occurs — vector search MUST soft-fail to the
+in-memory scan with unchanged results and without recording a lane degradation.
+`EXOMEM_VEC_BACKEND=numpy` MUST force the in-memory scan unconditionally. When the vec0
+backend serves search, the process MUST NOT need to hold the full vector matrix resident
+in Python memory for that search path.
+
+#### Scenario: Full-precision backend returns identical ranking
+
+- **WHEN** the same query runs once under the vec0 full-precision backend and once under
+  the in-memory scan, over an unchanged sidecar
+- **THEN** the ordered (path, chunk) results are identical
+- **AND** the scores match within floating-point tolerance
+
+#### Scenario: Unavailable extension falls back silently
+
+- **WHEN** sqlite-vec is not importable or the connection cannot load extensions
+- **THEN** vector search returns the in-memory scan's results
+- **AND** `find` records no vector-lane degradation for the fallback itself
+
+#### Scenario: Kill switch forces the in-memory scan
+
+- **WHEN** `EXOMEM_VEC_BACKEND=numpy` is set
+- **THEN** vector search uses the in-memory scan even where the vec0 backend is available
+
+#### Scenario: A runtime vec failure degrades to the scan for the process
+
+- **WHEN** a vec0 KNN query raises at runtime
+- **THEN** that search call returns correct results via the in-memory scan
+- **AND** subsequent searches in the process stop attempting the vec0 backend
+
+### Requirement: Opt-In Quantized Vector Mode
+
+The system SHALL support a binary-quantized vector search mode, enabled only by
+`EXOMEM_VEC_QUANT=binary` (default `off`). Quantized search MUST rescore its candidate set
+against the stored full-precision vectors and return true cosine scores, so downstream
+score semantics are unchanged. The quantized configuration MUST clear the golden retrieval
+floors (the same NDCG/MRR/recall floors and per-query zero-recall guard the default
+configuration is held to) before being recommended, and the mode MUST NOT be enabled
+implicitly by corpus size or any other heuristic.
+
+#### Scenario: Quantized mode passes the golden retrieval gate
+
+- **WHEN** the golden retrieval evaluation runs with `EXOMEM_VEC_QUANT=binary`
+- **THEN** mean NDCG@10, MRR, and recall@10 clear the same floors as the default
+  configuration
+- **AND** no golden query drops to zero recall
+
+#### Scenario: Quantized scores are full-precision cosine
+
+- **WHEN** a query runs in quantized mode
+- **THEN** returned scores are cosine similarities computed from full-precision vectors,
+  not quantized distances
+
+#### Scenario: Quantization is never implicit
+
+- **WHEN** `EXOMEM_VEC_QUANT` is unset
+- **THEN** vector search never uses the quantized tables, at any corpus size
+
+## MODIFIED Requirements
+
+### Requirement: Retrieval Architecture Changes Are Deferred Until Measured
+
+The system SHALL NOT adopt a retrieval-architecture change (a new vector index backend,
+LSH, ANN, or a new vector database) without per-lane timing measurement identifying the
+lane and cost the change addresses. The vec0 SQL-native backend is adopted under this
+rule: the per-lane timing diagnostics and the latency-vs-scale curve identified the vector
+lane's in-memory O(N) matrix load and scan as the corpus-linear cost, and the backend is
+held to exactness (full precision) or the golden retrieval floors (quantized). Any FURTHER
+retrieval-architecture change (including an ANN index) SHALL be considered only with the
+same evidence: a measured lane cost it addresses, plus the golden floors as its recall
+gate.
+
+#### Scenario: Backend adoption is evidence-gated
+
+- **WHEN** this change adopts the vec0 backend for the vector lane
+- **THEN** the latency-vs-scale harness records the in-memory scan's cost curve before the
+  swap and the backend's curve after it
+- **AND** the golden retrieval floors hold in every shipped configuration
+
+#### Scenario: Further rewrites remain deferred until measured
+
+- **WHEN** a future ANN index or retrieval rewrite is proposed
+- **THEN** it is adopted only with per-lane measurement identifying the cost it addresses
+- **AND** the golden retrieval floors gate its recall
+
+### Requirement: Process-Lifetime Embedding Matrix Cache
+
+The system SHALL load the embedding (and CLIP) vector matrix from its sidecar at most once
+per unchanged sidecar state and reuse it across `find` calls, via a process-shared
+per-vault index instance, whenever the in-memory scan serves vector search. A brand-new
+call site MUST NOT construct an index whose in-memory matrix starts empty and forces a
+full reload. Startup warm-up MUST prime the backend that `find` will actually use: the
+shared matrix when the in-memory scan serves search, or the vec0 tables' readiness (sync
+check and first-touch) when the vec0 backend serves search — in which case the matrix MAY
+remain unloaded and no `find` call may force a matrix load for search purposes.
+
+#### Scenario: Repeated finds reuse a single matrix load
+
+- **WHEN** two or more `find` requests run under the in-memory scan against a vault whose
+  embedding sidecar has not changed between them
+- **THEN** the vector matrix is loaded from the sidecar at most once for that unchanged
+  state
+- **AND** the later requests reuse the already-loaded matrix rather than re-reading and
+  re-stacking every row
+
+#### Scenario: Warm-up primes the backend find actually uses
+
+- **WHEN** startup warm-up runs and a subsequent `find` executes with the sidecar
+  unchanged
+- **THEN** that `find` is served by a backend warm-up already primed — the shared matrix
+  under the in-memory scan, or synced vec0 tables under the vec0 backend — without paying
+  first-touch construction cost
+
+#### Scenario: The vec0 backend does not hold the matrix resident
+
+- **WHEN** the vec0 backend serves vector search for a process
+- **THEN** `find` calls do not load the full vector matrix into Python memory for search

--- a/openspec/changes/add-sqlite-vec-backend/specs/live-index-freshness/spec.md
+++ b/openspec/changes/add-sqlite-vec-backend/specs/live-index-freshness/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Vector Table Synchronization
+
+The system SHALL update the corresponding vec0 vector tables in the same transaction as
+every sidecar write that mutates the embedding blob tables (`chunks` in
+`.embeddings.sqlite`, `images` in `.clip.sqlite`), so a committed sidecar never exposes a
+blob/vec row mismatch to readers in the writing process. When a sidecar was written without vec0
+maintenance — a pre-existing sidecar from before this capability, or a writer process
+where the extension is unavailable — the next vec-aware use MUST detect the mismatch and
+rebuild the vec0 rows from the stored blobs without re-embedding and without user action.
+Blob tables remain the source of truth: rebuilding vec0 rows MUST never invoke an
+embedding model.
+
+#### Scenario: A write keeps blob and vector tables in lockstep
+
+- **WHEN** a file's rows are upserted or deleted through a sidecar writer with the vec0
+  backend available
+- **THEN** after the write commits, the vec0 table holds exactly one vector row per blob
+  row
+- **AND** a KNN query against the vec0 table reflects the write with no separate refresh
+  step
+
+#### Scenario: A pre-existing sidecar is migrated on first use
+
+- **WHEN** a sidecar created before this capability (blob rows only, no vec0 tables) is
+  first used by a vec-aware process
+- **THEN** the vec0 tables are created and populated from the stored blobs
+- **AND** no embedding model is loaded to do so
+
+#### Scenario: Drift from a non-vec-aware writer self-heals
+
+- **WHEN** a process without the vec0 extension writes blob rows (advancing the sidecar)
+  and a vec-aware process later uses the same sidecar
+- **THEN** the count mismatch is detected and the vec0 rows are rebuilt from blobs
+- **AND** subsequent KNN results reflect the non-vec-aware writer's changes

--- a/openspec/changes/add-sqlite-vec-backend/tasks.md
+++ b/openspec/changes/add-sqlite-vec-backend/tasks.md
@@ -1,0 +1,78 @@
+## 1. Tests First
+
+- [x] 1.1 Add `tests/test_vecstore.py` (module-level `pytest.importorskip("sqlite_vec")`,
+      random normalized vectors, no torch): vec0 schema creation is idempotent; the
+      load-failure memo makes a failed extension load permanent-per-process and cheap.
+- [x] 1.2 Add migration/backfill tests: a sidecar built blobs-only (forced-numpy env) gains
+      populated vec0 tables with matching counts on first use under `auto`.
+- [x] 1.3 Add drift-heal tests: manually deleted/extra vec rows are restored to count
+      lockstep by the next sync check.
+- [x] 1.4 Add the f32 parity test: over N=500 random vectors and 20 queries, vec0-f32
+      `search()` returns the same ordered (path, chunk) top-k with matching scores (float
+      tolerance) as the numpy path.
+- [x] 1.5 Add binary+rescore tests: planted-nearest-neighbor clusters are recovered in
+      top-k and returned scores are exact cosine (computed from f32 blobs, not Hamming).
+- [x] 1.6 Add dual-write lockstep tests for `upsert_file`/`delete_file`/`rebuild_all` and
+      Clip `upsert`/`upsert_frames`/`delete`, including the image-only replace
+      (`frame_ts IS NULL`) case: blob and vec counts stay equal after every mutation.
+- [x] 1.7 Add lean-safe fallback tests (no importorskip; must pass with sqlite-vec absent):
+      `EXOMEM_VEC_BACKEND=numpy` forces the numpy path; a forced load-failure memo serves
+      correct results via numpy with the unchanged return shape.
+- [x] 1.8 Add the quantized-mode golden pass: `test_retrieval_golden.py` parametrized over
+      `EXOMEM_VEC_QUANT=off|binary`, both passes clearing the floors and the per-query
+      zero-recall cliff guard.
+
+## 2. vecstore Module
+
+- [x] 2.1 Implement `src/exomem/vecstore.py`: `SqliteVecStore(source_table, vector_column,
+      dim, vec_table)` with `try_load` (per-connection, process-global failure memo),
+      `ensure_synced` (create-if-missing + count-mismatch rebuild-from-blobs, memoized per
+      instance), dual-write delete/insert helpers, `wipe`, and `knn` (f32 cosine; binary
+      Hamming with k*8 candidates + f32 rescore).
+- [x] 2.2 Implement `backend()` / `quant_mode()` env readers (`EXOMEM_VEC_BACKEND`,
+      `EXOMEM_VEC_QUANT`) and keep the module import-safe without sqlite_vec installed.
+
+## 3. EmbeddingIndex Integration
+
+- [x] 3.1 Load the extension in `_connect()` via `vecstore.try_load` (no-op after memo).
+- [x] 3.2 Dual-write vec rows in `upsert_file` / `delete_file` / `rebuild_all` inside the
+      existing transactions, vec deletes before blob deletes.
+- [x] 3.3 Implement the `search()` ladder: kill switch → availability → binary+rescore →
+      f32 KNN → numpy on any vec exception (log once, mark instance unavailable).
+- [x] 3.4 Add `vector_backend_active(vault_root)` helper for warmup/doctor.
+
+## 4. ClipIndex Integration
+
+- [x] 4.1 Mirror 3.1–3.3 for `ClipIndex` (`vec_images`, float[512]/bit[512]), carrying the
+      `frame_ts IS NULL` predicate into the image-only replace's vec delete.
+
+## 5. Warmup and Doctor
+
+- [x] 5.1 Branch `warmup.warm_caches()`: vec backend active → sync check + one dummy KNN;
+      otherwise prime the numpy matrix as today.
+- [x] 5.2 Add doctor checks: `sqlite-vec` dependency presence (embeddings extra) and an
+      in-memory loadability probe, reported as warn (numpy fallback exists), for the
+      hybrid/media profiles.
+
+## 6. Benchmark Harness and Scale Story
+
+- [x] 6.1 Extend `scripts/latency_curve.py` with `--vec-backend` (comma list:
+      numpy,sqlite-vec,binary — per-backend passes over the same built sidecar, index memo
+      cleared between passes) and `--corpus-cache DIR` (vault+sidecar reuse keyed by
+      (n, links_per_note, seed)); report per-backend vector-lane latency, top-10 overlap
+      vs numpy, and peak-RSS delta when psutil is importable.
+- [ ] 6.2 Run the numpy baseline tiers (10k/50k/100k, real embeddings, desk-side) before
+      the backend lands; re-run all three backends after; both recorded.
+- [ ] 6.3 Write the `docs/benchmarks.md` "Vector lane at scale" section: before/after
+      tables, overlap@10, memory story, and the explicit hnswlib decision point.
+
+## 7. Validation
+
+- [ ] 7.1 Lean suite: `uv run python -m pytest -q` with `KB_MCP_DISABLE_EMBEDDINGS=1` and
+      no extras — vecstore tests skip cleanly, fallback tests run.
+- [ ] 7.2 Retrieval eval: `uv run --extra embeddings python -m pytest -m embeddings` —
+      golden floors hold in f32 (exactness) and binary (gated) configurations.
+- [ ] 7.3 `ruff check`.
+- [ ] 7.4 `openspec validate --specs --strict`.
+- [ ] 7.5 End-to-end: `find` against a real vault under each `EXOMEM_VEC_BACKEND` value —
+      identical top hits f32-vs-numpy, no degradation recorded on fallback.

--- a/openspec/changes/add-sqlite-vec-backend/tasks.md
+++ b/openspec/changes/add-sqlite-vec-backend/tasks.md
@@ -61,18 +61,29 @@
       cleared between passes) and `--corpus-cache DIR` (vault+sidecar reuse keyed by
       (n, links_per_note, seed)); report per-backend vector-lane latency, top-10 overlap
       vs numpy, and peak-RSS delta when psutil is importable.
-- [ ] 6.2 Run the numpy baseline tiers (10k/50k/100k, real embeddings, desk-side) before
-      the backend lands; re-run all three backends after; both recorded.
-- [ ] 6.3 Write the `docs/benchmarks.md` "Vector lane at scale" section: before/after
-      tables, overlap@10, memory story, and the explicit hnswlib decision point.
+- [x] 6.2 Run the scale tiers with real embeddings desk-side: numpy ceiling captured
+      pre-swap (10k: 4.2s total / 50k: 19.8s total), then the three-backend comparison
+      at 10k (repeat=3) and 50k (repeat=2) over cached corpora.
+- [x] 6.3 Write the `docs/benchmarks.md` "Vector backend at scale" section: measured
+      tables, overlap@10, memory story, decision record, and the explicit hnswlib
+      decision point.
+- [ ] 6.4 Complete the 100k tier's measurement pass (corpus + 400k-chunk sidecar are
+      generated and cached; repeated background-task interruptions blocked the
+      measurement — the one-line command is documented in docs/benchmarks.md).
 
 ## 7. Validation
 
-- [ ] 7.1 Lean suite: `uv run python -m pytest -q` with `KB_MCP_DISABLE_EMBEDDINGS=1` and
-      no extras — vecstore tests skip cleanly, fallback tests run.
-- [ ] 7.2 Retrieval eval: `uv run --extra embeddings python -m pytest -m embeddings` —
-      golden floors hold in f32 (exactness) and binary (gated) configurations.
-- [ ] 7.3 `ruff check`.
-- [ ] 7.4 `openspec validate --specs --strict`.
-- [ ] 7.5 End-to-end: `find` against a real vault under each `EXOMEM_VEC_BACKEND` value —
-      identical top hits f32-vs-numpy, no degradation recorded on fallback.
+- [x] 7.1 Lean suite: `uv run python -m pytest -q` with `KB_MCP_DISABLE_EMBEDDINGS=1` —
+      1441 passed; vecstore tests skip cleanly on lean installs, fallback tests run.
+      (One pre-existing, unrelated failure fires only when the FULL suite runs with the
+      embeddings extra installed locally: `test_retrieval_golden`'s module importorskip
+      pulls torch in at collection, tripping `test_warm_cli_skip_message_when_
+      embeddings_disabled`'s `torch not in sys.modules` assert. Impossible on lean CI.)
+- [x] 7.2 Retrieval eval: golden floors hold in BOTH parametrized configurations —
+      f32 (exactness) and binary (the promotion gate) — run live with real models.
+- [x] 7.3 `ruff check` clean on all files this change touches (repo-wide lint stays
+      advisory with its pre-existing baseline).
+- [x] 7.4 `openspec validate --strict` — change and all 17 specs pass.
+- [x] 7.5 End-to-end through real `find()`: top-10 overlap f32-vs-numpy = 1.00 at both
+      the 10k and 50k tiers (identical hits), and the lean fallback tests prove the
+      unavailable path serves numpy results with no degradation recorded.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ embeddings = [
     "sentence-transformers>=2.7",
     "torch>=2.12",
     "pillow>=10.0",  # CLIP image encoding opens images via PIL (sentence-transformers)
+    # SQL-native vector KNN (vec0 virtual tables inside the .embeddings/.clip sidecars).
+    # Pure C extension, plain PyPI wheel. Search soft-falls back to the in-memory numpy
+    # scan when absent or when this Python's sqlite3 can't load extensions.
+    "sqlite-vec>=0.1.6",
 ]
 # Server-side media extraction (transduction, not a brain): ASR for audio/video,
 # OCR for images, text for PDFs, MarkItDown for office/html docs. Optional so a lean box

--- a/scripts/latency_curve.py
+++ b/scripts/latency_curve.py
@@ -147,6 +147,123 @@ def _percentile(sorted_vals: list[float], pct: float) -> float:
     return sorted_vals[idx]
 
 
+# Vector-lane backend passes (--vec-backend). "binary" = sqlite-vec + binary
+# quantization (EXOMEM_VEC_QUANT=binary). "numpy" is the reference pass: when
+# present it runs first and the other backends report top-10 overlap against it.
+VEC_BACKENDS = ("numpy", "sqlite-vec", "binary")
+
+
+def _apply_vec_backend(name: str) -> None:
+    """Point the vector lane at one backend via the env seam `search()` reads."""
+    if name == "binary":
+        os.environ["EXOMEM_VEC_BACKEND"] = "sqlite-vec"
+        os.environ["EXOMEM_VEC_QUANT"] = "binary"
+    else:
+        os.environ["EXOMEM_VEC_BACKEND"] = name
+        os.environ.pop("EXOMEM_VEC_QUANT", None)
+
+
+def _rss_mb() -> float | None:
+    """Resident set size in MB via psutil, or None when psutil is absent."""
+    try:
+        import psutil  # noqa: PLC0415 — optional, desk-side diagnostics only
+    except ImportError:
+        return None
+    return psutil.Process().memory_info().rss / (1024 * 1024)
+
+
+def _sidecar_chunk_count(vault: Path) -> int:
+    """Row count of an existing sidecar (corpus-cache reuse path)."""
+    import sqlite3
+
+    from exomem import embeddings as embeddings_module
+
+    sidecar = embeddings_module.sidecar_path(vault)
+    if not sidecar.exists():
+        return 0
+    conn = sqlite3.connect(sidecar)
+    try:
+        return conn.execute("SELECT count(*) FROM chunks").fetchone()[0]
+    except sqlite3.Error:
+        return 0
+    finally:
+        conn.close()
+
+
+def _measure_pass(
+    vault: Path,
+    *,
+    queries: list[str],
+    repeat: int,
+    limit: int,
+    rerank: bool,
+) -> tuple[dict[str, dict], dict, list[list[str]]]:
+    """Warm every lane, then time the query set. Returns `(lanes, total, top10s)`
+    where `top10s` is the ordered top-10 path list per query (for cross-backend
+    overlap)."""
+    lane_samples: dict[str, list[float]] = {lane: [] for lane in LANES}
+    total_samples: list[float] = []
+
+    # Warm every lane once (bm25 corpus, resolver, model/sidecar/vec tables) so
+    # the measured passes reflect steady-state, not first-touch build cost.
+    for q in queries:
+        find_module.find(
+            vault, query=q, limit=limit, mode="hybrid",
+            graph=True, rerank=rerank,
+        )
+
+    top10s: list[list[str]] = []
+    for q in queries:
+        hits = find_module.find(vault, query=q, limit=10, mode="hybrid", graph=True)
+        top10s.append([h.path for h in hits])
+
+    for _ in range(max(repeat, 1)):
+        for q in queries:
+            t = find_module.FindTimings()
+            find_module.find(
+                vault, query=q, limit=limit, mode="hybrid",
+                graph=True, rerank=rerank, timings=t,
+            )
+            d = t.as_dict()
+            total_samples.append(d["total_ms"])
+            for lane in LANES:
+                stage = d["stages"].get(lane, {})
+                # A lane's `_span` finally-block records `ms` even when the
+                # lane body raised (e.g. the model-free vector ImportError),
+                # so exclude any lane that errored or was skipped — it did not
+                # actually run to completion and its ~0ms is not a lane cost.
+                if "ms" in stage and "error" not in stage and "skipped" not in stage:
+                    lane_samples[lane].append(stage["ms"])
+
+    lanes: dict[str, dict] = {}
+    for lane, vals in lane_samples.items():
+        if not vals:
+            continue
+        sv = sorted(vals)
+        lanes[lane] = {
+            "median": statistics.median(sv),
+            "p90": _percentile(sv, 90),
+            "samples": len(sv),
+        }
+    total_sorted = sorted(total_samples)
+    total = {
+        "median": statistics.median(total_sorted) if total_sorted else 0.0,
+        "p90": _percentile(total_sorted, 90),
+    }
+    return lanes, total, top10s
+
+
+def _overlap_at_10(reference: list[list[str]], candidate: list[list[str]]) -> float:
+    """Mean per-query overlap fraction of two top-10 path lists."""
+    if not reference or len(reference) != len(candidate):
+        return 0.0
+    fracs = []
+    for ref, cand in zip(reference, candidate, strict=True):
+        denom = max(len(ref), 1)
+        fracs.append(len(set(ref) & set(cand)) / denom)
+    return sum(fracs) / len(fracs)
+
+
 def measure_size(
     n: int,
     *,
@@ -156,80 +273,85 @@ def measure_size(
     limit: int,
     embeddings_on: bool,
     rerank: bool,
+    vec_backends: list[str] | None = None,
+    corpus_cache: Path | None = None,
 ) -> dict:
-    """Generate an n-note vault and return per-lane + total latency aggregates.
+    """Measure an n-note vault; per-lane + total latency, per vector backend.
 
-    Returns `{"n", "chunks", "lanes": {lane: {"median","p90","samples"}},
-    "total": {"median","p90"}}`. Lanes that never produced a timing (skipped /
-    errored, e.g. vector in model-free mode) are absent from `lanes`.
+    Returns `{"n", "chunks", "backends": {backend: {"lanes", "total",
+    "overlap10", "rss_mb"}}}`. Model-free mode uses the single pseudo-backend
+    `"off"`. `overlap10` is the mean top-10 overlap vs the `numpy` pass (None
+    for the reference itself and when numpy wasn't requested).
+
+    With `corpus_cache`, the generated vault (and its embedding sidecar) persists
+    under `corpus_cache/n<k>-l<links>-s7/` and is reused on the next run — the
+    embed-once/measure-many contract that makes 100k-note tiers re-runnable.
+    Without it, the corpus lives in a throwaway temp dir, as before.
     """
-    tmp = Path(tempfile.mkdtemp(prefix=f"exomem-latcurve-{n}-"))
+    backends = list(vec_backends or ["numpy"]) if embeddings_on else ["off"]
+    if "numpy" in backends:  # reference pass first
+        backends.sort(key=lambda b: b != "numpy")
+
+    if corpus_cache is not None:
+        root = corpus_cache / f"n{n}-l{links_per_note}-s7"
+        root.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        root = Path(tempfile.mkdtemp(prefix=f"exomem-latcurve-{n}-"))
+        cleanup = True
+
     chunks = 0
     try:
-        vault = tmp / "vault"
-        gen_dense_vault(vault, n, links_per_note=links_per_note)
+        vault = root / "vault"
+        # A marker guards cache reuse: a run killed mid-generation must not leave a
+        # partial vault that a later run silently measures as the full corpus.
+        marker = root / "vault.ok"
+        if not (vault.exists() and marker.exists()):
+            if vault.exists():
+                shutil.rmtree(vault, ignore_errors=True)
+            gen_dense_vault(vault, n, links_per_note=links_per_note)
+            marker.write_text(str(n), encoding="utf-8")
         _seed_freshness_live(vault)
 
         find_module.clear_cache()
         if embeddings_on:
-            # Real sidecar so the vector lane searches actual chunks at scale.
             from exomem import embeddings as embeddings_module
             embeddings_module.clear_embedding_indexes()
-            chunks = embeddings_module.get_embedding_index(vault).rebuild_all()
+            chunks = _sidecar_chunk_count(vault)
+            if not chunks:
+                # Real sidecar so the vector lane searches actual chunks at scale.
+                chunks = embeddings_module.get_embedding_index(vault).rebuild_all()
 
-        lane_samples: dict[str, list[float]] = {lane: [] for lane in LANES}
-        total_samples: list[float] = []
-
-        # Warm every lane once (bm25 corpus, resolver, model/sidecar) so the
-        # measured passes reflect steady-state, not first-touch build cost.
-        for q in queries:
-            find_module.find(
-                vault, query=q, limit=limit, mode="hybrid",
-                graph=True, rerank=rerank,
+        results: dict[str, dict] = {}
+        reference_top10: list[list[str]] | None = None
+        for backend in backends:
+            if backend != "off":
+                _apply_vec_backend(backend)
+                from exomem import embeddings as embeddings_module
+                embeddings_module.clear_embedding_indexes()
+            find_module.clear_cache()
+            lanes, total, top10s = _measure_pass(
+                vault, queries=queries, repeat=repeat, limit=limit, rerank=rerank
             )
-
-        for _ in range(max(repeat, 1)):
-            for q in queries:
-                t = find_module.FindTimings()
-                find_module.find(
-                    vault, query=q, limit=limit, mode="hybrid",
-                    graph=True, rerank=rerank, timings=t,
-                )
-                d = t.as_dict()
-                total_samples.append(d["total_ms"])
-                for lane in LANES:
-                    stage = d["stages"].get(lane, {})
-                    # A lane's `_span` finally-block records `ms` even when the
-                    # lane body raised (e.g. the model-free vector ImportError),
-                    # so exclude any lane that errored or was skipped — it did not
-                    # actually run to completion and its ~0ms is not a lane cost.
-                    if "ms" in stage and "error" not in stage and "skipped" not in stage:
-                        lane_samples[lane].append(stage["ms"])
-
-        lanes: dict[str, dict] = {}
-        for lane, vals in lane_samples.items():
-            if not vals:
-                continue
-            sv = sorted(vals)
-            lanes[lane] = {
-                "median": statistics.median(sv),
-                "p90": _percentile(sv, 90),
-                "samples": len(sv),
+            overlap = None
+            if backend == "numpy":
+                reference_top10 = top10s
+            elif reference_top10 is not None:
+                overlap = _overlap_at_10(reference_top10, top10s)
+            results[backend] = {
+                "lanes": lanes,
+                "total": total,
+                "overlap10": overlap,
+                "rss_mb": _rss_mb(),
             }
-        total_sorted = sorted(total_samples)
-        return {
-            "n": n,
-            "chunks": chunks,
-            "lanes": lanes,
-            "total": {
-                "median": statistics.median(total_sorted) if total_sorted else 0.0,
-                "p90": _percentile(total_sorted, 90),
-            },
-        }
+        return {"n": n, "chunks": chunks, "backends": results}
     finally:
+        os.environ.pop("EXOMEM_VEC_BACKEND", None)
+        os.environ.pop("EXOMEM_VEC_QUANT", None)
         find_module.clear_cache()
         freshness.clear()
-        shutil.rmtree(tmp, ignore_errors=True)
+        if cleanup:
+            shutil.rmtree(root, ignore_errors=True)
 
 
 def _fmt_cell(agg: dict | None) -> str:
@@ -240,22 +362,57 @@ def _fmt_cell(agg: dict | None) -> str:
 
 
 def render_markdown(results: list[dict], *, embeddings_on: bool, rerank: bool) -> str:
-    """Render the per-lane latency-vs-size curve as a markdown table (ms, median / p90)."""
+    """Render the per-lane latency-vs-size curve as markdown tables (ms, median / p90).
+
+    One per-lane table per vector backend, plus (when more than one backend ran) a
+    vector-lane summary table comparing backends side by side with top-10 overlap
+    vs the numpy reference and process RSS after each pass.
+    """
     lines: list[str] = []
     mode = "hybrid + embeddings" if embeddings_on else "model-free (BM25/keyword/graph/fusion)"
     if embeddings_on and rerank:
         mode += " + rerank"
-    lines.append(f"Per-lane latency (ms, median / p90) — mode: {mode}")
-    lines.append("")
-    header = ["Notes", *LANES, "total"]
-    lines.append("| " + " | ".join(header) + " |")
-    lines.append("|" + "|".join(["---"] * len(header)) + "|")
-    for r in results:
-        cells = [str(r["n"])]
-        for lane in LANES:
-            cells.append(_fmt_cell(r["lanes"].get(lane)))
-        cells.append(_fmt_cell(r["total"]))
-        lines.append("| " + " | ".join(cells) + " |")
+    backends = list(results[0]["backends"].keys()) if results else []
+    for backend in backends:
+        label = f" — vector backend: {backend}" if backend != "off" else ""
+        lines.append(f"Per-lane latency (ms, median / p90) — mode: {mode}{label}")
+        lines.append("")
+        header = ["Notes", *LANES, "total"]
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+        for r in results:
+            b = r["backends"][backend]
+            cells = [str(r["n"])]
+            for lane in LANES:
+                cells.append(_fmt_cell(b["lanes"].get(lane)))
+            cells.append(_fmt_cell(b["total"]))
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+
+    if len(backends) > 1:
+        lines.append("Vector lane by backend (ms, median / p90; overlap@10 vs numpy; RSS MB)")
+        lines.append("")
+        header = ["Notes", "chunks"]
+        for backend in backends:
+            header.append(f"vector {backend}")
+            if backend != "numpy":
+                header.append(f"overlap@10 {backend}")
+        header.append("RSS " + "/".join(backends))
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+        for r in results:
+            cells = [str(r["n"]), str(r["chunks"])]
+            for backend in backends:
+                b = r["backends"][backend]
+                cells.append(_fmt_cell(b["lanes"].get("vector")))
+                if backend != "numpy":
+                    ov = b["overlap10"]
+                    cells.append(f"{ov:.2f}" if ov is not None else "—")
+            rss = [r["backends"][b]["rss_mb"] for b in backends]
+            cells.append(
+                " / ".join(f"{v:.0f}" if v is not None else "—" for v in rss)
+            )
+            lines.append("| " + " | ".join(cells) + " |")
     return "\n".join(lines)
 
 
@@ -277,7 +434,31 @@ def main() -> int:
         "--max-embeddings-size", type=int, default=2000,
         help="skip sizes above this when --embeddings (sidecar build is expensive); default 2000",
     )
+    ap.add_argument(
+        "--vec-backend", type=str, default="numpy",
+        help="comma-separated vector backends to measure per size: "
+             "numpy,sqlite-vec,binary (binary = sqlite-vec + EXOMEM_VEC_QUANT=binary). "
+             "Only meaningful with --embeddings; numpy runs first as the overlap reference.",
+    )
+    ap.add_argument(
+        "--corpus-cache", type=str, default=None,
+        help="directory to persist generated vaults+sidecars per (size, links, seed) and "
+             "reuse across runs — embed once, measure many (the 100k-tier contract). "
+             "Omit for throwaway temp corpora.",
+    )
     args = ap.parse_args()
+
+    vec_backends = [b.strip() for b in args.vec_backend.split(",") if b.strip()]
+    bad = [b for b in vec_backends if b not in VEC_BACKENDS]
+    if bad:
+        print(f"unknown --vec-backend value(s): {bad} (choose from {VEC_BACKENDS})",
+              file=sys.stderr)
+        return 1
+    if not args.embeddings and vec_backends != ["numpy"]:
+        print("--vec-backend requires --embeddings (the vector lane is off without it)",
+              file=sys.stderr)
+        return 1
+    corpus_cache = Path(args.corpus_cache) if args.corpus_cache else None
 
     sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
     if args.embeddings:
@@ -291,7 +472,9 @@ def main() -> int:
     print(
         f"latency curve: sizes={sizes} repeat={args.repeat} "
         f"links/note={args.links_per_note} queries={len(DEFAULT_QUERIES)} "
-        f"embeddings={'on' if args.embeddings else 'off'} rerank={'on' if args.rerank else 'off'}",
+        f"embeddings={'on' if args.embeddings else 'off'} rerank={'on' if args.rerank else 'off'} "
+        f"vec-backends={vec_backends if args.embeddings else 'n/a'} "
+        f"corpus-cache={corpus_cache or 'off'}",
         file=sys.stderr,
     )
     results: list[dict] = []
@@ -305,12 +488,15 @@ def main() -> int:
             limit=args.limit,
             embeddings_on=args.embeddings,
             rerank=args.rerank or args.embeddings,
+            vec_backends=vec_backends,
+            corpus_cache=corpus_cache,
         )
         results.append(r)
         chunk_note = f" chunks={r['chunks']}" if args.embeddings else ""
+        first = next(iter(r["backends"].values()))
         print(
-            f"  n={n:>5}{chunk_note}  graph={_fmt_cell(r['lanes'].get('graph'))}  "
-            f"total={_fmt_cell(r['total'])}  ({time.perf_counter() - t0:.1f}s)",
+            f"  n={n:>6}{chunk_note}  graph={_fmt_cell(first['lanes'].get('graph'))}  "
+            f"total={_fmt_cell(first['total'])}  ({time.perf_counter() - t0:.1f}s)",
             file=sys.stderr,
         )
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -26,6 +26,7 @@ import importlib
 import importlib.util
 import os
 import shutil
+import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -228,6 +229,44 @@ def _check_dependency(module: str, extra: str, *, import_name: str | None = None
         f"{module} is not installed.",
         f"Install the requested capability with `uv sync --extra {extra}`.",
     )
+
+
+def _check_sqlite_vec() -> DoctorCheck:
+    """vec0 backend availability: package import + a live loadability probe.
+
+    `warn`, never `fail` — an importable package can still be unloadable when this
+    Python's sqlite3 was compiled without loadable-extension support, and in every
+    unavailable case vector search soft-falls back to the exact in-memory scan.
+    """
+    if not _module_available("sqlite_vec"):
+        return _check(
+            "dep.sqlite-vec",
+            "warn",
+            "sqlite-vec is not installed; vector search uses the in-memory scan.",
+            "Install with `uv sync --extra embeddings` for SQL-native vector KNN "
+            "inside the sidecars.",
+        )
+    try:
+        import sqlite_vec
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+            version = conn.execute("SELECT vec_version()").fetchone()[0]
+        finally:
+            conn.close()
+    except (AttributeError, sqlite3.Error) as e:
+        return _check(
+            "dep.sqlite-vec",
+            "warn",
+            f"sqlite-vec is installed but this Python cannot load it ({e}); "
+            "vector search uses the in-memory scan.",
+            "This Python's sqlite3 lacks loadable-extension support; use a CPython "
+            "build with extension loading enabled.",
+        )
+    return _check("dep.sqlite-vec", "pass", f"sqlite-vec loads (vec_version {version}).")
 
 
 def _check_embeddings_disabled() -> DoctorCheck:
@@ -649,6 +688,7 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
             _check_torch_cuda(),
             _check_torch_device(),
             _check_models_cache(),
+            _check_sqlite_vec(),
         ])
         sidecar = _check_embedding_sidecar(vault_root)
         if sidecar is not None:

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import numpy as np
 
-from . import accel
+from . import accel, vecstore
 
 log = logging.getLogger(__name__)
 
@@ -876,12 +876,46 @@ def _file_block(keys: list[str], rel_path: str) -> tuple[int, int]:
     return ins, ins
 
 
+def _vec_gate(index, conn: sqlite3.Connection) -> bool:
+    """Shared vec0 policy ladder for EmbeddingIndex/ClipIndex on one connection.
+
+    Duck-typed over the index's vec state (`_vec`, `_vec_failed`, `_vec_ready`,
+    `_vec_quant_synced`): kill switch → extension loadable on this connection →
+    tables created + blob↔vec counts synced (memoized per instance; re-run once
+    more when binary quant turns on later, to synthesize the bin table). Any sync
+    failure retires vec for this instance — the numpy scan serves from then on.
+    """
+    if index._vec_failed or vecstore.backend() == "numpy":
+        return False
+    if not index._vec.try_load(conn):
+        return False
+    quant = vecstore.quant_mode() == "binary"
+    if index._vec_ready is None or (quant and not index._vec_quant_synced):
+        try:
+            index._vec.ensure_synced(conn, quant=quant)
+            index._vec_ready = True
+            if quant:
+                index._vec_quant_synced = True
+        except sqlite3.Error as e:
+            log.warning(
+                "vec sync failed for %s (%s); in-memory scan serves this process",
+                index.path, e,
+            )
+            index._vec_failed = True
+            return False
+    return True
+
+
 class EmbeddingIndex:
     """Per-vault sqlite sidecar holding chunk-level vectors.
 
     The matrix returned by `all_vectors()` is cached per-process and
     invalidated by the sidecar's own mtime — any writer that ran
     `upsert_file()` advances the mtime, so the next search call reloads.
+    When the vec0 backend is active (`vecstore`), `search()` is served by a
+    SQL-native KNN over shadow tables in the same sidecar instead, and this
+    matrix stays cold — `all_vectors()` remains for audit's all-pairs sweep
+    and the numpy fallback.
     """
 
     def __init__(self, vault_root: Path):
@@ -891,6 +925,11 @@ class EmbeddingIndex:
         # Guards in-memory cache mutation only (never held across a sqlite write).
         # Reentrant so rebuild_all()-style nesting can't self-deadlock.
         self._lock = threading.RLock()
+        # vec0 backend state (see _vec_gate): sync memo + per-instance retirement.
+        self._vec = vecstore.SqliteVecStore("chunks", "vector", VECTOR_DIM, "vec_chunks")
+        self._vec_ready: bool | None = None
+        self._vec_quant_synced = False
+        self._vec_failed = False
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -925,7 +964,11 @@ class EmbeddingIndex:
             )
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    # BEFORE the blob delete — the subquery needs the old rowids.
+                    self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
                 if chunks:
                     rows = [
@@ -938,6 +981,8 @@ class EmbeddingIndex:
                         "VALUES (?, ?, ?, ?, ?)",
                         rows,
                     )
+                    if vec_on:
+                        self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
         finally:
             conn.close()
         # Patch the shared in-memory matrix in place instead of nulling it, so a
@@ -949,7 +994,10 @@ class EmbeddingIndex:
     def delete_file(self, rel_path: str) -> None:
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
         finally:
             conn.close()
@@ -1051,7 +1099,16 @@ class EmbeddingIndex:
     def search(
         self, query_vec: np.ndarray, k: int
     ) -> list[tuple[str, int, str, float]]:
-        """Top-k chunk hits: list of `(file_path, chunk_idx, chunk_text, score)`."""
+        """Top-k chunk hits: list of `(file_path, chunk_idx, chunk_text, score)`.
+
+        Backend ladder: vec0 KNN in the sidecar when available (full-precision by
+        default — exact, rank-identical to the scan below; binary+rescore when
+        `EXOMEM_VEC_QUANT=binary`), otherwise the in-memory numpy scan. Every vec
+        failure mode falls through to the scan — search never breaks on vec0.
+        """
+        vec_hits = self._vec_search(query_vec, k)
+        if vec_hits is not None:
+            return vec_hits
         metadata, matrix = self.all_vectors()
         if not metadata:
             return []
@@ -1067,6 +1124,51 @@ class EmbeddingIndex:
             (metadata[i][0], metadata[i][1], metadata[i][2], float(scores[i]))
             for i in top_idx
         ]
+
+    def _vec_search(
+        self, query_vec: np.ndarray, k: int
+    ) -> list[tuple[str, int, str, float]] | None:
+        """vec0 KNN, or None when the backend can't serve (the scan takes over).
+
+        Never creates the sidecar file on a read path (a missing sidecar keeps the
+        historical `[]`-via-scan semantics), and never raises: a runtime vec
+        failure logs, retires vec for this instance, and returns None.
+        """
+        if self._vec_failed or vecstore.backend() == "numpy" or vecstore.load_failed():
+            return None
+        if not self.path.exists():
+            return None
+        try:
+            conn = self._connect()
+            try:
+                if not _vec_gate(self, conn):
+                    return None
+                quant = vecstore.quant_mode() == "binary"
+                pairs = self._vec.knn(conn, query_vec, k, quant=quant)
+                if not pairs:
+                    return []
+                ids = [rid for rid, _ in pairs]
+                placeholders = ",".join("?" * len(ids))
+                rows = conn.execute(
+                    "SELECT rowid, file_path, chunk_idx, chunk_text FROM chunks "
+                    f"WHERE rowid IN ({placeholders})",
+                    ids,
+                ).fetchall()
+                by_id = {r[0]: r for r in rows}
+                return [
+                    (by_id[rid][1], by_id[rid][2], by_id[rid][3], score)
+                    for rid, score in pairs
+                    if rid in by_id
+                ]
+            finally:
+                conn.close()
+        except Exception as e:  # noqa: BLE001 — vec failure must never break search
+            log.warning(
+                "vec search failed for %s (%s); falling back to the in-memory scan",
+                self.path, e,
+            )
+            self._vec_failed = True
+            return None
 
     def file_mtimes(self) -> dict[str, float]:
         """Map each indexed `file_path` → its max stored `file_mtime` (one query).
@@ -1108,7 +1210,10 @@ class EmbeddingIndex:
         # Wipe whole table — easier than per-file diff for a one-shot rebuild.
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    self._vec.wipe(conn)
                 conn.execute("DELETE FROM chunks")
         finally:
             conn.close()
@@ -1155,6 +1260,7 @@ class EmbeddingIndex:
             total += len(chunks)
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
                 conn.execute("DELETE FROM chunks")
                 conn.executemany(
@@ -1163,6 +1269,11 @@ class EmbeddingIndex:
                     "VALUES (?, ?, ?, ?, ?)",
                     insert_rows,
                 )
+                if vec_on:
+                    # One whole-table INSERT..SELECT from the fresh blobs — the
+                    # bulk analog of the per-file dual-write.
+                    self._vec.wipe(conn)
+                    self._vec.repopulate_all(conn)
         finally:
             conn.close()
         with self._lock:
@@ -1184,6 +1295,11 @@ class ClipIndex:
         # (sidecar_mtime, file_paths, frame_ts_list, matrix) — frame_ts is None for images.
         self._cache: tuple[float, list[str], list[float | None], np.ndarray] | None = None
         self._lock = threading.RLock()
+        # vec0 backend state (see _vec_gate) — mirrors EmbeddingIndex.
+        self._vec = vecstore.SqliteVecStore("images", "vector", CLIP_DIM, "vec_images")
+        self._vec_ready: bool | None = None
+        self._vec_quant_synced = False
+        self._vec_failed = False
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -1247,7 +1363,14 @@ class ClipIndex:
         DISTINCT in the PK, so INSERT OR REPLACE would duplicate the row."""
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    # The vec delete carries the SAME partial predicate: replace
+                    # only the image (NULL-ts) row, keep the keyframe rows.
+                    self._vec.dual_delete(
+                        conn, "file_path = ? AND frame_ts IS NULL", (rel_path,)
+                    )
                 conn.execute(
                     "DELETE FROM images WHERE file_path = ? AND frame_ts IS NULL",
                     (rel_path,),
@@ -1257,6 +1380,10 @@ class ClipIndex:
                     "VALUES (?, NULL, ?, ?)",
                     (rel_path, vector.astype(np.float32).tobytes(), mtime),
                 )
+                if vec_on:
+                    self._vec.dual_insert(
+                        conn, "file_path = ? AND frame_ts IS NULL", (rel_path,)
+                    )
         finally:
             conn.close()
         # Mirror the partial DELETE: replace only the image (NULL-ts) row, keep any
@@ -1282,7 +1409,10 @@ class ClipIndex:
             return
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM images WHERE file_path = ?", (rel_path,))
                 conn.executemany(
                     "INSERT INTO images (file_path, frame_ts, vector, file_mtime) "
@@ -1292,6 +1422,8 @@ class ClipIndex:
                         for ts, vec in frames
                     ],
                 )
+                if vec_on:
+                    self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
         finally:
             conn.close()
         # Whole-file DELETE + re-insert → block-replace with the frames, ordered by
@@ -1307,7 +1439,10 @@ class ClipIndex:
     def delete(self, rel_path: str) -> None:
         conn = self._connect()
         try:
+            vec_on = _vec_gate(self, conn)
             with conn:
+                if vec_on:
+                    self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM images WHERE file_path = ?", (rel_path,))
         finally:
             conn.close()
@@ -1445,11 +1580,56 @@ class ClipIndex:
         matrix = np.stack([np.frombuffer(r[2], dtype=np.float32) for r in rows], axis=0)
         return paths, frame_ts, matrix
 
+    def _vec_search(
+        self, query_vec: np.ndarray, k: int
+    ) -> list[tuple[str, float | None, float]] | None:
+        """vec0 KNN, or None when the backend can't serve — mirrors
+        `EmbeddingIndex._vec_search` (no sidecar creation on read, never raises)."""
+        if self._vec_failed or vecstore.backend() == "numpy" or vecstore.load_failed():
+            return None
+        if not self.path.exists():
+            return None
+        try:
+            conn = self._connect()
+            try:
+                if not _vec_gate(self, conn):
+                    return None
+                quant = vecstore.quant_mode() == "binary"
+                pairs = self._vec.knn(conn, query_vec, k, quant=quant)
+                if not pairs:
+                    return []
+                ids = [rid for rid, _ in pairs]
+                placeholders = ",".join("?" * len(ids))
+                rows = conn.execute(
+                    "SELECT rowid, file_path, frame_ts FROM images "
+                    f"WHERE rowid IN ({placeholders})",
+                    ids,
+                ).fetchall()
+                by_id = {r[0]: r for r in rows}
+                return [
+                    (by_id[rid][1], by_id[rid][2], score)
+                    for rid, score in pairs
+                    if rid in by_id
+                ]
+            finally:
+                conn.close()
+        except Exception as e:  # noqa: BLE001 — vec failure must never break search
+            log.warning(
+                "vec search failed for %s (%s); falling back to the in-memory scan",
+                self.path, e,
+            )
+            self._vec_failed = True
+            return None
+
     def search(self, query_vec: np.ndarray, k: int) -> list[tuple[str, float | None, float]]:
         """Top-k visual hits: `(file_path, frame_ts, score)` by cosine similarity,
         sorted by score desc. `frame_ts` is None for images, seconds for video frames.
         Returns one row per stored vector — a multi-keyframe video yields several rows;
-        callers dedup to best-per-file as needed."""
+        callers dedup to best-per-file as needed. Served by the vec0 backend when
+        available (same ladder as `EmbeddingIndex.search`)."""
+        vec_hits = self._vec_search(query_vec, k)
+        if vec_hits is not None:
+            return vec_hits
         paths, frame_ts, matrix = self.all_vectors()
         if not paths:
             return []
@@ -1460,6 +1640,25 @@ class ClipIndex:
         top_idx = np.argpartition(-scores, k_eff - 1)[:k_eff]
         top_idx = top_idx[np.argsort(-scores[top_idx])]
         return [(paths[i], frame_ts[i], float(scores[i])) for i in top_idx]
+
+
+def vector_backend_active(vault_root: Path) -> bool:
+    """True when the vec0 backend would serve vector search for this vault now.
+
+    Consults the same ladder `search()` uses (kill switch, load memo, per-instance
+    sync state) without running a query. Warm-up branches on this: prime the vec
+    tables when True, the in-memory matrix when False. Never creates the sidecar.
+    """
+    if vecstore.backend() == "numpy" or vecstore.load_failed():
+        return False
+    idx = get_embedding_index(vault_root)
+    if idx._vec_failed or not idx.path.exists():
+        return False
+    conn = idx._connect()
+    try:
+        return _vec_gate(idx, conn)
+    finally:
+        conn.close()
 
 
 def get_embedding_index(vault_root: Path) -> EmbeddingIndex:

--- a/src/exomem/vecstore.py
+++ b/src/exomem/vecstore.py
@@ -42,6 +42,13 @@ log = logging.getLogger(__name__)
 # golden gate).
 RESCORE_MULTIPLIER = 8
 
+# vec0 hard-caps KNN k at 4096 and ERRORS above it. find()'s candidate over-fetch
+# legitimately reaches ~4000 (CLIP) and binary mode multiplies by RESCORE_MULTIPLIER,
+# so every MATCH clamps to this — an unclamped k would trip the failure ladder and
+# silently retire the backend for the process (the worst kind of regression: search
+# still "works", just slower). Top-4096 is far beyond anything fusion consumes.
+VEC0_MAX_K = 4096
+
 _LOAD_FAILED = False  # process-global one-time soft-fail (embeddings._IMPORT_FAILED idiom)
 _LOAD_LOCK = threading.Lock()
 
@@ -235,14 +242,14 @@ class SqliteVecStore:
             rows = conn.execute(
                 f"SELECT rowid, distance FROM {self.vec_table} "
                 f"WHERE embedding MATCH ? AND k = ? ORDER BY distance",
-                (blob, k),
+                (blob, min(k, VEC0_MAX_K)),
             ).fetchall()
             return [(rid, 1.0 - float(dist)) for rid, dist in rows]
 
         rows = conn.execute(
             f"SELECT rowid FROM {self.bin_table} "
             f"WHERE embedding MATCH vec_quantize_binary(?) AND k = ? ORDER BY distance",
-            (blob, k * RESCORE_MULTIPLIER),
+            (blob, min(k * RESCORE_MULTIPLIER, VEC0_MAX_K)),
         ).fetchall()
         if not rows:
             return []

--- a/src/exomem/vecstore.py
+++ b/src/exomem/vecstore.py
@@ -1,0 +1,261 @@
+"""SQL-native vector KNN: sqlite-vec vec0 shadow tables inside the embedding sidecars.
+
+One `SqliteVecStore` per blob table (`chunks` in `.embeddings.sqlite`, `images` in
+`.clip.sqlite`) owns everything vec0: extension loading, schema, blob↔vec sync,
+dual-write SQL, and KNN (full-precision cosine, or binary Hamming with an exact
+full-precision rescore). The blob tables remain the source of truth — every vec0 row
+is rebuildable from stored blobs with pure SQL, so sync never involves a model.
+
+Mapping contract: vec0 rowid == blob-table rowid (both blob tables are ordinary
+rowid tables). Callers join KNN rowids back to the blob table for metadata.
+
+Availability is a ladder, decided per process:
+- `EXOMEM_VEC_BACKEND` = `auto` (default) | `sqlite-vec` | `numpy` (kill switch).
+  Policy (who consults it) lives in the index classes; this module is mechanism.
+- `try_load()` soft-fails once per process (`_LOAD_FAILED` memo, mirroring
+  `embeddings._IMPORT_FAILED`): sqlite-vec not installed (lean deploy), or this
+  Python's sqlite3 compiled without loadable-extension support
+  (`AttributeError`), or the extension refusing to load (`sqlite3.Error`). All
+  of these leave vector search on the in-memory numpy scan with zero behavior
+  change.
+- `EXOMEM_VEC_QUANT` = `off` (default) | `binary` — strictly opt-in: quantization
+  can affect recall, so the golden retrieval floors are its promotion gate.
+
+This module is import-safe without sqlite_vec installed: the import is lazy,
+inside the load probe.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Binary-mode over-fetch: Hamming KNN retrieves k * this many candidates, which are
+# then rescored exactly against their float32 blobs. 8x is generous for 768-bit
+# signatures (per-query overlap is checked by the benchmark harness; recall by the
+# golden gate).
+RESCORE_MULTIPLIER = 8
+
+_LOAD_FAILED = False  # process-global one-time soft-fail (embeddings._IMPORT_FAILED idiom)
+_LOAD_LOCK = threading.Lock()
+
+
+def backend() -> str:
+    """`EXOMEM_VEC_BACKEND`: `auto` (default) | `sqlite-vec` | `numpy` (kill switch).
+
+    Unrecognized values fall back to `auto` — a typo must not silently disable the
+    exact numpy escape hatch someone reached for, nor hard-fail search.
+    """
+    raw = (os.environ.get("EXOMEM_VEC_BACKEND") or "").strip().lower()
+    return raw if raw in ("sqlite-vec", "numpy") else "auto"
+
+
+def quant_mode() -> str:
+    """`EXOMEM_VEC_QUANT`: `off` (default) | `binary`. Unrecognized → `off`."""
+    raw = (os.environ.get("EXOMEM_VEC_QUANT") or "").strip().lower()
+    return "binary" if raw == "binary" else "off"
+
+
+def load_failed() -> bool:
+    """True once this process has failed to import/load the extension."""
+    return _LOAD_FAILED
+
+
+def reset_load_memo() -> None:
+    """Test seam: forget a memoized load failure."""
+    global _LOAD_FAILED
+    _LOAD_FAILED = False
+
+
+def _import_sqlite_vec():
+    """Lazy import seam (monkeypatched by lean-suite tests to simulate absence)."""
+    import sqlite_vec  # heavy-free, but optional: embeddings extra only
+
+    return sqlite_vec
+
+
+class SqliteVecStore:
+    """vec0 shadow tables for ONE blob table: schema, sync, dual-write, KNN.
+
+    Stateless apart from configuration — connections are owned by the caller
+    (the index classes open one per operation), and per-instance sync memoization
+    lives in the index, which knows its own lifecycle.
+    """
+
+    def __init__(self, source_table: str, vector_column: str, dim: int, vec_table: str):
+        self.source_table = source_table
+        self.vector_column = vector_column
+        self.dim = dim
+        self.vec_table = vec_table
+        self.bin_table = f"{vec_table}_bin"
+
+    # ------------------------------------------------------------ availability
+
+    def try_load(self, conn: sqlite3.Connection) -> bool:
+        """Load the extension on this connection; memoize failure process-wide.
+
+        Mechanical only — backend policy (kill switch) is the caller's decision.
+        """
+        global _LOAD_FAILED
+        if _LOAD_FAILED:
+            return False
+        try:
+            sqlite_vec = _import_sqlite_vec()
+            conn.enable_load_extension(True)
+            try:
+                sqlite_vec.load(conn)
+            finally:
+                conn.enable_load_extension(False)
+            return True
+        except (ImportError, AttributeError, sqlite3.Error) as e:
+            with _LOAD_LOCK:
+                _LOAD_FAILED = True
+            log.info(
+                "sqlite-vec unavailable (%s); vector search stays on the numpy scan", e
+            )
+            return False
+
+    # ------------------------------------------------------------ schema + sync
+
+    def _bin_exists(self, conn: sqlite3.Connection) -> bool:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = ?", (self.bin_table,)
+            ).fetchone()
+            is not None
+        )
+
+    def ensure_synced(self, conn: sqlite3.Connection, *, quant: bool = False) -> None:
+        """Create vec tables if missing; heal any blob↔vec count drift from blobs.
+
+        This single check is both the MIGRATION for pre-existing sidecars (fresh
+        vec table: 0 ≠ N → backfill) and the DRIFT HEALER for sidecars advanced by
+        non-vec-aware writers. Pure SQL — never re-embeds. The caller must have
+        loaded the extension on `conn`.
+        """
+        conn.execute(
+            f"CREATE VIRTUAL TABLE IF NOT EXISTS {self.vec_table} "
+            f"USING vec0(embedding float[{self.dim}] distance_metric=cosine)"
+        )
+        if quant:
+            conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS {self.bin_table} "
+                f"USING vec0(embedding bit[{self.dim}])"
+            )
+        n_src = conn.execute(f"SELECT count(*) FROM {self.source_table}").fetchone()[0]
+        for table, quantize in ((self.vec_table, False), (self.bin_table, True)):
+            if quantize and not self._bin_exists(conn):
+                continue
+            n_vec = conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+            if n_vec == n_src:
+                continue
+            log.info(
+                "vec sync: rebuilding %s from %s blobs (%d vec rows vs %d source rows)",
+                table, self.source_table, n_vec, n_src,
+            )
+            with conn:
+                conn.execute(f"DELETE FROM {table}")
+                conn.execute(self._insert_select(table, quantize, where=None))
+
+    def _insert_select(self, table: str, quantize: bool, where: str | None) -> str:
+        expr = (
+            f"vec_quantize_binary({self.vector_column})" if quantize else self.vector_column
+        )
+        sql = (
+            f"INSERT INTO {table}(rowid, embedding) "
+            f"SELECT rowid, {expr} FROM {self.source_table}"
+        )
+        if where:
+            sql += f" WHERE {where}"
+        return sql
+
+    # ------------------------------------------------------------ dual-write
+
+    def dual_delete(self, conn: sqlite3.Connection, where: str, params: tuple) -> None:
+        """Delete vec rows for blob rows matching `where`. MUST run BEFORE the blob
+        delete — the subquery needs the blob rows' rowids."""
+        tables = [self.vec_table]
+        if self._bin_exists(conn):
+            tables.append(self.bin_table)
+        for table in tables:
+            conn.execute(
+                f"DELETE FROM {table} WHERE rowid IN "
+                f"(SELECT rowid FROM {self.source_table} WHERE {where})",
+                params,
+            )
+
+    def dual_insert(self, conn: sqlite3.Connection, where: str, params: tuple) -> None:
+        """Insert vec rows for blob rows matching `where` (after the blob insert)."""
+        conn.execute(self._insert_select(self.vec_table, False, where), params)
+        if self._bin_exists(conn):
+            conn.execute(self._insert_select(self.bin_table, True, where), params)
+
+    def wipe(self, conn: sqlite3.Connection) -> None:
+        """Empty the vec tables (rebuild_all's initial wipe)."""
+        conn.execute(f"DELETE FROM {self.vec_table}")
+        if self._bin_exists(conn):
+            conn.execute(f"DELETE FROM {self.bin_table}")
+
+    def repopulate_all(self, conn: sqlite3.Connection) -> None:
+        """Whole-table INSERT..SELECT after a bulk blob rebuild."""
+        conn.execute(self._insert_select(self.vec_table, False, where=None))
+        if self._bin_exists(conn):
+            conn.execute(self._insert_select(self.bin_table, True, where=None))
+
+    # ------------------------------------------------------------ KNN
+
+    def knn(
+        self,
+        conn: sqlite3.Connection,
+        query_vec: np.ndarray,
+        k: int,
+        *,
+        quant: bool = False,
+    ) -> list[tuple[int, float]]:
+        """Top-k `(rowid, cosine_score)` by KNN over the vec tables.
+
+        Full-precision mode is EXACT (same ranking as the numpy scan, modulo fp
+        ties). Binary mode over-fetches `k * RESCORE_MULTIPLIER` by Hamming
+        distance, then rescores those candidates against their float32 blobs — so
+        returned scores are true cosine in every mode.
+        """
+        if k <= 0:
+            return []
+        q = np.asarray(query_vec, dtype=np.float32)
+        if q.shape != (self.dim,):
+            raise ValueError(f"query_vec shape {q.shape} != ({self.dim},)")
+        blob = q.tobytes()
+        if not quant:
+            rows = conn.execute(
+                f"SELECT rowid, distance FROM {self.vec_table} "
+                f"WHERE embedding MATCH ? AND k = ? ORDER BY distance",
+                (blob, k),
+            ).fetchall()
+            return [(rid, 1.0 - float(dist)) for rid, dist in rows]
+
+        rows = conn.execute(
+            f"SELECT rowid FROM {self.bin_table} "
+            f"WHERE embedding MATCH vec_quantize_binary(?) AND k = ? ORDER BY distance",
+            (blob, k * RESCORE_MULTIPLIER),
+        ).fetchall()
+        if not rows:
+            return []
+        ids = [r[0] for r in rows]
+        placeholders = ",".join("?" * len(ids))
+        candidates = conn.execute(
+            f"SELECT rowid, {self.vector_column} FROM {self.source_table} "
+            f"WHERE rowid IN ({placeholders})",
+            ids,
+        ).fetchall()
+        scored = [
+            (rid, float(np.frombuffer(vec_blob, dtype=np.float32) @ q))
+            for rid, vec_blob in candidates
+        ]
+        scored.sort(key=lambda t: (-t[1], t[0]))
+        return scored[:k]

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -72,17 +72,36 @@ def warm_caches(vault_root: Path) -> dict[str, float]:
     _step("bm25_vault", lambda: bm25.warm(vault_root, "vault"))
     _step("resolver", lambda: find._get_query_resolver(vault_root))
     if not os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        # One tiny search warms WHICHEVER backend serves vector search: the vec0
+        # backend (sync check + first KNN faults in the vec tables; the numpy
+        # matrix stays cold — not holding it resident is the backend's point) or
+        # the in-memory scan (search loads the matrix via all_vectors(), the
+        # historical warm). A missing sidecar is a no-op either way.
 
         def _warm_matrix() -> None:
+            import numpy as np
+
             from . import embeddings
 
-            embeddings.get_embedding_index(vault_root).all_vectors()
+            q = np.full(
+                embeddings.VECTOR_DIM,
+                1.0 / (embeddings.VECTOR_DIM ** 0.5),
+                dtype=np.float32,
+            )
+            embeddings.get_embedding_index(vault_root).search(q, k=1)
 
         def _warm_clip() -> None:
+            import numpy as np
+
             from . import embeddings
 
             if embeddings.clip_enabled():
-                embeddings.get_clip_index(vault_root).all_vectors()
+                q = np.full(
+                    embeddings.CLIP_DIM,
+                    1.0 / (embeddings.CLIP_DIM ** 0.5),
+                    dtype=np.float32,
+                )
+                embeddings.get_clip_index(vault_root).search(q, k=1)
 
         _step("embedding_matrix", _warm_matrix)
         _step("clip_matrix", _warm_clip)

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -276,12 +276,19 @@ def test_find_vector_lane_reuses_shared_matrix(tmp_path, monkeypatch):
     """End-to-end through the REAL `find()` entry point (deterministic fake
     embedder, no torch): three distinct finds share ONE matrix load, and the
     vector lane genuinely ran — guarding against a silent BM25 fallback that
-    would make the reuse assertion pass for the wrong reason."""
+    would make the reuse assertion pass for the wrong reason.
+
+    Pinned to the in-memory scan (`EXOMEM_VEC_BACKEND=numpy`): the shared-matrix
+    contract this asserts is scoped to that backend — when the vec0 backend
+    serves search the matrix deliberately never loads (asserted in
+    tests/test_vecstore.py), which would make the one-load count read 0 wherever
+    sqlite-vec happens to be installed."""
     from exomem import find as find_module
     from exomem import readiness
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")  # bypass the hot result cache
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
     readiness.reset()
 
     vault = _fresh_vault(tmp_path)

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -25,6 +25,7 @@ after), regardless of whether the test itself also calls finish_warm().
 
 from __future__ import annotations
 
+import os
 import sys
 import threading
 from pathlib import Path
@@ -728,15 +729,32 @@ def test_upsert_after_write_defer_after_embeddable_filter_logmd_defers_nothing(
 # ============================================================================
 
 
-def test_warm_cli_skip_message_when_embeddings_disabled(capsys: pytest.CaptureFixture) -> None:
+def test_warm_cli_skip_message_when_embeddings_disabled() -> None:
     """With EXOMEM_DISABLE_EMBEDDINGS set (the suite default), `exomem warm`
-    must print a skip message, exit 0, and never import torch."""
-    code = main(["warm"])
-    out = capsys.readouterr().out
+    must print a skip message, exit 0, and never import torch.
 
-    assert code == 0
-    assert "EXOMEM_DISABLE_EMBEDDINGS" in out
-    assert "torch" not in sys.modules
+    Runs the CLI in a SUBPROCESS and asserts torch-absence THERE: the contract
+    is about the warm CLI's own process, and asserting on this pytest process's
+    `sys.modules` is corrupted by suite collection state — on a box with the
+    embeddings extra installed, any module-level `pytest.importorskip("torch")`
+    (e.g. test_retrieval_golden.py) imports torch at collection time and made
+    this test fail for reasons unrelated to the CLI under test."""
+    import subprocess
+
+    probe = (
+        "import sys; from exomem.__main__ import main; rc = main(['warm']); "
+        "assert 'torch' not in sys.modules, 'warm CLI imported torch'; "
+        "sys.exit(rc)"
+    )
+    proc = subprocess.run(  # noqa: S603 — sys.executable + literal code, no user input
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "EXOMEM_DISABLE_EMBEDDINGS": "1"},
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "EXOMEM_DISABLE_EMBEDDINGS" in proc.stdout
 
 
 def test_warm_cli_success_with_faked_models_clip_left_disabled(

--- a/tests/test_retrieval_golden.py
+++ b/tests/test_retrieval_golden.py
@@ -64,13 +64,27 @@ _MEAN_RECALL10_FLOOR = 0.88
 
 
 @pytest.mark.embeddings
-def test_golden_hybrid_ranking_clears_floors(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("vec_quant", ["off", "binary"])
+def test_golden_hybrid_ranking_clears_floors(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, vec_quant: str
+) -> None:
     """Hybrid ranking over the golden set must clear the measured floors.
+
+    Parametrized over the vector backend's quantization mode: `off` exercises the
+    default configuration (vec0 full-precision when sqlite-vec is installed — exact,
+    so the floors are the same regression gate they always were), and `binary` is the
+    PROMOTION GATE for the opt-in quantized mode — quantized recall must clear the
+    same floors and the same per-query cliff guard before the mode can be recommended.
 
     `vault` (conftest) copies tests/fixtures → a tmp dir and points
     EXOMEM_VAULT_PATH at it; the repo fixtures are never mutated and the sidecar
     lands in the throwaway copy.
     """
+    if vec_quant == "binary":
+        pytest.importorskip("sqlite_vec")
+        monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
+    else:
+        monkeypatch.delenv("EXOMEM_VEC_QUANT", raising=False)
     # Live vectors: lift the suite-wide disable (conftest autouse) and any
     # KB_MCP_ alias; leave CLIP off — the golden targets are all text notes.
     for var in ("EXOMEM_DISABLE_EMBEDDINGS", "KB_MCP_DISABLE_EMBEDDINGS"):

--- a/tests/test_vec_backend_fallback.py
+++ b/tests/test_vec_backend_fallback.py
@@ -1,0 +1,109 @@
+"""Vector-backend fallback ladder — LEAN-SAFE (no sqlite-vec, no torch required).
+
+These tests must pass on the lean CI matrix where sqlite-vec is genuinely absent:
+they prove the kill switch and every unavailability path serve correct results
+through the numpy scan with the unchanged return contract. `vecstore` itself must
+be importable without sqlite_vec installed (its import is lazy).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem import vecstore
+from exomem.embeddings import VECTOR_DIM, EmbeddingIndex
+
+
+def _unit_rows(rng: np.random.Generator, n: int, dim: int) -> np.ndarray:
+    m = rng.standard_normal((n, dim)).astype(np.float32)
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+def _has_table(path: Path, table: str) -> bool:
+    conn = sqlite3.connect(path)  # plain connection — vec tables show in sqlite_master
+    try:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = ?", (table,)
+            ).fetchone()
+            is not None
+        )
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_vec_state(monkeypatch: pytest.MonkeyPatch):
+    vecstore.reset_load_memo()
+    monkeypatch.delenv("EXOMEM_VEC_BACKEND", raising=False)
+    monkeypatch.delenv("EXOMEM_VEC_QUANT", raising=False)
+    yield
+    vecstore.reset_load_memo()
+
+
+def test_backend_env_reader_defaults(monkeypatch):
+    assert vecstore.backend() == "auto"
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+    assert vecstore.backend() == "numpy"
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
+    assert vecstore.backend() == "sqlite-vec"
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "bogus")
+    assert vecstore.backend() == "auto"
+    monkeypatch.delenv("EXOMEM_VEC_BACKEND")
+    monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
+    assert vecstore.quant_mode() == "binary"
+    monkeypatch.setenv("EXOMEM_VEC_QUANT", "bogus")
+    assert vecstore.quant_mode() == "off"
+
+
+def test_kill_switch_forces_numpy_and_skips_vec_writes(tmp_path, monkeypatch):
+    """EXOMEM_VEC_BACKEND=numpy is full old behavior: numpy serves search AND the
+    writers never touch vec tables (the escape hatch must not depend on vec code)."""
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+    rng = np.random.default_rng(21)
+    idx = EmbeddingIndex(tmp_path)
+    vecs = _unit_rows(rng, 3, VECTOR_DIM)
+    idx.upsert_file("Knowledge Base/a.md", ["c0", "c1", "c2"], vecs, 1.0)
+
+    hits = idx.search(vecs[1], k=2)
+    assert hits[0] == ("Knowledge Base/a.md", 1, "c1", pytest.approx(1.0, abs=1e-5))
+    assert not _has_table(idx.path, "vec_chunks")
+
+
+def test_unavailable_extension_serves_numpy_results(tmp_path, monkeypatch):
+    """Under `auto` with the extension unavailable (the lean deployment shape, forced
+    here deterministically), search serves the numpy scan with the same contract."""
+    monkeypatch.setattr(
+        vecstore, "_import_sqlite_vec", lambda: (_ for _ in ()).throw(ImportError("lean"))
+    )
+    rng = np.random.default_rng(22)
+    idx = EmbeddingIndex(tmp_path)
+    for f in range(3):
+        idx.upsert_file(
+            f"Knowledge Base/n{f}.md",
+            [f"t{f}-{i}" for i in range(2)],
+            _unit_rows(rng, 2, VECTOR_DIM),
+            1.0 + f,
+        )
+    query = _unit_rows(rng, 1, VECTOR_DIM)[0]
+    hits = idx.search(query, k=3)
+    assert len(hits) == 3
+    for h in hits:
+        assert isinstance(h[0], str) and isinstance(h[1], int)
+        assert isinstance(h[2], str) and isinstance(h[3], float)
+    # Ranking equals a direct numpy computation over the same rows.
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+    assert hits == EmbeddingIndex(tmp_path).search(query, k=3)
+
+
+def test_vecstore_importable_and_inert_without_sqlite_vec():
+    """The module never imports sqlite_vec at import time; availability probing is
+    lazy and a probe failure is final for the process until reset."""
+    store = vecstore.SqliteVecStore("chunks", "vector", VECTOR_DIM, "vec_chunks")
+    assert store.vec_table == "vec_chunks"
+    assert vecstore.load_failed() is False  # memo starts clean; nothing probed yet

--- a/tests/test_vecstore.py
+++ b/tests/test_vecstore.py
@@ -1,0 +1,415 @@
+"""vec0 backend: schema/sync/migration, dual-write lockstep, KNN parity, quantized rescore.
+
+Everything here runs with RANDOM normalized vectors through the low-level index APIs
+(`upsert_file`, `ClipIndex.upsert*`) — no torch, no model download. The one model seam
+(`rebuild_all`) is monkeypatched to deterministic random vectors, because what is under
+test is the dual-write wiring, not the embedding.
+
+Requires sqlite-vec (embeddings extra); skips cleanly on lean installs — the c112b5a rule:
+the marker alone is not enough, the lean CI matrix collects every module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sqlite_vec = pytest.importorskip("sqlite_vec")
+
+from exomem import embeddings as embeddings_module  # noqa: E402
+from exomem import vecstore  # noqa: E402
+from exomem.embeddings import CLIP_DIM, VECTOR_DIM, ClipIndex, EmbeddingIndex  # noqa: E402
+
+# ---------------------------------------------------------------- helpers
+
+
+def _unit_rows(rng: np.random.Generator, n: int, dim: int) -> np.ndarray:
+    """(n, dim) float32, L2-normalized — the shape embed_texts produces."""
+    m = rng.standard_normal((n, dim)).astype(np.float32)
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+def _vec_conn(path: Path) -> sqlite3.Connection:
+    """A raw connection with the extension loaded, for asserting on vec tables."""
+    conn = sqlite3.connect(path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def _count(conn: sqlite3.Connection, table: str) -> int:
+    return conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _build_text_index(
+    root: Path, rng: np.random.Generator, files: int = 8, chunks_per_file: int = 4
+) -> tuple[EmbeddingIndex, dict[str, np.ndarray]]:
+    """Populate a fresh EmbeddingIndex under `root` with random vectors."""
+    idx = EmbeddingIndex(root)
+    vecs_by_file: dict[str, np.ndarray] = {}
+    for f in range(files):
+        rel = f"Knowledge Base/Notes/note-{f:03d}.md"
+        vecs = _unit_rows(rng, chunks_per_file, VECTOR_DIM)
+        chunks = [f"chunk {f}-{i} text" for i in range(chunks_per_file)]
+        idx.upsert_file(rel, chunks, vecs, mtime=1000.0 + f)
+        vecs_by_file[rel] = vecs
+    return idx, vecs_by_file
+
+
+@pytest.fixture(autouse=True)
+def _fresh_vec_state(monkeypatch: pytest.MonkeyPatch):
+    """Every test starts from a clean process-global load memo and default env."""
+    vecstore.reset_load_memo()
+    monkeypatch.delenv("EXOMEM_VEC_BACKEND", raising=False)
+    monkeypatch.delenv("EXOMEM_VEC_QUANT", raising=False)
+    yield
+    vecstore.reset_load_memo()
+
+
+# (env-reader tests live in tests/test_vec_backend_fallback.py — they must run lean)
+
+# ---------------------------------------------------------------- schema + sync
+
+
+def test_writes_keep_vec_table_in_lockstep(tmp_path):
+    rng = np.random.default_rng(7)
+    idx, _ = _build_text_index(tmp_path, rng, files=4, chunks_per_file=3)
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "chunks") == 12
+        assert _count(conn, "vec_chunks") == 12
+        # Replace one file with a DIFFERENT chunk count.
+        idx.upsert_file(
+            "Knowledge Base/Notes/note-001.md",
+            ["a", "b", "c", "d", "e"],
+            _unit_rows(rng, 5, VECTOR_DIM),
+            mtime=2000.0,
+        )
+        assert _count(conn, "chunks") == 14
+        assert _count(conn, "vec_chunks") == 14
+        idx.delete_file("Knowledge Base/Notes/note-000.md")
+        assert _count(conn, "chunks") == 11
+        assert _count(conn, "vec_chunks") == 11
+    finally:
+        conn.close()
+
+
+def test_schema_creation_is_idempotent(tmp_path):
+    rng = np.random.default_rng(8)
+    idx, _ = _build_text_index(tmp_path, rng, files=2, chunks_per_file=2)
+    # Re-open and write again: CREATE IF NOT EXISTS + sync must not duplicate rows.
+    idx2 = EmbeddingIndex(tmp_path)
+    idx2.upsert_file(
+        "Knowledge Base/Notes/extra.md", ["x"], _unit_rows(rng, 1, VECTOR_DIM), 3000.0
+    )
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "chunks") == 5
+        assert _count(conn, "vec_chunks") == 5
+    finally:
+        conn.close()
+
+
+def test_legacy_blobs_only_sidecar_is_backfilled_on_first_use(tmp_path, monkeypatch):
+    """A sidecar written with the kill switch on (blob rows only) gains vec rows —
+    with correct search results — the first time a vec-aware instance touches it."""
+    rng = np.random.default_rng(9)
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+    legacy, vecs_by_file = _build_text_index(tmp_path, rng, files=5, chunks_per_file=4)
+    plain = sqlite3.connect(legacy.path)
+    try:
+        assert not _table_exists(plain, "vec_chunks")
+    finally:
+        plain.close()
+
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "auto")
+    idx = EmbeddingIndex(tmp_path)
+    query = vecs_by_file["Knowledge Base/Notes/note-002.md"][1]
+    hits = idx.search(query, k=3)
+    assert hits[0][0] == "Knowledge Base/Notes/note-002.md"
+    assert hits[0][1] == 1
+    assert hits[0][3] == pytest.approx(1.0, abs=1e-5)
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "vec_chunks") == _count(conn, "chunks") == 20
+    finally:
+        conn.close()
+
+
+def test_vec_row_drift_self_heals(tmp_path):
+    """Manually broken vec rows (count mismatch) are rebuilt from blobs by the next
+    fresh instance's sync check."""
+    rng = np.random.default_rng(10)
+    idx, vecs_by_file = _build_text_index(tmp_path, rng, files=3, chunks_per_file=4)
+    conn = _vec_conn(idx.path)
+    try:
+        conn.execute("DELETE FROM vec_chunks WHERE rowid IN (SELECT rowid FROM vec_chunks LIMIT 5)")
+        conn.commit()
+        assert _count(conn, "vec_chunks") == 7
+    finally:
+        conn.close()
+
+    healed = EmbeddingIndex(tmp_path)
+    query = vecs_by_file["Knowledge Base/Notes/note-000.md"][0]
+    hits = healed.search(query, k=1)
+    assert hits[0][0] == "Knowledge Base/Notes/note-000.md"
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "vec_chunks") == _count(conn, "chunks") == 12
+    finally:
+        conn.close()
+
+
+def test_search_on_missing_sidecar_returns_empty_without_creating_it(tmp_path):
+    idx = EmbeddingIndex(tmp_path)
+    rng = np.random.default_rng(11)
+    assert idx.search(_unit_rows(rng, 1, VECTOR_DIM)[0], k=5) == []
+    assert not idx.path.exists()
+
+
+def test_rebuild_all_repopulates_vec_table(tmp_path, monkeypatch):
+    """rebuild_all wipes and repopulates BOTH table families (model monkeypatched)."""
+    kb = tmp_path / "Knowledge Base" / "Notes"
+    kb.mkdir(parents=True)
+    for i in range(3):
+        (kb / f"page-{i}.md").write_text(
+            f"---\ntype: insight\ntitle: Page {i}\n---\n\n# Page {i}\n\nBody text {i}.\n",
+            encoding="utf-8",
+        )
+    rng = np.random.default_rng(12)
+
+    def _fake_embed(texts, is_query=False):
+        return _unit_rows(rng, len(texts), VECTOR_DIM)
+
+    monkeypatch.setattr(embeddings_module, "embed_texts", _fake_embed)
+    idx = EmbeddingIndex(tmp_path)
+    total = idx.rebuild_all()
+    assert total > 0
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "vec_chunks") == _count(conn, "chunks") == total
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------- f32 parity
+
+
+def test_f32_search_parity_with_numpy(tmp_path, monkeypatch):
+    """The vec0 full-precision backend is EXACT: same ordered (path, chunk) top-k and
+    matching scores as the numpy scan, over the same sidecar."""
+    rng = np.random.default_rng(13)
+    idx, _ = _build_text_index(tmp_path, rng, files=25, chunks_per_file=20)  # 500 rows
+    queries = _unit_rows(rng, 20, VECTOR_DIM)
+
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
+    vec_idx = EmbeddingIndex(tmp_path)
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+    np_idx = EmbeddingIndex(tmp_path)
+
+    for q in queries:
+        monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
+        vec_hits = vec_idx.search(q, k=10)
+        monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+        np_hits = np_idx.search(q, k=10)
+        assert [(h[0], h[1]) for h in vec_hits] == [(h[0], h[1]) for h in np_hits]
+        assert [h[2] for h in vec_hits] == [h[2] for h in np_hits]  # chunk_text joined back
+        np.testing.assert_allclose(
+            [h[3] for h in vec_hits], [h[3] for h in np_hits], atol=1e-5
+        )
+
+
+def test_clip_f32_search_parity_with_numpy(tmp_path, monkeypatch):
+    rng = np.random.default_rng(14)
+    idx = ClipIndex(tmp_path)
+    for i in range(30):
+        idx.upsert(f"Sources/img-{i:03d}.png", _unit_rows(rng, 1, CLIP_DIM)[0], 100.0 + i)
+    idx.upsert_frames(
+        "Sources/video.mp4",
+        [(float(ts), _unit_rows(rng, 1, CLIP_DIM)[0]) for ts in (1.0, 2.5, 9.0)],
+        200.0,
+    )
+    queries = _unit_rows(rng, 10, CLIP_DIM)
+
+    for q in queries:
+        monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
+        vec_hits = ClipIndex(tmp_path).search(q, k=8)
+        monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+        np_hits = ClipIndex(tmp_path).search(q, k=8)
+        assert [(h[0], h[1]) for h in vec_hits] == [(h[0], h[1]) for h in np_hits]
+        np.testing.assert_allclose(
+            [h[2] for h in vec_hits], [h[2] for h in np_hits], atol=1e-5
+        )
+
+
+# ---------------------------------------------------------------- CLIP lockstep
+
+
+def test_clip_writes_keep_vec_table_in_lockstep(tmp_path):
+    rng = np.random.default_rng(15)
+    idx = ClipIndex(tmp_path)
+    idx.upsert("Sources/a.png", _unit_rows(rng, 1, CLIP_DIM)[0], 1.0)
+    idx.upsert_frames(
+        "Sources/v.mp4",
+        [(float(ts), _unit_rows(rng, 1, CLIP_DIM)[0]) for ts in (0.0, 4.0)],
+        2.0,
+    )
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "images") == 3
+        assert _count(conn, "vec_images") == 3
+        idx.delete("Sources/v.mp4")
+        assert _count(conn, "images") == 1
+        assert _count(conn, "vec_images") == 1
+    finally:
+        conn.close()
+
+
+def test_clip_image_only_replace_keeps_frame_rows(tmp_path):
+    """upsert() replaces ONLY the NULL-frame_ts row; a file's keyframe rows survive in
+    both table families (the frame_ts IS NULL predicate must reach the vec delete)."""
+    rng = np.random.default_rng(16)
+    idx = ClipIndex(tmp_path)
+    idx.upsert_frames(
+        "Sources/clip.mp4",
+        [(float(ts), _unit_rows(rng, 1, CLIP_DIM)[0]) for ts in (0.0, 3.0, 6.0)],
+        1.0,
+    )
+    # A legacy-style whole-file poster row alongside the frames:
+    idx.upsert("Sources/clip.mp4", _unit_rows(rng, 1, CLIP_DIM)[0], 2.0)
+    idx.upsert("Sources/clip.mp4", _unit_rows(rng, 1, CLIP_DIM)[0], 3.0)  # replace poster
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "images") == 4  # 3 frames + 1 poster
+        assert _count(conn, "vec_images") == 4
+        frames = conn.execute(
+            "SELECT count(*) FROM images WHERE file_path = ? AND frame_ts IS NOT NULL",
+            ("Sources/clip.mp4",),
+        ).fetchone()[0]
+        assert frames == 3
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------- binary quantized mode
+
+
+def test_binary_mode_recovers_planted_neighbors_with_exact_scores(tmp_path, monkeypatch):
+    """Clustered corpus: quantized search must surface the planted near-duplicates in
+    top-k, and the returned scores must be full-precision cosine, not Hamming."""
+    rng = np.random.default_rng(17)
+    idx = EmbeddingIndex(tmp_path)
+    anchor = _unit_rows(rng, 1, VECTOR_DIM)[0]
+    # 5 planted near-neighbors of the anchor...
+    near = anchor + 0.05 * _unit_rows(rng, 5, VECTOR_DIM)
+    near /= np.linalg.norm(near, axis=1, keepdims=True)
+    idx.upsert_file("Knowledge Base/near.md", [f"n{i}" for i in range(5)], near, 1.0)
+    # ...drowned in 300 random rows.
+    for f in range(15):
+        idx.upsert_file(
+            f"Knowledge Base/noise-{f:02d}.md",
+            [f"x{i}" for i in range(20)],
+            _unit_rows(rng, 20, VECTOR_DIM),
+            2.0 + f,
+        )
+
+    monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
+    quant_idx = EmbeddingIndex(tmp_path)
+    hits = quant_idx.search(anchor, k=5)
+    assert {h[0] for h in hits} == {"Knowledge Base/near.md"}
+    # Scores are exact cosine (rescored from f32 blobs):
+    expected = sorted((float(near[i] @ anchor) for i in range(5)), reverse=True)
+    np.testing.assert_allclose([h[3] for h in hits], expected, atol=1e-5)
+    # The bin table was synthesized from blobs on first quantized use:
+    conn = _vec_conn(idx.path)
+    try:
+        assert _count(conn, "vec_chunks_bin") == _count(conn, "chunks")
+    finally:
+        conn.close()
+
+
+def test_quant_off_never_touches_bin_tables(tmp_path):
+    rng = np.random.default_rng(18)
+    idx, _ = _build_text_index(tmp_path, rng, files=2, chunks_per_file=2)
+    idx.search(_unit_rows(rng, 1, VECTOR_DIM)[0], k=2)
+    conn = _vec_conn(idx.path)
+    try:
+        assert not _table_exists(conn, "vec_chunks_bin")
+    finally:
+        conn.close()
+
+
+def test_vec_backend_leaves_matrix_cold(tmp_path):
+    """When vec0 serves search, the numpy matrix is never loaded — not holding
+    the (N, dim) matrix resident in Python is the backend's memory win."""
+    rng = np.random.default_rng(23)
+    idx, vecs_by_file = _build_text_index(tmp_path, rng, files=4, chunks_per_file=3)
+    idx._cache = None  # writes splice the cache; start cold like a fresh process
+    hits = idx.search(vecs_by_file["Knowledge Base/Notes/note-003.md"][2], k=3)
+    assert hits[0][0] == "Knowledge Base/Notes/note-003.md"
+    assert idx._cache is None  # served by vec0; all_vectors() never ran
+
+
+# ---------------------------------------------------------------- failure ladder
+
+
+def test_extension_load_failure_memoizes_and_falls_back(tmp_path, monkeypatch):
+    """A failed extension load: search still answers (numpy), no vec tables appear,
+    and the failure is not retried per call (process-global memo)."""
+    rng = np.random.default_rng(19)
+    calls = {"n": 0}
+
+    def _boom(conn):
+        calls["n"] += 1
+        raise sqlite3.OperationalError("extension loading disabled")
+
+    monkeypatch.setattr(sqlite_vec, "load", _boom)
+    vecstore.reset_load_memo()
+    idx, vecs_by_file = _build_text_index(tmp_path, rng, files=3, chunks_per_file=2)
+    query = vecs_by_file["Knowledge Base/Notes/note-001.md"][0]
+    hits = idx.search(query, k=1)
+    assert hits[0][0] == "Knowledge Base/Notes/note-001.md"
+    assert calls["n"] == 1  # memoized after the first failure
+    plain = sqlite3.connect(idx.path)
+    try:
+        assert not _table_exists(plain, "vec_chunks")
+    finally:
+        plain.close()
+
+
+def test_runtime_knn_failure_falls_back_for_the_process(tmp_path, monkeypatch):
+    """A vec KNN that raises at runtime: that call returns numpy results and later
+    searches on the instance stop attempting the vec backend."""
+    rng = np.random.default_rng(20)
+    idx, vecs_by_file = _build_text_index(tmp_path, rng, files=3, chunks_per_file=2)
+
+    knn_calls = {"n": 0}
+    real_knn = vecstore.SqliteVecStore.knn
+
+    def _flaky(self, conn, query_vec, k, quant=False):
+        knn_calls["n"] += 1
+        raise sqlite3.OperationalError("simulated vec failure")
+
+    monkeypatch.setattr(vecstore.SqliteVecStore, "knn", _flaky)
+    query = vecs_by_file["Knowledge Base/Notes/note-002.md"][1]
+    hits = idx.search(query, k=1)
+    assert hits[0][0] == "Knowledge Base/Notes/note-002.md"
+    idx.search(query, k=1)
+    assert knn_calls["n"] == 1  # second search did not re-attempt vec
+
+    monkeypatch.setattr(vecstore.SqliteVecStore, "knn", real_knn)

--- a/tests/test_vecstore.py
+++ b/tests/test_vecstore.py
@@ -354,6 +354,27 @@ def test_quant_off_never_touches_bin_tables(tmp_path):
         conn.close()
 
 
+def test_knn_k_above_vec0_cap_is_clamped_not_fatal(tmp_path, monkeypatch):
+    """vec0 hard-caps KNN k at 4096 and ERRORS above it. find() legitimately asks
+    for k up to ~4000 (CLIP candidate over-fetch), and binary mode multiplies by 8 —
+    an unclamped k would trip the failure ladder and silently retire the backend.
+    Both modes must clamp and answer."""
+    rng = np.random.default_rng(24)
+    idx, vecs_by_file = _build_text_index(tmp_path, rng, files=3, chunks_per_file=2)
+    query = vecs_by_file["Knowledge Base/Notes/note-001.md"][0]
+
+    hits = idx.search(query, k=5000)  # > 4096: f32 MATCH must clamp
+    assert len(hits) == 6  # every row, still served by vec (no fallback)
+    assert hits[0][0] == "Knowledge Base/Notes/note-001.md"
+    assert not idx._vec_failed
+
+    monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
+    quant_idx = EmbeddingIndex(tmp_path)
+    hits = quant_idx.search(query, k=1000)  # 1000*8 > 4096: over-fetch must clamp
+    assert len(hits) == 6
+    assert not quant_idx._vec_failed
+
+
 def test_vec_backend_leaves_matrix_cold(tmp_path):
     """When vec0 serves search, the numpy matrix is never loaded — not holding
     the (N, dim) matrix resident in Python is the backend's memory win."""

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.3.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -654,6 +654,7 @@ diarization = [
 embeddings = [
     { name = "pillow" },
     { name = "sentence-transformers" },
+    { name = "sqlite-vec" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -666,6 +667,9 @@ media = [
     { name = "pillow" },
     { name = "pymupdf" },
     { name = "pytesseract" },
+]
+media-mlx = [
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 vision = [
     { name = "transformers" },
@@ -682,6 +686,7 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'media'", specifier = ">=1.0" },
     { name = "fastmcp", specifier = ">=2.10" },
     { name = "markitdown", extras = ["docx", "xlsx", "pptx"], marker = "extra == 'media'", specifier = ">=0.1.1" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'media-mlx'", specifier = ">=0.4" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
     { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
@@ -699,12 +704,13 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.7" },
     { name = "snowballstemmer", specifier = ">=2.2" },
     { name = "speechbrain", marker = "extra == 'diarization'", specifier = ">=1.0" },
+    { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.6" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'embeddings') or (sys_platform == 'win32' and extra == 'embeddings')", specifier = ">=2.12", index = "https://download.pytorch.org/whl/cu132" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'embeddings'", specifier = ">=2.12" },
     { name = "transformers", marker = "extra == 'vision'", specifier = ">=4.40" },
     { name = "watchdog", specifier = ">=4.0" },
 ]
-provides-extras = ["embeddings", "media", "diarization", "vision"]
+provides-extras = ["embeddings", "media", "media-mlx", "diarization", "vision"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1112,6 +1118,19 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a0/acc8ffcd5bdc63df0097e22c719bfcd61b604358343089313a8aebbb24ab/llvmlite-0.48.0.tar.gz", hash = "sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2", size = 184016, upload-time = "2026-07-02T20:20:05.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/55/595981f14fbae9ba966feb12af552b1fe69889e44e64ac883a731ed335e0/llvmlite-0.48.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:56a7e24607d3f02d7b1bae8d29c7e1e423d53143d68b072999777f19678fe77b", size = 40480651, upload-time = "2026-07-01T18:41:18.438Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a2/28696a9e61e245d1a79816d29d106692a90a2b6e7d78c98b326db70827af/llvmlite-0.48.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d66c3beb4209087ddd4cf4ed2a0856b6887e6a913bdcf1aacfec9851cf2cba4e", size = 40480651, upload-time = "2026-07-01T18:41:35.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/23/fe9316d14626b42c73ef0b502e724705a6ee9450afe53759c0a99c37c2d7/llvmlite-0.48.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a83a99ef0c05b4ccddf9b6218ed9fe84b653a0caf7c1d9dbe148d6d16c67f518", size = 40480652, upload-time = "2026-07-01T18:41:52.216Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8e/8170f2e0c217f88069c333d85bb976e536b332aecfcce606ddbdb249385f/llvmlite-0.48.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:321f1ac39b462603f0b589751aecf2d237d056f6d005749c1752b6f23ec3f074", size = 40480650, upload-time = "2026-07-01T18:42:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e3/7a93e09c9f94e637ca90209ceef0334a9a1d45b0bdb7c92ff922d25d6187/llvmlite-0.48.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7a5c413317050a1d67c34708bde97707f9b2257ef1017f7532d21fe7d9a9ff30", size = 40480654, upload-time = "2026-07-01T18:42:25.076Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1439,6 +1458,57 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/89/1e77ec3ff380e8fb9e7258047374d31452a0f9828a0e370f127b07dd8288/mlx-0.31.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4a3f181b367d404e44a6bd68ef5eb573930809ac60cacd51d0c851c629b1b651", size = 586911, upload-time = "2026-04-22T03:14:29.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/c1907f05f8a3fc54025fb78ad68d3c4a4b931664d03c0a24f7f431cc4087/mlx-0.31.2-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:70297cbef7479429f69c966bfed10da20a6f0c2aa997eec2b4f6ba1a07caf2ef", size = 586915, upload-time = "2026-04-22T03:14:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b0/61ac2c14773c786fecbda28067b0207a0c654cb4d10c548808c51284d700/mlx-0.31.2-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:c0ff158b7ac93a4b5659adbc70053498b30a5964fc45f78596398e056a96c36a", size = 587030, upload-time = "2026-04-22T03:14:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+]
+
+[[package]]
+name = "mlx-whisper"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "mlx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "more-itertools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numba", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "scipy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "tiktoken", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "tqdm", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },
+]
+
+[[package]]
 name = "more-itertools"
 version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1463,6 +1533,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a0/570e3dc53e5602b49108f62a13e529f1eec8bfc7ef37d49c825924dcf546/numba-0.66.0.tar.gz", hash = "sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363", size = 2806181, upload-time = "2026-07-01T23:12:46.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/02/970796b4daa709604cde22e87a7cda9bde473c278ea4a75f59fe38cee47f/numba-0.66.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:bbd531c327557a9004507fa6bff06c53ab51a7a5776b75261bb9cef1efe2b2ea", size = 2727049, upload-time = "2026-07-01T23:12:11.296Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a3/70deb7f88461c1cd5d16aa990c2380604102661a427667b8950dcdccc27f/numba-0.66.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:53ca5900b7cab15109796030113a6b28576bae5ad7bb507ad6dd1360ddd81ba4", size = 2727264, upload-time = "2026-07-01T23:12:18.669Z" },
+    { url = "https://files.pythonhosted.org/packages/03/52/176c02d005c5c5143cde10a85bbcdcb6236d9e34c3aac089380e0506cd1d/numba-0.66.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:380b2556a2019ccd1e956ae77dd257eaa39403f7520768b626d44b755112785e", size = 2727084, upload-time = "2026-07-01T23:12:25.434Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7a/7e0e73550eb4e41ede6e72fb5371f4539537a4d770a3b73fa9b61aea0622/numba-0.66.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:46ae5f2b19e2af3c33c2df100306a90ea2f981c8158b0390f8bf6c20eee7357e", size = 2727296, upload-time = "2026-07-01T23:12:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6f/5e77a7397a37dd16f57a7b72e7e470db5227b68e3639df0d13a8e674883d/numba-0.66.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:db7735d15ea17a283d6485b9fa3504769f78fd86e5146638ad5e8da57c031b9e", size = 2730342, upload-time = "2026-07-01T23:12:38.758Z" },
 ]
 
 [[package]]
@@ -3054,6 +3141,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3107,6 +3206,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "requests", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a SQL-native vector KNN backend: vec0 virtual tables (sqlite-vec) living **inside** the existing `.embeddings.sqlite` / `.clip.sqlite` sidecars, transaction-locked to the blob tables. Blob tables stay the source of truth — vec0 rows are always rebuilt from stored blobs with pure SQL (no model, no re-embedding), which makes migration of pre-existing sidecars and drift-healing one and the same count-check mechanism.

`search()` gains a ladder on both lanes (`EmbeddingIndex` + `ClipIndex`):
**vec0-f32** (exact — rank-identical to the numpy scan) → **binary+rescore** (opt-in `EXOMEM_VEC_QUANT=binary`, golden-gated) → **numpy scan** (`EXOMEM_VEC_BACKEND=numpy` kill switch, lean installs, or any vec failure — soft-fail everywhere). `find()`/fusion: zero changes.

OpenSpec change: `openspec/changes/add-sqlite-vec-backend/` (modifies `find-recall-efficiency` + `live-index-freshness`; validates `--strict`).

## Measured (docs/benchmarks.md has the full section + decision record)

| vector lane | numpy | vec0-f32 | vec0-binary |
|---|---|---|---|
| 10k notes / 40k chunks | 17.5ms | 130.5ms (overlap@10 **1.00**) | 59.7ms (0.86) |
| 50k notes / 200k chunks | 31.2ms | 544.5ms (overlap@10 **1.00**) | 253.3ms (0.68) |

numpy wins the warm lane race (BLAS over a resident matrix) but holds **~1.8GB more RSS** at 200k chunks and pays O(N) reloads on sidecar churn; the lane is <2.2% of total `find()` either way. Decision: `auto` = vec0-f32; ANN behind the same seam is the recorded next step. Loudest finding: **bm25/keyword/graph are the real 100k wall** (~8s each at 50k notes). 100k tier corpus is cached; measurement pass documented as follow-up (OpenSpec task 6.4).

## Verification

- `tests/test_vecstore.py` (20 tests): f32 parity vs numpy, migration/backfill, drift-heal, dual-write lockstep incl. the `frame_ts IS NULL` partial delete, binary rescore exactness, vec0 k-cap clamp (4096 — probed), load-failure memo, matrix-stays-cold.
- `tests/test_vec_backend_fallback.py` — lean-safe: kill switch + unavailable-extension paths serve numpy results, unchanged contract (real coverage on the lean CI matrix where sqlite-vec is genuinely absent).
- Golden gate parametrized `off|binary`: **both pass live** (floors NDCG@10≥0.85 / MRR≥0.80 / recall@10≥0.88 + zero-recall cliff guard). `pytest -m embeddings`: 3 passed.
- Lean suite: 1441 passed. ruff clean on touched files. `openspec validate --strict`: change + 17/17 specs.

## Notes for reviewer

- Pre-existing (not this PR): running the FULL suite locally **with** the embeddings extra trips `test_warm_cli_skip_message_when_embeddings_disabled` — `test_retrieval_golden`'s module importorskip imports torch at collection. Impossible on lean CI; reproduces without this diff.
- Rollback-safe: old code ignores the extra vec0 tables; `EXOMEM_VEC_BACKEND=numpy` restores prior behavior wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9swsvpyKZGyok9Tjr3LoX