### PR TITLE
feat(resource): complete low-interrupt quiet mode

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -198,6 +198,32 @@ uv run python -m exomem doctor --vault "/path/to/your/Obsidian" --profile lean
 uv run python -m exomem doctor --vault "/path/to/your/Obsidian" --profile hybrid
 ```
 
+### Resource modes
+
+The safe default is `normal`: CPU steady-state, no automatic CUDA residency, and
+warm CPU caches allowed. For gaming or other foreground work, switch to quiet:
+
+```bash
+uv run python -m exomem mode quiet
+uv run python -m exomem status --resources --json
+```
+
+Quiet skips heavy startup warm-up, makes large caches evictable, and defers
+expensive semantic/CLIP indexing while keeping cheap freshness/inbound/resolver
+updates live. After foreground work, return to `normal` or run an explicit heal:
+
+```bash
+uv run python -m exomem mode normal
+uv run python -m exomem index --vault "/path/to/your/Obsidian"
+uv run python -m exomem reconcile --vault "/path/to/your/Obsidian"
+```
+
+Use `performance` only when you explicitly want GPU-capable bulk/model work:
+
+```bash
+uv run python -m exomem mode performance
+```
+
 ---
 
 ## 5. Add it to Claude Code

--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ The first start downloads search models in the background — `find` works
 immediately with keyword ranking and upgrades to semantic search automatically
 once the models land. Run `exomem warm` to pre-download them ahead of time.
 
+## Resource modes
+
+Exomem is CPU-first by default so an idle server does not quietly occupy GPU
+memory. Control the machine footprint without editing code:
+
+```bash
+exomem mode quiet          # low-resource: no heavy warm-up, evict caches, defer semantic reindex
+exomem mode normal         # default: CPU steady-state, warm CPU caches allowed
+exomem mode performance    # explicit opt-in for GPU-capable bulk/model work
+exomem status --resources --json
+```
+
+Use `quiet` before gaming or other foreground workloads. Keyword/BM25 freshness,
+file-change freshness, inbound links, and resolver state stay live; expensive
+semantic/CLIP reindex work can be deferred and is reported in resource status.
+Run `exomem index` or `kb reconcile` later to heal deferred semantic work.
+
 ## What it does
 
 - **Searches the vault you already own.** Markdown stays in place; exomem does
@@ -276,9 +293,9 @@ System tools: Tesseract is required for image OCR. On Windows:
 winget install --id UB-Mannheim.TesseractOCR -e
 ```
 
-GPU acceleration is useful but not required, and cross-platform: NVIDIA **CUDA**
-(Linux/Windows) and Apple Silicon **MPS/Metal** (macOS) are both auto-detected for
-the torch models (bge embeddings, reranker, CLIP), with CPU as the fallback. See
+GPU acceleration is useful but not required. Steady-state torch models default to
+CPU in `normal` and `quiet`; `performance` is the explicit opt-in for capable
+NVIDIA CUDA or Apple Silicon MPS/Metal paths. See
 [docs/deployment.md](docs/deployment.md) for CUDA, Blackwell, Apple Silicon,
 diarization, and remote-service details.
 
@@ -295,7 +312,10 @@ The server reads environment variables or a `.env` file. The main ones are:
 | `EXOMEM_REST_API_KEY` | Enables authenticated REST routes. |
 | `EXOMEM_DISABLE_MEDIA_EXTRACTION` | `1` skips server-side OCR/ASR/PDF/Office extraction. |
 | `EXOMEM_DISABLE_CLIP` | `1` disables CLIP image search. |
-| `EXOMEM_TORCH_DEVICE` | Force the device for all torch models: `cuda`, `mps`, or `cpu` (default: auto-detect CUDA → MPS → CPU). Pin `cpu` to avoid thermal throttling on a fanless Mac. |
+| `EXOMEM_MODE` | Hard-pin resource mode: `quiet`, `normal`, or `performance`. Env wins over config. |
+| `EXOMEM_QUIET_MODE` | Legacy truthy alias for `quiet` when `EXOMEM_MODE` is unset. |
+| `EXOMEM_AUTO_QUIET` | `1` enables optional non-torch GPU-pressure auto-quiet switching (default off). |
+| `EXOMEM_DEVICE` / `EXOMEM_TORCH_DEVICE` | Force all torch models to `cuda`, `mps`, or `cpu`. Normally leave unset and use `exomem mode`. |
 | `EXOMEM_MPS_FP16` | On Apple Silicon, run bge/CLIP in fp16 on the Metal GPU — ~half the memory, faster encodes (default on; set `0` to keep fp32). |
 | `EXOMEM_VIDEO_SCENE_FRAMES` | Set to enable video scene detection + persisted, OCR'd scene-frame JPEGs (default off). |
 | `EXOMEM_VIDEO_SCENE_THRESHOLD` | Scene-boundary hash threshold in bits of 64 (default 10). |

--- a/openspec/changes/complete-low-interrupt-mode/.openspec.yaml
+++ b/openspec/changes/complete-low-interrupt-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/complete-low-interrupt-mode/design.md
+++ b/openspec/changes/complete-low-interrupt-mode/design.md
@@ -1,0 +1,336 @@
+## Context
+
+The v0.10.0 codebase already contains the core GPU residency fix: `mode.py`
+defines `quiet|normal|performance`, `accel.py` makes CUDA opt-in and
+headroom-gated, `warmup.py` skips model preloads in quiet, and
+`model_reaper.py` unloads idle model singletons. That solves the largest idle
+VRAM problem, but it does not yet make quiet mode a complete low-resource state.
+
+The remaining user-visible problem is broader resource residency and background
+work:
+
+- large CPU caches can remain resident after warm-up or queries: parsed pages,
+  hot `find` results, resolver state, BM25 corpora/tokens, embedding matrices,
+  and CLIP matrices;
+- writer/watcher/reconcile paths can perform CPU-heavy indexing while the user is
+  trying to game or run another foreground workload;
+- the current status surface explains the mode policy, but not what is actually
+  resident or deferred.
+
+The design constraint is to keep Exomem correct and self-hostable while allowing
+quiet mode to trade latency and freshness for lower host interference. CPU-only
+and marginal-GPU hosts remain first-class. Optional detectors must be default-off
+and soft-fail. Any detector is substrate measurement only: it observes process,
+GPU, memory, or window state and switches policy; it never reasons over notes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `quiet` mean a full resource-saver posture:
+  - no CUDA allocation by default;
+  - no heavy startup preloads;
+  - large CPU-side caches are lazy and evictable;
+  - idle unload reclaims model and cache residency;
+  - watcher/reconcile work is coalesced, capped, or deferred.
+- Preserve result correctness when caches are evicted. A cold query may be slower,
+  but it must compute from disk/sidecars correctly.
+- Make semantic freshness in quiet explicit. Lightweight lexical/freshness
+  updates remain live; expensive embedding/CLIP work may be deferred and surfaced.
+- Keep `normal` as a safe default: CPU steady-state, no CUDA residency, but normal
+  latency-oriented CPU caches may remain warm.
+- Keep `performance` as the explicit high-throughput opt-in.
+- Provide a scriptable status surface that reports policy, residency, and
+  deferred work without loading torch models or allocating CUDA.
+- Make auto-quiet optional, default-off, and safe when probes are unavailable.
+
+**Non-Goals:**
+
+- No retrieval architecture rewrite, ANN backend, or new vector database.
+- No mandatory tray app in this change. CLI/config-file control remains the
+  baseline; a tray companion can be sized separately.
+- No server-side reasoning model, ranking judgment, or note-content inference.
+- No guarantee that quiet mode has the same latency as normal/performance. Quiet
+  intentionally favors foreground system behavior over warm-cache latency.
+- No guarantee that recently edited files have immediately fresh semantic/CLIP
+  rows while quiet mode is actively deferring expensive work. The lexical lane,
+  freshness metadata, and explicit reconcile/index paths remain the correctness
+  backstop.
+
+## Decisions
+
+### D1. Put policy in `mode.py`, not in each resource owner
+
+Add a small torch-free resource policy API to `mode.py`, for example:
+
+- `preload_cpu_caches() -> bool`
+- `retain_cpu_caches() -> bool`
+- `defer_expensive_indexes() -> bool`
+- `watcher_policy() -> WatcherPolicy`
+- `resolved() -> dict` including the above fields
+
+Existing helpers (`preload_models`, `release_when_idle`, `bulk_gpu_opted`) stay
+as compatibility wrappers over the same policy.
+
+Rationale: `mode.py` already owns the per-machine mode, config-file resolution,
+and live application. Keeping policy there avoids duplicating string checks in
+`warmup`, `find`, `embeddings`, and `file_watcher`, and preserves the current
+torch-free CLI dispatch path.
+
+Alternatives considered:
+
+- Read `EXOMEM_MODE` directly in every module. Rejected because it scatters
+  policy and makes live mode changes inconsistent.
+- Move mode policy into `accel.py`. Rejected because quiet mode now governs RAM
+  and CPU background work, not only torch/CUDA placement.
+
+### D2. Generalize the idle reaper to resource slots
+
+Extend `model_reaper.py` from model-only slots to generic idle resource slots
+while keeping the module entry points stable. The current `ModelSlot` shape is
+already close to the required contract:
+
+- `name`
+- `is_loaded()`
+- `inflight()`
+- `last_activity()`
+- `unload() -> bool`
+
+Add slots for large CPU resources:
+
+- bge/reranker/CLIP model singletons (existing);
+- embedding matrix caches and CLIP matrix caches;
+- BM25 corpora/token caches;
+- parsed page cache, resolver cache, and hot find-result cache;
+- optional lexical sidecar in-memory state if it is proven to hold meaningful RAM.
+
+Each resource owner exposes a narrow unload/status hook. The reaper coordinates
+only through the generic slot contract; it does not know how a BM25 index or
+embedding matrix is internally represented.
+
+Rationale: one idle loop already exists, is mode-aware, and is tested. Reusing it
+keeps live mode switching simple: entering quiet calls `apply_live()`, unloads
+models immediately, clears heavy caches, and ensures the reaper stays running.
+
+Alternatives considered:
+
+- Add separate reaper threads per module. Rejected because independent timers are
+  harder to reason about and can reintroduce background noise.
+- Clear every cache on every request end. Rejected because it would make quiet
+  mode unnecessarily slow and would punish short bursts of legitimate KB use.
+
+### D3. Add explicit unload/status hooks to heavy cache owners
+
+Implement narrow hooks rather than using broad test-only reset functions.
+
+Suggested hooks:
+
+- `embeddings.unload_index_caches()`: iterates process-shared
+  `EmbeddingIndex`/`ClipIndex` instances and atomically drops their `_cache`
+  matrices without deleting the index objects themselves.
+- `embeddings.index_cache_status()`: reports row counts and `matrix.nbytes`
+  where loaded.
+- `bm25.unload_cache()` / `bm25.cache_status()`: clears `_INDEX` corpora and
+  token caches, and reports corpus/token counts.
+- `find.unload_ram_caches()` / `find.cache_status()`: clears parsed pages,
+  resolver cache, and hot find cache, without clearing freshness registries or
+  inbound-link indexes unless explicitly requested.
+- `lexstore.cache_status()` and an unload hook only if the current store cache is
+  confirmed to hold material RAM beyond SQLite handles and small metadata.
+
+Do not use `find.clear_cache()` as the quiet-mode unload path because it also
+clears freshness and inbound state. In quiet mode the target is to remove heavy
+content/corpus residency while preserving lightweight metadata that prevents
+avoidable O(corpus) work.
+
+Concurrent safety rule: every unload hook swaps cache references to `None` or an
+empty dict under the module's existing lock. It must not mutate a matrix/list that
+an in-flight query may currently be reading. Existing queries may keep local
+references until they finish; future queries cold-load if needed.
+
+Rationale: explicit hooks give diagnostics and unload behavior a stable contract
+without changing the retrieval logic.
+
+### D4. Make startup warm-up mode-aware for CPU caches
+
+Change `warmup.warm_all()` and `warmup.warm_caches()` so quiet mode skips heavy
+CPU cache warm-up in addition to model preloads. In quiet:
+
+- do not walk all pages just to fill `find._CACHE`;
+- do not warm BM25 corpora;
+- do not warm resolver state;
+- do not touch embedding or CLIP matrices.
+
+Readiness behavior should still mark components so requests do not remain
+deferred forever. The first request computes what it needs lazily.
+
+Normal mode may keep today's CPU warm-up because it avoids CUDA and favors lower
+first-query latency. Performance mode keeps both CPU cache warm-up and model
+preloads.
+
+Rationale: quiet mode's idle RAM target is incompatible with warming O(vault)
+structures on boot.
+
+### D5. Defer expensive semantic/visual indexing in quiet mode
+
+Split index maintenance into cheap and expensive lanes:
+
+- cheap lanes: freshness registry, inbound/resolver patching, lexical sidecar
+  updates when they do not trigger O(corpus) repair;
+- expensive lanes: bge embedding, CLIP embedding, full lexical heal, and large
+  reconcile drift re-embedding.
+
+In quiet mode, writer/watcher paths should do cheap lanes promptly and queue or
+cap expensive lanes. The deferred queue should be durable enough for correctness
+across a server restart if feasible; otherwise it must be reconstructable by
+existing drift/reconcile checks. A pending-expensive-work status counter is
+required either way.
+
+When leaving quiet mode, a background flusher may process the queued expensive
+lanes according to the new mode:
+
+- `normal`: CPU, modest batches;
+- `performance`: GPU-capable batches when policy allows;
+- explicit `exomem index` / `reconcile`: process all pending work under user
+  control.
+
+Find behavior while expensive lanes are deferred:
+
+- keyword/BM25 and graph freshness should reflect the latest markdown;
+- vector/CLIP results may lag for changed files;
+- timing/status should surface that semantic or visual indexes have deferred
+  work, rather than pretending the sidecar is current.
+
+Rationale: a quiet pre-game state cannot also promise immediate semantic
+re-embedding for every filesystem or writer event. The important product promise
+is that Exomem does not interrupt the foreground workload, while correctness can
+be healed when the user leaves quiet mode or requests an explicit index.
+
+Alternatives considered:
+
+- Keep embedding-on-write in quiet because CPU is "safe". Rejected because the
+  user problem includes RAM and CPU spikes, not only VRAM.
+- Disable the watcher entirely in quiet. Rejected because it would lose cheap
+  freshness/inbound maintenance and make later reconciliation more expensive.
+
+### D6. Make watcher and reconcile read mode policy at runtime
+
+`FileWatcher` should consult a mode-derived policy instead of only constructor
+constants. Suggested fields:
+
+- `debounce_seconds`
+- `reconcile_interval_seconds`
+- `max_embed_files_per_batch`
+- `max_reconcile_embed_files`
+- `defer_expensive_indexes`
+
+Normal keeps today's behavior or close to it. Quiet increases debounce, lowers
+per-cycle caps, avoids BM25 warm-after-reconcile if that would materialize a
+large corpus, and queues expensive work instead of immediately embedding large
+drift batches.
+
+The reconcile loop should not need a restart to observe mode changes. It can read
+policy each cycle; the dispatch loop can read policy before waiting and before
+flushing.
+
+Rationale: the existing watcher is already the central point for coalescing and
+drift healing. Making it policy-aware is lower risk than adding a separate
+scheduler.
+
+### D7. Add a no-allocation resource status surface
+
+Extend `exomem mode --json` or add `exomem status --resources --json` using the
+same underlying helper. The status collection must be no-allocation:
+
+- do not import torch solely to answer status;
+- do not call APIs that create a CUDA context;
+- do not load models or sidecars;
+- report unknown/unavailable rather than probing destructively.
+
+Fields should include:
+
+- effective mode, source, and config path;
+- policy fields from `mode.resolved()`;
+- model residency booleans;
+- CUDA memory accounting only when CUDA is already initialized;
+- matrix/BM25/page/resolver/hot-cache residency estimates;
+- watcher/deferred-work counters;
+- auto-quiet state if enabled.
+
+Rationale: the user needs a quick "why is Exomem affecting my machine?" surface
+that is safe to call before gaming or from a script.
+
+### D8. Keep auto-quiet optional and probe with non-invasive signals
+
+Add `auto_quiet.py` only after manual quiet/resource-saver behavior is correct.
+It is controlled by `EXOMEM_AUTO_QUIET=1` or a config-file field and is disabled
+by default.
+
+Preferred signal order:
+
+1. Existing mode/config state: never override `EXOMEM_MODE`, because env is an
+   operator hard pin.
+2. GPU pressure from non-torch probes, for example `nvidia-smi` when present.
+   Do not import torch just to poll pressure.
+3. System memory pressure through platform-specific stdlib/optional probes.
+4. Fullscreen/game process detection only as a stretch path and only when it is
+   reliable enough to avoid flapping.
+
+Auto-quiet stores the previous config-file mode and restores it after pressure
+clears for a hysteresis window. It should not restore over a manual user change
+made while pressure was active.
+
+Rationale: auto-quiet is useful, but a wrong auto-switch is worse than a manual
+toggle. The manual `exomem mode quiet` path must remain the reliable baseline.
+
+## Risks / Trade-offs
+
+- Cold first query after quiet may be slower -> Accept this as the quiet-mode
+  trade-off; keep normal/performance for warm-cache latency.
+- Deferred semantic indexing can make vector/CLIP recall stale for recent edits
+  -> Surface pending work in status/timings, keep lexical freshness live, and
+  provide explicit `exomem index`/`reconcile` healing.
+- Cache eviction could race an in-flight query -> Use atomic reference swaps
+  under existing locks; never mutate arrays/lists in place.
+- Clearing too much metadata could cause more O(corpus) work and worsen CPU
+  interruption -> Keep lightweight freshness/inbound metadata by default; evict
+  heavy content/corpus/matrix caches first.
+- Auto-quiet could flap between modes -> Use hysteresis, cooldowns, and never
+  override an explicit `EXOMEM_MODE` env pin or a manual mode change.
+- Resource estimates may be approximate -> Label them as estimates and keep the
+  status surface useful for directionality, not byte-perfect accounting.
+- Optional probes may be missing or platform-specific -> Treat absence as
+  "unknown" and continue in manual mode without errors.
+
+## Migration Plan
+
+1. Land policy helpers in `mode.py` and tests for `quiet`, `normal`, and
+   `performance`.
+2. Add heavy-cache unload/status hooks without changing runtime behavior.
+3. Extend `model_reaper.py` to include cache slots and apply them on quiet
+   entry/idle.
+4. Make `warmup.py` honor CPU-cache preload policy.
+5. Make watcher/reconcile/index dispatch mode-aware, with deferred expensive
+   work surfaced in status.
+6. Add resource status JSON and doctor/setup messaging that does not allocate
+   CUDA or load models.
+7. Add optional auto-quiet after manual quiet behavior is tested.
+
+Rollback strategy: because this is mode-gated, rollback can first set mode to
+`normal` or disable the new policy fields through env/config flags. Code rollback
+is straightforward because the core retrieval algorithms and sidecar schemas do
+not change.
+
+## Open Questions
+
+- What should the quiet idle threshold default be for CPU caches? The existing
+  model threshold is 15 minutes; quiet may need a shorter default such as 1-5
+  minutes.
+- Should deferred expensive work be persisted as a small queue, or is it enough
+  to rely on drift detection plus explicit `index`/`reconcile`? Persistence is
+  more explicit; drift reconstruction is less state.
+- Should `normal` retain embedding matrices after a query? Current behavior
+  favors latency. The design keeps that for now and limits aggressive RAM
+  eviction to quiet unless measurements show normal is still too heavy.
+- Which memory-pressure probe is worth supporting first on Windows without a new
+  dependency?

--- a/openspec/changes/complete-low-interrupt-mode/proposal.md
+++ b/openspec/changes/complete-low-interrupt-mode/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+Exomem must not make the host machine worse to use while it is idle. On a single
+gaming/dev box, the current failure mode is concrete: the server can occupy enough
+VRAM and RAM, and run enough background indexing work, to change foreground system
+behavior before the user has made a query.
+
+This change completes quiet mode as a real low-resource operating state, not only
+a CUDA policy. The goal is that leaving Exomem running should be compatible with
+gaming and other foreground workloads: no idle GPU residency, bounded idle RAM,
+deferred/healed background work, and a visible way to enter and inspect that state.
+
+## What Changes
+
+- Tighten the compute modes around explicit resource posture:
+  - `quiet`: low-resource / do-not-interrupt mode. No CUDA use, no heavy startup
+    preloads, no large find/index caches held merely because the server is idle,
+    idle unload enabled, and background maintenance throttled.
+  - `normal`: safe default. CPU steady-state, CUDA only for short-lived bulk CLI
+    work when capable, normal latency-oriented CPU caches allowed.
+  - `performance`: explicit opt-in to GPU and warm caches for speed.
+- Add RAM residency controls for quiet mode:
+  - Do not warm or retain embedding/CLIP matrices, BM25 corpora, resolver/page
+    caches, or other O(vault) structures unless an actual request needs them.
+  - Evict large CPU-side caches after an idle window or when switching into quiet.
+  - Keep correctness: the first query may pay cold-cache cost, but it must return
+    the same result as normal mode.
+- Keep the existing GPU protections and make them measurable:
+  - CUDA remains opt-in and capability-gated.
+  - Reranker and CLIP remain lazy and never preload in quiet.
+  - Idle unload still calls model unload and best-effort CUDA cache release.
+  - Add diagnostics that report current mode, model residency, CUDA memory
+    accounting when available, and large CPU cache residency.
+- Make watcher/reconcile behavior mode-aware:
+  - In quiet mode, coalesce filesystem bursts more aggressively, avoid
+    user-visible CPU spikes, and cap/defer reconcile-driven re-embedding.
+  - Prevent O(corpus) sidecar repair from running repeatedly on the hot path.
+  - Maintain eventual correctness through deferred batches, explicit reconcile,
+    and logged drift/caps.
+- Add an optional auto-quiet layer:
+  - Default off and soft-fail: if GPU-pressure/fullscreen-process detection is
+    unavailable, Exomem behaves exactly as manual mode does.
+  - When enabled, observe local machine pressure signals and switch to quiet when
+    the GPU or system memory is under pressure, then restore the previous mode
+    after the pressure clears.
+  - This is pure substrate measurement and policy switching: it runs no reasoning
+    model and makes no note-content judgment.
+- Extend mode UX without requiring code edits:
+  - Keep `exomem mode quiet|normal|performance`.
+  - Add low-resource aliases such as `resource-saver`/`low-resource` only if they
+    normalize to `quiet`.
+  - Expose a stable JSON status suitable for scripts and a pre-game routine.
+
+No breaking changes are intended. Existing env overrides and manual GPU opt-in
+remain available for users who deliberately want the old high-throughput behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `resource-governance`: Defines Exomem's machine-resource modes, resource-saver
+  guarantees, RAM/VRAM residency expectations, idle unload behavior, optional
+  auto-quiet switching, and diagnostics. This is the main contract for "Exomem
+  must not negatively affect foreground system use."
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: Quiet mode changes the residency policy for find's
+  large CPU-side structures. The requirement change is that `find` remains
+  correct when matrices/corpora/resolver/page caches are lazy or evicted, while
+  normal/performance modes may still keep latency-oriented caches warm.
+- `live-index-freshness`: Watcher and periodic reconcile behavior become
+  mode-aware. Quiet mode may defer, coalesce, throttle, and cap background repair
+  work, while preserving eventual freshness and explicit reconcile correctness.
+- `command-surface`: The CLI must expose mode switching and resource status in a
+  scriptable form, including low-resource aliases that map to quiet mode and JSON
+  status suitable for automation.
+- `install-readiness`: Doctor/setup checks must treat CPU-only and marginal-GPU
+  hosts as first-class supported configurations, and should surface the current
+  resource posture and remediation without loading models or allocating CUDA.
+
+## Impact
+
+- Affected code:
+  - `src/exomem/mode.py`: resource-mode policy, aliases, live mode application.
+  - `src/exomem/accel.py`: GPU capability/headroom diagnostics and CUDA-safe
+    accounting.
+  - `src/exomem/model_reaper.py`: idle unload for model and large-cache slots.
+  - `src/exomem/warmup.py`: quiet-mode cache warm-up suppression.
+  - `src/exomem/embeddings.py`: embedding/CLIP matrix residency, lazy reload, and
+    unload hooks.
+  - `src/exomem/bm25.py`, `src/exomem/find.py`, resolver/page caches: RAM cache
+    accounting and eviction hooks.
+  - `src/exomem/file_watcher.py`, `src/exomem/reconcile.py`,
+    `src/exomem/index_sync.py`: quiet-mode debounce, batch caps, and deferred
+    repair.
+  - `src/exomem/__main__.py`, `src/exomem/doctor.py`, setup paths: CLI/status and
+    no-allocation diagnostics.
+- APIs and surfaces:
+  - Existing `exomem mode` remains the baseline control.
+  - JSON status may gain resource fields for current mode, residency, and policy.
+  - Optional auto-quiet configuration is default-off and soft-fail.
+- Dependencies:
+  - No mandatory new heavy dependency.
+  - Any OS/GPU pressure detector must be optional, platform-gated, and degrade to
+    manual mode when unavailable.
+- Verification:
+  - Unit tests for mode policy, cache eviction decisions, watcher throttling, and
+    no-CUDA/no-torch soft failure.
+  - Integration or desk-side checks for idle VRAM near zero in quiet/normal when
+    GPU features are unused.
+  - Regression checks that `find` results stay identical across warm and evicted
+    cache states, with latency allowed to trade off only in quiet mode.

--- a/openspec/changes/complete-low-interrupt-mode/specs/command-surface/spec.md
+++ b/openspec/changes/complete-low-interrupt-mode/specs/command-surface/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Resource Mode CLI Is Scriptable
+
+The system SHALL expose resource mode controls through the CLI without requiring
+code edits. The CLI SHALL support showing the current mode and setting the mode
+to `quiet`, `normal`, or `performance`. Low-resource aliases such as
+`resource-saver` or `low-resource`, if accepted, MUST normalize to `quiet`.
+Machine-readable output SHALL include the effective mode, source, config path,
+and resolved resource policy fields.
+
+#### Scenario: Show resource mode as JSON
+
+- **WHEN** the user runs the mode command with JSON output enabled
+- **THEN** the command emits stable JSON containing the effective mode, mode
+  source, config path, and resource policy fields
+- **AND** the command exits with status 0
+
+#### Scenario: Low-resource alias maps to quiet
+
+- **WHEN** the user sets the mode through an accepted low-resource alias
+- **THEN** the persisted canonical mode is `quiet`
+- **AND** subsequent mode status reports `quiet`
+
+#### Scenario: Running server applies CLI mode change
+
+- **WHEN** the CLI writes a new config-file mode
+- **THEN** a running server observes the change through the existing mode-watch
+  mechanism and applies the corresponding resource policy without a restart
+
+### Requirement: Resource Status CLI Is No-Allocation
+
+The system SHALL expose a scriptable resource status command or mode-status flag
+that reports residency and deferred-work diagnostics without allocating heavy
+resources. It MUST NOT load models, create sidecars, read vector matrices, or
+initialize CUDA solely to answer status.
+
+#### Scenario: Status is safe before gaming
+
+- **WHEN** the user runs the resource status command before starting a foreground
+  workload
+- **THEN** the command reports mode policy, loaded models, large-cache residency,
+  deferred work, and CUDA accounting when already initialized
+- **AND** the command does not initialize CUDA or load any absent model/cache
+
+#### Scenario: Unknown probes are represented explicitly
+
+- **WHEN** a platform-specific resource metric cannot be read without allocation
+  or without an unavailable dependency
+- **THEN** the JSON status reports that metric as unknown or unavailable
+- **AND** the command still exits successfully if the rest of status collection
+  succeeds

--- a/openspec/changes/complete-low-interrupt-mode/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/complete-low-interrupt-mode/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: Startup Cache Warm-Up
+
+The system SHALL warm the BM25 index (KB and vault scope), the wikilink resolver,
+and the parsed-page cache during server startup when startup warm-up is enabled
+and the active resource policy allows CPU cache preloading, so that a subsequent
+`find` call does not pay first-call index/resolver/page-parse construction cost.
+Warm-up SHALL be skipped when disabled by `EXOMEM_DISABLE_WARMUP` or when the
+active resource policy is `quiet`, where low RAM residency is preferred over
+first-query latency. Warm-up SHALL soft-fail per stage without preventing server
+startup and MUST NOT change `find`'s returned results.
+
+#### Scenario: Warm-up primes caches before the first query
+
+- **WHEN** the server starts with warm-up enabled
+- **AND** the active resource policy allows CPU cache preloading
+- **THEN** the BM25 index for KB scope, the BM25 index for vault scope, the
+  wikilink resolver, and the parsed-page cache are populated before the first
+  `find` call is served
+- **AND** the first `find` call's results are identical to what it would return
+  without warm-up
+
+#### Scenario: Warm-up can be disabled
+
+- **WHEN** the server starts with `EXOMEM_DISABLE_WARMUP` set
+- **THEN** no warm-up work is performed at startup
+- **AND** `find` still returns correct results, built lazily on first use as it
+  does today
+
+#### Scenario: Quiet mode skips CPU cache warm-up
+
+- **WHEN** the server starts in `quiet` mode
+- **THEN** startup warm-up does not populate BM25 corpora, the wikilink resolver,
+  parsed-page cache entries, embedding matrices, or CLIP matrices solely for
+  warm-up
+- **AND** `find` still returns correct results by building the required data
+  lazily on first use
+
+#### Scenario: A warm-up stage failure does not block startup
+
+- **WHEN** one warm-up stage (for example, building the BM25 vault-scope index)
+  fails
+- **THEN** the server still starts successfully
+- **AND** the failure is logged without raising, and other allowed warm-up stages
+  still run
+
+## ADDED Requirements
+
+### Requirement: Quiet Mode Uses Evictable Find Caches
+
+The system SHALL make find's large CPU-side caches evictable in quiet mode. This
+includes parsed pages, hot find-result entries, resolver state, BM25 corpora and
+token caches, embedding matrices, and CLIP matrices. Eviction MUST NOT delete
+sidecar rows, mutate vault files, or disable future `find` calls.
+
+#### Scenario: Entering quiet evicts find caches
+
+- **WHEN** the process has populated find-related RAM caches
+- **AND** the effective mode changes to `quiet`
+- **THEN** the process evicts the large find-related RAM caches that can be
+  rebuilt lazily
+- **AND** no vault file or sidecar row is deleted as part of cache eviction
+
+#### Scenario: Idle quiet cache is evicted
+
+- **WHEN** the effective mode is `quiet`
+- **AND** a find-related RAM cache has been idle longer than the configured idle
+  threshold
+- **THEN** the idle resource reaper evicts that cache
+
+#### Scenario: Find after eviction is correct
+
+- **WHEN** a `find` request runs after quiet-mode cache eviction
+- **THEN** `find` rebuilds or reloads the required cache data from the vault or
+  sidecar
+- **AND** the ranked result paths match a warm-cache request over the same vault
+  and sidecar state
+
+### Requirement: Resource Status Reports Find Cache Residency
+
+The system SHALL expose best-effort residency diagnostics for find-related caches
+without loading those caches. Diagnostics SHALL include whether each large cache
+class is loaded and SHOULD include counts or byte estimates when those values are
+available from existing in-memory objects.
+
+#### Scenario: Status reports matrix cache residency
+
+- **WHEN** an embedding or CLIP matrix cache is resident
+- **THEN** resource status reports that the matrix cache is loaded and includes
+  its row count or byte estimate
+- **AND** the status call does not read the sidecar to compute that value
+
+#### Scenario: Status reports absent cache without loading it
+
+- **WHEN** a BM25 corpus or parsed-page cache is not resident
+- **THEN** resource status reports it as absent or zero-sized
+- **AND** the status call does not build the cache to answer the query

--- a/openspec/changes/complete-low-interrupt-mode/specs/install-readiness/spec.md
+++ b/openspec/changes/complete-low-interrupt-mode/specs/install-readiness/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Doctor Reports Resource Posture Without Heavy Allocation
+
+The doctor command SHALL report the current resource posture for local installs
+without mutating the repo, vault, environment, service state, model caches, or
+CUDA state. The report SHALL identify the effective mode, CPU/GPU fallback
+posture, whether CUDA is required for the requested profile, and whether the host
+appears to be CPU-only or marginal for GPU use. The check MUST NOT load models,
+download model files, create sidecars, or initialize CUDA solely for diagnostics.
+
+#### Scenario: CPU-only host passes lean readiness
+
+- **WHEN** `doctor --profile lean` runs on a host with no usable CUDA device
+- **THEN** the doctor report does not fail because CUDA is absent
+- **AND** it reports that CPU is the supported baseline for the current profile
+
+#### Scenario: Marginal GPU produces remediation not failure for lean profile
+
+- **WHEN** `doctor --profile lean` or `doctor --profile hybrid` detects that the
+  GPU is absent, unavailable, or below the configured free-VRAM threshold
+- **THEN** the report explains that Exomem will use CPU unless the user explicitly
+  enables and satisfies GPU policy
+- **AND** the check does not allocate CUDA to prove that result
+
+#### Scenario: Resource posture appears in JSON output
+
+- **WHEN** `doctor --json` is run
+- **THEN** the JSON includes a resource-posture check with mode, policy, and
+  best-effort GPU availability fields
+- **AND** unknown probe results are represented as unknown or unavailable rather
+  than as failures
+
+### Requirement: Setup Recommends Safe Default Resource Mode
+
+The setup flow SHALL keep the safe resource default unless the user explicitly
+opts into performance mode. If setup detects a capable idle GPU, it MAY recommend
+performance mode for faster indexing, but it MUST explain that normal mode avoids
+steady-state CUDA residency and that quiet mode is available for gaming or other
+foreground workloads.
+
+#### Scenario: Capable GPU is discoverable but not silently enabled
+
+- **WHEN** setup detects a capable idle GPU
+- **THEN** setup may offer performance mode as an explicit option
+- **AND** setup does not silently switch the user into performance mode without
+  consent
+
+#### Scenario: Setup documents quiet mode
+
+- **WHEN** setup completes
+- **THEN** the user-facing next steps mention the CLI command for entering quiet
+  mode or inspecting resource status

--- a/openspec/changes/complete-low-interrupt-mode/specs/live-index-freshness/spec.md
+++ b/openspec/changes/complete-low-interrupt-mode/specs/live-index-freshness/spec.md
@@ -1,0 +1,111 @@
+## MODIFIED Requirements
+
+### Requirement: External File Edits Still Reindex Live
+
+The system SHALL continue to observe out-of-band markdown edits through the live
+watcher, including edits from Obsidian, mobile sync, manual filesystem writes,
+and git updates. Self-write suppression MUST NOT disable debounce, batching, or
+freshness/inbound maintenance for events that were not registered as
+Exomem-authored mutations. The watcher observes changes across the whole vault
+root, not only `Knowledge Base/`, but embedding reindex dispatch
+(`upsert_after_write`/`delete_after_remove`) MUST remain scoped to markdown under
+`Knowledge Base/` exactly as before. In `quiet` mode, expensive embedding and
+CLIP reindex work MAY be deferred or capped instead of running immediately, but
+cheap freshness and inbound-link maintenance MUST still reflect the observed
+filesystem change.
+
+#### Scenario: Manual markdown edit still upserts outside quiet mode
+
+- **WHEN** a markdown file under `Knowledge Base/` is modified outside an Exomem
+  writer path
+- **AND** the active resource policy does not defer expensive index work
+- **THEN** the watcher debounces the event and calls the embedding upsert path
+  for that file
+
+#### Scenario: Quiet manual markdown edit updates freshness and defers expensive work
+
+- **WHEN** a markdown file under `Knowledge Base/` is modified outside an Exomem
+  writer path
+- **AND** the effective mode is `quiet`
+- **THEN** the watcher updates freshness, inbound-link, and resolver state for
+  that file
+- **AND** the watcher records the expensive semantic or visual reindex work as
+  deferred rather than forcing immediate embedding work
+
+#### Scenario: Manual markdown delete still removes sidecar rows outside quiet mode
+
+- **WHEN** a markdown file under `Knowledge Base/` is deleted outside an Exomem
+  writer path
+- **AND** the active resource policy does not defer expensive index work
+- **THEN** the watcher debounces the event and calls the embedding delete path
+  with the vault-relative path
+
+#### Scenario: Vault-root edit outside KB updates freshness without embedding reindex
+
+- **WHEN** a markdown file outside `Knowledge Base/` but inside the vault root is
+  created, modified, or deleted
+- **THEN** the watcher observes the event and updates the vault-scope freshness
+  and inbound-link registries for that path
+- **AND** the watcher does not call embedding upsert or delete for that path
+
+## ADDED Requirements
+
+### Requirement: Quiet Mode Throttles Watcher And Reconcile Work
+
+The system SHALL make watcher dispatch and periodic reconcile mode-aware. In
+quiet mode the watcher SHALL use a low-interrupt policy that coalesces filesystem
+bursts more aggressively, caps expensive per-cycle indexing work, and avoids
+materializing large warm caches solely as a side effect of reconcile. The policy
+MUST be read at runtime so switching modes does not require restarting the
+server.
+
+#### Scenario: Quiet watcher coalesces bursts
+
+- **WHEN** the effective mode is `quiet`
+- **AND** multiple filesystem events arrive in a short burst
+- **THEN** the watcher waits for the quiet-mode debounce window and dispatches
+  one coalesced batch rather than one expensive operation per event
+
+#### Scenario: Quiet reconcile caps expensive reindex
+
+- **WHEN** periodic reconcile detects a large drift while the effective mode is
+  `quiet`
+- **THEN** freshness registries are corrected to match disk
+- **AND** expensive semantic or visual reindex work is capped or deferred
+- **AND** the cap or deferral is recorded for status or logs
+
+#### Scenario: Mode switch changes watcher policy without restart
+
+- **WHEN** the server is running and the effective mode changes from `quiet` to
+  `normal`
+- **THEN** the next watcher or reconcile cycle uses the normal-mode policy
+  without requiring a server restart
+
+### Requirement: Deferred Expensive Index Work Is Observable And Healable
+
+The system SHALL track expensive index work deferred by quiet mode. Deferred work
+SHALL be visible through resource status or logs, and it SHALL be healable by
+leaving quiet mode, running the explicit indexing command, or running explicit
+reconcile. Deferred work MUST NOT hide cheap freshness updates: keyword, BM25,
+and graph lanes SHALL see current markdown state when their underlying indexes
+can be updated cheaply.
+
+#### Scenario: Deferred work appears in status
+
+- **WHEN** quiet mode defers semantic or visual indexing work
+- **THEN** resource status reports that deferred expensive index work exists
+- **AND** it includes a best-effort count or summary of the pending paths
+
+#### Scenario: Leaving quiet can flush deferred work
+
+- **WHEN** deferred expensive index work exists
+- **AND** the effective mode changes from `quiet` to `normal` or `performance`
+- **THEN** Exomem may process the deferred work in the background according to
+  the new mode's device and batching policy
+
+#### Scenario: Explicit index heals deferred semantic work
+
+- **WHEN** deferred semantic index work exists
+- **AND** the user runs the explicit indexing command for the affected scope
+- **THEN** the command processes the changed files and clears the corresponding
+  deferred semantic work record

--- a/openspec/changes/complete-low-interrupt-mode/specs/resource-governance/spec.md
+++ b/openspec/changes/complete-low-interrupt-mode/specs/resource-governance/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: Resource Modes Define Host Footprint Policy
+
+The system SHALL expose resource modes that define how much of the host machine
+Exomem may occupy while running. The canonical modes SHALL be `quiet`, `normal`,
+and `performance`. `quiet` SHALL be the low-resource mode: CPU-only for steady
+state model work, no heavy startup preloads, idle unload enabled, large CPU-side
+caches evictable, and background maintenance throttled or deferred. `normal`
+SHALL be the safe default: CPU steady-state with no automatic CUDA residency, but
+latency-oriented CPU caches may remain warm. `performance` SHALL be an explicit
+high-throughput opt-in that may use a capable GPU and retain warm caches for
+speed.
+
+#### Scenario: Quiet mode resolves low-resource policy
+
+- **WHEN** the effective mode is `quiet`
+- **THEN** the resolved policy reports CPU steady-state device selection, disabled
+  heavy preloads, enabled idle unload, evictable CPU caches, and deferred expensive
+  background indexing
+
+#### Scenario: Normal mode does not automatically allocate CUDA
+
+- **WHEN** the effective mode is `normal`
+- **THEN** steady-state torch model selection does not choose CUDA unless an
+  explicit device override asks for it
+- **AND** normal mode may retain CPU-side caches for latency
+
+#### Scenario: Performance mode is explicit opt-in
+
+- **WHEN** the effective mode is `performance`
+- **THEN** CUDA may be selected only if the GPU capability and free-VRAM checks pass
+- **AND** the policy may preload and retain warm caches for speed
+
+### Requirement: Quiet Mode Reclaims Idle Model And Cache Residency
+
+The system SHALL reclaim resident model and large cache memory in quiet mode.
+Entering quiet mode SHALL unload loaded model singletons and SHALL evict large
+CPU-side caches that are safe to rebuild lazily, including vector matrices, CLIP
+matrices, BM25 corpora/tokens, parsed-page cache entries, resolver cache entries,
+and hot find-result cache entries. Idle unload SHALL repeat this reclamation after
+the configured idle window. Eviction MUST preserve correctness: later requests
+MUST rebuild or reload the needed data from the vault or sidecars.
+
+#### Scenario: Switching into quiet unloads resident resources
+
+- **WHEN** the process has loaded models and large find/index caches
+- **AND** the effective mode changes to `quiet`
+- **THEN** the process unloads model singletons and evicts large CPU-side caches
+- **AND** lightweight freshness and inbound-link metadata needed to avoid
+  unnecessary full-vault work remains available when safe
+
+#### Scenario: Idle quiet process reclaims resources
+
+- **WHEN** the effective mode is `quiet`
+- **AND** a loaded model or large cache has been idle longer than the configured
+  idle threshold
+- **THEN** the idle reaper unloads or evicts that resource without crashing the
+  process
+
+#### Scenario: Cache eviction preserves correctness
+
+- **WHEN** a large cache has been evicted in quiet mode
+- **AND** a later request needs that cache's data
+- **THEN** the request rebuilds or reloads the data from the authoritative vault
+  or sidecar source
+- **AND** it returns the same result it would return with a warm cache over the
+  same underlying state
+
+### Requirement: Resource Status Is No-Allocation
+
+The system SHALL provide a scriptable resource status surface that reports the
+effective mode, policy fields, model residency, large-cache residency, deferred
+work counters, and GPU memory accounting when already available. Gathering status
+MUST NOT load models, create sidecars, read entire matrices, or create a CUDA
+context. If a metric cannot be read without allocation or a platform-specific
+probe is unavailable, the status SHALL report it as unknown or unavailable.
+
+#### Scenario: Status does not create CUDA context
+
+- **WHEN** the process has not initialized CUDA
+- **AND** the user requests resource status
+- **THEN** the status command completes without initializing CUDA
+- **AND** CUDA memory accounting is reported as unavailable or not initialized
+
+#### Scenario: Status reports loaded resources
+
+- **WHEN** models or large CPU-side caches are resident
+- **THEN** resource status reports their loaded state and best-effort size or row
+  counts
+- **AND** the status command does not load any missing resource to compute those
+  fields
+
+### Requirement: GPU Use Degrades To CPU On Unsupported Or Marginal Hosts
+
+The system SHALL treat CPU as the universal baseline. A host with no CUDA, a torch
+build without usable CUDA, a CUDA probe failure, or a GPU below the configured
+free-VRAM threshold MUST degrade to CPU without failing startup, mode status,
+doctor checks, `find`, or writer paths. Warm-up and optional model loads MUST
+soft-fail and continue where CPU fallback is possible.
+
+#### Scenario: CPU-only host starts cleanly
+
+- **WHEN** the host has no usable CUDA device
+- **THEN** the server starts and reports CPU-backed policy without raising a GPU
+  error
+
+#### Scenario: Marginal GPU is declined
+
+- **WHEN** a GPU exists but the free-VRAM probe reports less than the configured
+  threshold
+- **THEN** Exomem declines CUDA for policy-gated model work
+- **AND** it falls back to CPU instead of attempting a GPU allocation
+
+### Requirement: Auto-Quiet Is Optional And Soft-Fail
+
+The system SHALL keep automatic quiet-mode switching disabled by default. When
+enabled, auto-quiet SHALL observe local machine pressure signals such as GPU
+pressure or memory pressure without importing torch or allocating CUDA solely for
+the probe. If probes are unavailable, fail, or are unsupported on the platform,
+auto-quiet SHALL log or report the unavailable signal and continue with manual
+mode behavior. Auto-quiet MUST NOT override an explicit `EXOMEM_MODE` environment
+pin.
+
+#### Scenario: Auto-quiet is disabled by default
+
+- **WHEN** no auto-quiet configuration is enabled
+- **THEN** Exomem changes modes only through the existing manual mode controls
+
+#### Scenario: Pressure enters and leaves quiet
+
+- **WHEN** auto-quiet is enabled
+- **AND** the configured pressure signal remains active past the hysteresis window
+- **THEN** Exomem switches the config-file mode to `quiet` and records the prior
+  config-file mode
+- **AND** when pressure clears past the restore window, Exomem restores the prior
+  mode unless the user changed modes manually while pressure was active
+
+#### Scenario: Probe failure does not change mode
+
+- **WHEN** auto-quiet is enabled but every configured pressure probe is unavailable
+  or fails
+- **THEN** Exomem does not crash
+- **AND** Exomem does not change the current mode based on the failed probe

--- a/openspec/changes/complete-low-interrupt-mode/tasks.md
+++ b/openspec/changes/complete-low-interrupt-mode/tasks.md
@@ -1,0 +1,70 @@
+## 1. Policy And Tests
+
+- [x] 1.1 Add unit tests for `mode.normalize()` covering `quiet`, `normal`, `performance`, `gpu`, `turbo`, `resource-saver`, and `low-resource`.
+- [x] 1.2 Add unit tests for `mode.resolved()` resource fields: CPU-cache preload, CPU-cache retention, expensive-index deferral, watcher policy, idle release, and bulk GPU policy.
+- [x] 1.3 Add tests proving `EXOMEM_MODE` remains the highest-precedence hard pin and cannot be overridden by config-file or auto-quiet state.
+- [x] 1.4 Add tests proving policy/status helpers do not import torch in a lean process.
+- [x] 1.5 Add fake-probe tests for CPU-only, CUDA probe exception, low free VRAM, and capable GPU behavior.
+
+## 2. Resource Policy
+
+- [x] 2.1 Extend `mode.py` aliases so accepted low-resource aliases normalize to `quiet`.
+- [x] 2.2 Add torch-free policy helpers in `mode.py` for CPU-cache preload, CPU-cache retention, expensive-index deferral, and watcher policy.
+- [x] 2.3 Include new resource policy fields in `mode.resolved()` and `exomem mode --json`.
+- [x] 2.4 Update `mode.apply_live()` so entering quiet unloads model singletons and heavy RAM caches.
+- [x] 2.5 Preserve existing env/config precedence, atomic config writes, and live mode-watch behavior.
+
+## 3. Cache Hooks And Reaper
+
+- [x] 3.1 Add `embeddings.unload_index_caches()` and `embeddings.index_cache_status()` with tests for loaded and absent embedding/CLIP matrix caches.
+- [x] 3.2 Add `bm25.unload_cache()` and `bm25.cache_status()` with tests proving later searches rebuild correctly.
+- [x] 3.3 Add `find.unload_ram_caches()` and `find.cache_status()` without clearing freshness or inbound-link metadata.
+- [x] 3.4 Audit `lexstore` residency and add status/unload hooks only if it holds material RAM.
+- [x] 3.5 Generalize `model_reaper.py` from model-only slots to generic resource slots while preserving start/stop behavior.
+- [x] 3.6 Add default reaper slots for models, embedding/CLIP matrices, BM25 caches, and find RAM caches.
+- [x] 3.7 Add tests proving the reaper unloads only loaded, idle, not-in-flight resources and soft-fails per slot.
+
+## 4. Quiet Startup And Find Correctness
+
+- [x] 4.1 Update `warmup.warm_caches()` so quiet skips parsed-page, BM25, resolver, embedding-matrix, and CLIP-matrix warm-up.
+- [x] 4.2 Preserve normal/performance warm-up behavior.
+- [x] 4.3 Add tests proving quiet startup marks readiness correctly and does not strand deferred writer work.
+- [x] 4.4 Add tests proving quiet startup does not call heavy CPU/vector warm-up helpers.
+- [x] 4.5 Add a regression test proving `find` after quiet cold start returns the same ranked paths as a warm-cache request over the same state.
+
+## 5. Watcher, Reconcile, And Deferred Work
+
+- [x] 5.1 Add tests proving `FileWatcher` reads watcher policy at flush/reconcile time so mode changes apply without restart.
+- [x] 5.2 Add quiet-mode burst coalescing tests for filesystem events.
+- [x] 5.3 Split index dispatch into cheap lanes and expensive lanes behind a shared dispatcher.
+- [x] 5.4 Add a deferred-work registry for expensive quiet-mode semantic/visual indexing with safe dedupe and status counts.
+- [x] 5.5 In quiet mode, update watcher flush so freshness/inbound/resolver work runs promptly while embedding/CLIP work is queued or capped.
+- [x] 5.6 In quiet mode, update periodic reconcile so freshness registries are corrected but large semantic/visual reindex work is capped or deferred.
+- [x] 5.7 Preserve non-quiet watcher behavior: external edits still upsert/delete embedding rows promptly when policy does not defer expensive work.
+- [x] 5.8 Add tests proving explicit index/reconcile processing clears corresponding deferred work.
+
+## 6. CLI, Doctor, And Setup
+
+- [x] 6.1 Add no-allocation resource status JSON with effective mode, source, config path, policy fields, loaded model flags, cache residency, deferred work, and CUDA accounting when already initialized.
+- [x] 6.2 Add tests proving resource status does not import torch, load models, create sidecars, read matrices, or initialize CUDA solely to answer status.
+- [x] 6.3 Add CLI tests for low-resource aliases persisting canonical `quiet`.
+- [x] 6.4 Add a no-allocation doctor resource-posture check for effective mode, CPU fallback, GPU availability, and marginal-GPU remediation.
+- [x] 6.5 Add doctor tests for CPU-only and marginal-GPU hosts across lean/hybrid profiles.
+- [x] 6.6 Update setup messaging so GPU performance mode remains explicit opt-in and quiet/resource-status commands appear in next steps.
+
+## 7. Optional Auto-Quiet
+
+- [x] 7.1 Add pure decision tests for auto-quiet hysteresis: enter quiet after sustained pressure, restore after clear, and do not restore over manual changes.
+- [x] 7.2 Implement optional/default-off `auto_quiet.py` using non-torch pressure probes.
+- [x] 7.3 Ensure auto-quiet never imports torch or initializes CUDA solely for pressure polling.
+- [x] 7.4 Add tests proving unavailable probes soft-fail and do not change mode.
+- [x] 7.5 Wire auto-quiet startup only when explicitly enabled by env/config.
+
+## 8. Verification And Docs
+
+- [x] 8.1 Run targeted tests for mode policy, accel fallback, cache hooks, reaper behavior, warm-up policy, watcher deferral, CLI status, doctor posture, and auto-quiet decisions.
+- [x] 8.2 Run `openspec validate --changes`.
+- [x] 8.3 Run `ruff check` on touched Python files.
+- [x] 8.4 Run `uv run python -m pytest -q` with embeddings disabled where appropriate.
+- [x] 8.5 Add desk-side verification notes for idle VRAM and RAM before/after quiet mode.
+- [x] 8.6 Update README/QUICKSTART or relevant docs for `quiet`, `normal`, `performance`, resource status, and quiet-mode freshness trade-offs.

--- a/openspec/changes/complete-low-interrupt-mode/verification.md
+++ b/openspec/changes/complete-low-interrupt-mode/verification.md
@@ -1,0 +1,41 @@
+# Desk-Side Verification Notes
+
+Date: 2026-07-06
+Change: `complete-low-interrupt-mode`
+
+## Idle VRAM / RAM Check
+
+1. Start the server in normal mode and capture baseline process memory:
+   ```powershell
+   exomem mode normal
+   exomem status --resources --json
+   nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+   Get-Process python,exomem -ErrorAction SilentlyContinue |
+     Select-Object Id,ProcessName,WorkingSet64,PrivateMemorySize64
+   ```
+
+2. Switch to quiet and wait one idle-unload interval or trigger live mode apply by
+   restarting the server:
+   ```powershell
+   exomem mode quiet
+   exomem status --resources --json
+   nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+   Get-Process python,exomem -ErrorAction SilentlyContinue |
+     Select-Object Id,ProcessName,WorkingSet64,PrivateMemorySize64
+   ```
+
+3. Expected quiet posture:
+   - `policy.defer_expensive_indexes=true`
+   - `policy.preload_models=false`
+   - `policy.preload_cpu_caches=false`
+   - `policy.retain_cpu_caches=false`
+   - `models.embeddings=false`, `models.reranker=false`, `models.clip=false` unless
+     a request actually loaded one
+   - `cuda.initialized=false` when the process has not already opted into CUDA
+   - `deferred_work.semantic_upserts.count` may be nonzero after edits; run
+     `exomem index --vault <vault>` or `kb reconcile` to heal it
+
+Acceptance target: idle Exomem should not appear as a material CUDA compute app
+when no GPU feature is in use, and resident RAM should fall after quiet cache
+unload compared with warm normal/performance state. Exact MB values are
+machine/vault dependent; record before/after values in the PR or release note.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -12,6 +12,7 @@ Subcommands:
 - `demo` — the packaged 30-second proof: doctor → find → get → audit against a
   bundled sample vault, no clone/config/vault needed (`uvx exomem demo`)
 - `doctor` — read-only local install/setup preflight
+- `status` — resource posture/residency diagnostics without loading models
 - `warm` — pre-download/load the search models (bge, reranker, CLIP) so the first
   server start doesn't pay the download in the background; optional `--vault`
   also warms the lexical caches
@@ -56,6 +57,8 @@ def main(argv: list[str] | None = None) -> int:
         return demo_main(raw[1:])
     if raw and raw[0] == "doctor":
         return _doctor_main(raw[1:])
+    if raw and raw[0] == "status":
+        return _status_main(raw[1:])
     if raw and raw[0] == "warm":
         return _warm_main(raw[1:])
     if raw and raw[0] == "mode":
@@ -245,12 +248,17 @@ def _index_main(argv: list[str]) -> int:
             )
             return 1
 
+    vault_root = Path(args.vault).expanduser()
     stats = embeddings.index_incremental(
-        Path(args.vault).expanduser(),
+        vault_root,
         batch_size=max(1, args.batch_size),
         dry_run=args.dry_run,
         log_fn=print,
     )
+    if not args.dry_run:
+        from . import index_sync
+
+        index_sync.clear_deferred_work(vault_root)
     print(json.dumps(stats))
     return 0
 
@@ -268,11 +276,15 @@ def _mode_main(argv: list[str]) -> int:
         prog="exomem mode",
         description="Show or set the compute mode: quiet (CPU, low footprint) | normal "
         "(default, CPU steady-state) | performance (use the GPU; aliases gpu/turbo). "
-        "Persisted to ~/.exomem/config.json, read by BOTH the server and CLI ops.",
+        "Low-resource aliases resource-saver/low-resource map to quiet. Persisted to "
+        "~/.exomem/config.json, read by BOTH the server and CLI ops.",
     )
     parser.add_argument(
         "mode", nargs="?",
-        choices=("quiet", "normal", "performance", "gpu", "turbo"),
+        choices=(
+            "quiet", "normal", "performance", "gpu", "turbo",
+            "resource-saver", "low-resource",
+        ),
         help="mode to set; omit to show the current one",
     )
     parser.add_argument("--json", action="store_true", help="emit stable JSON (status only)")
@@ -292,9 +304,12 @@ def _mode_main(argv: list[str]) -> int:
             print(json.dumps(policy))
         else:
             print(f"mode: {policy['mode']}  (source: {source})")
-            print(f"  preload_models:    {policy['preload_models']}")
-            print(f"  release_when_idle: {policy['release_when_idle']}")
-            print(f"  bulk_gpu:          {policy['bulk_gpu']}")
+            print(f"  preload_models:          {policy['preload_models']}")
+            print(f"  preload_cpu_caches:      {policy['preload_cpu_caches']}")
+            print(f"  retain_cpu_caches:       {policy['retain_cpu_caches']}")
+            print(f"  defer_expensive_indexes: {policy['defer_expensive_indexes']}")
+            print(f"  release_when_idle:       {policy['release_when_idle']}")
+            print(f"  bulk_gpu:                {policy['bulk_gpu']}")
             print(f"  config: {policy['config_path']}")
         return 0
 
@@ -308,6 +323,38 @@ def _mode_main(argv: list[str]) -> int:
     print("CLI ops (exomem index / warm) use it on their next run.")
     return 0
 
+
+def _status_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem status",
+        description="Report resource mode, residency, deferred work, and CUDA accounting.",
+    )
+    parser.add_argument(
+        "--resources",
+        action="store_true",
+        help="report resource posture and residency (default)",
+    )
+    parser.add_argument(
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
+        help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
+    args = parser.parse_args(argv)
+
+    from . import resource_status
+
+    vault_root = Path(args.vault).expanduser() if args.vault else None
+    status = resource_status.collect(vault_root)
+    if args.json:
+        print(json.dumps(status))
+    else:
+        print(f"mode: {status['mode']}  (source: {status['source']})")
+        print(f"  config: {status['config_path']}")
+        print(f"  models: {status['models']}")
+        print(f"  deferred_work: {status['deferred_work']}")
+        print(f"  cuda: {status['cuda']}")
+    return 0
 
 def _doctor_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
@@ -343,16 +390,22 @@ def _doctor_main(argv: list[str]) -> int:
         print(json.dumps(report.as_dict(), ensure_ascii=False, default=str))
     else:
         print(doctor_module.render_human(report))
-        # GPU-discoverability: offer the performance-mode upgrade when a capable idle GPU
-        # is present and we're not already using it. Silent when no/weak GPU (the default).
-        from . import accel
+        # GPU-discoverability: use a non-torch probe so doctor does not create
+        # a CUDA context or import model dependencies just to print guidance.
         from . import mode as mode_mod
+        from . import resource_status
 
-        if mode_mod.resolve_mode() != "performance" and accel.gpu_usable():
+        gpu = resource_status.gpu_headroom()
+        if mode_mod.resolve_mode() != "performance" and gpu.get("usable") is True:
             print(
-                "\n⚡ A capable GPU was detected. For faster indexing & search, enable "
-                "performance mode:\n    exomem mode performance"
+                "\nA capable idle GPU was detected. Normal mode still avoids "
+                "steady-state CUDA residency. For faster explicit indexing, run:\n"
+                "    exomem mode performance"
             )
+        print(
+            "\nResource controls: exomem mode quiet | normal | performance; "
+            "inspect with exomem status --resources --json."
+        )
     return 0 if report.success else 1
 
 
@@ -574,8 +627,15 @@ def _init_main(argv: list[str]) -> int:
     print(f"  {len(report['created'])} files created + the typed folder tree.")
     print("Next:")
     print("  1. Point Claude Code at this vault (see QUICKSTART.md).")
-    print(f"  2. Install the Exomem {kb_dirname()} skill so Claude knows how to use it: python -m exomem install-skill")
+    print(
+        f"  2. Install the Exomem {kb_dirname()} skill so Claude knows how to use it: "
+        "python -m exomem install-skill"
+    )
     print(f"  3. Adapt {kb_prefix()}_Schema/project-keys.yaml to your own projects.")
+    print(
+        "  4. For low-resource mode: exomem mode quiet; inspect with "
+        "exomem status --resources --json."
+    )
     return 0
 
 

--- a/src/exomem/auto_quiet.py
+++ b/src/exomem/auto_quiet.py
@@ -1,0 +1,200 @@
+"""Optional automatic quiet-mode switching from non-torch pressure signals."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+from . import mode, resource_status
+
+log = logging.getLogger(__name__)
+
+_ENABLED_ENV = "EXOMEM_AUTO_QUIET"
+_POLL_ENV = "EXOMEM_AUTO_QUIET_POLL_SECONDS"
+_ENTER_ENV = "EXOMEM_AUTO_QUIET_ENTER_SECONDS"
+_RESTORE_ENV = "EXOMEM_AUTO_QUIET_RESTORE_SECONDS"
+
+_DEFAULT_POLL_SECONDS = 5.0
+_DEFAULT_ENTER_SECONDS = 30.0
+_DEFAULT_RESTORE_SECONDS = 60.0
+
+Action = Literal["none", "enter_quiet", "restore"]
+
+
+@dataclass
+class AutoQuietState:
+    pressure_since: float | None = None
+    clear_since: float | None = None
+    previous_mode: str | None = None
+    engaged: bool = False
+
+
+@dataclass(frozen=True)
+class AutoQuietDecision:
+    action: Action
+    target_mode: str | None = None
+    reason: str = ""
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def enabled() -> bool:
+    env = os.environ.get(_ENABLED_ENV)
+    if env is not None:
+        return _truthy(env)
+    return _truthy(mode.read_config().get("auto_quiet"))
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return max(0.0, float(os.environ.get(name) or default))
+    except ValueError:
+        return default
+
+
+def pressure_active() -> bool | None:
+    """Return True under pressure, False when clear, None when probe is unavailable."""
+    try:
+        gpu = resource_status.gpu_headroom()
+    except Exception:  # noqa: BLE001
+        log.debug("auto-quiet pressure probe failed", exc_info=True)
+        return None
+    status = gpu.get("status")
+    if status == "marginal":
+        return True
+    if status in {"capable", "disabled"}:
+        return False
+    return None
+
+
+def decide(
+    state: AutoQuietState,
+    *,
+    current_mode: str,
+    config_mode: str | None,
+    pressure: bool | None,
+    now: float,
+    env_pinned: bool,
+    enter_after: float = _DEFAULT_ENTER_SECONDS,
+    restore_after: float = _DEFAULT_RESTORE_SECONDS,
+) -> AutoQuietDecision:
+    """Pure hysteresis decision; mutates only the supplied state object."""
+    current_mode = mode.normalize(current_mode) or "normal"
+    config_mode = mode.normalize(config_mode) or current_mode
+    if env_pinned:
+        return AutoQuietDecision("none", reason="EXOMEM_MODE pins mode")
+    if pressure is None:
+        state.pressure_since = None
+        return AutoQuietDecision("none", reason="pressure probe unavailable")
+
+    if state.engaged and current_mode != "quiet":
+        state.engaged = False
+        state.previous_mode = None
+        state.pressure_since = None
+        state.clear_since = None
+        return AutoQuietDecision("none", reason="manual mode change detected")
+
+    if pressure:
+        state.clear_since = None
+        if current_mode == "quiet":
+            return AutoQuietDecision("none", reason="already quiet")
+        if state.pressure_since is None:
+            state.pressure_since = now
+            return AutoQuietDecision("none", reason="pressure hysteresis started")
+        if now - state.pressure_since < enter_after:
+            return AutoQuietDecision("none", reason="pressure hysteresis pending")
+        state.previous_mode = config_mode if config_mode != "quiet" else "normal"
+        state.engaged = True
+        state.pressure_since = None
+        return AutoQuietDecision("enter_quiet", target_mode="quiet", reason="pressure sustained")
+
+    state.pressure_since = None
+    if not state.engaged:
+        state.clear_since = None
+        return AutoQuietDecision("none", reason="pressure clear")
+    if current_mode != "quiet":
+        state.engaged = False
+        state.previous_mode = None
+        state.clear_since = None
+        return AutoQuietDecision("none", reason="manual mode change detected")
+    if state.clear_since is None:
+        state.clear_since = now
+        return AutoQuietDecision("none", reason="restore hysteresis started")
+    if now - state.clear_since < restore_after:
+        return AutoQuietDecision("none", reason="restore hysteresis pending")
+    target = state.previous_mode or "normal"
+    state.engaged = False
+    state.previous_mode = None
+    state.clear_since = None
+    return AutoQuietDecision("restore", target_mode=target, reason="pressure clear")
+
+
+_STATE = AutoQuietState()
+_THREAD: threading.Thread | None = None
+_STOP = threading.Event()
+_LOCK = threading.Lock()
+
+
+def tick(state: AutoQuietState | None = None, *, now: float | None = None) -> AutoQuietDecision:
+    state = state or _STATE
+    now = time.monotonic() if now is None else now
+    cfg = mode.read_config()
+    decision = decide(
+        state,
+        current_mode=mode.resolve_mode(),
+        config_mode=cfg.get("mode"),
+        pressure=pressure_active(),
+        now=now,
+        env_pinned=bool(os.environ.get("EXOMEM_MODE")),
+        enter_after=_float_env(_ENTER_ENV, _DEFAULT_ENTER_SECONDS),
+        restore_after=_float_env(_RESTORE_ENV, _DEFAULT_RESTORE_SECONDS),
+    )
+    if decision.action in {"enter_quiet", "restore"} and decision.target_mode:
+        mode.write_mode(decision.target_mode)
+        try:
+            mode.apply_live()
+        except Exception:  # noqa: BLE001
+            log.debug("auto-quiet live apply failed", exc_info=True)
+        log.info("auto-quiet %s -> %s (%s)", decision.action, decision.target_mode, decision.reason)
+    return decision
+
+
+def _run() -> None:
+    while not _STOP.wait(_float_env(_POLL_ENV, _DEFAULT_POLL_SECONDS)):
+        try:
+            tick()
+        except Exception:  # noqa: BLE001
+            log.debug("auto-quiet tick failed", exc_info=True)
+
+
+def start_if_enabled() -> threading.Thread | None:
+    if not enabled():
+        return None
+    global _THREAD
+    with _LOCK:
+        if _THREAD is not None and _THREAD.is_alive():
+            return _THREAD
+        _STOP.clear()
+        _THREAD = threading.Thread(target=_run, name="exomem-auto-quiet", daemon=True)
+        _THREAD.start()
+        return _THREAD
+
+
+def stop() -> None:
+    global _THREAD
+    _STOP.set()
+    with _LOCK:
+        thread = _THREAD
+        _THREAD = None
+    if thread is not None:
+        thread.join(timeout=2)

--- a/src/exomem/bm25.py
+++ b/src/exomem/bm25.py
@@ -220,12 +220,31 @@ class BM25Index:
             return
         self._fresh_corpus(vault_root, scope, None)
 
-    def clear(self) -> None:
+    def unload_cache(self) -> bool:
+        """Drop rebuildable in-process BM25 corpus/token caches."""
         with self._build_lock:
+            loaded = bool(self._cache or self._tokens)
             self._cache.clear()
             self._tokens.clear()
             self.last_tokenized = 0
             self.last_reused = 0
+            return loaded
+
+    def cache_status(self) -> dict:
+        """No-allocation residency status for the Python BM25 rung."""
+        with self._build_lock:
+            doc_count = sum(len(entry[2]) for entry in self._cache.values())
+            token_count = sum(len(tokens) for _mtime, tokens in self._tokens.values())
+            return {
+                "loaded": bool(self._cache or self._tokens),
+                "corpora": len(self._cache),
+                "documents": doc_count,
+                "tokenized_documents": len(self._tokens),
+                "tokens": token_count,
+            }
+
+    def clear(self) -> None:
+        self.unload_cache()
 
 
 def corpus_key(vault_root: Path, scope: str) -> tuple:
@@ -259,6 +278,16 @@ def search(
 def warm(vault_root: Path, scope: str = "kb") -> None:
     """Module-level warm-up hook using the per-process singleton."""
     _INDEX.warm(vault_root, scope)
+
+
+def unload_cache() -> bool:
+    """Evict the singleton BM25 corpus/token cache without touching vault files."""
+    return _INDEX.unload_cache()
+
+
+def cache_status() -> dict:
+    """No-allocation residency status for the singleton BM25 cache."""
+    return _INDEX.cache_status()
 
 
 def clear_cache() -> None:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -47,14 +47,18 @@ class DoctorCheck:
     status: Status
     message: str
     remediation: str | None = None
+    details: dict | None = None
 
     def as_dict(self) -> dict:
-        return {
+        data = {
             "id": self.id,
             "status": self.status,
             "message": self.message,
             "remediation": self.remediation,
         }
+        if self.details is not None:
+            data["details"] = self.details
+        return data
 
 
 @dataclass
@@ -79,8 +83,16 @@ def _check(
     status: Status,
     message: str,
     remediation: str | None = None,
+    *,
+    details: dict | None = None,
 ) -> DoctorCheck:
-    return DoctorCheck(id=id_, status=status, message=message, remediation=remediation)
+    return DoctorCheck(
+        id=id_,
+        status=status,
+        message=message,
+        remediation=remediation,
+        details=details,
+    )
 
 
 def _module_available(module: str) -> bool:
@@ -232,6 +244,39 @@ def _check_dependency(module: str, extra: str, *, import_name: str | None = None
         f"Install the requested capability with `uv sync --extra {extra}`.",
     )
 
+
+def _check_resource_posture(profile: Profile) -> DoctorCheck:
+    from . import resource_status
+
+    posture = resource_status.resource_posture()
+    gpu = posture["gpu"]
+    mode_name = posture["mode"]
+    if gpu.get("usable") is False:
+        status: Status = "pass" if profile == "lean" else "warn"
+        reason = gpu.get("reason") or "GPU is not usable under current policy"
+        return _check(
+            "resource.posture",
+            status,
+            f"Resource mode is {mode_name}; CPU is the supported baseline. {reason}.",
+            "Use `exomem mode quiet` before foreground GPU work, or `exomem mode "
+            "performance` only when enough free VRAM is available.",
+            details=posture,
+        )
+    if gpu.get("usable") is True:
+        return _check(
+            "resource.posture",
+            "pass",
+            f"Resource mode is {mode_name}; GPU headroom probe is capable, but GPU "
+            "use remains explicit policy opt-in.",
+            details=posture,
+        )
+    return _check(
+        "resource.posture",
+        "pass",
+        f"Resource mode is {mode_name}; CPU is the supported baseline and GPU "
+        "headroom is unknown without an available non-torch probe.",
+        details=posture,
+    )
 
 def _check_lexical(vault_root: Path | None) -> DoctorCheck:
     """Lexical FTS5 backend availability + sidecar health.
@@ -735,6 +780,7 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
         *_check_schema_files(vault_root),
         _check_repo_env(),
         _check_registry(),
+        _check_resource_posture(profile),
         _check_lexical(vault_root),
     ]
 

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1499,6 +1499,26 @@ class EmbeddingIndex:
             self._cache = loaded
             return loaded.metadata, loaded.matrix
 
+    def unload_cache(self) -> bool:
+        """Drop the resident matrix cache without deleting sidecar rows."""
+        with self._lock:
+            loaded = self._cache is not None
+            self._cache = None
+            return loaded
+
+    def cache_status(self) -> dict:
+        """Best-effort residency status for this in-memory matrix only."""
+        c = self._cache
+        if c is None:
+            return {"loaded": False, "rows": 0, "bytes": 0}
+        return {
+            "loaded": True,
+            "rows": len(c.metadata),
+            "bytes": int(c.matrix.nbytes),
+            "epoch": c.epoch,
+            "generation": c.generation,
+        }
+
     def _load_all_rows(self) -> _EmbCache:
         """Full reload from the sidecar → an `_EmbCache`.
 
@@ -2102,6 +2122,26 @@ class ClipIndex:
             self._cache = loaded
             return loaded.paths, loaded.frame_ts, loaded.matrix
 
+    def unload_cache(self) -> bool:
+        """Drop the resident CLIP matrix cache without deleting sidecar rows."""
+        with self._lock:
+            loaded = self._cache is not None
+            self._cache = None
+            return loaded
+
+    def cache_status(self) -> dict:
+        """Best-effort residency status for this in-memory matrix only."""
+        c = self._cache
+        if c is None:
+            return {"loaded": False, "rows": 0, "bytes": 0}
+        return {
+            "loaded": True,
+            "rows": len(c.paths),
+            "bytes": int(c.matrix.nbytes),
+            "epoch": c.epoch,
+            "generation": c.generation,
+        }
+
     def _load_all_rows(self) -> _ClipCache:
         """Full reload → a `_ClipCache`, reading the meta token and rows in ONE
         `BEGIN` snapshot (see EmbeddingIndex._load_all_rows)."""
@@ -2253,6 +2293,40 @@ def clear_embedding_indexes() -> None:
     with _INDEX_CACHE_LOCK:
         _INDEX_CACHE.clear()
         _CLIP_INDEX_CACHE.clear()
+
+
+def unload_index_caches() -> dict[str, int]:
+    """Evict resident embedding/CLIP matrices from already-shared index objects."""
+    with _INDEX_CACHE_LOCK:
+        embedding_indexes = list(_INDEX_CACHE.values())
+        clip_indexes = list(_CLIP_INDEX_CACHE.values())
+    return {
+        "embedding": sum(1 for idx in embedding_indexes if idx.unload_cache()),
+        "clip": sum(1 for idx in clip_indexes if idx.unload_cache()),
+    }
+
+
+def _summarize_index_status(indexes: dict[str, object]) -> dict:
+    by_vault = {key: idx.cache_status() for key, idx in indexes.items()}
+    loaded = [s for s in by_vault.values() if s.get("loaded")]
+    return {
+        "indexes": len(by_vault),
+        "loaded": len(loaded),
+        "rows": sum(int(s.get("rows") or 0) for s in loaded),
+        "bytes": sum(int(s.get("bytes") or 0) for s in loaded),
+        "by_vault": by_vault,
+    }
+
+
+def index_cache_status() -> dict:
+    """No-allocation residency status for already-created embedding index objects."""
+    with _INDEX_CACHE_LOCK:
+        embedding_indexes = dict(_INDEX_CACHE)
+        clip_indexes = dict(_CLIP_INDEX_CACHE)
+    return {
+        "embedding": _summarize_index_status(embedding_indexes),
+        "clip": _summarize_index_status(clip_indexes),
+    }
 
 
 def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -36,7 +36,7 @@ import time
 from collections.abc import Iterable
 from pathlib import Path
 
-from . import freshness, index_sync
+from . import freshness, index_sync, mode
 from .kbdir import kb_dirname, kb_prefix
 
 log = logging.getLogger(__name__)
@@ -230,10 +230,10 @@ def _import_watchdog():
 class FileWatcher:
     """Watch Knowledge Base/ for `.md` changes and re-embed them, debounced."""
 
-    def __init__(self, vault_root: Path, *, debounce_seconds: float = DEBOUNCE_SECONDS) -> None:
+    def __init__(self, vault_root: Path, *, debounce_seconds: float | None = None) -> None:
         self._vault_root = vault_root
         self._kb_root = vault_root / kb_dirname()
-        self._debounce = debounce_seconds
+        self._debounce_override = debounce_seconds
         self._lock = threading.Lock()
         self._pending_upsert: set[Path] = set()
         self._pending_delete: set[Path] = set()
@@ -243,6 +243,17 @@ class FileWatcher:
         self._thread: threading.Thread | None = None
         self._observer = None
         self._reconcile_thread: threading.Thread | None = None
+
+    def _watcher_policy(self) -> mode.WatcherPolicy:
+        return mode.watcher_policy()
+
+    def _debounce_seconds(self) -> float:
+        if self._debounce_override is not None:
+            return self._debounce_override
+        return self._watcher_policy().debounce_seconds
+
+    def _reconcile_interval_seconds(self) -> float:
+        return self._watcher_policy().reconcile_interval_seconds
 
     def _is_kb(self, path: Path) -> bool:
         """True when `path` is under Knowledge Base/ — the subset that gets
@@ -330,9 +341,10 @@ class FileWatcher:
             # Wait for a quiet window so a burst of saves (or a git pull) coalesces
             # into one batch instead of one upsert per FS event.
             while not self._stop.is_set():
-                time.sleep(self._debounce)
+                debounce = self._debounce_seconds()
+                time.sleep(debounce)
                 with self._lock:
-                    quiet = (time.monotonic() - self._last_change) >= self._debounce
+                    quiet = (time.monotonic() - self._last_change) >= debounce
                 if quiet:
                     break
             self._wake.clear()
@@ -401,6 +413,9 @@ class FileWatcher:
             self._dispatch_reconcile_delta(list(changed_union), list(deleted_union))
         except Exception:  # noqa: BLE001
             log.exception("file watcher: reconcile drift dispatch failed")
+        if self._watcher_policy().defer_expensive_indexes:
+            log.info("file watcher: quiet reconcile deferred expensive warm-up")
+            return
         from . import bm25
         for scope in freshness.SCOPES:
             try:
@@ -519,14 +534,22 @@ class FileWatcher:
         # Index sidecars (embedding + lexical): Knowledge Base markdown only.
         kb_ups = [p for p in ups if self._is_kb(p)]
         kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
-        if cap and len(kb_ups) > RECONCILE_MAX_EMBED_FILES:
-            log.warning(
-                "file watcher: reconcile drift re-embed capped at %d of %d KB file(s); "
-                "the freshness registry is fully healed — run `reconcile` to re-embed "
-                "the remainder",
-                RECONCILE_MAX_EMBED_FILES, len(kb_ups),
+        policy = self._watcher_policy()
+        if cap and not policy.defer_expensive_indexes:
+            max_files = policy.max_reconcile_embed_files
+            if max_files is not None and len(kb_ups) > max_files:
+                log.warning(
+                    "file watcher: reconcile drift re-embed capped at %d of %d KB file(s); "
+                    "the freshness registry is fully healed — run `reconcile` to re-embed "
+                    "the remainder",
+                    max_files, len(kb_ups),
+                )
+                kb_ups = kb_ups[:max_files]
+        elif policy.defer_expensive_indexes and kb_ups:
+            log.info(
+                "file watcher: quiet mode deferring semantic indexing for %d KB file(s)",
+                len(kb_ups),
             )
-            kb_ups = kb_ups[:RECONCILE_MAX_EMBED_FILES]
         if kb_ups:
             try:
                 index_sync.upsert_after_write(self._vault_root, kb_ups)
@@ -536,13 +559,16 @@ class FileWatcher:
             try:
                 index_sync.delete_after_remove(self._vault_root, kb_del_rels)
             except Exception:  # noqa: BLE001
-                log.exception("file watcher: delete_after_remove failed for %d file(s)", len(kb_del_rels))
+                log.exception(
+                    "file watcher: delete_after_remove failed for %d file(s)",
+                    len(kb_del_rels),
+                )
 
     def _run_reconcile(self) -> None:
         # Seed immediately (off the boot path — this is the watcher's own
         # daemon thread), then re-walk every RECONCILE_INTERVAL to bound drift.
         self._reconcile_once(seed=True)
-        while not self._stop.wait(RECONCILE_INTERVAL_SECONDS):
+        while not self._stop.wait(self._reconcile_interval_seconds()):
             self._reconcile_once(seed=False)
 
     # ---- lifecycle ----

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -2723,14 +2723,42 @@ def _collapse(s: str) -> str:
     return re.sub(r"\s+", " ", s).strip()
 
 
+def unload_ram_caches() -> dict[str, int]:
+    """Evict rebuildable find RAM caches without clearing freshness/inbound metadata."""
+    page_entries = len(_CACHE.entries)
+    _CACHE.entries.clear()
+    with _RESOLVER_LOCK:
+        resolver_entries = len(_RESOLVER_CACHE)
+        _RESOLVER_CACHE.clear()
+    with _FIND_CACHE_LOCK:
+        hot_entries = len(_FIND_CACHE)
+        _FIND_CACHE.clear()
+    return {"pages": page_entries, "resolvers": resolver_entries, "hot_find": hot_entries}
+
+
+def cache_status() -> dict:
+    """No-allocation residency status for find's rebuildable RAM caches."""
+    page_entries = list(_CACHE.entries.values())
+    with _RESOLVER_LOCK:
+        resolver_entries = len(_RESOLVER_CACHE)
+    with _FIND_CACHE_LOCK:
+        hot_entries = len(_FIND_CACHE)
+        hot_hits = sum(len(v) for v in _FIND_CACHE.values())
+    return {
+        "pages": {
+            "entries": len(page_entries),
+            "body_chars": sum(len(p.body) for p in page_entries),
+        },
+        "resolvers": {"entries": resolver_entries},
+        "hot_find": {"entries": hot_entries, "hits": hot_hits},
+    }
+
+
 def clear_cache() -> None:
     """Test hook: flush every in-process find cache between tests — parsed
     pages, the wikilink resolver, the hot find-result cache, and the vault
     inbound-link index."""
-    _CACHE.entries.clear()
-    _RESOLVER_CACHE.clear()
-    with _FIND_CACHE_LOCK:
-        _FIND_CACHE.clear()
+    unload_ram_caches()
     freshness.clear()
     from . import vault as vault_module
     vault_module.clear_inbound_index()

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -3,7 +3,7 @@
 Writers, the file watcher, and reconcile used to call
 `embeddings.upsert_after_write` / `delete_after_remove` directly. Those entry
 points are (correctly) gated by `EXOMEM_DISABLE_EMBEDDINGS` and the torch
-import memo — gates the lexical sidecar must NOT sit behind, because the
+import memo -- gates the lexical sidecar must NOT sit behind, because the
 bm25/keyword lanes it serves are lean-install lanes. This module is the shared
 seam: each index family applies its own policy, and a call site says
 "markdown changed" exactly once.
@@ -13,7 +13,7 @@ process-shared resolver (`find.shared_resolver`) instead of rebuilding it per
 write, so this dispatch re-syncs the touched entries from disk and restamps
 the cache's freshness key. Without the restamp, every write would invalidate
 the cache (the vault freshness triple moves) and the next graph-lane query or
-write would pay a full O(vault) rebuild — the watcher also patches, but
+write would pay a full O(vault) rebuild -- the watcher also patches, but
 asynchronously, leaving a window this closes.
 
 All callees are best-effort by contract (they log and swallow their own
@@ -24,9 +24,20 @@ wrappers as the outermost belt.
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 
 log = logging.getLogger(__name__)
+
+_DEFERRED_LOCK = threading.Lock()
+_DEFERRED_SEMANTIC_UPSERTS: dict[str, set[str]] = {}
+
+
+def _root_key(vault_root: Path) -> str:
+    try:
+        return str(vault_root.resolve())
+    except OSError:
+        return str(vault_root)
 
 
 def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
@@ -43,15 +54,101 @@ def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
     return out
 
 
+def _record_deferred_semantic_upserts(vault_root: Path, paths: list[Path]) -> int:
+    rels = _rel_md_paths(vault_root, paths)
+    if not rels:
+        return 0
+    with _DEFERRED_LOCK:
+        pending = _DEFERRED_SEMANTIC_UPSERTS.setdefault(_root_key(vault_root), set())
+        before = len(pending)
+        pending.update(rels)
+        return len(pending) - before
+
+
+def deferred_work_status(vault_root: Path | None = None) -> dict:
+    """No-allocation summary of expensive index work queued by quiet mode."""
+    with _DEFERRED_LOCK:
+        if vault_root is not None:
+            root = _root_key(vault_root)
+            roots = {root: set(_DEFERRED_SEMANTIC_UPSERTS.get(root, set()))}
+        else:
+            roots = {root: set(rels) for root, rels in _DEFERRED_SEMANTIC_UPSERTS.items()}
+    count = sum(len(rels) for rels in roots.values())
+    paths = sorted({rel for rels in roots.values() for rel in rels})
+    return {
+        "semantic_upserts": {
+            "count": count,
+            "paths": paths[:50],
+            "truncated": len(paths) > 50,
+            "roots": len([rels for rels in roots.values() if rels]),
+        }
+    }
+
+
+def clear_deferred_work(
+    vault_root: Path | None = None,
+    *,
+    paths: list[Path] | list[str] | None = None,
+) -> int:
+    """Clear deferred semantic work after an explicit index/reconcile heal."""
+    with _DEFERRED_LOCK:
+        if vault_root is None:
+            count = sum(len(rels) for rels in _DEFERRED_SEMANTIC_UPSERTS.values())
+            _DEFERRED_SEMANTIC_UPSERTS.clear()
+            return count
+        root = _root_key(vault_root)
+        pending = _DEFERRED_SEMANTIC_UPSERTS.get(root)
+        if not pending:
+            return 0
+        if paths is None:
+            count = len(pending)
+            _DEFERRED_SEMANTIC_UPSERTS.pop(root, None)
+            return count
+        rels: set[str] = set()
+        for item in paths:
+            if isinstance(item, Path):
+                rels.update(_rel_md_paths(vault_root, [item]))
+            else:
+                rel = str(item).replace("\\", "/")
+                if rel.lower().endswith(".md"):
+                    rels.add(rel)
+        before = len(pending)
+        pending.difference_update(rels)
+        if not pending:
+            _DEFERRED_SEMANTIC_UPSERTS.pop(root, None)
+        return before - len(pending)
+
+
+def drain_deferred_work(vault_root: Path, *, limit: int | None = None) -> int:
+    """Process queued semantic upserts now and clear them on dispatch.
+
+    The embedding layer is best-effort and logs/soft-fails internally, matching
+    the normal writer path. Crash/restart recovery still comes from drift audit
+    and explicit reconcile/index.
+    """
+    root = _root_key(vault_root)
+    with _DEFERRED_LOCK:
+        pending = sorted(_DEFERRED_SEMANTIC_UPSERTS.get(root, set()))
+        if limit is not None:
+            pending = pending[:max(0, limit)]
+    if not pending:
+        return 0
+    from . import embeddings
+
+    paths = [vault_root / rel for rel in pending]
+    embeddings.upsert_after_write(vault_root, paths)
+    return clear_deferred_work(vault_root, paths=paths)
+
+
 def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
     """Fan a writer's markdown change out to every index sidecar.
 
-    Paths under excluded scan dirs (`_trash/`, `_archive/`, `_Schema/`, …) are
+    Paths under excluded scan dirs (`_trash/`, `_archive/`, `_Schema/`, ...) are
     dropped first: every index's FULL rebuild skips them, so the incremental
     path must too (`vault.in_excluded_scan_dir`). The watcher filters its own
     events the same way; this belt covers direct writer calls.
     """
-    from . import embeddings, find, lexstore
+    from . import find, lexstore, mode
     from .vault import in_excluded_scan_dir
 
     vr = vault_root.resolve()
@@ -71,13 +168,20 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
     if not eligible:
         return
     lexstore.upsert_after_write(vault_root, eligible)
-    embeddings.upsert_after_write(vault_root, eligible)
     try:
         rels = _rel_md_paths(vault_root, eligible)
         if rels:
             find.on_resolver_files_changed(vault_root, rels, [])
-    except Exception:  # noqa: BLE001 — resolver sync must never fail a write
+    except Exception:  # noqa: BLE001 -- resolver sync must never fail a write
         log.debug("resolver re-sync after write failed", exc_info=True)
+    if mode.defer_expensive_indexes():
+        added = _record_deferred_semantic_upserts(vault_root, eligible)
+        if added:
+            log.info("deferred semantic indexing for %d markdown file(s)", added)
+        return
+    from . import embeddings
+
+    embeddings.upsert_after_write(vault_root, eligible)
 
 
 def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
@@ -90,5 +194,5 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
         md_rels = [r for r in removed_rel_paths if r.lower().endswith(".md")]
         if md_rels:
             find.on_resolver_files_changed(vault_root, [], md_rels)
-    except Exception:  # noqa: BLE001 — resolver sync must never fail a delete
+    except Exception:  # noqa: BLE001 -- resolver sync must never fail a delete
         log.debug("resolver re-sync after delete failed", exc_info=True)

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -34,18 +34,45 @@ import json
 import logging
 import os
 import threading
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 CANON = ("quiet", "normal", "performance")
-_ALIASES = {"gpu": "performance", "turbo": "performance"}
+_ALIASES = {
+    "gpu": "performance",
+    "turbo": "performance",
+    "resource-saver": "quiet",
+    "low-resource": "quiet",
+}
 DEFAULT_MODE = "normal"
+
+_DEFAULT_DEBOUNCE_SECONDS = 0.5
+_QUIET_DEBOUNCE_SECONDS = 2.0
+_DEFAULT_RECONCILE_INTERVAL_SECONDS = 300.0
+_QUIET_RECONCILE_INTERVAL_SECONDS = 900.0
+_DEFAULT_RECONCILE_MAX_EMBED_FILES = 500
+_QUIET_EXPENSIVE_INDEX_CAP = 0
 
 _MODE_ENV = "EXOMEM_MODE"
 _QUIET_ALIAS_ENV = "EXOMEM_QUIET_MODE"
 _CONFIG_PATH_ENV = "EXOMEM_CONFIG_PATH"
 _RELEASE_ENV = "EXOMEM_RELEASE_GPU_WHEN_IDLE"
+
+
+@dataclass(frozen=True)
+class WatcherPolicy:
+    """Mode-derived watcher/reconcile limits, kept torch-free for lean status paths."""
+
+    debounce_seconds: float
+    reconcile_interval_seconds: float
+    max_embed_files_per_batch: int | None
+    max_reconcile_embed_files: int | None
+    defer_expensive_indexes: bool
+
+    def as_dict(self) -> dict:
+        return asdict(self)
 
 
 def _truthy(value: str | None) -> bool:
@@ -112,6 +139,40 @@ def preload_models() -> bool:
     return resolve_mode() != "quiet"
 
 
+def preload_cpu_caches() -> bool:
+    """Whether startup warm-up may materialize O(vault) CPU caches."""
+    return resolve_mode() != "quiet"
+
+
+def retain_cpu_caches() -> bool:
+    """Whether large CPU caches may stay resident after use."""
+    return resolve_mode() != "quiet"
+
+
+def defer_expensive_indexes() -> bool:
+    """Whether semantic/visual indexing should be queued or capped."""
+    return resolve_mode() == "quiet"
+
+
+def watcher_policy() -> WatcherPolicy:
+    """Mode-derived low-interrupt watcher/reconcile policy."""
+    if defer_expensive_indexes():
+        return WatcherPolicy(
+            debounce_seconds=_QUIET_DEBOUNCE_SECONDS,
+            reconcile_interval_seconds=_QUIET_RECONCILE_INTERVAL_SECONDS,
+            max_embed_files_per_batch=_QUIET_EXPENSIVE_INDEX_CAP,
+            max_reconcile_embed_files=_QUIET_EXPENSIVE_INDEX_CAP,
+            defer_expensive_indexes=True,
+        )
+    return WatcherPolicy(
+        debounce_seconds=_DEFAULT_DEBOUNCE_SECONDS,
+        reconcile_interval_seconds=_DEFAULT_RECONCILE_INTERVAL_SECONDS,
+        max_embed_files_per_batch=None,
+        max_reconcile_embed_files=_DEFAULT_RECONCILE_MAX_EMBED_FILES,
+        defer_expensive_indexes=False,
+    )
+
+
 def release_when_idle() -> bool:
     """Whether the idle-unload reaper should run.
 
@@ -141,6 +202,10 @@ def resolved() -> dict:
     return {
         "mode": m,
         "preload_models": preload_models(),
+        "preload_cpu_caches": preload_cpu_caches(),
+        "retain_cpu_caches": retain_cpu_caches(),
+        "defer_expensive_indexes": defer_expensive_indexes(),
+        "watcher_policy": watcher_policy().as_dict(),
         "release_when_idle": release_when_idle(),
         "bulk_gpu": bulk_gpu_opted(),
     }
@@ -193,6 +258,14 @@ def apply_live() -> dict:
             unload()
         except Exception:  # noqa: BLE001 — a live switch must never crash the caller
             log.warning("model unload during mode switch failed", exc_info=True)
+    if _applied_mode == "quiet":
+        from . import bm25, find
+
+        for unload in (embeddings.unload_index_caches, bm25.unload_cache, find.unload_ram_caches):
+            try:
+                unload()
+            except Exception:  # noqa: BLE001 — quiet entry must remain best-effort
+                log.warning("cache unload during quiet mode switch failed", exc_info=True)
     if release_when_idle():
         model_reaper.start()
     else:

--- a/src/exomem/model_reaper.py
+++ b/src/exomem/model_reaper.py
@@ -36,7 +36,7 @@ _stop = threading.Event()
 
 
 @dataclass
-class ModelSlot:
+class ResourceSlot:
     name: str
     is_loaded: Callable[[], bool]
     inflight: Callable[[], int]
@@ -56,7 +56,10 @@ def idle_seconds() -> float:
     return minutes * 60.0 if minutes > 0 else DEFAULT_IDLE_SECONDS
 
 
-def _should_unload(slot: ModelSlot, now: float, threshold: float) -> bool:
+ModelSlot = ResourceSlot
+
+
+def _should_unload(slot: ResourceSlot, now: float, threshold: float) -> bool:
     """Pure decision: unload iff not warming, loaded, not in-flight, idle-window elapsed."""
     if readiness.is_warming():
         return False
@@ -67,27 +70,70 @@ def _should_unload(slot: ModelSlot, now: float, threshold: float) -> bool:
     return (now - slot.last_activity()) >= threshold
 
 
-def default_slots() -> list[ModelSlot]:
-    """The find-path model trio (bge, reranker, CLIP) — the models that go resident."""
-    from . import embeddings as e
+def _quiet_cache_slot(
+    name: str,
+    is_loaded: Callable[[], bool],
+    unload: Callable[[], bool],
+) -> ResourceSlot:
+    """Cache slot with approximate idle tracking, active only when caches are evictable."""
+    from . import mode
+
+    state = {"last_empty": time.monotonic()}
+
+    def loaded() -> bool:
+        should_retain = mode.retain_cpu_caches()
+        resident = (not should_retain) and is_loaded()
+        if not resident:
+            state["last_empty"] = time.monotonic()
+        return resident
+
+    return ResourceSlot(
+        name=name,
+        is_loaded=loaded,
+        inflight=lambda: 0,
+        last_activity=lambda: state["last_empty"],
+        unload=unload,
+    )
+
+
+def default_slots() -> list[ResourceSlot]:
+    """Default reclaimable resources: models always, CPU caches only in quiet mode."""
+    from . import bm25, embeddings as e, find
 
     return [
-        ModelSlot(
+        ResourceSlot(
             "embeddings", lambda: e._MODEL is not None,
             e.BGE_GUARD.inflight, e.BGE_GUARD.last_activity, e.unload_model,
         ),
-        ModelSlot(
+        ResourceSlot(
             "reranker", lambda: e._RERANKER is not None,
             e.RERANKER_GUARD.inflight, e.RERANKER_GUARD.last_activity, e.unload_reranker,
         ),
-        ModelSlot(
+        ResourceSlot(
             "clip", lambda: e._CLIP_MODEL is not None,
             e.CLIP_GUARD.inflight, e.CLIP_GUARD.last_activity, e.unload_clip_model,
+        ),
+        _quiet_cache_slot(
+            "index-matrices",
+            lambda: any(v.get("loaded", 0) for v in e.index_cache_status().values()),
+            lambda: any(e.unload_index_caches().values()),
+        ),
+        _quiet_cache_slot(
+            "bm25-cache",
+            lambda: bool(bm25.cache_status().get("loaded")),
+            bm25.unload_cache,
+        ),
+        _quiet_cache_slot(
+            "find-ram-caches",
+            lambda: any(
+                section.get("entries", 0) for section in find.cache_status().values()
+            ),
+            lambda: any(find.unload_ram_caches().values()),
         ),
     ]
 
 
-def _reap_once(slots: list[ModelSlot], now: float, threshold: float) -> list[str]:
+def _reap_once(slots: list[ResourceSlot], now: float, threshold: float) -> list[str]:
     """Unload every stale slot once; return the names actually reaped. Never raises."""
     reaped: list[str] = []
     for s in slots:
@@ -105,7 +151,7 @@ def _reap_once(slots: list[ModelSlot], now: float, threshold: float) -> list[str
 def start(
     threshold: float | None = None,
     tick: float = TICK_SECONDS,
-    slots: list[ModelSlot] | None = None,
+    slots: list[ResourceSlot] | None = None,
 ) -> threading.Thread:
     """Start the idle-unload daemon (idempotent — a second call returns the live thread)."""
     global _thread

--- a/src/exomem/reconcile.py
+++ b/src/exomem/reconcile.py
@@ -109,8 +109,9 @@ def reconcile(vault_root: Path, *, dry_run: bool = False) -> ReconcileReport:
         drift = audit_module._check_embedding_drift(vault_root)
         drifted_abs = [vault_root / f.path for f in drift]
         if drifted_abs and not dry_run:
-            from . import embeddings
+            from . import embeddings, index_sync
             embeddings.upsert_after_write(vault_root, drifted_abs)
+            index_sync.clear_deferred_work(vault_root, paths=drifted_abs)
         report.embeddings_refreshed = len(drifted_abs)
         report.embeddings_status = "refreshed" if drifted_abs else "current"
 

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -1,0 +1,224 @@
+"""No-allocation resource posture and residency diagnostics.
+
+This module is intentionally conservative: status collection must not import
+`torch`, load models, create sidecars, read vector matrices, or initialize CUDA.
+It reports loaded state only from modules already present in `sys.modules`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import mode
+
+
+def _mode_source() -> str:
+    if os.environ.get("EXOMEM_MODE"):
+        return "env"
+    if mode.read_config().get("mode"):
+        return "config"
+    if os.environ.get("EXOMEM_QUIET_MODE"):
+        return "quiet-alias"
+    return "default"
+
+
+def _model_residency() -> dict[str, Any]:
+    embeddings = sys.modules.get("exomem.embeddings")
+    if embeddings is None:
+        return {
+            "module_loaded": False,
+            "embeddings": False,
+            "reranker": False,
+            "clip": False,
+        }
+    return {
+        "module_loaded": True,
+        "embeddings": getattr(embeddings, "_MODEL", None) is not None,
+        "reranker": getattr(embeddings, "_RERANKER", None) is not None,
+        "clip": getattr(embeddings, "_CLIP_MODEL", None) is not None,
+    }
+
+
+def _cache_residency() -> dict[str, Any]:
+    caches: dict[str, Any] = {}
+    embeddings = sys.modules.get("exomem.embeddings")
+    if embeddings is not None and hasattr(embeddings, "index_cache_status"):
+        caches["vector_matrices"] = embeddings.index_cache_status()
+    else:
+        caches["vector_matrices"] = {
+            "embedding": {"loaded": 0, "indexes": 0, "rows": 0, "bytes": 0},
+            "clip": {"loaded": 0, "indexes": 0, "rows": 0, "bytes": 0},
+        }
+
+    bm25 = sys.modules.get("exomem.bm25")
+    if bm25 is not None and hasattr(bm25, "cache_status"):
+        caches["bm25"] = bm25.cache_status()
+    else:
+        caches["bm25"] = {
+            "loaded": False,
+            "corpora": 0,
+            "documents": 0,
+            "tokenized_documents": 0,
+            "tokens": 0,
+        }
+
+    find = sys.modules.get("exomem.find")
+    if find is not None and hasattr(find, "cache_status"):
+        caches["find"] = find.cache_status()
+    else:
+        caches["find"] = {
+            "pages": {"entries": 0, "body_chars": 0},
+            "resolver": {"entries": 0},
+            "hot_results": {"entries": 0, "hits": 0},
+        }
+    return caches
+
+
+def _deferred_work(vault_root: Path | None) -> dict[str, Any]:
+    index_sync = sys.modules.get("exomem.index_sync")
+    if index_sync is None or not hasattr(index_sync, "deferred_work_status"):
+        return {
+            "semantic_upserts": {
+                "count": 0,
+                "paths": [],
+                "truncated": False,
+                "roots": 0,
+            }
+        }
+    return index_sync.deferred_work_status(vault_root)
+
+
+def cuda_accounting_if_initialized() -> dict[str, Any]:
+    """CUDA accounting without importing torch or creating a context."""
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return {"torch_imported": False, "initialized": False, "memory": None}
+    cuda = getattr(torch, "cuda", None)
+    if cuda is None:
+        return {"torch_imported": True, "initialized": False, "memory": None}
+    try:
+        initialized = bool(cuda.is_initialized())
+    except Exception:  # noqa: BLE001
+        return {
+            "torch_imported": True,
+            "initialized": "unknown",
+            "memory": None,
+        }
+    if not initialized:
+        return {"torch_imported": True, "initialized": False, "memory": None}
+    try:
+        memory = {
+            "allocated_mb": round(cuda.memory_allocated() / 2**20, 1),
+            "reserved_mb": round(cuda.memory_reserved() / 2**20, 1),
+        }
+    except Exception:  # noqa: BLE001
+        memory = None
+    return {"torch_imported": True, "initialized": True, "memory": memory}
+
+
+def collect(vault_root: Path | None = None) -> dict[str, Any]:
+    """Collect process-local resource status without allocating heavy resources."""
+    policy = mode.resolved()
+    return {
+        "mode": policy["mode"],
+        "source": _mode_source(),
+        "config_path": str(mode.config_path()),
+        "policy": policy,
+        "models": _model_residency(),
+        "caches": _cache_residency(),
+        "deferred_work": _deferred_work(vault_root),
+        "cuda": cuda_accounting_if_initialized(),
+    }
+
+
+def _min_free_vram_mb() -> int:
+    try:
+        gb = float(os.environ.get("EXOMEM_GPU_MIN_FREE_GB") or "2.0")
+    except ValueError:
+        gb = 2.0
+    return int(gb * 1024)
+
+
+def _probe_nvidia_smi() -> dict[str, Any]:
+    exe = shutil.which("nvidia-smi")
+    if not exe:
+        return {"status": "unavailable", "reason": "nvidia-smi not found"}
+    try:
+        proc = subprocess.run(
+            [
+                exe,
+                "--query-gpu=memory.free,memory.total,name",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=2,
+        )
+    except Exception as e:  # noqa: BLE001
+        return {"status": "unavailable", "reason": str(e)}
+    if proc.returncode != 0:
+        reason = (proc.stderr or proc.stdout or "nvidia-smi failed").strip()
+        return {"status": "unavailable", "reason": reason}
+    line = (proc.stdout or "").splitlines()[0].strip() if proc.stdout else ""
+    parts = [p.strip() for p in line.split(",")]
+    if len(parts) < 2:
+        return {"status": "unavailable", "reason": "unexpected nvidia-smi output"}
+    try:
+        free_mb = int(float(parts[0]))
+        total_mb = int(float(parts[1]))
+    except ValueError:
+        return {"status": "unavailable", "reason": "unparseable nvidia-smi output"}
+    return {
+        "status": "ok",
+        "free_mb": free_mb,
+        "total_mb": total_mb,
+        "name": parts[2] if len(parts) > 2 else None,
+    }
+
+
+def gpu_headroom() -> dict[str, Any]:
+    """Non-torch GPU headroom posture for doctor/setup messaging."""
+    if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
+        return {
+            "status": "disabled",
+            "usable": False,
+            "reason": "CUDA_VISIBLE_DEVICES is empty",
+            "min_free_mb": _min_free_vram_mb(),
+        }
+    probe = _probe_nvidia_smi()
+    min_free = _min_free_vram_mb()
+    if probe.get("status") != "ok":
+        return {
+            "status": "unknown",
+            "usable": None,
+            "reason": probe.get("reason"),
+            "min_free_mb": min_free,
+        }
+    free_mb = int(probe["free_mb"])
+    usable = free_mb >= min_free
+    return {
+        "status": "capable" if usable else "marginal",
+        "usable": usable,
+        "reason": None if usable else "free VRAM below policy threshold",
+        "free_mb": free_mb,
+        "total_mb": int(probe["total_mb"]),
+        "name": probe.get("name"),
+        "min_free_mb": min_free,
+    }
+
+
+def resource_posture() -> dict[str, Any]:
+    policy = mode.resolved()
+    return {
+        "mode": policy["mode"],
+        "source": _mode_source(),
+        "policy": policy,
+        "cpu_baseline": True,
+        "gpu": gpu_headroom(),
+    }

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -342,6 +342,11 @@ def build_server(*, require_auth: bool) -> FastMCP:
     # starts/stops the reaper. Off via EXOMEM_DISABLE_MODE_WATCH.
     mode.start_config_watch()
 
+    # Optional auto-quiet: default-off, non-torch pressure probes only.
+    from . import auto_quiet
+
+    auto_quiet.start_if_enabled()
+
     # Media-extraction worker: transcribes/OCRs binaries uploaded without text, off
     # the request path, and fills their sidecars (then re-embeds). Disabled in tests
     # and on lean boxes via EXOMEM_DISABLE_MEDIA_EXTRACTION (mirrors the embeddings flag).

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -206,14 +206,16 @@ def run_setup(
     # Interactive only (never blocks --yes automation), and only when embeddings are on
     # (a lean install has no models to accelerate). CPU stays the safe default otherwise.
     if not yes and profile != "lean":
-        from . import accel
         from . import mode as mode_mod
+        from . import resource_status
 
-        if mode_mod.resolve_mode() != "performance" and accel.gpu_usable():
+        gpu = resource_status.gpu_headroom()
+        if mode_mod.resolve_mode() != "performance" and gpu.get("usable") is True:
             if _ask_yn(
                 input_fn,
-                "\n⚡ A capable GPU was detected. Use it for faster indexing & search? "
-                "(change anytime with `exomem mode`)",
+                "\nA capable idle GPU was detected. Use performance mode for "
+                "faster explicit indexing? Normal mode avoids steady-state CUDA "
+                "residency. (change anytime with `exomem mode`)",
                 False,
             ):
                 mode_mod.write_mode("performance")
@@ -327,7 +329,11 @@ def run_setup(
     print_fn("Next steps:")
     print_fn("  1. Restart Claude Code so it loads the exomem server and skill.")
     print_fn('  2. Try: "what does this vault look like" or "find my notes on X".')
-    print_fn("  3. Optional, for direct CLI use (`kb find …`): set EXOMEM_VAULT_PATH.")
+    print_fn("  3. Optional, for direct CLI use (`kb find ...`): set EXOMEM_VAULT_PATH.")
+    print_fn(
+        "  4. For foreground work/gaming: exomem mode quiet; inspect with "
+        "exomem status --resources --json."
+    )
     return code
 
 

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -43,17 +43,28 @@ def warmup_enabled() -> bool:
     return not os.environ.get("EXOMEM_DISABLE_WARMUP")
 
 
-def warm_caches(vault_root: Path, *, preload_models: bool = True) -> dict[str, float]:
-    """Warm find's lexical/derived caches; returns per-step durations in ms
-    (empty when disabled). Never raises.
+def warm_caches(
+    vault_root: Path,
+    *,
+    preload_models: bool = True,
+    preload_cpu_caches: bool | None = None,
+) -> dict[str, float]:
+    """Warm find's rebuildable caches; returns per-step durations in ms.
 
-    The lexical steps (pages, BM25 both scopes, resolver) are CPU-only and always
-    run. The embedding/CLIP matrix dummy searches touch the vector backend and are
-    skipped when `preload_models` is False (quiet mode) so a quiet boot keeps its
-    RAM footprint minimal — the first find faults the matrix lazily instead.
+    Quiet mode disables CPU cache preloading entirely: parsed pages, BM25 corpora,
+    resolver state, and vector matrices all stay cold until a request needs them.
+    `preload_models=False` still only gates model-backed vector/CLIP matrix warm-up
+    when CPU cache preloading is otherwise allowed.
     """
     if not warmup_enabled():
         log.info("cache warm-up disabled via EXOMEM_DISABLE_WARMUP")
+        return {}
+    if preload_cpu_caches is None:
+        from . import mode
+
+        preload_cpu_caches = mode.preload_cpu_caches()
+    if not preload_cpu_caches:
+        log.info("cache warm-up skipped by resource mode")
         return {}
     from . import bm25, find
 
@@ -129,7 +140,11 @@ def warm_all(vault_root: Path) -> dict[str, float]:
     from . import mode, readiness
 
     preload = mode.preload_models()
-    durations = warm_caches(vault_root, preload_models=preload)
+    durations = warm_caches(
+        vault_root,
+        preload_models=preload,
+        preload_cpu_caches=mode.preload_cpu_caches(),
+    )
     readiness.mark_ready("lexical")
 
     def _model_step(name: str, fn) -> bool:

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -185,6 +185,20 @@ def test_gpu_usable_false_without_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
     assert accel.gpu_usable() is False
 
 
+def test_gpu_usable_false_when_cuda_available_probe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = types.ModuleType("torch")
+
+    def _boom():
+        raise RuntimeError("driver probe failed")
+
+    torch.cuda = types.SimpleNamespace(is_available=_boom)
+    torch.backends = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    assert accel.gpu_usable() is False
+
+
 def test_gpu_usable_false_on_marginal_vram(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_hw(monkeypatch, cuda=True, mps=False, free_gb=1.0)  # < 2 GB default
     assert accel.gpu_usable() is False

--- a/tests/test_auto_quiet.py
+++ b/tests/test_auto_quiet.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import builtins
+import sys
+
+from exomem import auto_quiet
+
+
+def _forbid_torch_import(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "torch" or name.startswith("torch."):
+            raise AssertionError("auto-quiet must not import torch")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+
+def test_decide_enters_quiet_after_sustained_pressure() -> None:
+    state = auto_quiet.AutoQuietState()
+
+    first = auto_quiet.decide(
+        state,
+        current_mode="normal",
+        config_mode="normal",
+        pressure=True,
+        now=10.0,
+        env_pinned=False,
+        enter_after=30.0,
+    )
+    second = auto_quiet.decide(
+        state,
+        current_mode="normal",
+        config_mode="normal",
+        pressure=True,
+        now=41.0,
+        env_pinned=False,
+        enter_after=30.0,
+    )
+
+    assert first.action == "none"
+    assert second == auto_quiet.AutoQuietDecision(
+        "enter_quiet", target_mode="quiet", reason="pressure sustained"
+    )
+    assert state.engaged is True
+    assert state.previous_mode == "normal"
+
+
+def test_decide_restores_after_clear_hysteresis() -> None:
+    state = auto_quiet.AutoQuietState(engaged=True, previous_mode="performance")
+
+    first = auto_quiet.decide(
+        state,
+        current_mode="quiet",
+        config_mode="quiet",
+        pressure=False,
+        now=100.0,
+        env_pinned=False,
+        restore_after=60.0,
+    )
+    second = auto_quiet.decide(
+        state,
+        current_mode="quiet",
+        config_mode="quiet",
+        pressure=False,
+        now=161.0,
+        env_pinned=False,
+        restore_after=60.0,
+    )
+
+    assert first.action == "none"
+    assert second == auto_quiet.AutoQuietDecision(
+        "restore", target_mode="performance", reason="pressure clear"
+    )
+    assert state.engaged is False
+
+
+def test_decide_does_not_restore_over_manual_mode_change() -> None:
+    state = auto_quiet.AutoQuietState(engaged=True, previous_mode="normal")
+
+    decision = auto_quiet.decide(
+        state,
+        current_mode="performance",
+        config_mode="performance",
+        pressure=False,
+        now=200.0,
+        env_pinned=False,
+    )
+
+    assert decision.action == "none"
+    assert decision.reason == "manual mode change detected"
+    assert state.engaged is False
+    assert state.previous_mode is None
+
+
+def test_decide_respects_env_pin() -> None:
+    state = auto_quiet.AutoQuietState()
+
+    decision = auto_quiet.decide(
+        state,
+        current_mode="normal",
+        config_mode="normal",
+        pressure=True,
+        now=100.0,
+        env_pinned=True,
+        enter_after=0.0,
+    )
+
+    assert decision.action == "none"
+    assert decision.reason == "EXOMEM_MODE pins mode"
+
+
+def test_pressure_probe_uses_non_torch_headroom(monkeypatch) -> None:
+    _forbid_torch_import(monkeypatch)
+    monkeypatch.setattr(
+        auto_quiet.resource_status,
+        "gpu_headroom",
+        lambda: {"status": "marginal", "usable": False},
+    )
+
+    assert auto_quiet.pressure_active() is True
+
+
+def test_unavailable_probe_soft_fails_without_mode_change(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auto_quiet.resource_status,
+        "gpu_headroom",
+        lambda: {"status": "unknown", "usable": None},
+    )
+    monkeypatch.setattr(
+        auto_quiet.mode,
+        "write_mode",
+        lambda value: (_ for _ in ()).throw(AssertionError("must not write mode")),
+    )
+
+    decision = auto_quiet.tick(auto_quiet.AutoQuietState(), now=100.0)
+
+    assert decision.action == "none"
+    assert decision.reason == "pressure probe unavailable"
+
+
+def test_start_if_enabled_is_default_off_and_env_gated(monkeypatch, tmp_path) -> None:
+    auto_quiet.stop()
+    monkeypatch.delenv("EXOMEM_AUTO_QUIET", raising=False)
+    monkeypatch.setenv("EXOMEM_CONFIG_PATH", str(tmp_path / "config.json"))
+
+    assert auto_quiet.start_if_enabled() is None
+
+    started: list[str] = []
+
+    class FakeThread:
+        def __init__(self, *, target, name, daemon) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self) -> None:
+            started.append(self.name)
+
+        def is_alive(self) -> bool:
+            return True
+
+        def join(self, timeout=None) -> None:
+            return None
+
+    monkeypatch.setenv("EXOMEM_AUTO_QUIET", "1")
+    monkeypatch.setattr(auto_quiet.threading, "Thread", FakeThread)
+
+    thread = auto_quiet.start_if_enabled()
+    try:
+        assert thread is not None
+        assert started == ["exomem-auto-quiet"]
+    finally:
+        auto_quiet.stop()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -203,3 +203,49 @@ def test_sidecar_live_probe_passes_on_built_sidecar(
 
     assert check.status == "pass", check.message
     assert "live" in check.message
+
+
+def test_resource_posture_check_cpu_unknown_is_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import resource_status
+
+    monkeypatch.setattr(
+        resource_status,
+        "gpu_headroom",
+        lambda: {
+            "status": "unknown",
+            "usable": None,
+            "reason": "nvidia-smi not found",
+            "min_free_mb": 2048,
+        },
+    )
+
+    check = doctor_module._check_resource_posture("lean")
+
+    assert check.status == "pass"
+    assert "CPU is the supported baseline" in check.message
+    assert check.as_dict()["details"]["gpu"]["status"] == "unknown"
+
+
+def test_resource_posture_check_marginal_gpu_warns_for_hybrid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import resource_status
+
+    monkeypatch.setattr(
+        resource_status,
+        "gpu_headroom",
+        lambda: {
+            "status": "marginal",
+            "usable": False,
+            "reason": "free VRAM below policy threshold",
+            "free_mb": 512,
+            "total_mb": 8192,
+            "min_free_mb": 2048,
+        },
+    )
+
+    check = doctor_module._check_resource_posture("hybrid")
+
+    assert check.status == "warn"
+    assert "free VRAM below policy threshold" in check.message
+    assert check.as_dict()["details"]["gpu"]["usable"] is False

--- a/tests/test_embedding_matrix_cache.py
+++ b/tests/test_embedding_matrix_cache.py
@@ -90,6 +90,41 @@ def test_matrix_loads_once_and_is_reused(tmp_path, monkeypatch):
     assert [m[0] for m in metadata] == ["a.md", "b.md"]
 
 
+def test_index_cache_status_and_unload_are_non_destructive(tmp_path):
+    vault = _fresh_vault(tmp_path)
+    emb = embeddings.get_embedding_index(vault)
+    clip = embeddings.get_clip_index(vault)
+
+    cold = embeddings.index_cache_status()
+    assert cold["embedding"]["indexes"] == 1
+    assert cold["embedding"]["loaded"] == 0
+    assert cold["clip"]["indexes"] == 1
+    assert cold["clip"]["loaded"] == 0
+
+    emb.upsert_file("a.md", ["a"], _mat([1, 0]), 1.0)
+    clip.upsert("a.png", _cpad([1, 0]), 1.0)
+    emb_meta, emb_matrix = emb.all_vectors()
+    clip_paths, clip_ts, clip_matrix = clip.all_vectors()
+    assert emb_meta == [("a.md", 0)]
+    assert clip_paths == ["a.png"] and clip_ts == [None]
+
+    warm = embeddings.index_cache_status()
+    assert warm["embedding"]["loaded"] == 1
+    assert warm["embedding"]["rows"] == 1
+    assert warm["embedding"]["bytes"] == emb_matrix.nbytes
+    assert warm["clip"]["loaded"] == 1
+    assert warm["clip"]["rows"] == 1
+    assert warm["clip"]["bytes"] == clip_matrix.nbytes
+
+    assert embeddings.unload_index_caches() == {"embedding": 1, "clip": 1}
+    assert embeddings.index_cache_status()["embedding"]["loaded"] == 0
+    assert embeddings.index_cache_status()["clip"]["loaded"] == 0
+
+    # The sidecars remain intact and lazily reload on next use.
+    assert emb.all_vectors()[0] == [("a.md", 0)]
+    assert clip.all_vectors()[0] == ["a.png"]
+
+
 def test_in_process_writes_never_force_reload(tmp_path, monkeypatch):
     """Warm cache + a stream of in-process writes → reads reload zero times.
 

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -105,6 +105,59 @@ def test_dispatch_thread_coalesces_within_debounce(vault, monkeypatch: pytest.Mo
         t.join(timeout=2)
 
 
+def test_file_watcher_reads_policy_without_restart(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    w = file_watcher.FileWatcher(vault)
+
+    assert w._debounce_seconds() == pytest.approx(2.0)
+    assert w._reconcile_interval_seconds() == pytest.approx(900.0)
+
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+
+    assert w._debounce_seconds() == pytest.approx(0.5)
+    assert w._reconcile_interval_seconds() == pytest.approx(300.0)
+
+
+def test_dispatch_thread_uses_quiet_policy_for_burst_coalescing(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[Path]] = []
+    monkeypatch.setattr(
+        file_watcher.index_sync,
+        "upsert_after_write",
+        lambda root, paths: calls.append(list(paths)),
+    )
+    monkeypatch.setattr(
+        file_watcher.mode,
+        "watcher_policy",
+        lambda: file_watcher.mode.WatcherPolicy(
+            debounce_seconds=0.05,
+            reconcile_interval_seconds=999.0,
+            max_embed_files_per_batch=0,
+            max_reconcile_embed_files=0,
+            defer_expensive_indexes=True,
+        ),
+    )
+    w = file_watcher.FileWatcher(vault)
+    t = threading.Thread(target=w._run_dispatch, daemon=True)
+    t.start()
+    try:
+        a = vault / "Knowledge Base" / "Notes" / "quiet-a.md"
+        b = vault / "Knowledge Base" / "Notes" / "quiet-b.md"
+        w._record(a, deleted=False)
+        time.sleep(0.01)
+        w._record(b, deleted=False)
+        deadline = time.monotonic() + 2.0
+        while not calls and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert len(calls) == 1
+        assert sorted(calls[0]) == sorted([a, b])
+    finally:
+        w._stop.set()
+        w._wake.set()
+        t.join(timeout=2)
+
+
 def test_start_soft_fails_when_watchdog_missing(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     def _boom():
         raise ImportError("No module named 'watchdog'")
@@ -284,6 +337,26 @@ def test_reconcile_dispatches_drift_delta_to_fanout(vault, monkeypatch: pytest.M
     assert calls["delete"] == []
     # bm25 corpus pre-warmed for both scopes off the query path.
     assert calls["warm"] == ["kb", "vault"]
+
+
+def test_quiet_reconcile_defers_embedding_and_skips_bm25_warm(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    file_watcher.clear_self_write_registry()
+    calls = _spy_reconcile_fanout(monkeypatch)
+    w = file_watcher.FileWatcher(vault)
+    w._reconcile_once(seed=True)
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+
+    w._reconcile_once(seed=False)
+
+    assert len(calls["upsert"]) == 1
+    assert [p.resolve() for p in calls["upsert"][0]] == [target.resolve()]
+    assert calls["warm"] == []
 
 
 def test_reconcile_seed_dispatches_nothing(vault, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_find_hot_cache.py
+++ b/tests/test_find_hot_cache.py
@@ -121,6 +121,32 @@ def test_clear_cache_clears_hot_cache(vault: Path, monkeypatch) -> None:
     assert calls["n"] == 2
 
 
+def test_unload_ram_caches_preserves_freshness(vault: Path) -> None:
+    from exomem import freshness
+
+    kb = vault / "Knowledge Base"
+    freshness.seed(
+        vault,
+        "kb",
+        ((str(p), p.stat().st_mtime_ns) for p in find_module._walk_md(kb)),
+    )
+    before_freshness = freshness.triple(vault, "kb")
+
+    assert find_module.find(vault, query="metabolism")
+    status = find_module.cache_status()
+    assert status["pages"]["entries"] > 0
+    assert status["hot_find"]["entries"] > 0
+
+    unloaded = find_module.unload_ram_caches()
+    assert unloaded["pages"] > 0
+    assert unloaded["hot_find"] > 0
+    assert find_module.cache_status()["pages"]["entries"] == 0
+    assert find_module.cache_status()["hot_find"]["entries"] == 0
+    assert freshness.triple(vault, "kb") == before_freshness
+
+    assert find_module.find(vault, query="metabolism")
+
+
 def test_keyword_mode_also_cached(vault: Path, monkeypatch) -> None:
     calls = {"n": 0}
     orig = find_module._find_keyword

--- a/tests/test_find_overhead.py
+++ b/tests/test_find_overhead.py
@@ -95,6 +95,32 @@ def test_bm25_sees_delete(vault: Path) -> None:
     assert not any(p.endswith("delete-probe.md") for p, _ in hits)
 
 
+def test_bm25_cache_status_and_unload_rebuilds(vault: Path, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    bm25.clear_cache()
+    cold = bm25.cache_status()
+    assert cold == {
+        "loaded": False,
+        "corpora": 0,
+        "documents": 0,
+        "tokenized_documents": 0,
+        "tokens": 0,
+    }
+
+    first = bm25.search(vault, "insulin", k=5)
+    warm = bm25.cache_status()
+    assert first
+    assert warm["loaded"] is True
+    assert warm["corpora"] == 1
+    assert warm["documents"] > 0
+    assert warm["tokenized_documents"] > 0
+    assert warm["tokens"] > 0
+
+    assert bm25.unload_cache() is True
+    assert bm25.cache_status()["loaded"] is False
+    assert bm25.search(vault, "insulin", k=5) == first
+
+
 def test_resolver_rebuilds_on_rename(vault: Path) -> None:
     """The resolver's old (count, max-mtime) key missed pure renames."""
     a = vault / "Knowledge Base" / "Notes" / "resolver-rename-a.md"
@@ -219,3 +245,20 @@ def test_warmup_soft_fails_on_broken_vault(tmp_path: Path) -> None:
     # No Knowledge Base/ dir at all — every step must soft-fail, not raise.
     durations = warmup.warm_caches(tmp_path / "nonexistent")
     assert isinstance(durations, dict)
+
+
+def test_quiet_cold_find_matches_warm_cache_find(vault: Path, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    find_module.clear_cache()
+    bm25.clear_cache()
+    assert warmup.warm_caches(vault) == {}
+    cold = find_module.find(vault, query="metabolism", mode="hybrid", limit=10)
+
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    find_module.clear_cache()
+    bm25.clear_cache()
+    warmup.warm_caches(vault)
+    warm = find_module.find(vault, query="metabolism", mode="hybrid", limit=10)
+
+    assert [h.path for h in cold] == [h.path for h in warm]

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -92,3 +92,125 @@ def test_index_sync_upsert_noop_when_all_excluded(
     index_sync.upsert_after_write(vault, [trashed])
 
     assert called == []
+
+
+def test_index_sync_quiet_defers_semantic_upserts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    index_sync.clear_deferred_work(vault)
+    from exomem import embeddings, find, lexstore
+
+    seen: dict[str, list] = {"lexstore": [], "embeddings": [], "resolver": []}
+    monkeypatch.setattr(
+        lexstore,
+        "upsert_after_write",
+        lambda root, paths: seen["lexstore"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write",
+        lambda root, paths: seen["embeddings"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        find,
+        "on_resolver_files_changed",
+        lambda root, changed, deleted: seen["resolver"].append(
+            (list(changed), list(deleted))
+        ),
+    )
+
+    good = vault / "Knowledge Base" / "Notes" / "Insights" / "quiet-defers.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text("# quiet\n", encoding="utf-8")
+
+    try:
+        index_sync.upsert_after_write(vault, [good, good])
+
+        assert seen["lexstore"] == [[good, good]]
+        assert seen["embeddings"] == []
+        assert seen["resolver"] == [
+            (
+                [
+                    "Knowledge Base/Notes/Insights/quiet-defers.md",
+                    "Knowledge Base/Notes/Insights/quiet-defers.md",
+                ],
+                [],
+            )
+        ]
+        status = index_sync.deferred_work_status(vault)["semantic_upserts"]
+        assert status["count"] == 1
+        assert status["paths"] == ["Knowledge Base/Notes/Insights/quiet-defers.md"]
+    finally:
+        index_sync.clear_deferred_work(vault)
+
+
+def test_index_sync_nonquiet_keeps_immediate_embedding_upsert(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    index_sync.clear_deferred_work(vault)
+    from exomem import embeddings, find, lexstore
+
+    seen: dict[str, list] = {"lexstore": [], "embeddings": [], "resolver": []}
+    monkeypatch.setattr(
+        lexstore,
+        "upsert_after_write",
+        lambda root, paths: seen["lexstore"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write",
+        lambda root, paths: seen["embeddings"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        find,
+        "on_resolver_files_changed",
+        lambda root, changed, deleted: seen["resolver"].append(
+            (list(changed), list(deleted))
+        ),
+    )
+
+    good = vault / "Knowledge Base" / "Notes" / "Insights" / "normal-upserts.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text("# normal\n", encoding="utf-8")
+
+    index_sync.upsert_after_write(vault, [good])
+
+    assert seen["lexstore"] == [[good]]
+    assert seen["embeddings"] == [[good]]
+    assert seen["resolver"] == [(["Knowledge Base/Notes/Insights/normal-upserts.md"], [])]
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0
+
+
+def test_drain_deferred_work_processes_and_clears_semantic_upserts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    index_sync.clear_deferred_work(vault)
+    from exomem import embeddings, find, lexstore
+
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda root, paths: None)
+    monkeypatch.setattr(
+        find,
+        "on_resolver_files_changed",
+        lambda root, changed, deleted: None,
+    )
+    calls: list[list[Path]] = []
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write",
+        lambda root, paths: calls.append(list(paths)),
+    )
+    good = vault / "Knowledge Base" / "Notes" / "Insights" / "drain-me.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text("# drain\n", encoding="utf-8")
+
+    index_sync.upsert_after_write(vault, [good])
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 1
+
+    processed = index_sync.drain_deferred_work(vault)
+
+    assert processed == 1
+    assert calls == [[good]]
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -276,7 +276,8 @@ def test_warm_all_quiet_mode_skips_preloads_but_marks_ready(
     the idle-VRAM win: no model touches CUDA at boot."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_MODE", "quiet")
-    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
+    cache_policy: dict = {}
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **kw: cache_policy.update(kw) or {})
 
     def _forbidden() -> None:
         raise AssertionError("model getters must not be called in quiet mode")
@@ -287,6 +288,8 @@ def test_warm_all_quiet_mode_skips_preloads_but_marks_ready(
 
     warmup.warm_all(tmp_path)
 
+    assert cache_policy["preload_models"] is False
+    assert cache_policy["preload_cpu_caches"] is False
     for c in readiness.COMPONENTS:
         assert readiness.is_ready(c) is True
 
@@ -318,11 +321,11 @@ def test_warm_all_quiet_mode_replays_deferred_write_embeds(
 def test_warm_caches_gates_matrix_warm_on_preload_models(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The embedding/CLIP matrix dummy searches (which touch the vector backend) are
-    skipped when preload_models is False and run when True — the CPU-only lexical
-    steps are unaffected either way."""
+    """The embedding/CLIP matrix dummy searches are skipped when preload_models is
+    False and run when True while CPU cache preloading is otherwise allowed."""
     monkeypatch.delenv("EXOMEM_DISABLE_WARMUP", raising=False)
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
 
     calls: list[int] = []
 
@@ -344,6 +347,34 @@ def test_warm_caches_gates_matrix_warm_on_preload_models(
     assert "embedding_matrix" in d_default
     assert "clip_matrix" in d_default
     assert calls == [1, 1]
+
+
+def test_warm_caches_quiet_skips_cpu_and_vector_warmup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_WARMUP", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    kb = tmp_path / "Knowledge Base"
+    kb.mkdir()
+    (kb / "a.md").write_text("# A\n\nbody", encoding="utf-8")
+
+    forbidden: list[str] = []
+
+    def _forbid(name: str):
+        def inner(*_args, **_kwargs):
+            forbidden.append(name)
+            raise AssertionError(f"{name} should not warm in quiet mode")
+        return inner
+
+    monkeypatch.setattr(bm25, "warm", _forbid("bm25"))
+    monkeypatch.setattr(find_module._CACHE, "get", _forbid("pages"))
+    monkeypatch.setattr(find_module, "_get_query_resolver", _forbid("resolver"))
+    monkeypatch.setattr(embeddings, "get_embedding_index", _forbid("embedding_matrix"))
+    monkeypatch.setattr(embeddings, "get_clip_index", _forbid("clip_matrix"))
+
+    assert warmup.warm_caches(tmp_path) == {}
+    assert forbidden == []
 
 
 def test_warm_all_soft_fails_one_step_and_continues_to_later_steps(

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -7,6 +7,7 @@ and the atomic config writer. No hardware needed.
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 from pathlib import Path
@@ -32,6 +33,8 @@ def test_normalize_canonical_and_aliases() -> None:
     assert mode.normalize("performance") == "performance"
     assert mode.normalize("gpu") == "performance"  # alias
     assert mode.normalize("turbo") == "performance"  # alias
+    assert mode.normalize("resource-saver") == "quiet"
+    assert mode.normalize("low-resource") == "quiet"
     assert mode.normalize(" GPU ") == "performance"  # case/space-insensitive
 
 
@@ -66,6 +69,23 @@ def test_env_beats_config_file(monkeypatch: pytest.MonkeyPatch) -> None:
     mode.write_mode("performance")
     monkeypatch.setenv("EXOMEM_MODE", "quiet")
     assert mode.resolve_mode() == "quiet"
+
+
+def test_env_beats_config_file_and_auto_quiet_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "mode": "quiet",
+                "auto_quiet": {"active": True, "previous_mode": "normal"},
+            }
+        ),
+        "utf-8",
+    )
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    assert mode.resolve_mode() == "performance"
 
 
 def test_legacy_quiet_alias(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,8 +133,97 @@ def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> 
     assert mode.bulk_gpu_opted() is bulk
 
 
-# ---- config file read/write ----
+@pytest.mark.parametrize(
+    "m, expected",
+    [
+        (
+            "quiet",
+            {
+                "preload_cpu_caches": False,
+                "retain_cpu_caches": False,
+                "defer_expensive_indexes": True,
+                "watcher_policy": {
+                    "debounce_seconds": 2.0,
+                    "reconcile_interval_seconds": 900.0,
+                    "max_embed_files_per_batch": 0,
+                    "max_reconcile_embed_files": 0,
+                    "defer_expensive_indexes": True,
+                },
+                "release_when_idle": True,
+                "bulk_gpu": False,
+            },
+        ),
+        (
+            "normal",
+            {
+                "preload_cpu_caches": True,
+                "retain_cpu_caches": True,
+                "defer_expensive_indexes": False,
+                "watcher_policy": {
+                    "debounce_seconds": 0.5,
+                    "reconcile_interval_seconds": 300.0,
+                    "max_embed_files_per_batch": None,
+                    "max_reconcile_embed_files": 500,
+                    "defer_expensive_indexes": False,
+                },
+                "release_when_idle": False,
+                "bulk_gpu": False,
+            },
+        ),
+        (
+            "performance",
+            {
+                "preload_cpu_caches": True,
+                "retain_cpu_caches": True,
+                "defer_expensive_indexes": False,
+                "watcher_policy": {
+                    "debounce_seconds": 0.5,
+                    "reconcile_interval_seconds": 300.0,
+                    "max_embed_files_per_batch": None,
+                    "max_reconcile_embed_files": 500,
+                    "defer_expensive_indexes": False,
+                },
+                "release_when_idle": True,
+                "bulk_gpu": True,
+            },
+        ),
+    ],
+)
+def test_resolved_resource_policy_fields(
+    monkeypatch: pytest.MonkeyPatch, m: str, expected: dict
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", m)
+    snap = mode.resolved()
+    for key, value in expected.items():
+        assert snap[key] == value
+    assert mode.preload_cpu_caches() is expected["preload_cpu_caches"]
+    assert mode.retain_cpu_caches() is expected["retain_cpu_caches"]
+    assert mode.defer_expensive_indexes() is expected["defer_expensive_indexes"]
+    assert mode.watcher_policy().as_dict() == expected["watcher_policy"]
 
+
+def test_policy_helpers_do_not_import_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):  # noqa: ANN001
+        if name == "torch" or name.startswith("torch."):
+            raise AssertionError("mode policy helpers must not import torch")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    mode.normalize("resource-saver")
+    mode.resolve_mode()
+    mode.preload_models()
+    mode.preload_cpu_caches()
+    mode.retain_cpu_caches()
+    mode.defer_expensive_indexes()
+    mode.watcher_policy()
+    mode.release_when_idle()
+    mode.bulk_gpu_opted()
+    mode.resolved()
+
+
+# ---- config file read/write ----
 def test_read_config_missing_is_empty() -> None:
     assert mode.read_config() == {}
 
@@ -152,6 +261,16 @@ def test_resolved_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
     assert snap == {
         "mode": "quiet",
         "preload_models": False,
+        "preload_cpu_caches": False,
+        "retain_cpu_caches": False,
+        "defer_expensive_indexes": True,
+        "watcher_policy": {
+            "debounce_seconds": 2.0,
+            "reconcile_interval_seconds": 900.0,
+            "max_embed_files_per_batch": 0,
+            "max_reconcile_embed_files": 0,
+            "defer_expensive_indexes": True,
+        },
         "release_when_idle": True,
         "bulk_gpu": False,
     }
@@ -160,13 +279,16 @@ def test_resolved_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
 # ---- apply_live: reconcile the running process to a mode ----
 
 def _patch_runtime(monkeypatch):
-    """Stub embeddings.unload_* + model_reaper.start/stop; return a call recorder."""
-    from exomem import embeddings, model_reaper
+    """Stub runtime unload/start hooks; return a call recorder."""
+    from exomem import bm25, embeddings, find, model_reaper
 
-    calls = {"unload": 0, "start": 0, "stop": 0}
+    calls = {"unload": 0, "cache": 0, "start": 0, "stop": 0}
     monkeypatch.setattr(embeddings, "unload_model", lambda: calls.__setitem__("unload", calls["unload"] + 1) or True)
     monkeypatch.setattr(embeddings, "unload_reranker", lambda: True)
     monkeypatch.setattr(embeddings, "unload_clip_model", lambda: True)
+    monkeypatch.setattr(embeddings, "unload_index_caches", lambda: calls.__setitem__("cache", calls["cache"] + 1) or {"embedding": 0, "clip": 0})
+    monkeypatch.setattr(bm25, "unload_cache", lambda: calls.__setitem__("cache", calls["cache"] + 1) or False)
+    monkeypatch.setattr(find, "unload_ram_caches", lambda: calls.__setitem__("cache", calls["cache"] + 1) or {})
     monkeypatch.setattr(model_reaper, "start", lambda: calls.__setitem__("start", calls["start"] + 1))
     monkeypatch.setattr(model_reaper, "stop", lambda: calls.__setitem__("stop", calls["stop"] + 1))
     return calls
@@ -185,6 +307,15 @@ def test_apply_live_performance_starts_reaper(monkeypatch: pytest.MonkeyPatch) -
     calls = _patch_runtime(monkeypatch)
     monkeypatch.setenv("EXOMEM_MODE", "performance")
     mode.apply_live()
+    assert calls["start"] == 1 and calls["stop"] == 0
+
+
+def test_apply_live_quiet_unloads_heavy_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_runtime(monkeypatch)
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    policy = mode.apply_live()
+    assert policy["mode"] == "quiet"
+    assert calls["cache"] == 3
     assert calls["start"] == 1 and calls["stop"] == 0
 
 
@@ -242,6 +373,17 @@ def test_mode_cli_set_writes_config(monkeypatch: pytest.MonkeyPatch, capsys: pyt
     assert main(["mode", "gpu"]) == 0  # alias → performance
     assert mode.read_config().get("mode") == "performance"
     assert "performance" in capsys.readouterr().out
+
+
+def test_mode_cli_low_resource_alias_writes_quiet(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    from exomem.__main__ import main
+
+    monkeypatch.delenv("EXOMEM_MODE", raising=False)
+    assert main(["mode", "low-resource"]) == 0
+    assert mode.read_config().get("mode") == "quiet"
+    assert "quiet" in capsys.readouterr().out
 
 
 # ---- config_path: cross-user (service vs CLI) resolution ----

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -201,6 +201,66 @@ def test_reap_once_unloads_only_stale() -> None:
     assert len(reaped) == 1
 
 
+def test_reap_once_soft_fails_per_slot() -> None:
+    def boom():
+        raise RuntimeError("bad slot")
+
+    bad = model_reaper.ModelSlot("bad", lambda: True, lambda: 0, lambda: 0.0, boom)
+    good, unloaded = _slot(last=0.0)
+    reaped = model_reaper._reap_once([bad, good], now=1000.0, threshold=900.0)
+    assert reaped == ["m"]
+    assert unloaded == [1]
+
+
+def test_default_cache_slots_reap_only_when_cpu_caches_are_evictable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import bm25, find
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        embeddings,
+        "index_cache_status",
+        lambda: {
+            "embedding": {"loaded": 1},
+            "clip": {"loaded": 1},
+        },
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "unload_index_caches",
+        lambda: calls.append("index") or {"embedding": 1, "clip": 1},
+    )
+    monkeypatch.setattr(bm25, "cache_status", lambda: {"loaded": True})
+    monkeypatch.setattr(bm25, "unload_cache", lambda: calls.append("bm25") or True)
+    monkeypatch.setattr(
+        find,
+        "cache_status",
+        lambda: {
+            "pages": {"entries": 1},
+            "resolvers": {"entries": 1},
+            "hot_find": {"entries": 1},
+        },
+    )
+    monkeypatch.setattr(
+        find,
+        "unload_ram_caches",
+        lambda: calls.append("find") or {"pages": 1},
+    )
+    monkeypatch.setattr(accel, "gpu_mem", lambda: None)
+
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    slots = [s for s in model_reaper.default_slots() if s.name.endswith("cache") or s.name.endswith("caches") or s.name == "index-matrices"]
+    model_reaper._reap_once(slots, now=time.monotonic() + 2.0, threshold=1.0)
+    assert calls == []
+
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    slots = [s for s in model_reaper.default_slots() if s.name.endswith("cache") or s.name.endswith("caches") or s.name == "index-matrices"]
+    reaped = model_reaper._reap_once(slots, now=time.monotonic() + 2.0, threshold=1.0)
+    assert reaped == ["index-matrices", "bm25-cache", "find-ram-caches"]
+    assert calls == ["index", "bm25", "find"]
+
+
 # ---- reaper lifecycle ----
 
 def test_reaper_start_fires_then_stops() -> None:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -8,8 +8,10 @@ remaining drift, without audit_fix's wikilink/frontmatter rewrites.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from exomem import audit as audit_module
+from exomem import index_sync
 from exomem import reconcile as reconcile_module
 
 
@@ -59,3 +61,55 @@ def test_reconcile_dry_run_reports_without_writing(vault: Path) -> None:
     assert rep.dry_run is True
     assert "Knowledge Base/index.md" in rep.indexes_updated
     assert top.read_text(encoding="utf-8") == drifted, "dry_run must not write"
+
+
+def test_reconcile_clears_deferred_semantic_work_after_embedding_refresh(
+    vault: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    index_sync.clear_deferred_work(vault)
+
+    from exomem import find, lexstore
+
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda root, paths: None)
+    monkeypatch.setattr(
+        find,
+        "on_resolver_files_changed",
+        lambda root, changed, deleted: None,
+    )
+    target = vault / "Knowledge Base" / "Notes" / "reconcile-deferred.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# reconcile deferred\n", encoding="utf-8")
+    index_sync.upsert_after_write(vault, [target])
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 1
+
+    calls: list[list[Path]] = []
+    monkeypatch.setattr(
+        "exomem.embeddings.upsert_after_write",
+        lambda root, paths: calls.append(list(paths)),
+    )
+    monkeypatch.setattr(
+        audit_module,
+        "_check_embedding_drift",
+        lambda root: [
+            SimpleNamespace(path=Path("Knowledge Base/Notes/reconcile-deferred.md"))
+        ],
+    )
+    monkeypatch.setattr(
+        audit_module,
+        "audit",
+        lambda root, categories: SimpleNamespace(findings=[]),
+    )
+    monkeypatch.setattr(
+        reconcile_module.indexes,
+        "compute_subindex_writes",
+        lambda root, top_index_text: ([], top_index_text),
+    )
+    monkeypatch.setattr("exomem.lexstore.ensure_fresh", lambda root: None)
+
+    rep = reconcile_module.reconcile(vault)
+
+    assert rep.embeddings_status == "refreshed"
+    assert calls == [[target]]
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0

--- a/tests/test_resource_status.py
+++ b/tests/test_resource_status.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+import types
+from pathlib import Path
+
+from exomem import resource_status
+
+
+def _forbid_torch_import(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    for module in (
+        "exomem.embeddings",
+        "exomem.bm25",
+        "exomem.find",
+        "exomem.index_sync",
+    ):
+        monkeypatch.delitem(sys.modules, module, raising=False)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "torch" or name.startswith("torch."):
+            raise AssertionError("resource status must not import torch")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+
+def test_collect_does_not_import_torch_or_probe_cuda(monkeypatch, tmp_path: Path) -> None:
+    _forbid_torch_import(monkeypatch)
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+
+    status = resource_status.collect(tmp_path)
+
+    assert status["mode"] == "quiet"
+    assert status["cuda"] == {
+        "torch_imported": False,
+        "initialized": False,
+        "memory": None,
+    }
+    assert status["models"] == {
+        "module_loaded": False,
+        "embeddings": False,
+        "reranker": False,
+        "clip": False,
+    }
+
+
+def test_collect_reports_already_loaded_modules_without_loading_missing_ones(
+    monkeypatch, tmp_path: Path
+) -> None:
+    fake_embeddings = types.SimpleNamespace(
+        _MODEL=object(),
+        _RERANKER=None,
+        _CLIP_MODEL=object(),
+        index_cache_status=lambda: {
+            "embedding": {"loaded": 1, "indexes": 1, "rows": 3, "bytes": 96},
+            "clip": {"loaded": 0, "indexes": 0, "rows": 0, "bytes": 0},
+        },
+    )
+    fake_bm25 = types.SimpleNamespace(
+        cache_status=lambda: {
+            "loaded": True,
+            "corpora": 1,
+            "documents": 2,
+            "tokenized_documents": 2,
+            "tokens": 7,
+        }
+    )
+    fake_find = types.SimpleNamespace(
+        cache_status=lambda: {
+            "pages": {"entries": 2, "body_chars": 10},
+            "resolver": {"entries": 1},
+            "hot_results": {"entries": 1, "hits": 3},
+        }
+    )
+    fake_index_sync = types.SimpleNamespace(
+        deferred_work_status=lambda root: {
+            "semantic_upserts": {
+                "count": 1,
+                "paths": ["Knowledge Base/Notes/x.md"],
+                "truncated": False,
+                "roots": 1,
+            }
+        }
+    )
+    monkeypatch.setitem(sys.modules, "exomem.embeddings", fake_embeddings)
+    monkeypatch.setitem(sys.modules, "exomem.bm25", fake_bm25)
+    monkeypatch.setitem(sys.modules, "exomem.find", fake_find)
+    monkeypatch.setitem(sys.modules, "exomem.index_sync", fake_index_sync)
+
+    status = resource_status.collect(tmp_path)
+
+    assert status["models"]["embeddings"] is True
+    assert status["models"]["reranker"] is False
+    assert status["models"]["clip"] is True
+    assert status["caches"]["vector_matrices"]["embedding"]["rows"] == 3
+    assert status["caches"]["bm25"]["tokens"] == 7
+    assert status["caches"]["find"]["hot_results"]["hits"] == 3
+    assert status["deferred_work"]["semantic_upserts"]["count"] == 1
+
+
+def test_status_cli_json_is_resource_status(monkeypatch, capsys, tmp_path: Path) -> None:
+    _forbid_torch_import(monkeypatch)
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+
+    from exomem.__main__ import main
+
+    assert main(["status", "--resources", "--json", "--vault", str(tmp_path)]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["mode"] == "normal"
+    assert data["policy"]["retain_cpu_caches"] is True
+    assert data["cuda"]["torch_imported"] is False


### PR DESCRIPTION
## Summary
- complete quiet/low-resource policy: CPU-default steady state, skipped heavy startup warm-up, idle model/cache eviction, and low-resource aliases
- make watcher/reconcile mode-aware and defer expensive semantic work in quiet while keeping freshness/inbound/resolver lanes live
- add no-allocation resource status, doctor/setup resource posture, default-off auto-quiet, docs, and OpenSpec artifacts

## Verification
- `openspec validate --changes`
- `uvx ruff check` on touched Python files
- targeted resource-mode suite: `298 passed, 1 skipped`
- full suite: `1571 passed, 16 skipped`

## Notes
- Desk-side RTX 5080 VRAM/RAM verification still needs to be measured on the real long-running server + gaming workload; commands are in `openspec/changes/complete-low-interrupt-mode/verification.md`.