### PR TITLE
feat(compute): reranker off/configurable + lite profile + compute-knob docs (PR5)

### DIFF
--- a/env.example
+++ b/env.example
@@ -32,6 +32,41 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # EXOMEM_TESSERACT_CMD=C:\Program Files\Tesseract-OCR\tesseract.exe
 
 # ---------------------------------------------------------------------------
+# Compute mode & device (per-machine) — optional
+# ---------------------------------------------------------------------------
+# The steady-state default is CPU (idle GPU VRAM ~0). GPU is an opt-in. The
+# simplest control is the MODE; set it once with `exomem mode <name>` (writes
+# ~/.exomem/config.json, read by BOTH the server and CLI ops) — the server applies
+# a change live within ~10s, no restart. EXOMEM_MODE below overrides the file for
+# THIS process only (the server reads .env; CLI ops do not).
+#   quiet       - CPU everywhere, no model preload, release models when idle.
+#   normal      - default. CPU steady-state (MPS on Apple Silicon); never auto-CUDA.
+#   performance - use the GPU when a capable one is present (aliases: gpu, turbo).
+# EXOMEM_MODE=normal
+#
+# Explicit device override (wins over the mode). cpu | gpu | auto | cuda | cuda:1 | mps
+#   'gpu'/'auto' opt in with a marginal-VRAM guard; 'cuda' forces it (legacy behavior).
+# EXOMEM_DEVICE=            # global; legacy alias EXOMEM_TORCH_DEVICE
+# EXOMEM_EMBED_DEVICE=      # bge embedder + reranker (text path) only
+# EXOMEM_CLIP_DEVICE=       # CLIP image/text only
+# EXOMEM_ASR_DEVICE=        # faster-whisper ASR (cpu|cuda|auto); own path, not via the above
+# EXOMEM_GPU_MIN_FREE_GB=2  # min free VRAM to accept a GPU (the marginal-VRAM guard)
+#
+# Idle-unload reaper (performance/quiet): release resident models after N idle minutes.
+# EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off; default on for quiet/performance, off for normal
+# EXOMEM_IDLE_MINUTES=15
+#
+# Model selection & footprint (advanced). The reranker is a stateless scorer, so it
+# can be swapped or disabled with no re-index.
+# EXOMEM_RANKING_MODEL=BAAI/bge-reranker-base   # legacy alias EXOMEM_RERANKER_MODEL
+# EXOMEM_DISABLE_RANKING=1   # turn the reranker OFF entirely (~0.44 GB + latency saved)
+#
+# "lite" recipe for a low-resource machine (keeps semantic search, drops the heavy
+# extras): hybrid embeddings ON, reranker + image search OFF.
+#   EXOMEM_DISABLE_RANKING=1
+#   EXOMEM_DISABLE_CLIP=1
+
+# ---------------------------------------------------------------------------
 # HTTP transport bind — optional (remote / service use)
 # ---------------------------------------------------------------------------
 

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -38,8 +38,16 @@ log = logging.getLogger(__name__)
 
 
 MODEL_NAME = "BAAI/bge-base-en-v1.5"
-RERANKER_NAME = "BAAI/bge-reranker-base"
 VECTOR_DIM = 768
+# The cross-encoder reranker is a stateless scorer (no stored vectors / sidecar dim),
+# so it can be swapped freely without a re-index. EXOMEM_RANKING_MODEL (legacy alias
+# EXOMEM_RERANKER_MODEL) overrides; EXOMEM_DISABLE_RANKING turns it off entirely (a
+# ~0.44 GB RAM + rerank-latency saving for low-resource / lite installs).
+RERANKER_NAME = (
+    os.environ.get("EXOMEM_RANKING_MODEL")
+    or os.environ.get("EXOMEM_RERANKER_MODEL")
+    or "BAAI/bge-reranker-base"
+)
 # bge documentation recommends prefixing queries (not passages) for retrieval.
 QUERY_PREFIX = "Represent this sentence for searching relevant passages: "
 # Rough word-count cap per chunk. bge-base's tokenizer maxes at 512 tokens;
@@ -180,6 +188,17 @@ def clip_sidecar_path(vault_root: Path) -> Path:
 def clip_enabled() -> bool:
     """False when EXOMEM_DISABLE_CLIP is set (mirrors EXOMEM_DISABLE_EMBEDDINGS)."""
     return not os.environ.get("EXOMEM_DISABLE_CLIP")
+
+
+def ranking_enabled() -> bool:
+    """False when EXOMEM_DISABLE_RANKING is set — the reranker never loads or scores.
+
+    The reranker is already opt-in per query (see find.should_rerank); this hard-off
+    keeps it from ever being preloaded or invoked, freeing ~0.44 GB and its latency —
+    the 'lite' knob for low-resource installs. Retrieval falls back to the fused
+    vector+BM25 ordering, which is what serves the un-reranked majority of queries anyway.
+    """
+    return not os.environ.get("EXOMEM_DISABLE_RANKING")
 
 
 # Which markdown scope the semantic (bge) text index covers.

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -1735,6 +1735,9 @@ def _find_semantic(
     else:
         do_rerank = rerank
 
+    if do_rerank and not embeddings.ranking_enabled():
+        do_rerank = False  # EXOMEM_DISABLE_RANKING — hard off, even for explicit rerank=True
+
     if do_rerank and hits and readiness.should_defer("reranker"):
         # Background warm-up owns the reranker load right now — calling
         # rerank_pairs would block on the singleton lock. Skip; caller marks

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -212,9 +212,13 @@ def warm_all(vault_root: Path) -> dict[str, float]:
         if drained:
             log.info("drained %d deferred write-embed batch(es)", len(drained))
 
-        log.info("preloading reranker %s", embeddings.RERANKER_NAME)
-        if _preload("model_reranker", embeddings.get_reranker, lambda m: m.predict([("warm", "warm")])):
-            log.info("reranker model ready")
+        if embeddings.ranking_enabled():
+            log.info("preloading reranker %s", embeddings.RERANKER_NAME)
+            if _preload("model_reranker", embeddings.get_reranker, lambda m: m.predict([("warm", "warm")])):
+                log.info("reranker model ready")
+                readiness.mark_ready("reranker")
+        else:
+            log.info("reranker disabled (EXOMEM_DISABLE_RANKING); skipping preload")
             readiness.mark_ready("reranker")
 
         if embeddings.clip_enabled():

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,52 @@
+"""EXOMEM_DISABLE_RANKING: the reranker never preloads or loads (the 'lite' knob)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exomem import embeddings, readiness, warmup
+
+
+@pytest.fixture(autouse=True)
+def _reset_readiness() -> None:
+    readiness.reset()
+    yield
+    readiness.reset()
+
+
+def test_ranking_enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_RANKING", raising=False)
+    assert embeddings.ranking_enabled() is True
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    assert embeddings.ranking_enabled() is False
+
+
+def test_warm_all_skips_reranker_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reranker getter is never called when ranking is disabled, but the component
+    is still marked ready (bge + CLIP preload normally)."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_DISABLE_RANKING", "1")
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
+    monkeypatch.setattr(embeddings, "get_model", lambda: object())
+
+    def _forbidden():
+        raise AssertionError("reranker must not load when EXOMEM_DISABLE_RANKING is set")
+
+    monkeypatch.setattr(embeddings, "get_reranker", _forbidden)
+    monkeypatch.setattr(embeddings, "get_clip_model", lambda: object())
+    monkeypatch.setattr(embeddings, "clip_enabled", lambda: True)
+
+    warmup.warm_all(tmp_path)
+
+    assert readiness.is_ready("embeddings") is True
+    assert readiness.is_ready("reranker") is True  # ready even though never loaded
+    assert readiness.is_ready("clip") is True
+
+
+def test_reranker_name_default() -> None:
+    """Default reranker unchanged (the env override is resolved at import; default here)."""
+    assert embeddings.RERANKER_NAME == "BAAI/bge-reranker-base"


### PR DESCRIPTION
PR5 of 5 — the safe slice of model configurability (footprint knob for low-resource installs; addresses the VRAM→CPU-RAM tradeoff from PR1/PR2), without touching the vector store.

- **`EXOMEM_DISABLE_RANKING`**: hard-off for the cross-encoder reranker (never preloads, loads, or scores — find falls back to the fused vector+BM25 order that serves the un-reranked majority anyway). ~0.44 GB RAM + latency saved. Gated in `ranking_enabled()`, find's `do_rerank`, and warmup.
- **`EXOMEM_RANKING_MODEL`** (alias `EXOMEM_RERANKER_MODEL`): swap the reranker — safe with no re-index (stateless scorer, no stored vectors/dim).
- **env.example**: full 'Compute mode & device' block documenting the PR1–5 knobs + the **lite recipe** (`DISABLE_RANKING` + `DISABLE_CLIP`, hybrid embeddings kept).

**Deferred (needs your review):** swapping the *embed* model (`EXOMEM_TEXT_MODEL`, e.g. bge-small) changes the stored vector **dimension** → requires a re-index + a migration guard on the live sidecar. I didn't want to land a vector-store change unreviewed overnight; it's scoped for a follow-up we do together.

Full suite **1534 passed / 16 skipped**, ruff clean. This completes the 5-PR quiet-mode arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ