### PR TITLE
feat(compute): extend CPU-default device policy to ASR + diarizer + bulk-index (PR2)

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -191,6 +191,13 @@ def _index_main(argv: list[str]) -> int:
         help="chunks per embedding batch (default: 256)",
     )
     parser.add_argument(
+        "--device", choices=("auto", "cpu", "gpu"), default=None,
+        help="embedding device for this run. Default: GPU when a capable one is present "
+        "and the mode isn't 'quiet' (this is a short-lived process, so it frees the CUDA "
+        "context on exit — safe even on a CPU-default server). 'cpu' forces CPU; 'gpu'/"
+        "'auto' opt in with the marginal-VRAM guard.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="report what would be (re)embedded and pruned; write nothing",
     )
@@ -204,7 +211,7 @@ def _index_main(argv: list[str]) -> int:
         os.environ["EXOMEM_INDEX_SCOPE"] = args.scope
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    from . import embeddings
+    from . import accel, embeddings
 
     # A real run needs the model; --dry-run only walks + reads the sidecar, so it
     # stays fast and works in stripped/embeddings-disabled environments.
@@ -215,6 +222,17 @@ def _index_main(argv: list[str]) -> int:
                 file=sys.stderr,
             )
             return 2
+        # Pick the embedding device for THIS one-shot process (accel.bulk_device):
+        # explicit --device wins; else GPU when capable and not quiet. A short-lived
+        # CLI process frees the CUDA context on exit, so GPU here is safe even on a
+        # normal-mode (CPU-default) server — this is how onboarding gets GPU speed
+        # without leaving a resident context floor.
+        bulk = accel.bulk_device(args.device)
+        if bulk:
+            os.environ["EXOMEM_EMBED_DEVICE"] = bulk
+        logging.getLogger(__name__).info(
+            "index: embedding on %s", accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
+        )
         try:
             embeddings.get_model()
         except Exception as e:  # noqa: BLE001 — surface a clean CLI error

--- a/src/exomem/accel.py
+++ b/src/exomem/accel.py
@@ -202,3 +202,36 @@ def pipeline_device(**kwargs):
     if device == "cpu":
         return -1
     return device  # "mps", or an explicit override like "cuda:1"
+
+
+def cuda_if_performance() -> str:
+    """``"cuda"`` | ``"cpu"`` for non-torch engines that bypass `select_device`.
+
+    The CTranslate2 ASR engine (faster-whisper) and the diarizer sidecar can't use
+    MPS, and they own their own device argument rather than routing through
+    `select_device`. This gives them the SAME mode-aware policy: CUDA only in
+    performance mode with a capable GPU, CPU otherwise (the default) — so a
+    normal/quiet server doesn't preload a ~3 GB Whisper model onto the GPU at boot.
+    """
+    if mode_module.resolve_mode() == "performance" and gpu_usable():
+        return "cuda"
+    return "cpu"
+
+
+def bulk_device(explicit: str | None = None) -> str | None:
+    """Device to set as ``EXOMEM_EMBED_DEVICE`` for a one-shot bulk index (the
+    ``exomem index`` CLI), or ``None`` to leave the CPU-default mode policy.
+
+    An explicit ``--device`` wins verbatim. Otherwise: GPU when a capable GPU is
+    present AND the mode isn't quiet — safe even on a normal-mode box because the
+    ``exomem index`` process is short-lived and frees the CUDA context on exit
+    (unlike the long-lived server, which stays CPU to avoid a resident context
+    floor). Quiet mode always stays on CPU (don't grab the GPU mid-game). The
+    returned value is understood by `select_device` (``"cpu"``/``"cuda"``/``"gpu"``/
+    ``"auto"``); ``"gpu"`` is probe-gated so it degrades if the GPU went marginal.
+    """
+    if explicit:
+        return explicit
+    if mode_module.resolve_mode() != "quiet" and gpu_usable():
+        return "gpu"
+    return None

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -201,13 +201,22 @@ def _ensure_cuda_dll_path() -> None:
 
 
 def _device() -> str:
-    """'cuda' when a GPU is visible, else 'cpu' — mirrors embeddings.py's check."""
-    try:
-        import torch
+    """ASR (faster-whisper / CTranslate2) compute device — mode-aware, CPU by default.
 
-        return "cuda" if torch.cuda.is_available() else "cpu"
-    except Exception:  # noqa: BLE001 — torch absent on a lean box → CPU
-        return "cpu"
+    CUDA only in `performance` mode with a capable GPU (via `accel.cuda_if_performance`),
+    so a normal/quiet server never preloads the ~3 GB Whisper model onto the GPU at boot
+    — the idle VRAM the accel-routed models (bge/reranker/CLIP) already avoid. CTranslate2
+    can't use MPS, so this is strictly cuda-or-cpu. `EXOMEM_ASR_DEVICE` (cpu | cuda | auto)
+    is an explicit override.
+    """
+    from . import accel
+
+    pref = (os.environ.get("EXOMEM_ASR_DEVICE") or "").strip().lower()
+    if pref in ("cpu", "cuda"):
+        return pref
+    if pref in ("auto", "gpu"):
+        return "cuda" if accel.gpu_usable() else "cpu"
+    return accel.cuda_if_performance()
 
 
 _WHISPER_LOCK = threading.Lock()
@@ -590,7 +599,16 @@ def _diarizer_child_env() -> dict[str, str]:
     can't shadow the sidecar's bundled cu130 CUDA/cuDNN (the CLIP/cuDNN shadow class of bug).
     """
     env = {**os.environ, "HF_HUB_DISABLE_PROGRESS_BARS": "1"}
-    pref = os.environ.get("EXOMEM_DIARIZE_DEVICE", "auto").lower()
+    pref = os.environ.get("EXOMEM_DIARIZE_DEVICE")
+    if pref is None or not pref.strip():
+        # No explicit override → follow the compute mode: CPU unless performance, so a
+        # normal/quiet box doesn't spin the diarizer up on the GPU mid-game. (The sidecar
+        # is transient, so this is about not interrupting, not idle VRAM.)
+        from . import accel
+
+        pref = accel.cuda_if_performance()  # "cuda" | "cpu"
+    else:
+        pref = pref.strip().lower()
     if pref == "cpu":
         env["CUDA_VISIBLE_DEVICES"] = ""
         return env

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -21,6 +21,8 @@ _ENV_KEYS = (
     "EXOMEM_EMBED_DEVICE",
     "EXOMEM_CLIP_DEVICE",
     "EXOMEM_VOICE_DEVICE",
+    "EXOMEM_ASR_DEVICE",
+    "EXOMEM_DIARIZE_DEVICE",
     "EXOMEM_MODE",
     "EXOMEM_QUIET_MODE",
     "EXOMEM_GPU_MIN_FREE_GB",
@@ -412,3 +414,86 @@ def test_maybe_half_swallows_conversion_failure(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.delenv("EXOMEM_MPS_FP16", raising=False)
     m = _Boom()
     assert embeddings._maybe_half(m, "mps") is m  # original returned, no raise
+
+
+# ---- cuda_if_performance: non-torch engines (CTranslate2 ASR, diarizer) ----
+
+def test_cuda_if_performance_cpu_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default (normal) mode keeps ASR/diarizer on CPU even with a capable GPU — this is
+    the fix for the ~3 GB Whisper model that PR1's accel change didn't reach."""
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert accel.cuda_if_performance() == "cpu"
+
+
+def test_cuda_if_performance_quiet_is_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert accel.cuda_if_performance() == "cpu"
+
+
+def test_cuda_if_performance_performance_capable_is_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert accel.cuda_if_performance() == "cuda"
+
+
+def test_cuda_if_performance_performance_marginal_is_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: False)
+    assert accel.cuda_if_performance() == "cpu"
+
+
+# ---- bulk_device: the `exomem index` CLI opt-in ----
+
+def test_bulk_device_explicit_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: False)
+    assert accel.bulk_device("cpu") == "cpu"
+    assert accel.bulk_device("gpu") == "gpu"
+    assert accel.bulk_device("auto") == "auto"
+
+
+def test_bulk_device_default_gpu_when_capable_and_not_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert accel.bulk_device() == "gpu"  # normal mode + capable GPU → opt in (subprocess frees it)
+
+
+def test_bulk_device_default_none_when_incapable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: False)
+    assert accel.bulk_device() is None  # leave the CPU-default mode policy
+
+
+def test_bulk_device_quiet_stays_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert accel.bulk_device() is None  # don't grab the GPU mid-game
+
+
+# ---- extract._device: ASR is now mode-aware (was bare torch.cuda.is_available) ----
+
+def test_asr_device_cpu_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import extract
+
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert extract._device() == "cpu"  # normal mode → CPU even with a capable GPU
+
+
+def test_asr_device_cuda_in_performance(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import extract
+
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert extract._device() == "cuda"
+
+
+def test_asr_device_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import extract
+
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: False)
+    monkeypatch.setenv("EXOMEM_ASR_DEVICE", "cuda")
+    assert extract._device() == "cuda"  # explicit verbatim wins over mode+probe
+    monkeypatch.setenv("EXOMEM_ASR_DEVICE", "cpu")
+    assert extract._device() == "cpu"
+    monkeypatch.setenv("EXOMEM_ASR_DEVICE", "auto")
+    assert extract._device() == "cpu"  # auto probes; gpu_usable False → cpu
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    assert extract._device() == "cuda"  # auto + capable → cuda

--- a/tests/test_diarizer_sidecar.py
+++ b/tests/test_diarizer_sidecar.py
@@ -167,6 +167,28 @@ def test_child_env_cuda_keeps_gpu_and_strips_nvidia_bins(monkeypatch) -> None:
     assert not any("nvidia" in p.lower() for p in parts)  # cu12 wheel bins stripped → no cuDNN shadow
 
 
+def test_child_env_default_follows_mode_cpu_in_normal(monkeypatch) -> None:
+    """With no explicit EXOMEM_DIARIZE_DEVICE, the sidecar follows the compute mode:
+    normal (default) → CPU, so it doesn't spin the GPU up mid-game."""
+    from exomem import accel
+
+    monkeypatch.delenv("EXOMEM_DIARIZE_DEVICE", raising=False)
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    env = extract._diarizer_child_env()
+    assert env["CUDA_VISIBLE_DEVICES"] == ""  # CPU by default
+
+
+def test_child_env_default_gpu_in_performance(monkeypatch) -> None:
+    from exomem import accel
+
+    monkeypatch.delenv("EXOMEM_DIARIZE_DEVICE", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "gpu_usable", lambda *a, **k: True)
+    monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", "/x/nvidia/cublas/bin"]))
+    env = extract._diarizer_child_env()
+    assert env.get("CUDA_VISIBLE_DEVICES", "x") != ""  # GPU stays visible in performance mode
+
+
 def test_run_diarization_passes_device_env(monkeypatch) -> None:
     _fake_python(monkeypatch)
     monkeypatch.setenv("EXOMEM_DIARIZE_DEVICE", "cpu")


### PR DESCRIPTION
## PR2 of 5 — extend CPU-default policy to the paths PR1 didn't reach

After PR1 deployed, the live service's GPU VRAM dropped ~3.3 GB (bge + reranker + CLIP left the GPU) but **~3 GB remained** — traced to the **faster-whisper ASR model**, which the media worker preloads onto the GPU at boot. ASR (CTranslate2) owns its own device selection in `extract.py` and bypasses `accel`, so PR1's flip didn't touch it. Two other paths were in the same boat.

This PR extends PR1's mode-aware policy to all three.

### What changed
- **ASR (`extract._device`)** — was bare `torch.cuda.is_available()`; now `accel.cuda_if_performance()`: **CPU by default**, CUDA only in `performance` mode with a capable GPU. Kills the ~3 GB boot-time Whisper VRAM in normal/quiet mode. `EXOMEM_ASR_DEVICE` (cpu|cuda|auto) overrides. (CTranslate2 has no MPS → strictly cuda-or-cpu.)
- **Diarizer sidecar (`extract._diarizer_child_env`)** — its default device now follows the mode (CPU unless performance) instead of GPU-visible, so a normal/quiet box doesn't spin the diarizer up on the GPU mid-game. It's a transient subprocess (no idle VRAM), so this is about *not interrupting*, and explicit `EXOMEM_DIARIZE_DEVICE` still wins.
- **`exomem index` CLI** — new `--device {auto,cpu,gpu}`; by default uses the GPU when capable and not quiet (`accel.bulk_device`). Safe even on a CPU-default server because the index process is **short-lived and frees the CUDA context on exit** — that's how normal-mode onboarding gets GPU speed without leaving a resident context floor (which `empty_cache()` can't reclaim — see the CUDA-context-floor note).
- **`accel`** — `cuda_if_performance()` (cuda-or-cpu for non-torch engines) + `bulk_device()` (CLI resolver).

### Deliberate non-change
In-server `rebuild_all` needs **no** change: it uses the model singleton, whose device already follows the mode (normal→CPU preserves the 0-context invariant; performance→GPU where a context already exists). A transient in-server GPU instance would *still* leave a context floor (per the CUDA-context-floor finding) **and** double VRAM in performance mode — so the singleton path is strictly correct.

### Verification
Full suite **1505 passed / 16 skipped** (optional-dep skips only), ruff clean. New unit tests cover `cuda_if_performance`, `bulk_device`, the ASR device policy + `EXOMEM_ASR_DEVICE` override, and the diarizer's mode-aware default. Real-box confirmation of the service dropping to ~0 comes after deploy.

### Follow-ups
PR3 idle-unload · PR4 `exomem mode` CLI + live switch + GPU prompt · PR5 model configurability + lite profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ
