### PR TITLE
feat(hooks): support Codex install target

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -309,10 +309,17 @@ The skill *tells* Claude to capture at stepping-stones and to consult the KB
 before answering, but those instructions are passive — over a long conversation
 Claude tends to forget them, so auto-save quietly never fires (you'll know:
 `Knowledge Base/log.md` only shows saves you asked for) and prior notes don't get
-pulled in. This one command installs two small hooks that fix both directions:
+pulled in. This one command installs two small Claude Code hooks that fix both
+directions:
 
 ```bash
 uv run python -m exomem install-hook
+```
+
+Codex CLI can use the same bundled Exomem hook scripts:
+
+```bash
+uv run python -m exomem install-hook --client codex
 ```
 
 If you maintain alternate Claude settings files with yadm, wire each active
@@ -331,9 +338,11 @@ prompts, but it also suppresses obvious short control/status prompts such as
 the reminder does not churn through routine command flow. They write scripts to
 `~/.claude/hooks/` and wire the two hooks into your settings.json — restart Claude
 Code to activate. Triggers log to `~/.claude/exomem-capture-nudge.log` and
-`~/.claude/exomem-retrieve-nudge.log` so you can see the real rate. Prefer to wire it
-by hand? `uv run python -m exomem install-hook --print-only` writes the scripts and
-prints the snippet to paste.
+`~/.claude/exomem-retrieve-nudge.log` so you can see the real rate. For Codex,
+the same scripts go to `~/.codex/hooks/`, wire into `~/.codex/hooks.json`, and
+log under `~/.codex/`. Prefer to wire it by hand?
+`uv run python -m exomem install-hook --print-only` writes the scripts and prints
+the snippet to paste.
 
 Tune with `EXOMEM_CAPTURE_NUDGE_MIN_CHARS` / `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (and the
 matching `_COOLDOWN_SEC`), `EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS` for the read
@@ -350,17 +359,18 @@ the `UserPromptSubmit` hook only reminds Claude to run `find` — set
 reminder, so relevant prior KB pages are already in context before Claude
 decides whether to search. It tries a short transport ladder and never blocks
 on a slow path: REST first (one `POST /api/find`, ~2s timeout) — only attempted
-when `EXOMEM_REST_API_KEY` is set **in the shell that launches Claude Code**
+when `EXOMEM_REST_API_KEY` is set **in the shell that launches the client**
 (not just the server's service environment — the hook can't read another
-process's env, so export it in the same profile Claude Code inherits from);
+process's env, so export it in the same profile Claude Code or Codex inherits from);
 then, only if you also set `EXOMEM_RETRIEVE_INJECT_CLI=1`, an `exomem find --json`
 subprocess call (~5s timeout, slower — cold Python start). If neither is
 configured or reachable, it falls straight back to the plain reminder — no
 network call is ever attempted unless `EXOMEM_RETRIEVE_INJECT` is on. (The legacy
 `KB_RETRIEVE_INJECT` / `KB_RETRIEVE_INJECT_CLI` names still work too.)
 
-(Hooks are Claude Code only — claude.ai web/mobile can't run them, so there the
-skill stays best-effort: nudge it with *"save that to kb"* or *"check the kb."*)
+(Hooks are local-client only — claude.ai web/mobile can't run them, so there the
+skill or `bootstrap()` contract stays best-effort: nudge it with *"save that to
+kb"* or *"check the kb."*)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ The skill installs under the Claude Code name `exomem` — the same name as the
 connector, so skill, server, and tools all read as one product. The skill is
 recommended for Claude Code —
 the server gives Claude the tools, the skill is what makes it use them. Hooks
-are Claude Code-only reliability nudges for long sessions: a read-side reminder
-before answers and a write-side reminder at natural stopping points. The
-read-side hook suppresses obvious control/status prompts like `continue`, `merge
-it`, and `are you done?`, and can optionally upgrade that reminder to real
+are local-client reliability nudges for Claude Code and Codex: a read-side
+reminder before answers and a write-side reminder at natural stopping points.
+The read-side hook suppresses obvious control/status prompts like `continue`,
+`merge it`, and `are you done?`, and can optionally upgrade that reminder to real
 retrieved KB content (`EXOMEM_RETRIEVE_INJECT=1`, opt-in; the legacy
-`KB_RETRIEVE_INJECT` name still works) — see
+`KB_RETRIEVE_INJECT` name still works). For Codex, run
+`exomem install-hook --client codex`; for Claude Code, `exomem install-hook` —
+see
 [QUICKSTART.md § 7](QUICKSTART.md#7-recommended-make-the-kb-automatic-both-directions).
 Other MCP clients can still use the server. If they do not support Skills,
 have them call `bootstrap()` once at the start of the session; it returns the
@@ -118,7 +120,7 @@ uv run exomem demo
 | Client | How |
 | --- | --- |
 | Claude Code | `exomem setup` registers it for you (see above) |
-| Codex CLI | `codex mcp add` — see below |
+| Codex CLI | `codex mcp add` plus optional `exomem install-hook --client codex` — see below |
 | claude.ai (remote) | Remote server — see [docs/remote-quickstart.md](docs/remote-quickstart.md) |
 | Any MCP client | Generic stdio config — see below; call `bootstrap()` first |
 | Docker (no Python) | One `docker run` line — see below and [docs/docker.md](docs/docker.md) |
@@ -128,6 +130,12 @@ uv run exomem demo
 
 ```bash
 codex mcp add exomem --env EXOMEM_VAULT_PATH="/path/to/vault" -- exomem --transport stdio
+```
+
+Optional local hooks, using the same Exomem scripts as Claude Code:
+
+```bash
+exomem install-hook --client codex
 ```
 
 Or add it directly to `~/.codex/config.toml`:

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -8,7 +8,7 @@ Subcommands:
 - `init` — bootstrap a fresh Knowledge Base into a vault
 - `install-skill` — install the Exomem skill into Claude Code
 - `personalize` — scan a vault and generate a starter `_access.yaml` (readonly/excluded siblings)
-- `install-hook` — wire the KB capture + retrieval hooks into Claude Code
+- `install-hook` — wire the KB capture + retrieval hooks into Claude Code or Codex
 - `demo` — the packaged 30-second proof: doctor → find → get → audit against a
   bundled sample vault, no clone/config/vault needed (`uvx exomem demo`)
 - `doctor` — read-only local install/setup preflight
@@ -693,20 +693,26 @@ def _install_hook_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem install-hook",
         description=(
-            "Wire the KB capture + retrieval hooks into Claude Code: a Stop hook "
-            "that captures conclusions at stepping-stones (write), and a "
-            "UserPromptSubmit hook that reminds Claude to consult the KB before "
+            "Wire the KB capture + retrieval hooks into Claude Code or Codex: a "
+            "Stop hook that captures conclusions at stepping-stones (write), and "
+            "a UserPromptSubmit hook that reminds the agent to consult the KB before "
             "answering (read). Language-agnostic and cheap (gated + cooldown). "
             "Re-running is idempotent."
         ),
     )
     parser.add_argument(
+        "--client",
+        choices=("claude", "codex"),
+        default="claude",
+        help="client hook config to wire (default: claude)",
+    )
+    parser.add_argument(
         "--hook-dir",
-        help="Where to write the hook script (default: ~/.claude/hooks).",
+        help="Where to write the hook scripts (default: ~/.claude/hooks or ~/.codex/hooks).",
     )
     parser.add_argument(
         "--settings",
-        help="settings.json to wire (default: ~/.claude/settings.json).",
+        help="hook config to wire (default: ~/.claude/settings.json or ~/.codex/hooks.json).",
     )
     parser.add_argument(
         "--print-only",
@@ -722,21 +728,24 @@ def _install_hook_main(argv: list[str]) -> int:
             hook_dir=args.hook_dir,
             settings_path=args.settings,
             wire=not args.print_only,
+            client=args.client,
         )
     except FileNotFoundError as e:
         print(f"exomem install-hook: {e}", file=sys.stderr)
         return 1
 
-    print("Installed the KB hook scripts:")
+    client_label = "Codex" if report["client"] == "codex" else "Claude Code"
+    print(f"Installed the KB hook scripts for {client_label}:")
     for item in report["installed"]:
         print(f"  {item['event']:<16} {item['script']}")
     if report["wired"]:
         print(f"Wired into {report['settings']}.")
-        print("Restart Claude Code to activate. Triggers log to:")
-        print("  ~/.claude/exomem-capture-nudge.log   (write / capture)")
-        print("  ~/.claude/exomem-retrieve-nudge.log  (read / retrieval)")
+        print(f"Restart {client_label} to activate. Triggers log to:")
+        home = "~/.codex" if report["client"] == "codex" else "~/.claude"
+        print(f"  {home}/exomem-capture-nudge.log   (write / capture)")
+        print(f"  {home}/exomem-retrieve-nudge.log  (read / retrieval)")
     else:
-        print("Add this to your settings.json (merge into hooks):")
+        print("Add this to your hook config (merge into hooks):")
         print(hook_module.snippet(report["installed"]))
     return 0
 

--- a/src/exomem/_hooks/exomem_capture_nudge.py
+++ b/src/exomem/_hooks/exomem_capture_nudge.py
@@ -17,18 +17,18 @@ it to do nothing if it isn't one).
 
 Cheap and safe: the script itself is free (stdlib only); the only token cost is a
 real capture (the feature). Self-disarms via `stop_hook_active` (no loops); the
-cooldown caps frequency; every trigger is logged to ~/.claude/exomem-capture-nudge.log
-for tuning.
+cooldown caps frequency; every trigger is logged under the active client home for
+tuning.
 
 Tunables (env): EXOMEM_CAPTURE_NUDGE_DISABLE=1 (off), EXOMEM_CAPTURE_NUDGE_MIN_CHARS
 (default 300 — lower it for a dense script like Japanese, which packs more meaning
 per char), EXOMEM_CAPTURE_NUDGE_COOLDOWN_SEC (default 300). The legacy KB_CAPTURE_NUDGE_*
 names are still accepted for back-compat (aliased to the EXOMEM_* names at startup).
 
-Contract (Claude Code Stop hook): read the event JSON on stdin; print
+Contract (Claude Code / Codex Stop hook): read the event JSON on stdin; print
 `{"decision":"block","reason":...}` and exit 0 to block the stop and feed the
-reminder to Claude; exit 0 with no output to allow the stop. Never raises — a hook
-crash must not break the session.
+reminder to the agent; exit 0 with no output to allow the stop. Never raises — a
+hook crash must not break the session.
 """
 
 from __future__ import annotations
@@ -81,6 +81,26 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _hook_client() -> str:
+    explicit = os.environ.get("EXOMEM_HOOK_CLIENT", "").strip().lower()
+    if explicit in {"claude", "codex"}:
+        return explicit
+    try:
+        parts = {p.lower() for p in Path(__file__).resolve().parts}
+    except Exception:
+        parts = set()
+    if ".codex" in parts:
+        return "codex"
+    return "claude"
+
+
+def _hook_home() -> Path:
+    explicit = os.environ.get("EXOMEM_HOOK_HOME")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / (".codex" if _hook_client() == "codex" else ".claude")
+
+
 def _content_blocks(msg: dict) -> list[dict]:
     if not isinstance(msg, dict):
         return []
@@ -121,7 +141,7 @@ def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[str]]:
         msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
         role = msg.get("role") if isinstance(msg, dict) else None
         typ = obj.get("type")
-        if role == "assistant" or typ == "assistant":
+        if role == "assistant" or typ in {"assistant", "agent_message"}:
             for b in _content_blocks(msg):
                 if b.get("type") == "text":
                     chunks.append(b.get("text", ""))
@@ -138,7 +158,7 @@ def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[str]]:
 
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based, so we never parse content)."""
-    state_dir = Path.home() / ".claude" / ".cache" / "exomem-nudge"
+    state_dir = _hook_home() / ".cache" / "exomem-nudge"
     key = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:128]
     stamp = state_dir / key
     try:
@@ -159,7 +179,7 @@ def _touch(stamp: Path) -> None:
 
 def _log(text: str) -> None:
     try:
-        logp = Path.home() / ".claude" / "exomem-capture-nudge.log"
+        logp = _hook_home() / "exomem-capture-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", text)[-160:]
         with open(logp, "a", encoding="utf-8") as f:
@@ -178,9 +198,9 @@ def main() -> int:
     except Exception:
         return 0
 
-    if data.get("stop_hook_active"):  # we already blocked once — stand down
+    if data.get("stop_hook_active") or data.get("stopHookActive"):  # already blocked once
         return 0
-    tpath = data.get("transcript_path")
+    tpath = data.get("transcript_path") or data.get("transcriptPath")
     if not tpath:
         return 0
 
@@ -195,7 +215,7 @@ def main() -> int:
     if len(assistant_text.strip()) < min_chars:  # trivial turn, not a landing
         return 0
 
-    ok, stamp = _cooldown_ok(data.get("session_id", ""), cooldown)
+    ok, stamp = _cooldown_ok(str(data.get("session_id") or data.get("sessionId") or ""), cooldown)
     if not ok:  # fired recently this session — keep cost bounded
         return 0
 

--- a/src/exomem/_hooks/exomem_retrieve_nudge.py
+++ b/src/exomem/_hooks/exomem_retrieve_nudge.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""UserPromptSubmit hook: nudge a KB retrieval before Claude answers.
+"""UserPromptSubmit hook: nudge a KB retrieval before the agent answers.
 
 The read-side mirror of the capture hook. The skill says to consult the KB
 proactively, but that prose is passive — Claude forgets, especially at the start
@@ -35,8 +35,8 @@ configured or fails. The legacy KB_RETRIEVE_* names (including KB_RETRIEVE_INJEC
 / KB_RETRIEVE_INJECT_CLI) are still accepted for back-compat, aliased to the
 EXOMEM_* names at startup.
 
-Contract (Claude Code UserPromptSubmit hook): read the event JSON on stdin (incl.
-`prompt`); on exit 0, print
+Contract (Claude Code / Codex UserPromptSubmit hook): read the event JSON on
+stdin (incl. `prompt`); on exit 0, print
 `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": ...}}`
 to add the reminder to context; print nothing to stay silent. Never raises — a
 hook crash must not break the session.
@@ -143,6 +143,34 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _hook_client() -> str:
+    explicit = os.environ.get("EXOMEM_HOOK_CLIENT", "").strip().lower()
+    if explicit in {"claude", "codex"}:
+        return explicit
+    try:
+        parts = {p.lower() for p in Path(__file__).resolve().parts}
+    except Exception:
+        parts = set()
+    if ".codex" in parts:
+        return "codex"
+    return "claude"
+
+
+def _hook_home() -> Path:
+    explicit = os.environ.get("EXOMEM_HOOK_HOME")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / (".codex" if _hook_client() == "codex" else ".claude")
+
+
+def _prompt(data: dict) -> str:
+    for key in ("prompt", "user_prompt", "userPrompt", "input"):
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
 def _is_obvious_control_prompt(prompt: str, max_chars: int) -> bool:
     """Skip short command/ack/status prompts that do not need prior KB context.
 
@@ -162,7 +190,7 @@ def _is_obvious_control_prompt(prompt: str, max_chars: int) -> bool:
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based). Namespaced so it never collides
     with the capture hook's cooldown stamp for the same session."""
-    state_dir = Path.home() / ".claude" / ".cache" / "exomem-nudge"
+    state_dir = _hook_home() / ".cache" / "exomem-nudge"
     key = "retrieve_" + re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:120]
     stamp = state_dir / key
     try:
@@ -183,7 +211,7 @@ def _touch(stamp: Path) -> None:
 
 def _log(prompt: str) -> None:
     try:
-        logp = Path.home() / ".claude" / "exomem-retrieve-nudge.log"
+        logp = _hook_home() / "exomem-retrieve-nudge.log"
         logp.parent.mkdir(parents=True, exist_ok=True)
         snippet = re.sub(r"\s+", " ", prompt)[:160]
         with open(logp, "a", encoding="utf-8") as f:
@@ -321,8 +349,8 @@ def main() -> int:
     except Exception:
         return 0
 
-    prompt = data.get("prompt")
-    if not isinstance(prompt, str):
+    prompt = _prompt(data)
+    if not prompt:
         return 0
 
     min_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", 20)
@@ -335,7 +363,7 @@ def main() -> int:
     if _is_obvious_control_prompt(prompt, control_max_chars):
         return 0
 
-    ok, stamp = _cooldown_ok(data.get("session_id", ""), cooldown)
+    ok, stamp = _cooldown_ok(str(data.get("session_id") or data.get("sessionId") or ""), cooldown)
     if not ok:  # already nudged recently this session — keep it quiet
         return 0
 

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -1,19 +1,17 @@
-"""install-hook: wire the KB capture + retrieval hooks into Claude Code.
+"""install-hook: wire the KB capture + retrieval hooks into supported agents.
 
 Ships two bundled hooks (each a Python script + a bash wrapper) and registers them
-in `~/.claude/settings.json`, so a friend gets the full reliable KB loop with one
-command:
+in the target client's hook config, so a friend gets the full reliable KB loop
+with one command:
 
 - `_hooks/exomem_capture_nudge.py`  (via `exomem-capture-nudge.sh`)  → a `Stop` hook (WRITE):
   captures durable conclusions at stepping-stones instead of waiting to be told.
 - `_hooks/exomem_retrieve_nudge.py` (via `exomem-retrieve-nudge.sh`) → a `UserPromptSubmit`
-  hook (READ): reminds Claude to consult the KB before answering.
+  hook (READ): reminds the agent to consult the KB before answering.
 
 The registered command is **machine-agnostic** — `bash ~/.claude/hooks/<name>.sh`,
-matching the convention of other hooks — so the same `~/.claude` works across
-machines (Windows Git Bash, WSL, Linux, macOS) and survives yadm/dotfile sync. The
-wrapper resolves python per machine; an absolute interpreter path would break the
-moment `~/.claude` is shared between a Windows box and WSL.
+matching the convention of other Claude Code hooks; Codex gets the same Python
+scripts directly with `command` + `commandWindows` entries in `~/.codex/hooks.json`.
 
 Both gates are language-agnostic (structural + cooldown, no English keywords). By
 default this copies the scripts AND merges settings.json; `wire=False`
@@ -27,13 +25,21 @@ import shutil
 from pathlib import Path
 
 _HOOK_DIR_SRC = Path(__file__).parent / "_hooks"
-# (python script, bash wrapper, Claude Code event) — the hooks this installs.
+# (python script, bash wrapper, hook event) — the hooks this installs.
 _HOOK_SPECS = (
     ("exomem_capture_nudge.py", "exomem-capture-nudge.sh", "Stop"),
     ("exomem_retrieve_nudge.py", "exomem-retrieve-nudge.sh", "UserPromptSubmit"),
 )
-DEFAULT_HOOK_DIR = Path.home() / ".claude" / "hooks"
-DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
+DEFAULT_CLIENT = "claude"
+SUPPORTED_CLIENTS = ("claude", "codex")
+DEFAULT_CLAUDE_HOOK_DIR = Path.home() / ".claude" / "hooks"
+DEFAULT_CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
+DEFAULT_CODEX_HOOK_DIR = Path.home() / ".codex" / "hooks"
+DEFAULT_CODEX_SETTINGS = Path.home() / ".codex" / "hooks.json"
+
+# Back-compat for existing tests and callers.
+DEFAULT_HOOK_DIR = DEFAULT_CLAUDE_HOOK_DIR
+DEFAULT_SETTINGS = DEFAULT_CLAUDE_SETTINGS
 
 # Substrings identifying a previously-installed nudge entry, so re-running is
 # idempotent and supersedes older entries (incl. the absolute-python-path form).
@@ -45,22 +51,70 @@ _MARKERS = (
 )
 
 
-def _command_for(wrapper: str, hook_dir: Path) -> str:
+def _normalize_client(client: str) -> str:
+    value = (client or DEFAULT_CLIENT).strip().lower()
+    if value not in SUPPORTED_CLIENTS:
+        raise ValueError(f"unsupported hook client {client!r}; expected one of {SUPPORTED_CLIENTS}")
+    return value
+
+
+def _default_hook_dir(client: str) -> Path:
+    return DEFAULT_CODEX_HOOK_DIR if _normalize_client(client) == "codex" else DEFAULT_CLAUDE_HOOK_DIR
+
+
+def _default_settings(client: str) -> Path:
+    return DEFAULT_CODEX_SETTINGS if _normalize_client(client) == "codex" else DEFAULT_CLAUDE_SETTINGS
+
+
+def _windows_python_command(script: Path) -> str:
+    return f'python "{script}"'
+
+
+def _command_for(
+    wrapper: str,
+    hook_dir: Path,
+    *,
+    client: str = DEFAULT_CLIENT,
+    script: str | None = None,
+) -> str:
     """Machine-agnostic `bash` invocation of the wrapper. For the default location
     use the `~`-relative form so the SAME settings.json works on every machine
-    (yadm-synced); for a custom dir (tests) use a POSIX absolute path."""
-    if hook_dir == DEFAULT_HOOK_DIR:
+    (yadm-synced); for a custom dir (tests) use a POSIX absolute path.
+
+    Codex runs the same bundled Python hook directly. On Unix-like hosts `command`
+    uses `python3`; on Windows the sibling `commandWindows` entry carries the
+    native `python` invocation.
+    """
+    client = _normalize_client(client)
+    hook_dir = Path(hook_dir).expanduser()
+    if client == "codex":
+        py_name = script or wrapper.removesuffix(".sh").replace("-", "_") + ".py"
+        if hook_dir == DEFAULT_CODEX_HOOK_DIR:
+            return f"python3 ~/.codex/hooks/{py_name}"
+        return f'python3 "{(hook_dir / py_name).as_posix()}"'
+    if hook_dir == DEFAULT_CLAUDE_HOOK_DIR:
         return f"bash ~/.claude/hooks/{wrapper}"
     return f'bash "{(hook_dir / wrapper).as_posix()}"'
 
 
+def _command_windows_for(script: str, hook_dir: Path, *, client: str = DEFAULT_CLIENT) -> str | None:
+    if _normalize_client(client) != "codex":
+        return None
+    return _windows_python_command(Path(hook_dir).expanduser() / script)
+
+
+def _hook_entry(item: dict, timeout: int) -> dict:
+    entry = {"type": "command", "command": item["command"], "timeout": timeout}
+    if item.get("commandWindows"):
+        entry["commandWindows"] = item["commandWindows"]
+    return entry
+
+
 def snippet(installed: list[dict], timeout: int = 10) -> str:
-    """The settings.json fragment to merge by hand (for --print-only)."""
+    """The hook config fragment to merge by hand (for --print-only)."""
     hooks: dict[str, list] = {}
     for item in installed:
-        hooks[item["event"]] = [
-            {"hooks": [{"type": "command", "command": item["command"], "timeout": timeout}]}
-        ]
+        hooks[item["event"]] = [{"hooks": [_hook_entry(item, timeout)]}]
     return json.dumps({"hooks": hooks}, indent=2)
 
 
@@ -71,19 +125,21 @@ def install_hook(
     wire: bool = True,
     timeout: int = 10,
     specs: tuple = _HOOK_SPECS,
+    client: str = DEFAULT_CLIENT,
 ) -> dict:
-    """Install the bundled hook scripts + wrappers and (optionally) wire settings.json.
+    """Install the bundled hook scripts + wrappers and (optionally) wire config.
 
-    Returns {"installed": [{event, script, wrapper, command}], "wired", "settings"}.
-    Raises FileNotFoundError if a bundled hook file is missing.
+    Returns {"installed": [{event, script, wrapper, command}], "wired", "settings",
+    "client"}. Raises FileNotFoundError if a bundled hook file is missing.
     """
+    client = _normalize_client(client)
     for py_name, sh_name, _event in specs:
         for name in (py_name, sh_name):
             if not (_HOOK_DIR_SRC / name).exists():
                 raise FileNotFoundError(
                     f"bundled hook file missing at {_HOOK_DIR_SRC / name} — is the exomem install intact?"
                 )
-    hook_dir = (Path(hook_dir).expanduser() if hook_dir else DEFAULT_HOOK_DIR)
+    hook_dir = (Path(hook_dir).expanduser() if hook_dir else _default_hook_dir(client))
     hook_dir.mkdir(parents=True, exist_ok=True)
 
     installed: list[dict] = []
@@ -94,12 +150,13 @@ def install_hook(
             "event": event,
             "script": str(hook_dir / py_name),
             "wrapper": str(hook_dir / sh_name),
-            "command": _command_for(sh_name, hook_dir),
+            "command": _command_for(sh_name, hook_dir, client=client, script=py_name),
+            "commandWindows": _command_windows_for(py_name, hook_dir, client=client),
         })
 
-    result = {"installed": installed, "wired": False, "settings": None}
+    result = {"installed": installed, "wired": False, "settings": None, "client": client}
     if wire:
-        sp = (Path(settings_path).expanduser() if settings_path else DEFAULT_SETTINGS)
+        sp = (Path(settings_path).expanduser() if settings_path else _default_settings(client))
         _merge_hooks(sp, installed, timeout)
         result["wired"] = True
         result["settings"] = str(sp)
@@ -125,21 +182,32 @@ def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> None:
         hooks = data["hooks"] = {}
 
     for item in installed:
-        event, command = item["event"], item["command"]
+        event = item["event"]
         arr = hooks.get(event) if isinstance(hooks.get(event), list) else []
         kept: list = []
+        inserted = False
+        replacement = {"hooks": [_hook_entry(item, timeout)]}
         for group in arr:
             if not isinstance(group, dict):
                 kept.append(group)
                 continue
+            original = group.get("hooks", [])
             ghooks = [
-                h for h in group.get("hooks", [])
-                if not any(m in str(h.get("command", "")) for m in _MARKERS)
+                h for h in original
+                if not any(
+                    m in f"{h.get('command', '')} {h.get('commandWindows', '')}"
+                    for m in _MARKERS
+                )
             ]
+            removed_ours = len(ghooks) != len(original)
             if ghooks:  # group still has non-ours hooks — keep it, minus ours
                 kept.append({**group, "hooks": ghooks})
-            # a group whose only hook was ours is dropped entirely
-        kept.append({"hooks": [{"type": "command", "command": command, "timeout": timeout}]})
+            if removed_ours and not inserted:
+                kept.append(replacement)
+                inserted = True
+            # duplicate groups whose only hook was ours are dropped entirely
+        if not inserted:
+            kept.append(replacement)
         hooks[event] = kept
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -5,7 +5,9 @@ The hooks are the reliability fix for the KB loop: skill prose is passive, so St
 re-arms "capture this stepping-stone" (write) and UserPromptSubmit re-arms "consult
 the KB first" (read). Both are language-agnostic (structural gate + cooldown). The
 registered command is machine-agnostic (`bash ~/.claude/hooks/<name>.sh`) so a
-yadm-synced ~/.claude works across Windows / WSL / Linux / macOS.
+yadm-synced ~/.claude works across Windows / WSL / Linux / macOS. Codex installs
+the same bundled Python scripts into ~/.codex/hooks with command + commandWindows
+wiring.
 """
 
 from __future__ import annotations
@@ -32,6 +34,10 @@ def _ups_cmds(data: dict) -> list[str]:
     return [h["command"] for g in data["hooks"].get("UserPromptSubmit", []) for h in g["hooks"]]
 
 
+def _hook_entries(data: dict, event: str) -> list[dict]:
+    return [h for g in data["hooks"].get(event, []) for h in g["hooks"]]
+
+
 # --- install_hook: the installer (both hooks, py + wrapper) ----------------------
 
 def test_install_hook_copies_scripts_and_wrappers_and_wires_both(tmp_path: Path) -> None:
@@ -54,6 +60,14 @@ def test_command_is_machine_agnostic(tmp_path: Path) -> None:
     # Custom dir -> POSIX (forward-slash) bash command, never Windows backslashes.
     custom = hook_module._command_for("exomem-capture-nudge.sh", tmp_path / "hooks")
     assert custom.startswith('bash "') and custom.endswith('.sh"') and "\\" not in custom
+
+    codex = hook_module._command_for(
+        "exomem-retrieve-nudge.sh",
+        hook_module.DEFAULT_CODEX_HOOK_DIR,
+        client="codex",
+        script="exomem_retrieve_nudge.py",
+    )
+    assert codex == "python3 ~/.codex/hooks/exomem_retrieve_nudge.py"
 
 
 def test_install_hook_idempotent(tmp_path: Path) -> None:
@@ -104,6 +118,38 @@ def test_install_hook_migrates_old_kb_entry(tmp_path: Path) -> None:
     assert sum("exomem-retrieve-nudge" in c for c in ups) == 1
 
 
+def test_install_hook_codex_migrates_old_kb_entries_and_preserves_other_hooks(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "codex-hooks", tmp_path / "hooks.json"
+    sp.write_text(
+        json.dumps({"hooks": {
+            "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "python guard.py"}]}],
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": "python3 ~/.codex/hooks/kb_retrieve_nudge.py"}]},
+                {"hooks": [{"type": "command", "command": "python3 ~/.codex/hooks/zellij_tab_context_rename.py"}]},
+            ],
+            "Stop": [{"hooks": [{"type": "command", "command": "python3 ~/.codex/hooks/kb_capture_nudge.py"}]}],
+        }}),
+        encoding="utf-8",
+    )
+
+    r = hook_module.install_hook(hook_dir=hd, settings_path=sp, client="codex")
+
+    assert r["client"] == "codex"
+    for f in ("exomem_capture_nudge.py", "exomem-capture-nudge.sh", "exomem_retrieve_nudge.py", "exomem-retrieve-nudge.sh"):
+        assert (hd / f).exists(), f
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    assert _stop_cmds(data).count("python3 \"" + (hd / "exomem_capture_nudge.py").as_posix() + "\"") == 1
+    ups = _ups_cmds(data)
+    assert sum("exomem_retrieve_nudge.py" in c for c in ups) == 1
+    assert not any("kb_retrieve_nudge" in c for c in ups)
+    assert not any("kb_capture_nudge" in c for c in _stop_cmds(data))
+    assert "exomem_retrieve_nudge.py" in ups[0]
+    assert "zellij_tab_context_rename.py" in ups[1]
+    assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python guard.py"
+    retrieve = [h for h in _hook_entries(data, "UserPromptSubmit") if "exomem_retrieve_nudge.py" in h["command"]][0]
+    assert retrieve["commandWindows"].endswith("exomem_retrieve_nudge.py\"")
+
+
 def test_install_hook_preserves_other_hooks_and_keys(tmp_path: Path) -> None:
     sp = tmp_path / "settings.json"
     sp.write_text(
@@ -145,10 +191,26 @@ def test_install_hook_via_cli(tmp_path: Path) -> None:
     assert data["hooks"]["Stop"] and data["hooks"]["UserPromptSubmit"]
 
 
+def test_install_hook_via_cli_for_codex(tmp_path: Path) -> None:
+    from exomem.__main__ import main
+
+    hd, sp = tmp_path / "hooks", tmp_path / "hooks.json"
+    assert main(["install-hook", "--client", "codex", "--hook-dir", str(hd), "--settings", str(sp)]) == 0
+    assert (hd / "exomem_capture_nudge.py").exists() and (hd / "exomem_retrieve_nudge.py").exists()
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    entries = _hook_entries(data, "UserPromptSubmit")
+    assert any("exomem_retrieve_nudge.py" in h["command"] and h.get("commandWindows") for h in entries)
+
+
 # --- shared subprocess helper ---------------------------------------------------
 
-def _run(script: Path, event: dict, home: Path):
-    env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}  # redirect Path.home()
+def _run(script: Path, event: dict, home: Path, extra_env: dict | None = None):
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        **(extra_env or {}),
+    }  # redirect Path.home()
     return subprocess.run(
         [sys.executable, str(script)],
         input=json.dumps(event), capture_output=True, text=True, env=env,
@@ -222,6 +284,21 @@ def test_capture_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
     assert second.stdout.strip() == ""
 
 
+def test_capture_codex_client_accepts_camel_case_and_uses_codex_state(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    t = _transcript(tmp_path, "q?", "We landed on a clear decision. " + "x" * 450)
+    r = _run(
+        CAPTURE_SCRIPT,
+        {"transcriptPath": str(t), "sessionId": "codex-cap"},
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+    assert '"decision": "block"' in r.stdout
+    assert (home / ".codex" / ".cache" / "exomem-nudge" / "codex-cap").exists()
+    assert (home / ".codex" / "exomem-capture-nudge.log").exists()
+    assert not (home / ".claude" / "exomem-capture-nudge.log").exists()
+
+
 # --- retrieval (UserPromptSubmit) gate ------------------------------------------
 
 def test_retrieve_fires_on_substantial_prompt(tmp_path: Path) -> None:
@@ -250,3 +327,17 @@ def test_retrieve_cooldown_suppresses_second_fire(tmp_path: Path) -> None:
     second = _run(RETRIEVE_SCRIPT, ev, home)
     assert "additionalContext" in first.stdout
     assert second.stdout.strip() == ""
+
+
+def test_retrieve_codex_client_accepts_camel_case_and_uses_codex_state(tmp_path: Path) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    r = _run(
+        RETRIEVE_SCRIPT,
+        {"userPrompt": "what did I conclude about the Codex hook setup earlier?", "sessionId": "codex-ret"},
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+    assert "additionalContext" in r.stdout
+    assert (home / ".codex" / ".cache" / "exomem-nudge" / "retrieve_codex-ret").exists()
+    assert (home / ".codex" / "exomem-retrieve-nudge.log").exists()
+    assert not (home / ".claude" / "exomem-retrieve-nudge.log").exists()


### PR DESCRIPTION
## Summary
- Add `exomem install-hook --client codex` to install the same bundled Exomem capture/retrieve hooks into `~/.codex/hooks` and wire `~/.codex/hooks.json`.
- Keep Claude Code as the default `install-hook` target while making hook cache/log paths client-aware.
- Migrate old `kb_*` Codex hook entries in-place so unrelated hooks, such as Zellij tab renaming, keep their ordering.
- Document Codex hook setup in README and QUICKSTART.

## Verification
- `PYTHONPATH=src python -m pytest tests/test_install_hook.py tests/test_retrieve_inject.py -q` -> 80 passed
- `git diff --check`
- Local install: `uv run python -m exomem install-hook --client codex`
- Manual Codex retrieve hook invocation: substantive prompt emitted `hookSpecificOutput`; `continue` emitted nothing

## Notes
- `python -m ruff` and `uv run ruff` were unavailable because `ruff` is not installed in this environment.