### PR TITLE
feat(hooks): add install health check

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -344,6 +344,17 @@ log under `~/.codex/`. Prefer to wire it by hand?
 `uv run python -m exomem install-hook --print-only` writes the scripts and prints
 the snippet to paste.
 
+To verify the deployed hooks without changing anything:
+
+```bash
+uv run python -m exomem install-hook --check
+```
+
+That checks both Claude Code and Codex by default. Use `--client claude` or
+`--client codex` to narrow it. The report flags stale deployed hook copies,
+legacy `kb_*` hook entries, missing config, and the log/cache paths where hook
+activity should land.
+
 Tune with `EXOMEM_CAPTURE_NUDGE_MIN_CHARS` / `EXOMEM_RETRIEVE_NUDGE_MIN_CHARS` (and the
 matching `_COOLDOWN_SEC`), `EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS` for the read
 hook's control-prompt skip ceiling, or disable either with `EXOMEM_CAPTURE_NUDGE_DISABLE=1` /

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Optional local hooks, using the same Exomem scripts as Claude Code:
 exomem install-hook --client codex
 ```
 
+Verify deployed Claude Code/Codex hooks without changing anything:
+
+```bash
+exomem install-hook --check
+```
+
 Or add it directly to `~/.codex/config.toml`:
 
 ```toml

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -703,8 +703,8 @@ def _install_hook_main(argv: list[str]) -> int:
     parser.add_argument(
         "--client",
         choices=("claude", "codex"),
-        default="claude",
-        help="client hook config to wire (default: claude)",
+        default=None,
+        help="client hook config to wire/check (default: claude for install; both for --check)",
     )
     parser.add_argument(
         "--hook-dir",
@@ -719,20 +719,48 @@ def _install_hook_main(argv: list[str]) -> int:
         action="store_true",
         help="Write the script but don't touch settings.json; print the snippet to add.",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Read-only health check for deployed Claude Code/Codex hooks; writes nothing.",
+    )
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
     args = parser.parse_args(argv)
 
     from . import install_hook as hook_module
+
+    if args.check:
+        if (args.hook_dir or args.settings) and args.client is None:
+            parser.error("--hook-dir/--settings with --check require --client")
+        try:
+            report = hook_module.check_hooks(
+                clients=(args.client,) if args.client else hook_module.SUPPORTED_CLIENTS,
+                hook_dir=Path(args.hook_dir) if args.hook_dir else None,
+                settings_path=Path(args.settings) if args.settings else None,
+            )
+        except ValueError as e:
+            print(f"exomem install-hook --check: {e}", file=sys.stderr)
+            return 2
+        if args.json:
+            print(json.dumps(report))
+        else:
+            print(hook_module.render_check_human(report))
+        return 0 if report["success"] else 1
 
     try:
         report = hook_module.install_hook(
             hook_dir=args.hook_dir,
             settings_path=args.settings,
             wire=not args.print_only,
-            client=args.client,
+            client=args.client or "claude",
         )
     except FileNotFoundError as e:
         print(f"exomem install-hook: {e}", file=sys.stderr)
         return 1
+
+    if args.json:
+        print(json.dumps(report))
+        return 0
 
     client_label = "Codex" if report["client"] == "codex" else "Claude Code"
     print(f"Installed the KB hook scripts for {client_label}:")

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -20,8 +20,10 @@ default this copies the scripts AND merges settings.json; `wire=False`
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
+import time
 from pathlib import Path
 
 _HOOK_DIR_SRC = Path(__file__).parent / "_hooks"
@@ -49,6 +51,7 @@ _MARKERS = (
     "kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge",
     "exomem_capture_nudge", "exomem_retrieve_nudge", "exomem-capture-nudge", "exomem-retrieve-nudge",
 )
+_LEGACY_MARKERS = ("kb_capture_nudge", "kb_retrieve_nudge", "kb-capture-nudge", "kb-retrieve-nudge")
 
 
 def _normalize_client(client: str) -> str:
@@ -108,6 +111,264 @@ def _hook_entry(item: dict, timeout: int) -> dict:
     if item.get("commandWindows"):
         entry["commandWindows"] = item["commandWindows"]
     return entry
+
+
+def _sha256(path: Path) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _read_json(path: Path) -> tuple[dict | None, str | None]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001 - diagnostic boundary
+        return None, str(e)
+    return (loaded, None) if isinstance(loaded, dict) else (None, "top-level JSON is not an object")
+
+
+def _commands_for_event(data: dict | None, event: str) -> list[dict]:
+    if not isinstance(data, dict):
+        return []
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+    groups = hooks.get(event)
+    if not isinstance(groups, list):
+        return []
+    entries: list[dict] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        for hook in group.get("hooks", []):
+            if isinstance(hook, dict):
+                entries.append(hook)
+    return entries
+
+
+def _contains_any(hook: dict, markers: tuple[str, ...]) -> bool:
+    haystack = f"{hook.get('command', '')} {hook.get('commandWindows', '')}"
+    return any(marker in haystack for marker in markers)
+
+
+def _fmt_age(ts: float | None) -> str | None:
+    if ts is None:
+        return None
+    age = max(0, int(time.time() - ts))
+    if age < 60:
+        return f"{age}s ago"
+    if age < 3600:
+        return f"{age // 60}m ago"
+    if age < 86400:
+        return f"{age // 3600}h ago"
+    return f"{age // 86400}d ago"
+
+
+def _file_mtime(path: Path) -> float | None:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _cache_summary(client: str) -> dict:
+    cache = Path.home() / (".codex" if client == "codex" else ".claude") / ".cache" / "exomem-nudge"
+    entries: list[Path] = []
+    try:
+        if cache.exists():
+            entries = [p for p in cache.iterdir() if p.is_file()]
+    except OSError:
+        entries = []
+    latest = max((_file_mtime(p) for p in entries), default=None)
+    return {
+        "path": str(cache),
+        "exists": cache.exists(),
+        "entries": len(entries),
+        "latest_age": _fmt_age(latest),
+    }
+
+
+def _log_summary(client: str, kind: str) -> dict:
+    home = Path.home() / (".codex" if client == "codex" else ".claude")
+    path = home / f"exomem-{kind}-nudge.log"
+    mtime = _file_mtime(path)
+    return {
+        "path": str(path),
+        "exists": path.exists(),
+        "last_trigger_age": _fmt_age(mtime),
+    }
+
+
+def _script_status(hook_dir: Path, script: str, wrapper: str) -> dict:
+    items = {}
+    for name in (script, wrapper):
+        src = _HOOK_DIR_SRC / name
+        dst = hook_dir / name
+        src_hash = _sha256(src)
+        dst_hash = _sha256(dst)
+        items[name] = {
+            "path": str(dst),
+            "exists": dst.exists(),
+            "matches_bundle": bool(src_hash and dst_hash and src_hash == dst_hash),
+            "bundle_hash": src_hash,
+            "deployed_hash": dst_hash,
+        }
+    return items
+
+
+def check_hooks(
+    *,
+    clients: tuple[str, ...] = SUPPORTED_CLIENTS,
+    hook_dir: Path | None = None,
+    settings_path: Path | None = None,
+) -> dict:
+    """Read-only hook health report.
+
+    Checks deployed hook copies against bundled source, verifies client configs point
+    at current `exomem_*` hooks instead of legacy `kb_*` hooks, and reports where
+    logs/cooldown state land. Returns a JSON-serializable report.
+    """
+    normalized = tuple(_normalize_client(c) for c in clients)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"duplicate clients requested: {clients!r}")
+    if (hook_dir or settings_path) and len(normalized) != 1:
+        raise ValueError("hook_dir/settings_path overrides require exactly one client")
+
+    reports = []
+    for client in normalized:
+        hd = Path(hook_dir).expanduser() if hook_dir else _default_hook_dir(client)
+        sp = Path(settings_path).expanduser() if settings_path else _default_settings(client)
+        data, parse_error = (None, "file does not exist")
+        if sp.exists():
+            data, parse_error = _read_json(sp)
+
+        checks: list[dict] = []
+
+        def add(id_: str, status: str, message: str, details: dict | None = None) -> None:
+            row = {"id": id_, "status": status, "message": message}
+            if details is not None:
+                row["details"] = details
+            checks.append(row)
+
+        add(
+            "config.file",
+            "pass" if data is not None else "fail",
+            f"hook config readable at {sp}" if data is not None else f"hook config unavailable at {sp}: {parse_error}",
+            {"path": str(sp), "exists": sp.exists(), "parse_error": parse_error},
+        )
+
+        any_legacy = False
+        for _py, _sh, event in _HOOK_SPECS:
+            for hook in _commands_for_event(data, event):
+                if _contains_any(hook, _LEGACY_MARKERS):
+                    any_legacy = True
+        add(
+            "config.legacy",
+            "fail" if any_legacy else "pass",
+            "legacy kb_* hook entries are still configured" if any_legacy else "no legacy kb_* hook entries configured",
+        )
+
+        scripts = {}
+        for script, wrapper, event in _HOOK_SPECS:
+            entries = _commands_for_event(data, event)
+            configured = any(_contains_any(h, (script, wrapper)) for h in entries)
+            legacy = [h for h in entries if _contains_any(h, _LEGACY_MARKERS)]
+            add(
+                f"config.{event}",
+                "pass" if configured and not legacy else "fail",
+                (
+                    f"{event} points at current Exomem hook"
+                    if configured and not legacy
+                    else f"{event} does not point cleanly at current Exomem hook"
+                ),
+                {"entries": entries},
+            )
+
+            status = _script_status(hd, script, wrapper)
+            scripts.update(status)
+            stale = [name for name, row in status.items() if not row["matches_bundle"]]
+            missing = [name for name, row in status.items() if not row["exists"]]
+            if missing:
+                add(
+                    f"scripts.{event}",
+                    "fail",
+                    f"{event} deployed hook file(s) missing: {', '.join(missing)}",
+                    status,
+                )
+            elif stale:
+                add(
+                    f"scripts.{event}",
+                    "fail",
+                    f"{event} deployed hook file(s) differ from bundled source: {', '.join(stale)}",
+                    status,
+                )
+            else:
+                add(f"scripts.{event}", "pass", f"{event} deployed hook files match bundled source", status)
+
+        logs = {
+            "capture": _log_summary(client, "capture"),
+            "retrieve": _log_summary(client, "retrieve"),
+        }
+        for kind, row in logs.items():
+            add(
+                f"log.{kind}",
+                "pass" if row["exists"] else "warn",
+                (
+                    f"{kind} hook log exists at {row['path']}"
+                    if row["exists"]
+                    else f"{kind} hook log has not been created yet at {row['path']}"
+                ),
+                row,
+            )
+
+        cache = _cache_summary(client)
+        add(
+            "cache.cooldown",
+            "pass" if cache["exists"] else "warn",
+            (
+                f"cooldown cache exists with {cache['entries']} entries"
+                if cache["exists"]
+                else f"cooldown cache has not been created yet at {cache['path']}"
+            ),
+            cache,
+        )
+
+        reports.append({
+            "client": client,
+            "success": not any(c["status"] == "fail" for c in checks),
+            "hook_dir": str(hd),
+            "settings_path": str(sp),
+            "scripts": scripts,
+            "logs": logs,
+            "cache": cache,
+            "checks": checks,
+        })
+
+    return {
+        "success": not any(not c["success"] for c in reports),
+        "clients": reports,
+    }
+
+
+def render_check_human(report: dict) -> str:
+    lines = [
+        "exomem hook check",
+        f"overall: {'PASS' if report.get('success') else 'FAIL'}",
+    ]
+    for client in report.get("clients", []):
+        lines.append("")
+        lines.append(client["client"].upper())
+        lines.append(f"- config: {client['settings_path']}")
+        lines.append(f"- hooks:  {client['hook_dir']}")
+        for check in client.get("checks", []):
+            label = check["status"].upper()
+            lines.append(f"- {label} {check['id']}: {check['message']}")
+    return "\n".join(lines)
 
 
 def snippet(installed: list[dict], timeout: int = 10) -> str:

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -202,6 +202,69 @@ def test_install_hook_via_cli_for_codex(tmp_path: Path) -> None:
     assert any("exomem_retrieve_nudge.py" in h["command"] and h.get("commandWindows") for h in entries)
 
 
+def test_install_hook_check_reports_healthy_codex_install(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    hd, sp = tmp_path / "hooks", tmp_path / "hooks.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp, client="codex")
+
+    report = hook_module.check_hooks(clients=("codex",), hook_dir=hd, settings_path=sp)
+
+    assert report["success"] is True
+    client = report["clients"][0]
+    assert client["client"] == "codex"
+    assert any(c["id"] == "config.UserPromptSubmit" and c["status"] == "pass" for c in client["checks"])
+    assert any(c["id"] == "scripts.Stop" and c["status"] == "pass" for c in client["checks"])
+    assert client["logs"]["retrieve"]["path"].startswith(str(home / ".codex"))
+
+
+def test_install_hook_check_flags_stale_deployed_copy(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp)
+    (hd / "exomem_retrieve_nudge.py").write_text("# stale\n", encoding="utf-8")
+
+    report = hook_module.check_hooks(clients=("claude",), hook_dir=hd, settings_path=sp)
+
+    assert report["success"] is False
+    checks = report["clients"][0]["checks"]
+    stale = [c for c in checks if c["id"] == "scripts.UserPromptSubmit"][0]
+    assert stale["status"] == "fail"
+    assert "differ from bundled source" in stale["message"]
+
+
+def test_install_hook_check_flags_legacy_kb_config(tmp_path: Path) -> None:
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp)
+    data = json.loads(sp.read_text(encoding="utf-8"))
+    data["hooks"]["UserPromptSubmit"] = [
+        {"hooks": [{"type": "command", "command": "bash ~/.claude/hooks/kb-retrieve-nudge.sh"}]}
+    ]
+    sp.write_text(json.dumps(data), encoding="utf-8")
+
+    report = hook_module.check_hooks(clients=("claude",), hook_dir=hd, settings_path=sp)
+
+    assert report["success"] is False
+    checks = report["clients"][0]["checks"]
+    assert [c for c in checks if c["id"] == "config.legacy"][0]["status"] == "fail"
+    assert [c for c in checks if c["id"] == "config.UserPromptSubmit"][0]["status"] == "fail"
+
+
+def test_install_hook_check_via_cli_json(tmp_path: Path, capsys) -> None:
+    from exomem.__main__ import main
+
+    hd, sp = tmp_path / "hooks", tmp_path / "hooks.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp, client="codex")
+
+    assert main([
+        "install-hook", "--check", "--client", "codex",
+        "--hook-dir", str(hd), "--settings", str(sp), "--json",
+    ]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["clients"][0]["client"] == "codex"
+
+
 # --- shared subprocess helper ---------------------------------------------------
 
 def _run(script: Path, event: dict, home: Path, extra_env: dict | None = None):


### PR DESCRIPTION
## Summary
- Add read-only `exomem install-hook --check` for Claude Code/Codex hook health.
- Verify deployed hook copies against bundled source hashes, flag legacy `kb_*` config, and report log/cache locations and last trigger age.
- Support `--client claude|codex`, `--json`, and custom `--hook-dir`/`--settings` for single-client checks.
- Document the check command in README and QUICKSTART.

## Verification
- `PYTHONPATH=src python -m pytest tests/test_install_hook.py tests/test_retrieve_inject.py -q` -> 84 passed
- `PYTHONPATH=src python -m exomem install-hook --check --json` -> success true for local Claude Code and Codex hooks
- `python -m compileall -q src/exomem/install_hook.py src/exomem/__main__.py`
- `git diff --check`

## Notes
- Local `uv run ruff ...` could not run because `ruff` is not installed in this environment; CI has the advisory ruff job.