### PR TITLE
feat: configurable governed-folder name via EXOMEM_KB_DIRNAME

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -58,7 +58,9 @@ That's the normal case, and it's safe:
   `Knowledge Base/` — a new folder that `setup`/`init` creates *next to* your
   existing ones. Everything else in the vault is read-only input; `init`
   refuses to run if `Knowledge Base/` already exists, so re-running can't
-  clobber anything.
+  clobber anything. *(The governed folder is named `Knowledge Base/` by default;
+  set `EXOMEM_KB_DIRNAME` to govern a differently-named folder — e.g. to adopt one
+  your vault already uses.)*
 - **Your notes stay searchable.** `find` reaches sibling folders (the default
   scope auto-widens; `scope="vault"` always walks everything), and `overview`
   gives Claude a bounded structural report of the whole vault — one call, not

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ The server reads environment variables or a `.env` file. The main ones are:
 
 | Variable | Purpose |
 | --- | --- |
-| `EXOMEM_VAULT_PATH` | Vault root containing `Knowledge Base/`. |
+| `EXOMEM_VAULT_PATH` | Vault root containing the governed folder (default `Knowledge Base/`). |
+| `EXOMEM_KB_DIRNAME` | Name of the governed folder inside the vault (default `Knowledge Base`). |
 | `EXOMEM_DISABLE_EMBEDDINGS` | `1` forces keyword/BM25-only search. |
 | `EXOMEM_DISABLE_TIER2` | `1` hides Tier-2 filesystem tools. |
 | `EXOMEM_REST_API_KEY` | Enables authenticated REST routes. |

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -31,6 +31,7 @@ import sys
 from pathlib import Path
 
 from . import server
+from .kbdir import kb_dirname, kb_prefix
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -124,7 +125,7 @@ def _backfill_media_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     parser.add_argument("--dry-run", action="store_true", help="report what would change; write nothing")
     parser.add_argument("--no-ocr", action="store_true", help="skip text extraction (sidecar + CLIP only)")
@@ -172,18 +173,18 @@ def _index_main(argv: list[str]) -> int:
         description="Build/refresh the semantic (bge) vector index INCREMENTALLY: "
         "skip files already up to date, embed new/changed ones in batches, prune "
         "rows for files that are gone. Idempotent; unlike a full audit_fix rebuild "
-        "it never wipes the sidecar first. Covers Knowledge Base/ by default, or "
-        "the whole vault with --scope vault (so notes outside Knowledge Base/ "
+        f"it never wipes the sidecar first. Covers {kb_prefix()} by default, or "
+        f"the whole vault with --scope vault (so notes outside {kb_prefix()} "
         "become semantically searchable).",
     )
     parser.add_argument(
         "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     parser.add_argument(
         "--scope", choices=("kb", "vault"), default=None,
         help="index scope override; default reads EXOMEM_INDEX_SCOPE (else 'kb'). "
-        "'vault' indexes the whole vault, not just Knowledge Base/.",
+        f"'vault' indexes the whole vault, not just {kb_prefix()}.",
     )
     parser.add_argument(
         "--batch-size", type=int, default=256,
@@ -242,7 +243,7 @@ def _doctor_main(argv: list[str]) -> int:
     parser.add_argument(
         "--vault",
         default=None,
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     parser.add_argument(
         "--profile",
@@ -388,7 +389,7 @@ def _enroll_speaker_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
 
@@ -418,7 +419,7 @@ def _list_speakers_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
 
@@ -446,7 +447,7 @@ def _remove_speaker_main(argv: list[str]) -> int:
     parser.add_argument("--name", required=True, help="profile name to remove")
     parser.add_argument(
         "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
-        help="vault root containing 'Knowledge Base/' (default: $EXOMEM_VAULT_PATH)",
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
 
@@ -464,7 +465,7 @@ def _remove_speaker_main(argv: list[str]) -> int:
 def _init_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem init",
-        description="Bootstrap a fresh Knowledge Base scaffold into a vault.",
+        description=f"Bootstrap a fresh {kb_dirname()} scaffold into a vault.",
     )
     parser.add_argument(
         "--vault",
@@ -473,7 +474,7 @@ def _init_main(argv: list[str]) -> int:
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Overlay the scaffold even if Knowledge Base/ exists (existing files kept).",
+        help=f"Overlay the scaffold even if {kb_prefix()} exists (existing files kept).",
     )
     args = parser.parse_args(argv)
 
@@ -485,12 +486,12 @@ def _init_main(argv: list[str]) -> int:
     except FileExistsError as e:
         print(f"exomem init: {e}", file=sys.stderr)
         return 1
-    print(f"Initialized Knowledge Base at {report['kb']}")
+    print(f"Initialized {kb_dirname()} at {report['kb']}")
     print(f"  {len(report['created'])} files created + the typed folder tree.")
     print("Next:")
     print("  1. Point Claude Code at this vault (see QUICKSTART.md).")
-    print("  2. Install the Exomem Knowledge Base skill so Claude knows how to use it: python -m exomem install-skill")
-    print("  3. Adapt Knowledge Base/_Schema/project-keys.yaml to your own projects.")
+    print(f"  2. Install the Exomem {kb_dirname()} skill so Claude knows how to use it: python -m exomem install-skill")
+    print(f"  3. Adapt {kb_prefix()}_Schema/project-keys.yaml to your own projects.")
     return 0
 
 
@@ -725,7 +726,7 @@ def _core_op_main(argv: list[str]) -> int:
         for c in commands_module.commands_for("cli", expose_tier2=_expose_tier2())
     }
 
-    parser = _CLIParser(prog="kb", description="Query and write the local Knowledge Base.")
+    parser = _CLIParser(prog="kb", description=f"Query and write the local {kb_dirname()}.")
     sub = parser.add_subparsers(dest="op", required=True, parser_class=_CLIParser)
     for name in sorted(cmds):
         cmd = cmds[name]

--- a/src/exomem/access.py
+++ b/src/exomem/access.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 import yaml
 
+from .kbdir import kb_dirname
+
 log = logging.getLogger(__name__)
 
 TIER_EXCLUDED = "excluded"
@@ -47,7 +49,7 @@ _CACHE: dict[str, tuple[float, dict[str, list[str]]]] = {}
 
 
 def access_config_path(vault_root: Path) -> Path:
-    return vault_root / "Knowledge Base" / "_access.yaml"
+    return vault_root / kb_dirname() / "_access.yaml"
 
 
 def _load_config(vault_root: Path) -> dict[str, list[str]]:
@@ -88,7 +90,7 @@ def _kb_relative(rel_path: str) -> str:
     """
     rel = rel_path.replace("\\", "/").strip("/")
     parts = rel.split("/")
-    if parts and parts[0] == "Knowledge Base":
+    if parts and parts[0] == kb_dirname():
         return "/".join(parts[1:])
     return rel
 

--- a/src/exomem/add.py
+++ b/src/exomem/add.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import corpus_aware, indexes, schema
+from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
     batch_atomic_write,
@@ -254,7 +255,7 @@ def _compute_updates_with_counts(
             source_type=folder_name.lower(),
             folder_title=folder_name,
             folder_description=FOLDER_DESCRIPTIONS.get(folder_name, "captured material"),
-            rel_source_path=f"Knowledge Base/Sources/{folder_name}/{rel_source_no_ext.rsplit('/', 1)[-1]}",
+            rel_source_path=f"{kb_prefix()}Sources/{folder_name}/{rel_source_no_ext.rsplit('/', 1)[-1]}",
             date_iso=date_iso,
             activity_summary=activity_summary,
             log_entry_body=log_entry_body,
@@ -322,7 +323,7 @@ def _activity_summary(
     tags: list[str],
 ) -> str:
     """One-liner for the top index's Recent activity bullet."""
-    base = f"`{rel_source_no_ext.replace('Knowledge Base/', '')}` (source, {source_type}, mobile capture via exomem)"
+    base = f"`{rel_source_no_ext.replace(kb_prefix(), '')}` (source, {source_type}, mobile capture via exomem)"
     excerpt = f"\"{title.strip()}\""
     tags_part = f"; tags: {tags}" if tags else ""
     return f"{base} — {excerpt}{tags_part}"

--- a/src/exomem/append_to_file.py
+++ b/src/exomem/append_to_file.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname
 from .vault import (
     PlannedWrite,
     VaultPathError,
@@ -70,7 +71,7 @@ def append_to_file(
     # description files (description.md style); the raw artifacts there are
     # binary and wouldn't be markdown-appended anyway.
     parts = rel_path.split("/")
-    head = parts[1] if parts[0] == "Knowledge Base" and len(parts) > 1 else parts[0]
+    head = parts[1] if parts[0] == kb_dirname() and len(parts) > 1 else parts[0]
     if head == "Sources":
         raise AppendError(
             code="APPEND_ONLY",

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -49,6 +49,7 @@ import yaml
 
 from . import access, indexes
 from . import find as find_module
+from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     _mask_code_spans,
     in_append_only_tree,
@@ -229,7 +230,7 @@ def _check_broken_wikilinks(
             continue
         no_ext = rel.removesuffix(".md")
         full_paths.add(no_ext)
-        kb_stripped_paths.add(no_ext.removeprefix("Knowledge Base/"))
+        kb_stripped_paths.add(no_ext.removeprefix(kb_prefix()))
         names_to_paths.setdefault(md_path.stem, no_ext)
         # Title fallback: lets `[[North-Led Content Manual]]` resolve to a
         # date-prefixed source whose frontmatter `title:` matches.
@@ -256,7 +257,7 @@ def _check_broken_wikilinks(
             target_for_resolve = target.split("#", 1)[0].strip()
             if not target_for_resolve:
                 continue
-            normalized = target_for_resolve.removeprefix("Knowledge Base/").lstrip("/")
+            normalized = target_for_resolve.removeprefix(kb_prefix()).lstrip("/")
             if normalized in kb_stripped_paths:
                 continue
             if target_for_resolve.lstrip("/") in full_paths:
@@ -282,7 +283,7 @@ def _check_broken_wikilinks(
             if suffix and suffix != ".md":
                 rel = target_for_resolve.lstrip("/")
                 if (vault_root / rel).exists() or (
-                    vault_root / "Knowledge Base" / normalized
+                    vault_root / kb_dirname() / normalized
                 ).exists():
                     continue
             # A broken link inside an append-only tree (Sources/, Evidence/)
@@ -347,19 +348,19 @@ def _check_orphan_entities(
     for page in pages:
         # Don't count self-references and don't count from inside Entities/index.md
         # (those are hub listings, not real "uses").
-        if page.rel_path.endswith("/Entities/index.md") or page.rel_path == "Knowledge Base/Entities/index.md":
+        if page.rel_path.endswith("/Entities/index.md") or page.rel_path == f"{kb_prefix()}Entities/index.md":
             continue
         for match in WIKILINK_PATTERN.finditer(page.body):
-            target = match.group(1).strip().removeprefix("Knowledge Base/").lstrip("/")
+            target = match.group(1).strip().removeprefix(kb_prefix()).lstrip("/")
             if target:
                 referenced.add(target)
         # Frontmatter wikilinks (sources, related, supersedes, etc.) count too.
         for value in page.frontmatter.values():
             for link in _extract_wikilinks_from_value(value):
-                referenced.add(link.removeprefix("Knowledge Base/").lstrip("/"))
+                referenced.add(link.removeprefix(kb_prefix()).lstrip("/"))
 
     for page in pages:
-        if not page.rel_path.startswith("Knowledge Base/Entities/"):
+        if not page.rel_path.startswith(f"{kb_prefix()}Entities/"):
             continue
         if page.path.name == "index.md":
             continue
@@ -511,7 +512,7 @@ def _check_index_drift(vault_root: Path) -> list[AuditFinding]:
             findings.append(AuditFinding(
                 category="index_drift",
                 severity="warn",
-                path="Knowledge Base/index.md",
+                path=f"{kb_prefix()}index.md",
                 detail=(
                     f"Counts row {key!r} declared {declared_count} but the on-disk "
                     "folder doesn't exist"
@@ -523,7 +524,7 @@ def _check_index_drift(vault_root: Path) -> list[AuditFinding]:
             findings.append(AuditFinding(
                 category="index_drift",
                 severity="warn",
-                path="Knowledge Base/index.md",
+                path=f"{kb_prefix()}index.md",
                 detail=(
                     f"Counts row {key!r} declared {declared_count}, actual is {actual_count}"
                 ),
@@ -777,7 +778,7 @@ def _check_embedding_drift(vault_root: Path) -> list[AuditFinding]:
     one wipe-and-rebuild.
     """
     findings: list[AuditFinding] = []
-    sidecar = vault_root / "Knowledge Base" / ".embeddings.sqlite"
+    sidecar = vault_root / kb_dirname() / ".embeddings.sqlite"
     if not sidecar.exists():
         return findings
     import sqlite3
@@ -845,7 +846,7 @@ def _check_embedding_drift(vault_root: Path) -> list[AuditFinding]:
         from .vault import walk_vault_md
         never_walk = walk_vault_md(vault_root)
     else:
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         never_walk = find_module._walk_md(kb) if kb.is_dir() else ()
     for md in never_walk:
         if not embeddings_module._is_embeddable_path(md):
@@ -1032,19 +1033,19 @@ def _inbound_degree(pages: list[find_module.ParsedPage]) -> dict[str, int]:
     for page in pages:
         if (
             page.rel_path.endswith("/Entities/index.md")
-            or page.rel_path == "Knowledge Base/Entities/index.md"
+            or page.rel_path == f"{kb_prefix()}Entities/index.md"
         ):
             continue
         self_key = _relevance_canon(page.rel_path)
         targets: set[str] = set()
         for match in WIKILINK_PATTERN.finditer(page.body):
-            target = match.group(1).strip().removeprefix("Knowledge Base/").lstrip("/")
+            target = match.group(1).strip().removeprefix(kb_prefix()).lstrip("/")
             if target:
                 targets.add(_relevance_canon(target))
         for value in page.frontmatter.values():
             for link in _extract_wikilinks_from_value(value):
                 targets.add(
-                    _relevance_canon(link.removeprefix("Knowledge Base/").lstrip("/"))
+                    _relevance_canon(link.removeprefix(kb_prefix()).lstrip("/"))
                 )
         for target in targets:
             if target == self_key:
@@ -1303,7 +1304,7 @@ def _contradiction_family(rel_path: str) -> str | None:
     leading `Knowledge Base/` is stripped) and None for anything outside that
     tree (or directly in it with no `<X>` subfolder).
     """
-    stripped = rel_path.removeprefix("Knowledge Base/").lstrip("/")
+    stripped = rel_path.removeprefix(kb_prefix()).lstrip("/")
     parts = stripped.split("/")
     # parts = ["Notes", "Research", "<X>", ..., "file.md"] → need an <X> dir
     # before the filename, so at least 4 components.
@@ -1561,7 +1562,7 @@ def _check_corpus_contradictions(
         findings.append(AuditFinding(
             category="corpus_contradictions",
             severity="info",
-            path="Knowledge Base/",
+            path=kb_prefix(),
             detail=(
                 f"{omitted} more lower-priority/same-family contradiction pair(s) "
                 f"not shown (showing top {top_n} of {len(scored)}; raise "
@@ -1587,4 +1588,4 @@ def _rel_kb_path_no_ext(absolute: Path, vault_root: Path) -> str:
     """
     rel = absolute.resolve().relative_to(vault_root.resolve())
     no_ext = rel.with_suffix("").as_posix()
-    return no_ext.removeprefix("Knowledge Base/").lstrip("/")
+    return no_ext.removeprefix(kb_prefix()).lstrip("/")

--- a/src/exomem/backfill.py
+++ b/src/exomem/backfill.py
@@ -26,6 +26,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from . import embeddings, extract, index_sync, preserve, scene_frames, semantic_segments
+from .kbdir import kb_dirname, kb_prefix
 from .vault import VAULT_SCAN_SKIP_DIRS
 
 log = logging.getLogger(__name__)
@@ -177,9 +178,9 @@ def backfill_media(
     semantic segmentation. One re-extraction serves both flags when both are requested.
     """
     stats = BackfillStats()
-    kb = vault_root / "Knowledge Base"
+    kb = vault_root / kb_dirname()
     if not kb.is_dir():
-        log_fn("no Knowledge Base/ directory; nothing to back-fill")
+        log_fn(f"no {kb_prefix()} directory; nothing to back-fill")
         return stats
     if rediarize and not extract._diarize_enabled():
         log_fn(
@@ -213,7 +214,7 @@ def backfill_media(
         key=lambda p: (_order.get(extract.media_type_for(p), 9), p.as_posix()),
     )
     stats.scanned = len(files)
-    log_fn(f"scanning {len(files)} media file(s) under Knowledge Base/ (dry_run={dry_run})")
+    log_fn(f"scanning {len(files)} media file(s) under {kb_prefix()} (dry_run={dry_run})")
 
     for i, f in enumerate(files, 1):
         media_type = extract.media_type_for(f)

--- a/src/exomem/bm25.py
+++ b/src/exomem/bm25.py
@@ -27,7 +27,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from . import find as find_module
-
+from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ class BM25Index:
             from .vault import walk_vault_md
             walk = walk_vault_md(vault_root)
         else:
-            kb = vault_root / "Knowledge Base"
+            kb = vault_root / kb_dirname()
             walk = find_module._walk_md(kb)
 
         self.last_tokenized = 0
@@ -234,7 +234,7 @@ def corpus_key(vault_root: Path, scope: str) -> tuple:
         from .vault import walk_vault_md
         walk = walk_vault_md(vault_root)
     else:
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         if not kb.is_dir():
             return (0, 0, "")
         walk = find_module._walk_md(kb)

--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -48,6 +48,7 @@ from pathlib import Path
 import numpy as np
 
 from . import embeddings
+from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
 
@@ -267,7 +268,7 @@ def sidecar_path(vault_root: Path) -> Path:
     """Per-machine claim sidecar. Same dotfile placement rules as
     `.embeddings.sqlite`: outside `_Schema/`, ignored by Obsidian Sync, never
     bundled into a schema upload, rebuildable from the markdown source of truth."""
-    return vault_root / "Knowledge Base" / ".claims.sqlite"
+    return vault_root / kb_dirname() / ".claims.sqlite"
 
 
 # Only compiled CONCLUSIONS carry a claim worth comparing — mirror the exact
@@ -437,7 +438,7 @@ class ClaimIndex:
         lost/stale sidecar; safe to call from an audit-fix lane."""
         from . import access, find as find_module
 
-        kb = self.vault_root / "Knowledge Base"
+        kb = self.vault_root / kb_dirname()
         if not kb.is_dir():
             return 0
         conn = self._connect()

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -34,6 +34,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_prefix
+
 log = logging.getLogger(__name__)
 
 # Tunable knobs — intuition-seeded like find.RankingConfig; revisit against the
@@ -128,8 +130,8 @@ def _canon(path: str) -> str:
     p = (path or "").strip().replace("\\", "/").split("#", 1)[0].strip()
     if p.lower().endswith(".md"):
         p = p[:-3]
-    if p.startswith("Knowledge Base/"):
-        p = p[len("Knowledge Base/"):]
+    if p.startswith(kb_prefix()):
+        p = p[len(kb_prefix()):]
     return p.lower()
 
 

--- a/src/exomem/delete_directory.py
+++ b/src/exomem/delete_directory.py
@@ -22,6 +22,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
     find_inbound_wikilinks,
@@ -83,7 +84,7 @@ def delete_directory(
             code="UNCONFIRMED",
             reason=(
                 "delete_directory requires `confirm=true` explicitly. "
-                "Deletes go to Knowledge Base/_trash/ (recoverable) but the "
+                f"Deletes go to {kb_prefix()}_trash/ (recoverable) but the "
                 "action is still deliberate."
             ),
         )
@@ -97,7 +98,7 @@ def delete_directory(
 
     # Don't allow deleting the trash itself, or trash subdirs.
     parts = rel_path.split("/")
-    if len(parts) >= 2 and parts[0] == "Knowledge Base" and parts[1] == TRASH_SUBPATH:
+    if len(parts) >= 2 and parts[0] == kb_dirname() and parts[1] == TRASH_SUBPATH:
         raise DeleteDirectoryError(
             code="ALREADY_TRASHED",
             reason=(
@@ -186,7 +187,7 @@ def delete_directory(
     today = today or now.date()
     date_dir = now.strftime("%Y-%m-%d")
     time_prefix = now.strftime("%H%M%S")
-    sanitized = rel_path.replace("Knowledge Base/", "", 1).replace("/", "__")
+    sanitized = rel_path.replace(kb_prefix(), "", 1).replace("/", "__")
     trash_basename = f"{time_prefix}-{sanitized}"
     trash_root = kb_root(vault_root) / TRASH_SUBPATH / date_dir
     trash_root.mkdir(parents=True, exist_ok=True)

--- a/src/exomem/delete_file.py
+++ b/src/exomem/delete_file.py
@@ -27,6 +27,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
     find_inbound_wikilinks,
@@ -90,7 +91,7 @@ def delete_file(
             code="UNCONFIRMED",
             reason=(
                 "delete_file requires `confirm=true` explicitly. "
-                "Deletes go to Knowledge Base/_trash/ (recoverable) but the "
+                f"Deletes go to {kb_prefix()}_trash/ (recoverable) but the "
                 "action is still deliberate. Supersession via `replace` is "
                 "the preferred path for compiled material (SKILL.md rule 6)."
             ),
@@ -105,7 +106,7 @@ def delete_file(
 
     # Trash items can't be re-trashed.
     parts = rel_path.split("/")
-    if len(parts) >= 2 and parts[0] == "Knowledge Base" and parts[1] == TRASH_SUBPATH:
+    if len(parts) >= 2 and parts[0] == kb_dirname() and parts[1] == TRASH_SUBPATH:
         raise DeleteFileError(
             code="ALREADY_TRASHED",
             reason=(
@@ -165,8 +166,8 @@ def delete_file(
             n = str(raw).strip().replace("\\", "/").lstrip("/")
             if not n.endswith(".md"):
                 n = n + ".md"
-            if not n.startswith("Knowledge Base/"):
-                n = "Knowledge Base/" + n
+            if not n.startswith(kb_prefix()):
+                n = kb_prefix() + n
             expected_set.add(n)
 
     # Inbound-link check (with `expected_dead_inbound` filtering).
@@ -205,7 +206,7 @@ def delete_file(
     today = today or now.date()
     date_dir = now.strftime("%Y-%m-%d")
     time_prefix = now.strftime("%H%M%S")
-    sanitized = rel_path.replace("Knowledge Base/", "", 1).replace("/", "__")
+    sanitized = rel_path.replace(kb_prefix(), "", 1).replace("/", "__")
     trash_filename = f"{time_prefix}-{sanitized}"
     trash_dir = kb_root(vault_root) / TRASH_SUBPATH / date_dir
     trash_dir.mkdir(parents=True, exist_ok=True)

--- a/src/exomem/demo.py
+++ b/src/exomem/demo.py
@@ -80,7 +80,7 @@ def run_demo(
     echo=print,
 ) -> int:
     """Run the four timed proof steps. Returns the process exit code."""
-    saved = {k: os.environ.get(k) for k in (*LEAN_ENV, "EXOMEM_VAULT_PATH")}
+    saved = {k: os.environ.get(k) for k in (*LEAN_ENV, "EXOMEM_VAULT_PATH", "EXOMEM_KB_DIRNAME")}
     target: Path | None = None
     is_temp = False
     steps: list[StepResult] = []
@@ -90,6 +90,10 @@ def run_demo(
         target, is_temp = _materialize_vault(vault)
         os.environ.update(LEAN_ENV)
         os.environ["EXOMEM_VAULT_PATH"] = str(target)
+        # The bundled sample vault ships with a literal "Knowledge Base/" tree,
+        # so pin the governed-folder name for the demo regardless of any
+        # EXOMEM_KB_DIRNAME the caller has set (restored in `finally`).
+        os.environ["EXOMEM_KB_DIRNAME"] = "Knowledge Base"
         from exomem import audit, doctor, find, get_page
 
         def _timed(name: str, fn) -> StepResult:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -32,6 +32,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from .kbdir import kb_dirname, kb_prefix
+
 Status = Literal["pass", "warn", "fail"]
 Profile = Literal["lean", "hybrid", "media", "remote"]
 VALID_PROFILES: tuple[Profile, ...] = ("lean", "hybrid", "media", "remote")
@@ -97,13 +99,13 @@ def _resolve_vault(vault: str | None) -> tuple[Path | None, DoctorCheck]:
         )
 
     path = Path(raw).expanduser()
-    skill = path / "Knowledge Base" / "_Schema" / "SKILL.md"
+    skill = path / kb_dirname() / "_Schema" / "SKILL.md"
     if not skill.exists():
         return path, _check(
             "vault.path",
             "fail",
-            f"{path} does not contain Knowledge Base/_Schema/SKILL.md.",
-            "Pass the vault root, not the Knowledge Base folder. For a new vault, run "
+            f"{path} does not contain {kb_prefix()}_Schema/SKILL.md.",
+            f"Pass the vault root, not the {kb_dirname()} folder. For a new vault, run "
             "`uv run python -m exomem init --vault <path>`.",
         )
     return path, _check("vault.path", "pass", f"Vault found at {path}.")
@@ -192,12 +194,12 @@ def _check_repo_env() -> DoctorCheck:
 def _check_schema_files(vault_root: Path | None) -> list[DoctorCheck]:
     if vault_root is None:
         return []
-    kb = vault_root / "Knowledge Base"
+    kb = vault_root / kb_dirname()
     checks: list[DoctorCheck] = []
     required = [
-        ("vault.schema", kb / "_Schema" / "SKILL.md", "Knowledge Base schema contract"),
-        ("vault.index", kb / "index.md", "Knowledge Base/index.md"),
-        ("vault.log", kb / "log.md", "Knowledge Base/log.md"),
+        ("vault.schema", kb / "_Schema" / "SKILL.md", f"{kb_dirname()} schema contract"),
+        ("vault.index", kb / "index.md", f"{kb_prefix()}index.md"),
+        ("vault.log", kb / "log.md", f"{kb_prefix()}log.md"),
         (
             "vault.project_keys",
             kb / "_Schema" / "project-keys.yaml",
@@ -425,7 +427,7 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
     """
     if vault_root is None:
         return None
-    sidecar = vault_root / "Knowledge Base" / ".embeddings.sqlite"
+    sidecar = vault_root / kb_dirname() / ".embeddings.sqlite"
     if not sidecar.exists():
         return _check(
             "embeddings.sidecar",

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from . import corpus_aware
 from . import find as find_module
 from . import indexes
+from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
     WikilinkResolver,
@@ -314,8 +315,8 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
     if not path or not path.strip():
         raise EditError(code="INVALID_PATH", missing=["path"], reason="path is empty")
     rel = path.strip().replace("\\", "/").lstrip("/")
-    if not rel.startswith("Knowledge Base/"):
-        rel = "Knowledge Base/" + rel
+    if not rel.startswith(kb_prefix()):
+        rel = kb_prefix() + rel
     if not rel.endswith(".md"):
         rel = rel + ".md"
     candidate = vault_root / rel
@@ -326,7 +327,7 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
         raise EditError(
             code="INVALID_PATH",
             missing=["path"],
-            reason=f"path escapes Knowledge Base/: {e}",
+            reason=f"path escapes {kb_prefix()}: {e}",
         ) from None
     if not candidate.exists():
         raise EditError(
@@ -617,7 +618,7 @@ def commit_edit(
         )
         writes.append(PlannedWrite(path=log_file, content=new_log))
     else:
-        warnings.append("Knowledge Base/log.md missing; skipped log entry")
+        warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
     try:
         batch_atomic_write(writes, vault_root=vault_root)
@@ -708,7 +709,7 @@ def _clean_tags(tags: list[str]) -> list[str]:
 def _prepend_log_entry(
     text: str, *, date_iso: str, rel_no_ext: str, body: str, op: str = "edit"
 ) -> str:
-    title = rel_no_ext.replace("Knowledge Base/", "", 1)
+    title = rel_no_ext.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] {op} | {title}\n\n{escape_wikilinks_for_log(body)}\n"
     sep_idx = text.find(indexes.LOG_SEPARATOR)
     if sep_idx == -1:

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import numpy as np
 
 from . import accel, vecstore
+from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
 
@@ -67,12 +68,12 @@ _INDEX_CACHE_LOCK = threading.Lock()
 
 
 def sidecar_path(vault_root: Path) -> Path:
-    return vault_root / "Knowledge Base" / ".embeddings.sqlite"
+    return vault_root / kb_dirname() / ".embeddings.sqlite"
 
 
 def clip_sidecar_path(vault_root: Path) -> Path:
     """Separate per-machine sidecar for CLIP image vectors (independent lifecycle)."""
-    return vault_root / "Knowledge Base" / ".clip.sqlite"
+    return vault_root / kb_dirname() / ".clip.sqlite"
 
 
 def clip_enabled() -> bool:
@@ -116,7 +117,7 @@ def _index_walk(vault_root: Path):
 
         yield from walk_vault_md(vault_root)
     else:
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         if kb.is_dir():
             yield from find_module._walk_md(kb)
 
@@ -1202,7 +1203,7 @@ class EmbeddingIndex:
         from . import find as find_module
 
         scope = index_scope()
-        kb = self.vault_root / "Knowledge Base"
+        kb = self.vault_root / kb_dirname()
         # KB scope with no Knowledge Base/ is a no-op that must NOT wipe (historical
         # early return). Vault scope always proceeds — it indexes the wider tree.
         if scope == "kb" and not kb.is_dir():

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -37,6 +37,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from . import freshness, index_sync
+from .kbdir import kb_dirname, kb_prefix
 
 log = logging.getLogger(__name__)
 
@@ -224,7 +225,7 @@ class FileWatcher:
 
     def __init__(self, vault_root: Path, *, debounce_seconds: float = DEBOUNCE_SECONDS) -> None:
         self._vault_root = vault_root
-        self._kb_root = vault_root / "Knowledge Base"
+        self._kb_root = vault_root / kb_dirname()
         self._debounce = debounce_seconds
         self._lock = threading.Lock()
         self._pending_upsert: set[Path] = set()
@@ -321,7 +322,7 @@ class FileWatcher:
 
         # Index sidecars (embedding + lexical): Knowledge Base markdown only.
         kb_ups = [p for p in ups if self._is_kb(p)]
-        kb_del_rels = [r for r in del_rels if r.startswith("Knowledge Base/")]
+        kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
         if kb_ups:
             try:
                 index_sync.upsert_after_write(self._vault_root, kb_ups)

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -29,6 +29,7 @@ from typing import Any
 import yaml
 
 from . import freshness
+from .kbdir import kb_dirname, kb_prefix
 
 log = logging.getLogger(__name__)
 
@@ -722,7 +723,7 @@ class FreshnessSnapshot:
             if live is not None:
                 self._kb = live
             else:
-                kb = self._root / "Knowledge Base"
+                kb = self._root / kb_dirname()
                 self._kb = _walk_freshness_key(_walk_md(kb) if kb.is_dir() else ())
         return self._kb
 
@@ -759,7 +760,7 @@ def _freshness_key(
       absent), since sidecar refreshes change semantic results.
     """
     parts: list[Any] = [date.today().toordinal()]
-    kb = vault_root / "Knowledge Base"
+    kb = vault_root / kb_dirname()
     if scope in ("kb", "kb-only"):
         parts.append(("kb", *snapshot.kb()))
     if scope == "vault" or (scope == "kb" and query_norm):
@@ -1171,7 +1172,7 @@ def _find_keyword(
 ) -> list[Hit]:
     """Original keyword-mode find. Preserved for backward compat."""
     if scope == "kb":
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         if not kb.is_dir():
             log.error("KB directory missing: %s", kb)
             return []
@@ -1840,7 +1841,7 @@ def _find_outside_kb(
             vault_root, query, k=bm25_k, scope="vault",
             freshness=snapshot.vault() if snapshot is not None else None,
         ):
-            if not path.startswith("Knowledge Base/"):
+            if not path.startswith(kb_prefix()):
                 candidates.append(path)
     except ImportError:
         candidates = _outside_kb_keyword_paths(vault_root, query_norm)
@@ -1910,7 +1911,7 @@ def _outside_kb_keyword_paths(vault_root: Path, query_norm: str) -> list[str]:
             rel = path.resolve().relative_to(vault_resolved).as_posix()
         except ValueError:
             continue
-        if rel.startswith("Knowledge Base/"):
+        if rel.startswith(kb_prefix()):
             continue
         page = _CACHE.get(path, vault_root)
         if page is None:
@@ -2298,7 +2299,7 @@ def _keyword_match_paths(
     if indexed is not None:
         return indexed
     if scope == "kb":
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         if not kb.is_dir():
             return []
         walk = _walk_md(kb)
@@ -2359,7 +2360,7 @@ def _outbound_wikilink_paths(
         rel_with_md = rel if rel.endswith(".md") else rel + ".md"
         # Sanity: only walk into the KB itself for graph expansion; curated
         # trees are intentional out-of-graph references.
-        if not rel_with_md.startswith("Knowledge Base/"):
+        if not rel_with_md.startswith(kb_prefix()):
             continue
         if rel_with_md in seen:
             continue

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -34,6 +34,8 @@ import threading
 from collections.abc import Iterable
 from pathlib import Path
 
+from .kbdir import kb_dirname
+
 log = logging.getLogger(__name__)
 
 SCOPES = ("kb", "vault")
@@ -100,7 +102,7 @@ def scopes_for(vault_root: Path, path: Path) -> tuple[bool, bool]:
 
     in_kb = False
     try:
-        kb_parts = path.relative_to(vault_root / "Knowledge Base").parts
+        kb_parts = path.relative_to(vault_root / kb_dirname()).parts
         in_kb = not any(d in EXCLUDED_DIR_NAMES for d in kb_parts[:-1])
     except ValueError:
         in_kb = False

--- a/src/exomem/get_page.py
+++ b/src/exomem/get_page.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import find as find_module
+from .kbdir import kb_prefix
 from .vault import content_hash
 
 
@@ -90,8 +91,8 @@ def get_page(vault_root: Path, *, path: str) -> GetResult:
     # Back-compat shortcut: if the literal path doesn't exist but the same
     # path under Knowledge Base/ does, use that. Lets callers write
     # `Notes/Insights/foo` without the leading prefix.
-    if not candidate.exists() and not rel.startswith("Knowledge Base/"):
-        kb_rel = "Knowledge Base/" + rel
+    if not candidate.exists() and not rel.startswith(kb_prefix()):
+        kb_rel = kb_prefix() + rel
         kb_candidate = vault_root / kb_rel
         if kb_candidate.exists():
             candidate = kb_candidate

--- a/src/exomem/indexes.py
+++ b/src/exomem/indexes.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
+from .kbdir import kb_prefix
 from .vault import PlannedWrite, escape_wikilinks_for_log, kb_root
 
 
@@ -196,7 +198,7 @@ def _replace_by_type_section(
 
     for name in sorted(counts.keys()):
         desc = known_descriptions.get(name, "captured material")
-        rows.append(f"- [[Knowledge Base/Sources/{name}/|{name}]] — {desc} ({counts[name]})")
+        rows.append(f"- [[{kb_prefix()}Sources/{name}/|{name}]] — {desc} ({counts[name]})")
 
     new_block = SOURCES_BY_TYPE_HEADER + "\n\n" + "\n".join(rows) + "\n"
     return _replace_section(text, SOURCES_BY_TYPE_HEADER, new_block, next_h2_or_end=True)
@@ -396,20 +398,26 @@ _NOTES_H3_COUNT = re.compile(
 )
 
 # Subfolder bullet in Notes/index.md:
-# `- [[Knowledge Base/Notes/Research/Project Alpha/|Project Alpha]] (2) — desc`
-_NOTES_SUBFOLDER_BULLET = re.compile(
-    r"^(- \[\[Knowledge Base/Notes/(?P<typef>[A-Za-z]+)/(?P<sub>[^|\]/]+)/?(?:\|[^\]]+)?\]\])"
-    r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
-    re.MULTILINE,
-)
+# `- [[<KB>/Notes/Research/Project Alpha/|Project Alpha]] (2) — desc`
+@cache
+def _notes_subfolder_bullet_re(kb_prefix_str: str) -> re.Pattern[str]:
+    return re.compile(
+        r"^(- \[\[" + re.escape(kb_prefix_str)
+        + r"Notes/(?P<typef>[A-Za-z]+)/(?P<sub>[^|\]/]+)/?(?:\|[^\]]+)?\]\])"
+        r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
+        re.MULTILINE,
+    )
 
 # Entities/index.md top-level bullet:
-# `- [[Knowledge Base/Entities/People/|People]] (12)` (optional description)
-_ENTITIES_BULLET = re.compile(
-    r"^(- \[\[Knowledge Base/Entities/(?P<folder>People|Concepts|Libraries|Decisions)/?(?:\|[^\]]+)?\]\])"
-    r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
-    re.MULTILINE,
-)
+# `- [[<KB>/Entities/People/|People]] (12)` (optional description)
+@cache
+def _entities_bullet_re(kb_prefix_str: str) -> re.Pattern[str]:
+    return re.compile(
+        r"^(- \[\[" + re.escape(kb_prefix_str)
+        + r"Entities/(?P<folder>People|Concepts|Libraries|Decisions)/?(?:\|[^\]]+)?\]\])"
+        r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
+        re.MULTILINE,
+    )
 
 
 def _count_notes_by_subfolder(notes_dir: Path) -> dict[str, dict[str, int]]:
@@ -498,7 +506,7 @@ def _refresh_notes_subindex_text(
         return f"{m.group(1)} ({actual}){rest}"
 
     text = _NOTES_H3_COUNT.sub(_h3, text)
-    text = _NOTES_SUBFOLDER_BULLET.sub(_bullet, text)
+    text = _notes_subfolder_bullet_re(kb_prefix()).sub(_bullet, text)
     return text
 
 
@@ -524,7 +532,7 @@ def _refresh_entities_subindex_text(
         rest = m.group("rest") or ""
         return f"{m.group(1)} ({actual}){rest}"
 
-    return _ENTITIES_BULLET.sub(_bullet, text)
+    return _entities_bullet_re(kb_prefix()).sub(_bullet, text)
 
 
 def compute_subindex_writes(
@@ -563,7 +571,7 @@ def compute_subindex_writes(
     # Virtually count each pending path so the index shows post-write state.
     for raw_path in pending_paths or []:
         rel = raw_path.removesuffix(".md").replace("\\", "/")
-        rel = rel.removeprefix("Knowledge Base/").lstrip("/")
+        rel = rel.removeprefix(kb_prefix()).lstrip("/")
         parts = rel.split("/")
         if len(parts) < 2:
             continue
@@ -644,7 +652,7 @@ def _update_log(
     log_entry_body: str,
 ) -> str:
     """Prepend `## [<date>] add | <path>` entry right after the `---` separator."""
-    title = rel_source_path.replace("Knowledge Base/", "", 1)
+    title = rel_source_path.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] add | {title}\n\n{escape_wikilinks_for_log(log_entry_body)}\n"
 
     sep_idx = text.find(LOG_SEPARATOR)

--- a/src/exomem/init.py
+++ b/src/exomem/init.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from .kbdir import kb_dirname
+
 _SCAFFOLD = Path(__file__).parent / "_scaffold"
 
 # Typed folder tree laid down up-front. Deeper folders (Sources/Articles,
@@ -41,7 +43,7 @@ def init_vault(vault_root: Path, *, force: bool = False) -> dict:
     any existing files).
     """
     vault_root = Path(vault_root)
-    kb = vault_root / "Knowledge Base"
+    kb = vault_root / kb_dirname()
     if kb.exists() and not force:
         raise FileExistsError(
             f"{kb} already exists. Pass force=True to overlay the scaffold "

--- a/src/exomem/kbdir.py
+++ b/src/exomem/kbdir.py
@@ -1,0 +1,25 @@
+"""The governed-folder name inside a vault — configurable via ``EXOMEM_KB_DIRNAME``.
+
+Defaults to ``"Knowledge Base"``. This is the single source of truth for the KB
+subtree name so it isn't hardcoded across the codebase. Read from the environment on
+each call (the same way ``vault.resolve_vault`` reads ``EXOMEM_VAULT_PATH``), so it is
+per-process and test-overridable — set ``EXOMEM_KB_DIRNAME`` and the whole engine
+resolves, indexes, and wikilinks against that folder name instead.
+"""
+
+from __future__ import annotations
+
+import os
+
+_DEFAULT = "Knowledge Base"
+
+
+def kb_dirname() -> str:
+    """The KB folder name, no slashes (``EXOMEM_KB_DIRNAME`` override, else default)."""
+    name = os.environ.get("EXOMEM_KB_DIRNAME", "").strip().strip("/")
+    return name or _DEFAULT
+
+
+def kb_prefix() -> str:
+    """The KB folder name with a trailing slash, for prefix ops (e.g. ``"Knowledge Base/"``)."""
+    return kb_dirname() + "/"

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -60,6 +60,8 @@ import sqlite3
 import threading
 from pathlib import Path
 
+from .kbdir import kb_dirname
+
 log = logging.getLogger(__name__)
 
 _NAV_BASENAMES = frozenset({"index.md", "log.md"})
@@ -122,7 +124,7 @@ def reset_memo() -> None:
 
 
 def lexical_path(vault_root: Path) -> Path:
-    return vault_root / "Knowledge Base" / ".lexical.sqlite"
+    return vault_root / kb_dirname() / ".lexical.sqlite"
 
 
 def get_store(vault_root: Path) -> LexicalStore:
@@ -389,7 +391,7 @@ class LexicalStore:
         from . import find as find_module
         from .vault import walk_vault_md
 
-        kb = self.vault_root / "Knowledge Base"
+        kb = self.vault_root / kb_dirname()
         members: dict[Path, list[bool]] = {}  # abs path -> [in_kb, in_vault]
         if kb.is_dir():
             for p in find_module._walk_md(kb):
@@ -516,7 +518,7 @@ class LexicalStore:
         in_vault = not any(d in VAULT_SCAN_SKIP_DIRS for d in dirs)
         in_kb = (
             len(rel_parts) > 1
-            and rel_parts[0] == "Knowledge Base"
+            and rel_parts[0] == kb_dirname()
             and not any(d in find_module.EXCLUDED_DIR_NAMES for d in dirs[1:])
         )
         return in_kb, in_vault

--- a/src/exomem/link.py
+++ b/src/exomem/link.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import indexes
+from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
     WikilinkResolver,
@@ -229,7 +230,7 @@ def link(
         writes.append(PlannedWrite(path=top_index, content=new_top))
         writes.extend(sub_writes)
     else:
-        warnings.append("Knowledge Base/index.md missing; skipped Recent activity bump")
+        warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
 
     log_file = kb / "log.md"
     if log_file.exists():
@@ -241,7 +242,7 @@ def link(
         )
         writes.append(PlannedWrite(path=log_file, content=new_log))
     else:
-        warnings.append("Knowledge Base/log.md missing; skipped log entry")
+        warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
     try:
         batch_atomic_write(writes, vault_root=vault_root)
@@ -452,7 +453,7 @@ def _activity_summary(
     domain: str | None,
     project: str | None,
 ) -> str:
-    path_part = rel_entity_no_ext.replace("Knowledge Base/", "")
+    path_part = rel_entity_no_ext.replace(kb_prefix(), "")
     modifier_parts: list[str] = [entity_type]
     if entity_type == "concept" and domain:
         modifier_parts.append(domain)
@@ -493,7 +494,7 @@ def _prepend_log_entry(
     text: str, *, date_iso: str, rel_path: str, body: str
 ) -> str:
     """Insert `## [<date>] link | <kb-relative-path>` after the `---` separator."""
-    title = rel_path.replace("Knowledge Base/", "", 1)
+    title = rel_path.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] link | {title}\n\n{escape_wikilinks_for_log(body)}\n"
     sep_idx = text.find(indexes.LOG_SEPARATOR)
     if sep_idx == -1:

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from . import embeddings, extract, index_sync, preserve, scene_frames, semantic_segments
 from .backfill import iter_kb_files
+from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
 
@@ -235,7 +236,7 @@ class MediaWorker:
 
     def _scan_pending_ocr(self) -> int:
         """Re-enqueue every `extracted_by: pending` sidecar under the KB. Returns count."""
-        kb = self._vault_root / "Knowledge Base"
+        kb = self._vault_root / kb_dirname()
         if not kb.is_dir():
             return 0
         n = 0
@@ -292,7 +293,7 @@ class MediaWorker:
         """
         if not embeddings.clip_enabled():
             return 0
-        kb = self._vault_root / "Knowledge Base"
+        kb = self._vault_root / kb_dirname()
         if not kb.is_dir():
             return 0
         n = 0

--- a/src/exomem/move_file.py
+++ b/src/exomem/move_file.py
@@ -20,6 +20,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     PlannedWrite,
     VaultPathError,
@@ -216,11 +217,11 @@ def move_file(
     # moves we leave it alone (the sidecar is still valid).
     parts = old_rel.split("/")
     moved_out_of_trash = (
-        len(parts) >= 2 and parts[0] == "Knowledge Base" and parts[1] == "_trash"
+        len(parts) >= 2 and parts[0] == kb_dirname() and parts[1] == "_trash"
     )
     new_parts = new_rel.split("/")
     moved_into_trash = (
-        len(new_parts) >= 2 and new_parts[0] == "Knowledge Base"
+        len(new_parts) >= 2 and new_parts[0] == kb_dirname()
         and new_parts[1] == "_trash"
     )
     if moved_out_of_trash and not moved_into_trash:
@@ -274,10 +275,10 @@ def _rewrite_wikilinks(text: str, old_rel: str, new_rel: str) -> tuple[str, int]
     """
     old_no_ext = old_rel.removesuffix(".md")
     new_no_ext = new_rel.removesuffix(".md")
-    old_full = old_no_ext if old_no_ext.startswith("Knowledge Base/") else "Knowledge Base/" + old_no_ext
-    new_full = new_no_ext if new_no_ext.startswith("Knowledge Base/") else "Knowledge Base/" + new_no_ext
-    old_stripped = old_full.removeprefix("Knowledge Base/")
-    new_stripped = new_full.removeprefix("Knowledge Base/")
+    old_full = old_no_ext if old_no_ext.startswith(kb_prefix()) else kb_prefix() + old_no_ext
+    new_full = new_no_ext if new_no_ext.startswith(kb_prefix()) else kb_prefix() + new_no_ext
+    old_stripped = old_full.removeprefix(kb_prefix())
+    new_stripped = new_full.removeprefix(kb_prefix())
     old_basename = old_no_ext.rsplit("/", 1)[-1]
     new_basename = new_no_ext.rsplit("/", 1)[-1]
 
@@ -302,7 +303,7 @@ def _rewrite_wikilinks(text: str, old_rel: str, new_rel: str) -> tuple[str, int]
             n += 1
             # Preserve whether the link was full-form or stripped-form, and
             # carry the anchor through unchanged.
-            if target_path.startswith("Knowledge Base/"):
+            if target_path.startswith(kb_prefix()):
                 return f"[[{new_full}{anchor_suffix}{alias}]]"
             return f"[[{new_stripped}{anchor_suffix}{alias}]]"
         if "/" not in target_no_ext and target_no_ext == old_basename:

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 from . import corpus_aware, indexes
 from . import project_keys as project_keys_module
+from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
     WikilinkResolver,
@@ -394,7 +395,7 @@ def note(
         writes.append(PlannedWrite(path=top_index, content=new_top))
         writes.extend(sub_writes)
     else:
-        warnings.append("Knowledge Base/index.md missing; skipped Recent activity bump")
+        warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
 
     if log_file.exists():
         full_body = log_body + (
@@ -409,7 +410,7 @@ def note(
         )
         writes.append(PlannedWrite(path=log_file, content=new_log))
     else:
-        warnings.append("Knowledge Base/log.md missing; skipped log entry")
+        warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
     try:
         batch_atomic_write(writes, vault_root=vault_root)
@@ -841,7 +842,7 @@ def _normalize_sources(
 def _resolve_source_path(vault_root: Path, kb_relative: str) -> Path | None:
     """Resolve a 'Knowledge Base/Sources/Articles/<slug>' wikilink to an on-disk
     .md path, or None if the path escapes the vault."""
-    rel = kb_relative.removeprefix("Knowledge Base/")
+    rel = kb_relative.removeprefix(kb_prefix())
     candidate = (kb_root(vault_root) / rel).with_suffix(".md")
     try:
         candidate.resolve().relative_to(vault_root.resolve())
@@ -858,7 +859,7 @@ def _prepend_log_entry(
 ) -> str:
     """Insert `## [<date>] <verb> | <kb-relative-path>` entry just after the
     log's `---` separator (newest entries at top)."""
-    title = rel_path.replace("Knowledge Base/", "", 1)
+    title = rel_path.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] {verb} | {title}\n\n{escape_wikilinks_for_log(body)}\n"
     sep_idx = text.find(indexes.LOG_SEPARATOR)
     if sep_idx == -1:
@@ -880,7 +881,7 @@ def _activity_summary(
     medium: str | None = None,
     status: str | None = None,
 ) -> str:
-    path_part = rel_note_no_ext.replace("Knowledge Base/", "")
+    path_part = rel_note_no_ext.replace(kb_prefix(), "")
     modifier_parts: list[str] = []
     if note_type == "research-note" and project:
         modifier_parts.append(project)

--- a/src/exomem/overview.py
+++ b/src/exomem/overview.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .kbdir import kb_dirname
+
 DEFAULT_MAX_DEPTH = 3
 BREADTH_CAP = 12           # tree entries per parent folder
 JUNK_LIST_CAP = 20         # listed junk paths per category (counts stay exact)
@@ -256,10 +258,10 @@ def overview(
         )
 
     kb: dict = {"present": False}
-    if (root / "Knowledge Base").is_dir():
-        kb = {"present": True, "path": "Knowledge Base"}
+    if (root / kb_dirname()).is_dir():
+        kb = {"present": True, "path": kb_dirname()}
         if not rel:
-            kb_stat = dirstats.get("Knowledge Base")
+            kb_stat = dirstats.get(kb_dirname())
             kb["files"] = kb_stat.files_rec if kb_stat else 0
 
     root_stat = dirstats[""]

--- a/src/exomem/personalize.py
+++ b/src/exomem/personalize.py
@@ -25,6 +25,7 @@ import yaml
 
 from . import access as access_module
 from . import overview as overview_module
+from .kbdir import kb_dirname, kb_prefix
 
 # Classification of a top-level sibling folder.
 CLASS_READONLY = "readonly"
@@ -114,7 +115,7 @@ def _sibling_signals(scan: dict) -> dict[str, dict]:
         if entry.get("depth") != 1:
             continue
         name = entry.get("path", "")
-        if not name or name == "Knowledge Base":
+        if not name or name == kb_dirname():
             continue
         junk_count = sum(1 for jp in junk_paths if jp == name or jp.startswith(name + "/"))
         signals[name] = {
@@ -197,8 +198,8 @@ def scan_and_classify(vault: str | Path, *, overview_fn=overview_module.overview
     """Scan and classify — never writes. Requires an initialized ``Knowledge Base/``
     (that's where ``_access.yaml`` lives), else raises ``PersonalizeError('NO_KB')``."""
     vault_path = Path(vault).expanduser()
-    if not (vault_path / "Knowledge Base").is_dir():
-        raise PersonalizeError("NO_KB", f"no Knowledge Base/ under {vault_path} - run `exomem init` first")
+    if not (vault_path / kb_dirname()).is_dir():
+        raise PersonalizeError("NO_KB", f"no {kb_prefix()} under {vault_path} - run `exomem init` first")
     scan = overview_fn(vault_path)
     existing = access_module._load_config(vault_path)
     proposals = classify_siblings(scan, existing)
@@ -300,7 +301,7 @@ def personalize_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem personalize",
         description=(
-            "Scan a vault and generate a starter Knowledge Base/_access.yaml - classify "
+            f"Scan a vault and generate a starter {kb_prefix()}_access.yaml - classify "
             "top-level sibling folders as readonly/excluded so exomem knows what is "
             "read-only input. Non-destructive; only adds entries it proposes."
         ),

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 from . import extract, indexes
+from .kbdir import kb_prefix
 from .vault import PlannedWrite, batch_atomic_write, escape_wikilinks_for_log, kb_root
 
 
@@ -258,7 +259,7 @@ def preserve(
                 sidecar_rel = sidecar_path.relative_to(vault_root).as_posix()
 
         # Index + log updates.
-        rel_artifact_for_summary = rel_artifact.replace("Knowledge Base/", "")
+        rel_artifact_for_summary = rel_artifact.replace(kb_prefix(), "")
         activity_summary = (
             f"`{rel_artifact_for_summary}` (evidence, {scope_safe}/{category_safe}, "
             f"mobile via exomem)"
@@ -292,7 +293,7 @@ def preserve(
             writes.append(PlannedWrite(path=top_index, content=new_top))
             writes.extend(sub_writes)
         else:
-            warnings.append("Knowledge Base/index.md missing; skipped Recent activity bump")
+            warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
 
         log_file = kb / "log.md"
         if log_file.exists():
@@ -304,7 +305,7 @@ def preserve(
             )
             writes.append(PlannedWrite(path=log_file, content=new_log))
         else:
-            warnings.append("Knowledge Base/log.md missing; skipped log entry")
+            warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
         if writes:
             # Pass vault_root so the sidecar (a real `.md`) is embedded on write
@@ -636,7 +637,7 @@ def _prepend_log_entry(
     text: str, *, date_iso: str, rel_path: str, body: str
 ) -> str:
     """Insert `## [<date>] preserve | <kb-relative-path>` after the `---` separator."""
-    title = rel_path.replace("Knowledge Base/", "", 1)
+    title = rel_path.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] preserve | {title}\n\n{escape_wikilinks_for_log(body)}\n"
     sep_idx = text.find(indexes.LOG_SEPARATOR)
     if sep_idx == -1:

--- a/src/exomem/recover_from_trash.py
+++ b/src/exomem/recover_from_trash.py
@@ -18,6 +18,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     VaultPathError,
     in_append_only_tree,
@@ -76,13 +77,13 @@ def recover_from_trash(
     # Must actually be a trash entry.
     parts = trash_rel.split("/")
     in_trash = (
-        len(parts) >= 2 and parts[0] == "Knowledge Base" and parts[1] == TRASH_SUBPATH
+        len(parts) >= 2 and parts[0] == kb_dirname() and parts[1] == TRASH_SUBPATH
     )
     if not in_trash:
         raise RecoverError(
             code="NOT_IN_TRASH",
             reason=(
-                f"{trash_rel} is not under Knowledge Base/{TRASH_SUBPATH}/. "
+                f"{trash_rel} is not under {kb_prefix()}{TRASH_SUBPATH}/. "
                 f"Use `move_file` for general relocations."
             ),
         )
@@ -116,7 +117,7 @@ def recover_from_trash(
 
     # The destination must not be inside the trash (recovery, not re-trashing).
     rparts = restore_rel.split("/")
-    if len(rparts) >= 2 and rparts[0] == "Knowledge Base" and rparts[1] == TRASH_SUBPATH:
+    if len(rparts) >= 2 and rparts[0] == kb_dirname() and rparts[1] == TRASH_SUBPATH:
         raise RecoverError(
             code="RESTORE_INTO_TRASH",
             reason=(

--- a/src/exomem/replace.py
+++ b/src/exomem/replace.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from . import find as find_module
 from . import indexes
 from . import note as note_module
+from .kbdir import kb_prefix
 from .vault import PlannedWrite, batch_atomic_write, kb_root
 
 
@@ -125,8 +126,8 @@ def replace(
     new_result = note_module.note(vault_root, today=today, **note_kwargs)
     new_path_str = new_result.path  # vault-relative, with .md
     rel_new_no_ext = new_path_str.removesuffix(".md")
-    if not rel_new_no_ext.startswith("Knowledge Base/"):
-        rel_new_no_ext = "Knowledge Base/" + rel_new_no_ext
+    if not rel_new_no_ext.startswith(kb_prefix()):
+        rel_new_no_ext = kb_prefix() + rel_new_no_ext
     new_resolved = vault_root / new_path_str
 
     warnings: list[str] = list(new_result.warnings)
@@ -168,7 +169,7 @@ def replace(
         )
         log_writes.append(PlannedWrite(path=log_file, content=new_log))
     else:
-        warnings.append("Knowledge Base/log.md missing; skipped replace log entry")
+        warnings.append(f"{kb_prefix()}log.md missing; skipped replace log entry")
 
     writes = [
         PlannedWrite(path=new_resolved, content=new_text_updated),
@@ -201,8 +202,8 @@ def _resolve_kb_path(vault_root: Path, path: str) -> tuple[Path, str]:
             reason="old_path is empty",
         )
     rel = path.strip().replace("\\", "/").lstrip("/")
-    if not rel.startswith("Knowledge Base/"):
-        rel = "Knowledge Base/" + rel
+    if not rel.startswith(kb_prefix()):
+        rel = kb_prefix() + rel
     if not rel.endswith(".md"):
         rel = rel + ".md"
     candidate = vault_root / rel
@@ -213,7 +214,7 @@ def _resolve_kb_path(vault_root: Path, path: str) -> tuple[Path, str]:
         raise ReplaceError(
             code="INVALID_PATH",
             missing=["old_path"],
-            reason=f"path escapes Knowledge Base/: {e}",
+            reason=f"path escapes {kb_prefix()}: {e}",
         ) from None
     if not candidate.exists():
         raise ReplaceError(
@@ -345,7 +346,7 @@ def _append_to_yaml_list(fm_text: str, key: str, new_quoted_value: str) -> str:
 def _prepend_replace_log_entry(
     text: str, *, date_iso: str, rel_new_no_ext: str, body: str
 ) -> str:
-    title = rel_new_no_ext.replace("Knowledge Base/", "", 1)
+    title = rel_new_no_ext.replace(kb_prefix(), "", 1)
     new_entry = f"## [{date_iso}] replace | {title}\n\n{body}\n"
     sep_idx = text.find(indexes.LOG_SEPARATOR)
     if sep_idx == -1:

--- a/src/exomem/schema.py
+++ b/src/exomem/schema.py
@@ -16,6 +16,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from .kbdir import kb_dirname
 
 SOURCE_TYPE_FIELD_PATTERN = re.compile(
     r"\|\s*`source_type`\s*\|\s*yes\s*\|\s*(.+?)\s*\|", re.IGNORECASE
@@ -53,7 +54,7 @@ def load_source_schema(vault_path: Path) -> SourceSchema:
 
     Raises SchemaParseError if anything looks wrong.
     """
-    schema_dir = vault_path / "Knowledge Base" / "_Schema" / "references"
+    schema_dir = vault_path / kb_dirname() / "_Schema" / "references"
     frontmatter_doc = schema_dir / "frontmatter.md"
     page_types_doc = schema_dir / "page-types.md"
 

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -31,6 +31,7 @@ from . import install_hook as hook_module
 from . import install_skill as install_module
 from . import overview as overview_module
 from . import personalize as personalize_module
+from .kbdir import kb_dirname, kb_prefix
 
 _SKILL_NAME_MARKER = "name: exomem"
 
@@ -138,7 +139,7 @@ def run_setup(
     if junk_total:
         print_fn(f"    {junk_total} junk candidate(s) — zero-byte or sync-conflict copies.")
     kb_state = "already present" if scan["kb"]["present"] else "not present yet"
-    print_fn(f"    Knowledge Base/: {kb_state}")
+    print_fn(f"    {kb_prefix()}: {kb_state}")
     print_fn("")
     print_fn(f"  Contract: {overview_module.SCOPE_NOTE}")
     print_fn("")
@@ -147,9 +148,9 @@ def run_setup(
     # 3. init — never forced from the wizard
     try:
         init_module.init_vault(vault_path)
-        report("init", "[done] Knowledge Base/ scaffold created")
+        report("init", f"[done] {kb_prefix()} scaffold created")
     except FileExistsError:
-        report("init", "[skipped: Knowledge Base/ already exists]")
+        report("init", f"[skipped: {kb_prefix()} already exists]")
 
     # 3b. personalize — propose per-subtree access governance for sibling folders
     try:
@@ -323,10 +324,11 @@ def setup_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem setup",
         description=(
-            "Guided local setup: scan the vault, init the Knowledge Base, pick a "
+            "Guided local setup: scan the vault, init the "
+            f"{kb_dirname()}, pick a "
             "search profile, run doctor, register with Claude Code, and install "
             "the skill — one idempotent command. Existing vault content is never "
-            "touched; exomem writes only under Knowledge Base/. For remote "
+            f"touched; exomem writes only under {kb_prefix()}. For remote "
             "connector setup (claude.ai / iOS), use `exomem setup --remote`."
         ),
     )

--- a/src/exomem/usage.py
+++ b/src/exomem/usage.py
@@ -34,6 +34,7 @@ import time
 from pathlib import Path
 
 from . import query_log
+from .kbdir import kb_prefix
 
 log = logging.getLogger(__name__)
 
@@ -44,8 +45,8 @@ def canon(path: str) -> str:
     p = (path or "").strip().replace("\\", "/")
     if p.lower().endswith(".md"):
         p = p[:-3]
-    if p.startswith("Knowledge Base/"):
-        p = p[len("Knowledge Base/"):]
+    if p.startswith(kb_prefix()):
+        p = p[len(kb_prefix()):]
     return p.lower()
 
 

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -22,6 +22,7 @@ import yaml
 from slugify import slugify as _slugify
 
 from . import freshness
+from .kbdir import kb_dirname, kb_prefix
 
 
 SLUG_MAX_LENGTH = 100
@@ -64,7 +65,7 @@ def resolve_vault(env_var: str = "EXOMEM_VAULT_PATH") -> Path:
     if not override:
         raise RuntimeError(
             f"{env_var} is not set. Point it at your vault root — the folder "
-            f"that contains 'Knowledge Base/'. For example:\n"
+            f"that contains '{kb_prefix()}'. For example:\n"
             f'  macOS/Linux:  export {env_var}="/path/to/your/Obsidian"\n'
             f'  Windows:      setx {env_var} "C:\\path\\to\\your\\Obsidian"'
         )
@@ -72,17 +73,17 @@ def resolve_vault(env_var: str = "EXOMEM_VAULT_PATH") -> Path:
     if not _is_vault(path):
         raise RuntimeError(
             f"{env_var}={override!r} does not look like a vault "
-            f"(no Knowledge Base/_Schema/SKILL.md found)"
+            f"(no {kb_prefix()}_Schema/SKILL.md found)"
         )
     return path
 
 
 def _is_vault(path: Path) -> bool:
-    return (path / "Knowledge Base" / "_Schema" / "SKILL.md").exists()
+    return (path / kb_dirname() / "_Schema" / "SKILL.md").exists()
 
 
 def kb_root(vault: Path) -> Path:
-    return vault / "Knowledge Base"
+    return vault / kb_dirname()
 
 
 def content_hash(content: str) -> str:
@@ -361,7 +362,7 @@ def in_append_only_tree(rel_path: str) -> str | None:
     parts = rel_path.split("/")
     if not parts:
         return None
-    if parts[0] == "Knowledge Base" and len(parts) > 1:
+    if parts[0] == kb_dirname() and len(parts) > 1:
         head = parts[1]
     else:
         head = parts[0]
@@ -728,8 +729,8 @@ def find_inbound_wikilinks(
     vault revision) — results identical to scanning every file per call.
     """
     target = target_rel_path.replace("\\", "/").removesuffix(".md")
-    target_full = target if target.startswith("Knowledge Base/") else "Knowledge Base/" + target
-    target_stripped = target_full.removeprefix("Knowledge Base/")
+    target_full = target if target.startswith(kb_prefix()) else kb_prefix() + target
+    target_stripped = target_full.removeprefix(kb_prefix())
     target_basename = target.rsplit("/", 1)[-1]
 
     data = _inbound_index(vault_root)
@@ -848,7 +849,7 @@ class WikilinkResolver:
         title edge only when a non-empty frontmatter `title:` was read.
         """
         self.full_paths.add(no_ext)
-        self.kb_stripped.add(no_ext.removeprefix("Knowledge Base/"))
+        self.kb_stripped.add(no_ext.removeprefix(kb_prefix()))
         stem = no_ext.rsplit("/", 1)[-1]
         self.stems.setdefault(stem, []).append(no_ext)
         if title_lower:
@@ -858,7 +859,7 @@ class WikilinkResolver:
     def _remove_entry(self, no_ext: str) -> None:
         """Drop every edge a file contributed (path, stem, title)."""
         self.full_paths.discard(no_ext)
-        self.kb_stripped.discard(no_ext.removeprefix("Knowledge Base/"))
+        self.kb_stripped.discard(no_ext.removeprefix(kb_prefix()))
         _discard_from_list(self.stems, no_ext.rsplit("/", 1)[-1], no_ext)
         old_title = self._title_by_rel.pop(no_ext, None)
         if old_title is not None:
@@ -975,22 +976,22 @@ def normalize_wikilink(
     # canonicalize beyond ensuring the Knowledge Base/ prefix.
     if cleaned.endswith("/"):
         canonical = (
-            cleaned if cleaned.startswith("Knowledge Base/")
-            else "Knowledge Base/" + cleaned
+            cleaned if cleaned.startswith(kb_prefix())
+            else kb_prefix() + cleaned
         )
         return canonical + anchor, None
 
     # 1. Full vault-rooted (with or without explicit Knowledge Base/ prefix).
     if cleaned in resolver.full_paths:
         return cleaned + anchor, None
-    if not cleaned.startswith("Knowledge Base/"):
-        candidate = "Knowledge Base/" + cleaned
+    if not cleaned.startswith(kb_prefix()):
+        candidate = kb_prefix() + cleaned
         if candidate in resolver.full_paths:
             return candidate + anchor, None
 
     # 2. KB-stripped match (target looks like KB-relative).
     if cleaned in resolver.kb_stripped:
-        return "Knowledge Base/" + cleaned + anchor, None
+        return kb_prefix() + cleaned + anchor, None
 
     # 3. Bare name (no `/`): stem match first, then frontmatter title.
     if "/" not in cleaned:
@@ -1032,12 +1033,12 @@ def normalize_wikilink(
         raise UnresolvedWikilinkError(
             f"wikilink {target!r} does not resolve to any file in the vault"
         )
-    if cleaned.startswith("Knowledge Base/"):
+    if cleaned.startswith(kb_prefix()):
         fallback = cleaned
     elif "/" in cleaned and _is_curated_top_level(vault_root, cleaned.split("/", 1)[0]):
         fallback = cleaned
     elif "/" in cleaned:
-        fallback = "Knowledge Base/" + cleaned
+        fallback = kb_prefix() + cleaned
     else:
         fallback = cleaned
     return fallback + anchor, (
@@ -1169,8 +1170,8 @@ def prepend_log_entry(
     full vault-relative form so curated-tree writes stay traceable.
     """
     title = rel_path_no_ext
-    if title.startswith("Knowledge Base/"):
-        title = title[len("Knowledge Base/"):]
+    if title.startswith(kb_prefix()):
+        title = title[len(kb_prefix()):]
     new_entry = f"## [{date_iso}] {op} | {title}\n\n{escape_wikilinks_for_log(body)}\n"
     # Reuse the same separator the indexes module emits.
     separator = "\n---\n"
@@ -1196,7 +1197,7 @@ def write_log_entry(
     """
     log_file = kb_root(vault_root) / "log.md"
     if not log_file.exists():
-        return "Knowledge Base/log.md missing; skipped log entry"
+        return f"{kb_prefix()}log.md missing; skipped log entry"
     text = log_file.read_text(encoding="utf-8")
     new_text = prepend_log_entry(
         text,
@@ -1234,8 +1235,8 @@ def read_log_entries(vault_root: Path, rel_path_no_ext: str) -> list[dict[str, s
     title = rel_path_no_ext
     if title.endswith(".md"):
         title = title[: -len(".md")]
-    if title.startswith("Knowledge Base/"):
-        title = title[len("Knowledge Base/"):]
+    if title.startswith(kb_prefix()):
+        title = title[len(kb_prefix()):]
 
     log_file = kb_root(vault_root) / "log.md"
     if not log_file.exists():

--- a/src/exomem/voice_profiles.py
+++ b/src/exomem/voice_profiles.py
@@ -22,12 +22,14 @@ import numpy as np
 
 from exomem.speaker_attribution import Profile
 
+from .kbdir import kb_dirname
+
 DEFAULT_THRESHOLD = 0.40
 
 
 def voice_profiles_path(vault_root: Path) -> Path:
     """Per-machine voice-profile store, beside the embedding sidecars (operational infra)."""
-    return vault_root / "Knowledge Base" / ".voice_profiles.json"
+    return vault_root / kb_dirname() / ".voice_profiles.json"
 
 
 def load_store(path: Path) -> dict[str, dict[str, Any]]:

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -32,6 +32,8 @@ import threading
 import time
 from pathlib import Path
 
+from .kbdir import kb_dirname
+
 log = logging.getLogger(__name__)
 
 _WARM_THREAD: threading.Thread | None = None
@@ -61,7 +63,7 @@ def warm_caches(vault_root: Path) -> dict[str, float]:
             durations[name] = round((time.perf_counter() - t0) * 1000.0, 1)
 
     def _warm_pages() -> None:
-        kb = vault_root / "Knowledge Base"
+        kb = vault_root / kb_dirname()
         if not kb.is_dir():
             return
         for p in find._walk_md(kb):

--- a/tests/test_kb_dirname.py
+++ b/tests/test_kb_dirname.py
@@ -1,0 +1,85 @@
+"""EXOMEM_KB_DIRNAME — the governed-folder name is configurable (default "Knowledge Base").
+
+Safety net for the "un-hardcode the KB folder name" refactor: with EXOMEM_KB_DIRNAME
+set, the engine must init, resolve, govern, and *wikilink* against that folder name
+instead of the literal "Knowledge Base". These assertions define "done"; the rest of the
+suite (which runs with no override) guards the default path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _min_vault(root: Path, kb: str) -> Path:
+    (root / kb / "_Schema").mkdir(parents=True)
+    (root / kb / "_Schema" / "SKILL.md").write_text("---\nname: exomem\n---\n", encoding="utf-8")
+    return root
+
+
+def test_kb_dirname_default(monkeypatch) -> None:
+    monkeypatch.delenv("EXOMEM_KB_DIRNAME", raising=False)
+    from exomem import kbdir
+
+    assert kbdir.kb_dirname() == "Knowledge Base"
+    assert kbdir.kb_prefix() == "Knowledge Base/"
+
+
+def test_kb_dirname_override(monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    from exomem import kbdir
+
+    assert kbdir.kb_dirname() == "Brain"
+    assert kbdir.kb_prefix() == "Brain/"
+
+
+def test_init_creates_custom_dir(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    from exomem import init as init_module
+
+    init_module.init_vault(tmp_path)
+    assert (tmp_path / "Brain" / "_Schema" / "SKILL.md").exists()
+    assert not (tmp_path / "Knowledge Base").exists()
+
+
+def test_resolve_and_kb_root_custom(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    _min_vault(tmp_path, "Brain")
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(tmp_path))
+    from exomem import vault as vault_module
+
+    assert vault_module.resolve_vault() == tmp_path
+    assert vault_module.kb_root(tmp_path) == tmp_path / "Brain"
+
+
+def test_access_config_path_custom(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    from exomem import access as access_module
+
+    assert access_module.access_config_path(tmp_path) == tmp_path / "Brain" / "_access.yaml"
+
+
+def test_access_tier_strips_custom_prefix(monkeypatch, tmp_path: Path) -> None:
+    """A path written with the custom KB prefix must resolve tiers the same as a
+    KB-relative one (the `_kb_relative` strip must use the configured name)."""
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    _min_vault(tmp_path, "Brain")
+    (tmp_path / "Brain" / "_access.yaml").write_text("readonly:\n- Reference\n", encoding="utf-8")
+    from exomem import access as access_module
+
+    assert access_module.access_tier(tmp_path, "Brain/Reference/x.md") == access_module.TIER_READONLY
+    assert access_module.access_tier(tmp_path, "Reference/x.md") == access_module.TIER_READONLY
+
+
+def test_normalize_wikilink_custom_prefix(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+    _min_vault(tmp_path, "Brain")
+    from exomem import vault as vault_module
+
+    # An unresolvable KB-relative target canonicalizes under the CUSTOM prefix.
+    canonical, _warn = vault_module.normalize_wikilink("Notes/Insights/foo", tmp_path, strict=False)
+    assert canonical == "Brain/Notes/Insights/foo"
+
+    # A target already carrying the custom prefix is preserved.
+    canonical2, _warn2 = vault_module.normalize_wikilink("Brain/Notes/Insights/foo", tmp_path, strict=False)
+    assert canonical2 == "Brain/Notes/Insights/foo"


### PR DESCRIPTION
## Why
The governed KB subtree name was hardcoded as the literal `Knowledge Base` in ~300 places. This un-hardcodes it so exomem can point at a governed folder of any name — e.g. onboarding a user whose existing markdown vault already uses a different folder. **Default is unchanged** (`Knowledge Base`), so this is fully backward-compatible.

## What
- **`src/exomem/kbdir.py`** — single source of truth: `kb_dirname()` / `kb_prefix()`, read from `EXOMEM_KB_DIRNAME` on each call (env-overridable, per-process), default `Knowledge Base`.
- Threaded through **165 call sites across 37 modules** — the correctness-critical ones being `vault.py` (`_is_vault`, `kb_root`, `resolve_vault`, the full **wikilink normalizer** + `WikilinkResolver.kb_stripped`, all `startswith`/prefix branches, log-title stripping), `access.py` (`_kb_relative`, `access_config_path`), `init.py` (creates `<vault>/{kb_dirname()}/`), plus audit/find/indexes and all runtime user-facing messages.
- `indexes.py` index-hub regexes → `@cache`-d builders on `re.escape(kb_prefix())` so index rewriting honors the custom name at call time.
- **README** documents `EXOMEM_KB_DIRNAME`.

## Deliberately left literal (scope boundary)
Docstrings/comments (represent the default), `demo.py` + the packaged `_sample_vault` (fixed sample data; demo pins the name so it runs even with the env set), the capture/retrieve **hooks** (they name the *skill/concept*, not a folder), and the shipped `_scaffold` static docs. **Engine behavior is fully configurable; static docs/tool-descriptions still show the default name** — the self-discovering skill (run `overview` first) handles the runtime layout regardless.

## Verification
- Safety net: `tests/test_kb_dirname.py` sets `EXOMEM_KB_DIRNAME=Brain` and pins that init / resolve / `kb_root` / access-tier prefix-strip / **wikilink normalization** all use the custom name.
- Full suite: **1393 passed, 16 skipped, 0 failed** (baseline 1386 + 7 new). ruff clean. The `vault.py` wikilink diff and `access.py` prefix-strip were reviewed by hand — the one place a bug could corrupt link resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm175jiA7wEGwnhME5TdWm