### PR TITLE
perf(lexstore): route _walk_matches_rows through the registry too (completes Lever A)

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -413,8 +413,11 @@ class LexicalStore:
             return None
 
     def _walk_matches_rows(self, conn: sqlite3.Connection, scope: str) -> bool:
-        """Exact (path, mtime_ns) comparison of the scope's walk vs stored rows."""
-        members, mtimes = self._walk_entries()
+        """Exact (path, mtime_ns) comparison of the scope's current set vs stored
+        rows — reads the live freshness registry when available (no filesystem
+        walk), else walks. Obsidian-Sync edits preserve mtimes, so this verify
+        path is the one a real out-of-band edit hits; it must be walk-free too."""
+        members, mtimes = self._delta_source()
         idx = 1 if scope == "vault" else 0
         walked = {
             (rel, mtimes[p])

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -304,6 +304,60 @@ def test_heal_reads_registry_map_not_filesystem_walk_when_live(tmp_path):
         freshness.clear()
 
 
+def test_mtime_preserving_drift_heals_from_registry_no_walk(tmp_path):
+    """Obsidian Sync preserves mtimes, so an out-of-band edit can land as
+    count/max-match + digest-differ — the `_walk_matches_rows` verify path, NOT
+    `_heal_delta`. With the registry live, that path must ALSO read the registry
+    instead of re-statting the corpus (this is the real-vault drift shape that
+    the earlier `_heal_delta`-only fix missed)."""
+    from exomem import find as find_module
+    from exomem import freshness
+    from exomem import vault as vault_module
+
+    freshness.clear()
+    try:
+        _write_page(tmp_path, "Knowledge Base/rename-old.md", "zanzibar quixotic marker", mtime=5_000)
+        _write_page(tmp_path, "Knowledge Base/other.md", "unrelated filler", mtime=4_000)
+        assert lexstore.search_bm25(tmp_path, "zanzibar", k=5, scope="kb")
+        lexstore.clear_stores()  # fresh process; no in-process hook witnessed anything
+
+        # Watcher seeds the registry live for both scopes at the current state.
+        kb_dir = tmp_path / "Knowledge Base"
+        freshness.seed(
+            tmp_path, "kb",
+            ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb_dir)),
+        )
+        freshness.seed(
+            tmp_path, "vault",
+            ((str(p), p.stat().st_mtime_ns) for p in vault_module.walk_vault_md(tmp_path)),
+        )
+
+        # Pure rename: os.replace preserves mtime, so count AND max_mtime are
+        # unchanged — only the digest differs (the `_walk_matches_rows` trigger).
+        old = tmp_path / "Knowledge Base/rename-old.md"
+        new = tmp_path / "Knowledge Base/rename-new.md"
+        os.replace(old, new)
+        freshness.on_files_changed(tmp_path, changed=[new], deleted=[old])
+
+        walks = {"n": 0}
+        real = lexstore.LexicalStore._walk_entries
+
+        def _counting(self):
+            walks["n"] += 1
+            return real(self)
+
+        lexstore.LexicalStore._walk_entries = _counting
+        try:
+            hits = lexstore.search_bm25(tmp_path, "zanzibar", k=5, scope="kb")
+        finally:
+            lexstore.LexicalStore._walk_entries = real
+
+        assert hits and hits[0][0] == "Knowledge Base/rename-new.md"  # healed via registry
+        assert walks["n"] == 0  # the verify path read the registry, not the filesystem
+    finally:
+        freshness.clear()
+
+
 def test_writer_hooks_keep_index_in_lockstep(tmp_path):
     """upsert_after_write / delete_after_remove maintain pages+fts+tri without a
     rebuild, and a subsequent query observes the change."""


### PR DESCRIPTION
## Problem

#122 made `_heal_delta` read the freshness registry instead of re-statting the
corpus — but only that heal path. `_walk_matches_rows` (the exact-verify branch for
**count/max-match + digest-differ** drift) still walked. And that's the branch a
**real** out-of-band edit hits: **Obsidian Sync preserves mtimes**, so a synced edit
lands count-and-max unchanged with only the digest moving — the verify path, not the
mismatch heal path that synthetic/local mtime-bumping edits take.

## Fix

Route `_walk_matches_rows` through `_delta_source` as well, so the **entire** lexstore
heal path is registry-driven (walk-free) when live, and falls back to the walk only
when the registry isn't live.

## Verification

- Full suite **1546 passed / 3 skipped**
- Golden recall **3 passed**
- New test: a pure mtime-preserving rename with the registry live asserts the verify
  path reads the registry (**0 filesystem walks**); the existing rename test confirms
  the walk-fallback when not live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
