### PR TITLE
Productize cognition layer adoption

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -63,19 +63,42 @@ That's the normal case, and it's safe:
   set `EXOMEM_KB_DIRNAME` to govern a differently-named folder — e.g. to adopt one
   your vault already uses.)*
 - **Your notes stay searchable.** `find` reaches sibling folders (the default
-  scope auto-widens; `scope="vault"` always walks everything), and `overview`
-  gives Claude a bounded structural report of the whole vault — one call, not
-  one read per file.
+  scope auto-widens; `scope="vault"` always walks everything), `overview`
+  gives Claude a bounded structural report of the whole vault, and `adopt`
+  turns that scan into a safe adoption report with likely knowledge packs and
+  copy/compile next actions — one call, not one read per file.
 - **Daily-notes vaults** (a `Daily/` or `Journal/` tree of dated logs): leave
   them exactly as they are. The Knowledge Base is a *compiled* layer beside
   your log, not a migration target — exomem never requires frontmatter, links,
-  or restructuring from existing notes. A good first prompt after setup:
-  *"what does this vault look like?"* — Claude answers with `overview`, and you
-  decide together what, if anything, to change.
+  or restructuring from existing notes. Good first prompts after setup:
+  *"what does this vault look like?"* — Claude answers with `overview`; or
+  *"adopt this vault safely"* — Claude answers with `adopt`, preserving originals
+  and proposing manifest/copy/compile next actions for you to approve.
 - **Same vault or a separate one?** Same vault is the default: notes and KB in
   one Obsidian window, cross-search included. Pick a separate vault only when
   you want hard isolation (e.g. a shared or team-synced vault where a new
   top-level folder would bother other tooling).
+
+Concrete adoption commands after setup:
+
+```bash
+# readable read-only report: no files created, moved, edited, or deleted
+exomem adopt
+
+# same report as a machine-readable envelope
+exomem adopt --json
+
+# save the report under Knowledge Base/_Adoption/
+exomem adopt --mode save-manifest --json
+
+# copy only files you explicitly name into governed Sources/Imported/
+exomem adopt --mode copy-as-sources \
+  --selected-paths "Warranty Case/laptop-receipt.md" \
+  --json
+```
+
+See [docs/product-model.md](docs/product-model.md) for the simple action model
+and [docs/knowledge-packs.md](docs/knowledge-packs.md) for the pack schema.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/Artexis10/exomem/actions/workflows/ci.yml/badge.svg)](https://github.com/Artexis10/exomem/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
-External memory for MCP-capable agents.
+Durable memory with sources, proof, history, and review for MCP-capable agents.
 
 exomem turns an owned Markdown/Obsidian vault into a local knowledge substrate
 for Codex, Claude Code, Cursor, chatbots, CLI agents, and any client that can
@@ -71,9 +71,10 @@ One command does the whole local setup: the wizard scans your vault and shows
 what's already there, initializes `Knowledge Base/`, runs the `doctor`
 preflight, registers the server with Claude Code, and installs the skill.
 
-Already have a vault full of notes? That's the normal case: the wizard shows
-what's there first, and exomem only ever writes under `Knowledge Base/` — your
-existing files stay untouched (read-only, still searchable). See
+Already have a vault full of notes? That's the normal case: `adopt` gives a
+scan-first, read-only report of what's there, suggested knowledge packs, and
+safe copy/compile next actions. Exomem only ever writes under `Knowledge Base/` — your
+existing files stay untouched unless you explicitly copy or compile selected material. See
 [QUICKSTART.md § Already have a vault full of notes?](QUICKSTART.md#already-have-a-vault-full-of-notes)
 for the full contract, including daily-notes vaults. Re-running `setup` is
 safe; completed steps report `[skipped]`. Non-interactive:
@@ -109,6 +110,8 @@ between Exomem and a chat product's built-in memory, see
 Full local setup is in [QUICKSTART.md](QUICKSTART.md). Remote/mobile setup is
 in [docs/remote-quickstart.md](docs/remote-quickstart.md) and
 [docs/deployment.md](docs/deployment.md).
+
+The product model is intentionally simple: built-in AI memory remembers preferences and routing, while Exomem stores durable governed knowledge with sources, proof, history, decisions, records, and review. See [docs/product-model.md](docs/product-model.md) for the full mental model and [docs/knowledge-packs.md](docs/knowledge-packs.md) for pack/admin details.
 
 For development, or to run the sample vault from a checkout instead of a
 package install:
@@ -220,6 +223,8 @@ Run `exomem index` or `kb reconcile` later to heal deferred semantic work.
 
 - **Searches the vault you already own.** Markdown stays in place; exomem does
   not import copies into a proprietary note store.
+- **Adopts messy vaults safely.** `adopt` starts with a read-only report and
+  explicit copy/compile options, so originals remain archival until you choose.
 - **Retrieves across text and media.** Markdown, PDFs, Office docs, images,
   screenshots, audio, and video can become searchable through local extraction.
 - **Keeps sources separate from conclusions.** Raw captures, compiled notes,
@@ -254,6 +259,20 @@ keyword/BM25 lanes served from an FTS5 sidecar index in milliseconds —
 built into stdlib SQLite, so it works on the lean install too. Methodology
 and numbers in [docs/benchmarks.md](docs/benchmarks.md).
 
+## Simple front door
+
+Agents should route normal user requests through simple actions first, then use the typed tools underneath.
+
+| Action | Use when the user says | Backed by |
+| --- | --- | --- |
+| Save | "remember this", "log this", "this is a decision" | `add`, `note`, `link`, `preserve` |
+| Adopt/import | "make this old vault usable", "import my notes safely" | `adopt`, `overview` |
+| Ask | "what do we know about X?", "show the sources" | `find`, `get` |
+| Prove | "save this for the warranty case", "show the evidence" | `preserve`, upload/download, `find` |
+| Review | "what needs cleanup?", "what is stale?" | `attention`, `audit`, `propose_compilation` |
+| Update | "this replaced the old conclusion", "fix that note" | `edit`, `replace`, `reconcile` |
+| Connect | "link this to X", "what should this cite?" | `link`, `suggest_links` |
+
 ## Core tools
 
 exomem exposes typed MCP tools for common knowledge-base work:
@@ -270,6 +289,7 @@ exomem exposes typed MCP tools for common knowledge-base work:
 | `audit` | Check graph and corpus health. |
 | `attention` | Surface review queues such as stale notes, close-by claims, and unprocessed sources. |
 | `overview` | Bounded, read-only structure report of the vault or a subtree — works outside `Knowledge Base/` and before `init`. |
+| `adopt` | Existing-vault adoption: scan-only by default; can save a manifest or copy selected legacy text files as Sources while preserving originals. |
 
 Tier-2 filesystem tools exist for escape hatches such as listing directories,
 creating files, moving pages, trashing files, and recovering from trash. Set

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,12 +6,12 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Registry commands: 28
-- Tier 1 commands: 18
+- Registry commands: 29
+- Tier 1 commands: 19
 - Tier 2 commands: 10
-- Registry-generated MCP commands: 27
-- REST commands: 27
-- CLI commands: 27
+- Registry-generated MCP commands: 28
+- REST commands: 28
+- CLI commands: 28
 - Hand-registered MCP tools: mint_download_token, mint_upload_token, note
 
 ## Command Registry
@@ -25,6 +25,7 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 | audit | 1 | MCP, REST, CLI | read | no | - | categories | Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, stale unprocessed sources, and stale-review candidates. Read-only. |
 | attention | 1 | MCP, REST, CLI | read | no | - | categories, limit | Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only. |
 | overview | 1 | MCP, REST, CLI | read | no | path | path, max_depth, include_hidden, samples | Bounded, read-only structure report of the vault (or a subtree). |
+| adopt | 1 | MCP, REST, CLI | write | no | path | path, mode, max_depth, include_hidden, samples, pack_limit, manifest_path, selected_paths | Adopt / import an existing vault safely: scan first, preserve originals. |
 | evolution | 1 | MCP, REST, CLI | read | no | query | query, limit, scope, projects, tags | How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only. |
 | audit_fix | 1 | MCP, REST, CLI | write | yes | - | dry_run, rebuild_embeddings | Run audit + auto-apply safe fixes; propose-only for risky categories. |
 | reconcile | 1 | MCP, REST, CLI | write | no | - | dry_run | Heal vault drift from out-of-band edits in one pass. |

--- a/docs/knowledge-packs.md
+++ b/docs/knowledge-packs.md
@@ -1,0 +1,75 @@
+# Knowledge packs
+
+Knowledge packs are declarative routing bundles. They help Exomem suggest how a messy vault might map onto durable primitives without hard-coding a new folder tree or asking users to understand the ontology first.
+
+Built-in packs live in `src/exomem/packs/*.json`. The runtime loads them with `importlib.resources`, validates them strictly, and exposes the schema in `adopt` reports through `pack_schema`.
+
+## Built-in packs
+
+- `legal-warranty` — cases, receipts, correspondence, deadlines, and proof.
+- `creative` — references, assets, drafts, productions, taste notes, and releases.
+- `technical` — projects, repositories, decisions, failures, incidents, and runbooks.
+- `health-athletic` — training, symptoms, measurements, protocols, injuries, and goals.
+- `business` — customers, meetings, commitments, contracts, risks, and decisions.
+- `personal-records` — purchases, travel, home, vehicles, admin records, and life logistics.
+
+## Schema
+
+Each pack is a JSON object with these required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable slug. |
+| `name` | Human-readable pack name. |
+| `description` | One-sentence product description. |
+| `primitives` | Durable primitives the pack commonly uses. |
+| `actions` | Simple actions the pack supports: `save`, `adopt`, `ask`, `prove`, `review`, `update`, `connect`. |
+| `examples` | User-facing prompts that should route to this pack. |
+| `signals` | Structural tokens used by adoption scans to suggest the pack. |
+
+Allowed primitives are `source`, `evidence`, `case`, `decision`, `record`, `asset`, `production`, `entity`, `failure`, `pattern`, and `experiment`.
+
+Unknown fields are rejected. That is intentional: a deployment should not believe a pack field is active when this Exomem version ignores it.
+
+## Example
+
+```json
+{
+  "id": "legal-warranty",
+  "name": "Legal / warranty",
+  "description": "Cases, receipts, correspondence, deadlines, and proof.",
+  "primitives": ["source", "evidence", "case", "decision", "record"],
+  "actions": ["save", "prove", "review", "update"],
+  "examples": [
+    "Save this receipt for the laptop warranty case.",
+    "Show the evidence for the landlord dispute."
+  ],
+  "signals": ["legal", "warranty", "receipt", "invoice", "contract"]
+}
+```
+
+## Adoption behavior
+
+Pack suggestions are deterministic. Exomem looks at structural signals from `overview`: folder names, sample file names, counts, and media mix. It does not read every note body or ask a model to classify the vault.
+
+A pack suggestion is a proposed route, not a migration. The safe loop is:
+
+1. Run `adopt(mode="scan-only")`.
+2. Review suggested packs and actions.
+3. Optionally save the manifest under `Knowledge Base/_Adoption/`.
+4. Copy selected legacy files as Sources when provenance matters.
+5. Compile selected material later, with citations.
+
+## Mapping to typed tools
+
+Packs do not bypass governance. They help agents choose existing typed tools:
+
+| Simple action | Typed operation |
+| --- | --- |
+| Save raw material | `add` |
+| Save durable conclusion | `note` or `link` |
+| Preserve proof | `preserve` or upload to Evidence |
+| Ask | `find` and `get` |
+| Review | `audit`, `attention`, `propose_compilation` |
+| Update | `edit`, `replace`, `reconcile` |
+| Connect | `link`, `suggest_links` |

--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -1,0 +1,49 @@
+# Exomem product model
+
+Exomem is durable memory with sources, proof, history, and review for MCP-capable agents.
+
+Built-in AI memory and Exomem should be complementary:
+
+| Layer | Use it for | Do not use it for |
+| --- | --- | --- |
+| Built-in AI memory | Preferences, working rules, tone, routing instructions, small stable facts about how to help the user | Project history, research conclusions, legal/warranty records, source material, proof, supersession history |
+| Exomem | Durable governed knowledge: sources, proof/evidence, decisions, records, compiled conclusions, review queues, and history | Ephemeral chat state or private assistant implementation preferences |
+
+## Simple actions
+
+Users and agents should think in verbs first. Exomem's internal page types still enforce governance, but normal prompts should not require the user to choose them.
+
+| User action | What it means | Backed by |
+| --- | --- | --- |
+| Save | Keep raw material or a durable conclusion | `add`, `note`, `link`, sometimes `preserve` |
+| Adopt/import | Understand an existing vault safely before changing anything | `adopt`, `overview` |
+| Ask | Retrieve what the vault already knows with citations | `find`, `get`, `find(pack=true)` |
+| Prove | Show or preserve proof for a claim, case, warranty, dispute, record, or receipt | `preserve`, `find`, `get`, upload/download tools |
+| Review | Surface stale, unprocessed, broken, or contradictory areas | `attention`, `audit`, `propose_compilation` |
+| Update | Correct, edit, or supersede knowledge while preserving history | `edit`, `replace`, `reconcile` |
+| Connect | Link related notes, entities, decisions, and sources | `link`, `suggest_links` |
+
+## Existing vaults
+
+An existing vault is not a migration problem by default. Exomem treats non-KB folders as read-only input and creates a governed `Knowledge Base/` layer beside them.
+
+The adoption modes are explicit:
+
+| Mode | Writes? | Purpose |
+| --- | --- | --- |
+| `scan-only` | No | Report structure, likely packs, governed vs read-only areas, and next actions |
+| `save-manifest` | Yes, under `Knowledge Base/_Adoption/` only | Save the scan as a durable onboarding artifact |
+| `copy-as-sources` | Yes, under `Knowledge Base/Sources/Imported/` only | Copy selected legacy text files with original path and SHA-256 provenance |
+| `compile-selected` | Planned | Create governed notes from selected sources with citations |
+
+There is no rewrite-in-place onboarding path in the normal product flow.
+
+## Sources versus evidence
+
+A Source is raw input captured so future notes can cite it. An article, meeting transcript, pasted conversation, or research excerpt is usually a Source.
+
+Evidence is proof-bound. A receipt saved for a warranty case, a legal letter, an insurance document, a medical record, or a screenshot preserved for a claim belongs in Evidence. Evidence does not mean "important source"; it means "used as proof for a case, claim, record, or decision."
+
+## Compared with note graph tools
+
+A searchable graph of Markdown notes is useful, but it is not the whole product. Exomem adds governed writes, source-to-note provenance, evidence/proof handling, explicit supersession, review queues, multimodal extraction, and one command registry that exposes the same behavior through MCP, CLI, REST, and OpenAPI.

--- a/openspec/changes/productize-cognition-layer/.openspec.yaml
+++ b/openspec/changes/productize-cognition-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/productize-cognition-layer/design.md
+++ b/openspec/changes/productize-cognition-layer/design.md
@@ -1,0 +1,135 @@
+# productize-cognition-layer — design
+
+## Context
+
+Exomem already has the deep pieces: governed writes, typed pages, sources,
+evidence, supersession, audit/attention, media extraction, hybrid search,
+overview, setup, bootstrap, and a registry-driven command surface. The product
+problem is that those pieces are visible as machinery instead of being composed
+into a simple experience.
+
+The design principle is: expose verbs, not ontology.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make Exomem legible as a durable cognition layer, not just a notes/search
+  tool.
+- Make onboarding an existing vault safe, bounded, and obvious.
+- Provide a simple front-door tool vocabulary for agents.
+- Keep internal page types and governance intact.
+- Introduce knowledge packs as extensible schema/workflow bundles.
+- Clarify Evidence as proof/case-bound material, not a generic raw-input bucket.
+
+**Non-Goals:**
+
+- No automatic rewrite of existing vaults.
+- No server-side LLM classification or summarization.
+- No full SaaS/multi-tenant hosting build in this change.
+- No removal of existing advanced tools.
+- No attempt to match Basic Memory's note grammar.
+
+## Decisions
+
+1. **Adoption is scan-first and read-only by default.**
+   The first-run path for an existing vault is `overview` plus an adoption
+   report/manifest. The default mode is no writes outside `Knowledge Base/`,
+   and no writes at all until the user chooses setup/adoption actions.
+
+2. **A sidecar/adoption manifest is the product bridge.**
+   The manifest records what was found: folder clusters, file counts,
+   frontmatter coverage, wikilinks, likely domains, media, broken links,
+   duplicates, stale areas, and suggested pack mappings. It is deterministic
+   and re-runnable. It does not claim to understand the content semantically.
+
+3. **Knowledge packs compose primitives.**
+   A pack defines recommended page types, frontmatter extensions, routing
+   hints, evidence/case semantics, review checks, and example prompts. It does
+   not hard-code a separate storage engine or require a new top-level folder for
+   every domain.
+
+4. **Evidence is a role, not a dumping ground.**
+   A Source becomes Evidence when preserved or cited for a claim, case, dispute,
+   warranty, legal matter, insurance issue, medical record, purchase record, or
+   other proof-bearing context. The product may call this "proof" or "case
+   files" in user-facing docs.
+
+5. **The MCP surface gets a front door, not a replacement.**
+   Existing typed operations remain the authoritative implementation. The
+   product layer adds readable intent operations/aliases and stronger tool
+   descriptions so agents can route user intent without exposing all internals.
+
+6. **Docs split by audience.**
+   Human docs explain the mental model and workflows. Agent docs explain when
+   to save/search/prove/review/update. Developer/admin docs explain schemas,
+   packs, storage, and command surfaces.
+
+## Pack Shape
+
+Initial pack metadata should be small and inspectable, for example:
+
+```yaml
+id: legal-warranty
+name: Legal / warranty
+description: Cases, purchases, disputes, receipts, correspondence, and proof.
+actions:
+  save:
+    prefer: source
+  prove:
+    prefer: evidence
+  update:
+    prefer: decision
+fields:
+  case:
+    required: [title, status]
+  evidence:
+    required: [case, why_preserved]
+review:
+  - open_deadlines
+  - missing_receipts
+examples:
+  - "Save this receipt for the laptop warranty case."
+```
+
+The exact file format can evolve, but it must stay declarative and generic.
+
+## Front-Door Tool Mapping
+
+The simple verbs are allowed to be aliases or thin orchestration leaves at
+first:
+
+- `save` routes to `add`, `note`, `link`, or `preserve` depending on explicit
+  intent and pack guidance.
+- `ask` wraps `find`/`get`/`pack` retrieval guidance and returns cited material
+  for the agent to reason over.
+- `prove` finds or creates case-bound evidence links.
+- `review` fronts `attention`, `audit`, and unprocessed-source queues.
+- `update` routes to `edit`/`replace` with an explicit reason.
+- `adopt` fronts existing-vault scan and optional manifest/proposal creation.
+
+Where ambiguity matters, the tool should return a short clarification request
+or candidate actions rather than guessing.
+
+## Risks / Trade-offs
+
+- **Ontology sprawl:** packs could become a new complexity layer. Mitigation:
+  packs compose durable primitives and expose simple verbs.
+- **Over-promising adoption:** scan/manifest is not semantic migration.
+  Mitigation: docs and output say "suggested mapping" and "proposed
+  compilation," not "understood everything."
+- **Tool duplication:** front-door verbs could overlap with typed tools.
+  Mitigation: registry metadata marks simple tools as primary and advanced tools
+  as secondary; implementation reuses the existing leaves.
+- **Evidence naming:** "Evidence" may sound legalistic. Mitigation: keep the
+  internal term, but allow user-facing "proof" / "case file" language.
+
+## Open Questions
+
+- Should `ask` be a real MCP tool, or should bootstrap teach agents to compose
+  `find(pack=true)` + `get`? The first tranche can specify behavior and defer
+  implementation if it risks server-side reasoning.
+- Should adoption manifests live under `Knowledge Base/_Adoption/`, in a hidden
+  sidecar directory, or only in command output until the user chooses to save?
+- What is the minimum useful first pack set: legal/warranty, creative,
+  technical, health/athletic, business, personal records?

--- a/openspec/changes/productize-cognition-layer/proposal.md
+++ b/openspec/changes/productize-cognition-layer/proposal.md
@@ -1,0 +1,86 @@
+# productize-cognition-layer
+
+## Why
+
+Exomem's technical depth is not yet legible as a product. The current surface
+exposes the real architecture — Sources, Notes, Entities, Evidence, audit,
+attention, supersession, media extraction, and search controls — but asks the
+user and many agents to understand too much of that ontology up front.
+
+Basic Memory is ahead on packaging because its first-run story is simple:
+Markdown notes become a searchable graph. Exomem's stronger thesis is broader:
+an evolving knowledge base with sources, proof, history, decisions, records,
+review, and agent-safe governance. That thesis needs a product layer that makes
+the depth feel simple instead of complicated.
+
+The immediate gap is not another retrieval lane. It is seamless onboarding and
+adoption:
+
+- a user with an existing vault should see what Exomem found, what stays
+  untouched, and what can be safely compiled into the governed layer;
+- an agent should have a small set of clear verbs instead of exposing every
+  internal operation as a first-choice tool;
+- common user domains should be expressible as extensible knowledge packs rather
+  than hard-coded folder sprawl;
+- docs should explain the simple mental model: built-in AI memory remembers how
+  to work with the user; Exomem stores durable governed knowledge.
+
+## What Changes
+
+- Add a first-class **cognition layer** product contract: Exomem is the durable
+  knowledge base with sources, proof, history, decisions, records, and review.
+  The internal ontology remains, but the public workflow is expressed through
+  simple actions: save, import/adopt, ask, prove, review, update, connect.
+- Add an **adopt existing vault** workflow that upgrades the existing
+  `overview`/setup behavior from "documented safety" to a guided product loop:
+  read-only scan, bounded report, safe mode choices, optional sidecar/adoption
+  manifest, and proposed compilations into `Knowledge Base/`. Originals are
+  never rewritten by default.
+- Add **extensible knowledge packs** as a product concept: small schema/workflow
+  bundles for common domains such as legal/warranty, creative, technical,
+  athletic/health, business, and personal records. Packs compose the durable
+  primitives rather than creating a rigid global taxonomy.
+- Add a **simple agent front door** over the existing registry: clear intent
+  operations or aliases for `save`, `ask`, `prove`, `review`, `update`, and
+  `adopt`, backed by the existing typed operations. Advanced tools remain
+  available but are secondary.
+- Update bootstrap/skill/docs so agents know when to use model memory versus
+  Exomem, when to create source/evidence/compiled knowledge, and how to avoid
+  leaking ontology complexity to the user.
+
+Pure-substrate note: this change adds routing, manifests, schema metadata,
+deterministic scans, and agent guidance. It does not add server-side reasoning.
+Classification is rule/schema based unless a human or external agent explicitly
+decides what to compile.
+
+## Capabilities
+
+### New Capabilities
+
+- `cognition-layer`: user-facing durable knowledge model, simple actions,
+  knowledge packs, evidence-as-proof semantics, and adoption workflow.
+
+### Modified Capabilities
+
+- `guided-setup`: setup must surface the cognition-layer model and route users
+  with existing vaults into adoption rather than only init.
+- `command-surface`: the registry must expose a simple front-door vocabulary
+  for agents while preserving advanced operations.
+- `agent-bootstrap-contract`: bootstrap must teach generic agents the simple
+  workflow and the complementary relationship with built-in AI memory.
+
+## Impact
+
+- Specs: new `cognition-layer` spec plus deltas for `guided-setup`,
+  `command-surface`, and `agent-bootstrap-contract`.
+- Likely implementation areas:
+  - `src/exomem/commands.py` registry metadata/aliases/front-door operations.
+  - setup wizard and/or a new `adopt` command.
+  - scaffold `SKILL.md` and operation guidance.
+  - README/QUICKSTART/docs concept pages.
+  - sample vault showing source → compiled note → evidence/case trail.
+- Tests should cover adoption read-only guarantees, registry/alias visibility,
+  bootstrap guidance, knowledge-pack loading/validation, and scaffold leak
+  safety.
+- This change should absorb or supersede the narrower
+  `document-existing-vault-onboarding` docs-only change.

--- a/openspec/changes/productize-cognition-layer/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/productize-cognition-layer/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,39 @@
+# agent-bootstrap-contract
+
+## MODIFIED Requirements
+
+### Requirement: Generic Client Workflow Guidance
+The bootstrap contract SHALL tell generic agents to search before answering
+project or durable-knowledge questions, treat misses as scoped misses, prefer
+compiled notes for conclusions, use raw sources/evidence for provenance, and
+save durable conclusions as compiled notes. It SHALL also teach the product
+distinction between built-in AI memory and Exomem: built-in memory is for user
+preferences, working rules, and routing instructions; Exomem is for durable
+governed knowledge with sources, proof, history, decisions, records, and review.
+
+#### Scenario: Bootstrap teaches the core workflow
+- **WHEN** an agent reads the bootstrap response
+- **THEN** it can identify the recommended loop from initial lookup through
+  optional `get`/`pack`, reasoning, and `note`/`edit`/`replace`
+- **AND** it can identify the normal, reasoning, and diagnostics `find`
+  defaults
+- **AND** it can identify when to use built-in model memory versus Exomem
+
+### Requirement: Bootstrap Presents Simple Front-Door Actions
+The bootstrap contract SHALL present the primary user/agent actions as save,
+adopt/import, ask, prove, review, update, and connect. For each action it SHALL
+name the preferred tool or composition of tools and the internal typed
+operation(s) that enforce governance. It SHALL keep advanced tools visible but
+secondary.
+
+#### Scenario: Agent can route a proof request
+- **WHEN** an agent reads the bootstrap response and the user asks "prove this"
+  or "save this for my warranty case"
+- **THEN** the agent can identify the evidence/proof workflow
+- **AND** it can distinguish that workflow from ordinary source capture
+
+#### Scenario: Agent can route an existing-vault request
+- **WHEN** an agent reads the bootstrap response and the user asks to import or
+  adopt an old vault
+- **THEN** the agent can identify the scan-first adoption workflow
+- **AND** it knows existing files are read-only by default

--- a/openspec/changes/productize-cognition-layer/specs/cognition-layer/spec.md
+++ b/openspec/changes/productize-cognition-layer/specs/cognition-layer/spec.md
@@ -1,0 +1,107 @@
+# cognition-layer
+
+## ADDED Requirements
+
+### Requirement: Exomem exposes a simple durable-cognition model
+The product documentation and agent bootstrap SHALL describe Exomem as a durable
+knowledge base for sources, proof, history, decisions, records, review, and
+compiled knowledge. The user-facing workflow SHALL be expressed through simple
+actions — save, import/adopt, ask, prove, review, update, and connect — rather
+than requiring users to understand internal page types before first value.
+
+#### Scenario: New user reads the product model
+- **WHEN** a new user reads the quickstart or bootstrap summary
+- **THEN** they see that built-in AI memory is for preferences/routing and
+  Exomem is for durable governed knowledge
+- **AND** the first workflow examples use simple verbs instead of requiring the
+  user to choose Sources, Notes, Entities, Evidence, or supersession directly
+
+### Requirement: Existing vault adoption is scan-first and non-destructive
+The system SHALL provide an adoption workflow for a vault that already contains
+notes or files. The default adoption mode SHALL be read-only and SHALL report
+what was found, what remains untouched, whether `Knowledge Base/` exists, likely
+content clusters, candidate knowledge packs, and proposed next actions. The
+workflow SHALL NOT rewrite, move, delete, add frontmatter to, or restructure
+existing non-KB files by default.
+
+#### Scenario: Existing vault scan does not mutate files
+- **WHEN** adoption scan runs on a vault with existing notes, media, and no
+  `Knowledge Base/`
+- **THEN** the report describes the vault and candidate next actions
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+#### Scenario: Adoption distinguishes searchable from governed
+- **WHEN** adoption scan runs on a vault with sibling folders and an initialized
+  `Knowledge Base/`
+- **THEN** the report states which content is searchable read-only input and
+  which content is governed Exomem-managed knowledge
+
+### Requirement: Adoption supports explicit safe modes
+The adoption workflow SHALL expose explicit modes: scan-only, save-manifest,
+copy-as-sources, and compile-selected. Scan-only SHALL be the default.
+Save-manifest SHALL write only an adoption report under a governed Exomem
+location. Copy-as-sources SHALL copy selected originals into `Sources/Imported`
+or an equivalent governed source location with original path/hash provenance.
+Compile-selected SHALL create compiled knowledge from selected sources with
+source links. Any rewrite-in-place behavior, if ever supported, SHALL be
+advanced-only and never the default.
+
+#### Scenario: Copy mode preserves provenance
+- **WHEN** a user selects files for copy-as-sources
+- **THEN** Exomem creates source records or copies under the governed KB layer
+- **AND** each copied/imported item records original path and content hash
+- **AND** the original file remains unchanged
+
+#### Scenario: Compile mode links back to sources
+- **WHEN** a user compiles selected legacy notes into governed knowledge
+- **THEN** the compiled page cites the imported or original source paths
+- **AND** the operation logs the reason and created paths
+
+### Requirement: Knowledge packs are extensible schema/workflow bundles
+The system SHALL support declarative knowledge packs that compose durable
+primitives such as sources, compiled knowledge, entities, decisions, evidence,
+records, assets, projects/cases, and review state. Packs SHALL define routing
+hints, optional frontmatter extensions, examples, and review checks for a
+domain without requiring a new storage engine or a hard-coded top-level folder
+per domain.
+
+#### Scenario: Built-in packs are listed
+- **WHEN** the system lists available knowledge packs
+- **THEN** it includes built-in packs for legal/warranty, creative, technical,
+  health/athletic, business, and personal records
+- **AND** each pack declares its primitives, actions, and examples
+
+#### Scenario: Custom pack validates
+- **WHEN** a user or deployment adds a custom pack file
+- **THEN** Exomem validates required metadata and rejects malformed packs with a
+  stable error code and remediation
+
+### Requirement: Evidence is treated as case-bound proof
+The product model SHALL distinguish raw Sources from Evidence. A Source is raw
+material captured into the knowledge base. Evidence is a source or artifact used
+as proof for a claim, case, dispute, warranty, insurance issue, legal matter,
+medical record, purchase, or other proof-bearing context. Evidence workflows
+SHALL preserve provenance and SHALL NOT imply that all raw material is evidence.
+
+#### Scenario: Receipt saved for warranty
+- **WHEN** a user asks to save a receipt for a warranty case
+- **THEN** Exomem treats the receipt as proof for that case, preserving source
+  or artifact provenance
+- **AND** retrieval can later answer "show the evidence for this case"
+
+#### Scenario: Article saved as ordinary source
+- **WHEN** a user saves an article for later research with no proof/case intent
+- **THEN** Exomem captures it as a Source, not as Evidence
+
+### Requirement: Product layer hides ontology unless requested
+The agent guidance and user documentation SHALL instruct agents to route user
+intent into the correct internal type while speaking in simple product language.
+Advanced ontology terms MAY be shown when the user asks for implementation
+details, audit output, or file paths, but they SHALL NOT be required for normal
+save, ask, prove, review, update, or adopt workflows.
+
+#### Scenario: Agent saves a durable conclusion
+- **WHEN** the user reaches a durable conclusion in conversation
+- **THEN** the agent can save it through the simple workflow
+- **AND** the response reports the saved path without requiring the user to pick
+  a page type unless the type/scope is genuinely ambiguous

--- a/openspec/changes/productize-cognition-layer/specs/command-surface/spec.md
+++ b/openspec/changes/productize-cognition-layer/specs/command-surface/spec.md
@@ -1,0 +1,67 @@
+# command-surface
+
+## MODIFIED Requirements
+
+### Requirement: Single Command Registry Generates Every Surface
+
+The system SHALL define a single declarative command registry (`commands.py`)
+that enumerates each operation with its name, leaf function, description,
+parameter specs, exposed surfaces, and product-surface metadata. Product-surface
+metadata SHALL identify whether an operation is `primary` or `advanced`, which
+simple action(s) it supports (`save`, `adopt`, `ask`, `prove`, `review`,
+`update`, `connect`), and whether it is safe for first-run/onboarding use. The
+MCP tools, the REST facade, the OpenAPI document, the CLI, and agent bootstrap
+guidance SHALL all derive from this registry metadata. No surface may maintain
+its own separate list of operations.
+
+#### Scenario: One entry exposes an op everywhere
+
+- **WHEN** a new operation is added as a single registry entry with surfaces
+  `{mcp, rest, cli}`
+- **THEN** its MCP tool, its `/api/<name>` REST route, its OpenAPI path, and its
+  `kb <name>` CLI subcommand all exist with no further per-surface edits
+- **AND** removing the entry removes it from all surfaces
+
+#### Scenario: Primary tools are discoverable without hiding advanced tools
+
+- **WHEN** an agent reads the bootstrap contract or generated tool metadata
+- **THEN** it can identify the primary front-door operations for save, adopt,
+  ask, prove, review, update, and connect
+- **AND** advanced typed/file operations remain available for agents that need
+  precise control
+
+### Requirement: Simple Front-Door Actions Route To Typed Operations
+
+The command surface SHALL provide a simple front-door vocabulary for agents.
+The first implementation MAY expose these as registry aliases, metadata, or
+thin orchestration leaves, but the behavior SHALL be backed by the existing
+typed operations rather than duplicating write logic. The front-door vocabulary
+SHALL include save, adopt/import, ask, prove, review, update, and connect.
+
+#### Scenario: Save routes without duplicate write logic
+- **WHEN** the simple save action creates raw input, compiled knowledge, an
+  entity, or proof
+- **THEN** it delegates to the existing typed leaf (`add`, `note`, `link`, or
+  `preserve`/evidence workflow) and preserves the same validation, logging,
+  frontmatter, and write-scope rules
+
+#### Scenario: Review fronts existing queues
+- **WHEN** the simple review action is invoked
+- **THEN** it can surface attention/audit/unprocessed-source findings through a
+  product-level response
+- **AND** the underlying audit/attention operations remain independently
+  callable
+
+### Requirement: Tool Descriptions Teach Intent
+
+Generated MCP tool descriptions SHALL state when an agent should use the tool,
+what kind of durable memory it creates or retrieves, and how it preserves
+sources/provenance. Primary tool descriptions SHALL use simple product language.
+Advanced tool descriptions MAY include internal page-type details.
+
+#### Scenario: Agent sees proof intent
+- **WHEN** the MCP schema/tool-description snapshot is inspected
+- **THEN** the proof/evidence path tells the agent to use it for cases, claims,
+  disputes, warranties, records, or other proof-bearing contexts
+- **AND** it does not describe Evidence as the default destination for all raw
+  input

--- a/openspec/changes/productize-cognition-layer/specs/guided-setup/spec.md
+++ b/openspec/changes/productize-cognition-layer/specs/guided-setup/spec.md
@@ -1,0 +1,46 @@
+# guided-setup
+
+## MODIFIED Requirements
+
+### Requirement: One-command guided local setup
+The system SHALL provide an `exomem setup` CLI subcommand that performs, in
+order: vault-path selection, a pre-init structure scan of the chosen vault, a
+statement of the write contract (writes only under `Knowledge Base/`; existing
+files untouched and read-only), Knowledge Base initialization, search-profile
+selection (lean/hybrid), a doctor preflight, agent/client registration, skill
+installation, optional hook installation, and a per-step summary with next
+steps. Each step SHALL report `[done]`, `[skipped: <reason>]`, or
+`[failed: <reason>]`.
+
+When the chosen vault already contains non-KB content, setup SHALL offer the
+adoption workflow as the next step: scan-only report by default, with explicit
+options to save an adoption manifest, copy selected material as sources, or
+compile selected material into governed knowledge. Setup SHALL NOT imply that
+existing notes must be restructured before Exomem is useful.
+
+#### Scenario: Fresh vault happy path
+- **WHEN** `exomem setup` runs against a directory with existing non-KB content
+- **THEN** the pre-init scan reports the existing files and the write contract,
+  `Knowledge Base/` is created, the skill is installed, and the summary lists
+  every step's outcome
+
+#### Scenario: Existing vault routes to adoption
+- **WHEN** setup detects substantial existing non-KB content
+- **THEN** it states that the content remains untouched/read-only
+- **AND** it offers the adoption workflow as a next step instead of telling the
+  user to restructure their vault
+
+### Requirement: Setup Teaches The Cognition Layer
+The setup summary and first-run docs SHALL explain the simple Exomem model:
+built-in AI memory stores preferences/routing; Exomem stores durable governed
+knowledge with sources, proof, history, decisions, records, and review. The
+summary SHALL include first prompts that use simple verbs rather than internal
+ontology.
+
+#### Scenario: First prompts are simple
+- **WHEN** setup finishes successfully
+- **THEN** the printed next steps include prompts such as "what does this vault
+  look like?", "import/adopt my old notes safely", "what do we know about X?",
+  "show the sources", and "what needs review?"
+- **AND** the prompt examples do not require the user to know internal page
+  types

--- a/openspec/changes/productize-cognition-layer/tasks.md
+++ b/openspec/changes/productize-cognition-layer/tasks.md
@@ -1,0 +1,68 @@
+# productize-cognition-layer — tasks
+
+## 1. Spec / Product Contract
+
+- [x] 1.1 Add the `cognition-layer` spec and validate with OpenSpec.
+- [x] 1.2 Decide whether this change supersedes
+      `document-existing-vault-onboarding`; archive or fold that docs-only
+      change after this plan is accepted.
+- [x] 1.3 Define the canonical user-facing tagline and mental model in README:
+      "durable memory with sources, proof, history, and review" or equivalent.
+
+## 2. Existing Vault Adoption
+
+- [x] 2.1 Design `adopt` output shape: scan summary, untouched-files contract,
+      candidate packs, suggested compile/copy actions, and truncation markers.
+- [x] 2.2 Implement scan-only adoption mode using existing `overview` and
+      vault/link/frontmatter scanners; no writes by default.
+- [x] 2.3 Add optional manifest save mode, with explicit destination and
+      no writes outside `Knowledge Base/`.
+- [x] 2.4 Add tests proving scan-only adoption creates/modifies/deletes no vault
+      files.
+- [x] 2.5 Add a worked existing-vault onboarding path to README/QUICKSTART.
+
+## 3. Knowledge Packs
+
+- [x] 3.1 Define declarative pack schema and built-in pack directory.
+- [x] 3.2 Ship initial packs: legal/warranty, creative, technical,
+      health/athletic, business, personal records.
+- [x] 3.3 Add pack validation tests, including unknown fields and scaffold leak
+      checks.
+- [x] 3.4 Make adoption report suggest likely packs from deterministic signals
+      such as folder names, file names, frontmatter keys, and media types.
+
+## 4. Simple Agent Front Door
+
+- [x] 4.1 Add registry metadata that marks tools as `primary` versus
+      `advanced`, with readable intent descriptions.
+- [x] 4.2 Decide first-tranche implementation for simple verbs:
+      aliases/descriptions only versus thin leaves for `save`, `adopt`,
+      `prove`, `review`, `update`, and possibly `ask`.
+- [x] 4.3 Update MCP schema snapshots after any public tool/description change.
+- [x] 4.4 Add tests that bootstrap and tool schemas expose the simple front door
+      while advanced tools remain available.
+
+## 5. Evidence / Proof Workflow
+
+- [x] 5.1 Update docs and skill guidance: Source = raw input; Evidence = source
+      or artifact used as proof for a claim/case/context.
+- [x] 5.2 Add a case/proof example to the sample vault.
+- [x] 5.3 Add or refine `prove` workflow tests: retrieve existing evidence,
+      link evidence to a case/claim, and avoid treating all sources as evidence.
+
+## 6. Documentation / Onboarding
+
+- [x] 6.1 Human docs: explain Exomem vs built-in AI memory and Exomem vs note
+      graph tools.
+- [x] 6.2 Agent docs/bootstrap: teach search-first, save durable conclusions,
+      prove with evidence, update via supersession, and hide ontology from the
+      user.
+- [x] 6.3 Developer/admin docs: document pack schema, adoption modes, and how
+      advanced typed tools map under simple verbs.
+
+## 7. Verification
+
+- [x] 7.1 Run OpenSpec validation.
+- [x] 7.2 Run `uv run pytest -q` or the targeted test subset if the full suite
+      is too slow for the tranche.
+- [x] 7.3 Run scaffold leak tests after docs/skill changes.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -881,7 +881,59 @@ def _collect_raw_args(
     return raw
 
 
-def _print_human(result) -> None:
+def _print_adopt_human(result: dict) -> None:
+    summary = result.get("summary") or {}
+    totals = summary.get("totals") or {}
+    governance = result.get("governance") or {}
+
+    print("Adoption report")
+    print(f"  Mode: {result.get('mode', 'scan-only')}")
+    print(
+        "  Scan: "
+        f"{totals.get('files', 0)} files, "
+        f"{totals.get('markdown', 0)} markdown, "
+        f"{totals.get('dirs', 0)} folders"
+    )
+    if governance.get("kb_present"):
+        print(f"  Governed layer: {governance.get('governed_path') or kb_prefix()}")
+    else:
+        print("  Governed layer: not initialized yet")
+    print("  Originals: untouched; non-KB files stay read-only input.")
+
+    packs = result.get("pack_suggestions") or []
+    print("\nLikely packs")
+    if packs:
+        for pack in packs[:6]:
+            name = pack.get("name") or pack.get("id") or "unknown"
+            score = int(pack.get("score") or 0)
+            signals = ", ".join(pack.get("matched_signals") or [])
+            suffix = f" - {signals}" if signals else " - default starting pack"
+            print(f"  - {name} ({score} signal{'s' if score != 1 else ''}){suffix}")
+    else:
+        print("  - None suggested by the structural scan")
+
+    actions = result.get("next_actions") or []
+    print("\nSafe next actions")
+    for action in actions:
+        print(
+            f"  - {action.get('action')} [{action.get('status')}]: "
+            f"{action.get('description')}"
+        )
+
+    if manifest := result.get("manifest"):
+        print(f"\nSaved manifest: {manifest.get('path')}")
+    if copy := result.get("copy"):
+        copied = copy.get("copied_sources") or []
+        skipped = copy.get("skipped") or []
+        print(f"\nCopied sources: {len(copied)} copied, {len(skipped)} skipped")
+        for item in copied[:10]:
+            print(f"  - {item.get('original_path')} -> {item.get('source_path')}")
+
+
+def _print_human(result, *, op: str | None = None) -> None:
+    if op == "adopt" and isinstance(result, dict):
+        _print_adopt_human(result)
+        return
     if isinstance(result, list):
         if not result:
             print("(no results)")
@@ -948,7 +1000,7 @@ def _core_op_main(argv: list[str]) -> int:
     if as_json:
         print(json.dumps(cli_ops.envelope(True, data=result), ensure_ascii=False, default=str))
     else:
-        _print_human(result)
+        _print_human(result, op=cmd.name)
     return 0
 
 

--- a/src/exomem/_sample_vault/Knowledge Base/Evidence/Warranty/Receipts/2026-06-30-laptop-receipt.md
+++ b/src/exomem/_sample_vault/Knowledge Base/Evidence/Warranty/Receipts/2026-06-30-laptop-receipt.md
@@ -1,0 +1,9 @@
+# Sample Laptop Receipt
+
+Vendor: Example Store
+Item: Sample Laptop
+Date: 2026-06-30
+Warranty term: 24 months
+
+This generic receipt is sample evidence for a warranty case. It is not a real
+purchase record.

--- a/src/exomem/_sample_vault/Knowledge Base/Notes/Research/Sample/sample-architecture.md
+++ b/src/exomem/_sample_vault/Knowledge Base/Notes/Research/Sample/sample-architecture.md
@@ -20,4 +20,5 @@ What does the smallest useful exomem vault need to demonstrate?
 - A raw source under `Sources/`.
 - A compiled conclusion under `Notes/`.
 - A concept entity under `Entities/`.
+- A proof artifact under `Evidence/`, e.g. [[Knowledge Base/Evidence/Warranty/Receipts/2026-06-30-laptop-receipt]].
 - Clean wikilinks between them.

--- a/src/exomem/_sample_vault/Knowledge Base/_Schema/SKILL.md
+++ b/src/exomem/_sample_vault/Knowledge Base/_Schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: exomem
 description: Minimal public sample schema for exomem smoke tests.
-version: 0.1.0
+version: 0.1.1
 ---
 
 # Knowledge Base Sample Schema
@@ -9,3 +9,10 @@ version: 0.1.0
 This is a deliberately tiny schema stub for the public sample vault. The full
 starter schema ships in `src/exomem/_scaffold/_Schema/` and is installed by
 `exomem init`.
+
+The sample vault demonstrates the product layers in miniature:
+
+- `Sources/` keeps raw captured input.
+- `Notes/` keeps compiled knowledge.
+- `Entities/` keeps reusable typed nodes.
+- `Evidence/` keeps proof artifacts for a case or claim.

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -28,7 +28,7 @@ is always clear.
 
 - `Sources/` — raw inputs. Append-only. Never edited after capture.
 - `Notes/`, `Entities/` — compiled, structured, supersedable. Always carry frontmatter, sources, and links.
-- `Evidence/` — raw factual artifacts (binaries, documents, screenshots). Append-only. No analysis at this layer.
+- `Evidence/` — proof/case-bound artifacts (binaries, documents, screenshots). Append-only. No analysis at this layer. A raw item is a Source by default; it becomes Evidence when preserved for a claim, case, dispute, warranty, record, or other proof-bearing context.
 - Anything outside `Knowledge Base/` — Claude reads, Claude does not write.
 
 ## Proactive engagement
@@ -142,7 +142,7 @@ you'll almost always need `find` (search), `get` (read a page), and one or more
 of `note`, `add`, `link`, `suggest_links`, `edit`, `audit`. In Claude Code, load
 them by exact name in a single call:
 
-`ToolSearch("select:find,get,note,add,link,suggest_links,edit,audit")`
+`ToolSearch("select:adopt,overview,find,get,note,add,link,suggest_links,edit,audit")`
 
 On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 "search the knowledge base", "read a KB page", "compile a note" — and each
@@ -158,6 +158,27 @@ mode, reranking, `pack`, or `include_timings`.
 
 The Tier 2 filesystem ops below may be turned off on lean deployments
 (`EXOMEM_DISABLE_TIER2`), in which case only the Tier 1 ops are registered.
+
+
+## Simple front door
+
+Speak to users in simple product actions; use the typed operations underneath.
+Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
+`replace` unless that implementation detail matters.
+
+| User action | Preferred route |
+|---|---|
+| save | `add` for raw material; `note`/`link` for durable conclusions; `preserve` only for proof-bound material |
+| adopt/import | `adopt(mode="scan-only")` first; then ask before `save-manifest`, `copy-as-sources`, or compile actions |
+| ask | `find` first, then `get` or `find(pack=true)` for synthesis context |
+| prove | `preserve` or upload to Evidence for cases, claims, warranties, disputes, records, and receipts |
+| review | `attention`, `audit`, or `propose_compilation` |
+| update | `edit` for small changes; `replace` for supersession; `reconcile` for out-of-band drift |
+| connect | `link` and `suggest_links` |
+
+Built-in AI memory is for preferences, working rules, and routing instructions.
+Exomem is for durable governed knowledge with sources, proof, history, decisions,
+records, review, and compiled conclusions.
 
 ## Operations
 
@@ -185,6 +206,7 @@ and index updates are determined by the operation, not the caller.
 | **get** | Read a full file by path; `frontmatter_only=true` returns just the frontmatter. Returns `content_hash` + `mtime` for the two-writer drift guard (echo `content_hash` to `edit` via `expected_hash`). Read-only | — |
 | **audit** | Lint pass: orphans, broken links, supersession integrity, aged unprocessed sources | proposals only |
 | **overview** | Bounded structure report of the vault or a subtree — folder tree, counts, frontmatter coverage, junk candidates. Works outside the KB and pre-init (read-only) | — |
+| **adopt** | Safe first-run adoption workflow for an existing vault: scan-only by default; can save a manifest or copy selected legacy text files as Sources while preserving originals | `Knowledge Base/_Adoption/` or `Sources/Imported/` only in explicit write modes |
 | **propose_compilation** | Draft a note scaffold from unprocessed source(s) — the backlog-drain companion to audit (read-only) | proposals only |
 | **replace** | Supersession: mark old, write new with header pointer | both old + new |
 | **reconcile** | Heal drift from out-of-band edits (any editor/sync/mobile, e.g. Obsidian): recompute index counts + re-embed stale files + report remaining drift. Idempotent; `dry_run` reports only | drifted indexes + embedding sidecar |
@@ -281,6 +303,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "log this batch," "add this episode," "record this launch" → **note** with type=production-log
 - "this is connected to [[X]]," "create an entity for X" → **link**
 - "preserve this letter," "file this in evidence," "save this for the record" → **preserve**
+- "import my vault," "adopt these notes," "make this old knowledge base usable" → **adopt** first (`mode="scan-only"`), then ask before `save-manifest`, `copy-as-sources`, or compile actions
 - "update the skill," "the KB structure needs to change" → no MCP tool — hand-edit `_Schema/` files directly
 - "fill in the take for X," "set the take on that row" → **edit** (`row_key`+`take`)
 - "make these few edits to the page" (same page) → **edit** (`edits=[…]`)
@@ -291,6 +314,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "what should I compile next," "drain the source backlog" → **propose_compilation**
 - "audit the KB," "lint the vault," "check for orphans" → **audit**
 - "what does this vault look like," "assess my vault," "how is this vault organized" → **overview**
+- "what should Exomem do with this existing vault," "how can we migrate this safely" → **adopt**
 - "I edited the vault directly / on my phone — sync it up," "heal the drift" → **reconcile**
 - "this replaces the old strategy," "supersede the old note on X" → **replace**
 - "make a new folder for X" → **create_file** (`kind="dir"`, Tier 2)
@@ -364,9 +388,11 @@ Vector embeddings live in a per-machine sidecar at
 Writers refresh it incrementally after every atomic batch. To bootstrap or after
 drift, call `audit_fix(rebuild_embeddings=true)`.
 
-### Assessing a vault you didn't build
+### Assessing or adopting a vault you didn't build
 
-**Make this your first move in any unfamiliar vault.** For structural questions —
+**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
+
+For structural questions —
 "what does this vault look like," "how is this vault organized," "is there junk in
 here" — and simply to learn the layout before you write, run **overview** first: one bounded,
 read-only report of folder structure, counts, frontmatter coverage, naming
@@ -375,7 +401,7 @@ works on any folder under the vault root, including trees outside
 `Knowledge Base/` (a `Daily/` or `Journal/` folder), and on vaults with no KB at
 all. The folders it reports *outside* `Knowledge Base/` are read-only input — link
 to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `list_directory` on folders of interest,
-`find scope="vault"` for content, targeted `get` for individual files. **Never
+`find scope="vault"` for content, targeted `get` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
 bulk-read a vault file-by-file to answer a structural question** — the report
 answers in one call what would otherwise cost hundreds of reads.
 

--- a/src/exomem/adopt.py
+++ b/src/exomem/adopt.py
@@ -1,0 +1,586 @@
+"""Existing-vault adoption report.
+
+``adopt`` is the product-facing companion to ``overview``: it says what Exomem
+found, what remains untouched, which packs look relevant, and which safe next
+actions are available. The default mode is read-only and must work before
+``Knowledge Base/`` exists. Write modes are explicit and only write under the
+governed Knowledge Base layer.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from . import indexes, knowledge_packs, overview as overview_module
+from .kbdir import kb_dirname, kb_prefix
+from .vault import (
+    PlannedWrite,
+    VaultPathError,
+    batch_atomic_write,
+    kb_root,
+    prepend_log_entry,
+    resolve_under_vault,
+    slugify_with_truncation_check,
+    unique_path,
+)
+
+DEFAULT_MODE = "scan-only"
+SUPPORTED_MODES = ("scan-only", "save-manifest", "copy-as-sources")
+PLANNED_MODES = ("compile-selected",)
+ADOPTION_DIR = "_Adoption"
+IMPORTED_SOURCE_FOLDER = "Imported"
+_TEXT_IMPORT_SUFFIXES = frozenset(
+    {".md", ".markdown", ".txt", ".text", ".csv", ".tsv", ".json", ".yaml", ".yml", ".rst", ".log"}
+)
+
+
+class AdoptError(Exception):
+    """Structured failure: ``code`` is machine-readable, ``reason`` human-readable."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(f"{code}: {reason}")
+        self.code = code
+        self.reason = reason
+
+
+def _safe_next_actions(kb_present: bool) -> list[dict]:
+    actions = [
+        {
+            "action": "scan-only",
+            "status": "done",
+            "description": "Read-only structure and pack report. No files changed.",
+        }
+    ]
+    if kb_present:
+        actions.extend(
+            [
+                {
+                    "action": "save-manifest",
+                    "status": "available",
+                    "description": (
+                        f"Save this adoption report under {kb_dirname()}/{ADOPTION_DIR}/ "
+                        "without touching sibling folders."
+                    ),
+                },
+                {
+                    "action": "copy-as-sources",
+                    "status": "available",
+                    "description": (
+                        f"Copy explicitly selected legacy text files into governed "
+                        f"{kb_dirname()}/Sources/{IMPORTED_SOURCE_FOLDER}/ with original "
+                        "path/hash provenance. Originals remain unchanged."
+                    ),
+                },
+                {
+                    "action": "compile-selected",
+                    "status": "planned",
+                    "description": (
+                        "Create governed notes from selected sources, linked back "
+                        "to originals or imported source copies."
+                    ),
+                },
+            ]
+        )
+    else:
+        actions.append(
+            {
+                "action": "initialize-kb",
+                "status": "available",
+                "description": (
+                    f"Run setup/init to create {kb_dirname()}/ beside existing files "
+                    "before saving manifests or compiled knowledge."
+                ),
+            }
+        )
+    return actions
+
+
+def _governance(scan: dict) -> dict:
+    kb = scan.get("kb") or {}
+    present = bool(kb.get("present"))
+    return {
+        "kb_present": present,
+        "governed_path": kb.get("path") if present else None,
+        "read_only_input": (
+            "All existing files outside the governed Knowledge Base are searchable "
+            "read-only input. Exomem does not rewrite, move, delete, or add "
+            "frontmatter to them by default."
+        ),
+    }
+
+
+def _require_kb(root: Path) -> None:
+    if not (root / kb_dirname()).is_dir():
+        raise AdoptError(
+            "KB_NOT_INITIALIZED",
+            f"{kb_dirname()}/ is required for this adopt mode; run setup/init first",
+        )
+
+
+def _today(today: dt.date | None) -> dt.date:
+    return today or dt.date.today()
+
+
+def _resolve_manifest_path(root: Path, manifest_path: str | None, today: dt.date) -> tuple[Path, str]:
+    raw = (manifest_path or "").strip().replace("\\", "/")
+    defaulted = not raw
+    if defaulted:
+        raw = f"{kb_prefix()}{ADOPTION_DIR}/{today.isoformat()}-adoption-manifest.md"
+    elif "/" not in raw:
+        raw = f"{kb_prefix()}{ADOPTION_DIR}/{raw}"
+    if raw.endswith("/"):
+        raise AdoptError("INVALID_MANIFEST_PATH", "manifest_path must name a markdown file")
+    if not raw.startswith(kb_prefix()):
+        raise AdoptError(
+            "INVALID_MANIFEST_PATH",
+            f"manifest_path must be under {kb_dirname()}/",
+        )
+    if not raw.lower().endswith(".md"):
+        raw += ".md"
+    try:
+        target, rel = resolve_under_vault(root, raw)
+    except VaultPathError as e:
+        raise AdoptError(e.code, e.reason) from e
+    if not rel.startswith(kb_prefix()):
+        raise AdoptError(
+            "INVALID_MANIFEST_PATH",
+            f"manifest_path must be under {kb_dirname()}/",
+        )
+    if defaulted:
+        target = unique_path(target.parent, target.stem, target.suffix)
+        rel = target.relative_to(root).as_posix()
+    elif target.exists():
+        raise AdoptError("MANIFEST_EXISTS", f"manifest already exists: {rel}")
+    return target, rel
+
+
+def _compact_report(report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "mode": report.get("mode"),
+        "write_contract": report.get("write_contract"),
+        "governance": report.get("governance"),
+        "summary": report.get("summary"),
+        "pack_suggestions": report.get("pack_suggestions"),
+        "next_actions": report.get("next_actions"),
+        "overview": report.get("overview"),
+    }
+
+
+def _render_manifest(report: dict[str, Any], *, rel_path: str, today: dt.date) -> str:
+    compact = _compact_report(report)
+    suggested = report.get("pack_suggestions") or []
+    actions = report.get("next_actions") or []
+    totals = ((report.get("summary") or {}).get("totals") or {})
+    lines = [
+        "---",
+        "type: adoption-manifest",
+        f"created: {today.isoformat()}",
+        "status: active",
+        "tags: [adoption, onboarding]",
+        "---",
+        "",
+        "# Adoption Manifest",
+        "",
+        f"Saved at `{rel_path}` by `adopt(mode=\"save-manifest\")`.",
+        "",
+        "## Write Contract",
+        "",
+        str(report.get("write_contract", "")),
+        "",
+        "## Scan Summary",
+        "",
+        f"- Files: {totals.get('files', 0)}",
+        f"- Directories: {totals.get('dirs', 0)}",
+        f"- Markdown: {totals.get('markdown', 0)}",
+        f"- Binary/media-like files: {totals.get('binary', 0)}",
+        "",
+        "## Suggested Knowledge Packs",
+        "",
+    ]
+    if suggested:
+        for pack in suggested:
+            signals = ", ".join(pack.get("matched_signals") or [])
+            suffix = f" (signals: {signals})" if signals else ""
+            lines.append(f"- {pack.get('name', pack.get('id'))}{suffix}")
+    else:
+        lines.append("- None suggested by structural signals.")
+    lines.extend(["", "## Safe Next Actions", ""])
+    for action in actions:
+        lines.append(
+            f"- {action.get('action')} [{action.get('status')}]: {action.get('description')}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Machine-Readable Report",
+            "",
+            "```json",
+            json.dumps(compact, indent=2, sort_keys=True, ensure_ascii=False, default=str),
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _add_manifest_index_writes(
+    *,
+    root: Path,
+    writes: list[PlannedWrite],
+    rel_path: str,
+    today: dt.date,
+) -> list[str]:
+    warnings: list[str] = []
+    kb = kb_root(root)
+    rel_no_ext = rel_path[:-3] if rel_path.endswith(".md") else rel_path
+    top_index = kb / "index.md"
+    if top_index.exists():
+        top_text, _trim = indexes._prepend_recent_activity(
+            top_index.read_text(encoding="utf-8"),
+            date_iso=today.isoformat(),
+            summary=f"`{rel_no_ext.removeprefix(kb_prefix())}` (adoption manifest) — saved scan-first existing-vault report",
+        )
+        sub_writes, top_text = indexes.compute_subindex_writes(root, top_index_text=top_text)
+        writes.append(PlannedWrite(path=top_index, content=top_text or top_index.read_text(encoding="utf-8")))
+        writes.extend(sub_writes)
+    else:
+        warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
+    log_file = kb / "log.md"
+    if log_file.exists():
+        writes.append(
+            PlannedWrite(
+                path=log_file,
+                content=prepend_log_entry(
+                    log_file.read_text(encoding="utf-8"),
+                    date_iso=today.isoformat(),
+                    op="adopt",
+                    rel_path_no_ext=rel_no_ext,
+                    body="Saved existing-vault adoption manifest. Originals remain untouched.",
+                ),
+            )
+        )
+    else:
+        warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
+    return warnings
+
+
+def _save_manifest(
+    root: Path,
+    report: dict[str, Any],
+    *,
+    manifest_path: str | None,
+    today: dt.date,
+) -> dict:
+    _require_kb(root)
+    target, rel = _resolve_manifest_path(root, manifest_path, today)
+    content = _render_manifest(report, rel_path=rel, today=today)
+    writes = [PlannedWrite(path=target, content=content)]
+    warnings = _add_manifest_index_writes(root=root, writes=writes, rel_path=rel, today=today)
+    batch_atomic_write(writes, vault_root=root)
+    return {"path": rel, "warnings": warnings}
+
+
+def _title_from_text(path: Path, text: str) -> str:
+    for line in text.splitlines()[:40]:
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip() or path.stem
+    return path.stem.replace("-", " ").replace("_", " ").strip() or path.stem
+
+
+def _fence_for(text: str) -> str:
+    run = 3
+    while "`" * run in text:
+        run += 1
+    return "`" * run
+
+
+def _render_imported_source(
+    *,
+    title: str,
+    rel_original: str,
+    sha256: str,
+    size: int,
+    date_iso: str,
+    content: str,
+) -> str:
+    fence = _fence_for(content)
+    return "\n".join(
+        [
+            "---",
+            "type: source",
+            "source_type: other",
+            f"captured: {date_iso}",
+            f"imported_from: {rel_original}",
+            f"original_sha256: {sha256}",
+            f"original_bytes: {size}",
+            "tags: [imported]",
+            "ingested_into: []",
+            "---",
+            "",
+            f"# Source: Imported legacy note - {title}",
+            "",
+            f"> Copied from `{rel_original}` by `adopt(mode=\"copy-as-sources\")`. The original remains unchanged.",
+            "",
+            "## Original Metadata",
+            "",
+            f"- Original path: `{rel_original}`",
+            f"- SHA-256: `{sha256}`",
+            f"- Bytes: {size}",
+            "",
+            "## Capture",
+            "",
+            fence,
+            content.rstrip(),
+            fence,
+            "",
+        ]
+    )
+
+
+def _resolve_selected_text_file(root: Path, raw: str) -> tuple[Path, str] | dict:
+    try:
+        abs_path, rel = resolve_under_vault(root, raw, must_exist=True, must_be_file=True)
+    except VaultPathError as e:
+        return {"path": raw, "code": e.code, "reason": e.reason}
+    if rel.startswith(kb_prefix()):
+        return {
+            "path": rel,
+            "code": "ALREADY_GOVERNED",
+            "reason": f"copy-as-sources expects legacy files outside {kb_dirname()}/",
+        }
+    if abs_path.suffix.lower() not in _TEXT_IMPORT_SUFFIXES:
+        return {
+            "path": rel,
+            "code": "UNSUPPORTED_IMPORT_TYPE",
+            "reason": "copy-as-sources currently imports text/markdown-like files only",
+        }
+    return abs_path, rel
+
+
+def _copy_as_sources(
+    root: Path,
+    *,
+    selected_paths: list[str] | None,
+    today: dt.date,
+) -> dict:
+    _require_kb(root)
+    if not selected_paths:
+        raise AdoptError(
+            "MISSING_SELECTION",
+            "copy-as-sources requires selected_paths; scan first, then pass explicit files",
+        )
+
+    kb = kb_root(root)
+    folder = kb / "Sources" / IMPORTED_SOURCE_FOLDER
+    folder.mkdir(parents=True, exist_ok=True)
+    date_iso = today.isoformat()
+    copied: list[dict] = []
+    skipped: list[dict] = []
+    writes: list[PlannedWrite] = []
+
+    for raw in selected_paths:
+        resolved = _resolve_selected_text_file(root, raw)
+        if isinstance(resolved, dict):
+            skipped.append(resolved)
+            continue
+        abs_path, rel = resolved
+        data = abs_path.read_bytes()
+        sha = hashlib.sha256(data).hexdigest()
+        text = data.decode("utf-8", errors="replace")
+        title = _title_from_text(abs_path, text)
+        slug, slug_warning = slugify_with_truncation_check(title)
+        target = unique_path(folder, f"{date_iso}-{slug}")
+        rel_target = target.relative_to(root).as_posix()
+        if slug_warning:
+            skipped.append({"path": rel, "code": "SLUG_TRUNCATED", "reason": slug_warning})
+        writes.append(
+            PlannedWrite(
+                path=target,
+                content=_render_imported_source(
+                    title=title,
+                    rel_original=rel,
+                    sha256=sha,
+                    size=len(data),
+                    date_iso=date_iso,
+                    content=text,
+                ),
+            )
+        )
+        copied.append(
+            {
+                "original_path": rel,
+                "source_path": rel_target,
+                "original_sha256": sha,
+                "original_bytes": len(data),
+            }
+        )
+
+    if not copied:
+        return {"copied_sources": [], "skipped": skipped, "warnings": ["no importable files copied"]}
+
+    sources_dir = kb / "Sources"
+    post_counts = indexes._count_sources(sources_dir)
+    post_counts[IMPORTED_SOURCE_FOLDER] = post_counts.get(IMPORTED_SOURCE_FOLDER, 0) + len(copied)
+
+    sources_index = sources_dir / "index.md"
+    warnings: list[str] = []
+    if sources_index.exists():
+        sources_text = indexes._replace_by_type_section(
+            sources_index.read_text(encoding="utf-8"),
+            folder_title=IMPORTED_SOURCE_FOLDER,
+            folder_description="copied legacy-vault material with provenance",
+            counts=post_counts,
+        )
+        for item in reversed(copied):
+            rel_no_ext = item["source_path"][:-3]
+            sources_text = indexes._prepend_recent_capture(
+                sources_text,
+                date_iso=date_iso,
+                rel_source_path=rel_no_ext,
+            )
+        writes.append(PlannedWrite(path=sources_index, content=sources_text))
+    else:
+        warnings.append(f"{kb_prefix()}Sources/index.md missing; skipped Sources index update")
+
+    top_index = kb / "index.md"
+    if top_index.exists():
+        summary = (
+            f"`Sources/{IMPORTED_SOURCE_FOLDER}/` (imported sources) - copied "
+            f"{len(copied)} selected legacy file(s) with original path/hash provenance"
+        )
+        top_text, trim_note = indexes._update_top_index(
+            top_index.read_text(encoding="utf-8"),
+            counts=post_counts,
+            date_iso=date_iso,
+            activity_summary=summary,
+        )
+        sub_writes, top_text = indexes.compute_subindex_writes(root, top_index_text=top_text)
+        writes.append(PlannedWrite(path=top_index, content=top_text or top_index.read_text(encoding="utf-8")))
+        writes.extend(sub_writes)
+        if trim_note:
+            warnings.append(trim_note)
+    else:
+        warnings.append(f"{kb_prefix()}index.md missing; skipped Recent activity bump")
+
+    log_file = kb / "log.md"
+    if log_file.exists():
+        body_lines = [
+            f"Copied {len(copied)} selected legacy file(s) into Sources/{IMPORTED_SOURCE_FOLDER}/. Originals remain unchanged.",
+            "",
+        ]
+        for item in copied:
+            body_lines.append(
+                f"- {item['original_path']} -> {item['source_path']} sha256={item['original_sha256']}"
+            )
+        writes.append(
+            PlannedWrite(
+                path=log_file,
+                content=prepend_log_entry(
+                    log_file.read_text(encoding="utf-8"),
+                    date_iso=date_iso,
+                    op="adopt-copy",
+                    rel_path_no_ext=f"{kb_prefix()}Sources/{IMPORTED_SOURCE_FOLDER}",
+                    body="\n".join(body_lines),
+                ),
+            )
+        )
+    else:
+        warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
+
+    batch_atomic_write(writes, vault_root=root)
+    return {"copied_sources": copied, "skipped": skipped, "warnings": warnings}
+
+
+def adopt(
+    root: Path | str,
+    *,
+    path: str = "",
+    mode: str = DEFAULT_MODE,
+    max_depth: int = overview_module.DEFAULT_MAX_DEPTH,
+    include_hidden: bool = False,
+    samples: int = 5,
+    pack_limit: int = 6,
+    manifest_path: str | None = None,
+    selected_paths: list[str] | None = None,
+    today: dt.date | None = None,
+) -> dict:
+    """Return an adoption report for an existing vault.
+
+    Args:
+        path: Optional vault subtree to scan. Defaults to the vault root.
+        mode: Adoption mode. ``scan-only`` is read-only; write modes are
+            explicit and only write under ``Knowledge Base/``.
+        max_depth: Folder-tree depth cap passed to ``overview``.
+        include_hidden: Include hidden files/directories in the scan.
+        samples: Sample filename count per folder.
+        pack_limit: Maximum pack suggestions to return.
+        manifest_path: Optional markdown destination for ``save-manifest``.
+        selected_paths: Explicit vault-relative files for ``copy-as-sources``.
+
+    Scan-only never writes. Unsupported modes fail explicitly instead of
+    silently pretending to migrate content.
+    """
+    if mode not in SUPPORTED_MODES:
+        planned = ", ".join(PLANNED_MODES)
+        raise AdoptError(
+            "UNSUPPORTED_MODE",
+            f"adopt mode {mode!r} is not implemented yet; planned safe modes: {planned}",
+        )
+    root_path = Path(root)
+    run_date = _today(today)
+    try:
+        scan = overview_module.overview(
+            root_path,
+            path=path,
+            max_depth=max_depth,
+            include_hidden=include_hidden,
+            samples=samples,
+        )
+    except overview_module.OverviewError as e:
+        raise AdoptError(e.code, e.reason) from e
+
+    governance = _governance(scan)
+    kb_present = bool(governance["kb_present"])
+    report: dict[str, Any] = {
+        "mode": mode,
+        "implemented_modes": list(SUPPORTED_MODES),
+        "planned_modes": list(PLANNED_MODES),
+        "scope_note": overview_module.SCOPE_NOTE,
+        "write_contract": (
+            "Default adoption is read-only. Originals stay where they are. "
+            "Governed Exomem writes happen only under Knowledge Base/ after an "
+            "explicit save/copy/compile action."
+        ),
+        "governance": governance,
+        "summary": {
+            "root": scan.get("root", ""),
+            "totals": scan.get("totals", {}),
+            "kb": scan.get("kb", {}),
+            "junk_counts": (scan.get("junk") or {}).get("counts", {}),
+            "skipped": scan.get("skipped", {}),
+        },
+        "pack_suggestions": knowledge_packs.suggest_packs(scan, limit=pack_limit),
+        "available_packs": knowledge_packs.list_builtin_packs(),
+        "pack_schema": knowledge_packs.pack_schema(),
+        "next_actions": _safe_next_actions(kb_present),
+        "overview": scan,
+    }
+    if mode == "save-manifest":
+        report["manifest"] = _save_manifest(
+            root_path,
+            report,
+            manifest_path=manifest_path,
+            today=run_date,
+        )
+    elif mode == "copy-as-sources":
+        report["copy"] = _copy_as_sources(
+            root_path,
+            selected_paths=selected_paths,
+            today=run_date,
+        )
+    return report

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -66,6 +66,9 @@ class Command:
     cli_writes: bool = False
     needs_schema: bool = False
     description: str = ""
+    product_surface: str = "advanced"
+    product_actions: tuple[str, ...] = ()
+    first_run_safe: bool = False
 
     @property
     def doc(self) -> str:

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -28,6 +28,7 @@ from fastmcp.utilities.types import Image as FastMCPImage
 from mcp.types import TextContent
 
 from . import add as add_module
+from . import adopt as adopt_module
 from . import append_to_file as append_to_file_module
 from . import attention as attention_module
 from . import audit as audit_module
@@ -140,7 +141,7 @@ def op_bootstrap(
     compute_policy = mode_module.resolved()
     requested_workflow = workflow.strip() if workflow and workflow.strip() else "general"
     payload: dict = {
-        "contract_version": "2026-07-06.1",
+        "contract_version": "2026-07-07.1",
         "profile": profile,
         "server": {
             "name": "exomem",
@@ -150,10 +151,21 @@ def op_bootstrap(
             "content_included": False,
             "compute_policy": compute_policy,
         },
+        "memory_model": {
+            "built_in_ai_memory": (
+                "Use for user preferences, working rules, and the instruction to route "
+                "durable knowledge into Exomem."
+            ),
+            "exomem": (
+                "Use for durable governed knowledge: sources, proof/evidence, "
+                "history, decisions, records, review, and compiled conclusions."
+            ),
+        },
         "workflow": {
             "requested": requested_workflow,
             "loop": [
                 "bootstrap",
+                "adopt or overview when first seeing an existing vault",
                 "find",
                 "get or find(pack=true) when more context is needed",
                 "reason in the agent",
@@ -177,6 +189,11 @@ def op_bootstrap(
             "reasoning_lookup": {
                 "tool": "find",
                 "args": {"pack": True},
+            },
+            "adopt_existing_vault": {
+                "tool": "adopt",
+                "args": {"mode": "scan-only"},
+                "when": "first-run import/adoption of an existing vault",
             },
             "diagnostics_lookup": {
                 "tool": "find",
@@ -227,10 +244,15 @@ def op_bootstrap(
                 "try synonyms and singular/plural forms",
                 "try adjacent domain terms",
                 "try scope='vault' if Knowledge Base recall is sparse",
+                "use adopt(mode='scan-only') before proposing migration/copy actions",
                 "try pack=true for synthesis instead of many get calls",
             ],
         },
+        "front_door_actions": product_front_door_catalog(),
+        "tool_catalog": product_tool_catalog(),
         "common_tools": [
+            "adopt",
+            "overview",
             "find",
             "get",
             "note",
@@ -244,6 +266,10 @@ def op_bootstrap(
 
     if profile in ("full", "diagnostics"):
         payload["examples"] = [
+            {
+                "goal": "safe existing-vault adoption",
+                "call": "adopt(mode='scan-only')",
+            },
             {
                 "goal": "cheap proactive recall",
                 "call": "find(query='...', detail='compact', rerank=false)",
@@ -1855,6 +1881,57 @@ def op_overview(
         raise ValueError(f"{e.code}: {e.reason}") from e
 
 
+def op_adopt(
+    vault_root: Path,
+    path: str = "",
+    mode: str = "scan-only",
+    max_depth: int = overview_module.DEFAULT_MAX_DEPTH,
+    include_hidden: bool = False,
+    samples: int = 5,
+    pack_limit: int = 6,
+    manifest_path: str | None = None,
+    selected_paths: list[str] | None = None,
+) -> dict:
+    """Adopt / import an existing vault safely: scan first, preserve originals.
+
+    This is the product-facing first step for a vault that already contains
+    notes, media, records, or project folders. `mode="scan-only"` returns a
+    bounded read-only adoption report: what Exomem found, which content is
+    governed versus read-only input, likely knowledge packs, and safe next
+    actions. Explicit write modes only write under `Knowledge Base/`:
+    `save-manifest` saves the report, and `copy-as-sources` copies selected
+    legacy text files into governed Sources with original path/hash provenance.
+
+    Use this when the user says "import my vault", "adopt these notes", "make
+    this existing knowledge base usable", or asks what Exomem would do with an
+    old folder before committing to migration.
+
+    Args:
+        path: Optional vault subtree to scan. Defaults to the vault root.
+        mode: Adoption mode: scan-only, save-manifest, or copy-as-sources.
+        max_depth: Folder-tree depth cap for the scan.
+        include_hidden: Include hidden files/directories in the scan.
+        samples: Sample filename count per folder.
+        pack_limit: Maximum knowledge-pack suggestions to return.
+        manifest_path: Optional markdown destination under Knowledge Base/ for
+            save-manifest. A default under _Adoption/ is used when omitted.
+        selected_paths: Explicit vault-relative legacy files for copy-as-sources.
+    """
+    try:
+        return adopt_module.adopt(
+            vault_root,
+            path=path,
+            mode=mode,
+            max_depth=max_depth,
+            include_hidden=include_hidden,
+            samples=samples,
+            pack_limit=pack_limit,
+            manifest_path=manifest_path,
+            selected_paths=selected_paths,
+        )
+    except adopt_module.AdoptError as e:
+        raise ValueError(f"adopt: {e.code}: {e.reason}") from e
+
 def op_list_directory(
     vault_root: Path,
     path: str = "",
@@ -2242,6 +2319,28 @@ def note_description(project_keys_hint: str) -> str:
 # The registry
 # --------------------------------------------------------------------------- #
 # (name, leaf, tier, cli_writes, needs_schema, cli_positional, surfaces)
+_PRODUCT_ACTIONS: tuple[str, ...] = ("save", "adopt", "ask", "prove", "review", "update", "connect")
+_PRODUCT_METADATA: dict[str, dict] = {
+    "bootstrap": {"surface": "primary", "actions": (), "first_run_safe": True},
+    "adopt": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
+    "overview": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
+    "find": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
+    "get": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
+    "add": {"surface": "primary", "actions": ("save",), "first_run_safe": False},
+    "note": {"surface": "primary", "actions": ("save", "update"), "first_run_safe": False},
+    "preserve": {"surface": "primary", "actions": ("prove", "save"), "first_run_safe": False},
+    "attention": {"surface": "primary", "actions": ("review",), "first_run_safe": True},
+    "audit": {"surface": "primary", "actions": ("review",), "first_run_safe": True},
+    "edit": {"surface": "primary", "actions": ("update",), "first_run_safe": False},
+    "replace": {"surface": "primary", "actions": ("update",), "first_run_safe": False},
+    "link": {"surface": "primary", "actions": ("connect", "save"), "first_run_safe": False},
+    "suggest_links": {"surface": "primary", "actions": ("connect", "ask"), "first_run_safe": True},
+    "propose_compilation": {"surface": "primary", "actions": ("review", "save"), "first_run_safe": True},
+    "provenance_report": {"surface": "advanced", "actions": ("ask", "prove"), "first_run_safe": True},
+    "evolution": {"surface": "advanced", "actions": ("ask", "review"), "first_run_safe": True},
+    "reconcile": {"surface": "advanced", "actions": ("update",), "first_run_safe": False},
+    "audit_fix": {"surface": "advanced", "actions": ("review", "update"), "first_run_safe": False},
+}
 _MCRC = frozenset({"mcp", "rest", "cli"})
 _RC = frozenset({"rest", "cli"})
 # `get_video_frames` returns MCP image content blocks (a FastMCP ToolResult) —
@@ -2255,6 +2354,7 @@ _SPEC: tuple[tuple, ...] = (
     ("audit", op_audit, 1, False, False, None, _MCRC),
     ("attention", op_attention, 1, False, False, None, _MCRC),
     ("overview", op_overview, 1, False, False, "path", _MCRC),
+    ("adopt", op_adopt, 1, True, False, "path", _MCRC),
     ("evolution", op_evolution, 1, False, False, "query", _MCRC),
     ("audit_fix", op_audit_fix, 1, True, False, None, _MCRC),
     ("reconcile", op_reconcile, 1, True, False, None, _MCRC),
@@ -2284,6 +2384,7 @@ _SPEC: tuple[tuple, ...] = (
 def _build_commands() -> tuple[Command, ...]:
     cmds: list[Command] = []
     for name, leaf, tier, writes, needs_schema, positional, surfaces in _SPEC:
+        meta = _PRODUCT_METADATA.get(name, {})
         skip = 2 if needs_schema else 1
         desc = leaf.__doc__ or ""
         if name == "note":
@@ -2300,6 +2401,9 @@ def _build_commands() -> tuple[Command, ...]:
                 cli_writes=writes,
                 needs_schema=needs_schema,
                 description=desc,
+                product_surface=meta.get("surface", "advanced"),
+                product_actions=tuple(meta.get("actions", ())),
+                first_run_safe=bool(meta.get("first_run_safe", False)),
             )
         )
     return tuple(cmds)
@@ -2325,3 +2429,35 @@ def commands_for(surface: str, *, expose_tier2: bool = True) -> tuple[Command, .
     return tuple(
         c for c in COMMANDS if surface in c.surfaces and (expose_tier2 or c.tier == 1)
     )
+
+
+def product_tool_catalog() -> dict:
+    """Registry-derived product surface: primary tools first, advanced tools visible."""
+    primary = [c.name for c in COMMANDS if c.product_surface == "primary"]
+    advanced = [c.name for c in COMMANDS if c.product_surface != "primary"]
+    return {
+        "primary": primary,
+        "advanced": advanced,
+        "first_run_safe": [c.name for c in COMMANDS if c.first_run_safe],
+    }
+
+
+def product_front_door_catalog() -> dict:
+    """Map simple product verbs to the typed tools that enforce governance."""
+    out = {
+        action: {"primary_tools": [], "advanced_tools": []}
+        for action in _PRODUCT_ACTIONS
+    }
+    for command in COMMANDS:
+        bucket = "primary_tools" if command.product_surface == "primary" else "advanced_tools"
+        for action in command.product_actions:
+            if action in out:
+                out[action][bucket].append(command.name)
+    out["adopt"]["contract"] = "scan-only by default; write modes preserve originals and stay under Knowledge Base/"
+    out["ask"]["contract"] = "retrieve with citations; prefer compiled notes, then sources/evidence for provenance"
+    out["prove"]["contract"] = "use Evidence/proof for cases, claims, disputes, warranties, records, or other proof contexts"
+    out["review"]["contract"] = "surface review queues and lint findings; do not auto-change conclusions"
+    out["save"]["contract"] = "raw material becomes Sources; durable conclusions become governed notes/entities"
+    out["update"]["contract"] = "edit or supersede with an explicit reason; keep history"
+    out["connect"]["contract"] = "link entities and related notes so the graph compounds"
+    return out

--- a/src/exomem/indexes.py
+++ b/src/exomem/indexes.py
@@ -192,6 +192,7 @@ def _replace_by_type_section(
         "Papers": "academic papers",
         "Videos": "captured video transcripts/notes",
         "Other": "miscellaneous captures",
+        "Imported": "copied legacy-vault material with provenance",
     }
     if folder_title not in known_descriptions:
         known_descriptions[folder_title] = folder_description

--- a/src/exomem/knowledge_packs.py
+++ b/src/exomem/knowledge_packs.py
@@ -1,0 +1,253 @@
+"""Built-in knowledge-pack definitions and deterministic pack suggestions.
+
+Knowledge packs are product-level routing hints: small, declarative bundles that
+describe common domains in terms of Exomem's durable primitives. They are not a
+new storage engine and they do not infer meaning from note bodies. Suggestions
+come from cheap structural signals surfaced by ``overview``: folder names, sample
+file names, counts, and media mix.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from importlib import resources
+from typing import Any
+
+
+PACK_DIRECTORY = "packs"
+PACK_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {"id", "name", "description", "primitives", "actions", "examples", "signals"}
+)
+PACK_OPTIONAL_FIELDS: frozenset[str] = frozenset()
+PACK_ALLOWED_FIELDS: frozenset[str] = PACK_REQUIRED_FIELDS | PACK_OPTIONAL_FIELDS
+PACK_ALLOWED_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        "source",
+        "evidence",
+        "case",
+        "decision",
+        "record",
+        "asset",
+        "production",
+        "entity",
+        "failure",
+        "pattern",
+        "experiment",
+    }
+)
+PACK_ALLOWED_ACTIONS: frozenset[str] = frozenset(
+    {"save", "adopt", "ask", "prove", "review", "update", "connect"}
+)
+
+
+class PackValidationError(ValueError):
+    """Stable validation failure for declarative knowledge-pack metadata."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(f"{code}: {reason}")
+        self.code = code
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class KnowledgePack:
+    id: str
+    name: str
+    description: str
+    primitives: tuple[str, ...]
+    actions: tuple[str, ...]
+    examples: tuple[str, ...]
+    signals: tuple[str, ...]
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PackSuggestion:
+    pack: KnowledgePack
+    score: int
+    matched_signals: tuple[str, ...]
+
+    def as_dict(self) -> dict:
+        data = self.pack.as_dict()
+        data["score"] = self.score
+        data["matched_signals"] = list(self.matched_signals)
+        return data
+
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+
+def pack_schema() -> dict:
+    """Return the public declarative schema for knowledge-pack metadata."""
+    return {
+        "format": "json",
+        "directory": f"src/exomem/{PACK_DIRECTORY}/",
+        "required_fields": sorted(PACK_REQUIRED_FIELDS),
+        "optional_fields": sorted(PACK_OPTIONAL_FIELDS),
+        "allowed_primitives": sorted(PACK_ALLOWED_PRIMITIVES),
+        "allowed_actions": sorted(PACK_ALLOWED_ACTIONS),
+    }
+
+
+def validate_pack_dict(raw: dict[str, Any]) -> KnowledgePack:
+    """Validate a declarative knowledge-pack mapping and return a typed pack.
+
+    Validation is intentionally strict: unknown fields are rejected so a custom
+    pack cannot silently depend on metadata this version of Exomem ignores.
+    """
+    if not isinstance(raw, dict):
+        raise PackValidationError("INVALID_PACK", "pack must be a mapping")
+    unknown = sorted(set(raw) - PACK_ALLOWED_FIELDS)
+    if unknown:
+        raise PackValidationError("UNKNOWN_FIELD", f"unknown field(s): {unknown}")
+    missing = sorted(PACK_REQUIRED_FIELDS - set(raw))
+    if missing:
+        raise PackValidationError("MISSING_FIELD", f"missing required field(s): {missing}")
+
+    def _nonempty_string(field: str) -> str:
+        value = raw[field]
+        if not isinstance(value, str) or not value.strip():
+            raise PackValidationError("INVALID_FIELD", f"{field!r} must be a non-empty string")
+        return value.strip()
+
+    def _string_tuple(field: str) -> tuple[str, ...]:
+        value = raw[field]
+        if not isinstance(value, (list, tuple)) or not value:
+            raise PackValidationError("INVALID_FIELD", f"{field!r} must be a non-empty list")
+        out: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                raise PackValidationError(
+                    "INVALID_FIELD",
+                    f"{field!r} entries must be non-empty strings",
+                )
+            out.append(item.strip())
+        return tuple(out)
+
+    primitives = _string_tuple("primitives")
+    bad_primitives = sorted(set(primitives) - PACK_ALLOWED_PRIMITIVES)
+    if bad_primitives:
+        raise PackValidationError(
+            "INVALID_PRIMITIVE",
+            f"unsupported primitive(s): {bad_primitives}",
+        )
+
+    actions = _string_tuple("actions")
+    bad_actions = sorted(set(actions) - PACK_ALLOWED_ACTIONS)
+    if bad_actions:
+        raise PackValidationError("INVALID_ACTION", f"unsupported action(s): {bad_actions}")
+
+    return KnowledgePack(
+        id=_nonempty_string("id"),
+        name=_nonempty_string("name"),
+        description=_nonempty_string("description"),
+        primitives=primitives,
+        actions=actions,
+        examples=_string_tuple("examples"),
+        signals=_string_tuple("signals"),
+    )
+
+
+def _validate_pack_catalog(packs: tuple[KnowledgePack, ...]) -> None:
+    seen: set[str] = set()
+    for pack in packs:
+        validate_pack_dict(pack.as_dict())
+        if pack.id in seen:
+            raise PackValidationError("DUPLICATE_PACK", f"duplicate pack id: {pack.id}")
+        seen.add(pack.id)
+
+
+def _load_builtin_packs() -> tuple[KnowledgePack, ...]:
+    base = resources.files(__package__).joinpath(PACK_DIRECTORY)
+    packs: list[KnowledgePack] = []
+    for entry in sorted(base.iterdir(), key=lambda item: item.name):
+        if not entry.name.endswith(".json"):
+            continue
+        try:
+            raw = json.loads(entry.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise PackValidationError(
+                "INVALID_PACK_JSON",
+                f"{PACK_DIRECTORY}/{entry.name}: {e.msg}",
+            ) from e
+        try:
+            packs.append(validate_pack_dict(raw))
+        except PackValidationError as e:
+            raise PackValidationError(
+                e.code,
+                f"{PACK_DIRECTORY}/{entry.name}: {e.reason}",
+            ) from e
+    if not packs:
+        raise PackValidationError("NO_BUILTIN_PACKS", f"no .json packs found in {PACK_DIRECTORY}/")
+    out = tuple(packs)
+    _validate_pack_catalog(out)
+    return out
+
+
+BUILTIN_PACKS: tuple[KnowledgePack, ...] = _load_builtin_packs()
+_PACK_BY_ID = {pack.id: pack for pack in BUILTIN_PACKS}
+
+
+def list_builtin_packs() -> list[dict]:
+    """Return the built-in pack catalog as JSON-serializable dictionaries."""
+    _validate_builtin_pack_catalog()
+    return [pack.as_dict() for pack in BUILTIN_PACKS]
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN.findall(text.lower()))
+
+
+def _overview_signal_text(scan: dict) -> dict[str, str]:
+    """Pack-suggestion input by top-level folder, derived from overview output."""
+    by_folder: dict[str, list[str]] = {}
+    for entry in scan.get("tree", []):
+        path = str(entry.get("path") or "")
+        if not path:
+            continue
+        top = path.split("/", 1)[0]
+        sample_names = " ".join(str(name) for name in entry.get("sample_names") or [])
+        by_folder.setdefault(top, []).append(f"{path} {sample_names}")
+    return {folder: " ".join(parts) for folder, parts in by_folder.items()}
+
+
+def suggest_packs(scan: dict, *, limit: int = 6) -> list[dict]:
+    """Suggest likely built-in knowledge packs from deterministic overview signals.
+
+    This intentionally uses only structural text (folder paths and sample file
+    names), not note bodies. Scores are simple counts of matched signal tokens.
+    """
+    folder_text = _overview_signal_text(scan)
+    scored: list[PackSuggestion] = []
+    for pack in BUILTIN_PACKS:
+        matched: set[str] = set()
+        pack_signals = set(pack.signals)
+        for text in folder_text.values():
+            matched.update(pack_signals & _tokens(text))
+        if matched:
+            scored.append(
+                PackSuggestion(
+                    pack=pack,
+                    score=len(matched),
+                    matched_signals=tuple(sorted(matched)),
+                )
+            )
+    scored.sort(key=lambda s: (-s.score, s.pack.id))
+    if not scored:
+        default = _PACK_BY_ID["personal-records"]
+        scored.append(
+            PackSuggestion(
+                pack=default,
+                score=0,
+                matched_signals=("default-general-vault",),
+            )
+        )
+    return [suggestion.as_dict() for suggestion in scored[: max(limit, 0)]]
+
+
+def _validate_builtin_pack_catalog() -> None:
+    _validate_pack_catalog(BUILTIN_PACKS)

--- a/src/exomem/packs/business.json
+++ b/src/exomem/packs/business.json
@@ -1,0 +1,36 @@
+{
+  "id": "business",
+  "name": "Business",
+  "description": "Customers, meetings, commitments, contracts, risks, and decisions.",
+  "primitives": [
+    "source",
+    "entity",
+    "decision",
+    "record",
+    "evidence"
+  ],
+  "actions": [
+    "save",
+    "ask",
+    "review",
+    "update",
+    "prove"
+  ],
+  "examples": [
+    "Save the customer commitment from this call.",
+    "What risks are open for this account?"
+  ],
+  "signals": [
+    "business",
+    "customer",
+    "client",
+    "meeting",
+    "sales",
+    "contract",
+    "proposal",
+    "invoice",
+    "risk",
+    "commitment",
+    "account"
+  ]
+}

--- a/src/exomem/packs/creative.json
+++ b/src/exomem/packs/creative.json
@@ -1,0 +1,37 @@
+{
+  "id": "creative",
+  "name": "Creative",
+  "description": "References, assets, drafts, productions, taste notes, and releases.",
+  "primitives": [
+    "source",
+    "asset",
+    "production",
+    "entity",
+    "record"
+  ],
+  "actions": [
+    "save",
+    "connect",
+    "review",
+    "update"
+  ],
+  "examples": [
+    "Save these references for the next shoot.",
+    "Turn this draft into a production log."
+  ],
+  "signals": [
+    "creative",
+    "photo",
+    "photos",
+    "image",
+    "images",
+    "video",
+    "draft",
+    "asset",
+    "assets",
+    "production",
+    "portfolio",
+    "music",
+    "design"
+  ]
+}

--- a/src/exomem/packs/health-athletic.json
+++ b/src/exomem/packs/health-athletic.json
@@ -1,0 +1,38 @@
+{
+  "id": "health-athletic",
+  "name": "Health / athletic",
+  "description": "Training, symptoms, measurements, protocols, injuries, and goals.",
+  "primitives": [
+    "source",
+    "record",
+    "experiment",
+    "entity",
+    "evidence"
+  ],
+  "actions": [
+    "save",
+    "ask",
+    "review",
+    "update",
+    "prove"
+  ],
+  "examples": [
+    "Log this training session.",
+    "What changed after the new protocol?"
+  ],
+  "signals": [
+    "health",
+    "workout",
+    "training",
+    "athlete",
+    "athletic",
+    "run",
+    "running",
+    "sleep",
+    "symptom",
+    "injury",
+    "protocol",
+    "blood",
+    "medical"
+  ]
+}

--- a/src/exomem/packs/legal-warranty.json
+++ b/src/exomem/packs/legal-warranty.json
@@ -1,0 +1,35 @@
+{
+  "id": "legal-warranty",
+  "name": "Legal / warranty",
+  "description": "Cases, receipts, correspondence, deadlines, and proof.",
+  "primitives": [
+    "source",
+    "evidence",
+    "case",
+    "decision",
+    "record"
+  ],
+  "actions": [
+    "save",
+    "prove",
+    "review",
+    "update"
+  ],
+  "examples": [
+    "Save this receipt for the laptop warranty case.",
+    "Show the evidence for the landlord dispute."
+  ],
+  "signals": [
+    "legal",
+    "warranty",
+    "receipt",
+    "invoice",
+    "contract",
+    "insurance",
+    "claim",
+    "dispute",
+    "case",
+    "return",
+    "refund"
+  ]
+}

--- a/src/exomem/packs/personal-records.json
+++ b/src/exomem/packs/personal-records.json
@@ -1,0 +1,38 @@
+{
+  "id": "personal-records",
+  "name": "Personal records",
+  "description": "Purchases, travel, home, vehicles, admin records, and life logistics.",
+  "primitives": [
+    "source",
+    "record",
+    "entity",
+    "evidence",
+    "decision"
+  ],
+  "actions": [
+    "save",
+    "ask",
+    "prove",
+    "review",
+    "update"
+  ],
+  "examples": [
+    "Save this vehicle maintenance record.",
+    "Find the documents for the trip."
+  ],
+  "signals": [
+    "personal",
+    "home",
+    "house",
+    "vehicle",
+    "car",
+    "travel",
+    "trip",
+    "purchase",
+    "admin",
+    "records",
+    "passport",
+    "tax",
+    "finance"
+  ]
+}

--- a/src/exomem/packs/technical.json
+++ b/src/exomem/packs/technical.json
@@ -1,0 +1,39 @@
+{
+  "id": "technical",
+  "name": "Technical",
+  "description": "Projects, repositories, decisions, failures, incidents, and runbooks.",
+  "primitives": [
+    "source",
+    "decision",
+    "failure",
+    "pattern",
+    "experiment",
+    "entity"
+  ],
+  "actions": [
+    "save",
+    "ask",
+    "review",
+    "update",
+    "connect"
+  ],
+  "examples": [
+    "Save this architecture decision.",
+    "What failed in the last deployment?"
+  ],
+  "signals": [
+    "code",
+    "repo",
+    "repos",
+    "github",
+    "incident",
+    "bug",
+    "debug",
+    "architecture",
+    "runbook",
+    "api",
+    "server",
+    "deploy",
+    "experiment"
+  ]
+}

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from . import adopt as adopt_module
 from . import doctor as doctor_module
 from . import init as init_module
 from . import install_hook as hook_module
@@ -34,6 +35,18 @@ from . import personalize as personalize_module
 from .kbdir import kb_dirname, kb_prefix
 
 _SKILL_NAME_MARKER = "name: exomem"
+
+
+def _format_pack_suggestions(packs: list[dict], *, limit: int = 3) -> str:
+    shown = []
+    for pack in packs[:limit]:
+        name = pack.get("name") or pack.get("id") or "unknown"
+        score = int(pack.get("score") or 0)
+        if score > 0:
+            shown.append(f"{name} ({score} signal{'s' if score != 1 else ''})")
+        else:
+            shown.append(f"{name} (default)")
+    return ", ".join(shown)
 
 
 def _ask_yn(input_fn, prompt: str, default: bool) -> bool:
@@ -119,8 +132,9 @@ def run_setup(
 
     # 2. pre-init scan — the "you already have notes here" moment
     try:
-        scan = overview_module.overview(vault_path)
-    except overview_module.OverviewError as e:
+        adoption = adopt_module.adopt(vault_path)
+        scan = adoption["overview"]
+    except adopt_module.AdoptError as e:
         report("scan", f"[failed: {e}]")
         return finish()
     totals = scan["totals"]
@@ -140,8 +154,12 @@ def run_setup(
         print_fn(f"    {junk_total} junk candidate(s) — zero-byte or sync-conflict copies.")
     kb_state = "already present" if scan["kb"]["present"] else "not present yet"
     print_fn(f"    {kb_prefix()}: {kb_state}")
+    packs = adoption.get("pack_suggestions") or []
+    if packs:
+        print_fn(f"    Likely packs: {_format_pack_suggestions(packs)}")
     print_fn("")
     print_fn(f"  Contract: {overview_module.SCOPE_NOTE}")
+    print_fn("  Adoption: run `exomem adopt` anytime for the copy/manifest plan.")
     print_fn("")
     report("scan", "[done]")
 

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: exomem
-description: Operates on your personal Obsidian Knowledge Base — raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts. Triggers when you want to save, file, log, compile, distill, search, audit, supersede, or preserve anything in your KB, vault, Obsidian, or notes — including oblique phrasings ("interesting, save it," "I want to remember this"). Also engages proactively — it consults the KB for prior conclusions when a turn touches a topic it likely covers, and captures durable conclusions when the conversation reaches a stepping-stone (a decision, a solved problem, a diagnosed failure, a recognized pattern). Do NOT write outside the Knowledge Base folder; any sibling folders in the vault are read-only inputs.
-version: 0.29.1
+description: Use when working with Exomem — your personal knowledge base (a markdown vault, Obsidian optional, of raw sources, compiled research notes, insights, failures, patterns, experiments, production-logs, typed entities, and Evidence artifacts). Triggers whenever you name Exomem (the connector/MCP you talk to) or want to save, file, log, compile, distill, search, audit, supersede, or preserve anything in Exomem, your KB, vault, Obsidian, or notes — including oblique phrasings ("interesting, save it," "I want to remember this," "what does Exomem have on X"). Also engages proactively — it consults Exomem for prior conclusions when a turn touches a topic it likely covers, and captures durable conclusions when the conversation reaches a stepping-stone (a decision, a solved problem, a diagnosed failure, a recognized pattern). Governed writes stay inside the folder Exomem manages; the rest of your vault is read-only input.
+version: 0.32.0
 ---
 
-# Knowledge Base
+# Exomem
 
-The compiled, structured layer of your Obsidian vault. Everything in
+This skill is the Exomem contract. "Exomem" is the connector/MCP you talk to;
+your Knowledge Base is the governed set of folders it manages inside your markdown
+vault (Obsidian optional). This file pins the `exomem` skill identity while teaching agents how to use
+Exomem's MCP tools over that vault.
+
+The compiled, structured layer of your markdown vault (Obsidian optional). Everything in
 `Knowledge Base/` is either a raw source (immutable), compiled material under
 explicit governance, or a preserved factual artifact (Evidence). Any other
 folders in the vault are hand-authored and are **read-only input** to this
@@ -23,7 +28,7 @@ is always clear.
 
 - `Sources/` — raw inputs. Append-only. Never edited after capture.
 - `Notes/`, `Entities/` — compiled, structured, supersedable. Always carry frontmatter, sources, and links.
-- `Evidence/` — raw factual artifacts (binaries, documents, screenshots). Append-only. No analysis at this layer.
+- `Evidence/` — proof/case-bound artifacts (binaries, documents, screenshots). Append-only. No analysis at this layer. A raw item is a Source by default; it becomes Evidence when preserved for a claim, case, dispute, warranty, record, or other proof-bearing context.
 - Anything outside `Knowledge Base/` — Claude reads, Claude does not write.
 
 ## Proactive engagement
@@ -61,12 +66,25 @@ diagnosed, a pattern is recognized — capture it:
 Not a stepping-stone: mid-thought exploration, brainstorm tangents, unresolved
 questions. Capture at the landing, not during the flight.
 
+**Comprehensive coverage, minimal expression.** Capturing at the landing is about
+*timing*, not *volume* — it never means keep less. Minimality is a property of
+*expression* — distillation, signal-density, no redundancy — never of *coverage*.
+Don't drop context or detail because it "doesn't seem important": importance is
+usually only legible in hindsight, and nothing here forces the tradeoff (no
+retention decay, hybrid BM25+vector retrieval, append-only `Sources/`, no storage
+limit). Default coverage to comprehensive; reserve concision for *how* a note is
+written, not *what* it keeps. Torn between keeping a detail and dropping it? Keep
+it — an over-kept detail is free to retrieval, a dropped one is unrecoverable.
+Capture more, at the right layer: raw verbatim to `Sources/` liberally; compiled
+notes stay distilled in form but never context-pruned.
+
 ## Vault layout
 
 ```
 <vault>/Knowledge Base/
 ├── index.md                      Top-level catalog; updated on every write
 ├── log.md                        Append-only activity log; most recent first
+├── _access.yaml                  (optional) per-subtree readonly/excluded — see references/write-scope.md
 ├── _Schema/
 │   ├── SKILL.md                  This file (canonical)
 │   ├── project-keys.yaml         Registered research scope keys
@@ -100,9 +118,17 @@ questions. Capture at the landing, not during the flight.
     └── <scope>/                  Per-incident binary/document/factual preservation
 ```
 
-`<vault>` resolves to your Obsidian vault root — the folder that contains
-`Knowledge Base/`, set via `EXOMEM_VAULT_PATH`. Verify allowed filesystem paths
-before writing.
+**This tree is the `Knowledge Base/` layer only — not the shape of your whole vault.**
+The vault around it is yours: any top-level folders you keep (`Daily/`, `Projects/`,
+`Reference/`, a journal — whatever) sit *beside* `Knowledge Base/` and are **read-only
+input** to this skill. Don't infer a fixed vault shape from the tree above. On your
+first engagement in a vault, run `overview` once to learn its real top-level layout
+(see § Assessing a vault you didn't build), then treat everything outside
+`Knowledge Base/` as read-only. Only `Knowledge Base/` is governed and writeable.
+
+`<vault>` resolves to your markdown vault root (Obsidian optional) — the folder that
+contains `Knowledge Base/`, set via `EXOMEM_VAULT_PATH`. Verify allowed filesystem
+paths before writing.
 
 The research scopes are an open set you grow over time, registered in
 `_Schema/project-keys.yaml` (see § Research scope keys). New users start with a
@@ -116,7 +142,7 @@ you'll almost always need `find` (search), `get` (read a page), and one or more
 of `note`, `add`, `link`, `suggest_links`, `edit`, `audit`. In Claude Code, load
 them by exact name in a single call:
 
-`ToolSearch("select:find,get,note,add,link,suggest_links,edit,audit")`
+`ToolSearch("select:adopt,overview,find,get,note,add,link,suggest_links,edit,audit")`
 
 On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 "search the knowledge base", "read a KB page", "compile a note" — and each
@@ -132,6 +158,27 @@ mode, reranking, `pack`, or `include_timings`.
 
 The Tier 2 filesystem ops below may be turned off on lean deployments
 (`EXOMEM_DISABLE_TIER2`), in which case only the Tier 1 ops are registered.
+
+
+## Simple front door
+
+Speak to users in simple product actions; use the typed operations underneath.
+Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
+`replace` unless that implementation detail matters.
+
+| User action | Preferred route |
+|---|---|
+| save | `add` for raw material; `note`/`link` for durable conclusions; `preserve` only for proof-bound material |
+| adopt/import | `adopt(mode="scan-only")` first; then ask before `save-manifest`, `copy-as-sources`, or compile actions |
+| ask | `find` first, then `get` or `find(pack=true)` for synthesis context |
+| prove | `preserve` or upload to Evidence for cases, claims, warranties, disputes, records, and receipts |
+| review | `attention`, `audit`, or `propose_compilation` |
+| update | `edit` for small changes; `replace` for supersession; `reconcile` for out-of-band drift |
+| connect | `link` and `suggest_links` |
+
+Built-in AI memory is for preferences, working rules, and routing instructions.
+Exomem is for durable governed knowledge with sources, proof, history, decisions,
+records, review, and compiled conclusions.
 
 ## Operations
 
@@ -158,9 +205,11 @@ and index updates are determined by the operation, not the caller.
 | **suggest_links** | Surface existing pages a draft or page should link to, hub-aware (read-only) | — |
 | **get** | Read a full file by path; `frontmatter_only=true` returns just the frontmatter. Returns `content_hash` + `mtime` for the two-writer drift guard (echo `content_hash` to `edit` via `expected_hash`). Read-only | — |
 | **audit** | Lint pass: orphans, broken links, supersession integrity, aged unprocessed sources | proposals only |
+| **overview** | Bounded structure report of the vault or a subtree — folder tree, counts, frontmatter coverage, junk candidates. Works outside the KB and pre-init (read-only) | — |
+| **adopt** | Safe first-run adoption workflow for an existing vault: scan-only by default; can save a manifest or copy selected legacy text files as Sources while preserving originals | `Knowledge Base/_Adoption/` or `Sources/Imported/` only in explicit write modes |
 | **propose_compilation** | Draft a note scaffold from unprocessed source(s) — the backlog-drain companion to audit (read-only) | proposals only |
 | **replace** | Supersession: mark old, write new with header pointer | both old + new |
-| **reconcile** | Heal drift from out-of-band edits (Obsidian/mobile/manual): recompute index counts + re-embed stale files + report remaining drift. Idempotent; `dry_run` reports only | drifted indexes + embedding sidecar |
+| **reconcile** | Heal drift from out-of-band edits (any editor/sync/mobile, e.g. Obsidian): recompute index counts + re-embed stale files + report remaining drift. Idempotent; `dry_run` reports only | drifted indexes + embedding sidecar |
 | **provenance_report** | Scan note bodies for `<!-- key:value -->` provenance tags (filter by key/value/path). Read-only | — |
 
 For the full per-operation spec — inputs, validation, write rules, edge cases —
@@ -218,9 +267,21 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   searchable by *visual content* (CLIP), not just text — a purely-visual hit
   carries a `clip_score`; a video visual hit also carries `clip_match_at` (e.g.
   `"14:32"`), the timestamp of the matching keyframe.
-- **Read-only subtrees are write-protected.** Any vault subtree marked read-only
-  (see `references/write-scope.md`) refuses Tier 2 writes by default; reads are
-  unrestricted.
+- **View a video's frames on demand — `get_video_frames`.** To *see* what a vault
+  video shows (slides, screen recordings, meetings), call
+  `get_video_frames(path, max_frames=8, start_sec=?, end_sec=?)` — it returns
+  sampled keyframes INLINE as JPEG image blocks (no download round-trip needed),
+  preceded by per-frame timestamps. The comprehension companion to visual search:
+  `find` locates the moment (`clip_match_at`), `get_video_frames` shows it — an
+  overview call first, then zoom with `start_sec`/`end_sec` around that timestamp.
+  Bounded and read-only (default 8 frames, hard cap 16, JPEG ≤768px); soft-fails
+  with a clear code when the server lacks the media extra.
+- **Read-only / excluded subtrees are write-protected.** Mark a subtree `readonly:`
+  or `excluded:` in `Knowledge Base/_access.yaml` (see `references/write-scope.md` §
+  Per-subtree access overrides): `readonly` stays searchable but refuses **every**
+  write (Tier 1 and Tier 2) — hard, no override; `excluded` is additionally hidden
+  from `find`/embeddings. This is the in-KB counterpart to the by-location rule that
+  everything outside `Knowledge Base/` is read-only.
 - **Every write logs to `Knowledge Base/log.md`** with the operation, path, and a
   one-line rationale. Where appropriate, ops require a `why:` (e.g. `edit`'s
   frontmatter-patch mode).
@@ -242,6 +303,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "log this batch," "add this episode," "record this launch" → **note** with type=production-log
 - "this is connected to [[X]]," "create an entity for X" → **link**
 - "preserve this letter," "file this in evidence," "save this for the record" → **preserve**
+- "import my vault," "adopt these notes," "make this old knowledge base usable" → **adopt** first (`mode="scan-only"`), then ask before `save-manifest`, `copy-as-sources`, or compile actions
 - "update the skill," "the KB structure needs to change" → no MCP tool — hand-edit `_Schema/` files directly
 - "fill in the take for X," "set the take on that row" → **edit** (`row_key`+`take`)
 - "make these few edits to the page" (same page) → **edit** (`edits=[…]`)
@@ -251,6 +313,8 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "what should this link to," "densify this page's links" → **suggest_links**
 - "what should I compile next," "drain the source backlog" → **propose_compilation**
 - "audit the KB," "lint the vault," "check for orphans" → **audit**
+- "what does this vault look like," "assess my vault," "how is this vault organized" → **overview**
+- "what should Exomem do with this existing vault," "how can we migrate this safely" → **adopt**
 - "I edited the vault directly / on my phone — sync it up," "heal the drift" → **reconcile**
 - "this replaces the old strategy," "supersede the old note on X" → **replace**
 - "make a new folder for X" → **create_file** (`kind="dir"`, Tier 2)
@@ -300,9 +364,10 @@ Empty queries degrade to filtered-most-recent regardless of mode.
 Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
 `rerank=true` (CrossEncoder re-sort, opt-in), `prefer_compiled=true` (default;
 favours compiled types over raw `source`), `prefer_active=true` (default;
-soft-demotes superseded pages), and `file_types` / `exclude_file_types` (scope to
+soft-demotes superseded pages), `file_types` / `exclude_file_types` (scope to
 or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
-`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`).
+`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`), and `speakers`
+(restrict to diarized media whose `speakers:` frontmatter names a given person).
 
 Performance presets:
 - Normal lookup: `detail="compact"`, `rerank=false`.
@@ -319,9 +384,26 @@ data files aren't `find`-searchable. To make a dataset findable, write a
 from the `data_file` with `query_data`.
 
 Vector embeddings live in a per-machine sidecar at
-`<vault>/Knowledge Base/.embeddings.sqlite` (a dotfile Obsidian Sync ignores).
+`<vault>/Knowledge Base/.embeddings.sqlite` (a dotfile that file-sync tools like Obsidian Sync ignore).
 Writers refresh it incrementally after every atomic batch. To bootstrap or after
 drift, call `audit_fix(rebuild_embeddings=true)`.
+
+### Assessing or adopting a vault you didn't build
+
+**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
+
+For structural questions —
+"what does this vault look like," "how is this vault organized," "is there junk in
+here" — and simply to learn the layout before you write, run **overview** first: one bounded,
+read-only report of folder structure, counts, frontmatter coverage, naming
+patterns, and junk candidates (zero-byte files, sync-conflict duplicates). It
+works on any folder under the vault root, including trees outside
+`Knowledge Base/` (a `Daily/` or `Journal/` folder), and on vaults with no KB at
+all. The folders it reports *outside* `Knowledge Base/` are read-only input — link
+to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `list_directory` on folders of interest,
+`find scope="vault"` for content, targeted `get` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
+bulk-read a vault file-by-file to answer a structural question** — the report
+answers in one call what would otherwise cost hundreds of reads.
 
 ## Activity log
 
@@ -439,7 +521,7 @@ The `project` field on a research note is a slug-shaped key registered in
 most-specific scope first. A typical starter set:
 
 - Products / projects: `project-alpha`, `project-beta` — one key per project.
-- Domains: `work`, plus your own (`health`, `finance`, `creative`, …).
+- Domains: `work`, plus your own (`research`, `ops`, …).
 - Cross-cutting: `personal` — anything not tied to a specific project or domain.
 
 For **patterns** that apply across multiple projects, use `projects:` (plural
@@ -451,8 +533,8 @@ slug-shaped project keys to `_Schema/project-keys.yaml` and create the matching
 `Notes/Research/<Folder>/` directory on first use — no manual YAML edit needed.
 Pass `project_category` to bucket the new key (product / activity / domain /
 cross-cutting); omitted, it lands `uncategorized`. A **typo guard** rejects new
-keys within edit distance ≤2 of an existing key (`helath` → "Did you mean
-'health'?") so the registry stays clean.
+keys within edit distance ≤2 of an existing key (`wrok` → "Did you mean
+'work'?") so the registry stays clean.
 
 ### Experiment vs production-log
 
@@ -518,8 +600,10 @@ auto-fixes); the report is reviewed before anything is written. It covers:
 orphans, broken wikilinks, supersession integrity, stale frontmatter,
 `index.md`/`log.md` drift, aged unprocessed sources (oldest-first — pair with
 `propose_compilation`), status/location mismatch, unfinished experiments, stalled
-production lifecycles, stale hubs/snapshots, unregistered project keys, and
-embedding drift.
+production lifecycles, **stale-review candidates** (active conclusions that are old
+AND rarely surfaced in `find` AND low inbound-link degree — surfaced for review
+only, never decayed or down-ranked; hubs/snapshots excluded as expected-to-drift),
+unregistered project keys, and embedding drift.
 
 Per-check detail — exactly what each flags, its severity, and the proposed fix —
 is in **`references/audit-checks.md`**.
@@ -528,11 +612,18 @@ is in **`references/audit-checks.md`**.
 
 - Touch anything outside `Knowledge Base/`.
 - Auto-compile *blindly* after every capture. Compilation is a deliberate step
-  taken at a stepping-stone; it's always reported, never a silent dump.
+  taken at a stepping-stone; it's always reported, never a silent dump of raw
+  transcripts or every passing remark. "No silent dump" targets *noise* —
+  transcripts, mid-flight tangents — not *signal*: it never licenses pruning
+  context or detail from a note (see *Comprehensive coverage, minimal expression*
+  under Proactive engagement).
 - Assign numeric confidence scores. Use citation count and recency as the trust
   signal.
 - Apply retention decay or "forgetting curves." Old material stays. If superseded,
-  mark it; if irrelevant, archive into an `_archive/` subfolder.
+  mark it; if irrelevant, archive into an `_archive/` subfolder. (`audit`'s
+  `stale_review` check **surfaces** old/cold/low-inbound conclusions as *review
+  candidates* for you to judge — but never auto-decays, down-ranks, hides, or moves
+  anything; `find` ordering is unchanged. Surfacing a candidate ≠ a forgetting curve.)
 - Run on hooks, schedules, or background triggers. Operations happen because you
   asked, or because the conversation reached a point where consulting or capturing
   is clearly warranted.

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -64,6 +64,72 @@
       "type": "object"
     }
   },
+  "adopt": {
+    "description": "Adopt / import an existing vault safely: scan first, preserve originals.\n\nThis is the product-facing first step for a vault that already contains\nnotes, media, records, or project folders. `mode=\"scan-only\"` returns a\nbounded read-only adoption report: what Exomem found, which content is\ngoverned versus read-only input, likely knowledge packs, and safe next\nactions. Explicit write modes only write under `Knowledge Base/`:\n`save-manifest` saves the report, and `copy-as-sources` copies selected\nlegacy text files into governed Sources with original path/hash provenance.\n\nUse this when the user says \"import my vault\", \"adopt these notes\", \"make\nthis existing knowledge base usable\", or asks what Exomem would do with an\nold folder before committing to migration.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "default": "",
+          "type": "string",
+          "description": "Optional vault subtree to scan. Defaults to the vault root."
+        },
+        "mode": {
+          "default": "scan-only",
+          "type": "string",
+          "description": "Adoption mode: scan-only, save-manifest, or copy-as-sources."
+        },
+        "max_depth": {
+          "default": 3,
+          "type": "integer",
+          "description": "Folder-tree depth cap for the scan."
+        },
+        "include_hidden": {
+          "default": false,
+          "type": "boolean",
+          "description": "Include hidden files/directories in the scan."
+        },
+        "samples": {
+          "default": 5,
+          "type": "integer",
+          "description": "Sample filename count per folder."
+        },
+        "pack_limit": {
+          "default": 6,
+          "type": "integer",
+          "description": "Maximum knowledge-pack suggestions to return."
+        },
+        "manifest_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional markdown destination under Knowledge Base/ for\nsave-manifest. A default under _Adoption/ is used when omitted."
+        },
+        "selected_paths": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Explicit vault-relative legacy files for copy-as-sources."
+        }
+      },
+      "type": "object"
+    }
+  },
   "append_to_file": {
     "description": "Tier 2: append text to an existing file.\n\nRefuses Sources/ (immutable). Allowed on Evidence/ sidecars and\ngeneral vault files. Curated trees need `allow_curated=true`.\nEnsures a single newline boundary between existing tail and new\ncontent.",
     "inputSchema": {

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -1,0 +1,224 @@
+"""Existing-vault adoption workflow."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+from exomem import adopt as adopt_module
+from exomem import knowledge_packs
+from exomem.__main__ import main
+
+
+def _snapshot(root: Path, *, exclude_kb: bool = False) -> dict[str, tuple[int, float]]:
+    out: dict[str, tuple[int, float]] = {}
+    kb = root / "Knowledge Base"
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if exclude_kb and p.is_relative_to(kb):
+            continue
+        out[p.relative_to(root).as_posix()] = (p.stat().st_size, p.stat().st_mtime)
+    return out
+
+
+def _legacy_vault(root: Path, *, kb: bool = False) -> Path:
+    vault = root / "legacy-vault"
+    (vault / "Warranty Case").mkdir(parents=True)
+    (vault / "Warranty Case" / "laptop-receipt.md").write_text("# Laptop receipt\n\nreceipt\n", encoding="utf-8")
+    (vault / "Creative Assets").mkdir()
+    (vault / "Creative Assets" / "shoot-reference.md").write_text("photo ideas\n", encoding="utf-8")
+    (vault / "Repos").mkdir()
+    (vault / "Repos" / "api-incident.md").write_text("deploy failed\n", encoding="utf-8")
+    if kb:
+        kb_root = vault / "Knowledge Base"
+        (kb_root / "Notes").mkdir(parents=True)
+        (kb_root / "Sources").mkdir(parents=True)
+        (kb_root / "Sources" / "index.md").write_text(
+            "# Sources - Index\n\n## By type\n\n## Recent captures\n\n",
+            encoding="utf-8",
+        )
+        (kb_root / "index.md").write_text(
+            "# Knowledge Base\n\n## Counts\n\n- Sources: 0\n\n## Recent activity\n\n",
+            encoding="utf-8",
+        )
+        (kb_root / "log.md").write_text("# Log\n\n---\n", encoding="utf-8")
+    return vault
+
+
+def test_adopt_scan_only_is_read_only_before_init(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=False)
+    before = _snapshot(vault)
+
+    report = adopt_module.adopt(vault)
+
+    assert _snapshot(vault) == before
+    assert report["mode"] == "scan-only"
+    assert report["governance"]["kb_present"] is False
+    assert report["summary"]["kb"] == {"present": False}
+    assert {a["action"] for a in report["next_actions"]} == {"scan-only", "initialize-kb"}
+
+
+def test_adopt_suggests_builtin_packs_from_structure(tmp_path: Path) -> None:
+    report = adopt_module.adopt(_legacy_vault(tmp_path, kb=True))
+    by_id = {p["id"]: p for p in report["pack_suggestions"]}
+
+    assert {"creative", "legal-warranty", "technical"} <= set(by_id)
+    assert by_id["legal-warranty"]["score"] >= 3
+    assert by_id["technical"]["score"] >= 3
+    assert "creative" in by_id
+    assert {p["id"] for p in report["available_packs"]} >= {
+        "legal-warranty",
+        "creative",
+        "technical",
+        "health-athletic",
+        "business",
+        "personal-records",
+    }
+    assert "required_fields" in report["pack_schema"]
+    assert report["governance"]["kb_present"] is True
+    assert {a["action"] for a in report["next_actions"]} >= {"save-manifest", "copy-as-sources"}
+
+
+def test_adopt_save_manifest_writes_only_under_kb(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+    before_legacy = _snapshot(vault, exclude_kb=True)
+
+    report = adopt_module.adopt(
+        vault,
+        mode="save-manifest",
+        today=dt.date(2026, 7, 7),
+    )
+
+    assert _snapshot(vault, exclude_kb=True) == before_legacy
+    manifest = report["manifest"]
+    assert manifest["path"].startswith("Knowledge Base/_Adoption/")
+    manifest_path = vault / manifest["path"]
+    assert manifest_path.exists()
+    text = manifest_path.read_text(encoding="utf-8")
+    assert "# Adoption Manifest" in text
+    assert "Originals stay where they are" in text
+
+
+def test_adopt_copy_as_sources_preserves_original_and_records_provenance(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+    original = vault / "Warranty Case" / "laptop-receipt.md"
+    before = original.read_bytes()
+    expected_hash = hashlib.sha256(before).hexdigest()
+
+    report = adopt_module.adopt(
+        vault,
+        mode="copy-as-sources",
+        selected_paths=["Warranty Case/laptop-receipt.md"],
+        today=dt.date(2026, 7, 7),
+    )
+
+    assert original.read_bytes() == before
+    copied = report["copy"]["copied_sources"]
+    assert len(copied) == 1
+    assert copied[0]["original_path"] == "Warranty Case/laptop-receipt.md"
+    assert copied[0]["original_sha256"] == expected_hash
+    source_path = vault / copied[0]["source_path"]
+    assert source_path.exists()
+    assert source_path.as_posix().endswith("Knowledge Base/Sources/Imported/2026-07-07-laptop-receipt.md")
+    source_text = source_path.read_text(encoding="utf-8")
+    assert "imported_from: Warranty Case/laptop-receipt.md" in source_text
+    assert f"original_sha256: {expected_hash}" in source_text
+    assert "# Laptop receipt" in source_text
+
+
+def test_adopt_copy_as_sources_requires_explicit_selection(tmp_path: Path) -> None:
+    with pytest.raises(adopt_module.AdoptError) as ei:
+        adopt_module.adopt(_legacy_vault(tmp_path, kb=True), mode="copy-as-sources")
+    assert ei.value.code == "MISSING_SELECTION"
+
+
+def test_adopt_unsupported_mode_is_explicit(tmp_path: Path) -> None:
+    with pytest.raises(adopt_module.AdoptError) as ei:
+        adopt_module.adopt(_legacy_vault(tmp_path), mode="compile-selected")
+    assert ei.value.code == "UNSUPPORTED_MODE"
+    assert "planned safe modes" in ei.value.reason
+
+
+def test_pack_suggestions_default_to_personal_records() -> None:
+    out = knowledge_packs.suggest_packs({"tree": []})
+    assert out[0]["id"] == "personal-records"
+    assert out[0]["score"] == 0
+
+
+def test_pack_validation_rejects_unknown_fields() -> None:
+    raw = knowledge_packs.list_builtin_packs()[0]
+    raw["surprise"] = True
+    with pytest.raises(knowledge_packs.PackValidationError) as ei:
+        knowledge_packs.validate_pack_dict(raw)
+    assert ei.value.code == "UNKNOWN_FIELD"
+
+
+def test_builtin_packs_are_declarative_files() -> None:
+    base = resources.files("exomem").joinpath("packs")
+    names = sorted(entry.name for entry in base.iterdir() if entry.name.endswith(".json"))
+
+    assert names == [
+        "business.json",
+        "creative.json",
+        "health-athletic.json",
+        "legal-warranty.json",
+        "personal-records.json",
+        "technical.json",
+    ]
+    raw = json.loads(base.joinpath("legal-warranty.json").read_text(encoding="utf-8"))
+    assert knowledge_packs.validate_pack_dict(raw).id == "legal-warranty"
+    assert knowledge_packs.pack_schema()["directory"] == "src/exomem/packs/"
+
+
+def test_pack_validation_rejects_invalid_primitives_and_actions() -> None:
+    raw = knowledge_packs.list_builtin_packs()[0]
+    raw["primitives"] = ["source", "mind-palace"]
+    with pytest.raises(knowledge_packs.PackValidationError) as ei:
+        knowledge_packs.validate_pack_dict(raw)
+    assert ei.value.code == "INVALID_PRIMITIVE"
+
+    raw = knowledge_packs.list_builtin_packs()[0]
+    raw["actions"] = ["save", "teleport"]
+    with pytest.raises(knowledge_packs.PackValidationError) as ei:
+        knowledge_packs.validate_pack_dict(raw)
+    assert ei.value.code == "INVALID_ACTION"
+
+
+def test_adopt_registry_exposure_survives_tier2_optout() -> None:
+    from exomem.commands import commands_for
+
+    for surface in ("mcp", "cli", "rest"):
+        commands = {c.name: c for c in commands_for(surface, expose_tier2=False)}
+        assert "adopt" in commands, f"adopt missing from {surface} with Tier 2 off"
+        assert commands["adopt"].product_surface == "primary"
+        assert "adopt" in commands["adopt"].product_actions
+
+
+def test_adopt_cli_door(vault: Path, capsys) -> None:
+    code = main(["adopt", "--json"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"]["mode"] == "scan-only"
+    assert payload["data"]["summary"]["kb"]["present"] is True
+
+
+def test_adopt_cli_human_output_is_product_shaped(vault: Path, capsys) -> None:
+    code = main(["adopt"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "Adoption report" in out
+    assert "Likely packs" in out
+    assert "Safe next actions" in out
+    assert "Originals: untouched" in out
+    assert '"mode"' not in out
+

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -35,7 +35,10 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
     assert out["server"]["content_included"] is False
     assert out["server"]["pure_substrate"] is True
     assert "compute_policy" in out["server"]
-    assert {"workflow", "tool_defaults", "performance_profiles"} <= set(out)
+    assert {"workflow", "tool_defaults", "performance_profiles", "memory_model"} <= set(out)
+    assert "durable governed knowledge" in out["memory_model"]["exomem"]
+    assert out["tool_defaults"]["adopt_existing_vault"]["tool"] == "adopt"
+    assert "adopt" in out["common_tools"]
     assert out["tool_defaults"]["normal_lookup"]["args"] == {
         "detail": "compact",
         "rerank": False,
@@ -58,6 +61,26 @@ def test_bootstrap_profiles_and_validation(vault: Path) -> None:
         commands.op_bootstrap(vault, profile="verbose")
 
 
+def test_product_front_door_metadata_is_registry_derived() -> None:
+    catalog = commands.product_tool_catalog()
+    front_door = commands.product_front_door_catalog()
+
+    assert {"save", "adopt", "ask", "prove", "review", "update", "connect"} <= set(front_door)
+    assert "adopt" in catalog["primary"]
+    assert "find" in catalog["primary"]
+    assert "preserve" in front_door["prove"]["primary_tools"]
+    assert "audit" in front_door["review"]["primary_tools"]
+    assert "create_file" in catalog["advanced"]
+    assert "list_directory" in catalog["advanced"]
+    assert "scan-only" in front_door["adopt"]["contract"]
+    assert "proof" in front_door["prove"]["contract"]
+
+    actions = set(front_door)
+    for command in commands.COMMANDS:
+        assert command.product_surface in {"primary", "advanced"}
+        assert set(command.product_actions) <= actions
+
+
 def test_bootstrap_is_registry_generated_on_public_surfaces(
     vault: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
@@ -69,7 +92,9 @@ def test_bootstrap_is_registry_generated_on_public_surfaces(
     monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
     monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
     mcp = server.build_server(require_auth=False)
-    assert "bootstrap" in _tool_names(mcp)
+    names = _tool_names(mcp)
+    assert "bootstrap" in names
+    assert "adopt" in names
 
     client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
     r = client.post(

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 import exomem
+from exomem import commands
 from exomem import demo
 from exomem.__main__ import _core_op_names
 from exomem.__main__ import main as cli_main
@@ -38,6 +39,30 @@ def test_packaged_sample_vault_present() -> None:
     assert demo.SAMPLE_VAULT.is_dir()
     assert (demo.SAMPLE_VAULT / "Knowledge Base" / "_Schema" / "SKILL.md").is_file()
     assert (demo.SAMPLE_VAULT / demo.TARGET_PATH).is_file()
+
+
+def test_sample_vault_shows_proof_without_treating_sources_as_evidence() -> None:
+    evidence_rel = "Knowledge Base/Evidence/Warranty/Receipts/2026-06-30-laptop-receipt.md"
+    source_rel = "Knowledge Base/Sources/Sessions/2026-06-30-sample-session.md"
+    note = demo.SAMPLE_VAULT / "Knowledge Base" / "Notes" / "Research" / "Sample" / "sample-architecture.md"
+
+    assert (demo.SAMPLE_VAULT / evidence_rel).is_file()
+    assert (demo.SAMPLE_VAULT / source_rel).is_file()
+    assert f"[[{evidence_rel[:-3]}]]" in note.read_text(encoding="utf-8")
+
+    hits = commands.op_find(
+        demo.SAMPLE_VAULT,
+        query="receipt warranty",
+        mode="keyword",
+        scope="vault",
+        limit=10,
+        prefer_compiled=False,
+    )
+    paths = [hit["path"] for hit in hits]
+
+    assert evidence_rel in paths
+    assert source_rel not in paths
+    assert any(hit["path"] == evidence_rel and hit["title"] == "Sample Laptop Receipt" for hit in hits)
 
 
 def test_happy_path_human_output() -> None:

--- a/tests/test_scaffold_no_leak.py
+++ b/tests/test_scaffold_no_leak.py
@@ -143,7 +143,11 @@ def test_sample_vault_ships_no_personal_data() -> None:
     for f in sorted(SAMPLE_VAULT.rglob("*")):
         if not f.is_file():
             continue
-        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            lines = f.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue  # binary sidecars in the sample vault are not text leak surfaces
+        for i, line in enumerate(lines, 1):
             for p in patterns:
                 if p.search(line):
                     offenders.append(

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -69,8 +69,10 @@ def test_fresh_vault_happy_path(tmp_path: Path) -> None:
     # KB scaffold landed; skill installed under the injected home
     assert (vault / "Knowledge Base" / "index.md").is_file()
     assert (home / "skills" / "exomem" / "SKILL.md").is_file()
-    # pre-init scan surfaced the existing content + the write contract
+    # pre-init scan surfaced the existing content, likely packs, and write contract
     assert "2 files" in out
+    assert "Likely packs:" in out
+    assert "Adoption: run `exomem adopt`" in out
     assert "writes only under 'Knowledge Base/'" in out
     # registration argv shape
     (reg,) = [c for c in recorder.calls if "add" in c]

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.7.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- add a safe existing-vault adoption flow with scan-only, manifest, and copy-as-sources modes
- add declarative knowledge packs and simpler front-door action metadata for agents
- update onboarding/product docs, sample Evidence workflow, MCP schema fixture, and tests

## Conflict resolution
- rebased onto current `origin/main`
- kept main's extracted `command_surface.py` / `link_summary.py` architecture
- moved the new product metadata fields onto the extracted `Command` dataclass

## Verification
- uv run pytest -q (`1623 passed, 16 skipped`)
- uv run pytest tests/test_adopt.py tests/test_setup_wizard.py tests/test_bootstrap.py tests/test_demo.py tests/test_scaffold_no_leak.py tests/test_mcp_schema_fidelity.py -q (`47 passed`)
- openspec validate productize-cognition-layer --strict
- git diff --check
- python -m py_compile src/exomem/adopt.py src/exomem/knowledge_packs.py src/exomem/commands.py src/exomem/command_surface.py src/exomem/setup_wizard.py src/exomem/__main__.py