### PR TITLE
perf(embeddings): key the matrix caches on a write generation, not the WAL-checkpoint mtime

### DIFF
--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -1408,7 +1408,7 @@ def _check_corpus_contradictions(
     supersede; nothing is ever auto-acted.
 
     Reuses the existing vector sidecar (`EmbeddingIndex.all_vectors()`, cached by
-    mtime) — it reads the chunk vectors already on disk and never re-encodes, so the
+    the write generation) — it reads the chunk vectors already on disk and never re-encodes, so the
     sweep is O(eligible_files) matmuls over the sidecar matrix and needs no model
     (works on a CPU/offline box as long as a sidecar exists). The band edges are the
     same knobs the write-time check uses: floor = `corpus_aware._contradiction_floor`,
@@ -1450,7 +1450,7 @@ def _check_corpus_contradictions(
         return []
 
     idx = embeddings_module.get_embedding_index(vault_root)
-    metadata, matrix = idx.all_vectors()  # cached by sidecar mtime
+    metadata, matrix = idx.all_vectors()  # cached by the sidecar write generation
     if not metadata or matrix.shape[0] == 0:
         return []
 

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -878,6 +878,116 @@ def _file_block(keys: list[str], rel_path: str) -> tuple[int, int]:
     return ins, ins
 
 
+# --------------------------------------------------------------- generation meta
+#
+# The matrix caches key on an in-band WRITE GENERATION, not the sidecar file's
+# mtime. The sidecars are WAL sqlite: a commit does NOT move the main file's
+# mtime — a CHECKPOINT does, and under concurrent connections the checkpoint
+# fires whenever the last connection (often a pure reader) closes, at a moment no
+# writer runs. So mtime-keyed invalidation BOTH spuriously misses (a checkpoint
+# with no content change) AND goes stale (an uncheckpointed commit leaves the
+# mtime unmoved). A `meta(key, value)` row bumped inside each write's own
+# transaction changes iff the content did. Third occurrence of this class in the
+# repo; precedent + rationale: lexstore.cache_token.
+
+
+def _ensure_meta_table(
+    conn: sqlite3.Connection, data_table: str, sidecar_name: str
+) -> None:
+    """Create the `meta(key, value)` generation table if absent (idempotent).
+
+    Logs ONCE when the table is first created over an EXISTING non-empty sidecar
+    (a legacy DB written before this binary): its generation reads 0 until the
+    first gen-bumping write, and the caches fall back to mtime keying meanwhile.
+    """
+    existed = (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'"
+        ).fetchone()
+        is not None
+    )
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value INTEGER)")
+    if not existed:
+        # data_table is a trusted literal ("chunks"/"images"), never user input.
+        has_rows = (
+            conn.execute(f"SELECT 1 FROM {data_table} LIMIT 1").fetchone() is not None
+        )
+        if has_rows:
+            log.info(
+                "%s: created generation-meta over an existing non-empty sidecar "
+                "(legacy migration; mtime-keyed cache until the first gen-bumping write)",
+                sidecar_name,
+            )
+
+
+def _read_generation(conn: sqlite3.Connection) -> tuple[int, int]:
+    """Return `(epoch, generation)` from the sidecar's meta table.
+
+    A missing key reads as 0 — a legacy sidecar, or a fresh one before its first
+    gen-bumping write. One SELECT is one implicit snapshot, so the pair is
+    internally consistent even in autocommit.
+    """
+    rows = conn.execute(
+        "SELECT key, value FROM meta WHERE key IN ('epoch', 'generation')"
+    ).fetchall()
+    d = {k: v for k, v in rows}
+    return int(d.get("epoch") or 0), int(d.get("generation") or 0)
+
+
+def _bump_meta(conn: sqlite3.Connection, key: str) -> int:
+    """Increment `meta[key]` inside the caller's OPEN write txn; return the new value.
+
+    UPDATE-then-INSERT (never `INSERT OR REPLACE` with a subselect, which yields
+    NULL on the missing row). The read-back is stable because the caller holds the
+    write lock for the whole transaction.
+    """
+    cur = conn.execute("UPDATE meta SET value = value + 1 WHERE key = ?", (key,))
+    if cur.rowcount == 0:
+        conn.execute("INSERT INTO meta (key, value) VALUES (?, 1)", (key,))
+    return int(
+        conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()[0]
+    )
+
+
+def _reload_reason(old_cache: tuple | None, new_epoch: int, new_gen: int) -> str:
+    """Observability tag for a full matrix load: cold|legacy|epoch|genuine.
+
+    The `old_cache` tuple's [0] element is its captured epoch. This log line is
+    the blind spot that made the WAL-mtime bug cost two debugging sessions — every
+    full reload now says WHY, greppable in logs/exomem.log.
+    """
+    if old_cache is None:
+        return "cold"
+    if new_gen == 0:
+        return "legacy"  # gen-0 sidecar: reload was mtime-triggered (version-skew fallback)
+    if new_epoch != old_cache[0]:
+        return "epoch"  # a rebuild_all re-embed bumped the epoch
+    return "genuine"  # generation advanced — an external incremental write
+
+
+def _sidecar_cache_token(path: Path) -> tuple[int, int]:
+    """`(epoch, generation)` read READ-ONLY from a sidecar; `(0, 0)` when the file
+    is absent or predates the meta table. Never creates the sidecar or its tables —
+    a plain connection, not `_connect()`, so a find on a KB with no sidecar stays
+    a no-op. Shared by `EmbeddingIndex.cache_token` / `ClipIndex.cache_token`."""
+    if not path.exists():
+        return (0, 0)
+    try:
+        conn = sqlite3.connect(path)
+        try:
+            has_meta = (
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'"
+                ).fetchone()
+                is not None
+            )
+            return _read_generation(conn) if has_meta else (0, 0)
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return (0, 0)
+
+
 def _vec_gate(index, conn: sqlite3.Connection) -> bool:
     """Shared vec0 policy ladder for EmbeddingIndex/ClipIndex on one connection.
 
@@ -912,9 +1022,10 @@ class EmbeddingIndex:
     """Per-vault sqlite sidecar holding chunk-level vectors.
 
     The matrix returned by `all_vectors()` is cached per-process and
-    invalidated by the sidecar's own mtime — any writer that ran
-    `upsert_file()` advances the mtime, so the next search call reloads.
-    When the vec0 backend is active (`vecstore`), `search()` is served by a
+    invalidated by an in-band WRITE GENERATION (a `meta` row bumped inside every
+    write's own transaction), NOT the sidecar mtime — see the generation-meta
+    note above for why WAL-checkpoint timing makes mtime keying both spuriously
+    miss and go stale. When the vec0 backend is active (`vecstore`), `search()` is served by a
     SQL-native KNN over shadow tables in the same sidecar instead, and this
     matrix stays cold — `all_vectors()` remains for audit's all-pairs sweep
     and the numpy fallback.
@@ -930,7 +1041,11 @@ class EmbeddingIndex:
     def __init__(self, vault_root: Path):
         self.vault_root = vault_root
         self.path = sidecar_path(vault_root)
-        self._cache: tuple[float, list[tuple[str, int]], np.ndarray] | None = None
+        # (epoch, generation, mtime, metadata, matrix). Keyed on (epoch, gen);
+        # mtime is retained only for the gen==0 legacy-sidecar fallback.
+        self._cache: (
+            tuple[int, int, float, list[tuple[str, int]], np.ndarray] | None
+        ) = None
         # Guards in-memory cache mutation only (never held across a sqlite write).
         # Reentrant so rebuild_all()-style nesting can't self-deadlock.
         self._lock = threading.RLock()
@@ -956,6 +1071,7 @@ class EmbeddingIndex:
             )
             """
         )
+        _ensure_meta_table(conn, "chunks", self.path.name)
         return conn
 
     def upsert_file(
@@ -992,6 +1108,9 @@ class EmbeddingIndex:
                     )
                     if vec_on:
                         self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
+                # Bump the write generation INSIDE this txn — the read-back is
+                # stable under the write lock. The cache keys on it, not the mtime.
+                own_gen = _bump_meta(conn, "generation")
         finally:
             conn.close()
         # Patch the shared in-memory matrix in place instead of nulling it, so a
@@ -999,7 +1118,7 @@ class EmbeddingIndex:
         # numpy-lite: metadata rows carry no chunk text (see class docstring).
         new_meta = [(rel_path, i) for i in range(len(chunks))]
         new_vecs = np.asarray(vectors, dtype=np.float32) if chunks else None
-        self._patch_cache(rel_path, new_meta, new_vecs)
+        self._patch_cache(rel_path, new_meta, new_vecs, own_gen)
 
     def delete_file(self, rel_path: str) -> None:
         conn = self._connect()
@@ -1009,17 +1128,27 @@ class EmbeddingIndex:
                 if vec_on:
                     self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
+                own_gen = _bump_meta(conn, "generation")
         finally:
             conn.close()
-        self._patch_cache(rel_path, [], None)
+        self._patch_cache(rel_path, [], None, own_gen)
 
     def _patch_cache(
         self,
         rel_path: str,
-        new_meta: list[tuple[str, int, str]],
+        new_meta: list[tuple[str, int]],
         new_vecs: np.ndarray | None,
+        own_gen: int,
     ) -> None:
         """Splice one file's rows into the cached matrix (copy-on-write).
+
+        `own_gen` is the writer's OWN in-transaction generation. The file's rows
+        are ALWAYS spliced (this write's commit is durable). The cached generation
+        advances ONLY when this write is contiguous with the cache
+        (`own_gen == cached + 1`): a gap means another writer committed rows this
+        splice never saw, so claiming `own_gen` would let the cache serve a
+        generation whose rows it lacks (never use `max()`). On a gap the cache
+        keeps its generation and the next `all_vectors()` full-reload converges.
 
         Builds fresh `metadata`/`matrix` and atomically swaps `self._cache`; never
         mutates the arrays a concurrent reader may be holding. Best-effort: any
@@ -1031,12 +1160,7 @@ class EmbeddingIndex:
             if c is None:
                 return
             try:
-                new_mtime = self.path.stat().st_mtime
-            except OSError:
-                self._cache = None
-                return
-            try:
-                _, metadata, matrix = c
+                c_epoch, c_gen, c_mtime, metadata, matrix = c
                 lo, hi = _file_block([m[0] for m in metadata], rel_path)
                 new_metadata = metadata[:lo] + list(new_meta) + metadata[hi:]
                 parts = [matrix[:lo]]
@@ -1054,62 +1178,107 @@ class EmbeddingIndex:
                         f"splice invariant broken for {rel_path}: "
                         f"{len(new_metadata)} meta rows vs {new_matrix.shape[0]} vectors"
                     )
-                self._cache = (new_mtime, new_metadata, new_matrix)
+                next_gen = own_gen if own_gen == c_gen + 1 else c_gen
+                self._cache = (c_epoch, next_gen, c_mtime, new_metadata, new_matrix)
             except Exception as e:  # noqa: BLE001 — self-heal, never break a write
                 log.warning("embedding matrix splice failed (%s); dropping cache", e)
                 self._cache = None
 
+    def _read_token(self) -> tuple[int, int]:
+        """Read `(epoch, generation)` from the sidecar — the cheap freshness probe
+        every `all_vectors()` pays (~2ms on the real sidecar). No sidecar creation:
+        callers gate on `self.path.exists()` first."""
+        conn = self._connect()
+        try:
+            return _read_generation(conn)
+        finally:
+            conn.close()
+
+    def _cache_matches(self, c: tuple, epoch: int, gen: int) -> bool:
+        """Does cache tuple `c` still serve for on-disk `(epoch, gen)`?
+
+        gen >= 1 → trust the generation only. gen == 0 (legacy sidecar, pre-meta)
+        → version-skew fallback to today's mtime keying until a gen-bumping write.
+        """
+        c_epoch, c_gen, c_mtime = c[0], c[1], c[2]
+        if gen >= 1:
+            return c_gen == gen and c_epoch == epoch
+        try:
+            return c_mtime == self.path.stat().st_mtime
+        except OSError:
+            return False
+
     def all_vectors(self) -> tuple[list[tuple[str, int]], np.ndarray]:
-        """Return `(metadata, matrix)` cached until the sidecar mtime advances.
+        """Return `(metadata, matrix)` cached until the sidecar's write generation
+        (or epoch) advances — NOT its mtime (see the class + generation-meta notes).
 
         metadata[i] = (file_path, chunk_idx); matrix[i] = vector. Chunk text
         is deliberately NOT here (numpy-lite — see class docstring); fetch the
         winners' texts via `_texts_for` when needed.
         """
-        try:
-            sidecar_mtime = self.path.stat().st_mtime
-        except FileNotFoundError:
+        if not self.path.exists():
             return [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
+        epoch, gen = self._read_token()
         # Snapshot the cache tuple ONCE: another thread may swap or null it between
-        # reads, and `self._cache[0]` then `self._cache[1]` would race (TypeError on
-        # a mid-flight None). This fast path takes no lock — the common case.
+        # reads. This fast path takes no lock — the common case.
         c = self._cache
-        if c is not None and c[0] == sidecar_mtime:
-            return c[1], c[2]
+        if c is not None and self._cache_matches(c, epoch, gen):
+            return c[3], c[4]
         with self._lock:
-            c = self._cache  # re-check under the lock; another thread may have loaded
-            if c is not None and c[0] == sidecar_mtime:
-                return c[1], c[2]
-            metadata, matrix = self._load_all_rows()
-            self._cache = (sidecar_mtime, metadata, matrix)
+            # Re-read the token under the lock so the double-check compares the
+            # cache against the CURRENT on-disk generation: a thread that just
+            # loaded while we waited leaves a cache our pre-lock token can't match.
+            epoch, gen = self._read_token()
+            c = self._cache
+            if c is not None and self._cache_matches(c, epoch, gen):
+                return c[3], c[4]
+            s_epoch, s_gen, mtime, metadata, matrix = self._load_all_rows()
+            log.info(
+                "embedding matrix full load: reason=%s rows=%d gen=%d epoch=%d",
+                _reload_reason(c, s_epoch, s_gen), len(metadata), s_gen, s_epoch,
+            )
+            self._cache = (s_epoch, s_gen, mtime, metadata, matrix)
             return metadata, matrix
 
-    def _load_all_rows(self) -> tuple[list[tuple[str, int]], np.ndarray]:
-        """Full reload of every row from the sidecar → `(metadata, matrix)`.
+    def _load_all_rows(
+        self,
+    ) -> tuple[int, int, float, list[tuple[str, int]], np.ndarray]:
+        """Full reload from the sidecar → `(epoch, gen, mtime, metadata, matrix)`.
 
-        This is the O(vault) `SELECT` + `np.stack` the incremental cache exists to
-        avoid paying per find. Isolated as a named method so tests can count how
-        often a genuine full reload happens. numpy-lite: chunk text is neither
-        SELECTed nor retained (it dominated both the reload I/O and the resident
-        cost at scale); file_path strings are interned so N rows of one file
-        share a single str object.
+        Reads the meta generation AND the rows inside ONE explicit `BEGIN` so they
+        are a single consistent snapshot — python sqlite3 in autocommit runs each
+        bare SELECT in its OWN snapshot, so a naive two-statement read could pair a
+        generation with rows from a different write. This is the O(vault) `SELECT`
+        + `np.stack` the incremental cache exists to avoid paying per find; kept a
+        named method so tests can count genuine full reloads. numpy-lite: chunk
+        text is neither SELECTed nor retained; file_path strings are interned so N
+        rows of one file share a single str object.
         """
         conn = self._connect()
         try:
-            rows = conn.execute(
-                "SELECT file_path, chunk_idx, vector FROM chunks "
-                "ORDER BY file_path, chunk_idx"
-            ).fetchall()
+            conn.execute("BEGIN")
+            try:
+                epoch, gen = _read_generation(conn)
+                rows = conn.execute(
+                    "SELECT file_path, chunk_idx, vector FROM chunks "
+                    "ORDER BY file_path, chunk_idx"
+                ).fetchall()
+            finally:
+                conn.rollback()  # read-only txn — release the snapshot
         finally:
             conn.close()
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
         if not rows:
-            return [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
+            return epoch, gen, mtime, [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
         metadata: list[tuple[str, int]] = []
         vectors: list[np.ndarray] = []
         for fp, idx, blob in rows:
             metadata.append((sys.intern(fp), idx))
             vectors.append(np.frombuffer(blob, dtype=np.float32))
-        return metadata, np.stack(vectors, axis=0)
+        return epoch, gen, mtime, metadata, np.stack(vectors, axis=0)
 
     def search(
         self, query_vec: np.ndarray, k: int
@@ -1325,26 +1494,52 @@ class EmbeddingIndex:
                     # bulk analog of the per-file dual-write.
                     self._vec.wipe(conn)
                     self._vec.repopulate_all(conn)
+                # Bump generation (monotonic write counter) AND epoch (re-embed
+                # marker) in the FINAL txn only — never the wipe txn above, so a
+                # reader between wipe and this commit keeps serving its consistent
+                # pre-rebuild cache instead of catching the empty intermediate.
+                # epoch catches re-embeds that changed no file mtimes.
+                _bump_meta(conn, "generation")
+                _bump_meta(conn, "epoch")
         finally:
             conn.close()
         with self._lock:
             self._cache = None
         return total
 
+    @staticmethod
+    def cache_token(vault_root: Path) -> tuple[int, int]:
+        """`(epoch, generation)` for this vault's embedding sidecar — the freshness
+        signal find keys its hot cache on. `(0, 0)` when the sidecar is absent or
+        pre-meta (legacy); find's walk triples cover invalidation meanwhile.
+
+        Deliberately NOT the sidecar file's mtime: WAL-checkpoint timing moves the
+        mtime independent of content (spurious misses) and an uncheckpointed commit
+        leaves it unmoved (stale hits). The in-band generation is bumped inside
+        every write's transaction, so it changes iff the content did. Precedent and
+        rationale: lexstore.cache_token. Read-only: never creates the sidecar.
+        """
+        path = sidecar_path(vault_root)
+        return _sidecar_cache_token(path)
+
 
 class ClipIndex:
     """Per-vault sqlite sidecar of CLIP image vectors — one vector per image.
 
-    Mirrors EmbeddingIndex (mtime-cached matrix, cosine search) but keyed by image
-    file with no chunking. Lives in its own `.clip.sqlite` so the bge text index is
+    Mirrors EmbeddingIndex (generation-cached matrix, cosine search) but keyed by
+    image file with no chunking. Lives in its own `.clip.sqlite` so the bge text index is
     untouched and the two evolve independently.
     """
 
     def __init__(self, vault_root: Path):
         self.vault_root = vault_root
         self.path = clip_sidecar_path(vault_root)
-        # (sidecar_mtime, file_paths, frame_ts_list, matrix) — frame_ts is None for images.
-        self._cache: tuple[float, list[str], list[float | None], np.ndarray] | None = None
+        # (epoch, generation, mtime, file_paths, frame_ts_list, matrix). Keyed on
+        # (epoch, gen) like EmbeddingIndex; mtime is the gen==0 legacy fallback.
+        # frame_ts is None for images, a float (seconds) for video keyframes.
+        self._cache: (
+            tuple[int, int, float, list[str], list[float | None], np.ndarray] | None
+        ) = None
         self._lock = threading.RLock()
         # vec0 backend state (see _vec_gate) — mirrors EmbeddingIndex.
         self._vec = vecstore.SqliteVecStore("images", "vector", CLIP_DIM, "vec_images")
@@ -1373,6 +1568,7 @@ class ClipIndex:
             """
         )
         self._migrate_add_frame_ts(conn)
+        _ensure_meta_table(conn, "images", self.path.name)
         return conn
 
     @staticmethod
@@ -1435,6 +1631,7 @@ class ClipIndex:
                     self._vec.dual_insert(
                         conn, "file_path = ? AND frame_ts IS NULL", (rel_path,)
                     )
+                own_gen = _bump_meta(conn, "generation")
         finally:
             conn.close()
         # Mirror the partial DELETE: replace only the image (NULL-ts) row, keep any
@@ -1444,6 +1641,7 @@ class ClipIndex:
             [rel_path],
             [None],
             np.asarray(vector, dtype=np.float32).reshape(1, -1),
+            own_gen,
             images_only=True,
         )
 
@@ -1475,6 +1673,7 @@ class ClipIndex:
                 )
                 if vec_on:
                     self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
+                own_gen = _bump_meta(conn, "generation")
         finally:
             conn.close()
         # Whole-file DELETE + re-insert → block-replace with the frames, ordered by
@@ -1485,6 +1684,7 @@ class ClipIndex:
             [rel_path] * len(ordered),
             [float(ts) for ts, _ in ordered],
             np.stack([np.asarray(vec, dtype=np.float32) for _, vec in ordered], axis=0),
+            own_gen,
         )
 
     def delete(self, rel_path: str) -> None:
@@ -1495,9 +1695,10 @@ class ClipIndex:
                 if vec_on:
                     self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM images WHERE file_path = ?", (rel_path,))
+                own_gen = _bump_meta(conn, "generation")
         finally:
             conn.close()
-        self._patch_cache(rel_path, [], [], None)
+        self._patch_cache(rel_path, [], [], None, own_gen)
 
     def _patch_cache(
         self,
@@ -1505,10 +1706,15 @@ class ClipIndex:
         new_paths: list[str],
         new_frame_ts: list[float | None],
         new_vecs: np.ndarray | None,
+        own_gen: int,
         *,
         images_only: bool = False,
     ) -> None:
         """Splice one file's CLIP rows into the cached matrix (copy-on-write).
+
+        `own_gen` is the writer's own in-transaction generation; the cached
+        generation advances only when contiguous (`own_gen == cached + 1`) — see
+        `EmbeddingIndex._patch_cache` for why `max()` is unsafe.
 
         `images_only=True` keeps existing video keyframe rows (frame_ts NOT NULL)
         and replaces only the image (NULL-ts) row, mirroring `upsert()`'s partial
@@ -1520,12 +1726,7 @@ class ClipIndex:
             if c is None:
                 return
             try:
-                new_mtime = self.path.stat().st_mtime
-            except OSError:
-                self._cache = None
-                return
-            try:
-                _, paths, frame_ts, matrix = c
+                c_epoch, c_gen, c_mtime, paths, frame_ts, matrix = c
                 lo, hi = _file_block(paths, rel_path)
                 if images_only and hi > lo:
                     keep = [j for j in range(lo, hi) if frame_ts[j] is not None]
@@ -1557,7 +1758,8 @@ class ClipIndex:
                         f"CLIP splice invariant broken for {rel_path}: "
                         f"{len(out_paths)} paths / {len(out_ts)} ts / {out_matrix.shape[0]} vecs"
                     )
-                self._cache = (new_mtime, out_paths, out_ts, out_matrix)
+                next_gen = own_gen if own_gen == c_gen + 1 else c_gen
+                self._cache = (c_epoch, next_gen, c_mtime, out_paths, out_ts, out_matrix)
             except Exception as e:  # noqa: BLE001 — self-heal, never break a write
                 log.warning("CLIP matrix splice failed (%s); dropping cache", e)
                 self._cache = None
@@ -1597,39 +1799,82 @@ class ClipIndex:
             conn.close()
         return row is not None
 
-    def all_vectors(self) -> tuple[list[str], list[float | None], np.ndarray]:
-        """Returns parallel `(file_paths, frame_ts_list, matrix)`. frame_ts is None
-        for image rows, a float (seconds) for video keyframe rows."""
-        try:
-            sidecar_mtime = self.path.stat().st_mtime
-        except FileNotFoundError:
-            return [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
-        c = self._cache  # snapshot once — a concurrent writer may swap/null it
-        if c is not None and c[0] == sidecar_mtime:
-            return c[1], c[2], c[3]
-        with self._lock:
-            c = self._cache
-            if c is not None and c[0] == sidecar_mtime:
-                return c[1], c[2], c[3]
-            paths, frame_ts, matrix = self._load_all_rows()
-            self._cache = (sidecar_mtime, paths, frame_ts, matrix)
-            return paths, frame_ts, matrix
-
-    def _load_all_rows(self) -> tuple[list[str], list[float | None], np.ndarray]:
-        """Full reload of every CLIP row from the sidecar (the O(vault) path)."""
+    def _read_token(self) -> tuple[int, int]:
+        """`(epoch, generation)` from the CLIP sidecar (mirrors EmbeddingIndex)."""
         conn = self._connect()
         try:
-            rows = conn.execute(
-                "SELECT file_path, frame_ts, vector FROM images ORDER BY file_path, frame_ts"
-            ).fetchall()
+            return _read_generation(conn)
         finally:
             conn.close()
-        if not rows:
+
+    def _cache_matches(self, c: tuple, epoch: int, gen: int) -> bool:
+        """gen >= 1 → trust generation; gen == 0 (legacy) → mtime fallback."""
+        c_epoch, c_gen, c_mtime = c[0], c[1], c[2]
+        if gen >= 1:
+            return c_gen == gen and c_epoch == epoch
+        try:
+            return c_mtime == self.path.stat().st_mtime
+        except OSError:
+            return False
+
+    def all_vectors(self) -> tuple[list[str], list[float | None], np.ndarray]:
+        """Returns parallel `(file_paths, frame_ts_list, matrix)`, cached until the
+        write generation advances (NOT the mtime — see EmbeddingIndex.all_vectors).
+        frame_ts is None for image rows, a float (seconds) for video keyframe rows."""
+        if not self.path.exists():
             return [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
+        epoch, gen = self._read_token()
+        c = self._cache  # snapshot once — a concurrent writer may swap/null it
+        if c is not None and self._cache_matches(c, epoch, gen):
+            return c[3], c[4], c[5]
+        with self._lock:
+            # Re-read the token under the lock (see EmbeddingIndex.all_vectors).
+            epoch, gen = self._read_token()
+            c = self._cache
+            if c is not None and self._cache_matches(c, epoch, gen):
+                return c[3], c[4], c[5]
+            s_epoch, s_gen, mtime, paths, frame_ts, matrix = self._load_all_rows()
+            log.info(
+                "CLIP matrix full load: reason=%s rows=%d gen=%d epoch=%d",
+                _reload_reason(c, s_epoch, s_gen), len(paths), s_gen, s_epoch,
+            )
+            self._cache = (s_epoch, s_gen, mtime, paths, frame_ts, matrix)
+            return paths, frame_ts, matrix
+
+    def _load_all_rows(
+        self,
+    ) -> tuple[int, int, float, list[str], list[float | None], np.ndarray]:
+        """Full reload → `(epoch, gen, mtime, paths, frame_ts, matrix)`, reading the
+        meta generation and rows in ONE `BEGIN` snapshot (see EmbeddingIndex)."""
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            try:
+                epoch, gen = _read_generation(conn)
+                rows = conn.execute(
+                    "SELECT file_path, frame_ts, vector FROM images "
+                    "ORDER BY file_path, frame_ts"
+                ).fetchall()
+            finally:
+                conn.rollback()  # read-only txn — release the snapshot
+        finally:
+            conn.close()
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        if not rows:
+            return epoch, gen, mtime, [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
         paths = [r[0] for r in rows]
         frame_ts = [r[1] for r in rows]
         matrix = np.stack([np.frombuffer(r[2], dtype=np.float32) for r in rows], axis=0)
-        return paths, frame_ts, matrix
+        return epoch, gen, mtime, paths, frame_ts, matrix
+
+    @staticmethod
+    def cache_token(vault_root: Path) -> tuple[int, int]:
+        """`(epoch, generation)` for this vault's CLIP sidecar — `(0, 0)` when
+        absent or pre-meta. Read-only (mirrors EmbeddingIndex.cache_token)."""
+        return _sidecar_cache_token(clip_sidecar_path(vault_root))
 
     def _vec_search(
         self, query_vec: np.ndarray, k: int

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 import logging
 import math
 import os
+import random
 import sqlite3
 import sys
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 
@@ -889,12 +891,32 @@ def _file_block(keys: list[str], rel_path: str) -> tuple[int, int]:
 # mtime unmoved). A `meta(key, value)` row bumped inside each write's own
 # transaction changes iff the content did. Third occurrence of this class in the
 # repo; precedent + rationale: lexstore.cache_token.
+#
+# One-way legacy fallback: once a sidecar's generation reaches >= 1, the cache
+# trusts (epoch, generation, instance) EXCLUSIVELY and stops checking mtime. A
+# write from a PRE-generation binary (one that predates this whole mechanism)
+# past that point is invisible to invalidation — old and new binaries writing
+# the SAME sidecar concurrently is unsupported. Fine for this single-user,
+# single-machine-per-sidecar deployment; would need re-litigating for multi-writer.
+
+_INSTANCE_MIN = 1
+_INSTANCE_MAX = 2**31 - 1
 
 
 def _ensure_meta_table(
     conn: sqlite3.Connection, data_table: str, sidecar_name: str
 ) -> None:
     """Create the `meta(key, value)` generation table if absent (idempotent).
+
+    On first creation (never on a later `_connect()` against the same physical
+    file) also writes a random nonzero `instance` row — the ABA guard (F3): a
+    sidecar file that gets DELETED and recreated from scratch restarts its
+    (epoch, generation) counters at (0, 1), so a still-warm cache from the OLD
+    file could otherwise coincidentally match the NEW file's early tokens and
+    serve the old file's stale rows forever (impossible with mtime, which a
+    brand-new file can't collide with). `instance` is committed immediately
+    (this runs before the caller's own write txn opens) so a concurrent reader
+    can never observe the meta table without it.
 
     Logs ONCE when the table is first created over an EXISTING non-empty sidecar
     (a legacy DB written before this binary): its generation reads 0 until the
@@ -908,6 +930,12 @@ def _ensure_meta_table(
     )
     conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value INTEGER)")
     if not existed:
+        instance = random.SystemRandom().randint(_INSTANCE_MIN, _INSTANCE_MAX)
+        conn.execute(
+            "INSERT OR IGNORE INTO meta (key, value) VALUES ('instance', ?)",
+            (instance,),
+        )
+        conn.commit()
         # data_table is a trusted literal ("chunks"/"images"), never user input.
         has_rows = (
             conn.execute(f"SELECT 1 FROM {data_table} LIMIT 1").fetchone() is not None
@@ -920,18 +948,26 @@ def _ensure_meta_table(
             )
 
 
-def _read_generation(conn: sqlite3.Connection) -> tuple[int, int]:
-    """Return `(epoch, generation)` from the sidecar's meta table.
+def _read_meta_token(conn: sqlite3.Connection) -> tuple[int, int, int]:
+    """Return `(epoch, generation, instance)` from the sidecar's meta table.
 
-    A missing key reads as 0 — a legacy sidecar, or a fresh one before its first
-    gen-bumping write. One SELECT is one implicit snapshot, so the pair is
-    internally consistent even in autocommit.
+    A missing key reads as 0 — epoch/generation: a legacy sidecar, or a fresh one
+    before its first gen-bumping write; instance: a sidecar migrated before the
+    instance nonce existed (self-consistent — see `_ensure_meta_table`: such a
+    sidecar always reports 0 here, so a cache built from the SAME physical file
+    compares 0 == 0, and only a genuinely NEW file — random nonzero — differs).
+    One SELECT is one implicit snapshot, so the triple is internally consistent
+    even in autocommit.
     """
     rows = conn.execute(
-        "SELECT key, value FROM meta WHERE key IN ('epoch', 'generation')"
+        "SELECT key, value FROM meta WHERE key IN ('epoch', 'generation', 'instance')"
     ).fetchall()
     d = {k: v for k, v in rows}
-    return int(d.get("epoch") or 0), int(d.get("generation") or 0)
+    return (
+        int(d.get("epoch") or 0),
+        int(d.get("generation") or 0),
+        int(d.get("instance") or 0),
+    )
 
 
 def _bump_meta(conn: sqlite3.Connection, key: str) -> int:
@@ -949,29 +985,41 @@ def _bump_meta(conn: sqlite3.Connection, key: str) -> int:
     )
 
 
-def _reload_reason(old_cache: tuple | None, new_epoch: int, new_gen: int) -> str:
+def _reload_reason(old_cache, new_epoch: int, new_gen: int) -> str:
     """Observability tag for a full matrix load: cold|legacy|epoch|genuine.
 
-    The `old_cache` tuple's [0] element is its captured epoch. This log line is
-    the blind spot that made the WAL-mtime bug cost two debugging sessions — every
-    full reload now says WHY, greppable in logs/exomem.log.
+    `old_cache` is the previous `_EmbCache`/`_ClipCache` (or None) — `.epoch` is
+    its captured epoch. This log line is the blind spot that made the WAL-mtime
+    bug cost two debugging sessions — every full reload now says WHY, greppable
+    in logs/exomem.log.
     """
     if old_cache is None:
         return "cold"
     if new_gen == 0:
         return "legacy"  # gen-0 sidecar: reload was mtime-triggered (version-skew fallback)
-    if new_epoch != old_cache[0]:
+    if new_epoch != old_cache.epoch:
         return "epoch"  # a rebuild_all re-embed bumped the epoch
-    return "genuine"  # generation advanced — an external incremental write
+    return "genuine"  # generation (or instance) advanced — an external write
 
 
-def _sidecar_cache_token(path: Path) -> tuple[int, int]:
-    """`(epoch, generation)` read READ-ONLY from a sidecar; `(0, 0)` when the file
-    is absent or predates the meta table. Never creates the sidecar or its tables —
-    a plain connection, not `_connect()`, so a find on a KB with no sidecar stays
-    a no-op. Shared by `EmbeddingIndex.cache_token` / `ClipIndex.cache_token`."""
+def _peek_sidecar_token(path: Path) -> tuple[int, int, int] | None:
+    """Bare-connection freshness probe: `(epoch, generation, instance)`.
+
+    Plain `sqlite3.connect` — NO WAL/synchronous pragmas, NO schema CREATE TABLE
+    DDL (mirrors the original `_sidecar_cache_token` pattern; F4). A find touches
+    this 4-6x per query (the hot-cache freshness key plus `all_vectors()`, and
+    hybrid mode reads both sidecars), so skipping pragma/DDL setup on every peek
+    materially cuts the per-call overhead versus routing through `_connect()`.
+
+    Returns `(0, 0, 0)` when the sidecar doesn't exist yet or predates the `meta`
+    table — a real, expected state (fresh or legacy sidecar), not a failure.
+    Returns `None` when the read itself failed (locked/corrupt sidecar): callers
+    holding a warm cache should serve it rather than treat this as invalidation
+    (F2) — a plain `stat()` never raised this way, so a bare read here must not
+    newly break a caller that previously only paid a filesystem stat.
+    """
     if not path.exists():
-        return (0, 0)
+        return (0, 0, 0)
     try:
         conn = sqlite3.connect(path)
         try:
@@ -981,11 +1029,98 @@ def _sidecar_cache_token(path: Path) -> tuple[int, int]:
                 ).fetchone()
                 is not None
             )
-            return _read_generation(conn) if has_meta else (0, 0)
+            return _read_meta_token(conn) if has_meta else (0, 0, 0)
         finally:
             conn.close()
     except sqlite3.Error:
-        return (0, 0)
+        return None
+
+
+def _sidecar_cache_token(path: Path) -> tuple[int, int, int]:
+    """`(epoch, generation, instance)` for `find._freshness_key` — `(0, 0, 0)` on
+    ANY failure (absent, legacy, or a transient read error). A wrong reading here
+    only makes find's hot cache MISS (recompute), never serve a stale HIT, so
+    failing open to `(0, 0, 0)` is safe (contrast `_peek_sidecar_token`, whose
+    `all_vectors()` caller must distinguish a real `(0,0,0)` from a failed read to
+    avoid dropping a perfectly good warm cache — see that docstring). Read-only:
+    never creates the sidecar. Shared by `EmbeddingIndex.cache_token` /
+    `ClipIndex.cache_token`.
+    """
+    return _peek_sidecar_token(path) or (0, 0, 0)
+
+
+def _cache_is_fresh(c, path: Path, epoch: int, gen: int, instance: int) -> bool:
+    """Does cached token `(c.epoch, c.generation, c.instance, c.mtime)` still
+    serve for on-disk `(epoch, gen, instance)`?
+
+    `gen >= 1` → trust the full `(epoch, gen, instance)` triple only — matching
+    `instance` too guards the ABA case (F3): a sidecar deleted and recreated from
+    scratch restarts (epoch, generation) at (0, 1), which could otherwise
+    coincidentally match a still-warm cache from the OLD file.
+    `gen == 0` (legacy sidecar, pre-meta) → version-skew fallback to today's
+    mtime keying until the first gen-bumping write.
+
+    Shared by `EmbeddingIndex`/`ClipIndex` (F4): both cache NamedTuples expose the
+    same `.epoch`/`.generation`/`.instance`/`.mtime` fields regardless of their
+    different payloads (metadata+matrix vs paths+frame_ts+matrix).
+    """
+    if gen >= 1:
+        return c.generation == gen and c.epoch == epoch and c.instance == instance
+    try:
+        return c.mtime == path.stat().st_mtime
+    except OSError:
+        return False
+
+
+def _try_serve_cached(c, path: Path):
+    """Return `c` unchanged if it can serve the CURRENT on-disk token, else None.
+
+    Centralizes the double-checked-locking freshness gate for both classes'
+    `all_vectors()` (F4). `_peek_sidecar_token` returning `None` means the read
+    itself failed (locked/corrupt sidecar, F2): a WARM cache is served anyway
+    (stale-by-seconds under contention is acceptable and matches busy semantics)
+    — only a COLD cache (`c is None`) falls through (returns None) to the
+    caller's full-load attempt, which has its own connect/BEGIN and can still
+    raise on a genuinely broken sidecar (that failure mode is unchanged from
+    before this fix — this function only protects the fast, no-lock-needed path).
+    """
+    token = _peek_sidecar_token(path)
+    if token is None:
+        if c is not None:
+            log.warning(
+                "sidecar token read failed for %s; serving the warm cache", path
+            )
+        return c
+    if c is not None and _cache_is_fresh(c, path, *token):
+        return c
+    return None
+
+
+class _EmbCache(NamedTuple):
+    """EmbeddingIndex's in-memory matrix cache. `(epoch, generation, instance)` is
+    the write token (F1-F3); `mtime` is retained only for the gen==0 legacy
+    fallback. `metadata[i] = (file_path, chunk_idx)`; `matrix[i]` = its vector."""
+
+    epoch: int
+    generation: int
+    instance: int
+    mtime: float
+    metadata: list[tuple[str, int]]
+    matrix: np.ndarray
+
+
+class _ClipCache(NamedTuple):
+    """ClipIndex's in-memory matrix cache — mirrors `_EmbCache`. `frame_ts[i]` is
+    None for an image row, seconds for a video keyframe row; `paths`/`frame_ts`/
+    `matrix` are parallel arrays."""
+
+    epoch: int
+    generation: int
+    instance: int
+    mtime: float
+    paths: list[str]
+    frame_ts: list[float | None]
+    matrix: np.ndarray
 
 
 def _vec_gate(index, conn: sqlite3.Connection) -> bool:
@@ -1041,11 +1176,7 @@ class EmbeddingIndex:
     def __init__(self, vault_root: Path):
         self.vault_root = vault_root
         self.path = sidecar_path(vault_root)
-        # (epoch, generation, mtime, metadata, matrix). Keyed on (epoch, gen);
-        # mtime is retained only for the gen==0 legacy-sidecar fallback.
-        self._cache: (
-            tuple[int, int, float, list[tuple[str, int]], np.ndarray] | None
-        ) = None
+        self._cache: _EmbCache | None = None
         # Guards in-memory cache mutation only (never held across a sqlite write).
         # Reentrant so rebuild_all()-style nesting can't self-deadlock.
         self._lock = threading.RLock()
@@ -1108,9 +1239,11 @@ class EmbeddingIndex:
                     )
                     if vec_on:
                         self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
-                # Bump the write generation INSIDE this txn — the read-back is
-                # stable under the write lock. The cache keys on it, not the mtime.
-                own_gen = _bump_meta(conn, "generation")
+                # Bump the write generation INSIDE this txn, then read back the
+                # FULL (epoch, generation, instance) token — stable under the
+                # write lock. The cache keys on it, not the mtime.
+                _bump_meta(conn, "generation")
+                own_epoch, own_gen, own_instance = _read_meta_token(conn)
         finally:
             conn.close()
         # Patch the shared in-memory matrix in place instead of nulling it, so a
@@ -1118,7 +1251,7 @@ class EmbeddingIndex:
         # numpy-lite: metadata rows carry no chunk text (see class docstring).
         new_meta = [(rel_path, i) for i in range(len(chunks))]
         new_vecs = np.asarray(vectors, dtype=np.float32) if chunks else None
-        self._patch_cache(rel_path, new_meta, new_vecs, own_gen)
+        self._patch_cache(rel_path, new_meta, new_vecs, own_epoch, own_gen, own_instance)
 
     def delete_file(self, rel_path: str) -> None:
         conn = self._connect()
@@ -1128,45 +1261,62 @@ class EmbeddingIndex:
                 if vec_on:
                     self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
-                own_gen = _bump_meta(conn, "generation")
+                _bump_meta(conn, "generation")
+                own_epoch, own_gen, own_instance = _read_meta_token(conn)
         finally:
             conn.close()
-        self._patch_cache(rel_path, [], None, own_gen)
+        self._patch_cache(rel_path, [], None, own_epoch, own_gen, own_instance)
 
     def _patch_cache(
         self,
         rel_path: str,
         new_meta: list[tuple[str, int]],
         new_vecs: np.ndarray | None,
+        own_epoch: int,
         own_gen: int,
+        own_instance: int,
     ) -> None:
-        """Splice one file's rows into the cached matrix (copy-on-write).
+        """Splice one file's rows into the cached matrix (copy-on-write) — ONLY
+        when this write is contiguous with the CURRENT cache: `own_epoch ==
+        cached.epoch AND own_instance == cached.instance AND own_gen ==
+        cached.generation + 1`. On ANY mismatch, the splice is skipped ENTIRELY —
+        content is NOT spliced and the label does NOT advance — leaving the cache
+        exactly as it was; the resulting token mismatch heals via a full reload on
+        the next `all_vectors()` (cheap enough — Phase 1 semantics).
 
-        `own_gen` is the writer's OWN in-transaction generation. The file's rows
-        are ALWAYS spliced (this write's commit is durable). The cached generation
-        advances ONLY when this write is contiguous with the cache
-        (`own_gen == cached + 1`): a gap means another writer committed rows this
-        splice never saw, so claiming `own_gen` would let the cache serve a
-        generation whose rows it lacks (never use `max()`). On a gap the cache
-        keeps its generation and the next `all_vectors()` full-reload converges.
+        This gates content and label TOGETHER because splicing content whose
+        label can't (yet) advance is unsafe on its own (a corrected design point:
+        an earlier version of this cache spliced content unconditionally and only
+        gated the label, which does not prevent corruption). Proven trace: writer
+        A upserts file F (capturing generation 5) then stalls before calling this;
+        writer B upserts the SAME file F (generation 6) and patches immediately —
+        contiguous, so B's rows land and the label advances to 6; A then resumes
+        and calls this with its OWN (now stale) generation 5 and its OLDER rows —
+        if content were spliced unconditionally (as before), A's stale rows would
+        overwrite B's current ones while the label still reads a plausible value,
+        risking B's genuinely-current rows being replaced by A's stale ones. Never
+        use `max()` on the generation either, for the same reason: it would let
+        the cache claim a generation whose rows it never received.
 
         Builds fresh `metadata`/`matrix` and atomically swaps `self._cache`; never
         mutates the arrays a concurrent reader may be holding. Best-effort: any
-        inconsistency drops the cache to None so the next `all_vectors()` does a
-        safe full reload. Leaves a cold (`None`) cache cold — the next read loads.
+        inconsistency (post-gate) drops the cache to None so the next
+        `all_vectors()` does a safe full reload. Leaves a cold (`None`) cache
+        cold — the next read loads.
         """
         with self._lock:
             c = self._cache
             if c is None:
                 return
+            if own_epoch != c.epoch or own_instance != c.instance or own_gen != c.generation + 1:
+                return  # not contiguous with what THIS cache holds -> never splice
             try:
-                c_epoch, c_gen, c_mtime, metadata, matrix = c
-                lo, hi = _file_block([m[0] for m in metadata], rel_path)
-                new_metadata = metadata[:lo] + list(new_meta) + metadata[hi:]
-                parts = [matrix[:lo]]
+                lo, hi = _file_block([m[0] for m in c.metadata], rel_path)
+                new_metadata = c.metadata[:lo] + list(new_meta) + c.metadata[hi:]
+                parts = [c.matrix[:lo]]
                 if new_vecs is not None and new_vecs.shape[0]:
                     parts.append(new_vecs)
-                parts.append(matrix[hi:])
+                parts.append(c.matrix[hi:])
                 parts = [p for p in parts if p.shape[0]]
                 new_matrix = (
                     np.concatenate(parts, axis=0)
@@ -1178,35 +1328,12 @@ class EmbeddingIndex:
                         f"splice invariant broken for {rel_path}: "
                         f"{len(new_metadata)} meta rows vs {new_matrix.shape[0]} vectors"
                     )
-                next_gen = own_gen if own_gen == c_gen + 1 else c_gen
-                self._cache = (c_epoch, next_gen, c_mtime, new_metadata, new_matrix)
+                self._cache = _EmbCache(
+                    c.epoch, own_gen, c.instance, c.mtime, new_metadata, new_matrix
+                )
             except Exception as e:  # noqa: BLE001 — self-heal, never break a write
                 log.warning("embedding matrix splice failed (%s); dropping cache", e)
                 self._cache = None
-
-    def _read_token(self) -> tuple[int, int]:
-        """Read `(epoch, generation)` from the sidecar — the cheap freshness probe
-        every `all_vectors()` pays (~2ms on the real sidecar). No sidecar creation:
-        callers gate on `self.path.exists()` first."""
-        conn = self._connect()
-        try:
-            return _read_generation(conn)
-        finally:
-            conn.close()
-
-    def _cache_matches(self, c: tuple, epoch: int, gen: int) -> bool:
-        """Does cache tuple `c` still serve for on-disk `(epoch, gen)`?
-
-        gen >= 1 → trust the generation only. gen == 0 (legacy sidecar, pre-meta)
-        → version-skew fallback to today's mtime keying until a gen-bumping write.
-        """
-        c_epoch, c_gen, c_mtime = c[0], c[1], c[2]
-        if gen >= 1:
-            return c_gen == gen and c_epoch == epoch
-        try:
-            return c_mtime == self.path.stat().st_mtime
-        except OSError:
-            return False
 
     def all_vectors(self) -> tuple[list[tuple[str, int]], np.ndarray]:
         """Return `(metadata, matrix)` cached until the sidecar's write generation
@@ -1218,34 +1345,32 @@ class EmbeddingIndex:
         """
         if not self.path.exists():
             return [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
-        epoch, gen = self._read_token()
         # Snapshot the cache tuple ONCE: another thread may swap or null it between
         # reads. This fast path takes no lock — the common case.
         c = self._cache
-        if c is not None and self._cache_matches(c, epoch, gen):
-            return c[3], c[4]
+        served = _try_serve_cached(c, self.path)
+        if served is not None:
+            return served.metadata, served.matrix
         with self._lock:
-            # Re-read the token under the lock so the double-check compares the
-            # cache against the CURRENT on-disk generation: a thread that just
-            # loaded while we waited leaves a cache our pre-lock token can't match.
-            epoch, gen = self._read_token()
+            # Re-check under the lock: another thread may have loaded while we
+            # waited, or the fast-path token read may have failed transiently.
             c = self._cache
-            if c is not None and self._cache_matches(c, epoch, gen):
-                return c[3], c[4]
-            s_epoch, s_gen, mtime, metadata, matrix = self._load_all_rows()
+            served = _try_serve_cached(c, self.path)
+            if served is not None:
+                return served.metadata, served.matrix
+            loaded = self._load_all_rows()
             log.info(
                 "embedding matrix full load: reason=%s rows=%d gen=%d epoch=%d",
-                _reload_reason(c, s_epoch, s_gen), len(metadata), s_gen, s_epoch,
+                _reload_reason(c, loaded.epoch, loaded.generation),
+                len(loaded.metadata), loaded.generation, loaded.epoch,
             )
-            self._cache = (s_epoch, s_gen, mtime, metadata, matrix)
-            return metadata, matrix
+            self._cache = loaded
+            return loaded.metadata, loaded.matrix
 
-    def _load_all_rows(
-        self,
-    ) -> tuple[int, int, float, list[tuple[str, int]], np.ndarray]:
-        """Full reload from the sidecar → `(epoch, gen, mtime, metadata, matrix)`.
+    def _load_all_rows(self) -> _EmbCache:
+        """Full reload from the sidecar → an `_EmbCache`.
 
-        Reads the meta generation AND the rows inside ONE explicit `BEGIN` so they
+        Reads the meta token AND the rows inside ONE explicit `BEGIN` so they
         are a single consistent snapshot — python sqlite3 in autocommit runs each
         bare SELECT in its OWN snapshot, so a naive two-statement read could pair a
         generation with rows from a different write. This is the O(vault) `SELECT`
@@ -1258,7 +1383,7 @@ class EmbeddingIndex:
         try:
             conn.execute("BEGIN")
             try:
-                epoch, gen = _read_generation(conn)
+                epoch, gen, instance = _read_meta_token(conn)
                 rows = conn.execute(
                     "SELECT file_path, chunk_idx, vector FROM chunks "
                     "ORDER BY file_path, chunk_idx"
@@ -1272,13 +1397,15 @@ class EmbeddingIndex:
         except OSError:
             mtime = 0.0
         if not rows:
-            return epoch, gen, mtime, [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
+            return _EmbCache(
+                epoch, gen, instance, mtime, [], np.zeros((0, VECTOR_DIM), dtype=np.float32)
+            )
         metadata: list[tuple[str, int]] = []
         vectors: list[np.ndarray] = []
         for fp, idx, blob in rows:
             metadata.append((sys.intern(fp), idx))
             vectors.append(np.frombuffer(blob, dtype=np.float32))
-        return epoch, gen, mtime, metadata, np.stack(vectors, axis=0)
+        return _EmbCache(epoch, gen, instance, mtime, metadata, np.stack(vectors, axis=0))
 
     def search(
         self, query_vec: np.ndarray, k: int
@@ -1495,10 +1622,16 @@ class EmbeddingIndex:
                     self._vec.wipe(conn)
                     self._vec.repopulate_all(conn)
                 # Bump generation (monotonic write counter) AND epoch (re-embed
-                # marker) in the FINAL txn only — never the wipe txn above, so a
-                # reader between wipe and this commit keeps serving its consistent
-                # pre-rebuild cache instead of catching the empty intermediate.
-                # epoch catches re-embeds that changed no file mtimes.
+                # marker) in the FINAL txn only — never the wipe txn above. A WARM
+                # reader whose cache still matches the PRE-bump token keeps serving
+                # its correct pre-rebuild snapshot through the wipe→final-txn gap
+                # (the whole point of gating patch-cache on contiguity, F1). A COLD
+                # reader (or any cache miss) racing that same gap instead loads the
+                # wipe's EMPTY table under that pre-bump token, and would keep
+                # serving empty until this commit moves the token — the same
+                # exposure a full reload always had racing a wipe/rebuild window,
+                # unchanged by this PR. epoch catches re-embeds that changed no
+                # file mtimes.
                 _bump_meta(conn, "generation")
                 _bump_meta(conn, "epoch")
         finally:
@@ -1508,15 +1641,18 @@ class EmbeddingIndex:
         return total
 
     @staticmethod
-    def cache_token(vault_root: Path) -> tuple[int, int]:
-        """`(epoch, generation)` for this vault's embedding sidecar — the freshness
-        signal find keys its hot cache on. `(0, 0)` when the sidecar is absent or
-        pre-meta (legacy); find's walk triples cover invalidation meanwhile.
+    def cache_token(vault_root: Path) -> tuple[int, int, int]:
+        """`(epoch, generation, instance)` for this vault's embedding sidecar —
+        the freshness signal find keys its hot cache on. `(0, 0, 0)` when the
+        sidecar is absent or pre-meta (legacy); find's walk triples cover
+        invalidation meanwhile.
 
         Deliberately NOT the sidecar file's mtime: WAL-checkpoint timing moves the
         mtime independent of content (spurious misses) and an uncheckpointed commit
         leaves it unmoved (stale hits). The in-band generation is bumped inside
-        every write's transaction, so it changes iff the content did. Precedent and
+        every write's transaction, so it changes iff the content did; `instance`
+        additionally guards the ABA case where the sidecar was deleted and
+        recreated from scratch (see `_ensure_meta_table`). Precedent and
         rationale: lexstore.cache_token. Read-only: never creates the sidecar.
         """
         path = sidecar_path(vault_root)
@@ -1534,12 +1670,7 @@ class ClipIndex:
     def __init__(self, vault_root: Path):
         self.vault_root = vault_root
         self.path = clip_sidecar_path(vault_root)
-        # (epoch, generation, mtime, file_paths, frame_ts_list, matrix). Keyed on
-        # (epoch, gen) like EmbeddingIndex; mtime is the gen==0 legacy fallback.
-        # frame_ts is None for images, a float (seconds) for video keyframes.
-        self._cache: (
-            tuple[int, int, float, list[str], list[float | None], np.ndarray] | None
-        ) = None
+        self._cache: _ClipCache | None = None
         self._lock = threading.RLock()
         # vec0 backend state (see _vec_gate) — mirrors EmbeddingIndex.
         self._vec = vecstore.SqliteVecStore("images", "vector", CLIP_DIM, "vec_images")
@@ -1631,7 +1762,8 @@ class ClipIndex:
                     self._vec.dual_insert(
                         conn, "file_path = ? AND frame_ts IS NULL", (rel_path,)
                     )
-                own_gen = _bump_meta(conn, "generation")
+                _bump_meta(conn, "generation")
+                own_epoch, own_gen, own_instance = _read_meta_token(conn)
         finally:
             conn.close()
         # Mirror the partial DELETE: replace only the image (NULL-ts) row, keep any
@@ -1641,7 +1773,9 @@ class ClipIndex:
             [rel_path],
             [None],
             np.asarray(vector, dtype=np.float32).reshape(1, -1),
+            own_epoch,
             own_gen,
+            own_instance,
             images_only=True,
         )
 
@@ -1673,7 +1807,8 @@ class ClipIndex:
                 )
                 if vec_on:
                     self._vec.dual_insert(conn, "file_path = ?", (rel_path,))
-                own_gen = _bump_meta(conn, "generation")
+                _bump_meta(conn, "generation")
+                own_epoch, own_gen, own_instance = _read_meta_token(conn)
         finally:
             conn.close()
         # Whole-file DELETE + re-insert → block-replace with the frames, ordered by
@@ -1684,7 +1819,9 @@ class ClipIndex:
             [rel_path] * len(ordered),
             [float(ts) for ts, _ in ordered],
             np.stack([np.asarray(vec, dtype=np.float32) for _, vec in ordered], axis=0),
+            own_epoch,
             own_gen,
+            own_instance,
         )
 
     def delete(self, rel_path: str) -> None:
@@ -1695,10 +1832,11 @@ class ClipIndex:
                 if vec_on:
                     self._vec.dual_delete(conn, "file_path = ?", (rel_path,))
                 conn.execute("DELETE FROM images WHERE file_path = ?", (rel_path,))
-                own_gen = _bump_meta(conn, "generation")
+                _bump_meta(conn, "generation")
+                own_epoch, own_gen, own_instance = _read_meta_token(conn)
         finally:
             conn.close()
-        self._patch_cache(rel_path, [], [], None, own_gen)
+        self._patch_cache(rel_path, [], [], None, own_epoch, own_gen, own_instance)
 
     def _patch_cache(
         self,
@@ -1706,27 +1844,34 @@ class ClipIndex:
         new_paths: list[str],
         new_frame_ts: list[float | None],
         new_vecs: np.ndarray | None,
+        own_epoch: int,
         own_gen: int,
+        own_instance: int,
         *,
         images_only: bool = False,
     ) -> None:
-        """Splice one file's CLIP rows into the cached matrix (copy-on-write).
-
-        `own_gen` is the writer's own in-transaction generation; the cached
-        generation advances only when contiguous (`own_gen == cached + 1`) — see
-        `EmbeddingIndex._patch_cache` for why `max()` is unsafe.
+        """Splice one file's CLIP rows into the cached matrix (copy-on-write) —
+        ONLY when contiguous with the CURRENT cache: `own_epoch == cached.epoch
+        AND own_instance == cached.instance AND own_gen == cached.generation + 1`.
+        On ANY mismatch, skip the splice ENTIRELY (no content change, no label
+        advance) — see `EmbeddingIndex._patch_cache` for the full corruption
+        rationale (a delayed/out-of-order patch must never overwrite newer rows
+        with stale ones just because its own label looks superficially valid).
 
         `images_only=True` keeps existing video keyframe rows (frame_ts NOT NULL)
         and replaces only the image (NULL-ts) row, mirroring `upsert()`'s partial
         DELETE. Otherwise the file's whole block is replaced. Best-effort: any
-        inconsistency drops the cache to None for a safe full reload next read.
+        inconsistency (post-gate) drops the cache to None for a safe full reload
+        next read.
         """
         with self._lock:
             c = self._cache
             if c is None:
                 return
+            if own_epoch != c.epoch or own_instance != c.instance or own_gen != c.generation + 1:
+                return  # not contiguous with what THIS cache holds -> never splice
             try:
-                c_epoch, c_gen, c_mtime, paths, frame_ts, matrix = c
+                paths, frame_ts, matrix = c.paths, c.frame_ts, c.matrix
                 lo, hi = _file_block(paths, rel_path)
                 if images_only and hi > lo:
                     keep = [j for j in range(lo, hi) if frame_ts[j] is not None]
@@ -1758,8 +1903,9 @@ class ClipIndex:
                         f"CLIP splice invariant broken for {rel_path}: "
                         f"{len(out_paths)} paths / {len(out_ts)} ts / {out_matrix.shape[0]} vecs"
                     )
-                next_gen = own_gen if own_gen == c_gen + 1 else c_gen
-                self._cache = (c_epoch, next_gen, c_mtime, out_paths, out_ts, out_matrix)
+                self._cache = _ClipCache(
+                    c.epoch, own_gen, c.instance, c.mtime, out_paths, out_ts, out_matrix
+                )
             except Exception as e:  # noqa: BLE001 — self-heal, never break a write
                 log.warning("CLIP matrix splice failed (%s); dropping cache", e)
                 self._cache = None
@@ -1799,58 +1945,39 @@ class ClipIndex:
             conn.close()
         return row is not None
 
-    def _read_token(self) -> tuple[int, int]:
-        """`(epoch, generation)` from the CLIP sidecar (mirrors EmbeddingIndex)."""
-        conn = self._connect()
-        try:
-            return _read_generation(conn)
-        finally:
-            conn.close()
-
-    def _cache_matches(self, c: tuple, epoch: int, gen: int) -> bool:
-        """gen >= 1 → trust generation; gen == 0 (legacy) → mtime fallback."""
-        c_epoch, c_gen, c_mtime = c[0], c[1], c[2]
-        if gen >= 1:
-            return c_gen == gen and c_epoch == epoch
-        try:
-            return c_mtime == self.path.stat().st_mtime
-        except OSError:
-            return False
-
     def all_vectors(self) -> tuple[list[str], list[float | None], np.ndarray]:
         """Returns parallel `(file_paths, frame_ts_list, matrix)`, cached until the
         write generation advances (NOT the mtime — see EmbeddingIndex.all_vectors).
         frame_ts is None for image rows, a float (seconds) for video keyframe rows."""
         if not self.path.exists():
             return [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
-        epoch, gen = self._read_token()
         c = self._cache  # snapshot once — a concurrent writer may swap/null it
-        if c is not None and self._cache_matches(c, epoch, gen):
-            return c[3], c[4], c[5]
+        served = _try_serve_cached(c, self.path)
+        if served is not None:
+            return served.paths, served.frame_ts, served.matrix
         with self._lock:
-            # Re-read the token under the lock (see EmbeddingIndex.all_vectors).
-            epoch, gen = self._read_token()
+            # Re-check under the lock (see EmbeddingIndex.all_vectors).
             c = self._cache
-            if c is not None and self._cache_matches(c, epoch, gen):
-                return c[3], c[4], c[5]
-            s_epoch, s_gen, mtime, paths, frame_ts, matrix = self._load_all_rows()
+            served = _try_serve_cached(c, self.path)
+            if served is not None:
+                return served.paths, served.frame_ts, served.matrix
+            loaded = self._load_all_rows()
             log.info(
                 "CLIP matrix full load: reason=%s rows=%d gen=%d epoch=%d",
-                _reload_reason(c, s_epoch, s_gen), len(paths), s_gen, s_epoch,
+                _reload_reason(c, loaded.epoch, loaded.generation),
+                len(loaded.paths), loaded.generation, loaded.epoch,
             )
-            self._cache = (s_epoch, s_gen, mtime, paths, frame_ts, matrix)
-            return paths, frame_ts, matrix
+            self._cache = loaded
+            return loaded.paths, loaded.frame_ts, loaded.matrix
 
-    def _load_all_rows(
-        self,
-    ) -> tuple[int, int, float, list[str], list[float | None], np.ndarray]:
-        """Full reload → `(epoch, gen, mtime, paths, frame_ts, matrix)`, reading the
-        meta generation and rows in ONE `BEGIN` snapshot (see EmbeddingIndex)."""
+    def _load_all_rows(self) -> _ClipCache:
+        """Full reload → a `_ClipCache`, reading the meta token and rows in ONE
+        `BEGIN` snapshot (see EmbeddingIndex._load_all_rows)."""
         conn = self._connect()
         try:
             conn.execute("BEGIN")
             try:
-                epoch, gen = _read_generation(conn)
+                epoch, gen, instance = _read_meta_token(conn)
                 rows = conn.execute(
                     "SELECT file_path, frame_ts, vector FROM images "
                     "ORDER BY file_path, frame_ts"
@@ -1864,16 +1991,19 @@ class ClipIndex:
         except OSError:
             mtime = 0.0
         if not rows:
-            return epoch, gen, mtime, [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
+            return _ClipCache(
+                epoch, gen, instance, mtime, [], [], np.zeros((0, CLIP_DIM), dtype=np.float32)
+            )
         paths = [r[0] for r in rows]
         frame_ts = [r[1] for r in rows]
         matrix = np.stack([np.frombuffer(r[2], dtype=np.float32) for r in rows], axis=0)
-        return epoch, gen, mtime, paths, frame_ts, matrix
+        return _ClipCache(epoch, gen, instance, mtime, paths, frame_ts, matrix)
 
     @staticmethod
-    def cache_token(vault_root: Path) -> tuple[int, int]:
-        """`(epoch, generation)` for this vault's CLIP sidecar — `(0, 0)` when
-        absent or pre-meta. Read-only (mirrors EmbeddingIndex.cache_token)."""
+    def cache_token(vault_root: Path) -> tuple[int, int, int]:
+        """`(epoch, generation, instance)` for this vault's CLIP sidecar —
+        `(0, 0, 0)` when absent or pre-meta. Read-only (mirrors
+        EmbeddingIndex.cache_token)."""
         return _sidecar_cache_token(clip_sidecar_path(vault_root))
 
     def _vec_search(

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -756,8 +756,9 @@ def _freshness_key(
     - scope="vault": full-vault walk key.
     - scope="kb" with a non-empty query: BOTH (auto-widen reserves out-of-KB
       slots on every non-empty query).
-    - hybrid/vector modes: each semantic sidecar's `(epoch, generation)` write
-      token (0,0 when absent), since sidecar refreshes change semantic results.
+    - hybrid/vector modes: each semantic sidecar's `(epoch, generation, instance)`
+      write token (0,0,0 when absent), since sidecar refreshes change semantic
+      results.
       Deliberately NOT the sidecar file mtime — WAL-checkpoint timing moves it
       independent of content (spurious misses) and leaves an uncheckpointed commit
       unmoved (STALE hits); the in-band generation changes iff the content did.

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -756,21 +756,23 @@ def _freshness_key(
     - scope="vault": full-vault walk key.
     - scope="kb" with a non-empty query: BOTH (auto-widen reserves out-of-KB
       slots on every non-empty query).
-    - hybrid/vector modes: the embedding and CLIP sidecar mtimes (0 when
-      absent), since sidecar refreshes change semantic results.
+    - hybrid/vector modes: each semantic sidecar's `(epoch, generation)` write
+      token (0,0 when absent), since sidecar refreshes change semantic results.
+      Deliberately NOT the sidecar file mtime — WAL-checkpoint timing moves it
+      independent of content (spurious misses) and leaves an uncheckpointed commit
+      unmoved (STALE hits); the in-band generation changes iff the content did.
+      See EmbeddingIndex.cache_token / lexstore.cache_token.
     """
     parts: list[Any] = [date.today().toordinal()]
-    kb = vault_root / kb_dirname()
     if scope in ("kb", "kb-only"):
         parts.append(("kb", *snapshot.kb()))
     if scope == "vault" or (scope == "kb" and query_norm):
         parts.append(("vault", *snapshot.vault()))
     if mode in ("hybrid", "vector"):
-        for name in (".embeddings.sqlite", ".clip.sqlite"):
-            try:
-                parts.append((name, (kb / name).stat().st_mtime_ns))
-            except OSError:
-                parts.append((name, 0))
+        from . import embeddings
+
+        parts.append((".embeddings.sqlite", embeddings.EmbeddingIndex.cache_token(vault_root)))
+        parts.append((".clip.sqlite", embeddings.ClipIndex.cache_token(vault_root)))
     if mode in ("hybrid", "keyword"):
         # Which lexical backend serves (fts5 vs python) changes bm25-lane
         # scores, so a mid-process flip must not hit entries cached under the

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -521,21 +521,28 @@ def test_epoch_bump_invalidates_without_gen_or_mtime(tmp_path, monkeypatch):
 
 def test_out_of_order_patch_gen_gap_does_not_advance(tmp_path, monkeypatch):
     """A patch whose own generation skips ahead (a concurrent writer's rows this
-    splice never saw) must not let the cache claim a generation it lacks rows for.
-    The cache holds its generation; the next all_vectors() reload converges."""
+    splice never saw) must not let the cache claim a generation it lacks rows
+    for — NOR splice its content (F1: content and label are gated TOGETHER, never
+    independently). The cache holds its generation; the next all_vectors()
+    reload converges."""
     vault = _fresh_vault(tmp_path)
     idx = embeddings.get_embedding_index(vault)
     idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)  # DB + cache generation 1
     idx.all_vectors()
     assert idx._cache[1] == 1
+    own_epoch = idx._cache.epoch
+    own_instance = idx._cache.instance
 
-    # Gap: own_gen 3 while the cache is at generation 1 -> refuse to advance.
-    idx._patch_cache("z.md", [("z.md", 0)], _mat([9, 0]), 3)
+    # Gap: own_gen 3 while the cache is at generation 1 -> refuse to advance AND
+    # refuse to splice (z.md must not appear in the cache at all).
+    idx._patch_cache("z.md", [("z.md", 0)], _mat([9, 0]), own_epoch, 3, own_instance)
     assert idx._cache[1] == 1  # stayed put — did not jump to 3
+    assert "z.md" not in [m[0] for m in idx._cache.metadata]  # content NOT spliced
 
-    # Contiguous: own_gen 2 == cached 1 + 1 -> advance.
-    idx._patch_cache("b.md", [("b.md", 0)], _mat([0, 1]), 2)
+    # Contiguous: own_gen 2 == cached 1 + 1 -> advance AND splice.
+    idx._patch_cache("b.md", [("b.md", 0)], _mat([0, 1]), own_epoch, 2, own_instance)
     assert idx._cache[1] == 2
+    assert "b.md" in [m[0] for m in idx._cache.metadata]
 
     # The manual splices desynced the cache from the DB (still at generation 1);
     # the mismatch forces exactly one reload that converges on the DB's truth.
@@ -543,6 +550,143 @@ def test_out_of_order_patch_gen_gap_does_not_advance(tmp_path, monkeypatch):
     metadata, _ = idx.all_vectors()
     assert count["n"] == 1
     assert [m[0] for m in metadata] == ["a.md"]
+
+
+def test_delayed_patch_same_file_does_not_serve_stale_content(tmp_path, monkeypatch):
+    """F1 corruption trace (a): writer A upserts file F, then stalls before
+    calling `_patch_cache` (simulated: its token is captured but the patch call is
+    delayed). Writer B — a later, real write through the SAME shared index —
+    upserts the SAME F and patches immediately: contiguous, so B's rows land and
+    the label advances. A then resumes and calls `_patch_cache` with its OWN
+    (now-stale, non-contiguous) captured token and its OLDER rows. The delayed
+    call must be rejected wholesale: no splice, no label move — B's genuinely
+    current content must still be served, never A's stale rows."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("f.md", ["v0"], _mat([0, 0]), 0.0)  # generation 1
+    idx.all_vectors()  # warm cache at generation 1
+    stale_epoch = idx._cache.epoch
+    stale_gen = idx._cache.generation
+    stale_instance = idx._cache.instance
+
+    # Writer B: a REAL upsert_file through the shared idx — DB write + patch both
+    # happen now, advancing the cache to generation 2 with fresh content.
+    idx.upsert_file("f.md", ["v2-new"], _mat([2, 2]), 2.0)
+    assert idx._cache.generation == stale_gen + 1
+    assert idx._cache.epoch == stale_epoch
+
+    # Writer A resumes: its captured generation (stale_gen) is now BEHIND the
+    # cache (B already advanced past it) — non-contiguous — carrying A's OLDER
+    # rows for the SAME file.
+    idx._patch_cache(
+        "f.md", [("f.md", 0)], _mat([1, 1]), stale_epoch, stale_gen, stale_instance,
+    )
+
+    # Rejected wholesale: generation/content stay exactly what B produced.
+    assert idx._cache.generation == stale_gen + 1
+    metadata, matrix = idx.all_vectors()
+    row = matrix[[m[0] for m in metadata].index("f.md")]
+    assert np.array_equal(row[:2], [2, 2])  # B's fresh content still served
+    assert not np.array_equal(row[:2], [1, 1])  # A's stale content never spliced in
+
+
+def test_delayed_patch_after_rebuild_epoch_bump_does_not_serve_stale_content(
+    tmp_path, monkeypatch
+):
+    """F1 corruption trace (b): same shape but racing rebuild_all's epoch bump. A
+    patch captured BEFORE a rebuild (carrying the pre-rebuild epoch) must not be
+    allowed to splice its stale rows into the freshly-reloaded post-rebuild cache
+    — the epoch mismatch alone rejects it, independent of generation contiguity."""
+    vault = _fresh_vault(tmp_path)
+    kb = vault / "Knowledge Base"
+    (kb / "f.md").write_text("---\ntype: note\n---\n# F\nalpha\n", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def fake_embed(texts, *, is_query=False):
+        calls["n"] += 1
+        return np.stack([_pad([float(calls["n"]), 0.0]) for _ in texts], axis=0)
+
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+
+    idx = embeddings.get_embedding_index(vault)
+    idx.rebuild_all()  # first embed pass -> vectors tagged 1.0
+    idx.all_vectors()  # warm cache post-first-rebuild
+    pre_epoch = idx._cache.epoch
+    pre_gen = idx._cache.generation
+    pre_instance = idx._cache.instance
+
+    idx.rebuild_all()  # second embed pass -> vectors tagged 2.0; epoch AND gen bump
+    idx.all_vectors()  # cache reloads fresh post-second-rebuild content
+
+    # A delayed writer captured its (epoch, gen, instance) BEFORE the SECOND
+    # rebuild and now tries to splice its stale (pre-rebuild) rows in.
+    idx._patch_cache(
+        "Knowledge Base/f.md", [("Knowledge Base/f.md", 0)], _mat([9, 9]),
+        pre_epoch, pre_gen, pre_instance,
+    )
+    metadata, matrix = idx.all_vectors()
+    row = matrix[[m[0] for m in metadata].index("Knowledge Base/f.md")]
+    assert not np.array_equal(row[:2], [9, 9])  # stale patch rejected
+    assert row[0] == 2.0  # genuinely current (2nd rebuild) content served
+
+
+def test_token_read_failure_serves_warm_cache_without_raising(tmp_path, monkeypatch):
+    """F2: a transient sqlite error on the freshness token read (e.g. a
+    locked/corrupt sidecar) must not propagate out of `all_vectors()` — a WARM
+    cache is served instead (stale-by-seconds under contention is acceptable,
+    matching busy semantics). Pre-PR this path was a bare `stat()` that never
+    raised this way; a caller like `audit.py` must not be taken down by it."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    real_connect = sqlite3.connect
+
+    def boom(path, *a, **kw):
+        if str(path) == str(idx.path):
+            raise sqlite3.OperationalError("database is locked")
+        return real_connect(path, *a, **kw)
+
+    monkeypatch.setattr(sqlite3, "connect", boom)
+    metadata, matrix = idx.all_vectors()  # must not raise
+    assert [m[0] for m in metadata] == ["a.md"]  # warm cache served despite the failure
+
+
+def test_sidecar_deleted_and_recreated_aba_detected_via_instance(tmp_path, monkeypatch):
+    """F3 ABA guard: a sidecar file deleted and recreated from scratch restarts
+    its (epoch, generation) counters, so a still-warm cache could otherwise
+    coincidentally match the NEW file's tokens and serve the OLD file's stale
+    rows forever (impossible with mtime, which a brand-new file can't collide
+    with). The random `instance` nonce (unique per physical file) makes the
+    mismatch detectable even when (epoch, gen) happen to coincide."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("old.md", ["old"], _mat([1, 0]), 1.0)  # generation 1
+    idx.all_vectors()  # warm
+    old_instance = idx._cache.instance
+    old_gen = idx._cache.generation
+
+    count = _count_loads(monkeypatch, idx)
+
+    # Delete the sidecar (and its WAL siblings) and recreate it from scratch via
+    # a second instance, driving it to the SAME generation value the old cache
+    # already holds — the interesting collision case for F3.
+    for suffix in ("", "-wal", "-shm"):
+        p = idx.path.with_name(idx.path.name + suffix)
+        if p.exists():
+            p.unlink()
+    fresh = embeddings.EmbeddingIndex(vault)
+    fresh.upsert_file("new.md", ["new"], _mat([0, 1]), 5.0)  # new file's gen -> 1
+
+    new_epoch, new_gen, new_instance = embeddings._peek_sidecar_token(idx.path)
+    assert new_gen == old_gen  # (epoch, gen) ALONE would have looked "fresh"
+    assert new_instance != old_instance  # the instance nonce catches it
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 1  # detected via instance mismatch -> reloaded
+    assert [m[0] for m in metadata] == ["new.md"]  # NEW file's rows, never stale "old.md"
 
 
 def test_legacy_sidecar_migrates_and_mtime_fallback_invalidates(tmp_path, monkeypatch):
@@ -661,6 +805,34 @@ def test_clip_external_delete_detected_via_generation(tmp_path, monkeypatch):
     paths, ts, matrix = idx.all_vectors()
     assert count["n"] == 1
     assert paths == ["b.png"]
+
+
+def test_clip_out_of_order_patch_does_not_splice_stale_content(tmp_path, monkeypatch):
+    """ClipIndex mirror of the F1 gate: a non-contiguous patch must not splice
+    content OR advance the label — content and label are gated TOGETHER."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_clip_index(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)  # generation 1
+    idx.all_vectors()
+    own_epoch = idx._cache.epoch
+    own_instance = idx._cache.instance
+    assert idx._cache.generation == 1
+
+    # Gap: own_gen 3 while cached generation is 1 -> reject splice AND label.
+    idx._patch_cache(
+        "z.png", ["z.png"], [None], _cpad([9, 0]).reshape(1, -1),
+        own_epoch, 3, own_instance,
+    )
+    assert idx._cache.generation == 1
+    assert "z.png" not in idx._cache.paths
+
+    # Contiguous: own_gen 2 == cached 1 + 1 -> splice AND advance.
+    idx._patch_cache(
+        "b.png", ["b.png"], [None], _cpad([0, 1]).reshape(1, -1),
+        own_epoch, 2, own_instance,
+    )
+    assert idx._cache.generation == 2
+    assert "b.png" in idx._cache.paths
 
 
 def _bump_mtime(path: Path) -> None:

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -11,6 +11,7 @@ never wall-clock — deterministic in CI. All fabricated vectors: no torch/model
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import threading
 from pathlib import Path
@@ -191,6 +192,26 @@ def test_external_writer_triggers_exactly_one_reload(tmp_path, monkeypatch):
     assert count["n"] == 1
 
 
+def test_utime_bump_alone_does_not_reload(tmp_path, monkeypatch):
+    """A sidecar mtime bump with NO content change must not invalidate the cache.
+
+    This is the WAL-checkpoint symptom in the small: a checkpoint (fired by a
+    pure reader closing last) moves the main file's mtime without any row change,
+    so the OLD mtime-keyed cache spuriously full-reloads. The generation-keyed
+    cache ignores a bare mtime move. RED on the mtime-keyed implementation.
+    """
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm; cache keyed on generation
+
+    count = _count_loads(monkeypatch, idx)
+    _bump_mtime(idx.path)  # move mtime WITHOUT changing content (checkpoint symptom)
+    idx.all_vectors()
+    idx.all_vectors()
+    assert count["n"] == 0  # generation unchanged -> served from cache, no reload
+
+
 def test_rebuild_all_does_not_splice_per_file(tmp_path, monkeypatch):
     """rebuild_all writes in one transaction and leaves a cold cache (one reload
     on next read) — never O(N) per-file splices."""
@@ -333,6 +354,220 @@ def test_find_vector_lane_reuses_shared_matrix(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# Generation keying (the WAL-checkpoint/mtime bug fix)
+# --------------------------------------------------------------------------- #
+
+
+def _make_legacy_sidecar(
+    path: Path, rows: list[tuple[str, int, list[float], float]]
+) -> None:
+    """Write an OLD sidecar: the `chunks` table only, NO `meta` table — exactly
+    what a pre-generation binary left on disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE chunks (file_path TEXT NOT NULL, chunk_idx INTEGER NOT NULL, "
+            "chunk_text TEXT NOT NULL, vector BLOB NOT NULL, file_mtime REAL NOT NULL, "
+            "PRIMARY KEY (file_path, chunk_idx))"
+        )
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?, ?)",
+            [(fp, i, "t", _pad(v).tobytes(), m) for fp, i, v, m in rows],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _meta_exists(path: Path) -> bool:
+    conn = sqlite3.connect(path)
+    try:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'"
+            ).fetchone()
+            is not None
+        )
+    finally:
+        conn.close()
+
+
+def test_writer_under_held_reader_txn_no_reload(tmp_path, monkeypatch):
+    """The proven WAL race: a reader holds an open txn while a writer commits, so
+    the reader closes LAST and the checkpoint (and the main-file mtime move) lands
+    after the writer's _patch_cache. Old mtime keying spuriously reloads; the
+    generation-keyed cache does not."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm at generation 1
+
+    count = _count_loads(monkeypatch, idx)
+
+    # A separate connection opens a read txn and holds it — this is what defers
+    # the WAL checkpoint to whichever connection closes last.
+    reader = sqlite3.connect(idx.path)
+    try:
+        reader.execute("BEGIN")
+        reader.execute("SELECT count(*) FROM chunks").fetchone()
+        # Writer commits through the shared index while the reader txn is open.
+        idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)  # bumps gen, patches cache
+        metadata, matrix = idx.all_vectors()
+        assert [m[0] for m in metadata] == ["a.md", "b.md"]
+        assert matrix.shape[0] == 2
+    finally:
+        reader.close()  # reader closes LAST -> the deferred checkpoint fires now
+
+    # Stand in for that checkpoint's observable effect: the mtime moves with the
+    # content unchanged. Old mtime keying reloads here; generation keying does not.
+    _bump_mtime(idx.path)
+    idx.all_vectors()
+    idx.all_vectors()
+    assert count["n"] == 0  # generation stayed at 2 the whole time -> no reload
+
+
+def test_external_writer_detected_via_generation(tmp_path, monkeypatch):
+    """A second instance writing the sidecar bumps the on-disk generation; the
+    shared index detects it and serves the new rows — with NO mtime bump needed."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    external = embeddings.EmbeddingIndex(vault)
+    external.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)  # bumps DB generation
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+    idx.all_vectors()
+    assert count["n"] == 1  # second read reuses the reloaded cache
+
+
+def test_external_delete_detected_via_generation(tmp_path, monkeypatch):
+    """An external delete bumps the generation; the block is dropped on next read."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.upsert_file("b.md", ["b"], _mat([0, 1]), 2.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    external = embeddings.EmbeddingIndex(vault)
+    external.delete_file("a.md")  # bumps DB generation
+
+    metadata, matrix = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["b.md"]
+    assert matrix.shape[0] == 1
+
+
+def test_external_rebuild_serves_fresh_vectors_frozen_mtime(tmp_path, monkeypatch):
+    """rebuild_all re-embeds with an UNCHANGED file mtime; the epoch/generation
+    bump — not the sidecar mtime — is what invalidates. Freezing the sidecar mtime
+    across the external rebuild proves the cache no longer depends on it."""
+    vault = _fresh_vault(tmp_path)
+    kb = vault / "Knowledge Base"
+    (kb / "one.md").write_text(
+        "---\ntype: note\n---\n# One\nalpha beta\n", encoding="utf-8"
+    )
+
+    seq = {"n": 0}
+
+    def fake_embed(texts, *, is_query=False):
+        seq["n"] += 1
+        return np.stack([_pad([float(seq["n"]), 0.0]) for _ in texts], axis=0)
+
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+
+    idx = embeddings.get_embedding_index(vault)
+    idx.rebuild_all()
+    first = idx.all_vectors()[1][0].copy()
+    frozen = idx.path.stat()
+
+    ext = embeddings.EmbeddingIndex(vault)
+    ext.rebuild_all()  # re-embed -> different vectors; epoch + generation bumped
+    os.utime(idx.path, ns=(frozen.st_atime_ns, frozen.st_mtime_ns))  # freeze mtime
+
+    second = idx.all_vectors()[1][0]
+    assert not np.array_equal(second, first)  # fresh vectors served despite frozen mtime
+
+
+def test_epoch_bump_invalidates_without_gen_or_mtime(tmp_path, monkeypatch):
+    """The epoch key catches a re-embed that neither moved a file mtime NOR is
+    distinguishable by generation alone: bumping only epoch invalidates the cache."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    idx.all_vectors()  # warm at (epoch 0, gen 1)
+    frozen = idx.path.stat()
+
+    count = _count_loads(monkeypatch, idx)
+    # Bump ONLY the epoch (rebuild_all's re-embed marker), leave generation, and
+    # freeze the mtime — isolating epoch as the sole invalidation signal.
+    conn = sqlite3.connect(idx.path)
+    try:
+        with conn:
+            embeddings._bump_meta(conn, "epoch")
+    finally:
+        conn.close()
+    os.utime(idx.path, ns=(frozen.st_atime_ns, frozen.st_mtime_ns))
+
+    idx.all_vectors()
+    assert count["n"] == 1  # epoch moved -> reload despite unchanged gen and mtime
+
+
+def test_out_of_order_patch_gen_gap_does_not_advance(tmp_path, monkeypatch):
+    """A patch whose own generation skips ahead (a concurrent writer's rows this
+    splice never saw) must not let the cache claim a generation it lacks rows for.
+    The cache holds its generation; the next all_vectors() reload converges."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    idx.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)  # DB + cache generation 1
+    idx.all_vectors()
+    assert idx._cache[1] == 1
+
+    # Gap: own_gen 3 while the cache is at generation 1 -> refuse to advance.
+    idx._patch_cache("z.md", [("z.md", 0)], _mat([9, 0]), 3)
+    assert idx._cache[1] == 1  # stayed put — did not jump to 3
+
+    # Contiguous: own_gen 2 == cached 1 + 1 -> advance.
+    idx._patch_cache("b.md", [("b.md", 0)], _mat([0, 1]), 2)
+    assert idx._cache[1] == 2
+
+    # The manual splices desynced the cache from the DB (still at generation 1);
+    # the mismatch forces exactly one reload that converges on the DB's truth.
+    count = _count_loads(monkeypatch, idx)
+    metadata, _ = idx.all_vectors()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["a.md"]
+
+
+def test_legacy_sidecar_migrates_and_mtime_fallback_invalidates(tmp_path, monkeypatch):
+    """A pre-meta sidecar reads generation 0; the meta table is migrated in on
+    first connect, the cache retains mtime-keyed invalidation (version-skew
+    fallback) until a gen-bumping write, and an mtime bump still invalidates."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_embedding_index(vault)
+    _make_legacy_sidecar(idx.path, [("a.md", 0, [1, 0], 1.0)])
+    assert not _meta_exists(idx.path)  # legacy: no meta table yet
+
+    count = _count_loads(monkeypatch, idx)
+    metadata, matrix = idx.all_vectors()  # migrates meta, loads at generation 0
+    assert [m[0] for m in metadata] == ["a.md"]
+    assert idx._cache[1] == 0  # legacy sidecar reads generation 0
+    assert count["n"] == 1
+    assert _meta_exists(idx.path)  # migration created the meta table
+
+    # gen==0 fallback: a bare mtime bump STILL invalidates (today's semantics).
+    _bump_mtime(idx.path)
+    idx.all_vectors()
+    assert count["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
 # ClipIndex (visual matrix) — structural twin
 # --------------------------------------------------------------------------- #
 
@@ -377,6 +612,55 @@ def test_clip_sidecar_uses_wal(tmp_path):
     finally:
         conn.close()
     assert mode.lower() == "wal"
+
+
+def test_clip_utime_bump_alone_does_not_reload(tmp_path, monkeypatch):
+    """ClipIndex mirror: a bare mtime bump (checkpoint symptom) does not reload."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_clip_index(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    _bump_mtime(idx.path)
+    idx.all_vectors()
+    idx.all_vectors()
+    assert count["n"] == 0
+
+
+def test_clip_external_writer_detected_via_generation(tmp_path, monkeypatch):
+    """ClipIndex mirror: a second instance's write is caught via the generation."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_clip_index(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    ext = embeddings.ClipIndex(vault)
+    ext.upsert("b.png", _cpad([0, 1]), 2.0)  # bumps DB generation
+
+    paths, ts, matrix = idx.all_vectors()
+    assert count["n"] == 1
+    assert paths == ["a.png", "b.png"]
+    idx.all_vectors()
+    assert count["n"] == 1
+
+
+def test_clip_external_delete_detected_via_generation(tmp_path, monkeypatch):
+    """ClipIndex mirror: an external delete drops the block on next read."""
+    vault = _fresh_vault(tmp_path)
+    idx = embeddings.get_clip_index(vault)
+    idx.upsert("a.png", _cpad([1, 0]), 1.0)
+    idx.upsert("b.png", _cpad([0, 1]), 2.0)
+    idx.all_vectors()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    ext = embeddings.ClipIndex(vault)
+    ext.delete("a.png")  # bumps DB generation
+
+    paths, ts, matrix = idx.all_vectors()
+    assert count["n"] == 1
+    assert paths == ["b.png"]
 
 
 def _bump_mtime(path: Path) -> None:

--- a/tests/test_find_hot_cache.py
+++ b/tests/test_find_hot_cache.py
@@ -3,12 +3,12 @@ invalidation, caller-mutation safety, and the clear_cache() test hook."""
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from exomem import commands
+from exomem import commands, embeddings
 from exomem import find as find_module
 
 
@@ -76,17 +76,33 @@ def test_markdown_write_invalidates(vault: Path, monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("sidecar_name", [".embeddings.sqlite", ".clip.sqlite"])
-def test_sidecar_mtime_invalidates(vault: Path, monkeypatch, sidecar_name: str) -> None:
+def test_sidecar_generation_invalidates(
+    vault: Path, monkeypatch, sidecar_name: str
+) -> None:
+    """A gen-bumping write to a semantic sidecar invalidates the hot cache — keyed
+    on the in-band (epoch, generation) token, NOT the sidecar file mtime (a WAL
+    checkpoint moves the mtime with no content change; an uncheckpointed commit
+    leaves it unmoved). Replaces the old mtime/utime-driven invalidation."""
     calls = _count_semantic(monkeypatch)
     find_module.find(vault, query="metabolism")
-    sidecar = vault / "Knowledge Base" / sidecar_name
-    sidecar.write_bytes(b"stub")
     find_module.find(vault, query="metabolism")
-    assert calls["n"] == 2
-    ns = sidecar.stat().st_mtime_ns
-    os.utime(sidecar, ns=(ns + 2_000_000_000, ns + 2_000_000_000))
+    assert calls["n"] == 1  # second serve came from the hot cache
+
+    if sidecar_name == ".embeddings.sqlite":
+        vec = np.zeros((1, embeddings.VECTOR_DIM), dtype=np.float32)
+        vec[0, 0] = 1.0
+        embeddings.get_embedding_index(vault).upsert_file(
+            "Knowledge Base/Notes/gen-probe.md", ["x"], vec, 1.0
+        )
+    else:
+        vec = np.zeros(embeddings.CLIP_DIM, dtype=np.float32)
+        vec[0] = 1.0
+        embeddings.get_clip_index(vault).upsert(
+            "Knowledge Base/Attachments/gen-probe.png", vec, 1.0
+        )
+
     find_module.find(vault, query="metabolism")
-    assert calls["n"] == 3
+    assert calls["n"] == 2  # the generation bump invalidated the cache
 
 
 def test_cache_disabled_by_env(vault: Path, monkeypatch) -> None:

--- a/tests/test_numpy_lite_cache.py
+++ b/tests/test_numpy_lite_cache.py
@@ -66,7 +66,7 @@ def test_cache_holds_no_chunk_text(tmp_path: Path) -> None:
     idx, _ = _build(tmp_path, rng)
     idx.search(_unit_rows(rng, 1)[0], k=3)  # loads the cache
     assert idx._cache is not None
-    _epoch, _gen, _mtime, metadata, _matrix = idx._cache
+    _epoch, _gen, _instance, _mtime, metadata, _matrix = idx._cache
     assert metadata and all(len(m) == 2 for m in metadata), (
         "numpy-lite cache must hold (file_path, chunk_idx) only — no text"
     )
@@ -88,6 +88,6 @@ def test_write_splice_keeps_hydration_and_shape(tmp_path: Path) -> None:
     assert hits[0][0] == rel and hits[0][1] == 2  # its own vector wins
     for fp, ci, txt, _score in hits:
         assert txt == texts[(fp, ci)]
-    _epoch, _gen, _mtime, metadata, matrix = idx._cache
+    _epoch, _gen, _instance, _mtime, metadata, matrix = idx._cache
     assert len(metadata) == matrix.shape[0]
     assert all(len(m) == 2 for m in metadata)

--- a/tests/test_numpy_lite_cache.py
+++ b/tests/test_numpy_lite_cache.py
@@ -66,7 +66,7 @@ def test_cache_holds_no_chunk_text(tmp_path: Path) -> None:
     idx, _ = _build(tmp_path, rng)
     idx.search(_unit_rows(rng, 1)[0], k=3)  # loads the cache
     assert idx._cache is not None
-    _mtime, metadata, _matrix = idx._cache
+    _epoch, _gen, _mtime, metadata, _matrix = idx._cache
     assert metadata and all(len(m) == 2 for m in metadata), (
         "numpy-lite cache must hold (file_path, chunk_idx) only — no text"
     )
@@ -88,6 +88,6 @@ def test_write_splice_keeps_hydration_and_shape(tmp_path: Path) -> None:
     assert hits[0][0] == rel and hits[0][1] == 2  # its own vector wins
     for fp, ci, txt, _score in hits:
         assert txt == texts[(fp, ci)]
-    _mtime, metadata, matrix = idx._cache
+    _epoch, _gen, _mtime, metadata, matrix = idx._cache
     assert len(metadata) == matrix.shape[0]
     assert all(len(m) == 2 for m in metadata)


### PR DESCRIPTION
## What

Key the embedding + CLIP matrix caches (and find's hot cache) on an **in-band write generation** instead of the sidecar file's mtime. This is PR2 of the "keep real-vault find() ~280ms under active editing" arc.

## The proven WAL-checkpoint mechanism (root cause)

The `.embeddings.sqlite` / `.clip.sqlite` sidecars run in WAL mode. A **commit does not move the main file's mtime — a checkpoint does.** Under any concurrent connection holding a read txn, SQLite defers the checkpoint to whichever connection closes *last* (often a pure reader), at a moment no `_patch_cache` runs. Two consequences on the old mtime-keyed caches:

- **Spurious full reloads:** `_patch_cache` recorded a pre-checkpoint mtime; the next `all_vectors()` saw the post-checkpoint mtime and full-reloaded a matrix that was already correct (~397ms idle, seconds under load).
- **`find._freshness_key` staleness in both directions:** keying the hot cache on the sidecar `st_mtime_ns` gave spurious misses *and* a stale-hit path (an uncheckpointed commit leaves the mtime unmoved → the cache serves stale results).

Single-threaded unit tests never caught this — a solo connection always checkpoints consistently. The race only appears under the reader/writer concurrency of the live service.

## The generation design

- **`meta(key TEXT PRIMARY KEY, value INTEGER)`** created in `_connect()`. `generation` is bumped **inside each write's own transaction** (`upsert_file` / `delete_file` / `upsert` / `upsert_frames` / `delete`, and `rebuild_all`'s **final bulk txn only**, never the wipe) via `UPDATE … value+1` → `INSERT` if absent → read-back, all under the write lock. A separate **`epoch`** key, bumped only by `rebuild_all`, catches re-embeds that change no file mtimes.
- **`all_vectors()`** drops the stat. It reads `(epoch, gen)` per call and serves the existing lock-free snapshot when equal; a mismatch full-reloads capturing `gen`+`epoch`+rows in **one explicit `BEGIN` snapshot** (bare SELECTs in autocommit are each their own snapshot).
- **`_patch_cache`** takes the writer's own in-txn generation and advances the cached generation **only when contiguous** (`own == cached + 1`) — never `max()`, which would let the cache claim a generation whose rows it lacks if a writer died between commit and patch.
- **`find._freshness_key`** keys on new `EmbeddingIndex.cache_token()` / `ClipIndex.cache_token()` = `(epoch, generation)` (precedent: `lexstore.cache_token`).
- **Version-skew fallback:** a legacy sidecar whose generation reads 0 (pre-meta) keeps today's mtime keying until the first gen-bumping write; the `meta` table is migrated in on first connect (one-time log).
- **Observability:** every full matrix load logs `reason=cold|epoch|legacy|genuine` — the blind spot that made this bug cost two debugging sessions, now greppable in `logs/exomem.log`.

Third occurrence of the WAL-mtime class in this repo (precedent: `lexstore.cache_token`). `claims.py` has the same pattern — **documented follow-up, not touched here.** The vec0 KNN ladder in `search()` is untouched and still serves without loading the matrix (invariant asserted in `tests/test_vecstore.py`).

## Test evidence (TDD, red-first)

The proving test `test_utime_bump_alone_does_not_reload` was **RED on the old code** (`assert 1 == 0` — a bare mtime bump forced one spurious full reload), and is green now. New/updated tests in `tests/test_embedding_matrix_cache.py` + `tests/test_find_hot_cache.py`:

- utime-only mtime bump → no reload
- writer commits under a held reader txn (reader closes last) → no reload — the live race in test form
- external second-instance write / delete → detected via generation, new rows served
- external `rebuild_all` with a **frozen** sidecar mtime → fresh vectors served (epoch), plus an epoch-only isolation test
- legacy sidecar (no `meta`) migrates + gen==0 mtime fallback still invalidates
- out-of-order patch (gen gap) → cached generation does not advance past the gap; next `all_vectors()` converges
- ClipIndex mirrors (utime no-reload, external write, external delete)
- find hot-cache invalidates via a gen-bumping write (rewritten from the old utime test)

## Gates

- `uv run pytest` (full lean suite): **1557 passed, 3 skipped**
- `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings`: **3 passed** (recall floors: ndcg10 ≥ 0.85, mrr ≥ 0.80, recall10 ≥ 0.88)
- `uvx ruff check` on the changed files: **zero new errors** (test files clean; source files carry only pre-existing advisory findings)
- vec0/CLIP/video/hybrid suites (with embeddings extra): **72 passed** — the "vec0 never loads the matrix" invariant holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsYrCghxuK4yCaC8QoMUV
