### PR TITLE
docs: add assistant onboarding guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -22,7 +22,8 @@ If you're comfortable in Claude Code, this is ~20–30 minutes.
 > (step 6) is the *brain* — it tells Claude *when* to save, how to file a source,
 > and how to compile a note. Generic MCP clients that cannot load Skills should
 > call `bootstrap()` once after connecting; that returns the compact operating
-> contract through MCP.
+> contract through MCP. See [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md)
+> for Codex, hosted chat clients, Cursor/Windsurf/Gemini, and generic MCP setup.
 
 ---
 
@@ -299,7 +300,8 @@ own — or just start writing; the writer auto-registers new keys as you use the
 > **Other MCP clients.** ChatGPT, Codex, Cursor, Gemini, Windsurf, or any client
 > without Skill support should call `bootstrap()` once after connecting. It returns
 > Exomem's search/save/upload defaults and performance guidance in a structured
-> MCP response.
+> MCP response. The copyable standing instruction lives in
+> [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md).
 
 ---
 
@@ -343,6 +345,10 @@ the same scripts go to `~/.codex/hooks/`, wire into `~/.codex/hooks.json`, and
 log under `~/.codex/`. Prefer to wire it by hand?
 `uv run python -m exomem install-hook --print-only` writes the scripts and prints
 the snippet to paste.
+
+The read hook is a nudge, not a forced retrieval policy. The agent should still
+skip Exomem for unrelated chat, tiny control prompts, or follow-ups where the
+current conversation already contains the needed KB evidence.
 
 To verify the deployed hooks without changing anything:
 
@@ -430,10 +436,12 @@ responses?"**:
 ```
 Precise and non-performative: no hype, fluff, or motivational tone; clarity and correctness over filler. Use lists/structure only when they genuinely help; plain prose is fine. Match length to the substance, terse when simple and fuller when it's not.
 
-I keep a personal Knowledge Base served by the Exomem MCP. Use it proactively: search first when a turn touches my projects, notes, decisions, or domains (cite what you find; an empty search is a gap, not a dead end). Capture durable conclusions on your own — a decision, solved problem, diagnosed failure, or recognized pattern — as a short compiled note, not a transcript, then report one line: "Saved -> <path>". Ask before saving only if type/scope is genuinely ambiguous. Stay quiet on chit-chat; don't narrate empty searches.
+I keep a personal Knowledge Base served by the Exomem MCP. If no Exomem skill is loaded, call bootstrap(profile="compact") once at the start of a new chat and follow it. Use Exomem proactively: search first when a turn touches my projects, notes, decisions, or domains (cite what you find; an empty search is a gap, not a dead end). Do not search on unrelated chit-chat, small control prompts, or follow-ups where the current conversation already has the needed KB evidence. Capture durable conclusions on your own — a decision, solved problem, diagnosed failure, or recognized pattern — as a short compiled note, not a transcript, then report one line: "Saved -> <path>". Ask before saving only if type/scope is genuinely ambiguous. Stay quiet on chit-chat; don't narrate empty searches.
 ```
 
 The first paragraph is general response style (trim to taste); the second is the KB
 nudge. Account-level custom instructions are always in context, so they make Claude
 reach for the connected KB on its own — the app-side equivalent of the Claude Code
-hooks. The "stay quiet on chit-chat" line keeps it from firing on unrelated chats.
+hooks. The "do not search" line keeps it from firing on unrelated or already
+answered turns. For more client-specific instructions, see
+[docs/ai-assistant-guide.md](docs/ai-assistant-guide.md).

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ have them call `bootstrap()` once at the start of the session; it returns the
 same compact operating contract through MCP, including when to search, when to
 save, upload guidance, and performance profiles.
 
+For client-specific assistant instructions, see
+[docs/ai-assistant-guide.md](docs/ai-assistant-guide.md). For the boundary
+between Exomem and a chat product's built-in memory, see
+[docs/vs-built-in-memory.md](docs/vs-built-in-memory.md).
+
 Full local setup is in [QUICKSTART.md](QUICKSTART.md). Remote/mobile setup is
 in [docs/remote-quickstart.md](docs/remote-quickstart.md) and
 [docs/deployment.md](docs/deployment.md).
@@ -120,9 +125,9 @@ uv run exomem demo
 | Client | How |
 | --- | --- |
 | Claude Code | `exomem setup` registers it for you (see above) |
-| Codex CLI | `codex mcp add` plus optional `exomem install-hook --client codex` — see below |
-| claude.ai (remote) | Remote server — see [docs/remote-quickstart.md](docs/remote-quickstart.md) |
-| Any MCP client | Generic stdio config — see below; call `bootstrap()` first |
+| Codex CLI | `codex mcp add` plus optional `exomem install-hook --client codex` - see [docs/ai-assistant-guide.md#codex-cli](docs/ai-assistant-guide.md#codex-cli) |
+| claude.ai or hosted chat | Remote MCP/connector - see [docs/remote-quickstart.md](docs/remote-quickstart.md) and [docs/ai-assistant-guide.md#hosted-chat-clients](docs/ai-assistant-guide.md#hosted-chat-clients) |
+| Any MCP client | Generic stdio config - see below and [docs/ai-assistant-guide.md#generic-stdio-mcp-clients](docs/ai-assistant-guide.md#generic-stdio-mcp-clients); call `bootstrap()` first |
 | Docker (no Python) | One `docker run` line — see below and [docs/docker.md](docs/docker.md) |
 
 <details>
@@ -143,6 +148,9 @@ Verify deployed Claude Code/Codex hooks without changing anything:
 ```bash
 exomem install-hook --check
 ```
+
+For the `AGENTS.md` instruction block and the "do not search every tiny prompt"
+policy, see [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md).
 
 Or add it directly to `~/.codex/config.toml`:
 
@@ -165,6 +173,8 @@ env = { EXOMEM_VAULT_PATH = "/path/to/vault" }
 After connecting, ask the agent to call `bootstrap()` before using the KB. Claude
 Skills are still the best UX where available, but `bootstrap()` lets generic MCP
 clients learn Exomem's search/save/upload contract without a separate skill file.
+See [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md) for the copyable
+standing instruction.
 
 </details>
 
@@ -232,7 +242,9 @@ store. exomem works the other way around: agents come to your vault.
 | Memory hidden inside one assistant | exomem is client-agnostic: use the same vault from Claude Code, Codex, Cursor, scripts, or a custom chatbot. |
 
 For a deeper point-in-time comparison, see
-[docs/comparison-engraph.md](docs/comparison-engraph.md).
+[docs/comparison-engraph.md](docs/comparison-engraph.md). For the practical
+boundary with chat products' own memory features, see
+[docs/vs-built-in-memory.md](docs/vs-built-in-memory.md).
 
 **Measured retrieval quality — and speed.** Retrieval is graded by a
 reproducible golden-set eval harness, not asserted, and latency is measured

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -1,0 +1,174 @@
+# Exomem assistant guide
+
+This guide is for making an AI client use Exomem well after the MCP server is
+connected. The transport gives the agent tools. The behavioral layer tells it
+when to search, when to save, how to treat misses, and how to avoid confusing
+raw evidence with compiled notes.
+
+Claude Code gets that layer from the Exomem skill and optional hooks. Other
+clients should get it from `bootstrap()` plus a short standing instruction.
+
+## Client matrix
+
+| Client | Setup | Behavioral layer |
+| --- | --- | --- |
+| Claude Code | `exomem setup` or the manual quickstart | Exomem skill plus optional hooks |
+| Codex CLI | `codex mcp add ...` | Codex hooks, `AGENTS.md`, and `bootstrap()` as fallback |
+| ChatGPT or other hosted chat clients | Remote MCP/connector support, when available | Custom instructions plus `bootstrap()` |
+| claude.ai web/mobile | Remote connector | Custom instructions plus `bootstrap()` |
+| Cursor, Windsurf, Gemini, or generic MCP clients | Stdio MCP config | `bootstrap()` at session start |
+| Scripts or custom chatbots | MCP, REST, or CLI | Cache `bootstrap()` once per session or process |
+
+## The rule
+
+Use Exomem when the turn touches prior projects, notes, decisions, failures,
+sources, experiments, or domains the vault may know about. Do not search on
+every prompt just because Exomem exists. If the current conversation already has
+fresh KB evidence, reuse it unless the user changes topic, asks for a broader
+check, or the answer depends on something not yet retrieved.
+
+An empty search means "not found for that query and scope." It is not proof that
+the memory does not exist. Try synonyms, adjacent domain terms, singular/plural
+forms, or `scope="vault"` before concluding absence.
+
+## Copyable instruction block
+
+Paste this into `AGENTS.md`, a project instruction, or a hosted chat client's
+custom instructions. Trim the tone line to match your own preferences.
+
+```text
+Use Exomem as my durable Knowledge Base.
+
+At the start of a new session, if no Exomem skill has already been loaded, call
+bootstrap(profile="compact") once and follow the returned contract.
+
+Search Exomem before answering questions that touch my projects, notes,
+decisions, failures, sources, experiments, or domains. Use cheap recall first:
+find(query="...", detail="compact", rerank=false). Follow with get() only for
+hits that matter, or find(pack=true) when synthesizing across several hits.
+
+Do not search on unrelated chit-chat, simple control prompts, or every follow-up
+when the needed KB evidence is already in the conversation. If a search misses,
+try synonyms, adjacent terms, singular/plural variants, or scope="vault" before
+saying the KB has no relevant material.
+
+Save durable conclusions on your own: decisions, solved problems, diagnosed
+failures, reusable patterns, and stable project context. Save them as concise
+compiled notes, not transcripts. Keep raw artifacts as sources or evidence. Use
+edit() for small corrections and replace() when superseding an older compiled
+note.
+
+For latency or ranking questions, call bootstrap(profile="diagnostics") and use
+find(include_timings=true, rerank=true). Distinguish CPU/GPU/low-power mode from
+rerank, pack, cold model download, and cache state.
+```
+
+## Codex CLI
+
+Add the MCP server:
+
+```bash
+codex mcp add exomem --env EXOMEM_VAULT_PATH="/path/to/vault" -- exomem --transport stdio
+```
+
+Install the same local hook scripts Claude Code uses:
+
+```bash
+exomem install-hook --client codex
+```
+
+Check deployed Claude Code and Codex hooks:
+
+```bash
+exomem install-hook --check
+```
+
+Codex reads repository instructions from `AGENTS.md`. Put the instruction block
+above there, or keep your own equivalent policy. Restart Codex sessions after
+changing MCP config or hook config.
+
+The hooks are nudges. They should remind Codex to consider Exomem on substantive
+turns, not force a tool call for every prompt.
+
+## Generic stdio MCP clients
+
+Use the standard stdio config shape:
+
+```json
+{
+  "mcpServers": {
+    "exomem": {
+      "command": "exomem",
+      "args": ["--transport", "stdio"],
+      "env": {
+        "EXOMEM_VAULT_PATH": "/path/to/vault"
+      }
+    }
+  }
+}
+```
+
+After connecting, ask the agent to call:
+
+```text
+bootstrap(profile="compact")
+```
+
+Use `profile="full"` when examples help a weaker client. Use
+`profile="diagnostics"` when discussing speed, ranking, GPU/CPU behavior, or
+model/cache state.
+
+## Hosted chat clients
+
+Hosted clients cannot use local filesystem hooks and usually cannot load the
+repo's Claude Code skill. Connect Exomem through whatever remote MCP/connector
+support the client offers, then add the instruction block above as account-level
+or project-level custom instructions.
+
+If the hosted client cannot reliably call `bootstrap()` on its own, start a new
+chat with:
+
+```text
+Call Exomem bootstrap(profile="compact") once, then use that contract for this
+chat. Do not search the KB unless this turn touches my prior projects, notes,
+decisions, sources, or domains.
+```
+
+## Performance profiles
+
+These are the defaults returned by `bootstrap()`.
+
+| Use case | Tool shape | Meaning |
+| --- | --- | --- |
+| Normal lookup | `find(detail="compact", rerank=false)` | Cheap routing recall; follow with `get()` if needed |
+| Reasoning | `find(pack=true)` | Bounded context assembly for synthesis |
+| Diagnostics | `find(detail="compact", include_timings=true, rerank=true)` | Explain latency and ranking behavior |
+
+Resource mode is separate from search knobs:
+
+| Mode | Meaning |
+| --- | --- |
+| `quiet` | Low-resource CPU mode; avoid warm-up and release models when idle |
+| `normal` | CPU-first default; keyword/BM25 recall is ready first |
+| `performance` | Explicit opt-in for GPU-capable steady-state work |
+
+Do not interpret a slow diagnostic search with rerank enabled as "Exomem is
+slow" without checking timings and resource mode.
+
+## Verification
+
+After setup:
+
+```bash
+exomem doctor
+exomem install-hook --check
+```
+
+Then ask the client to call `bootstrap(profile="compact")`. A good response
+includes a `contract_version`, a server `compute_policy`, tool defaults, and the
+search/save workflow. Ask one known vault question next and confirm it uses
+`find()` before answering.
+
+For remote connectors, use [remote-quickstart.md](remote-quickstart.md). For
+what belongs in Exomem instead of an assistant's built-in memory, see
+[vs-built-in-memory.md](vs-built-in-memory.md).

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -4,6 +4,10 @@
 remote MCP connector — the same vault you already use locally, reachable from
 anywhere.
 
+For the assistant-side behavior after the connector is added, see
+[ai-assistant-guide.md](ai-assistant-guide.md). Remote clients cannot use local
+hooks, so they should rely on custom instructions plus `bootstrap()`.
+
 **What you need:** a machine that stays on (desktop, home server, or a cheap
 VPS) and about **15 minutes**.
 
@@ -193,6 +197,10 @@ just importable.
 claude.ai → **Settings** → **Connectors** → **Add custom connector** →
 `https://<host>/mcp` → log in with GitHub as the account named in
 `EXOMEM_GITHUB_USERNAME`.
+
+Then add Exomem behavior to the hosted client. Paste the instruction block from
+[ai-assistant-guide.md](ai-assistant-guide.md), or at minimum start new chats by
+asking it to call `bootstrap(profile="compact")` once before using the KB.
 
 ## ngrok free-tier limits
 

--- a/docs/vs-built-in-memory.md
+++ b/docs/vs-built-in-memory.md
@@ -1,0 +1,79 @@
+# Exomem vs built-in assistant memory
+
+Built-in assistant memory and Exomem solve different problems. They work best
+together when the boundary is explicit.
+
+## Short version
+
+Use built-in memory for tiny, durable preferences that should shape every chat.
+Use Exomem for project knowledge, sourced material, decisions, failures,
+experiments, and anything you may need to inspect, cite, edit, supersede, or use
+from more than one client.
+
+Built-in memory is usually hidden inside one assistant product. Exomem is a
+user-owned Markdown vault served through MCP, REST, and CLI, so the same memory
+can be used by Claude Code, Codex, Cursor, hosted chat clients, scripts, and your
+own tools.
+
+## Routing table
+
+| Information | Put it where |
+| --- | --- |
+| Response style, tone, formatting preferences | Built-in memory or custom instructions |
+| "Always check my Exomem KB for project/domain questions" | Built-in memory or custom instructions |
+| Project decisions and architectural context | Exomem compiled notes |
+| Research findings and reusable conclusions | Exomem compiled notes, with sources linked |
+| Raw articles, transcripts, screenshots, PDFs, images, audio, or video | Exomem sources/evidence |
+| Diagnosed failures and fixes | Exomem failure or pattern notes |
+| Experiments and benchmark results | Exomem experiment notes |
+| Temporary scratch thoughts that will not matter later | Usually nowhere |
+| Calendar tasks, reminders, or operational todos | A calendar/task system, unless they become project knowledge |
+| Passwords, tokens, private keys, or credentials | Neither; use a secret manager |
+
+## Why Exomem needs a behavioral layer
+
+An MCP connection only exposes tools. It does not guarantee the agent knows when
+to use them. Claude Code can load the Exomem skill. Other clients should call
+`bootstrap(profile="compact")` once per session and follow the returned contract.
+
+The practical behavior is:
+
+```text
+For questions about my prior work, search Exomem first. For unrelated chat or
+small control prompts, stay quiet. Save durable conclusions as compiled notes.
+Treat empty searches as query/scope misses, not proof of absence.
+```
+
+## Compiled notes vs raw evidence
+
+Exomem separates raw material from conclusions.
+
+Raw evidence belongs in sources or evidence pages: uploaded files, quoted
+articles, transcripts, screenshots, datasets, and other artifacts. These should
+preserve provenance.
+
+Compiled notes are the durable layer: decisions, solved problems, patterns,
+entities, failures, research notes, and experiments. They should be concise and
+usable by a future agent without replaying the whole chat.
+
+When a compiled note changes slightly, use `edit()`. When a newer conclusion
+supersedes an older one, use `replace()` so the history stays understandable
+instead of accumulating duplicates.
+
+## Sharing one memory across clients
+
+Assistant built-in memories do not usually travel across products. A preference
+saved in one chat product will not automatically help Codex, Cursor, a script, or
+a custom MCP client.
+
+Exomem is the portable layer. Keep only the routing preference in each client:
+
+```text
+I keep durable project knowledge in Exomem. Search it when this turn touches my
+projects, notes, decisions, sources, failures, experiments, or domains. Do not
+search on unrelated chit-chat or when the current conversation already contains
+the needed KB evidence.
+```
+
+For concrete client setup and the full copyable instruction block, see
+[ai-assistant-guide.md](ai-assistant-guide.md).


### PR DESCRIPTION
## Summary
- add a dedicated assistant guide for Claude Code, Codex, hosted chat clients, and generic MCP clients
- document the Exomem vs built-in assistant memory boundary
- link the new guidance from README, QUICKSTART, and the remote connector quickstart

## Verification
- git diff --check
- uv run python -m pytest tests/test_bootstrap.py -q