### PR TITLE
feat(deploy): add CUDA container setup path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -162,6 +162,19 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push cuda image (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: cuda
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:cuda
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-cuda
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   publish-existing-image:
     if: ${{ github.event_name == 'workflow_dispatch' && vars.GHCR_PUBLISH_ENABLED == 'true' }}
     runs-on: ubuntu-latest
@@ -208,6 +221,18 @@ jobs:
           push: true
           tags: |
             ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-ml
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push cuda image (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: cuda
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-cuda
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,13 @@ uncommitted work would conflict); and anything off the git tree — building/syn
 venvs (`uv sync`), running or restarting the service, editing a file you yourself
 just created. Don't hand the user a command you can safely run yourself.
 
-**Mitigation:** isolate any *new change* — feature, fix, or docs — in a dedicated
-git worktree (its own branch + tree) and commit/push from there, leaving the
-primary untouched for the other session. The worktree is the default for new work;
-the rule above is the guardrail for when you must operate on the primary.
+**Mitigation:** before editing for any *new change* — feature, fix, docs,
+OpenSpec artifact, or release prep — first check whether the current checkout is
+an isolated worktree. If it is the shared primary checkout, create a dedicated
+worktree from `origin/main` and do the edits there. Do not ask the user to repeat
+this preference; state the worktree path in your first progress update. The
+worktree is the default for new work; the rule above is the guardrail for when
+you must operate on the primary.
 
 - Native (Claude Code): `EnterWorktree` — branches off `origin/main`; edit,
   commit, `git push origin HEAD:main` (or open a PR), then `ExitWorktree`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # exomem — multi-stage container image.
 #
-# Two final targets share this one file (openspec/changes/add-docker-distribution/design.md D6):
+# Three final targets share this one file:
 #   lean (target `lean`, DEFAULT — base deps only, no torch, no model download)
 #   ml   (target `ml`   — the `embeddings` extra, CPU-only torch, no CUDA runtime)
+#   cuda (target `cuda` — the `embeddings` extra, CUDA-capable torch, CPU-default at idle)
 #
 # `lean` is intentionally the LAST stage in this file: `docker build .` / `docker
 # buildx build .` with no `--target` builds the final stage in the file, and lean
 # is meant to be that zero-argument default (matches the stdio one-liner's
 # zero-Python, zero-model-download onboarding promise — see docs/docker.md).
 # Build `ml` explicitly with `--target ml` (or pull the published `:ml` tag).
+# Build `cuda` explicitly with `--target cuda` (or pull the published `:cuda` tag).
 #
 # Every stage builds from the checked-out source tree (COPY src/ pyproject.toml
 # uv.lock), never a published PyPI wheel — see design.md D1.
@@ -70,6 +72,19 @@ RUN uv pip install --python /app/.venv/bin/python "torch>=2.12" --index-url http
  && uv pip install --python /app/.venv/bin/python ".[embeddings]"
 
 ########################################################################
+# builder-cuda — adds the `embeddings` extra with CUDA-capable torch.
+#
+# This is intentionally separate from `ml`: the CPU image stays portable and
+# small, while this image carries the NVIDIA/CUDA torch wheel for Linux hosts
+# that run Docker with the NVIDIA container runtime. CUDA capability still does
+# NOT imply CUDA residency: exomem's default `normal` mode selects CPU unless the
+# user opts into performance mode or an explicit CUDA device.
+########################################################################
+FROM builder-lean AS builder-cuda
+RUN uv pip install --python /app/.venv/bin/python "torch>=2.12" --index-url https://download.pytorch.org/whl/cu132 \
+ && uv pip install --python /app/.venv/bin/python ".[embeddings]"
+
+########################################################################
 # Final: ml (target `ml`). Fresh slim base — no build tooling, no uv, no
 # source tree — just the populated venv. HF_HOME pins the downloaded
 # embedding/CLIP model weights under the declared /data volume so they
@@ -82,7 +97,8 @@ COPY LICENSE /LICENSE
 ENV PATH=/app/.venv/bin:$PATH \
     EXOMEM_HOST=0.0.0.0 \
     EXOMEM_LOG_DIR=/data/logs \
-    HF_HOME=/data/hf
+    HF_HOME=/data/hf \
+    EXOMEM_CONTAINER_VARIANT=ml
 
 LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
       org.opencontainers.image.licenses="AGPL-3.0-or-later" \
@@ -92,6 +108,37 @@ LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
 # would run unconditionally, including for `--transport stdio`, where there is
 # no HTTP server to probe. The healthcheck lives in compose.yaml instead, where
 # it only applies to the long-running HTTP deployment.
+VOLUME /data
+EXPOSE 8765
+ENTRYPOINT ["exomem"]
+CMD ["--transport", "http", "--port", "8765"]
+
+########################################################################
+# Final: cuda (target `cuda`). Fresh slim base — no build tooling, no uv, no
+# source tree — just the populated venv. The image is CUDA-capable but remains
+# CPU-default at idle via exomem's mode resolver. NVIDIA_* env vars are hints
+# consumed by the NVIDIA container runtime; without that runtime, doctor reports
+# CUDA unavailable and the service degrades to CPU.
+########################################################################
+FROM python:3.12-slim AS cuda
+COPY --from=builder-cuda /app/.venv /app/.venv
+COPY LICENSE /LICENSE
+
+ENV PATH=/app/.venv/bin:$PATH \
+    EXOMEM_HOST=0.0.0.0 \
+    EXOMEM_LOG_DIR=/data/logs \
+    HF_HOME=/data/hf \
+    EXOMEM_CONTAINER_VARIANT=cuda \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.description="exomem — local knowledge substrate for owned markdown/Obsidian vaults, exposed through MCP, REST, and CLI (cuda: hybrid embeddings + CLIP search, CUDA-capable torch, CPU-default at idle)"
+
+# No HEALTHCHECK here by design — a Dockerfile-level HEALTHCHECK would run
+# unconditionally, including for `--transport stdio`, where there is no HTTP
+# server to probe. The healthcheck lives in compose.yaml instead.
 VOLUME /data
 EXPOSE 8765
 ENTRYPOINT ["exomem"]
@@ -111,7 +158,8 @@ COPY LICENSE /LICENSE
 ENV PATH=/app/.venv/bin:$PATH \
     EXOMEM_HOST=0.0.0.0 \
     EXOMEM_LOG_DIR=/data/logs \
-    EXOMEM_DISABLE_EMBEDDINGS=1
+    EXOMEM_DISABLE_EMBEDDINGS=1 \
+    EXOMEM_CONTAINER_VARIANT=lean
 
 LABEL org.opencontainers.image.source="https://github.com/Artexis10/exomem" \
       org.opencontainers.image.licenses="AGPL-3.0-or-later" \

--- a/README.md
+++ b/README.md
@@ -161,9 +161,13 @@ clients learn Exomem's search/save/upload contract without a separate skill file
 claude mcp add exomem -- docker run -i --rm -v "/path/to/vault:/vault" -e EXOMEM_VAULT_PATH=/vault ghcr.io/artexis10/exomem:latest --transport stdio
 ```
 
+Use `:latest` for the lean keyword/BM25 image, `:ml` for CPU hybrid search, or
+`:cuda` for NVIDIA/Linux CUDA capability. CUDA images still boot CPU-default at
+idle; opt into GPU residency with `EXOMEM_MODE=performance` when you want it.
 The image also runs as an always-on remote server via `docker compose` with a
-tunnel sidecar — see [docs/docker.md](docs/docker.md). Windows users: prefer
-the native install (WSL2 bind mounts miss live file-watch events).
+tunnel sidecar — see [docs/docker.md](docs/docker.md). Windows users with a live
+vault should usually prefer the native install (WSL2 bind mounts miss live
+file-watch events); macOS Apple Silicon users need native install for MPS/MLX.
 
 </details>
 

--- a/compose.cuda.yaml
+++ b/compose.cuda.yaml
@@ -1,0 +1,13 @@
+# exomem — NVIDIA CUDA-capable container override.
+#
+# Usage:
+#   docker compose -f compose.yaml -f compose.cuda.yaml up -d
+#   docker compose -f compose.yaml -f compose.cuda.yaml --profile cloudflared up -d
+#
+# The CUDA image is CPU-default at idle. Set EXOMEM_MODE=performance in .env only
+# when you want steady-state model work to use the GPU.
+
+services:
+  exomem:
+    image: ghcr.io/artexis10/exomem:cuda
+    gpus: all

--- a/compose.ml.yaml
+++ b/compose.ml.yaml
@@ -1,0 +1,9 @@
+# exomem — CPU hybrid container override.
+#
+# Usage:
+#   docker compose -f compose.yaml -f compose.ml.yaml up -d
+#   docker compose -f compose.yaml -f compose.ml.yaml --profile cloudflared up -d
+
+services:
+  exomem:
+    image: ghcr.io/artexis10/exomem:ml

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,10 +194,14 @@ command.
 ## 6. Install as a service (auto-start on boot)
 
 **Option 0 (container):** `docker compose --profile cloudflared up -d` (or
-`--profile ngrok`) runs the server plus the tunnel as one supervised unit —
-see [docker.md](docker.md). The native services below suit hosts where Docker
-isn't wanted, Windows vaults (WSL2 bind mounts miss live file-watch events),
-and GPU setups.
+`--profile ngrok`) runs the lean server plus the tunnel as one supervised unit.
+Use `docker compose -f compose.yaml -f compose.ml.yaml ...` for CPU hybrid search,
+or `docker compose -f compose.yaml -f compose.cuda.yaml ...` for NVIDIA/Linux
+CUDA capability. The CUDA image remains CPU-default at idle unless you explicitly
+set performance mode. See [docker.md](docker.md). The native services below suit
+Windows live vaults (Docker Desktop/WSL2 bind mounts miss live file-watch events),
+macOS Apple Silicon GPU paths (MPS/MLX are native-only), and hosts where Docker
+isn't wanted.
 
 Pick your platform — all three run the same `streamable-http` server and differ
 only in the OS service manager.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,6 +21,7 @@ For an always-on remote deployment (mobile/web access via claude.ai), skip to
 | --- | --- | --- | --- |
 | `latest`, `X.Y.Z` | `lean` | keyword/BM25 only, no torch | ~250–350 MB |
 | `ml`, `X.Y.Z-ml` | `ml` | hybrid embeddings + CLIP search, CPU-only torch | ~1.5–2 GB |
+| `cuda`, `X.Y.Z-cuda` | `cuda` | hybrid embeddings + CLIP search, CUDA-capable torch, CPU-default at idle | larger; NVIDIA/Linux amd64 only |
 
 `lean` is the default and is what the stdio one-liner above pulls — no torch,
 no model download, matching a fast zero-Python onboarding path. Opt into
@@ -28,10 +29,33 @@ hybrid search with the `ml` tag (`ghcr.io/artexis10/exomem:ml`); the first
 `find` call downloads the embedding/CLIP model weights into the `/data` volume
 (see below), so later restarts don't re-download them.
 
-**GPU is out of scope for both variants.** `ml` runs CPU-only torch — no CUDA
-runtime is bundled, and none is documented for this image. If you need GPU
-throughput, use the native install instead ([../QUICKSTART.md](../QUICKSTART.md),
-[deployment.md](deployment.md)'s CUDA/GPU notes).
+For NVIDIA Linux hosts, use the CUDA-capable image:
+
+```bash
+docker run --gpus all -i --rm \
+  -v "/path/to/vault:/vault" \
+  -v exomem-data:/data \
+  -e EXOMEM_VAULT_PATH=/vault \
+  ghcr.io/artexis10/exomem:cuda --transport stdio
+```
+
+The CUDA image is **capable**, not **resident by default**. It still boots in
+normal mode, where exomem's steady-state torch models select CPU so the container
+does not grab VRAM at idle. Opt into GPU use explicitly when you want it:
+
+```bash
+docker run --gpus all -i --rm \
+  -v "/path/to/vault:/vault" \
+  -v exomem-data:/data \
+  -e EXOMEM_VAULT_PATH=/vault \
+  -e EXOMEM_MODE=performance \
+  ghcr.io/artexis10/exomem:cuda --transport stdio
+```
+
+Use `ml` for reproducible hybrid search without NVIDIA runtime. Use native install
+instead ([../QUICKSTART.md](../QUICKSTART.md), [deployment.md](deployment.md)'s
+CUDA/GPU notes) when you need Windows live-vault watcher reliability or macOS
+Apple Silicon MPS/MLX.
 
 ## Volume contract
 
@@ -44,7 +68,7 @@ throughput, use the native install instead ([../QUICKSTART.md](../QUICKSTART.md)
     `queries.jsonl` / `writes.jsonl` / `reads.jsonl` audit logs land here too,
     but only in the `ml` image (the lean image runs with embeddings disabled,
     which also turns the query log off).
-  - `ml` only: `HF_HOME=/data/hf` — downloaded embedding/CLIP model weights.
+  - `ml`/`cuda` only: `HF_HOME=/data/hf` — downloaded embedding/CLIP model weights.
 
   Mount a named volume (or bind mount) at `/data` so logs and model weights
   survive container restarts instead of resetting every time. `/data` is
@@ -78,7 +102,24 @@ documented in [deployment.md](deployment.md).
    - Whichever tunnel credential you're using: `CLOUDFLARE_TUNNEL_TOKEN`, or
      `NGROK_AUTHTOKEN` + `NGROK_DOMAIN`.
 
-3. Bring it up with the tunnel profile you have an account for:
+3. Pick the runtime image:
+
+   ```bash
+   # lean keyword/BM25 (default)
+   docker compose up -d
+
+   # CPU hybrid search
+   docker compose -f compose.yaml -f compose.ml.yaml up -d
+
+   # NVIDIA/Linux CUDA-capable hybrid search
+   docker compose -f compose.yaml -f compose.cuda.yaml up -d
+   ```
+
+   The CUDA override declares `gpus: all`, so it requires Docker with the NVIDIA
+   container runtime. It still boots normal/CPU-default unless `.env` sets
+   `EXOMEM_MODE=performance`.
+
+4. Add the tunnel profile you have an account for when you need public ingress:
 
    ```bash
    docker compose --profile ngrok up -d
@@ -86,12 +127,18 @@ documented in [deployment.md](deployment.md).
    docker compose --profile cloudflared up -d
    ```
 
+   Combine the runtime override and tunnel profile when needed:
+
+   ```bash
+   docker compose -f compose.yaml -f compose.cuda.yaml --profile cloudflared up -d
+   ```
+
    With **no** `--profile` flag, only the `exomem` service starts: no host
    port published, no tunnel sidecar running — useful for a LAN-only or
    locally-debugged setup. Uncomment the `ports:` line in `compose.yaml` to
    bind `127.0.0.1:8765` for local access.
 
-4. Verify:
+5. Verify:
 
    ```bash
    docker compose exec exomem exomem doctor --profile remote
@@ -120,7 +167,7 @@ before running non-root against it. The
 image does not impose a fixed `USER`, so you can pick the uid/gid that matches
 your host's volume ownership.
 
-## Windows caveat
+## Windows and macOS caveats
 
 If you're on Windows, prefer the native install
 ([../QUICKSTART.md](../QUICKSTART.md)) over Docker for day-to-day editing.
@@ -131,3 +178,12 @@ container. NTFS-backed WSL2 mounts are also noticeably slower than a native
 filesystem for the same reason. Docker remains a good choice for a Linux/macOS
 host, or for the remote-compose walkthrough above running on a remote Linux
 box.
+
+On Windows+WSL2 with NVIDIA, the `cuda` image can use the GPU when Docker Desktop
+and the NVIDIA runtime are configured, but the bind-mount watcher caveat still
+applies. For a live Obsidian vault on the Windows filesystem, native NSSM remains
+the recommended default; use Docker CUDA when you accept the watcher tradeoff or
+run against a Linux-native vault path.
+
+On macOS Apple Silicon, Docker Linux containers do not expose Metal/MPS/MLX to
+exomem. Use the native install for GPU-backed bge/CLIP or MLX Whisper.

--- a/openspec/changes/add-cross-os-deployment-setup/.openspec.yaml
+++ b/openspec/changes/add-cross-os-deployment-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/add-cross-os-deployment-setup/design.md
+++ b/openspec/changes/add-cross-os-deployment-setup/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Exomem currently ships a lean Docker image and a CPU-only `ml` image. The live
+Windows desktop deployment is native NSSM over the repo `.venv`, because that path
+preserves direct vault file-watching and GPU/MPS-capable local runtimes. A recent
+incident showed the native path can silently lose optional extras when a plain
+`uv sync` strips `sentence-transformers`/`torch`; a separate earlier incident showed
+that eager CUDA residency can steal enough VRAM to affect games and other desktop
+workloads.
+
+The product needs a low-friction cross-OS setup story without forcing one runtime
+everywhere. Linux users with NVIDIA should get a reproducible CUDA container. Windows
+live-vault users should keep native as the default. macOS Apple Silicon should keep
+native for MPS/MLX. All paths must preserve the pure-substrate boundary: the packaged
+models are deterministic measurement components, not server-side reasoning.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an NVIDIA CUDA Docker variant that can run hybrid search and media paths with
+  CUDA available.
+- Keep all installs resource-safe by default: normal mode remains CPU-default and
+  CUDA is explicit opt-in through mode/device/bulk operations.
+- Make Docker Compose express lean, CPU-ML, and CUDA runtime choices clearly.
+- Make setup/doctor report the runtime and compute profile accurately enough to
+  catch missing extras, missing NVIDIA runtime, and unintended GPU residency.
+- Preserve native Windows as the recommended live-vault/GPU path while making
+  Linux CUDA Docker a first-class one-command path.
+
+**Non-Goals:**
+
+- Do not make Docker the only supported deployment path.
+- Do not add a server-side reasoning model.
+- Do not make the CUDA image the default `latest` image.
+- Do not solve full auto-quiet in this change; this change should leave a clean
+  hook point and not regress the existing `quiet|normal|performance` mode system.
+
+## Decisions
+
+1. **Publish three image families.**
+   Keep `lean` as `latest`/`X.Y.Z`; keep CPU hybrid as `ml`/`X.Y.Z-ml`; add CUDA
+   hybrid as `cuda`/`X.Y.Z-cuda`. Alternative considered: replace `ml` with CUDA.
+   Rejected because CPU-only hybrid remains smaller, easier to run anywhere, and
+   safer for hosts without NVIDIA runtime.
+
+2. **CUDA image contains CUDA capability, not CUDA residency.**
+   The CUDA image may include CUDA torch/runtime libraries, but it still boots in
+   normal CPU-default mode. Users opt into GPU via `EXOMEM_MODE=performance`,
+   `exomem mode performance`, explicit device env, or bulk indexing. Alternative:
+   have the CUDA tag imply performance mode. Rejected because it recreates idle VRAM
+   contention and breaks the established quiet-mode product principle.
+
+3. **Compose overrides select runtime shape.**
+   `docker compose up` remains lean. `compose.ml.yaml` and `compose.cuda.yaml`
+   override only the `exomem` service image/runtime fields, so they do not start
+   a second server alongside the default service. The CUDA override declares
+   NVIDIA device access. Alternative: mutually-exclusive Compose profile services.
+   Rejected because profile services would start alongside the profile-less default
+   service unless every command changed, making accidental double servers likely.
+
+4. **Native setup becomes deterministic through gates, not by being replaced.**
+   Windows service install/restart should fail early when the requested profile lacks
+   dependencies, and docs/scripts should use locked extras for hybrid/media profiles.
+   Alternative: switch Windows to Docker by default. Rejected because Docker Desktop
+   Windows bind mounts can miss watcher events and Docker Linux containers cannot use
+   Windows-native GPU/media affordances as cleanly as the native service.
+
+5. **Doctor owns deployment truth reporting.**
+   Doctor/setup should name runtime (`native`, `docker`), dependency profile, compute
+   mode, selected device, CUDA availability, and whether CUDA was initialized/resident
+   when detectable. Alternative: leave this in prose docs. Rejected because the prior
+   failure was only obvious after inspecting logs and timings.
+
+## Risks / Trade-offs
+
+- **Large CUDA images** -> publish CUDA as opt-in tags and keep lean/CPU-ML available.
+- **NVIDIA runtime variance across Docker Desktop, WSL2, and Linux** -> doctor reports
+  the exact runtime/device state and Compose docs include verification commands.
+- **CUDA context floor after performance use** -> default normal mode avoids creating
+  the context at idle; docs explain restart/quiet implications when performance has
+  been used in-process.
+- **Windows watcher tradeoff in Docker** -> setup recommends native for Windows
+  live-vault use and only offers WSL2 CUDA Docker with explicit disclosure.
+- **Dependency drift in native service** -> service install/restart gates run the
+  relevant doctor profile before declaring success.

--- a/openspec/changes/add-cross-os-deployment-setup/proposal.md
+++ b/openspec/changes/add-cross-os-deployment-setup/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Exomem now has multiple legitimate runtime shapes: native Windows for live-vault
+watching and GPU/MPS paths, lean Docker for low-friction trials, CPU-ML Docker for
+reproducible hybrid search, and a missing CUDA Docker path for NVIDIA Linux/WSL2.
+The setup experience should select and verify the right shape per host so users get
+one-command installation without recreating the prior idle VRAM/RAM contention failure.
+
+## What Changes
+
+- Add a CUDA-capable Docker variant and publish immutable CUDA tags alongside the
+  existing lean and CPU-ML images.
+- Add Docker Compose runtime overrides that distinguish lean, CPU-ML, and CUDA
+  choices, including `/data` persistence for logs/model caches and explicit NVIDIA
+  device wiring only for CUDA.
+- Extend install/setup guidance so Windows native remains the recommended live-vault
+  path, Linux+NVIDIA can choose CUDA Docker, Windows+WSL2 can choose CUDA Docker with
+  watcher tradeoff disclosure, and macOS Apple Silicon stays native for MPS/MLX.
+- Harden `doctor`/setup reporting so it names the actual runtime, dependency profile,
+  compute mode, selected device, and whether CUDA is only available or actually resident.
+- Preserve the resource-safe default: CUDA-capable installs MUST still boot in normal
+  CPU-default mode unless the user explicitly opts into performance/GPU use.
+
+## Capabilities
+
+### New Capabilities
+
+- `container-runtime-profiles`: Docker image, tag, and Compose-runtime behavior for
+  lean, CPU-ML, and CUDA-capable deployments.
+
+### Modified Capabilities
+
+- `install-readiness`: setup and doctor requirements for cross-OS runtime selection,
+  native-vs-container recommendations, and deterministic dependency/profile gates.
+
+## Impact
+
+- `Dockerfile`, `compose.yaml`, `.github/workflows/release-please.yml`, and Docker docs.
+- Setup/doctor CLI paths and tests around dependency/runtime reporting.
+- Native Windows service docs/scripts where they must enforce locked extras and avoid
+  silently starting a degraded hybrid install.
+- No server-side reasoning model is introduced; Docker CUDA only packages deterministic
+  measurement models already used by embeddings/CLIP/ASR paths and remains default-off
+  for GPU residency through the existing mode system.

--- a/openspec/changes/add-cross-os-deployment-setup/specs/container-runtime-profiles/spec.md
+++ b/openspec/changes/add-cross-os-deployment-setup/specs/container-runtime-profiles/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Published Container Runtime Families
+
+The project SHALL publish distinct container runtime families for lean lexical
+search, CPU hybrid search, and NVIDIA CUDA-capable hybrid search. The lean family
+SHALL remain the default `latest` and `X.Y.Z` tag. The CPU hybrid family SHALL use
+`ml` and `X.Y.Z-ml` tags. The CUDA-capable family SHALL use `cuda` and `X.Y.Z-cuda`
+tags. The CUDA family SHALL package deterministic measurement dependencies only
+and MUST NOT add any server-side reasoning model.
+
+#### Scenario: Release publishes all runtime tags
+
+- **WHEN** a release publishes container images
+- **THEN** lean tags include `latest` and the immutable version tag
+- **AND** CPU hybrid tags include `ml` and the immutable `X.Y.Z-ml` tag
+- **AND** CUDA tags include `cuda` and the immutable `X.Y.Z-cuda` tag
+
+#### Scenario: Default pull remains resource-light
+
+- **WHEN** a user pulls `ghcr.io/artexis10/exomem:latest`
+- **THEN** the image is the lean runtime family
+- **AND** it does not include torch, CUDA runtime libraries, or model downloads
+
+### Requirement: CUDA Capability Does Not Imply Idle CUDA Residency
+
+The CUDA-capable container SHALL boot in the same resource-safe normal mode as
+native installs unless overridden. It SHALL make CUDA available for explicit
+performance mode, explicit device selection, or bulk indexing, but MUST NOT
+initialize CUDA merely because the CUDA image was selected.
+
+#### Scenario: CUDA image starts in normal mode
+
+- **WHEN** the CUDA-capable image starts without `EXOMEM_MODE=performance` or an
+  explicit CUDA device override
+- **THEN** the service reports normal mode
+- **AND** steady-state torch models select CPU by default
+- **AND** CUDA is not initialized just because the image includes CUDA libraries
+
+#### Scenario: Performance mode can use CUDA
+
+- **WHEN** the CUDA-capable image runs with `EXOMEM_MODE=performance` on a host with
+  a working NVIDIA container runtime
+- **THEN** the service may select CUDA for torch-backed measurement models
+- **AND** failures to access CUDA degrade to CPU with an actionable diagnostic rather
+  than crashing the MCP server
+
+### Requirement: Compose Overrides Select Runtime Shape Explicitly
+
+The root Compose configuration SHALL expose explicit runtime choices for lean,
+CPU-ML, and CUDA-capable deployments without starting multiple Exomem services.
+CPU-ML and CUDA SHALL be selected through Compose override files or an equivalent
+single-service mechanism. The CUDA runtime selection SHALL declare the NVIDIA
+device/runtime requirements separately from CPU paths. All container runtime
+choices SHALL persist `/data` so logs, query telemetry, and model caches survive
+restarts without being stored in the mounted vault.
+
+#### Scenario: CPU runtime avoids NVIDIA requirements
+
+- **WHEN** a user starts the lean Compose file or CPU-ML override
+- **THEN** the Compose service does not require NVIDIA devices or runtime settings
+- **AND** it mounts the vault at `/vault` and persists service state under `/data`
+
+#### Scenario: CUDA runtime declares NVIDIA access
+
+- **WHEN** a user starts the CUDA Compose override
+- **THEN** the Compose service uses the CUDA image tag
+- **AND** it declares NVIDIA device access in Compose
+- **AND** it still persists `/data` separately from `/vault`
+
+### Requirement: Container Documentation Names OS Tradeoffs
+
+Docker documentation SHALL explain which runtime family to choose by host shape.
+It SHALL recommend native Windows for live-vault file-watcher reliability, native
+macOS for MPS/MLX, CUDA Docker for Linux+NVIDIA, and CUDA Docker on Windows+WSL2
+only when the user accepts bind-mount watcher tradeoffs. The documentation SHALL
+state that GPU-capable containers are still CPU-default at idle.
+
+#### Scenario: User can choose a runtime from docs
+
+- **WHEN** a user reads the Docker setup documentation
+- **THEN** it distinguishes lean, CPU-ML, and CUDA-capable images
+- **AND** it names the Windows and macOS native recommendations
+- **AND** it states that CUDA capability is opt-in for residency through mode or
+  device settings

--- a/openspec/changes/add-cross-os-deployment-setup/specs/install-readiness/spec.md
+++ b/openspec/changes/add-cross-os-deployment-setup/specs/install-readiness/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Cross-OS Runtime Recommendation
+
+Setup and install-readiness documentation SHALL recommend a runtime shape based on
+host capabilities and tradeoffs rather than forcing one universal path. Windows
+live-vault installs SHALL default to native service guidance. Linux hosts with
+NVIDIA container runtime SHALL be able to choose CUDA Docker as the low-friction
+hybrid/GPU-capable route. Windows+WSL2 CUDA Docker SHALL be offered with an
+explicit file-watcher bind-mount tradeoff. macOS Apple Silicon SHALL default to
+native setup for MPS/MLX support.
+
+#### Scenario: Windows native remains recommended
+
+- **WHEN** setup or documentation addresses a Windows user with a live local vault
+- **THEN** it recommends the native Windows service path by default
+- **AND** it explains that Docker Desktop bind mounts can miss live file-watch events
+
+#### Scenario: Linux NVIDIA can choose CUDA Docker
+
+- **WHEN** setup or documentation addresses a Linux user with Docker and NVIDIA
+  runtime available
+- **THEN** it offers the CUDA Docker path as a supported one-command route
+- **AND** it states that the service still boots resource-safe unless performance
+  mode or an explicit CUDA device is selected
+
+### Requirement: Deterministic Native Dependency Gates
+
+Native service setup SHALL gate the selected dependency profile before declaring the
+service installed or restarted successfully. A hybrid native service SHALL fail the
+gate when `sentence-transformers`, `torch`, `Pillow`, or `sqlite-vec` are missing.
+A media native service SHALL additionally fail the gate when media dependencies are
+missing. Remediation SHALL name the locked `uv sync` command for the selected profile.
+
+#### Scenario: Hybrid service missing embeddings fails before success
+
+- **WHEN** native service setup or restart is run for a hybrid profile and
+  `sentence-transformers` is not importable
+- **THEN** the operation reports failure instead of declaring the service healthy
+- **AND** the remediation names `uv sync --frozen --extra embeddings`
+
+#### Scenario: Media service missing media dependencies fails before success
+
+- **WHEN** native service setup or restart is run for a media profile and media
+  dependencies are not importable
+- **THEN** the operation reports failure instead of declaring the service healthy
+- **AND** the remediation names the media extra and any required system tools
+
+### Requirement: Runtime And Compute Diagnostics
+
+The doctor command SHALL report the effective runtime and compute profile when that
+information is available. The report SHALL distinguish native versus container
+runtime, dependency profile, compute mode, selected torch device, CUDA availability,
+and CUDA residency or initialization status when detectable. Diagnostics MUST
+distinguish "CUDA-capable but not resident" from "running on CUDA".
+
+#### Scenario: Docker CUDA image in normal mode reports capability separately
+
+- **WHEN** doctor runs inside a CUDA-capable container in normal mode
+- **THEN** it reports the CUDA image/runtime capability
+- **AND** it reports normal compute mode and CPU-default selected device
+- **AND** it does not describe CUDA as resident unless CUDA has actually been
+  initialized
+
+#### Scenario: Native hybrid install reports missing extras clearly
+
+- **WHEN** doctor runs for a native hybrid profile without the embeddings extra
+- **THEN** it reports the missing dependency checks as failures
+- **AND** it does not require inspecting server logs to understand that search would
+  degrade to lexical ranking
+
+### Requirement: Terminal-Safe Doctor Output
+
+Human-readable doctor output SHALL be safe on Windows consoles using legacy code
+pages as well as UTF-8 terminals. It MUST NOT crash while rendering advisory text
+because of a non-ASCII symbol. Any optional decorative symbol SHALL have an ASCII
+fallback or be omitted.
+
+#### Scenario: Windows cp1252 console renders doctor output
+
+- **WHEN** doctor emits human-readable output on a Windows cp1252 console
+- **THEN** it completes without `UnicodeEncodeError`
+- **AND** all warnings, failures, and remediation text remain readable

--- a/openspec/changes/add-cross-os-deployment-setup/tasks.md
+++ b/openspec/changes/add-cross-os-deployment-setup/tasks.md
@@ -1,0 +1,31 @@
+## 1. Agent And Planning Guardrails
+
+- [x] 1.1 Add `AGENTS.md` as the shared non-Claude entry point to the canonical repo instructions.
+- [x] 1.2 Tighten the repo instruction that new implementation work starts in an isolated worktree.
+- [x] 1.3 Validate the OpenSpec change artifacts.
+
+## 2. Doctor And Native Determinism
+
+- [x] 2.1 Fix human-readable doctor output so Windows legacy consoles cannot crash on non-ASCII advisory text.
+- [x] 2.2 Add doctor/runtime checks that report native versus container runtime, compute mode, selected device, CUDA availability, and CUDA residency when detectable.
+- [x] 2.3 Harden Windows service install/restart scripts so selected hybrid/media profiles fail before success when required extras are missing.
+- [x] 2.4 Add focused tests for terminal-safe output and missing-extra native gates.
+
+## 3. Container Runtime Profiles
+
+- [x] 3.1 Add a CUDA-capable Dockerfile target that packages CUDA-capable deterministic measurement dependencies without making CUDA resident by default.
+- [x] 3.2 Extend the release workflow to publish `cuda` and immutable `X.Y.Z-cuda` tags.
+- [x] 3.3 Extend Compose runtime selection for lean, CPU-ML, and CUDA with explicit NVIDIA device wiring only on the CUDA path.
+- [x] 3.4 Add Docker smoke/build checks that cover the lean path cheaply and validate CUDA target metadata without requiring a CI GPU.
+
+## 4. Cross-OS Setup UX And Docs
+
+- [x] 4.1 Update Docker docs to explain lean, CPU-ML, and CUDA images plus Windows/macOS native recommendations.
+- [x] 4.2 Update deployment/quickstart docs so one-command setup chooses or recommends native Windows, native macOS, Linux CUDA Docker, or CPU Docker appropriately.
+- [x] 4.3 Ensure setup/doctor wording distinguishes CUDA-capable from CUDA-resident and keeps normal mode as CPU-default.
+
+## 5. Verification
+
+- [x] 5.1 Run OpenSpec validation for the change.
+- [x] 5.2 Run focused unit tests for doctor/setup/service-script behavior.
+- [x] 5.3 Run lint or targeted static checks for changed Python files and shell/PowerShell scripts where applicable.

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -9,6 +9,7 @@
 # Usage:
 #   pwsh -File scripts/install-service.ps1
 #   pwsh -File scripts/install-service.ps1 -NssmPath "C:\nssm\nssm.exe"
+#   pwsh -File scripts/install-service.ps1 -Profile lean    # lexical-only service
 #
 # Uninstall:
 #   nssm stop exomem
@@ -18,7 +19,9 @@ param(
     [string]$NssmPath = "nssm",
     [string]$ServiceName = "exomem",
     [string]$BindHost = "127.0.0.1",
-    [int]$Port = 8765
+    [int]$Port = 8765,
+    [ValidateSet("lean", "hybrid", "media")]
+    [string]$Profile = "hybrid"
 )
 
 $ErrorActionPreference = "Stop"
@@ -39,7 +42,8 @@ if (-not $isAdmin) {
         "-NssmPath", "`"$NssmPath`"",
         "-ServiceName", $ServiceName,
         "-BindHost", $BindHost,
-        "-Port", $Port
+        "-Port", $Port,
+        "-Profile", $Profile
     )
     Start-Process -FilePath $hostExe -Verb RunAs -ArgumentList $relaunchArgs
     exit
@@ -56,6 +60,31 @@ if (-not (Test-Path (Join-Path $repoRoot ".env"))) {
     throw ".env file missing in $repoRoot. See the Install section of README.md for the required GitHub OAuth vars."
 }
 if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir | Out-Null }
+
+function Get-DotenvValue {
+    param([string]$Name)
+    $envPath = Join-Path $repoRoot ".env"
+    if (-not (Test-Path $envPath)) { return $null }
+    foreach ($line in Get-Content $envPath) {
+        if ($line -match "^\s*$([Regex]::Escape($Name))\s*=\s*(.*)\s*$") {
+            $value = $Matches[1].Trim()
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+            return $value
+        }
+    }
+    return $null
+}
+
+$doctorArgs = @("-m", "exomem", "doctor", "--profile", $Profile)
+$vault = Get-DotenvValue "EXOMEM_VAULT_PATH"
+if ($vault) { $doctorArgs += @("--vault", $vault) }
+Write-Host "Preflight: exomem doctor --profile $Profile..."
+& $python @doctorArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Doctor preflight failed for profile '$Profile'. Install the missing extras (for example: uv sync --frozen --extra embeddings) before installing the service."
+}
 
 # Install
 & $NssmPath install $ServiceName $python "-m" "exomem" "--transport" "streamable-http" "--host" $BindHost "--port" $Port

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -4,10 +4,13 @@
 # Usage:
 #   pwsh -File scripts/restart.ps1
 #   pwsh -File scripts/restart.ps1 -Force   # also kills orphan python.exe procs
+#   pwsh -File scripts/restart.ps1 -Profile lean    # lexical-only service
 
 param(
     [switch]$Force,
-    [string]$ServiceName = "exomem"
+    [string]$ServiceName = "exomem",
+    [ValidateSet("lean", "hybrid", "media")]
+    [string]$Profile = "hybrid"
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,6 +39,34 @@ $RepoRoot  = Split-Path -Parent $PSScriptRoot
 $VenvPy    = Join-Path $RepoRoot ".venv\Scripts\python.exe"
 $PyvenvCfg = Join-Path $RepoRoot ".venv\pyvenv.cfg"
 
+function Get-DotenvValue {
+    param([string]$Name)
+    $envPath = Join-Path $RepoRoot ".env"
+    if (-not (Test-Path $envPath)) { return $null }
+    foreach ($line in Get-Content $envPath) {
+        if ($line -match "^\s*$([Regex]::Escape($Name))\s*=\s*(.*)\s*$") {
+            $value = $Matches[1].Trim()
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+            return $value
+        }
+    }
+    return $null
+}
+
+function Invoke-DoctorGate {
+    param([string]$Profile)
+    $args = @("-m", "exomem", "doctor", "--profile", $Profile)
+    $vault = Get-DotenvValue "EXOMEM_VAULT_PATH"
+    if ($vault) { $args += @("--vault", $vault) }
+    Write-Host "Preflight: exomem doctor --profile $Profile..."
+    & $VenvPy @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "Doctor preflight failed for profile '$Profile'. Install the missing extras (for example: uv sync --frozen --extra embeddings) before restarting."
+    }
+}
+
 function Test-VenvInterpreter {
     if (-not (Test-Path $VenvPy)) { return $false }
     try { & $VenvPy --version 2>$null | Out-Null; return ($LASTEXITCODE -eq 0) }
@@ -56,6 +87,8 @@ if (-not (Test-VenvInterpreter)) {
     }
     Write-Host "  interpreter restored."
 }
+
+Invoke-DoctorGate -Profile $Profile
 
 # Back-compat with the kb-mcp -> exomem rename: boxes provisioned before the
 # rename still run the service under the OLD name. If the requested service isn't

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -249,6 +249,10 @@ def _check_resource_posture(profile: Profile) -> DoctorCheck:
     from . import resource_status
 
     posture = resource_status.resource_posture()
+    runtime = posture["runtime"]
+    runtime_label = runtime["kind"]
+    if runtime.get("variant"):
+        runtime_label += f"({runtime['variant']})"
     gpu = posture["gpu"]
     mode_name = posture["mode"]
     if gpu.get("usable") is False:
@@ -257,7 +261,8 @@ def _check_resource_posture(profile: Profile) -> DoctorCheck:
         return _check(
             "resource.posture",
             status,
-            f"Resource mode is {mode_name}; CPU is the supported baseline. {reason}.",
+            f"Runtime is {runtime_label}; resource mode is {mode_name}; CPU is the "
+            f"supported baseline. {reason}.",
             "Use `exomem mode quiet` before foreground GPU work, or `exomem mode "
             "performance` only when enough free VRAM is available.",
             details=posture,
@@ -266,15 +271,16 @@ def _check_resource_posture(profile: Profile) -> DoctorCheck:
         return _check(
             "resource.posture",
             "pass",
-            f"Resource mode is {mode_name}; GPU headroom probe is capable, but GPU "
-            "use remains explicit policy opt-in.",
+            f"Runtime is {runtime_label}; resource mode is {mode_name}; GPU headroom "
+            "probe is capable, but GPU use remains explicit policy opt-in.",
             details=posture,
         )
     return _check(
         "resource.posture",
         "pass",
-        f"Resource mode is {mode_name}; CPU is the supported baseline and GPU "
-        "headroom is unknown without an available non-torch probe.",
+        f"Runtime is {runtime_label}; resource mode is {mode_name}; CPU is the "
+        "supported baseline and GPU headroom is unknown without an available "
+        "non-torch probe.",
         details=posture,
     )
 

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -121,10 +121,31 @@ def cuda_accounting_if_initialized() -> dict[str, Any]:
     return {"torch_imported": True, "initialized": True, "memory": memory}
 
 
+def runtime_info() -> dict[str, Any]:
+    """Runtime shape without shelling out or importing heavy modules."""
+    variant = (os.environ.get("EXOMEM_CONTAINER_VARIANT") or "").strip() or None
+    marker = None
+    for candidate in (Path("/.dockerenv"), Path("/run/.containerenv")):
+        try:
+            if candidate.exists():
+                marker = str(candidate)
+                break
+        except OSError:
+            continue
+    in_container = bool(variant or marker)
+    return {
+        "kind": "container" if in_container else "native",
+        "container": in_container,
+        "variant": variant,
+        "marker": marker,
+    }
+
+
 def collect(vault_root: Path | None = None) -> dict[str, Any]:
     """Collect process-local resource status without allocating heavy resources."""
     policy = mode.resolved()
     return {
+        "runtime": runtime_info(),
         "mode": policy["mode"],
         "source": _mode_source(),
         "config_path": str(mode.config_path()),
@@ -216,9 +237,11 @@ def gpu_headroom() -> dict[str, Any]:
 def resource_posture() -> dict[str, Any]:
     policy = mode.resolved()
     return {
+        "runtime": runtime_info(),
         "mode": policy["mode"],
         "source": _mode_source(),
         "policy": policy,
         "cpu_baseline": True,
         "gpu": gpu_headroom(),
+        "cuda": cuda_accounting_if_initialized(),
     }

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -1,0 +1,65 @@
+"""Static checks for the published container runtime contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_dockerfile_declares_cuda_target_as_capable_not_resident() -> None:
+    text = _read("Dockerfile")
+
+    assert "FROM builder-lean AS builder-cuda" in text
+    assert "--index-url https://download.pytorch.org/whl/cu132" in text
+    assert "FROM python:3.12-slim AS cuda" in text
+    assert "CUDA-capable torch, CPU-default at idle" in text
+    assert "EXOMEM_CONTAINER_VARIANT=cuda" in text
+    assert "EXOMEM_MODE=performance" not in text
+
+
+def test_release_workflow_publishes_cuda_tags() -> None:
+    text = _read(".github/workflows/release-please.yml")
+
+    assert "target: cuda" in text
+    assert "platforms: linux/amd64" in text
+    assert "ghcr.io/artexis10/exomem:cuda" in text
+    assert "ghcr.io/artexis10/exomem:${{ steps.meta.outputs.version }}-cuda" in text
+
+
+def test_compose_overrides_select_cpu_ml_and_cuda() -> None:
+    ml = _read("compose.ml.yaml")
+    cuda = _read("compose.cuda.yaml")
+
+    assert "image: ghcr.io/artexis10/exomem:ml" in ml
+    assert "image: ghcr.io/artexis10/exomem:cuda" in cuda
+    assert "gpus: all" in cuda
+    assert "EXOMEM_MODE=performance" in cuda
+
+
+def test_docker_docs_explain_cuda_capability_and_os_tradeoffs() -> None:
+    text = _read("docs/docker.md")
+
+    assert "`cuda`, `X.Y.Z-cuda`" in text
+    assert "The CUDA image is **capable**, not **resident by default**" in text
+    assert "native NSSM remains" in text
+    assert "Docker Linux containers do not expose Metal/MPS/MLX" in text
+
+
+def test_windows_service_scripts_gate_selected_profile_before_success() -> None:
+    restart = _read("scripts/restart.ps1")
+    install = _read("scripts/install-service.ps1")
+
+    assert '[string]$Profile = "hybrid"' in restart
+    assert "Invoke-DoctorGate -Profile $Profile" in restart
+    assert restart.index("Invoke-DoctorGate -Profile $Profile") < restart.index('Write-Host "Stopping $ServiceName..."')
+
+    assert '[string]$Profile = "hybrid"' in install
+    assert '"-Profile", $Profile' in install
+    assert "exomem\", \"doctor\", \"--profile\", $Profile" in install
+    assert install.index("exomem\", \"doctor\", \"--profile\", $Profile") < install.index("& $NssmPath install")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -6,7 +6,9 @@ is exercised by stubbing the import-spec seam rather than importing heavy extras
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -91,6 +93,35 @@ def test_doctor_human_output_includes_remediation(
     assert "FAIL" in out
     assert "vault.path" in out
     assert "fix:" in out
+
+
+def test_doctor_gpu_advisory_is_safe_on_cp1252_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for Windows legacy consoles: advisory text must be encodable."""
+    from exomem import doctor as doctor_module
+    from exomem import mode as mode_module
+    from exomem import resource_status
+
+    class Cp1252Stdout(io.StringIO):
+        encoding = "cp1252"
+
+        def write(self, text: str) -> int:
+            text.encode("cp1252")
+            return super().write(text)
+
+    stdout = Cp1252Stdout()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(
+        doctor_module,
+        "doctor",
+        lambda **kw: doctor_module.DoctorReport(profile=kw.get("profile", "lean"), checks=[]),
+    )
+    monkeypatch.setattr(resource_status, "gpu_headroom", lambda: {"usable": True})
+    monkeypatch.setattr(mode_module, "resolve_mode", lambda: "normal")
+
+    assert main(["doctor"]) == 0
+    assert "A capable idle GPU was detected" in stdout.getvalue()
 
 
 def test_doctor_unknown_profile_exits_2(capsys) -> None:
@@ -249,3 +280,32 @@ def test_resource_posture_check_marginal_gpu_warns_for_hybrid(
     assert check.status == "warn"
     assert "free VRAM below policy threshold" in check.message
     assert check.as_dict()["details"]["gpu"]["usable"] is False
+
+
+def test_resource_posture_reports_container_variant_without_cuda_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import resource_status
+
+    monkeypatch.setenv("EXOMEM_CONTAINER_VARIANT", "cuda")
+    monkeypatch.setattr(
+        resource_status,
+        "gpu_headroom",
+        lambda: {
+            "status": "capable",
+            "usable": True,
+            "free_mb": 8192,
+            "total_mb": 16384,
+            "min_free_mb": 2048,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    check = doctor_module._check_resource_posture("hybrid")
+    details = check.as_dict()["details"]
+
+    assert check.status == "pass"
+    assert "Runtime is container(cuda)" in check.message
+    assert details["runtime"]["kind"] == "container"
+    assert details["runtime"]["variant"] == "cuda"
+    assert details["cuda"] == {"torch_imported": False, "initialized": False, "memory": None}


### PR DESCRIPTION
## Summary
- add `AGENTS.md` as a symlink to canonical `CLAUDE.md` and tighten the worktree-first instruction
- add OpenSpec change `add-cross-os-deployment-setup`
- add CUDA-capable Docker target plus release tags `:cuda` / `X.Y.Z-cuda`
- add `compose.ml.yaml` and `compose.cuda.yaml` runtime overrides
- document lean, CPU-ML, CUDA, Windows native, and macOS native deployment choices
- extend doctor/resource diagnostics with runtime variant and CUDA initialized/resident state without importing torch
- gate Windows service install/restart through `doctor --profile lean|hybrid|media` before claiming success

## Verification
- `openspec validate add-cross-os-deployment-setup --strict`
- `uv run python -m pytest tests/test_container_distribution.py tests/test_doctor.py::test_doctor_gpu_advisory_is_safe_on_cp1252_stdout tests/test_doctor.py::test_resource_posture_check_cpu_unknown_is_supported tests/test_doctor.py::test_resource_posture_check_marginal_gpu_warns_for_hybrid tests/test_doctor.py::test_resource_posture_reports_container_variant_without_cuda_import -q`
- `git diff --check` (no whitespace errors; PowerShell LF/CRLF warnings only)