### PR TITLE
Add semantic block schema layer

### DIFF
--- a/docs/semantic-blocks.md
+++ b/docs/semantic-blocks.md
@@ -1,0 +1,131 @@
+# Semantic blocks
+
+Semantic blocks are optional Markdown sections that make Exomem notes easier to
+parse without making them harder to read. They are normal headings plus optional
+metadata bullets. The body remains ordinary Markdown.
+
+This is not a separate DSL and not a Basic Memory clone. The goal is governed
+cognition: claims, evidence, decisions, assumptions, risks, records, cases, and
+actions can be named, related, validated, and reused by Exomem tooling.
+
+## Block shape
+
+Use a heading whose text is a supported block type:
+
+```markdown
+## Claim
+- id: retrieval-owned-files
+- relations: evidenced_by: [[Knowledge Base/Sources/Sessions/2026-07-07-session]]
+
+Retrieval works best when durable conclusions live in owned Markdown files.
+```
+
+Metadata is optional. Leading bullets of the form `- key: value` are parsed as
+metadata and removed from the block body. Any other body content stays Markdown:
+paragraphs, bullets, wikilinks, tables, and code blocks.
+
+Headings inside fenced code blocks are ignored by the parser.
+
+## Block types
+
+Supported types:
+
+- `claim`
+- `finding`
+- `evidence`
+- `decision`
+- `assumption`
+- `inference`
+- `constraint`
+- `risk`
+- `open_question`
+- `hypothesis`
+- `result`
+- `metric`
+- `failure`
+- `pattern`
+- `record`
+- `case`
+- `timeline_event`
+- `requirement`
+- `action`
+- `definition`
+- `procedure`
+
+Heading labels normalize spaces and hyphens to underscores, so these are
+equivalent:
+
+```markdown
+## Open Question
+## open-question
+## open_question
+```
+
+Unknown headings remain normal Markdown and are not validation errors.
+
+## Relations
+
+Relations live in a `relations` metadata bullet. Use comma-separated
+`relation: target` entries:
+
+```markdown
+## Risk
+- id: schema-dsl-risk
+- relations: mitigates: [[Decision#Use headings]], blocks: [[Requirement#Plain Markdown]]
+
+A custom grammar would make notes harder to read and harder to edit by hand.
+```
+
+Supported relations:
+
+- `supports`
+- `contradicts`
+- `refines`
+- `supersedes`
+- `derived_from`
+- `depends_on`
+- `evidenced_by`
+- `used_for`
+- `mitigates`
+- `causes`
+- `blocks`
+- `resolves`
+- `cites`
+- `implements`
+- `tests`
+- `owns`
+
+Unsupported relation names and malformed relation entries are validation
+errors. Duplicate block IDs are warnings because the file remains readable, but
+references become ambiguous.
+
+## Examples
+
+```markdown
+## Evidence
+- id: receipt-photo
+- relations: supports: [[Case#Laptop warranty]]
+
+Photo of the purchase receipt preserved for the warranty claim.
+
+## Decision
+- id: use-markdown-headings
+- relations: resolves: [[Open Question#Block syntax]], mitigates: [[Risk#DSL sprawl]]
+
+Use ordinary headings plus optional metadata bullets for v1 semantic blocks.
+
+## Action
+- id: add-tests
+- relations: implements: [[Requirement#Validation Result Shape]], owns: [[Hugo]]
+
+Add parser, validation, claim extraction, and context-pack tests.
+```
+
+## Integration
+
+`claims.extract_claim_text` prefers the first semantic `claim` block when one is
+present, then falls back to the legacy section-based extraction.
+
+`context_pack.assemble_pack` includes a `semantic_blocks` map keyed by packed
+page path when pages contain supported blocks. This is additive: existing pack
+fields and find ordering are unchanged.

--- a/openspec/changes/add-semantic-block-schema/.openspec.yaml
+++ b/openspec/changes/add-semantic-block-schema/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/add-semantic-block-schema/design.md
+++ b/openspec/changes/add-semantic-block-schema/design.md
@@ -1,0 +1,99 @@
+# add-semantic-block-schema — design
+
+## Context
+
+Exomem already extracts claims structurally and assembles context packs from
+Markdown, frontmatter, wikilinks, and existing sidecars. That code proves the
+right direction: deterministic structure from the user's own files, not a
+server-side reasoning layer.
+
+The missing piece is a reusable semantic block layer that can parse a broader
+epistemic vocabulary from normal Markdown and expose it to existing machinery.
+This must stay readable in Obsidian and plain text, and must not require users
+to adopt a fenced directive language or a graph database.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Parse typed semantic blocks from ordinary Markdown headings.
+- Validate a fixed first vocabulary of block types and relation names.
+- Preserve Markdown compatibility: semantic metadata is optional plain bullets,
+  and section body remains normal Markdown.
+- Let claim extraction and context packs reuse parsed blocks without changing
+  public tool surfaces.
+- Keep behavior deterministic, local, and model-free.
+
+**Non-Goals:**
+
+- No Basic Memory-compatible DSL or import clone.
+- No new REST/MCP/CLI operation.
+- No new sidecar, graph database, migration, or dependency.
+- No automatic inference of block types or relations.
+- No authority/confidence scoring.
+
+## Decisions
+
+1. **Use headings as the block boundary.**
+   A semantic block is an ATX heading whose normalized heading text matches a
+   supported block type, such as `## Claim`, `### Open Question`, or
+   `## Timeline Event`. This keeps the file plain Markdown and lets unknown
+   headings remain ordinary document structure. A heavier directive syntax was
+   rejected because it would make the layer less readable and less compatible
+   with existing notes.
+
+2. **Use optional metadata bullets, not inline mini-languages.**
+   The parser reads leading bullets of the form `- key: value` immediately below
+   the block heading. `id` is a conventional identifier. `relations` carries
+   comma-separated typed relation entries such as
+   `supports: [[Knowledge Base/Notes/X#Claim]]`. Unrecognized metadata keys are
+   preserved; only relation names are validated. This gives agents structured
+   handles without turning note bodies into a DSL.
+
+3. **Fence-aware, deterministic parsing.**
+   Headings and metadata-looking text inside fenced code blocks are ignored.
+   The parser records heading level, title, source line, metadata, relations,
+   and body exactly enough for tests and downstream consumers. It does not call
+   any model or inspect embeddings.
+
+4. **Validation is strict where structure is explicit.**
+   Unsupported relation names and malformed relation entries are errors.
+   Duplicate block IDs are warnings because duplicates make references
+   ambiguous but should not make old Markdown unreadable. Unknown ordinary
+   headings are not errors because semantic blocks are opt-in.
+
+5. **Integration is additive.**
+   `claims.extract_claim_text` prefers the first parsed `claim` block, then uses
+   its existing section-based fallback. `context_pack.assemble_pack` adds a
+   `semantic_blocks` field for pages with parsed blocks while preserving
+   `claims`, `neighborhood`, `contradictions`, caps, no-mutation behavior, and
+   find ordering.
+
+## Risks / Trade-offs
+
+- **Heading ambiguity:** a normal `## Claim` heading becomes semantic. Mitigation:
+  that is acceptable because the block body remains unchanged Markdown and the
+  type is explicitly named by the author.
+- **Relation grammar too small:** comma-separated `relation: target` cannot
+  express rich relation metadata. Mitigation: keep v1 parseable and extend
+  later with additional preserved metadata keys if needed.
+- **Context pack payload growth:** exposing all blocks can add output size.
+  Mitigation: only include the field when blocks exist, and use compact block
+  dictionaries.
+- **Validator overreach:** rejecting unknown headings would break normal notes.
+  Mitigation: only recognized semantic headings become blocks.
+
+## Migration Plan
+
+No migration is required. Existing Markdown remains valid. Notes gain semantic
+structure only when authors add supported headings and optional metadata.
+
+Rollback is removing the integration calls; the parser module has no persistent
+state.
+
+## Open Questions
+
+- Whether future increments should add stable cross-file block references beyond
+  plain Markdown anchors and IDs.
+- Whether context packs should later cap `semantic_blocks` separately from the
+  existing pack caps.

--- a/openspec/changes/add-semantic-block-schema/proposal.md
+++ b/openspec/changes/add-semantic-block-schema/proposal.md
@@ -1,0 +1,59 @@
+# add-semantic-block-schema
+
+## Why
+
+Exomem has claim extraction, context packs, evidence, audit, and supersession,
+but it does not yet have a general Markdown-readable semantic block layer that
+agents can parse and validate without inventing a separate storage model. This
+change makes typed epistemic structure explicit while keeping ordinary Markdown
+as the source of truth.
+
+The goal is not to copy Basic Memory's generic note grammar. Exomem's moat is
+governed cognition: claims, findings, evidence, decisions, assumptions, risks,
+records, cases, requirements, actions, and their typed relations can be read by
+humans, parsed deterministically, and reused by existing claim/context-pack
+machinery.
+
+## What Changes
+
+- Add a semantic block parser/model/validator over normal ATX Markdown headings
+  plus optional plain metadata bullets.
+- Support the first block vocabulary: `claim`, `finding`, `evidence`,
+  `decision`, `assumption`, `inference`, `constraint`, `risk`,
+  `open_question`, `hypothesis`, `result`, `metric`, `failure`, `pattern`,
+  `record`, `case`, `timeline_event`, `requirement`, `action`, `definition`,
+  and `procedure`.
+- Support typed relations: `supports`, `contradicts`, `refines`, `supersedes`,
+  `derived_from`, `depends_on`, `evidenced_by`, `used_for`, `mitigates`,
+  `causes`, `blocks`, `resolves`, `cites`, `implements`, `tests`, and `owns`.
+- Add focused tests and docs for the Markdown shape, validation behavior, and
+  compatibility guarantees.
+- Integrate lightly with existing code: claim extraction may prefer semantic
+  `claim` blocks, and context packs may expose parsed semantic blocks when
+  present.
+
+Pure-substrate note: this is deterministic parsing and validation only. It adds
+no server-side reasoning model, no confidence scores, no new sidecar, and no
+generated summaries.
+
+## Capabilities
+
+### New Capabilities
+
+- `semantic-block-schema`: Markdown-readable semantic blocks and typed
+  relations for Exomem notes.
+
+### Modified Capabilities
+
+- `context-packs`: packs may include parsed semantic blocks for packed pages
+  while preserving existing fields and ordering.
+
+## Impact
+
+- New module: `src/exomem/semantic_blocks.py`.
+- Tests: `tests/test_semantic_blocks.py`, plus targeted claim/context-pack
+  coverage.
+- Docs: `docs/semantic-blocks.md`.
+- Limited integration points: `src/exomem/claims.py` and
+  `src/exomem/context_pack.py`.
+- No dependency, CLI, REST, MCP, storage, or migration changes.

--- a/openspec/changes/add-semantic-block-schema/specs/context-packs/spec.md
+++ b/openspec/changes/add-semantic-block-schema/specs/context-packs/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Optional Context Pack Assembly From `find`
+
+The system SHALL provide an optional `pack` parameter on `find` (default
+`false`) that, when `false`, returns the existing hit list **unchanged** and,
+when `true`, returns an object `{"hits": [...], "pack": {...}}` where `pack` is
+an assembled context pack over the top hits carrying `packed_paths`, `claims`,
+`semantic_blocks`, `neighborhood`, `contradictions`, `embeddings_available`,
+and `truncation`. The assembly SHALL NOT alter the hits, their order, or any
+existing `find` behaviour, and the core `find` ranker signature and return type
+SHALL be unchanged (the parameter and the object return are confined to the
+command leaf).
+
+#### Scenario: Pack off is byte-identical to today
+
+- **WHEN** `find` is called with `pack` omitted or `false`
+- **THEN** it returns the same hit list it returns today, with no `pack` object
+  and no change to ordering or fields
+
+#### Scenario: Pack on returns hits plus an assembled pack
+
+- **WHEN** `find` is called with `pack=true` over a vault with matching notes
+- **THEN** it returns `{"hits", "pack"}` where `hits` is the usual list and
+  `pack` carries `packed_paths` (the top notes covered), `claims`,
+  `semantic_blocks`, `neighborhood`, `contradictions`, `embeddings_available`,
+  and `truncation`
+- **AND** no file under the vault is created, modified, moved, or deleted
+
+#### Scenario: Semantic blocks are additive
+
+- **WHEN** a packed page contains supported semantic block headings
+- **THEN** `pack.semantic_blocks` includes parsed block dictionaries keyed by
+  packed page path
+- **AND** pages without semantic blocks do not require any placeholder block
+  entries

--- a/openspec/changes/add-semantic-block-schema/specs/semantic-block-schema/spec.md
+++ b/openspec/changes/add-semantic-block-schema/specs/semantic-block-schema/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Markdown Semantic Block Parsing
+
+The system SHALL parse semantic blocks from ordinary ATX Markdown headings whose
+normalized heading text matches a supported block type. The supported block
+types SHALL include `claim`, `finding`, `evidence`, `decision`, `assumption`,
+`inference`, `constraint`, `risk`, `open_question`, `hypothesis`, `result`,
+`metric`, `failure`, `pattern`, `record`, `case`, `timeline_event`,
+`requirement`, `action`, `definition`, and `procedure`.
+
+#### Scenario: Required block types parse from headings
+
+- **WHEN** a Markdown page contains headings such as `## Claim`,
+  `## Open Question`, and `## Timeline Event`
+- **THEN** the parser returns semantic blocks with normalized types `claim`,
+  `open_question`, and `timeline_event`
+- **AND** each block preserves its heading title, heading level, source line,
+  and Markdown body
+
+#### Scenario: Unknown headings stay ordinary Markdown
+
+- **WHEN** a Markdown page contains `## Background` and no supported semantic
+  heading at that section
+- **THEN** the parser does not emit a semantic block for `Background`
+- **AND** validation does not report an error for that ordinary heading
+
+### Requirement: Plain Metadata And Typed Relations
+
+The system SHALL parse optional leading metadata bullets under a semantic block
+heading using `- key: value` syntax and SHALL parse relation metadata from a
+`relations` key containing comma-separated `relation: target` entries. Relation
+names SHALL be limited to `supports`, `contradicts`, `refines`, `supersedes`,
+`derived_from`, `depends_on`, `evidenced_by`, `used_for`, `mitigates`,
+`causes`, `blocks`, `resolves`, `cites`, `implements`, `tests`, and `owns`.
+
+#### Scenario: Relation metadata is parsed
+
+- **WHEN** a semantic block contains
+  `- relations: supports: [[A]], evidenced_by: [[Source]]`
+- **THEN** the parser returns two relations named `supports` and `evidenced_by`
+  with their Markdown targets preserved
+
+#### Scenario: Invalid relation names fail validation
+
+- **WHEN** a semantic block contains `- relations: agrees_with: [[A]]`
+- **THEN** validation reports an error for unsupported relation `agrees_with`
+
+#### Scenario: Malformed relation entries fail validation
+
+- **WHEN** a semantic block contains `- relations: supports [[A]]`
+- **THEN** validation reports a malformed relation entry error
+
+### Requirement: Markdown Compatibility
+
+The system SHALL keep semantic block syntax compatible with plain Markdown. The
+parser MUST ignore headings and metadata-looking text inside fenced code blocks,
+MUST preserve non-metadata body text as Markdown, and MUST NOT require custom
+fences, directives, comments, or inline markers.
+
+#### Scenario: Fenced code is ignored
+
+- **WHEN** a fenced code block contains a line `## Claim`
+- **THEN** that line is not parsed as a semantic block heading
+
+#### Scenario: Body remains Markdown
+
+- **WHEN** a semantic block body contains paragraphs, bullets, and wikilinks
+- **THEN** those body lines are preserved as the block body after leading
+  metadata bullets are removed
+
+### Requirement: Validation Result Shape
+
+The system SHALL expose validation results with separate `errors` and
+`warnings`. Duplicate semantic block IDs SHALL be warnings, while unsupported
+relations and malformed relation entries SHALL be errors.
+
+#### Scenario: Duplicate IDs warn without blocking parsing
+
+- **WHEN** two semantic blocks use `- id: same-id`
+- **THEN** validation returns a duplicate ID warning
+- **AND** the parsed blocks remain available to callers
+
+### Requirement: Claim And Context Pack Reuse
+
+The system SHALL let existing claim extraction prefer parsed semantic `claim`
+blocks and SHALL let context pack assembly include parsed semantic blocks when
+present, without changing existing find ordering, pack caps, or mutation
+behavior.
+
+#### Scenario: Claim extraction prefers semantic claim block
+
+- **WHEN** a note has a semantic `## Claim` block and another legacy claim-like
+  section later in the note
+- **THEN** claim extraction uses the semantic claim block body first
+
+#### Scenario: Context packs include semantic blocks additively
+
+- **WHEN** `assemble_pack` packs a page containing semantic blocks
+- **THEN** the returned pack includes semantic block data for that page
+- **AND** the existing `claims`, `neighborhood`, `contradictions`,
+  `embeddings_available`, and `truncation` fields remain present

--- a/openspec/changes/add-semantic-block-schema/tasks.md
+++ b/openspec/changes/add-semantic-block-schema/tasks.md
@@ -1,0 +1,27 @@
+# add-semantic-block-schema — tasks
+
+## 1. OpenSpec Contract
+
+- [x] 1.1 Add proposal, design, and delta specs for semantic blocks and context-pack exposure.
+- [x] 1.2 Validate the OpenSpec change structure.
+
+## 2. Core Semantic Blocks
+
+- [x] 2.1 Implement `src/exomem/semantic_blocks.py` with block/relation constants, dataclasses, parser, serializer helpers, and validation results.
+- [x] 2.2 Make parsing fence-aware and Markdown-compatible: recognized headings become blocks, unknown headings remain ordinary Markdown, and leading `- key: value` metadata is optional.
+- [x] 2.3 Parse and validate relation metadata for the supported relation vocabulary.
+
+## 3. Integration
+
+- [x] 3.1 Update claim extraction to prefer parsed semantic `claim` blocks before the existing section fallback.
+- [x] 3.2 Update context-pack assembly to include parsed semantic blocks additively when present.
+
+## 4. Tests And Docs
+
+- [x] 4.1 Add `tests/test_semantic_blocks.py` covering parsing, validation, fence handling, aliases, duplicate ID warnings, claim extraction, and context-pack exposure.
+- [x] 4.2 Add `docs/semantic-blocks.md` with the Markdown shape, supported vocabulary, and examples.
+
+## 5. Verification
+
+- [x] 5.1 Run OpenSpec validation for `add-semantic-block-schema`.
+- [x] 5.2 Run targeted pytest coverage for semantic blocks, claims, and context packs.

--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -48,7 +48,7 @@ from typing import NamedTuple
 
 import numpy as np
 
-from . import embeddings, index_paths, sidecar_store
+from . import embeddings, index_paths, semantic_blocks, sidecar_store
 from .kbdir import kb_dirname
 
 log = logging.getLogger(__name__)
@@ -215,6 +215,13 @@ def extract_claim_text(
     the return contract (a short claim string, or None) stays the same.
     """
     title = (title or "").strip()
+    semantic_claim = semantic_blocks.first_block_body(body or "", "claim")
+    if semantic_claim:
+        claim_body = _cap_words(semantic_claim.strip())
+        if title and claim_body:
+            return f"{title}\n\n{claim_body}"
+        return title or claim_body or None
+
     _, sections = _split_sections(body or "")
 
     kind = _claim_kind(page_type, entity_type)

--- a/src/exomem/context_pack.py
+++ b/src/exomem/context_pack.py
@@ -26,7 +26,7 @@ import os
 import re
 from pathlib import Path
 
-from . import corpus_aware
+from . import corpus_aware, semantic_blocks
 from . import find as find_module
 from . import vault as vault_module
 from .find import Hit, ParsedPage
@@ -180,6 +180,11 @@ def _extract_claims(page: ParsedPage, *, claim_chars: int = _DEFAULT_CLAIM_CHARS
         "sections": _sections(lines),
         "outline": _outline(lines),
     }
+
+
+def _extract_semantic_blocks(page: ParsedPage) -> list[dict]:
+    document = semantic_blocks.parse_semantic_blocks(page.body, validate=False)
+    return [block.to_dict() for block in document.blocks]
 
 
 # ----------------------------- neighbourhood -----------------------------
@@ -359,6 +364,12 @@ def assemble_pack(
     claims = {
         p.rel_path: _extract_claims(p, claim_chars=claim_chars) for p in packed_pages
     }
+    semantic_block_map: dict[str, list[dict]] = {}
+    for page in packed_pages:
+        blocks = _extract_semantic_blocks(page)
+        if blocks:
+            semantic_block_map[page.rel_path] = blocks
+
     neighborhood, n_dropped = _neighborhood(vault_root, packed_pages, max_neighbors)
     if n_dropped > 0:
         truncation.append(
@@ -379,6 +390,7 @@ def assemble_pack(
     return {
         "packed_paths": [p.rel_path for p in packed_pages],
         "claims": claims,
+        "semantic_blocks": semantic_block_map,
         "neighborhood": neighborhood,
         "contradictions": {"superseded": superseded, "tension": tension},
         "embeddings_available": embeddings_available,

--- a/src/exomem/semantic_blocks.py
+++ b/src/exomem/semantic_blocks.py
@@ -1,0 +1,385 @@
+"""Markdown-readable semantic blocks for Exomem notes.
+
+This module is deliberately small: normal ATX headings name semantic blocks,
+optional leading ``- key: value`` bullets carry metadata, and the rest of the
+section remains plain Markdown. It performs deterministic parsing and
+validation only; no model, sidecar, or graph store is involved.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+BLOCK_TYPES: frozenset[str] = frozenset(
+    {
+        "claim",
+        "finding",
+        "evidence",
+        "decision",
+        "assumption",
+        "inference",
+        "constraint",
+        "risk",
+        "open_question",
+        "hypothesis",
+        "result",
+        "metric",
+        "failure",
+        "pattern",
+        "record",
+        "case",
+        "timeline_event",
+        "requirement",
+        "action",
+        "definition",
+        "procedure",
+    }
+)
+
+RELATION_TYPES: frozenset[str] = frozenset(
+    {
+        "supports",
+        "contradicts",
+        "refines",
+        "supersedes",
+        "derived_from",
+        "depends_on",
+        "evidenced_by",
+        "used_for",
+        "mitigates",
+        "causes",
+        "blocks",
+        "resolves",
+        "cites",
+        "implements",
+        "tests",
+        "owns",
+    }
+)
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+_METADATA_RE = re.compile(r"^\s*[-*+]\s+([A-Za-z0-9 _-]+):\s*(.*)$")
+_NORMALIZE_RE = re.compile(r"[\s-]+")
+
+
+@dataclass(frozen=True)
+class SemanticRelation:
+    kind: str
+    target: str
+    raw: str
+    line: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "target": self.target,
+            "raw": self.raw,
+            "line": self.line,
+        }
+
+
+@dataclass(frozen=True)
+class SemanticBlockValidationError:
+    code: str
+    message: str
+    line: int | None = None
+    block_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.line is not None:
+            out["line"] = self.line
+        if self.block_id:
+            out["block_id"] = self.block_id
+        return out
+
+
+@dataclass(frozen=True)
+class SemanticBlock:
+    type: str
+    title: str
+    level: int
+    line: int
+    end_line: int
+    body: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    relations: list[SemanticRelation] = field(default_factory=list)
+
+    @property
+    def id(self) -> str | None:
+        return self.metadata.get("id")
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "type": self.type,
+            "title": self.title,
+            "level": self.level,
+            "line": self.line,
+            "end_line": self.end_line,
+            "body": self.body,
+            "metadata": dict(self.metadata),
+            "relations": [r.to_dict() for r in self.relations],
+        }
+        if self.id:
+            out["id"] = self.id
+        return out
+
+
+@dataclass(frozen=True)
+class SemanticBlockDocument:
+    blocks: list[SemanticBlock]
+    errors: list[SemanticBlockValidationError] = field(default_factory=list)
+    warnings: list[SemanticBlockValidationError] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+    def blocks_by_type(self, block_type: str) -> list[SemanticBlock]:
+        normalized = normalize_label(block_type)
+        return [block for block in self.blocks if block.type == normalized]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "blocks": [block.to_dict() for block in self.blocks],
+            "errors": [error.to_dict() for error in self.errors],
+            "warnings": [warning.to_dict() for warning in self.warnings],
+        }
+
+
+def normalize_label(label: str) -> str:
+    """Normalize user-visible heading/relation labels to schema keys."""
+    normalized = (label or "").strip().lower().rstrip(":").strip()
+    normalized = _NORMALIZE_RE.sub("_", normalized)
+    normalized = re.sub(r"_+", "_", normalized)
+    return normalized.strip("_")
+
+
+def parse_semantic_blocks(markdown: str, *, validate: bool = True) -> SemanticBlockDocument:
+    """Parse semantic blocks from Markdown.
+
+    Unknown headings are treated as normal Markdown structure. A recognized
+    semantic heading starts a block and the block ends at the next non-fenced
+    ATX heading. Leading metadata bullets are removed from the block body.
+    """
+    lines = (markdown or "").splitlines()
+    blocks: list[SemanticBlock] = []
+    errors: list[SemanticBlockValidationError] = []
+    current: tuple[str, str, int, int, list[tuple[int, str]]] | None = None
+    in_fence = False
+
+    def flush(end_line: int) -> None:
+        nonlocal current
+        if current is None:
+            return
+        block_type, title, level, start_line, body_lines = current
+        block, block_errors = _build_block(
+            block_type=block_type,
+            title=title,
+            level=level,
+            start_line=start_line,
+            end_line=max(start_line, end_line),
+            lines=body_lines,
+        )
+        blocks.append(block)
+        if validate:
+            errors.extend(block_errors)
+        current = None
+
+    for line_number, line in enumerate(lines, start=1):
+        if _FENCE_RE.match(line):
+            if current is not None:
+                current[4].append((line_number, line))
+            in_fence = not in_fence
+            continue
+
+        heading = _HEADING_RE.match(line)
+        if heading and not in_fence:
+            flush(line_number - 1)
+            title = heading.group(2).strip()
+            block_type = normalize_label(title)
+            if block_type in BLOCK_TYPES:
+                current = (block_type, title, len(heading.group(1)), line_number, [])
+            continue
+
+        if current is not None:
+            current[4].append((line_number, line))
+
+    flush(len(lines))
+
+    warnings = _duplicate_id_warnings(blocks) if validate else []
+    return SemanticBlockDocument(blocks=blocks, errors=errors, warnings=warnings)
+
+
+def first_block_body(markdown: str, block_type: str) -> str | None:
+    """Body text for the first parsed block of `block_type`, or None."""
+    document = parse_semantic_blocks(markdown, validate=False)
+    normalized = normalize_label(block_type)
+    for block in document.blocks:
+        if block.type == normalized and block.body.strip():
+            return block.body.strip()
+    return None
+
+
+def _build_block(
+    *,
+    block_type: str,
+    title: str,
+    level: int,
+    start_line: int,
+    end_line: int,
+    lines: list[tuple[int, str]],
+) -> tuple[SemanticBlock, list[SemanticBlockValidationError]]:
+    metadata, relation_values, body_lines = _split_metadata(lines)
+    relations, errors = _parse_relations(relation_values)
+    body = "\n".join(body_lines).strip()
+    block = SemanticBlock(
+        type=block_type,
+        title=title,
+        level=level,
+        line=start_line,
+        end_line=end_line,
+        body=body,
+        metadata=metadata,
+        relations=relations,
+    )
+    return block, errors
+
+
+def _split_metadata(
+    lines: list[tuple[int, str]],
+) -> tuple[dict[str, str], list[tuple[str, int]], list[str]]:
+    metadata: dict[str, str] = {}
+    relation_values: list[tuple[str, int]] = []
+    i = 0
+
+    while i < len(lines) and not lines[i][1].strip():
+        i += 1
+
+    while i < len(lines):
+        line_number, line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        match = _METADATA_RE.match(line)
+        if not match:
+            break
+        key = normalize_label(match.group(1))
+        value = match.group(2).strip()
+        metadata[key] = value
+        if key == "relations":
+            relation_values.append((value, line_number))
+        i += 1
+
+    return metadata, relation_values, [line for _, line in lines[i:]]
+
+
+def _parse_relations(
+    values: list[tuple[str, int]],
+) -> tuple[list[SemanticRelation], list[SemanticBlockValidationError]]:
+    relations: list[SemanticRelation] = []
+    errors: list[SemanticBlockValidationError] = []
+
+    for value, line_number in values:
+        entries = _split_relation_entries(value)
+        if not entries:
+            errors.append(
+                SemanticBlockValidationError(
+                    code="malformed_relation",
+                    message="relations metadata must contain relation: target entries",
+                    line=line_number,
+                )
+            )
+            continue
+        for entry in entries:
+            if ":" not in entry:
+                errors.append(
+                    SemanticBlockValidationError(
+                        code="malformed_relation",
+                        message=f"malformed relation entry: {entry}",
+                        line=line_number,
+                    )
+                )
+                continue
+            raw_kind, raw_target = entry.split(":", 1)
+            kind = normalize_label(raw_kind)
+            target = raw_target.strip()
+            if kind not in RELATION_TYPES:
+                errors.append(
+                    SemanticBlockValidationError(
+                        code="unsupported_relation",
+                        message=f"unsupported relation: {raw_kind.strip()}",
+                        line=line_number,
+                    )
+                )
+                continue
+            if not target:
+                errors.append(
+                    SemanticBlockValidationError(
+                        code="malformed_relation",
+                        message=f"relation {kind} is missing a target",
+                        line=line_number,
+                    )
+                )
+                continue
+            relations.append(
+                SemanticRelation(kind=kind, target=target, raw=entry, line=line_number)
+            )
+
+    return relations, errors
+
+
+def _split_relation_entries(value: str) -> list[str]:
+    entries: list[str] = []
+    buf: list[str] = []
+    wikilink_depth = 0
+    i = 0
+    while i < len(value):
+        pair = value[i : i + 2]
+        if pair == "[[":
+            wikilink_depth += 1
+            buf.append(pair)
+            i += 2
+            continue
+        if pair == "]]" and wikilink_depth:
+            wikilink_depth -= 1
+            buf.append(pair)
+            i += 2
+            continue
+        char = value[i]
+        if char == "," and wikilink_depth == 0:
+            entry = "".join(buf).strip()
+            if entry:
+                entries.append(entry)
+            buf = []
+        else:
+            buf.append(char)
+        i += 1
+
+    entry = "".join(buf).strip()
+    if entry:
+        entries.append(entry)
+    return entries
+
+
+def _duplicate_id_warnings(blocks: list[SemanticBlock]) -> list[SemanticBlockValidationError]:
+    seen: dict[str, SemanticBlock] = {}
+    warnings: list[SemanticBlockValidationError] = []
+    for block in blocks:
+        if not block.id:
+            continue
+        if block.id in seen:
+            warnings.append(
+                SemanticBlockValidationError(
+                    code="duplicate_id",
+                    message=f"duplicate semantic block id: {block.id}",
+                    line=block.line,
+                    block_id=block.id,
+                )
+            )
+            continue
+        seen[block.id] = block
+    return warnings

--- a/tests/test_semantic_blocks.py
+++ b/tests/test_semantic_blocks.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import claims, context_pack, find as find_module, semantic_blocks
+from exomem.find import Hit
+
+
+def _label(name: str) -> str:
+    return name.replace("_", " ").title()
+
+
+def test_parses_all_required_block_types_from_headings() -> None:
+    markdown = "\n\n".join(
+        f"## {_label(block_type)}\n\nBody for {block_type}."
+        for block_type in sorted(semantic_blocks.BLOCK_TYPES)
+    )
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.is_valid
+    assert {block.type for block in document.blocks} == semantic_blocks.BLOCK_TYPES
+    assert all(block.level == 2 for block in document.blocks)
+    assert all(block.line > 0 for block in document.blocks)
+    assert all(block.body.startswith("Body for ") for block in document.blocks)
+
+
+def test_unknown_headings_are_not_semantic_blocks_or_errors() -> None:
+    markdown = "# Title\n\n## Background\n\nOrdinary section.\n"
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.blocks == []
+    assert document.errors == []
+    assert document.warnings == []
+
+
+def test_metadata_relations_and_body_are_parsed() -> None:
+    markdown = """\
+## Claim
+- id: c1
+- status: active
+- relations: supports: [[A]], evidenced_by: [[Source]]
+
+The claim remains Markdown.
+
+- A normal body bullet.
+- [[A wikilink]]
+"""
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+    block = document.blocks[0]
+
+    assert document.is_valid
+    assert block.id == "c1"
+    assert block.metadata["status"] == "active"
+    assert [relation.kind for relation in block.relations] == ["supports", "evidenced_by"]
+    assert [relation.target for relation in block.relations] == ["[[A]]", "[[Source]]"]
+    assert "- id:" not in block.body
+    assert block.body.startswith("The claim remains Markdown.")
+    assert "- [[A wikilink]]" in block.body
+
+
+def test_parses_all_required_relation_types() -> None:
+    relation_names = [
+        "supports",
+        "contradicts",
+        "refines",
+        "supersedes",
+        "derived_from",
+        "depends_on",
+        "evidenced_by",
+        "used_for",
+        "mitigates",
+        "causes",
+        "blocks",
+        "resolves",
+        "cites",
+        "implements",
+        "tests",
+        "owns",
+    ]
+    relation_text = ", ".join(f"{name}: [[Target {i}]]" for i, name in enumerate(relation_names))
+    markdown = f"## Finding\n- relations: {relation_text}\n\nFinding body.\n"
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.is_valid
+    assert [relation.kind for relation in document.blocks[0].relations] == relation_names
+    assert {relation.kind for relation in document.blocks[0].relations} == semantic_blocks.RELATION_TYPES
+
+
+def test_relation_split_ignores_commas_inside_wikilinks() -> None:
+    markdown = "## Evidence\n- relations: cites: [[Source, With Comma]], supports: [[Claim]]\n\nBody.\n"
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.is_valid
+    assert [relation.target for relation in document.blocks[0].relations] == [
+        "[[Source, With Comma]]",
+        "[[Claim]]",
+    ]
+
+
+def test_invalid_relation_name_reports_error() -> None:
+    markdown = "## Claim\n- relations: agrees_with: [[A]]\n\nBody.\n"
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert not document.is_valid
+    assert document.errors[0].code == "unsupported_relation"
+    assert "agrees_with" in document.errors[0].message
+    assert document.blocks[0].relations == []
+
+
+def test_malformed_relation_reports_error() -> None:
+    markdown = "## Claim\n- relations: supports [[A]]\n\nBody.\n"
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert not document.is_valid
+    assert document.errors[0].code == "malformed_relation"
+    assert "supports [[A]]" in document.errors[0].message
+
+
+def test_duplicate_ids_warn_without_blocking_parse() -> None:
+    markdown = """\
+## Claim
+- id: same
+
+A.
+
+## Decision
+- id: same
+
+B.
+"""
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.is_valid
+    assert len(document.blocks) == 2
+    assert len(document.warnings) == 1
+    assert document.warnings[0].code == "duplicate_id"
+    assert document.warnings[0].block_id == "same"
+
+
+def test_aliases_normalize_to_open_question() -> None:
+    markdown = """\
+## Open Question
+
+A.
+
+## open-question
+
+B.
+
+## open_question
+
+C.
+"""
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert [block.type for block in document.blocks] == [
+        "open_question",
+        "open_question",
+        "open_question",
+    ]
+
+
+def test_fenced_code_is_ignored() -> None:
+    markdown = """\
+```markdown
+## Claim
+- relations: agrees_with: [[A]]
+```
+
+## Decision
+
+Use the parser.
+"""
+
+    document = semantic_blocks.parse_semantic_blocks(markdown)
+
+    assert document.is_valid
+    assert [block.type for block in document.blocks] == ["decision"]
+    assert document.blocks[0].body == "Use the parser."
+
+
+def test_first_block_body_returns_metadata_stripped_body() -> None:
+    markdown = "## Claim\n- id: c1\n\nClaim body.\n"
+
+    assert semantic_blocks.first_block_body(markdown, "claim") == "Claim body."
+
+
+def test_claim_extraction_prefers_semantic_claim_block() -> None:
+    body = """\
+# T
+
+## Claim
+- id: c1
+
+Semantic claim body.
+
+## Conclusion
+
+Legacy conclusion body.
+"""
+
+    extracted = claims.extract_claim_text("T", body, page_type="research-note")
+
+    assert extracted == "T\n\nSemantic claim body."
+    assert "id: c1" not in extracted
+    assert "Legacy" not in extracted
+
+
+def test_context_pack_includes_semantic_blocks_additively(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    rel = "Knowledge Base/Notes/Semantic.md"
+    path = vault / rel
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """\
+---
+type: insight
+---
+# Semantic
+
+## Claim
+- id: c1
+- relations: evidenced_by: [[Knowledge Base/Sources/Session]]
+
+Semantic claim.
+
+## Risk
+
+The implementation could grow a DSL.
+""",
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+
+    pack = context_pack.assemble_pack(
+        vault, [Hit(path=rel, type=None, scope=None, title="", updated="", excerpt="")]
+    )
+
+    assert set(pack) >= {
+        "packed_paths",
+        "claims",
+        "semantic_blocks",
+        "neighborhood",
+        "contradictions",
+        "embeddings_available",
+        "truncation",
+    }
+    blocks = pack["semantic_blocks"][rel]
+    assert [block["type"] for block in blocks] == ["claim", "risk"]
+    assert blocks[0]["id"] == "c1"
+    assert blocks[0]["relations"][0]["kind"] == "evidenced_by"
+    assert pack["claims"][rel]["title"] == "Semantic"


### PR DESCRIPTION
## Summary
- Add Markdown-readable semantic block parser/model/validator for typed blocks, metadata, relations, errors, and warnings.
- Let claim extraction prefer semantic claim blocks before the legacy fallback.
- Add semantic_blocks to context packs and document the OpenSpec-backed schema.

## Verification
- openspec validate add-semantic-block-schema --strict
- uv run pytest tests/test_semantic_blocks.py tests/test_claims.py tests/test_context_pack.py (28 passed, 1 skipped: optional sentence_transformers)