### PR TITLE
Productize knowledge pack surface

### DIFF
--- a/docs/knowledge-packs.md
+++ b/docs/knowledge-packs.md
@@ -1,19 +1,30 @@
 # Knowledge packs
 
-Knowledge packs are declarative routing bundles. They help Exomem suggest how a messy vault might map onto durable primitives without hard-coding a new folder tree or asking users to understand the ontology first.
+Knowledge packs are product-level guidance for Exomem. They let a fresh user pick
+useful starting domains, and they let agents route simple intentions into the
+right governed layer without asking the user to understand Sources, Evidence,
+Notes, Entities, or supersession first.
 
-Built-in packs live in `src/exomem/packs/*.json`. The runtime loads them with `importlib.resources`, validates them strictly, and exposes the schema in `adopt` reports through `pack_schema`.
+Packs do not create a new storage engine. They compose Exomem's durable
+primitives and typed tools.
 
 ## Built-in packs
 
-- `legal-warranty` — cases, receipts, correspondence, deadlines, and proof.
-- `creative` — references, assets, drafts, productions, taste notes, and releases.
-- `technical` — projects, repositories, decisions, failures, incidents, and runbooks.
-- `health-athletic` — training, symptoms, measurements, protocols, injuries, and goals.
-- `business` — customers, meetings, commitments, contracts, risks, and decisions.
-- `personal-records` — purchases, travel, home, vehicles, admin records, and life logistics.
+- `legal-warranty` - receipts, disputes, insurance, contracts, deadlines, cases, and proof.
+- `creative` - references, assets, drafts, productions, taste notes, and releases.
+- `technical` - projects, repositories, decisions, failures, incidents, experiments, and runbooks.
+- `health-athletic` - training, symptoms, measurements, protocols, injuries, goals, and health records.
+- `business` - customers, meetings, commitments, contracts, invoices, risks, and decisions.
+- `personal-records` - everyday documents, purchases, travel, home, vehicles, admin records, and life logistics.
+
+`personal-records` is the default when Exomem cannot infer a more specific pack,
+which makes it suitable for fresh or empty vaults.
 
 ## Schema
+
+Built-in packs live in `src/exomem/packs/*.json`. The runtime loads them with
+`importlib.resources`, validates them strictly, and exposes the schema in
+`adopt` reports through `pack_schema`.
 
 Each pack is a JSON object with these required fields:
 
@@ -21,44 +32,75 @@ Each pack is a JSON object with these required fields:
 | --- | --- |
 | `id` | Stable slug. |
 | `name` | Human-readable pack name. |
-| `description` | One-sentence product description. |
+| `description` | Short catalog description. |
+| `purpose` | What the pack is for at product level. |
+| `audience` | Who should choose it. |
+| `beginner_description` | Plain-language onboarding copy. |
+| `agent_instructions` | Routing guidance for agents; user-facing replies should stay simple. |
+| `default_note_types` | Common compiled-note types for the pack. |
+| `default_entity_types` | Common entity types for the pack. |
+| `default_block_types` | Common conceptual blocks such as receipt, decision, protocol, or incident. |
+| `suggested_folders` | Governed KB locations the pack commonly uses; selection does not create them. |
+| `suggested_workflows` | Beginner-facing workflows with `title`, `intent`, `route`, and `example`. |
 | `primitives` | Durable primitives the pack commonly uses. |
 | `actions` | Simple actions the pack supports: `save`, `adopt`, `ask`, `prove`, `review`, `update`, `connect`. |
 | `examples` | User-facing prompts that should route to this pack. |
 | `signals` | Structural tokens used by adoption scans to suggest the pack. |
 
-Allowed primitives are `source`, `evidence`, `case`, `decision`, `record`, `asset`, `production`, `entity`, `failure`, `pattern`, and `experiment`.
+Allowed primitives are `source`, `evidence`, `case`, `decision`, `record`,
+`asset`, `production`, `entity`, `failure`, `pattern`, and `experiment`.
 
-Unknown fields are rejected. That is intentional: a deployment should not believe a pack field is active when this Exomem version ignores it.
+Unknown pack fields are rejected. Unknown workflow fields are also rejected. This
+is intentional: a deployment should not believe a pack field is active when this
+Exomem version ignores it.
 
-## Example
+## Selection manifest
+
+Setup persists selected packs at:
+
+```text
+Knowledge Base/_Packs/selected-packs.json
+```
+
+Example:
 
 ```json
 {
-  "id": "legal-warranty",
-  "name": "Legal / warranty",
-  "description": "Cases, receipts, correspondence, deadlines, and proof.",
-  "primitives": ["source", "evidence", "case", "decision", "record"],
-  "actions": ["save", "prove", "review", "update"],
-  "examples": [
-    "Save this receipt for the laptop warranty case.",
-    "Show the evidence for the landlord dispute."
-  ],
-  "signals": ["legal", "warranty", "receipt", "invoice", "contract"]
+  "schema_version": 1,
+  "selected_pack_ids": ["personal-records"],
+  "source": "setup",
+  "updated": "2026-07-07",
+  "packs": [
+    {
+      "id": "personal-records",
+      "name": "Personal records",
+      "beginner_description": "Use this as the starter pack for everyday documents, purchases, travel, home, vehicles, and personal admin.",
+      "agent_instructions": "Use this as the default when no stronger domain pack is selected...",
+      "suggested_workflows": [],
+      "actions": ["save", "ask", "prove", "review", "update"]
+    }
+  ]
 }
 ```
 
-## Adoption behavior
+Selection is guidance only. It does not create folders, migrate content, rewrite
+old notes, or compile material. Setup writes the manifest only after the
+`Knowledge Base/` scaffold exists.
 
-Pack suggestions are deterministic. Exomem looks at structural signals from `overview`: folder names, sample file names, counts, and media mix. It does not read every note body or ask a model to classify the vault.
+## Adoption and setup behavior
 
-A pack suggestion is a proposed route, not a migration. The safe loop is:
+Pack suggestions are deterministic. Exomem looks at structural signals from
+`overview`: folder paths and sample file names. It does not read every note body
+or ask a model to classify the vault.
 
-1. Run `adopt(mode="scan-only")`.
-2. Review suggested packs and actions.
-3. Optionally save the manifest under `Knowledge Base/_Adoption/`.
-4. Copy selected legacy files as Sources when provenance matters.
-5. Compile selected material later, with citations.
+The safe loop is:
+
+1. Run `exomem setup` or `adopt(mode="scan-only")`.
+2. Review suggested packs or choose explicit packs for a fresh vault.
+3. Persist selected packs under `Knowledge Base/_Packs/`.
+4. Optionally save an adoption manifest under `Knowledge Base/_Adoption/`.
+5. Copy selected legacy files as Sources when provenance matters.
+6. Compile selected material later, with citations.
 
 ## Mapping to typed tools
 
@@ -73,3 +115,6 @@ Packs do not bypass governance. They help agents choose existing typed tools:
 | Review | `audit`, `attention`, `propose_compilation` |
 | Update | `edit`, `replace`, `reconcile` |
 | Connect | `link`, `suggest_links` |
+
+Agents should speak in product language. The user can say "save this warranty
+receipt"; the agent chooses the evidence/proof route and reports the saved path.

--- a/openspec/changes/productize-pack-surface/.openspec.yaml
+++ b/openspec/changes/productize-pack-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/productize-pack-surface/design.md
+++ b/openspec/changes/productize-pack-surface/design.md
@@ -1,0 +1,58 @@
+# productize-pack-surface - design
+
+## Context
+
+The previous cognition-layer tranche added built-in pack files and adoption
+suggestions. This change promotes packs from "likely routing hints" to durable,
+visible product primitives while keeping the typed write layer intact.
+
+## Decisions
+
+1. **Selection is metadata, not migration.**
+   Selecting a pack writes a small manifest under `Knowledge Base/_Packs/`.
+   It does not create folders, rewrite old notes, or auto-compile content.
+
+2. **Built-ins define the public pack schema.**
+   Built-in JSON files remain strict and generic. Unknown fields still fail
+   validation so deployments cannot assume ignored metadata is active.
+
+3. **Fresh vaults get explicit defaults.**
+   When setup has no useful structural signals, it selects `personal-records`
+   in non-interactive mode and lets interactive users choose one or more packs.
+
+4. **Existing vaults combine inference with choice.**
+   Adoption still suggests packs from deterministic structure. Setup persists
+   accepted or adjusted selections so bootstrap can expose the user's active
+   product surface.
+
+5. **Agents route through typed tools.**
+   Bootstrap and command metadata describe simple product actions plus pack
+   guidance. They do not add server-side reasoning or bypass `add`, `note`,
+   `preserve`, `find`, `get`, `audit`, `edit`, `replace`, and `link`.
+
+## Data Shape
+
+`Knowledge Base/_Packs/selected-packs.json`:
+
+```json
+{
+  "schema_version": 1,
+  "selected_pack_ids": ["personal-records"],
+  "source": "setup",
+  "updated": "2026-07-07",
+  "packs": [{ "id": "personal-records", "name": "Personal records" }]
+}
+```
+
+The manifest is rebuilt from current built-in metadata on write. Read helpers
+tolerate a missing manifest and invalid selected IDs by falling back to the
+default pack.
+
+## Risks
+
+- Pack metadata could become a second ontology. Mitigation: metadata maps to
+  existing durable primitives and simple front-door actions only.
+- Setup could imply migration. Mitigation: every output says selection is
+  guidance and writes only under `Knowledge Base/`.
+- MCP schema churn is easy to miss. Mitigation: update the committed schema
+  fixture only when descriptions or input schemas change intentionally.

--- a/openspec/changes/productize-pack-surface/proposal.md
+++ b/openspec/changes/productize-pack-surface/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Knowledge packs exist, but they still read like internal routing config. Fresh
+users with empty vaults need a useful first choice, and agents need pack guidance
+that translates simple user intent into governed Exomem operations without
+requiring users to learn Sources, Evidence, Notes, and Entities first.
+
+## What Changes
+
+- Expand built-in knowledge packs with product metadata: purpose, audience,
+  beginner-facing description, agent-facing instructions, default note/entity/block
+  types, suggested folders, and suggested workflows.
+- Persist selected packs under the governed Knowledge Base layer so setup,
+  bootstrap, MCP/REST/CLI, and future personalization share the same pack state.
+- Make `exomem setup` offer explicit pack selection for fresh vaults and confirm
+  inferred packs for existing vaults.
+- Enrich bootstrap and front-door metadata so agents can route save, ask, prove,
+  review, update, adopt, and connect through typed tools while speaking product
+  language.
+- Update knowledge-pack docs and generated capability docs when the public command
+  surface changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cognition-layer`: knowledge packs become user-selectable product primitives
+  with richer metadata and selected-pack persistence.
+- `guided-setup`: setup supports explicit fresh-vault pack selection and writes a
+  governed selected-pack manifest.
+- `agent-bootstrap-contract`: bootstrap exposes available/selected packs and
+  agent routing guidance.
+- `command-surface`: front-door metadata includes pack-aware product guidance
+  while typed tools remain authoritative.
+
+## Impact
+
+Affected code includes `src/exomem/knowledge_packs.py`,
+`src/exomem/setup_wizard.py`, `src/exomem/commands.py`, built-in pack JSON files,
+and docs. Tests cover pack validation, setup/bootstrap behavior, adoption output,
+and MCP schema stability. No new dependencies or server-side reasoning models are
+introduced; pack suggestion and selection remain deterministic pure-substrate
+metadata.

--- a/openspec/changes/productize-pack-surface/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/productize-pack-surface/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,30 @@
+# agent-bootstrap-contract
+
+## MODIFIED Requirements
+
+### Requirement: Bootstrap Presents Simple Front-Door Actions
+The bootstrap contract SHALL present the primary user/agent actions as save,
+adopt/import, ask, prove, review, update, and connect. For each action it SHALL
+name the preferred tool or composition of tools, the internal typed operation(s)
+that enforce governance, and any selected-pack routing guidance. It SHALL keep
+advanced tools visible but secondary.
+
+#### Scenario: Bootstrap exposes available and selected packs
+- **WHEN** an agent reads the bootstrap response
+- **THEN** it can list available built-in packs with beginner descriptions
+- **AND** it can list selected packs and their agent instructions
+- **AND** a missing selection falls back to a default personal-records pack
+
+#### Scenario: Agent can route a proof request
+- **WHEN** an agent reads the bootstrap response and the user asks "prove this"
+  or "save this for my warranty case"
+- **THEN** the agent can identify the evidence/proof workflow
+- **AND** it can distinguish that workflow from ordinary source capture
+- **AND** selected pack guidance can refine the route without exposing internal
+  ontology to the user
+
+#### Scenario: Agent can route an existing-vault request
+- **WHEN** an agent reads the bootstrap response and the user asks to import or
+  adopt an old vault
+- **THEN** the agent can identify the scan-first adoption workflow
+- **AND** it knows existing files are read-only by default

--- a/openspec/changes/productize-pack-surface/specs/cognition-layer/spec.md
+++ b/openspec/changes/productize-pack-surface/specs/cognition-layer/spec.md
@@ -1,0 +1,31 @@
+# cognition-layer
+
+## MODIFIED Requirements
+
+### Requirement: Knowledge packs are extensible schema/workflow bundles
+The system SHALL support declarative knowledge packs that compose durable
+primitives such as sources, compiled knowledge, entities, decisions, evidence,
+records, assets, projects/cases, and review state. Packs SHALL define purpose,
+audience, beginner-facing description, agent-facing instructions, default note
+types, default entity types, default block types, suggested folders, suggested
+workflows, routing hints, examples, and structural signals for a domain without
+requiring a new storage engine or a hard-coded top-level folder per domain.
+
+#### Scenario: Built-in packs expose product metadata
+- **WHEN** the system lists available knowledge packs
+- **THEN** it includes built-in packs for legal/warranty, creative, technical,
+  health/athletic, business, and personal records
+- **AND** each pack declares purpose, audience, beginner description, agent
+  instructions, defaults, suggested folders, suggested workflows, primitives,
+  actions, examples, and signals
+
+#### Scenario: Selected packs persist as governed guidance
+- **WHEN** setup or another front-door action selects one or more packs
+- **THEN** Exomem records the selection under the governed Knowledge Base layer
+- **AND** selection does not create suggested folders, rewrite old notes, or
+  compile content by itself
+
+#### Scenario: Custom pack validates
+- **WHEN** a user or deployment adds a custom pack file
+- **THEN** Exomem validates required metadata and rejects malformed packs with a
+  stable error code and remediation

--- a/openspec/changes/productize-pack-surface/specs/command-surface/spec.md
+++ b/openspec/changes/productize-pack-surface/specs/command-surface/spec.md
@@ -1,0 +1,23 @@
+# command-surface
+
+## MODIFIED Requirements
+
+### Requirement: Product surface metadata is registry-derived
+The command registry SHALL expose product metadata that marks tools as primary
+or advanced, maps simple user actions to typed tools, and provides pack-aware
+guidance for first-run and selected-pack workflows without duplicating business
+logic across MCP, REST, and CLI surfaces.
+
+#### Scenario: Front-door metadata is pack-aware
+- **WHEN** bootstrap or documentation renders the product front door
+- **THEN** each simple action maps to typed tools
+- **AND** the response can include selected-pack workflows and agent
+  instructions
+- **AND** advanced tools remain visible but secondary
+
+#### Scenario: Typed tools remain authoritative
+- **WHEN** an agent follows a simple action such as save, ask, prove, review,
+  update, adopt, or connect
+- **THEN** the actual operation still routes through the existing typed tool
+  contracts
+- **AND** pack metadata never bypasses write governance

--- a/openspec/changes/productize-pack-surface/specs/guided-setup/spec.md
+++ b/openspec/changes/productize-pack-surface/specs/guided-setup/spec.md
@@ -1,0 +1,31 @@
+# guided-setup
+
+## MODIFIED Requirements
+
+### Requirement: Setup Teaches The Cognition Layer
+The setup summary and first-run docs SHALL explain the simple Exomem model:
+built-in AI memory stores preferences/routing; Exomem stores durable governed
+knowledge with sources, proof, history, decisions, records, and review. The
+summary SHALL include first prompts that use simple verbs rather than internal
+ontology. Setup SHALL also present knowledge packs as beginner-facing product
+choices and persist selected packs under the governed Knowledge Base layer.
+
+#### Scenario: Fresh vault chooses useful packs
+- **WHEN** setup runs against a fresh or structurally empty vault
+- **THEN** it presents available packs with beginner-facing descriptions
+- **AND** non-interactive setup persists the default personal-records pack
+- **AND** interactive setup can persist multiple selected packs
+
+#### Scenario: Existing vault confirms inferred packs
+- **WHEN** setup detects existing non-KB content and adoption suggests packs
+- **THEN** setup shows the suggested packs as choices rather than a migration
+- **AND** persisted selection records only guidance metadata under
+  `Knowledge Base/`
+
+#### Scenario: First prompts are simple
+- **WHEN** setup finishes successfully
+- **THEN** the printed next steps include prompts such as "what does this vault
+  look like?", "import/adopt my old notes safely", "what do we know about X?",
+  "show the sources", and "what needs review?"
+- **AND** the prompt examples do not require the user to know internal page
+  types

--- a/openspec/changes/productize-pack-surface/tasks.md
+++ b/openspec/changes/productize-pack-surface/tasks.md
@@ -1,0 +1,24 @@
+# productize-pack-surface - tasks
+
+## 1. OpenSpec Contract
+
+- [x] 1.1 Add proposal, design, delta specs, and implementation task list.
+- [x] 1.2 Validate the OpenSpec change.
+
+## 2. Pack Metadata And Persistence
+
+- [x] 2.1 Expand pack schema and built-in JSON files with product metadata.
+- [x] 2.2 Add selected-pack manifest read/write helpers.
+- [x] 2.3 Keep adoption suggestions deterministic and include richer metadata.
+
+## 3. Setup And Bootstrap
+
+- [x] 3.1 Add setup pack selection for fresh and existing vaults.
+- [x] 3.2 Expose available/selected packs and pack-aware routing in bootstrap.
+- [x] 3.3 Preserve typed-tool governance and MCP schema expectations.
+
+## 4. Docs And Tests
+
+- [x] 4.1 Update knowledge-pack docs and regenerate capabilities if needed.
+- [x] 4.2 Add/adjust tests for pack schema, setup, bootstrap, adoption, and MCP schemas.
+- [x] 4.3 Run targeted verification and mark tasks complete.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -47,6 +47,7 @@ from . import get_frontmatter as get_frontmatter_module
 from . import get_page as get_page_module
 from . import link as link_module
 from . import link_summary as link_summary_module
+from . import knowledge_packs as knowledge_packs_module
 from . import list_directory as list_directory_module
 from . import list_inbound_links as list_inbound_links_module
 from . import list_trash as list_trash_module
@@ -140,6 +141,7 @@ def op_bootstrap(
 
     compute_policy = mode_module.resolved()
     requested_workflow = workflow.strip() if workflow and workflow.strip() else "general"
+    selected_packs = knowledge_packs_module.selected_pack_state(vault_root)
     payload: dict = {
         "contract_version": "2026-07-07.1",
         "profile": profile,
@@ -159,6 +161,14 @@ def op_bootstrap(
             "exomem": (
                 "Use for durable governed knowledge: sources, proof/evidence, "
                 "history, decisions, records, review, and compiled conclusions."
+            ),
+        },
+        "knowledge_packs": {
+            "available": knowledge_packs_module.list_builtin_packs(),
+            "selected": selected_packs,
+            "selection_rule": (
+                "Packs are product guidance only. They help route simple user intent "
+                "into typed tools; they do not create folders, migrate files, or bypass governance."
             ),
         },
         "workflow": {
@@ -249,7 +259,7 @@ def op_bootstrap(
                 "try pack=true for synthesis instead of many get calls",
             ],
         },
-        "front_door_actions": product_front_door_catalog(),
+        "front_door_actions": product_front_door_catalog(selected_packs),
         "tool_catalog": product_tool_catalog(),
         "common_tools": [
             "adopt",
@@ -2445,7 +2455,7 @@ def product_tool_catalog() -> dict:
     }
 
 
-def product_front_door_catalog() -> dict:
+def product_front_door_catalog(selected_packs: dict | None = None) -> dict:
     """Map simple product verbs to the typed tools that enforce governance."""
     out = {
         action: {"primary_tools": [], "advanced_tools": []}
@@ -2463,4 +2473,22 @@ def product_front_door_catalog() -> dict:
     out["save"]["contract"] = "raw material becomes Sources; durable conclusions become governed notes/entities"
     out["update"]["contract"] = "edit or supersede with an explicit reason; keep history"
     out["connect"]["contract"] = "link entities and related notes so the graph compounds"
+
+    packs = (selected_packs or {}).get("packs") or []
+    if packs:
+        for action in out:
+            guidance = []
+            for pack in packs:
+                if action not in set(pack.get("actions") or []):
+                    continue
+                guidance.append(
+                    {
+                        "pack_id": pack.get("id"),
+                        "name": pack.get("name"),
+                        "agent_instructions": pack.get("agent_instructions"),
+                        "suggested_workflows": pack.get("suggested_workflows") or [],
+                    }
+                )
+            if guidance:
+                out[action]["selected_pack_guidance"] = guidance
     return out

--- a/src/exomem/knowledge_packs.py
+++ b/src/exomem/knowledge_packs.py
@@ -1,27 +1,56 @@
-"""Built-in knowledge-pack definitions and deterministic pack suggestions.
+"""Built-in knowledge-pack definitions and selected-pack persistence.
 
 Knowledge packs are product-level routing hints: small, declarative bundles that
-describe common domains in terms of Exomem's durable primitives. They are not a
-new storage engine and they do not infer meaning from note bodies. Suggestions
-come from cheap structural signals surfaced by ``overview``: folder names, sample
-file names, counts, and media mix.
+make common domains feel like first-class Exomem primitives without changing the
+storage engine. Suggestions are deterministic measurements over vault structure;
+selection is durable guidance stored under the governed Knowledge Base layer.
 """
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import re
 from dataclasses import asdict, dataclass
 from importlib import resources
+from pathlib import Path
 from typing import Any
+
+from .kbdir import kb_dirname, kb_prefix
+from .vault import PlannedWrite, batch_atomic_write, kb_root
 
 
 PACK_DIRECTORY = "packs"
+PACK_SELECTION_DIR = "_Packs"
+PACK_SELECTION_FILE = "selected-packs.json"
+PACK_SELECTION_SCHEMA_VERSION = 1
+DEFAULT_PACK_ID = "personal-records"
 PACK_REQUIRED_FIELDS: frozenset[str] = frozenset(
-    {"id", "name", "description", "primitives", "actions", "examples", "signals"}
+    {
+        "id",
+        "name",
+        "description",
+        "purpose",
+        "audience",
+        "beginner_description",
+        "agent_instructions",
+        "default_note_types",
+        "default_entity_types",
+        "default_block_types",
+        "suggested_folders",
+        "suggested_workflows",
+        "primitives",
+        "actions",
+        "examples",
+        "signals",
+    }
 )
 PACK_OPTIONAL_FIELDS: frozenset[str] = frozenset()
 PACK_ALLOWED_FIELDS: frozenset[str] = PACK_REQUIRED_FIELDS | PACK_OPTIONAL_FIELDS
+PACK_WORKFLOW_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {"title", "intent", "route", "example"}
+)
+PACK_WORKFLOW_ALLOWED_FIELDS: frozenset[str] = PACK_WORKFLOW_REQUIRED_FIELDS
 PACK_ALLOWED_PRIMITIVES: frozenset[str] = frozenset(
     {
         "source",
@@ -51,11 +80,29 @@ class PackValidationError(ValueError):
         self.reason = reason
 
 
+class PackSelectionError(ValueError):
+    """Stable failure for selected-pack manifest operations."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(f"{code}: {reason}")
+        self.code = code
+        self.reason = reason
+
+
 @dataclass(frozen=True)
 class KnowledgePack:
     id: str
     name: str
     description: str
+    purpose: str
+    audience: str
+    beginner_description: str
+    agent_instructions: str
+    default_note_types: tuple[str, ...]
+    default_entity_types: tuple[str, ...]
+    default_block_types: tuple[str, ...]
+    suggested_folders: tuple[str, ...]
+    suggested_workflows: tuple[dict[str, str], ...]
     primitives: tuple[str, ...]
     actions: tuple[str, ...]
     examples: tuple[str, ...]
@@ -90,6 +137,9 @@ def pack_schema() -> dict:
         "optional_fields": sorted(PACK_OPTIONAL_FIELDS),
         "allowed_primitives": sorted(PACK_ALLOWED_PRIMITIVES),
         "allowed_actions": sorted(PACK_ALLOWED_ACTIONS),
+        "workflow_required_fields": sorted(PACK_WORKFLOW_REQUIRED_FIELDS),
+        "selection_manifest": f"{kb_prefix()}{PACK_SELECTION_DIR}/{PACK_SELECTION_FILE}",
+        "selection_schema_version": PACK_SELECTION_SCHEMA_VERSION,
     }
 
 
@@ -128,6 +178,41 @@ def validate_pack_dict(raw: dict[str, Any]) -> KnowledgePack:
             out.append(item.strip())
         return tuple(out)
 
+    def _workflow_tuple(field: str) -> tuple[dict[str, str], ...]:
+        value = raw[field]
+        if not isinstance(value, (list, tuple)) or not value:
+            raise PackValidationError("INVALID_WORKFLOW", f"{field!r} must be a non-empty list")
+        workflows: list[dict[str, str]] = []
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise PackValidationError(
+                    "INVALID_WORKFLOW",
+                    f"{field!r}[{index}] must be a mapping",
+                )
+            unknown = sorted(set(item) - PACK_WORKFLOW_ALLOWED_FIELDS)
+            if unknown:
+                raise PackValidationError(
+                    "UNKNOWN_WORKFLOW_FIELD",
+                    f"{field!r}[{index}] unknown field(s): {unknown}",
+                )
+            missing = sorted(PACK_WORKFLOW_REQUIRED_FIELDS - set(item))
+            if missing:
+                raise PackValidationError(
+                    "MISSING_WORKFLOW_FIELD",
+                    f"{field!r}[{index}] missing field(s): {missing}",
+                )
+            clean: dict[str, str] = {}
+            for key in sorted(PACK_WORKFLOW_REQUIRED_FIELDS):
+                item_value = item[key]
+                if not isinstance(item_value, str) or not item_value.strip():
+                    raise PackValidationError(
+                        "INVALID_WORKFLOW",
+                        f"{field!r}[{index}].{key} must be a non-empty string",
+                    )
+                clean[key] = item_value.strip()
+            workflows.append(clean)
+        return tuple(workflows)
+
     primitives = _string_tuple("primitives")
     bad_primitives = sorted(set(primitives) - PACK_ALLOWED_PRIMITIVES)
     if bad_primitives:
@@ -145,6 +230,15 @@ def validate_pack_dict(raw: dict[str, Any]) -> KnowledgePack:
         id=_nonempty_string("id"),
         name=_nonempty_string("name"),
         description=_nonempty_string("description"),
+        purpose=_nonempty_string("purpose"),
+        audience=_nonempty_string("audience"),
+        beginner_description=_nonempty_string("beginner_description"),
+        agent_instructions=_nonempty_string("agent_instructions"),
+        default_note_types=_string_tuple("default_note_types"),
+        default_entity_types=_string_tuple("default_entity_types"),
+        default_block_types=_string_tuple("default_block_types"),
+        suggested_folders=_string_tuple("suggested_folders"),
+        suggested_workflows=_workflow_tuple("suggested_workflows"),
         primitives=primitives,
         actions=actions,
         examples=_string_tuple("examples"),
@@ -198,6 +292,132 @@ def list_builtin_packs() -> list[dict]:
     return [pack.as_dict() for pack in BUILTIN_PACKS]
 
 
+def get_builtin_pack(pack_id: str) -> dict:
+    """Return one built-in pack by ID."""
+    try:
+        return _PACK_BY_ID[pack_id].as_dict()
+    except KeyError as e:
+        raise PackValidationError("UNKNOWN_PACK", f"unknown pack id: {pack_id}") from e
+
+
+def normalize_pack_ids(pack_ids: list[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    """Validate, dedupe, and default a selected-pack ID list."""
+    raw_ids = list(pack_ids or [DEFAULT_PACK_ID])
+    out: list[str] = []
+    seen: set[str] = set()
+    unknown: list[str] = []
+    for raw in raw_ids:
+        pack_id = str(raw).strip()
+        if not pack_id:
+            continue
+        if pack_id not in _PACK_BY_ID:
+            unknown.append(pack_id)
+            continue
+        if pack_id not in seen:
+            seen.add(pack_id)
+            out.append(pack_id)
+    if unknown:
+        raise PackSelectionError("UNKNOWN_PACK", f"unknown pack id(s): {unknown}")
+    if not out:
+        out = [DEFAULT_PACK_ID]
+    return tuple(out)
+
+
+def _selection_rel_path() -> str:
+    return f"{kb_prefix()}{PACK_SELECTION_DIR}/{PACK_SELECTION_FILE}"
+
+
+def _selection_path(root: Path) -> Path:
+    return kb_root(root) / PACK_SELECTION_DIR / PACK_SELECTION_FILE
+
+
+def _pack_summaries(pack_ids: tuple[str, ...]) -> list[dict]:
+    return [
+        {
+            "id": pack.id,
+            "name": pack.name,
+            "beginner_description": pack.beginner_description,
+            "agent_instructions": pack.agent_instructions,
+            "suggested_workflows": list(pack.suggested_workflows),
+            "actions": list(pack.actions),
+        }
+        for pack in (_PACK_BY_ID[pack_id] for pack_id in pack_ids)
+    ]
+
+
+def selected_pack_state(root: Path | str) -> dict:
+    """Read selected packs, falling back to the default when no manifest exists."""
+    root_path = Path(root)
+    rel = _selection_rel_path()
+    path = _selection_path(root_path)
+    warnings: list[str] = []
+    source = "default"
+    updated: str | None = None
+    pack_ids: tuple[str, ...] = (DEFAULT_PACK_ID,)
+    manifest_present = path.is_file()
+
+    if manifest_present:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            source = str(raw.get("source") or "unknown")
+            updated_raw = raw.get("updated")
+            updated = str(updated_raw) if updated_raw else None
+            pack_ids = normalize_pack_ids(raw.get("selected_pack_ids"))
+        except (OSError, json.JSONDecodeError, PackSelectionError) as e:
+            warnings.append(f"selected-pack manifest ignored: {e}")
+            pack_ids = (DEFAULT_PACK_ID,)
+            source = "default"
+            updated = None
+
+    return {
+        "schema_version": PACK_SELECTION_SCHEMA_VERSION,
+        "path": rel,
+        "manifest_present": manifest_present,
+        "selected_pack_ids": list(pack_ids),
+        "source": source,
+        "updated": updated,
+        "packs": _pack_summaries(pack_ids),
+        "warnings": warnings,
+    }
+
+
+def write_selected_packs(
+    root: Path | str,
+    pack_ids: list[str] | tuple[str, ...] | None,
+    *,
+    source: str = "setup",
+    today: dt.date | None = None,
+) -> dict:
+    """Persist selected packs under the governed Knowledge Base layer."""
+    root_path = Path(root)
+    kb = kb_root(root_path)
+    if not kb.is_dir():
+        raise PackSelectionError(
+            "KB_NOT_INITIALIZED",
+            f"{kb_dirname()}/ is required before selecting packs",
+        )
+    selected_ids = normalize_pack_ids(pack_ids)
+    date_iso = (today or dt.date.today()).isoformat()
+    rel = _selection_rel_path()
+    payload = {
+        "schema_version": PACK_SELECTION_SCHEMA_VERSION,
+        "selected_pack_ids": list(selected_ids),
+        "source": source,
+        "updated": date_iso,
+        "packs": _pack_summaries(selected_ids),
+    }
+    batch_atomic_write(
+        [
+            PlannedWrite(
+                path=_selection_path(root_path),
+                content=json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            )
+        ],
+        vault_root=root_path,
+    )
+    return {"path": rel, **payload, "warnings": []}
+
+
 def _tokens(text: str) -> set[str]:
     return set(_TOKEN.findall(text.lower()))
 
@@ -238,7 +458,7 @@ def suggest_packs(scan: dict, *, limit: int = 6) -> list[dict]:
             )
     scored.sort(key=lambda s: (-s.score, s.pack.id))
     if not scored:
-        default = _PACK_BY_ID["personal-records"]
+        default = _PACK_BY_ID[DEFAULT_PACK_ID]
         scored.append(
             PackSuggestion(
                 pack=default,

--- a/src/exomem/packs/business.json
+++ b/src/exomem/packs/business.json
@@ -2,6 +2,49 @@
   "id": "business",
   "name": "Business",
   "description": "Customers, meetings, commitments, contracts, risks, and decisions.",
+  "purpose": "Keep customer, partner, contract, meeting, risk, and commitment knowledge findable with provenance and review.",
+  "audience": "Founders, operators, consultants, sales teams, account owners, and solo professionals tracking business context.",
+  "beginner_description": "Use this for work relationships, meetings, promises, contracts, open risks, and business decisions.",
+  "agent_instructions": "Treat meeting notes and documents as sources first. Preserve proof for commitments, contracts, invoices, disputes, and compliance records. Compile durable conclusions as research notes or decisions, and link customers, accounts, and counterparties as entities.",
+  "default_note_types": [
+    "research-note",
+    "insight",
+    "failure"
+  ],
+  "default_entity_types": [
+    "person",
+    "concept",
+    "decision"
+  ],
+  "default_block_types": [
+    "commitment",
+    "risk",
+    "decision",
+    "meeting-note",
+    "proof"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Sessions",
+    "Knowledge Base/Sources/Articles",
+    "Knowledge Base/Evidence/Business",
+    "Knowledge Base/Notes/Research/Business",
+    "Knowledge Base/Entities/People",
+    "Knowledge Base/Entities/Decisions"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Save a customer commitment",
+      "intent": "Capture an obligation, promise, or follow-up from a call or document.",
+      "route": "add raw material, then note or link the durable commitment and entities",
+      "example": "Save the customer commitment from this call."
+    },
+    {
+      "title": "Review open risks",
+      "intent": "Find risks, stalled commitments, or decisions needing follow-up.",
+      "route": "find with compact detail, then audit or attention for review queues",
+      "example": "What risks are open for this account?"
+    }
+  ],
   "primitives": [
     "source",
     "entity",

--- a/src/exomem/packs/creative.json
+++ b/src/exomem/packs/creative.json
@@ -2,6 +2,50 @@
   "id": "creative",
   "name": "Creative",
   "description": "References, assets, drafts, productions, taste notes, and releases.",
+  "purpose": "Organize creative references, drafts, assets, production decisions, releases, and reusable taste knowledge.",
+  "audience": "Creators, designers, writers, musicians, filmmakers, photographers, and teams managing creative work.",
+  "beginner_description": "Use this for references, drafts, production logs, assets, taste notes, release notes, and creative decisions.",
+  "agent_instructions": "Save references and drafts as sources unless the user is preserving a final artifact or proof. Compile durable production knowledge as production logs, insights, or research notes. Link people, concepts, tools, and decisions when they recur across projects.",
+  "default_note_types": [
+    "production-log",
+    "insight",
+    "research-note"
+  ],
+  "default_entity_types": [
+    "person",
+    "concept",
+    "library",
+    "decision"
+  ],
+  "default_block_types": [
+    "reference",
+    "asset",
+    "draft",
+    "production-note",
+    "release"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Other",
+    "Knowledge Base/Sources/Videos",
+    "Knowledge Base/Evidence/Creative",
+    "Knowledge Base/Notes/Productions",
+    "Knowledge Base/Notes/Insights",
+    "Knowledge Base/Entities/Concepts"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Save references",
+      "intent": "Keep inspiration, source material, and examples connected to future work.",
+      "route": "add references as sources, then suggest links to related concepts or productions",
+      "example": "Save these references for the next shoot."
+    },
+    {
+      "title": "Log a production",
+      "intent": "Turn a creative artifact into a durable production record with outcomes and lessons.",
+      "route": "note with note_type production-log, then connect recurring people, tools, and ideas",
+      "example": "Turn this draft into a production log."
+    }
+  ],
   "primitives": [
     "source",
     "asset",

--- a/src/exomem/packs/health-athletic.json
+++ b/src/exomem/packs/health-athletic.json
@@ -2,6 +2,49 @@
   "id": "health-athletic",
   "name": "Health / athletic",
   "description": "Training, symptoms, measurements, protocols, injuries, and goals.",
+  "purpose": "Track health, training, symptoms, protocols, measurements, and evidence without turning raw logs into unsupported conclusions.",
+  "audience": "Athletes, patients, coaches, health experimenters, and people managing personal records with professional oversight.",
+  "beginner_description": "Use this for workouts, symptoms, injuries, measurements, protocols, appointments, and health records.",
+  "agent_instructions": "Keep raw logs and external documents as sources or evidence. Do not infer medical advice. Compile only user-stated observations, protocols, decisions, and experiment summaries with source links and review prompts.",
+  "default_note_types": [
+    "experiment",
+    "research-note",
+    "insight"
+  ],
+  "default_entity_types": [
+    "person",
+    "concept",
+    "decision"
+  ],
+  "default_block_types": [
+    "measurement",
+    "symptom",
+    "protocol",
+    "session-log",
+    "medical-record"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Sessions",
+    "Knowledge Base/Sources/Other",
+    "Knowledge Base/Evidence/Health",
+    "Knowledge Base/Notes/Experiments/Health",
+    "Knowledge Base/Notes/Research/Health",
+    "Knowledge Base/Entities/People"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Log a training or symptom record",
+      "intent": "Capture observations without prematurely turning them into conclusions.",
+      "route": "add raw log or preserve proof, then compile only durable observations when needed",
+      "example": "Log this training session."
+    },
+    {
+      "title": "Review a protocol change",
+      "intent": "Compare what changed after a protocol, injury, or intervention.",
+      "route": "find relevant logs and experiments, then reason in the agent with citations",
+      "example": "What changed after the new protocol?"
+    }
+  ],
   "primitives": [
     "source",
     "record",

--- a/src/exomem/packs/legal-warranty.json
+++ b/src/exomem/packs/legal-warranty.json
@@ -2,6 +2,49 @@
   "id": "legal-warranty",
   "name": "Legal / warranty",
   "description": "Cases, receipts, correspondence, deadlines, and proof.",
+  "purpose": "Keep proof-bearing case material, receipts, correspondence, deadlines, and decisions organized with provenance.",
+  "audience": "People managing warranties, returns, disputes, insurance claims, legal matters, contracts, or other proof-heavy records.",
+  "beginner_description": "Use this for receipts, warranties, disputes, insurance, contracts, deadlines, and case files.",
+  "agent_instructions": "Treat proof-bearing material as evidence when it supports a case, claim, warranty, insurance issue, dispute, or record. Preserve provenance, cite originals, and avoid converting every ordinary source into evidence.",
+  "default_note_types": [
+    "research-note",
+    "failure",
+    "insight"
+  ],
+  "default_entity_types": [
+    "person",
+    "concept",
+    "decision"
+  ],
+  "default_block_types": [
+    "case",
+    "receipt",
+    "deadline",
+    "correspondence",
+    "proof"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Other",
+    "Knowledge Base/Evidence/Legal",
+    "Knowledge Base/Evidence/Warranty",
+    "Knowledge Base/Notes/Research/Legal",
+    "Knowledge Base/Entities/People",
+    "Knowledge Base/Entities/Decisions"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Save proof for a case",
+      "intent": "Preserve a receipt, document, message, or artifact as proof for a specific matter.",
+      "route": "preserve or upload to Evidence, then link or note the case context",
+      "example": "Save this receipt for the laptop warranty case."
+    },
+    {
+      "title": "Show case evidence",
+      "intent": "Retrieve the proof and source trail for a dispute, warranty, claim, or contract question.",
+      "route": "find evidence and compiled case notes, then get selected pages for citations",
+      "example": "Show the evidence for the landlord dispute."
+    }
+  ],
   "primitives": [
     "source",
     "evidence",

--- a/src/exomem/packs/personal-records.json
+++ b/src/exomem/packs/personal-records.json
@@ -2,6 +2,49 @@
   "id": "personal-records",
   "name": "Personal records",
   "description": "Purchases, travel, home, vehicles, admin records, and life logistics.",
+  "purpose": "Provide a safe default for everyday records, purchases, travel, home, vehicle, and life-admin knowledge.",
+  "audience": "Fresh Exomem users and anyone tracking personal logistics, household records, travel, purchases, or administrative documents.",
+  "beginner_description": "Use this as the starter pack for everyday documents, purchases, travel, home, vehicles, and personal admin.",
+  "agent_instructions": "Use this as the default when no stronger domain pack is selected. Save raw documents as sources, preserve proof for receipts or records, and compile only durable decisions, solved problems, and reusable patterns.",
+  "default_note_types": [
+    "research-note",
+    "insight",
+    "failure"
+  ],
+  "default_entity_types": [
+    "person",
+    "concept",
+    "decision"
+  ],
+  "default_block_types": [
+    "record",
+    "receipt",
+    "admin-note",
+    "decision",
+    "proof"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Other",
+    "Knowledge Base/Evidence/Personal",
+    "Knowledge Base/Notes/Research/Personal",
+    "Knowledge Base/Notes/Insights",
+    "Knowledge Base/Entities/People",
+    "Knowledge Base/Entities/Concepts"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Save a personal record",
+      "intent": "Capture a document, purchase, travel detail, or administrative record.",
+      "route": "add as source or preserve as evidence when proof matters",
+      "example": "Save this vehicle maintenance record."
+    },
+    {
+      "title": "Find everyday documents",
+      "intent": "Retrieve records by topic, person, trip, purchase, or household context.",
+      "route": "find with compact detail, then get the most relevant record or source",
+      "example": "Find the documents for the trip."
+    }
+  ],
   "primitives": [
     "source",
     "record",

--- a/src/exomem/packs/technical.json
+++ b/src/exomem/packs/technical.json
@@ -2,6 +2,51 @@
   "id": "technical",
   "name": "Technical",
   "description": "Projects, repositories, decisions, failures, incidents, and runbooks.",
+  "purpose": "Compound engineering knowledge across projects, repositories, incidents, decisions, failures, experiments, and runbooks.",
+  "audience": "Engineers, maintainers, technical founders, operators, and agents working across software projects.",
+  "beginner_description": "Use this for code projects, architecture decisions, incidents, debugging, runbooks, experiments, and reusable engineering lessons.",
+  "agent_instructions": "Treat code repositories and specs as source-of-truth outside Exomem. Use Exomem for cross-session conclusions, decisions, architecture orientation, failures, patterns, experiments, and project entities. Do not mirror code inventories that will drift.",
+  "default_note_types": [
+    "research-note",
+    "failure",
+    "pattern",
+    "experiment"
+  ],
+  "default_entity_types": [
+    "concept",
+    "library",
+    "decision"
+  ],
+  "default_block_types": [
+    "architecture",
+    "decision",
+    "incident",
+    "failure",
+    "runbook"
+  ],
+  "suggested_folders": [
+    "Knowledge Base/Sources/Sessions",
+    "Knowledge Base/Sources/Articles",
+    "Knowledge Base/Notes/Research/Technical",
+    "Knowledge Base/Notes/Failures",
+    "Knowledge Base/Notes/Patterns",
+    "Knowledge Base/Entities/Libraries",
+    "Knowledge Base/Entities/Decisions"
+  ],
+  "suggested_workflows": [
+    {
+      "title": "Save an architecture decision",
+      "intent": "Capture a decision, tradeoff, or implementation conclusion that should survive the coding session.",
+      "route": "note as research-note or link as decision entity with source/context links",
+      "example": "Save this architecture decision."
+    },
+    {
+      "title": "Review incidents and failures",
+      "intent": "Find failure modes, incident context, and reusable prevention patterns.",
+      "route": "find failures and patterns, then get cited notes for reasoning",
+      "example": "What failed in the last deployment?"
+    }
+  ],
   "primitives": [
     "source",
     "decision",

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -30,6 +30,7 @@ from . import doctor as doctor_module
 from . import init as init_module
 from . import install_hook as hook_module
 from . import install_skill as install_module
+from . import knowledge_packs as knowledge_packs_module
 from . import overview as overview_module
 from . import personalize as personalize_module
 from .kbdir import kb_dirname, kb_prefix
@@ -47,6 +48,60 @@ def _format_pack_suggestions(packs: list[dict], *, limit: int = 3) -> str:
         else:
             shown.append(f"{name} (default)")
     return ", ".join(shown)
+
+
+def _default_pack_ids(suggested: list[dict]) -> list[str]:
+    ids: list[str] = []
+    for pack in suggested:
+        pack_id = str(pack.get("id") or "").strip()
+        if pack_id and pack_id not in ids:
+            ids.append(pack_id)
+    return ids or [knowledge_packs_module.DEFAULT_PACK_ID]
+
+
+def _format_selected_pack_names(selection: dict) -> str:
+    names = [pack.get("name") or pack.get("id") for pack in selection.get("packs") or []]
+    return ", ".join(str(name) for name in names if name) or knowledge_packs_module.DEFAULT_PACK_ID
+
+
+def _choose_pack_ids(input_fn, print_fn, *, available: list[dict], suggested: list[dict], yes: bool) -> list[str]:
+    default_ids = _default_pack_ids(suggested)
+    if yes:
+        return default_ids
+
+    suggested_set = set(default_ids)
+    print_lines = ["  Choose starter knowledge packs (guidance only; no folders are created):"]
+    for index, pack in enumerate(available, start=1):
+        marker = "*" if pack.get("id") in suggested_set else " "
+        desc = pack.get("beginner_description") or pack.get("description") or ""
+        print_lines.append(f"    {index}. [{marker}] {pack.get('name')} - {desc}")
+    print_lines.append("  Press Enter to accept the marked packs, or enter numbers/IDs separated by commas.")
+    for line in print_lines:
+        print_fn(line)
+
+    answer = input_fn("Packs: ").strip()
+    if not answer:
+        return default_ids
+    by_number = {str(index): str(pack.get("id")) for index, pack in enumerate(available, start=1)}
+    by_id = {str(pack.get("id")): str(pack.get("id")) for pack in available}
+    selected: list[str] = []
+    unknown: list[str] = []
+    for raw in answer.replace(";", ",").split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        pack_id = by_number.get(token) or by_id.get(token)
+        if not pack_id:
+            unknown.append(token)
+            continue
+        if pack_id not in selected:
+            selected.append(pack_id)
+    if unknown:
+        raise knowledge_packs_module.PackSelectionError(
+            "UNKNOWN_PACK",
+            f"unknown pack selection(s): {unknown}",
+        )
+    return selected or default_ids
 
 
 def _ask_yn(input_fn, prompt: str, default: bool) -> bool:
@@ -170,7 +225,28 @@ def run_setup(
     except FileExistsError:
         report("init", f"[skipped: {kb_prefix()} already exists]")
 
-    # 3b. personalize — propose per-subtree access governance for sibling folders
+    # 3b. packs — product guidance for fresh vaults and suggested routes for existing vaults
+    try:
+        selected_ids = _choose_pack_ids(
+            input_fn,
+            print_fn,
+            available=adoption.get("available_packs") or knowledge_packs_module.list_builtin_packs(),
+            suggested=packs,
+            yes=yes,
+        )
+        selection = knowledge_packs_module.write_selected_packs(
+            vault_path,
+            selected_ids,
+            source="setup",
+        )
+        print_fn(f"    Selected packs: {_format_selected_pack_names(selection)}")
+        print_fn("    Pack selection is guidance only; no folders or notes were created.")
+        report("packs", f"[done] {', '.join(selection['selected_pack_ids'])}")
+    except knowledge_packs_module.PackSelectionError as e:
+        report("packs", f"[failed: {e}]")
+        return finish()
+
+    # 3c. personalize — propose per-subtree access governance for sibling folders
     try:
         prep = personalize_module.scan_and_classify(vault_path)
     except personalize_module.PersonalizeError as e:

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -81,6 +81,10 @@ def test_adopt_suggests_builtin_packs_from_structure(tmp_path: Path) -> None:
         "personal-records",
     }
     assert "required_fields" in report["pack_schema"]
+    assert "purpose" in report["pack_schema"]["required_fields"]
+    assert report["pack_schema"]["selection_manifest"] == "Knowledge Base/_Packs/selected-packs.json"
+    assert by_id["technical"]["beginner_description"]
+    assert by_id["legal-warranty"]["suggested_workflows"][0]["route"]
     assert report["governance"]["kb_present"] is True
     assert {a["action"] for a in report["next_actions"]} >= {"save-manifest", "copy-as-sources"}
 
@@ -157,6 +161,36 @@ def test_pack_validation_rejects_unknown_fields() -> None:
     with pytest.raises(knowledge_packs.PackValidationError) as ei:
         knowledge_packs.validate_pack_dict(raw)
     assert ei.value.code == "UNKNOWN_FIELD"
+def test_pack_validation_rejects_invalid_workflows() -> None:
+    raw = knowledge_packs.list_builtin_packs()[0]
+    raw["suggested_workflows"] = [{"title": "Missing route", "intent": "x", "example": "x"}]
+    with pytest.raises(knowledge_packs.PackValidationError) as ei:
+        knowledge_packs.validate_pack_dict(raw)
+    assert ei.value.code == "MISSING_WORKFLOW_FIELD"
+
+    raw = knowledge_packs.list_builtin_packs()[0]
+    raw["default_note_types"] = []
+    with pytest.raises(knowledge_packs.PackValidationError) as ei:
+        knowledge_packs.validate_pack_dict(raw)
+    assert ei.value.code == "INVALID_FIELD"
+
+
+def test_selected_pack_manifest_roundtrip(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+
+    written = knowledge_packs.write_selected_packs(
+        vault,
+        ["technical", "creative", "technical"],
+        source="test",
+        today=dt.date(2026, 7, 7),
+    )
+    state = knowledge_packs.selected_pack_state(vault)
+
+    assert written["path"] == "Knowledge Base/_Packs/selected-packs.json"
+    assert written["selected_pack_ids"] == ["technical", "creative"]
+    assert state["manifest_present"] is True
+    assert state["selected_pack_ids"] == ["technical", "creative"]
+    assert state["packs"][0]["agent_instructions"]
 
 
 def test_builtin_packs_are_declarative_files() -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -35,8 +35,11 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
     assert out["server"]["content_included"] is False
     assert out["server"]["pure_substrate"] is True
     assert "compute_policy" in out["server"]
-    assert {"workflow", "tool_defaults", "performance_profiles", "memory_model"} <= set(out)
+    assert {"workflow", "tool_defaults", "performance_profiles", "memory_model", "knowledge_packs"} <= set(out)
     assert "durable governed knowledge" in out["memory_model"]["exomem"]
+    assert out["knowledge_packs"]["selected"]["selected_pack_ids"] == ["personal-records"]
+    assert out["knowledge_packs"]["available"][0]["beginner_description"]
+    assert out["front_door_actions"]["save"]["selected_pack_guidance"][0]["pack_id"] == "personal-records"
     assert out["tool_defaults"]["adopt_existing_vault"]["tool"] == "adopt"
     assert "adopt" in out["common_tools"]
     assert out["tool_defaults"]["normal_lookup"]["args"] == {
@@ -74,6 +77,21 @@ def test_product_front_door_metadata_is_registry_derived() -> None:
     assert "list_directory" in catalog["advanced"]
     assert "scan-only" in front_door["adopt"]["contract"]
     assert "proof" in front_door["prove"]["contract"]
+
+    selected = {
+        "packs": [
+            {
+                "id": "technical",
+                "name": "Technical",
+                "actions": ["save", "ask"],
+                "agent_instructions": "Route technical work through governed notes.",
+                "suggested_workflows": [{"title": "Save", "intent": "x", "route": "note", "example": "x"}],
+            }
+        ]
+    }
+    guided = commands.product_front_door_catalog(selected)
+    assert guided["save"]["selected_pack_guidance"][0]["pack_id"] == "technical"
+    assert "selected_pack_guidance" not in guided["prove"]
 
     actions = set(front_door)
     for command in commands.COMMANDS:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -6,6 +6,7 @@ print_fn): no test touches the real `~/.claude` or spawns a real `claude`.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -69,9 +70,12 @@ def test_fresh_vault_happy_path(tmp_path: Path) -> None:
     # KB scaffold landed; skill installed under the injected home
     assert (vault / "Knowledge Base" / "index.md").is_file()
     assert (home / "skills" / "exomem" / "SKILL.md").is_file()
+    selected = json.loads((vault / "Knowledge Base" / "_Packs" / "selected-packs.json").read_text(encoding="utf-8"))
+    assert selected["selected_pack_ids"] == ["personal-records"]
     # pre-init scan surfaced the existing content, likely packs, and write contract
     assert "2 files" in out
     assert "Likely packs:" in out
+    assert "Selected packs: Personal records" in out
     assert "Adoption: run `exomem adopt`" in out
     assert "writes only under 'Knowledge Base/'" in out
     # registration argv shape
@@ -83,6 +87,32 @@ def test_fresh_vault_happy_path(tmp_path: Path) -> None:
     assert "EXOMEM_DISABLE_EMBEDDINGS=1" in reg  # lean profile
     assert "--" in reg
 
+
+def test_interactive_setup_can_select_multiple_packs(tmp_path: Path) -> None:
+    vault, home = _messy_vault(tmp_path), tmp_path / "home"
+    recorder = Recorder()
+    answers = iter(["technical, creative", "n"])
+    lines: list[str] = []
+
+    code = setup_wizard.run_setup(
+        vault=str(vault),
+        yes=False,
+        profile="lean",
+        with_hooks=False,
+        skip_claude_register=True,
+        scope="user",
+        input_fn=lambda prompt="": next(answers),
+        run_fn=recorder,
+        which_fn=lambda name: None,
+        home=home,
+        print_fn=lines.append,
+    )
+
+    selected = json.loads((vault / "Knowledge Base" / "_Packs" / "selected-packs.json").read_text(encoding="utf-8"))
+    assert code == 0
+    assert selected["selected_pack_ids"] == ["technical", "creative"]
+    assert "Choose starter knowledge packs" in "\n".join(lines)
+    assert "Selected packs: Technical, Creative" in "\n".join(lines)
 
 def test_rerun_converges_to_skips(tmp_path: Path) -> None:
     vault, home = _messy_vault(tmp_path), tmp_path / "home"


### PR DESCRIPTION
Summary: expand knowledge packs into product-facing metadata; persist selected packs during setup; expose available/selected packs and pack-aware front-door routing through bootstrap; add OpenSpec change productize-pack-surface and docs/tests. Tests: uv run pytest tests/test_adopt.py tests/test_setup_wizard.py tests/test_bootstrap.py tests/test_mcp_schema_fidelity.py -q; openspec validate productize-pack-surface --strict; uv run python scripts/generate-capabilities.py --check; git diff --check. Note: ruff was not available in the uv environment.