### PR TITLE
feat(compute): exomem mode CLI + live switch + GPU-detection prompt (PR4)

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -58,6 +58,8 @@ def main(argv: list[str] | None = None) -> int:
         return _doctor_main(raw[1:])
     if raw and raw[0] == "warm":
         return _warm_main(raw[1:])
+    if raw and raw[0] == "mode":
+        return _mode_main(raw[1:])
     if raw and raw[0] == "backfill-media":
         return _backfill_media_main(raw[1:])
     if raw and raw[0] == "index":
@@ -253,6 +255,60 @@ def _index_main(argv: list[str]) -> int:
     return 0
 
 
+def _mode_main(argv: list[str]) -> int:
+    """`exomem mode [quiet|normal|performance]` — show or set the per-machine compute mode.
+
+    Torch-free (no vault, no model import) so it stays instant. Writing persists to
+    ~/.exomem/config.json, which the running server picks up live within ~10s and CLI
+    ops read on their next run.
+    """
+    from . import mode as mode_mod
+
+    parser = argparse.ArgumentParser(
+        prog="exomem mode",
+        description="Show or set the compute mode: quiet (CPU, low footprint) | normal "
+        "(default, CPU steady-state) | performance (use the GPU; aliases gpu/turbo). "
+        "Persisted to ~/.exomem/config.json, read by BOTH the server and CLI ops.",
+    )
+    parser.add_argument(
+        "mode", nargs="?",
+        choices=("quiet", "normal", "performance", "gpu", "turbo"),
+        help="mode to set; omit to show the current one",
+    )
+    parser.add_argument("--json", action="store_true", help="emit stable JSON (status only)")
+    args = parser.parse_args(argv)
+
+    if args.mode is None:
+        source = (
+            "env" if os.environ.get("EXOMEM_MODE")
+            else "config" if mode_mod.read_config().get("mode")
+            else "quiet-alias" if os.environ.get("EXOMEM_QUIET_MODE")
+            else "default"
+        )
+        policy = mode_mod.resolved()
+        policy["source"] = source
+        policy["config_path"] = str(mode_mod.config_path())
+        if args.json:
+            print(json.dumps(policy))
+        else:
+            print(f"mode: {policy['mode']}  (source: {source})")
+            print(f"  preload_models:    {policy['preload_models']}")
+            print(f"  release_when_idle: {policy['release_when_idle']}")
+            print(f"  bulk_gpu:          {policy['bulk_gpu']}")
+            print(f"  config: {policy['config_path']}")
+        return 0
+
+    try:
+        path = mode_mod.write_mode(args.mode)
+    except ValueError as e:
+        print(f"mode: {e}", file=sys.stderr)
+        return 2
+    print(f"Compute mode set to '{mode_mod.normalize(args.mode)}'  ({path})")
+    print("A running exomem server applies it live within ~10s (or restart to apply now).")
+    print("CLI ops (exomem index / warm) use it on their next run.")
+    return 0
+
+
 def _doctor_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem doctor",
@@ -287,6 +343,16 @@ def _doctor_main(argv: list[str]) -> int:
         print(json.dumps(report.as_dict(), ensure_ascii=False, default=str))
     else:
         print(doctor_module.render_human(report))
+        # GPU-discoverability: offer the performance-mode upgrade when a capable idle GPU
+        # is present and we're not already using it. Silent when no/weak GPU (the default).
+        from . import accel
+        from . import mode as mode_mod
+
+        if mode_mod.resolve_mode() != "performance" and accel.gpu_usable():
+            print(
+                "\n⚡ A capable GPU was detected. For faster indexing & search, enable "
+                "performance mode:\n    exomem mode performance"
+            )
     return 0 if report.success else 1
 
 

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -30,8 +30,12 @@ a torch import. `accel` imports this; this never imports `accel`.
 from __future__ import annotations
 
 import json
+import logging
 import os
+import threading
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 CANON = ("quiet", "normal", "performance")
 _ALIASES = {"gpu": "performance", "turbo": "performance"}
@@ -144,3 +148,78 @@ def write_mode(value: str) -> Path:
     tmp.write_text(json.dumps(data, indent=2), "utf-8")
     os.replace(tmp, path)  # atomic swap
     return path
+
+
+# --------------------------------------------------------------- live application
+#
+# The server watches the config file and reconciles the running process to a mode
+# change WITHOUT a restart (the user's chosen UX). Reconciliation = unload the model
+# singletons so they lazily reload on the new device, and start/stop the idle-unload
+# reaper to match. Lazy imports keep this module torch-free at import time.
+
+_watch_thread: threading.Thread | None = None
+_watch_stop = threading.Event()
+_applied_mode: str | None = None
+
+
+def apply_live() -> dict:
+    """Reconcile the running process to the currently-resolved mode. Returns the policy.
+
+    Unloads the model singletons (skipping any mid-encode — they reload on the new
+    device next use) and starts/stops the idle-unload reaper. Safe to call repeatedly.
+    Caveat (CUDA-context-floor note): a performance→quiet live switch frees weights but
+    the CUDA context floor persists until the process restarts; the default normal mode
+    never holds a context, so ordinary use is unaffected.
+    """
+    global _applied_mode
+    _applied_mode = resolve_mode()
+    from . import embeddings, model_reaper
+
+    for unload in (embeddings.unload_model, embeddings.unload_reranker, embeddings.unload_clip_model):
+        try:
+            unload()
+        except Exception:  # noqa: BLE001 — a live switch must never crash the caller
+            log.warning("model unload during mode switch failed", exc_info=True)
+    if release_when_idle():
+        model_reaper.start()
+    else:
+        model_reaper.stop()
+    return resolved()
+
+
+def _config_watch_disabled() -> bool:
+    return _truthy(os.environ.get("EXOMEM_DISABLE_MODE_WATCH"))
+
+
+def start_config_watch(interval: float = 10.0) -> threading.Thread | None:
+    """Daemon that applies a config-file mode change live (idempotent).
+
+    Polls `resolve_mode()` every `interval`s and calls `apply_live()` when it changes,
+    so `exomem mode <name>` takes effect on the running server within one interval — no
+    restart. Off via `EXOMEM_DISABLE_MODE_WATCH`. Returns None when disabled/already up.
+    """
+    global _watch_thread, _applied_mode
+    if _config_watch_disabled():
+        return None
+    if _watch_thread is not None and _watch_thread.is_alive():
+        return _watch_thread
+    _watch_stop.clear()
+    _applied_mode = resolve_mode()  # baseline; don't reconcile on startup
+
+    def _run() -> None:
+        while not _watch_stop.wait(interval):
+            try:
+                if resolve_mode() != _applied_mode:
+                    log.info("compute mode changed to %s; applying live", resolve_mode())
+                    apply_live()
+            except Exception:  # noqa: BLE001 — the watch must never die on a bad tick
+                log.warning("mode-watch tick failed", exc_info=True)
+
+    t = threading.Thread(target=_run, name="exomem-mode-watch", daemon=True)
+    _watch_thread = t
+    t.start()
+    return t
+
+
+def stop_config_watch() -> None:
+    _watch_stop.set()

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -337,6 +337,11 @@ def build_server(*, require_auth: bool) -> FastMCP:
 
         model_reaper.start()
 
+    # Watch the per-machine config file so `exomem mode <name>` applies live (no restart):
+    # on a mode change the server unloads the models (reload on the new device) and
+    # starts/stops the reaper. Off via EXOMEM_DISABLE_MODE_WATCH.
+    mode.start_config_watch()
+
     # Media-extraction worker: transcribes/OCRs binaries uploaded without text, off
     # the request path, and fills their sidecars (then re-embeds). Disabled in tests
     # and on lean boxes via EXOMEM_DISABLE_MEDIA_EXTRACTION (mirrors the embeddings flag).

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -202,6 +202,25 @@ def run_setup(
         if yes or not _ask_yn(input_fn, "Doctor reported failures. Continue anyway?", False):
             return finish()
 
+    # 5b. GPU discoverability — offer performance mode when a capable idle GPU is present.
+    # Interactive only (never blocks --yes automation), and only when embeddings are on
+    # (a lean install has no models to accelerate). CPU stays the safe default otherwise.
+    if not yes and profile != "lean":
+        from . import accel
+        from . import mode as mode_mod
+
+        if mode_mod.resolve_mode() != "performance" and accel.gpu_usable():
+            if _ask_yn(
+                input_fn,
+                "\n⚡ A capable GPU was detected. Use it for faster indexing & search? "
+                "(change anytime with `exomem mode`)",
+                False,
+            ):
+                mode_mod.write_mode("performance")
+                report("gpu", "[done] performance mode enabled")
+            else:
+                report("gpu", "[skipped] staying on CPU (normal mode)")
+
     # 6. Claude Code registration
     if skip_claude_register:
         report("register", "[skipped: --skip-claude-register]")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,9 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # freshness/inbound registries too), so build_server would spawn a real
     # watchdog observer in the suite without this. Watcher tests opt back in.
     monkeypatch.setenv("EXOMEM_DISABLE_FILE_WATCHER", "1")
+    # Don't spawn the mode-config watch daemon from build_server in the suite; mode-watch
+    # tests drive it directly.
+    monkeypatch.setenv("EXOMEM_DISABLE_MODE_WATCH", "1")
 
 
 @pytest.fixture

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -154,3 +154,90 @@ def test_resolved_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
         "release_when_idle": True,
         "bulk_gpu": False,
     }
+
+
+# ---- apply_live: reconcile the running process to a mode ----
+
+def _patch_runtime(monkeypatch):
+    """Stub embeddings.unload_* + model_reaper.start/stop; return a call recorder."""
+    from exomem import embeddings, model_reaper
+
+    calls = {"unload": 0, "start": 0, "stop": 0}
+    monkeypatch.setattr(embeddings, "unload_model", lambda: calls.__setitem__("unload", calls["unload"] + 1) or True)
+    monkeypatch.setattr(embeddings, "unload_reranker", lambda: True)
+    monkeypatch.setattr(embeddings, "unload_clip_model", lambda: True)
+    monkeypatch.setattr(model_reaper, "start", lambda: calls.__setitem__("start", calls["start"] + 1))
+    monkeypatch.setattr(model_reaper, "stop", lambda: calls.__setitem__("stop", calls["stop"] + 1))
+    return calls
+
+
+def test_apply_live_normal_unloads_and_stops_reaper(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_runtime(monkeypatch)
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    policy = mode.apply_live()
+    assert calls["unload"] == 1  # models unloaded so they reload on the new device
+    assert calls["stop"] == 1 and calls["start"] == 0  # normal → reaper off
+    assert policy["mode"] == "normal"
+
+
+def test_apply_live_performance_starts_reaper(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_runtime(monkeypatch)
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    mode.apply_live()
+    assert calls["start"] == 1 and calls["stop"] == 0
+
+
+# ---- config watch: apply a file-driven mode change live ----
+
+def test_config_watch_applies_on_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    monkeypatch.delenv("EXOMEM_DISABLE_MODE_WATCH", raising=False)
+    monkeypatch.delenv("EXOMEM_MODE", raising=False)  # let the config file drive resolution
+    applied: list[str] = []
+    monkeypatch.setattr(mode, "apply_live", lambda: applied.append(mode.resolve_mode()))
+    try:
+        mode.start_config_watch(interval=0.02)
+        time.sleep(0.06)
+        assert applied == []  # baseline normal, no change yet
+        mode.write_mode("quiet")
+        time.sleep(0.12)
+    finally:
+        mode.stop_config_watch()
+    assert "quiet" in applied
+
+
+def test_config_watch_disabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_MODE_WATCH", "1")
+    assert mode.start_config_watch(interval=0.01) is None
+
+
+# ---- exomem mode CLI ----
+
+def test_mode_cli_status_human(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    from exomem.__main__ import main
+
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    assert main(["mode"]) == 0
+    out = capsys.readouterr().out
+    assert "quiet" in out and "source: env" in out
+
+
+def test_mode_cli_status_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    from exomem.__main__ import main
+
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert main(["mode", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["mode"] == "performance"
+    assert data["source"] == "env"
+    assert data["bulk_gpu"] is True
+
+
+def test_mode_cli_set_writes_config(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    from exomem.__main__ import main
+
+    monkeypatch.delenv("EXOMEM_MODE", raising=False)
+    assert main(["mode", "gpu"]) == 0  # alias → performance
+    assert mode.read_config().get("mode") == "performance"
+    assert "performance" in capsys.readouterr().out


### PR DESCRIPTION
PR4 of 5 — the user-facing layer for the compute modes.

- **`exomem mode [quiet|normal|performance]`** (aliases gpu/turbo): torch-free CLI to show the resolved policy (+ source) or persist a mode to `~/.exomem/config.json`. `--json` for scripts. Read by both server and CLI ops.
- **Live switch (no restart):** `mode.apply_live()` + a config-watch daemon started from `build_server` — the server polls the config and reconciles on change (unloads models so they reload on the new device; starts/stops the PR3 reaper). `exomem mode X` takes effect within ~10s. Off via `EXOMEM_DISABLE_MODE_WATCH`. Caveat: performance→quiet frees weights but the CUDA context floor persists until restart (normal never holds a context).
- **GPU discoverability:** `exomem doctor` prints a performance-mode tip when a capable idle GPU is detected; `exomem setup` asks interactively (never blocks `--yes` / lean installs).

Full suite **1531 passed / 16 skipped**, ruff clean. Follow-up: PR5 model configurability + lite profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ