### PR TITLE
refactor(hooks): rename kb_* nudge hooks to exomem_* (migration + back-compat)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -297,20 +297,21 @@ Both are **language-agnostic** (no keyword matching — they work the same in an
 language you write in) and cheap (gated so they stay quiet on ordinary
 turns/prompts, plus a per-session cooldown). They write scripts to
 `~/.claude/hooks/` and wire the two hooks into your settings.json — restart Claude
-Code to activate. Triggers log to `~/.claude/kb-capture-nudge.log` and
-`~/.claude/kb-retrieve-nudge.log` so you can see the real rate. Prefer to wire it
+Code to activate. Triggers log to `~/.claude/exomem-capture-nudge.log` and
+`~/.claude/exomem-retrieve-nudge.log` so you can see the real rate. Prefer to wire it
 by hand? `uv run python -m exomem install-hook --print-only` writes the scripts and
 prints the snippet to paste.
 
-Tune with `KB_CAPTURE_NUDGE_MIN_CHARS` / `KB_RETRIEVE_NUDGE_MIN_CHARS` (and the
-matching `_COOLDOWN_SEC`), or disable either with `KB_CAPTURE_NUDGE_DISABLE=1` /
-`KB_RETRIEVE_NUDGE_DISABLE=1`. **Writing in a dense script (Japanese, Chinese)?**
+Tune with `EXOMEM_CAPTURE_NUDGE_MIN_CHARS` / `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (and the
+matching `_COOLDOWN_SEC`), or disable either with `EXOMEM_CAPTURE_NUDGE_DISABLE=1` /
+`EXOMEM_RETRIEVE_NUDGE_DISABLE=1`. **Writing in a dense script (Japanese, Chinese)?**
 Lower the `MIN_CHARS` values — those scripts pack more meaning per character, so
-the defaults (tuned for English) can under-fire.
+the defaults (tuned for English) can under-fire. (These tunables were renamed from
+`KB_*` to `EXOMEM_*`; the old `KB_*` names are still accepted for back-compat.)
 
 **Opt-in: upgrade the read-side reminder to real retrieved content.** By default
 the `UserPromptSubmit` hook only reminds Claude to run `find` — set
-`KB_RETRIEVE_INJECT=1` and it instead fetches the top 3 compact routing stubs
+`EXOMEM_RETRIEVE_INJECT=1` and it instead fetches the top 3 compact routing stubs
 (keyword mode, no embeddings) for the same gated prompt and appends them to the
 reminder, so relevant prior KB pages are already in context before Claude
 decides whether to search. It tries a short transport ladder and never blocks
@@ -318,10 +319,11 @@ on a slow path: REST first (one `POST /api/find`, ~2s timeout) — only attempte
 when `EXOMEM_REST_API_KEY` is set **in the shell that launches Claude Code**
 (not just the server's service environment — the hook can't read another
 process's env, so export it in the same profile Claude Code inherits from);
-then, only if you also set `KB_RETRIEVE_INJECT_CLI=1`, an `exomem find --json`
+then, only if you also set `EXOMEM_RETRIEVE_INJECT_CLI=1`, an `exomem find --json`
 subprocess call (~5s timeout, slower — cold Python start). If neither is
 configured or reachable, it falls straight back to the plain reminder — no
-network call is ever attempted unless `KB_RETRIEVE_INJECT` is on.
+network call is ever attempted unless `EXOMEM_RETRIEVE_INJECT` is on. (The legacy
+`KB_RETRIEVE_INJECT` / `KB_RETRIEVE_INJECT_CLI` names still work too.)
 
 (Hooks are Claude Code only — claude.ai web/mobile can't run them, so there the
 skill stays best-effort: nudge it with *"save that to kb"* or *"check the kb."*)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ the server gives Claude the tools, the skill is what makes it use them. Hooks
 are Claude Code-only reliability nudges for long sessions: a read-side reminder
 before answers and a write-side reminder at natural stopping points. The
 read-side hook can optionally upgrade that reminder to real retrieved KB
-content (`KB_RETRIEVE_INJECT=1`, opt-in) — see
+content (`EXOMEM_RETRIEVE_INJECT=1`, opt-in; the legacy `KB_RETRIEVE_INJECT`
+name still works) — see
 [QUICKSTART.md § 7](QUICKSTART.md#7-recommended-make-the-kb-automatic-both-directions).
 Other MCP clients can still use the server; put the same knowledge-discipline
 instructions in their system/project instructions if they do not support

--- a/openspec/specs/retrieve-inject-hook/spec.md
+++ b/openspec/specs/retrieve-inject-hook/spec.md
@@ -5,16 +5,18 @@ TBD - created by archiving change retrieve-inject-hook. Update Purpose after arc
 ## Requirements
 ### Requirement: Recall Injection Defaults Off
 
-The `UserPromptSubmit` retrieve hook (`kb_retrieve_nudge.py`) SHALL keep its
+The `UserPromptSubmit` retrieve hook (`exomem_retrieve_nudge.py`) SHALL keep its
 current reminder-only `additionalContext` behavior unchanged unless
-`KB_RETRIEVE_INJECT` is set truthy (per the repo's `_env_flag` truthy-parse
+`EXOMEM_RETRIEVE_INJECT` is set truthy (per the repo's `_env_flag` truthy-parse
 convention: unset, `""`, `0`, `false`, `no`, `off` — any case — count as unset).
-No inject-mode code path SHALL be reached, and no network or subprocess call
-SHALL be attempted, when `KB_RETRIEVE_INJECT` is unset.
+The legacy `KB_RETRIEVE_INJECT` name is still accepted (aliased onto
+`EXOMEM_RETRIEVE_INJECT` at startup). No inject-mode code path SHALL be reached,
+and no network or subprocess call SHALL be attempted, when `EXOMEM_RETRIEVE_INJECT`
+(nor its legacy alias) is set.
 
 #### Scenario: Default install is untouched
 
-- **WHEN** `KB_RETRIEVE_INJECT` is not set in the hook's environment
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is not set in the hook's environment
 - **THEN** a `UserPromptSubmit` event that passes the existing min-chars and
   cooldown gates produces the exact same `additionalContext` reminder string
   the hook produces today
@@ -25,14 +27,14 @@ SHALL be attempted, when `KB_RETRIEVE_INJECT` is unset.
 The hook SHALL attempt exactly one `POST http://127.0.0.1:8765/api/find` request
 (`detail=compact`, `mode=keyword`, `limit=3`, `Authorization: Bearer
 <EXOMEM_REST_API_KEY>`) with a socket timeout of about 2 seconds, before
-considering any other transport, whenever `KB_RETRIEVE_INJECT` is truthy and
+considering any other transport, whenever `EXOMEM_RETRIEVE_INJECT` is truthy and
 `EXOMEM_REST_API_KEY` is present in the hook's own environment. The hook SHALL
 treat any failure of that request (connection error, timeout, non-200 status,
 malformed JSON, or an envelope with `success: false`) as "REST unreachable."
 
 #### Scenario: REST configured and reachable
 
-- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, and
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, and
   the local REST facade answers with `{"success": true, "data": [...compact
   hits...]}`
 - **THEN** the hook's `additionalContext` includes a routing-stub block built
@@ -41,9 +43,9 @@ malformed JSON, or an envelope with `success: false`) as "REST unreachable."
 
 #### Scenario: REST configured but unreachable, CLI not opted in
 
-- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, the
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is set, the
   REST request fails (any of: connection error, timeout, non-200, malformed
-  JSON, `success: false`), and `KB_RETRIEVE_INJECT_CLI` is not set truthy
+  JSON, `success: false`), and `EXOMEM_RETRIEVE_INJECT_CLI` is not set truthy
 - **THEN** the hook falls back to today's reminder-only `additionalContext`
 - **AND** no CLI subprocess is attempted
 
@@ -52,15 +54,15 @@ malformed JSON, or an envelope with `success: false`) as "REST unreachable."
 The hook SHALL locate an installed `exomem` or `kb` console script via `PATH`
 lookup and invoke it as `find --detail compact --limit 3 --mode keyword --json
 <prompt>` (subprocess timeout of about 5 seconds) whenever REST was not
-attempted (no `EXOMEM_REST_API_KEY`) or failed, and `KB_RETRIEVE_INJECT_CLI` is
+attempted (no `EXOMEM_REST_API_KEY`) or failed, and `EXOMEM_RETRIEVE_INJECT_CLI` is
 set truthy. The hook SHALL treat any failure of that invocation (console
 script not found, non-zero exit, malformed JSON, timeout) the same as "no
 hits."
 
 #### Scenario: REST unconfigured, CLI transport opted in
 
-- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
-  `KB_RETRIEVE_INJECT_CLI` is truthy, and an `exomem` or `kb` console script is
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
+  `EXOMEM_RETRIEVE_INJECT_CLI` is truthy, and an `exomem` or `kb` console script is
   resolvable on `PATH`
 - **THEN** the hook invokes that console script's `find` command and, on
   success, includes a routing-stub block built from its compact hits in
@@ -68,8 +70,8 @@ hits."
 
 #### Scenario: Neither REST nor CLI transport available
 
-- **WHEN** `KB_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
-  `KB_RETRIEVE_INJECT_CLI` is not set truthy (or no `exomem`/`kb` console
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy, `EXOMEM_REST_API_KEY` is unset, and
+  `EXOMEM_RETRIEVE_INJECT_CLI` is not set truthy (or no `exomem`/`kb` console
   script resolves on `PATH`)
 - **THEN** the hook falls back to today's reminder-only `additionalContext`
 - **AND** no REST request or CLI subprocess is attempted
@@ -113,23 +115,23 @@ characters if the formatted block would otherwise exceed that.
 
 ### Requirement: Injection Reuses The Existing Prompt-Length Gate And Cooldown
 
-Inject mode SHALL reuse `KB_RETRIEVE_NUDGE_MIN_CHARS` (checked before any
+Inject mode SHALL reuse `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (checked before any
 transport is attempted) and the existing per-session cooldown
-(`KB_RETRIEVE_NUDGE_COOLDOWN_SEC`) exactly as the reminder-only path does
+(`EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC`) exactly as the reminder-only path does
 today. Inject mode SHALL NOT introduce a second, independent trigger or a
 second cooldown clock.
 
 #### Scenario: A trivial prompt skips inject mode entirely
 
-- **WHEN** `KB_RETRIEVE_INJECT` is truthy and the prompt is shorter than
-  `KB_RETRIEVE_NUDGE_MIN_CHARS`
+- **WHEN** `EXOMEM_RETRIEVE_INJECT` is truthy and the prompt is shorter than
+  `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS`
 - **THEN** the hook produces no `additionalContext` at all
 - **AND** no REST request or CLI subprocess is attempted
 
 #### Scenario: The per-session cooldown suppresses a second fire
 
 - **WHEN** inject mode fired (REST or CLI) once for a session and a second
-  qualifying prompt arrives before `KB_RETRIEVE_NUDGE_COOLDOWN_SEC` has
+  qualifying prompt arrives before `EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC` has
   elapsed
 - **THEN** the second call produces no `additionalContext`
 - **AND** no REST request or CLI subprocess is attempted for that second call

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -589,8 +589,8 @@ def _install_hook_main(argv: list[str]) -> int:
     if report["wired"]:
         print(f"Wired into {report['settings']}.")
         print("Restart Claude Code to activate. Triggers log to:")
-        print("  ~/.claude/kb-capture-nudge.log   (write / capture)")
-        print("  ~/.claude/kb-retrieve-nudge.log  (read / retrieval)")
+        print("  ~/.claude/exomem-capture-nudge.log   (write / capture)")
+        print("  ~/.claude/exomem-retrieve-nudge.log  (read / retrieval)")
     else:
         print("Add this to your settings.json (merge into hooks):")
         print(hook_module.snippet(report["installed"]))

--- a/src/exomem/_hooks/exomem-capture-nudge.sh
+++ b/src/exomem/_hooks/exomem-capture-nudge.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Stop-hook wrapper for kb_capture_nudge.py. Resolves the interpreter per machine
+# Stop-hook wrapper for exomem_capture_nudge.py. Resolves the interpreter per machine
 # (python3 on Linux/WSL/macOS, python on Windows Git Bash) and runs the sibling
 # script, so the SAME yadm-synced ~/.claude/hooks works across machines. Registered
-# in settings.json as `bash ~/.claude/hooks/kb-capture-nudge.sh` — machine-agnostic,
+# in settings.json as `bash ~/.claude/hooks/exomem-capture-nudge.sh` — machine-agnostic,
 # unlike an absolute interpreter path. Exit 0 always: a hook must never break the session.
 here="$(cd "$(dirname "$0")" && pwd)"
-py="$here/kb_capture_nudge.py"
+py="$here/exomem_capture_nudge.py"
 if command -v python3 >/dev/null 2>&1; then exec python3 "$py"; fi
 command -v python >/dev/null 2>&1 && exec python "$py"
 exit 0

--- a/src/exomem/_hooks/exomem-retrieve-nudge.sh
+++ b/src/exomem/_hooks/exomem-retrieve-nudge.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# UserPromptSubmit-hook wrapper for kb_retrieve_nudge.py. Resolves the interpreter
+# UserPromptSubmit-hook wrapper for exomem_retrieve_nudge.py. Resolves the interpreter
 # per machine (python3 on Linux/WSL/macOS, python on Windows Git Bash) and runs the
 # sibling script, so the SAME yadm-synced ~/.claude/hooks works across machines.
-# Registered as `bash ~/.claude/hooks/kb-retrieve-nudge.sh` — machine-agnostic.
+# Registered as `bash ~/.claude/hooks/exomem-retrieve-nudge.sh` — machine-agnostic.
 # Exit 0 always: a hook must never break the session.
 here="$(cd "$(dirname "$0")" && pwd)"
-py="$here/kb_retrieve_nudge.py"
+py="$here/exomem_retrieve_nudge.py"
 if command -v python3 >/dev/null 2>&1; then exec python3 "$py"; fi
 command -v python >/dev/null 2>&1 && exec python "$py"
 exit 0

--- a/src/exomem/_hooks/exomem_capture_nudge.py
+++ b/src/exomem/_hooks/exomem_capture_nudge.py
@@ -17,12 +17,13 @@ it to do nothing if it isn't one).
 
 Cheap and safe: the script itself is free (stdlib only); the only token cost is a
 real capture (the feature). Self-disarms via `stop_hook_active` (no loops); the
-cooldown caps frequency; every trigger is logged to ~/.claude/kb-capture-nudge.log
+cooldown caps frequency; every trigger is logged to ~/.claude/exomem-capture-nudge.log
 for tuning.
 
-Tunables (env): KB_CAPTURE_NUDGE_DISABLE=1 (off), KB_CAPTURE_NUDGE_MIN_CHARS
+Tunables (env): EXOMEM_CAPTURE_NUDGE_DISABLE=1 (off), EXOMEM_CAPTURE_NUDGE_MIN_CHARS
 (default 300 — lower it for a dense script like Japanese, which packs more meaning
-per char), KB_CAPTURE_NUDGE_COOLDOWN_SEC (default 300).
+per char), EXOMEM_CAPTURE_NUDGE_COOLDOWN_SEC (default 300). The legacy KB_CAPTURE_NUDGE_*
+names are still accepted for back-compat (aliased to the EXOMEM_* names at startup).
 
 Contract (Claude Code Stop hook): read the event JSON on stdin; print
 `{"decision":"block","reason":...}` and exit 0 to block the stop and feed the
@@ -44,7 +45,7 @@ from pathlib import Path
 _KB_WRITE = re.compile(r"(?:exomem|knowledge[_-]?base).*(note|add|edit|append|create_file|replace)", re.I)
 
 REMINDER = (
-    "[KB capture check] This turn did substantial work. If your Exomem knowledge-base "
+    "[Exomem capture check] This turn did substantial work. If your Exomem knowledge-base "
     "skill is available and the turn reached a durable conclusion — a decision, a "
     "solved problem, a diagnosed failure, or a recognized pattern, in whatever "
     "language you were working in — capture it now as a *compiled note* (the "
@@ -54,6 +55,23 @@ REMINDER = (
     "configured here, do nothing and stop — that is the common case, and skipping "
     "is correct and free."
 )
+
+
+# Back-compat: the tunables were renamed KB_CAPTURE_NUDGE_* -> EXOMEM_CAPTURE_NUDGE_*
+# with the knowledge-base -> exomem rename. The OLD names still work — normalized to
+# the new names at startup so the rest of the hook reads only EXOMEM_* everywhere.
+_ENV_ALIASES = (
+    ("EXOMEM_CAPTURE_NUDGE_DISABLE", "KB_CAPTURE_NUDGE_DISABLE"),
+    ("EXOMEM_CAPTURE_NUDGE_MIN_CHARS", "KB_CAPTURE_NUDGE_MIN_CHARS"),
+    ("EXOMEM_CAPTURE_NUDGE_COOLDOWN_SEC", "KB_CAPTURE_NUDGE_COOLDOWN_SEC"),
+)
+
+
+def _normalize_env_aliases() -> None:
+    """Map any legacy KB_* tunable onto its EXOMEM_* name (new wins if both set)."""
+    for new, old in _ENV_ALIASES:
+        if new not in os.environ and old in os.environ:
+            os.environ[new] = os.environ[old]
 
 
 def _env_int(name: str, default: int) -> int:
@@ -120,7 +138,7 @@ def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[str]]:
 
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based, so we never parse content)."""
-    state_dir = Path.home() / ".claude" / ".cache" / "kb-nudge"
+    state_dir = Path.home() / ".claude" / ".cache" / "exomem-nudge"
     key = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:128]
     stamp = state_dir / key
     try:
@@ -141,7 +159,7 @@ def _touch(stamp: Path) -> None:
 
 def _log(text: str) -> None:
     try:
-        logp = Path.home() / ".claude" / "kb-capture-nudge.log"
+        logp = Path.home() / ".claude" / "exomem-capture-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", text)[-160:]
         with open(logp, "a", encoding="utf-8") as f:
@@ -151,7 +169,8 @@ def _log(text: str) -> None:
 
 
 def main() -> int:
-    if os.environ.get("KB_CAPTURE_NUDGE_DISABLE"):
+    _normalize_env_aliases()
+    if os.environ.get("EXOMEM_CAPTURE_NUDGE_DISABLE"):
         return 0
     try:
         raw = sys.stdin.read()
@@ -165,8 +184,8 @@ def main() -> int:
     if not tpath:
         return 0
 
-    min_chars = _env_int("KB_CAPTURE_NUDGE_MIN_CHARS", 300)
-    cooldown = _env_int("KB_CAPTURE_NUDGE_COOLDOWN_SEC", 300)
+    min_chars = _env_int("EXOMEM_CAPTURE_NUDGE_MIN_CHARS", 300)
+    cooldown = _env_int("EXOMEM_CAPTURE_NUDGE_COOLDOWN_SEC", 300)
 
     assistant_text, tools = _latest_turn(tpath)
     if any(_KB_WRITE.search(t) for t in tools):  # already captured this turn

--- a/src/exomem/_hooks/exomem_retrieve_nudge.py
+++ b/src/exomem/_hooks/exomem_retrieve_nudge.py
@@ -13,21 +13,23 @@ keywords. By default it injects only a *reminder* — Claude still runs the real
 start until the hook returns, so the hook must be fast: stdlib only, no search
 here by default.)
 
-Opt-in **inject mode** (`KB_RETRIEVE_INJECT`) upgrades the reminder to real
+Opt-in **inject mode** (`EXOMEM_RETRIEVE_INJECT`) upgrades the reminder to real
 retrieved content: on the same gated prompt, it fetches the top compact routing
 stubs (`find(detail="compact")`, keyword mode only — no embeddings, no GPU) via a
 short transport ladder — REST first (`EXOMEM_REST_API_KEY` in this env), then an
-opt-in CLI fallback (`KB_RETRIEVE_INJECT_CLI`) — and appends them to the
+opt-in CLI fallback (`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the
 reminder. Any transport failure (or the flag being off) falls straight through to
 the reminder-only floor; the hook never blocks or raises past that point.
 
-Tunables (env): KB_RETRIEVE_NUDGE_DISABLE=1 (off), KB_RETRIEVE_NUDGE_MIN_CHARS
+Tunables (env): EXOMEM_RETRIEVE_NUDGE_DISABLE=1 (off), EXOMEM_RETRIEVE_NUDGE_MIN_CHARS
 (default 20 — short, since prompts are short and a dense script like Japanese
-packs more per char), KB_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300),
-KB_RETRIEVE_INJECT (opt-in, default off — truthy-parsed: unset/""/"0"/"false"/
+packs more per char), EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300),
+EXOMEM_RETRIEVE_INJECT (opt-in, default off — truthy-parsed: unset/""/"0"/"false"/
 "no"/"off", any case, count as off) to turn on retrieve-and-inject, and
-KB_RETRIEVE_INJECT_CLI (opt-in, same truthy parse) to additionally allow the
-slower CLI transport when REST isn't configured or fails.
+EXOMEM_RETRIEVE_INJECT_CLI (opt-in, same truthy parse) to additionally allow the
+slower CLI transport when REST isn't configured or fails. The legacy KB_RETRIEVE_*
+names (including KB_RETRIEVE_INJECT / KB_RETRIEVE_INJECT_CLI) are still accepted for
+back-compat, aliased to the EXOMEM_* names at startup.
 
 Contract (Claude Code UserPromptSubmit hook): read the event JSON on stdin (incl.
 `prompt`); on exit 0, print
@@ -49,7 +51,7 @@ import urllib.request
 from pathlib import Path
 
 REMINDER = (
-    "[KB retrieval check] Before answering: if this prompt touches a topic your "
+    "[Exomem retrieval check] Before answering: if this prompt touches a topic your "
     "Exomem knowledge base might hold — a project, a past decision, a domain you've taken "
     "notes on, or a 'what did I conclude / have I looked at' question — run a quiet "
     "`find` FIRST and fold any hits into the answer (cite them). The KB is the "
@@ -72,10 +74,29 @@ _FALSY_ENV = {"", "0", "false", "no", "off"}
 def _env_flag(name: str) -> bool:
     """Truthy opt-in parse: unset, '', '0', 'false', 'no', 'off' (any case) → False.
 
-    A bare presence/truthiness check would read `KB_RETRIEVE_INJECT=0` as opted in —
+    A bare presence/truthiness check would read `EXOMEM_RETRIEVE_INJECT=0` as opted in —
     the same bug class fixed elsewhere in this repo (extract.py::_env_flag).
     """
     return os.environ.get(name, "").strip().lower() not in _FALSY_ENV
+
+
+# Back-compat: the tunables were renamed KB_RETRIEVE_* -> EXOMEM_RETRIEVE_* with the
+# knowledge-base -> exomem rename. The OLD names still work — normalized to the new
+# names at startup so the rest of the hook reads only EXOMEM_* everywhere.
+_ENV_ALIASES = (
+    ("EXOMEM_RETRIEVE_NUDGE_DISABLE", "KB_RETRIEVE_NUDGE_DISABLE"),
+    ("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", "KB_RETRIEVE_NUDGE_MIN_CHARS"),
+    ("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", "KB_RETRIEVE_NUDGE_COOLDOWN_SEC"),
+    ("EXOMEM_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT"),
+    ("EXOMEM_RETRIEVE_INJECT_CLI", "KB_RETRIEVE_INJECT_CLI"),
+)
+
+
+def _normalize_env_aliases() -> None:
+    """Map any legacy KB_* tunable onto its EXOMEM_* name (new wins if both set)."""
+    for new, old in _ENV_ALIASES:
+        if new not in os.environ and old in os.environ:
+            os.environ[new] = os.environ[old]
 
 
 def _env_int(name: str, default: int) -> int:
@@ -88,7 +109,7 @@ def _env_int(name: str, default: int) -> int:
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based). Namespaced so it never collides
     with the capture hook's cooldown stamp for the same session."""
-    state_dir = Path.home() / ".claude" / ".cache" / "kb-nudge"
+    state_dir = Path.home() / ".claude" / ".cache" / "exomem-nudge"
     key = "retrieve_" + re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:120]
     stamp = state_dir / key
     try:
@@ -109,7 +130,7 @@ def _touch(stamp: Path) -> None:
 
 def _log(prompt: str) -> None:
     try:
-        logp = Path.home() / ".claude" / "kb-retrieve-nudge.log"
+        logp = Path.home() / ".claude" / "exomem-retrieve-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", prompt)[:160]
         with open(logp, "a", encoding="utf-8") as f:
@@ -200,7 +221,7 @@ def _fetch_via_cli(prompt: str, limit: int = 3, timeout: float = 5.0) -> list[di
 
 def _gather_hits(prompt: str) -> list[dict]:
     """Transport ladder decision: REST first (only when `EXOMEM_REST_API_KEY` is
-    set), CLI only when REST wasn't attempted/failed AND `KB_RETRIEVE_INJECT_CLI`
+    set), CLI only when REST wasn't attempted/failed AND `EXOMEM_RETRIEVE_INJECT_CLI`
     is truthy. Returns [] when neither rung is usable, or when the resolved
     transport itself reports zero hits (caller renders that as "nothing extra")."""
     api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip()
@@ -208,7 +229,7 @@ def _gather_hits(prompt: str) -> list[dict]:
         hits = _fetch_via_rest(prompt, api_key)
         if hits is not None:  # REST reachable (even with 0 hits) -> CLI never tried
             return hits
-    if _env_flag("KB_RETRIEVE_INJECT_CLI"):
+    if _env_flag("EXOMEM_RETRIEVE_INJECT_CLI"):
         hits = _fetch_via_cli(prompt)
         if hits is not None:
             return hits
@@ -238,7 +259,8 @@ def _format_inject_block(hits: list[dict]) -> str:
 
 
 def main() -> int:
-    if os.environ.get("KB_RETRIEVE_NUDGE_DISABLE"):
+    _normalize_env_aliases()
+    if os.environ.get("EXOMEM_RETRIEVE_NUDGE_DISABLE"):
         return 0
     try:
         raw = sys.stdin.read()
@@ -250,8 +272,8 @@ def main() -> int:
     if not isinstance(prompt, str):
         return 0
 
-    min_chars = _env_int("KB_RETRIEVE_NUDGE_MIN_CHARS", 20)
-    cooldown = _env_int("KB_RETRIEVE_NUDGE_COOLDOWN_SEC", 300)
+    min_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", 20)
+    cooldown = _env_int("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", 300)
 
     if len(prompt.strip()) < min_chars:  # trivial prompt ("yes", "go", "thanks")
         return 0
@@ -264,7 +286,7 @@ def main() -> int:
     _log(prompt)
 
     additional_context = REMINDER
-    if _env_flag("KB_RETRIEVE_INJECT"):
+    if _env_flag("EXOMEM_RETRIEVE_INJECT"):
         # Inject mode is a payload upgrade on this same gate, not a second
         # trigger — REST/CLI are only ever attempted past this point. Any
         # unanticipated failure here must still fall through to the

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -4,9 +4,9 @@ Ships two bundled hooks (each a Python script + a bash wrapper) and registers th
 in `~/.claude/settings.json`, so a friend gets the full reliable KB loop with one
 command:
 
-- `_hooks/kb_capture_nudge.py`  (via `kb-capture-nudge.sh`)  → a `Stop` hook (WRITE):
+- `_hooks/exomem_capture_nudge.py`  (via `exomem-capture-nudge.sh`)  → a `Stop` hook (WRITE):
   captures durable conclusions at stepping-stones instead of waiting to be told.
-- `_hooks/kb_retrieve_nudge.py` (via `kb-retrieve-nudge.sh`) → a `UserPromptSubmit`
+- `_hooks/exomem_retrieve_nudge.py` (via `exomem-retrieve-nudge.sh`) → a `UserPromptSubmit`
   hook (READ): reminds Claude to consult the KB before answering.
 
 The registered command is **machine-agnostic** — `bash ~/.claude/hooks/<name>.sh`,
@@ -29,15 +29,20 @@ from pathlib import Path
 _HOOK_DIR_SRC = Path(__file__).parent / "_hooks"
 # (python script, bash wrapper, Claude Code event) — the hooks this installs.
 _HOOK_SPECS = (
-    ("kb_capture_nudge.py", "kb-capture-nudge.sh", "Stop"),
-    ("kb_retrieve_nudge.py", "kb-retrieve-nudge.sh", "UserPromptSubmit"),
+    ("exomem_capture_nudge.py", "exomem-capture-nudge.sh", "Stop"),
+    ("exomem_retrieve_nudge.py", "exomem-retrieve-nudge.sh", "UserPromptSubmit"),
 )
 DEFAULT_HOOK_DIR = Path.home() / ".claude" / "hooks"
 DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
 
-# Substrings identifying a previously-installed kb nudge entry, so re-running is
+# Substrings identifying a previously-installed nudge entry, so re-running is
 # idempotent and supersedes older entries (incl. the absolute-python-path form).
-_MARKERS = ("kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge")
+# BOTH the legacy `kb_*`/`kb-*` names AND the current `exomem_*`/`exomem-*` names are
+# listed, so re-running install-hook cleanly migrates a machine off the old kb entry.
+_MARKERS = (
+    "kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge",
+    "exomem_capture_nudge", "exomem_retrieve_nudge", "exomem-capture-nudge", "exomem-retrieve-nudge",
+)
 
 
 def _command_for(wrapper: str, hook_dir: Path) -> str:
@@ -103,8 +108,9 @@ def install_hook(
 
 def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> None:
     """Add each hook to its event in settings.json, preserving every other key and
-    hook. Idempotent: strips any prior kb nudge entry from the target event first
-    (so re-running, or superseding the old absolute-path command, never duplicates)."""
+    hook. Idempotent: strips any prior exomem/kb nudge entry from the target event
+    first (so re-running, migrating off the legacy `kb-*` names, or superseding the
+    old absolute-path command, never duplicates)."""
     data: dict = {}
     if path.exists():
         try:

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -20,8 +20,8 @@ import exomem
 from exomem import install_hook as hook_module
 
 _HOOKS = Path(exomem.__file__).parent / "_hooks"
-CAPTURE_SCRIPT = _HOOKS / "kb_capture_nudge.py"
-RETRIEVE_SCRIPT = _HOOKS / "kb_retrieve_nudge.py"
+CAPTURE_SCRIPT = _HOOKS / "exomem_capture_nudge.py"
+RETRIEVE_SCRIPT = _HOOKS / "exomem_retrieve_nudge.py"
 
 
 def _stop_cmds(data: dict) -> list[str]:
@@ -37,22 +37,22 @@ def _ups_cmds(data: dict) -> list[str]:
 def test_install_hook_copies_scripts_and_wrappers_and_wires_both(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp)
-    for f in ("kb_capture_nudge.py", "kb-capture-nudge.sh", "kb_retrieve_nudge.py", "kb-retrieve-nudge.sh"):
+    for f in ("exomem_capture_nudge.py", "exomem-capture-nudge.sh", "exomem_retrieve_nudge.py", "exomem-retrieve-nudge.sh"):
         assert (hd / f).exists(), f
     assert r["wired"] is True
     data = json.loads(sp.read_text(encoding="utf-8"))
-    assert any("kb-capture-nudge.sh" in c for c in _stop_cmds(data))     # write -> Stop, via wrapper
-    assert any("kb-retrieve-nudge.sh" in c for c in _ups_cmds(data))     # read -> UserPromptSubmit
+    assert any("exomem-capture-nudge.sh" in c for c in _stop_cmds(data))     # write -> Stop, via wrapper
+    assert any("exomem-retrieve-nudge.sh" in c for c in _ups_cmds(data))     # read -> UserPromptSubmit
 
 
 def test_command_is_machine_agnostic(tmp_path: Path) -> None:
     # Default location -> ~-relative bash command (no abs path / interpreter / backslash),
     # so the same settings.json works on every machine after a yadm sync.
-    cmd = hook_module._command_for("kb-capture-nudge.sh", hook_module.DEFAULT_HOOK_DIR)
-    assert cmd == "bash ~/.claude/hooks/kb-capture-nudge.sh"
+    cmd = hook_module._command_for("exomem-capture-nudge.sh", hook_module.DEFAULT_HOOK_DIR)
+    assert cmd == "bash ~/.claude/hooks/exomem-capture-nudge.sh"
     assert "\\" not in cmd and "python" not in cmd.lower() and ":" not in cmd
     # Custom dir -> POSIX (forward-slash) bash command, never Windows backslashes.
-    custom = hook_module._command_for("kb-capture-nudge.sh", tmp_path / "hooks")
+    custom = hook_module._command_for("exomem-capture-nudge.sh", tmp_path / "hooks")
     assert custom.startswith('bash "') and custom.endswith('.sh"') and "\\" not in custom
 
 
@@ -61,8 +61,8 @@ def test_install_hook_idempotent(tmp_path: Path) -> None:
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     hook_module.install_hook(hook_dir=hd, settings_path=sp)
     data = json.loads(sp.read_text(encoding="utf-8"))
-    assert sum("kb-capture-nudge" in c for c in _stop_cmds(data)) == 1
-    assert sum("kb-retrieve-nudge" in c for c in _ups_cmds(data)) == 1
+    assert sum("exomem-capture-nudge" in c for c in _stop_cmds(data)) == 1
+    assert sum("exomem-retrieve-nudge" in c for c in _ups_cmds(data)) == 1
 
 
 def test_install_hook_supersedes_prior_absolute_path_entry(tmp_path: Path) -> None:
@@ -78,8 +78,30 @@ def test_install_hook_supersedes_prior_absolute_path_entry(tmp_path: Path) -> No
     hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
     data = json.loads(sp.read_text(encoding="utf-8"))
     stop = _stop_cmds(data)
-    assert not any("python.exe" in c for c in stop)            # absolute-path form gone
-    assert sum("kb-capture-nudge" in c for c in stop) == 1     # exactly one, the wrapper
+    assert not any("python.exe" in c for c in stop)             # absolute-path form gone
+    assert sum("exomem-capture-nudge" in c for c in stop) == 1  # exactly one, the wrapper
+
+
+def test_install_hook_migrates_old_kb_entry(tmp_path: Path) -> None:
+    # A machine that installed the pre-rename hook has a `kb-capture-nudge.sh`
+    # wrapper command wired in. Re-running install-hook must STRIP that legacy entry
+    # (via the retained old _MARKERS) and leave only the new `exomem-capture-nudge`
+    # one — a clean migration, not a duplicate.
+    sp = tmp_path / "settings.json"
+    sp.write_text(
+        json.dumps({"hooks": {
+            "Stop": [{"hooks": [{"type": "command", "command": "bash ~/.claude/hooks/kb-capture-nudge.sh"}]}],
+            "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "bash ~/.claude/hooks/kb-retrieve-nudge.sh"}]}],
+        }}),
+        encoding="utf-8",
+    )
+    hook_module.install_hook(hook_dir=tmp_path / "hooks", settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    stop, ups = _stop_cmds(data), _ups_cmds(data)
+    assert not any("kb-capture-nudge" in c for c in stop)        # legacy entry gone
+    assert not any("kb-retrieve-nudge" in c for c in ups)
+    assert sum("exomem-capture-nudge" in c for c in stop) == 1   # new entry present, once
+    assert sum("exomem-retrieve-nudge" in c for c in ups) == 1
 
 
 def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
@@ -98,15 +120,15 @@ def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
     data = json.loads(sp.read_text(encoding="utf-8"))
     assert data["theme"] == "dark"
     assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "bash guard.sh"
-    assert "bash other-stop.sh" in _stop_cmds(data)                 # unrelated Stop hook kept
-    assert any("kb-capture-nudge" in c for c in _stop_cmds(data))   # ours added
-    assert any("kb-retrieve-nudge" in c for c in _ups_cmds(data))
+    assert "bash other-stop.sh" in _stop_cmds(data)                     # unrelated Stop hook kept
+    assert any("exomem-capture-nudge" in c for c in _stop_cmds(data))   # ours added
+    assert any("exomem-retrieve-nudge" in c for c in _ups_cmds(data))
 
 
 def test_install_hook_print_only_leaves_settings(tmp_path: Path) -> None:
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     r = hook_module.install_hook(hook_dir=hd, settings_path=sp, wire=False)
-    assert (hd / "kb_capture_nudge.py").exists() and (hd / "kb-capture-nudge.sh").exists()
+    assert (hd / "exomem_capture_nudge.py").exists() and (hd / "exomem-capture-nudge.sh").exists()
     assert r["wired"] is False
     assert not sp.exists()
     snip = hook_module.snippet(r["installed"])
@@ -118,7 +140,7 @@ def test_install_hook_via_cli(tmp_path: Path) -> None:
 
     hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
     assert main(["install-hook", "--hook-dir", str(hd), "--settings", str(sp)]) == 0
-    assert (hd / "kb_capture_nudge.py").exists() and (hd / "kb-retrieve-nudge.sh").exists()
+    assert (hd / "exomem_capture_nudge.py").exists() and (hd / "exomem-retrieve-nudge.sh").exists()
     data = json.loads(sp.read_text(encoding="utf-8"))
     assert data["hooks"]["Stop"] and data["hooks"]["UserPromptSubmit"]
 

--- a/tests/test_retrieve_inject.py
+++ b/tests/test_retrieve_inject.py
@@ -1,4 +1,4 @@
-"""`kb_retrieve_nudge.py`'s opt-in retrieve-and-inject upgrade (KB_RETRIEVE_INJECT).
+"""`exomem_retrieve_nudge.py`'s opt-in retrieve-and-inject upgrade (EXOMEM_RETRIEVE_INJECT).
 
 The hook is a standalone, stdlib-only script — not a package member — so it is
 loaded via `importlib.util.spec_from_file_location` (matching how
@@ -28,11 +28,11 @@ import pytest
 
 import exomem
 
-RETRIEVE_SCRIPT = Path(exomem.__file__).parent / "_hooks" / "kb_retrieve_nudge.py"
+RETRIEVE_SCRIPT = Path(exomem.__file__).parent / "_hooks" / "exomem_retrieve_nudge.py"
 
 
 def _load_hook_module():
-    spec = importlib.util.spec_from_file_location("kb_retrieve_nudge_under_test", RETRIEVE_SCRIPT)
+    spec = importlib.util.spec_from_file_location("exomem_retrieve_nudge_under_test", RETRIEVE_SCRIPT)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -44,15 +44,23 @@ hook_mod = _load_hook_module()
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every test starts from a known-clean env — a real EXOMEM_REST_API_KEY or
-    KB_RETRIEVE_INJECT already set on the host machine must never leak in."""
+    EXOMEM_RETRIEVE_INJECT already set on the host machine must never leak in. The
+    legacy KB_RETRIEVE_* names are cleared too: they still alias onto the EXOMEM_*
+    names at startup (back-compat), so a host-set old name would leak just the same."""
     for var in (
+        "EXOMEM_RETRIEVE_NUDGE_DISABLE",
+        "EXOMEM_RETRIEVE_NUDGE_MIN_CHARS",
+        "EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC",
+        "EXOMEM_RETRIEVE_INJECT",
+        "EXOMEM_RETRIEVE_INJECT_CLI",
+        "EXOMEM_REST_API_KEY",
+        "EXOMEM_HOST",
+        # Legacy aliases (still honored via _normalize_env_aliases).
         "KB_RETRIEVE_NUDGE_DISABLE",
         "KB_RETRIEVE_NUDGE_MIN_CHARS",
         "KB_RETRIEVE_NUDGE_COOLDOWN_SEC",
         "KB_RETRIEVE_INJECT",
         "KB_RETRIEVE_INJECT_CLI",
-        "EXOMEM_REST_API_KEY",
-        "EXOMEM_HOST",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -97,18 +105,18 @@ def _call_main(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, e
 
 @pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "No", "OFF", "off"])
 def test_env_flag_falsy_values_are_disabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", value)
-    assert hook_mod._env_flag("KB_RETRIEVE_INJECT") is False
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", value)
+    assert hook_mod._env_flag("EXOMEM_RETRIEVE_INJECT") is False
 
 
 def test_env_flag_unset_is_disabled() -> None:
-    assert hook_mod._env_flag("KB_RETRIEVE_INJECT_DOES_NOT_EXIST") is False
+    assert hook_mod._env_flag("EXOMEM_RETRIEVE_INJECT_DOES_NOT_EXIST") is False
 
 
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "anything"])
 def test_env_flag_truthy_values_are_enabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", value)
-    assert hook_mod._env_flag("KB_RETRIEVE_INJECT_CLI") is True
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", value)
+    assert hook_mod._env_flag("EXOMEM_RETRIEVE_INJECT_CLI") is True
 
 
 # --- _format_inject_block ---------------------------------------------------------
@@ -343,7 +351,7 @@ def test_gather_hits_rest_failing_cli_unset_is_nudge_only(monkeypatch: pytest.Mo
     monkeypatch.setattr(hook_mod, "_fetch_via_rest", lambda prompt, api_key, **kw: None)
 
     def _boom(*a, **kw):
-        raise AssertionError("_fetch_via_cli must not be called when KB_RETRIEVE_INJECT_CLI is unset")
+        raise AssertionError("_fetch_via_cli must not be called when EXOMEM_RETRIEVE_INJECT_CLI is unset")
 
     monkeypatch.setattr(hook_mod, "_fetch_via_cli", _boom)
     assert hook_mod._gather_hits("prompt") == []
@@ -351,7 +359,7 @@ def test_gather_hits_rest_failing_cli_unset_is_nudge_only(monkeypatch: pytest.Mo
 
 def test_gather_hits_rest_unconfigured_cli_opted_in_uses_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     hits = [{"path": "Notes/b.md", "type": "insight", "updated": "2026-01-02"}]
-    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
 
     def _boom(*a, **kw):
         raise AssertionError("_fetch_via_rest must not be called when EXOMEM_REST_API_KEY is unset")
@@ -383,10 +391,10 @@ def test_default_off_no_network_or_subprocess_attempted(
     home.mkdir()
 
     def _boom_url(req, timeout=None):
-        raise AssertionError("urlopen must not be called when KB_RETRIEVE_INJECT is unset")
+        raise AssertionError("urlopen must not be called when EXOMEM_RETRIEVE_INJECT is unset")
 
     def _boom_run(cmd, **kwargs):
-        raise AssertionError("subprocess.run must not be called when KB_RETRIEVE_INJECT is unset")
+        raise AssertionError("subprocess.run must not be called when EXOMEM_RETRIEVE_INJECT is unset")
 
     monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
     monkeypatch.setattr(hook_mod.subprocess, "run", _boom_run)
@@ -408,7 +416,7 @@ def test_inject_rest_configured_and_reachable_appends_stubs(
     home.mkdir()
     hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
     monkeypatch.setattr(urllib_request, "urlopen", lambda req, timeout=None: _FakeResponse(200, _envelope_bytes(hits)))
 
@@ -424,13 +432,32 @@ def test_inject_rest_configured_and_reachable_appends_stubs(
     assert "excerpt" not in ctx.lower()
 
 
+def test_legacy_kb_retrieve_inject_env_still_activates_inject(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    # Back-compat: the OLD env name (KB_RETRIEVE_INJECT, no EXOMEM_ prefix) must
+    # still turn inject mode on, aliased onto EXOMEM_RETRIEVE_INJECT at startup.
+    home = tmp_path / "home"
+    home.mkdir()
+    hits = [{"path": "Notes/a.md", "type": "note", "updated": "2026-01-01"}]
+
+    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")  # legacy name only — NOT EXOMEM_RETRIEVE_INJECT
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+    monkeypatch.setattr(urllib_request, "urlopen", lambda req, timeout=None: _FakeResponse(200, _envelope_bytes(hits)))
+
+    out = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "e2e-legacy-inject"}, home)
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert ctx.startswith(hook_mod.REMINDER + "\n\n")            # inject mode activated
+    assert "- Notes/a.md (note, 2026-01-01)" in ctx
+
+
 def test_inject_rest_unreachable_cli_not_opted_in_is_nudge_only(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
 
     def _boom_url(req, timeout=None):
@@ -450,8 +477,8 @@ def test_inject_cli_opt_in_which_resolves_appends_stubs(
     home.mkdir()
     hits = [{"path": "Notes/b.md", "type": "insight", "updated": "2026-01-02"}]
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
-    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
     monkeypatch.setattr(hook_mod.shutil, "which", lambda name: "/usr/local/bin/exomem" if name == "exomem" else None)
     monkeypatch.setattr(
         hook_mod.subprocess, "run",
@@ -469,8 +496,8 @@ def test_inject_cli_opt_in_but_unresolvable_is_nudge_only(
     home = tmp_path / "home"
     home.mkdir()
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
-    monkeypatch.setenv("KB_RETRIEVE_INJECT_CLI", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", "1")
     monkeypatch.setattr(hook_mod.shutil, "which", lambda name: None)
 
     def _boom_run(cmd, **kwargs):
@@ -489,7 +516,7 @@ def test_min_chars_gate_short_circuits_before_any_transport(
     home = tmp_path / "home"
     home.mkdir()
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
 
     def _boom_url(req, timeout=None):
@@ -507,7 +534,7 @@ def test_cooldown_gate_short_circuits_second_transport_attempt(
     home = tmp_path / "home"
     home.mkdir()
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
     call_count = {"n": 0}
 
@@ -526,17 +553,17 @@ def test_cooldown_gate_short_circuits_second_transport_attempt(
     assert call_count["n"] == 1
 
 
-def test_kb_retrieve_inject_zero_is_disabled_end_to_end(
+def test_exomem_retrieve_inject_zero_is_disabled_end_to_end(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     home = tmp_path / "home"
     home.mkdir()
 
-    monkeypatch.setenv("KB_RETRIEVE_INJECT", "0")
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "0")
     monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
 
     def _boom_url(req, timeout=None):
-        raise AssertionError("urlopen must not be called when KB_RETRIEVE_INJECT=0 (falsy)")
+        raise AssertionError("urlopen must not be called when EXOMEM_RETRIEVE_INJECT=0 (falsy)")
 
     monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
 
@@ -550,7 +577,10 @@ def test_kb_retrieve_inject_zero_is_disabled_end_to_end(
 
 def _run_subprocess(event: dict, home: Path) -> subprocess.CompletedProcess:
     env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}
-    for key in ("KB_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT_CLI", "EXOMEM_REST_API_KEY", "EXOMEM_HOST"):
+    for key in (
+        "EXOMEM_RETRIEVE_INJECT", "EXOMEM_RETRIEVE_INJECT_CLI", "EXOMEM_REST_API_KEY", "EXOMEM_HOST",
+        "KB_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT_CLI",  # legacy aliases, cleared too
+    ):
         env.pop(key, None)
     return subprocess.run(
         [sys.executable, str(RETRIEVE_SCRIPT)],


### PR DESCRIPTION
Final follow-up to the `knowledge-base` → `exomem` rename: the bundled Stop / UserPromptSubmit nudge hooks kept the legacy `kb_` naming.

## What changed
- **Renamed (via `git mv`, history preserved):** `kb_{capture,retrieve}_nudge.py` + `kb-{capture,retrieve}-nudge.sh` → `exomem_*`. Wrappers, `install_hook._HOOK_SPECS`, and `__main__` text updated.
- **Clean migration (no duplicate hooks):** `install_hook._MARKERS` now lists **both** the legacy `kb_*` and the new `exomem_*` substrings, so re-running `exomem install-hook` strips an existing legacy entry from `settings.json` and installs the new one. → `test_install_hook_migrates_old_kb_entry`.
- **Env back-compat (existing config keeps working):** `KB_{CAPTURE,RETRIEVE}_NUDGE_*` and `KB_RETRIEVE_INJECT[_CLI]` → `EXOMEM_*`, but each hook normalizes old→new aliases at `main()` start, so old `KB_*` vars still take effect. → back-compat test proves legacy `KB_RETRIEVE_INJECT=1` still activates inject mode.
- Also renamed: log files (`exomem-*-nudge.log`), cooldown cache dir (`.cache/exomem-nudge`), reminder labels (`[Exomem capture/retrieval check]`). Docs (README/QUICKSTART) + the active openspec spec updated with back-compat notes; `CHANGELOG` + `openspec/changes/archive/**` left as history.

## Not renamed (deliberate)
Nothing — this completes the rename. Existing users just re-run `exomem install-hook` once to migrate.

## Verification
- Hook tests **66 passed** (incl. the 2 new guards); full suite **1395 passed, 16 skipped**.
- Residual `kb_*`/`KB_*` greps are all intentional back-compat (markers, env-alias maps, tests, doc notes).
- No new lint (pre-existing `BLE001` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm175jiA7wEGwnhME5TdWm