### PR TITLE
Gate auto rerank by compute mode

### DIFF
--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -362,19 +362,23 @@ Empty queries degrade to filtered-most-recent regardless of mode.
   try `scope="vault"`, vary the query terms, or `get` a path you suspect.
 
 Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
-`rerank=true` (CrossEncoder re-sort, opt-in), `prefer_compiled=true` (default;
-favours compiled types over raw `source`), `prefer_active=true` (default;
-soft-demotes superseded pages), `file_types` / `exclude_file_types` (scope to
-or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
-`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`), and `speakers`
-(restrict to diarized media whose `speakers:` frontmatter names a given person).
+`rerank=true` (CrossEncoder re-sort, explicit precision spend),
+`prefer_compiled=true` (default; favours compiled types over raw `source`),
+`prefer_active=true` (default; soft-demotes superseded pages), `file_types` /
+`exclude_file_types` (scope to or drop artifact kinds: `note`, `pdf`, `image`,
+`audio`, `video`, `docx`, `xlsx`, `pptx`, `html`, `text`, `email`, `calendar`,
+`csv`, `json`, `tsv`), and `speakers` (restrict to diarized media whose
+`speakers:` frontmatter names a given person). Leaving `rerank` unset is
+mode-aware auto: CPU steady-state modes keep it off; accelerated/performance
+mode may auto-rerank when lanes strongly disagree or the query is long.
 
 Performance presets:
 - Normal lookup: `detail="compact"`, `rerank=false`.
 - Reasoning context: `pack=true` when you need a compressed evidence bundle.
 - Diagnostics: `include_timings=true`; add `rerank=true` only when you are
-  intentionally measuring reranking. Interpret timing output with the returned
-  compute mode, embedding backend, cache state, rerank flag, and search profile.
+  intentionally measuring reranking or spending latency for precision. Interpret
+  timing output with the returned compute mode, embedding backend, cache state,
+  rerank flag, and search profile.
 
 **Tabular data is card-based.** Raw CSV/JSON/TSV rows are never embedded and raw
 data files aren't `find`-searchable. To make a dataset findable, write a

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -289,9 +289,12 @@ Search for modes, scope, and ranking knobs.
 - Reasoning context: `pack=true` when you need a compact evidence bundle for
   downstream reasoning.
 - Diagnostics: `include_timings=true`; add `rerank=true` only when you are
-  intentionally measuring reranking. Timing output should be interpreted with the
-  returned compute mode, embedding backend, cache state, rerank flag, and search
-  profile when present.
+  intentionally measuring reranking or spending latency for precision. Leaving
+  `rerank` unset is mode-aware auto: CPU steady-state modes keep it off;
+  accelerated/performance mode may auto-rerank when lanes strongly disagree or
+  the query is long. Timing output should be interpreted with the returned
+  compute mode, embedding backend, cache state, rerank flag, and search profile
+  when present.
 - If one search misses, try synonyms and adjacent domain terms before concluding
   the KB lacks coverage. Example: `wood`, `woods`, `smoke`, `smoking`, `kamado`,
   `grill`, `apple`, `oak`, `hickory`.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -231,8 +231,9 @@ def op_bootstrap(
             "diagnostics": {
                 "find_args": {"include_timings": True, "rerank": True},
                 "interpretation": (
-                    "timings measure retrieval stages; compute_policy explains "
-                    "quiet/normal/performance mode separately from rerank/pack knobs"
+                    "timings measure retrieval stages; unset rerank is mode-aware "
+                    "and CPU steady-state modes keep auto-rerank off; compute_policy "
+                    "explains quiet/normal/performance mode separately from rerank/pack knobs"
                 ),
             },
         },
@@ -287,7 +288,8 @@ def op_bootstrap(
         payload["diagnostics"] = {
             "timings": (
                 "Use include_timings=true when discussing latency. Rerank and pack "
-                "can dominate wall time and are not the same as CPU/GPU mode."
+                "can dominate wall time; unset rerank is mode-aware, while explicit "
+                "rerank=true may still spend CPU seconds for precision."
             ),
             "compute_modes": {
                 "quiet": "CPU/low-power, no preload, releases models when idle",
@@ -375,11 +377,12 @@ def op_find(
             ranking — surfaces 1-hop neighbours of strong matches.
         rerank: Cross-encoder re-sort of the top fused candidates
             (bge-reranker-base) for higher-precision ordering. Default
-            (unset) is AUTO: the server reranks only when the ranking
-            lanes disagree or the query is long — the cases where it
-            measurably helps — and skips the ~100-200ms cost otherwise.
-            Pass true to force it on every query, false to disable
-            entirely (yesterday's default).
+            (unset) is mode-aware AUTO: in CPU steady-state modes it stays
+            off for predictable latency; when the text/reranker device is
+            accelerated, the server reranks only when ranking lanes
+            disagree or the query is long. Pass true to force reranking
+            for a high-value query, including on CPU; pass false to skip
+            it entirely.
         prefer_compiled: When true (default), applies a small boost to
             compiled types (insight, pattern, failure, research-note,
             entity) and a small penalty to raw `source` after fusion
@@ -469,6 +472,7 @@ def op_find(
         raise ValueError(
             f"find: detail must be 'full' or 'compact', got {detail!r}"
         )
+    auto_rerank = rerank is None and find_module.auto_rerank_allowed_by_policy()
     timings = find_module.FindTimings() if include_timings else None
     if timings is not None:
         from . import mode as mode_module
@@ -481,7 +485,7 @@ def op_find(
                 "pack": pack,
                 "graph": graph,
                 "rerank_requested": rerank,
-                "auto_rerank": rerank is None,
+                "auto_rerank": auto_rerank,
                 "prefer_compiled": prefer_compiled,
                 "prefer_active": prefer_active,
                 "prefer_used": prefer_used,
@@ -504,10 +508,9 @@ def op_find(
         mode=mode,
         graph=graph,
         rerank=rerank,
-        # rerank=None defers to the engine's per-query heuristic
-        # (should_rerank: lane disagreement / long query). Explicit
+        # rerank=None uses the mode/device-gated auto policy. Explicit
         # true/false from the caller always wins over auto.
-        auto_rerank=rerank is None,
+        auto_rerank=auto_rerank,
         prefer_compiled=prefer_compiled,
         prefer_active=prefer_active,
         prefer_used=prefer_used,

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -115,6 +115,38 @@ def reset_active_ranking_cache() -> None:
     _ranking_config.reset_active_ranking_cache()
 
 
+def _accelerated_device(device: str) -> bool:
+    """Whether a resolved torch device is an accelerator worth auto-reranking on."""
+    d = (device or "").strip().lower()
+    return d == "mps" or d == "cuda" or d.startswith("cuda:")
+
+
+def auto_rerank_allowed_by_policy() -> bool:
+    """True when unset `rerank` may invoke the CrossEncoder automatically.
+
+    Explicit `rerank=True` remains allowed anywhere unless EXOMEM_DISABLE_RANKING
+    hard-disables the reranker. This gates only the default/auto path so normal
+    and quiet CPU service modes keep `find` latency predictable. The common
+    normal/quiet path avoids probing torch; the device selector is consulted only
+    when performance mode or an explicit text-device override asks for acceleration.
+    """
+    from . import mode as mode_module
+
+    explicit_device = any(
+        os.environ.get(env) and os.environ.get(env, "").strip()
+        for env in ("EXOMEM_EMBED_DEVICE", "EXOMEM_DEVICE", "EXOMEM_TORCH_DEVICE")
+    )
+    if not explicit_device and mode_module.resolve_mode() != "performance":
+        return False
+    try:
+        from . import accel
+
+        return _accelerated_device(
+            accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
+        )
+    except Exception:  # noqa: BLE001 - auto-rerank must fail closed to cheap find.
+        return False
+
 
 # --------------------------------------------------------------------------- #
 # Hot find cache: bounded in-process LRU over base Hit lists (OpenSpec change
@@ -309,8 +341,10 @@ def find(
 
     `auto_rerank`: when True AND `rerank` is left unset (None), the reranker
     fires only when `should_rerank()` judges it worthwhile (top-3 vector/bm25
-    disagreement >50% or a long query). An explicit `rerank=True/False` always
-    wins over this. Default False so the suite never loads the model implicitly.
+    disagreement >50% or a long query). Public callers should gate this through
+    `auto_rerank_allowed_by_policy()` so CPU steady-state modes keep predictable
+    latency. An explicit `rerank=True/False` always wins over this. Default
+    False so the suite never loads the model implicitly.
 
     `temporal`: when True (default), temporal queries (recent/latest/when/...)
     get a recency fusion lane and the optional Gaussian recency boost

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -362,19 +362,23 @@ Empty queries degrade to filtered-most-recent regardless of mode.
   try `scope="vault"`, vary the query terms, or `get` a path you suspect.
 
 Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
-`rerank=true` (CrossEncoder re-sort, opt-in), `prefer_compiled=true` (default;
-favours compiled types over raw `source`), `prefer_active=true` (default;
-soft-demotes superseded pages), `file_types` / `exclude_file_types` (scope to
-or drop artifact kinds: `note`, `pdf`, `image`, `audio`, `video`, `docx`, `xlsx`,
-`pptx`, `html`, `text`, `email`, `calendar`, `csv`, `json`, `tsv`), and `speakers`
-(restrict to diarized media whose `speakers:` frontmatter names a given person).
+`rerank=true` (CrossEncoder re-sort, explicit precision spend),
+`prefer_compiled=true` (default; favours compiled types over raw `source`),
+`prefer_active=true` (default; soft-demotes superseded pages), `file_types` /
+`exclude_file_types` (scope to or drop artifact kinds: `note`, `pdf`, `image`,
+`audio`, `video`, `docx`, `xlsx`, `pptx`, `html`, `text`, `email`, `calendar`,
+`csv`, `json`, `tsv`), and `speakers` (restrict to diarized media whose
+`speakers:` frontmatter names a given person). Leaving `rerank` unset is
+mode-aware auto: CPU steady-state modes keep it off; accelerated/performance
+mode may auto-rerank when lanes strongly disagree or the query is long.
 
 Performance presets:
 - Normal lookup: `detail="compact"`, `rerank=false`.
 - Reasoning context: `pack=true` when you need a compressed evidence bundle.
 - Diagnostics: `include_timings=true`; add `rerank=true` only when you are
-  intentionally measuring reranking. Interpret timing output with the returned
-  compute mode, embedding backend, cache state, rerank flag, and search profile.
+  intentionally measuring reranking or spending latency for precision. Interpret
+  timing output with the returned compute mode, embedding backend, cache state,
+  rerank flag, and search profile.
 
 **Tabular data is card-based.** Raw CSV/JSON/TSV rows are never embedded and raw
 data files aren't `find`-searchable. To make a dataset findable, write a

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -750,7 +750,7 @@
             }
           ],
           "default": null,
-          "description": "Cross-encoder re-sort of the top fused candidates\n(bge-reranker-base) for higher-precision ordering. Default\n(unset) is AUTO: the server reranks only when the ranking\nlanes disagree or the query is long — the cases where it\nmeasurably helps — and skips the ~100-200ms cost otherwise.\nPass true to force it on every query, false to disable\nentirely (yesterday's default)."
+          "description": "Cross-encoder re-sort of the top fused candidates\n(bge-reranker-base) for higher-precision ordering. Default\n(unset) is mode-aware AUTO: in CPU steady-state modes it stays\noff for predictable latency; when the text/reranker device is\naccelerated, the server reranks only when ranking lanes\ndisagree or the query is long. Pass true to force reranking\nfor a high-value query, including on CPU; pass false to skip\nit entirely."
         },
         "prefer_compiled": {
           "default": true,

--- a/tests/test_find_timings_compact.py
+++ b/tests/test_find_timings_compact.py
@@ -32,7 +32,7 @@ def test_timings_envelope_and_stages(vault: Path) -> None:
     assert t["profile"]["mode"] == "hybrid"
     assert t["profile"]["detail"] == "full"
     assert t["profile"]["pack"] is False
-    assert t["profile"]["auto_rerank"] is True
+    assert t["profile"]["auto_rerank"] is False
     assert t["profile"]["compute_policy"]["mode"] in {"quiet", "normal", "performance"}
     stages = t["stages"]
     # Lexical lanes always run in hybrid mode; vector is present as a timed

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from exomem import embeddings, readiness, warmup
+from exomem import accel, embeddings, readiness, warmup
+from exomem import find as find_module
 
 
 @pytest.fixture(autouse=True)
@@ -50,3 +51,38 @@ def test_warm_all_skips_reranker_when_disabled(
 def test_reranker_name_default() -> None:
     """Default reranker unchanged (the env override is resolved at import; default here)."""
     assert embeddings.RERANKER_NAME == "BAAI/bge-reranker-base"
+
+def test_auto_rerank_policy_off_in_normal_without_device_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+
+    def _forbidden(**_kwargs):
+        raise AssertionError("normal-mode auto policy should not probe torch/device")
+
+    monkeypatch.setattr(accel, "select_device", _forbidden)
+    assert find_module.auto_rerank_allowed_by_policy() is False
+
+
+def test_auto_rerank_policy_requires_accelerated_performance_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    monkeypatch.setattr(accel, "select_device", lambda **_kwargs: "cuda")
+    assert find_module.auto_rerank_allowed_by_policy() is True
+
+    monkeypatch.setattr(accel, "select_device", lambda **_kwargs: "cpu")
+    assert find_module.auto_rerank_allowed_by_policy() is False
+
+
+def test_auto_rerank_policy_honors_explicit_text_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    monkeypatch.setenv("EXOMEM_EMBED_DEVICE", "cuda")
+    monkeypatch.setattr(accel, "select_device", lambda **_kwargs: "cuda")
+    assert find_module.auto_rerank_allowed_by_policy() is True
+
+    monkeypatch.setenv("EXOMEM_EMBED_DEVICE", "cpu")
+    monkeypatch.setattr(accel, "select_device", lambda **_kwargs: "cpu")
+    assert find_module.auto_rerank_allowed_by_policy() is False


### PR DESCRIPTION
## Summary
- gate default/auto rerank so normal and quiet CPU modes do not invoke the CrossEncoder implicitly
- preserve explicit rerank=true, including CPU precision spends, and keep EXOMEM_DISABLE_RANKING as hard-off
- update bootstrap/tool schema and shipped skill guidance for the new mode-aware behavior

## Tests
- uv run pytest tests/test_ranking.py tests/test_find_timings_compact.py tests/test_bootstrap.py tests/test_mcp_schema_fidelity.py

Note: uv run ruff check src/exomem/find.py src/exomem/commands.py tests/test_ranking.py tests/test_find_timings_compact.py could not run because ruff is not installed in this environment.