### PR TITLE
feat(vecstore): numpy is the default vector backend; sqlite-vec becomes explicit opt-in

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -211,10 +211,11 @@ Reading it honestly:
   slowest configuration. "Sub-second search at 100k notes" is gated on the
   lexical/graph lanes, not on vector search — that is the next scaling build.
 
-**Decision record.** `auto` defaults to vec0-f32: the lane-latency delta is
-invisible end-to-end today, while the residency and reload wins are large and
-grow with corpus size. `EXOMEM_VEC_BACKEND=numpy` restores the previous behavior
-wholesale. If a future build makes the vector lane the visible bottleneck (e.g.
+**Decision record.** (Superseded 2026-07-05 — the default is now `numpy`; see the
+"Default-backend flip" note at the end of this section.) `auto` defaults to
+vec0-f32: the lane-latency delta is invisible end-to-end today, while the
+residency and reload wins are large and grow with corpus size.
+`EXOMEM_VEC_BACKEND=numpy` restores the previous behavior wholesale. If a future build makes the vector lane the visible bottleneck (e.g.
 after the lexical lanes are fixed), the recorded next step is a real ANN index —
 hnswlib, or sqlite-vec's ANN once it leaves alpha — behind the same `vecstore`
 seam, recall-gated by the same golden floors.
@@ -258,6 +259,24 @@ it overnight, or drop the python passes:
 ```
 uv run python scripts/latency_curve.py --embeddings --sizes 100000 --max-embeddings-size 100000 --repeat 1 --vec-backend numpy,sqlite-vec,binary --lexical-backend fts5 --corpus-cache <cache-dir>
 ```
+
+**Default-backend flip (2026-07-05): numpy is now the default; sqlite-vec is
+opt-in.** The `add-sqlite-vec-backend` decision above defaulted `auto` to vec0-f32
+on the *synthetic* evidence, where its brute f32 scan lost the warm race to numpy
+but won on residency. Real-vault measurement reversed the call. On the owner's
+production vault (41k chunks on a spinning D: drive), the vec0 f32 KNN measured
+123–134ms only while its ~127MB of vec tables stayed warm in the OS page cache; as
+soon as the cache evicted them (routine on a working machine) the same query cost
+1–12s. The RAM-resident numpy scan with the generation-keyed matrix cache (#125)
+measures 24–65ms and is write-independent — no page-cache cliff. Both backends are
+exact and rank-identical (the golden floors and the f32 parity tests still hold),
+so recall is unaffected; this is purely a latency/robustness decision. The trigger
+was also operational: the old probe-and-activate `auto` silently flipped production
+onto vec0 the moment a `uv sync` installed the extension — a behavior change no one
+requested. `EXOMEM_VEC_BACKEND` now defaults to `numpy`, and vec0 activates ONLY on
+the explicit value `sqlite-vec`; there is no `auto`. The at-scale synthetic numbers
+in the table above are unchanged and still measured by naming both backends
+explicitly (`--vec-backend numpy,sqlite-vec,binary`).
 
 ## Lexical backend at scale (10k–50k notes, FTS5 vs in-process)
 

--- a/openspec/changes/make-sqlite-vec-opt-in/.openspec.yaml
+++ b/openspec/changes/make-sqlite-vec-opt-in/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/make-sqlite-vec-opt-in/proposal.md
+++ b/openspec/changes/make-sqlite-vec-opt-in/proposal.md
@@ -1,0 +1,85 @@
+## Why
+
+`add-sqlite-vec-backend` made `EXOMEM_VEC_BACKEND` default to `auto`: the vec0
+full-precision backend served vector search whenever the sqlite-vec extension was
+importable and loadable, with the numpy scan as fallback. That default was chosen on
+*synthetic* evidence (the dense-vault latency curve), where vec0-f32 was exact and won on
+memory residency. Real-vault measurement reversed the call, and the probe-and-activate
+mechanism turned out to be bug-shaped:
+
+- **Page-cache cliff on a real vault.** On the maintainer's production vault (41k chunks on
+  a spinning D: drive), the vec0 f32 KNN measured 123–134ms only while its ~127MB of vec
+  tables stayed warm in the OS page cache. When the cache evicted them — routine on a
+  working machine — the same query cost 1–12s. The RAM-resident numpy scan with the
+  generation-keyed matrix cache measures 24–65ms and is write-independent: no cliff.
+- **Silent behavior flip in production.** Because `auto` probed for the extension and
+  activated vec0 on success, a routine `uv sync` that installed sqlite-vec silently flipped
+  production onto the vec0 backend mid-day — a retrieval-path change nobody requested.
+  Probe-and-activate makes "which backend serves search" depend on package presence rather
+  than an explicit choice.
+
+Both backends are exact and rank-identical (vec0-f32's overlap@10 vs numpy is 1.00; the f32
+parity unit tests and the golden retrieval floors both hold), so this is purely a
+latency/robustness/operability decision — recall is unaffected.
+
+## What Changes
+
+- `EXOMEM_VEC_BACKEND` now defaults to `numpy`. vec0 activates ONLY on the explicit value
+  `sqlite-vec`. Unset, the legacy `auto`, and any unrecognized value all resolve to `numpy`.
+  There is no probe-and-activate: nothing loads or probes the extension unless a caller
+  opts in, so installing sqlite-vec can never again silently change the serving backend.
+- `EXOMEM_VEC_BACKEND=numpy` keeps its explicit kill-switch reading (unchanged).
+- With vec0 off (the default) the sidecar writers skip their vec dual-writes, so the shadow
+  tables drift from the blob tables. This is benign and self-healing: opting back into
+  `sqlite-vec` re-runs the existing `ensure_synced` count-mismatch check, which rebuilds the
+  vec rows from the stored blobs in pure SQL before the first opt-in search.
+- Docs and the latency harness record the flip: `scripts/latency_curve.py` continues to set
+  the backend explicitly per pass (it never relied on the product default) and names both
+  `numpy` and `sqlite-vec` so the published comparison stays honest; `docs/benchmarks.md`
+  gains a dated decision record for the reversal.
+
+Defaults and soft-fail, stated explicitly: the default (`numpy`) needs no optional package —
+the base install serves vector search unchanged. Opting into `sqlite-vec` retains every
+soft-fail path from `add-sqlite-vec-backend`: a missing package, a sqlite3 built without
+loadable-extension support, or a runtime vec error all fall back to the numpy scan with
+identical results. Binary quantization (`EXOMEM_VEC_QUANT=binary`) is unchanged — still
+default-off, still gated by the golden floors, and now (correctly) inert unless the vec0
+backend is also opted into.
+
+Pure-substrate note: unchanged from `add-sqlite-vec-backend` — sqlite-vec is a distance
+calculator over vectors the server already measured; no model runs. This change only moves
+which exact calculator is the default.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: the SQL-Native Vector Search Backend requirement is updated so
+  the default backend is the in-memory numpy scan and the vec0 backend is strictly opt-in
+  via `EXOMEM_VEC_BACKEND=sqlite-vec`; installing sqlite-vec MUST NOT change the serving
+  backend on its own. Exactness, soft-fail, kill-switch, and runtime-degradation behavior
+  are otherwise preserved.
+
+## Impact
+
+- Code: `src/exomem/vecstore.py` (`backend()` resolves unset/`auto`/unrecognized → `numpy`;
+  only `sqlite-vec` enables vec0; module + function docstrings). The consequence sites in
+  `src/exomem/embeddings.py` (`_vec_gate`, both `_vec_search`, `vector_backend_active`) are
+  unchanged in logic — they already gate on `backend() == "numpy"`, so the default flip
+  flows through automatically; only `_vec_gate`'s docstring is updated to record the
+  drift/self-heal consequence.
+- Surfaces: none — no MCP, REST, or CLI parameter changes; `find`'s request/response shapes
+  and (given exactness) its ranking are unchanged for both defaults.
+- Tests: `tests/test_vec_backend_fallback.py` (env-reader default is `numpy`; a new test
+  asserts the default serves numpy and NEVER probes/loads the extension; the
+  unavailable-extension fallback now opts into `sqlite-vec` to stay meaningful);
+  `tests/test_vecstore.py` (the vec0-mechanics suite opts into `sqlite-vec` explicitly);
+  `tests/test_retrieval_golden.py` (the binary promotion-gate case opts into `sqlite-vec`,
+  else the flag would be silently ignored under the numpy default).
+- Docs: `scripts/latency_curve.py` comments, `docs/benchmarks.md` decision record.
+- Dependencies: none. `sqlite-vec` remains in the `embeddings` extra; the base install is
+  unaffected and is now the default serving path.

--- a/openspec/changes/make-sqlite-vec-opt-in/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/make-sqlite-vec-opt-in/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: SQL-Native Vector Search Backend
+
+The system SHALL be able to serve vector KNN search from vec0 virtual tables co-located in
+the existing embedding and CLIP sidecars, selected by `EXOMEM_VEC_BACKEND` (`numpy` |
+`sqlite-vec`, default `numpy`). The default backend is the in-memory numpy scan; the vec0
+backend MUST activate ONLY when `EXOMEM_VEC_BACKEND` is set explicitly to `sqlite-vec`. Any
+other value — unset, the legacy `auto`, or an unrecognized string — MUST resolve to the
+numpy scan. Under the default, the system MUST NOT probe for or load the sqlite-vec
+extension, so installing the package MUST NOT change which backend serves search. When the
+vec0 backend is opted into, in full-precision mode it MUST be exact: the ranked (path,
+chunk) results and cosine scores MUST match what the in-memory scan returns for the same
+sidecar state, within floating-point tolerance. When the opted-in backend is unavailable in
+any way — the package is not installed, the Python build cannot load SQLite extensions, or a
+runtime error occurs — vector search MUST soft-fail to the in-memory scan with unchanged
+results and without recording a lane degradation. `EXOMEM_VEC_BACKEND=numpy` MUST force the
+in-memory scan unconditionally. When the vec0 backend serves search, the process MUST NOT
+need to hold the full vector matrix resident in Python memory for that search path. While
+the vec0 backend is off, sidecar writers MAY skip vec dual-writes; a later opt-in MUST heal
+any resulting blob-vs-vec drift from the stored blobs before serving vec0 results.
+
+#### Scenario: Numpy is the default and the extension is never probed
+
+- **WHEN** `EXOMEM_VEC_BACKEND` is unset (or set to `auto` or any unrecognized value)
+- **THEN** vector search is served by the in-memory numpy scan
+- **AND** the sqlite-vec extension is neither probed nor loaded, and no vec tables are
+  written
+
+#### Scenario: The vec0 backend is opt-in and exact
+
+- **WHEN** `EXOMEM_VEC_BACKEND=sqlite-vec` is set and the same query runs once under the
+  vec0 full-precision backend and once under the in-memory scan, over an unchanged sidecar
+- **THEN** the ordered (path, chunk) results are identical
+- **AND** the scores match within floating-point tolerance
+
+#### Scenario: Installing sqlite-vec does not change the serving backend
+
+- **WHEN** the sqlite-vec package becomes importable but `EXOMEM_VEC_BACKEND` is not set to
+  `sqlite-vec`
+- **THEN** vector search continues to use the in-memory numpy scan
+- **AND** no vec tables are created by the search or write paths
+
+#### Scenario: Unavailable extension falls back silently when opted in
+
+- **WHEN** `EXOMEM_VEC_BACKEND=sqlite-vec` is set but sqlite-vec is not importable or the
+  connection cannot load extensions
+- **THEN** vector search returns the in-memory scan's results
+- **AND** `find` records no vector-lane degradation for the fallback itself
+
+#### Scenario: Kill switch forces the in-memory scan
+
+- **WHEN** `EXOMEM_VEC_BACKEND=numpy` is set
+- **THEN** vector search uses the in-memory scan even where the vec0 backend is available
+
+#### Scenario: A runtime vec failure degrades to the scan for the process
+
+- **WHEN** the vec0 backend is opted in and a vec0 KNN query raises at runtime
+- **THEN** that search call returns correct results via the in-memory scan
+- **AND** subsequent searches in the process stop attempting the vec0 backend
+
+#### Scenario: Re-enabling vec0 heals drifted shadow tables
+
+- **WHEN** a sidecar was advanced while the numpy default was in effect (vec shadow tables
+  drifted from the blob tables) and a process later opts into `EXOMEM_VEC_BACKEND=sqlite-vec`
+- **THEN** the first opt-in use rebuilds the vec rows from the stored blobs in pure SQL
+- **AND** the vec0 backend then serves results identical to the in-memory scan

--- a/openspec/changes/make-sqlite-vec-opt-in/tasks.md
+++ b/openspec/changes/make-sqlite-vec-opt-in/tasks.md
@@ -1,0 +1,41 @@
+## 1. Flip the default (TDD)
+
+- [x] 1.1 Red: update `tests/test_vec_backend_fallback.py::test_backend_env_reader_defaults`
+      to expect `numpy` for unset / `auto` / unrecognized, and add
+      `test_default_serves_numpy_and_never_probes_extension` asserting the default serves
+      the numpy scan and never probes/loads the extension. Confirm both fail on current code.
+- [x] 1.2 Green: `src/exomem/vecstore.py` `backend()` resolves unset/`auto`/unrecognized →
+      `numpy`; only the explicit `sqlite-vec` enables vec0. `numpy` still accepted explicitly.
+- [x] 1.3 Update the module docstring and `backend()`'s docstring: numpy default, sqlite-vec
+      opt-in, no probe-and-activate, drift/self-heal note.
+
+## 2. Sweep consequences
+
+- [x] 2.1 Verify `_vec_gate`, both `_vec_search`, and `vector_backend_active` follow from
+      `backend()` with no logic change (they gate on `backend() == "numpy"`); update
+      `_vec_gate`'s docstring to record the drift/self-heal consequence.
+- [x] 2.2 Confirm no other site hardcodes `auto`/probe semantics (grep).
+
+## 3. Tests
+
+- [x] 3.1 `tests/test_vecstore.py`: the vec0-mechanics suite opts into `sqlite-vec`
+      explicitly (fixture) so it exercises vec0 exactly as the old `auto` did; the legacy
+      re-enable test opts in via `sqlite-vec` instead of `auto`.
+- [x] 3.2 `tests/test_vec_backend_fallback.py`: the unavailable-extension fallback test opts
+      into `sqlite-vec` so it still exercises the soft-fail path.
+- [x] 3.3 `tests/test_retrieval_golden.py`: the binary promotion-gate case opts into
+      `sqlite-vec` (else the QUANT flag is silently ignored under the numpy default); the
+      `off` cases run the numpy default; comments corrected.
+
+## 4. Docs + harness
+
+- [x] 4.1 `scripts/latency_curve.py`: record that numpy is the product default and the
+      harness names backends explicitly (no `auto`); no behavior change (already explicit).
+- [x] 4.2 `docs/benchmarks.md`: dated decision record for the flip + supersession pointer.
+
+## 5. Gates
+
+- [x] 5.1 `uv run pytest` full suite green.
+- [x] 5.2 Golden gate `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings` (default backend = numpy).
+- [x] 5.3 `uvx ruff check` on changed files.
+- [x] 5.4 OpenSpec validation: `npm exec --yes @fission-ai/openspec -- validate --specs --strict` and this change validates `--strict`.

--- a/scripts/latency_curve.py
+++ b/scripts/latency_curve.py
@@ -154,11 +154,19 @@ def _percentile(sorted_vals: list[float], pct: float) -> float:
 # Vector-lane backend passes (--vec-backend). "binary" = sqlite-vec + binary
 # quantization (EXOMEM_VEC_QUANT=binary). "numpy" is the reference pass: when
 # present it runs first and the other backends report top-10 overlap against it.
+# numpy is ALSO the product default now (vec0 is opt-in) — there is no `auto`
+# value — so this harness always sets EXOMEM_VEC_BACKEND explicitly for each pass
+# and must name both `numpy` and `sqlite-vec` to keep a published comparison honest.
 VEC_BACKENDS = ("numpy", "sqlite-vec", "binary")
 
 
 def _apply_vec_backend(name: str) -> None:
-    """Point the vector lane at one backend via the env seam `search()` reads."""
+    """Point the vector lane at one backend via the env seam `search()` reads.
+
+    Always sets EXOMEM_VEC_BACKEND to an explicit value (`numpy` or `sqlite-vec`);
+    the harness never relies on the product default, so the pass measures exactly
+    the named backend regardless of what production defaults to.
+    """
     if name == "binary":
         os.environ["EXOMEM_VEC_BACKEND"] = "sqlite-vec"
         os.environ["EXOMEM_VEC_QUANT"] = "binary"

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1127,10 +1127,16 @@ def _vec_gate(index, conn: sqlite3.Connection) -> bool:
     """Shared vec0 policy ladder for EmbeddingIndex/ClipIndex on one connection.
 
     Duck-typed over the index's vec state (`_vec`, `_vec_failed`, `_vec_ready`,
-    `_vec_quant_synced`): kill switch → extension loadable on this connection →
+    `_vec_quant_synced`): backend gate → extension loadable on this connection →
     tables created + blob↔vec counts synced (memoized per instance; re-run once
     more when binary quant turns on later, to synthesize the bin table). Any sync
     failure retires vec for this instance — the numpy scan serves from then on.
+
+    numpy is the default backend, so this gate returns False (and every dual-write
+    site below is skipped) unless `EXOMEM_VEC_BACKEND=sqlite-vec` opts in. While
+    vec0 is off, the shadow tables drift as the blob tables advance without them;
+    that drift is self-healing — the first opt-in call reaches `ensure_synced`,
+    whose count-mismatch check rebuilds the vec rows from the blobs in pure SQL.
     """
     if index._vec_failed or vecstore.backend() == "numpy":
         return False

--- a/src/exomem/vecstore.py
+++ b/src/exomem/vecstore.py
@@ -10,8 +10,16 @@ Mapping contract: vec0 rowid == blob-table rowid (both blob tables are ordinary
 rowid tables). Callers join KNN rowids back to the blob table for metadata.
 
 Availability is a ladder, decided per process:
-- `EXOMEM_VEC_BACKEND` = `auto` (default) | `sqlite-vec` | `numpy` (kill switch).
+- `EXOMEM_VEC_BACKEND` = `numpy` (default) | `sqlite-vec` (opt-in). The numpy scan
+  is the default backend; vec0 activates ONLY when this is set explicitly to
+  `sqlite-vec`. There is no probe-and-activate: nothing here is touched unless a
+  caller opts in, so installing the extension can never silently flip the backend.
   Policy (who consults it) lives in the index classes; this module is mechanism.
+- With vec0 off (the default), the sidecar writers skip their vec dual-writes, so
+  the shadow tables drift out of sync with the blob tables over time. That is
+  benign: opting back in re-runs `ensure_synced`, whose count-mismatch check
+  rebuilds the vec rows from the blobs in pure SQL ("vec sync: rebuilding") before
+  the first opt-in search.
 - `try_load()` soft-fails once per process (`_LOAD_FAILED` memo, mirroring
   `embeddings._IMPORT_FAILED`): sqlite-vec not installed (lean deploy), or this
   Python's sqlite3 compiled without loadable-extension support
@@ -54,13 +62,18 @@ _LOAD_LOCK = threading.Lock()
 
 
 def backend() -> str:
-    """`EXOMEM_VEC_BACKEND`: `auto` (default) | `sqlite-vec` | `numpy` (kill switch).
+    """`EXOMEM_VEC_BACKEND`: `numpy` (default) | `sqlite-vec` (opt-in).
 
-    Unrecognized values fall back to `auto` — a typo must not silently disable the
-    exact numpy escape hatch someone reached for, nor hard-fail search.
+    numpy is the default vector backend. vec0 activates ONLY on the explicit value
+    `sqlite-vec`; everything else — unset, the legacy `auto`, or any unrecognized
+    value — resolves to `numpy`. This is a deliberate reversal of the old
+    probe-and-activate `auto`: enabling vec0 is now an explicit choice, so a fresh
+    `sqlite-vec` install can never silently flip production onto it. `numpy` is
+    still accepted as an explicit value, preserving its kill-switch reading for
+    anyone who pins it.
     """
     raw = (os.environ.get("EXOMEM_VEC_BACKEND") or "").strip().lower()
-    return raw if raw in ("sqlite-vec", "numpy") else "auto"
+    return "sqlite-vec" if raw == "sqlite-vec" else "numpy"
 
 
 def quant_mode() -> str:

--- a/tests/test_retrieval_golden.py
+++ b/tests/test_retrieval_golden.py
@@ -67,9 +67,9 @@ _MEAN_RECALL10_FLOOR = 0.88
 @pytest.mark.parametrize(
     ("vec_quant", "lexical_backend"),
     [
-        ("off", "fts5"),     # the shipped default: vec0-f32 + FTS5 lexical lanes
+        ("off", "fts5"),     # the shipped default: numpy scan + FTS5 lexical lanes
         ("off", "python"),   # lexical kill switch: yesterday's ranking wholesale
-        ("binary", "fts5"),  # promotion gate for opt-in binary quantization
+        ("binary", "fts5"),  # promotion gate for opt-in binary quantization (vec0)
     ],
 )
 def test_golden_hybrid_ranking_clears_floors(
@@ -78,9 +78,10 @@ def test_golden_hybrid_ranking_clears_floors(
     """Hybrid ranking over the golden set must clear the measured floors.
 
     Parametrized over the vector backend's quantization mode AND the lexical
-    backend: `off` exercises vec0 full-precision (exact, so the floors are the
-    same regression gate they always were); `binary` is the PROMOTION GATE for
-    the opt-in quantized mode. `fts5` is the PROMOTION GATE for the FTS5
+    backend: `off` exercises the numpy scan (the shipped default; exact, so the
+    floors are the same regression gate they always were); `binary` opts into the
+    vec0 backend and is the PROMOTION GATE for its quantized mode. `fts5` is the
+    PROMOTION GATE for the FTS5
     lexical backend — its bm25() scorer differs from BM25Okapi, so it is
     floors-gated (including the stemming pin), not rank-identical; `python`
     proves the kill switch still clears the same floors. The gates compose.
@@ -93,8 +94,15 @@ def test_golden_hybrid_ranking_clears_floors(
 
     if vec_quant == "binary":
         pytest.importorskip("sqlite_vec")
+        # numpy is now the default backend; binary quantization lives ONLY in the
+        # vec0 backend, so this promotion gate must opt into it explicitly — else
+        # the QUANT flag would be silently ignored and the case would re-run numpy.
+        monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
         monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
     else:
+        # `off` cases run the shipped default (numpy) — unset both so no stray
+        # process env forces a backend.
+        monkeypatch.delenv("EXOMEM_VEC_BACKEND", raising=False)
         monkeypatch.delenv("EXOMEM_VEC_QUANT", raising=False)
     if lexical_backend == "fts5" and not lexstore.fts5_available():
         pytest.skip("this SQLite build lacks FTS5/trigram")

--- a/tests/test_vec_backend_fallback.py
+++ b/tests/test_vec_backend_fallback.py
@@ -47,18 +47,56 @@ def _fresh_vec_state(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_backend_env_reader_defaults(monkeypatch):
-    assert vecstore.backend() == "auto"
+    # numpy is the default backend; sqlite-vec is strictly opt-in. Unset, the
+    # legacy `auto`, and any unrecognized value all resolve to numpy — a typo (or
+    # a stale `auto`) must never silently activate vec0.
+    assert vecstore.backend() == "numpy"
     monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
     assert vecstore.backend() == "numpy"
     monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
     assert vecstore.backend() == "sqlite-vec"
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "auto")  # legacy value → no longer special
+    assert vecstore.backend() == "numpy"
     monkeypatch.setenv("EXOMEM_VEC_BACKEND", "bogus")
-    assert vecstore.backend() == "auto"
+    assert vecstore.backend() == "numpy"
     monkeypatch.delenv("EXOMEM_VEC_BACKEND")
     monkeypatch.setenv("EXOMEM_VEC_QUANT", "binary")
     assert vecstore.quant_mode() == "binary"
     monkeypatch.setenv("EXOMEM_VEC_QUANT", "bogus")
     assert vecstore.quant_mode() == "off"
+
+
+def test_default_serves_numpy_and_never_probes_extension(tmp_path, monkeypatch):
+    """The new default (EXOMEM_VEC_BACKEND unset): search serves the numpy scan and
+    the sqlite-vec extension is NEVER probed or loaded. This is the whole point of
+    the opt-in flip — no silent probe-and-activate. Both the write path (dual-write
+    gate) and the read path (search) must short-circuit before touching vec code."""
+    probes = {"n": 0}
+
+    def _spy_import():
+        probes["n"] += 1
+        raise ImportError("vec extension must not be probed under the numpy default")
+
+    monkeypatch.setattr(vecstore, "_import_sqlite_vec", _spy_import)
+    loads = {"n": 0}
+    real_try_load = vecstore.SqliteVecStore.try_load
+
+    def _count_try_load(self, conn):
+        loads["n"] += 1
+        return real_try_load(self, conn)
+
+    monkeypatch.setattr(vecstore.SqliteVecStore, "try_load", _count_try_load)
+
+    rng = np.random.default_rng(42)
+    idx = EmbeddingIndex(tmp_path)
+    vecs = _unit_rows(rng, 3, VECTOR_DIM)
+    idx.upsert_file("Knowledge Base/a.md", ["c0", "c1", "c2"], vecs, 1.0)  # write path
+
+    hits = idx.search(vecs[1], k=2)  # read path
+    assert hits[0] == ("Knowledge Base/a.md", 1, "c1", pytest.approx(1.0, abs=1e-5))
+    assert not _has_table(idx.path, "vec_chunks")  # no vec tables ever written
+    assert loads["n"] == 0  # the gate short-circuits on the numpy default
+    assert probes["n"] == 0  # the extension import is never attempted
 
 
 def test_kill_switch_forces_numpy_and_skips_vec_writes(tmp_path, monkeypatch):
@@ -76,8 +114,10 @@ def test_kill_switch_forces_numpy_and_skips_vec_writes(tmp_path, monkeypatch):
 
 
 def test_unavailable_extension_serves_numpy_results(tmp_path, monkeypatch):
-    """Under `auto` with the extension unavailable (the lean deployment shape, forced
-    here deterministically), search serves the numpy scan with the same contract."""
+    """With `sqlite-vec` opted in but the extension unavailable (the lean deployment
+    shape, forced here deterministically), search soft-fails to the numpy scan with
+    the same contract."""
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
     monkeypatch.setattr(
         vecstore, "_import_sqlite_vec", lambda: (_ for _ in ()).throw(ImportError("lean"))
     )

--- a/tests/test_vecstore.py
+++ b/tests/test_vecstore.py
@@ -73,9 +73,13 @@ def _build_text_index(
 
 @pytest.fixture(autouse=True)
 def _fresh_vec_state(monkeypatch: pytest.MonkeyPatch):
-    """Every test starts from a clean process-global load memo and default env."""
+    """Every test starts from a clean process-global load memo, with the vec0
+    backend OPTED IN. This is the vec0-mechanics suite; since numpy is now the
+    product default, the whole file must set `sqlite-vec` explicitly to exercise
+    vec0 (this is "exactly as the old `auto` behaved"). Individual tests still
+    override to `numpy` where they assert the kill-switch / parity paths."""
     vecstore.reset_load_memo()
-    monkeypatch.delenv("EXOMEM_VEC_BACKEND", raising=False)
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
     monkeypatch.delenv("EXOMEM_VEC_QUANT", raising=False)
     yield
     vecstore.reset_load_memo()
@@ -126,8 +130,10 @@ def test_schema_creation_is_idempotent(tmp_path):
 
 
 def test_legacy_blobs_only_sidecar_is_backfilled_on_first_use(tmp_path, monkeypatch):
-    """A sidecar written with the kill switch on (blob rows only) gains vec rows —
-    with correct search results — the first time a vec-aware instance touches it."""
+    """A sidecar written with the numpy backend (blob rows only) gains vec rows —
+    with correct search results — the first time a vec-opted-in instance touches
+    it. This is also the re-enable path: after running numpy-default for a while,
+    opting back into `sqlite-vec` rebuilds the drifted shadow tables from blobs."""
     rng = np.random.default_rng(9)
     monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
     legacy, vecs_by_file = _build_text_index(tmp_path, rng, files=5, chunks_per_file=4)
@@ -137,7 +143,7 @@ def test_legacy_blobs_only_sidecar_is_backfilled_on_first_use(tmp_path, monkeypa
     finally:
         plain.close()
 
-    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "auto")
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "sqlite-vec")
     idx = EmbeddingIndex(tmp_path)
     query = vecs_by_file["Knowledge Base/Notes/note-002.md"][1]
     hits = idx.search(query, k=3)


### PR DESCRIPTION
## Summary

Flips the vector-search backend default from probe-sqlite-vec (`auto`) to **numpy**, making `sqlite-vec` strictly opt-in via `EXOMEM_VEC_BACKEND=sqlite-vec`.

## Why (evidence-gated per the find-recall-efficiency spec)

`add-sqlite-vec-backend` defaulted `EXOMEM_VEC_BACKEND=auto` to vec0 on *synthetic* dense-vault evidence, where vec0-f32 was exact and won on memory residency. Real-vault measurement reversed the call:

- **Page-cache cliff on a real vault.** On the maintainer's production vault (41k chunks, spinning D: drive), vec0 brute KNN measured 123–134ms warm — but 1–12s whenever the OS page cache evicted its ~127MB of vec tables. The RAM-resident numpy scan with the generation-keyed matrix cache (#125) measures 24–65ms and is write-independent — no cliff.
- **Silent behavior flip in production.** The old `auto` probed for the extension and activated vec0 on success — a routine `uv sync` that installed `sqlite-vec` silently flipped production onto a different retrieval backend mid-day, with no explicit request. Probe-and-activate is bug-shaped; explicit opt-in is the fix.

Both backends are exact and rank-identical (vec0-f32 overlap@10 vs numpy = 1.00; f32 parity unit tests and the golden retrieval floors both hold) — this is a latency/robustness/operability decision, not a recall tradeoff.

## What changed

- `src/exomem/vecstore.py` `backend()`: unset / legacy `auto` / any unrecognized value → `numpy`. Only the explicit value `sqlite-vec` activates vec0. `numpy` remains accepted as an explicit kill-switch value.
- Consequence sites (`_vec_gate`, both `_vec_search` methods, `vector_backend_active`) already gated on `backend() == "numpy"` — behavior follows automatically with no logic changes; only `_vec_gate`'s docstring was updated to record the drift/self-heal consequence (vec dual-writes stop while vec0 is off; re-enabling triggers `ensure_synced`'s existing rebuild-from-blobs).
- Tests: the vec0-mechanics suite (`tests/test_vecstore.py`) now opts into `sqlite-vec` explicitly via its fixture; `tests/test_vec_backend_fallback.py` gets a new test asserting the default serves numpy and the extension is **never** probed/loaded, plus the updated env-reader-defaults test; `tests/test_retrieval_golden.py`'s binary promotion-gate case now opts into `sqlite-vec` (it would otherwise silently degrade to numpy under the new default).
- `scripts/latency_curve.py`: comments record that numpy is now the product default and the harness always sets the backend explicitly (no behavior change — it never relied on `auto`).
- `docs/benchmarks.md`: dated decision record for the flip, with a supersession pointer on the old "auto defaults to vec0-f32" record.
- OpenSpec: `openspec/changes/make-sqlite-vec-opt-in/` (proposal, tasks, spec delta modifying `find-recall-efficiency`'s SQL-Native Vector Search Backend requirement).

## Test plan

- [x] Red-test evidence: `test_backend_env_reader_defaults` and new `test_default_serves_numpy_and_never_probes_extension` fail on pre-flip code (see report)
- [x] Green after the flip: same 2 tests pass
- [x] Full suite: `uv run pytest` → 1573 passed, 3 skipped
- [x] Golden gate: `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings` → 3 passed (`off-fts5`, `off-python` exercise the new **numpy** default; `binary-fts5` explicitly opts into `sqlite-vec` as the quantization promotion gate)
- [x] vecstore + fallback suites: 21 passed
- [x] `uvx ruff check` on all changed files: clean (pre-existing BLE001s in `embeddings.py` are untouched by this diff, at unrelated lines; that CI lint job is `continue-on-error: true`)
- [x] OpenSpec validation: `npm exec --yes @fission-ai/openspec -- validate --specs --strict` → 17/17 passed; new change validates `--strict`; `--changes --strict` → 14/14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsYrCghxuK4yCaC8QoMUV