### PR TITLE
Clarify agent memory boundaries

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -45,6 +45,34 @@ is safe: completed steps report `[skipped]`.
 Non-interactive (scripts/CI):
 `uv run python -m exomem setup --yes --vault "/path/to/vault" --lean`
 
+## Not CLI-comfortable? Ask an assistant to drive
+
+You do not need to understand Exomem internals to get started. Give Claude Code,
+Codex, or another terminal-capable assistant this prompt from the cloned repo:
+
+```text
+Set up Exomem for my local markdown or Obsidian vault. Use the recommended lean
+path unless I explicitly ask for embeddings. Run the setup wizard, explain each
+prompt in plain language before I answer it, and do not move or rewrite my
+existing vault files. After setup, verify with doctor, call
+bootstrap(profile="compact") if you are not using the Exomem skill, ask one
+known vault question with find, and
+save one harmless test conclusion so I can see where it lands.
+```
+
+The expected first-run verification is concrete:
+
+1. `exomem doctor` passes for the selected vault.
+2. The connected assistant can call `bootstrap(profile="compact")`, unless it has
+   already loaded the Exomem skill.
+3. A known question about your vault triggers `find()` before the answer.
+4. A safe test such as "remember that setup succeeded today" writes a compiled
+   note and reports `Saved -> <path>`.
+
+Existing vault material remains read-only input. Exomem writes governed knowledge
+under `Knowledge Base/` unless you deliberately configure a different governed
+folder.
+
 The numbered steps below are the **manual path** — exactly what `setup` does
 under the hood, kept for troubleshooting and for people who prefer explicit
 steps.

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -1,66 +1,205 @@
 # Exomem assistant guide
 
-This guide is for making an AI client use Exomem well after the MCP server is
-connected. The transport gives the agent tools. The behavioral layer tells it
-when to search, when to save, how to treat misses, and how to avoid confusing
-raw evidence with compiled notes.
+This guide is for agents using Exomem after the MCP server or connector is
+available. It keeps the contract simple:
 
-Claude Code gets that layer from the Exomem skill and optional hooks. Other
-clients should get it from `bootstrap()` plus a short standing instruction.
+- Use the assistant's native memory or custom instructions for preferences and
+  routing rules.
+- Use Exomem for durable governed knowledge: project context, decisions, sourced
+  conclusions, failures, experiments, proof-bearing records, and anything that
+  should be searchable, citeable, reviewable, or supersedable across clients.
+- Do not make the user choose internal folders or page types unless the choice
+  changes the outcome.
 
-## Client matrix
+## Start here
 
-| Client | Setup | Behavioral layer |
-| --- | --- | --- |
-| Claude Code | `exomem setup` or the manual quickstart | Exomem skill plus optional hooks |
-| Codex CLI | `codex mcp add ...` | Codex hooks, `AGENTS.md`, and `bootstrap()` as fallback |
-| ChatGPT or other hosted chat clients | Remote MCP/connector support, when available | Custom instructions plus `bootstrap()` |
-| claude.ai web/mobile | Remote connector | Custom instructions plus `bootstrap()` |
-| Cursor, Windsurf, Gemini, or generic MCP clients | Stdio MCP config | `bootstrap()` at session start |
-| Scripts or custom chatbots | MCP, REST, or CLI | Cache `bootstrap()` once per session or process |
+If the Exomem skill has already been loaded, follow it. Otherwise call:
+
+```text
+bootstrap(profile="compact")
+```
+
+Do this once at the start of a session for generic MCP clients, hosted chat
+clients, Cursor, Codex, ChatGPT, scripts, and future clients that only see tool
+schemas. Use `bootstrap(profile="full")` when the client needs examples. Use
+`bootstrap(profile="diagnostics")` only for speed, ranking, cache, CPU/GPU,
+rerank, or packed-context questions.
 
 ## The rule
 
-Use Exomem when the turn touches prior projects, notes, decisions, failures,
-sources, experiments, or domains the vault may know about. Do not search on
-every prompt just because Exomem exists. If the current conversation already has
-fresh KB evidence, reuse it unless the user changes topic, asks for a broader
-check, or the answer depends on something not yet retrieved.
+Search Exomem before answering when the turn touches the user's prior projects,
+notes, decisions, sources, failures, experiments, entities, or domains. Stay
+quiet for unrelated chat, short control prompts, and follow-ups where the current
+conversation already contains fresh KB evidence.
 
-An empty search means "not found for that query and scope." It is not proof that
-the memory does not exist. Try synonyms, adjacent domain terms, singular/plural
-forms, or `scope="vault"` before concluding absence.
+An empty search means "not found with that query and scope." It is not proof that
+the knowledge does not exist. Try synonyms, adjacent terms, singular/plural
+forms, or `scope="vault"` before saying there is no relevant material.
+
+Save durable conclusions when the conversation lands on one: a decision, solved
+problem, diagnosed failure, reusable pattern, stable project fact, or conclusion
+that future agents should find. Save a concise compiled note, not a transcript.
+Capture raw material separately when provenance matters.
+
+## Simple actions for agents
+
+| User intent | What the agent should do | Typical Exomem action |
+| --- | --- | --- |
+| "Remember this" | Decide whether it is raw material, a durable conclusion, or both. Save the conclusion as a compiled note; preserve the raw input if it matters. | `note`, sometimes `add` first |
+| "Find what I concluded" | Search first, cite relevant hits, and treat misses as scoped misses. Read full pages only when needed. | `find`, then `get` or `find(pack=true)` |
+| "Preserve this source" | Keep the raw material with provenance. Do not rewrite it into a conclusion unless asked or clearly useful. | `add` |
+| "Preserve this proof/record" | Store as proof-bearing material for a case, claim, receipt, warranty, dispute, or record. | `preserve` or upload |
+| "Compile this evidence" | Turn raw sources/evidence into a concise conclusion with links back to the originals. | `note` with citations |
+| "Review stale knowledge" | Surface old or low-use conclusions for human review; do not hide, decay, or auto-rank them down. | `audit`, stale-review checks |
+| "This replaces the old conclusion" | Supersede the old compiled page instead of creating an unlinked duplicate. | `replace` |
+| "Update this small detail" | Patch a compiled page when the claim is still the same. | `edit` |
+| "Connect these ideas" | Add links or entity pages only when they clarify retrieval and future reasoning. | `suggest_links`, `link` |
+
+Use internal names only as implementation details. With the user, say "save the
+source," "write the conclusion," "preserve the record," "review stale notes," or
+"replace the old conclusion."
+
+## Examples
+
+### Remember this
+
+User:
+
+```text
+Remember this: for the onboarding docs, lead with simple actions, not schema
+folders.
+```
+
+Agent behavior:
+
+1. Recognize a durable project conclusion.
+2. Save a concise compiled note.
+3. Report the path.
+
+```text
+Saved -> Knowledge Base/Notes/Research/Exomem/<title>.md
+```
+
+### Find what I concluded
+
+User:
+
+```text
+What did I conclude about Exomem vs built-in memory?
+```
+
+Agent behavior:
+
+1. Run `find(query="Exomem built-in memory boundary", detail="compact")`.
+2. Cite relevant hits.
+3. If results are thin, retry with adjacent terms such as `native memory`,
+   `assistant memory`, `custom instructions`, or `durable governed knowledge`.
+
+### Preserve source
+
+User:
+
+```text
+Save this article as a source and keep the URL.
+```
+
+Agent behavior:
+
+1. Use `add` for the raw article or excerpt.
+2. Keep the URL and capture rationale.
+3. Offer to compile a note only if there is a durable conclusion to extract.
+
+### Preserve proof
+
+User:
+
+```text
+Keep this receipt for the warranty case.
+```
+
+Agent behavior:
+
+1. Treat it as a proof-bearing record, not a research source.
+2. Preserve the original file or text under the evidence workflow.
+3. Report the stored path and any metadata the server returns.
+
+### Compile evidence
+
+User:
+
+```text
+Compile the notes from these two sources into what we learned.
+```
+
+Agent behavior:
+
+1. Search or read the named sources.
+2. Draft a compiled conclusion that links back to the sources.
+3. Use `suggest_links` before writing so the new note connects to prior work.
+
+### Review stale knowledge
+
+User:
+
+```text
+Show me conclusions that may be stale.
+```
+
+Agent behavior:
+
+1. Run the stale-review audit path.
+2. Present candidates as review items only.
+3. Ask whether to keep, edit, supersede, or archive. Do not auto-decay old
+   knowledge.
+
+### Supersede old conclusion
+
+User:
+
+```text
+The old setup recommendation is wrong now; this new one replaces it.
+```
+
+Agent behavior:
+
+1. Find and confirm the old compiled page.
+2. Use `replace` to write the new conclusion and mark the old page superseded.
+3. Surface downstream pages that may need review; do not silently rewrite them.
+
+## Client setup
+
+| Client | Connection | Behavioral layer |
+| --- | --- | --- |
+| Claude Code | Local MCP via setup or manual config | Exomem skill, optional hooks |
+| Codex CLI | `codex mcp add ...` | `AGENTS.md`, optional hooks, `bootstrap()` fallback |
+| ChatGPT or hosted chat clients | Remote MCP/connector when supported | Custom instructions plus `bootstrap()` |
+| claude.ai web/mobile | Remote connector | Custom instructions plus `bootstrap()` |
+| Cursor, Windsurf, Gemini, generic MCP clients | Stdio or remote MCP config | `bootstrap()` at session start |
+| Scripts and custom chatbots | MCP, REST, or CLI | Cache `bootstrap()` per process/session |
 
 ## Copyable instruction block
 
-Paste this into `AGENTS.md`, a project instruction, or a hosted chat client's
-custom instructions. Trim the tone line to match your own preferences.
+Paste this into `AGENTS.md`, project instructions, or hosted chat custom
+instructions. Trim the tone line to your preference.
 
 ```text
 Use Exomem as my durable Knowledge Base.
 
-At the start of a new session, if no Exomem skill has already been loaded, call
-bootstrap(profile="compact") once and follow the returned contract.
+If no Exomem skill is loaded, call bootstrap(profile="compact") once at the
+start of a session and follow the returned contract.
 
-Search Exomem before answering questions that touch my projects, notes,
-decisions, failures, sources, experiments, or domains. Use cheap recall first:
-find(query="...", detail="compact", rerank=false). Follow with get() only for
-hits that matter, or find(pack=true) when synthesizing across several hits.
-
-Do not search on unrelated chit-chat, simple control prompts, or every follow-up
-when the needed KB evidence is already in the conversation. If a search misses,
-try synonyms, adjacent terms, singular/plural variants, or scope="vault" before
-saying the KB has no relevant material.
+Search Exomem before answering when a turn touches my prior projects, notes,
+decisions, sources, failures, experiments, or domains. Do not search on unrelated
+chit-chat, short control prompts, or follow-ups where the current conversation
+already contains the needed KB evidence. Cite relevant hits. Treat an empty
+search as a scoped miss, not proof of absence; retry with better terms or
+scope="vault" when absence matters.
 
 Save durable conclusions on your own: decisions, solved problems, diagnosed
-failures, reusable patterns, and stable project context. Save them as concise
-compiled notes, not transcripts. Keep raw artifacts as sources or evidence. Use
-edit() for small corrections and replace() when superseding an older compiled
-note.
-
-For latency or ranking questions, call bootstrap(profile="diagnostics") and use
-find(include_timings=true, rerank=true). Distinguish CPU/GPU/low-power mode from
-rerank, pack, cold model download, and cache state.
+failures, reusable patterns, and stable project context. Save concise compiled
+notes, not transcripts. Preserve raw sources or proof-bearing records separately
+when provenance matters. Use edit for small corrections and replace when a newer
+conclusion supersedes an older one.
 ```
 
 ## Codex CLI
@@ -84,11 +223,8 @@ exomem install-hook --check
 ```
 
 Codex reads repository instructions from `AGENTS.md`. Put the instruction block
-above there, or keep your own equivalent policy. Restart Codex sessions after
-changing MCP config or hook config.
-
-The hooks are nudges. They should remind Codex to consider Exomem on substantive
-turns, not force a tool call for every prompt.
+there, or keep an equivalent policy. Restart Codex sessions after changing MCP
+or hook config.
 
 ## Generic stdio MCP clients
 
@@ -114,16 +250,12 @@ After connecting, ask the agent to call:
 bootstrap(profile="compact")
 ```
 
-Use `profile="full"` when examples help a weaker client. Use
-`profile="diagnostics"` when discussing speed, ranking, GPU/CPU behavior, or
-model/cache state.
-
 ## Hosted chat clients
 
-Hosted clients cannot use local filesystem hooks and usually cannot load the
-repo's Claude Code skill. Connect Exomem through whatever remote MCP/connector
-support the client offers, then add the instruction block above as account-level
-or project-level custom instructions.
+Hosted clients usually cannot use local filesystem hooks or load the repo's
+Claude Code skill. Connect Exomem through whatever remote MCP/connector support
+the client offers, then add the instruction block above as account-level or
+project-level custom instructions.
 
 If the hosted client cannot reliably call `bootstrap()` on its own, start a new
 chat with:
@@ -131,16 +263,14 @@ chat with:
 ```text
 Call Exomem bootstrap(profile="compact") once, then use that contract for this
 chat. Do not search the KB unless this turn touches my prior projects, notes,
-decisions, sources, or domains.
+decisions, sources, failures, experiments, or domains.
 ```
 
-## Performance profiles
-
-These are the defaults returned by `bootstrap()`.
+## Performance guidance
 
 | Use case | Tool shape | Meaning |
 | --- | --- | --- |
-| Normal lookup | `find(detail="compact", rerank=false)` | Cheap routing recall; follow with `get()` if needed |
+| Normal lookup | `find(detail="compact", rerank=false)` | Cheap routing recall |
 | Reasoning | `find(pack=true)` | Bounded context assembly for synthesis |
 | Diagnostics | `find(detail="compact", include_timings=true, rerank=true)` | Explain latency and ranking behavior |
 
@@ -153,7 +283,8 @@ Resource mode is separate from search knobs:
 | `performance` | Explicit opt-in for GPU-capable steady-state work |
 
 Do not interpret a slow diagnostic search with rerank enabled as "Exomem is
-slow" without checking timings and resource mode.
+slow" without checking timings, resource mode, cache state, and whether a model
+was cold.
 
 ## Verification
 
@@ -165,10 +296,9 @@ exomem install-hook --check
 ```
 
 Then ask the client to call `bootstrap(profile="compact")`. A good response
-includes a `contract_version`, a server `compute_policy`, tool defaults, and the
+includes a `contract_version`, server compute policy, tool defaults, and the
 search/save workflow. Ask one known vault question next and confirm it uses
 `find()` before answering.
 
-For remote connectors, use [remote-quickstart.md](remote-quickstart.md). For
-what belongs in Exomem instead of an assistant's built-in memory, see
-[vs-built-in-memory.md](vs-built-in-memory.md).
+For remote connectors, use [remote-quickstart.md](remote-quickstart.md). For the
+memory boundary, see [vs-built-in-memory.md](vs-built-in-memory.md).

--- a/docs/vs-built-in-memory.md
+++ b/docs/vs-built-in-memory.md
@@ -1,79 +1,109 @@
 # Exomem vs built-in assistant memory
 
 Built-in assistant memory and Exomem solve different problems. They work best
-together when the boundary is explicit.
+when the boundary is explicit.
 
 ## Short version
 
-Use built-in memory for tiny, durable preferences that should shape every chat.
-Use Exomem for project knowledge, sourced material, decisions, failures,
-experiments, and anything you may need to inspect, cite, edit, supersede, or use
-from more than one client.
+Use built-in memory or custom instructions for small preferences that should
+shape every chat. Use Exomem for durable governed knowledge: project context,
+sourced conclusions, decisions, failures, experiments, evidence, and anything you
+may need to inspect, cite, edit, review, supersede, or use from more than one
+client.
 
-Built-in memory is usually hidden inside one assistant product. Exomem is a
-user-owned Markdown vault served through MCP, REST, and CLI, so the same memory
-can be used by Claude Code, Codex, Cursor, hosted chat clients, scripts, and your
-own tools.
+Exomem is not a replacement for every native memory feature. It is the portable,
+user-owned knowledge layer behind Claude, Codex, ChatGPT, Cursor, hosted chat
+clients, scripts, and future MCP clients.
 
-## Routing table
+## What goes where
 
-| Information | Put it where |
-| --- | --- |
-| Response style, tone, formatting preferences | Built-in memory or custom instructions |
-| "Always check my Exomem KB for project/domain questions" | Built-in memory or custom instructions |
-| Project decisions and architectural context | Exomem compiled notes |
-| Research findings and reusable conclusions | Exomem compiled notes, with sources linked |
-| Raw articles, transcripts, screenshots, PDFs, images, audio, or video | Exomem sources/evidence |
-| Diagnosed failures and fixes | Exomem failure or pattern notes |
-| Experiments and benchmark results | Exomem experiment notes |
-| Temporary scratch thoughts that will not matter later | Usually nowhere |
-| Calendar tasks, reminders, or operational todos | A calendar/task system, unless they become project knowledge |
-| Passwords, tokens, private keys, or credentials | Neither; use a secret manager |
+| Need | Best home | Why |
+| --- | --- | --- |
+| Response style, tone, formatting preferences | Built-in memory or custom instructions | These should shape nearly every chat with minimal retrieval cost |
+| "Use Exomem for project/domain questions" | Built-in memory or custom instructions | This is a routing rule for the assistant |
+| Stable personal identity facts the assistant should always respect | Built-in memory or custom instructions | Small, cross-chat personalization fits native memory |
+| Project decisions and architecture context | Exomem | They need provenance, history, edits, and cross-client access |
+| Research findings and reusable conclusions | Exomem | They should be searchable, citeable, and supersedable |
+| Raw articles, transcripts, screenshots, PDFs, images, audio, or video | Exomem source capture | Raw material needs provenance and should not be rewritten as memory |
+| Receipts, warranty records, case documents, or proof-bearing artifacts | Exomem evidence preservation | These need as-received preservation, not summarization first |
+| Diagnosed failures and fixes | Exomem | Failures become reusable project knowledge |
+| Experiments and benchmark results | Exomem | They need protocol, data, results, and later review |
+| Temporary scratch thoughts | Usually nowhere | Do not store noise just because a memory system exists |
+| Calendar tasks, reminders, operational todos | Calendar/task system | They are action management, not durable knowledge |
+| Passwords, tokens, private keys, credentials | Secret manager | Do not put secrets in assistant memory or Exomem |
 
-## Why Exomem needs a behavioral layer
+## The boundary in one sentence
 
-An MCP connection only exposes tools. It does not guarantee the agent knows when
-to use them. Claude Code can load the Exomem skill. Other clients should call
+Native assistant memory tells the assistant how to behave. Exomem tells the
+assistant what durable, governed knowledge the user has accumulated.
+
+A good native-memory entry is tiny:
+
+```text
+Use Exomem for my durable project knowledge. Search it before answering project,
+decision, source, failure, experiment, or domain questions, and save durable
+conclusions there.
+```
+
+The actual project knowledge belongs in Exomem, not in that native-memory entry.
+
+## Why Exomem needs agent instructions
+
+An MCP connection exposes tools. It does not guarantee the agent knows when to
+use them. Claude Code can load the Exomem skill. Other clients should call
 `bootstrap(profile="compact")` once per session and follow the returned contract.
 
 The practical behavior is:
 
 ```text
-For questions about my prior work, search Exomem first. For unrelated chat or
-small control prompts, stay quiet. Save durable conclusions as compiled notes.
-Treat empty searches as query/scope misses, not proof of absence.
+Search Exomem before answering prior-work questions. Skip it for unrelated chat
+or follow-ups where fresh KB evidence is already in context. Save durable
+conclusions as compiled notes. Preserve raw sources and proof separately. Treat
+empty searches as scoped misses, not proof of absence.
 ```
 
-## Compiled notes vs raw evidence
+## What Exomem adds beyond native memory
 
-Exomem separates raw material from conclusions.
+Exomem gives agents a governed knowledge layer:
 
-Raw evidence belongs in sources or evidence pages: uploaded files, quoted
-articles, transcripts, screenshots, datasets, and other artifacts. These should
-preserve provenance.
+- provenance: raw sources and proof-bearing records stay linked to conclusions;
+- editability: small corrections can be patched without losing structure;
+- supersession: changed conclusions point back to what they replaced;
+- review: stale or contradictory knowledge can be surfaced for judgment;
+- portability: the same vault can serve multiple clients and scripts;
+- visibility: Markdown files remain user-owned and inspectable.
 
-Compiled notes are the durable layer: decisions, solved problems, patterns,
-entities, failures, research notes, and experiments. They should be concise and
-usable by a future agent without replaying the whole chat.
+Native memory usually does not expose enough structure for those jobs. It may be
+hidden inside one assistant product, hard to cite, hard to diff, and unavailable
+to other clients.
 
-When a compiled note changes slightly, use `edit()`. When a newer conclusion
-supersedes an older one, use `replace()` so the history stays understandable
-instead of accumulating duplicates.
+## What Exomem does not replace
 
-## Sharing one memory across clients
+Exomem does not replace:
 
-Assistant built-in memories do not usually travel across products. A preference
-saved in one chat product will not automatically help Codex, Cursor, a script, or
-a custom MCP client.
+- the current chat context;
+- short-lived scratch reasoning;
+- assistant style preferences;
+- account-level personalization;
+- calendars, task managers, or notification systems;
+- secret managers;
+- the repository as the source of truth for code.
 
-Exomem is the portable layer. Keep only the routing preference in each client:
+For software projects, the repo remains the source of truth for code and current
+implementation. Exomem holds the cross-session layer the repo usually does not:
+decisions, rationale, empirical findings, source-backed conclusions, and reusable
+lessons.
 
-```text
-I keep durable project knowledge in Exomem. Search it when this turn touches my
-projects, notes, decisions, sources, failures, experiments, or domains. Do not
-search on unrelated chit-chat or when the current conversation already contains
-the needed KB evidence.
-```
+## Agent examples
 
-For concrete client setup and the full copyable instruction block, see
+| User says | Agent behavior |
+| --- | --- |
+| "Remember that we chose the simple action model." | Save a concise compiled conclusion in Exomem; do not stuff it into native memory. |
+| "What did I conclude about onboarding?" | Search Exomem first, cite the relevant note, then answer. |
+| "Save this article." | Capture it as a raw source with provenance; offer to compile only if there is a conclusion. |
+| "Keep this receipt for the warranty case." | Preserve it as proof-bearing evidence, not as a general note. |
+| "This new approach replaces the old one." | Supersede the old compiled conclusion instead of creating a duplicate. |
+| "Always use terse answers." | Put that in native memory or custom instructions, not Exomem. |
+
+For client-specific setup and a copyable instruction block, see
 [ai-assistant-guide.md](ai-assistant-guide.md).

--- a/openspec/changes/clarify-agent-memory-boundaries/.openspec.yaml
+++ b/openspec/changes/clarify-agent-memory-boundaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/clarify-agent-memory-boundaries/design.md
+++ b/openspec/changes/clarify-agent-memory-boundaries/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The current docs already contain most of the underlying Exomem rules, but they
+often introduce internal layers and tool names before the user or agent has a
+simple routing model. That makes Exomem feel more complex than it needs to feel
+for Claude, Codex, ChatGPT, Cursor, and generic MCP clients.
+
+The existing `bootstrap()` contract already exposes a product-facing action
+catalog. The docs and scaffold should reuse that vocabulary instead of creating
+parallel terms. The implementation is scoped to documentation, scaffold text,
+fixture mirrors, and focused tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the native assistant memory vs. Exomem boundary direct and honest.
+- Teach agents to map user phrasing to simple actions before exposing internal
+  folders or page types.
+- Give non-CLI-comfortable users a first-run path that still verifies the setup.
+- Include concrete examples for remember, find, preserve source/proof, compile,
+  review stale knowledge, and supersede old conclusions.
+- Keep scaffold text generic and leak-guard compatible.
+
+**Non-Goals:**
+
+- No MCP, REST, CLI, storage, ranking, or model behavior changes.
+- No new dependency, background service, or client-specific integration.
+- No claim that Exomem replaces all built-in assistant memory features.
+
+## Decisions
+
+1. Use simple product actions as the front door.
+
+   Agents should first think in terms of `ask`, `save`, `prove`, `review`,
+   `update`, and `connect`. Internal operations such as `find`, `add`, `note`,
+   `preserve`, `audit`, `edit`, and `replace` remain the implementation layer.
+   Alternative considered: document only tool names. That keeps precision but
+   forces users to understand schema internals.
+
+2. Keep the memory boundary as a two-layer model.
+
+   Native assistant memory/custom instructions hold preferences, style, identity
+   facts, and the instruction to use Exomem. Exomem holds governed durable
+   knowledge with provenance, review, and supersession. Alternative considered:
+   positioning Exomem as a complete replacement for built-in memory. That would
+   be inaccurate and would weaken the docs.
+
+3. Put first-run user guidance in quickstart, and agent behavior in the assistant
+   guide/scaffold.
+
+   `QUICKSTART.md` should help a non-CLI user ask an assistant to drive setup and
+   verification. `docs/ai-assistant-guide.md` and the scaffold skill should teach
+   agents what to do after tools are connected.
+
+4. Mirror scaffold edits into test fixtures.
+
+   Tests load schema docs from `tests/fixtures/Knowledge Base/_Schema`. Any
+   canonical scaffold changes that affect parsed or copied schema text must be
+   reflected there so fixture-backed tests keep representing shipped text.
+
+## Risks / Trade-offs
+
+- Internal terminology may disappear too far from agent guidance -> keep a short
+  "implementation mapping" table for agents.
+- Docs may drift from `bootstrap()` -> reuse the same front-door action names and
+  run `test_bootstrap.py`.
+- Scaffold edits can introduce private tokens or path leaks -> run
+  `test_scaffold_no_leak.py`.
+- Quickstart can become too long -> add a compact non-CLI path and leave deep
+  operational detail in existing setup sections.

--- a/openspec/changes/clarify-agent-memory-boundaries/proposal.md
+++ b/openspec/changes/clarify-agent-memory-boundaries/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Exomem's agent-facing docs expose too much internal structure before agents and
+users have a simple mental model. Claude, Codex, ChatGPT, Cursor, and future MCP
+clients need a clear boundary between native assistant memory and Exomem, plus a
+small set of user intents that map to the right Exomem actions.
+
+## What Changes
+
+- Reframe assistant-facing docs around simple product actions and user intents:
+  remember, find, preserve, compile, review, supersede.
+- Make the built-in memory boundary explicit and honest: native assistant memory
+  is still useful for preferences and routing, while Exomem is durable governed
+  knowledge with sources, proof, history, review, and supersession.
+- Add first-run guidance for users who are not CLI-comfortable, including what an
+  assistant should do after setup to verify the connection.
+- Update the shipped scaffold skill and relevant schema references so agents use
+  Exomem correctly without asking users to choose internal folders or page types
+  unless the distinction matters.
+- Keep the change documentation/scaffold-only. No MCP, REST, CLI, or storage
+  API change is intended.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-memory-onboarding`: Agent-facing onboarding and memory-boundary guidance
+  for using Exomem across Claude, Codex, ChatGPT, Cursor, generic MCP clients,
+  and future clients.
+
+### Modified Capabilities
+
+- `agent-bootstrap-contract`: Documentation will align generic-client guidance
+  with `bootstrap()`'s existing operating contract; no bootstrap schema change is
+  planned.
+
+## Impact
+
+- Affected docs: `docs/ai-assistant-guide.md`, `docs/vs-built-in-memory.md`,
+  `QUICKSTART.md`.
+- Affected scaffold: `src/exomem/_scaffold/_Schema/SKILL.md` and relevant
+  `src/exomem/_scaffold/_Schema/references/*.md`.
+- Affected fixtures/tests: mirrored schema docs under
+  `tests/fixtures/Knowledge Base/_Schema/` and focused docs/scaffold tests.
+- No new dependencies, services, transport behavior, model behavior, or public
+  API surfaces.

--- a/openspec/changes/clarify-agent-memory-boundaries/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/clarify-agent-memory-boundaries/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Documentation Aligns With Bootstrap Contract
+Agent-facing documentation SHALL align generic-client onboarding with the
+existing `bootstrap()` operating contract.
+
+#### Scenario: Generic client instructions match bootstrap behavior
+- **WHEN** a generic MCP client, hosted chat client, or client without the
+  Exomem skill is documented
+- **THEN** the guidance tells the agent to call `bootstrap(profile="compact")`
+  once at session start
+- **AND** uses the existing bootstrap action model rather than inventing a
+  conflicting memory workflow
+
+#### Scenario: Diagnostics remain separate from normal lookup
+- **WHEN** documentation discusses performance or retrieval behavior
+- **THEN** it distinguishes normal lookup from diagnostics and does not imply
+  that rerank, packed context, cold model load, or compute mode are the same
+  concern

--- a/openspec/changes/clarify-agent-memory-boundaries/specs/agent-memory-onboarding/spec.md
+++ b/openspec/changes/clarify-agent-memory-boundaries/specs/agent-memory-onboarding/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Native Memory Boundary
+Agent-facing documentation SHALL distinguish native assistant memory from Exomem
+without presenting either as a replacement for the other.
+
+#### Scenario: Boundary is visible to users and agents
+- **WHEN** a user reads the built-in memory comparison or assistant guide
+- **THEN** the documentation identifies native memory/custom instructions as the
+  place for preferences, tone, identity facts, and routing reminders
+- **AND** identifies Exomem as the place for durable governed knowledge with
+  provenance, review, and supersession
+
+#### Scenario: Non-memory uses are excluded
+- **WHEN** a user needs to store secrets, transient scratch, reminders, or task
+  state
+- **THEN** the documentation points away from both Exomem and native assistant
+  memory where those systems are not appropriate
+
+### Requirement: Intent To Action Guidance
+Agent-facing documentation SHALL map common user intents to simple Exomem
+actions before exposing internal page-type or folder terminology.
+
+#### Scenario: Agent sees a remember request
+- **WHEN** the user says "remember this" or equivalent phrasing
+- **THEN** the guidance tells the agent to preserve raw material when needed and
+  save durable conclusions as concise compiled notes
+
+#### Scenario: Agent sees a source or proof request
+- **WHEN** the user asks to preserve a source, receipt, document, case artifact,
+  or proof-bearing record
+- **THEN** the guidance distinguishes source capture from evidence preservation
+  in user-facing language
+
+#### Scenario: Agent sees a stale or superseded knowledge request
+- **WHEN** the user asks whether old knowledge is still valid or says a new
+  conclusion replaces an old one
+- **THEN** the guidance routes the agent to review/audit behavior or
+  supersession behavior instead of duplicating notes
+
+### Requirement: First Run Guidance For Non CLI Users
+Quickstart documentation SHALL include a path for users who are not comfortable
+driving CLI setup unaided.
+
+#### Scenario: User asks an assistant to help set up Exomem
+- **WHEN** a non-CLI-comfortable user reads the quickstart
+- **THEN** the quickstart gives them a concise prompt they can hand to an AI
+  assistant
+- **AND** states the expected verification steps after setup: doctor, bootstrap,
+  one known lookup, and one safe test save
+
+### Requirement: Concrete Examples
+Agent-facing documentation SHALL include concrete examples for the memory
+workflows Exomem wants agents to perform.
+
+#### Scenario: Required examples are present
+- **WHEN** the assistant guide and scaffold guidance are reviewed
+- **THEN** examples cover remembering a conclusion, finding a previous
+  conclusion, preserving a source or proof artifact, compiling evidence,
+  reviewing stale knowledge, and superseding an old conclusion
+
+### Requirement: Scaffold Remains Generic
+The shipped scaffold guidance SHALL stay generic and free of private paths,
+private names, and project-specific tenant tokens.
+
+#### Scenario: Scaffold leak guard runs
+- **WHEN** the scaffold no-leak tests scan `src/exomem/_scaffold`
+- **THEN** they pass without private-token or machine-path findings

--- a/openspec/changes/clarify-agent-memory-boundaries/tasks.md
+++ b/openspec/changes/clarify-agent-memory-boundaries/tasks.md
@@ -1,0 +1,17 @@
+## 1. Assistant-Facing Docs
+
+- [x] 1.1 Rewrite `docs/ai-assistant-guide.md` around simple agent actions, client setup, skip/search rules, and the required examples.
+- [x] 1.2 Rewrite `docs/vs-built-in-memory.md` to state the native assistant memory vs. Exomem boundary and what belongs in neither.
+- [x] 1.3 Add a non-CLI-comfortable first-run path to `QUICKSTART.md` with assistant handoff and verification steps.
+
+## 2. Scaffold Guidance
+
+- [x] 2.1 Update `src/exomem/_scaffold/_Schema/SKILL.md` so agents use a simple front door before internal categories.
+- [x] 2.2 Update relevant scaffold references for operation, write-scope, and supersession wording where examples need to match the new boundary story.
+- [x] 2.3 Mirror scaffold schema changes into `tests/fixtures/Knowledge Base/_Schema/`.
+
+## 3. Verification
+
+- [x] 3.1 Run focused tests for scaffold leaks, schema parsing, and bootstrap contract.
+- [x] 3.2 Run additional setup/adoption/stale-review tests if touched docs or fixtures indicate risk.
+- [x] 3.3 Mark tasks complete and record the implementation conclusion in Exomem.

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -56,7 +56,7 @@ diagnosed, a pattern is recognized — capture it:
   is how the corpus grows.
 - Raw material → **add**. A durable conclusion → draft the compiled
   **note**/**link**, run **suggest_links** and the near-duplicate check first,
-  then write and report one line: `Saved → <path>`.
+  then write and report one line: `Saved -> <path>`.
 - The guardrails that remain are the ones that matter: dedupe (prefer
   **edit**/**replace** over a parallel page; surface a near-duplicate warning when
   it fires) and clean links.
@@ -162,23 +162,44 @@ The Tier 2 filesystem ops below may be turned off on lean deployments
 
 ## Simple front door
 
-Speak to users in simple product actions; use the typed operations underneath.
+Speak to users in simple actions first. Use the typed operations underneath.
 Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
-`replace` unless that implementation detail matters.
+`replace` unless that implementation detail changes what will happen.
 
-| User action | Preferred route |
-|---|---|
-| save | `add` for raw material; `note`/`link` for durable conclusions; `preserve` only for proof-bound material |
-| adopt/import | `adopt(mode="scan-only")` first; then ask before `save-manifest`, `copy-as-sources`, or compile actions |
-| ask | `find` first, then `get` or `find(pack=true)` for synthesis context |
-| prove | `preserve` or upload to Evidence for cases, claims, warranties, disputes, records, and receipts |
-| review | `attention`, `audit`, or `propose_compilation` |
-| update | `edit` for small changes; `replace` for supersession; `reconcile` for out-of-band drift |
-| connect | `link` and `suggest_links` |
+Native assistant memory is for preferences, style, identity facts, and routing
+rules such as "use Exomem for my project knowledge." Exomem is for durable
+governed knowledge: sourced conclusions, project context, decisions, failures,
+experiments, proof-bearing records, review, and supersession.
 
-Built-in AI memory is for preferences, working rules, and routing instructions.
-Exomem is for durable governed knowledge with sources, proof, history, decisions,
-records, review, and compiled conclusions.
+| User phrasing | User-facing action | Preferred route |
+|---|---|---|
+| "remember this," "save this conclusion" | Save durable knowledge | `note` for the conclusion; `add` first if raw provenance matters |
+| "find what I concluded," "what do I know about X" | Search prior knowledge | `find` first, then `get` or `find(pack=true)` when synthesis needs context |
+| "save this article/source/transcript" | Preserve raw source | `add`; offer compilation only when there is a stable conclusion |
+| "keep this receipt/record/proof" | Preserve proof-bearing material | `preserve` or upload to Evidence for cases, claims, warranties, disputes, and records |
+| "compile this evidence" | Write a sourced conclusion | `note` with source/evidence links; run `suggest_links` before writing |
+| "review stale knowledge" | Surface review candidates | `attention`, `audit`, or stale-review checks; never auto-decay or down-rank |
+| "this replaces the old conclusion" | Supersede old knowledge | `replace`; do not create an unlinked duplicate |
+| "fix this small detail" | Patch an existing conclusion | `edit` when the core claim is unchanged |
+| "connect these ideas" | Improve the graph | `suggest_links` and `link` |
+| "what does this existing vault contain" | Assess before writing | `overview` or `adopt(mode="scan-only")` |
+
+Examples:
+
+- "Remember this decision" -> write a concise compiled note and report
+  `Saved -> <path>`.
+- "What did I conclude about onboarding?" -> `find` first, cite hits, and retry
+  with adjacent terms before treating a miss as meaningful.
+- "Save this article" -> `add` the source with provenance; ask about compiling
+  only if a conclusion is present.
+- "Keep this receipt for the warranty case" -> preserve it as proof-bearing
+  evidence, not as a general note.
+- "Compile these three sources" -> draft a sourced note, run `suggest_links`,
+  then write after the applicable approval rule.
+- "Show stale conclusions" -> run the review path and present candidates for
+  keep/edit/supersede/archive.
+- "This new strategy replaces the old one" -> use supersession so history stays
+  visible.
 
 ## Operations
 

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -2,6 +2,24 @@
 
 Detailed specs for the Knowledge Base operations. Read on first use of an operation.
 
+## Plain-language routing
+
+Agents should hear user intent first and choose the operation second:
+
+| User intent | Operation path |
+|---|---|
+| Remember a durable conclusion | `note`; use `add` first when raw provenance matters |
+| Find a prior conclusion | `find`, then `get` or `find(pack=true)` if needed |
+| Preserve a source | `add` |
+| Preserve proof or a record | `preserve` or upload |
+| Compile evidence into a conclusion | `note` with source/evidence links |
+| Review stale knowledge | `audit` / stale-review checks |
+| Supersede old knowledge | `replace` |
+| Patch a small detail | `edit` |
+
+Do not ask users to choose internal folders or page types unless the distinction
+changes the write. Translate back to simple language when reporting results.
+
 ## Index and log discipline (applies to every write)
 
 Every confirmed write that creates, moves, or supersedes a page performs two
@@ -43,7 +61,7 @@ can use Exomem without relying on a client-specific skill.
 
 ### Profiles
 - `profile="compact"` — terse operation map and defaults. Use for normal startup.
-- `profile="default"` — startup contract plus workflow guidance and examples.
+- `profile="full"` — startup contract plus workflow guidance and examples.
 - `profile="diagnostics"` — includes timing/performance guidance, search profile,
   compute mode, backend/cache hints, rerank state, and recommended debug knobs.
 

--- a/src/exomem/_scaffold/_Schema/references/supersession.md
+++ b/src/exomem/_scaffold/_Schema/references/supersession.md
@@ -4,6 +4,13 @@ When information in the Knowledge Base needs to be replaced, **supersede; do not
 delete or rewrite in place**. Supersession preserves causal history (why is the
 current page the way it is?) and keeps the audit trail intact.
 
+## User-facing trigger
+
+When a user says "this replaces the old conclusion," "the old recommendation is
+wrong now," or "make the new version the current answer," use supersession. Do
+not create a parallel note unless the old page is not actually being replaced.
+Report it in user language: "Saved the new conclusion and marked the old one as
+superseded."
 ## When to supersede vs. edit
 
 **Edit in place** (small changes; same `updated` field bump):

--- a/src/exomem/_scaffold/_Schema/references/write-scope.md
+++ b/src/exomem/_scaffold/_Schema/references/write-scope.md
@@ -3,6 +3,18 @@
 The single most important rule of this skill: **what can and cannot be written
 to.** Everything else is downstream.
 
+## Memory boundary
+
+Built-in assistant memory and custom instructions are the right place for small
+preferences, style rules, identity facts, and reminders to use Exomem. Exomem is
+the right place for durable governed knowledge: sourced conclusions, project
+context, decisions, failures, experiments, proof-bearing records, review, and
+supersession.
+
+Do not turn transient scratch, reminders, tasks, credentials, or every passing
+chat remark into KB material. Capture only raw material worth preserving or a
+compiled conclusion that future agents should be able to retrieve.
+
 ## Binary placement decision tree
 
 Three locations hold binary files in the KB. Pick by **origin and purpose**:

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -56,7 +56,7 @@ diagnosed, a pattern is recognized — capture it:
   is how the corpus grows.
 - Raw material → **add**. A durable conclusion → draft the compiled
   **note**/**link**, run **suggest_links** and the near-duplicate check first,
-  then write and report one line: `Saved → <path>`.
+  then write and report one line: `Saved -> <path>`.
 - The guardrails that remain are the ones that matter: dedupe (prefer
   **edit**/**replace** over a parallel page; surface a near-duplicate warning when
   it fires) and clean links.
@@ -162,23 +162,44 @@ The Tier 2 filesystem ops below may be turned off on lean deployments
 
 ## Simple front door
 
-Speak to users in simple product actions; use the typed operations underneath.
+Speak to users in simple actions first. Use the typed operations underneath.
 Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
-`replace` unless that implementation detail matters.
+`replace` unless that implementation detail changes what will happen.
 
-| User action | Preferred route |
-|---|---|
-| save | `add` for raw material; `note`/`link` for durable conclusions; `preserve` only for proof-bound material |
-| adopt/import | `adopt(mode="scan-only")` first; then ask before `save-manifest`, `copy-as-sources`, or compile actions |
-| ask | `find` first, then `get` or `find(pack=true)` for synthesis context |
-| prove | `preserve` or upload to Evidence for cases, claims, warranties, disputes, records, and receipts |
-| review | `attention`, `audit`, or `propose_compilation` |
-| update | `edit` for small changes; `replace` for supersession; `reconcile` for out-of-band drift |
-| connect | `link` and `suggest_links` |
+Native assistant memory is for preferences, style, identity facts, and routing
+rules such as "use Exomem for my project knowledge." Exomem is for durable
+governed knowledge: sourced conclusions, project context, decisions, failures,
+experiments, proof-bearing records, review, and supersession.
 
-Built-in AI memory is for preferences, working rules, and routing instructions.
-Exomem is for durable governed knowledge with sources, proof, history, decisions,
-records, review, and compiled conclusions.
+| User phrasing | User-facing action | Preferred route |
+|---|---|---|
+| "remember this," "save this conclusion" | Save durable knowledge | `note` for the conclusion; `add` first if raw provenance matters |
+| "find what I concluded," "what do I know about X" | Search prior knowledge | `find` first, then `get` or `find(pack=true)` when synthesis needs context |
+| "save this article/source/transcript" | Preserve raw source | `add`; offer compilation only when there is a stable conclusion |
+| "keep this receipt/record/proof" | Preserve proof-bearing material | `preserve` or upload to Evidence for cases, claims, warranties, disputes, and records |
+| "compile this evidence" | Write a sourced conclusion | `note` with source/evidence links; run `suggest_links` before writing |
+| "review stale knowledge" | Surface review candidates | `attention`, `audit`, or stale-review checks; never auto-decay or down-rank |
+| "this replaces the old conclusion" | Supersede old knowledge | `replace`; do not create an unlinked duplicate |
+| "fix this small detail" | Patch an existing conclusion | `edit` when the core claim is unchanged |
+| "connect these ideas" | Improve the graph | `suggest_links` and `link` |
+| "what does this existing vault contain" | Assess before writing | `overview` or `adopt(mode="scan-only")` |
+
+Examples:
+
+- "Remember this decision" -> write a concise compiled note and report
+  `Saved -> <path>`.
+- "What did I conclude about onboarding?" -> `find` first, cite hits, and retry
+  with adjacent terms before treating a miss as meaningful.
+- "Save this article" -> `add` the source with provenance; ask about compiling
+  only if a conclusion is present.
+- "Keep this receipt for the warranty case" -> preserve it as proof-bearing
+  evidence, not as a general note.
+- "Compile these three sources" -> draft a sourced note, run `suggest_links`,
+  then write after the applicable approval rule.
+- "Show stale conclusions" -> run the review path and present candidates for
+  keep/edit/supersede/archive.
+- "This new strategy replaces the old one" -> use supersession so history stays
+  visible.
 
 ## Operations
 


### PR DESCRIPTION
## Summary
- add OpenSpec change for agent memory onboarding and bootstrap alignment
- rewrite assistant-facing docs around simple user intents and the native-memory boundary
- add non-CLI first-run guidance and update scaffold guidance/fixture mirror

## Tests
- uv run pytest -q tests/test_scaffold_no_leak.py tests/test_schema.py tests/test_bootstrap.py
- uv run pytest -q tests/test_init.py tests/test_setup_wizard.py tests/test_adopt.py tests/test_audit_stale_review.py
- git diff --check