### PR TITLE
fix(compute): machine-wide config path so the service + CLI share it (PR6)

### DIFF
--- a/env.example
+++ b/env.example
@@ -35,10 +35,12 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # Compute mode & device (per-machine) — optional
 # ---------------------------------------------------------------------------
 # The steady-state default is CPU (idle GPU VRAM ~0). GPU is an opt-in. The
-# simplest control is the MODE; set it once with `exomem mode <name>` (writes
-# ~/.exomem/config.json, read by BOTH the server and CLI ops) — the server applies
-# a change live within ~10s, no restart. EXOMEM_MODE below overrides the file for
-# THIS process only (the server reads .env; CLI ops do not).
+# simplest control is the MODE; set it once with `exomem mode <name>`. It writes a
+# machine-wide config (%PROGRAMDATA%\exomem\config.json on Windows, ~/.exomem/config.json
+# on macOS/Linux) read by BOTH the server and CLI ops — machine-wide on purpose so a
+# LocalSystem service and your user CLI share it. The server applies a change live within
+# ~10s, no restart. EXOMEM_MODE below overrides the file for THIS process only (the
+# server reads .env; CLI ops do not). EXOMEM_CONFIG_PATH overrides the file location.
 #   quiet       - CPU everywhere, no model preload, release models when idle.
 #   normal      - default. CPU steady-state (MPS on Apple Silicon); never auto-CUDA.
 #   performance - use the GPU when a capable one is present (aliases: gpu, turbo).

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -16,12 +16,13 @@ Three canonical modes (aliases in `_ALIASES` so whatever a user types works):
                    present; release when idle. Aliases: `gpu`, `turbo`.
 
 Resolution precedence: `EXOMEM_MODE` env → the per-machine config file
-(`~/.exomem/config.json`, or `EXOMEM_CONFIG_PATH`) → the legacy `EXOMEM_QUIET_MODE`
-boolean → the `normal` default. The config file is read explicitly (never injected
-into the environment) so an exported `EXOMEM_MODE` always wins over it — and it is a
-fixed home path, not `.env`, because a Windows service launched via `sc.exe` has an
-unpredictable cwd and CLI subcommands never `load_dotenv`, yet both must read the
-same mode.
+(`%PROGRAMDATA%\\exomem\\config.json` on Windows, `~/.exomem/config.json` on POSIX, or
+`EXOMEM_CONFIG_PATH`) → the legacy `EXOMEM_QUIET_MODE` boolean → the `normal` default.
+The config file is read explicitly (never injected into the environment) so an exported
+`EXOMEM_MODE` always wins over it — and it is a fixed, machine-wide path (not `.env`,
+whose cwd-relative discovery a `sc.exe`-launched service can't rely on, and which CLI
+subcommands never `load_dotenv`) so the service and the CLI — often different OS users —
+read the SAME mode. See `config_path` for the Windows LocalSystem-vs-user rationale.
 
 Torch-free by design: importable in keyword-mode / lean CLI dispatch without paying
 a torch import. `accel` imports this; this never imports `accel`.
@@ -65,10 +66,22 @@ def normalize(value: str | None) -> str | None:
 
 
 def config_path() -> Path:
-    """Per-machine config file. `EXOMEM_CONFIG_PATH` overrides (tests/multi-instance)."""
+    """Per-machine config file. `EXOMEM_CONFIG_PATH` overrides (tests/multi-instance).
+
+    On Windows the default is machine-wide (`%PROGRAMDATA%\\exomem\\config.json`), NOT
+    the user home: a service commonly runs as LocalSystem while the `exomem` CLI runs as
+    the logged-in user, and `~` resolves to two different profiles — so a home-relative
+    file would let the CLI write one config the service never reads, silently breaking the
+    live mode switch. ProgramData is shared (the CLI user creates+writes it; the service
+    reads it). On POSIX, home is kept — services there usually run as the user, and the
+    override covers the rest.
+    """
     override = os.environ.get(_CONFIG_PATH_ENV)
     if override:
         return Path(override)
+    if os.name == "nt":
+        base = os.environ.get("PROGRAMDATA") or os.environ.get("ALLUSERSPROFILE") or r"C:\ProgramData"
+        return Path(base) / "exomem" / "config.json"
     return Path.home() / ".exomem" / "config.json"
 
 

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -8,6 +8,7 @@ and the atomic config writer. No hardware needed.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -241,3 +242,33 @@ def test_mode_cli_set_writes_config(monkeypatch: pytest.MonkeyPatch, capsys: pyt
     assert main(["mode", "gpu"]) == 0  # alias → performance
     assert mode.read_config().get("mode") == "performance"
     assert "performance" in capsys.readouterr().out
+
+
+# ---- config_path: cross-user (service vs CLI) resolution ----
+
+def test_config_path_env_override_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(tmp_path / "c.json"))
+    assert mode.config_path() == tmp_path / "c.json"
+
+
+def test_config_path_default_shared_and_machine_wide(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default resolves to a machine-wide file (NATIVE platform — patching os.name would
+    break pathlib): ProgramData\\exomem on Windows so a LocalSystem service and the user
+    CLI share it (the live-switch fix), ~/.exomem on POSIX."""
+    monkeypatch.delenv("EXOMEM_CONFIG_PATH", raising=False)
+    p = mode.config_path()
+    assert p.name == "config.json"
+    if os.name == "nt":
+        assert "exomem" in p.parts       # %PROGRAMDATA%\exomem\config.json
+        assert ".exomem" not in p.parts  # NOT the per-user home dotdir
+    else:
+        assert ".exomem" in p.parts      # ~/.exomem/config.json
+
+
+def test_config_path_windows_programdata_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """On Windows, PROGRAMDATA drives the base (native os.name only — no cross-platform patch)."""
+    if os.name != "nt":
+        pytest.skip("Windows-only path branch")
+    monkeypatch.delenv("EXOMEM_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("PROGRAMDATA", str(tmp_path / "PD"))
+    assert mode.config_path() == tmp_path / "PD" / "exomem" / "config.json"


### PR DESCRIPTION
Follow-up to the quiet-mode arc — fixes the live mode switch across the service/CLI **user boundary**, found by testing it live.

**The bug:** the mode config was home-relative (`~/.exomem/config.json`). The exomem Windows service runs as **LocalSystem**, the `exomem` CLI runs as the logged-in **user** → `~` resolves to two different profiles. The CLI wrote `C:\Users\<you>\.exomem\config.json`; the service read an empty `C:\Windows\System32\config\systemprofile\.exomem\` → always `normal`, so `exomem mode performance` never reached the running server.

**Fix:** `mode.config_path()` defaults to `%PROGRAMDATA%\exomem\config.json` on Windows (machine-wide, shared — the CLI user creates+writes it, the LocalSystem service reads it); `~/.exomem` stays on POSIX; `EXOMEM_CONFIG_PATH` still overrides. Docstring + env.example updated.

The core VRAM fix (normal mode) was never affected. After this + a restart, live-switch works with no per-machine nssm workaround.

Full suite **1537 passed / 16 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TfqCrJdHamMhHBMFetxUZ
