### PR TITLE
Reduce eager media import memory

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -53,7 +53,6 @@ from . import move_file as move_file_module
 from . import multi_edit as multi_edit_module
 from . import note as note_module
 from . import overview as overview_module
-from . import preserve as preserve_module
 from . import provenance as provenance_module
 from . import query_data as query_data_module
 from . import query_log, vault
@@ -63,7 +62,6 @@ from . import recover_from_trash as recover_from_trash_module
 from . import replace as replace_module
 from . import set_frontmatter_field as set_frontmatter_field_module
 from . import set_take as set_take_module
-from . import video_frames as video_frames_module
 from .kbdir import kb_dirname
 from .vault import (
     VaultPathError,
@@ -82,6 +80,18 @@ from .command_surface import (
 )
 
 _link_summary = link_summary_module.link_summary
+
+
+def _preserve_module():
+    from . import preserve as preserve_module
+
+    return preserve_module
+
+
+def _video_frames_module():
+    from . import video_frames as video_frames_module
+
+    return video_frames_module
 
 
 # ----- op-leaves: the former per-surface wrapper bodies (vault_root injected) -----
@@ -1484,6 +1494,7 @@ def op_preserve(
         INVALID_PRESERVE (missing required); ARTIFACT_EXISTS (file already
         exists — Evidence is append-only, pick a new filename).
     """
+    preserve_module = _preserve_module()
     try:
         result = preserve_module.preserve(
             vault_root,
@@ -2182,6 +2193,7 @@ def op_get_video_frames(
         NO_DECODABLE_FRAMES (corrupt/streamless video, or a window on a
         video of unknown duration).
     """
+    video_frames_module = _video_frames_module()
     try:
         result = video_frames_module.get_frames(
             vault_root,

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -45,9 +45,27 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
-from . import accel, semantic_segments
+from . import accel
 
 log = logging.getLogger(__name__)
+
+_SEMANTIC_SEGMENTS_FALSY = {"", "0", "false", "no", "off"}
+_TIMED_LINE_RE = re.compile(
+    r"^\[(?:(\d+):)?(\d{1,2}):(\d{2})\](?:\s\[([^\]\n]+)\]:)?\s?(.*)$"
+)
+
+
+def _semantic_segments_enabled() -> bool:
+    return (
+        os.environ.get("EXOMEM_SEMANTIC_SEGMENTS", "").strip().lower()
+        not in _SEMANTIC_SEGMENTS_FALSY
+    )
+
+
+def _semantic_segments_module():
+    from . import semantic_segments
+
+    return semantic_segments
 
 # Media-type buckets by extension. Extension-based is deliberate: no libmagic dep, and
 # the uploader names the file. Unknown extension → not extractable (returns None).
@@ -475,8 +493,9 @@ def _transcribe(path: Path, media_type: str, vault_root: Path | None = None) -> 
     # segment with a `[m:ss]` prefix — the substrate for semantic segmentation
     # and `transcript_match_at`. Soft-fail: any renderer error falls back to the
     # flat join below; gate unset is byte-identical to it.
-    if semantic_segments.semantic_segments_enabled():
+    if _semantic_segments_enabled():
         try:
+            semantic_segments = _semantic_segments_module()
             timed_text = semantic_segments.render_timed_lines(
                 [
                     (
@@ -502,7 +521,7 @@ def _transcribe(path: Path, media_type: str, vault_root: Path | None = None) -> 
 def _is_timed_text(text: str) -> bool:
     """True when the transcript's first line carries a `[m:ss]` marker."""
     first = text.split("\n", 1)[0] if text else ""
-    m = semantic_segments.TIMED_LINE_RE.match(first)
+    m = _TIMED_LINE_RE.match(first)
     return bool(m and m.group(2) is not None)
 
 
@@ -788,8 +807,9 @@ def _diarize(
     # and match localization. The structured `merged` list keeps the merged-turn
     # shape either way (speakers: frontmatter + filters are unaffected). Soft-fail
     # to the merged-turn rendering below.
-    if semantic_segments.semantic_segments_enabled():
+    if _semantic_segments_enabled():
         try:
+            semantic_segments = _semantic_segments_module()
             timed_text = semantic_segments.render_timed_lines(timed_segs).strip()
             if timed_text:
                 return timed_text, merged

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -34,12 +34,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
-from . import extract, indexes
+from . import indexes
 from .kbdir import kb_prefix
 from .vault import PlannedWrite, batch_atomic_write, escape_wikilinks_for_log, kb_root
 
 
 log = logging.getLogger(__name__)
+
+
+def _extract_module():
+    from . import extract
+
+    return extract
 
 # Cap extracted text written into a sidecar. `find` rebuilds BM25 over the whole
 # corpus per query, so one oversized document (e.g. a 7 MB HTML export rendered to
@@ -253,6 +259,7 @@ def preserve(
         # sidecar — pointer + media_type + `extracted_by: pending` — so it's a
         # first-class find() result immediately and the extraction worker fills the
         # text later. Only when server extraction is enabled (else nothing fills it).
+        extract = _extract_module()
         media_type = extract.media_type_for(filename_safe)
         want_stub = media_type is not None and not text_clean and extract.extraction_enabled()
         if desc_clean or text_clean or want_stub:
@@ -581,6 +588,7 @@ def ensure_media_sidecar(
     `extracted_by: none`) and embeds it. Idempotent: returns (existing_sidecar, False) if one
     already exists, else (new_sidecar, True). Used by `exomem backfill-media`.
     """
+    extract = _extract_module()
     media_type = extract.media_type_for(binary_path)
     if media_type is None:
         raise ValueError(f"not an extractable media file: {binary_path.name!r}")

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import env_compat, extract, project_keys, schema
+from . import env_compat, project_keys, schema
 from .vault import resolve_vault
 
 log = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ def _start_compute_runtime(vault_root: Path) -> None:
 
 def _start_media_worker(vault_root: Path) -> Any | None:
     """Start the optional off-request media extraction worker."""
-    if not extract.extraction_enabled():
+    if os.environ.get("EXOMEM_DISABLE_MEDIA_EXTRACTION"):
         return None
 
     from . import media_worker as media_worker_module

--- a/src/exomem/server_transfer.py
+++ b/src/exomem/server_transfer.py
@@ -14,8 +14,22 @@ from starlette.formparsers import MultiPartException
 from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 
-from . import cf_access, extract, preserve as preserve_module, upload_tokens
+from . import cf_access, upload_tokens
 from .vault import VaultPathError, resolve_under_vault
+
+DEFAULT_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
+
+
+def _extract_module():
+    from . import extract
+
+    return extract
+
+
+def _preserve_module():
+    from . import preserve as preserve_module
+
+    return preserve_module
 
 
 @dataclass(frozen=True)
@@ -36,7 +50,7 @@ def load_transfer_config() -> TransferConfig:
     """Read upload/download auth and sizing config from the environment."""
     upload_token = os.environ.get("EXOMEM_UPLOAD_TOKEN", "").strip() or None
     upload_max_bytes = int(
-        os.environ.get("EXOMEM_UPLOAD_MAX_BYTES", str(preserve_module.MAX_UPLOAD_BYTES))
+        os.environ.get("EXOMEM_UPLOAD_MAX_BYTES", str(DEFAULT_UPLOAD_MAX_BYTES))
     )
     large_upload_base = (
         os.environ.get("EXOMEM_LARGE_UPLOAD_BASE_URL", "").strip().rstrip("/") or None
@@ -122,6 +136,7 @@ def register_transfer_routes(
         filename = str(form.get("filename") or "").strip() or (
             getattr(upload, "filename", "") or ""
         )
+        preserve_module = _preserve_module()
         try:
             result = await run_in_threadpool(
                 preserve_module.preserve_stream,
@@ -147,6 +162,7 @@ def register_transfer_routes(
             )
 
         if media_worker is not None and result.sidecar_path:
+            extract = _extract_module()
             media_type = extract.media_type_for(filename)
             if media_type:
                 do_ocr = text is None

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -314,9 +314,13 @@ def test_transcribe_timed_render_failure_falls_back_flat(
     monkeypatch.delenv("EXOMEM_DIARIZE", raising=False)
     segs = [_FakeSeg("hello there", 0.0, 1.0)]
     monkeypatch.setattr(extract, "_get_whisper", lambda: _FakeWhisper(segs))
+    class _BoomSemanticSegments:
+        @staticmethod
+        def render_timed_lines(_segments):
+            raise RuntimeError("boom")
+
     monkeypatch.setattr(
-        extract.semantic_segments, "render_timed_lines",
-        lambda s: (_ for _ in ()).throw(RuntimeError("boom")),
+        extract, "_semantic_segments_module", lambda: _BoomSemanticSegments
     )
     r = extract._transcribe(Path("x.wav"), "audio")
     assert r.text == "hello there"

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_import_probe(code: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    env["EXOMEM_DISABLE_EMBEDDINGS"] = "1"
+    env["EXOMEM_DISABLE_MEDIA_EXTRACTION"] = "1"
+    env["EXOMEM_DISABLE_RELEVANCE_CHECK"] = "1"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_commands_import_does_not_load_media_numpy_stack() -> None:
+    result = _run_import_probe(
+        """
+import sys
+from exomem import commands
+assert "numpy" not in sys.modules
+assert "exomem.preserve" not in sys.modules
+assert "exomem.extract" not in sys.modules
+assert "exomem.video_frames" not in sys.modules
+"""
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_server_import_does_not_load_media_numpy_stack() -> None:
+    result = _run_import_probe(
+        """
+import sys
+import exomem.server
+assert "numpy" not in sys.modules
+assert "exomem.preserve" not in sys.modules
+assert "exomem.extract" not in sys.modules
+assert "exomem.video_frames" not in sys.modules
+"""
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_extract_import_and_media_type_check_do_not_load_numpy() -> None:
+    result = _run_import_probe(
+        """
+import sys
+from exomem import extract
+assert extract.media_type_for("demo.pdf") == "pdf"
+assert "numpy" not in sys.modules
+assert "exomem.semantic_segments" not in sys.modules
+"""
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_video_frames.py
+++ b/tests/test_video_frames.py
@@ -294,8 +294,14 @@ def test_mcp_tool_returns_metadata_then_images(video_vault, monkeypatch) -> None
         dedup_dropped=2,
         max_frames_effective=2,
     )
+
+    class _CannedVideoFramesModule:
+        @staticmethod
+        def get_frames(*args, **kwargs):
+            return canned
+
     monkeypatch.setattr(
-        commands_module.video_frames_module, "get_frames", lambda *a, **k: canned
+        commands_module, "_video_frames_module", lambda: _CannedVideoFramesModule
     )
     mcp = _build_server(monkeypatch)
     result = asyncio.run(


### PR DESCRIPTION
## Summary
- lazy-load media-heavy command modules (`preserve`, `video_frames`) instead of importing them during command registry import
- keep `extract` lightweight for extension checks by lazy-loading semantic segmentation only when `EXOMEM_SEMANTIC_SEGMENTS` is enabled
- avoid eager `preserve`/`extract` imports from server transfer/runtime setup, and add fresh-process tests that pin the no-NumPy import contract

## Memory check
Windows Job Object peak process memory, embeddings/media extraction disabled:

| Probe | Before | After |
| --- | ---: | ---: |
| `from exomem import commands` | ~546 MB | 57.36 MB |
| `import exomem.server` | not separately measured before | 75.12 MB |
| `import exomem.extract` | previously pulled NumPy via semantic segments | 11.69 MB |
| `import exomem.preserve` | previously pulled extract/NumPy | 18.67 MB |

For context, `import numpy` alone peaks at ~498 MB in this environment.

## Tests
- `python -m pytest tests/test_lazy_imports.py tests/test_preserve.py tests/test_upload_endpoint.py tests/test_video_frames.py tests/test_extract.py tests/test_mcp_schema_fidelity.py tests/test_tool_annotations.py` -> 129 passed, 1 skipped
- `python -m pytest` -> 1742 passed, 3 skipped