### PR TITLE
feat(compute): idle-unload subsystem — reclaim resident models after N idle minutes (PR3)

### DIFF
--- a/src/exomem/accel.py
+++ b/src/exomem/accel.py
@@ -235,3 +235,41 @@ def bulk_device(explicit: str | None = None) -> str | None:
     if mode_module.resolve_mode() != "quiet" and gpu_usable():
         return "gpu"
     return None
+
+
+def empty_cache() -> None:
+    """Return unused caching-allocator blocks to the driver after a model unload.
+
+    Only touches CUDA when a context already exists (`is_initialized`) so it never
+    creates one on a CPU-default process. Note (see the CUDA-context-floor KB note):
+    this frees weights + the reserved pool, NOT the CUDA context itself — so it can't
+    reach ~0 VRAM on its own; that's why CPU-default is the primary idle-VRAM fix and
+    this is the complement for the GPU-opt-in path. Never raises.
+    """
+    try:
+        import torch
+
+        if torch.cuda.is_available() and torch.cuda.is_initialized():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001 — cache release is best-effort
+        pass
+
+
+def gpu_mem() -> dict | None:
+    """`{"allocated_mb", "reserved_mb"}` for the current CUDA device, or None.
+
+    For unload/reaper observability and `doctor`. Returns None when torch is absent or
+    CUDA isn't available; never raises. Reads the accounting only if a context exists so
+    it doesn't create one.
+    """
+    try:
+        import torch
+
+        if not (torch.cuda.is_available() and torch.cuda.is_initialized()):
+            return None
+        return {
+            "allocated_mb": round(torch.cuda.memory_allocated() / 2**20, 1),
+            "reserved_mb": round(torch.cuda.memory_reserved() / 2**20, 1),
+        }
+    except Exception:  # noqa: BLE001 — observability must never break a caller
+        return None

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -15,6 +15,8 @@ Sidecar lives outside `_Schema/` deliberately:
 
 from __future__ import annotations
 
+import contextlib
+import gc
 import logging
 import math
 import os
@@ -22,6 +24,7 @@ import random
 import sqlite3
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
@@ -58,6 +61,101 @@ _CLIP_MODEL = None
 _CLIP_LOCK = threading.Lock()
 _IMPORT_FAILED = False  # one-time soft-fail flag for upsert_after_write
 _CLIP_IMPORT_FAILED = False
+
+
+class _ModelGuard:
+    """In-flight + last-activity tracking for a lazily-loaded model singleton, so the
+    idle-unload reaper (`model_reaper`) can reclaim it safely.
+
+    Correctness rests on the worker holding a live LOCAL ref to the model for the whole
+    encode (get_model() returns it, the worker calls model.encode on that local): nulling
+    the module singleton can't collect it and `empty_cache()` frees only unused blocks, so
+    an unload racing an in-flight encode is never a use-after-free. This guard therefore
+    only prevents INEFFICIENCY — a transient double-load or empty_cache stealing reusable
+    blocks mid-encode — via the in-flight counter, not a crash. Its lock guards only the
+    counter + timestamp; it is never held across a model load or an encode.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._lock = threading.Lock()
+        self._inflight = 0
+        self._last_activity = 0.0  # time.monotonic() of last load/encode; 0 = never loaded
+
+    def touch(self) -> None:
+        """Stamp activity (called on model load so a fresh model isn't instantly reaped)."""
+        with self._lock:
+            self._last_activity = time.monotonic()
+
+    @contextlib.contextmanager
+    def active(self):
+        """Bracket an encode/predict: bump in-flight so the reaper skips this model."""
+        with self._lock:
+            self._inflight += 1
+            self._last_activity = time.monotonic()
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._inflight -= 1
+                self._last_activity = time.monotonic()
+
+    def inflight(self) -> int:
+        with self._lock:
+            return self._inflight
+
+    def last_activity(self) -> float:
+        with self._lock:
+            return self._last_activity
+
+
+BGE_GUARD = _ModelGuard("embeddings")
+RERANKER_GUARD = _ModelGuard("reranker")
+CLIP_GUARD = _ModelGuard("clip")
+
+
+def unload_model() -> bool:
+    """Drop the bge singleton and release its GPU cache. Skips if a worker is mid-encode.
+
+    Returns True if it actually unloaded. Safe under concurrent use (see `_ModelGuard`):
+    a worker that already holds the model finishes its encode on its local ref. The busy
+    check + null happen under `_MODEL_LOCK`, so no new get_model() can complete a load in
+    between (get_model also takes `_MODEL_LOCK`)."""
+    global _MODEL
+    with _MODEL_LOCK:
+        if _MODEL is None or BGE_GUARD.inflight() > 0:
+            return False
+        m, _MODEL = _MODEL, None
+    del m
+    gc.collect()
+    accel.empty_cache()
+    return True
+
+
+def unload_reranker() -> bool:
+    """Drop the reranker singleton + release GPU cache. See `unload_model`."""
+    global _RERANKER
+    with _RERANKER_LOCK:
+        if _RERANKER is None or RERANKER_GUARD.inflight() > 0:
+            return False
+        m, _RERANKER = _RERANKER, None
+    del m
+    gc.collect()
+    accel.empty_cache()
+    return True
+
+
+def unload_clip_model() -> bool:
+    """Drop the CLIP singleton + release GPU cache. See `unload_model`."""
+    global _CLIP_MODEL
+    with _CLIP_LOCK:
+        if _CLIP_MODEL is None or CLIP_GUARD.inflight() > 0:
+            return False
+        m, _CLIP_MODEL = _CLIP_MODEL, None
+    del m
+    gc.collect()
+    accel.empty_cache()
+    return True
 
 # Process-lifetime memo of the per-vault index objects. Sharing ONE instance per
 # vault is what makes the in-memory matrix cache survive across find() calls (and
@@ -153,6 +251,7 @@ def get_model():
         device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
         log.info("loading embedding model %s on %s", MODEL_NAME, device)
         _MODEL = _maybe_half(SentenceTransformer(MODEL_NAME, device=device), device)
+    BGE_GUARD.touch()  # start the idle clock at load, not epoch 0
     return _MODEL
 
 
@@ -169,6 +268,7 @@ def get_reranker():
         device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
         log.info("loading reranker %s on %s", RERANKER_NAME, device)
         _RERANKER = CrossEncoder(RERANKER_NAME, device=device)
+    RERANKER_GUARD.touch()
     return _RERANKER
 
 
@@ -228,6 +328,7 @@ def get_clip_model():
         device = _clip_device()
         log.info("loading CLIP model %s on %s", CLIP_MODEL_NAME, device)
         _CLIP_MODEL = _maybe_half(SentenceTransformer(CLIP_MODEL_NAME, device=device), device)
+    CLIP_GUARD.touch()
     return _CLIP_MODEL
 
 
@@ -244,7 +345,7 @@ def embed_image(path: Path) -> np.ndarray:
         model = get_clip_model()
     except ImportError as e:
         raise ClipUnavailable(f"sentence-transformers not installed: {e}") from e
-    with Image.open(path) as img:
+    with Image.open(path) as img, CLIP_GUARD.active():
         vec = model.encode(img.convert("RGB"), convert_to_numpy=True, normalize_embeddings=True)
     return vec.astype(np.float32, copy=False)
 
@@ -255,7 +356,8 @@ def embed_clip_text(query: str) -> np.ndarray:
         model = get_clip_model()
     except ImportError as e:
         raise ClipUnavailable(f"sentence-transformers not installed: {e}") from e
-    vec = model.encode([query], convert_to_numpy=True, normalize_embeddings=True)[0]
+    with CLIP_GUARD.active():
+        vec = model.encode([query], convert_to_numpy=True, normalize_embeddings=True)[0]
     return vec.astype(np.float32, copy=False)
 
 
@@ -272,7 +374,8 @@ def embed_clip_texts(texts: list[str]) -> np.ndarray:
         model = get_clip_model()
     except ImportError as e:
         raise ClipUnavailable(f"sentence-transformers not installed: {e}") from e
-    vecs = model.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
+    with CLIP_GUARD.active():
+        vecs = model.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
     return vecs.astype(np.float32, copy=False)
 
 
@@ -679,9 +782,10 @@ def embed_video_scenes(
     pairs = sample_video_scenes(path)
     if not pairs:
         raise ClipUnavailable(f"no decodable video frames in {path.name}")
-    vecs = model.encode(
-        [img for _, img in pairs], convert_to_numpy=True, normalize_embeddings=True
-    )
+    with CLIP_GUARD.active():
+        vecs = model.encode(
+            [img for _, img in pairs], convert_to_numpy=True, normalize_embeddings=True
+        )
     vectors = [
         (float(s.rep_ts), vecs[i].astype(np.float32, copy=False))
         for i, (s, _) in enumerate(pairs)
@@ -722,7 +826,8 @@ def embed_video_frames(path: Path) -> list[tuple[float, np.ndarray]]:
         idx = sorted(set(np.linspace(0, len(kept) - 1, cap).round().astype(int).tolist()))
         kept = [kept[i] for i in idx]
     images = [img for _, img in kept]
-    vecs = model.encode(images, convert_to_numpy=True, normalize_embeddings=True)
+    with CLIP_GUARD.active():
+        vecs = model.encode(images, convert_to_numpy=True, normalize_embeddings=True)
     return [(float(ts), vecs[i].astype(np.float32, copy=False)) for i, (ts, _) in enumerate(kept)]
 
 
@@ -736,12 +841,13 @@ def rerank_pairs(query: str, passages: list[str]) -> np.ndarray:
         return np.zeros(0, dtype=np.float32)
     model = get_reranker()
     pairs = [(query, p) for p in passages]
-    scores = model.predict(
-        pairs,
-        batch_size=32,
-        convert_to_numpy=True,
-        show_progress_bar=False,
-    )
+    with RERANKER_GUARD.active():
+        scores = model.predict(
+            pairs,
+            batch_size=32,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+        )
     return scores.astype(np.float32, copy=False)
 
 
@@ -823,13 +929,14 @@ def embed_texts(texts: list[str], *, is_query: bool = False) -> np.ndarray:
     model = get_model()
     if is_query:
         texts = [QUERY_PREFIX + t for t in texts]
-    vecs = model.encode(
-        texts,
-        batch_size=32,
-        convert_to_numpy=True,
-        normalize_embeddings=True,
-        show_progress_bar=False,
-    )
+    with BGE_GUARD.active():
+        vecs = model.encode(
+            texts,
+            batch_size=32,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
     return vecs.astype(np.float32, copy=False)
 
 

--- a/src/exomem/model_reaper.py
+++ b/src/exomem/model_reaper.py
@@ -1,0 +1,135 @@
+"""Idle-unload reaper — reclaim model singletons that sit resident beyond a threshold.
+
+Only relevant for the GPU-opt-in path (`performance` mode) and `quiet` mode, where a
+model may load lazily and then idle. Started from `server.build_server` ONLY when
+`mode.release_when_idle()`. On a CPU-default normal-mode server it never runs — the
+models are cheap CPU-RAM and there is no CUDA context to reclaim anyway (that's the
+whole point of the CPU-default primary fix; this is the complement for GPU-opt-in).
+
+One daemon thread; each tick it unloads any registered model that is loaded, not
+in-flight, and idle past the threshold, coordinating with the warm thread via
+`readiness.is_warming()`. Unloading under a concurrent encode is inefficiency, not a
+use-after-free — see `embeddings._ModelGuard`. `stop()` lets a live mode switch (PR4)
+or shutdown end it cleanly.
+
+Pure substrate: process telemetry only. Nothing here reasons over notes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from . import accel, readiness
+
+log = logging.getLogger(__name__)
+
+DEFAULT_IDLE_SECONDS = 900.0  # 15 min
+TICK_SECONDS = 60.0
+
+_thread: threading.Thread | None = None
+_stop = threading.Event()
+
+
+@dataclass
+class ModelSlot:
+    name: str
+    is_loaded: Callable[[], bool]
+    inflight: Callable[[], int]
+    last_activity: Callable[[], float]
+    unload: Callable[[], bool]
+
+
+def idle_seconds() -> float:
+    """Idle threshold in seconds from `EXOMEM_IDLE_MINUTES` (default 15 min)."""
+    raw = os.environ.get("EXOMEM_IDLE_MINUTES")
+    if not raw:
+        return DEFAULT_IDLE_SECONDS
+    try:
+        minutes = float(raw)
+    except ValueError:
+        return DEFAULT_IDLE_SECONDS
+    return minutes * 60.0 if minutes > 0 else DEFAULT_IDLE_SECONDS
+
+
+def _should_unload(slot: ModelSlot, now: float, threshold: float) -> bool:
+    """Pure decision: unload iff not warming, loaded, not in-flight, idle-window elapsed."""
+    if readiness.is_warming():
+        return False
+    if not slot.is_loaded():
+        return False
+    if slot.inflight() > 0:
+        return False
+    return (now - slot.last_activity()) >= threshold
+
+
+def default_slots() -> list[ModelSlot]:
+    """The find-path model trio (bge, reranker, CLIP) — the models that go resident."""
+    from . import embeddings as e
+
+    return [
+        ModelSlot(
+            "embeddings", lambda: e._MODEL is not None,
+            e.BGE_GUARD.inflight, e.BGE_GUARD.last_activity, e.unload_model,
+        ),
+        ModelSlot(
+            "reranker", lambda: e._RERANKER is not None,
+            e.RERANKER_GUARD.inflight, e.RERANKER_GUARD.last_activity, e.unload_reranker,
+        ),
+        ModelSlot(
+            "clip", lambda: e._CLIP_MODEL is not None,
+            e.CLIP_GUARD.inflight, e.CLIP_GUARD.last_activity, e.unload_clip_model,
+        ),
+    ]
+
+
+def _reap_once(slots: list[ModelSlot], now: float, threshold: float) -> list[str]:
+    """Unload every stale slot once; return the names actually reaped. Never raises."""
+    reaped: list[str] = []
+    for s in slots:
+        try:
+            if _should_unload(s, now, threshold):
+                before = accel.gpu_mem()
+                if s.unload():
+                    reaped.append(s.name)
+                    log.info("reaped idle model %s (gpu_mem %s -> %s)", s.name, before, accel.gpu_mem())
+        except Exception:  # noqa: BLE001 — a reaper tick must never crash the thread
+            log.warning("reaper tick failed for %s", s.name, exc_info=True)
+    return reaped
+
+
+def start(
+    threshold: float | None = None,
+    tick: float = TICK_SECONDS,
+    slots: list[ModelSlot] | None = None,
+) -> threading.Thread:
+    """Start the idle-unload daemon (idempotent — a second call returns the live thread)."""
+    global _thread
+    if _thread is not None and _thread.is_alive():
+        return _thread
+    _stop.clear()
+    thr = threshold if threshold is not None else idle_seconds()
+    the_slots = slots if slots is not None else default_slots()
+
+    def _run() -> None:
+        log.info("idle-unload reaper started (threshold=%.0fs, tick=%.0fs)", thr, tick)
+        while not _stop.wait(tick):  # returns True when stopped, False on timeout
+            _reap_once(the_slots, time.monotonic(), thr)
+
+    t = threading.Thread(target=_run, name="exomem-reaper", daemon=True)
+    _thread = t
+    t.start()
+    return t
+
+
+def stop() -> None:
+    """Signal the reaper to stop (live mode switch / shutdown). Idempotent."""
+    _stop.set()
+
+
+def is_running() -> bool:
+    return _thread is not None and _thread.is_alive()

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -328,6 +328,15 @@ def build_server(*, require_auth: bool) -> FastMCP:
         else:
             warmup.start_background(vault_root)
 
+    # Idle-unload reaper: reclaim resident models once they go idle. Only for the
+    # GPU-opt-in (performance) / quiet paths — a CPU-default normal-mode server never
+    # starts it (nothing resident to reclaim; no CUDA context). A live `exomem mode`
+    # switch (PR4) starts/stops it to match the new mode.
+    if mode.release_when_idle():
+        from . import model_reaper
+
+        model_reaper.start()
+
     # Media-extraction worker: transcribes/OCRs binaries uploaded without text, off
     # the request path, and fills their sidecars (then re-embeds). Disabled in tests
     # and on lean boxes via EXOMEM_DISABLE_MEDIA_EXTRACTION (mirrors the embeddings flag).

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -1,0 +1,222 @@
+"""Idle-unload subsystem: per-model guards, unload setters, accel seams, and the reaper.
+
+Torch-free — models are plain sentinels; the torch-touching seams (accel.empty_cache /
+gpu_mem) are exercised with a fake torch module. Proves the concurrency-safety contract
+(skip-if-inflight, skip-if-warming), the reload-after-unload path, and the reaper decision.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+
+import pytest
+
+from exomem import accel, embeddings, model_reaper, readiness
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
+    for g in (embeddings.BGE_GUARD, embeddings.RERANKER_GUARD, embeddings.CLIP_GUARD):
+        g._inflight = 0
+        g._last_activity = 0.0
+    readiness.reset()
+    yield
+    model_reaper.stop()
+    model_reaper._thread = None
+    embeddings._MODEL = embeddings._RERANKER = embeddings._CLIP_MODEL = None
+    readiness.reset()
+
+
+# ---- _ModelGuard ----
+
+def test_guard_active_tracks_inflight_and_activity() -> None:
+    g = embeddings.BGE_GUARD
+    assert g.inflight() == 0
+    with g.active():
+        assert g.inflight() == 1
+        stamped = g.last_activity()
+        assert stamped > 0
+    assert g.inflight() == 0
+    assert g.last_activity() >= stamped  # stamped again on exit
+
+
+def test_guard_active_decrements_on_exception() -> None:
+    g = embeddings.CLIP_GUARD
+    with pytest.raises(ValueError):
+        with g.active():
+            assert g.inflight() == 1
+            raise ValueError("boom")
+    assert g.inflight() == 0  # finally always decrements
+
+
+# ---- unload setters ----
+
+def test_unload_model_nulls_and_empties(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr(accel, "empty_cache", lambda: calls.append(1))
+    embeddings._MODEL = object()
+    assert embeddings.unload_model() is True
+    assert embeddings._MODEL is None
+    assert calls == [1]
+
+
+def test_unload_noop_when_not_loaded() -> None:
+    assert embeddings._MODEL is None
+    assert embeddings.unload_model() is False
+
+
+def test_unload_skips_when_inflight() -> None:
+    embeddings._MODEL = object()
+    embeddings.BGE_GUARD._inflight = 1
+    assert embeddings.unload_model() is False
+    assert embeddings._MODEL is not None  # kept — a worker is mid-encode
+
+
+def test_unload_reranker_and_clip() -> None:
+    embeddings._RERANKER = object()
+    embeddings._CLIP_MODEL = object()
+    assert embeddings.unload_reranker() is True
+    assert embeddings._RERANKER is None
+    assert embeddings.unload_clip_model() is True
+    assert embeddings._CLIP_MODEL is None
+
+
+def test_reload_after_unload_reconstructs(monkeypatch: pytest.MonkeyPatch) -> None:
+    constructions: list[int] = []
+
+    class _Fake:
+        def __init__(self, *a, **k) -> None:
+            constructions.append(1)
+
+    st = types.ModuleType("sentence_transformers")
+    st.SentenceTransformer = lambda name, device=None: _Fake()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", st)
+    monkeypatch.setattr(embeddings, "_maybe_half", lambda m, d: m)
+    monkeypatch.setattr(accel, "select_device", lambda **k: "cpu")
+
+    m1 = embeddings.get_model()
+    assert len(constructions) == 1
+    assert embeddings.BGE_GUARD.last_activity() > 0  # touched on load
+    embeddings.unload_model()
+    m2 = embeddings.get_model()
+    assert len(constructions) == 2  # reconstructed on the next use
+    assert m2 is not m1
+
+
+# ---- accel.empty_cache / gpu_mem seams ----
+
+def test_empty_cache_no_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", None)  # import torch → ImportError
+    accel.empty_cache()  # must not raise
+
+
+def test_empty_cache_only_when_context_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: True,
+        is_initialized=lambda: False,
+        empty_cache=lambda: calls.append(1),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    accel.empty_cache()
+    assert calls == []  # no context yet → must NOT create one
+    torch.cuda.is_initialized = lambda: True
+    accel.empty_cache()
+    assert calls == [1]
+
+
+def test_gpu_mem_none_without_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False, is_initialized=lambda: False)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    assert accel.gpu_mem() is None
+
+
+def test_gpu_mem_reports_when_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: True,
+        is_initialized=lambda: True,
+        memory_allocated=lambda: 100 * 2**20,
+        memory_reserved=lambda: 200 * 2**20,
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    assert accel.gpu_mem() == {"allocated_mb": 100.0, "reserved_mb": 200.0}
+
+
+# ---- reaper decision (pure) ----
+
+def _slot(*, loaded: bool = True, inflight: int = 0, last: float = 0.0):
+    unloaded: list[int] = []
+    slot = model_reaper.ModelSlot(
+        name="m",
+        is_loaded=lambda: loaded and not unloaded,
+        inflight=lambda: inflight,
+        last_activity=lambda: last,
+        unload=lambda: (unloaded.append(1), True)[1],
+    )
+    return slot, unloaded
+
+
+def test_should_unload_true_when_idle() -> None:
+    slot, _ = _slot(last=0.0)
+    assert model_reaper._should_unload(slot, now=1000.0, threshold=900.0) is True
+
+
+def test_should_unload_false_before_threshold() -> None:
+    slot, _ = _slot(last=500.0)
+    assert model_reaper._should_unload(slot, now=1000.0, threshold=900.0) is False
+
+
+def test_should_unload_false_when_inflight() -> None:
+    slot, _ = _slot(inflight=1, last=0.0)
+    assert model_reaper._should_unload(slot, now=1e9, threshold=900.0) is False
+
+
+def test_should_unload_false_when_not_loaded() -> None:
+    slot, _ = _slot(loaded=False)
+    assert model_reaper._should_unload(slot, now=1e9, threshold=900.0) is False
+
+
+def test_should_unload_false_when_warming() -> None:
+    readiness.begin_warm()
+    slot, _ = _slot(last=0.0)
+    assert model_reaper._should_unload(slot, now=1e9, threshold=900.0) is False
+    readiness.finish_warm()
+    assert model_reaper._should_unload(slot, now=1e9, threshold=900.0) is True
+
+
+def test_reap_once_unloads_only_stale() -> None:
+    stale, s_un = _slot(inflight=0, last=0.0)      # 1000-0 = 1000 >= 900 → reap
+    active, a_un = _slot(inflight=1, last=0.0)      # in-flight → skip
+    fresh, f_un = _slot(inflight=0, last=1000.0)    # 1000-1000 = 0 < 900 → skip
+    reaped = model_reaper._reap_once([stale, active, fresh], now=1000.0, threshold=900.0)
+    assert s_un == [1]
+    assert a_un == []
+    assert f_un == []
+    assert len(reaped) == 1
+
+
+# ---- reaper lifecycle ----
+
+def test_reaper_start_fires_then_stops() -> None:
+    slot, un = _slot(inflight=0, last=0.0)  # always stale; is_loaded flips False after unload
+    model_reaper.start(threshold=0.0, tick=0.01, slots=[slot])
+    time.sleep(0.08)
+    model_reaper.stop()
+    time.sleep(0.05)
+    assert un == [1]  # unloaded exactly once (is_loaded False afterwards)
+    assert not model_reaper.is_running()
+
+
+def test_idle_seconds_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_IDLE_MINUTES", raising=False)
+    assert model_reaper.idle_seconds() == model_reaper.DEFAULT_IDLE_SECONDS
+    monkeypatch.setenv("EXOMEM_IDLE_MINUTES", "5")
+    assert model_reaper.idle_seconds() == 300.0
+    monkeypatch.setenv("EXOMEM_IDLE_MINUTES", "garbage")
+    assert model_reaper.idle_seconds() == model_reaper.DEFAULT_IDLE_SECONDS


### PR DESCRIPTION
## PR3 of 5 — idle-unload subsystem

Adds a reaper that unloads model singletons idle beyond `EXOMEM_IDLE_MINUTES` (default 15) and returns their GPU cache. It's the **complement to PR1/PR2's CPU-default fix** for the GPU-opt-in path: when a user runs `performance` mode (models resident on the GPU), the reaper reclaims them between query bursts. It also reclaims **CPU RAM**, which matters for the VRAM→RAM tradeoff PR1/PR2 introduced (whisper + bge/reranker/CLIP now live in RAM by default).

A **CPU-default normal-mode server never starts it** — there's nothing resident to reclaim and no CUDA context to free.

### What changed
- **`embeddings`** — per-model `_ModelGuard` (in-flight counter + last-activity stamp) brackets every `encode`/`predict` (bge, reranker, all CLIP paths). `unload_model` / `unload_reranker` / `unload_clip_model` null the singleton under its lock (skip if in-flight) and call `accel.empty_cache()`. Getters stamp activity on load so a fresh model isn't instantly reaped.
- **`accel`** — `empty_cache()` (CUDA cache release, gated on `is_initialized()` so it never creates a context on a CPU process) + `gpu_mem()` (allocated/reserved, for observability + `doctor`). Both never raise.
- **`model_reaper`** (new) — `ModelSlot` registry (bge/reranker/clip), a pure `_should_unload` decision (skip if warming / not loaded / in-flight / within threshold), and one `exomem-reaper` daemon with a **stoppable** tick (PR4's live mode switch uses `stop()`/`start()`). Wired into `build_server` only when `mode.release_when_idle()`.

### Concurrency safety
Unloading under a concurrent encode is **inefficiency, not a use-after-free**: the worker holds a live *local* ref to the model (from `get_model()`), so nulling the module singleton can't collect it, and `empty_cache()` frees only unused blocks. The in-flight counter avoids the churn (transient double-load / cache-block theft). Lock order `_MODEL_LOCK → guard-lock` is acyclic. Tests cover the truth table, skip-if-inflight, skip-if-warming, reload-after-unload, the device-gated seams, and the reaper lifecycle.

**Honest limit** (see the CUDA-context-floor KB note): this reclaims model weights + the reserved pool, **not** the CUDA context floor — which is exactly why CPU-default (PR1/PR2), not idle-unload, is the primary path to ~0 idle VRAM.

### Verification
Full suite **1524 passed / 16 skipped**, ruff clean on new code.

### Follow-ups
PR4 `exomem mode` CLI + live switch (uses this) + GPU-detection prompt · PR5 model configurability + lite profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ
