### PR TITLE
Implement compile-selected adoption planning

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -66,14 +66,14 @@ That's the normal case, and it's safe:
   scope auto-widens; `scope="vault"` always walks everything), `overview`
   gives Claude a bounded structural report of the whole vault, and `adopt`
   turns that scan into a safe adoption report with likely knowledge packs and
-  copy/compile next actions — one call, not one read per file.
+  manifest/copy/compile-planning next actions — one call, not one read per file.
 - **Daily-notes vaults** (a `Daily/` or `Journal/` tree of dated logs): leave
   them exactly as they are. The Knowledge Base is a *compiled* layer beside
   your log, not a migration target — exomem never requires frontmatter, links,
   or restructuring from existing notes. Good first prompts after setup:
   *"what does this vault look like?"* — Claude answers with `overview`; or
   *"adopt this vault safely"* — Claude answers with `adopt`, preserving originals
-  and proposing manifest/copy/compile next actions for you to approve.
+  and proposing manifest/copy/compile-planning next actions for you to approve.
 - **Same vault or a separate one?** Same vault is the default: notes and KB in
   one Obsidian window, cross-search included. Pick a separate vault only when
   you want hard isolation (e.g. a shared or team-synced vault where a new
@@ -93,6 +93,12 @@ exomem adopt --mode save-manifest --json
 
 # copy only files you explicitly name into governed Sources/Imported/
 exomem adopt --mode copy-as-sources \
+  --selected-paths "Warranty Case/laptop-receipt.md" \
+  --json
+
+# copy selected legacy text if needed, then return a compile plan;
+# no compiled note is created until you review and call note()
+exomem adopt --mode compile-selected \
   --selected-paths "Warranty Case/laptop-receipt.md" \
   --json
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ preflight, registers the server with Claude Code, and installs the skill.
 
 Already have a vault full of notes? That's the normal case: `adopt` gives a
 scan-first, read-only report of what's there, suggested knowledge packs, and
-safe copy/compile next actions. Exomem only ever writes under `Knowledge Base/` — your
+safe copy/compile-planning next actions. Exomem only ever writes under `Knowledge Base/` — your
 existing files stay untouched unless you explicitly copy or compile selected material. See
 [QUICKSTART.md § Already have a vault full of notes?](QUICKSTART.md#already-have-a-vault-full-of-notes)
 for the full contract, including daily-notes vaults. Re-running `setup` is
@@ -224,7 +224,7 @@ Run `exomem index` or `kb reconcile` later to heal deferred semantic work.
 - **Searches the vault you already own.** Markdown stays in place; exomem does
   not import copies into a proprietary note store.
 - **Adopts messy vaults safely.** `adopt` starts with a read-only report and
-  explicit copy/compile options, so originals remain archival until you choose.
+  explicit copy and compile-planning options, so originals remain archival until you choose.
 - **Retrieves across text and media.** Markdown, PDFs, Office docs, images,
   screenshots, audio, and video can become searchable through local extraction.
 - **Keeps sources separate from conclusions.** Raw captures, compiled notes,
@@ -289,7 +289,7 @@ exomem exposes typed MCP tools for common knowledge-base work:
 | `audit` | Check graph and corpus health. |
 | `attention` | Surface review queues such as stale notes, close-by claims, and unprocessed sources. |
 | `overview` | Bounded, read-only structure report of the vault or a subtree — works outside `Knowledge Base/` and before `init`. |
-| `adopt` | Existing-vault adoption: scan-only by default; can save a manifest or copy selected legacy text files as Sources while preserving originals. |
+| `adopt` | Existing-vault adoption: scan-only by default; can save a manifest, copy selected legacy text files as Sources, or return a compile plan while preserving originals. |
 
 Tier-2 filesystem tools exist for escape hatches such as listing directories,
 creating files, moving pages, trashing files, and recovering from trash. Set

--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -34,9 +34,9 @@ The adoption modes are explicit:
 | `scan-only` | No | Report structure, likely packs, governed vs read-only areas, and next actions |
 | `save-manifest` | Yes, under `Knowledge Base/_Adoption/` only | Save the scan as a durable onboarding artifact |
 | `copy-as-sources` | Yes, under `Knowledge Base/Sources/Imported/` only | Copy selected legacy text files with original path and SHA-256 provenance |
-| `compile-selected` | Planned | Create governed notes from selected sources with citations |
+| `compile-selected` | Yes, under `Knowledge Base/Sources/Imported/` when legacy files need source copies | Copy selected legacy text files when needed, then return a reviewable compile plan; compiled notes are written later through `note` |
 
-There is no rewrite-in-place onboarding path in the normal product flow.
+There is no rewrite-in-place onboarding path in the normal product flow. `compile-selected` is a planning step, not auto-migration: it prepares governed sources and a note scaffold so the user or agent can deliberately compile with `note`.
 
 ## Sources versus evidence
 

--- a/openspec/changes/complete-adoption-compile-selected/.openspec.yaml
+++ b/openspec/changes/complete-adoption-compile-selected/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/complete-adoption-compile-selected/design.md
+++ b/openspec/changes/complete-adoption-compile-selected/design.md
@@ -1,0 +1,46 @@
+# complete-adoption-compile-selected - design
+
+## Context
+
+`adopt` already gives a bounded scan, a governed manifest, and explicit source copies with original path and SHA-256 provenance. `compile-selected` is advertised as planned, and `propose_compilation` already produces read-only note scaffolds from governed Sources. The missing piece is the adoption bridge: selected legacy files should be normalized into governed source refs and handed to compilation planning without rewriting originals or auto-writing compiled notes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `adopt(mode="compile-selected")` an implemented, selected-path-only planning mode.
+- Preserve the current non-destructive adoption contract and reuse existing safe copy/source provenance.
+- Return stable refs for originals, copied sources, and compile proposals so agents can review and cite the plan.
+- Keep the same leaf function across MCP, CLI, and REST.
+
+**Non-Goals:**
+- No automatic creation of `Notes/...` compiled pages.
+- No bulk migration, restructure, frontmatter insertion, deletion, or moves outside `Knowledge Base/`.
+- No server-side reasoning LLM. The server prepares deterministic scaffolds; the agent/user decides the final note.
+
+## Decisions
+
+1. **`compile-selected` is planning, not writing compiled knowledge.**
+   It calls the existing read-only `propose_compilation` helper after selected legacy files are represented as governed Sources. The compiled page is still created later through `note`.
+
+2. **Legacy selected files are copied using the existing `copy-as-sources` path.**
+   This keeps path resolution, text suffix filtering, hash provenance, index updates, and log entries consistent. The mode returns skipped items instead of widening selection implicitly.
+
+3. **Stable context refs are metadata, not a replacement path API.**
+   Add a small helper that formats `exomem://vault/...`, `exomem://source/...`, and `exomem://manifest/...` refs. Existing vault-relative and KB-relative paths remain authoritative for tool inputs.
+
+4. **Already-governed Sources can be planned directly.**
+   If a selected path is under `Knowledge Base/Sources/`, skip copying and pass the canonical source path to `propose_compilation`. Other `Knowledge Base/` paths are skipped because adoption is for legacy/source material, not compiled-page rewrites.
+
+## Risks / Trade-offs
+
+- **Duplicate source copies on repeated compile planning** -> Accept for now; the copied source carries original path/hash provenance and `unique_path` prevents overwrite. Deduplication can be added later without changing the public contract.
+- **Proposal text is scaffold quality, not final knowledge** -> Mitigated by naming the output `compile_plan`/`proposal` and documenting that `note` is the deliberate write step.
+- **Tool schema drift** -> Update the committed MCP schema fixture if `op_adopt` description/signature changes.
+
+## Migration Plan
+
+No migration is required. Existing manifests and imported sources remain valid. New runs of `adopt(mode="compile-selected")` write only governed source copies for legacy selections and return read-only compile plans.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/complete-adoption-compile-selected/proposal.md
+++ b/openspec/changes/complete-adoption-compile-selected/proposal.md
@@ -1,0 +1,28 @@
+# complete-adoption-compile-selected
+
+## Why
+
+Existing-vault adoption currently stops at safe scan, manifest save, and source copying while `compile-selected` is only advertised as planned. The next adoption step should let a user select messy legacy notes, preserve originals, copy source material with provenance, and receive a deliberate compilation plan without silently migrating or rewriting anything.
+
+## What Changes
+
+- Implement `adopt(mode="compile-selected")` as a non-destructive compile-planning mode.
+- Reuse existing safe selection/copy behavior for legacy text files outside `Knowledge Base/`.
+- Return reviewable compilation proposals backed by governed source paths, not auto-written compiled notes.
+- Add stable adoption context refs for originals, copied sources, manifests, and compilation proposals.
+- Update setup and product docs so one-command onboarding points to manifest review, copy-as-sources, and compile-selected planning.
+
+## Capabilities
+
+### New Capabilities
+- `adoption-compile-planning`: selected legacy material can be copied into governed Sources and turned into read-only compilation plans with stable refs.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- `src/exomem/adopt.py`, `src/exomem/setup_wizard.py`, and a small context reference helper.
+- `adopt` public behavior across MCP, CLI, and REST because it gains an implemented mode and updated docs/schema text.
+- Adoption tests, setup wizard tests, context-ref tests, MCP schema fixture if the tool description changes, and onboarding/product docs.

--- a/openspec/changes/complete-adoption-compile-selected/specs/adoption-compile-planning/spec.md
+++ b/openspec/changes/complete-adoption-compile-selected/specs/adoption-compile-planning/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Compile-selected adoption plans selected material without migrating originals
+The system SHALL implement `adopt(mode="compile-selected")` as an explicit selected-path workflow that preserves every original file outside `Knowledge Base/`, copies importable legacy text files into governed Sources with provenance when needed, and returns compilation proposals without creating compiled notes.
+
+#### Scenario: Legacy file is planned through a governed source copy
+- **WHEN** a user runs `adopt(mode="compile-selected")` with an importable legacy markdown file outside `Knowledge Base/`
+- **THEN** the original file remains byte-identical
+- **AND** the system creates a governed `Knowledge Base/Sources/Imported/` copy with original path, SHA-256, and byte-size provenance
+- **AND** the response includes a compile plan whose suggested sources point at the governed source copy
+- **AND** no `Knowledge Base/Notes/` compiled page is created
+
+#### Scenario: Missing selection is rejected
+- **WHEN** a user runs `adopt(mode="compile-selected")` without `selected_paths`
+- **THEN** the system fails with a structured missing-selection error
+- **AND** no files are written
+
+#### Scenario: Unsupported selections are skipped safely
+- **WHEN** selected paths include unsupported file types or non-source governed files
+- **THEN** those selections are reported in `skipped` with structured reasons
+- **AND** importable selections still proceed
+- **AND** no original file is modified, moved, or deleted
+
+### Requirement: Adoption outputs expose stable context references
+The system SHALL include stable `exomem://` context references in adoption outputs for original files, copied sources, saved manifests, and compile proposals while preserving existing path fields for tool compatibility.
+
+#### Scenario: Compile plan returns refs for review
+- **WHEN** `adopt(mode="compile-selected")` returns a compile plan
+- **THEN** each planned item exposes an original ref such as `exomem://vault/<path>` when an original exists
+- **AND** each governed source exposes a source ref such as `exomem://source/<Knowledge Base source path>`
+- **AND** the plan exposes a proposal ref that can be cited in manifest/review text
+
+#### Scenario: Existing mode outputs remain compatible
+- **WHEN** a user runs existing modes such as `save-manifest` or `copy-as-sources`
+- **THEN** existing path fields remain present and unchanged
+- **AND** new ref metadata is additive

--- a/openspec/changes/complete-adoption-compile-selected/tasks.md
+++ b/openspec/changes/complete-adoption-compile-selected/tasks.md
@@ -1,0 +1,19 @@
+# complete-adoption-compile-selected - tasks
+
+## 1. Adoption Behavior
+
+- [x] 1.1 Add a small context reference helper for stable `exomem://` refs.
+- [x] 1.2 Implement `adopt(mode="compile-selected")` using explicit `selected_paths`.
+- [x] 1.3 Reuse copy-as-sources for outside-KB legacy text files and plan already-governed Sources directly.
+- [x] 1.4 Return additive refs and compile proposal metadata without creating compiled notes.
+
+## 2. Surfaces and Docs
+
+- [x] 2.1 Update `op_adopt` tool docs and any schema fixture affected by that public description.
+- [x] 2.2 Update setup wizard text to name manifest review, source copy, and compile-selected planning.
+- [x] 2.3 Update product/quickstart docs so `compile-selected` is implemented as planning, not automatic migration.
+
+## 3. Verification
+
+- [x] 3.1 Add adoption and context-ref tests for compile-selected behavior and non-destruction.
+- [x] 3.2 Run focused tests for adoption, compile proposals, setup wizard, and schema fidelity if needed.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -929,6 +929,18 @@ def _print_adopt_human(result: dict) -> None:
         for item in copied[:10]:
             print(f"  - {item.get('original_path')} -> {item.get('source_path')}")
 
+    if plan := result.get("compile_plan"):
+        sources = plan.get("sources") or []
+        skipped = plan.get("skipped") or []
+        print(f"\nCompile plan: {plan.get('status', 'unknown')} ({len(sources)} source(s), {len(skipped)} skipped)")
+        proposal = plan.get("proposal") or {}
+        if proposal.get("suggested_title"):
+            print(f"  Suggested title: {proposal.get('suggested_title')}")
+        if proposal.get("suggested_note_type"):
+            print(f"  Suggested type: {proposal.get('suggested_note_type')}")
+        if plan.get("proposal_ref"):
+            print(f"  Ref: {plan.get('proposal_ref')}")
+
 
 def _print_human(result, *, op: str | None = None) -> None:
     if op == "adopt" and isinstance(result, dict):

--- a/src/exomem/adopt.py
+++ b/src/exomem/adopt.py
@@ -15,7 +15,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from . import indexes, knowledge_packs, overview as overview_module
+from . import compile_proposal as compile_proposal_module
+from . import context_refs, indexes, knowledge_packs, overview as overview_module
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
     PlannedWrite,
@@ -29,8 +30,8 @@ from .vault import (
 )
 
 DEFAULT_MODE = "scan-only"
-SUPPORTED_MODES = ("scan-only", "save-manifest", "copy-as-sources")
-PLANNED_MODES = ("compile-selected",)
+SUPPORTED_MODES = ("scan-only", "save-manifest", "copy-as-sources", "compile-selected")
+PLANNED_MODES: tuple[str, ...] = ()
 ADOPTION_DIR = "_Adoption"
 IMPORTED_SOURCE_FOLDER = "Imported"
 _TEXT_IMPORT_SUFFIXES = frozenset(
@@ -77,10 +78,11 @@ def _safe_next_actions(kb_present: bool) -> list[dict]:
                 },
                 {
                     "action": "compile-selected",
-                    "status": "planned",
+                    "status": "available",
                     "description": (
-                        "Create governed notes from selected sources, linked back "
-                        "to originals or imported source copies."
+                        "Copy explicitly selected legacy text files as governed Sources "
+                        "when needed, then return a compile plan. No compiled note is "
+                        "created until the user deliberately calls note()."
                     ),
                 },
             ]
@@ -166,6 +168,9 @@ def _compact_report(report: dict[str, Any]) -> dict[str, Any]:
         "summary": report.get("summary"),
         "pack_suggestions": report.get("pack_suggestions"),
         "next_actions": report.get("next_actions"),
+        "refs": report.get("refs"),
+        "copy": report.get("copy"),
+        "compile_plan": report.get("compile_plan"),
         "overview": report.get("overview"),
     }
 
@@ -281,7 +286,7 @@ def _save_manifest(
     writes = [PlannedWrite(path=target, content=content)]
     warnings = _add_manifest_index_writes(root=root, writes=writes, rel_path=rel, today=today)
     batch_atomic_write(writes, vault_root=root)
-    return {"path": rel, "warnings": warnings}
+    return {"path": rel, "ref": context_refs.manifest_ref(rel), "warnings": warnings}
 
 
 def _title_from_text(path: Path, text: str) -> str:
@@ -352,12 +357,14 @@ def _resolve_selected_text_file(root: Path, raw: str) -> tuple[Path, str] | dict
             "path": rel,
             "code": "ALREADY_GOVERNED",
             "reason": f"copy-as-sources expects legacy files outside {kb_dirname()}/",
+            "ref": context_refs.vault_ref(rel),
         }
     if abs_path.suffix.lower() not in _TEXT_IMPORT_SUFFIXES:
         return {
             "path": rel,
             "code": "UNSUPPORTED_IMPORT_TYPE",
             "reason": "copy-as-sources currently imports text/markdown-like files only",
+            "ref": context_refs.vault_ref(rel),
         }
     return abs_path, rel
 
@@ -414,7 +421,9 @@ def _copy_as_sources(
         copied.append(
             {
                 "original_path": rel,
+                "original_ref": context_refs.vault_ref(rel),
                 "source_path": rel_target,
+                "source_ref": context_refs.source_ref(rel_target),
                 "original_sha256": sha,
                 "original_bytes": len(data),
             }
@@ -496,6 +505,131 @@ def _copy_as_sources(
     return {"copied_sources": copied, "skipped": skipped, "warnings": warnings}
 
 
+def _source_wikilink_path(rel_path: str) -> str:
+    return rel_path[:-3] if rel_path.lower().endswith(".md") else rel_path
+
+
+def _resolve_compile_selection(root: Path, raw: str) -> dict:
+    try:
+        abs_path, rel = resolve_under_vault(root, raw, must_exist=True, must_be_file=True)
+    except VaultPathError as e:
+        return {"kind": "skip", "path": raw, "code": e.code, "reason": e.reason}
+
+    if rel.startswith(kb_prefix()):
+        if rel.startswith(f"{kb_prefix()}Sources/") and rel.lower().endswith(".md"):
+            return {"kind": "governed_source", "abs_path": abs_path, "rel": rel}
+        return {
+            "kind": "skip",
+            "path": rel,
+            "code": "NOT_ADOPTION_SOURCE",
+            "reason": "compile-selected expects legacy files or governed Sources",
+            "ref": context_refs.vault_ref(rel),
+        }
+
+    if abs_path.suffix.lower() not in _TEXT_IMPORT_SUFFIXES:
+        return {
+            "kind": "skip",
+            "path": rel,
+            "code": "UNSUPPORTED_IMPORT_TYPE",
+            "reason": "compile-selected currently imports text/markdown-like files only",
+            "ref": context_refs.vault_ref(rel),
+        }
+    return {"kind": "legacy_text", "abs_path": abs_path, "rel": rel}
+
+
+def _compile_selected(
+    root: Path,
+    *,
+    selected_paths: list[str] | None,
+    today: dt.date,
+) -> dict:
+    _require_kb(root)
+    if not selected_paths:
+        raise AdoptError(
+            "MISSING_SELECTION",
+            "compile-selected requires selected_paths; scan first, then pass explicit files",
+        )
+
+    legacy_paths: list[str] = []
+    planned_sources: list[dict] = []
+    skipped: list[dict] = []
+    warnings: list[str] = []
+    copied_sources: list[dict] = []
+
+    for raw in selected_paths:
+        resolved = _resolve_compile_selection(root, raw)
+        kind = resolved.get("kind")
+        if kind == "governed_source":
+            rel = resolved["rel"]
+            data = resolved["abs_path"].read_bytes()
+            planned_sources.append(
+                {
+                    "source_path": rel,
+                    "source_wikilink": _source_wikilink_path(rel),
+                    "source_ref": context_refs.source_ref(rel),
+                    "source_sha256": hashlib.sha256(data).hexdigest(),
+                    "source_bytes": len(data),
+                    "already_governed": True,
+                }
+            )
+        elif kind == "legacy_text":
+            legacy_paths.append(resolved["rel"])
+        else:
+            item = dict(resolved)
+            item.pop("kind", None)
+            skipped.append(item)
+
+    if legacy_paths:
+        copy_result = _copy_as_sources(root, selected_paths=legacy_paths, today=today)
+        copied_sources = copy_result.get("copied_sources") or []
+        skipped.extend(copy_result.get("skipped") or [])
+        warnings.extend(copy_result.get("warnings") or [])
+        for item in copied_sources:
+            source_path = item["source_path"]
+            planned_sources.append(
+                {
+                    "original_path": item["original_path"],
+                    "original_ref": item.get("original_ref") or context_refs.vault_ref(item["original_path"]),
+                    "source_path": source_path,
+                    "source_wikilink": _source_wikilink_path(source_path),
+                    "source_ref": item.get("source_ref") or context_refs.source_ref(source_path),
+                    "original_sha256": item["original_sha256"],
+                    "original_bytes": item["original_bytes"],
+                    "already_governed": False,
+                }
+            )
+
+    if not planned_sources:
+        return {
+            "status": "empty",
+            "proposal_ref": None,
+            "sources": [],
+            "copied_sources": copied_sources,
+            "skipped": skipped,
+            "warnings": warnings + ["no source material available for compilation plan"],
+            "proposal": None,
+        }
+
+    source_wikilinks = [item["source_wikilink"] for item in planned_sources]
+    try:
+        proposal = compile_proposal_module.propose_compilation(root, sources=source_wikilinks)
+    except compile_proposal_module.ProposeError as e:
+        raise AdoptError(e.code, e.reason) from e
+
+    proposal_sources = proposal.get("suggested_sources") or source_wikilinks
+    proposal_ref = context_refs.proposal_ref(proposal_sources)
+    proposal["proposal_ref"] = proposal_ref
+    return {
+        "status": "ready",
+        "proposal_ref": proposal_ref,
+        "sources": planned_sources,
+        "copied_sources": copied_sources,
+        "skipped": skipped,
+        "warnings": warnings + list(proposal.get("warnings") or []),
+        "proposal": proposal,
+        "next_step": "Review outline_markdown, then call note() with suggested_sources when ready.",
+    }
+
 def adopt(
     root: Path | str,
     *,
@@ -520,16 +654,16 @@ def adopt(
         samples: Sample filename count per folder.
         pack_limit: Maximum pack suggestions to return.
         manifest_path: Optional markdown destination for ``save-manifest``.
-        selected_paths: Explicit vault-relative files for ``copy-as-sources``.
+        selected_paths: Explicit vault-relative files for ``copy-as-sources`` or ``compile-selected``.
 
     Scan-only never writes. Unsupported modes fail explicitly instead of
     silently pretending to migrate content.
     """
     if mode not in SUPPORTED_MODES:
-        planned = ", ".join(PLANNED_MODES)
+        supported = ", ".join(SUPPORTED_MODES)
         raise AdoptError(
             "UNSUPPORTED_MODE",
-            f"adopt mode {mode!r} is not implemented yet; planned safe modes: {planned}",
+            f"adopt mode {mode!r} is not supported; supported modes: {supported}",
         )
     root_path = Path(root)
     run_date = _today(today)
@@ -568,6 +702,7 @@ def adopt(
         "available_packs": knowledge_packs.list_builtin_packs(),
         "pack_schema": knowledge_packs.pack_schema(),
         "next_actions": _safe_next_actions(kb_present),
+        "refs": {"root": context_refs.vault_ref(path or "")},
         "overview": scan,
     }
     if mode == "save-manifest":
@@ -579,6 +714,12 @@ def adopt(
         )
     elif mode == "copy-as-sources":
         report["copy"] = _copy_as_sources(
+            root_path,
+            selected_paths=selected_paths,
+            today=run_date,
+        )
+    elif mode == "compile-selected":
+        report["compile_plan"] = _compile_selected(
             root_path,
             selected_paths=selected_paths,
             today=run_date,

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -1902,8 +1902,10 @@ def op_adopt(
     bounded read-only adoption report: what Exomem found, which content is
     governed versus read-only input, likely knowledge packs, and safe next
     actions. Explicit write modes only write under `Knowledge Base/`:
-    `save-manifest` saves the report, and `copy-as-sources` copies selected
-    legacy text files into governed Sources with original path/hash provenance.
+    `save-manifest` saves the report, `copy-as-sources` copies selected
+    legacy text files into governed Sources with original path/hash provenance,
+    and `compile-selected` copies selected legacy files when needed then returns
+    a reviewable compile plan. It does not create compiled notes automatically.
 
     Use this when the user says "import my vault", "adopt these notes", "make
     this existing knowledge base usable", or asks what Exomem would do with an
@@ -1911,14 +1913,14 @@ def op_adopt(
 
     Args:
         path: Optional vault subtree to scan. Defaults to the vault root.
-        mode: Adoption mode: scan-only, save-manifest, or copy-as-sources.
+        mode: Adoption mode: scan-only, save-manifest, copy-as-sources, or compile-selected.
         max_depth: Folder-tree depth cap for the scan.
         include_hidden: Include hidden files/directories in the scan.
         samples: Sample filename count per folder.
         pack_limit: Maximum knowledge-pack suggestions to return.
         manifest_path: Optional markdown destination under Knowledge Base/ for
             save-manifest. A default under _Adoption/ is used when omitted.
-        selected_paths: Explicit vault-relative legacy files for copy-as-sources.
+        selected_paths: Explicit vault-relative legacy files for copy-as-sources or compile-selected.
     """
     try:
         return adopt_module.adopt(

--- a/src/exomem/context_refs.py
+++ b/src/exomem/context_refs.py
@@ -1,0 +1,46 @@
+"""Stable context references for adoption/review surfaces.
+
+These refs are labels for agents and manifests, not a new path-resolution API.
+Existing vault-relative paths remain the authoritative tool inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from urllib.parse import quote
+
+
+SCHEME = "exomem"
+
+
+def _clean_path(path: str) -> str:
+    return str(path or "").replace("\\", "/").strip().lstrip("/")
+
+
+def _encode(path: str) -> str:
+    return quote(_clean_path(path), safe="/-._~")
+
+
+def vault_ref(path: str) -> str:
+    """Reference a vault-relative file or folder."""
+    return f"{SCHEME}://vault/{_encode(path)}"
+
+
+def source_ref(path: str) -> str:
+    """Reference a governed source path, with a stable no-extension form."""
+    clean = _clean_path(path)
+    if clean.lower().endswith(".md"):
+        clean = clean[:-3]
+    return f"{SCHEME}://source/{_encode(clean)}"
+
+
+def manifest_ref(path: str) -> str:
+    """Reference an adoption manifest path."""
+    return f"{SCHEME}://manifest/{_encode(path)}"
+
+
+def proposal_ref(sources: list[str]) -> str:
+    """Reference an in-response compile proposal derived from source paths."""
+    normalized = "\n".join(_clean_path(s) for s in sources)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    return f"{SCHEME}://proposal/{digest}"

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -159,7 +159,7 @@ def run_setup(
         print_fn(f"    Likely packs: {_format_pack_suggestions(packs)}")
     print_fn("")
     print_fn(f"  Contract: {overview_module.SCOPE_NOTE}")
-    print_fn("  Adoption: run `exomem adopt` anytime for the copy/manifest plan.")
+    print_fn("  Adoption: run `exomem adopt` anytime for manifest review, source copy, and compile planning.")
     print_fn("")
     report("scan", "[done]")
 

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -65,7 +65,7 @@
     }
   },
   "adopt": {
-    "description": "Adopt / import an existing vault safely: scan first, preserve originals.\n\nThis is the product-facing first step for a vault that already contains\nnotes, media, records, or project folders. `mode=\"scan-only\"` returns a\nbounded read-only adoption report: what Exomem found, which content is\ngoverned versus read-only input, likely knowledge packs, and safe next\nactions. Explicit write modes only write under `Knowledge Base/`:\n`save-manifest` saves the report, and `copy-as-sources` copies selected\nlegacy text files into governed Sources with original path/hash provenance.\n\nUse this when the user says \"import my vault\", \"adopt these notes\", \"make\nthis existing knowledge base usable\", or asks what Exomem would do with an\nold folder before committing to migration.",
+    "description": "Adopt / import an existing vault safely: scan first, preserve originals.\n\nThis is the product-facing first step for a vault that already contains\nnotes, media, records, or project folders. `mode=\"scan-only\"` returns a\nbounded read-only adoption report: what Exomem found, which content is\ngoverned versus read-only input, likely knowledge packs, and safe next\nactions. Explicit write modes only write under `Knowledge Base/`:\n`save-manifest` saves the report, `copy-as-sources` copies selected\nlegacy text files into governed Sources with original path/hash provenance,\nand `compile-selected` copies selected legacy files when needed then returns\na reviewable compile plan. It does not create compiled notes automatically.\n\nUse this when the user says \"import my vault\", \"adopt these notes\", \"make\nthis existing knowledge base usable\", or asks what Exomem would do with an\nold folder before committing to migration.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
@@ -77,7 +77,7 @@
         "mode": {
           "default": "scan-only",
           "type": "string",
-          "description": "Adoption mode: scan-only, save-manifest, or copy-as-sources."
+          "description": "Adoption mode: scan-only, save-manifest, copy-as-sources, or compile-selected."
         },
         "max_depth": {
           "default": 3,
@@ -124,7 +124,7 @@
             }
           ],
           "default": null,
-          "description": "Explicit vault-relative legacy files for copy-as-sources."
+          "description": "Explicit vault-relative legacy files for copy-as-sources or compile-selected."
         }
       },
       "type": "object"

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -132,6 +132,87 @@ def test_adopt_copy_as_sources_preserves_original_and_records_provenance(tmp_pat
     assert "# Laptop receipt" in source_text
 
 
+def test_adopt_compile_selected_copies_and_returns_reviewable_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+    original = vault / "Warranty Case" / "laptop-receipt.md"
+    before_legacy = _snapshot(vault, exclude_kb=True)
+
+    def fake_propose(root: Path, *, sources: list[str], suggested_title: str | None = None) -> dict:
+        assert root == vault
+        assert sources == ["Knowledge Base/Sources/Imported/2026-07-07-laptop-receipt"]
+        return {
+            "suggested_note_type": "insight",
+            "suggested_title": "Laptop receipt",
+            "suggested_sources": list(sources),
+            "suggested_connections": [],
+            "outline_markdown": "# Laptop receipt\n\n## Claim\n",
+            "warnings": [],
+        }
+
+    monkeypatch.setattr(adopt_module.compile_proposal_module, "propose_compilation", fake_propose)
+
+    report = adopt_module.adopt(
+        vault,
+        mode="compile-selected",
+        selected_paths=["Warranty Case/laptop-receipt.md"],
+        today=dt.date(2026, 7, 7),
+    )
+
+    assert original.read_text(encoding="utf-8") == "# Laptop receipt\n\nreceipt\n"
+    assert _snapshot(vault, exclude_kb=True) == before_legacy
+    assert list((vault / "Knowledge Base" / "Notes").rglob("*.md")) == []
+
+    plan = report["compile_plan"]
+    assert plan["status"] == "ready"
+    assert plan["proposal"]["suggested_sources"] == [
+        "Knowledge Base/Sources/Imported/2026-07-07-laptop-receipt"
+    ]
+    assert plan["proposal"]["proposal_ref"].startswith("exomem://proposal/")
+    assert plan["next_step"].startswith("Review outline_markdown")
+
+    [source] = plan["sources"]
+    assert source["original_path"] == "Warranty Case/laptop-receipt.md"
+    assert source["original_ref"] == "exomem://vault/Warranty%20Case/laptop-receipt.md"
+    assert source["source_path"] == "Knowledge Base/Sources/Imported/2026-07-07-laptop-receipt.md"
+    assert source["source_ref"] == (
+        "exomem://source/Knowledge%20Base/Sources/Imported/2026-07-07-laptop-receipt"
+    )
+    assert source["already_governed"] is False
+
+
+def test_adopt_compile_selected_requires_explicit_selection(tmp_path: Path) -> None:
+    with pytest.raises(adopt_module.AdoptError) as ei:
+        adopt_module.adopt(_legacy_vault(tmp_path, kb=True), mode="compile-selected")
+    assert ei.value.code == "MISSING_SELECTION"
+
+
+def test_adopt_compile_selected_skips_unsupported_without_writing(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+    (vault / "scan.jpg").write_bytes(b"not really an image")
+    before = _snapshot(vault)
+
+    report = adopt_module.adopt(
+        vault,
+        mode="compile-selected",
+        selected_paths=["scan.jpg"],
+        today=dt.date(2026, 7, 7),
+    )
+
+    assert _snapshot(vault) == before
+    plan = report["compile_plan"]
+    assert plan["status"] == "empty"
+    assert plan["proposal"] is None
+    assert plan["skipped"] == [
+        {
+            "path": "scan.jpg",
+            "code": "UNSUPPORTED_IMPORT_TYPE",
+            "reason": "compile-selected currently imports text/markdown-like files only",
+            "ref": "exomem://vault/scan.jpg",
+        }
+    ]
+
 def test_adopt_copy_as_sources_requires_explicit_selection(tmp_path: Path) -> None:
     with pytest.raises(adopt_module.AdoptError) as ei:
         adopt_module.adopt(_legacy_vault(tmp_path, kb=True), mode="copy-as-sources")
@@ -140,9 +221,10 @@ def test_adopt_copy_as_sources_requires_explicit_selection(tmp_path: Path) -> No
 
 def test_adopt_unsupported_mode_is_explicit(tmp_path: Path) -> None:
     with pytest.raises(adopt_module.AdoptError) as ei:
-        adopt_module.adopt(_legacy_vault(tmp_path), mode="compile-selected")
+        adopt_module.adopt(_legacy_vault(tmp_path), mode="teleport")
     assert ei.value.code == "UNSUPPORTED_MODE"
-    assert "planned safe modes" in ei.value.reason
+    assert "supported modes" in ei.value.reason
+    assert "compile-selected" in ei.value.reason
 
 
 def test_pack_suggestions_default_to_personal_records() -> None:

--- a/tests/test_context_refs.py
+++ b/tests/test_context_refs.py
@@ -1,0 +1,23 @@
+"""Stable Exomem context refs."""
+
+from __future__ import annotations
+
+from exomem import context_refs
+
+
+def test_vault_and_source_refs_are_url_safe() -> None:
+    assert (
+        context_refs.vault_ref("Warranty Case/laptop-receipt.md")
+        == "exomem://vault/Warranty%20Case/laptop-receipt.md"
+    )
+    assert (
+        context_refs.source_ref("Knowledge Base/Sources/Imported/2026-07-07-laptop-receipt.md")
+        == "exomem://source/Knowledge%20Base/Sources/Imported/2026-07-07-laptop-receipt"
+    )
+
+
+def test_proposal_ref_is_stable_for_source_set() -> None:
+    sources = ["Knowledge Base/Sources/Imported/a", "Knowledge Base/Sources/Imported/b"]
+    assert context_refs.proposal_ref(sources) == context_refs.proposal_ref(list(sources))
+    assert context_refs.proposal_ref(sources).startswith("exomem://proposal/")
+    assert context_refs.proposal_ref(sources) != context_refs.proposal_ref(list(reversed(sources)))

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -73,6 +73,7 @@ def test_fresh_vault_happy_path(tmp_path: Path) -> None:
     assert "2 files" in out
     assert "Likely packs:" in out
     assert "Adoption: run `exomem adopt`" in out
+    assert "compile planning" in out
     assert "writes only under 'Knowledge Base/'" in out
     # registration argv shape
     (reg,) = [c for c in recorder.calls if "add" in c]


### PR DESCRIPTION
Summary
- Implement `adopt(mode="compile-selected")` as a selected-path compile-planning flow that preserves originals.
- Add stable `exomem://` context refs for manifests, vault files, sources, and proposals.
- Update setup/docs/schema text and add OpenSpec change artifacts.

Tests
- `uv run pytest -q tests/test_context_refs.py tests/test_adopt.py tests/test_compile_proposal.py tests/test_setup_wizard.py tests/test_mcp_schema_fidelity.py`
