### PR TITLE
perf(claims): key the claim cache on the shared write-generation token

### DIFF
--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -44,6 +44,7 @@ import sqlite3
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 
@@ -280,22 +281,44 @@ def _claim_types() -> frozenset[str]:
     return find_module._COMPILED_TYPES
 
 
+class _ClaimCache(NamedTuple):
+    """ClaimIndex's in-memory matrix cache — mirrors `embeddings._EmbCache`.
+    `(epoch, generation, instance)` is the write token; `mtime` is retained only
+    for the gen==0 legacy fallback. metadata[i] = (file_path, claim_text,
+    page_type, status); matrix[i] = its bge vector."""
+
+    epoch: int
+    generation: int
+    instance: int
+    mtime: float
+    metadata: list[tuple[str, str, str | None, str | None]]
+    matrix: np.ndarray
+
+
 class ClaimIndex:
     """Per-vault sqlite sidecar holding ONE claim vector per compiled page.
 
     The lighter cousin of `EmbeddingIndex`: one row per file (not per chunk), so
-    the matrix is small and a plain mtime-cached full reload replaces the chunk
-    index's copy-on-write splice. Same durability contract otherwise — WAL
-    pragmas via `embeddings._apply_sidecar_pragmas`, incremental checksum-keyed
-    upsert, process-shared memo.
+    the matrix is small — every local write NULLS the cache and the next read does
+    one full reload (no copy-on-write splice; there is no `_patch_cache`). Same
+    durability contract otherwise — WAL pragmas via
+    `embeddings._apply_sidecar_pragmas`, incremental checksum-keyed upsert,
+    process-shared memo.
+
+    `all_claims()` is cached and invalidated by the same in-band WRITE GENERATION
+    the chunk/image indexes use (a `meta` row bumped inside every write's own
+    transaction, read via the shared `embeddings._*_token` helpers), NOT the
+    sidecar mtime: the sidecar is WAL sqlite, so a commit does not move the main
+    file's mtime while a checkpoint does — at a moment no writer runs — making
+    mtime keying both spuriously miss and go stale. Third occurrence of this class
+    in the repo (after EmbeddingIndex/ClipIndex, PR #125); precedent + rationale:
+    the generation-meta note in `embeddings`.
     """
 
     def __init__(self, vault_root: Path):
         self.vault_root = vault_root
         self.path = sidecar_path(vault_root)
-        # (sidecar_mtime, metadata, matrix); metadata[i] = (file_path, claim_text,
-        # page_type, status).
-        self._cache: tuple[float, list[tuple[str, str, str | None, str | None]], np.ndarray] | None = None
+        self._cache: _ClaimCache | None = None
         self._lock = threading.RLock()
 
     def _connect(self) -> sqlite3.Connection:
@@ -315,6 +338,7 @@ class ClaimIndex:
             )
             """
         )
+        embeddings._ensure_meta_table(conn, "claims", self.path.name)
         return conn
 
     def checksums(self) -> dict[str, str]:
@@ -355,8 +379,9 @@ class ClaimIndex:
 
         Each row is `(file_path, claim_text, checksum, vector, page_type, status,
         mtime)`. `file_path` is the PK, so `INSERT OR REPLACE` cleanly overwrites a
-        changed claim. Drops the cache (small matrix → a single full reload is
-        cheaper than a splice).
+        changed claim. Bumps the in-band write generation INSIDE the txn (so the
+        cache invalidates on content, not mtime) and drops the cache (small matrix
+        → a single full reload is cheaper than a splice).
         """
         if not rows:
             return
@@ -372,6 +397,7 @@ class ClaimIndex:
                         for fp, ct, cs, vec, pt, st, mt in rows
                     ],
                 )
+                embeddings._bump_meta(conn, "generation")
         finally:
             conn.close()
         with self._lock:
@@ -384,6 +410,7 @@ class ClaimIndex:
         try:
             with conn:
                 conn.execute("DELETE FROM claims WHERE file_path = ?", (file_path,))
+                embeddings._bump_meta(conn, "generation")
         finally:
             conn.close()
         with self._lock:
@@ -392,45 +419,74 @@ class ClaimIndex:
     def all_claims(
         self,
     ) -> tuple[list[tuple[str, str, str | None, str | None]], np.ndarray]:
-        """`(metadata, matrix)` cached until the sidecar mtime advances.
+        """`(metadata, matrix)` cached until the sidecar's write generation (or
+        epoch) advances — NOT its mtime (see the class + generation-meta notes).
 
         metadata[i] = (file_path, claim_text, page_type, status); matrix[i] =
         the claim's bge vector. Empty when the sidecar is absent.
         """
-        try:
-            sidecar_mtime = self.path.stat().st_mtime
-        except FileNotFoundError:
+        if not self.path.exists():
             return [], np.zeros((0, embeddings.VECTOR_DIM), dtype=np.float32)
+        # Snapshot the cache tuple ONCE: another thread may swap or null it between
+        # reads. This fast path takes no lock — the common case.
         c = self._cache
-        if c is not None and c[0] == sidecar_mtime:
-            return c[1], c[2]
+        served = embeddings._try_serve_cached(c, self.path)
+        if served is not None:
+            return served.metadata, served.matrix
         with self._lock:
+            # Re-check under the lock: another thread may have loaded while we
+            # waited, or the fast-path token read may have failed transiently.
             c = self._cache
-            if c is not None and c[0] == sidecar_mtime:
-                return c[1], c[2]
-            metadata, matrix = self._load_all_rows()
-            self._cache = (sidecar_mtime, metadata, matrix)
-            return metadata, matrix
+            served = embeddings._try_serve_cached(c, self.path)
+            if served is not None:
+                return served.metadata, served.matrix
+            loaded = self._load_all_rows()
+            log.info(
+                "claim matrix full load: reason=%s rows=%d gen=%d epoch=%d",
+                embeddings._reload_reason(c, loaded.epoch, loaded.generation),
+                len(loaded.metadata), loaded.generation, loaded.epoch,
+            )
+            self._cache = loaded
+            return loaded.metadata, loaded.matrix
 
-    def _load_all_rows(
-        self,
-    ) -> tuple[list[tuple[str, str, str | None, str | None]], np.ndarray]:
+    def _load_all_rows(self) -> _ClaimCache:
+        """Full reload from the sidecar → a `_ClaimCache`.
+
+        Reads the meta token AND the rows inside ONE explicit `BEGIN` so they are a
+        single consistent snapshot (python sqlite3 runs each bare SELECT in its own
+        snapshot in autocommit, so a naive two-statement read could pair a
+        generation with rows from a different write — mirrors
+        `EmbeddingIndex._load_all_rows`). Kept a named method so tests can count
+        genuine full reloads.
+        """
         conn = self._connect()
         try:
-            rows = conn.execute(
-                "SELECT file_path, claim_text, page_type, status, vector FROM claims "
-                "ORDER BY file_path"
-            ).fetchall()
+            conn.execute("BEGIN")
+            try:
+                epoch, gen, instance = embeddings._read_meta_token(conn)
+                rows = conn.execute(
+                    "SELECT file_path, claim_text, page_type, status, vector FROM claims "
+                    "ORDER BY file_path"
+                ).fetchall()
+            finally:
+                conn.rollback()  # read-only txn — release the snapshot
         finally:
             conn.close()
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
         if not rows:
-            return [], np.zeros((0, embeddings.VECTOR_DIM), dtype=np.float32)
+            return _ClaimCache(
+                epoch, gen, instance, mtime, [],
+                np.zeros((0, embeddings.VECTOR_DIM), dtype=np.float32),
+            )
         metadata: list[tuple[str, str, str | None, str | None]] = []
         vectors: list[np.ndarray] = []
         for fp, ct, pt, st, blob in rows:
             metadata.append((fp, ct, pt, st))
             vectors.append(np.frombuffer(blob, dtype=np.float32))
-        return metadata, np.stack(vectors, axis=0)
+        return _ClaimCache(epoch, gen, instance, mtime, metadata, np.stack(vectors, axis=0))
 
     def rebuild_all(self) -> int:
         """Wipe + re-extract/re-embed a claim for every compiled page. Returns the

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -13,6 +13,8 @@ The one model-loading test (real bge claim vectors) import-skips without torch.
 
 from __future__ import annotations
 
+import os
+import sqlite3
 from pathlib import Path
 
 import numpy as np
@@ -337,6 +339,259 @@ def test_overlap_warning_byte_identical_without_polarity() -> None:
         "— review: does this restate, refine, or contradict it? supersede the "
         "stale one if they conflict"
     )
+
+
+# ---------------- matrix cache: shared write-generation keying (mirrors #125) ----------------
+#
+# ClaimIndex is the THIRD occurrence of the WAL-mtime cache class (after
+# EmbeddingIndex/ClipIndex in PR #125): a WAL commit does not move the sidecar's
+# main-file mtime — a checkpoint does, at a moment no writer runs — so mtime
+# keying both spuriously reloads (checkpoint with no content change) AND goes
+# stale (uncheckpointed commit leaves the mtime unmoved). These lock the
+# migration onto the in-band write generation. All torch-free (fabricated
+# vectors); assertions count genuine full reloads, never wall-clock.
+#
+# ClaimIndex has NO in-place splice (unlike EmbeddingIndex/ClipIndex): its matrix
+# is small, so every local write NULLS the cache and the next read does one full
+# reload. The out-of-order-patch/contiguity tests therefore do not apply here —
+# there is no `_patch_cache`; the null-on-write behavior is asserted instead.
+
+
+def _fresh_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    return vault
+
+
+def _cvec(*vals: float) -> np.ndarray:
+    out = np.zeros(embeddings.VECTOR_DIM, dtype=np.float32)
+    out[: len(vals)] = vals
+    return out
+
+
+def _claim_row(
+    file_path: str, vec: np.ndarray, *, checksum: str = "cs", mtime: float = 1.0
+) -> tuple[str, str, str, np.ndarray, str | None, str | None, float]:
+    """One `upsert_many` row: `(file_path, claim_text, checksum, vector,
+    page_type, status, mtime)`."""
+    return (file_path, f"{file_path}\n\nclaim", checksum, vec, "insight", "active", mtime)
+
+
+def _count_loads(
+    monkeypatch: pytest.MonkeyPatch, idx: claims.ClaimIndex
+) -> dict[str, int]:
+    """Wrap `idx._load_all_rows` to count genuine full reloads (mirrors the
+    embedding-matrix cache tests)."""
+    calls = {"n": 0}
+    orig = idx._load_all_rows
+
+    def wrapped():
+        calls["n"] += 1
+        return orig()
+
+    monkeypatch.setattr(idx, "_load_all_rows", wrapped)
+    return calls
+
+
+def _bump_mtime(path: Path) -> None:
+    """Push the sidecar mtime clearly forward (coarse Windows resolution) WITHOUT
+    changing content — the WAL-checkpoint symptom in the small."""
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+
+
+def _make_legacy_claims_sidecar(
+    path: Path,
+    rows: list[tuple[str, str, str, list[float], str | None, str | None, float]],
+) -> None:
+    """Write an OLD `.claims.sqlite`: the `claims` table only, NO `meta` table —
+    exactly what a pre-generation binary left on disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE claims (file_path TEXT NOT NULL PRIMARY KEY, "
+            "claim_text TEXT NOT NULL, checksum TEXT NOT NULL, vector BLOB NOT NULL, "
+            "page_type TEXT, status TEXT, file_mtime REAL NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO claims VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (fp, ct, cs, _cvec(*v).tobytes(), pt, st, mt)
+                for fp, ct, cs, v, pt, st, mt in rows
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _claims_meta_exists(path: Path) -> bool:
+    conn = sqlite3.connect(path)
+    try:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'"
+            ).fetchone()
+            is not None
+        )
+    finally:
+        conn.close()
+
+
+def test_claim_matrix_loads_once_and_is_reused(tmp_path, monkeypatch) -> None:
+    """A quiescent claim sidecar loads the matrix once, then every read reuses it."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0)), _claim_row("b.md", _cvec(0, 1))])
+
+    count = _count_loads(monkeypatch, idx)
+    metadata = matrix = None
+    for _ in range(5):
+        metadata, matrix = idx.all_claims()
+    assert count["n"] == 1  # loaded once, not per call
+    assert matrix.shape[0] == 2
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+
+
+def test_claim_utime_bump_alone_does_not_reload(tmp_path, monkeypatch) -> None:
+    """A sidecar mtime bump with NO content change must not invalidate the cache
+    (the WAL-checkpoint symptom). RED on the old mtime-keyed ClaimIndex."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0))])
+    idx.all_claims()  # warm; cache keyed on generation
+
+    count = _count_loads(monkeypatch, idx)
+    _bump_mtime(idx.path)  # move mtime WITHOUT changing content
+    idx.all_claims()
+    idx.all_claims()
+    assert count["n"] == 0  # generation unchanged -> served from cache, no reload
+
+
+def test_claim_local_write_nulls_cache_then_reloads_once(tmp_path, monkeypatch) -> None:
+    """ClaimIndex has NO in-place splice — the small matrix is nulled on every
+    local write. Assert that behavior survives the generation migration: a write
+    drops the cache to None and the next read does exactly one converging reload."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0))])
+    idx.all_claims()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    idx.upsert_many([_claim_row("b.md", _cvec(0, 1), mtime=2.0)])
+    with idx._lock:
+        assert idx._cache is None  # nulled on write, never spliced
+    metadata, matrix = idx.all_claims()
+    assert count["n"] == 1  # one reload after the write
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+    idx.all_claims()
+    assert count["n"] == 1  # reused after the reload
+
+
+def test_claim_external_writer_detected_via_generation(tmp_path, monkeypatch) -> None:
+    """A second instance's write bumps the on-disk generation; the shared index
+    detects it and serves the new rows — with NO mtime bump needed."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0))])
+    idx.all_claims()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    external = claims.ClaimIndex(vault)
+    external.upsert_many([_claim_row("b.md", _cvec(0, 1), mtime=2.0)])  # bumps DB generation
+
+    metadata, matrix = idx.all_claims()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["a.md", "b.md"]
+    idx.all_claims()
+    assert count["n"] == 1  # second read reuses the reloaded cache
+
+
+def test_claim_external_delete_detected_via_generation(tmp_path, monkeypatch) -> None:
+    """An external delete bumps the generation; the row is dropped on next read."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0)), _claim_row("b.md", _cvec(0, 1))])
+    idx.all_claims()  # warm
+
+    count = _count_loads(monkeypatch, idx)
+    external = claims.ClaimIndex(vault)
+    external.delete("a.md")  # bumps DB generation
+
+    metadata, matrix = idx.all_claims()
+    assert count["n"] == 1
+    assert [m[0] for m in metadata] == ["b.md"]
+    assert matrix.shape[0] == 1
+
+
+def test_claim_sidecar_deleted_and_recreated_aba_detected_via_instance(
+    tmp_path, monkeypatch
+) -> None:
+    """F3 ABA guard: a sidecar deleted and recreated from scratch restarts its
+    (epoch, generation) counters, so a still-warm cache could coincidentally match
+    the NEW file's early tokens. The random `instance` nonce catches it even when
+    (epoch, gen) coincide."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("old.md", _cvec(1, 0))])  # generation 1
+    idx.all_claims()  # warm
+    old_instance = idx._cache.instance
+    old_gen = idx._cache.generation
+
+    count = _count_loads(monkeypatch, idx)
+    for suffix in ("", "-wal", "-shm"):
+        p = idx.path.with_name(idx.path.name + suffix)
+        if p.exists():
+            p.unlink()
+    fresh = claims.ClaimIndex(vault)
+    fresh.upsert_many([_claim_row("new.md", _cvec(0, 1), mtime=5.0)])  # new file's gen -> 1
+
+    new_epoch, new_gen, new_instance = embeddings._peek_sidecar_token(idx.path)
+    assert new_gen == old_gen  # (epoch, gen) ALONE would have looked "fresh"
+    assert new_instance != old_instance  # the instance nonce catches it
+
+    metadata, matrix = idx.all_claims()
+    assert count["n"] == 1  # detected via instance mismatch -> reloaded
+    assert [m[0] for m in metadata] == ["new.md"]  # NEW file's rows, never stale "old.md"
+
+
+def test_claim_legacy_sidecar_migrates_and_mtime_fallback_invalidates(
+    tmp_path, monkeypatch
+) -> None:
+    """A pre-meta `.claims.sqlite` reads generation 0; the meta table migrates in
+    on first connect, the cache retains mtime-keyed invalidation (version-skew
+    fallback) until a gen-bumping write, and an mtime bump still invalidates."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    _make_legacy_claims_sidecar(
+        idx.path, [("a.md", "a.md\n\nclaim", "cs", [1, 0], "insight", "active", 1.0)]
+    )
+    assert not _claims_meta_exists(idx.path)  # legacy: no meta table yet
+
+    count = _count_loads(monkeypatch, idx)
+    metadata, matrix = idx.all_claims()  # migrates meta, loads at generation 0
+    assert [m[0] for m in metadata] == ["a.md"]
+    assert idx._cache.generation == 0  # legacy sidecar reads generation 0
+    assert count["n"] == 1
+    assert _claims_meta_exists(idx.path)  # migration created the meta table
+
+    _bump_mtime(idx.path)  # gen==0 fallback: a bare mtime bump STILL invalidates
+    idx.all_claims()
+    assert count["n"] == 2
+
+
+def test_claim_sidecar_uses_wal(tmp_path) -> None:
+    """WAL is what lets a reader proceed without blocking a concurrent writer."""
+    vault = _fresh_vault(tmp_path)
+    idx = claims.ClaimIndex(vault)
+    idx.upsert_many([_claim_row("a.md", _cvec(1, 0))])  # creates the sidecar
+    conn = sqlite3.connect(idx.path)
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+    assert mode.lower() == "wal"
 
 
 # ---------------- semantic (model-loading) ----------------


### PR DESCRIPTION
## What

Migrate `ClaimIndex` (`src/exomem/claims.py`) off its mtime-keyed matrix cache
onto the in-band **write-generation token** that PR #125 established for
`EmbeddingIndex`/`ClipIndex`. This is the documented follow-up from #125 — the
design is mirrored, not redesigned.

## Why

`ClaimIndex` is the **third occurrence of the WAL-mtime cache class**. The
`.claims.sqlite` sidecar is WAL sqlite: a commit does **not** move the main
file's mtime — a *checkpoint* does, and under concurrent connections the
checkpoint fires whenever the last connection (often a pure reader) closes, at a
moment no writer runs. So mtime-keyed invalidation both **spuriously reloads** (a
checkpoint with no content change) and **goes stale** (an uncheckpointed commit
leaves the mtime unmoved). A `meta(key, value)` generation row bumped inside each
write's own transaction changes iff the content did.

## How (mirrors #125)

Reuses the shared module-level helpers from `embeddings.py` (imported, not
copy-pasted): `_ensure_meta_table`, `_bump_meta`, `_read_meta_token`,
`_try_serve_cached`, `_reload_reason`.

- `_connect` creates the `meta` table via `_ensure_meta_table`.
- `upsert_many`/`delete` bump `generation` inside their write txn.
- `all_claims` serves on token equality; `_load_all_rows` reads the token AND
  rows inside one explicit `BEGIN` snapshot and returns a `_ClaimCache`
  `(epoch, generation, instance, mtime, metadata, matrix)`.
- gen==0 legacy sidecars keep mtime keying until the first gen-bumping write; the
  random `instance` nonce guards the ABA (deleted-and-recreated) case.

**Deliberate deviation from #125:** `ClaimIndex` has **no `_patch_cache`**. Its
matrix is one row per file (small), so every local write still NULLS the cache
and the next read does a single full reload — no copy-on-write splice. The
out-of-order/contiguity splice tests therefore do not apply; the null-on-write
behavior is asserted instead. `all_claims` is latent (only tests exercise it);
the production polarity lane uses `get_row`/`classify_polarity`, so the blast
radius is minimal.

## Tests (mirror `tests/test_embedding_matrix_cache.py`)

Torch-free, placed before the `importorskip` block so they run in lean CI jobs:

- `test_claim_utime_bump_alone_does_not_reload` — **red on the old mtime keying**
  (`assert 1 == 0`), green now.
- external write / external delete via a second instance → detected via generation.
- ABA via the `instance` nonce; legacy sidecar migration + mtime fallback.
- loads-once, null-on-write reload-once, WAL pragma.

## Gates

- `uv run pytest` → **1580 passed, 3 skipped** (skips unrelated: diarizer venv,
  missing `av`).
- `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings`
  → **3 passed**.
- `uvx ruff check` on changed files → 5 findings, **all pre-existing on HEAD**
  (0 introduced; ruff is advisory in CI per `pyproject.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsYrCghxuK4yCaC8QoMUV
