### PR TITLE
fix(hooks): suppress retrieval nudge on control prompts

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -298,9 +298,11 @@ variant too, for example `--settings ~/.claude/settings.json##os.Msys`.
   when your message touches something the KB might hold, so it actually behaves as
   your source of truth.
 
-Both are **language-agnostic** (no keyword matching — they work the same in any
-language you write in) and cheap (gated so they stay quiet on ordinary
-turns/prompts, plus a per-session cooldown). They write scripts to
+Both are cheap: gated so they stay quiet on ordinary turns/prompts, plus a
+per-session cooldown. The read hook is still language-agnostic for substantive
+prompts, but it also suppresses obvious short control/status prompts such as
+`continue`, `thanks`, `are you done?`, `merge it`, and `restart the server` so
+the reminder does not churn through routine command flow. They write scripts to
 `~/.claude/hooks/` and wire the two hooks into your settings.json — restart Claude
 Code to activate. Triggers log to `~/.claude/exomem-capture-nudge.log` and
 `~/.claude/exomem-retrieve-nudge.log` so you can see the real rate. Prefer to wire it
@@ -308,7 +310,8 @@ by hand? `uv run python -m exomem install-hook --print-only` writes the scripts 
 prints the snippet to paste.
 
 Tune with `EXOMEM_CAPTURE_NUDGE_MIN_CHARS` / `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (and the
-matching `_COOLDOWN_SEC`), or disable either with `EXOMEM_CAPTURE_NUDGE_DISABLE=1` /
+matching `_COOLDOWN_SEC`), `EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS` for the read
+hook's control-prompt skip ceiling, or disable either with `EXOMEM_CAPTURE_NUDGE_DISABLE=1` /
 `EXOMEM_RETRIEVE_NUDGE_DISABLE=1`. **Writing in a dense script (Japanese, Chinese)?**
 Lower the `MIN_CHARS` values — those scripts pack more meaning per character, so
 the defaults (tuned for English) can under-fire. (These tunables were renamed from

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ recommended for Claude Code —
 the server gives Claude the tools, the skill is what makes it use them. Hooks
 are Claude Code-only reliability nudges for long sessions: a read-side reminder
 before answers and a write-side reminder at natural stopping points. The
-read-side hook can optionally upgrade that reminder to real retrieved KB
-content (`EXOMEM_RETRIEVE_INJECT=1`, opt-in; the legacy `KB_RETRIEVE_INJECT`
-name still works) — see
+read-side hook suppresses obvious control/status prompts like `continue`, `merge
+it`, and `are you done?`, and can optionally upgrade that reminder to real
+retrieved KB content (`EXOMEM_RETRIEVE_INJECT=1`, opt-in; the legacy
+`KB_RETRIEVE_INJECT` name still works) — see
 [QUICKSTART.md § 7](QUICKSTART.md#7-recommended-make-the-kb-automatic-both-directions).
 Other MCP clients can still use the server. If they do not support Skills,
 have them call `bootstrap()` once at the start of the session; it returns the

--- a/openspec/specs/retrieve-inject-hook/spec.md
+++ b/openspec/specs/retrieve-inject-hook/spec.md
@@ -136,6 +136,29 @@ second cooldown clock.
 - **THEN** the second call produces no `additionalContext`
 - **AND** no REST request or CLI subprocess is attempted for that second call
 
+### Requirement: Obvious Control Prompts Stay Silent
+
+The hook SHALL suppress obvious short control/status/acknowledgement prompts
+before emitting reminder context or attempting any inject-mode transport. Examples
+include "continue", "thanks", "are you done?", "perfect merge then to main", and
+"restart the server". The skip gate SHALL be conservative: prompts that explicitly
+touch KB-bearing topics (for example `kb`, `knowledge base`, `Exomem`, `notes`,
+`save`, `remember`, prior conclusions, previous decisions, or "have I looked at")
+SHALL still flow through the normal prompt-length and cooldown gates.
+
+#### Scenario: Control-only prompt skips the hook
+
+- **WHEN** a `UserPromptSubmit` event contains a short control-only prompt such as
+  "perfect merge then to main gj"
+- **THEN** the hook produces no `additionalContext`
+- **AND** no REST request or CLI subprocess is attempted
+
+#### Scenario: KB-bearing prompt still gets the reminder
+
+- **WHEN** a prompt asks "what did I conclude about the kb hook design earlier?"
+- **THEN** the prompt is not suppressed by the control-prompt gate
+- **AND** the hook continues through the existing min-chars and cooldown gates
+
 ### Requirement: The Hook Never Blocks Indefinitely Or Raises
 
 Every transport attempt SHALL be wrapped so that any exception (network
@@ -151,4 +174,3 @@ exit `0`.
   next rung or the nudge-only floor
 - **AND** the hook process exits `0` with no traceback on stderr affecting the
   Claude Code session
-

--- a/src/exomem/_hooks/exomem_retrieve_nudge.py
+++ b/src/exomem/_hooks/exomem_retrieve_nudge.py
@@ -7,11 +7,12 @@ of a thread. This re-arms the read side: when the user submits a substantial
 prompt, it injects a one-line reminder to run `find` first and fold prior
 conclusions into the answer, so the KB actually functions as the source of truth.
 
-Language-agnostic and cheap: gates on prompt length + a per-session cooldown, no
-keywords. By default it injects only a *reminder* — Claude still runs the real
-(semantic) find — so it never stalls the prompt. (UserPromptSubmit blocks model
-start until the hook returns, so the hook must be fast: stdlib only, no search
-here by default.)
+Cheap by default: gates on prompt length, an obvious-control-prompt filter, and
+a per-session cooldown. By default it injects only a *reminder* — Claude still
+runs the real (semantic) find only when the prompt actually needs prior KB
+context — so it never stalls the prompt. (UserPromptSubmit blocks model start
+until the hook returns, so the hook must be fast: stdlib only, no search here by
+default.)
 
 Opt-in **inject mode** (`EXOMEM_RETRIEVE_INJECT`) upgrades the reminder to real
 retrieved content: on the same gated prompt, it fetches the top compact routing
@@ -21,15 +22,18 @@ opt-in CLI fallback (`EXOMEM_RETRIEVE_INJECT_CLI`) — and appends them to the
 reminder. Any transport failure (or the flag being off) falls straight through to
 the reminder-only floor; the hook never blocks or raises past that point.
 
-Tunables (env): EXOMEM_RETRIEVE_NUDGE_DISABLE=1 (off), EXOMEM_RETRIEVE_NUDGE_MIN_CHARS
-(default 20 — short, since prompts are short and a dense script like Japanese
-packs more per char), EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300),
-EXOMEM_RETRIEVE_INJECT (opt-in, default off — truthy-parsed: unset/""/"0"/"false"/
-"no"/"off", any case, count as off) to turn on retrieve-and-inject, and
-EXOMEM_RETRIEVE_INJECT_CLI (opt-in, same truthy parse) to additionally allow the
-slower CLI transport when REST isn't configured or fails. The legacy KB_RETRIEVE_*
-names (including KB_RETRIEVE_INJECT / KB_RETRIEVE_INJECT_CLI) are still accepted for
-back-compat, aliased to the EXOMEM_* names at startup.
+Tunables (env): EXOMEM_RETRIEVE_NUDGE_DISABLE=1 (off),
+EXOMEM_RETRIEVE_NUDGE_MIN_CHARS (default 20 — short, since prompts are short and
+a dense script like Japanese packs more per char),
+EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS (default 180 — only prompts at or below
+this length are eligible for the obvious-control-prompt skip gate),
+EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300), EXOMEM_RETRIEVE_INJECT (opt-in,
+default off — truthy-parsed: unset/""/"0"/"false"/"no"/"off", any case, count as
+off) to turn on retrieve-and-inject, and EXOMEM_RETRIEVE_INJECT_CLI (opt-in, same
+truthy parse) to additionally allow the slower CLI transport when REST isn't
+configured or fails. The legacy KB_RETRIEVE_* names (including KB_RETRIEVE_INJECT
+/ KB_RETRIEVE_INJECT_CLI) are still accepted for back-compat, aliased to the
+EXOMEM_* names at startup.
 
 Contract (Claude Code UserPromptSubmit hook): read the event JSON on stdin (incl.
 `prompt`); on exit 0, print
@@ -54,10 +58,13 @@ REMINDER = (
     "[Exomem retrieval check] Before answering: if this prompt touches a topic your "
     "Exomem knowledge base might hold — a project, a past decision, a domain you've taken "
     "notes on, or a 'what did I conclude / have I looked at' question — run a quiet "
-    "`find` FIRST and fold any hits into the answer (cite them). The KB is the "
-    "source of truth for prior conclusions; a miss means 'not found in what I "
-    "searched,' not 'doesn't exist.' If the prompt plainly has no KB bearing "
-    "(chit-chat, or a fresh task with no prior notes), skip silently."
+    "`find` only if recent conversation context does not already cover it, then fold "
+    "any hits into the answer (cite them). Do not repeat a KB search just because this "
+    "reminder appears again; reuse fresh KB context until the topic changes or the "
+    "answer needs more evidence. The KB is the source of truth for prior conclusions; "
+    "a miss means 'not found in what I searched,' not 'doesn't exist.' If the prompt "
+    "plainly has no KB bearing (chit-chat, status/control messages, or a fresh task "
+    "with no prior notes), skip silently."
 )
 
 # Inject-mode routing-stub block: header + up to 3 `- path (type, updated)` lines,
@@ -69,6 +76,35 @@ _STUB_BLOCK_MAX_CHARS = 400
 # deliberately never imports exomem (see module docstring), so the helper is
 # duplicated rather than shared.
 _FALSY_ENV = {"", "0", "false", "no", "off"}
+
+_KB_BEARING_RE = re.compile(
+    r"\b("
+    r"kb|knowledge\s+base|exomem|note|notes|remember|save|capture|"
+    r"conclud(?:e|ed|ion|ions)?|decision|decisions|"
+    r"prior|previous|earlier|history|looked\s+at|have\s+i|did\s+i"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_CONTROL_PROMPT_RE = re.compile(
+    r"""
+    ^\s*
+    (?:
+        y(?:es|ep|eah)?|ok(?:ay)?|no(?:pe)?|thanks?|thank\s+you|thx|
+        good\s+job|gj|perfect|cool|nice|great|done|
+        perfect\s+merge(?:\s+\w+){0,8}|
+        (?:cool|ok(?:ay)?|nice|great)\s+(?:did|are|is|merge|continue|go)\b.*|
+        so\s+everything\s+done\??|
+        continue|carry\s+on|go\s+on|go\s+ahead|proceed|do\s+it|do\s+that|
+        merge(?:\s+(?:it|then|to|into|main))*|ship\s+it|
+        open(?:\s+(?:the\s+)?)?pr|put(?:\s+it)?\s+to\s+pr|
+        restart(?:\s+the)?\s+server|cut(?:\s+the)?\s+release|
+        status|stuck|are\s+you\s+done|done\s+yet|why\s+is\s+it\s+taking
+    )
+    [\s\.,!?:;\-]*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 
 def _env_flag(name: str) -> bool:
@@ -86,6 +122,7 @@ def _env_flag(name: str) -> bool:
 _ENV_ALIASES = (
     ("EXOMEM_RETRIEVE_NUDGE_DISABLE", "KB_RETRIEVE_NUDGE_DISABLE"),
     ("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", "KB_RETRIEVE_NUDGE_MIN_CHARS"),
+    ("EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS", "KB_RETRIEVE_NUDGE_CONTROL_MAX_CHARS"),
     ("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", "KB_RETRIEVE_NUDGE_COOLDOWN_SEC"),
     ("EXOMEM_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT"),
     ("EXOMEM_RETRIEVE_INJECT_CLI", "KB_RETRIEVE_INJECT_CLI"),
@@ -104,6 +141,22 @@ def _env_int(name: str, default: int) -> int:
         return int(os.environ.get(name) or default)
     except (ValueError, TypeError):
         return default
+
+
+def _is_obvious_control_prompt(prompt: str, max_chars: int) -> bool:
+    """Skip short command/ack/status prompts that do not need prior KB context.
+
+    This is deliberately a narrow English-only fast path. Non-English prompts
+    and substantive English prompts still flow through the length+cooldown gate,
+    preserving the hook's language-agnostic default for real questions while
+    suppressing the common churn cases ("continue", "merge it", "done?").
+    """
+    text = re.sub(r"\s+", " ", prompt).strip()
+    if not text or len(text) > max_chars:
+        return False
+    if _KB_BEARING_RE.search(text):
+        return False
+    return bool(_CONTROL_PROMPT_RE.match(text))
 
 
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
@@ -273,9 +326,13 @@ def main() -> int:
         return 0
 
     min_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", 20)
+    control_max_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS", 180)
     cooldown = _env_int("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", 300)
 
     if len(prompt.strip()) < min_chars:  # trivial prompt ("yes", "go", "thanks")
+        return 0
+
+    if _is_obvious_control_prompt(prompt, control_max_chars):
         return 0
 
     ok, stamp = _cooldown_ok(data.get("session_id", ""), cooldown)

--- a/tests/test_retrieve_inject.py
+++ b/tests/test_retrieve_inject.py
@@ -50,6 +50,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "EXOMEM_RETRIEVE_NUDGE_DISABLE",
         "EXOMEM_RETRIEVE_NUDGE_MIN_CHARS",
+        "EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS",
         "EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC",
         "EXOMEM_RETRIEVE_INJECT",
         "EXOMEM_RETRIEVE_INJECT_CLI",
@@ -58,6 +59,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         # Legacy aliases (still honored via _normalize_env_aliases).
         "KB_RETRIEVE_NUDGE_DISABLE",
         "KB_RETRIEVE_NUDGE_MIN_CHARS",
+        "KB_RETRIEVE_NUDGE_CONTROL_MAX_CHARS",
         "KB_RETRIEVE_NUDGE_COOLDOWN_SEC",
         "KB_RETRIEVE_INJECT",
         "KB_RETRIEVE_INJECT_CLI",
@@ -117,6 +119,36 @@ def test_env_flag_unset_is_disabled() -> None:
 def test_env_flag_truthy_values_are_enabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT_CLI", value)
     assert hook_mod._env_flag("EXOMEM_RETRIEVE_INJECT_CLI") is True
+
+
+# --- prompt relevance gate ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "perfect merge then to main gj",
+        "are you done?",
+        "restart the server",
+        "continue",
+        "status?",
+    ],
+)
+def test_obvious_control_prompts_are_skipped(prompt: str) -> None:
+    assert hook_mod._is_obvious_control_prompt(prompt, max_chars=180) is True
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "what did I conclude about the kb hook design earlier?",
+        "save this to the knowledge base",
+        "Have I looked at this Exomem decision before?",
+        "去年このプロジェクトについて何を結論づけましたか？詳しく教えてください。",
+    ],
+)
+def test_kb_bearing_or_non_english_prompts_are_not_control_skipped(prompt: str) -> None:
+    assert hook_mod._is_obvious_control_prompt(prompt, max_chars=180) is False
 
 
 # --- _format_inject_block ---------------------------------------------------------
@@ -407,6 +439,33 @@ def test_default_off_no_network_or_subprocess_attempted(
             "additionalContext": hook_mod.REMINDER,
         }
     }
+
+
+def test_control_prompt_skips_before_reminder_or_transport(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("EXOMEM_RETRIEVE_INJECT", "1")
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "secret")
+
+    def _boom_url(req, timeout=None):
+        raise AssertionError("urlopen must not be called for control-only prompts")
+
+    def _boom_run(cmd, **kwargs):
+        raise AssertionError("subprocess.run must not be called for control-only prompts")
+
+    monkeypatch.setattr(urllib_request, "urlopen", _boom_url)
+    monkeypatch.setattr(hook_mod.subprocess, "run", _boom_run)
+
+    out = _call_main(
+        monkeypatch,
+        capsys,
+        {"prompt": "perfect merge then to main gj", "session_id": "e2e-control"},
+        home,
+    )
+    assert out.strip() == ""
 
 
 def test_inject_rest_configured_and_reachable_appends_stubs(


### PR DESCRIPTION
## Summary
- suppress the retrieve nudge for obvious short control/status prompts like `continue`, `are you done?`, `merge it`, and `restart the server`
- update the reminder text so agents do not repeat KB searches when recent conversation context already covers the topic
- document and spec the new control-prompt gate

## Verification
- `python -m pytest tests/test_retrieve_inject.py tests/test_install_hook.py -q`
- `npm exec --yes @fission-ai/openspec -- validate retrieve-inject-hook --strict`
- `git diff --check -- src/exomem/_hooks/exomem_retrieve_nudge.py tests/test_retrieve_inject.py openspec/specs/retrieve-inject-hook/spec.md QUICKSTART.md README.md`
