### PR TITLE
fix: dead PyPI SETUP-LOCAL link + hooks recognise renamed exomem tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Also works on Linux. Safe to run again later — it skips whatever's already
 done. If it can't prompt you interactively (e.g. run from another script), it
 prints the exact command to run next instead of guessing. Prefer to run each
 step yourself? See below or the full manual walkthrough in
-[SETUP-LOCAL.md](SETUP-LOCAL.md).
+[QUICKSTART.md](https://github.com/Artexis10/exomem/blob/main/QUICKSTART.md).
 
 ## Set it up in 5 minutes
 

--- a/src/exomem/_hooks/kb_capture_nudge.py
+++ b/src/exomem/_hooks/kb_capture_nudge.py
@@ -39,11 +39,12 @@ import sys
 import time
 from pathlib import Path
 
-# KB write tools — if one ran this turn, the capture already happened.
-_KB_WRITE = re.compile(r"knowledge_base.*(note|add|edit|append|create_file|replace)", re.I)
+# KB write tools — if an Exomem write tool ran this turn (e.g. mcp__…_Exomem__note/add;
+# legacy `knowledge_base` names still matched for back-compat), the capture already happened.
+_KB_WRITE = re.compile(r"(?:exomem|knowledge[_-]?base).*(note|add|edit|append|create_file|replace)", re.I)
 
 REMINDER = (
-    "[KB capture check] This turn did substantial work. If your Knowledge Base "
+    "[KB capture check] This turn did substantial work. If your Exomem knowledge-base "
     "skill is available and the turn reached a durable conclusion — a decision, a "
     "solved problem, a diagnosed failure, or a recognized pattern, in whatever "
     "language you were working in — capture it now as a *compiled note* (the "

--- a/src/exomem/_hooks/kb_retrieve_nudge.py
+++ b/src/exomem/_hooks/kb_retrieve_nudge.py
@@ -49,8 +49,8 @@ import urllib.request
 from pathlib import Path
 
 REMINDER = (
-    "[KB retrieval check] Before answering: if this prompt touches a topic the "
-    "Knowledge Base might hold — a project, a past decision, a domain you've taken "
+    "[KB retrieval check] Before answering: if this prompt touches a topic your "
+    "Exomem knowledge base might hold — a project, a past decision, a domain you've taken "
     "notes on, or a 'what did I conclude / have I looked at' question — run a quiet "
     "`find` FIRST and fold any hits into the answer (cite them). The KB is the "
     "source of truth for prior conclusions; a miss means 'not found in what I "

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -175,8 +175,10 @@ def test_capture_silent_on_trivial_turn(tmp_path: Path) -> None:
 
 def test_capture_silent_when_already_saved(tmp_path: Path) -> None:
     home = tmp_path / "home"; home.mkdir()
+    # Real post-rename connector tool name is Exomem (not Knowledge_Base) — the guard
+    # regex must recognise it, or the nudge misfires after every real capture.
     t = _transcript(tmp_path, "q?", "Big conclusion. " + "x" * 450,
-                    assistant_tool="mcp__claude_ai_Knowledge_Base__note")
+                    assistant_tool="mcp__claude_ai_Exomem__note")
     r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "s3"}, home)
     assert r.stdout.strip() == ""
 


### PR DESCRIPTION
Two small follow-ups to the `knowledge-base` → `exomem` rename.

## 1. Dead PyPI link (user-reported)
`README.md` pointed the "full manual walkthrough" at `[SETUP-LOCAL.md](SETUP-LOCAL.md)` — a file **removed** in the onboarding rework (its content is now `QUICKSTART.md`). Relative → dead on PyPI. Repointed to `QUICKSTART.md` via an **absolute GitHub URL** so it resolves on PyPI, not just GitHub.

## 2. Capture hook misfired after the rename (a real bug)
`kb_capture_nudge.py`'s "already captured this turn?" guard was `knowledge_base.*(note|add|…)` — which **no longer matches the renamed `exomem` tools** (`mcp__…_Exomem__note`). So the Stop-hook nudge fired **after every real capture**, thinking none had happened. Widened to `(?:exomem|knowledge[_-]?base).*…` (legacy names kept for back-compat).

The tell: `test_capture_silent_when_already_saved` asserted silence using the **stale** `mcp__claude_ai_Knowledge_Base__note` tool name, so the fixture passed while production misfired — *the exact "fixtures hid it" failure class*. Updated the test to the real `Exomem` tool name (+ comment) so it can't regress silently.

Both hooks' reminder text now names the **Exomem** skill / knowledge base.

## Scope note (deliberately NOT done)
Renaming the hook *files* (`kb_*_nudge.py`) and `KB_*` env vars to `exomem_*` — invisible internal plumbing, and renaming forces every installed hook to be re-installed (settings.json points at the old paths) for no user-visible gain. Left as an optional follow-up.

## Verification
- Hook tests: **64 passed** (incl. the now-real-tool-name capture test that proves the fix).
- No new lint (only pre-existing `BLE001`/`E702`, identical on `main`; ruff is advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm175jiA7wEGwnhME5TdWm