### PR TITLE
docs(skill): align scaffold with bootstrap contract

### DIFF
--- a/src/exomem/_sample_vault/Knowledge Base/_Schema/SKILL.md
+++ b/src/exomem/_sample_vault/Knowledge Base/_Schema/SKILL.md
@@ -7,5 +7,5 @@ version: 0.1.0
 # Knowledge Base Sample Schema
 
 This is a deliberately tiny schema stub for the public sample vault. The full
-starter schema ships in ksrc/kb_mcp/_scaffold/_Schema/k and is installed by
+starter schema ships in `src/exomem/_scaffold/_Schema/` and is installed by
 `exomem init`.

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -149,6 +149,13 @@ On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 resolves to the right tool. `find` is the read-only hybrid (semantic + keyword)
 search and your default entry point.
 
+This skill is the rich behavioural contract for Exomem-aware agents. If this
+file has been read, routine KB work does not need a separate `bootstrap()` call.
+Generic MCP clients without this skill should call `bootstrap()` once at session
+start to get the portable operating contract. Skill-aware agents may still use
+`bootstrap(profile="diagnostics")` when interpreting retrieval speed, compute
+mode, reranking, `pack`, or `include_timings`.
+
 The Tier 2 filesystem ops below may be turned off on lean deployments
 (`EXOMEM_DISABLE_TIER2`), in which case only the Tier 1 ops are registered.
 
@@ -167,12 +174,13 @@ and index updates are determined by the operation, not the caller.
 
 | Op | Intent | Writes to |
 |---|---|---|
+| **bootstrap** | Return a portable, versioned operating contract for generic MCP clients. Skill-aware agents can skip routine calls after reading this file; use diagnostics profile for timing/performance interpretation | — |
 | **add** | Capture raw input as immutable source | `Sources/<type>/` |
 | **note** | Compile a structured note from raw input or thinking | `Notes/<type>/` |
 | **link** | Create or update an entity, wire backlinks | `Entities/<type>/` |
 | **preserve** | Capture a **text** factual artifact for an incident scope. Binaries (PDF / image / any file) go out-of-band via upload (see below), not this tool | `Evidence/<scope>/` |
 | **edit** | In-place edit of a compiled page. One mode per call: whole `body` / `tags` / surgical `old_string`→`new_string`; `edits=[…]` several surgical pairs in one atomic batch; `row_key`+`take` fill a `[take: ]` row by its leading text; `field`+`value` patch ONE frontmatter field (requires `why:`). Bumps `updated:`. Optional `expected_hash` (drift guard) + `validate_only` | the page |
-| **find** | Type-aware search across the KB (read-only) | — |
+| **find** | Type-aware search across the KB (read-only). Supports compact lookups, packed reasoning context, and diagnostics via `include_timings` / `rerank` when needed | — |
 | **suggest_links** | Surface existing pages a draft or page should link to, hub-aware (read-only) | — |
 | **get** | Read a full file by path; `frontmatter_only=true` returns just the frontmatter. Returns `content_hash` + `mtime` for the two-writer drift guard (echo `content_hash` to `edit` via `expected_hash`). Read-only | — |
 | **audit** | Lint pass: orphans, broken links, supersession integrity, aged unprocessed sources | proposals only |
@@ -223,7 +231,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   and CLIP-embeds images and per-keyframe video frames for visual search — all
   server-side after upload, filling an embedded sidecar so any upload becomes
   findable by content. You *may* still pass a `text` field to supply your own
-  extraction; it takes precedence. The write tools take text only and reject
+  extraction; it takes precedence. Upload responses return concrete metadata (`stored_path`, `size`, `hash`, `hash_algorithm`, `media_id`, `content_type`) so agents can report exactly what landed. The write tools take text only and reject
   inline byte blobs (`BINARY_BLOB_REJECTED`). Full workflow:
   `references/operations.md` § preserve.
 - **Pull a vault file back out — the download channel.** Call
@@ -336,6 +344,13 @@ soft-demotes superseded pages), `file_types` / `exclude_file_types` (scope to
 or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
 `pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`), and `speakers`
 (restrict to diarized media whose `speakers:` frontmatter names a given person).
+
+Performance presets:
+- Normal lookup: `detail="compact"`, `rerank=false`.
+- Reasoning context: `pack=true` when you need a compressed evidence bundle.
+- Diagnostics: `include_timings=true`; add `rerank=true` only when you are
+  intentionally measuring reranking. Interpret timing output with the returned
+  compute mode, embedding backend, cache state, rerank flag, and search profile.
 
 **Tabular data is card-based.** Raw CSV/JSON/TSV rows are never embedded and raw
 data files aren't `find`-searchable. To make a dataset findable, write a
@@ -538,7 +553,7 @@ under the vault root with no prefix guessing:
 `Sources/` file via the `sources:` frontmatter list (mirrors the source's
 `ingested_into:` list).
 
-**The writer normalizes on your behalf.** exomem's writers run every wikilink
+**The writer normalizes on your behalf.** Exomem's writers run every wikilink
 through `vault.normalize_wikilink()` before writing — bare names, KB-relative
 paths, `.md` suffixes, and stale paths get rewritten to canonical full form. You
 can write in any form; the on-disk file lands canonical.

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -1,6 +1,6 @@
 # Operations
 
-Detailed specs for each operation. Read on first use of an operation.
+Detailed specs for the Knowledge Base operations. Read on first use of an operation.
 
 ## Index and log discipline (applies to every write)
 
@@ -20,8 +20,44 @@ bookkeeping updates:
    `<op>` is one of: `add`, `note`, `link`, `preserve`, `replace`, `edit`,
    `audit`. (`find` doesn't append because it's read-only.)
 
-These two updates are non-negotiable for every operation below. The per-operation
-specs note their primary writes; the index + log update is implicit.
+These two updates are non-negotiable for every write operation below. Read-only
+operations such as `bootstrap`, `find`, `get`, `suggest_links`, `overview`,
+`propose_compilation`, `query_data`, `provenance_report`, and `download` do not
+update indexes or logs. The per-operation specs note their primary writes; the
+index + log update is implicit.
+
+---
+
+## bootstrap
+
+**Goal:** Return a portable, versioned operating contract so generic MCP clients
+can use Exomem without relying on a client-specific skill.
+
+### Triggers
+- A new MCP session in ChatGPT, Cursor, Codex, Gemini, Windsurf, or another
+  client that only receives tool schemas.
+- The agent needs to understand preferred workflows, defaults, retrieval modes,
+  upload semantics, or performance diagnostics.
+- A skill-aware client is diagnosing retrieval speed or comparing CPU/GPU/low
+  power behaviour.
+
+### Profiles
+- `profile="compact"` — terse operation map and defaults. Use for normal startup.
+- `profile="default"` — startup contract plus workflow guidance and examples.
+- `profile="diagnostics"` — includes timing/performance guidance, search profile,
+  compute mode, backend/cache hints, rerank state, and recommended debug knobs.
+
+### Procedure
+1. Call once at the beginning of a generic MCP-client session.
+2. Treat the returned contract as behavioural guidance for tool choice: search
+   before absence claims, use compiled notes for durable conclusions, preserve raw
+   evidence separately, and prefer supersession over deletion.
+3. Use diagnostics output when interpreting search latency. Do not label Exomem
+   slow from a single CPU rerank measurement; identify whether rerank, embedding
+   backend, compute mode, cache state, or cold start dominated the run.
+
+### Writes performed
+None.
 
 ---
 
@@ -172,10 +208,15 @@ Binaries are delivered out-of-band — never inline as a tool argument (the
   multipart-`curl` each attached file to `upload_url` with `Authorization: Bearer
   <token>` and form fields `file` / `scope` / `category` (optional `filename`,
   `description`, **`text`**); (3) **searchability is automatic** — the server
-  transcribes audio/video (Whisper), OCRs images (Tesseract), and reads PDFs after
-  the upload and fills an embedded sidecar, so the binary becomes findable by its
-  content. You *may* still pass a `text` field to supply your own extraction; it
-  wins and skips the server pass. No inline bytes, no pasted secret. Files must be
+  transcribes audio/video (Whisper), OCRs images (Tesseract), reads PDFs
+  (pymupdf), extracts office/web documents (docx/xlsx/pptx/html via MarkItDown;
+  txt/eml/ics via native parsers), and CLIP-embeds images and per-keyframe video
+  frames for visual search. It fills an embedded sidecar so the binary becomes
+  findable by content. You *may* still pass a `text` field to supply your own
+  extraction; it wins and skips the server pass. Upload responses return concrete
+  metadata (`stored_path`, `size`, `hash`, `hash_algorithm`, `media_id`,
+  `content_type`) so agents can report exactly what landed. No inline bytes, no
+  pasted secret. Files must be
   **attached** (inline-pasted images never land on the sandbox disk), and the host
   must be in the sandbox's egress allowlist (Settings → network; one-time). If the
   sandbox can't reach the host, fall back to handing the user the prefilled link
@@ -242,6 +283,18 @@ Search for modes, scope, and ranking knobs.
 - "what do I have on X," "find my notes on Y"
 - "have I covered Z," "show me everything tagged W"
 - "list all my failure modes on <project>"
+
+### Diagnostics and performance
+- Normal lookup: `detail="compact"`, `rerank=false`.
+- Reasoning context: `pack=true` when you need a compact evidence bundle for
+  downstream reasoning.
+- Diagnostics: `include_timings=true`; add `rerank=true` only when you are
+  intentionally measuring reranking. Timing output should be interpreted with the
+  returned compute mode, embedding backend, cache state, rerank flag, and search
+  profile when present.
+- If one search misses, try synonyms and adjacent domain terms before concluding
+  the KB lacks coverage. Example: `wood`, `woods`, `smoke`, `smoking`, `kamado`,
+  `grill`, `apple`, `oak`, `hickory`.
 
 ### Edge cases
 - **No filesystem MCP available.** This skill cannot run without a connected KB server. Surface this and stop — don't fake search.

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -123,6 +123,13 @@ On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 resolves to the right tool. `find` is the read-only hybrid (semantic + keyword)
 search and your default entry point.
 
+This skill is the rich behavioural contract for Exomem-aware agents. If this
+file has been read, routine KB work does not need a separate `bootstrap()` call.
+Generic MCP clients without this skill should call `bootstrap()` once at session
+start to get the portable operating contract. Skill-aware agents may still use
+`bootstrap(profile="diagnostics")` when interpreting retrieval speed, compute
+mode, reranking, `pack`, or `include_timings`.
+
 The Tier 2 filesystem ops below may be turned off on lean deployments
 (`EXOMEM_DISABLE_TIER2`), in which case only the Tier 1 ops are registered.
 
@@ -141,12 +148,13 @@ and index updates are determined by the operation, not the caller.
 
 | Op | Intent | Writes to |
 |---|---|---|
+| **bootstrap** | Return a portable, versioned operating contract for generic MCP clients. Skill-aware agents can skip routine calls after reading this file; use diagnostics profile for timing/performance interpretation | — |
 | **add** | Capture raw input as immutable source | `Sources/<type>/` |
 | **note** | Compile a structured note from raw input or thinking | `Notes/<type>/` |
 | **link** | Create or update an entity, wire backlinks | `Entities/<type>/` |
 | **preserve** | Capture a **text** factual artifact for an incident scope. Binaries (PDF / image / any file) go out-of-band via upload (see below), not this tool | `Evidence/<scope>/` |
 | **edit** | In-place edit of a compiled page. One mode per call: whole `body` / `tags` / surgical `old_string`→`new_string`; `edits=[…]` several surgical pairs in one atomic batch; `row_key`+`take` fill a `[take: ]` row by its leading text; `field`+`value` patch ONE frontmatter field (requires `why:`). Bumps `updated:`. Optional `expected_hash` (drift guard) + `validate_only` | the page |
-| **find** | Type-aware search across the KB (read-only) | — |
+| **find** | Type-aware search across the KB (read-only). Supports compact lookups, packed reasoning context, and diagnostics via `include_timings` / `rerank` when needed | — |
 | **suggest_links** | Surface existing pages a draft or page should link to, hub-aware (read-only) | — |
 | **get** | Read a full file by path; `frontmatter_only=true` returns just the frontmatter. Returns `content_hash` + `mtime` for the two-writer drift guard (echo `content_hash` to `edit` via `expected_hash`). Read-only | — |
 | **audit** | Lint pass: orphans, broken links, supersession integrity, aged unprocessed sources | proposals only |
@@ -196,7 +204,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   and CLIP-embeds images and per-keyframe video frames for visual search — all
   server-side after upload, filling an embedded sidecar so any upload becomes
   findable by content. You *may* still pass a `text` field to supply your own
-  extraction; it takes precedence. The write tools take text only and reject
+  extraction; it takes precedence. Upload responses return concrete metadata (`stored_path`, `size`, `hash`, `hash_algorithm`, `media_id`, `content_type`) so agents can report exactly what landed. The write tools take text only and reject
   inline byte blobs (`BINARY_BLOB_REJECTED`). Full workflow:
   `references/operations.md` § preserve.
 - **Pull a vault file back out — the download channel.** Call
@@ -295,6 +303,13 @@ favours compiled types over raw `source`), `prefer_active=true` (default;
 soft-demotes superseded pages), and `file_types` / `exclude_file_types` (scope to
 or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
 `pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`).
+
+Performance presets:
+- Normal lookup: `detail="compact"`, `rerank=false`.
+- Reasoning context: `pack=true` when you need a compressed evidence bundle.
+- Diagnostics: `include_timings=true`; add `rerank=true` only when you are
+  intentionally measuring reranking. Interpret timing output with the returned
+  compute mode, embedding backend, cache state, rerank flag, and search profile.
 
 **Tabular data is card-based.** Raw CSV/JSON/TSV rows are never embedded and raw
 data files aren't `find`-searchable. To make a dataset findable, write a
@@ -482,7 +497,7 @@ under the vault root with no prefix guessing:
 `Sources/` file via the `sources:` frontmatter list (mirrors the source's
 `ingested_into:` list).
 
-**The writer normalizes on your behalf.** exomem's writers run every wikilink
+**The writer normalizes on your behalf.** Exomem's writers run every wikilink
 through `vault.normalize_wikilink()` before writing — bare names, KB-relative
 paths, `.md` suffixes, and stale paths get rewritten to canonical full form. You
 can write in any form; the on-disk file lands canonical.


### PR DESCRIPTION
## Summary
- update the canonical Exomem skill scaffold with the portable `bootstrap()` guidance
- document lookup/reasoning/diagnostics search presets and upload response metadata
- add the bootstrap operation reference and fix stale generated-skill source wording

## Verification
- `git diff --check -- src/exomem/_sample_vault/Knowledge Base/_Schema/SKILL.md src/exomem/_scaffold/_Schema/SKILL.md src/exomem/_scaffold/_Schema/references/operations.md tests/fixtures/Knowledge Base/_Schema/SKILL.md`
- `python -m pytest tests/test_scaffold_no_leak.py tests/test_install_skill.py tests/test_init.py tests/test_demo.py --basetemp C:\tmp\pytest-exomem-skill-source-... -o cache_dir=C:\tmp\pytest-cache-exomem-skill-source -q --tb=short`
