### PR TITLE
perf(lexstore): incremental heal — no full rebuild on drift (fixes real-vault find() thrash)

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -369,7 +369,7 @@ class LexicalStore:
                 return
             self._ensure_schema(conn)
             if self._stored_count_max(conn, scope) != (freshness[0], freshness[1]):
-                self._rebuild(conn)  # definite drift (add/delete/edit shape)
+                self._heal_delta(conn)  # incremental: patch only the drifted rows
                 return
             if self._witnessed:
                 # In-process hooks applied every change they saw; matching
@@ -384,7 +384,7 @@ class LexicalStore:
             if self._walk_matches_rows(conn, scope):
                 self._bless(conn, scope, freshness)
             else:
-                self._rebuild(conn)
+                self._heal_delta(conn)
 
     def _walk_entries(self) -> tuple[dict[Path, list[bool]], dict[Path, int]]:
         """One pass over both walks: membership flags + stat'ed mtimes."""
@@ -446,6 +446,49 @@ class LexicalStore:
             conn.execute("DELETE FROM tri")
             for path, (in_kb, in_vault) in members.items():
                 self._insert_page(conn, path, mtimes[path], in_kb, in_vault)
+        self._witnessed = False
+        for scope, idx in (("kb", 0), ("vault", 1)):
+            entries = [
+                (str(p), mtimes[p]) for p, flags in members.items() if flags[idx]
+            ]
+            self._bless(conn, scope, freshness_module.triple_from_entries(entries))
+
+    def _heal_delta(self, conn: sqlite3.Connection) -> None:
+        """Reconcile the sidecar to the markdown walks by touching ONLY the rows
+        that drifted — the incremental alternative to `_rebuild`'s wipe-and-repopulate.
+
+        Reaches the same end state (pages+fts+tri match the walks; both scopes
+        blessed) but its writes are O(changed files), not O(corpus). This is the
+        heal for the common real-vault case: a handful of out-of-band edits that
+        the in-process hooks never witnessed (a watcher that missed the events).
+        A single changed file therefore costs one delete+reinsert, not a full
+        1,900-file rebuild. `rel` is computed once per file and used for both the
+        stored-row lookup and the insert, so the delete-key and insert-key cannot
+        diverge (the class of `UNIQUE constraint failed: pages.path`)."""
+        from . import freshness as freshness_module
+
+        members, mtimes = self._walk_entries()
+        walk: dict[str, tuple[Path, int, bool, bool]] = {}
+        for path, (in_kb, in_vault) in members.items():
+            rel = self._rel(path)
+            if rel is not None:
+                walk[rel] = (path, mtimes[path], in_kb, in_vault)
+        # path(rel) -> (rowid, mtime_ns, in_kb, in_vault), snapshotted before writes.
+        stored = {
+            row[0]: (int(row[1]), int(row[2]), bool(row[3]), bool(row[4]))
+            for row in conn.execute(
+                "SELECT path, rowid, mtime_ns, in_kb, in_vault FROM pages"
+            )
+        }
+        with conn:
+            for rel, (rowid, mtime_ns, in_kb, in_vault) in stored.items():
+                w = walk.get(rel)
+                if w is None or (w[1], w[2], w[3]) != (mtime_ns, in_kb, in_vault):
+                    self._delete_rowid(conn, rowid)  # removed, or replaced below
+            for rel, (path, mtime_ns, in_kb, in_vault) in walk.items():
+                s = stored.get(rel)
+                if s is None or (s[1], s[2], s[3]) != (mtime_ns, in_kb, in_vault):
+                    self._insert_page(conn, path, mtime_ns, in_kb, in_vault)
         self._witnessed = False
         for scope, idx in (("kb", 0), ("vault", 1)):
             entries = [

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -185,6 +185,71 @@ def test_manual_row_drift_self_heals(tmp_path):
     assert _count(side, "pages") == 4
 
 
+def test_out_of_band_single_edit_heals_incrementally_not_full_rebuild(tmp_path):
+    """A single out-of-band file edit (count unchanged, one mtime bumped) must
+    heal by patching ONLY that file's rows — not by wiping and repopulating the
+    whole corpus. The full-rebuild heal is O(corpus); on a large real vault
+    behind a flaky watcher it fires on every missed event (the 10-17s keyword
+    lane / 3-6s cold find() observed 2026-07-05)."""
+    for i in range(6):
+        _write_page(tmp_path, f"Knowledge Base/n{i}.md", f"payload token{i}", mtime=1_000 + i)
+    assert lexstore.search_bm25(tmp_path, "payload", k=10, scope="kb")
+    lexstore.clear_stores()  # fresh process; no in-process hook witnessed the edit
+
+    # One file rewritten out-of-band: same file count, a newer max mtime.
+    _write_page(tmp_path, "Knowledge Base/n3.md", "payload zzzreplacement", mtime=9_000)
+
+    calls = {"n": 0}
+    real = lexstore.LexicalStore._rebuild
+
+    def _counting(self, conn):
+        calls["n"] += 1
+        return real(self, conn)
+
+    lexstore.LexicalStore._rebuild = _counting
+    try:
+        hits = lexstore.search_bm25(tmp_path, "zzzreplacement", k=5, scope="kb")
+    finally:
+        lexstore.LexicalStore._rebuild = real
+
+    assert hits and hits[0][0] == "Knowledge Base/n3.md"       # new content indexed
+    assert lexstore.search_bm25(tmp_path, "token3", k=5, scope="kb") == []  # old tokens gone
+    assert lexstore.search_bm25(tmp_path, "token5", k=5, scope="kb")        # untouched intact
+    assert _count(lexstore.lexical_path(tmp_path), "pages") == 6
+    assert calls["n"] == 0  # healed incrementally, NOT via full rebuild
+
+
+def test_out_of_band_add_and_delete_heal_incrementally(tmp_path):
+    """A file removed from disk and another added out-of-band heal by patching
+    just those two rows (delete + insert branches), never a full rebuild."""
+    for i in range(5):
+        _write_page(tmp_path, f"Knowledge Base/n{i}.md", f"corpus token{i}", mtime=1_000 + i)
+    assert lexstore.search_bm25(tmp_path, "corpus", k=10, scope="kb")
+    lexstore.clear_stores()
+
+    (tmp_path / "Knowledge Base/n0.md").unlink()                                   # removed
+    _write_page(tmp_path, "Knowledge Base/added.md", "corpus freshadd", mtime=8_000)  # added
+
+    calls = {"n": 0}
+    real = lexstore.LexicalStore._rebuild
+
+    def _counting(self, conn):
+        calls["n"] += 1
+        return real(self, conn)
+
+    lexstore.LexicalStore._rebuild = _counting
+    try:
+        hits = lexstore.search_bm25(tmp_path, "freshadd", k=5, scope="kb")
+    finally:
+        lexstore.LexicalStore._rebuild = real
+
+    assert hits and hits[0][0] == "Knowledge Base/added.md"
+    assert lexstore.search_bm25(tmp_path, "token0", k=5, scope="kb") == []  # removed file gone
+    assert lexstore.search_bm25(tmp_path, "token4", k=5, scope="kb")        # survivor intact
+    assert _count(lexstore.lexical_path(tmp_path), "pages") == 5            # 5 - 1 + 1
+    assert calls["n"] == 0  # incremental delete+insert, not a full rebuild
+
+
 def test_writer_hooks_keep_index_in_lockstep(tmp_path):
     """upsert_after_write / delete_after_remove maintain pages+fts+tri without a
     rebuild, and a subsequent query observes the change."""


### PR DESCRIPTION
## Problem

Real-vault `find()` was **3–6s cold** (measured 2026-07-05), dominated by a full
`.lexical.sqlite` rebuild (~1,900 files, 10–17s) that `_ensure_synced` runs on any
`(count, max_mtime)` drift. On an actively-edited vault behind a watcher that misses
D: filesystem events, this fired on every unwitnessed out-of-band edit. The static
synthetic benchmark never surfaced it (no watcher, no out-of-band edits) — a textbook
case of `synthetic-benchmarks-are-relative-grade`.

## Fix

`_heal_delta` reconciles the sidecar to the markdown walks by patching only the rows
whose `(mtime_ns, membership)` drifted — O(changed) writes, same end state as
`_rebuild` (pages+fts+tri match, both scopes blessed). A single out-of-band edit now
costs one delete+reinsert instead of a full rebuild. `rel` is computed once per file
for both the stored-row lookup and the insert.

## Verification

- Full suite: **1544 passed / 3 skipped**
- Golden recall gate (`test_retrieval_golden`): **3 passed** — no recall regression
- New tests assert the heal is incremental (spy on `_rebuild`) for the edit and
  add/delete branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
