### PR TITLE
spec: add-fts5-lexical-backend — indexed lexical lanes for the 100k scale story

### DIFF
--- a/openspec/changes/add-fts5-lexical-backend/.openspec.yaml
+++ b/openspec/changes/add-fts5-lexical-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/add-fts5-lexical-backend/design.md
+++ b/openspec/changes/add-fts5-lexical-backend/design.md
@@ -1,0 +1,171 @@
+# Design - FTS5 lexical backend
+
+## Context
+
+Measured at 50k notes (dense synthetic corpus, reference host, 2026-07-03):
+bm25 8.2 s, keyword 8.7 s, graph 7.8 s **warm**, per query — the three lanes that
+gate "sub-second at 100k notes". Root causes differ:
+
+- `bm25.py` already tokenizes incrementally (per-doc mtime-keyed token cache);
+  the O(N) is `rank_bm25.BM25Okapi.get_scores()`, which scores every document in
+  Python per query. No inverted index exists.
+- The keyword lane is a strict case-insensitive substring scan (every
+  whitespace token must appear as a substring in title or body) over every page.
+- The graph lane's warm cost grows linearly with corpus size (226 ms → 7.8 s,
+  2k → 50k) despite the event-maintained resolver — an unprofiled per-query
+  recompute. Its fix is measurement-first (see Decisions).
+
+The sqlite-vec change established the template this design reuses wholesale:
+a shadow index in a sidecar, kept in lockstep by dual-writes through the
+existing freshness seams, count-mismatch sync-on-first-use as both migration
+and drift healer, a per-call backend ladder with a process-global failure memo,
+an env kill switch, and promotion gated by the golden floors plus the latency
+harness over cached corpora.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make bm25-lane and keyword-lane per-query cost sub-linear in corpus size
+  (posting-list / trigram lookups, not full scans), preserving lane contracts.
+- Keep stemming semantics byte-identical (Snowball via the existing
+  `bm25.tokenize()`); keep the keyword substring contract exactly.
+- Lean-install first: both lanes run on lean installs today, so the backend
+  must add no dependency and no extension loading (FTS5 is in the stdlib
+  SQLite build).
+- Identify and eliminate the graph lane's warm O(N) per-query recompute, with
+  a scaling bound in the latency gate so it cannot regress silently.
+- Before/after evidence on the cached 10k/50k(/100k) benchmark corpora.
+
+**Non-Goals:**
+
+- No ranking-quality change beyond what the golden floors and pins permit —
+  this is an indexing change, not a ranker redesign.
+- No change to fusion, the vector/CLIP/rerank lanes, or any command surface.
+- No removal of the in-process paths: `rank-bm25` scoring and the substring
+  scan remain the fallback, the kill-switch target, and the reference
+  implementation for parity tests.
+- No FTS5 custom tokenizer (stdlib `sqlite3` cannot register Python
+  tokenizers) — pre-stemming makes it unnecessary.
+
+## Decisions
+
+### Pre-stemmed external text, not FTS5 tokenizer stemming
+
+The FTS5 table indexes text already passed through `bm25.tokenize()` (lowercase,
+`[a-z0-9]+` split, Snowball-English stem, space-joined), with `tokenize =
+"unicode61"` effectively splitting on the same boundaries; queries are stemmed
+identically before `MATCH`. FTS5's own `porter` tokenizer is the original Porter
+algorithm — close to but not identical to Snowball English — and stdlib
+`sqlite3` cannot register a custom Python tokenizer. Pre-stemming keeps token
+semantics byte-identical to today and reduces the ranking delta to exactly one
+variable: BM25Okapi's scoring vs FTS5's `bm25()`. The golden set's stemming pin
+plus the floors gate that residual delta.
+
+Alternative considered: FTS5 `porter unicode61` on raw text. Two deltas at once
+(tokenization AND scoring) with a 26-query gate is too coarse to attribute a
+regression; pre-stemming removes one.
+
+### One new sidecar: `<vault>/Knowledge Base/.lexical.sqlite`
+
+Not the embeddings sidecar: the lexical lanes are lean-install lanes, and
+`.embeddings.sqlite` is semantically the embeddings-extra artifact (absent on
+lean deploys, rebuilt by embedding tooling). A separate dotfile sidecar keeps
+lifecycles independent — same WAL pragmas, same Obsidian-Sync-ignored
+per-machine model. Contents: one row per page (`pages(path, mtime, title,
+body_stemmed, title_raw_lower, body_raw_lower)` or equivalent), an FTS5 table
+over the stemmed text, and a trigram FTS5 table over raw lowercased text.
+Storage is roughly corpus-sized (stemmed text + trigram postings) — acceptable
+for a local dotfile; documented in the proposal.
+
+Alternative considered: contentless/external-content FTS5 to avoid storing text
+twice. Rejected: contentless tables cannot rebuild rows without the source and
+complicate the count-sync heal; the storage saved is small relative to the
+trigram index that is needed regardless.
+
+### Keyword lane via trigram FTS5, held to exact parity
+
+The keyword contract is strict case-insensitive substring, all tokens, title or
+body — including mid-word matches phrase queries cannot express. FTS5's
+`trigram` tokenizer supports exactly this (substring matching for terms of
+length ≥ 3; shorter needles fall back to the scan path or a LIKE over the
+stored raw text, decided by a parity suite that enumerates 1-, 2-, and
+3+-char-needle cases). Unlike the bm25 lane this is not floors-gated — the
+parity suite asserts the FTS5-served keyword lane returns the same match set as
+the reference scan on the same corpus.
+
+### Backend ladder and env surface
+
+`EXOMEM_LEXICAL_BACKEND` = `auto` (default) | `fts5` | `python` (kill switch).
+`auto` = FTS5 when the sidecar is available and healthy; every failure —
+FTS5 absent from the SQLite build (probed once per process, memoized), sidecar
+unreadable, runtime error — soft-fails to the in-process paths, logged once,
+process-memoized, exactly the `vecstore` ladder. `bm25.BM25Index.search()` and
+find.py's keyword block consult the ladder internally; callers unchanged.
+
+### Sync via the existing seams; rebuild from markdown
+
+Writers, the file watcher, and reconcile already funnel markdown changes
+through `embeddings.upsert_after_write` / `delete_after_remove`; the lexical
+sidecar hooks the same seams (a shared post-write dispatch, so a lean install
+without the embeddings extra still maintains the lexical index). Page-count +
+max-mtime mismatch on first use triggers a rebuild from the markdown walk —
+the migration for existing vaults and the drift healer for out-of-band writers,
+`_migrate_add_frame_ts`/vec0 precedent. The find-cache freshness key gains the
+lexical sidecar mtime alongside the embedding/CLIP sidecars.
+
+### Graph lane: profile first, then event-maintain; gate by scaling bound
+
+The warm graph lane's linear growth has a cause this design refuses to guess.
+Task order: (1) add intra-lane spans to the graph stage (FindTimings already
+carries per-lane spans; the graph lane gains sub-spans: freshness derivation,
+seed resolution, expansion, in-degree) and capture a 2k/10k/50k profile over
+the cached corpora; (2) event-maintain or memoize the identified recompute —
+the resolver-rebuild fix (14 s → 226 ms) is the precedent and the code seams
+(freshness registry, event-maintained indexes) already exist; (3) extend
+`tests/test_latency_gate.py` with a second corpus size and a ratio bound
+(warm graph median at 4× the corpus MUST NOT exceed ~1.5× — exact bound set
+from the post-fix measurement, not hand-tuned) so linear warm cost cannot
+return unnoticed. The fix lands in this change; only its precise target awaits
+the profile.
+
+### What "done" looks like, measured
+
+On the cached corpora: bm25 and keyword lanes drop from ~8 s to low tens of ms
+at 50k notes (posting-list cost), the graph lane's warm median stops scaling
+linearly, and end-to-end `find()` at 50k lands near the sum of the remaining
+lanes (vector backend + rerank + fusion) — the sub-second story at 100k becomes
+a measurement, not a claim. Golden floors hold; keyword parity suite exact.
+
+## Risks / Trade-offs
+
+- FTS5 `bm25()` ranking differs from BM25Okapi -> floors + per-query pins gate
+  promotion; the kill switch preserves today's ranking wholesale; RRF consumes
+  ranks, damping small score-order shifts.
+- Trigram tables don't match needles shorter than 3 chars -> parity suite
+  enumerates the short-needle cases; those fall back to LIKE over stored raw
+  text (indexed lookup is unaffected for the common case).
+- Write amplification (markdown + embeddings + vec0 + lexical) -> per-write
+  cost stays milliseconds; rebuild-from-source unchanged; measured by the
+  existing write-latency tests.
+- A second sidecar to keep fresh -> same seams, same heal mechanism, same
+  audit surface as the sidecars that already exist; doctor gains a lexical
+  sidecar probe.
+- Graph-lane fix scoped before profiling -> the task explicitly reserves the
+  target; if the profile reveals a cause that needs its own change (e.g. a
+  find.py architectural issue), the scaling-bound gate still lands here and
+  the fix spins out — surfaced at review, not silently absorbed.
+
+## Migration Plan
+
+No user action. First use by a new version creates and populates
+`.lexical.sqlite` from the markdown walk (seconds to low minutes at 100k notes
+— tokenization is the dominant cost and the per-doc token cache already
+exists). Rollback: older code ignores the sidecar; `EXOMEM_LEXICAL_BACKEND=python`
+disables it in place. Deleting the sidecar is always safe (rebuilt on next use).
+
+## Open Questions
+
+None blocking implementation. The graph-lane profile determines its fix target
+(reserved in tasks); the trigram short-needle fallback shape is decided by the
+parity suite's cases.

--- a/openspec/changes/add-fts5-lexical-backend/proposal.md
+++ b/openspec/changes/add-fts5-lexical-backend/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+The latency-vs-scale curve (shipped in the benchmark upgrade, extended by the
+sqlite-vec change) identified where `find()` actually degrades at OSS scale, and it
+is not the vector lane: at 50k notes the whole call costs ~25 s because **bm25
+(~8.2 s), keyword (~8.7 s), and graph (~7.8 s, warm) are each O(N) per query**.
+`rank-bm25` has no inverted index — `get_scores()` scores every document in Python
+on every query (document tokenization is already incremental; the scoring is the
+wall). The keyword lane substring-scans every page. The graph lane's warm cost
+grew 226 ms → 1.1 s → 7.8 s from 2k → 10k → 50k notes, indicating a per-query
+recompute proportional to corpus size that has not yet been profiled. "Sub-second
+search at 100k notes" — the OSS scale story — is gated on these lanes.
+
+## What Changes
+
+- Add an **FTS5 lexical index** in a new per-vault sidecar (`.lexical.sqlite`):
+  an inverted index serving the BM25 lane via FTS5's C-implemented `bm25()`
+  ranking, so a query touches only its terms' posting lists instead of all N
+  documents. Indexed text is **pre-stemmed with the existing Snowball
+  `bm25.tokenize()`** (queries stemmed the same way), so stemming and token
+  semantics stay byte-identical to today — FTS5 supplies only the index and the
+  scorer. FTS5 ships compiled into CPython's bundled SQLite: no new dependency,
+  no extension loading, available on lean installs (BM25 is a lean-install lane).
+- Add a **trigram companion table** in the same sidecar to serve the keyword
+  lane's strict-substring contract (FTS5 `trigram` tokenizer supports true
+  substring matching, including mid-word) at index speed.
+- Keep the lexical sidecar synchronized through the same three freshness seams
+  as the embedding sidecars (writer hooks, file watcher, reconcile), with the
+  count-mismatch sync-on-first-use from the vec0 backend as migration and drift
+  healer — rebuilt from the markdown source of truth, page-level.
+- **Profile the graph lane's warm O(N) growth, then fix it** by event-maintaining
+  whatever per-query recompute the profile identifies (the resolver-rebuild fix
+  is the precedent). Acceptance is measured: the latency gate gains a second
+  corpus size with a scaling bound so a linear warm graph lane cannot return.
+- Extend the latency-curve benchmark with `--lexical-backend` passes and re-run
+  the 10k/50k(/100k) tiers over the cached corpora; publish before/after in
+  `docs/benchmarks.md`.
+
+Defaults and soft-fail, stated explicitly: `EXOMEM_LEXICAL_BACKEND` defaults to
+`auto` — FTS5 serves the bm25/keyword lanes when the sidecar is available, and
+every failure mode (FTS5 missing from the SQLite build, sidecar unreadable,
+runtime error) soft-fails to the current in-process `rank-bm25`/substring-scan
+paths with zero behavior change; `EXOMEM_LEXICAL_BACKEND=python` is the kill
+switch restoring today's behavior wholesale.
+
+Honest gating note (this differs from the vec0 swap): FTS5's `bm25()` is a BM25
+variant with its own parameters, so **rankings are floors-gated, not
+rank-identical** — the golden retrieval floors (and their per-query pins,
+including the stemming pin) plus a keyword-lane contract suite are the acceptance
+gate, and the substring contract IS held to exact parity. Pure-substrate note:
+FTS5 is deterministic term statistics over already-owned text — measurement, no
+model, no judgment.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: the bm25 and keyword lanes gain a SQL-native indexed
+  backend (floors-gated BM25 via FTS5; exact-parity substring via trigram; kill
+  switch; soft-fail to the in-process paths).
+- `live-index-freshness`: sidecar writes and watcher/reconcile seams keep the
+  lexical index synchronized, with rebuild-from-markdown self-heal.
+
+## Impact
+
+- Code: `src/exomem/lexstore.py` (new, modeled on `vecstore.py`), `src/exomem/bm25.py`
+  (backend ladder), the keyword-lane block in `src/exomem/find.py`, writer/watcher/
+  reconcile seams, `src/exomem/warmup.py`, `src/exomem/doctor.py`,
+  `scripts/latency_curve.py`, `tests/test_latency_gate.py`, `docs/benchmarks.md`.
+- Surfaces: none — no command-registry, MCP, REST, or CLI parameter changes.
+- Tests: lexstore unit suite (sync, migration, drift, substring parity), golden
+  gate under the FTS5 backend, keyword-contract suite, graph-lane scaling gate.
+- Dependencies: none. FTS5 and the trigram tokenizer are in CPython 3.11+'s
+  bundled SQLite (trigram needs SQLite ≥ 3.34; CPython 3.11 bundles ≥ 3.37).
+- Storage: the lexical sidecar adds roughly corpus-sized bytes (stemmed text +
+  trigram index) as a local, per-machine dotfile — documented in design.md.

--- a/openspec/changes/add-fts5-lexical-backend/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/add-fts5-lexical-backend/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: SQL-Native Lexical Search Backend
+
+The system SHALL be able to serve the bm25 lane from an FTS5 inverted index in a
+per-vault lexical sidecar, selected by `EXOMEM_LEXICAL_BACKEND` (`auto` | `fts5` |
+`python`, default `auto`), so that per-query lexical cost scales with the query's
+matching terms rather than with corpus size. Indexed text MUST be stemmed with the
+same Snowball tokenization the in-process scorer uses, applied identically to
+queries, so token and stemming semantics are unchanged. Because FTS5's BM25
+scoring is a different variant, promotion of this backend MUST be gated by the
+golden retrieval floors and their per-query pins (including the stemming pin) —
+not by rank-identity. When the backend is unavailable in any way — FTS5 missing
+from the SQLite build, the sidecar unreadable, or a runtime error — the lane MUST
+soft-fail to the in-process scorer with unchanged results and without recording a
+lane degradation. `EXOMEM_LEXICAL_BACKEND=python` MUST force the in-process paths
+unconditionally.
+
+#### Scenario: Indexed backend serves the bm25 lane
+
+- **WHEN** the lexical sidecar is healthy and `EXOMEM_LEXICAL_BACKEND` is `auto`
+- **THEN** the bm25 lane's ranked paths are produced by the FTS5 index
+- **AND** the lane's interface to fusion is unchanged
+
+#### Scenario: Golden floors gate the backend
+
+- **WHEN** the golden retrieval evaluation runs with the FTS5 backend serving the
+  bm25 lane
+- **THEN** the golden floors and per-query pins hold, including the
+  morphological-variant (stemming) pin
+
+#### Scenario: Unavailable backend falls back silently
+
+- **WHEN** FTS5 is unavailable or the lexical sidecar cannot be used
+- **THEN** the bm25 lane returns the in-process scorer's results
+- **AND** `find` records no lane degradation for the fallback itself
+
+#### Scenario: Kill switch restores in-process behavior
+
+- **WHEN** `EXOMEM_LEXICAL_BACKEND=python` is set
+- **THEN** the bm25 and keyword lanes use the in-process paths even where the
+  FTS5 backend is available
+
+### Requirement: Keyword Substring Contract Preserved At Scale
+
+The system SHALL preserve the keyword lane's exact matching contract — strict
+case-insensitive substring, every whitespace token present, in title or body,
+including mid-word matches — when the lane is served by the indexed backend. This
+lane's gate is exact parity, not floors: for any query and corpus state, the
+indexed keyword lane MUST return the same match set as the reference in-process
+substring scan. Needles below the trigram indexable length MUST still honor the
+contract via a fallback lookup over the stored raw text.
+
+#### Scenario: Indexed keyword lane matches the reference scan
+
+- **WHEN** the same keyword-mode query runs once under the indexed backend and
+  once under the in-process scan, over the same corpus
+- **THEN** the match sets are identical, including mid-word substring matches
+
+#### Scenario: Short needles still honor the contract
+
+- **WHEN** a keyword query contains a token shorter than the trigram indexable
+  length
+- **THEN** the returned match set still equals the reference scan's

--- a/openspec/changes/add-fts5-lexical-backend/specs/live-index-freshness/spec.md
+++ b/openspec/changes/add-fts5-lexical-backend/specs/live-index-freshness/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Lexical Index Synchronization
+
+The system SHALL keep the lexical sidecar synchronized with the vault's markdown
+through the same freshness seams that maintain the embedding sidecars — in-process
+writer hooks, the live file watcher, and reconcile — on lean installs as well as
+full ones (lexical maintenance MUST NOT be gated behind the embeddings extra).
+When the sidecar is missing, stale, or was written past by a non-aware process,
+the next use MUST detect the mismatch (page count and max mtime against the
+markdown walk) and rebuild the affected state from the markdown source of truth
+without user action. The `find` hot-cache freshness key MUST incorporate the
+lexical sidecar's freshness so cached results cannot outlive a lexical reindex.
+
+#### Scenario: A write keeps the lexical index current
+
+- **WHEN** a markdown page is created, edited, or deleted through a writer path
+  or observed by the watcher
+- **THEN** the lexical sidecar reflects the change through the same seam that
+  refreshes the embedding sidecars
+- **AND** a subsequent bm25- or keyword-lane query observes the change
+
+#### Scenario: A pre-existing vault is indexed on first use
+
+- **WHEN** a vault that predates the lexical sidecar is first used by an aware
+  version
+- **THEN** the sidecar is created and populated from the markdown walk
+- **AND** no user action is required
+
+#### Scenario: Lean installs maintain the lexical index
+
+- **WHEN** the server runs a lean install (no embeddings extra)
+- **THEN** writer and watcher events still keep the lexical sidecar current
+
+#### Scenario: Out-of-band drift self-heals
+
+- **WHEN** markdown changed without the lexical sidecar being updated
+- **THEN** the next use detects the count/mtime mismatch and rebuilds the
+  affected state from markdown

--- a/openspec/changes/add-fts5-lexical-backend/tasks.md
+++ b/openspec/changes/add-fts5-lexical-backend/tasks.md
@@ -1,0 +1,73 @@
+## 1. Tests First
+
+- [ ] 1.1 Add `tests/test_lexstore.py`: FTS5-availability probe + failure memo;
+      schema creation idempotent; page-count/mtime sync-on-first-use populates a
+      fresh sidecar from markdown (migration) and heals manual drift; lockstep
+      after write/delete/move through the writer seams.
+- [ ] 1.2 Add the bm25 backend gate tests: FTS5-served lane returns ranked paths
+      feeding RRF with the unchanged interface; `EXOMEM_LEXICAL_BACKEND=python`
+      kill switch forces the rank-bm25 path; forced FTS5-unavailable serves the
+      rank-bm25 path with no degradation recorded.
+- [ ] 1.3 Add the keyword-contract parity suite: FTS5/trigram-served keyword lane
+      returns the SAME match set as the reference substring scan — including
+      mid-word substrings, multi-token all-present semantics, title-vs-body hits,
+      and 1-/2-char needles (the trigram floor cases).
+- [ ] 1.4 Add the stemming pin: a query whose target page uses a morphological
+      variant ("regulation" → "regulator") ranks under the FTS5 backend as it
+      does under rank-bm25 (byte-identical pre-stemming makes this hold).
+- [ ] 1.5 Add graph-lane sub-span timing tests: the graph stage exposes
+      sub-spans (freshness, seed resolution, expansion, in-degree) in
+      FindTimings without changing results.
+- [ ] 1.6 Extend `tests/test_latency_gate.py` with a second corpus size and a
+      warm-graph scaling-ratio bound (bound value set from post-fix
+      measurement — re-measure, don't hand-tune).
+
+## 2. lexstore Module
+
+- [ ] 2.1 Implement `src/exomem/lexstore.py` modeled on `vecstore.py`: sidecar
+      path/pragmas, FTS5 + trigram schema, availability probe with
+      process-global memo, sync-on-first-use (page count + max mtime vs the
+      markdown walk), page upsert/delete, `bm25_search(stemmed_query, k)` and
+      `substring_search(tokens, k)`, `EXOMEM_LEXICAL_BACKEND` reader.
+
+## 3. Lane Integration
+
+- [ ] 3.1 `bm25.BM25Index.search()` gains the ladder: FTS5 when available →
+      rank-bm25 otherwise; interface to find.py unchanged.
+- [ ] 3.2 find.py keyword block gains the ladder: trigram-served match set →
+      reference scan otherwise; short-needle fallback per the parity suite.
+- [ ] 3.3 Hook the lexical sidecar into the writer / watcher / reconcile seams
+      via a shared post-write dispatch that runs on lean installs (not gated
+      behind the embeddings import); fold the sidecar mtime into the find-cache
+      freshness key.
+
+## 4. Graph Lane
+
+- [ ] 4.1 Profile the warm graph lane at 2k/10k/50k over the cached corpora
+      using the new sub-spans; record the identified O(N) recompute in
+      design.md's decision (replacing the reserved target).
+- [ ] 4.2 Event-maintain or memoize the identified recompute; warm graph median
+      passes the new scaling bound at both gate sizes.
+
+## 5. Warmup, Doctor, Benchmark
+
+- [ ] 5.1 Warm the lexical sidecar at startup through the existing warm seam
+      (sync check + one query), soft-fail as ever.
+- [ ] 5.2 Doctor: lexical sidecar presence/health probe + FTS5/trigram
+      availability check (warn, not fail — the in-process paths exist).
+- [ ] 5.3 Extend `scripts/latency_curve.py` with `--lexical-backend
+      python,fts5` passes; re-run 10k/50k (and the cached 100k) tiers; publish
+      before/after + the graph-lane fix in `docs/benchmarks.md`.
+
+## 6. Validation
+
+- [ ] 6.1 Lean suite green: `uv run python -m pytest -q` with
+      `KB_MCP_DISABLE_EMBEDDINGS=1` — the lexical backend runs and is exercised
+      on lean installs (no extras involved).
+- [ ] 6.2 Retrieval eval: golden floors + per-query pins hold under
+      `EXOMEM_LEXICAL_BACKEND=fts5` (and the vec backend's two modes remain
+      green — the gates compose).
+- [ ] 6.3 Keyword parity suite exact; `ruff check`; `openspec validate --strict`.
+- [ ] 6.4 End-to-end at scale: 50k-note cached corpus, bm25/keyword lanes at
+      low-tens-of-ms, warm graph within the scaling bound, end-to-end `find()`
+      total recorded in docs.


### PR DESCRIPTION
## Summary

Spec-only PR (OpenSpec change `add-fts5-lexical-backend`, validates `--strict`). No code.

The measured latency curve (PR #111's benchmark work) shows the 100k-note scale story is gated on **bm25 (~8.2s), keyword (~8.7s), and graph (~7.8s warm) at 50k notes — each O(N) per query** — not the vector lane (<2.2% of total). This change specs the fix:

- **FTS5 inverted index** in a new lean-first `.lexical.sqlite` sidecar, over **pre-stemmed** text so Snowball tokenization stays byte-identical and the only ranking delta is the BM25 scorer — gated by the golden floors + per-query pins (not rank-identity; stated honestly in the proposal).
- **Trigram companion table** serving the keyword lane's strict-substring contract at **exact parity** (parity suite incl. mid-word and short-needle cases).
- Sync through the existing writer/watcher/reconcile seams with count/mtime sync-on-first-use as migration + drift-heal (the vec0 template), on lean installs too — FTS5 needs no dependency and no extension loading.
- **Graph lane: profile-first** (intra-lane sub-spans over the cached 2k/10k/50k corpora), then event-maintain the identified recompute, with a latency-gate **scaling-ratio bound** so warm O(N) cannot silently return.
- `EXOMEM_LEXICAL_BACKEND` = `auto` | `fts5` | `python` (kill switch); soft-fail to the in-process paths everywhere.

Expected, to be proven on the cached benchmark corpora: lexical lanes ~8s → low tens of ms at 50k; end-to-end `find()` approaches the sum of the remaining lanes — the sub-second-at-100k story as a measurement.

Implementation lands in a follow-up session picking up this spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9swsvpyKZGyok9Tjr3LoX