### PR TITLE
perf(lexstore): heal from the freshness registry, not a filesystem walk

### DIFF
--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -184,6 +184,25 @@ def triple(vault_root: Path, scope: str) -> tuple[int, int, str] | None:
         return cached
 
 
+def live_entries(vault_root: Path, scope: str) -> dict[str, int] | None:
+    """The live `{abs_path_str: mtime_ns}` map for a scope, or None when not live.
+
+    Returns a copy so callers can diff without holding the lock. The lexical heal
+    reads this instead of re-walking the filesystem: whenever a heal fires, this
+    map is already current (the watcher or the 300s reconcile updated it — that's
+    exactly why the sidecar's triple drifted), so re-statting the whole corpus is
+    redundant. Not live (kill-switched, or a scope never seeded) → None, and the
+    caller falls back to a fresh walk.
+    """
+    if not event_indexes_enabled():
+        return None
+    key = _key(vault_root, scope)
+    with _lock:
+        if key not in _live:
+            return None
+        return dict(_maps.get(key, {}))
+
+
 def on_files_changed(
     vault_root: Path,
     changed: Iterable[Path] = (),

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -453,6 +453,32 @@ class LexicalStore:
             ]
             self._bless(conn, scope, freshness_module.triple_from_entries(entries))
 
+    def _delta_source(self) -> tuple[dict[Path, list[bool]], dict[Path, int]]:
+        """`(members, mtimes)` for the heal's diff — from the live freshness
+        registry (no filesystem walk) when BOTH scopes are live, else a fresh walk.
+
+        Whenever a heal fires, the registry map is already current (it's why the
+        scope triple drifted from the sidecar), so reading it in-memory avoids
+        re-statting the whole corpus — the ~2.7s drift-walk measured on the real
+        D: vault. Byte-identical to `_walk_entries` by the freshness contract (the
+        registry mirrors the same two walks). Falls back to the walk when the
+        registry isn't live (kill-switched, or a scope never seeded)."""
+        from . import freshness as freshness_module
+
+        kb = freshness_module.live_entries(self.vault_root, "kb")
+        vault = freshness_module.live_entries(self.vault_root, "vault")
+        if kb is None or vault is None:
+            return self._walk_entries()
+        members: dict[Path, list[bool]] = {}
+        mtimes: dict[Path, int] = {}
+        for sp, ns in kb.items():
+            members.setdefault(Path(sp), [False, False])[0] = True
+            mtimes[Path(sp)] = ns
+        for sp, ns in vault.items():
+            members.setdefault(Path(sp), [False, False])[1] = True
+            mtimes[Path(sp)] = ns
+        return members, mtimes
+
     def _heal_delta(self, conn: sqlite3.Connection) -> None:
         """Reconcile the sidecar to the markdown walks by touching ONLY the rows
         that drifted — the incremental alternative to `_rebuild`'s wipe-and-repopulate.
@@ -467,7 +493,7 @@ class LexicalStore:
         diverge (the class of `UNIQUE constraint failed: pages.path`)."""
         from . import freshness as freshness_module
 
-        members, mtimes = self._walk_entries()
+        members, mtimes = self._delta_source()
         walk: dict[str, tuple[Path, int, bool, bool]] = {}
         for path, (in_kb, in_vault) in members.items():
             rel = self._rel(path)

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -250,6 +250,60 @@ def test_out_of_band_add_and_delete_heal_incrementally(tmp_path):
     assert calls["n"] == 0  # incremental delete+insert, not a full rebuild
 
 
+def test_heal_reads_registry_map_not_filesystem_walk_when_live(tmp_path):
+    """When the freshness registry is live (watcher-maintained), the incremental
+    heal must diff against the registry's in-memory map, NOT re-stat the whole
+    corpus — the ~2.7s drift-walk observed on the real D: vault. The registry is
+    already current whenever a heal fires (that's why the triple drifted from the
+    sidecar), so the filesystem walk is redundant."""
+    from exomem import find as find_module
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    freshness.clear()
+    try:
+        for i in range(5):
+            _write_page(tmp_path, f"Knowledge Base/n{i}.md", f"payload token{i}", mtime=1_000 + i)
+        assert lexstore.search_bm25(tmp_path, "payload", k=10, scope="kb")
+        lexstore.clear_stores()  # fresh lexstore process; sidecar left on disk
+
+        # The watcher seeds the registry live for both scopes at the current state.
+        kb_dir = tmp_path / "Knowledge Base"
+        freshness.seed(
+            tmp_path, "kb",
+            ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb_dir)),
+        )
+        freshness.seed(
+            tmp_path, "vault",
+            ((str(p), p.stat().st_mtime_ns) for p in vault_module.walk_vault_md(tmp_path)),
+        )
+
+        # One file edited out-of-band; the watcher catches it and patches the
+        # registry (but not the lexstore sidecar) — the exact drift the heal fixes.
+        p = _write_page(tmp_path, "Knowledge Base/n2.md", "payload zzzreplaced", mtime=9_000)
+        freshness.on_files_changed(tmp_path, changed=[p])
+
+        walks = {"n": 0}
+        real = lexstore.LexicalStore._walk_entries
+
+        def _counting(self):
+            walks["n"] += 1
+            return real(self)
+
+        lexstore.LexicalStore._walk_entries = _counting
+        try:
+            hits = lexstore.search_bm25(tmp_path, "zzzreplaced", k=5, scope="kb")
+        finally:
+            lexstore.LexicalStore._walk_entries = real
+
+        assert hits and hits[0][0] == "Knowledge Base/n2.md"                   # healed
+        assert lexstore.search_bm25(tmp_path, "token2", k=5, scope="kb") == []  # old gone
+        assert lexstore.search_bm25(tmp_path, "token4", k=5, scope="kb")        # survivor
+        assert walks["n"] == 0  # read the registry map, did NOT walk the filesystem
+    finally:
+        freshness.clear()
+
+
 def test_writer_hooks_keep_index_in_lockstep(tmp_path):
     """upsert_after_write / delete_after_remove maintain pages+fts+tri without a
     rebuild, and a subsequent query observes the change."""


### PR DESCRIPTION
## Problem

After #121 the lexical heal is incremental, but `_heal_delta` still *discovers* the
changed files by re-statting the whole corpus (`_walk_entries`) — **~2.7s on the real
D: vault**, and it fires on every out-of-band edit the watcher misses. Measured live:
a drifted `find()` spiked to 3043ms (bm25 lane 2717ms = the walk) while the next
steady query was 281ms.

## Fix

Whenever a heal fires, the freshness registry map is **already current** (that's *why*
the sidecar's triple drifted from it), so re-walking is redundant. New
`freshness.live_entries()` exposes the live per-scope map; `LexicalStore._delta_source`
reads it (both scopes live) and diffs in-memory, falling back to the walk only when the
registry isn't live (kill-switched / a scope never seeded). Byte-identical to the walk
by the freshness contract.

Result: real-vault `find()` under active writing stays **~280ms** instead of spiking to
~3s on drift.

## Verification

- Full suite **1545 passed / 3 skipped**
- Golden recall gate **3 passed** — no recall regression
- New test asserts the heal reads the registry (**0 filesystem walks**) when live; the
  existing heal tests confirm the walk-fallback when not live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
