### PR TITLE
perf(freshness): reconcile dispatches the drift delta through the event fan-out

### DIFF
--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -45,6 +45,13 @@ DEBOUNCE_SECONDS = 0.5
 # How often the watcher re-walks and reconciles the freshness registry against
 # disk truth, bounding how long a dropped watchdog event can leave it stale.
 RECONCILE_INTERVAL_SECONDS = 300.0
+# Upper bound on how many KB files one reconcile cycle re-embeds. Drift deltas
+# are normally a handful of files (a missed event or two per 300s window); this
+# only fires on a pathological drift (e.g. watchdog was dead while a large sync
+# landed). The freshness map is ALWAYS fully healed regardless — only the embed
+# dispatch is capped, and it logs the cap so the remainder can be closed with an
+# explicit `reconcile`.
+RECONCILE_MAX_EMBED_FILES = 500
 
 # ---- Self-write suppression registry (module-level: available to writers even
 # when no FileWatcher is running; keyed by (resolved vault root, vault-rel path)) ----
@@ -382,15 +389,121 @@ class FileWatcher:
     def _reconcile_once(self, *, seed: bool) -> None:
         """Re-derive the freshness maps from a fresh walk. `seed=True` on the
         first pass installs the maps and marks the scopes live; later passes
-        heal any drift from a missed watchdog event."""
+        heal any drift from a missed watchdog event AND dispatch that drift
+        delta through the same event fan-out `_flush` uses, so the derived
+        indexes (resolver, bm25, keyword, embeddings) heal off the query path
+        instead of rebuilding lazily on the next `find`.
+
+        Ordering matters: every scope's registry map is replaced FIRST (below),
+        THEN the deduped union of the deltas is dispatched — so a query racing
+        the short dispatch window pays at most today's rebuild cost, never
+        worse. Seed is NOT drift: the boot pass dispatches nothing (it must not
+        re-embed the whole vault)."""
+        changed_union: dict[str, None] = {}  # insertion-ordered dedupe across scopes
+        deleted_union: dict[str, None] = {}
+        drifted = False
         for scope in freshness.SCOPES:
             try:
                 if seed:
                     freshness.seed(self._vault_root, scope, self._walk_entries(scope))
                 else:
-                    freshness.reconcile(self._vault_root, scope, self._walk_entries(scope))
+                    delta = freshness.reconcile(
+                        self._vault_root, scope, self._walk_entries(scope)
+                    )
+                    if delta.drifted:
+                        drifted = True
+                        # vault ⊇ kb, so a KB file lands in both deltas — dedupe
+                        # to dispatch it at most once per cycle.
+                        for sp in delta.changed:
+                            changed_union.setdefault(sp, None)
+                        for sp in delta.deleted:
+                            deleted_union.setdefault(sp, None)
             except Exception:  # noqa: BLE001 — reconcile must never kill the watcher
                 log.exception("file watcher: freshness reconcile failed (scope=%s)", scope)
+        if seed or not drifted:
+            return
+        # Maps are healed; fan the drift delta out and pre-warm the triple-keyed
+        # bm25 corpus. Each step is belt-and-suspenders exception-safe — a bad
+        # batch must never kill the reconcile loop.
+        try:
+            self._dispatch_reconcile_delta(list(changed_union), list(deleted_union))
+        except Exception:  # noqa: BLE001
+            log.exception("file watcher: reconcile drift dispatch failed")
+        from . import bm25
+        for scope in freshness.SCOPES:
+            try:
+                bm25.warm(self._vault_root, scope)
+            except Exception:  # noqa: BLE001
+                log.exception("file watcher: reconcile bm25 warm failed (scope=%s)", scope)
+
+    def _dispatch_reconcile_delta(self, changed: list[str], deleted: list[str]) -> None:
+        """Fan a reconcile drift delta out through the per-batch event path.
+
+        Mirrors `_flush` MINUS the freshness publish — `reconcile` already
+        replaced the freshness map, so re-publishing it would be redundant. The
+        delta paths are the registry map's own absolute-path-string keys. A path
+        that matches a still-live self-write registration is dropped: the writer
+        already fanned it out via `register_self_write`, so re-dispatching would
+        double-embed (normally moot — the 30s suppression TTL has expired by the
+        300s reconcile — but correct under a tight race)."""
+        changed_paths = [
+            p
+            for p in (Path(sp) for sp in changed)
+            if not _is_self_write_event(self._vault_root, p, deleted=False)
+        ]
+        deleted_paths = [
+            p
+            for p in (Path(sp) for sp in deleted)
+            if not _is_self_write_event(self._vault_root, p, deleted=True)
+        ]
+        up_rels = [r for r in (self._rel(p) for p in changed_paths) if r]
+        del_rels = [r for r in (self._rel(p) for p in deleted_paths) if r]
+        if not (up_rels or del_rels):
+            return
+
+        # Inbound + resolver: the whole vault (both index sibling folders). The
+        # resolver patch also restamps its freshness triple, so the next graph
+        # query HITS the cache instead of paying the full-vault rebuild.
+        try:
+            from . import vault as vault_module
+
+            vault_module.on_inbound_files_changed(self._vault_root, up_rels, del_rels)
+        except Exception:  # noqa: BLE001
+            log.exception("file watcher: reconcile inbound publish failed")
+        try:
+            from . import find as find_module
+
+            find_module.on_resolver_files_changed(self._vault_root, up_rels, del_rels)
+        except Exception:  # noqa: BLE001
+            log.exception("file watcher: reconcile resolver publish failed")
+
+        # Index sidecars (embedding + lexical): Knowledge Base markdown only.
+        kb_ups = [p for p in changed_paths if self._is_kb(p)]
+        kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
+        if len(kb_ups) > RECONCILE_MAX_EMBED_FILES:
+            log.warning(
+                "file watcher: reconcile drift re-embed capped at %d of %d KB file(s); "
+                "the freshness registry is fully healed — run `reconcile` to re-embed "
+                "the remainder",
+                RECONCILE_MAX_EMBED_FILES, len(kb_ups),
+            )
+            kb_ups = kb_ups[:RECONCILE_MAX_EMBED_FILES]
+        if kb_ups:
+            try:
+                index_sync.upsert_after_write(self._vault_root, kb_ups)
+            except Exception:  # noqa: BLE001
+                log.exception(
+                    "file watcher: reconcile upsert_after_write failed for %d file(s)",
+                    len(kb_ups),
+                )
+        if kb_del_rels:
+            try:
+                index_sync.delete_after_remove(self._vault_root, kb_del_rels)
+            except Exception:  # noqa: BLE001
+                log.exception(
+                    "file watcher: reconcile delete_after_remove failed for %d file(s)",
+                    len(kb_del_rels),
+                )
 
     def _run_reconcile(self) -> None:
         # Seed immediately (off the boot path — this is the watcher's own

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -308,45 +308,17 @@ class FileWatcher:
         """Dispatch the coalesced batch: publish freshness/inbound for every
         changed path (vault-wide), and re-embed only the Knowledge Base subset."""
         ups, del_rels = self._drain()
+        if not (ups or del_rels):
+            return
 
-        # Freshness + inbound: the whole vault, since both index sibling folders too.
-        if ups or del_rels:
-            deleted_paths = [self._vault_root / r for r in del_rels]
-            try:
-                freshness.on_files_changed(self._vault_root, changed=ups, deleted=deleted_paths)
-            except Exception:  # noqa: BLE001 — a bad batch must never kill the watcher
-                log.exception("file watcher: freshness publish failed")
-            up_rels = [r for r in (self._rel(p) for p in ups) if r]
-            try:
-                from . import vault as vault_module
-
-                vault_module.on_inbound_files_changed(
-                    self._vault_root, up_rels, del_rels
-                )
-            except Exception:  # noqa: BLE001
-                log.exception("file watcher: inbound publish failed")
-            try:
-                from . import find as find_module
-
-                find_module.on_resolver_files_changed(
-                    self._vault_root, up_rels, del_rels
-                )
-            except Exception:  # noqa: BLE001
-                log.exception("file watcher: resolver publish failed")
-
-        # Index sidecars (embedding + lexical): Knowledge Base markdown only.
-        kb_ups = [p for p in ups if self._is_kb(p)]
-        kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
-        if kb_ups:
-            try:
-                index_sync.upsert_after_write(self._vault_root, kb_ups)
-            except Exception:  # noqa: BLE001
-                log.exception("file watcher: upsert_after_write failed for %d file(s)", len(kb_ups))
-        if kb_del_rels:
-            try:
-                index_sync.delete_after_remove(self._vault_root, kb_del_rels)
-            except Exception:  # noqa: BLE001
-                log.exception("file watcher: delete_after_remove failed for %d file(s)", len(kb_del_rels))
+        # Freshness: the whole vault, since both index sibling folders too.
+        deleted_paths = [self._vault_root / r for r in del_rels]
+        try:
+            freshness.on_files_changed(self._vault_root, changed=ups, deleted=deleted_paths)
+        except Exception:  # noqa: BLE001 — a bad batch must never kill the watcher
+            log.exception("file watcher: freshness publish failed")
+        up_rels = [r for r in (self._rel(p) for p in ups) if r]
+        self._dispatch_batch(ups, up_rels, del_rels, cap=False)
 
     # ---- debounce loop ----
 
@@ -441,23 +413,63 @@ class FileWatcher:
 
         Mirrors `_flush` MINUS the freshness publish — `reconcile` already
         replaced the freshness map, so re-publishing it would be redundant. The
-        delta paths are the registry map's own absolute-path-string keys. A path
-        that matches a still-live self-write registration is dropped: the writer
-        already fanned it out via `register_self_write`, so re-dispatching would
-        double-embed (normally moot — the 30s suppression TTL has expired by the
-        300s reconcile — but correct under a tight race)."""
+        delta paths are the registry map's own absolute-path-string keys.
+
+        The kb/vault scope walks that produced `changed`/`deleted` are two
+        separate, non-atomic snapshots — a file deleted+recreated (or vice
+        versa) between them can land in BOTH lists. Resolve that split-brain by
+        trusting the filesystem NOW: a path present in both is routed by
+        `Path(sp).exists()` (exists -> changed only, absent -> deleted only), so
+        a live file never loses its index rows to a delete dispatched after its
+        upsert.
+
+        A path that matches a still-live self-write registration is dropped:
+        the writer already fanned it out via `register_self_write`, so
+        re-dispatching would double-embed (normally moot — the 30s suppression
+        TTL has expired by the 300s reconcile — but correct under a tight
+        race)."""
+        changed_set = set(changed)
+        deleted_set = set(deleted)
+        for sp in changed_set & deleted_set:
+            if Path(sp).exists():
+                deleted_set.discard(sp)
+            else:
+                changed_set.discard(sp)
+
         changed_paths = [
             p
-            for p in (Path(sp) for sp in changed)
+            for p in (Path(sp) for sp in changed_set)
             if not _is_self_write_event(self._vault_root, p, deleted=False)
         ]
         deleted_paths = [
             p
-            for p in (Path(sp) for sp in deleted)
+            for p in (Path(sp) for sp in deleted_set)
             if not _is_self_write_event(self._vault_root, p, deleted=True)
         ]
         up_rels = [r for r in (self._rel(p) for p in changed_paths) if r]
         del_rels = [r for r in (self._rel(p) for p in deleted_paths) if r]
+        self._dispatch_batch(changed_paths, up_rels, del_rels, cap=True)
+
+    def _dispatch_batch(
+        self,
+        ups: list[Path],
+        up_rels: list[str],
+        del_rels: list[str],
+        *,
+        cap: bool,
+    ) -> None:
+        """Shared fan-out tail for `_flush` and `_dispatch_reconcile_delta`:
+        inbound publish -> resolver publish -> KB-filtered index_sync
+        upsert/delete. Each step keeps its own exception guard — a bad batch
+        must never kill the watcher or the reconcile loop.
+
+        `cap`: when True (reconcile only), the KB re-embed list fed to
+        `index_sync.upsert_after_write` is bounded by
+        `RECONCILE_MAX_EMBED_FILES` and logs when exceeded — the resolver and
+        inbound publishes still get the FULL lists regardless of `cap`; only
+        the embed dispatch is ever bounded, and the freshness/registry maps are
+        always fully healed independent of this cap.
+        """
         if not (up_rels or del_rels):
             return
 
@@ -469,18 +481,18 @@ class FileWatcher:
 
             vault_module.on_inbound_files_changed(self._vault_root, up_rels, del_rels)
         except Exception:  # noqa: BLE001
-            log.exception("file watcher: reconcile inbound publish failed")
+            log.exception("file watcher: inbound publish failed")
         try:
             from . import find as find_module
 
             find_module.on_resolver_files_changed(self._vault_root, up_rels, del_rels)
         except Exception:  # noqa: BLE001
-            log.exception("file watcher: reconcile resolver publish failed")
+            log.exception("file watcher: resolver publish failed")
 
         # Index sidecars (embedding + lexical): Knowledge Base markdown only.
-        kb_ups = [p for p in changed_paths if self._is_kb(p)]
+        kb_ups = [p for p in ups if self._is_kb(p)]
         kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
-        if len(kb_ups) > RECONCILE_MAX_EMBED_FILES:
+        if cap and len(kb_ups) > RECONCILE_MAX_EMBED_FILES:
             log.warning(
                 "file watcher: reconcile drift re-embed capped at %d of %d KB file(s); "
                 "the freshness registry is fully healed — run `reconcile` to re-embed "
@@ -492,18 +504,12 @@ class FileWatcher:
             try:
                 index_sync.upsert_after_write(self._vault_root, kb_ups)
             except Exception:  # noqa: BLE001
-                log.exception(
-                    "file watcher: reconcile upsert_after_write failed for %d file(s)",
-                    len(kb_ups),
-                )
+                log.exception("file watcher: upsert_after_write failed for %d file(s)", len(kb_ups))
         if kb_del_rels:
             try:
                 index_sync.delete_after_remove(self._vault_root, kb_del_rels)
             except Exception:  # noqa: BLE001
-                log.exception(
-                    "file watcher: reconcile delete_after_remove failed for %d file(s)",
-                    len(kb_del_rels),
-                )
+                log.exception("file watcher: delete_after_remove failed for %d file(s)", len(kb_del_rels))
 
     def _run_reconcile(self) -> None:
         # Seed immediately (off the boot path — this is the watcher's own

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -33,12 +33,28 @@ import os
 import threading
 from collections.abc import Iterable
 from pathlib import Path
+from typing import NamedTuple
 
 from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
 
 SCOPES = ("kb", "vault")
+
+
+class ReconcileDelta(NamedTuple):
+    """What `reconcile` found: whether the map drifted, and the exact delta.
+
+    `changed` (created/modified) and `deleted` are absolute path strings — the
+    registry map's own keys — so the caller can dispatch precisely the paths a
+    missed watchdog event left stale through the same event fan-out a live batch
+    uses, healing the derived indexes off the query path instead of letting them
+    rebuild lazily on the next `find`.
+    """
+
+    drifted: bool
+    changed: list[str]
+    deleted: list[str]
 
 _lock = threading.RLock()
 # (vault_root_str, scope) -> {absolute_path_str: mtime_ns}
@@ -142,27 +158,37 @@ def seed(vault_root: Path, scope: str, entries: Iterable[tuple[str, int]]) -> No
         _live.add(key)
 
 
-def reconcile(vault_root: Path, scope: str, entries: Iterable[tuple[str, int]]) -> bool:
-    """Replace the map from a fresh walk; return True if it drifted.
+def reconcile(
+    vault_root: Path, scope: str, entries: Iterable[tuple[str, int]]
+) -> ReconcileDelta:
+    """Replace the map from a fresh walk; return the drift delta.
 
     The 300s safety net for a missed watchdog event: the walk's result wins.
     A drift means an event was lost between reconciles — logged for visibility,
-    never silently dropped.
+    never silently dropped. The returned `ReconcileDelta` carries the exact
+    changed/deleted paths (this function holds both the old map and the fresh
+    walk) so the caller can dispatch them through the event fan-out; the map is
+    always fully replaced regardless of what the caller does with the delta.
     """
     key = _key(vault_root, scope)
     fresh = {sp: ns for sp, ns in entries}
     with _lock:
-        drifted = _maps.get(key) != fresh
+        old = _maps.get(key)
         _maps[key] = fresh
         _triples[key] = None
         _live.add(key)
+    old = old or {}
+    changed = [sp for sp, ns in fresh.items() if old.get(sp) != ns]
+    deleted = [sp for sp in old if sp not in fresh]
+    drifted = bool(changed or deleted)
     if drifted:
         log.warning(
             "freshness_reconcile_drift: %s scope=%s map re-derived from a fresh walk "
-            "(a filesystem event was missed since the last reconcile)",
-            vault_root, scope,
+            "(a filesystem event was missed since the last reconcile): "
+            "%d changed, %d deleted",
+            vault_root, scope, len(changed), len(deleted),
         )
-    return drifted
+    return ReconcileDelta(drifted=drifted, changed=changed, deleted=deleted)
 
 
 def triple(vault_root: Path, scope: str) -> tuple[int, int, str] | None:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -398,3 +398,42 @@ def test_reconcile_dispatch_suppresses_registered_self_write(
 
     assert ups == [] and dels == []
     assert inbound == [] and resolver == []
+
+
+def test_reconcile_delta_conflict_existing_file_routes_as_changed_only(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The kb/vault scope walks are two separate, non-atomic snapshots — a file
+    deleted+recreated between them can appear in BOTH the changed and deleted
+    delta lists in the same cycle. Split-brain must resolve by trusting the
+    filesystem now: a path that exists is dispatched as changed ONLY, never
+    also as a delete (a delete-after-upsert would strip a live file's index
+    rows until the next drift cycle re-surfaces it)."""
+    file_watcher.clear_self_write_registry()
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "split-brain-exists.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("# split brain\n", encoding="utf-8")
+
+    w._dispatch_reconcile_delta([str(p)], [str(p)])
+
+    assert len(ups) == 1 and ups[0] == [p]
+    assert dels == []
+
+
+def test_reconcile_delta_conflict_missing_file_routes_as_deleted_only(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirror case: a path present in both lists that is ABSENT on disk must
+    dispatch as a delete only, never also as an upsert."""
+    file_watcher.clear_self_write_registry()
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "split-brain-gone.md"
+    # Deliberately never created — absent on disk.
+
+    w._dispatch_reconcile_delta([str(p)], [str(p)])
+
+    assert ups == []
+    assert dels == [["Knowledge Base/Notes/split-brain-gone.md"]]

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -8,6 +8,7 @@ the lazy import.
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from pathlib import Path
@@ -15,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from exomem import embeddings, file_watcher
+from exomem import find as find_module
 
 
 def _stub_embeddings(monkeypatch: pytest.MonkeyPatch):
@@ -215,3 +217,184 @@ def test_batch_atomic_write_registers_suppression(vault, monkeypatch: pytest.Mon
     w._record(p, deleted=False)
     w._flush()
     assert ups == []
+
+
+# ---- Reconcile drift dispatch through the event fan-out (PR1) ----------------
+#
+# The 300s reconcile only re-derives the freshness map from a fresh walk. When a
+# watchdog event is missed, that drift used to force every triple-keyed derived
+# index (resolver, bm25, keyword) to rebuild lazily on the NEXT query — a
+# multi-second first-query-after-drift stall — and never re-embedded the missed
+# files (a recall gap). PR1 makes reconcile return the drift delta and the
+# watcher dispatch it through the SAME fan-out a live batch uses, off the query
+# path. We drive drift by writing/utime WITHOUT _record (a missed event), then
+# call _reconcile_once directly (the pattern in test_freshness_registry.py:215).
+
+
+def _spy_reconcile_fanout(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
+    """Capture the reconcile dispatch seams: inbound + resolver publishes, the
+    KB-filtered embed heal (index_sync), and the bm25 pre-warm."""
+    calls: dict[str, list] = {
+        "inbound": [], "resolver": [], "upsert": [], "delete": [], "warm": [],
+    }
+    monkeypatch.setattr(
+        "exomem.vault.on_inbound_files_changed",
+        lambda root, up, dl: calls["inbound"].append((list(up), list(dl))),
+    )
+    monkeypatch.setattr(
+        "exomem.find.on_resolver_files_changed",
+        lambda root, up, dl: calls["resolver"].append((list(up), list(dl))),
+    )
+    monkeypatch.setattr(
+        file_watcher.index_sync, "upsert_after_write",
+        lambda root, paths: calls["upsert"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        file_watcher.index_sync, "delete_after_remove",
+        lambda root, rels: calls["delete"].append(list(rels)),
+    )
+    monkeypatch.setattr("exomem.bm25.warm", lambda root, scope: calls["warm"].append(scope))
+    return calls
+
+
+def _vault_rel(vault: Path, path: Path) -> str:
+    return path.resolve().relative_to(vault.resolve()).as_posix()
+
+
+def test_reconcile_dispatches_drift_delta_to_fanout(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_watcher.clear_self_write_registry()
+    calls = _spy_reconcile_fanout(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    future = time.time() + 10_000
+    os.utime(target, (future, future))  # a missed watchdog event
+
+    w._reconcile_once(seed=False)
+
+    rel = _vault_rel(vault, target)
+    # The exact delta reaches inbound + resolver once, no phantom deletes.
+    assert calls["inbound"] == [([rel], [])]
+    assert calls["resolver"] == [([rel], [])]
+    # The KB file is handed to the embed/lexical heal exactly once (deduped
+    # across the kb + vault scopes).
+    assert len(calls["upsert"]) == 1
+    assert [p.resolve() for p in calls["upsert"][0]] == [target.resolve()]
+    assert calls["delete"] == []
+    # bm25 corpus pre-warmed for both scopes off the query path.
+    assert calls["warm"] == ["kb", "vault"]
+
+
+def test_reconcile_seed_dispatches_nothing(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boot seed is NOT drift — it must not re-embed the whole vault."""
+    file_watcher.clear_self_write_registry()
+    calls = _spy_reconcile_fanout(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+
+    w._reconcile_once(seed=True)
+
+    assert calls == {"inbound": [], "resolver": [], "upsert": [], "delete": [], "warm": []}
+
+
+def test_reconcile_no_drift_dispatches_nothing(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_watcher.clear_self_write_registry()
+    calls = _spy_reconcile_fanout(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    w._reconcile_once(seed=False)  # nothing changed on disk since the seed
+
+    assert calls == {"inbound": [], "resolver": [], "upsert": [], "delete": [], "warm": []}
+
+
+def test_reconcile_delete_routes_to_delete_after_remove(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_watcher.clear_self_write_registry()
+    calls = _spy_reconcile_fanout(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    rel = _vault_rel(vault, target)
+    target.unlink()  # a missed delete event
+
+    w._reconcile_once(seed=False)
+
+    assert calls["delete"] == [[rel]]
+    assert calls["upsert"] == []
+    assert calls["resolver"] == [([], [rel])]
+    assert calls["inbound"] == [([], [rel])]
+
+
+def test_reconcile_reembeds_missed_kb_file(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The recall-gap fix: a missed KB edit reaches embeddings.upsert_after_write
+    through the real index_sync seam (stubbed embedder, as in _stub_embeddings)."""
+    file_watcher.clear_self_write_registry()
+    ups, dels = _stub_embeddings(monkeypatch)
+    monkeypatch.setattr("exomem.bm25.warm", lambda root, scope: None)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+
+    w._reconcile_once(seed=False)
+
+    embedded = [p for batch in ups for p in batch]
+    assert any(p.resolve() == target.resolve() for p in embedded)
+    assert dels == []
+
+
+def test_reconcile_restamps_resolver_triple_no_rebuild(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 11.3s fix: after reconcile dispatch, the cached resolver's freshness
+    triple is restamped, so the next _get_query_resolver HITS the same instance
+    instead of a full-vault rebuild."""
+    file_watcher.clear_self_write_registry()
+    _stub_embeddings(monkeypatch)  # keep torch out; lexstore/resolver run for real
+    monkeypatch.setattr("exomem.bm25.warm", lambda root, scope: None)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    # Prime the process-shared resolver at the current freshness triple.
+    r1 = find_module._get_query_resolver(vault)
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+
+    w._reconcile_once(seed=False)
+
+    r2 = find_module._get_query_resolver(vault)
+    assert r2 is r1, "reconcile must restamp the resolver triple, not force a rebuild"
+
+
+def test_reconcile_dispatch_suppresses_registered_self_write(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path that was a registered self-write (already fanned out by the writer)
+    must not be re-dispatched by reconcile drift."""
+    file_watcher.clear_self_write_registry()
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "reconcile-self-write.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("# self\n", encoding="utf-8")
+    file_watcher.register_self_write(vault, [p])  # matching signature registered
+
+    # Spy AFTER register_self_write so the writer's own publish isn't counted.
+    ups, dels = _stub_embeddings(monkeypatch)
+    inbound: list = []
+    resolver: list = []
+    monkeypatch.setattr(
+        "exomem.vault.on_inbound_files_changed",
+        lambda root, up, dl: inbound.append((list(up), list(dl))),
+    )
+    monkeypatch.setattr(
+        "exomem.find.on_resolver_files_changed",
+        lambda root, up, dl: resolver.append((list(up), list(dl))),
+    )
+
+    w._dispatch_reconcile_delta([str(p)], [])
+
+    assert ups == [] and dels == []
+    assert inbound == [] and resolver == []

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -230,9 +230,12 @@ def test_reconcile_detects_and_heals_a_missed_event(vault: Path) -> None:
 
     kb_dir = vault / "Knowledge Base"
     fresh_entries = ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb_dir))
-    drifted = freshness.reconcile(vault, "kb", fresh_entries)
+    delta = freshness.reconcile(vault, "kb", fresh_entries)
 
-    assert drifted is True
+    assert delta.drifted is True
+    # The delta names exactly the file whose event was missed.
+    assert delta.changed == [str(target)]
+    assert delta.deleted == []
     assert freshness.triple(vault, "kb") == fresh_truth
 
 
@@ -241,9 +244,31 @@ def test_reconcile_with_no_drift_returns_false(vault: Path) -> None:
 
     kb_dir = vault / "Knowledge Base"
     fresh_entries = ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb_dir))
-    drifted = freshness.reconcile(vault, "kb", fresh_entries)
+    delta = freshness.reconcile(vault, "kb", fresh_entries)
 
-    assert drifted is False
+    assert delta.drifted is False
+    assert delta.changed == []
+    assert delta.deleted == []
+    assert freshness.triple(vault, "kb") == _fresh_walk_triple(vault, "kb")
+
+
+def test_reconcile_delta_reports_changed_and_deleted_paths(vault: Path) -> None:
+    _seed_both_scopes(vault)
+
+    kb_files = list(find_module._walk_md(vault / "Knowledge Base"))
+    modified, removed = kb_files[0], kb_files[1]
+    future = time.time() + 10_000
+    os.utime(modified, (future, future))
+    removed.unlink()
+    # No on_files_changed calls — both events are "missed".
+
+    kb_dir = vault / "Knowledge Base"
+    fresh_entries = ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb_dir))
+    delta = freshness.reconcile(vault, "kb", fresh_entries)
+
+    assert delta.drifted is True
+    assert delta.changed == [str(modified)]
+    assert delta.deleted == [str(removed)]
     assert freshness.triple(vault, "kb") == _fresh_walk_triple(vault, "kb")
 
 


### PR DESCRIPTION
## Problem

The 300s reconcile loop only re-derives the freshness registry map from a fresh
walk (`freshness.reconcile`). It never feeds the drift *delta* to the event
fan-out. So when a watchdog event is missed, two things go wrong on the next
query:

- **Every triple-keyed derived index rebuilds on the query path.** The freshness
  triple moves, so the cached `WikilinkResolver` full-rebuilds (measured
  **~11.3s**), bm25's triple-keyed corpus rebuilds (**~3.1s**), and the keyword
  lexstore heal runs on-query (**~1.3s**) — a **16.2s first-query-after-drift**
  on a large, actively-synced vault, versus ~366ms all-warm.
- **A recall gap.** Files whose events were missed are never re-embedded (the
  embeddings sidecar is healed only by caught live events or an explicit
  `reconcile` command), so their vectors stay stale indefinitely.

## Fix

`freshness.reconcile` now returns a `ReconcileDelta` (`drifted` plus the exact
changed/deleted absolute paths — it already holds both the old map and the fresh
walk).

`file_watcher._reconcile_once` replaces every scope's registry map **first**,
then dispatches the deduped union of the deltas through the **same per-batch
fan-out `_flush` uses** (minus the freshness publish reconcile already did):

1. `vault.on_inbound_files_changed`
2. `find.on_resolver_files_changed` — patches the cached resolver **and restamps
   its freshness triple**, so the next graph query hits the cache instead of the
   11.3s rebuild
3. KB-filtered `index_sync.upsert_after_write` / `delete_after_remove` — heals
   lexstore **and re-embeds the missed files, closing the recall gap**

After dispatching, it pre-warms the triple-keyed bm25 corpus (`bm25.warm`) for
both scopes in the reconcile thread, so that rebuild also lands off the query
path.

### Guards

- The reconcile loop stays exception-safe end-to-end: a failed dispatch logs and
  never kills the loop or skips the registry map heal.
- **Seed is not drift** — the first `_reconcile_once(seed=True)` at boot
  dispatches nothing (no whole-vault re-embed).
- The union is deduped across `SCOPES` (vault ⊇ kb), so a file is dispatched at
  most once per cycle.
- A path matching a still-live self-write registration is dropped (the writer
  already fanned it out via `register_self_write`).
- The re-embed batch is capped at `RECONCILE_MAX_EMBED_FILES` with a log line
  when exceeded — the freshness map is always fully healed; only the embed
  dispatch is bounded.
- Ordering: map update first, then dispatch — a query racing the short window
  pays at most today's cost, never worse.

## Test evidence

TDD, red-first (drove drift with `os.utime`/writes/`unlink` **without**
`on_files_changed`, then called reconcile — the `test_freshness_registry.py`
pattern; embeddings stubbed as in `_stub_embeddings`). New/updated tests:

- `freshness.reconcile` returns the exact changed/deleted delta (and empty on no
  drift).
- `_reconcile_once` dispatches exactly the delta to a stubbed fan-out.
- The resolver triple is restamped — the next `_get_query_resolver` returns the
  **same instance** (no full-vault rebuild).
- The missed KB file reaches `embeddings.upsert_after_write` through the real
  `index_sync` seam.
- Seed dispatches nothing; no-drift reconcile dispatches nothing.
- Deletes route to `delete_after_remove`.
- A registered self-write is suppressed at reconcile dispatch.

Gates (all green locally):

- `uv run python -m pytest` → **1554 passed, 3 skipped** (skips are unrelated
  optional deps: `av`, diarizer sidecar).
- `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings` → **3 passed** (golden NDCG@10 / MRR / recall@10 floors hold).
- `uvx ruff check` on the four changed files → **All checks passed!**

## Files changed

- `src/exomem/freshness.py` — `reconcile` returns `ReconcileDelta`.
- `src/exomem/file_watcher.py` — `_reconcile_once` collects + dispatches the
  delta; new `_dispatch_reconcile_delta`; `RECONCILE_MAX_EMBED_FILES` cap.
- `tests/test_freshness_registry.py`, `tests/test_file_watcher.py` — coverage above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsYrCghxuK4yCaC8QoMUV
