### PR TITLE
feat(compute): CPU-default device policy + quiet/normal/performance modes (PR1: idle-VRAM kill)

### DIFF
--- a/src/exomem/accel.py
+++ b/src/exomem/accel.py
@@ -12,11 +12,14 @@ cuda/cpu choice in `extract`; it does NOT route through here. On Apple Silicon,
 transcription therefore still runs on CPU until a Metal-capable backend (e.g.
 mlx-whisper) is added behind the `extract` transcription seam.
 
-Overrides are checked first, in order: a per-model env var (e.g.
-`EXOMEM_CLIP_DEVICE`, `EXOMEM_VOICE_DEVICE`), then the global
-`EXOMEM_TORCH_DEVICE`. An override value is returned verbatim, so
-`EXOMEM_TORCH_DEVICE=cpu` forces every torch model to CPU (a handy escape hatch
-for debugging or thermal control on a fanless Mac).
+CPU is the steady-state default (idle VRAM ~0); CUDA is never auto-selected —
+it is reached only via `performance` mode (see `exomem.mode`) or an explicit
+device value. Overrides are checked first, in order: a per-model env var (e.g.
+`EXOMEM_CLIP_DEVICE`, `EXOMEM_EMBED_DEVICE`, `EXOMEM_VOICE_DEVICE`), then the
+global `EXOMEM_DEVICE` (legacy alias `EXOMEM_TORCH_DEVICE`). A device value is
+returned verbatim, so `EXOMEM_DEVICE=cpu` forces every torch model to CPU and
+`EXOMEM_DEVICE=cuda` forces the GPU (the back-compat door) — except `gpu`/`auto`,
+which mean "use a GPU if one is capable" and run the headroom-checked probe.
 
 Linux note: AMD ROCm builds of torch report `torch.cuda.is_available() == True`
 (HIP masquerades as CUDA), so the existing `"cuda"` path already covers ROCm —
@@ -29,10 +32,22 @@ from __future__ import annotations
 import logging
 import os
 
+from . import mode as mode_module
+
 log = logging.getLogger(__name__)
 
-# Global torch-device override, consulted after any per-model override.
-GLOBAL_OVERRIDE_ENV = "EXOMEM_TORCH_DEVICE"
+# Friendly global torch-device override, consulted after any per-model override.
+GLOBAL_OVERRIDE_ENV = "EXOMEM_DEVICE"
+# Legacy alias for the global override (pre-rename configs), checked after the
+# friendly name. `=cuda`/`=gpu` here is the back-compat door for users who want the
+# old GPU-first behavior after the CPU-default flip.
+LEGACY_OVERRIDE_ENV = "EXOMEM_TORCH_DEVICE"
+# Min free VRAM (GB) to accept a GPU — the marginal-VRAM guard. Overridable.
+GPU_MIN_FREE_ENV = "EXOMEM_GPU_MIN_FREE_GB"
+_DEFAULT_GPU_MIN_FREE_GB = 2.0
+# Device-env values that mean "pick a GPU if you can" rather than a literal device:
+# probe-gated (degrade politely to CPU) instead of returned verbatim.
+_GPU_SENTINELS = frozenset({"auto", "gpu"})
 # Lets ops the MPS backend hasn't implemented fall back to CPU instead of raising.
 _MPS_FALLBACK_ENV = "PYTORCH_ENABLE_MPS_FALLBACK"
 
@@ -71,6 +86,53 @@ def _enable_mps_fallback() -> None:
     os.environ.setdefault(_MPS_FALLBACK_ENV, "1")
 
 
+def gpu_usable(min_free_gb: float | None = None) -> bool:
+    """True iff torch has a working CUDA device with free VRAM above a threshold.
+
+    The marginal-VRAM guard: a small card or a GPU already busy with a game reports
+    little free VRAM → we decline it and stay on CPU rather than OOM the host or the
+    user's other app. **Never raises** — a CPU-only build, absent driver, init
+    crash, or `CUDA_VISIBLE_DEVICES=""` (which `mem_get_info` honors) all degrade to
+    False. This is what makes a no/weak-GPU host a zero-error, CPU-by-default config.
+    """
+    if min_free_gb is None:
+        try:
+            min_free_gb = float(os.environ.get(GPU_MIN_FREE_ENV) or _DEFAULT_GPU_MIN_FREE_GB)
+        except ValueError:
+            min_free_gb = _DEFAULT_GPU_MIN_FREE_GB
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return False
+        free, _total = torch.cuda.mem_get_info()  # bytes, current device; respects CVD
+        return free >= min_free_gb * 1024**3
+    except Exception:  # noqa: BLE001 — any probe failure degrades to CPU
+        return False
+
+
+def _auto_device(*, auto_mps: bool, avoid_cuda_when_asr: bool, want_cuda: bool) -> str:
+    """Resolve a non-verbatim device: CUDA (if wanted + capable) → MPS → CPU.
+
+    `want_cuda` gates whether CUDA is even considered — normal mode never wants it,
+    performance mode and the explicit `gpu`/`auto` sentinels do. CUDA is accepted
+    only through `gpu_usable()` (headroom-checked) so a marginal GPU degrades to CPU.
+    """
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
+        return "cpu"
+
+    if want_cuda and gpu_usable():
+        if avoid_cuda_when_asr and _asr_active():
+            return "cpu"
+        return "cuda"
+    if auto_mps and _mps_available(torch):
+        _enable_mps_fallback()
+        return "mps"
+    return "cpu"
+
+
 def select_device(
     *,
     override_env: str | None = None,
@@ -79,46 +141,52 @@ def select_device(
 ) -> str:
     """Pick a torch device string: ``"cuda"`` | ``"mps"`` | ``"cpu"``.
 
-    Priority: explicit override (``override_env`` then ``EXOMEM_TORCH_DEVICE``)
-    → CUDA → MPS → CPU.
+    Precedence (highest first): explicit per-model override (``override_env``) →
+    ``EXOMEM_DEVICE`` (alias ``EXOMEM_TORCH_DEVICE``) → the resolved compute *mode*
+    → CPU. CPU is the steady-state default; CUDA is **never** auto-selected — it is
+    reached only via performance mode or an explicit device value.
+
+    Device-env values are returned verbatim (``"cpu"``, ``"cuda"``, ``"cuda:1"``,
+    ``"mps"``) **except** the sentinels ``"gpu"``/``"auto"``, which mean "use a GPU
+    if one is capable" and run the headroom-checked probe (degrading to MPS/CPU).
+    So ``EXOMEM_DEVICE=cuda`` forces CUDA unconditionally (the back-compat door),
+    while ``EXOMEM_DEVICE=gpu`` opts in politely.
 
     Args:
-        override_env: name of a per-model device override checked first. An
-            override is returned verbatim (e.g. ``"cuda"``, ``"cpu"``, ``"mps"``,
-            ``"cuda:1"``).
-        avoid_cuda_when_asr: when the auto-pick would be CUDA *and* media
-            extraction (ASR) is active in this process, return CPU instead. This
-            is the faster-whisper cuDNN-shadow workaround and is **CUDA-only** —
-            it never forces CPU on an MPS host, so CLIP/ECAPA keep the Apple GPU
-            even with ASR running (an improvement over the previous
-            unconditional force-to-CPU). See `embeddings._clip_device`.
-        auto_mps: whether auto-detection may select MPS. False keeps the default
-            on CPU (e.g. ECAPA voiceprints, for cross-machine numeric parity)
-            while an explicit override to ``"mps"`` is still honored.
+        override_env: name of a per-model device override checked first (e.g.
+            ``EXOMEM_CLIP_DEVICE``, or ``EXOMEM_EMBED_DEVICE`` for the text path).
+        avoid_cuda_when_asr: when the pick would be CUDA *and* media extraction
+            (ASR) is active in this process, return CPU instead — the CUDA-only
+            faster-whisper cuDNN-shadow workaround (never penalizes MPS). See
+            `embeddings._clip_device`.
+        auto_mps: whether auto-detection may select MPS. False keeps the default on
+            CPU (e.g. ECAPA voiceprints, for cross-machine numeric parity) while an
+            explicit override to ``"mps"`` is still honored.
     """
-    for env in (override_env, GLOBAL_OVERRIDE_ENV):
+    for env in (override_env, GLOBAL_OVERRIDE_ENV, LEGACY_OVERRIDE_ENV):
         if not env:
             continue
-        value = os.environ.get(env)
-        if value:
-            value = value.strip()
-            if value == "mps":
-                _enable_mps_fallback()
-            return value
+        raw = os.environ.get(env)
+        if not raw or not raw.strip():
+            continue
+        value = raw.strip()
+        if value.lower() in _GPU_SENTINELS:
+            return _auto_device(
+                auto_mps=auto_mps, avoid_cuda_when_asr=avoid_cuda_when_asr, want_cuda=True
+            )
+        if value.lower() == "mps":
+            _enable_mps_fallback()
+            return "mps"
+        return value  # verbatim: cpu / cuda / cuda:1 / ...
 
-    try:
-        import torch
-    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
+    m = mode_module.resolve_mode()
+    if m == "quiet":
         return "cpu"
-
-    if torch.cuda.is_available():
-        if avoid_cuda_when_asr and _asr_active():
-            return "cpu"
-        return "cuda"
-    if auto_mps and _mps_available(torch):
-        _enable_mps_fallback()
-        return "mps"
-    return "cpu"
+    return _auto_device(
+        auto_mps=auto_mps,
+        avoid_cuda_when_asr=avoid_cuda_when_asr,
+        want_cuda=(m == "performance"),
+    )
 
 
 def pipeline_device(**kwargs):

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -139,7 +139,7 @@ def _is_embeddable_path(path: Path) -> bool:
 
 
 def get_model():
-    """Lazy singleton. Device via `accel.select_device` (CUDA > MPS > CPU)."""
+    """Lazy singleton. Device via `accel.select_device` — CPU-default, `EXOMEM_EMBED_DEVICE` opts in."""
     global _MODEL
     if _MODEL is not None:
         return _MODEL
@@ -150,14 +150,14 @@ def get_model():
         # pay this cost.
         from sentence_transformers import SentenceTransformer
 
-        device = accel.select_device()
+        device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
         log.info("loading embedding model %s on %s", MODEL_NAME, device)
         _MODEL = _maybe_half(SentenceTransformer(MODEL_NAME, device=device), device)
     return _MODEL
 
 
 def get_reranker():
-    """Lazy singleton for the cross-encoder reranker. Device via `accel.select_device`."""
+    """Lazy singleton for the cross-encoder reranker. Shares the text-path device (`EXOMEM_EMBED_DEVICE`)."""
     global _RERANKER
     if _RERANKER is not None:
         return _RERANKER
@@ -166,7 +166,7 @@ def get_reranker():
             return _RERANKER
         from sentence_transformers import CrossEncoder
 
-        device = accel.select_device()
+        device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
         log.info("loading reranker %s on %s", RERANKER_NAME, device)
         _RERANKER = CrossEncoder(RERANKER_NAME, device=device)
     return _RERANKER

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -1,0 +1,146 @@
+"""Compute mode — one per-machine knob that governs device + footprint policy.
+
+The mode answers "how much of this machine may exomem use?" and is the single
+setting ~90% of users ever touch. It resolves to concrete policy the rest of the
+code reads: which torch device steady-state models load on (via `accel`), whether
+boot preloads models, and whether idle models are released.
+
+Three canonical modes (aliases in `_ALIASES` so whatever a user types works):
+
+- **quiet**      — don't touch my machine. CPU everywhere, no boot preload, release
+                   models when idle. Idle VRAM ~0. ("I'm gaming / low power.")
+- **normal**     — the safe default. CPU steady-state (MPS on Apple Silicon), never
+                   auto-selects CUDA; bulk index may still use the GPU in a separate
+                   process. Boot preloads onto CPU RAM.
+- **performance** — use my GPU for speed. Steady-state on CUDA when a capable GPU is
+                   present; release when idle. Aliases: `gpu`, `turbo`.
+
+Resolution precedence: `EXOMEM_MODE` env → the per-machine config file
+(`~/.exomem/config.json`, or `EXOMEM_CONFIG_PATH`) → the legacy `EXOMEM_QUIET_MODE`
+boolean → the `normal` default. The config file is read explicitly (never injected
+into the environment) so an exported `EXOMEM_MODE` always wins over it — and it is a
+fixed home path, not `.env`, because a Windows service launched via `sc.exe` has an
+unpredictable cwd and CLI subcommands never `load_dotenv`, yet both must read the
+same mode.
+
+Torch-free by design: importable in keyword-mode / lean CLI dispatch without paying
+a torch import. `accel` imports this; this never imports `accel`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+CANON = ("quiet", "normal", "performance")
+_ALIASES = {"gpu": "performance", "turbo": "performance"}
+DEFAULT_MODE = "normal"
+
+_MODE_ENV = "EXOMEM_MODE"
+_QUIET_ALIAS_ENV = "EXOMEM_QUIET_MODE"
+_CONFIG_PATH_ENV = "EXOMEM_CONFIG_PATH"
+_RELEASE_ENV = "EXOMEM_RELEASE_GPU_WHEN_IDLE"
+
+
+def _truthy(value: str | None) -> bool:
+    """Shared truthiness convention (mirrors `freshness._truthy`)."""
+    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def normalize(value: str | None) -> str | None:
+    """Canonical mode for a raw string (accepting aliases), or None if unknown."""
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if not v:
+        return None
+    if v in CANON:
+        return v
+    return _ALIASES.get(v)
+
+
+def config_path() -> Path:
+    """Per-machine config file. `EXOMEM_CONFIG_PATH` overrides (tests/multi-instance)."""
+    override = os.environ.get(_CONFIG_PATH_ENV)
+    if override:
+        return Path(override)
+    return Path.home() / ".exomem" / "config.json"
+
+
+def read_config() -> dict:
+    """Parsed config dict; `{}` when missing or corrupt. Never raises."""
+    try:
+        data = json.loads(config_path().read_text("utf-8"))
+    except Exception:  # noqa: BLE001 — missing/corrupt config must degrade to default
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def resolve_mode() -> str:
+    """The effective mode: env → config file → legacy quiet alias → default."""
+    env = normalize(os.environ.get(_MODE_ENV))
+    if env:
+        return env
+    cfg = normalize(read_config().get("mode"))
+    if cfg:
+        return cfg
+    if _truthy(os.environ.get(_QUIET_ALIAS_ENV)):
+        return "quiet"
+    return DEFAULT_MODE
+
+
+def preload_models() -> bool:
+    """Whether boot should eagerly preload models. Off only in quiet mode."""
+    return resolve_mode() != "quiet"
+
+
+def release_when_idle() -> bool:
+    """Whether the idle-unload reaper should run.
+
+    `EXOMEM_RELEASE_GPU_WHEN_IDLE` (truthy/falsy) overrides; otherwise on for quiet
+    and performance (where a model may become resident and idle), off for normal.
+    """
+    override = os.environ.get(_RELEASE_ENV)
+    if override is not None and override.strip() != "":
+        return _truthy(override)
+    return resolve_mode() in ("quiet", "performance")
+
+
+def bulk_gpu_opted() -> bool:
+    """Whether an in-server bulk index (rebuild_all) may use the GPU.
+
+    Only in performance mode, where the server already holds a CUDA context — so
+    an in-server GPU rebuild adds no new idle-context floor. Normal/quiet keep
+    in-server rebuilds on CPU; the separate `exomem index` CLI process is where
+    normal-mode onboarding gets the GPU (it frees the context on exit).
+    """
+    return resolve_mode() == "performance"
+
+
+def resolved() -> dict:
+    """Diagnostic snapshot of the effective policy (for `exomem mode` / logs)."""
+    m = resolve_mode()
+    return {
+        "mode": m,
+        "preload_models": preload_models(),
+        "release_when_idle": release_when_idle(),
+        "bulk_gpu": bulk_gpu_opted(),
+    }
+
+
+def write_mode(value: str) -> Path:
+    """Persist a mode to the config file (atomic). Accepts aliases. Raises on unknown."""
+    canonical = normalize(value)
+    if canonical is None:
+        raise ValueError(
+            f"unknown mode: {value!r} (expected one of {CANON} or an alias {tuple(_ALIASES)})"
+        )
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = read_config()
+    data.update(schema=1, mode=canonical)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2), "utf-8")
+    os.replace(tmp, path)  # atomic swap
+    return path

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -320,7 +320,8 @@ def build_server(*, require_auth: bool) -> FastMCP:
     # add-instant-start-boot). EXOMEM_EAGER_BOOT=1 restores the old blocking
     # boot (rollback lever for deploys); EXOMEM_DISABLE_WARMUP skips warm-up
     # entirely (pure lazy).
-    from . import warmup
+    from . import mode, warmup
+    log.info("compute policy: %s", mode.resolved())
     if warmup.warmup_enabled():
         if os.environ.get("EXOMEM_EAGER_BOOT"):
             warmup.warm_all(vault_root)

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -43,9 +43,15 @@ def warmup_enabled() -> bool:
     return not os.environ.get("EXOMEM_DISABLE_WARMUP")
 
 
-def warm_caches(vault_root: Path) -> dict[str, float]:
+def warm_caches(vault_root: Path, *, preload_models: bool = True) -> dict[str, float]:
     """Warm find's lexical/derived caches; returns per-step durations in ms
-    (empty when disabled). Never raises."""
+    (empty when disabled). Never raises.
+
+    The lexical steps (pages, BM25 both scopes, resolver) are CPU-only and always
+    run. The embedding/CLIP matrix dummy searches touch the vector backend and are
+    skipped when `preload_models` is False (quiet mode) so a quiet boot keeps its
+    RAM footprint minimal — the first find faults the matrix lazily instead.
+    """
     if not warmup_enabled():
         log.info("cache warm-up disabled via EXOMEM_DISABLE_WARMUP")
         return {}
@@ -73,7 +79,7 @@ def warm_caches(vault_root: Path) -> dict[str, float]:
     _step("bm25_kb", lambda: bm25.warm(vault_root, "kb"))
     _step("bm25_vault", lambda: bm25.warm(vault_root, "vault"))
     _step("resolver", lambda: find._get_query_resolver(vault_root))
-    if not os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+    if preload_models and not os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
         # One tiny search warms WHICHEVER backend serves vector search: the vec0
         # backend (sync check + first KNN faults in the vec tables; the numpy
         # matrix stays cold — not holding it resident is the backend's point) or
@@ -120,9 +126,10 @@ def warm_all(vault_root: Path) -> dict[str, float]:
     not-ready (never marked), so requests defer for the rest of the warm and
     then return to inline lazy-load semantics. Never raises.
     """
-    from . import readiness
+    from . import mode, readiness
 
-    durations = warm_caches(vault_root)
+    preload = mode.preload_models()
+    durations = warm_caches(vault_root, preload_models=preload)
     readiness.mark_ready("lexical")
 
     def _model_step(name: str, fn) -> bool:
@@ -154,14 +161,31 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             log.debug("%s warm-encode skipped", step, exc_info=True)
         return True
 
-    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
-        # Lexical-only install: there are no models to wait for, so mark the
-        # model components ready immediately — otherwise finds during the
-        # few-second lexical warm would carry a "warming" marker naming
-        # models this install will never load.
-        log.info("model preloads skipped (EXOMEM_DISABLE_EMBEDDINGS)")
-        for component in ("embeddings", "reranker", "clip"):
-            readiness.mark_ready(component)
+    disabled = bool(os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"))
+    if disabled or not preload:
+        # Skip model preloads: either a lexical-only install (DISABLE_EMBEDDINGS,
+        # nothing to load) or quiet mode (models lazy-load on first use, then the
+        # idle-unload reaper reclaims them). Mark the model components ready either
+        # way so finds during the lexical warm don't carry a "warming" marker for
+        # models that won't preload, and writers stop deferring.
+        reason = "EXOMEM_DISABLE_EMBEDDINGS" if disabled else "quiet mode"
+        log.info("model preloads skipped (%s); models lazy-load on first use", reason)
+        readiness.mark_ready("reranker")
+        readiness.mark_ready("clip")
+        drained = readiness.mark_ready("embeddings")
+        # Quiet mode: embeddings ARE available (just lazy), so replay any write
+        # parked during the brief lexical warm — mirror the real-preload branch so
+        # those edits aren't stranded. Under DISABLE_EMBEDDINGS there's nothing to
+        # embed (upsert_after_write no-ops), so the drain is discarded.
+        if not disabled and drained:
+            from . import embeddings
+
+            for item_vault, paths in drained:
+                try:
+                    embeddings.upsert_after_write(item_vault, list(paths))
+                except Exception:  # noqa: BLE001 — drain is best-effort
+                    log.warning("deferred embed drain failed", exc_info=True)
+            log.info("drained %d deferred write-embed batch(es)", len(drained))
     else:
         from . import embeddings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,19 @@ FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
 
 
 @pytest.fixture(autouse=True)
-def _disable_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Skip the heavy bge-base load by default in the test suite.
 
     Individual tests that exercise embeddings (test_hybrid_search.py)
     delete this env var via their own monkeypatch.
     """
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    # Isolate compute-mode resolution from the developer's real ~/.exomem/config.json
+    # and any ambient EXOMEM_MODE/EXOMEM_DEVICE — the suite must resolve to the
+    # `normal` default deterministically (device selection now consults mode.py).
+    monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(tmp_path / "no-such-exomem-config.json"))
+    for _var in ("EXOMEM_MODE", "EXOMEM_QUIET_MODE", "EXOMEM_DEVICE", "EXOMEM_GPU_MIN_FREE_GB"):
+        monkeypatch.delenv(_var, raising=False)
     monkeypatch.setenv("EXOMEM_DISABLE_RELEVANCE_CHECK", "1")
     # Never spawn the background warm thread from build_server in tests — it
     # would outlive the per-test tmp vault. Warm/readiness tests manage their

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -16,9 +16,14 @@ import pytest
 from exomem import accel
 
 _ENV_KEYS = (
+    "EXOMEM_DEVICE",
     "EXOMEM_TORCH_DEVICE",
+    "EXOMEM_EMBED_DEVICE",
     "EXOMEM_CLIP_DEVICE",
     "EXOMEM_VOICE_DEVICE",
+    "EXOMEM_MODE",
+    "EXOMEM_QUIET_MODE",
+    "EXOMEM_GPU_MIN_FREE_GB",
     "EXOMEM_DISABLE_MEDIA_EXTRACTION",
     "PYTORCH_ENABLE_MPS_FALLBACK",
     "EXOMEM_ASR_BACKEND",
@@ -29,32 +34,38 @@ _ENV_KEYS = (
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Isolate every test from ambient device/env config."""
+    """Isolate every test from ambient device/env config. Mode resolves to `normal`
+    by default (conftest points EXOMEM_CONFIG_PATH at an empty tmp path)."""
     for key in _ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
 
 
-def _set_hw(monkeypatch: pytest.MonkeyPatch, *, cuda: bool, mps: bool) -> None:
+def _set_hw(monkeypatch: pytest.MonkeyPatch, *, cuda: bool, mps: bool, free_gb: float = 8.0) -> None:
     """Advertise a fake `torch` with the given accelerators — no real torch needed, so the
-    matrix runs on lean CI too (matching the suite's torch-optional design)."""
+    matrix runs on lean CI too (matching the suite's torch-optional design). `free_gb` feeds
+    the `gpu_usable()` marginal-VRAM probe via a fake `torch.cuda.mem_get_info`."""
     torch = types.ModuleType("torch")
-    torch.cuda = types.SimpleNamespace(is_available=lambda: cuda)
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: cuda,
+        mem_get_info=lambda *a, **k: (int(free_gb * 1024**3), int(16 * 1024**3)),
+    )
     torch.backends = types.SimpleNamespace()  # MPS is probed via accel._mps_available (patched)
     monkeypatch.setitem(sys.modules, "torch", torch)
     monkeypatch.setattr(accel, "_mps_available", lambda _torch: mps)
 
 
-# ---- auto-detection priority: CUDA > MPS > CPU ----
+# ---- steady-state default policy: CPU-first, CUDA never auto-selected ----
 
-def test_cuda_wins(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_hw(monkeypatch, cuda=True, mps=True)
-    assert accel.select_device() == "cuda"
+def test_normal_mode_stays_cpu_even_with_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The core VRAM-kill: the default (normal) mode never grabs CUDA at idle."""
+    _set_hw(monkeypatch, cuda=True, mps=False)
+    assert accel.select_device() == "cpu"
 
 
-def test_mps_when_no_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_normal_mode_prefers_mps_on_apple_silicon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MPS is unified memory (no discrete idle-VRAM cost), so normal mode keeps it."""
     _set_hw(monkeypatch, cuda=False, mps=True)
     assert accel.select_device() == "mps"
-    # Selecting MPS must arm the op-fallback so unimplemented ops don't crash.
     assert os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
 
 
@@ -67,6 +78,39 @@ def test_no_torch_is_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
     # `import torch` with None in sys.modules raises ImportError → CPU.
     monkeypatch.setitem(sys.modules, "torch", None)
     assert accel.select_device() == "cpu"
+
+
+def test_quiet_mode_forces_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=True)  # even with both accelerators present
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    assert accel.select_device() == "cpu"
+
+
+# ---- performance mode: the discoverable GPU opt-in, capability-gated ----
+
+def test_performance_mode_selects_cuda_when_capable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=8.0)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert accel.select_device() == "cuda"
+
+
+def test_performance_mode_degrades_to_cpu_on_marginal_vram(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Marginal-VRAM guard: a GPU busy with a game (little free VRAM) → CPU, not OOM."""
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=0.5)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert accel.select_device() == "cpu"
+
+
+def test_performance_mode_falls_back_to_mps_without_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=True)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert accel.select_device() == "mps"
+
+
+def test_mode_alias_gpu_maps_to_performance(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=8.0)
+    monkeypatch.setenv("EXOMEM_MODE", "gpu")  # alias for performance
+    assert accel.select_device() == "cuda"
 
 
 # ---- auto_mps=False (ECAPA voiceprint parity default) ----
@@ -82,44 +126,105 @@ def test_auto_mps_false_still_honors_explicit_override(monkeypatch: pytest.Monke
     assert accel.select_device(override_env="EXOMEM_VOICE_DEVICE", auto_mps=False) == "mps"
 
 
-# ---- overrides ----
+# ---- explicit device values: verbatim, with gpu/auto sentinels ----
 
 def test_per_model_override_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_hw(monkeypatch, cuda=True, mps=False)  # would auto-pick cuda
+    _set_hw(monkeypatch, cuda=True, mps=False)
     monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cpu")
     assert accel.select_device(override_env="EXOMEM_CLIP_DEVICE") == "cpu"
 
 
-def test_global_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_global_override_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=True, mps=False)
-    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "cpu")
+    monkeypatch.setenv("EXOMEM_DEVICE", "cpu")
+    assert accel.select_device() == "cpu"
+
+
+def test_legacy_torch_device_alias_forces_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Back-compat door: an explicit EXOMEM_TORCH_DEVICE=cuda keeps GPU verbatim,
+    unconditionally (no headroom probe) — existing GPU users are undisturbed."""
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=0.1)  # verbatim ignores headroom
+    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "cuda")
+    assert accel.select_device() == "cuda"
+
+
+def test_device_gpu_sentinel_is_probe_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`EXOMEM_DEVICE=gpu` opts in politely: uses CUDA only if capable, else degrades."""
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=8.0)
+    monkeypatch.setenv("EXOMEM_DEVICE", "gpu")
+    assert accel.select_device() == "cuda"
+    monkeypatch.setenv("EXOMEM_GPU_MIN_FREE_GB", "16")  # now marginal
     assert accel.select_device() == "cpu"
 
 
 def test_per_model_override_beats_global(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=False, mps=False)
-    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "cpu")
+    monkeypatch.setenv("EXOMEM_DEVICE", "cpu")
     monkeypatch.setenv("EXOMEM_CLIP_DEVICE", "cuda")
     assert accel.select_device(override_env="EXOMEM_CLIP_DEVICE") == "cuda"
 
 
 def test_explicit_mps_override_arms_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=True, mps=False)
-    monkeypatch.setenv("EXOMEM_TORCH_DEVICE", "mps")
+    monkeypatch.setenv("EXOMEM_DEVICE", "mps")
     assert accel.select_device() == "mps"
     assert os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
+
+
+# ---- gpu_usable(): the capability / marginal-VRAM probe ----
+
+def test_gpu_usable_true_with_ample_vram(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=8.0)
+    assert accel.gpu_usable() is True
+
+
+def test_gpu_usable_false_without_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=False)
+    assert accel.gpu_usable() is False
+
+
+def test_gpu_usable_false_on_marginal_vram(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=1.0)  # < 2 GB default
+    assert accel.gpu_usable() is False
+
+
+def test_gpu_usable_threshold_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=1.5)
+    monkeypatch.setenv("EXOMEM_GPU_MIN_FREE_GB", "1")
+    assert accel.gpu_usable() is True
+    monkeypatch.setenv("EXOMEM_GPU_MIN_FREE_GB", "3")
+    assert accel.gpu_usable() is False
+
+
+def test_gpu_usable_no_raise_on_probe_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    torch = types.ModuleType("torch")
+
+    def _boom(*a, **k):
+        raise RuntimeError("driver mismatch")
+
+    torch.cuda = types.SimpleNamespace(is_available=lambda: True, mem_get_info=_boom)
+    torch.backends = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    assert accel.gpu_usable() is False
+
+
+def test_gpu_usable_no_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert accel.gpu_usable() is False
 
 
 # ---- avoid_cuda_when_asr: the cuDNN-shadow workaround is CUDA-only ----
 
 def test_avoid_cuda_when_asr_active_falls_to_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=True, mps=False)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")  # so CUDA is even considered
     # ASR active = EXOMEM_DISABLE_MEDIA_EXTRACTION unset (cleared by the fixture).
     assert accel.select_device(avoid_cuda_when_asr=True) == "cpu"
 
 
 def test_avoid_cuda_when_asr_disabled_keeps_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=True, mps=False)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
     monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
     assert accel.select_device(avoid_cuda_when_asr=True) == "cuda"
 
@@ -128,19 +233,30 @@ def test_avoid_cuda_when_asr_does_not_penalize_mps(monkeypatch: pytest.MonkeyPat
     """The key Apple-Silicon win: CLIP/ECAPA keep MPS even with ASR active, because the
     cuDNN clash only exists on CUDA."""
     _set_hw(monkeypatch, cuda=False, mps=True)  # a Mac: MPS, no CUDA
-    # ASR active. On the old code this returned "cpu"; now it stays on the GPU.
     assert accel.select_device(avoid_cuda_when_asr=True) == "mps"
 
 
 # ---- pipeline_device (HF transformers device form) ----
 
-@pytest.mark.parametrize(
-    "cuda, mps, expected",
-    [(True, False, 0), (False, True, "mps"), (False, False, -1)],
-)
-def test_pipeline_device(monkeypatch: pytest.MonkeyPatch, cuda, mps, expected) -> None:
-    _set_hw(monkeypatch, cuda=cuda, mps=mps)
-    assert accel.pipeline_device() == expected
+def test_pipeline_device_cpu_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False)  # normal mode → CPU → -1
+    assert accel.pipeline_device() == -1
+
+
+def test_pipeline_device_mps(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=True)
+    assert accel.pipeline_device() == "mps"
+
+
+def test_pipeline_device_cuda_in_performance_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=True, mps=False, free_gb=8.0)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert accel.pipeline_device() == 0
+
+
+def test_pipeline_device_no_accel(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_hw(monkeypatch, cuda=False, mps=False)
+    assert accel.pipeline_device() == -1
 
 
 # ---- ASR transcription backend seam (Phase 2) ----

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -228,7 +228,7 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
     ready as it lands."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     call_order: list[str] = []
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: call_order.append("lexical") or {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: call_order.append("lexical") or {})
     monkeypatch.setattr(embeddings, "get_model", lambda: call_order.append("embeddings") or object())
     monkeypatch.setattr(embeddings, "get_reranker", lambda: call_order.append("reranker") or object())
     monkeypatch.setattr(embeddings, "get_clip_model", lambda: call_order.append("clip") or object())
@@ -250,7 +250,7 @@ def test_warm_all_skips_model_preloads_when_embeddings_disabled(
     finds during the lexical warm must not carry a "warming" marker naming
     models this install will never load."""
     monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
 
     def _forbidden() -> None:
         raise AssertionError("model getters must not be called when embeddings are disabled")
@@ -267,13 +267,92 @@ def test_warm_all_skips_model_preloads_when_embeddings_disabled(
     assert readiness.is_ready("clip") is True
 
 
+def test_warm_all_quiet_mode_skips_preloads_but_marks_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Quiet mode (models available, just lazy) skips the bge/reranker/CLIP preloads
+    entirely — the getters are never called — yet marks every model component ready
+    so finds during the lexical warm don't carry a bogus "warming" marker. This is
+    the idle-VRAM win: no model touches CUDA at boot."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
+
+    def _forbidden() -> None:
+        raise AssertionError("model getters must not be called in quiet mode")
+
+    monkeypatch.setattr(embeddings, "get_model", _forbidden)
+    monkeypatch.setattr(embeddings, "get_reranker", _forbidden)
+    monkeypatch.setattr(embeddings, "get_clip_model", _forbidden)
+
+    warmup.warm_all(tmp_path)
+
+    for c in readiness.COMPONENTS:
+        assert readiness.is_ready(c) is True
+
+
+def test_warm_all_quiet_mode_replays_deferred_write_embeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unlike the DISABLE_EMBEDDINGS leg, quiet mode HAS embeddings (lazy), so a write
+    parked via readiness.defer during the brief lexical warm must be replayed through
+    embeddings.upsert_after_write — not stranded."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
+    drained_calls: list[tuple] = []
+    monkeypatch.setattr(
+        embeddings, "upsert_after_write",
+        lambda vr, paths: drained_calls.append((vr, list(paths))),
+    )
+
+    readiness.begin_warm()
+    some_paths = (tmp_path / "a.md", tmp_path / "b.md")
+    assert readiness.defer("embeddings", (tmp_path, some_paths)) is True
+
+    warmup.warm_all(tmp_path)
+
+    assert drained_calls == [(tmp_path, list(some_paths))]
+
+
+def test_warm_caches_gates_matrix_warm_on_preload_models(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The embedding/CLIP matrix dummy searches (which touch the vector backend) are
+    skipped when preload_models is False and run when True — the CPU-only lexical
+    steps are unaffected either way."""
+    monkeypatch.delenv("EXOMEM_DISABLE_WARMUP", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+
+    calls: list[int] = []
+
+    class _Idx:
+        def search(self, q, k):
+            calls.append(k)
+            return []
+
+    monkeypatch.setattr(embeddings, "get_embedding_index", lambda vr: _Idx())
+    monkeypatch.setattr(embeddings, "get_clip_index", lambda vr: _Idx())
+    monkeypatch.setattr(embeddings, "clip_enabled", lambda: True)
+
+    d_quiet = warmup.warm_caches(tmp_path, preload_models=False)
+    assert "embedding_matrix" not in d_quiet
+    assert "clip_matrix" not in d_quiet
+    assert calls == []
+
+    d_default = warmup.warm_caches(tmp_path, preload_models=True)
+    assert "embedding_matrix" in d_default
+    assert "clip_matrix" in d_default
+    assert calls == [1, 1]
+
+
 def test_warm_all_soft_fails_one_step_and_continues_to_later_steps(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A raising loader must not abort later steps — bge failing leaves only
     "embeddings" unready while reranker/clip still load and mark ready."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
 
     def _boom() -> None:
         raise RuntimeError("network unreachable")
@@ -302,7 +381,7 @@ def test_warm_all_drains_deferred_write_embeds_after_embeddings_ready(
     parked via readiness.defer("embeddings", ...) during the warm and
     replay it through embeddings.upsert_after_write."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
     monkeypatch.setattr(embeddings, "get_model", lambda: object())
     monkeypatch.setattr(embeddings, "get_reranker", lambda: object())
     monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
@@ -332,7 +411,7 @@ def test_warm_all_drains_deferred_write_embeds_even_when_bge_preload_fails(
     WITHOUT marking the component ready: request paths keep their inline
     lazy-load + soft-degrade fallback, but the parked writes are replayed."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
 
     def _boom() -> None:
         raise RuntimeError("network unreachable")
@@ -376,7 +455,7 @@ def test_warm_all_runs_a_throwaway_encode_after_each_preload(
             warmed.append("predict")
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
     monkeypatch.setattr(embeddings, "get_model", _FakeST)
     monkeypatch.setattr(embeddings, "get_reranker", _FakeCE)
     monkeypatch.setattr(embeddings, "get_clip_model", _FakeST)
@@ -402,7 +481,7 @@ def test_warm_encode_failure_is_swallowed_and_does_not_block_readiness(
             raise RuntimeError("mps kernel compile failed")
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
     monkeypatch.setattr(embeddings, "get_model", _Boom)
     monkeypatch.setattr(embeddings, "get_reranker", _Boom)
     monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
@@ -809,7 +888,7 @@ def test_warm_cli_vault_flag_also_warms_lexical_caches(
     monkeypatch.setattr(embeddings, "get_model", lambda: object())
     monkeypatch.setattr(embeddings, "get_reranker", lambda: object())
     calls: list[Path] = []
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr: calls.append(vr) or {})
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: calls.append(vr) or {})
 
     code = main(["warm", "--vault", str(tmp_path)])
 

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1,0 +1,156 @@
+"""Compute-mode resolution + per-machine config persistence (`exomem.mode`).
+
+Torch-free policy layer: taxonomy/aliases, the env → config-file → legacy-alias →
+default precedence, the derived booleans (preload / release-when-idle / bulk-gpu),
+and the atomic config writer. No hardware needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import mode
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the config file at a controllable tmp path and clear ambient mode env."""
+    monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(tmp_path / "config.json"))
+    for var in ("EXOMEM_MODE", "EXOMEM_QUIET_MODE", "EXOMEM_RELEASE_GPU_WHEN_IDLE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---- normalize / aliases ----
+
+def test_normalize_canonical_and_aliases() -> None:
+    assert mode.normalize("quiet") == "quiet"
+    assert mode.normalize("normal") == "normal"
+    assert mode.normalize("performance") == "performance"
+    assert mode.normalize("gpu") == "performance"  # alias
+    assert mode.normalize("turbo") == "performance"  # alias
+    assert mode.normalize(" GPU ") == "performance"  # case/space-insensitive
+
+
+def test_normalize_unknown_is_none() -> None:
+    assert mode.normalize("nonsense") is None
+    assert mode.normalize("") is None
+    assert mode.normalize(None) is None
+
+
+# ---- resolve_mode precedence ----
+
+def test_default_is_normal() -> None:
+    assert mode.resolve_mode() == "normal"
+
+
+def test_env_mode_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    assert mode.resolve_mode() == "quiet"
+
+
+def test_env_mode_accepts_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "turbo")
+    assert mode.resolve_mode() == "performance"
+
+
+def test_config_file_used_when_no_env() -> None:
+    mode.write_mode("performance")
+    assert mode.resolve_mode() == "performance"
+
+
+def test_env_beats_config_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    mode.write_mode("performance")
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    assert mode.resolve_mode() == "quiet"
+
+
+def test_legacy_quiet_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_QUIET_MODE", "1")
+    assert mode.resolve_mode() == "quiet"
+
+
+def test_invalid_env_mode_falls_through_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "bogus")
+    assert mode.resolve_mode() == "normal"
+
+
+# ---- derived policy booleans ----
+
+@pytest.mark.parametrize(
+    "m, preload", [("quiet", False), ("normal", True), ("performance", True)]
+)
+def test_preload_models(monkeypatch: pytest.MonkeyPatch, m: str, preload: bool) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", m)
+    assert mode.preload_models() is preload
+
+
+@pytest.mark.parametrize(
+    "m, release", [("quiet", True), ("normal", False), ("performance", True)]
+)
+def test_release_when_idle_by_mode(monkeypatch: pytest.MonkeyPatch, m: str, release: bool) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", m)
+    assert mode.release_when_idle() is release
+
+
+def test_release_when_idle_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")  # default off
+    monkeypatch.setenv("EXOMEM_RELEASE_GPU_WHEN_IDLE", "on")
+    assert mode.release_when_idle() is True
+    monkeypatch.setenv("EXOMEM_MODE", "performance")  # default on
+    monkeypatch.setenv("EXOMEM_RELEASE_GPU_WHEN_IDLE", "off")
+    assert mode.release_when_idle() is False
+
+
+@pytest.mark.parametrize(
+    "m, bulk", [("quiet", False), ("normal", False), ("performance", True)]
+)
+def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", m)
+    assert mode.bulk_gpu_opted() is bulk
+
+
+# ---- config file read/write ----
+
+def test_read_config_missing_is_empty() -> None:
+    assert mode.read_config() == {}
+
+
+def test_read_config_corrupt_is_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text("{not json", "utf-8")
+    assert mode.read_config() == {}
+
+
+def test_write_mode_roundtrip_and_atomic(tmp_path: Path) -> None:
+    path = mode.write_mode("gpu")  # alias normalized to canonical
+    assert path == tmp_path / "config.json"
+    data = json.loads(path.read_text("utf-8"))
+    assert data["mode"] == "performance"
+    assert data["schema"] == 1
+    assert not list(tmp_path.glob("*.tmp"))  # temp file cleaned up by os.replace
+
+
+def test_write_mode_preserves_other_keys(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps({"schema": 1, "other": "keep"}), "utf-8")
+    mode.write_mode("quiet")
+    data = json.loads((tmp_path / "config.json").read_text("utf-8"))
+    assert data["mode"] == "quiet"
+    assert data["other"] == "keep"
+
+
+def test_write_mode_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        mode.write_mode("bogus")
+
+
+def test_resolved_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    snap = mode.resolved()
+    assert snap == {
+        "mode": "quiet",
+        "preload_models": False,
+        "release_when_idle": True,
+        "bulk_gpu": False,
+    }


### PR DESCRIPTION
## PR1 of 5 — the idle-VRAM kill

Flips exomem's steady-state torch device from **GPU-first to CPU-first**, so the long-lived server **never initializes CUDA at idle**. That removes the ~5.5 GB of VRAM the server held at rest (eager `exomem-warm` preload of bge + reranker + CLIP onto CUDA), which silently hijacked the GPU on single-box self-hosts and was the hidden cause of the Spider-Man 2 "16 GB wall". GPU becomes an explicit, discoverable, capability-gated opt-in.

**Why this is the right layer:** retrieval (`find`) is already CPU, so user-facing latency is unchanged; quality is identical (bge stays fp32 on CPU and CUDA → bit-identical vectors). Only `torch.cuda.empty_cache()` can't free the CUDA *context* floor once initialized, so **never initializing CUDA (CPU-default) is the only path to ~0 idle VRAM** — idle-unload (PR3) is the complement for the opt-in GPU path.

### What changed
- **New `exomem.mode`** — one per-machine knob, `quiet | normal | performance` (aliases `gpu`/`turbo`), resolved `EXOMEM_MODE` → `~/.exomem/config.json` → legacy `EXOMEM_QUIET_MODE` → `normal` default. Torch-free so lean-CLI dispatch pays no torch import.
- **`accel.select_device`** — removes the unconditional auto-CUDA. CPU is the default; MPS still auto on Apple Silicon; CUDA reached only via `performance` mode or an explicit device value. New **`gpu_usable()`** marginal-VRAM probe (`torch.cuda.mem_get_info`, **never raises** → CPU) is the graceful-degradation / no-CUDA-host correctness layer. Friendly **`EXOMEM_DEVICE`** (legacy `EXOMEM_TORCH_DEVICE` alias); `gpu`/`auto` are probe-gated sentinels, `cuda` is verbatim (the back-compat door for existing GPU users). `EXOMEM_EMBED_DEVICE` for the text path.
- **`warmup`** — skips model preloads (and the vector-matrix dummy searches) in quiet mode, mirroring the existing `DISABLE_EMBEDDINGS` mark-ready template and replaying deferred writes so lazy CPU load stays correct.
- **`server`** — logs the resolved compute policy at boot.

### Tests
- Rewrote `test_accel` device-priority tests for the new CPU-default policy + the `gpu_usable` probe (marginal-VRAM, no-CUDA, threshold, no-raise).
- New `test_mode` (resolution precedence, aliases, config round-trip).
- Quiet-mode warm-gating tests in `test_instant_start` (no preload, all components ready, deferred-write replay, matrix-warm gate).
- Suite-wide config isolation in `conftest` so a real `~/.exomem/config.json` never perturbs the suite.

**Verification:** full suite **1492 passed, 16 skipped** (skips are missing optional deps in the lean venv), ruff clean on changed files. The `-m embeddings` golden floors need the embeddings extra (real-box); device selection doesn't alter vectors (fp32 both devices), so golden output is unaffected — will confirm on the RTX 5080 box after deploy.

### Follow-ups (per the approved plan)
PR2 bulk-GPU opt-in · PR3 idle-unload subsystem · PR4 `exomem mode` CLI + live switch + GPU prompt · PR5 model configurability + lite profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ
