### PR TITLE
feat(agent): add portable bootstrap contract

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -17,12 +17,12 @@ shell; the few Windows (PowerShell) differences are called out inline.
 
 If you're comfortable in Claude Code, this is ~20–30 minutes.
 
-> **exomem is two parts, and you need both.** The **MCP server** (steps 1–5) is
-> the *hands* — the `find`/`add`/`note` tools. The **skill** (step 6) is the
-> *brain* — it's what tells Claude *when* to save, how to file a source, and how
-> to compile a note. Install the server but skip the skill and Claude has the
-> tools but no idea it's meant to use them: it sits silent and feels broken.
-> **This is the #1 "it does nothing" trap — don't skip step 6.**
+> **For Claude Code, exomem is two parts and you want both.** The **MCP server**
+> (steps 1–5) is the *hands* — the `find`/`add`/`note` tools. The **skill**
+> (step 6) is the *brain* — it tells Claude *when* to save, how to file a source,
+> and how to compile a note. Generic MCP clients that cannot load Skills should
+> call `bootstrap()` once after connecting; that returns the compact operating
+> contract through MCP.
 
 ---
 
@@ -237,13 +237,13 @@ Restart Claude Code; you should see the `exomem` tools (`find`, `note`, `add`,
 
 ---
 
-## 6. Install the skill (REQUIRED — this is the brain)
+## 6. Install the skill (Claude Code best UX)
 
 The server gives Claude the tools; **the Exomem Knowledge Base skill is what
-makes Claude actually use them** — capture at natural stopping points, file
-sources to the right folder,
-compile notes under the schema. One command installs it straight from the repo
-into Claude Code's skills folder (no vault path needed — it ships in the package):
+makes Claude Code use them well** — capture at natural stopping points, file
+sources to the right folder, and compile notes under the schema. One command
+installs it straight from the repo into Claude Code's skills folder (no vault
+path needed — it ships in the package):
 
 ```bash
 uv run python -m exomem install-skill
@@ -269,6 +269,11 @@ own — or just start writing; the writer auto-registers new keys as you use the
 > stepping-stone — a decision, a solved problem, a recognized pattern. There's
 > **no background daemon**: it won't save things while you're away from the chat,
 > and a fresh thread starts fresh. You can always just say *"save that to kb."*
+>
+> **Other MCP clients.** ChatGPT, Codex, Cursor, Gemini, Windsurf, or any client
+> without Skill support should call `bootstrap()` once after connecting. It returns
+> Exomem's search/save/upload defaults and performance guidance in a structured
+> MCP response.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ read-side hook can optionally upgrade that reminder to real retrieved KB
 content (`EXOMEM_RETRIEVE_INJECT=1`, opt-in; the legacy `KB_RETRIEVE_INJECT`
 name still works) — see
 [QUICKSTART.md § 7](QUICKSTART.md#7-recommended-make-the-kb-automatic-both-directions).
-Other MCP clients can still use the server; put the same knowledge-discipline
-instructions in their system/project instructions if they do not support
-skills.
+Other MCP clients can still use the server. If they do not support Skills,
+have them call `bootstrap()` once at the start of the session; it returns the
+same compact operating contract through MCP, including when to search, when to
+save, upload guidance, and performance profiles.
 
 Full local setup is in [QUICKSTART.md](QUICKSTART.md). Remote/mobile setup is
 in [docs/remote-quickstart.md](docs/remote-quickstart.md) and
@@ -118,7 +119,7 @@ uv run exomem demo
 | Claude Code | `exomem setup` registers it for you (see above) |
 | Codex CLI | `codex mcp add` — see below |
 | claude.ai (remote) | Remote server — see [docs/remote-quickstart.md](docs/remote-quickstart.md) |
-| Any MCP client | Generic stdio config — see below |
+| Any MCP client | Generic stdio config — see below; call `bootstrap()` first |
 | Docker (no Python) | One `docker run` line — see below and [docs/docker.md](docs/docker.md) |
 
 <details>
@@ -145,6 +146,10 @@ env = { EXOMEM_VAULT_PATH = "/path/to/vault" }
 ```json
 {"mcpServers": {"exomem": {"command": "exomem", "args": ["--transport", "stdio"], "env": {"EXOMEM_VAULT_PATH": "/path/to/vault"}}}}
 ```
+
+After connecting, ask the agent to call `bootstrap()` before using the KB. Claude
+Skills are still the best UX where available, but `bootstrap()` lets generic MCP
+clients learn Exomem's search/save/upload contract without a separate skill file.
 
 </details>
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,18 +6,19 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Registry commands: 27
-- Tier 1 commands: 17
+- Registry commands: 28
+- Tier 1 commands: 18
 - Tier 2 commands: 10
-- Registry-generated MCP commands: 26
-- REST commands: 26
-- CLI commands: 26
+- Registry-generated MCP commands: 27
+- REST commands: 27
+- CLI commands: 27
 - Hand-registered MCP tools: mint_download_token, mint_upload_token, note
 
 ## Command Registry
 
 | Command | Tier | Surfaces | Mode | Destructive | CLI positional | Parameters | Summary |
 | --- | ---: | --- | --- | --- | --- | --- | --- |
+| bootstrap | 1 | MCP, REST, CLI | read | no | - | profile, workflow | Return Exomem's versioned operating contract for generic MCP clients. |
 | find | 1 | MCP, REST, CLI | read | no | query | query, types, projects, tags, speakers, file_types, exclude_file_types, limit, scope, mode, graph, rerank, prefer_compiled, prefer_active, prefer_used, pack, detail, include_timings | Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within. |
 | suggest_links | 1 | MCP, REST, CLI | read | no | - | path, draft_title, draft_body, limit, scope | Suggest existing KB pages a note should link to. Read-only. |
 | add | 1 | MCP, REST, CLI | write | no | - | content*, source_type*, title*, url, tags, why_captured | Capture raw content as an immutable source page in the Knowledge Base. |

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/design.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Exomem already has a rich Claude Skill scaffold, but MCP clients that do not load
+that skill only see tool schemas. The command registry is the correct place to add
+a portable contract because it generates MCP, REST, CLI, and OpenAPI surfaces from
+one leaf function. Existing `find` timing diagnostics and compute mode resolution
+already expose the measurements needed to explain performance, but agents need a
+single place to learn how to interpret them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give generic MCP clients a read-only `bootstrap` call that returns Exomem's
+  operating contract in structured form.
+- Keep the contract deterministic, generic, and public-safe.
+- Preserve default response shapes for `find` and `/upload` while adding useful
+  metadata when those paths already return structured JSON.
+- Keep all public surfaces generated from the existing command registry.
+
+**Non-Goals:**
+
+- No server-side LLM, agent reasoning, confidence scoring, or automatic policy
+  enforcement.
+- No change to retrieval ranking, reranking heuristics, upload authorization, or
+  media extraction behavior.
+- No requirement that every MCP client automatically calls `bootstrap`; docs and
+  tool discoverability make the intended call explicit.
+
+## Decisions
+
+- **Registry command, not hand-registered MCP only.** `bootstrap` is a normal
+  read-only command with MCP/REST/CLI surfaces so generic clients and scripts get
+  the same contract. Alternative considered: hand-register only in MCP. Rejected
+  because it would violate the command-surface single-source rule.
+- **Static-plus-runtime payload.** Most contract content is static guidance; runtime
+  fields come from cheap local state such as package version and `mode.resolved()`.
+  This keeps the operation deterministic and within the pure-substrate constraint.
+- **Profiles are verbosity controls.** `compact` is the default for first-session
+  use, `full` adds longer examples, and `diagnostics` adds performance-oriented
+  interpretation. Invalid profile values fail fast.
+- **Upload metadata is additive.** Existing `path` and `sidecar_path` stay in the
+  response; new fields add hash/size/media identity so agents can report outcomes
+  without guessing.
+- **Timing profile metadata remains opt-in.** `find` diagnostics stay behind
+  `include_timings=true`; the bootstrap contract teaches agents when to request
+  them instead of changing normal lookup cost or response shape.
+
+## Risks / Trade-offs
+
+- [Risk] Some clients may not call `bootstrap`.
+  -> Mitigation: name and describe the tool clearly and document it in generic
+  client setup instructions.
+- [Risk] The bootstrap prose can drift from the shipped Claude Skill.
+  -> Mitigation: keep it compact, test for key invariants, and avoid duplicating
+  every detail from `_Schema/SKILL.md`.
+- [Risk] Upload hashing could increase memory usage.
+  -> Mitigation: compute hash and size during streaming copy, not by reading the
+  whole file after upload.
+- [Risk] MCP schema snapshot churn is intentional.
+  -> Mitigation: update the fixture only after tests prove the new tool is the
+  expected registry-generated addition.

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/proposal.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Exomem's best behavior currently lives partly in the Claude Skill, so generic MCP
+clients see tools but not the operating contract that makes those tools reliable.
+ChatGPT/Codex/Cursor-style usage showed that Exomem should teach agents how to use
+itself through MCP, while keeping Claude Skills as the richer native UX.
+
+## What Changes
+
+- Add a read-only `bootstrap` operation that returns a versioned, deterministic
+  agent contract for generic MCP clients.
+- Include workflow guidance, preferred tool defaults, retry/search guidance,
+  performance profiles, and current compute policy in the bootstrap payload.
+- Extend `/upload` success responses with structured metadata so agents can report
+  exactly what was stored.
+- Extend opt-in `find` timing diagnostics with compact request/profile metadata so
+  performance discussions distinguish retrieval knobs from compute mode.
+- Update user-facing docs to say Claude Skills are best UX, while generic MCP
+  clients should call `bootstrap()` first.
+
+## Capabilities
+
+### New Capabilities
+- `agent-bootstrap-contract`: A versioned MCP-visible operating contract that lets
+  non-Skill clients become Exomem-native after one read-only call.
+
+### Modified Capabilities
+- `command-surface`: Expose `bootstrap` consistently through MCP, REST, CLI, and
+  OpenAPI from the command registry.
+- `find-recall-efficiency`: Add profile/policy metadata to opt-in timing diagnostics
+  without changing default `find` response shape or retrieval behavior.
+
+## Impact
+
+- Affected code: command registry, server upload route, preserve streaming result
+  metadata, find timing serialization, CLI/REST generated surfaces.
+- Public APIs: new `bootstrap` tool/REST/CLI command; additive fields in `/upload`
+  success JSON and `find(include_timings=true).timings`.
+- Docs: README/Quickstart generic-client guidance.
+- No new model path or reasoning dependency; this is deterministic instruction and
+  measurement metadata under the pure-substrate constraint.

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Agent Bootstrap Contract
+The system SHALL expose a read-only `bootstrap` operation that returns a
+versioned operating contract for agents using Exomem without a native skill.
+The contract MUST be deterministic, structured JSON and MUST NOT inspect or
+summarize private vault content.
+
+#### Scenario: Compact bootstrap returns the operating contract
+- **WHEN** `bootstrap` is called with default arguments
+- **THEN** the response includes `contract_version`, `server`, `workflow`,
+  `tool_defaults`, `performance_profiles`, `search_guidance`, and `common_tools`
+- **AND** the response identifies the current compute policy
+- **AND** the response does not include note bodies, excerpts, paths from the
+  user's vault contents, or private project names
+
+#### Scenario: Invalid bootstrap profile is rejected
+- **WHEN** `bootstrap(profile="invalid")` is called
+- **THEN** the operation fails with a validation error naming the accepted profiles
+
+### Requirement: Bootstrap Profiles
+The system SHALL support `compact`, `full`, and `diagnostics` bootstrap profiles.
+`compact` SHALL be the default. `full` SHALL include concrete workflow examples.
+`diagnostics` SHALL include performance interpretation guidance for timing and
+compute-mode discussions.
+
+#### Scenario: Diagnostics profile includes performance guidance
+- **WHEN** `bootstrap(profile="diagnostics")` is called
+- **THEN** the response includes guidance for normal lookup, reasoning lookup, and
+  diagnostics lookup
+- **AND** the guidance distinguishes compute mode from retrieval knobs such as
+  `rerank`, `pack`, and `include_timings`
+
+### Requirement: Generic Client Workflow Guidance
+The bootstrap contract SHALL tell generic agents to search before answering project
+or durable-knowledge questions, treat misses as scoped misses, prefer compiled
+notes for conclusions, use raw sources/evidence for provenance, and save durable
+conclusions as compiled notes.
+
+#### Scenario: Bootstrap teaches the core workflow
+- **WHEN** an agent reads the bootstrap response
+- **THEN** it can identify the recommended loop from initial lookup through
+  optional `get`/`pack`, reasoning, and `note`/`edit`/`replace`
+- **AND** it can identify the normal, reasoning, and diagnostics `find` defaults

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/command-surface/spec.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/command-surface/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Bootstrap Is Exposed On Every Generated Surface
+The system SHALL expose `bootstrap` through the single command registry on MCP,
+REST, CLI, and OpenAPI. The tool SHALL be marked read-only and non-destructive in
+MCP annotations.
+
+#### Scenario: Bootstrap appears in generated surfaces
+- **WHEN** the server is built
+- **THEN** `bootstrap` appears in the MCP tool list
+- **AND** `/api/bootstrap` appears in the REST facade and OpenAPI document
+- **AND** the CLI exposes a `bootstrap` subcommand
+
+#### Scenario: Bootstrap is accounted for by schema fidelity tests
+- **WHEN** the MCP schema fidelity test runs
+- **THEN** the live tool set includes `bootstrap`
+- **AND** `bootstrap` is registry-generated rather than a hand-registered exception

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Timing Diagnostics Include Request Profile Metadata
+The system SHALL include compact request/profile metadata in `find` timing
+diagnostics when `include_timings=true`. This metadata MUST be limited to
+diagnostic flags and compute policy, and MUST NOT include note content, excerpts,
+expanded query text, vectors, or private vault paths.
+
+#### Scenario: Timed find includes profile metadata
+- **WHEN** `find` is called with `include_timings=true`
+- **THEN** `timings` includes a profile block identifying request knobs such as
+  mode, detail, pack, graph, and rerank request state
+- **AND** `timings` includes the current compute policy
+- **AND** the hit ranking is unchanged compared with the same timed request before
+  metadata serialization
+
+#### Scenario: Untimed find shape is unchanged
+- **WHEN** `find` is called without `include_timings=true`
+- **THEN** the default response shape remains the existing hit list or pack envelope
+- **AND** no timing profile metadata is returned
+
+### Requirement: Structured Upload Success Metadata
+The system SHALL return structured upload success metadata from `/upload` in
+addition to the existing stored path fields. The metadata SHALL include the stored
+binary path, byte size, SHA-256 hash, hash algorithm, media identifier, and content
+type when available.
+
+#### Scenario: Upload response identifies stored artifact
+- **WHEN** a file is uploaded successfully through `/upload`
+- **THEN** the JSON response includes existing `path` and `sidecar_path` fields
+- **AND** it includes `stored_path`, `size`, `hash`, `hash_algorithm`,
+  `media_id`, and `content_type`
+
+#### Scenario: Upload metadata does not change authorization or duplicate behavior
+- **WHEN** upload auth fails, a file is oversized, or a duplicate path is uploaded
+- **THEN** the existing error codes and status codes are preserved

--- a/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/tasks.md
+++ b/openspec/changes/archive/2026-07-06-add-agent-bootstrap-contract/tasks.md
@@ -1,0 +1,17 @@
+## 1. Bootstrap Contract
+
+- [x] 1.1 Add a deterministic `op_bootstrap` leaf returning compact/full/diagnostics contract payloads.
+- [x] 1.2 Register `bootstrap` in the command registry for MCP, REST, CLI, and OpenAPI with read-only annotations.
+- [x] 1.3 Add unit and surface tests for bootstrap payload shape, profile validation, and generated MCP accounting.
+
+## 2. Upload And Timing Metadata
+
+- [x] 2.1 Extend preserve streaming results with SHA-256 hash, byte size, media identifier, and content type metadata.
+- [x] 2.2 Return the new metadata from `/upload` while preserving existing success and error fields.
+- [x] 2.3 Add timing profile metadata to `find(include_timings=true)` without changing untimed response shapes.
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update README/Quickstart generic-client guidance to call `bootstrap()` first when no native Skill is available.
+- [x] 3.2 Update the committed MCP schema fixture for the intentional `bootstrap` tool addition.
+- [x] 3.3 Run targeted tests for bootstrap, MCP schema fidelity, upload metadata, and find timings.

--- a/openspec/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,48 @@
+# agent-bootstrap-contract Specification
+
+## Purpose
+TBD - created by archiving change add-agent-bootstrap-contract. Update Purpose after archive.
+## Requirements
+### Requirement: Agent Bootstrap Contract
+The system SHALL expose a read-only `bootstrap` operation that returns a
+versioned operating contract for agents using Exomem without a native skill.
+The contract MUST be deterministic, structured JSON and MUST NOT inspect or
+summarize private vault content.
+
+#### Scenario: Compact bootstrap returns the operating contract
+- **WHEN** `bootstrap` is called with default arguments
+- **THEN** the response includes `contract_version`, `server`, `workflow`,
+  `tool_defaults`, `performance_profiles`, `search_guidance`, and `common_tools`
+- **AND** the response identifies the current compute policy
+- **AND** the response does not include note bodies, excerpts, paths from the
+  user's vault contents, or private project names
+
+#### Scenario: Invalid bootstrap profile is rejected
+- **WHEN** `bootstrap(profile="invalid")` is called
+- **THEN** the operation fails with a validation error naming the accepted profiles
+
+### Requirement: Bootstrap Profiles
+The system SHALL support `compact`, `full`, and `diagnostics` bootstrap profiles.
+`compact` SHALL be the default. `full` SHALL include concrete workflow examples.
+`diagnostics` SHALL include performance interpretation guidance for timing and
+compute-mode discussions.
+
+#### Scenario: Diagnostics profile includes performance guidance
+- **WHEN** `bootstrap(profile="diagnostics")` is called
+- **THEN** the response includes guidance for normal lookup, reasoning lookup, and
+  diagnostics lookup
+- **AND** the guidance distinguishes compute mode from retrieval knobs such as
+  `rerank`, `pack`, and `include_timings`
+
+### Requirement: Generic Client Workflow Guidance
+The bootstrap contract SHALL tell generic agents to search before answering project
+or durable-knowledge questions, treat misses as scoped misses, prefer compiled
+notes for conclusions, use raw sources/evidence for provenance, and save durable
+conclusions as compiled notes.
+
+#### Scenario: Bootstrap teaches the core workflow
+- **WHEN** an agent reads the bootstrap response
+- **THEN** it can identify the recommended loop from initial lookup through
+  optional `get`/`pack`, reasoning, and `note`/`edit`/`replace`
+- **AND** it can identify the normal, reasoning, and diagnostics `find` defaults
+

--- a/openspec/specs/command-surface/spec.md
+++ b/openspec/specs/command-surface/spec.md
@@ -95,3 +95,19 @@ and no `error`; a failure carries `success:false` and an `error` block with a st
 - **WHEN** a REST request passes an oversized base64 blob in a text field
 - **THEN** it is rejected with the existing `BINARY_BLOB_REJECTED`-class error, as before
 
+### Requirement: Bootstrap Is Exposed On Every Generated Surface
+The system SHALL expose `bootstrap` through the single command registry on MCP,
+REST, CLI, and OpenAPI. The tool SHALL be marked read-only and non-destructive in
+MCP annotations.
+
+#### Scenario: Bootstrap appears in generated surfaces
+- **WHEN** the server is built
+- **THEN** `bootstrap` appears in the MCP tool list
+- **AND** `/api/bootstrap` appears in the REST facade and OpenAPI document
+- **AND** the CLI exposes a `bootstrap` subcommand
+
+#### Scenario: Bootstrap is accounted for by schema fidelity tests
+- **WHEN** the MCP schema fidelity test runs
+- **THEN** the live tool set includes `bootstrap`
+- **AND** `bootstrap` is registry-generated rather than a hand-registered exception
+

--- a/openspec/specs/find-recall-efficiency/spec.md
+++ b/openspec/specs/find-recall-efficiency/spec.md
@@ -369,3 +369,38 @@ structural rather than a formatting convention.
 - **THEN** the report contains exactly N result rows, one per mode
 - **AND** the row count does not scale with the number of golden queries
 
+### Requirement: Timing Diagnostics Include Request Profile Metadata
+The system SHALL include compact request/profile metadata in `find` timing
+diagnostics when `include_timings=true`. This metadata MUST be limited to
+diagnostic flags and compute policy, and MUST NOT include note content, excerpts,
+expanded query text, vectors, or private vault paths.
+
+#### Scenario: Timed find includes profile metadata
+- **WHEN** `find` is called with `include_timings=true`
+- **THEN** `timings` includes a profile block identifying request knobs such as
+  mode, detail, pack, graph, and rerank request state
+- **AND** `timings` includes the current compute policy
+- **AND** the hit ranking is unchanged compared with the same timed request before
+  metadata serialization
+
+#### Scenario: Untimed find shape is unchanged
+- **WHEN** `find` is called without `include_timings=true`
+- **THEN** the default response shape remains the existing hit list or pack envelope
+- **AND** no timing profile metadata is returned
+
+### Requirement: Structured Upload Success Metadata
+The system SHALL return structured upload success metadata from `/upload` in
+addition to the existing stored path fields. The metadata SHALL include the stored
+binary path, byte size, SHA-256 hash, hash algorithm, media identifier, and content
+type when available.
+
+#### Scenario: Upload response identifies stored artifact
+- **WHEN** a file is uploaded successfully through `/upload`
+- **THEN** the JSON response includes existing `path` and `sidecar_path` fields
+- **AND** it includes `stored_path`, `size`, `hash`, `hash_algorithm`,
+  `media_id`, and `content_type`
+
+#### Scenario: Upload metadata does not change authorization or duplicate behavior
+- **WHEN** upload auth fails, a file is oversized, or a duplicate path is uploaded
+- **THEN** the existing error codes and status codes are preserved
+

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -25,6 +25,7 @@ import types
 import typing
 from collections.abc import Callable
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from fastmcp.tools import ToolResult
@@ -67,6 +68,7 @@ from . import replace as replace_module
 from . import set_frontmatter_field as set_frontmatter_field_module
 from . import set_take as set_take_module
 from . import video_frames as video_frames_module
+from .kbdir import kb_dirname
 from .vault import (
     VaultPathError,
     find_body_wikilinks,
@@ -249,6 +251,183 @@ def _link_summary(vault_root: Path, rel_path: str, body: str) -> dict:
 # descriptions Claude reads (byte-pinned by tests/test_mcp_schema_fidelity.py).
 
 
+def op_bootstrap(
+    vault_root: Path,
+    profile: str = "compact",
+    workflow: str | None = None,
+) -> dict:
+    """Return Exomem's versioned operating contract for generic MCP clients.
+
+    Call this once at the start of a session when the client does not have the
+    Exomem Claude Skill loaded. It teaches the agent how to use the tools: when
+    to search, when to save, how to interpret scoped misses, which `find` knobs
+    are cheap vs diagnostic, and how compiled notes differ from raw evidence.
+    The payload is deterministic instruction plus local compute policy; it does
+    not inspect or summarize vault content.
+
+    Args:
+        profile: "compact" (default), "full", or "diagnostics". Compact is
+            enough for normal clients. Full adds examples. Diagnostics adds
+            performance interpretation guidance.
+        workflow: Optional caller-selected workflow label. Returned as context
+            only; it does not change server behavior.
+
+    Returns:
+        A structured, versioned contract with workflow, search, save, upload,
+        and performance guidance for MCP clients.
+    """
+    if profile not in ("compact", "full", "diagnostics"):
+        raise ValueError(
+            "bootstrap: profile must be 'compact', 'full', or 'diagnostics', "
+            f"got {profile!r}"
+        )
+
+    try:
+        package_version = version("exomem")
+    except PackageNotFoundError:
+        package_version = "0+unknown"
+
+    from . import mode as mode_module
+
+    compute_policy = mode_module.resolved()
+    requested_workflow = workflow.strip() if workflow and workflow.strip() else "general"
+    payload: dict = {
+        "contract_version": "2026-07-06.1",
+        "profile": profile,
+        "server": {
+            "name": "exomem",
+            "version": package_version,
+            "kb_dir": kb_dirname(),
+            "pure_substrate": True,
+            "content_included": False,
+            "compute_policy": compute_policy,
+        },
+        "workflow": {
+            "requested": requested_workflow,
+            "loop": [
+                "bootstrap",
+                "find",
+                "get or find(pack=true) when more context is needed",
+                "reason in the agent",
+                "note, edit, or replace when there is a durable conclusion",
+            ],
+            "save_rule": (
+                "Save durable decisions, solved problems, diagnosed failures, "
+                "and reusable patterns as compiled notes; keep raw artifacts in "
+                "Sources or Evidence."
+            ),
+            "miss_rule": (
+                "An empty search means not found in that query/scope. Try synonyms, "
+                "related terms, compact recall, or scope='vault' before concluding absence."
+            ),
+        },
+        "tool_defaults": {
+            "normal_lookup": {
+                "tool": "find",
+                "args": {"detail": "compact", "rerank": False},
+            },
+            "reasoning_lookup": {
+                "tool": "find",
+                "args": {"pack": True},
+            },
+            "diagnostics_lookup": {
+                "tool": "find",
+                "args": {
+                    "detail": "compact",
+                    "include_timings": True,
+                    "rerank": True,
+                },
+            },
+            "read_full_page": {"tool": "get", "when": "after choosing a hit"},
+            "write_compiled_note": {
+                "tool": "note",
+                "when": "new durable conclusion",
+            },
+            "minor_edit": {"tool": "edit", "when": "small correction to an existing page"},
+            "supersede": {
+                "tool": "replace",
+                "when": "substantial rewrite of compiled material",
+            },
+            "binary_upload": {
+                "tool": "mint_upload_token",
+                "endpoint": "/upload",
+                "fields": ["file", "scope", "category", "description", "text"],
+            },
+        },
+        "performance_profiles": {
+            "normal": {
+                "find_args": {"detail": "compact", "rerank": False},
+                "interpretation": "cheap routing recall; follow with get if needed",
+            },
+            "reasoning": {
+                "find_args": {"pack": True},
+                "interpretation": "bounded context assembly for synthesis",
+            },
+            "diagnostics": {
+                "find_args": {"include_timings": True, "rerank": True},
+                "interpretation": (
+                    "timings measure retrieval stages; compute_policy explains "
+                    "quiet/normal/performance mode separately from rerank/pack knobs"
+                ),
+            },
+        },
+        "search_guidance": {
+            "prefer_compiled_default": True,
+            "compiled_types": ["research-note", "insight", "failure", "pattern", "entity"],
+            "raw_types": ["source", "evidence"],
+            "retry_examples": [
+                "try synonyms and singular/plural forms",
+                "try adjacent domain terms",
+                "try scope='vault' if Knowledge Base recall is sparse",
+                "try pack=true for synthesis instead of many get calls",
+            ],
+        },
+        "common_tools": [
+            "find",
+            "get",
+            "note",
+            "edit",
+            "replace",
+            "suggest_links",
+            "mint_upload_token",
+            "get_video_frames",
+        ],
+    }
+
+    if profile in ("full", "diagnostics"):
+        payload["examples"] = [
+            {
+                "goal": "cheap proactive recall",
+                "call": "find(query='...', detail='compact', rerank=false)",
+            },
+            {
+                "goal": "reason across top matches",
+                "call": "find(query='...', pack=true)",
+            },
+            {
+                "goal": "capture a durable conclusion",
+                "call": "note(note_type='research-note'|'insight'|..., title='...', content='...')",
+            },
+        ]
+    if profile == "diagnostics":
+        payload["diagnostics"] = {
+            "timings": (
+                "Use include_timings=true when discussing latency. Rerank and pack "
+                "can dominate wall time and are not the same as CPU/GPU mode."
+            ),
+            "compute_modes": {
+                "quiet": "CPU/low-power, no preload, releases models when idle",
+                "normal": "safe default, CPU steady-state with lexical recall ready first",
+                "performance": "GPU-preferred steady-state when available",
+            },
+            "upload_response": (
+                "/upload returns stored_path, hash, media_id, size, and sidecar_path "
+                "so the agent can report stored artifacts exactly."
+            ),
+        }
+    return payload
+
+
 def op_find(
     vault_root: Path,
     query: str = "",
@@ -417,6 +596,24 @@ def op_find(
             f"find: detail must be 'full' or 'compact', got {detail!r}"
         )
     timings = find_module.FindTimings() if include_timings else None
+    if timings is not None:
+        from . import mode as mode_module
+
+        timings.profile.update(
+            {
+                "mode": mode,
+                "scope": scope,
+                "detail": detail,
+                "pack": pack,
+                "graph": graph,
+                "rerank_requested": rerank,
+                "auto_rerank": rerank is None,
+                "prefer_compiled": prefer_compiled,
+                "prefer_active": prefer_active,
+                "prefer_used": prefer_used,
+                "compute_policy": mode_module.resolved(),
+            }
+        )
     degraded: list[str] = []
     failed: list[str] = []
     hits = find_module.find(
@@ -2288,6 +2485,7 @@ _RC = frozenset({"rest", "cli"})
 # meaningless through the REST/CLI JSON envelopes, so it is mcp-only.
 _M = frozenset({"mcp"})
 _SPEC: tuple[tuple, ...] = (
+    ("bootstrap", op_bootstrap, 1, False, False, None, _MCRC),
     ("find", op_find, 1, False, False, "query", _MCRC),
     ("suggest_links", op_suggest_links, 1, False, False, None, _MCRC),
     ("add", op_add, 1, True, True, None, _MCRC),

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -550,13 +550,16 @@ SCENE_HIST_THRESHOLD = 0.35  # L1 distance between normalized 32-bin histograms 
 SCENE_MIN_SECS = 4.0  # boundaries closer than this merge; EXOMEM_VIDEO_SCENE_MIN_SECS overrides
 
 
+_FALSY_ENV = {"", "0", "false", "no", "off"}
+
+
 def scene_frames_enabled() -> bool:
     """EXOMEM_VIDEO_SCENE_FRAMES gates scene detection + persisted scene frames.
 
     Default OFF: video keyframe selection stays the uniform sampler and no frame
     files are written — byte-identical to the pre-feature behavior.
     """
-    return bool(os.environ.get("EXOMEM_VIDEO_SCENE_FRAMES"))
+    return os.environ.get("EXOMEM_VIDEO_SCENE_FRAMES", "").strip().lower() not in _FALSY_ENV
 
 
 def _scene_hash_threshold() -> int:

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -628,6 +628,7 @@ class FindTimings:
         self._t0 = time.perf_counter()
         self.stages: dict[str, dict[str, Any]] = {}
         self.cache: dict[str, Any] = {"enabled": False, "hit": False}
+        self.profile: dict[str, Any] = {}
 
     @contextmanager
     def span(self, name: str):
@@ -648,6 +649,7 @@ class FindTimings:
         return {
             "total_ms": round((time.perf_counter() - self._t0) * 1000.0, 3),
             "cache": dict(self.cache),
+            "profile": dict(self.profile),
             "stages": {k: dict(v) for k, v in self.stages.items()},
         }
 

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 
 import base64
 import datetime as dt
+import hashlib
 import io
 import logging
+import mimetypes
 import os
 import re
 from dataclasses import dataclass
@@ -78,12 +80,23 @@ class PreserveResult:
     path: str                 # vault-relative path of the artifact
     sidecar_path: str | None  # vault-relative path of the .md sidecar (if any)
     warnings: list[str]
+    size: int | None = None
+    hash: str | None = None
+    hash_algorithm: str | None = None
+    media_id: str | None = None
+    content_type: str | None = None
 
     def as_dict(self) -> dict:
         return {
             "path": self.path,
+            "stored_path": self.path,
             "sidecar_path": self.sidecar_path,
             "warnings": self.warnings,
+            "size": self.size,
+            "hash": self.hash,
+            "hash_algorithm": self.hash_algorithm,
+            "media_id": self.media_id,
+            "content_type": self.content_type,
         }
 
 
@@ -106,6 +119,7 @@ def preserve(
     content_base64: str | None = None,
     content: str | None = None,
     content_stream: BinaryIO | None = None,
+    content_type: str | None = None,
     description: str | None = None,
     text: str | None = None,
     today: dt.date | None = None,
@@ -194,20 +208,34 @@ def preserve(
     warnings: list[str] = []
     written_artifact = False
     sidecar_rel: str | None = None
+    artifact_size: int | None = None
+    artifact_hash: str | None = None
+    content_type_effective = (
+        content_type.strip()
+        if content_type and content_type.strip()
+        else mimetypes.guess_type(filename_safe)[0]
+    )
 
     try:
         if content_stream is not None:
             # Stream the upload to disk in chunks — peak memory is one chunk, not
             # the whole file. Enforces the byte cap mid-copy (defense in depth; the
             # HTTP layer's max_part_size already bounds the part during parsing).
-            _copy_stream_to_file(content_stream, artifact_path, limit=max_stream_bytes)
+            artifact_size, artifact_hash = _copy_stream_to_file(
+                content_stream, artifact_path, limit=max_stream_bytes
+            )
             written_artifact = True
         elif artifact_bytes is not None:
             # Binary: write directly, no atomic batch (batch_atomic_write is text-only).
             artifact_path.write_bytes(artifact_bytes)
+            artifact_size = len(artifact_bytes)
+            artifact_hash = hashlib.sha256(artifact_bytes).hexdigest()
             written_artifact = True
         else:
+            artifact_text_bytes = (artifact_text or "").encode("utf-8")
             artifact_path.write_text(artifact_text or "", encoding="utf-8", newline="\n")
+            artifact_size = len(artifact_text_bytes)
+            artifact_hash = hashlib.sha256(artifact_text_bytes).hexdigest()
             written_artifact = True
 
         writes: list[PlannedWrite] = []
@@ -322,6 +350,11 @@ def preserve(
         path=artifact_path.relative_to(vault_root).as_posix(),
         sidecar_path=sidecar_rel,
         warnings=warnings,
+        size=artifact_size,
+        hash=artifact_hash,
+        hash_algorithm="sha256" if artifact_hash else None,
+        media_id=f"sha256:{artifact_hash}" if artifact_hash else None,
+        content_type=content_type_effective,
     )
 
 
@@ -332,6 +365,7 @@ def preserve_stream(
     category: str,
     filename: str,
     stream: BinaryIO,
+    content_type: str | None = None,
     description: str | None = None,
     text: str | None = None,
     today: dt.date | None = None,
@@ -354,6 +388,7 @@ def preserve_stream(
         category=category,
         filename=filename,
         content_stream=stream,
+        content_type=content_type,
         description=description,
         text=text,
         today=today,
@@ -368,6 +403,7 @@ def preserve_bytes(
     category: str,
     filename: str,
     data: bytes,
+    content_type: str | None = None,
     description: str | None = None,
     text: str | None = None,
     today: dt.date | None = None,
@@ -385,6 +421,7 @@ def preserve_bytes(
         category=category,
         filename=filename,
         stream=io.BytesIO(data),
+        content_type=content_type,
         description=description,
         text=text,
         today=today,
@@ -398,17 +435,18 @@ def preserve_bytes(
 _STREAM_CHUNK = 1024 * 1024  # 1 MiB copy buffer
 
 
-def _copy_stream_to_file(stream: BinaryIO, dest: Path, *, limit: int) -> int:
+def _copy_stream_to_file(stream: BinaryIO, dest: Path, *, limit: int) -> tuple[int, str]:
     """Copy a binary file-like to `dest` in chunks, enforcing `limit` bytes.
 
     Peak memory is one chunk regardless of file size. On overflow the partial
-    file is removed and TOO_LARGE is raised. Returns the bytes written.
+    file is removed and TOO_LARGE is raised. Returns bytes written and SHA-256.
     """
     try:
         stream.seek(0)
     except (OSError, AttributeError, ValueError):
         pass  # non-seekable stream: copy from the current position
     written = 0
+    digest = hashlib.sha256()
     overflow = False
     with dest.open("wb") as out:
         while True:
@@ -419,11 +457,12 @@ def _copy_stream_to_file(stream: BinaryIO, dest: Path, *, limit: int) -> int:
             if written > limit:
                 overflow = True
                 break
+            digest.update(buf)
             out.write(buf)
     if overflow:
         dest.unlink(missing_ok=True)
         _raise("TOO_LARGE", ["file"], f"upload exceeds the {limit:,}-byte limit")
-    return written
+    return written, digest.hexdigest()
 
 
 _INVALID_PATH_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -579,6 +579,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
                 category=category,
                 filename=filename,
                 stream=upload.file,
+                content_type=getattr(upload, "content_type", None),
                 description=description,
                 text=text,
                 max_bytes=upload_max_bytes,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,10 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
     # No real CLIP either; tests that exercise it stub embeddings.embed_image/embed_clip_text.
     monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    # Opt-in media upgrades must not leak from a developer's real environment into
+    # default tests. Tests that exercise these gates set them explicitly.
+    monkeypatch.delenv("EXOMEM_SEMANTIC_SEGMENTS", raising=False)
+    monkeypatch.delenv("EXOMEM_VIDEO_SCENE_FRAMES", raising=False)
     # The watcher now starts independently of embeddings (it maintains the
     # freshness/inbound registries too), so build_server would spawn a real
     # watchdog observer in the suite without this. Watcher tests opt back in.

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -162,6 +162,32 @@
       "type": "object"
     }
   },
+  "bootstrap": {
+    "description": "Return Exomem's versioned operating contract for generic MCP clients.\n\nCall this once at the start of a session when the client does not have the\nExomem Claude Skill loaded. It teaches the agent how to use the tools: when\nto search, when to save, how to interpret scoped misses, which `find` knobs\nare cheap vs diagnostic, and how compiled notes differ from raw evidence.\nThe payload is deterministic instruction plus local compute policy; it does\nnot inspect or summarize vault content.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "profile": {
+          "default": "compact",
+          "type": "string",
+          "description": "\"compact\" (default), \"full\", or \"diagnostics\". Compact is\nenough for normal clients. Full adds examples. Diagnostics adds\nperformance interpretation guidance."
+        },
+        "workflow": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional caller-selected workflow label. Returned as context\nonly; it does not change server behavior."
+        }
+      },
+      "type": "object"
+    }
+  },
   "create_file": {
     "description": "Tier 2: write a file — or, with `kind=\"dir\"`, create a folder — at an\narbitrary vault path.\n\nWith `kind=\"dir\"`, this creates a folder (mkdir -p when `parents=true`)\nand ignores `content`/`frontmatter`/`overwrite` (folds in the former\n`create_directory` tool); returns {path, created, warnings}.\n\nEscape hatch for files that don't fit Tier 1 type routing — new folder\nstructures (`Identity/`, `Templates/`), skill files, scratch. For\ntyped notes use `note`/`add`/`link`/`preserve`.\n\nIf `frontmatter` is a dict, this op prepends a YAML block built from\nit (and auto-fills `created`/`updated` to today if not provided);\n`content` is the body in that case. If `frontmatter` is omitted,\n`content` is written verbatim — the caller is responsible for any\nfrontmatter already in it.\n\nRefuses:\n- Sources/, Evidence/ (append-only — use `add` or `preserve`).\n- Subtrees marked `readonly`/`excluded` in `_access.yaml` (curated,\n  read-only material) — a hard refusal with no override.\n- Existing files unless `overwrite=true`.",
     "inputSchema": {

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from exomem import commands
+from exomem import server
+from exomem.__main__ import main
+
+
+def _tool_names(mcp) -> set[str]:
+    return {t.name for t in asyncio.run(mcp.list_tools())}
+
+
+def _client(vault: Path, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    for leaky in ("EXOMEM_REST_API_KEY", "EXOMEM_UPLOAD_TOKEN"):
+        monkeypatch.delenv(leaky, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    mcp = server.build_server(require_auth=False)
+    return TestClient(mcp.http_app())
+
+
+def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
+    out = commands.op_bootstrap(vault)
+
+    assert out["contract_version"]
+    assert out["profile"] == "compact"
+    assert out["server"]["name"] == "exomem"
+    assert out["server"]["content_included"] is False
+    assert out["server"]["pure_substrate"] is True
+    assert "compute_policy" in out["server"]
+    assert {"workflow", "tool_defaults", "performance_profiles"} <= set(out)
+    assert out["tool_defaults"]["normal_lookup"]["args"] == {
+        "detail": "compact",
+        "rerank": False,
+    }
+    serialized = json.dumps(out)
+    assert str(vault) not in serialized
+    assert "Progressive disclosure" not in serialized
+
+
+def test_bootstrap_profiles_and_validation(vault: Path) -> None:
+    full = commands.op_bootstrap(vault, profile="full", workflow="research")
+    assert full["workflow"]["requested"] == "research"
+    assert "examples" in full
+
+    diagnostics = commands.op_bootstrap(vault, profile="diagnostics")
+    assert "diagnostics" in diagnostics
+    assert "compute_modes" in diagnostics["diagnostics"]
+
+    with pytest.raises(ValueError, match="compact.*full.*diagnostics"):
+        commands.op_bootstrap(vault, profile="verbose")
+
+
+def test_bootstrap_is_registry_generated_on_public_surfaces(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    cmd = next(c for c in commands.COMMANDS if c.name == "bootstrap")
+    assert cmd.read_only is True
+    assert {"mcp", "rest", "cli"} <= set(cmd.surfaces)
+    assert "bootstrap" not in commands.HAND_REGISTERED_EXCEPTIONS
+
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    mcp = server.build_server(require_auth=False)
+    assert "bootstrap" in _tool_names(mcp)
+
+    client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
+    r = client.post(
+        "/api/bootstrap",
+        json={"profile": "diagnostics"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["profile"] == "diagnostics"
+    openapi = client.get("/api/openapi.json")
+    assert "/api/bootstrap" in openapi.json()["paths"]
+
+    code = main(["bootstrap", "--json"])
+    captured = capsys.readouterr()
+    assert code == 0
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"]["contract_version"]

--- a/tests/test_find_timings_compact.py
+++ b/tests/test_find_timings_compact.py
@@ -29,6 +29,11 @@ def test_timings_envelope_and_stages(vault: Path) -> None:
     t = out["timings"]
     assert t["total_ms"] >= 0
     assert "cache" in t and "hit" in t["cache"]
+    assert t["profile"]["mode"] == "hybrid"
+    assert t["profile"]["detail"] == "full"
+    assert t["profile"]["pack"] is False
+    assert t["profile"]["auto_rerank"] is True
+    assert t["profile"]["compute_policy"]["mode"] in {"quiet", "normal", "performance"}
     stages = t["stages"]
     # Lexical lanes always run in hybrid mode; vector is present as a timed
     # or errored stage even with embeddings disabled (soft-fail, never fatal).

--- a/tests/test_upload_endpoint.py
+++ b/tests/test_upload_endpoint.py
@@ -7,6 +7,8 @@ can't clobber the per-test fixture vault.
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -48,6 +50,12 @@ def test_upload_happy_path_lands_in_evidence(vault, monkeypatch: pytest.MonkeyPa
     assert r.status_code == 201, r.text
     body = r.json()
     assert "Evidence/Yolo/01 - Check-in/shot.png" in body["path"]
+    assert body["stored_path"] == body["path"]
+    assert body["size"] == len(b"\x89PNGrealbytes")
+    assert body["hash"] == hashlib.sha256(b"\x89PNGrealbytes").hexdigest()
+    assert body["hash_algorithm"] == "sha256"
+    assert body["media_id"] == f"sha256:{body['hash']}"
+    assert body["content_type"] == "image/png"
     written = vault / body["path"]
     assert written.read_bytes() == b"\x89PNGrealbytes"
 

--- a/tests/test_video_visual.py
+++ b/tests/test_video_visual.py
@@ -29,6 +29,17 @@ def _three_frames():
     ]
 
 
+def test_scene_frame_gate_accepts_falsey_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_VIDEO_SCENE_FRAMES", raising=False)
+    assert embeddings.scene_frames_enabled() is False
+    monkeypatch.setenv("EXOMEM_VIDEO_SCENE_FRAMES", "0")
+    assert embeddings.scene_frames_enabled() is False
+    monkeypatch.setenv("EXOMEM_VIDEO_SCENE_FRAMES", "off")
+    assert embeddings.scene_frames_enabled() is False
+    monkeypatch.setenv("EXOMEM_VIDEO_SCENE_FRAMES", "1")
+    assert embeddings.scene_frames_enabled() is True
+
+
 def test_worker_clip_embeds_video_via_keyframes(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXOMEM_DISABLE_CLIP", raising=False)
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)


### PR DESCRIPTION
## Summary
- add a read-only bootstrap operation for generic MCP/REST/CLI clients
- expose upload success metadata and find timing profile metadata
- update generic-client docs, generated capabilities, tests, and archived OpenSpec specs

## Verification
- full suite earlier in this change: 1680 passed, 1 skipped
- uv run python -m pytest tests/test_bootstrap.py tests/test_mcp_schema_fidelity.py tests/test_find_timings_compact.py tests/test_upload_endpoint.py tests/test_video_visual.py -q
- openspec validate --specs --strict
- npm exec --yes @fission-ai/openspec -- validate --specs --strict
- .venv\\Scripts\\python scripts\\generate-capabilities.py --check
- uv sync --frozen
- uv run exomem demo --json
- uv build

Note: uvx ruff check . currently reports the repo's known lint baseline; CI marks Ruff advisory/non-blocking.