### PR TITLE
fix(freshness): canonicalize event-path registry keys — Windows 8.3 aliases dropped live notes

### DIFF
--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -427,7 +427,15 @@ class FileWatcher:
         the writer already fanned it out via `register_self_write`, so
         re-dispatching would double-embed (normally moot — the 30s suppression
         TTL has expired by the 300s reconcile — but correct under a tight
-        race)."""
+        race).
+
+        The abs-string guard above only catches a conflict when both event
+        forms are the literal SAME string. Two DIFFERENT abs-path forms of one
+        file (e.g. a Windows 8.3 short name vs. the long form, #126) evade it
+        but can still collapse to the SAME rel once `_rel()` resolves them —
+        so the same split-brain tie-break is repeated at the rel level below,
+        after computing `up_rels`/`del_rels`: a rel the filesystem still has on
+        disk is a change, not a delete."""
         changed_set = set(changed)
         deleted_set = set(deleted)
         for sp in changed_set & deleted_set:
@@ -446,8 +454,27 @@ class FileWatcher:
             for p in (Path(sp) for sp in deleted_set)
             if not _is_self_write_event(self._vault_root, p, deleted=True)
         ]
-        up_rels = [r for r in (self._rel(p) for p in changed_paths) if r]
+        changed_rel_pairs: list[tuple[Path, str]] = []
+        for p in changed_paths:
+            r = self._rel(p)
+            if r:
+                changed_rel_pairs.append((p, r))
+        up_rels = [r for _, r in changed_rel_pairs]
         del_rels = [r for r in (self._rel(p) for p in deleted_paths) if r]
+
+        rel_conflicts = set(up_rels) & set(del_rels)
+        if rel_conflicts:
+            exists_now = {r for r in rel_conflicts if (self._vault_root / r).is_file()}
+            gone_now = rel_conflicts - exists_now
+            if exists_now:
+                del_rels = [r for r in del_rels if r not in exists_now]
+            if gone_now:
+                up_rels = [r for r in up_rels if r not in gone_now]
+                changed_rel_pairs = [
+                    (p, r) for p, r in changed_rel_pairs if r not in gone_now
+                ]
+                changed_paths = [p for p, _ in changed_rel_pairs]
+
         self._dispatch_batch(changed_paths, up_rels, del_rels, cap=True)
 
     def _dispatch_batch(

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -22,6 +22,35 @@ vault; `.md`-only; sync-conflict duplicates excluded). A registry that included
 one extra file or directory would silently diverge from the walk it stands in
 for, so the equality is pinned by tests across create/modify/delete/move/rename.
 
+Canonicalization contract (event side only — see #126): the walk side
+(`seed`/`reconcile`, fed by `walk_vault_md`/`_walk_md`'s `iterdir()`) always
+yields a file's long-form name — the OS directory listing never returns an
+8.3 short alias unless specifically asked. The EVENT side (`on_files_changed`,
+fed by watchdog callbacks and self-write registrations) has no such guarantee:
+on Windows, a file whose basename is long enough to earn an 8.3 short alias
+(e.g. a long slug like `real-vault-...-by-d.md` → `REAL-V~1.MD`) can be
+reported by an event under either form. Two string forms of the SAME file
+would otherwise coexist as two separate keys in `_maps`; the next `reconcile()`
+then reads that as "one file deleted, one file created", and any consumer
+keyed on that identity (the wikilink resolver, the inbound-link index) drops
+the file's entry until it's touched again — exactly the false "does not
+resolve to any file in the vault" writer warning #126 reported.
+
+`on_files_changed` is the single ingress point for EVENT-derived keys (its
+only two callers — the watcher's debounced batch flush and the self-write
+publish path — both funnel through it), so it canonicalizes there: each event
+path is `resolve()`d and rejoined onto the literal `vault_root` prefix before
+becoming a map key, so an 8.3 short segment expands to the long form the walk
+side would have produced for the SAME still-existing file. For an already
+DELETED path, `resolve()` can't query a vanished directory entry, so it can't
+expand the leaf; canonicalization falls back to the best-effort partial result
+(or the raw form, if `resolve()` itself raises). Any resulting stale "ghost"
+key is not data loss — the 300s periodic `reconcile()` re-walks from disk and
+replaces the map wholesale, so a leftover short-form key from a delete self-
+heals on the very next cycle. Cost: this adds one `resolve()` call per
+debounced EVENT file (a handful per batch), not per walk entry — negligible
+next to the O(vault) walk the registry exists to avoid.
+
 Pure substrate: mechanical file-change bookkeeping, no reasoning over content.
 """
 
@@ -229,6 +258,28 @@ def live_entries(vault_root: Path, scope: str) -> dict[str, int] | None:
         return dict(_maps.get(key, {}))
 
 
+def _canonicalize_event_path(vault_root: Path, vr: Path, p: Path) -> Path:
+    """Best-effort long-form path for an EVENT-derived filesystem change.
+
+    See the module docstring's "Canonicalization contract" for the full
+    rationale. `resolve()` expands an 8.3 short segment to its long form when
+    the underlying directory entry still exists; the result is re-rooted onto
+    the literal `vault_root` (not `vr`, its resolved form) so the reconstructed
+    key shares the exact prefix the walk side's `iterdir()`-built keys use —
+    resolving only the sub-path relative to `vr` avoids introducing a NEW
+    mismatch class for vaults where `vault_root` itself isn't already in
+    resolved form. Falls back to `p` unchanged when `resolve()`/`relative_to`
+    can't establish that relationship (e.g. a deleted path's vanished leaf
+    segment can't be queried, or `vault_root` is momentarily unreachable) —
+    the raw form is exactly today's behavior, healed by the next reconcile.
+    """
+    try:
+        rel = p.resolve().relative_to(vr)
+    except (OSError, ValueError):
+        return p
+    return vault_root / rel
+
+
 def on_files_changed(
     vault_root: Path,
     changed: Iterable[Path] = (),
@@ -241,9 +292,17 @@ def on_files_changed(
     that was never seeded stays not-live and keeps falling back to the walk.
     Classification is stat-free, so a path that vanished between the event and
     here is still correctly removed.
+
+    Every path is canonicalized first (see the module docstring's
+    "Canonicalization contract") so an event-derived path never produces a
+    map key that diverges from the walk side's for the same file.
     """
     if not event_indexes_enabled():
         return
+    try:
+        vr = vault_root.resolve()
+    except OSError:
+        vr = vault_root
     # Phase 1 — classify + stat OUTSIDE the lock. `scopes_for` is stat-free;
     # only changed paths stat. A big external burst (a git pull / Obsidian Sync
     # landing hundreds of files) must not stat under the lock, or it would block
@@ -251,13 +310,13 @@ def on_files_changed(
     # the 300s reconcile heals them, and a self-write also publishes here.
     del_items: list[tuple[str, bool, bool]] = []
     for path in deleted:
-        p = Path(path)
+        p = _canonicalize_event_path(vault_root, vr, Path(path))
         in_kb, in_vault = scopes_for(vault_root, p)
         if in_kb or in_vault:
             del_items.append((str(p), in_kb, in_vault))
     chg_items: list[tuple[str, int | None, bool, bool]] = []
     for path in changed:
-        p = Path(path)
+        p = _canonicalize_event_path(vault_root, vr, Path(path))
         in_kb, in_vault = scopes_for(vault_root, p)
         if not (in_kb or in_vault):
             continue

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -564,9 +564,23 @@ class _InboundIndexData:
         entries from OTHER files touched at a different time does not mirror
         a fresh full-walk order, but the output SET per target always
         matches a full rebuild.
+
+        A rel present in BOTH `changed_rels` and `deleted_rels` in the same
+        batch (two path-string forms of one file collapsing to the same rel
+        upstream — Windows 8.3 short names are the concrete vector, #126, but
+        this defends against ANY dual-form vector: case aliasing, symlinks,
+        a future one) is a same-batch conflict. Trust the filesystem to break
+        the tie: a rel whose file still exists is a change, not a delete —
+        dropping it would silently remove a live file's inbound-link edges.
         """
+        changed = set(changed_rels)
         deleted = set(deleted_rels)
-        changed = set(changed_rels) - deleted
+        conflict = changed & deleted
+        for rel in conflict:
+            if (vault_root / rel).is_file():
+                deleted.discard(rel)
+            else:
+                changed.discard(rel)
         affected = changed | deleted
         if not affected:
             return
@@ -932,6 +946,14 @@ class WikilinkResolver:
         the graph lane's 1-hop recall) is byte-for-byte unchanged; only the
         cost is (patch a handful of files vs. re-read + YAML-parse the whole
         vault). `*_rels` are vault-relative POSIX, with or without `.md`.
+
+        A rel present in BOTH `changed_rels` and `deleted_rels` in the same
+        batch (two path-string forms of one file collapsing to the same rel
+        upstream — Windows 8.3 short names are the concrete vector, #126, but
+        this defends against ANY dual-form vector: case aliasing, symlinks, a
+        future one) is a same-batch conflict. Trust the filesystem to break
+        the tie: a rel whose file still exists is a change, not a delete —
+        dropping it would silently remove a live file from the resolver.
         """
         def _norm(rels: Iterable[str]) -> set[str]:
             out: set[str] = set()
@@ -941,8 +963,14 @@ class WikilinkResolver:
                     out.add(s[:-3])
             return out
 
+        changed = _norm(changed_rels)
         deleted = _norm(deleted_rels)
-        changed = _norm(changed_rels) - deleted
+        conflict = changed & deleted
+        for no_ext in conflict:
+            if (vault_root / (no_ext + ".md")).is_file():
+                deleted.discard(no_ext)
+            else:
+                changed.discard(no_ext)
         if not (deleted or changed):
             return
         for no_ext in deleted | changed:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -437,3 +437,78 @@ def test_reconcile_delta_conflict_missing_file_routes_as_deleted_only(
 
     assert ups == []
     assert dels == [["Knowledge Base/Notes/split-brain-gone.md"]]
+
+
+# ---- Rel-level dispatch guard for dual-form path collapse (#126) ----------
+#
+# The abs-string guard above only catches a conflict when both event forms are
+# the literal SAME string. Two DIFFERENT abs-path forms of one file (e.g. a
+# Windows 8.3 short name vs. the long form) evade it but can still collapse to
+# the SAME rel once `_rel()` resolves them. We drive that collapse platform-
+# free by monkeypatching `_rel` so a distinct "alias" string resolves to the
+# same rel a real path would — modeling the 8.3 short-name vector without
+# depending on it actually being enabled on the test box.
+
+
+def test_reconcile_delta_dual_form_collapse_existing_file_routes_as_changed_only(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two different abs-path STRING forms of the SAME on-disk file (e.g. a
+    Windows 8.3 short name vs. the long form, #126) don't collide in the
+    abs-string guard (different strings) but collapse to the identical rel
+    once `_rel()` resolves them. That collapse must still route the live file
+    as changed only — never also as a delete that would strip its index
+    rows."""
+    file_watcher.clear_self_write_registry()
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "dual-form-exists.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("# dual form\n", encoding="utf-8")
+
+    long_form = str(p)
+    alias_form = long_form + ".8dot3-alias"  # a distinct string; never touches disk
+    rel = _vault_rel(vault, p)
+    real_rel = w._rel
+
+    def fake_rel(path: Path):
+        if str(path) == alias_form:
+            return rel
+        return real_rel(path)
+
+    monkeypatch.setattr(w, "_rel", fake_rel)
+
+    w._dispatch_reconcile_delta([long_form], [alias_form])
+
+    assert len(ups) == 1 and ups[0] == [p]
+    assert dels == []
+
+
+def test_reconcile_delta_dual_form_collapse_missing_file_routes_as_deleted_only(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirror case: the dual-form collapse resolves to a rel whose file is
+    genuinely ABSENT — must dispatch as a delete only, never also as an
+    upsert."""
+    file_watcher.clear_self_write_registry()
+    ups, dels = _stub_embeddings(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    p = vault / "Knowledge Base" / "Notes" / "dual-form-gone.md"
+    # Deliberately never created — absent on disk.
+
+    long_form = str(p)
+    alias_form = long_form + ".8dot3-alias"
+    rel = "Knowledge Base/Notes/dual-form-gone.md"
+    real_rel = w._rel
+
+    def fake_rel(path: Path):
+        if str(path) in (long_form, alias_form):
+            return rel
+        return real_rel(path)
+
+    monkeypatch.setattr(w, "_rel", fake_rel)
+
+    w._dispatch_reconcile_delta([long_form], [alias_form])
+
+    assert ups == []
+    assert dels == [[rel]]

--- a/tests/test_inbound_index_incremental.py
+++ b/tests/test_inbound_index_incremental.py
@@ -140,6 +140,45 @@ def test_incremental_patch_matches_full_rebuild_across_add_edit_delete_move(
     assert {ln.path for ln in links} == {moved_rel}
 
 
+def test_on_files_changed_same_rel_in_both_lists_retains_live_entries(
+    vault: Path,
+) -> None:
+    """Mirrors the WikilinkResolver defense (#126): a rel present in BOTH
+    `changed_rels` and `deleted_rels` in the same batch — two path-string
+    forms of one file (Windows 8.3 short name vs. the walk's long form)
+    collapsing to the identical rel upstream — must not drop a file's
+    inbound-link edges when it is still on disk. The old code (`changed =
+    set(changed_rels) - deleted`) unconditionally subtracted the conflicting
+    rel out of `changed`, so the linker's edges were dropped and never
+    re-added even though the file was live. The filesystem breaks the tie:
+    re-add wins."""
+    notes = vault / "Knowledge Base" / "Notes"
+    notes.mkdir(parents=True, exist_ok=True)
+    target = notes / "dual-form-target.md"
+    target.write_text("# Target\n", encoding="utf-8")
+    target_rel = "Knowledge Base/Notes/dual-form-target.md"
+
+    linker = notes / "dual-form-linker.md"
+    linker.write_text("# L\n\n[[Notes/dual-form-target]]\n", encoding="utf-8")
+    linker_rel = "Knowledge Base/Notes/dual-form-linker.md"
+
+    # Seed live.
+    seeded = find_inbound_wikilinks(vault, target_rel)
+    assert len(seeded) == 1
+    _assert_matches_full_rebuild(vault, target_rel)
+
+    # Same rel in both lists (the collapse scenario) — file still exists.
+    on_inbound_files_changed(vault, changed_rels=[linker_rel], deleted_rels=[linker_rel])
+
+    got = find_inbound_wikilinks(vault, target_rel)
+    assert len(got) == 1, (
+        "inbound index dropped a live linker's edges when its rel appeared "
+        "in both changed_rels and deleted_rels in the same batch"
+    )
+    assert got[0].path == linker_rel
+    _assert_matches_full_rebuild(vault, target_rel)
+
+
 def test_incremental_patch_updates_stem_counts_for_basename_uniqueness(
     vault: Path,
 ) -> None:

--- a/tests/test_normalize_wikilink.py
+++ b/tests/test_normalize_wikilink.py
@@ -182,6 +182,35 @@ def test_pending_path_resolves_before_disk_write(vault: Path) -> None:
     assert canonical == "Knowledge Base/Notes/Insights/fresh-note"
 
 
+def test_on_files_changed_same_rel_in_both_lists_retains_live_file(vault: Path) -> None:
+    """A rel present in BOTH `changed_rels` and `deleted_rels` in the same batch
+    — the two-path-string-forms-collapse-to-one-rel case (Windows 8.3 short
+    names are the concrete vector, #126: a watchdog event reporting a long
+    slug's `REAL-V~1.MD` short alias vs. the walk's long form) — must not drop
+    a file that is still on disk. The old code (`changed = _norm(changed_rels)
+    - deleted`) unconditionally subtracted the conflicting rel out of
+    `changed`, so both the remove-and-re-add loops skipped it entirely and the
+    resolver silently lost a live file's entry. The filesystem breaks the tie:
+    re-add wins."""
+    target = vault / "Knowledge Base" / "Notes" / "Failures" / "dual-form.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('---\ntitle: "Dual Form"\n---\n\nbody\n', encoding="utf-8")
+    rel = "Knowledge Base/Notes/Failures/dual-form"
+
+    resolver = WikilinkResolver(vault)
+    assert rel in resolver.full_paths
+
+    resolver.on_files_changed(vault, [rel + ".md"], [rel + ".md"])
+
+    assert rel in resolver.full_paths, (
+        "resolver dropped a live on-disk file when its rel appeared in both "
+        "changed_rels and deleted_rels in the same batch"
+    )
+    canonical, warning = normalize_wikilink(rel, vault, resolver=resolver)
+    assert warning is None
+    assert canonical == rel
+
+
 def test_body_normalization_rewrites_kb_relative_to_full(vault: Path) -> None:
     body = "See [[Notes/Insights/progressive-disclosure-without-mode-fragmentation]] for context."
     new_body, warnings = normalize_body_wikilinks(body, vault)

--- a/tests/test_win32_short_name_registry.py
+++ b/tests/test_win32_short_name_registry.py
@@ -1,0 +1,164 @@
+"""Real end-to-end proof of the Windows 8.3 short-name registry fix (#126).
+
+The unit tests in `test_normalize_wikilink.py` / `test_inbound_index_incremental.py`
+/ `test_file_watcher.py` pin the defense-in-depth and dispatch-guard layers
+platform-free (they model the dual-form collapse via monkeypatching, so they run
+on CI's Linux runners). This module is the on-box proof that REAL Windows 8.3
+short-name aliasing (`REAL-V~1.MD`) triggers the exact failure #126 reported and
+that the ingress canonicalization fix (`freshness._canonicalize_event_path`)
+closes it.
+
+GATED: skips unless running on Windows AND 8.3 short-name generation is enabled
+for the volume backing the temp directory (`fsutil 8dot3name query <drive>`). A
+long enough basename normally earns a short alias by default, but some volumes
+have 8.3 generation disabled — skip gracefully rather than false-fail there.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+from ctypes import wintypes
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows 8.3 short-name aliasing only applies on Windows",
+)
+
+
+def _short_path_name(path: Path) -> str | None:
+    """The Windows 8.3 short form of an EXISTING path, or None if unavailable
+    (API missing, or 8.3 generation disabled for the volume)."""
+    if sys.platform != "win32":
+        return None
+    get_short = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
+    get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    buf = ctypes.create_unicode_buffer(1024)
+    n = get_short(str(path), buf, 1024)
+    if n == 0:
+        return None
+    return buf.value
+
+
+def test_reconcile_heals_resolver_after_8dot3_registry_drift(vault: Path) -> None:
+    """The exact production mechanism behind #126, reproduced with a REAL
+    Windows 8.3 short-name alias:
+
+    1. A note with a long (>8.3) basename is seeded live in both the freshness
+       registry and the process-shared WikilinkResolver, keyed under its long
+       form (a correct initial seed).
+    2. The registry then drifts to holding the SAME file under its 8.3 SHORT
+       form (modeling a watchdog event that reported `event.src_path` in short
+       form — the exact split the module docstring in `freshness.py` describes).
+    3. The 300s periodic reconcile fires (`FileWatcher._reconcile_once`): its
+       fresh walk always yields the long form, so it detects "1 changed
+       (long), 1 deleted (short)" and dispatches that delta through the event
+       fan-out — the SAME path #126's writers hit.
+
+    Before the fix, the resolver lost the note's entry after step 3 even
+    though the file was untouched on disk the whole time (the false "does not
+    resolve to any file in the vault" writer warning). After the fix, the
+    entry survives.
+    """
+    from exomem import find as find_module
+    from exomem import freshness
+    from exomem.file_watcher import FileWatcher
+
+    notes = vault / "Knowledge Base" / "Notes" / "Failures"
+    notes.mkdir(parents=True, exist_ok=True)
+    # A ~96-char slug — long enough to earn an 8.3 short alias (the exact
+    # length class #126 reported), short enough to fit comfortably in
+    # MAX_PATH for the test's tmp_path-backed vault.
+    name = (
+        "real-vault-find-thrash-lexical-sidecar-heal-is-a-full-o-corpus-"
+        "rebuild-triggered-constantly-by-drift"
+    )
+    abspath = notes / (name + ".md")
+    abspath.write_text('---\ntitle: "Dual Form"\n---\n\nbody\n', encoding="utf-8")
+    mt = abspath.stat().st_mtime_ns
+
+    short_form = _short_path_name(abspath)
+    if short_form is None or short_form == str(abspath):
+        pytest.skip(
+            "8.3 short-name generation is disabled for this volume "
+            "(fsutil 8dot3name) — nothing to reproduce here"
+        )
+
+    rel = abspath.relative_to(vault).with_suffix("").as_posix()
+
+    try:
+        # 1. Correct initial seed: registry + shared resolver both keyed
+        #    under the file's long form.
+        freshness.invalidate(vault)
+        freshness.seed(vault, "vault", [(str(abspath), mt)])
+        freshness.seed(vault, "kb", [(str(abspath), mt)])
+        resolver = find_module.shared_resolver(vault)
+        assert rel in resolver.full_paths, "test setup: resolver should see the seeded note"
+
+        # 2. Registry drifts to the SAME file's 8.3 SHORT form (the watchdog
+        #    split #126's mechanism depends on).
+        freshness.invalidate(vault)
+        freshness.seed(vault, "vault", [(short_form, mt)])
+        freshness.seed(vault, "kb", [(short_form, mt)])
+
+        # 3. The 300s periodic reconcile: fresh walk (long form) vs. the
+        #    drifted map (short form) -> dispatches the drift delta through
+        #    the same event fan-out a live batch uses.
+        FileWatcher(vault)._reconcile_once(seed=False)
+
+        assert abspath.is_file(), "test invariant: the file was never touched on disk"
+        assert rel in resolver.full_paths, (
+            "the shared WikilinkResolver dropped a live, on-disk note after a "
+            "reconcile healed a Windows 8.3 short-name registry drift — the "
+            "exact false 'does not resolve to any file in the vault' warning #126 "
+            "reported"
+        )
+    finally:
+        freshness.invalidate(vault)
+        find_module._RESOLVER_CACHE.pop(vault, None)
+
+
+def test_on_files_changed_canonicalizes_8dot3_short_form_to_long_form_key(
+    vault: Path,
+) -> None:
+    """Isolates the root fix: `freshness.on_files_changed` fed a REAL 8.3
+    short-form event path (as a watchdog `on_modified` callback would report
+    it) must key the registry map under the file's long form — not the raw
+    short form — so it lines up with the walk side's keys."""
+    from exomem import freshness
+
+    notes = vault / "Knowledge Base" / "Notes" / "Failures"
+    notes.mkdir(parents=True, exist_ok=True)
+    name = (
+        "real-vault-find-thrash-lexical-sidecar-heal-is-a-full-o-corpus-"
+        "rebuild-triggered-constantly-by-drift-ingress"
+    )
+    abspath = notes / (name + ".md")
+    abspath.write_text("body\n", encoding="utf-8")
+
+    short_form = _short_path_name(abspath)
+    if short_form is None or short_form == str(abspath):
+        pytest.skip(
+            "8.3 short-name generation is disabled for this volume "
+            "(fsutil 8dot3name) — nothing to reproduce here"
+        )
+
+    try:
+        freshness.invalidate(vault)
+        freshness.seed(vault, "vault", [])
+        freshness.seed(vault, "kb", [])
+
+        freshness.on_files_changed(vault, changed=[Path(short_form)], deleted=[])
+
+        live = freshness.live_entries(vault, "vault")
+        assert live is not None
+        assert str(abspath) in live, (
+            f"ingress did not canonicalize the 8.3 short form to the long-form "
+            f"key; live keys: {list(live.keys())}"
+        )
+        assert short_form not in live, "ingress left the raw short form as a live key"
+    finally:
+        freshness.invalidate(vault)


### PR DESCRIPTION
## Summary

Fixes #126 — writers falsely warned `wikilink '...' does not resolve to any file in the vault` for a target that existed at exactly the linked path. Root cause: the freshness registry's event ingress (`on_files_changed`) keyed its maps on raw `str(path)`, while the walk side (`seed`/`reconcile` via `iterdir()`) always produces long-form names. On Windows, a long slug (the reported target's basename was a ~97-char truncated slug) earns an 8.3 short alias (`REAL-V~1.MD`); a watchdog event reporting the file under either form let two string keys coexist for the same file. The next reconcile read that as "one file deleted, one file created," and any consumer keyed on that identity (the wikilink resolver, the inbound-link index) dropped the file's entry until it was touched again.

This became reachable in practice through reconcile's dispatch path added in #124 (drift now fans out through the same event path a live batch uses); the dual-key invariant break itself is older, but #124 made it bite.

- **Root fix (a):** `freshness.on_files_changed` — the single ingress point for event-derived keys (its only two callers, the watcher's debounced batch flush and the self-write publish path, both funnel through it) — now canonicalizes each event path: `resolve()` expands an 8.3 short segment to the long form for a still-existing file, re-rooted onto the literal `vault_root` prefix so it can't introduce a new mismatch class where `vault_root` itself isn't already resolved. A deleted path's vanished leaf can't be queried, so it falls back to the raw form — the 300s reconcile's walk heals any resulting ghost key on the next cycle.
- **Defense-in-depth (c):** `WikilinkResolver.on_files_changed` and its inbound-index mirror both did `changed = set(changed_rels) - deleted`, silently dropping a rel present in both lists from both the remove and re-add loops (any dual-form vector, not just 8.3). Now the filesystem breaks the tie: a rel whose file still exists is a change, not a delete.
- **Dispatch guard:** `_dispatch_reconcile_delta`'s existing abs-string conflict check only catches the same literal string in both `changed`/`deleted`; added a rel-level check after `_rel()` resolution to catch two different string forms that collapse to the same rel.

## Test plan
- [x] `tests/test_normalize_wikilink.py::test_on_files_changed_same_rel_in_both_lists_retains_live_file` — platform-free, CI-enforced
- [x] `tests/test_inbound_index_incremental.py::test_on_files_changed_same_rel_in_both_lists_retains_live_entries` — platform-free, CI-enforced
- [x] `tests/test_file_watcher.py::test_reconcile_delta_dual_form_collapse_{existing,missing}_file_routes_as_*` — platform-free (monkeypatched `_rel`), CI-enforced
- [x] `tests/test_win32_short_name_registry.py` — Windows-only, uses real `GetShortPathNameW` 8.3 aliases; skips gracefully if 8.3 generation is disabled for the volume. **Ran and passed on the dev box** (8.3 is enabled there).
- [x] All 4 new/changed tests confirmed RED against the pre-fix code (verified via `git stash` of the source files only), then GREEN after restoring the fix.
- [x] Full suite: `uv run pytest` → 1578 passed, 3 skipped (pre-existing, unrelated: diarizer sidecar venv, `av` module), 0 failed.
- [x] `uvx ruff check` on all changed files → clean (two pre-existing `vault.py` findings at unrelated lines, B905/B005, left untouched — out of scope).
- [x] Golden gate: `uv run --extra embeddings python -m pytest tests/test_retrieval_golden.py -m embeddings` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEsYrCghxuK4yCaC8QoMUV