### PR TITLE
refactor(server): split architecture boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,104 @@
+# Exomem Architecture
+
+Exomem is an owned-vault memory layer. Markdown files, binary evidence, and
+their sidecars are the durable source of truth; indexes, embeddings, freshness
+registries, and access logs are derived operating data.
+
+The architecture should stay explicit without becoming enterprise-shaped. The
+command registry is the contract. Transport adapters, CLI dispatch, and tests
+should route through that registry instead of wrapping separate business logic.
+
+## Composition root
+
+`src/exomem/server.py` is the FastMCP composition root. It wires runtime startup,
+auth, public assets, transfer routes, the REST facade, and MCP tool registration.
+It should not own operation behavior.
+
+Server support modules:
+
+- `server_runtime.py` - environment promotion, vault/schema resolution, warmup,
+  model reaper policy, media worker startup, and file watcher startup.
+- `server_auth.py` - GitHub OAuth verifier and OAuth proxy construction.
+- `server_assets.py` - favicon and OAuth metadata routes.
+- `server_transfer.py` - `/upload` and `/download` routes plus transfer auth.
+- `server_rest.py` - personal `/api/*` facade generated from the command
+  registry.
+
+## Command boundary
+
+`src/exomem/commands.py` is the source of truth for operation metadata:
+
+- command name
+- parameters and coercion metadata
+- description exposed to MCP/REST/CLI
+- guarded write fields
+- Tier 2 exposure policy
+- MCP annotations
+
+Operation leaves should implement behavior once. MCP, REST, and CLI paths should
+bind those leaves through the registry rather than duplicating validation or
+surface-specific wrappers.
+
+Hand-registered server tools are exceptions only when the operation is bound to
+server-local runtime state rather than the vault command surface, such as
+`mint_upload_token` and `mint_download_token`.
+
+## Vault boundary
+
+The vault is the durable system boundary. Modules that resolve paths, parse
+frontmatter, update indexes, preserve evidence, or reconcile drift must treat
+vault-relative paths and append-only trees as explicit invariants.
+
+The main rule: do not let transport code perform filesystem policy. It should
+pass requests into vault-aware helpers and return their structured result or
+error envelope.
+
+## Retrieval boundary
+
+Retrieval behavior belongs in retrieval modules, not in server wiring:
+
+- `find.py` owns query execution and result shaping.
+- `ranking_config.py` owns ranker knobs and adopted-config loading.
+- embeddings, BM25, graph/freshness registries, usage activation, and media
+  sidecars are implementation lanes feeding `find`.
+
+Ranking changes should be measurable. Keep defaults byte-compatible unless a
+retrieval evaluation or focused test intentionally changes behavior.
+
+## Derived data
+
+Sidecars are rebuildable. This includes embeddings, CLIP vectors, media
+transcripts/OCR, freshness/inbound registries, and relevance-pair snapshots.
+
+Durable decisions, evidence, and source material belong in the vault. Derived
+data should be safe to delete and regenerate, or explicitly documented when it
+is not.
+
+## Non-goals
+
+Do not add a service/repository/database stack just to look layered. Exomem is
+not a multi-tenant cloud product, a graph database product, or a general CMS.
+
+Avoid:
+
+- SQLAlchemy-style repository layers around markdown files.
+- duplicated API/MCP/CLI business logic.
+- graph database dependencies for the current vault scale.
+- cloud sync/control-plane code in the core memory path.
+- transport-specific validation that bypasses the command registry.
+
+## Refactor rules
+
+Preserve these invariants during architecture cleanup:
+
+- MCP tool schemas and docstrings are compatibility surface.
+- `commands.py` remains the registry for shared command behavior.
+- `server.py` remains a thin composition root.
+- filesystem safety stays in vault/preserve/reconcile helpers, not route code.
+- retrieval changes require focused retrieval tests or evaluation output.
+- extracted modules should start as behavior-preserving moves before deeper
+  redesign.
+
+The comparison with Basic Memory suggests borrowing discipline, not mass. The
+right target is clearer boundaries around Exomem's existing depth-focused
+system.

--- a/docs/ranking-tuning.md
+++ b/docs/ranking-tuning.md
@@ -1,100 +1,101 @@
-# Ranbing auto-tune — the closed feedbacb loop
+# Ranking auto-tune - the closed feedback loop
 
-bb-mcp's hybrid ranber (`RanbingConfig` in `src/bb_mcp/find.py`) self-tunes from
-your own usage. The loop is **asynchronous and reviewed**: cheap continuous
-mining, a periodic desb-side tune that only *proposes*, and an explicit, reversible
-adopt. Nothing on the server holds a model or a bey — it is deterministic
-measurement end to end (see `openspec/specs/ranbing-autotune`).
+Exomem's hybrid ranker (`RankingConfig` in `src/exomem/ranking_config.py`) self-tunes from
+your own usage. The loop is asynchronous and reviewed: cheap continuous
+mining, a periodic desk-side tune that only proposes, and an explicit, reversible
+adopt. Nothing on the server holds a model or a key for this loop. It is
+deterministic measurement end to end (see `openspec/specs/ranking-autotune`).
 
 ## The loop
 
-```
-capture ──→ mine ──→ tune ──→ review ──→ adopt ──→ (restart)
-(logs)     (snapshot) (desb)  (report)  (commit)   (find reloads)
+```text
+capture -> mine -> tune -> review -> adopt -> restart
+(logs)    (snapshot) (desk) (report) (commit)  (find reloads)
 ```
 
-1. **Capture** — every `find()` and citing write is logged to
+1. **Capture** - every `find()` and citing write is logged to
    `logs/queries.jsonl` / `logs/writes.jsonl` (already on). No action needed.
-2. **Mine** — `derive_relevance_pairs.py` joins those logs into weab
-   `(query → cited_path)` relevance pairs and rewrites `logs/relevance_pairs.jsonl`
-   as an **idempotent, deduped snapshot** (re-running over the same logs is
-   byte-identical, so it is safe to schedule):
+2. **Mine** - `derive_relevance_pairs.py` joins those logs into weak
+   `(query -> cited_path)` relevance pairs and rewrites
+   `logs/relevance_pairs.jsonl` as an idempotent, deduped snapshot. Re-running
+   over the same logs is byte-identical, so it is safe to schedule:
 
-   ```
+   ```bash
    uv run python scripts/derive_relevance_pairs.py
    uv run python scripts/derive_relevance_pairs.py --window-hours 6 --dry-run
    ```
 
-3. **Tune** — `auto_tune_ranbing.py` mines fresh, then coordinate-descends the
-   bnobs under a lexicographic objective `(pair_mrr, golden_ndcg)`: the 9
-   hand-authored golden queries are a **hard floor** (no candidate may drop golden
+3. **Tune** - `auto_tune_ranking.py` mines fresh, then coordinate-descends the
+   knobs under a lexicographic objective `(pair_mrr, golden_ndcg)`: the
+   hand-authored golden queries are a hard floor (no candidate may drop golden
    NDCG@10 more than `--epsilon` below baseline), and the mined pairs are the
-   improvement signal (scored as **binary** relevance — a cited doc is relevant,
+   improvement signal (scored as binary relevance - a cited doc is relevant,
    full stop; mined `confidence` is only a `--conf-min` filter, never a grade).
-   Below `--min-pairs` distinct eligible pair queries the pairs term is **off** and
-   the run reduces to a golden-only tune. Needs torch + the live vault, so it is
-   **desb-side only**:
+   Below `--min-pairs` distinct eligible pair queries the pairs term is off and
+   the run reduces to a golden-only tune. Needs torch plus the live vault, so it
+   is desk-side only:
 
-   ```
-   uv run python scripts/auto_tune_ranbing.py
+   ```bash
+   uv run python scripts/auto_tune_ranking.py
    ```
 
-   It writes a candidate (`logs/ranbing_config.candidate.json`) + a delta report
-   (`logs/ranbing_config.report.md`). It **never** edits `find.py` or applies
+   It writes a candidate (`logs/ranking_config.candidate.json`) and a delta
+   report (`logs/ranking_config.report.md`). It never edits `find.py` or applies
    anything.
 
-   > The `--min-pairs` guard beeps the pairs term off until enough distinct cited
-   > queries accumulate (then the candidate equals `DEFAULT_RANKING`, which is correct
-   > — safe, not idle). On a vault with real usage the guard is typically already
-   > cleared, so the pairs term engages and the tune reflects how you actually search.
+   > The `--min-pairs` guard keeps the pairs term off until enough distinct
+   > cited queries accumulate. On a vault with real usage the guard is typically
+   > already cleared, so the pairs term engages and the tune reflects how you
+   > actually search.
 
-4. **Review** — read `logs/ranbing_config.report.md` (bnob deltas, golden/pairs
-   metrics, guard status).
+4. **Review** - read `logs/ranking_config.report.md` (knob deltas,
+   golden/pairs metrics, guard status).
 
-5. **Adopt** — promote the candidate to the committed repo-root
-   `ranbing_config.json`. Adoption reuses the golden floor: it refuses a
+5. **Adopt** - promote the candidate to the committed repo-root
+   `ranking_config.json`. Adoption reuses the golden floor: it refuses a
    golden-regressing candidate unless `--force`.
 
-   ```
-   uv run python scripts/auto_tune_ranbing.py --adopt
-   git add ranbing_config.json && git commit -m "tune: adopt ranbing config"
+   ```bash
+   uv run python scripts/auto_tune_ranking.py --adopt
+   git add ranking_config.json && git commit -m "tune: adopt ranking config"
    # deploy + restart the service so find() reloads it
    ```
 
-6. **Reload** — `find()` loads `ranbing_config.json` once per process at startup
-   (same as `.env`: restart to picb up a change).
+6. **Reload** - `find()` loads `ranking_config.json` once per process at startup
+   (same as `.env`: restart to pick up a change).
 
 ## How `find()` resolves its config
 
-When `find()` is called **without** an explicit `config` (the live server's path),
-it resolves the active `RanbingConfig` in this order:
+When `find()` is called without an explicit `config` (the live server path), it
+resolves the active `RankingConfig` in this order:
 
-1. `EXOMEM_DISABLE_RANKING_CONFIG` set → `DEFAULT_RANKING` (the test suite sets this).
-2. `EXOMEM_RANKING_CONFIG=<path>` → that file.
-3. repo-root `ranbing_config.json` → that file.
-4. otherwise → `DEFAULT_RANKING`.
+1. `EXOMEM_DISABLE_RANKING_CONFIG` set -> `DEFAULT_RANKING` (the test suite sets this).
+2. `EXOMEM_RANKING_CONFIG=<path>` -> that file.
+3. repo-root `ranking_config.json` -> that file.
+4. otherwise -> `DEFAULT_RANKING`.
 
-A malformed / wrong-typed / bad-lane-length file is logged at **error** and falls
-bacb to `DEFAULT_RANKING` — it never crashes the server and never applies a partial
-config. **With no file present, ranbing is byte-identical to the in-code default.**
+A malformed, wrong-typed, or bad-lane-length file is logged at error and falls
+back to `DEFAULT_RANKING`. It never crashes the server and never applies a
+partial config. With no file present, ranking is byte-identical to the in-code
+default.
 
 ## Revert
 
-Delete `ranbing_config.json` (or `git revert` the adoption) and restart →
+Delete `ranking_config.json` (or `git revert` the adoption) and restart:
 `DEFAULT_RANKING`, exactly as before. The candidate/report under `logs/` are
-gitignored desb-side artifacts.
+gitignored desk-side artifacts.
 
 ## Env vars
 
 | var | effect |
 |---|---|
-| `EXOMEM_RANKING_CONFIG` | override the adopted-config path (tests / per-box). |
-| `EXOMEM_DISABLE_RANKING_CONFIG` | force `DEFAULT_RANKING` (set in the test suite). |
-| `EXOMEM_DISABLE_EMBEDDINGS` | unset for the desb-side eval/tune (they force it off). |
+| `EXOMEM_RANKING_CONFIG` | Override the adopted-config path (tests / per-box). |
+| `EXOMEM_DISABLE_RANKING_CONFIG` | Force `DEFAULT_RANKING` (set in the test suite). |
+| `EXOMEM_DISABLE_EMBEDDINGS` | Unset for the desk-side eval/tune (tests force it off). |
 
-## Pure-substrate
+## Pure substrate
 
-No server-side reasoning LLM anywhere. Relevance labels come only from recorded
-usage (your real citations), the evaluator computes deterministic ranbing metrics,
-and the tuner is deterministic coordinate descent — the same logs + vault always
-produce the same proposed config.
+No server-side reasoning LLM is involved. Relevance labels come only from
+recorded usage (your real citations), the evaluator computes deterministic
+ranking metrics, and the tuner is deterministic coordinate descent. The same
+logs and vault always produce the same proposed config.

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -10,8 +10,6 @@ Cached in-process between calls: keyed by file path, invalidated by mtime.
 from __future__ import annotations
 
 import copy
-import dataclasses
-import json
 import logging
 import math
 import os
@@ -83,188 +81,25 @@ def reset_degradation_counts() -> None:
         _DEGRADATION_COUNTS.clear()
 
 
-@dataclass(frozen=True)
-class RankingConfig:
-    """The tunable knobs of the hybrid ranker, in one place.
+from . import ranking_config as _ranking_config
 
-    Every value here was historically a hardcoded literal scattered through
-    `_find_semantic`/`fusion`/`_type_multiplier`. Bundling them lets the
-    offline eval harness (`scripts/eval_retrieval.py`) sweep them against a
-    golden set and pick winners by NDCG/MRR instead of intuition. The
-    field defaults reproduce the pre-refactor behaviour byte-for-byte — see
-    `tests/test_ranking_config.py`, which guards that invariant.
-
-    Intentionally NOT exposed on the MCP `find` tool signature: claude.ai
-    needs no knobs API. It's an internal seam for measurement + tuning.
-    """
-
-    rrf_k: int = 60  # Cormack/Clarke/Buettcher 2009 default; fusion.py
-    compiled_boost: float = 1.15  # must equal _COMPILED_BOOST
-    source_penalty: float = 0.85  # must equal _SOURCE_PENALTY
-    superseded_penalty: float = 0.5  # must equal _SUPERSEDED_PENALTY
-    candidate_multiplier: int = 5  # candidate_k = max(limit*mult, floor)
-    candidate_floor: int = 50
-    graph_seed_cap: int = 20  # per-ranker fanout cap for 1-hop expansion
-
-    # ---- Temporal lane (Gaussian recency) ----
-    # `temporal_boost` is the peak multiplier a brand-new page gets on a
-    # temporal query: 1.0 = OFF (the default), so recency NEVER perturbs a
-    # non-temporal ranking. The post-RRF boost only fires when both
-    # `_is_temporal_query(query)` is true AND `temporal_boost != 1.0`.
-    temporal_boost: float = 1.0
-    temporal_sigma_days: float = 60.0  # Gaussian width: ~halflife of "recent"
-
-    # ---- Usage-activation boost (opt-in via find(prefer_used=true)) ----
-    # Bounded multiplicative post-boost from ACT-R activation over the JSONL
-    # access logs (see usage.py). `usage_boost` is the CEILING of the
-    # multiplier — deliberately below `compiled_boost` so usage can break
-    # ties but never override the epistemic hierarchy, and low enough that
-    # a superseded tombstone at max usage still loses to its active
-    # successor (0.5 × 1.10 < 1.0). `usage_w_surfaced` defaults to 0: being
-    # surfaced by find is not a choice anyone made (rich-get-richer guard);
-    # reads and citations are genuine selection acts.
-    usage_boost: float = 1.10
-    usage_decay: float = 0.5
-    usage_horizon_days: float = 90.0
-    usage_w_surfaced: float = 0.0
-    usage_w_read: float = 1.0
-    usage_w_cited: float = 2.0
-
-    # ---- Intent-adaptive weighted RRF ----
-    # One weight per fusion lane, aligned positionally to LANE_ORDER:
-    #   (vector, bm25, keyword, clip, graph, temporal)
-    # `conceptual` is fully neutral (all 1.0) so the common case reproduces the
-    # pre-feature unweighted RRF byte-for-byte; only the non-conceptual intents
-    # diverge. The adaptivity is the feature, not a global ranking change.
-    intent_weights_conceptual: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
-    # exact: literal lookups — favour the lexical lanes (bm25 + keyword), damp
-    # the semantic/connectivity lanes that float topical-but-inexact matches.
-    intent_weights_exact: tuple[float, ...] = (0.7, 1.5, 1.5, 1.0, 0.7, 1.0)
-    # relationship: "what links/cites/relates to X" — favour the graph lane.
-    intent_weights_relationship: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.8, 1.0)
-    # temporal: up-weight the recency lane so newer matches surface first.
-    intent_weights_temporal: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.0, 2.0)
-
-    def intent_weights(self, intent: str) -> tuple[float, ...]:
-        """Lane-weight tuple for a classified intent; conceptual (neutral) default."""
-        return {
-            "exact": self.intent_weights_exact,
-            "temporal": self.intent_weights_temporal,
-            "relationship": self.intent_weights_relationship,
-            "conceptual": self.intent_weights_conceptual,
-        }.get(intent, self.intent_weights_conceptual)
-
-
-# Fusion lane order — the canonical alignment for the per-intent weight tuples.
-# MUST match the order lanes are assembled into the weighted RRF in
-# `_find_semantic` (see `lane_rankings`).
-LANE_ORDER = ("vector", "bm25", "keyword", "clip", "graph", "temporal")
-
-DEFAULT_RANKING = RankingConfig()
-
-
-# --------------------------------------------------------------------------- #
-# Adopted-config seam: the auto-tuner writes a reviewed `ranking_config.json`;
-# `find()` loads it once per process when no explicit `config` is passed. Absent
-# file (or any parse error) → DEFAULT_RANKING, byte-identical to the in-code
-# baseline. The live `op_find` calls find() WITHOUT config (consults disk); the
-# eval harnesses pass config= explicitly (hermetic, never touch disk).
-# --------------------------------------------------------------------------- #
-# src/exomem/find.py → parents[2] is the repo (or deploy-checkout) root.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-
-_ACTIVE_RANKING: RankingConfig | None = None
-_ACTIVE_RANKING_LOADED = False
-
-
-def ranking_config_to_jsonable(cfg: RankingConfig) -> dict[str, Any]:
-    """Plain-dict form of a RankingConfig (tuples render as JSON arrays)."""
-    return dataclasses.asdict(cfg)
-
-
-def ranking_config_from_jsonable(data: dict[str, Any]) -> RankingConfig:
-    """Build a RankingConfig from a parsed JSON dict, field by field.
-
-    Unknown keys are ignored (schema-drift-safe) and missing keys fall back to
-    the dataclass default. Scalar fields are coerced to int/float per their
-    default; the four `intent_weights_*` fields are coerced to float tuples and
-    MUST have exactly `len(LANE_ORDER)` entries. Raises on an uncoercible value
-    or a wrong-length lane tuple so the caller can fail loud.
-    """
-    field_names = {f.name for f in dataclasses.fields(RankingConfig)}
-    unknown = set(data) - field_names
-    if unknown:
-        log.warning(
-            "ranking config: ignoring unknown knob(s): %s", ", ".join(sorted(unknown))
-        )
-    n_lanes = len(LANE_ORDER)
-    kwargs: dict[str, Any] = {}
-    for f in dataclasses.fields(RankingConfig):
-        if f.name not in data:
-            continue
-        value = data[f.name]
-        if f.name.startswith("intent_weights_"):
-            tup = tuple(float(x) for x in value)
-            if len(tup) != n_lanes:
-                raise ValueError(
-                    f"{f.name}: expected {n_lanes} lane weights, got {len(tup)}"
-                )
-            kwargs[f.name] = tup
-        elif isinstance(f.default, bool):
-            kwargs[f.name] = bool(value)
-        elif isinstance(f.default, int):
-            kwargs[f.name] = int(value)
-        else:
-            kwargs[f.name] = float(value)
-    return RankingConfig(**kwargs)
-
-
-def _load_adopted_ranking() -> RankingConfig:
-    """Resolve the active RankingConfig from disk; DEFAULT_RANKING on absence/error.
-
-    Resolution order:
-      1. ``EXOMEM_DISABLE_RANKING_CONFIG`` set → DEFAULT_RANKING (hermetic; the
-         test suite sets this so a committed file never pollutes the suite).
-      2. ``EXOMEM_RANKING_CONFIG=<path>`` → that path.
-      3. ``<repo_root>/ranking_config.json`` if present.
-      4. else DEFAULT_RANKING.
-
-    A malformed / wrong-typed / bad-lane-length file fails LOUD (``log.error``)
-    and falls back to DEFAULT_RANKING — it never crashes the server and never
-    applies a partially-parsed config.
-    """
-    if os.environ.get("EXOMEM_DISABLE_RANKING_CONFIG"):
-        return DEFAULT_RANKING
-    override = os.environ.get("EXOMEM_RANKING_CONFIG")
-    path = Path(override) if override else _REPO_ROOT / "ranking_config.json"
-    if not path.exists():
-        return DEFAULT_RANKING
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            raise ValueError("ranking config must be a JSON object")
-        return ranking_config_from_jsonable(data)
-    except Exception as exc:  # noqa: BLE001 — degrade to known-good, loudly.
-        log.error(
-            "adopted ranking config %s invalid (%s); using DEFAULT_RANKING", path, exc
-        )
-        return DEFAULT_RANKING
+DEFAULT_RANKING = _ranking_config.DEFAULT_RANKING
+LANE_ORDER = _ranking_config.LANE_ORDER
+RankingConfig = _ranking_config.RankingConfig
+ranking_config_from_jsonable = _ranking_config.ranking_config_from_jsonable
+ranking_config_to_jsonable = _ranking_config.ranking_config_to_jsonable
+_REPO_ROOT = _ranking_config._REPO_ROOT
 
 
 def _active_ranking() -> RankingConfig:
-    """The adopted RankingConfig, loaded once per process (memoized)."""
-    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
-    if not _ACTIVE_RANKING_LOADED:
-        _ACTIVE_RANKING = _load_adopted_ranking()
-        _ACTIVE_RANKING_LOADED = True
-    return _ACTIVE_RANKING if _ACTIVE_RANKING is not None else DEFAULT_RANKING
+    """Compatibility wrapper for find.py's historical adopted-config seam."""
+    _ranking_config._REPO_ROOT = _REPO_ROOT
+    return _ranking_config._active_ranking()
 
 
 def reset_active_ranking_cache() -> None:
-    """Drop the memoized adopted config (tests; desk-side adopt happens out of band)."""
-    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
-    _ACTIVE_RANKING = None
-    _ACTIVE_RANKING_LOADED = False
+    """Drop the memoized adopted ranking config."""
+    _ranking_config.reset_active_ranking_cache()
 
 
 @dataclass

--- a/src/exomem/ranking_config.py
+++ b/src/exomem/ranking_config.py
@@ -1,0 +1,197 @@
+"""Ranking configuration and adopted-config loading for ``find``."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RankingConfig:
+    """The tunable knobs of the hybrid ranker, in one place.
+
+    Every value here was historically a hardcoded literal scattered through
+    `_find_semantic`/`fusion`/`_type_multiplier`. Bundling them lets the
+    offline eval harness (`scripts/eval_retrieval.py`) sweep them against a
+    golden set and pick winners by NDCG/MRR instead of intuition. The
+    field defaults reproduce the pre-refactor behaviour byte-for-byte — see
+    `tests/test_ranking_config.py`, which guards that invariant.
+
+    Intentionally NOT exposed on the MCP `find` tool signature: claude.ai
+    needs no knobs API. It's an internal seam for measurement + tuning.
+    """
+
+    rrf_k: int = 60  # Cormack/Clarke/Buettcher 2009 default; fusion.py
+    compiled_boost: float = 1.15  # must equal _COMPILED_BOOST
+    source_penalty: float = 0.85  # must equal _SOURCE_PENALTY
+    superseded_penalty: float = 0.5  # must equal _SUPERSEDED_PENALTY
+    candidate_multiplier: int = 5  # candidate_k = max(limit*mult, floor)
+    candidate_floor: int = 50
+    graph_seed_cap: int = 20  # per-ranker fanout cap for 1-hop expansion
+
+    # ---- Temporal lane (Gaussian recency) ----
+    # `temporal_boost` is the peak multiplier a brand-new page gets on a
+    # temporal query: 1.0 = OFF (the default), so recency NEVER perturbs a
+    # non-temporal ranking. The post-RRF boost only fires when both
+    # `_is_temporal_query(query)` is true AND `temporal_boost != 1.0`.
+    temporal_boost: float = 1.0
+    temporal_sigma_days: float = 60.0  # Gaussian width: ~halflife of "recent"
+
+    # ---- Usage-activation boost (opt-in via find(prefer_used=true)) ----
+    # Bounded multiplicative post-boost from ACT-R activation over the JSONL
+    # access logs (see usage.py). `usage_boost` is the CEILING of the
+    # multiplier — deliberately below `compiled_boost` so usage can break
+    # ties but never override the epistemic hierarchy, and low enough that
+    # a superseded tombstone at max usage still loses to its active
+    # successor (0.5 × 1.10 < 1.0). `usage_w_surfaced` defaults to 0: being
+    # surfaced by find is not a choice anyone made (rich-get-richer guard);
+    # reads and citations are genuine selection acts.
+    usage_boost: float = 1.10
+    usage_decay: float = 0.5
+    usage_horizon_days: float = 90.0
+    usage_w_surfaced: float = 0.0
+    usage_w_read: float = 1.0
+    usage_w_cited: float = 2.0
+
+    # ---- Intent-adaptive weighted RRF ----
+    # One weight per fusion lane, aligned positionally to LANE_ORDER:
+    #   (vector, bm25, keyword, clip, graph, temporal)
+    # `conceptual` is fully neutral (all 1.0) so the common case reproduces the
+    # pre-feature unweighted RRF byte-for-byte; only the non-conceptual intents
+    # diverge. The adaptivity is the feature, not a global ranking change.
+    intent_weights_conceptual: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+    # exact: literal lookups — favour the lexical lanes (bm25 + keyword), damp
+    # the semantic/connectivity lanes that float topical-but-inexact matches.
+    intent_weights_exact: tuple[float, ...] = (0.7, 1.5, 1.5, 1.0, 0.7, 1.0)
+    # relationship: "what links/cites/relates to X" — favour the graph lane.
+    intent_weights_relationship: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.8, 1.0)
+    # temporal: up-weight the recency lane so newer matches surface first.
+    intent_weights_temporal: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.0, 2.0)
+
+    def intent_weights(self, intent: str) -> tuple[float, ...]:
+        """Lane-weight tuple for a classified intent; conceptual (neutral) default."""
+        return {
+            "exact": self.intent_weights_exact,
+            "temporal": self.intent_weights_temporal,
+            "relationship": self.intent_weights_relationship,
+            "conceptual": self.intent_weights_conceptual,
+        }.get(intent, self.intent_weights_conceptual)
+
+
+# Fusion lane order — the canonical alignment for the per-intent weight tuples.
+# MUST match the order lanes are assembled into the weighted RRF in
+# `_find_semantic` (see `lane_rankings`).
+LANE_ORDER = ("vector", "bm25", "keyword", "clip", "graph", "temporal")
+
+DEFAULT_RANKING = RankingConfig()
+
+
+# --------------------------------------------------------------------------- #
+# Adopted-config seam: the auto-tuner writes a reviewed `ranking_config.json`;
+# `find()` loads it once per process when no explicit `config` is passed. Absent
+# file (or any parse error) → DEFAULT_RANKING, byte-identical to the in-code
+# baseline. The live `op_find` calls find() WITHOUT config (consults disk); the
+# eval harnesses pass config= explicitly (hermetic, never touch disk).
+# --------------------------------------------------------------------------- #
+# src/exomem/find.py → parents[2] is the repo (or deploy-checkout) root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_ACTIVE_RANKING: RankingConfig | None = None
+_ACTIVE_RANKING_LOADED = False
+
+
+def ranking_config_to_jsonable(cfg: RankingConfig) -> dict[str, Any]:
+    """Plain-dict form of a RankingConfig (tuples render as JSON arrays)."""
+    return dataclasses.asdict(cfg)
+
+
+def ranking_config_from_jsonable(data: dict[str, Any]) -> RankingConfig:
+    """Build a RankingConfig from a parsed JSON dict, field by field.
+
+    Unknown keys are ignored (schema-drift-safe) and missing keys fall back to
+    the dataclass default. Scalar fields are coerced to int/float per their
+    default; the four `intent_weights_*` fields are coerced to float tuples and
+    MUST have exactly `len(LANE_ORDER)` entries. Raises on an uncoercible value
+    or a wrong-length lane tuple so the caller can fail loud.
+    """
+    field_names = {f.name for f in dataclasses.fields(RankingConfig)}
+    unknown = set(data) - field_names
+    if unknown:
+        log.warning(
+            "ranking config: ignoring unknown knob(s): %s", ", ".join(sorted(unknown))
+        )
+    n_lanes = len(LANE_ORDER)
+    kwargs: dict[str, Any] = {}
+    for f in dataclasses.fields(RankingConfig):
+        if f.name not in data:
+            continue
+        value = data[f.name]
+        if f.name.startswith("intent_weights_"):
+            tup = tuple(float(x) for x in value)
+            if len(tup) != n_lanes:
+                raise ValueError(
+                    f"{f.name}: expected {n_lanes} lane weights, got {len(tup)}"
+                )
+            kwargs[f.name] = tup
+        elif isinstance(f.default, bool):
+            kwargs[f.name] = bool(value)
+        elif isinstance(f.default, int):
+            kwargs[f.name] = int(value)
+        else:
+            kwargs[f.name] = float(value)
+    return RankingConfig(**kwargs)
+
+
+def _load_adopted_ranking() -> RankingConfig:
+    """Resolve the active RankingConfig from disk; DEFAULT_RANKING on absence/error.
+
+    Resolution order:
+      1. ``EXOMEM_DISABLE_RANKING_CONFIG`` set → DEFAULT_RANKING (hermetic; the
+         test suite sets this so a committed file never pollutes the suite).
+      2. ``EXOMEM_RANKING_CONFIG=<path>`` → that path.
+      3. ``<repo_root>/ranking_config.json`` if present.
+      4. else DEFAULT_RANKING.
+
+    A malformed / wrong-typed / bad-lane-length file fails LOUD (``log.error``)
+    and falls back to DEFAULT_RANKING — it never crashes the server and never
+    applies a partially-parsed config.
+    """
+    if os.environ.get("EXOMEM_DISABLE_RANKING_CONFIG"):
+        return DEFAULT_RANKING
+    override = os.environ.get("EXOMEM_RANKING_CONFIG")
+    path = Path(override) if override else _REPO_ROOT / "ranking_config.json"
+    if not path.exists():
+        return DEFAULT_RANKING
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("ranking config must be a JSON object")
+        return ranking_config_from_jsonable(data)
+    except Exception as exc:  # noqa: BLE001 — degrade to known-good, loudly.
+        log.error(
+            "adopted ranking config %s invalid (%s); using DEFAULT_RANKING", path, exc
+        )
+        return DEFAULT_RANKING
+
+
+def _active_ranking() -> RankingConfig:
+    """The adopted RankingConfig, loaded once per process (memoized)."""
+    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
+    if not _ACTIVE_RANKING_LOADED:
+        _ACTIVE_RANKING = _load_adopted_ranking()
+        _ACTIVE_RANKING_LOADED = True
+    return _ACTIVE_RANKING if _ACTIVE_RANKING is not None else DEFAULT_RANKING
+
+
+def reset_active_ranking_cache() -> None:
+    """Drop the memoized adopted config (tests; desk-side adopt happens out of band)."""
+    global _ACTIVE_RANKING, _ACTIVE_RANKING_LOADED
+    _ACTIVE_RANKING = None
+    _ACTIVE_RANKING_LOADED = False

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -1,93 +1,51 @@
-"""FastMCP server construction: tool registration + GitHub OAuth + transports.
+"""FastMCP server composition root for Exomem.
 
-Tools (registered in build_server):
-- `find` — read-only hybrid search across Knowledge Base/
-- `add`  — capture a `source` page with full SKILL.md rule-7 writes
-- ~20 more (edit / note / preserve / audit / link / reconcile / …)
-
-Auth (HTTP transports):
-- GitHub OAuth via FastMCP `OAuthProxy`. `SingleUserGitHubVerifier` gates access
-  to a single GitHub login (`EXOMEM_GITHUB_USERNAME`); any other login is rejected.
-- Requires `EXOMEM_BASE_URL`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`,
-  `EXOMEM_GITHUB_USERNAME` (build_server raises if any are missing). Optional
-  `EXOMEM_JWT_SIGNING_KEY` pins the token-store signing key for a stable
-  connector across restarts / FastMCP upgrades.
-- stdio needs no auth; OAuth is only wired in when require_auth is set (HTTP).
-
-Transports:
-- stdio (local; no auth needed)
-- streamable-http aka http (public; GitHub OAuth required)
+The transport-specific wiring lives here. Startup/runtime setup, OAuth, public
+asset routes, transfer routes, and the REST facade are split into sibling
+modules so this file stays focused on composing the server and registering MCP
+tools from the command registry.
 """
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
 import logging
 import os
-import secrets
 import time
 from pathlib import Path
 
-import mcp.types
 from dotenv import load_dotenv
 from fastmcp import FastMCP
-from fastmcp.server.auth.auth import AccessToken
-from fastmcp.server.auth.oauth_proxy import OAuthProxy
-from fastmcp.server.auth.providers.github import GitHubTokenVerifier
 from fastmcp.server.middleware.middleware import Middleware, MiddlewareContext
-from starlette.concurrency import run_in_threadpool
-from starlette.formparsers import MultiPartException
-from starlette.requests import Request
-from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 
-from . import cf_access, cli_ops, env_compat, extract, guards, schema, upload_tokens
 from . import commands as commands_module
-from . import preserve as preserve_module
-from . import project_keys as project_keys_module
-from .vault import (
-    VaultPathError,
-    resolve_under_vault,
-    resolve_vault,
+from . import guards, upload_tokens
+from .server_assets import (
+    register_asset_routes,
+    register_oauth_metadata_route,
+    server_icons,
 )
+from .server_auth import SingleUserGitHubVerifier, build_oauth
+from .server_rest import register_rest_facade
+from .server_runtime import initialize_runtime
+from .server_transfer import register_transfer_routes
 
 log = logging.getLogger(__name__)
 _call_log = logging.getLogger("exomem.calls")
 
-# Text-write tools → the argument field(s) whose value must not be a base64
-# binary blob. The model pays for those characters as output tokens before the
-# request even arrives, so we reject them at the boundary and point at /upload.
-# Single source of truth in the command registry (MCP write boundary + REST coercion).
 _GUARDED_WRITE_FIELDS = commands_module.GUARDED_WRITE_FIELDS
+_link_summary = commands_module._link_summary
 
 
 class CallTraceMiddleware(Middleware):
-    """Per-call traceability: log every tool invocation with name + duration.
-
-    Service-log only (`logs/exomem.log`). The durable content history lives
-    in `Knowledge Base/log.md` (writes only, KB-scoped) — this layer is
-    operational: which tool was called, when, by whom, did it succeed.
-    Reads land here too, by design, so we can answer "did the connector
-    actually invoke X?" without polluting log.md.
-
-    Payloads (args + results) deliberately NOT logged — they can be large
-    (`add(content=...)` is unbounded). Tool name + duration + outcome is
-    what's useful for traceability; deeper inspection goes through the
-    audit + the log.md content history.
-    """
+    """Per-call traceability: log every tool invocation with name + duration."""
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
-        import time
         tool_name = _extract_tool_name(context.message)
-        # Reject base64 binary blobs pushed into text-write tools BEFORE dispatch.
-        # Can't refund the output tokens already spent generating the blob — but it
-        # stops the vault being polluted and tells the model to use /upload instead.
         guarded_fields = _GUARDED_WRITE_FIELDS.get(tool_name)
         if guarded_fields:
             args = _extract_tool_args(context.message)
-            for f in guarded_fields:
-                guards.guard_text_content(args.get(f), tool=tool_name, field=f)
+            for field in guarded_fields:
+                guards.guard_text_content(args.get(field), tool=tool_name, field=field)
             if tool_name == "edit":
                 for item in args.get("edits") or []:
                     if isinstance(item, dict):
@@ -96,36 +54,26 @@ class CallTraceMiddleware(Middleware):
                             tool=tool_name,
                             field="edits[].new_string",
                         )
-        # For find calls, log query + mode + scope so failure modes
-        # ("hybrid whiffed on X") are reproducible without a screenshot.
-        # Other tools log only tool name + duration — their payloads can be
-        # huge (add(content=...)) or sensitive (preserve()).
+
         extras = _find_call_summary(context.message) if tool_name == "find" else ""
         _call_log.info(f"event=tool_start tool={tool_name}{extras}")
         t0 = time.perf_counter()
         try:
             result = await call_next(context)
             dur = round((time.perf_counter() - t0) * 1000, 2)
-            _call_log.info(
-                f"event=tool_success tool={tool_name} duration_ms={dur}{extras}"
-            )
+            _call_log.info(f"event=tool_success tool={tool_name} duration_ms={dur}{extras}")
             return result
-        except Exception as e:
+        except Exception as exc:
             dur = round((time.perf_counter() - t0) * 1000, 2)
-            # `e` may include full tracebacks if rendered as str; trim to keep
-            # the call-log line readable. Full tracebacks land in service.err.log.
-            err = type(e).__name__
             _call_log.error(
-                f"event=tool_error tool={tool_name} duration_ms={dur} err={err}{extras}"
+                f"event=tool_error tool={tool_name} duration_ms={dur} "
+                f"err={type(exc).__name__}{extras}"
             )
             raise
 
 
 def _extract_tool_name(message) -> str:
     """Pull the tool name out of a tools/call request payload, defensively."""
-    # FastMCP's MiddlewareContext.message for tool calls carries the request
-    # body; the actual shape varies by version. Try common access patterns
-    # and fall back to "?" so logging never raises.
     for accessor in (
         lambda m: m.params.name,
         lambda m: m.name,
@@ -133,772 +81,87 @@ def _extract_tool_name(message) -> str:
         lambda m: m["name"],
     ):
         try:
-            v = accessor(message)
-            if v:
-                return str(v)
+            value = accessor(message)
+            if value:
+                return str(value)
         except (AttributeError, KeyError, TypeError):
             continue
     return "?"
 
 
 def _extract_tool_args(message) -> dict:
-    """Pull the tool-call arguments out of the request payload, defensively.
-
-    Returns `{}` when the shape doesn't match (so logging never raises).
-    """
+    """Pull the tool-call arguments out of a request payload, defensively."""
     for accessor in (
         lambda m: m.params.arguments,
         lambda m: m["params"]["arguments"],
         lambda m: m.arguments,
     ):
         try:
-            v = accessor(message)
-            if isinstance(v, dict):
-                return v
+            value = accessor(message)
+            if isinstance(value, dict):
+                return value
         except (AttributeError, KeyError, TypeError):
             continue
     return {}
 
 
 def _find_call_summary(message) -> str:
-    """One-line summary of find()'s key args for the call log.
-
-    Keeps the query truncated so a long natural-language query doesn't blow
-    up log lines, but long enough that "hybrid whiffed on X" is debuggable.
-    """
+    """One-line summary of find()'s key args for the service call log."""
     args = _extract_tool_args(message)
     if not args:
         return ""
-    q = str(args.get("query", ""))
-    if len(q) > 120:
-        q = q[:117] + "..."
-    q = q.replace('"', "'")  # keep the log line single-quote-friendly
+    query = str(args.get("query", ""))
+    if len(query) > 120:
+        query = query[:117] + "..."
+    query = query.replace('"', "'")
     mode = args.get("mode", "hybrid")
     scope = args.get("scope", "kb")
-    return f' query="{q}" mode={mode} scope={scope}'
-
-
-class _RestJSONResponse(JSONResponse):
-    """JSONResponse that renders frontmatter dates (datetime.date) as ISO strings.
-
-    YAML parses `created: 2026-01-01` to a `datetime.date`, which Starlette's default
-    json.dumps can't serialize. The MCP transport sidesteps this via pydantic; the
-    REST facade needs its own `default=str` fallback.
-    """
-
-    def render(self, content) -> bytes:  # noqa: ANN001
-        return json.dumps(
-            content, ensure_ascii=False, allow_nan=False, default=str
-        ).encode("utf-8")
-
-
-# Single definition in the command registry; used by the REST `get` route.
-_link_summary = commands_module._link_summary
-
-
-def _server_icons() -> list[mcp.types.Icon]:
-    """Load icon.svg from the package dir and return an mcp.types.Icon list.
-
-    Embeds as a base64 data URI so the server has no external fetch
-    dependency; claude.ai's connector renders it directly from the
-    initialize response.
-    """
-    icon_path = Path(__file__).parent / "icon.svg"
-    if not icon_path.exists():
-        return []
-    svg_bytes = icon_path.read_bytes()
-    b64 = base64.b64encode(svg_bytes).decode("ascii")
-    return [mcp.types.Icon(
-        src=f"data:image/svg+xml;base64,{b64}",
-        mimeType="image/svg+xml",
-        sizes=["any"],
-    )]
-
-
-class SingleUserGitHubVerifier(GitHubTokenVerifier):
-    """Reject any GitHub token whose login isn't the allowed user.
-
-    Caches *validated* tokens for a short TTL (``EXOMEM_AUTH_CACHE_TTL`` seconds,
-    default 300). Without it every MCP request — and a single connector operation
-    fires several (ListTools + ListResources + ListPrompts + CallTool) — re-hits the
-    GitHub API to revalidate the same token, adding seconds of `api.github.com`
-    round-trips to the hot path. GitHub OAuth-App tokens carry no time-expiry, so the
-    only invalidation is a deliberate revoke / secret rotation, and a re-authorized
-    client presents a *new* token (a new cache key) that validates immediately — so
-    the TTL only bounds how long a revoked-but-still-presented token keeps working,
-    which doesn't happen for a single user. Only successes are cached (a rejection is
-    re-checked every call, so recovery is instant); set the TTL to 0 to disable.
-    """
-
-    _DEFAULT_TTL = 300.0
-    _MAX_ENTRIES = 64  # single user → tiny; cap guards against unbounded distinct tokens
-
-    def __init__(self, *, allowed_login: str, **kwargs):
-        super().__init__(**kwargs)
-        self._allowed_login = allowed_login.lower()
-        # NOTE: this MUST NOT be named ``_cache`` — the parent GitHubTokenVerifier
-        # owns ``self._cache`` (a fastmcp ``TokenCache``) and unpacks its
-        # ``.get()`` as a 2-tuple inside ``super().verify_token``. Shadowing it
-        # with a plain dict made that line raise "cannot unpack non-iterable
-        # NoneType object", failing the OAuth token-swap → 401 on every request.
-        self._login_cache: dict[str, tuple[float, AccessToken]] = {}
-
-    def _ttl(self) -> float:
-        raw = os.environ.get("EXOMEM_AUTH_CACHE_TTL")
-        if raw is None:
-            return self._DEFAULT_TTL
-        try:
-            return max(0.0, float(raw))
-        except ValueError:
-            return self._DEFAULT_TTL
-
-    async def verify_token(self, token: str) -> AccessToken | None:
-        ttl = self._ttl()
-        key = hashlib.sha256(token.encode("utf-8")).hexdigest() if token else ""
-        if ttl > 0 and key:
-            hit = self._login_cache.get(key)
-            if hit is not None:
-                ts, cached = hit
-                if time.monotonic() - ts < ttl:
-                    return cached
-                del self._login_cache[key]  # expired
-
-        access = await super().verify_token(token)
-        if access is None:
-            # GitHub rejected the token (expired / revoked / invalid). This is what
-            # makes claude.ai re-authorize, so log it (with a timestamp via the log
-            # formatter) to diagnose recurring re-auth churn: frequent regular
-            # intervals point to GitHub OAuth-App token expiry; clustering around a
-            # restart points to the token store / signing key.
-            log.info("exomem auth: token rejected by GitHub (expired/revoked/invalid); client will re-authorize")
-            return None
-        login = (access.claims.get("login") or "").lower()
-        if login != self._allowed_login:
-            log.warning("rejecting token for github login=%r", login)
-            return None
-
-        if ttl > 0 and key:
-            now = time.monotonic()
-            if len(self._login_cache) >= self._MAX_ENTRIES:
-                # Drop expired entries before inserting; cheap, the cache is tiny.
-                self._login_cache = {
-                    k: v for k, v in self._login_cache.items() if now - v[0] < ttl
-                }
-            self._login_cache[key] = (now, access)
-        return access
+    return f' query="{query}" mode={mode} scope={scope}'
 
 
 def build_server(*, require_auth: bool) -> FastMCP:
-    """Construct and return the FastMCP app, ready to .run().
+    """Construct and return the FastMCP app, ready to run."""
+    runtime = initialize_runtime(load_dotenv_func=load_dotenv)
+    auth = build_oauth(require_auth=require_auth, base_url=runtime.base_url)
 
-    `require_auth` controls whether the GitHub OAuth flow is wired in. Always
-    True for HTTP transports; False for stdio.
-    """
-    load_dotenv(override=True)
-    # A .env written before the exomem rename supplies KB_MCP_* names, and it
-    # loads AFTER the import-time promotion — re-promote so legacy configs keep
-    # working (explicitly set EXOMEM_* values still win).
-    env_compat.promote_legacy()
-
-    vault_root = resolve_vault()
-    source_schema = schema.load_source_schema(vault_root)
-    log.info(
-        "vault=%s source_types=%s", vault_root, source_schema.source_types
-    )
-
-    # The project-key set is open and auto-grows (project_keys.register_project_key
-    # appends unknown slugs on first write). Read the live list here so the tool
-    # schemas advertise the *current* keys + the auto-register contract, instead
-    # of a frozen docstring list that drifts. Re-read on each server start.
-    project_keys_hint = project_keys_module.keys_hint(vault_root)
-
-    # Warm-up: lexical caches (parsed pages, BM25 both scopes, resolver,
-    # embedding/CLIP matrices) and model preloads (bge, reranker, CLIP).
-    # Default is a background daemon thread so the transport listens
-    # immediately — lexical `find` works right away; model-touching lanes
-    # defer via `readiness` until their component lands (OpenSpec:
-    # add-instant-start-boot). EXOMEM_EAGER_BOOT=1 restores the old blocking
-    # boot (rollback lever for deploys); EXOMEM_DISABLE_WARMUP skips warm-up
-    # entirely (pure lazy).
-    from . import mode, warmup
-    log.info("compute policy: %s", mode.resolved())
-    if warmup.warmup_enabled():
-        if os.environ.get("EXOMEM_EAGER_BOOT"):
-            warmup.warm_all(vault_root)
-        else:
-            warmup.start_background(vault_root)
-
-    # Idle-unload reaper: reclaim resident models once they go idle. Only for the
-    # GPU-opt-in (performance) / quiet paths — a CPU-default normal-mode server never
-    # starts it (nothing resident to reclaim; no CUDA context). A live `exomem mode`
-    # switch (PR4) starts/stops it to match the new mode.
-    if mode.release_when_idle():
-        from . import model_reaper
-
-        model_reaper.start()
-
-    # Watch the per-machine config file so `exomem mode <name>` applies live (no restart):
-    # on a mode change the server unloads the models (reload on the new device) and
-    # starts/stops the reaper. Off via EXOMEM_DISABLE_MODE_WATCH.
-    mode.start_config_watch()
-
-    # Optional auto-quiet: default-off, non-torch pressure probes only.
-    from . import auto_quiet
-
-    auto_quiet.start_if_enabled()
-
-    # Media-extraction worker: transcribes/OCRs binaries uploaded without text, off
-    # the request path, and fills their sidecars (then re-embeds). Disabled in tests
-    # and on lean boxes via EXOMEM_DISABLE_MEDIA_EXTRACTION (mirrors the embeddings flag).
-    media_worker = None
-    if extract.extraction_enabled():
-        from . import media_worker as media_worker_module
-
-        media_worker = media_worker_module.MediaWorker(vault_root)
-        media_worker.start()
-        try:
-            media_worker.scan_pending()  # re-enqueue anything a prior run left pending
-        except Exception as e:  # noqa: BLE001 — startup scan is best-effort
-            log.warning("media worker startup scan failed: %s", e)
-
-    # Live file-watcher: re-embed out-of-band Obsidian/mobile/filesystem `.md` edits in
-    # ~1s, AND maintain the event-driven freshness/inbound registries so `find` never
-    # walks the vault per request. Off only when EXOMEM_DISABLE_FILE_WATCHER is set — no
-    # longer coupled to embeddings, because it now has registry-maintenance work even on
-    # a lexical-only install; the embed dispatch inside the watcher already no-ops when
-    # embeddings are disabled. The suite sets EXOMEM_DISABLE_FILE_WATCHER so it never
-    # spawns a real observer.
-    file_watcher = None
-    if not os.environ.get("EXOMEM_DISABLE_FILE_WATCHER"):
-        from . import file_watcher as file_watcher_module
-
-        file_watcher = file_watcher_module.FileWatcher(vault_root)
-        try:
-            file_watcher.start()  # soft no-op if watchdog isn't installed
-        except Exception as e:  # noqa: BLE001 — the watcher must never break startup
-            log.warning("file watcher start failed: %s", e)
-
-    # Public base URL (e.g. https://kb.example.com). Used by the OAuth
-    # discovery route AND the mint_upload_token tool, so define it unconditionally.
-    base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
-    auth = None
-    if require_auth:
-        gh_id = os.environ.get("GITHUB_CLIENT_ID", "").strip()
-        gh_secret = os.environ.get("GITHUB_CLIENT_SECRET", "").strip()
-        gh_username = os.environ.get("EXOMEM_GITHUB_USERNAME", "").strip()
-        missing = [
-            k for k, v in {
-                "EXOMEM_BASE_URL": base_url,
-                "GITHUB_CLIENT_ID": gh_id,
-                "GITHUB_CLIENT_SECRET": gh_secret,
-                "EXOMEM_GITHUB_USERNAME": gh_username,
-            }.items() if not v
-        ]
-        if missing:
-            raise RuntimeError(
-                f"Missing required env vars for GitHub OAuth: {', '.join(missing)}. "
-                "See README.md § Install for setup steps."
-            )
-        # Pin the JWT signing key to an explicit secret when provided. FastMCP
-        # otherwise derives it from GITHUB_CLIENT_SECRET, and the encrypted
-        # token-store path is fingerprinted from that key — so rotating the secret
-        # or a FastMCP reinstall/upgrade that changes the derivation orphans the
-        # store and forces claude.ai to re-authorize. An explicit key keeps the
-        # signing key (and the store) stable across both. Set EXOMEM_JWT_SIGNING_KEY
-        # (any long random string) in .env; leave unset to keep the derived default.
-        jwt_signing_key = os.environ.get("EXOMEM_JWT_SIGNING_KEY", "").strip() or None
-        if jwt_signing_key is None:
-            log.info(
-                "EXOMEM_JWT_SIGNING_KEY not set; OAuth signing key derives from the "
-                "GitHub client secret, so connector re-auth can recur on secret "
-                "rotation or FastMCP upgrades. Set it in .env for a stable connector."
-            )
-        auth = OAuthProxy(
-            upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
-            upstream_token_endpoint="https://github.com/login/oauth/access_token",
-            upstream_client_id=gh_id,
-            upstream_client_secret=gh_secret,
-            token_verifier=SingleUserGitHubVerifier(allowed_login=gh_username),
-            base_url=base_url,
-            jwt_signing_key=jwt_signing_key,
-            # GitHub OAuth-App tokens carry no expiry, so FastMCP falls back to a
-            # 1-hour access token by default. For a single-user KB reached from a
-            # phone over the Funnel, that short TTL forces re-auth churn whenever a
-            # client (mobile app especially) can't silently refresh in time. Issue
-            # 30-day access tokens instead; the refresh token already never expires,
-            # and access is still gated to one GitHub login.
-            fallback_access_token_expiry_seconds=30 * 24 * 60 * 60,  # 30 days
-        )
-
-    mcp = FastMCP("exomem", auth=auth, icons=_server_icons())
+    mcp = FastMCP("exomem", auth=auth, icons=server_icons())
     mcp.add_middleware(CallTraceMiddleware())
 
-    # Public brand assets (no auth): the claude.ai connector — and any browser
-    # hitting the base URL — fetches the site favicon from the domain root, so a
-    # served /favicon.ico is what brands the connector. Served straight off the
-    # package dir; both files are generated by scripts/gen-icon-assets.py.
-    _asset_dir = Path(__file__).parent
-
-    @mcp.custom_route("/favicon.ico", methods=["GET"])
-    async def _favicon_ico(request: Request):
-        return FileResponse(
-            _asset_dir / "favicon.ico",
-            media_type="image/x-icon",
-            headers={"Cache-Control": "public, max-age=86400"},
-        )
-
-    @mcp.custom_route("/favicon.svg", methods=["GET"])
-    async def _favicon_svg(request: Request):
-        return FileResponse(
-            _asset_dir / "icon.svg",
-            media_type="image/svg+xml",
-            headers={"Cache-Control": "public, max-age=86400"},
-        )
-
-    if auth is not None:
-        # claude.ai's OAuth gateway probes /.well-known/oauth-protected-resource
-        # (the bare path, no resource suffix) before following the
-        # WWW-Authenticate `resource_metadata` pointer. When it 404s there,
-        # the connect flow aborts with `mcp_registration_failed`. FastMCP only
-        # serves the RFC-9728 path-specific variant (/oauth-protected-resource/mcp),
-        # so mirror the metadata at the bare path to make registration reliable.
-        _resource_url = f"{base_url}/mcp"
-        _issuer_url = f"{base_url}/"
-
-        @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
-        async def _oauth_protected_resource_bare(request: Request) -> JSONResponse:
-            return JSONResponse(
-                {
-                    "resource": _resource_url,
-                    "authorization_servers": [_issuer_url],
-                    "scopes_supported": [],
-                    "bearer_methods_supported": ["header"],
-                },
-                headers={"Cache-Control": "public, max-age=3600"},
-            )
-
-    # ---- Out-of-band binary upload: the token-free path for binaries ----
-    #
-    # The model never carries the bytes. A browser / phone / curl / Claude Code
-    # POSTs multipart/form-data straight into Evidence/, so a multi-MB file costs
-    # ZERO output tokens (unlike base64-through-a-tool-call). See the SKILL
-    # "binary evidence" workflow.
-    #
-    # Reachability: this route is NOT behind the MCP GitHub OAuth (that guards
-    # /mcp). It is publicly reachable via cloudflared, so it carries its OWN auth:
-    # a bearer token (EXOMEM_UPLOAD_TOKEN) and/or a *signature-verified* Cloudflare
-    # Access JWT (EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD). With neither
-    # configured the route refuses every request (never an open write hole). NOTE:
-    # the claude.ai web code sandbox is network-locked and CANNOT reach this route;
-    # it's for the user's own browser / phone / CLI.
-    upload_token = os.environ.get("EXOMEM_UPLOAD_TOKEN", "").strip() or None
-    upload_max_bytes = int(
-        os.environ.get("EXOMEM_UPLOAD_MAX_BYTES", str(preserve_module.MAX_UPLOAD_BYTES))
+    register_asset_routes(mcp)
+    register_oauth_metadata_route(
+        mcp, base_url=runtime.base_url, auth_enabled=auth is not None
     )
-    # Alternate upload host NOT behind the ~100 MB Cloudflare edge cap (e.g. a
-    # Tailscale Funnel) — surfaced to clients as `large_upload_url` for the rare
-    # >100 MB web upload that Cloudflare would 413. Optional; inert when unset.
-    large_upload_base = (
-        os.environ.get("EXOMEM_LARGE_UPLOAD_BASE_URL", "").strip().rstrip("/") or None
+    transfer_config = register_transfer_routes(
+        mcp, vault_root=runtime.vault_root, media_worker=runtime.media_worker
     )
-    cf_team = os.environ.get("EXOMEM_CF_ACCESS_TEAM_DOMAIN", "").strip() or None
-    cf_aud = os.environ.get("EXOMEM_CF_ACCESS_AUD", "").strip() or None
-    cf_jwks = cf_access.make_jwks_client(cf_team) if (cf_team and cf_aud) else None
-    upload_enabled = upload_token is not None or cf_jwks is not None
+    expose_tier2 = register_rest_facade(
+        mcp,
+        vault_root=runtime.vault_root,
+        source_schema=runtime.source_schema,
+        transfer_config=transfer_config,
+    )
 
-    def _upload_authorized(request: Request) -> bool:
-        # Two independent, non-spoofable credentials. (1) the bearer token,
-        # constant-time compared. (2) a Cloudflare Access JWT whose SIGNATURE is
-        # verified against the team JWKS (aud / iss / exp) — never the plaintext
-        # cf-access-authenticated-user-email header, which is client-spoofable.
-        if upload_token is not None:
-            header = request.headers.get("authorization", "")
-            if header.startswith("Bearer "):
-                presented = header[len("Bearer ") :].strip()
-                # long-lived secret, or a short-lived token minted from it
-                if secrets.compare_digest(presented, upload_token):
-                    return True
-                if upload_tokens.verify(presented, upload_token):
-                    return True
-        if cf_jwks is not None:
-            if cf_access.verify(
-                request.headers.get("cf-access-jwt-assertion"),
-                jwks_client=cf_jwks,
-                team_domain=cf_team,
-                audience=cf_aud,
-            ):
-                return True
-        return False
-
-    @mcp.custom_route("/upload", methods=["POST"])
-    async def _upload(request: Request) -> JSONResponse:
-        if not upload_enabled:
-            return JSONResponse(
-                {
-                    "code": "UPLOAD_DISABLED",
-                    "reason": "uploads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
-                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
-                },
-                status_code=503,
-            )
-        if not _upload_authorized(request):
-            return JSONResponse(
-                {"code": "UNAUTHORIZED", "reason": "missing or invalid upload credential"},
-                status_code=401,
-            )
-        try:
-            form = await request.form(max_part_size=upload_max_bytes)
-        except MultiPartException as e:
-            return JSONResponse(
-                {
-                    "code": "TOO_LARGE",
-                    "reason": f"upload rejected (exceeds {upload_max_bytes:,}-byte "
-                    f"limit or malformed): {e}",
-                },
-                status_code=413,
-            )
-        upload = form.get("file")
-        if not hasattr(upload, "read"):
-            return JSONResponse(
-                {"code": "INVALID_UPLOAD", "reason": "multipart field `file` is required"},
-                status_code=400,
-            )
-        scope = str(form.get("scope") or "").strip()
-        category = str(form.get("category") or "").strip()
-        description = str(form.get("description") or "").strip() or None
-        # Full extracted/OCR'd text of the artifact (the sandbox does the
-        # extraction). Lands in the sidecar body so the binary becomes findable.
-        text = str(form.get("text") or "").strip() or None
-        filename = str(form.get("filename") or "").strip() or (
-            getattr(upload, "filename", "") or ""
-        )
-        # Stream the spooled upload straight to Evidence/, off the event loop. The
-        # part size is already bounded by max_part_size above; preserve_stream copies
-        # in chunks, so even a multi-hundred-MB file never lands in RAM (no read() of
-        # the whole body, no base64 round-trip).
-        try:
-            result = await run_in_threadpool(
-                preserve_module.preserve_stream,
-                vault_root,
-                scope=scope,
-                category=category,
-                filename=filename,
-                stream=upload.file,
-                content_type=getattr(upload, "content_type", None),
-                description=description,
-                text=text,
-                max_bytes=upload_max_bytes,
-            )
-        except preserve_module.PreserveError as e:
-            status = {
-                "ARTIFACT_EXISTS": 409,
-                "TOO_LARGE": 413,
-                "INVALID_PRESERVE": 400,
-            }.get(e.code, 400)
-            return JSONResponse(
-                {"code": e.code, "reason": e.reason, "missing": e.missing},
-                status_code=status,
-            )
-        # Off-request-path media processing for the uploaded binary:
-        #  - OCR/ASR/PDF text when no `text` was supplied (fills the pending sidecar);
-        #  - CLIP-embed every IMAGE and VIDEO (keyframes) so visual content — including a
-        #    silent video with no transcript — is findable. Both run in the worker; 201 now.
-        if media_worker is not None and result.sidecar_path:
-            media_type = extract.media_type_for(filename)
-            if media_type:
-                do_ocr = text is None
-                do_clip = media_type in ("image", "video") and not os.environ.get("EXOMEM_DISABLE_CLIP")
-                if do_ocr or do_clip:
-                    media_worker.enqueue(
-                        binary_path=vault_root / result.path,
-                        sidecar_path=vault_root / result.sidecar_path,
-                        media_type=media_type,
-                        do_ocr=do_ocr,
-                        do_clip=do_clip,
-                    )
-        return JSONResponse(result.as_dict(), status_code=201)
-
-    @mcp.custom_route("/upload", methods=["GET"])
-    async def _upload_form(request: Request) -> HTMLResponse:
-        # Minimal browser/phone uploader. Behind Cloudflare Access it just works;
-        # otherwise paste the upload token. scope/category/description prefill from
-        # query params so Claude can hand over a ready-to-tap link.
-        q = request.query_params
-
-        def _attr(name: str) -> str:
-            return (q.get(name) or "").replace('"', "&quot;")
-
-        html = f"""<!doctype html><meta charset=utf-8>
-<meta name=viewport content="width=device-width,initial-scale=1">
-<title>exomem upload</title>
-<style>body{{font:16px system-ui;max-width:34rem;margin:2rem auto;padding:0 1rem}}
-label{{display:block;margin:.75rem 0 .2rem}}input,textarea{{width:100%;padding:.5rem;font:inherit}}
-button{{margin-top:1rem;padding:.6rem 1rem;font:inherit}}#out{{margin-top:1rem;white-space:pre-wrap}}</style>
-<h1>Add evidence to the KB</h1>
-<form id=f>
-<label>File <small>(max {upload_max_bytes // (1024 * 1024)} MB; a public link may be capped lower by the proxy)</small></label><input type=file name=file required>
-<label>Scope</label><input name=scope value="{_attr('scope')}" placeholder="e.g. Yolo" required>
-<label>Category</label><input name=category value="{_attr('category')}" placeholder="e.g. 01 - Check-in" required>
-<label>Filename (optional)</label><input name=filename value="{_attr('filename')}">
-<label>Description (optional)</label><input name=description value="{_attr('description')}">
-<label>Extracted text (optional — makes the file searchable)</label><textarea name=text rows=4 placeholder="OCR / transcribed text"></textarea>
-<label>Upload token (blank if behind Cloudflare Access)</label><input name=token type=password>
-<button type=submit>Upload</button></form>
-<div id=out></div>
-<script>
-f.onsubmit=async e=>{{e.preventDefault();const fd=new FormData(f);const t=fd.get('token');fd.delete('token');
-const h={{}};if(t)h['Authorization']='Bearer '+t;out.textContent='Uploading…';
-try{{const r=await fetch('/upload',{{method:'POST',body:fd,headers:h}});
-out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error: '+err}}}};
-</script>"""
-        return HTMLResponse(html)
-
-    # ---- Out-of-band binary DOWNLOAD: the reverse of /upload ----
-    # The sandbox pulls a vault file (dataset, evidence, scan) to analyze it.
-    # Read-only, token-gated (download-scoped), path confined to the vault root.
-    def _download_authorized(request: Request) -> bool:
-        # Same model as /upload: the long-lived master token, a *download*-scoped
-        # minted token, or a verified CF Access JWT. Never a spoofable header.
-        if upload_token is not None:
-            header = request.headers.get("authorization", "")
-            if header.startswith("Bearer "):
-                presented = header[len("Bearer ") :].strip()
-                if secrets.compare_digest(presented, upload_token):
-                    return True
-                if upload_tokens.verify(presented, upload_token, scope="download"):
-                    return True
-        if cf_jwks is not None:
-            if cf_access.verify(
-                request.headers.get("cf-access-jwt-assertion"),
-                jwks_client=cf_jwks,
-                team_domain=cf_team,
-                audience=cf_aud,
-            ):
-                return True
-        return False
-
-    @mcp.custom_route("/download", methods=["GET"])
-    async def _download(request: Request):
-        if not upload_enabled:
-            return JSONResponse(
-                {
-                    "code": "DOWNLOAD_DISABLED",
-                    "reason": "downloads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
-                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
-                },
-                status_code=503,
-            )
-        if not _download_authorized(request):
-            return JSONResponse(
-                {"code": "UNAUTHORIZED", "reason": "missing or invalid download credential"},
-                status_code=401,
-            )
-        path = request.query_params.get("path", "")
-        if not path.strip():
-            return JSONResponse(
-                {"code": "INVALID_PATH", "reason": "query param `path` (vault-relative) is required"},
-                status_code=400,
-            )
-        try:
-            abs_path, _rel = resolve_under_vault(
-                vault_root, path, must_exist=True, must_be_file=True
-            )
-        except VaultPathError as e:
-            status = 404 if e.code == "NOT_FOUND" else 400
-            return JSONResponse({"code": e.code, "reason": e.reason}, status_code=status)
-        return FileResponse(abs_path, filename=abs_path.name)
-
-    # ---- Personal REST facade: /api/<tool> JSON wrappers over the SAME leaves ----
-    #
-    # A token-gated HTTP/JSON surface for scripting the KB from your own tools
-    # (a cron job, a shell script, a phone shortcut) WITHOUT the MCP/OAuth dance.
-    # This is NOT a public/ChatGPT plugin surface: single long-lived API key
-    # (EXOMEM_REST_API_KEY), no /.well-known/ai-plugin.json. Disabled (503) unless
-    # the key is set — opt-in only. Each handler calls the exact same leaf function
-    # the matching MCP tool calls (no duplicated business logic) and maps the JSON
-    # body to kwargs, returning the leaf's structured error as 400 {error, reason}.
-    rest_api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip() or None
-    rest_enabled = rest_api_key is not None
-
-    def _rest_authorized(request: Request) -> bool:
-        # Same non-spoofable model as /upload: the long-lived REST key (constant-time
-        # compared), a short-lived `rest`-scoped minted token, or a verified CF Access
-        # JWT. Never the plaintext cf-access-* email header.
-        if rest_api_key is not None:
-            header = request.headers.get("authorization", "")
-            if header.startswith("Bearer "):
-                presented = header[len("Bearer ") :].strip()
-                if secrets.compare_digest(presented, rest_api_key):
-                    return True
-                if upload_tokens.verify(presented, rest_api_key, scope="rest"):
-                    return True
-        if cf_jwks is not None:
-            if cf_access.verify(
-                request.headers.get("cf-access-jwt-assertion"),
-                jwks_client=cf_jwks,
-                team_domain=cf_team,
-                audience=cf_aud,
-            ):
-                return True
-        return False
-
-    def _rest_err(
-        code: str, message: str, status: int, remediation: str | None = None
-    ) -> JSONResponse:
-        return _RestJSONResponse(
-            cli_ops.envelope(
-                False, error={"code": code, "message": message, "remediation": remediation}
-            ),
-            status_code=status,
-        )
-
-    def _rest_gate(request: Request) -> JSONResponse | None:
-        """503 when the facade is off, 401 when unauthorized, else None (proceed)."""
-        if not rest_enabled:
-            return _rest_err(
-                "REST_DISABLED",
-                "REST API is off: set EXOMEM_REST_API_KEY to enable the /api/* facade",
-                503,
-            )
-        if not _rest_authorized(request):
-            return _rest_err("UNAUTHORIZED", "missing or invalid REST API key", 401)
-        return None
-
-    async def _rest_body(request: Request) -> dict | None:
-        """Parse the JSON request body to a dict. `{}` for empty; None if malformed."""
-        try:
-            raw = await request.body()
-        except Exception:  # noqa: BLE001
-            return {}
-        if not raw or not raw.strip():
-            return {}
-        try:
-            data = json.loads(raw)
-        except Exception:  # noqa: BLE001
-            return None
-        return data if isinstance(data, dict) else None
-
-    # ---- Personal REST facade + OpenAPI: generated from the command registry ----
-    # Every op marked `rest` gets POST /api/<name> via one generic handler
-    # (gate -> JSON body -> registry coercion -> threadpool leaf -> shared envelope).
-    # The previously hand-wired 9 routes keep their names + leaf calls (pinned by
-    # tests/test_rest_registry.py); ops that lacked a route (replace, link,
-    # provenance_report, query_data, ...) now have one. Tier-2 ops drop out when
-    # EXOMEM_DISABLE_TIER2 is set.
-    _expose_tier2 = not os.environ.get("EXOMEM_DISABLE_TIER2")
-    _rest_commands = commands_module.commands_for("rest", expose_tier2=_expose_tier2)
-
-    def _register_rest(cmd: commands_module.Command) -> None:
-        @mcp.custom_route(f"/api/{cmd.name}", methods=["POST"])
-        async def _handler(request: Request, _cmd: commands_module.Command = cmd) -> JSONResponse:
-            gate = _rest_gate(request)
-            if gate is not None:
-                return gate
-            body = await _rest_body(request)
-            if body is None:
-                return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
-            try:
-                kwargs = cli_ops.coerce(
-                    _cmd.params, body, guarded_fields=_cmd.guarded_fields, tool=_cmd.name
-                )
-                injected = (vault_root, source_schema) if _cmd.needs_schema else (vault_root,)
-                result = await run_in_threadpool(_cmd.leaf, *injected, **kwargs)
-            except (cli_ops.OpError, ValueError, TypeError) as e:
-                err = cli_ops.error_dict(e)
-                return _RestJSONResponse(
-                    cli_ops.envelope(False, error=err),
-                    status_code=cli_ops.http_status_for(err["code"]),
-                )
-            return _RestJSONResponse(cli_ops.envelope(True, data=result))
-
-        _handler.__name__ = f"_api_{cmd.name}"
-
-    for _cmd in _rest_commands:
-        _register_rest(_cmd)
-
-    _OPENAPI_TYPES = {
-        "str": {"type": "string"},
-        "int": {"type": "integer"},
-        "bool": {"type": "boolean"},
-        "list[str]": {"type": "array", "items": {"type": "string"}},
-        "dict": {"type": "object"},
-        "json": {},
-    }
-
-    @mcp.custom_route("/api/openapi.json", methods=["GET"])
-    async def _api_openapi(request: Request) -> JSONResponse:
-        # Self-documentation only — OpenAPI 3.1 generated from the command registry
-        # (real per-parameter schemas). NOT a public plugin manifest.
-        if not rest_enabled:
-            return _rest_err("REST_DISABLED", "set EXOMEM_REST_API_KEY to enable", 503)
-        paths: dict = {}
-        for cmd in _rest_commands:
-            properties: dict = {}
-            required: list[str] = []
-            for prm in cmd.params:
-                schema_obj = dict(_OPENAPI_TYPES.get(prm.type, {}))
-                if prm.help:
-                    schema_obj["description"] = prm.help
-                properties[prm.name] = schema_obj
-                if prm.required:
-                    required.append(prm.name)
-            request_schema: dict = {"type": "object", "properties": properties}
-            if required:
-                request_schema["required"] = required
-            summary = (cmd.description or cmd.name).strip().splitlines()[0]
-            paths[f"/api/{cmd.name}"] = {
-                "post": {
-                    "operationId": cmd.name,
-                    "summary": summary,
-                    "security": [{"bearerAuth": []}],
-                    "requestBody": {
-                        "content": {"application/json": {"schema": request_schema}}
-                    },
-                    "responses": {
-                        "200": {"description": "{success: true, data: ...}"},
-                        "400": {"description": "{success: false, error: {code, message, remediation}}"},
-                        "401": {"description": "missing/invalid API key"},
-                        "503": {"description": "REST API disabled"},
-                    },
-                }
-            }
-        return JSONResponse(
-            {
-                "openapi": "3.1.0",
-                "info": {"title": "exomem personal REST facade", "version": "1.0.0"},
-                "components": {
-                    "securitySchemes": {"bearerAuth": {"type": "http", "scheme": "bearer"}}
-                },
-                "paths": paths,
-            }
-        )
-
-    # ---- MCP tools: generated from the command registry (commands.COMMANDS) ----
-    # One declarative entry per op drives the MCP tool, the REST route, the CLI
-    # subcommand, and the OpenAPI path. bind_vault presents each leaf's signature
-    # (minus vault_root) + its docstring, so each generated tool is byte-identical to
-    # the former hand-written wrapper (pinned by tests/test_mcp_schema_fidelity.py).
-    # Tier-2 escape hatches drop out of the surface when EXOMEM_DISABLE_TIER2 is set
-    # (_expose_tier2 was resolved with the REST facade above).
-    for _cmd in commands_module.commands_for("mcp", expose_tier2=_expose_tier2):
-        if _cmd.name in commands_module.HAND_REGISTERED_EXCEPTIONS:
+    for cmd in commands_module.commands_for("mcp", expose_tier2=expose_tier2):
+        if cmd.name in commands_module.HAND_REGISTERED_EXCEPTIONS:
             continue
-        _injected = (vault_root, source_schema) if _cmd.needs_schema else (vault_root,)
+        injected = (
+            (runtime.vault_root, runtime.source_schema)
+            if cmd.needs_schema
+            else (runtime.vault_root,)
+        )
         mcp.tool(
             commands_module.bind_vault(
-                _cmd.leaf, *_injected, name=_cmd.name, description=_cmd.doc
+                cmd.leaf, *injected, name=cmd.name, description=cmd.doc
             ),
-            annotations=_cmd.mcp_annotations,
+            annotations=cmd.mcp_annotations,
         )
 
-    # `note` stays a hand-registered MCP exception: its description carries the live
-    # per-vault project-key hint, injected here. Same leaf the REST/CLI surfaces use.
     mcp.tool(
         commands_module.bind_vault(
             commands_module.op_note,
-            vault_root,
+            runtime.vault_root,
             name="note",
-            description=commands_module.note_description(project_keys_hint),
+            description=commands_module.note_description(runtime.project_keys_hint),
         ),
         annotations=commands_module.mcp_tool_annotations("note", read_only=False),
     )
@@ -940,7 +203,9 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         Raises: UPLOAD_DISABLED if the server has no upload token configured.
         """
         return upload_tokens.mint_for_endpoint(
-            upload_token, base_url, large_base_url=large_upload_base
+            transfer_config.upload_token,
+            runtime.base_url,
+            large_base_url=transfer_config.large_upload_base,
         )
 
     @mcp.tool(
@@ -960,7 +225,9 @@ out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error
         Returns: {token, ttl_seconds, download_url}.
         Raises: DOWNLOAD_DISABLED if the server has no upload token configured.
         """
-        return upload_tokens.mint_for_endpoint(upload_token, base_url, scope="download")
+        return upload_tokens.mint_for_endpoint(
+            transfer_config.upload_token, runtime.base_url, scope="download"
+        )
 
     return mcp
 
@@ -972,25 +239,13 @@ def run(
     port: int = 8765,
     log_dir: Path | None = None,
 ) -> None:
-    """CLI entry: configure logging, build the server, run it.
-
-    Auth is required for HTTP transports; stdio runs auth-free.
-
-    Bind host precedence: $EXOMEM_HOST > the passed `host` > 127.0.0.1. The env var
-    wins (and is resolved AFTER build_server() loads .env) so the deployment can flip
-    the bind from .env without changing the service's launch args. Set
-    EXOMEM_HOST=0.0.0.0 to also serve a non-Cloudflare route (e.g. a direct Tailscale
-    connection to the origin) for uploads larger than the Cloudflare edge cap.
-    """
+    """CLI entry: configure logging, build the server, run it."""
     from .logging_config import configure_logging, resolve_log_dir
 
-    # Precedence: an explicit `log_dir` argument (programmatic callers, tests)
-    # wins; otherwise $EXOMEM_LOG_DIR (containers, non-root installs); else
-    # the checkout-derived <repo>/logs.
     configure_logging(log_dir if log_dir is not None else resolve_log_dir())
 
     require_auth = transport != "stdio"
-    mcp = build_server(require_auth=require_auth)  # loads .env (EXOMEM_HOST, etc.)
+    mcp = build_server(require_auth=require_auth)
 
     if transport == "stdio":
         log.info("exomem starting on stdio")

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -1,0 +1,71 @@
+"""Public asset and OAuth metadata routes for the FastMCP server."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import mcp.types
+from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse
+
+
+def server_icons() -> list[mcp.types.Icon]:
+    """Load the packaged SVG icon as an MCP initialize icon."""
+    icon_path = Path(__file__).parent / "icon.svg"
+    if not icon_path.exists():
+        return []
+    svg_bytes = icon_path.read_bytes()
+    b64 = base64.b64encode(svg_bytes).decode("ascii")
+    return [
+        mcp.types.Icon(
+            src=f"data:image/svg+xml;base64,{b64}",
+            mimeType="image/svg+xml",
+            sizes=["any"],
+        )
+    ]
+
+
+def register_asset_routes(mcp_app: FastMCP) -> None:
+    """Serve public favicon assets outside MCP auth."""
+    asset_dir = Path(__file__).parent
+
+    @mcp_app.custom_route("/favicon.ico", methods=["GET"])
+    async def _favicon_ico(request: Request):  # noqa: ARG001
+        return FileResponse(
+            asset_dir / "favicon.ico",
+            media_type="image/x-icon",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    @mcp_app.custom_route("/favicon.svg", methods=["GET"])
+    async def _favicon_svg(request: Request):  # noqa: ARG001
+        return FileResponse(
+            asset_dir / "icon.svg",
+            media_type="image/svg+xml",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+
+def register_oauth_metadata_route(
+    mcp_app: FastMCP, *, base_url: str, auth_enabled: bool
+) -> None:
+    """Mirror OAuth protected-resource metadata at the bare well-known path."""
+    if not auth_enabled:
+        return
+
+    resource_url = f"{base_url}/mcp"
+    issuer_url = f"{base_url}/"
+
+    @mcp_app.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
+    async def _oauth_protected_resource_bare(request: Request) -> JSONResponse:  # noqa: ARG001
+        return JSONResponse(
+            {
+                "resource": resource_url,
+                "authorization_servers": [issuer_url],
+                "scopes_supported": [],
+                "bearer_methods_supported": ["header"],
+            },
+            headers={"Cache-Control": "public, max-age=3600"},
+        )

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -1,0 +1,118 @@
+"""OAuth wiring for Exomem's HTTP transport."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.providers.github import GitHubTokenVerifier
+
+log = logging.getLogger(__name__)
+
+
+class SingleUserGitHubVerifier(GitHubTokenVerifier):
+    """Reject any GitHub token whose login is not the allowed user.
+
+    Caches validated tokens for a short TTL (``EXOMEM_AUTH_CACHE_TTL`` seconds,
+    default 300). Without it every MCP request, and a single connector operation
+    fires several, re-hits the GitHub API to revalidate the same token.
+    """
+
+    _DEFAULT_TTL = 300.0
+    _MAX_ENTRIES = 64
+
+    def __init__(self, *, allowed_login: str, **kwargs):
+        super().__init__(**kwargs)
+        self._allowed_login = allowed_login.lower()
+        # Do not name this ``_cache``. The parent GitHubTokenVerifier owns that
+        # attribute and expects a fastmcp TokenCache instance.
+        self._login_cache: dict[str, tuple[float, AccessToken]] = {}
+
+    def _ttl(self) -> float:
+        raw = os.environ.get("EXOMEM_AUTH_CACHE_TTL")
+        if raw is None:
+            return self._DEFAULT_TTL
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            return self._DEFAULT_TTL
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        ttl = self._ttl()
+        key = hashlib.sha256(token.encode("utf-8")).hexdigest() if token else ""
+        if ttl > 0 and key:
+            hit = self._login_cache.get(key)
+            if hit is not None:
+                ts, cached = hit
+                if time.monotonic() - ts < ttl:
+                    return cached
+                del self._login_cache[key]
+
+        access = await super().verify_token(token)
+        if access is None:
+            log.info(
+                "exomem auth: token rejected by GitHub (expired/revoked/invalid); "
+                "client will re-authorize"
+            )
+            return None
+        login = (access.claims.get("login") or "").lower()
+        if login != self._allowed_login:
+            log.warning("rejecting token for github login=%r", login)
+            return None
+
+        if ttl > 0 and key:
+            now = time.monotonic()
+            if len(self._login_cache) >= self._MAX_ENTRIES:
+                self._login_cache = {
+                    k: v for k, v in self._login_cache.items() if now - v[0] < ttl
+                }
+            self._login_cache[key] = (now, access)
+        return access
+
+
+def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
+    """Return the GitHub OAuth proxy for HTTP transports, or None for stdio."""
+    if not require_auth:
+        return None
+
+    gh_id = os.environ.get("GITHUB_CLIENT_ID", "").strip()
+    gh_secret = os.environ.get("GITHUB_CLIENT_SECRET", "").strip()
+    gh_username = os.environ.get("EXOMEM_GITHUB_USERNAME", "").strip()
+    missing = [
+        k
+        for k, v in {
+            "EXOMEM_BASE_URL": base_url,
+            "GITHUB_CLIENT_ID": gh_id,
+            "GITHUB_CLIENT_SECRET": gh_secret,
+            "EXOMEM_GITHUB_USERNAME": gh_username,
+        }.items()
+        if not v
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Missing required env vars for GitHub OAuth: {', '.join(missing)}. "
+            "See README.md section Install for setup steps."
+        )
+
+    jwt_signing_key = os.environ.get("EXOMEM_JWT_SIGNING_KEY", "").strip() or None
+    if jwt_signing_key is None:
+        log.info(
+            "EXOMEM_JWT_SIGNING_KEY not set; OAuth signing key derives from the "
+            "GitHub client secret, so connector re-auth can recur on secret "
+            "rotation or FastMCP upgrades. Set it in .env for a stable connector."
+        )
+
+    return OAuthProxy(
+        upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
+        upstream_token_endpoint="https://github.com/login/oauth/access_token",
+        upstream_client_id=gh_id,
+        upstream_client_secret=gh_secret,
+        token_verifier=SingleUserGitHubVerifier(allowed_login=gh_username),
+        base_url=base_url,
+        jwt_signing_key=jwt_signing_key,
+        fallback_access_token_expiry_seconds=30 * 24 * 60 * 60,
+    )

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -1,0 +1,183 @@
+"""Personal REST facade generated from the command registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from . import cf_access, cli_ops, commands as commands_module, upload_tokens
+from .server_transfer import TransferConfig
+
+
+class RestJSONResponse(JSONResponse):
+    """JSONResponse that renders frontmatter dates as ISO-like strings."""
+
+    def render(self, content) -> bytes:  # noqa: ANN001
+        return json.dumps(
+            content, ensure_ascii=False, allow_nan=False, default=str
+        ).encode("utf-8")
+
+
+_OPENAPI_TYPES = {
+    "str": {"type": "string"},
+    "int": {"type": "integer"},
+    "bool": {"type": "boolean"},
+    "list[str]": {"type": "array", "items": {"type": "string"}},
+    "dict": {"type": "object"},
+    "json": {},
+}
+
+
+def register_rest_facade(
+    mcp_app: FastMCP,
+    *,
+    vault_root: Path,
+    source_schema: Any,
+    transfer_config: TransferConfig,
+) -> bool:
+    """Register /api routes and return whether Tier 2 is exposed."""
+    rest_api_key = os.environ.get("EXOMEM_REST_API_KEY", "").strip() or None
+    rest_enabled = rest_api_key is not None
+    expose_tier2 = not os.environ.get("EXOMEM_DISABLE_TIER2")
+    rest_commands = commands_module.commands_for("rest", expose_tier2=expose_tier2)
+
+    def _rest_authorized(request: Request) -> bool:
+        if rest_api_key is not None:
+            header = request.headers.get("authorization", "")
+            if header.startswith("Bearer "):
+                presented = header[len("Bearer ") :].strip()
+                if secrets.compare_digest(presented, rest_api_key):
+                    return True
+                if upload_tokens.verify(presented, rest_api_key, scope="rest"):
+                    return True
+        if transfer_config.cf_jwks is not None:
+            if cf_access.verify(
+                request.headers.get("cf-access-jwt-assertion"),
+                jwks_client=transfer_config.cf_jwks,
+                team_domain=transfer_config.cf_team,
+                audience=transfer_config.cf_aud,
+            ):
+                return True
+        return False
+
+    def _rest_err(
+        code: str, message: str, status: int, remediation: str | None = None
+    ) -> JSONResponse:
+        return RestJSONResponse(
+            cli_ops.envelope(
+                False, error={"code": code, "message": message, "remediation": remediation}
+            ),
+            status_code=status,
+        )
+
+    def _rest_gate(request: Request) -> JSONResponse | None:
+        if not rest_enabled:
+            return _rest_err(
+                "REST_DISABLED",
+                "REST API is off: set EXOMEM_REST_API_KEY to enable the /api/* facade",
+                503,
+            )
+        if not _rest_authorized(request):
+            return _rest_err("UNAUTHORIZED", "missing or invalid REST API key", 401)
+        return None
+
+    async def _rest_body(request: Request) -> dict | None:
+        try:
+            raw = await request.body()
+        except Exception:  # noqa: BLE001
+            return {}
+        if not raw or not raw.strip():
+            return {}
+        try:
+            data = json.loads(raw)
+        except Exception:  # noqa: BLE001
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _register_rest(cmd: commands_module.Command) -> None:
+        @mcp_app.custom_route(f"/api/{cmd.name}", methods=["POST"])
+        async def _handler(
+            request: Request, _cmd: commands_module.Command = cmd
+        ) -> JSONResponse:
+            gate = _rest_gate(request)
+            if gate is not None:
+                return gate
+            body = await _rest_body(request)
+            if body is None:
+                return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+            try:
+                kwargs = cli_ops.coerce(
+                    _cmd.params, body, guarded_fields=_cmd.guarded_fields, tool=_cmd.name
+                )
+                injected = (vault_root, source_schema) if _cmd.needs_schema else (vault_root,)
+                result = await run_in_threadpool(_cmd.leaf, *injected, **kwargs)
+            except (cli_ops.OpError, ValueError, TypeError) as exc:
+                err = cli_ops.error_dict(exc)
+                return RestJSONResponse(
+                    cli_ops.envelope(False, error=err),
+                    status_code=cli_ops.http_status_for(err["code"]),
+                )
+            return RestJSONResponse(cli_ops.envelope(True, data=result))
+
+        _handler.__name__ = f"_api_{cmd.name}"
+
+    for cmd in rest_commands:
+        _register_rest(cmd)
+
+    @mcp_app.custom_route("/api/openapi.json", methods=["GET"])
+    async def _api_openapi(request: Request) -> JSONResponse:  # noqa: ARG001
+        if not rest_enabled:
+            return _rest_err("REST_DISABLED", "set EXOMEM_REST_API_KEY to enable", 503)
+        paths: dict = {}
+        for cmd in rest_commands:
+            properties: dict = {}
+            required: list[str] = []
+            for prm in cmd.params:
+                schema_obj = dict(_OPENAPI_TYPES.get(prm.type, {}))
+                if prm.help:
+                    schema_obj["description"] = prm.help
+                properties[prm.name] = schema_obj
+                if prm.required:
+                    required.append(prm.name)
+            request_schema: dict = {"type": "object", "properties": properties}
+            if required:
+                request_schema["required"] = required
+            summary = (cmd.description or cmd.name).strip().splitlines()[0]
+            paths[f"/api/{cmd.name}"] = {
+                "post": {
+                    "operationId": cmd.name,
+                    "summary": summary,
+                    "security": [{"bearerAuth": []}],
+                    "requestBody": {
+                        "content": {"application/json": {"schema": request_schema}}
+                    },
+                    "responses": {
+                        "200": {"description": "{success: true, data: ...}"},
+                        "400": {
+                            "description": "{success: false, error: {code, message, remediation}}"
+                        },
+                        "401": {"description": "missing/invalid API key"},
+                        "503": {"description": "REST API disabled"},
+                    },
+                }
+            }
+        return JSONResponse(
+            {
+                "openapi": "3.1.0",
+                "info": {"title": "exomem personal REST facade", "version": "1.0.0"},
+                "components": {
+                    "securitySchemes": {"bearerAuth": {"type": "http", "scheme": "bearer"}}
+                },
+                "paths": paths,
+            }
+        )
+
+    return expose_tier2

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -1,0 +1,115 @@
+"""Server startup wiring for Exomem.
+
+This module owns process-local runtime setup: environment loading, vault
+resolution, warmup/model policy, media extraction, and file watching. It is kept
+separate from transport route registration so ``server.build_server`` stays a
+small composition root.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import env_compat, extract, project_keys, schema
+from .vault import resolve_vault
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ServerRuntime:
+    vault_root: Path
+    source_schema: Any
+    project_keys_hint: str
+    base_url: str
+    media_worker: Any | None = None
+    file_watcher: Any | None = None
+
+
+def initialize_runtime(*, load_dotenv_func: Callable[..., object]) -> ServerRuntime:
+    """Initialize process-local server runtime state.
+
+    ``load_dotenv_func`` is injected from ``server.py`` so tests that monkeypatch
+    ``exomem.server.load_dotenv`` still neutralize dotenv loading exactly as they
+    did before this extraction.
+    """
+    load_dotenv_func(override=True)
+    env_compat.promote_legacy()
+
+    vault_root = resolve_vault()
+    source_schema = schema.load_source_schema(vault_root)
+    log.info("vault=%s source_types=%s", vault_root, source_schema.source_types)
+
+    project_keys_hint = project_keys.keys_hint(vault_root)
+    _start_compute_runtime(vault_root)
+    media_worker = _start_media_worker(vault_root)
+    file_watcher = _start_file_watcher(vault_root)
+
+    base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
+    return ServerRuntime(
+        vault_root=vault_root,
+        source_schema=source_schema,
+        project_keys_hint=project_keys_hint,
+        base_url=base_url,
+        media_worker=media_worker,
+        file_watcher=file_watcher,
+    )
+
+
+def _start_compute_runtime(vault_root: Path) -> None:
+    """Start warmup, model unloading, and live compute-mode watching."""
+    from . import mode, warmup
+
+    log.info("compute policy: %s", mode.resolved())
+    if warmup.warmup_enabled():
+        if os.environ.get("EXOMEM_EAGER_BOOT"):
+            warmup.warm_all(vault_root)
+        else:
+            warmup.start_background(vault_root)
+
+    if mode.release_when_idle():
+        from . import model_reaper
+
+        model_reaper.start()
+
+    mode.start_config_watch()
+
+    from . import auto_quiet
+
+    auto_quiet.start_if_enabled()
+
+
+def _start_media_worker(vault_root: Path) -> Any | None:
+    """Start the optional off-request media extraction worker."""
+    if not extract.extraction_enabled():
+        return None
+
+    from . import media_worker as media_worker_module
+
+    worker = media_worker_module.MediaWorker(vault_root)
+    worker.start()
+    try:
+        worker.scan_pending()
+    except Exception as exc:  # noqa: BLE001 - startup scan is best-effort
+        log.warning("media worker startup scan failed: %s", exc)
+    return worker
+
+
+def _start_file_watcher(vault_root: Path) -> Any | None:
+    """Start the optional live file watcher."""
+    if os.environ.get("EXOMEM_DISABLE_FILE_WATCHER"):
+        return None
+
+    from . import file_watcher as file_watcher_module
+
+    watcher = file_watcher_module.FileWatcher(vault_root)
+    try:
+        watcher.start()
+    except Exception as exc:  # noqa: BLE001 - watcher must not break startup
+        log.warning("file watcher start failed: %s", exc)
+    return watcher

--- a/src/exomem/server_transfer.py
+++ b/src/exomem/server_transfer.py
@@ -1,0 +1,229 @@
+"""Out-of-band upload/download routes for Exomem."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+from starlette.concurrency import run_in_threadpool
+from starlette.formparsers import MultiPartException
+from starlette.requests import Request
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse
+
+from . import cf_access, extract, preserve as preserve_module, upload_tokens
+from .vault import VaultPathError, resolve_under_vault
+
+
+@dataclass(frozen=True)
+class TransferConfig:
+    upload_token: str | None
+    upload_max_bytes: int
+    large_upload_base: str | None
+    cf_team: str | None
+    cf_aud: str | None
+    cf_jwks: Any | None
+
+    @property
+    def enabled(self) -> bool:
+        return self.upload_token is not None or self.cf_jwks is not None
+
+
+def load_transfer_config() -> TransferConfig:
+    """Read upload/download auth and sizing config from the environment."""
+    upload_token = os.environ.get("EXOMEM_UPLOAD_TOKEN", "").strip() or None
+    upload_max_bytes = int(
+        os.environ.get("EXOMEM_UPLOAD_MAX_BYTES", str(preserve_module.MAX_UPLOAD_BYTES))
+    )
+    large_upload_base = (
+        os.environ.get("EXOMEM_LARGE_UPLOAD_BASE_URL", "").strip().rstrip("/") or None
+    )
+    cf_team = os.environ.get("EXOMEM_CF_ACCESS_TEAM_DOMAIN", "").strip() or None
+    cf_aud = os.environ.get("EXOMEM_CF_ACCESS_AUD", "").strip() or None
+    cf_jwks = cf_access.make_jwks_client(cf_team) if (cf_team and cf_aud) else None
+    return TransferConfig(
+        upload_token=upload_token,
+        upload_max_bytes=upload_max_bytes,
+        large_upload_base=large_upload_base,
+        cf_team=cf_team,
+        cf_aud=cf_aud,
+        cf_jwks=cf_jwks,
+    )
+
+
+def register_transfer_routes(
+    mcp_app: FastMCP,
+    *,
+    vault_root: Path,
+    media_worker: Any | None,
+) -> TransferConfig:
+    """Register /upload and /download routes and return their config."""
+    config = load_transfer_config()
+
+    def _authorized(request: Request, *, scope: str = "upload") -> bool:
+        if config.upload_token is not None:
+            header = request.headers.get("authorization", "")
+            if header.startswith("Bearer "):
+                presented = header[len("Bearer ") :].strip()
+                if secrets.compare_digest(presented, config.upload_token):
+                    return True
+                if upload_tokens.verify(presented, config.upload_token, scope=scope):
+                    return True
+        if config.cf_jwks is not None:
+            if cf_access.verify(
+                request.headers.get("cf-access-jwt-assertion"),
+                jwks_client=config.cf_jwks,
+                team_domain=config.cf_team,
+                audience=config.cf_aud,
+            ):
+                return True
+        return False
+
+    @mcp_app.custom_route("/upload", methods=["POST"])
+    async def _upload(request: Request) -> JSONResponse:
+        if not config.enabled:
+            return JSONResponse(
+                {
+                    "code": "UPLOAD_DISABLED",
+                    "reason": "uploads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
+                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
+                },
+                status_code=503,
+            )
+        if not _authorized(request):
+            return JSONResponse(
+                {"code": "UNAUTHORIZED", "reason": "missing or invalid upload credential"},
+                status_code=401,
+            )
+        try:
+            form = await request.form(max_part_size=config.upload_max_bytes)
+        except MultiPartException as exc:
+            return JSONResponse(
+                {
+                    "code": "TOO_LARGE",
+                    "reason": f"upload rejected (exceeds {config.upload_max_bytes:,}-byte "
+                    f"limit or malformed): {exc}",
+                },
+                status_code=413,
+            )
+        upload = form.get("file")
+        if not hasattr(upload, "read"):
+            return JSONResponse(
+                {"code": "INVALID_UPLOAD", "reason": "multipart field `file` is required"},
+                status_code=400,
+            )
+        scope = str(form.get("scope") or "").strip()
+        category = str(form.get("category") or "").strip()
+        description = str(form.get("description") or "").strip() or None
+        text = str(form.get("text") or "").strip() or None
+        filename = str(form.get("filename") or "").strip() or (
+            getattr(upload, "filename", "") or ""
+        )
+        try:
+            result = await run_in_threadpool(
+                preserve_module.preserve_stream,
+                vault_root,
+                scope=scope,
+                category=category,
+                filename=filename,
+                stream=upload.file,
+                content_type=getattr(upload, "content_type", None),
+                description=description,
+                text=text,
+                max_bytes=config.upload_max_bytes,
+            )
+        except preserve_module.PreserveError as exc:
+            status = {
+                "ARTIFACT_EXISTS": 409,
+                "TOO_LARGE": 413,
+                "INVALID_PRESERVE": 400,
+            }.get(exc.code, 400)
+            return JSONResponse(
+                {"code": exc.code, "reason": exc.reason, "missing": exc.missing},
+                status_code=status,
+            )
+
+        if media_worker is not None and result.sidecar_path:
+            media_type = extract.media_type_for(filename)
+            if media_type:
+                do_ocr = text is None
+                do_clip = media_type in ("image", "video") and not os.environ.get(
+                    "EXOMEM_DISABLE_CLIP"
+                )
+                if do_ocr or do_clip:
+                    media_worker.enqueue(
+                        binary_path=vault_root / result.path,
+                        sidecar_path=vault_root / result.sidecar_path,
+                        media_type=media_type,
+                        do_ocr=do_ocr,
+                        do_clip=do_clip,
+                    )
+        return JSONResponse(result.as_dict(), status_code=201)
+
+    @mcp_app.custom_route("/upload", methods=["GET"])
+    async def _upload_form(request: Request) -> HTMLResponse:
+        q = request.query_params
+
+        def _attr(name: str) -> str:
+            return (q.get(name) or "").replace('"', "&quot;")
+
+        html = f"""<!doctype html><meta charset=utf-8>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>exomem upload</title>
+<style>body{{font:16px system-ui;max-width:34rem;margin:2rem auto;padding:0 1rem}}
+label{{display:block;margin:.75rem 0 .2rem}}input,textarea{{width:100%;padding:.5rem;font:inherit}}
+button{{margin-top:1rem;padding:.6rem 1rem;font:inherit}}#out{{margin-top:1rem;white-space:pre-wrap}}</style>
+<h1>Add evidence to the KB</h1>
+<form id=f>
+<label>File <small>(max {config.upload_max_bytes // (1024 * 1024)} MB; a public link may be capped lower by the proxy)</small></label><input type=file name=file required>
+<label>Scope</label><input name=scope value="{_attr('scope')}" placeholder="e.g. Yolo" required>
+<label>Category</label><input name=category value="{_attr('category')}" placeholder="e.g. 01 - Check-in" required>
+<label>Filename (optional)</label><input name=filename value="{_attr('filename')}">
+<label>Description (optional)</label><input name=description value="{_attr('description')}">
+<label>Extracted text (optional - makes the file searchable)</label><textarea name=text rows=4 placeholder="OCR / transcribed text"></textarea>
+<label>Upload token (blank if behind Cloudflare Access)</label><input name=token type=password>
+<button type=submit>Upload</button></form>
+<div id=out></div>
+<script>
+f.onsubmit=async e=>{{e.preventDefault();const fd=new FormData(f);const t=fd.get('token');fd.delete('token');
+const h={{}};if(t)h['Authorization']='Bearer '+t;out.textContent='Uploading...';
+try{{const r=await fetch('/upload',{{method:'POST',body:fd,headers:h}});
+out.textContent=r.status+' '+await r.text();}}catch(err){{out.textContent='Error: '+err}}}};
+</script>"""
+        return HTMLResponse(html)
+
+    @mcp_app.custom_route("/download", methods=["GET"])
+    async def _download(request: Request):
+        if not config.enabled:
+            return JSONResponse(
+                {
+                    "code": "DOWNLOAD_DISABLED",
+                    "reason": "downloads are off: set EXOMEM_UPLOAD_TOKEN (or configure "
+                    "Cloudflare Access via EXOMEM_CF_ACCESS_TEAM_DOMAIN + EXOMEM_CF_ACCESS_AUD)",
+                },
+                status_code=503,
+            )
+        if not _authorized(request, scope="download"):
+            return JSONResponse(
+                {"code": "UNAUTHORIZED", "reason": "missing or invalid download credential"},
+                status_code=401,
+            )
+        path = request.query_params.get("path", "")
+        if not path.strip():
+            return JSONResponse(
+                {"code": "INVALID_PATH", "reason": "query param `path` (vault-relative) is required"},
+                status_code=400,
+            )
+        try:
+            abs_path, _rel = resolve_under_vault(
+                vault_root, path, must_exist=True, must_be_file=True
+            )
+        except VaultPathError as exc:
+            status = 404 if exc.code == "NOT_FOUND" else 400
+            return JSONResponse({"code": exc.code, "reason": exc.reason}, status_code=status)
+        return FileResponse(abs_path, filename=abs_path.name)
+
+    return config


### PR DESCRIPTION
## Summary

- document Exomem's architecture boundaries and non-goals
- split `server.py` into runtime/auth/assets/transfer/REST modules while keeping it as the FastMCP composition root
- extract ranking config loading from `find.py` into `ranking_config.py` with compatibility wrappers
- refresh ranking-tuning docs to current Exomem names

## Verification

- `python -m py_compile src/exomem/server.py src/exomem/server_auth.py src/exomem/server_runtime.py src/exomem/server_assets.py src/exomem/server_transfer.py src/exomem/server_rest.py src/exomem/ranking_config.py src/exomem/find.py`
- `git diff --check`
- `pytest -q -p no:cacheprovider tests/test_auth_cache.py tests/test_ranking_config.py tests/test_ranking_config_load.py tests/test_favicon_endpoint.py tests/test_upload_endpoint.py tests/test_download_endpoint.py tests/test_rest_api.py tests/test_rest_registry.py tests/test_mcp_schema_fidelity.py tests/test_tool_annotations.py tests/test_bootstrap.py tests/test_instant_start.py tests/test_rename_compat.py tests/test_consolidated_tools.py tests/test_event_indexes_wiring.py tests/test_get_links.py tests/test_tier2.py tests/test_supersession_surface.py tests/test_video_frames.py`

Result: 249 passed, 3 skipped (optional `PIL`/`av` media tests), 357 warnings.