### PR TITLE
Teach agents the Exomem write loop

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -22,7 +22,8 @@ If you're comfortable in Claude Code, this is ~20–30 minutes.
 > (step 6) is the *brain* — it tells Claude *when* to save, how to file a source,
 > and how to compile a note. Generic MCP clients that cannot load Skills should
 > call `bootstrap()` once after connecting; that returns the compact operating
-> contract through MCP. See [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md)
+> contract through MCP, including the write loop: search, draft, `suggest_links`,
+> write, inspect warnings/suggestions, report path. See [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md)
 > for Codex, hosted chat clients, Cursor/Windsurf/Gemini, and generic MCP setup.
 
 ---
@@ -362,8 +363,8 @@ own — or just start writing; the writer auto-registers new keys as you use the
 >
 > **Other MCP clients.** ChatGPT, Codex, Cursor, Gemini, Windsurf, or any client
 > without Skill support should call `bootstrap()` once after connecting. It returns
-> Exomem's search/save/upload defaults and performance guidance in a structured
-> MCP response. The copyable standing instruction lives in
+> Exomem's search/save/upload defaults, the compiled-note write loop, and
+> performance guidance in a structured MCP response. The copyable standing instruction lives in
 > [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ see
 Other MCP clients can still use the server. If they do not support Skills,
 have them call `bootstrap()` once at the start of the session; it returns the
 same compact operating contract through MCP, including when to search, when to
-save, workflow-skill discovery, upload guidance, and performance profiles.
+save, workflow-skill discovery, upload guidance, and performance profiles. It
+also teaches the authoring loop: search first, draft the typed note, run
+`suggest_links`, write with the right tool, inspect warnings/suggestions, then
+report the path.
 
 For client-specific assistant instructions, see
 [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md). For the boundary
@@ -175,7 +178,8 @@ env = { EXOMEM_VAULT_PATH = "/path/to/vault" }
 
 After connecting, ask the agent to call `bootstrap()` before using the KB. Claude
 Skills are still the best UX where available, but `bootstrap()` lets generic MCP
-clients learn Exomem's search/save/upload contract without a separate skill file.
+clients learn Exomem's search/save/upload contract without a separate skill file,
+including the write loop for compiled notes.
 See [docs/ai-assistant-guide.md](docs/ai-assistant-guide.md) for the copyable
 standing instruction.
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,12 +6,12 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Registry commands: 31
-- Tier 1 commands: 21
+- Registry commands: 33
+- Tier 1 commands: 23
 - Tier 2 commands: 10
-- Registry-generated MCP commands: 30
-- REST commands: 30
-- CLI commands: 30
+- Registry-generated MCP commands: 32
+- REST commands: 32
+- CLI commands: 32
 - Hand-registered MCP tools: mint_download_token, mint_upload_token, note
 
 ## Command Registry
@@ -19,6 +19,8 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 | Command | Tier | Surfaces | Mode | Destructive | CLI positional | Parameters | Summary |
 | --- | ---: | --- | --- | --- | --- | --- | --- |
 | bootstrap | 1 | MCP, REST, CLI | read | no | - | profile, workflow | Return Exomem's versioned operating contract for generic MCP clients. |
+| search | 1 | MCP, REST, CLI | read | no | query | query, types, projects, tags, limit, scope | Search the Knowledge Base with a portable metadata-only response. Read-only. |
+| fetch | 1 | MCP, REST, CLI | read | no | id | id*, max_chars | Fetch one Knowledge Base document by `search` result ID with bounded text. Read-only. |
 | find | 1 | MCP, REST, CLI | read | no | query | query, types, projects, tags, speakers, file_types, exclude_file_types, limit, scope, mode, graph, rerank, prefer_compiled, prefer_active, prefer_used, pack, graph_enrich, detail, include_timings | Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within. |
 | suggest_links | 1 | MCP, REST, CLI | read | no | - | path, draft_title, draft_body, limit, scope | Suggest existing KB pages a note should link to. Read-only. |
 | graph_context | 1 | MCP, REST, CLI | read | no | path | path, query, depth, relation_types, node_types, max_nodes, max_edges | Return a bounded typed-graph neighborhood for a page or query. Read-only. |
@@ -33,7 +35,7 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 | reconcile | 1 | MCP, REST, CLI | write | no | - | dry_run | Heal vault drift from out-of-band edits in one pass. |
 | provenance_report | 1 | MCP, REST, CLI | read | no | - | tag, key, value, path | Trace provenance: scan note bodies for `<!-- key:value -->` tags — where an opinion/take/flag came from. Read-only. |
 | propose_compilation | 1 | MCP, REST, CLI | read | no | - | sources*, suggested_title | Draft / scaffold a compiled note from unprocessed source(s) — what to compile next, drain the source backlog. Read-only. |
-| get | 1 | MCP, REST, CLI | read | no | path | path*, frontmatter_only, include_history, links, include_raw | Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body (+ raw content on request). |
+| get | 1 | MCP, REST, CLI | read | no | path | path*, frontmatter_only, include_history, links, include_raw, max_body_chars | Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body (+ raw content on request). |
 | edit | 1 | MCP, REST, CLI | write | yes | path | path*, why*, new_body, tags, old_string, new_string, replace_all, heading, section_position, edits, row_key, take, overwrite, field, value, allow_curated, expected_hash, validate_only | Lightweight in-place edit of a page (body, tags, a surgical snippet, |
 | replace | 1 | MCP, REST, CLI | write | yes | old_path | old_path*, content*, note_type*, title*, reason, project, projects, sources, tags, status, severity, pattern_type, domain, started, duration, hypothesis, n, concluded, medium, recorded, published, host, editor, project_category | Supersede an existing compiled page with a new one. |
 | link | 1 | MCP, REST, CLI | write | no | - | entity_type*, name*, summary*, why_in_kb, tags, connections, affiliation, relationship, domain, language, repo, license, used_in, decided, project, decision_status | Create a typed entity under Entities/<Folder>/<Name>.md. |

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 
 # Text-write ops -> the argument field(s) whose value must not be a base64 binary
@@ -107,7 +108,15 @@ def bind_vault(
     except Exception:  # noqa: BLE001 - fall back to inspect's annotations
         resolved = {}
 
-    visible = [p.replace(annotation=resolved.get(p.name, p.annotation)) for p in visible]
+    help_text = parse_args_help(description if description is not None else leaf.__doc__)
+    visible = [
+        p.replace(
+            annotation=_annotate_description(
+                resolved.get(p.name, p.annotation), help_text.get(p.name, "")
+            )
+        )
+        for p in visible
+    ]
     new_sig = sig.replace(parameters=visible)
 
     def wrapper(**kwargs):
@@ -126,6 +135,16 @@ def bind_vault(
         ann["return"] = resolved["return"]
     wrapper.__annotations__ = ann
     return wrapper
+
+
+def _annotate_description(annotation: object, description: str) -> object:
+    if (
+        not description
+        or annotation is inspect.Parameter.empty
+        or typing.get_origin(annotation) is typing.Annotated
+    ):
+        return annotation
+    return typing.Annotated[annotation, Field(description=description)]
 
 
 def parse_args_help(doc: str | None) -> dict[str, str]:

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 import json
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, NotRequired, TypedDict
+from typing import Any
+from typing_extensions import NotRequired, TypedDict
 
 from fastmcp.tools import ToolResult
 from fastmcp.utilities.types import Image as FastMCPImage

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Any, NotRequired, TypedDict
 
 from fastmcp.tools import ToolResult
 from fastmcp.utilities.types import Image as FastMCPImage
@@ -91,6 +92,16 @@ from .vault import (
 
 _link_summary = link_summary_module.link_summary
 
+# Keep commands.py as the public command-surface facade for server, CLI, docs,
+# and tests while the implementation lives in command_surface.py.
+_COMMAND_SURFACE_EXPORTS = (
+    DESTRUCTIVE_OPS,
+    GUARDED_WRITE_FIELDS,
+    Param,
+    bind_vault,
+    mcp_tool_annotations,
+)
+
 
 def _preserve_module():
     from . import preserve as preserve_module
@@ -102,6 +113,67 @@ def _video_frames_module():
     from . import video_frames as video_frames_module
 
     return video_frames_module
+
+
+
+class FindHit(TypedDict):
+    path: str
+    type: str
+    scope: str
+    title: str
+    updated: str
+    excerpt: NotRequired[str]
+    outside_kb: NotRequired[bool]
+    status: NotRequired[str]
+    superseded_by: NotRequired[str]
+    signals: NotRequired[dict[str, Any]]
+    media_type: NotRequired[str]
+    media_file: NotRequired[str]
+    clip_match_at: NotRequired[str]
+    scene_frame: NotRequired[str]
+    scene_match_at: NotRequired[str]
+    transcript_match_at: NotRequired[str]
+
+
+class FindEnvelope(TypedDict):
+    hits: list[FindHit]
+    pack: NotRequired[dict[str, Any]]
+    timings: NotRequired[dict[str, Any]]
+    warming: NotRequired[dict[str, Any]]
+    degraded: NotRequired[list[str]]
+
+
+class SearchResult(TypedDict):
+    id: str
+    title: str
+    url: str
+    metadata: dict[str, str]
+
+
+class SearchResponse(TypedDict):
+    results: list[SearchResult]
+
+
+class FetchResponse(TypedDict):
+    id: str
+    title: str
+    text: str
+    url: str
+    metadata: NotRequired[dict[str, str]]
+
+
+class GetResponse(TypedDict):
+    path: str
+    frontmatter: dict[str, Any]
+    body: NotRequired[str]
+    content_hash: NotRequired[str]
+    mtime: NotRequired[float]
+    content: NotRequired[str]
+    has_frontmatter: NotRequired[bool]
+    body_truncated: NotRequired[bool]
+    body_chars: NotRequired[int]
+    history: NotRequired[list[dict[str, Any]]]
+    links: NotRequired[dict[str, Any]]
 
 
 # ----- op-leaves: the former per-surface wrapper bodies (vault_root injected) -----
@@ -119,8 +191,9 @@ def op_bootstrap(
     Call this once at the start of a session when the client does not have the
     Exomem Claude Skill loaded. It teaches the agent how to use the tools: when
     to search, when to save, how to interpret scoped misses, which `find` knobs
-    are cheap vs diagnostic, and how compiled notes differ from raw evidence.
-    The payload is deterministic instruction plus local compute policy; it does
+    are cheap vs diagnostic, how compiled notes differ from raw sources/evidence,
+    and how Exomem differs from built-in AI memory. The payload is deterministic
+    instruction plus local compute policy and product-surface metadata; it does
     not inspect or summarize vault content.
 
     Args:
@@ -184,26 +257,70 @@ def op_bootstrap(
             "loop": [
                 "bootstrap",
                 "adopt or overview when first seeing an existing vault",
-                "find",
-                "get or find(pack=true) when more context is needed",
+                "search for cheap metadata-only recall",
+                "fetch a bounded page, or use find/get when richer context is needed",
                 "reason in the agent",
+                "run suggest_links before important writes",
                 "note, edit, or replace when there is a durable conclusion",
+                "read warnings/suggestions/write_feedback and follow up on unresolved links or duplicate warnings",
             ],
             "save_rule": (
                 "Save durable decisions, solved problems, diagnosed failures, "
                 "and reusable patterns as compiled notes; keep raw artifacts in "
-                "Sources or Evidence."
+                "Sources and case-bound proof in Evidence."
             ),
             "miss_rule": (
-                "An empty search means not found in that query/scope. Try synonyms, "
+                "An empty find result means not found in that query/scope. Try synonyms, "
                 "related terms, compact recall, or scope='vault' before concluding absence."
             ),
         },
         "workflow_skills": workflow_skills_module.bootstrap_entries(),
+        "authoring_contract": {
+            "canonical_loop": [
+                "find relevant prior notes and sources",
+                "get enough context; use max_body_chars for bounded reads or find(pack=true) for synthesis",
+                "draft the smallest durable compiled conclusion",
+                "run suggest_links on the draft",
+                "write with note, edit, replace, add, preserve, or link as appropriate",
+                "inspect warnings, suggestions, and write_feedback from the write result",
+                "apply any accepted links through edit",
+                "report the written path",
+            ],
+            "route_by_intent": {
+                "raw_material": "add",
+                "raw_evidence_or_artifact": "preserve or upload",
+                "new_durable_conclusion": "note",
+                "small_correction": "edit",
+                "substantial_rewrite": "replace",
+                "named_person_concept_library_or_decision": "link",
+            },
+            "preflight": {
+                "suggest_links": "standard read-only check before a compiled note write",
+                "near_duplicate_warnings": "if they fire, consider edit or replace instead of a parallel page",
+            },
+            "post_write": {
+                "note_suggestions": "non-binding related pages returned by note(suggestions=true)",
+                "write_feedback": "structural feedback returned by note(): semantic block counts, source/link counts, unresolved wikilinks, and next actions",
+                "accepted_links": "persist only through normal edit/note/replace; never auto-write suggestions",
+            },
+            "note_type_recipes": {
+                "research-note": "Project-scoped finding with Question, Findings, and Connections.",
+                "insight": "Cross-cutting claim with Claim, Why it holds, and Connections.",
+                "failure": "Failure mode with mechanism, detection, mitigation, and Connections.",
+                "pattern": "Reusable solution with Problem, Solution, When to use, When not to use, and Connections.",
+                "experiment": "Primary protocol with Hypothesis, Protocol, Results, and Conclusion.",
+                "production-log": "Creative artifact record with Frame, Artifact, Outcomes, Reflection, and Connections.",
+            },
+        },
         "tool_defaults": {
             "normal_lookup": {
+                "tool": "search",
+                "args": {},
+            },
+            "metadata_lookup": {
                 "tool": "find",
                 "args": {"detail": "compact", "rerank": False},
+                "when": "caller needs the richer find filters or compact stubs",
             },
             "reasoning_lookup": {
                 "tool": "find",
@@ -222,7 +339,8 @@ def op_bootstrap(
                     "rerank": True,
                 },
             },
-            "read_full_page": {"tool": "get", "when": "after choosing a hit"},
+            "read_bounded_page": {"tool": "fetch", "when": "after choosing a search result"},
+            "read_full_page": {"tool": "get", "when": "after choosing a hit and needing the full body/frontmatter"},
             "write_compiled_note": {
                 "tool": "note",
                 "when": "new durable conclusion",
@@ -240,8 +358,9 @@ def op_bootstrap(
         },
         "performance_profiles": {
             "normal": {
+                "tool": "find",
                 "find_args": {"detail": "compact", "rerank": False},
-                "interpretation": "cheap routing recall; follow with get if needed",
+                "interpretation": "cheap compact routing recall; follow with get(max_body_chars=...) if needed",
             },
             "reasoning": {
                 "find_args": {"pack": True},
@@ -266,6 +385,7 @@ def op_bootstrap(
                 "try scope='vault' if Knowledge Base recall is sparse",
                 "use adopt(mode='scan-only') before proposing migration/copy actions",
                 "try pack=true for synthesis instead of many get calls",
+                "use get(max_body_chars=...) for bounded reads before full get",
             ],
         },
         "front_door_actions": product_front_door_catalog(selected_packs),
@@ -273,6 +393,8 @@ def op_bootstrap(
         "common_tools": [
             "adopt",
             "overview",
+            "search",
+            "fetch",
             "find",
             "get",
             "note",
@@ -344,7 +466,7 @@ def op_find(
     graph_enrich: bool = False,
     detail: str = "full",
     include_timings: bool = False,
-) -> list[dict] | dict:
+) -> list[FindHit] | FindEnvelope:
     """Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.
 
     Args:
@@ -599,6 +721,178 @@ def op_find(
     return out
 
 
+
+
+
+
+def _citation_url(_path: str) -> str:
+    """Citation URL placeholder for portable clients.
+
+    The local vault path is the stable citation ID; exposing file:// URLs here
+    would make remote clients less portable.
+    """
+    return ""
+
+
+def _string_metadata(**items: object) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, value in items.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            out[key] = "true" if value else "false"
+        elif isinstance(value, (list, tuple, dict)):
+            out[key] = json.dumps(value, ensure_ascii=False)
+        else:
+            out[key] = str(value)
+    return out
+
+
+def _search_result_from_hit(hit: dict) -> SearchResult:
+    path = str(hit.get("path") or "")
+    title = str(hit.get("title") or path)
+    metadata = _string_metadata(
+        path=path,
+        type=hit.get("type"),
+        scope=hit.get("scope"),
+        updated=hit.get("updated"),
+        status=hit.get("status"),
+        superseded_by=hit.get("superseded_by"),
+        outside_kb=hit.get("outside_kb"),
+        media_type=hit.get("media_type"),
+        media_file=hit.get("media_file"),
+    )
+    return {"id": path, "title": title, "url": _citation_url(path), "metadata": metadata}
+
+
+def _frontmatter_metadata(path: str, frontmatter: dict[str, Any]) -> dict[str, str]:
+    allowed = (
+        "type",
+        "status",
+        "created",
+        "updated",
+        "project",
+        "projects",
+        "tags",
+        "severity",
+        "pattern_type",
+        "domain",
+    )
+    items = {key: frontmatter.get(key) for key in allowed if key in frontmatter}
+    items["path"] = path
+    return _string_metadata(**items)
+
+
+def _title_from_page(path: str, frontmatter: dict[str, Any]) -> str:
+    title = frontmatter.get("title")
+    if title:
+        return str(title)
+    return Path(path).stem.replace("-", " ").replace("_", " ").strip() or path
+
+
+def _bounded_text(text: str, max_chars: int) -> tuple[str, bool]:
+    max_chars = max(500, min(int(max_chars), 6000))
+    if len(text) <= max_chars:
+        return text, False
+    marker = "\n\n[truncated]"
+    keep = max(0, max_chars - len(marker))
+    return text[:keep].rstrip() + marker, True
+
+
+def op_search(
+    vault_root: Path,
+    query: str = "",
+    types: list[str] | None = None,
+    projects: list[str] | None = None,
+    tags: list[str] | None = None,
+    limit: int = 10,
+    scope: str = "kb",
+) -> SearchResponse:
+    """Search the Knowledge Base with a portable metadata-only response. Read-only.
+
+    This is the conservative companion to `find`: it returns result IDs, titles,
+    URLs, and string metadata only. It never returns note excerpts, graph/ranking
+    signals, context packs, timings, raw content, or page bodies. Use `fetch`
+    with one returned `id` to read bounded document text, or use `find`/`get`
+    directly when the caller intentionally needs richer retrieval output.
+
+    Args:
+        query: Free-text search string.
+        types: Optional page-type filter; values are OR'd within the filter.
+        projects: Optional project filter; values are OR'd within the filter.
+        tags: Optional tag filter; values are OR'd within the filter.
+        limit: Maximum number of results. Capped to 50.
+        scope: "kb" for Knowledge Base first, or "vault" to search the broader vault.
+
+    Returns:
+        {"results": [{"id", "title", "url", "metadata"}, ...]}. `id` is the
+        canonical vault-relative path to pass to `fetch` or `get`; `metadata`
+        contains string-only routing fields such as path, type, scope, updated,
+        status, and media markers.
+    """
+    limit = max(1, min(int(limit), 50))
+    raw = op_find(
+        vault_root,
+        query=query,
+        types=types,
+        projects=projects,
+        tags=tags,
+        limit=limit,
+        scope=scope,
+        mode="hybrid",
+        graph=True,
+        rerank=False,
+        prefer_compiled=True,
+        prefer_active=True,
+        prefer_used=False,
+        pack=False,
+        detail="compact",
+        include_timings=False,
+    )
+    hits = raw.get("hits", []) if isinstance(raw, dict) else raw
+    return {"results": [_search_result_from_hit(hit) for hit in hits]}
+
+
+def op_fetch(
+    vault_root: Path,
+    id: str,
+    max_chars: int = 3000,
+) -> FetchResponse:
+    """Fetch one Knowledge Base document by `search` result ID with bounded text. Read-only.
+
+    This is a bounded read step between metadata-only `search` and full `get`.
+    It returns the markdown body without raw frontmatter and caps body text at
+    6000 characters. Use `get` when the caller intentionally needs the full
+    frontmatter/body/edit hash envelope.
+
+    Args:
+        id: A result `id` returned by `search` (the canonical vault-relative path).
+        max_chars: Maximum body characters to return. Values below 500 are raised
+            to 500; values above 6000 are capped server-side.
+
+    Returns:
+        {"id", "title", "text", "url", "metadata"}. `text` is the markdown body;
+        it ends with `[truncated]` when the body exceeded the effective cap.
+    """
+    try:
+        page = get_page_module.get_page(vault_root, path=id)
+    except get_page_module.GetError as e:
+        raise ValueError(f"{e.code}: {e.reason}") from e
+    text_out, truncated = _bounded_text(page.body, max_chars)
+    metadata = _frontmatter_metadata(page.path, page.frontmatter)
+    metadata.update(_string_metadata(truncated=truncated))
+    query_log.log_get_call(
+        read_path=page.path,
+        frontmatter_only=False,
+        include_history=False,
+    )
+    return {
+        "id": page.path,
+        "title": _title_from_page(page.path, page.frontmatter),
+        "text": text_out,
+        "url": _citation_url(page.path),
+        "metadata": metadata,
+    }
 def _timing_log_summary(timings_dict: dict | None) -> dict | None:
     """Query-log-safe slice of a timings envelope: totals + per-stage ms only
     (never content; stage entries drop skip/error detail to stay compact)."""
@@ -959,7 +1253,8 @@ def op_evolution(
          versions: [{path, title, status, date, claims: {title, type, lede, sections,
          outline}, transition: {reason, date} | null}]}], truncation: [...]}.
         `transition` is null on the active head; `versions` run oldest → newest by
-        supersession order; `span`/`n_versions` describe the whole chain.
+        supersession order; `span`/
+_versions` describe the whole chain.
     """
     return evolution_module.evolution(
         vault_root,
@@ -1151,7 +1446,8 @@ def op_get(
     include_history: bool = False,
     links: bool = False,
     include_raw: bool = False,
-) -> dict:
+    max_body_chars: int | None = None,
+) -> GetResponse:
     """Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body (+ raw content on request).
 
     Reads anywhere under the vault root — not just `Knowledge Base/`.
@@ -1193,6 +1489,9 @@ def op_get(
             read) and nothing in the normal workflow needs it: edits
             round-trip `body`, and the drift guard uses `content_hash`,
             which the server always computes over the raw bytes for you.
+        max_body_chars: Optional cap for the returned `body`. Use this when a
+            client wants bounded content instead of an arbitrary full-page read.
+            Values above 12000 are capped server-side; negative values are rejected.
 
     Returns:
         {path, frontmatter, body, content_hash, mtime}.
@@ -1202,6 +1501,7 @@ def op_get(
         refuse a write if the file changed on disk since this read
         (two-writer drift guard); `mtime` is advisory.
         Adds `content` (raw file text) when `include_raw=true`.
+        Adds `body_truncated` and `body_chars` when `max_body_chars` is supplied.
         Adds `history` when `include_history=true`.
 
     Errors:
@@ -1222,6 +1522,19 @@ def op_get(
         except get_page_module.GetError as e:
             raise ValueError(f"{e.code}: {e.reason}") from e
         out = result.as_dict(include_raw=include_raw)
+    if max_body_chars is not None and not frontmatter_only:
+        if max_body_chars < 0:
+            raise ValueError("get: max_body_chars must be non-negative")
+        max_body_chars = min(max_body_chars, 12000)
+        body = str(out.get("body", ""))
+        if len(body) > max_body_chars:
+            marker = "\n\n[truncated]"
+            keep = max(0, max_body_chars - len(marker))
+            out["body"] = body[:keep].rstrip() + marker
+            out["body_truncated"] = True
+        else:
+            out["body_truncated"] = False
+        out["body_chars"] = len(str(out.get("body", "")))
     query_log.log_get_call(
         read_path=out["path"],
         frontmatter_only=frontmatter_only,
@@ -1700,7 +2013,8 @@ def op_note(
       → `Notes/Patterns/<slug>.md`
     - `experiment`: hypothesis + protocol. `domain`, `started` (YYYY-MM-DD),
       and `duration` (e.g. "30 days", "ongoing") REQUIRED. Optional
-      `hypothesis`, `n` (default 1), `concluded`.
+      `hypothesis`,
+` (default 1), `concluded`.
       → `Notes/Experiments/<domain>/YYYY-MM-<slug>.md`
     - `production-log`: creative artifact log. `medium` REQUIRED (e.g.
       "Posts", "Articles"). Optional `recorded`, `published`, `host`,
@@ -1711,6 +2025,10 @@ def op_note(
 
     For each `sources:` wikilink, appends this note's wikilink to that
     source's `ingested_into:` frontmatter (maintaining the source→note graph).
+
+    The result includes `write_feedback`: deterministic structural feedback with
+    semantic block counts, source/link counts, unresolved wikilink warnings, and
+    suggested next actions. Treat it as write-shape feedback, not semantic truth.
 
     Args:
         content: Full markdown body, written verbatim after the
@@ -1753,15 +2071,20 @@ def op_note(
         editor: production-log only. Producer/editor name.
 
         suggestions: When true (default), the result carries a `suggestions`
-            block — existing pages this note should probably link to, ranked
+            block: existing pages this note should probably link to, ranked
             by the retrieval stack. Set false for a faster write when you
             already know the note's links; the near-duplicate/overlap
             warnings stay ON either way (dedupe is a guardrail, not a
-            suggestion).
+            suggestion). For important drafts, call `suggest_links` before
+            `note` and wire accepted links into the body or with a follow-up
+            `edit`.
 
     Returns:
-        {path, warnings}. On validation failure, raises a structured error
-        with code=INVALID_NOTE, the missing fields, and the reason.
+        {path, warnings, suggestions?, write_feedback}. `write_feedback` is
+        deterministic structural feedback: semantic block counts, source/link
+        counts, unresolved wikilink warnings, and suggested next actions. On
+        validation failure, raises a structured error with code=INVALID_NOTE,
+        the missing fields, and the reason.
     """
     try:
         result = note_module.note(
@@ -2444,6 +2767,8 @@ _PRODUCT_METADATA: dict[str, dict] = {
     "bootstrap": {"surface": "primary", "actions": (), "first_run_safe": True},
     "adopt": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
     "overview": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
+    "search": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
+    "fetch": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
     "find": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
     "get": {"surface": "primary", "actions": ("ask",), "first_run_safe": True},
     "add": {"surface": "primary", "actions": ("save",), "first_run_safe": False},
@@ -2470,6 +2795,8 @@ _RC = frozenset({"rest", "cli"})
 _M = frozenset({"mcp"})
 _SPEC: tuple[tuple, ...] = (
     ("bootstrap", op_bootstrap, 1, False, False, None, _MCRC),
+    ("search", op_search, 1, False, False, "query", _MCRC),
+    ("fetch", op_fetch, 1, False, False, "id", _MCRC),
     ("find", op_find, 1, False, False, "query", _MCRC),
     ("suggest_links", op_suggest_links, 1, False, False, None, _MCRC),
     ("graph_context", op_graph_context, 1, False, False, "path", _MCRC),

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -35,7 +35,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import corpus_aware, indexes
+from . import corpus_aware, indexes, semantic_blocks
 from . import project_keys as project_keys_module
 from .kbdir import kb_prefix
 from .vault import (
@@ -85,15 +85,20 @@ STATUS_PRODUCTION = (
 class NoteResult:
     path: str  # vault-relative
     warnings: list[str]
-    # Corpus-aware "you might want to link these" hints. Non-binding — the
+    # Corpus-aware "you might want to link these" hints. Non-binding; the
     # client decides. Omitted from as_dict() when empty so existing callers
-    # (and the ~256 tests) see no shape change unless a suggestion fires.
+    # see no shape change unless a suggestion fires.
     suggestions: list[dict] = field(default_factory=list)
+    # Deterministic structural feedback for agents. This is a write-quality
+    # checklist over the Markdown shape, not a semantic truth judgment.
+    write_feedback: dict = field(default_factory=dict)
 
     def as_dict(self) -> dict:
         out: dict = {"path": self.path, "warnings": self.warnings}
         if self.suggestions:
             out["suggestions"] = self.suggestions
+        if self.write_feedback:
+            out["write_feedback"] = self.write_feedback
         return out
 
 
@@ -105,6 +110,71 @@ class NoteError(Exception):
 
     def as_dict(self) -> dict:
         return {"code": self.code, "missing": self.missing, "reason": self.reason}
+
+
+def _build_write_feedback(
+    *,
+    vault_root: Path,
+    note_path: Path,
+    note_md: str,
+    note_type: str,
+    sources_norm: list[str],
+    body_clean: str,
+    body_warnings: list[str],
+    source_warnings: list[str],
+    backrefs_planned: int,
+    suggestions_count: int,
+) -> dict:
+    document = semantic_blocks.parse_semantic_blocks(note_md)
+    by_kind: dict[str, int] = {}
+    for block in document.blocks:
+        by_kind[block.type] = by_kind.get(block.type, 0) + 1
+
+    body_targets: list[str] = []
+    seen_targets: set[str] = set()
+    for match in find_body_wikilinks(body_clean):
+        target = match.group(0)[2:-2].split("|", 1)[0].split("#", 1)[0].strip()
+        if target and target not in seen_targets:
+            seen_targets.add(target)
+            body_targets.append(target)
+
+    unresolved = list(source_warnings) + list(body_warnings)
+    next_actions: list[str] = []
+    if unresolved:
+        next_actions.append("resolve or intentionally leave unresolved wikilinks")
+    if suggestions_count:
+        next_actions.append("review related-page suggestions and edit in accepted links")
+    if not sources_norm:
+        next_actions.append("add a source link later if this conclusion came from raw material")
+    if not body_targets and not sources_norm:
+        next_actions.append("add at least one meaningful connection when one exists")
+    if not next_actions:
+        next_actions.append("no immediate structural follow-up")
+
+    return {
+        "contract": "compiled-note",
+        "note_type": note_type,
+        "semantic_blocks": {
+            "total": len(document.blocks),
+            "by_kind": by_kind,
+            "errors": [error.to_dict() for error in document.errors],
+            "warnings": [warning.to_dict() for warning in document.warnings],
+        },
+        "sources": {
+            "cited": len(sources_norm),
+            "backrefs_planned": backrefs_planned,
+        },
+        "links": {
+            "body_wikilinks": len(body_targets),
+            "source_wikilinks": len(sources_norm),
+            "unresolved_count": len(unresolved),
+            "unresolved": unresolved,
+        },
+        "suggestions": {
+            "related_pages": suggestions_count,
+        },
+        "next_actions": next_actions,
+    }
 
 
 def note(
@@ -337,6 +407,18 @@ def note(
     )
 
     kb = kb_root(vault_root)
+    write_feedback = _build_write_feedback(
+        vault_root=vault_root,
+        note_path=note_path,
+        note_md=note_md,
+        note_type=note_type,
+        sources_norm=sources_norm,
+        body_clean=body_clean,
+        body_warnings=body_warnings,
+        source_warnings=source_warnings,
+        backrefs_planned=0,
+        suggestions_count=len(corpus_suggestions),
+    )
     writes: list[PlannedWrite] = [PlannedWrite(path=note_path, content=note_md)]
     warnings: list[str] = (
         list(autoregister_warnings)
@@ -349,6 +431,7 @@ def note(
         warnings.append(slug_warning)
 
     # Back-refs: append the new note's wikilink to each cited source's ingested_into.
+    backrefs_planned = 0
     for src in sources_norm:
         src_path = _resolve_source_path(vault_root, src)
         if src_path is None or not src_path.exists():
@@ -360,6 +443,7 @@ def note(
         updated = _append_to_ingested_into(original, new_note_wikilink)
         if updated != original:
             writes.append(PlannedWrite(path=src_path, content=updated))
+            backrefs_planned += 1
         else:
             warnings.append(
                 f"could not locate ingested_into: field in {src}, back-ref skipped"
@@ -454,10 +538,13 @@ def note(
     if rotate_note:
         warnings.append(rotate_note)
 
+    write_feedback["sources"]["backrefs_planned"] = backrefs_planned
+
     return NoteResult(
         path=note_path.relative_to(vault_root).as_posix(),
         warnings=warnings,
         suggestions=corpus_suggestions,
+        write_feedback=write_feedback,
     )
 
 

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -1,389 +1,4 @@
 {
-  "bootstrap": {
-    "description": "Return Exomem's versioned operating contract for generic MCP clients.\n\nCall this once at the start of a session when the client does not have the\nExomem Claude Skill loaded. It teaches the agent how to use the tools: when\nto search, when to save, how to interpret scoped misses, which `find` knobs\nare cheap vs diagnostic, and how compiled notes differ from raw evidence.\nThe payload is deterministic instruction plus local compute policy; it does\nnot inspect or summarize vault content.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "profile": {
-          "default": "compact",
-          "type": "string",
-          "description": "\"compact\" (default), \"full\", or \"diagnostics\". Compact is\nenough for normal clients. Full adds examples. Diagnostics adds\nperformance interpretation guidance."
-        },
-        "workflow": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional caller-selected workflow label. Returned as context\nonly; it does not change server behavior."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "find": {
-    "description": "Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "query": {
-          "default": "",
-          "type": "string",
-          "description": "Free-text search string. In \"hybrid\"/\"vector\" mode it's\nembedded with bge-base for semantic recall. In \"keyword\" mode\nit's tokenized on whitespace and every token must appear in\ntitle or body (any order) — `contract employment` matches a\npage about \"employment contract\". Empty string always falls\nback to \"most-recent filtered\" behaviour regardless of mode."
-        },
-        "types": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Filter to these page types (source, research-note, insight, failure, pattern, experiment, production-log, entity)."
-        },
-        "projects": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Filter to pages whose `project` or `projects:` includes any of these keys."
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Filter to pages whose `tags:` includes any of these (case-insensitive)."
-        },
-        "speakers": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Filter to diarized media whose `speakers:` frontmatter includes any of\nthese named speakers (case-insensitive) — e.g. \"what did Alice say about X\".\nAND'd with the query/other filters; OR'd within the list."
-        },
-        "file_types": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Scope results to these artifact kinds — note, pdf, image,\naudio, video, csv, json, tsv. A binary surfaces under its media\nkind (pdf/image/...); a data file under its dataset card's format\n(csv/json). Omit to return ALL kinds (the default — search never\nhides a type unless you ask)."
-        },
-        "exclude_file_types": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Drop these kinds from results (same vocabulary)."
-        },
-        "limit": {
-          "default": 15,
-          "type": "integer",
-          "description": "Max hits to return. Default 15, hard cap 100."
-        },
-        "scope": {
-          "default": "kb",
-          "type": "string",
-          "description": "\"kb\" (default) searches Knowledge Base/ first and\nAUTO-WIDENS to the whole vault when the KB doesn't fill\n`limit` — so content in sibling folders (Tracking/,\nReference/, Finance/, ... and curated, read-only trees kept\noutside Knowledge Base/) is never silently invisible. Widened\nhits carry `outside_kb: true`. \"vault\" always walks the\nwhole vault. \"kb-only\" is the strict opt-out: KB only,\nnever widens. Outside-KB recall is BM25/keyword (the\nvector sidecar is KB-scoped), with a relaxed gate so terse\nfiles (e.g. a numbers-heavy tracker) surface on a partial\ntoken match. `_Schema/`, `_trash/`, `_attachments/`, and\n`.obsidian/` are excluded under every scope. NOTE: an\nempty result means \"not found in what I searched,\" NOT\n\"doesn't exist\" — say so, and try \"vault\" before\nconcluding absence."
-        },
-        "mode": {
-          "default": "hybrid",
-          "type": "string",
-          "description": "Ranker. \"hybrid\" (default) fuses BM25 + local vector\nembeddings via reciprocal rank fusion — best recall on\nnatural-language queries. \"keyword\" preserves the original\ncase-insensitive substring matching, sorted by `updated:`.\n\"vector\" is vector-only (testing aid). BM25 corpus is\nSnowball-stemmed so \"regulation\" reaches pages with\n\"regulator\"; keyword mode stays strict-substring. If the\nembedding sidecar hasn't been built yet, hybrid degrades\nto BM25-only; run `audit_fix(rebuild_embeddings=true)` to\npopulate it."
-        },
-        "graph": {
-          "default": true,
-          "type": "boolean",
-          "description": "When true (default) and mode is hybrid/vector, outbound\nwikilinks of top BM25/vector candidates contribute a third\nranking — surfaces 1-hop neighbours of strong matches."
-        },
-        "rerank": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cross-encoder re-sort of the top fused candidates\n(bge-reranker-base) for higher-precision ordering. Default\n(unset) is mode-aware AUTO: in CPU steady-state modes it stays\noff for predictable latency; when the text/reranker device is\naccelerated, the server reranks only when ranking lanes\ndisagree or the query is long. Pass true to force reranking\nfor a high-value query, including on CPU; pass false to skip\nit entirely."
-        },
-        "prefer_compiled": {
-          "default": true,
-          "type": "boolean",
-          "description": "When true (default), applies a small boost to\ncompiled types (insight, pattern, failure, research-note,\nentity) and a small penalty to raw `source` after fusion\nAND rerank. Reflects the KB's epistemic hierarchy. Set\nfalse to retrieve raw source discussion verbatim (e.g.\n\"what did I capture from Dr. X\")."
-        },
-        "prefer_active": {
-          "default": true,
-          "type": "boolean",
-          "description": "When true (default), soft-demotes `status:\nsuperseded` pages so a replaced conclusion can't outrank the\npage that superseded it. The tombstone stays findable and its\nhit still carries `status` + `superseded_by` (the forward\npointer) so you can see it's superseded. Set false to rank a\nsuperseded page on its content alone (e.g. \"what did I used to\nthink about X\")."
-        },
-        "prefer_used": {
-          "default": false,
-          "type": "boolean",
-          "description": "When true (OFF by default — default ranking is\nusage-blind), applies a bounded, positive-only usage boost:\npages you actually read (`get`) and cite in written notes rank\nslightly higher, from ACT-R activation over the server's own\naccess logs. Capped below the compiled boost so usage breaks\nties but never overrides the epistemic hierarchy; never a\npenalty; never ADDS results — it only reorders pages the\ncontent lanes already matched. Boosted hits expose\n`signals.activation` + `signals.usage_boost` so you can see\nexactly why. Reading and citing pages IS the feedback loop —\nno separate feedback call exists or is needed. Use for \"what\nhave I been working with lately\" recall; leave off for\nneutral knowledge lookup."
-        },
-        "pack": {
-          "default": false,
-          "type": "boolean",
-          "description": "When true (off by default), ALSO assemble a reasoning-ready\ncontext pack from the top hits and change the return to\n{\"hits\": [...], \"pack\": {...}} (with pack off, the return is the\nusual hit list, unchanged). The pack is PURE MEASUREMENT over the\nnotes you already wrote — no server-side reasoning: each top note's\nstructurally-extracted key claims (lede + headline-section lines +\nheading outline), the 1-hop wikilink neighbourhood of those notes\nranked by co-citation, and the contradictions among them (recorded\nsupersession edges + proximity \"tension\" pairs in the embedding\nband, surfaced for you to judge — proximity, not polarity). Lets you\nreason over the matches in one shot instead of fanning out `get`\ncalls. Bounded with explicit `truncation`; the tension part needs\nthe embedding sidecar and reports `embeddings_available`."
-        },
-        "graph_enrich": {
-          "default": false,
-          "type": "boolean",
-          "description": "When true with `pack=true`, add typed graph neighborhood\ndata from the derived epistemic graph sidecar to the pack. Default\nfalse; missing/disabled/stale graph state soft-fails inside\n`pack.graph.available` without changing hits, hit ordering, or the\ndefault pack contract."
-        },
-        "detail": {
-          "default": "full",
-          "type": "string",
-          "description": "Result verbosity. \"full\" (default) keeps the current hit\nshape including `excerpt` and `signals`. \"compact\" returns the\nSAME ranked hits as token-cheap routing stubs — path, title,\ntype, scope, updated, plus lifecycle/media/outside_kb markers\nwhen present — omitting `excerpt` and `signals`. Use compact\nfor cheap proactive recall, then `get` a chosen page (or rerun\nwith detail=\"full\") when you need the why."
-        },
-        "include_timings": {
-          "default": false,
-          "type": "boolean",
-          "description": "When true (off by default), the return becomes an\nenvelope {\"hits\": [...], \"timings\": {...}} (with pack=true the\nenvelope also carries \"pack\"). `timings` reports total_ms,\nhot-cache status, and per-stage milliseconds for the retrieval\nlanes (skipped/failed optional lanes are marked, never fatal).\nDiagnostics only — timings never include note content. Omitted\n→ the response shape is unchanged."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "suggest_links": {
-    "description": "Suggest existing KB pages a note should link to. Read-only.\n\nCloses the corpus-blind-write gap: surfaces the related prior work a\ndraft (or an existing page) should connect to, so the graph gets denser\nwith every write instead of just bigger. For link suggestions only — it\nreuses the same hybrid ranker as `find`, prefers well-connected hubs, and excludes\nthe page itself plus anything it already links. Suggestions are\nnon-binding: YOU decide which to wire in (e.g. via a follow-up `edit`).\n\nTwo call shapes:\n- `path`: suggest links for an EXISTING page (densify it retroactively).\n  Same path conventions as `get`/`find`.\n- `draft_title` + `draft_body`: suggest links for a note you're about to\n  create, BEFORE calling `note` — so you can cite/connect on first write.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Existing page to suggest links for. Mutually exclusive with\nthe draft_* args."
-        },
-        "draft_title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Title of a not-yet-written note."
-        },
-        "draft_body": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Body (markdown) of a not-yet-written note. Wikilinks\nalready present in it are treated as \"already linked\" and excluded."
-        },
-        "limit": {
-          "default": 8,
-          "type": "integer",
-          "description": "Max suggestions (default 8)."
-        },
-        "scope": {
-          "default": "kb",
-          "type": "string",
-          "description": "\"kb\" (default) or \"vault\" — same meaning as `find`."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "graph_context": {
-    "description": "Return a bounded typed-graph neighborhood for a page or query. Read-only.\n\nReads the derived `.graph.sqlite` sidecar created from Markdown,\nfrontmatter, wikilinks, source/evidence links, supersession fields, and\nsemantic blocks. Markdown remains the source of truth; this operation does\nnot build the sidecar, modify notes, accept suggested relations, or change\n`find` ranking. If the graph sidecar is missing, disabled, or incompatible,\nthe response reports `available: false` instead of failing.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Existing page path to use as the graph seed. Optional when `query`\nis supplied."
-        },
-        "query": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Text seed for matching graph node titles/content. Optional when\n`path` is supplied."
-        },
-        "depth": {
-          "default": 1,
-          "type": "integer",
-          "description": "Traversal depth from seed nodes. Default 1."
-        },
-        "relation_types": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional allowlist of relation types, e.g.\n`derived_from`, `evidenced_by`, `supports`, `contradicts`,\n`supersedes`, `links_to`."
-        },
-        "node_types": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional allowlist of node kinds, e.g. `file`, `decision`,\n`finding`, `risk`, `action`, `claim`, `evidence`."
-        },
-        "max_nodes": {
-          "default": 40,
-          "type": "integer",
-          "description": "Cap returned nodes. Default 40."
-        },
-        "max_edges": {
-          "default": 80,
-          "type": "integer",
-          "description": "Cap returned edges. Default 80."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "suggest_relations": {
-    "description": "Suggest candidate typed graph relations. Read-only and proposal-only.\n\nUses deterministic signals from wikilinks, frontmatter sources, shared\nsources/entities, supersession, and optional embedding proximity when\navailable. Model-backed suggestions are default-off and soft-fail as\nwarnings; accepted relations still require an explicit `note` or `edit`\nwrite. This operation never mutates Markdown or the graph sidecar.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Existing page to inspect. Mutually exclusive with draft-only use."
-        },
-        "draft_title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional title for a not-yet-written draft."
-        },
-        "draft_body": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Draft body; wikilinks in it become proposal candidates."
-        },
-        "include_model_suggestions": {
-          "default": false,
-          "type": "boolean",
-          "description": "Request optional model-backed suggestion\npaths. Default false; unavailable paths soft-fail with warnings."
-        },
-        "limit": {
-          "default": 10,
-          "type": "integer",
-          "description": "Max candidates to return. Default 10."
-        }
-      },
-      "type": "object"
-    }
-  },
   "add": {
     "description": "Capture raw content as an immutable source page in the Knowledge Base.\n\nWrites a frontmatter-compliant page to Sources/<Type>/YYYY-MM-DD-<slug>.md\nand updates Sources/index.md, the top-level index.md (Recent activity\n+ Counts), and log.md. Per SKILL.md rule 7.",
     "inputSchema": {
@@ -446,88 +61,6 @@
         "source_type",
         "title"
       ],
-      "type": "object"
-    }
-  },
-  "audit": {
-    "description": "Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, stale unprocessed sources, and stale-review candidates. Read-only.\n\nReturns a structured report Claude can read to propose follow-up\nedits via `note`/`add`. Does NOT modify anything.\n\nCategories (default: all):\n- `broken_wikilink`: `[[X]]` whose target file doesn't exist.\n  Skips wikilinks inside fenced code blocks and inline code spans.\n  Bare names resolve against filename stems AND frontmatter `title:`\n  (so date-prefixed sources with a title match are not flagged).\n- `orphan_entity`: `Entities/...` file with no inbound wikilinks\n- `unprocessed_source`: source with empty `ingested_into:` (no notes\n  have compiled from it yet)\n- `index_drift`: top-level `index.md` Counts disagree with on-disk counts\n- `tag_inconsistency`: case/separator variants of the same tag\n  (`warning_letter_incident` vs `warning-letter-incident` vs\n  `Warning-Letter-Incident`). Mechanical drift only; semantic\n  near-duplicates like `workflow` vs `workflows` aren't flagged.\n- `frontmatter_compliance`: per-page-type required-field gaps,\n  a `tenant:` set without the expected project, patterns using singular\n  `project:` instead of plural `projects:`.\n- `unregistered_project_key`: a `project`/`projects` value not in the\n  registry (typo or genuinely new scope).\n- `embedding_drift`: vector sidecar rows out of sync with disk (a file\n  changed/added/removed since it was last embedded).\n- `relevance_pairs_pending`: real-usage (query -> cited_path) labels not\n  yet in the golden retrieval set.\n- `stale_review`: active compiled conclusion that is old AND rarely\n  surfaced in `find` AND low inbound-link degree — a measurement-only\n  review candidate (still true? keep / supersede / archive). Never\n  decays or down-ranks; `find` ordering is unchanged.\n- `corpus_contradictions`: corpus-wide pairs of active read-write\n  compiled conclusions whose embeddings sit just below the near-dup\n  threshold (close enough to restate/refine/contradict). A proximity\n  measurement surfaced for review (reconcile or supersede); never\n  auto-acted. The queue is ordered by review priority (cosine + ACT-R\n  dormancy), same-family `Notes/Research/<X>/` architecture noise is\n  demoted, and the surfaced set is capped at EXOMEM_CONTRADICTION_TOP_N\n  (default 40; 0 = uncapped) with an explicit \"N more not shown\" line.\n  No-ops when embeddings are disabled.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "categories": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional filter; only run these checks. Each must be\none of the categories above. Omit to run all."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "attention": {
-    "description": "Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only.\n\nComposes the three measurement-only epistemic queues into a single list,\nranked by Reciprocal Rank Fusion over each queue's own ordering — a note\nflagged by more than one queue rises to the top:\n- `stale_review`: active conclusions that are old AND rarely surfaced in\n  `find` AND low inbound-degree (possibly stale — still true?).\n- `corpus_contradictions`: pairs of active conclusions whose embeddings sit\n  close enough to restate, refine, or contradict (do they conflict?).\n- `unprocessed_source`: sources captured but never compiled (nothing\n  distilled from them yet).\n\nEach item carries its reason(s), the related note(s) for a contradiction\npair, and severity. Surfaced for REVIEW only: the ranking is a deterministic\nmeasurement, not a judgment that anything is wrong — you decide keep /\n`replace` (supersede) / `reconcile` / `propose_compilation` / archive.\nNothing is auto-acted; `find` ordering is unchanged.\n\nFront door for daily review. Use `audit` instead for the full lint/health\nreport (broken wikilinks, frontmatter compliance, index drift, embedding\ndrift, etc.).",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "categories": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional subset of {corpus_contradictions, stale_review,\nunprocessed_source}. Omit to include all three."
-        },
-        "limit": {
-          "default": 25,
-          "type": "integer",
-          "description": "Max items to surface (default 25; 0 or negative = uncapped,\nsurface all). Lower-priority items beyond the cap are summarized in\na \"N more not shown\" note, never dropped silently."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "overview": {
-    "description": "Bounded, read-only structure report of the vault (or a subtree).\n\nAnswers \"what does this vault look like?\" in ONE call — use this instead\nof reading files one by one for structural questions. Reports totals,\nwhether a `Knowledge Base/` tree is present, a depth/breadth-capped folder\ntree (per-folder file counts, frontmatter coverage %, wikilink/md-link\ncounts, dominant filename patterns, sample names), junk candidates\n(zero-byte files, sync-conflict duplicates like `note 2.md`), largest and\noldest-unmodified files, and exactly what was skipped. Lists are capped;\ncounts are always exact. Works on vaults with no initialized\n`Knowledge Base/` (`kb.present` false).",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "default": "",
-          "type": "string",
-          "description": "Vault-relative subtree to report on. Empty string (default)\nreports the whole vault. Auto-handles forward/back slashes."
-        },
-        "max_depth": {
-          "default": 3,
-          "type": "integer",
-          "description": "Tree depth cap; deeper folders roll up into their\nancestors (counts stay exact). Default 3."
-        },
-        "include_hidden": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, include dot-directories/dotfiles and\n`_trash`/`_attachments`. Default false."
-        },
-        "samples": {
-          "default": 5,
-          "type": "integer",
-          "description": "Filename samples listed per folder. Default 5."
-        }
-      },
       "type": "object"
     }
   },
@@ -597,27 +130,67 @@
       "type": "object"
     }
   },
-  "evolution": {
-    "description": "How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only.\n\nFor a topic `query`, finds the matching notes, follows each one's supersession\nchain (the `supersedes`/`superseded_by` links `replace` records), and returns one\nordered timeline per chain — oldest version → newest. Each version carries its own\nstructurally-extracted claims, its date, and the RECORDED reason it was superseded\n(the `why:` logged at that edit). The server only orders and surfaces what you\nwrote; it does NOT generate a \"here's how your thinking changed\" summary — you read\nthe consecutive versions and see the shift.\n\nUse this for \"how did my view on X evolve / what did I used to think / why did this\nchange\". Use `find` for plain lookup. Notes never superseded are omitted (no\nevolution to show); a topic with no supersession returns empty `timelines` — an\nhonest \"nothing changed here\", not an error. Read-only: mutates nothing; `find`\nordering is unchanged.",
+  "append_to_file": {
+    "description": "Tier 2: append text to an existing file.\n\nRefuses Sources/ (immutable). Allowed on Evidence/ sidecars and\ngeneral vault files. Curated trees need `allow_curated=true`.\nEnsures a single newline boundary between existing tail and new\ncontent.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
-        "query": {
-          "default": "",
+        "path": {
           "type": "string",
-          "description": "The topic to trace (free text, like `find`)."
+          "description": "Vault-relative."
+        },
+        "content": {
+          "type": "string",
+          "description": "Text to append (text only; binaries go via /upload)."
+        },
+        "allow_curated": {
+          "default": false,
+          "type": "boolean",
+          "description": "Required under curated trees."
+        }
+      },
+      "required": [
+        "path",
+        "content"
+      ],
+      "type": "object"
+    }
+  },
+  "attention": {
+    "description": "Your review queue: the one ranked list of what in the Knowledge Base needs your attention today. Read-only.\n\nComposes the three measurement-only epistemic queues into a single list,\nranked by Reciprocal Rank Fusion over each queue's own ordering — a note\nflagged by more than one queue rises to the top:\n- `stale_review`: active conclusions that are old AND rarely surfaced in\n  `find` AND low inbound-degree (possibly stale — still true?).\n- `corpus_contradictions`: pairs of active conclusions whose embeddings sit\n  close enough to restate, refine, or contradict (do they conflict?).\n- `unprocessed_source`: sources captured but never compiled (nothing\n  distilled from them yet).\n\nEach item carries its reason(s), the related note(s) for a contradiction\npair, and severity. Surfaced for REVIEW only: the ranking is a deterministic\nmeasurement, not a judgment that anything is wrong — you decide keep /\n`replace` (supersede) / `reconcile` / `propose_compilation` / archive.\nNothing is auto-acted; `find` ordering is unchanged.\n\nFront door for daily review. Use `audit` instead for the full lint/health\nreport (broken wikilinks, frontmatter compliance, index drift, embedding\ndrift, etc.).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "categories": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional subset of {corpus_contradictions, stale_review,\nunprocessed_source}. Omit to include all three."
         },
         "limit": {
-          "default": 10,
+          "default": 25,
           "type": "integer",
-          "description": "Max chains (timelines) to return, by find relevance (default 10;\n0 or negative = uncapped). Chains beyond the cap are reported in\n`truncation`, never dropped silently."
-        },
-        "scope": {
-          "default": "kb",
-          "type": "string",
-          "description": "Search scope passed to `find` — \"kb\" (default) / \"vault\" / \"kb-only\"."
-        },
-        "projects": {
+          "description": "Max items to surface (default 25; 0 or negative = uncapped,\nsurface all). Lower-priority items beyond the cap are summarized in\na \"N more not shown\" note, never dropped silently."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "audit": {
+    "description": "Audit / lint / health-check the Knowledge Base: find orphans, broken wikilinks, supersession gaps, stale unprocessed sources, and stale-review candidates. Read-only.\n\nReturns a structured report Claude can read to propose follow-up\nedits via `note`/`add`. Does NOT modify anything.\n\nCategories (default: all):\n- `broken_wikilink`: `[[X]]` whose target file doesn't exist.\n  Skips wikilinks inside fenced code blocks and inline code spans.\n  Bare names resolve against filename stems AND frontmatter `title:`\n  (so date-prefixed sources with a title match are not flagged).\n- `orphan_entity`: `Entities/...` file with no inbound wikilinks\n- `unprocessed_source`: source with empty `ingested_into:` (no notes\n  have compiled from it yet)\n- `index_drift`: top-level `index.md` Counts disagree with on-disk counts\n- `tag_inconsistency`: case/separator variants of the same tag\n  (`warning_letter_incident` vs `warning-letter-incident` vs\n  `Warning-Letter-Incident`). Mechanical drift only; semantic\n  near-duplicates like `workflow` vs `workflows` aren't flagged.\n- `frontmatter_compliance`: per-page-type required-field gaps,\n  a `tenant:` set without the expected project, patterns using singular\n  `project:` instead of plural `projects:`.\n- `unregistered_project_key`: a `project`/`projects` value not in the\n  registry (typo or genuinely new scope).\n- `embedding_drift`: vector sidecar rows out of sync with disk (a file\n  changed/added/removed since it was last embedded).\n- `relevance_pairs_pending`: real-usage (query -> cited_path) labels not\n  yet in the golden retrieval set.\n- `stale_review`: active compiled conclusion that is old AND rarely\n  surfaced in `find` AND low inbound-link degree — a measurement-only\n  review candidate (still true? keep / supersede / archive). Never\n  decays or down-ranks; `find` ordering is unchanged.\n- `corpus_contradictions`: corpus-wide pairs of active read-write\n  compiled conclusions whose embeddings sit just below the near-dup\n  threshold (close enough to restate/refine/contradict). A proximity\n  measurement surfaced for review (reconcile or supersede); never\n  auto-acted. The queue is ordered by review priority (cosine + ACT-R\n  dormancy), same-family `Notes/Research/<X>/` architecture noise is\n  demoted, and the surfaced set is capped at EXOMEM_CONTRADICTION_TOP_N\n  (default 40; 0 = uncapped) with an explicit \"N more not shown\" line.\n  No-ops when embeddings are disabled.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "categories": {
           "anyOf": [
             {
               "items": {
@@ -630,22 +203,7 @@
             }
           ],
           "default": null,
-          "description": "Optional project-key filter passed to `find`."
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional tag filter passed to `find`."
+          "description": "Optional filter; only run these checks. Each must be\none of the categories above. Omit to run all."
         }
       },
       "type": "object"
@@ -670,140 +228,138 @@
       "type": "object"
     }
   },
-  "reconcile": {
-    "description": "Heal vault drift from out-of-band edits in one pass.\n\nThe writers keep the embedding sidecar, index.md count rows, and log.md\ncurrent on every write. But editing the vault directly — in Obsidian,\non mobile, or via a manual filesystem edit — bypasses those hooks, so\nthe sidecar and the counts drift silently. `reconcile` is the\nfirst-class \"I edited around the system, fix it\" command:\n\n1. Index counts — recompute Sources/Notes/Entities count rows from\n   on-disk reality and rewrite any that drifted (curated descriptions\n   and Recent-activity are preserved; only count tokens move).\n2. Embeddings — incrementally re-embed only the *stale* files (those\n   `embedding_drift` flags: on-disk mtime newer than the sidecar row),\n   via the same path the writers use. Cheaper than\n   `audit_fix(rebuild_embeddings=true)`'s full wipe-and-rebuild.\n3. Drift report — re-run index_drift + embedding_drift, return what\n   remains.\n\nNarrower than `audit_fix`: it does NOT canonicalize wikilinks or\nbackfill frontmatter (those are content rewrites you opt into).\nIdempotent; `dry_run=true` reports without writing.",
+  "bootstrap": {
+    "description": "Return Exomem's versioned operating contract for generic MCP clients.\n\nCall this once at the start of a session when the client does not have the\nExomem Claude Skill loaded. It teaches the agent how to use the tools: when\nto search, when to save, how to interpret scoped misses, which `find` knobs\nare cheap vs diagnostic, how compiled notes differ from raw sources/evidence,\nand how Exomem differs from built-in AI memory. The payload is deterministic\ninstruction plus local compute policy and product-surface metadata; it does\nnot inspect or summarize vault content.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
-        "dry_run": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, compute what would change without writing.\nDefault false."
+        "profile": {
+          "default": "compact",
+          "type": "string",
+          "description": "\"compact\" (default), \"full\", or \"diagnostics\". Compact is\nenough for normal clients. Full adds examples. Diagnostics adds\nperformance interpretation guidance."
+        },
+        "workflow": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional caller-selected workflow label. Returned as context\nonly; it does not change server behavior."
         }
       },
       "type": "object"
     }
   },
-  "provenance_report": {
-    "description": "Trace provenance: scan note bodies for `<!-- key:value -->` tags — where an opinion/take/flag came from. Read-only.\n\nOn-demand scan over markdown bodies — no index, no sidecar. Use it to\nanswer \"show all conv:-derived takes\" or \"what's flagged add-to-imdb\"\nwithout grepping. The opinion/taste rows carry provenance as HTML\ncomments (e.g. `<!-- platform:imdb -->`, `<!-- conv:2026-06-01 -->`);\nthis reads them in place. Tags inside fenced code are ignored; multiple\ncomments and multiple key:value pairs on one line are all parsed.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "tag": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Shorthand filter — \"key\" or \"key:value\" (e.g. \"platform:imdb\")."
-        },
-        "key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Filter to rows carrying this provenance key."
-        },
-        "value": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "With key, require this exact value."
-        },
-        "path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Restrict the scan to one vault-relative file (else the whole\nKnowledge Base is walked)."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "propose_compilation": {
-    "description": "Draft / scaffold a compiled note from unprocessed source(s) — what to compile next, drain the source backlog. Read-only.\n\nThe backlog-drain companion to `audit`'s `unprocessed_source` findings:\npoint it at one or more raw sources and it hands back a ready-to-fill\nnote skeleton — inferred note_type, a Question/Findings/Connections (or\nClaim/…) outline, the `sources[]` to cite, and adjacent compiled pages to\nlink (computed via the same hybrid retrieval as `suggest_links`). It\ndoes NOT write anything: you fill the prose and call `note()` with the\nreturned `suggested_sources` + `suggested_connections`.\n\nGroup sources yourself before calling — pass a set that genuinely belongs\nin one note (the audit list is aged oldest-first to help you triage).",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "sources": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Vault-relative paths/wikilinks to the source(s) to compile.\nSame path conventions as `note.sources` (brackets and the\nleading `Knowledge Base/` are tolerated)."
-        },
-        "suggested_title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional title override; otherwise one is derived\nfrom the source titles."
-        }
-      },
-      "required": [
-        "sources"
-      ],
-      "type": "object"
-    }
-  },
-  "get": {
-    "description": "Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body (+ raw content on request).\n\nReads anywhere under the vault root — not just `Knowledge Base/`.\nThis lets you cite from curated, read-only sibling folders (e.g.\n`Reference/`) kept outside Knowledge Base/ when compiling. Those are\nread-only by convention (marked in `_access.yaml`); `get` honors that\nby only reading.\n\nUse this when `find` gives you a path and you need the whole page\n(to cite, build on, or rewrite). `find` only returns excerpts.",
+  "create_file": {
+    "description": "Tier 2: write a file — or, with `kind=\"dir\"`, create a folder — at an\narbitrary vault path.\n\nWith `kind=\"dir\"`, this creates a folder (mkdir -p when `parents=true`)\nand ignores `content`/`frontmatter`/`overwrite` (folds in the former\n`create_directory` tool); returns {path, created, warnings}.\n\nEscape hatch for files that don't fit Tier 1 type routing — new folder\nstructures (`Identity/`, `Templates/`), skill files, scratch. For\ntyped notes use `note`/`add`/`link`/`preserve`.\n\nIf `frontmatter` is a dict, this op prepends a YAML block built from\nit (and auto-fills `created`/`updated` to today if not provided);\n`content` is the body in that case. If `frontmatter` is omitted,\n`content` is written verbatim — the caller is responsible for any\nfrontmatter already in it.\n\nRefuses:\n- Sources/, Evidence/ (append-only — use `add` or `preserve`).\n- Subtrees marked `readonly`/`excluded` in `_access.yaml` (curated,\n  read-only material) — a hard refusal with no override.\n- Existing files unless `overwrite=true`.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
         "path": {
           "type": "string",
-          "description": "Vault-relative path. Accepted shapes:\n- `Knowledge Base/Notes/Insights/foo.md`\n- `Reference/Strategy.md`\n- `Notes/Insights/foo` (auto-prepends `Knowledge Base/` if\n  literal path doesn't resolve; auto-adds `.md`)."
+          "description": "Vault-relative, e.g. `Knowledge Base/Identity/Career.md`.\nForward or back slashes accepted. Path-escape guarded."
         },
-        "frontmatter_only": {
+        "content": {
+          "default": "",
+          "type": "string",
+          "description": "File body (or full file if `frontmatter` is None). Text\nonly; for binaries use the /upload endpoint."
+        },
+        "frontmatter": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional dict prepended as YAML frontmatter."
+        },
+        "overwrite": {
           "default": false,
           "type": "boolean",
-          "description": "If true, return ONLY the frontmatter (no body) —\ncheap for scanning many files by field (folds in the former\n`get_frontmatter` tool). Returns {path, frontmatter,\nhas_frontmatter} instead of the full page below."
+          "description": "If true, replace existing file. Default false."
         },
-        "include_history": {
+        "allow_curated": {
           "default": false,
           "type": "boolean",
-          "description": "If true, attach a `history` list — the page's\nchange log from the append-only `log.md`, newest-first\n(`[{date, op, summary}]`, where `summary` is the `why:`\nrationale recorded at write time). Use this to answer \"why was\nthis note changed / what was the old version / show its history\"\nand to verify an edit's rationale. `[]` when the page has no\nrecorded edits."
+          "description": "Required to write under a curated tree. Default false."
         },
-        "links": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, attach a `links` summary —\n`{inbound: [...], outbound: [...]}`. `inbound` lists files whose\nwikilinks resolve to this page (each\n`{path, line_number, context, raw_target}`); `outbound` lists\nthe distinct wikilink targets in this page's body. Use it to\nsee a note's graph neighbourhood in one call. Default off (no\nbehaviour change)."
+        "kind": {
+          "default": "file",
+          "type": "string",
+          "description": "\"file\" (default) or \"dir\". With \"dir\", creates a folder\ninstead of a file (former `create_directory`)."
         },
-        "include_raw": {
-          "default": false,
+        "parents": {
+          "default": true,
           "type": "boolean",
-          "description": "If true, ALSO return `content` — the raw file text\nincluding the frontmatter delimiters. Off by default because it\nduplicates `frontmatter` + `body` (double the tokens on every\nread) and nothing in the normal workflow needs it: edits\nround-trip `body`, and the drift guard uses `content_hash`,\nwhich the server always computes over the raw bytes for you."
+          "description": "In \"dir\" mode, create intermediate folders (mkdir -p).\nDefault true."
         }
       },
       "required": [
         "path"
+      ],
+      "type": "object"
+    }
+  },
+  "delete": {
+    "description": "Tier 2: trash a file OR folder (auto-detected). Reversible — moves to\n_trash/, not /dev/null.\n\nDispatches on the path: a directory is trashed whole (needs\n`recursive=true` if non-empty; folds in the former `delete_directory`),\notherwise a single file. `force_superseded`/`expected_dead_inbound`\napply to files; `recursive` applies to folders.\n\nDeletes are NEVER permanent at this layer. The file moves to\n`Knowledge Base/_trash/YYYY-MM-DD/HHMMSS-<sanitized-original-path>.md`\nwith a `.meta.json` sidecar capturing original path, timestamp,\ninbound link count, and which force-flags were used. Recovery is\n`move_file` from the trash path back. Permanent removal happens\ndesk-side via `rm Knowledge Base/_trash/...`.\n\nPer SKILL.md rule 6, supersession via `replace` is still preferred\nfor compiled material. Use this op for scratch, mistakes outside the\ntyped-note set, and cleanup of files that genuinely shouldn't exist.\n\nRefuses:\n- Sources/, Evidence/ (append-only).\n- Files already in `_trash/` (already trashed — recover via move_file).\n- Curated trees unless `allow_curated=true`.\n- When `confirm=false`.\n- When `superseded_by:` is set (history) unless `force_superseded=true`.\n- When inbound wikilinks exist (after `expected_dead_inbound` filtering)\n  unless `force_orphan=true`.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Vault-relative."
+        },
+        "confirm": {
+          "type": "boolean",
+          "description": "Must be `true` explicitly. Marks the action deliberate."
+        },
+        "recursive": {
+          "default": false,
+          "type": "boolean",
+          "description": "For a non-empty FOLDER, required to confirm you know it\nhas contents. Ignored for files."
+        },
+        "force_orphan": {
+          "default": false,
+          "type": "boolean",
+          "description": "Allow trash even if inbound wikilinks exist."
+        },
+        "force_superseded": {
+          "default": false,
+          "type": "boolean",
+          "description": "Allow trash of a file in the supersession chain."
+        },
+        "allow_curated": {
+          "default": false,
+          "type": "boolean",
+          "description": "Required to trash under a curated tree."
+        },
+        "expected_dead_inbound": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Vault-relative paths whose inbound links\nto this file should be ignored. Use when you're trashing\nmultiple files in one workflow (e.g. cleaning a supersession\nchain) and don't want each step to false-positive on\nlinks that will die in the same batch."
+        }
+      },
+      "required": [
+        "path",
+        "confirm"
       ],
       "type": "object"
     }
@@ -1006,6 +562,1286 @@
       "required": [
         "path",
         "why"
+      ],
+      "type": "object"
+    }
+  },
+  "evolution": {
+    "description": "How a conclusion CHANGED over time — the supersession history of a topic, as timelines. Read-only.\n\n    For a topic `query`, finds the matching notes, follows each one's supersession\n    chain (the `supersedes`/`superseded_by` links `replace` records), and returns one\n    ordered timeline per chain — oldest version → newest. Each version carries its own\n    structurally-extracted claims, its date, and the RECORDED reason it was superseded\n    (the `why:` logged at that edit). The server only orders and surfaces what you\n    wrote; it does NOT generate a \"here's how your thinking changed\" summary — you read\n    the consecutive versions and see the shift.\n\n    Use this for \"how did my view on X evolve / what did I used to think / why did this\n    change\". Use `find` for plain lookup. Notes never superseded are omitted (no\n    evolution to show); a topic with no supersession returns empty `timelines` — an\n    honest \"nothing changed here\", not an error. Read-only: mutates nothing; `find`\n    ordering is unchanged.\n\n    Args:\n        query: The topic to trace (free text, like `find`).\n        limit: Max chains (timelines) to return, by find relevance (default 10;\n            0 or negative = uncapped). Chains beyond the cap are reported in\n            `truncation`, never dropped silently.\n        scope: Search scope passed to `find` — \"kb\" (default) / \"vault\" / \"kb-only\".\n        projects: Optional project-key filter passed to `find`.\n        tags: Optional tag filter passed to `find`.\n\n    Returns:\n        {query, timelines: [{chain_id, topic_anchor, span: {from, to, n_versions},\n         versions: [{path, title, status, date, claims: {title, type, lede, sections,\n         outline}, transition: {reason, date} | null}]}], truncation: [...]}.\n        `transition` is null on the active head; `versions` run oldest → newest by\n        supersession order; `span`/\n_versions` describe the whole chain.\n    ",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "type": "integer"
+        },
+        "scope": {
+          "default": "kb",
+          "type": "string"
+        },
+        "projects": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "type": "object"
+    }
+  },
+  "fetch": {
+    "description": "Fetch one Knowledge Base document by `search` result ID with bounded text. Read-only.\n\nThis is a bounded read step between metadata-only `search` and full `get`.\nIt returns the markdown body without raw frontmatter and caps body text at\n6000 characters. Use `get` when the caller intentionally needs the full\nfrontmatter/body/edit hash envelope.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A result `id` returned by `search` (the canonical vault-relative path)."
+        },
+        "max_chars": {
+          "default": 3000,
+          "type": "integer",
+          "description": "Maximum body characters to return. Values below 500 are raised\nto 500; values above 6000 are capped server-side."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    }
+  },
+  "find": {
+    "description": "Search / find / look up / query / retrieve / recall pages in the Knowledge Base (KB vault): notes, sources, insights, failures, patterns, experiments, entities. Hybrid semantic + keyword search, read-only. Filters are AND'd; tag/project lists are OR'd within.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "default": "",
+          "type": "string",
+          "description": "Free-text search string. In \"hybrid\"/\"vector\" mode it's\nembedded with bge-base for semantic recall. In \"keyword\" mode\nit's tokenized on whitespace and every token must appear in\ntitle or body (any order) — `contract employment` matches a\npage about \"employment contract\". Empty string always falls\nback to \"most-recent filtered\" behaviour regardless of mode."
+        },
+        "types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to these page types (source, research-note, insight, failure, pattern, experiment, production-log, entity)."
+        },
+        "projects": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to pages whose `project` or `projects:` includes any of these keys."
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to pages whose `tags:` includes any of these (case-insensitive)."
+        },
+        "speakers": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to diarized media whose `speakers:` frontmatter includes any of\nthese named speakers (case-insensitive) — e.g. \"what did Alice say about X\".\nAND'd with the query/other filters; OR'd within the list."
+        },
+        "file_types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Scope results to these artifact kinds — note, pdf, image,\naudio, video, csv, json, tsv. A binary surfaces under its media\nkind (pdf/image/...); a data file under its dataset card's format\n(csv/json). Omit to return ALL kinds (the default — search never\nhides a type unless you ask)."
+        },
+        "exclude_file_types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Drop these kinds from results (same vocabulary)."
+        },
+        "limit": {
+          "default": 15,
+          "type": "integer",
+          "description": "Max hits to return. Default 15, hard cap 100."
+        },
+        "scope": {
+          "default": "kb",
+          "type": "string",
+          "description": "\"kb\" (default) searches Knowledge Base/ first and\nAUTO-WIDENS to the whole vault when the KB doesn't fill\n`limit` — so content in sibling folders (Tracking/,\nReference/, Finance/, ... and curated, read-only trees kept\noutside Knowledge Base/) is never silently invisible. Widened\nhits carry `outside_kb: true`. \"vault\" always walks the\nwhole vault. \"kb-only\" is the strict opt-out: KB only,\nnever widens. Outside-KB recall is BM25/keyword (the\nvector sidecar is KB-scoped), with a relaxed gate so terse\nfiles (e.g. a numbers-heavy tracker) surface on a partial\ntoken match. `_Schema/`, `_trash/`, `_attachments/`, and\n`.obsidian/` are excluded under every scope. NOTE: an\nempty result means \"not found in what I searched,\" NOT\n\"doesn't exist\" — say so, and try \"vault\" before\nconcluding absence."
+        },
+        "mode": {
+          "default": "hybrid",
+          "type": "string",
+          "description": "Ranker. \"hybrid\" (default) fuses BM25 + local vector\nembeddings via reciprocal rank fusion — best recall on\nnatural-language queries. \"keyword\" preserves the original\ncase-insensitive substring matching, sorted by `updated:`.\n\"vector\" is vector-only (testing aid). BM25 corpus is\nSnowball-stemmed so \"regulation\" reaches pages with\n\"regulator\"; keyword mode stays strict-substring. If the\nembedding sidecar hasn't been built yet, hybrid degrades\nto BM25-only; run `audit_fix(rebuild_embeddings=true)` to\npopulate it."
+        },
+        "graph": {
+          "default": true,
+          "type": "boolean",
+          "description": "When true (default) and mode is hybrid/vector, outbound\nwikilinks of top BM25/vector candidates contribute a third\nranking — surfaces 1-hop neighbours of strong matches."
+        },
+        "rerank": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cross-encoder re-sort of the top fused candidates\n(bge-reranker-base) for higher-precision ordering. Default\n(unset) is mode-aware AUTO: in CPU steady-state modes it stays\noff for predictable latency; when the text/reranker device is\naccelerated, the server reranks only when ranking lanes\ndisagree or the query is long. Pass true to force reranking\nfor a high-value query, including on CPU; pass false to skip\nit entirely."
+        },
+        "prefer_compiled": {
+          "default": true,
+          "type": "boolean",
+          "description": "When true (default), applies a small boost to\ncompiled types (insight, pattern, failure, research-note,\nentity) and a small penalty to raw `source` after fusion\nAND rerank. Reflects the KB's epistemic hierarchy. Set\nfalse to retrieve raw source discussion verbatim (e.g.\n\"what did I capture from Dr. X\")."
+        },
+        "prefer_active": {
+          "default": true,
+          "type": "boolean",
+          "description": "When true (default), soft-demotes `status:\nsuperseded` pages so a replaced conclusion can't outrank the\npage that superseded it. The tombstone stays findable and its\nhit still carries `status` + `superseded_by` (the forward\npointer) so you can see it's superseded. Set false to rank a\nsuperseded page on its content alone (e.g. \"what did I used to\nthink about X\")."
+        },
+        "prefer_used": {
+          "default": false,
+          "type": "boolean",
+          "description": "When true (OFF by default — default ranking is\nusage-blind), applies a bounded, positive-only usage boost:\npages you actually read (`get`) and cite in written notes rank\nslightly higher, from ACT-R activation over the server's own\naccess logs. Capped below the compiled boost so usage breaks\nties but never overrides the epistemic hierarchy; never a\npenalty; never ADDS results — it only reorders pages the\ncontent lanes already matched. Boosted hits expose\n`signals.activation` + `signals.usage_boost` so you can see\nexactly why. Reading and citing pages IS the feedback loop —\nno separate feedback call exists or is needed. Use for \"what\nhave I been working with lately\" recall; leave off for\nneutral knowledge lookup."
+        },
+        "pack": {
+          "default": false,
+          "type": "boolean",
+          "description": "When true (off by default), ALSO assemble a reasoning-ready\ncontext pack from the top hits and change the return to\n{\"hits\": [...], \"pack\": {...}} (with pack off, the return is the\nusual hit list, unchanged). The pack is PURE MEASUREMENT over the\nnotes you already wrote — no server-side reasoning: each top note's\nstructurally-extracted key claims (lede + headline-section lines +\nheading outline), the 1-hop wikilink neighbourhood of those notes\nranked by co-citation, and the contradictions among them (recorded\nsupersession edges + proximity \"tension\" pairs in the embedding\nband, surfaced for you to judge — proximity, not polarity). Lets you\nreason over the matches in one shot instead of fanning out `get`\ncalls. Bounded with explicit `truncation`; the tension part needs\nthe embedding sidecar and reports `embeddings_available`."
+        },
+        "graph_enrich": {
+          "default": false,
+          "type": "boolean",
+          "description": "When true with `pack=true`, add typed graph neighborhood\ndata from the derived epistemic graph sidecar to the pack. Default\nfalse; missing/disabled/stale graph state soft-fails inside\n`pack.graph.available` without changing hits, hit ordering, or the\ndefault pack contract."
+        },
+        "detail": {
+          "default": "full",
+          "type": "string",
+          "description": "Result verbosity. \"full\" (default) keeps the current hit\nshape including `excerpt` and `signals`. \"compact\" returns the\nSAME ranked hits as token-cheap routing stubs — path, title,\ntype, scope, updated, plus lifecycle/media/outside_kb markers\nwhen present — omitting `excerpt` and `signals`. Use compact\nfor cheap proactive recall, then `get` a chosen page (or rerun\nwith detail=\"full\") when you need the why."
+        },
+        "include_timings": {
+          "default": false,
+          "type": "boolean",
+          "description": "When true (off by default), the return becomes an\nenvelope {\"hits\": [...], \"timings\": {...}} (with pack=true the\nenvelope also carries \"pack\"). `timings` reports total_ms,\nhot-cache status, and per-stage milliseconds for the retrieval\nlanes (skipped/failed optional lanes are marked, never fatal).\nDiagnostics only — timings never include note content. Omitted\n→ the response shape is unchanged."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "get": {
+    "description": "Read / open / fetch / load the full contents of a KB or vault page by path. Returns frontmatter + body (+ raw content on request).\n\nReads anywhere under the vault root — not just `Knowledge Base/`.\nThis lets you cite from curated, read-only sibling folders (e.g.\n`Reference/`) kept outside Knowledge Base/ when compiling. Those are\nread-only by convention (marked in `_access.yaml`); `get` honors that\nby only reading.\n\nUse this when `find` gives you a path and you need the whole page\n(to cite, build on, or rewrite). `find` only returns excerpts.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Vault-relative path. Accepted shapes:\n- `Knowledge Base/Notes/Insights/foo.md`\n- `Reference/Strategy.md`\n- `Notes/Insights/foo` (auto-prepends `Knowledge Base/` if\n  literal path doesn't resolve; auto-adds `.md`)."
+        },
+        "frontmatter_only": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, return ONLY the frontmatter (no body) —\ncheap for scanning many files by field (folds in the former\n`get_frontmatter` tool). Returns {path, frontmatter,\nhas_frontmatter} instead of the full page below."
+        },
+        "include_history": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, attach a `history` list — the page's\nchange log from the append-only `log.md`, newest-first\n(`[{date, op, summary}]`, where `summary` is the `why:`\nrationale recorded at write time). Use this to answer \"why was\nthis note changed / what was the old version / show its history\"\nand to verify an edit's rationale. `[]` when the page has no\nrecorded edits."
+        },
+        "links": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, attach a `links` summary —\n`{inbound: [...], outbound: [...]}`. `inbound` lists files whose\nwikilinks resolve to this page (each\n`{path, line_number, context, raw_target}`); `outbound` lists\nthe distinct wikilink targets in this page's body. Use it to\nsee a note's graph neighbourhood in one call. Default off (no\nbehaviour change)."
+        },
+        "include_raw": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, ALSO return `content` — the raw file text\nincluding the frontmatter delimiters. Off by default because it\nduplicates `frontmatter` + `body` (double the tokens on every\nread) and nothing in the normal workflow needs it: edits\nround-trip `body`, and the drift guard uses `content_hash`,\nwhich the server always computes over the raw bytes for you."
+        },
+        "max_body_chars": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional cap for the returned `body`. Use this when a\nclient wants bounded content instead of an arbitrary full-page read.\nValues above 12000 are capped server-side; negative values are rejected."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    }
+  },
+  "get_video_frames": {
+    "description": "View / analyze / look inside a vault video: sampled keyframes returned INLINE as images — no download round-trip.\n\nUse this to see what a video actually contains (slides, screen\nrecordings, whiteboards, meetings) directly in the tool result. Frames\nare sampled evenly across the video (or the requested window),\nnear-duplicates are collapsed, and each frame comes back as a JPEG\nimage content block, preceded by one metadata block with per-frame\ntimestamps. Typical loop: overview call first, then zoom into a moment\nwith `start_sec`/`end_sec` — e.g. around a `find` hit's\n`clip_match_at`/`scene_match_at` timestamp.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Vault-relative path to a video file\n(`.mp4 .mov .mkv .webm .avi .m4v .wmv .flv .mpeg .mpg`)."
+        },
+        "max_frames": {
+          "default": 8,
+          "type": "integer",
+          "description": "Maximum frames to return. Default 8, hard-capped\nserver-side (16); out-of-range values clamp silently and the\nmetadata reports `max_frames_effective`. Each frame costs\nimage tokens — prefer a time window over raising this."
+        },
+        "start_sec": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional window start in seconds — sample at/after this\ntimestamp only."
+        },
+        "end_sec": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional window end in seconds — sample before this\ntimestamp only (clamped to the video's duration)."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    }
+  },
+  "graph_context": {
+    "description": "Return a bounded typed-graph neighborhood for a page or query. Read-only.\n\nReads the derived `.graph.sqlite` sidecar created from Markdown,\nfrontmatter, wikilinks, source/evidence links, supersession fields, and\nsemantic blocks. Markdown remains the source of truth; this operation does\nnot build the sidecar, modify notes, accept suggested relations, or change\n`find` ranking. If the graph sidecar is missing, disabled, or incompatible,\nthe response reports `available: false` instead of failing.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Existing page path to use as the graph seed. Optional when `query`\nis supplied."
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Text seed for matching graph node titles/content. Optional when\n`path` is supplied."
+        },
+        "depth": {
+          "default": 1,
+          "type": "integer",
+          "description": "Traversal depth from seed nodes. Default 1."
+        },
+        "relation_types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional allowlist of relation types, e.g.\n`derived_from`, `evidenced_by`, `supports`, `contradicts`,\n`supersedes`, `links_to`."
+        },
+        "node_types": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional allowlist of node kinds, e.g. `file`, `decision`,\n`finding`, `risk`, `action`, `claim`, `evidence`."
+        },
+        "max_nodes": {
+          "default": 40,
+          "type": "integer",
+          "description": "Cap returned nodes. Default 40."
+        },
+        "max_edges": {
+          "default": 80,
+          "type": "integer",
+          "description": "Cap returned edges. Default 80."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "link": {
+    "description": "Create a typed entity under Entities/<Folder>/<Name>.md.\n\nEntities are the typed nodes of the KB graph — people, concepts,\nlibraries, decisions. Name them after the thing they are (Title Case,\nnot slugified): `Ada Lovelace`, `Agentic RAG`, `pgvector`.\n\nFour entity types with conditional frontmatter:\n- `person`   → Entities/People/. Optional: `affiliation`, `relationship`.\n- `concept`  → Entities/Concepts/. Optional: `domain` (e.g.\n  \"retrieval\", \"workflow\", \"infrastructure\").\n- `library`  → Entities/Libraries/. Optional: `language`, `repo`,\n  `license`, `used_in` (list of projects).\n- `decision` → Entities/Decisions/. Optional: `decided` (YYYY-MM-DD),\n  `project` (project key — any slug; unknown keys auto-register on first\n  use, same as `note`), `decision_status` ∈ {proposed, accepted,\n  superseded}.\n\nv1 is create-only. If the entity file already exists, returns\nENTITY_EXISTS — use `replace` to supersede instead. Sub-folder index\n(e.g. Entities/Concepts/index.md categorization) is NOT auto-updated;\nreconcile via desk audit.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_type": {
+          "type": "string",
+          "description": "One of person, concept, library, decision."
+        },
+        "name": {
+          "type": "string",
+          "description": "Title Case, the entity's actual name. Will be the filename."
+        },
+        "summary": {
+          "type": "string",
+          "description": "One-paragraph description for the `## Summary` section."
+        },
+        "why_in_kb": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional `## Why in the KB` paragraph — explains what\nthis entity is relevant to in your work."
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Lowercase dash-separated; normalized by the server."
+        },
+        "connections": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of vault-relative wikilink targets to put under\n`## Connections`. Same path conventions as `note.sources`."
+        },
+        "affiliation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relationship": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "domain": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "language": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "repo": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "license": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "used_in": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "decided": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "project": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "decision_status": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "entity_type",
+        "name",
+        "summary"
+      ],
+      "type": "object"
+    }
+  },
+  "list_directory": {
+    "description": "Tier 2: list files and subfolders at a vault path. Read-only.\n\nWorks anywhere under vault root including curated trees (consistent\nwith `get`). For .md files, surfaces the frontmatter `type` field\nso callers can scan typed content quickly.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "default": "",
+          "type": "string",
+          "description": "Vault-relative. Empty string lists vault root. Auto-handles\nforward/back slashes."
+        },
+        "recursive": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, walk subfolders. Default false."
+        },
+        "include_hidden": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, include dotfiles and _attachments/.\nDefault false."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "list_inbound_links": {
+    "description": "Tier 2: find files whose wikilinks resolve to `target`. Read-only.\n\nUseful before `move_file` (preview what update_wikilinks will touch)\nor `delete_file` (preview what would break). Matches three forms:\n- Full path: `[[Knowledge Base/Notes/Insights/foo]]`\n- KB-stripped: `[[Notes/Insights/foo]]`\n- Bare basename (only when unique vault-wide): `[[foo]]`",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Vault-relative path or bare basename. `.md` optional."
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object"
+    }
+  },
+  "list_trash": {
+    "description": "Tier 2: enumerate recoverable trash entries. Read-only.\n\nWalks Knowledge Base/_trash/YYYY-MM-DD/ and parses each .meta.json\nsidecar. Returns entries most-recent-first with original path,\ntimestamp, kind (file or directory), and which force-flags fired\nat trash time. Also surfaces drift: orphan_sidecars (sidecars with\nno target file) and orphan_files (trashed files with no sidecar).\nPair with `recover_from_trash` to undo.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "date": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional YYYY-MM-DD filter to scope to one day."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "mint_download_token": {
+    "description": "Mint a short-lived bearer token for the HTTP `/download` endpoint.\n\nUse to PULL a vault file into the sandbox — a dataset, an evidence\nbinary, a scan — so you can analyze it. Call this, then from the code\nsandbox GET `download_url?path=<vault-relative path>` with header\n`Authorization: Bearer <token>`. Read-only; the token is download-scoped\n(can't write) and expires after `ttl_seconds`.\n\nReturns: {token, ttl_seconds, download_url}.\nRaises: DOWNLOAD_DISABLED if the server has no upload token configured.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "mint_upload_token": {
+    "description": "Mint a short-lived bearer token for the HTTP `/upload` endpoint.\n\nThis is how you file BINARY evidence (images, PDFs, any file) from a\nclaude.ai web session — the bytes travel out-of-band, never through the\nmodel. Steps:\n\n1. Call this tool → `{token, ttl_seconds, upload_url[, large_upload_url]}`.\n2. In the code sandbox, multipart-POST the user's ATTACHED files to\n   `upload_url` with header `Authorization: Bearer <token>` and form\n   fields `file`, `scope`, `category` (optional `filename`, `description`,\n   `text`). Files must be ATTACHMENTS — inline-pasted images never reach\n   the sandbox disk and cannot be sent.\n3. To make the binary SEARCHABLE, extract its text in the sandbox (OCR an\n   image/scan, read a PDF, transcribe audio/video) and pass it as the\n   `text` field above — it lands in an embedded sidecar so the otherwise-\n   opaque file is findable by its content.\n\n**Large files (>100 MB):** `upload_url` is fronted by Cloudflare, which\n413s any body over ~100 MB at the edge. If a file exceeds ~100 MB (or a\nPOST to `upload_url` returns 413), send it to `large_upload_url` instead\nwhen that field is present — same token, same form fields, an alternate\nhost with no edge cap. If `large_upload_url` is absent, only `upload_url`\nis available and >100 MB must go desk-side.\n\nThe token is Evidence-write only and expires after `ttl_seconds`; the\nserver's long-lived secret never leaves the server.\n\nReturns: {token, ttl_seconds, upload_url, large_upload_url?}.\nRaises: UPLOAD_DISABLED if the server has no upload token configured.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "move_file": {
+    "description": "Tier 2: relocate a file, optionally rewriting inbound wikilinks.\n\nRefuses moves out of OR into Sources/ and Evidence/ (append-only).\nCurated trees on either end need `allow_curated=true`. Refuses to\noverwrite existing destinations.\n\nWhen `update_wikilinks=true` (default), scans the full vault for\n`[[<old>]]`, `[[<old.md>]]`, and `[[<old_basename>]]` (only when the\nbasename is unique vault-wide) and rewrites them to point at the\nnew location. Preserves full-form vs stripped-form per link.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "old_path": {
+          "type": "string",
+          "description": "Vault-relative source."
+        },
+        "new_path": {
+          "type": "string",
+          "description": "Vault-relative destination (must not exist)."
+        },
+        "update_wikilinks": {
+          "default": true,
+          "type": "boolean",
+          "description": "Default true."
+        },
+        "allow_curated": {
+          "default": false,
+          "type": "boolean",
+          "description": "Required if either end is in a curated tree."
+        }
+      },
+      "required": [
+        "old_path",
+        "new_path"
+      ],
+      "type": "object"
+    }
+  },
+  "note": {
+    "description": "Create a compiled note in the Knowledge Base.\n\n    Use this for distilled thinking — not raw capture. For raw capture\n    (an article you read, a session transcript), use `add` instead.\n\n    Six note types:\n    - `research-note`: project-scoped findings. `project` REQUIRED.\n      → `Notes/Research/<Project>/<slug>.md`\n    - `insight`: cross-cutting claim. Optional `projects` (plural).\n      → `Notes/Insights/<slug>.md`\n    - `failure`: documented failure mode. Optional `projects`, optional\n      `severity` ∈ {minor, moderate, serious, critical}.\n      → `Notes/Failures/<slug>.md`\n    - `pattern`: reusable cross-cutting pattern. Optional `projects`,\n      optional `pattern_type` ∈ {architectural, workflow, prompting,\n      governance, pedagogical}.\n      → `Notes/Patterns/<slug>.md`\n    - `experiment`: hypothesis + protocol. `domain`, `started` (YYYY-MM-DD),\n      and `duration` (e.g. \"30 days\", \"ongoing\") REQUIRED. Optional\n      `hypothesis`,\n` (default 1), `concluded`.\n      → `Notes/Experiments/<domain>/YYYY-MM-<slug>.md`\n    - `production-log`: creative artifact log. `medium` REQUIRED (e.g.\n      \"Posts\", \"Articles\"). Optional `recorded`, `published`, `host`,\n      `editor`, `projects`. Status enum is richer: {planned, recorded,\n      edited, published, reflected, dropped, archived}; defaults to\n      `planned`.\n      → `Notes/Productions/<medium>/YYYY-MM-<slug>.md`\n\n    For each `sources:` wikilink, appends this note's wikilink to that\n    source's `ingested_into:` frontmatter (maintaining the source→note graph).\n\n    The result includes `write_feedback`: deterministic structural feedback with\n    semantic block counts, source/link counts, unresolved wikilink warnings, and\n    suggested next actions. Treat it as write-shape feedback, not semantic truth.\n\n    Args:\n        content: Full markdown body, written verbatim after the\n            frontmatter. Should start with `# <title>` (the H1 matching\n            the title arg) followed by the section conventions per type:\n            research-note: `## Question`/`## Findings`/`## Connections`.\n            insight: `## Claim`/`## Why it holds`/`## Connections`.\n            failure: `## What happened`/`## Mechanism`/`## Detection`/`## Mitigation`/`## Connections`.\n            pattern: `## Problem`/`## Solution`/`## When to use`/`## When NOT to use`/`## Connections`.\n            experiment: `## Hypothesis`/`## Protocol`/`## Baseline`/`## Intervention`/`## Results`/`## Conclusion`/`## Connections`.\n            production-log: `## Frame`/`## Artifact`/`## Production session`/`## Outcomes`/`## Reflection`/`## Connections`.\n            Conventions only — no shape is enforced.\n        note_type: One of research-note, insight, failure, pattern,\n            experiment, production-log.\n        title: Human title; used to derive a kebab-case filename slug.\n            Experiments and production-logs auto-prefix with YYYY-MM.\n        project: REQUIRED for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work.\n        projects: List of project keys (plural). Optional for insight,\n            failure, pattern, production-log. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work.\n        sources: Vault-relative wikilinks to existing pages this note draws\n            from, e.g. `[\"Knowledge Base/Sources/Articles/2026-05-18-foo\"]`\n            or `[\"[[Knowledge Base/Sources/Articles/2026-05-18-foo]]\"]`.\n            Brackets and the leading `Knowledge Base/` are tolerated.\n        tags: Lowercase dash-separated; the server normalizes case/spacing.\n        status: Defaults to `active` for most types, `planned` for\n            production-log. Valid set varies by type.\n        severity: failure only. {minor, moderate, serious, critical}.\n        pattern_type: pattern only. {architectural, workflow, prompting,\n            governance, pedagogical}.\n        domain: experiment only. Becomes the subfolder name (lowercased).\n        started: experiment only. YYYY-MM-DD when the experiment began.\n        duration: experiment only. Freeform, e.g. \"30 days\", \"ongoing\".\n        hypothesis: experiment only. One-line claim being tested.\n        n: experiment only. Sample size. Defaults to 1 (n-of-1).\n        concluded: experiment only. YYYY-MM-DD when it ended (absent while ongoing).\n        medium: production-log only. Subfolder, e.g. \"Posts\", \"Articles\".\n        recorded: production-log only. YYYY-MM-DD of recording session.\n        published: production-log only. YYYY-MM-DD of publication.\n        host: production-log only. Creator/talent name.\n        editor: production-log only. Producer/editor name.\n\n        suggestions: When true (default), the result carries a `suggestions`\n            block: existing pages this note should probably link to, ranked\n            by the retrieval stack. Set false for a faster write when you\n            already know the note's links; the near-duplicate/overlap\n            warnings stay ON either way (dedupe is a guardrail, not a\n            suggestion). For important drafts, call `suggest_links` before\n            `note` and wire accepted links into the body or with a follow-up\n            `edit`.\n\n    Returns:\n        {path, warnings, suggestions?, write_feedback}. `write_feedback` is\n        deterministic structural feedback: semantic block counts, source/link\n        counts, unresolved wikilink warnings, and suggested next actions. On\n        validation failure, raises a structured error with code=INVALID_NOTE,\n        the missing fields, and the reason.\n    ",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "note_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "project": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "projects": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sources": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "status": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "pattern_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "domain": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "started": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "duration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hypothesis": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "concluded": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "medium": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "published": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "editor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "suggestions": {
+          "default": true,
+          "type": "boolean"
+        },
+        "project_category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "content",
+        "note_type",
+        "title"
+      ],
+      "type": "object"
+    }
+  },
+  "overview": {
+    "description": "Bounded, read-only structure report of the vault (or a subtree).\n\nAnswers \"what does this vault look like?\" in ONE call — use this instead\nof reading files one by one for structural questions. Reports totals,\nwhether a `Knowledge Base/` tree is present, a depth/breadth-capped folder\ntree (per-folder file counts, frontmatter coverage %, wikilink/md-link\ncounts, dominant filename patterns, sample names), junk candidates\n(zero-byte files, sync-conflict duplicates like `note 2.md`), largest and\noldest-unmodified files, and exactly what was skipped. Lists are capped;\ncounts are always exact. Works on vaults with no initialized\n`Knowledge Base/` (`kb.present` false).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "default": "",
+          "type": "string",
+          "description": "Vault-relative subtree to report on. Empty string (default)\nreports the whole vault. Auto-handles forward/back slashes."
+        },
+        "max_depth": {
+          "default": 3,
+          "type": "integer",
+          "description": "Tree depth cap; deeper folders roll up into their\nancestors (counts stay exact). Default 3."
+        },
+        "include_hidden": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, include dot-directories/dotfiles and\n`_trash`/`_attachments`. Default false."
+        },
+        "samples": {
+          "default": 5,
+          "type": "integer",
+          "description": "Filename samples listed per folder. Default 5."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "preserve": {
+    "description": "Capture a TEXT artifact to Evidence/<scope>/<category>/.\n\nFor raw factual artifacts that are text — transcripts, pasted letters,\nemail bodies — preserved as-received with no analytical processing. Per\nSKILL.md rule 2, Evidence is append-only; analytical takes go in compiled\nnotes that link to the evidence file.\n\nBINARY artifacts (PDFs, images, .docx — any non-text file) are delivered\nout-of-band, not through this tool: call `mint_upload_token` and POST the\nbytes to `/upload`, or drop the file into Evidence/ desk-side via Obsidian\nSync. The bytes never pass through the model.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Incident or domain key (e.g. \"project-alpha\", \"incident-2026-04\").\nCreates the subfolder if it doesn't exist."
+        },
+        "category": {
+          "type": "string",
+          "description": "Sub-category within scope (e.g. \"letters\", \"labs\",\n\"court-docs\"). Creates the subfolder if it doesn't exist."
+        },
+        "filename": {
+          "type": "string",
+          "description": "The artifact's filename including extension\n(e.g. `2026-04-15-statement.txt`)."
+        },
+        "content": {
+          "type": "string",
+          "description": "UTF-8 text to preserve as-received."
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional. If supplied, a sidecar `<filename>.md`\nis written alongside the artifact with frontmatter and the\ndescription under `## Description`."
+        }
+      },
+      "required": [
+        "scope",
+        "category",
+        "filename",
+        "content"
+      ],
+      "type": "object"
+    }
+  },
+  "propose_compilation": {
+    "description": "Draft / scaffold a compiled note from unprocessed source(s) — what to compile next, drain the source backlog. Read-only.\n\nThe backlog-drain companion to `audit`'s `unprocessed_source` findings:\npoint it at one or more raw sources and it hands back a ready-to-fill\nnote skeleton — inferred note_type, a Question/Findings/Connections (or\nClaim/…) outline, the `sources[]` to cite, and adjacent compiled pages to\nlink (computed via the same hybrid retrieval as `suggest_links`). It\ndoes NOT write anything: you fill the prose and call `note()` with the\nreturned `suggested_sources` + `suggested_connections`.\n\nGroup sources yourself before calling — pass a set that genuinely belongs\nin one note (the audit list is aged oldest-first to help you triage).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Vault-relative paths/wikilinks to the source(s) to compile.\nSame path conventions as `note.sources` (brackets and the\nleading `Knowledge Base/` are tolerated)."
+        },
+        "suggested_title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional title override; otherwise one is derived\nfrom the source titles."
+        }
+      },
+      "required": [
+        "sources"
+      ],
+      "type": "object"
+    }
+  },
+  "provenance_report": {
+    "description": "Trace provenance: scan note bodies for `<!-- key:value -->` tags — where an opinion/take/flag came from. Read-only.\n\nOn-demand scan over markdown bodies — no index, no sidecar. Use it to\nanswer \"show all conv:-derived takes\" or \"what's flagged add-to-imdb\"\nwithout grepping. The opinion/taste rows carry provenance as HTML\ncomments (e.g. `<!-- platform:imdb -->`, `<!-- conv:2026-06-01 -->`);\nthis reads them in place. Tags inside fenced code are ignored; multiple\ncomments and multiple key:value pairs on one line are all parsed.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "tag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Shorthand filter — \"key\" or \"key:value\" (e.g. \"platform:imdb\")."
+        },
+        "key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filter to rows carrying this provenance key."
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "With key, require this exact value."
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restrict the scan to one vault-relative file (else the whole\nKnowledge Base is walked)."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "query_data": {
+    "description": "Tier 2: structured query over a CSV/JSON data file under the vault.\n\nThe retrieval half of the data-search pattern — `find` surfaces a\ndataset's markdown \"card\"; this reads the raw file the card points at\nand returns exact rows / aggregates (no whole-file dump). KB datasets\nare small, so it reads on demand — no index, no new infra.\n\nFormats: CSV / TSV, and JSON (a top-level array, or a nested array via\n`record_path` / common-key auto-detect). Column names may be dotted to\nreach nested JSON fields (e.g. \"performer.name\", \"id.extension\")\nanywhere a column is named (filters / columns / sort / aggregate).",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "vault-relative path to the `.csv` / `.tsv` / `.json` file."
+        },
+        "record_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(JSON) dotted path to the array inside a nested\nobject, e.g. \"sections.work_incapacity\". Omit for a top-level\narray or the common keys result/results/data/rows/items/entries."
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "items": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "list of `{column, op, value}`. `op` ∈ eq, ne, gt, gte, lt,\nlte, contains, icontains, startswith, in, nin, exists, missing.\nNumeric compares coerce tolerantly (comma decimals; lab\noperators like \"<0.4\"/\">75\" are stripped for the comparison)."
+        },
+        "columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "project to these columns (dotted ok). Omit for all."
+        },
+        "sort_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "descending": {
+          "default": false,
+          "type": "boolean"
+        },
+        "limit": {
+          "default": 100,
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "type": "integer"
+        },
+        "aggregate": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "instead of rows — \"count\"; \"func:column\" where func ∈\nmin, max, sum, avg, latest, distinct; or \"profile\" to get a\ndeterministic content profile (per-column kind, distinct values,\nnumeric ranges, date span) under `aggregate.profile` PLUS a\nready-to-write markdown dataset card under `aggregate.dataset_card`.\nUse \"profile\" to make a CSV/JSON findable — write the card into\nthe KB (fill in its \"What this holds\" line) so the dataset is\ndiscoverable by content without ever embedding its raw rows."
+        },
+        "date_from": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "date_to": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "date_column": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    }
+  },
+  "reconcile": {
+    "description": "Heal vault drift from out-of-band edits in one pass.\n\nThe writers keep the embedding sidecar, index.md count rows, and log.md\ncurrent on every write. But editing the vault directly — in Obsidian,\non mobile, or via a manual filesystem edit — bypasses those hooks, so\nthe sidecar and the counts drift silently. `reconcile` is the\nfirst-class \"I edited around the system, fix it\" command:\n\n1. Index counts — recompute Sources/Notes/Entities count rows from\n   on-disk reality and rewrite any that drifted (curated descriptions\n   and Recent-activity are preserved; only count tokens move).\n2. Embeddings — incrementally re-embed only the *stale* files (those\n   `embedding_drift` flags: on-disk mtime newer than the sidecar row),\n   via the same path the writers use. Cheaper than\n   `audit_fix(rebuild_embeddings=true)`'s full wipe-and-rebuild.\n3. Drift report — re-run index_drift + embedding_drift, return what\n   remains.\n\nNarrower than `audit_fix`: it does NOT canonicalize wikilinks or\nbackfill frontmatter (those are content rewrites you opt into).\nIdempotent; `dry_run=true` reports without writing.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "dry_run": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, compute what would change without writing.\nDefault false."
+        }
+      },
+      "type": "object"
+    }
+  },
+  "recover_from_trash": {
+    "description": "Tier 2: undo a delete_file/delete_directory.\n\nReads the .meta.json sidecar to discover where the file lived\nbefore being trashed, moves it back there, and cleans up the\nsidecar. If `restore_path` is provided, uses that instead of the\nsidecar's original location (useful when the original parent\ndirectory has been removed).\n\nRefuses to overwrite existing files at the restore destination.\nRefuses restore into Sources/Evidence (append-only). Curated trees\nneed `allow_curated=true`.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "trash_path": {
+          "type": "string",
+          "description": "Vault-relative path to the trashed entry\n(under `Knowledge Base/_trash/...`)."
+        },
+        "restore_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional override; defaults to the original\nlocation from the sidecar."
+        },
+        "allow_curated": {
+          "default": false,
+          "type": "boolean",
+          "description": "Required if restoring into a curated tree."
+        }
+      },
+      "required": [
+        "trash_path"
       ],
       "type": "object"
     }
@@ -1268,500 +2104,17 @@
       "type": "object"
     }
   },
-  "link": {
-    "description": "Create a typed entity under Entities/<Folder>/<Name>.md.\n\nEntities are the typed nodes of the KB graph — people, concepts,\nlibraries, decisions. Name them after the thing they are (Title Case,\nnot slugified): `Ada Lovelace`, `Agentic RAG`, `pgvector`.\n\nFour entity types with conditional frontmatter:\n- `person`   → Entities/People/. Optional: `affiliation`, `relationship`.\n- `concept`  → Entities/Concepts/. Optional: `domain` (e.g.\n  \"retrieval\", \"workflow\", \"infrastructure\").\n- `library`  → Entities/Libraries/. Optional: `language`, `repo`,\n  `license`, `used_in` (list of projects).\n- `decision` → Entities/Decisions/. Optional: `decided` (YYYY-MM-DD),\n  `project` (project key — any slug; unknown keys auto-register on first\n  use, same as `note`), `decision_status` ∈ {proposed, accepted,\n  superseded}.\n\nv1 is create-only. If the entity file already exists, returns\nENTITY_EXISTS — use `replace` to supersede instead. Sub-folder index\n(e.g. Entities/Concepts/index.md categorization) is NOT auto-updated;\nreconcile via desk audit.",
+  "search": {
+    "description": "Search the Knowledge Base with a portable metadata-only response. Read-only.\n\nThis is the conservative companion to `find`: it returns result IDs, titles,\nURLs, and string metadata only. It never returns note excerpts, graph/ranking\nsignals, context packs, timings, raw content, or page bodies. Use `fetch`\nwith one returned `id` to read bounded document text, or use `find`/`get`\ndirectly when the caller intentionally needs richer retrieval output.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
-        "entity_type": {
-          "type": "string",
-          "description": "One of person, concept, library, decision."
-        },
-        "name": {
-          "type": "string",
-          "description": "Title Case, the entity's actual name. Will be the filename."
-        },
-        "summary": {
-          "type": "string",
-          "description": "One-paragraph description for the `## Summary` section."
-        },
-        "why_in_kb": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional `## Why in the KB` paragraph — explains what\nthis entity is relevant to in your work."
-        },
-        "tags": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Lowercase dash-separated; normalized by the server."
-        },
-        "connections": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "List of vault-relative wikilink targets to put under\n`## Connections`. Same path conventions as `note.sources`."
-        },
-        "affiliation": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "relationship": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "domain": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "language": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "repo": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "license": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "used_in": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "decided": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "project": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "decision_status": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "required": [
-        "entity_type",
-        "name",
-        "summary"
-      ],
-      "type": "object"
-    }
-  },
-  "preserve": {
-    "description": "Capture a TEXT artifact to Evidence/<scope>/<category>/.\n\nFor raw factual artifacts that are text — transcripts, pasted letters,\nemail bodies — preserved as-received with no analytical processing. Per\nSKILL.md rule 2, Evidence is append-only; analytical takes go in compiled\nnotes that link to the evidence file.\n\nBINARY artifacts (PDFs, images, .docx — any non-text file) are delivered\nout-of-band, not through this tool: call `mint_upload_token` and POST the\nbytes to `/upload`, or drop the file into Evidence/ desk-side via Obsidian\nSync. The bytes never pass through the model.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "scope": {
-          "type": "string",
-          "description": "Incident or domain key (e.g. \"project-alpha\", \"incident-2026-04\").\nCreates the subfolder if it doesn't exist."
-        },
-        "category": {
-          "type": "string",
-          "description": "Sub-category within scope (e.g. \"letters\", \"labs\",\n\"court-docs\"). Creates the subfolder if it doesn't exist."
-        },
-        "filename": {
-          "type": "string",
-          "description": "The artifact's filename including extension\n(e.g. `2026-04-15-statement.txt`)."
-        },
-        "content": {
-          "type": "string",
-          "description": "UTF-8 text to preserve as-received."
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional. If supplied, a sidecar `<filename>.md`\nis written alongside the artifact with frontmatter and the\ndescription under `## Description`."
-        }
-      },
-      "required": [
-        "scope",
-        "category",
-        "filename",
-        "content"
-      ],
-      "type": "object"
-    }
-  },
-  "query_data": {
-    "description": "Tier 2: structured query over a CSV/JSON data file under the vault.\n\nThe retrieval half of the data-search pattern — `find` surfaces a\ndataset's markdown \"card\"; this reads the raw file the card points at\nand returns exact rows / aggregates (no whole-file dump). KB datasets\nare small, so it reads on demand — no index, no new infra.\n\nFormats: CSV / TSV, and JSON (a top-level array, or a nested array via\n`record_path` / common-key auto-detect). Column names may be dotted to\nreach nested JSON fields (e.g. \"performer.name\", \"id.extension\")\nanywhere a column is named (filters / columns / sort / aggregate).",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "vault-relative path to the `.csv` / `.tsv` / `.json` file."
-        },
-        "record_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "(JSON) dotted path to the array inside a nested\nobject, e.g. \"sections.work_incapacity\". Omit for a top-level\narray or the common keys result/results/data/rows/items/entries."
-        },
-        "filters": {
-          "anyOf": [
-            {
-              "items": {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "list of `{column, op, value}`. `op` ∈ eq, ne, gt, gte, lt,\nlte, contains, icontains, startswith, in, nin, exists, missing.\nNumeric compares coerce tolerantly (comma decimals; lab\noperators like \"<0.4\"/\">75\" are stripped for the comparison)."
-        },
-        "columns": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "project to these columns (dotted ok). Omit for all."
-        },
-        "sort_by": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "descending": {
-          "default": false,
-          "type": "boolean"
-        },
-        "limit": {
-          "default": 100,
-          "type": "integer"
-        },
-        "offset": {
-          "default": 0,
-          "type": "integer"
-        },
-        "aggregate": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "instead of rows — \"count\"; \"func:column\" where func ∈\nmin, max, sum, avg, latest, distinct; or \"profile\" to get a\ndeterministic content profile (per-column kind, distinct values,\nnumeric ranges, date span) under `aggregate.profile` PLUS a\nready-to-write markdown dataset card under `aggregate.dataset_card`.\nUse \"profile\" to make a CSV/JSON findable — write the card into\nthe KB (fill in its \"What this holds\" line) so the dataset is\ndiscoverable by content without ever embedding its raw rows."
-        },
-        "date_from": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "date_to": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "date_column": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "required": [
-        "path"
-      ],
-      "type": "object"
-    }
-  },
-  "create_file": {
-    "description": "Tier 2: write a file — or, with `kind=\"dir\"`, create a folder — at an\narbitrary vault path.\n\nWith `kind=\"dir\"`, this creates a folder (mkdir -p when `parents=true`)\nand ignores `content`/`frontmatter`/`overwrite` (folds in the former\n`create_directory` tool); returns {path, created, warnings}.\n\nEscape hatch for files that don't fit Tier 1 type routing — new folder\nstructures (`Identity/`, `Templates/`), skill files, scratch. For\ntyped notes use `note`/`add`/`link`/`preserve`.\n\nIf `frontmatter` is a dict, this op prepends a YAML block built from\nit (and auto-fills `created`/`updated` to today if not provided);\n`content` is the body in that case. If `frontmatter` is omitted,\n`content` is written verbatim — the caller is responsible for any\nfrontmatter already in it.\n\nRefuses:\n- Sources/, Evidence/ (append-only — use `add` or `preserve`).\n- Subtrees marked `readonly`/`excluded` in `_access.yaml` (curated,\n  read-only material) — a hard refusal with no override.\n- Existing files unless `overwrite=true`.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Vault-relative, e.g. `Knowledge Base/Identity/Career.md`.\nForward or back slashes accepted. Path-escape guarded."
-        },
-        "content": {
+        "query": {
           "default": "",
           "type": "string",
-          "description": "File body (or full file if `frontmatter` is None). Text\nonly; for binaries use the /upload endpoint."
+          "description": "Free-text search string."
         },
-        "frontmatter": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional dict prepended as YAML frontmatter."
-        },
-        "overwrite": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, replace existing file. Default false."
-        },
-        "allow_curated": {
-          "default": false,
-          "type": "boolean",
-          "description": "Required to write under a curated tree. Default false."
-        },
-        "kind": {
-          "default": "file",
-          "type": "string",
-          "description": "\"file\" (default) or \"dir\". With \"dir\", creates a folder\ninstead of a file (former `create_directory`)."
-        },
-        "parents": {
-          "default": true,
-          "type": "boolean",
-          "description": "In \"dir\" mode, create intermediate folders (mkdir -p).\nDefault true."
-        }
-      },
-      "required": [
-        "path"
-      ],
-      "type": "object"
-    }
-  },
-  "list_directory": {
-    "description": "Tier 2: list files and subfolders at a vault path. Read-only.\n\nWorks anywhere under vault root including curated trees (consistent\nwith `get`). For .md files, surfaces the frontmatter `type` field\nso callers can scan typed content quickly.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "default": "",
-          "type": "string",
-          "description": "Vault-relative. Empty string lists vault root. Auto-handles\nforward/back slashes."
-        },
-        "recursive": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, walk subfolders. Default false."
-        },
-        "include_hidden": {
-          "default": false,
-          "type": "boolean",
-          "description": "If true, include dotfiles and _attachments/.\nDefault false."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "move_file": {
-    "description": "Tier 2: relocate a file, optionally rewriting inbound wikilinks.\n\nRefuses moves out of OR into Sources/ and Evidence/ (append-only).\nCurated trees on either end need `allow_curated=true`. Refuses to\noverwrite existing destinations.\n\nWhen `update_wikilinks=true` (default), scans the full vault for\n`[[<old>]]`, `[[<old.md>]]`, and `[[<old_basename>]]` (only when the\nbasename is unique vault-wide) and rewrites them to point at the\nnew location. Preserves full-form vs stripped-form per link.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "old_path": {
-          "type": "string",
-          "description": "Vault-relative source."
-        },
-        "new_path": {
-          "type": "string",
-          "description": "Vault-relative destination (must not exist)."
-        },
-        "update_wikilinks": {
-          "default": true,
-          "type": "boolean",
-          "description": "Default true."
-        },
-        "allow_curated": {
-          "default": false,
-          "type": "boolean",
-          "description": "Required if either end is in a curated tree."
-        }
-      },
-      "required": [
-        "old_path",
-        "new_path"
-      ],
-      "type": "object"
-    }
-  },
-  "delete": {
-    "description": "Tier 2: trash a file OR folder (auto-detected). Reversible — moves to\n_trash/, not /dev/null.\n\nDispatches on the path: a directory is trashed whole (needs\n`recursive=true` if non-empty; folds in the former `delete_directory`),\notherwise a single file. `force_superseded`/`expected_dead_inbound`\napply to files; `recursive` applies to folders.\n\nDeletes are NEVER permanent at this layer. The file moves to\n`Knowledge Base/_trash/YYYY-MM-DD/HHMMSS-<sanitized-original-path>.md`\nwith a `.meta.json` sidecar capturing original path, timestamp,\ninbound link count, and which force-flags were used. Recovery is\n`move_file` from the trash path back. Permanent removal happens\ndesk-side via `rm Knowledge Base/_trash/...`.\n\nPer SKILL.md rule 6, supersession via `replace` is still preferred\nfor compiled material. Use this op for scratch, mistakes outside the\ntyped-note set, and cleanup of files that genuinely shouldn't exist.\n\nRefuses:\n- Sources/, Evidence/ (append-only).\n- Files already in `_trash/` (already trashed — recover via move_file).\n- Curated trees unless `allow_curated=true`.\n- When `confirm=false`.\n- When `superseded_by:` is set (history) unless `force_superseded=true`.\n- When inbound wikilinks exist (after `expected_dead_inbound` filtering)\n  unless `force_orphan=true`.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Vault-relative."
-        },
-        "confirm": {
-          "type": "boolean",
-          "description": "Must be `true` explicitly. Marks the action deliberate."
-        },
-        "recursive": {
-          "default": false,
-          "type": "boolean",
-          "description": "For a non-empty FOLDER, required to confirm you know it\nhas contents. Ignored for files."
-        },
-        "force_orphan": {
-          "default": false,
-          "type": "boolean",
-          "description": "Allow trash even if inbound wikilinks exist."
-        },
-        "force_superseded": {
-          "default": false,
-          "type": "boolean",
-          "description": "Allow trash of a file in the supersession chain."
-        },
-        "allow_curated": {
-          "default": false,
-          "type": "boolean",
-          "description": "Required to trash under a curated tree."
-        },
-        "expected_dead_inbound": {
+        "types": {
           "anyOf": [
             {
               "items": {
@@ -1774,185 +2127,7 @@
             }
           ],
           "default": null,
-          "description": "Vault-relative paths whose inbound links\nto this file should be ignored. Use when you're trashing\nmultiple files in one workflow (e.g. cleaning a supersession\nchain) and don't want each step to false-positive on\nlinks that will die in the same batch."
-        }
-      },
-      "required": [
-        "path",
-        "confirm"
-      ],
-      "type": "object"
-    }
-  },
-  "append_to_file": {
-    "description": "Tier 2: append text to an existing file.\n\nRefuses Sources/ (immutable). Allowed on Evidence/ sidecars and\ngeneral vault files. Curated trees need `allow_curated=true`.\nEnsures a single newline boundary between existing tail and new\ncontent.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Vault-relative."
-        },
-        "content": {
-          "type": "string",
-          "description": "Text to append (text only; binaries go via /upload)."
-        },
-        "allow_curated": {
-          "default": false,
-          "type": "boolean",
-          "description": "Required under curated trees."
-        }
-      },
-      "required": [
-        "path",
-        "content"
-      ],
-      "type": "object"
-    }
-  },
-  "list_trash": {
-    "description": "Tier 2: enumerate recoverable trash entries. Read-only.\n\nWalks Knowledge Base/_trash/YYYY-MM-DD/ and parses each .meta.json\nsidecar. Returns entries most-recent-first with original path,\ntimestamp, kind (file or directory), and which force-flags fired\nat trash time. Also surfaces drift: orphan_sidecars (sidecars with\nno target file) and orphan_files (trashed files with no sidecar).\nPair with `recover_from_trash` to undo.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "date": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional YYYY-MM-DD filter to scope to one day."
-        }
-      },
-      "type": "object"
-    }
-  },
-  "recover_from_trash": {
-    "description": "Tier 2: undo a delete_file/delete_directory.\n\nReads the .meta.json sidecar to discover where the file lived\nbefore being trashed, moves it back there, and cleans up the\nsidecar. If `restore_path` is provided, uses that instead of the\nsidecar's original location (useful when the original parent\ndirectory has been removed).\n\nRefuses to overwrite existing files at the restore destination.\nRefuses restore into Sources/Evidence (append-only). Curated trees\nneed `allow_curated=true`.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "trash_path": {
-          "type": "string",
-          "description": "Vault-relative path to the trashed entry\n(under `Knowledge Base/_trash/...`)."
-        },
-        "restore_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional override; defaults to the original\nlocation from the sidecar."
-        },
-        "allow_curated": {
-          "default": false,
-          "type": "boolean",
-          "description": "Required if restoring into a curated tree."
-        }
-      },
-      "required": [
-        "trash_path"
-      ],
-      "type": "object"
-    }
-  },
-  "list_inbound_links": {
-    "description": "Tier 2: find files whose wikilinks resolve to `target`. Read-only.\n\nUseful before `move_file` (preview what update_wikilinks will touch)\nor `delete_file` (preview what would break). Matches three forms:\n- Full path: `[[Knowledge Base/Notes/Insights/foo]]`\n- KB-stripped: `[[Notes/Insights/foo]]`\n- Bare basename (only when unique vault-wide): `[[foo]]`",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "target": {
-          "type": "string",
-          "description": "Vault-relative path or bare basename. `.md` optional."
-        }
-      },
-      "required": [
-        "target"
-      ],
-      "type": "object"
-    }
-  },
-  "get_video_frames": {
-    "description": "View / analyze / look inside a vault video: sampled keyframes returned INLINE as images — no download round-trip.\n\nUse this to see what a video actually contains (slides, screen\nrecordings, whiteboards, meetings) directly in the tool result. Frames\nare sampled evenly across the video (or the requested window),\nnear-duplicates are collapsed, and each frame comes back as a JPEG\nimage content block, preceded by one metadata block with per-frame\ntimestamps. Typical loop: overview call first, then zoom into a moment\nwith `start_sec`/`end_sec` — e.g. around a `find` hit's\n`clip_match_at`/`scene_match_at` timestamp.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Vault-relative path to a video file\n(`.mp4 .mov .mkv .webm .avi .m4v .wmv .flv .mpeg .mpg`)."
-        },
-        "max_frames": {
-          "default": 8,
-          "type": "integer",
-          "description": "Maximum frames to return. Default 8, hard-capped\nserver-side (16); out-of-range values clamp silently and the\nmetadata reports `max_frames_effective`. Each frame costs\nimage tokens — prefer a time window over raising this."
-        },
-        "start_sec": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional window start in seconds — sample at/after this\ntimestamp only."
-        },
-        "end_sec": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional window end in seconds — sample before this\ntimestamp only (clamped to the video's duration)."
-        }
-      },
-      "required": [
-        "path"
-      ],
-      "type": "object"
-    }
-  },
-  "note": {
-    "description": "Create a compiled note in the Knowledge Base.\n\nUse this for distilled thinking — not raw capture. For raw capture\n(an article you read, a session transcript), use `add` instead.\n\nSix note types:\n- `research-note`: project-scoped findings. `project` REQUIRED.\n  → `Notes/Research/<Project>/<slug>.md`\n- `insight`: cross-cutting claim. Optional `projects` (plural).\n  → `Notes/Insights/<slug>.md`\n- `failure`: documented failure mode. Optional `projects`, optional\n  `severity` ∈ {minor, moderate, serious, critical}.\n  → `Notes/Failures/<slug>.md`\n- `pattern`: reusable cross-cutting pattern. Optional `projects`,\n  optional `pattern_type` ∈ {architectural, workflow, prompting,\n  governance, pedagogical}.\n  → `Notes/Patterns/<slug>.md`\n- `experiment`: hypothesis + protocol. `domain`, `started` (YYYY-MM-DD),\n  and `duration` (e.g. \"30 days\", \"ongoing\") REQUIRED. Optional\n  `hypothesis`, `n` (default 1), `concluded`.\n  → `Notes/Experiments/<domain>/YYYY-MM-<slug>.md`\n- `production-log`: creative artifact log. `medium` REQUIRED (e.g.\n  \"Posts\", \"Articles\"). Optional `recorded`, `published`, `host`,\n  `editor`, `projects`. Status enum is richer: {planned, recorded,\n  edited, published, reflected, dropped, archived}; defaults to\n  `planned`.\n  → `Notes/Productions/<medium>/YYYY-MM-<slug>.md`\n\nFor each `sources:` wikilink, appends this note's wikilink to that\nsource's `ingested_into:` frontmatter (maintaining the source→note graph).",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "content": {
-          "type": "string",
-          "description": "Full markdown body, written verbatim after the\nfrontmatter. Should start with `# <title>` (the H1 matching\nthe title arg) followed by the section conventions per type:\nresearch-note: `## Question`/`## Findings`/`## Connections`.\ninsight: `## Claim`/`## Why it holds`/`## Connections`.\nfailure: `## What happened`/`## Mechanism`/`## Detection`/`## Mitigation`/`## Connections`.\npattern: `## Problem`/`## Solution`/`## When to use`/`## When NOT to use`/`## Connections`.\nexperiment: `## Hypothesis`/`## Protocol`/`## Baseline`/`## Intervention`/`## Results`/`## Conclusion`/`## Connections`.\nproduction-log: `## Frame`/`## Artifact`/`## Production session`/`## Outcomes`/`## Reflection`/`## Connections`.\nConventions only — no shape is enforced."
-        },
-        "note_type": {
-          "type": "string",
-          "description": "One of research-note, insight, failure, pattern,\nexperiment, production-log."
-        },
-        "title": {
-          "type": "string",
-          "description": "Human title; used to derive a kebab-case filename slug.\nExperiments and production-logs auto-prefix with YYYY-MM."
-        },
-        "project": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "REQUIRED for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
+          "description": "Optional page-type filter; values are OR'd within the filter."
         },
         "projects": {
           "anyOf": [
@@ -1967,22 +2142,7 @@
             }
           ],
           "default": null,
-          "description": "List of project keys (plural). Optional for insight,\nfailure, pattern, production-log. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
-        },
-        "sources": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Vault-relative wikilinks to existing pages this note draws\nfrom, e.g. `[\"Knowledge Base/Sources/Articles/2026-05-18-foo\"]`\nor `[\"[[Knowledge Base/Sources/Articles/2026-05-18-foo]]\"]`.\nBrackets and the leading `Knowledge Base/` are tolerated."
+          "description": "Optional project filter; values are OR'd within the filter."
         },
         "tags": {
           "anyOf": [
@@ -1997,214 +2157,129 @@
             }
           ],
           "default": null,
-          "description": "Lowercase dash-separated; the server normalizes case/spacing."
+          "description": "Optional tag filter; values are OR'd within the filter."
         },
-        "status": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Defaults to `active` for most types, `planned` for\nproduction-log. Valid set varies by type."
+        "limit": {
+          "default": 10,
+          "type": "integer",
+          "description": "Maximum number of results. Capped to 50."
         },
-        "severity": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "failure only. {minor, moderate, serious, critical}."
-        },
-        "pattern_type": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "pattern only. {architectural, workflow, prompting,\ngovernance, pedagogical}."
-        },
-        "domain": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. Becomes the subfolder name (lowercased)."
-        },
-        "started": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. YYYY-MM-DD when the experiment began."
-        },
-        "duration": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. Freeform, e.g. \"30 days\", \"ongoing\"."
-        },
-        "hypothesis": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. One-line claim being tested."
-        },
-        "n": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. Sample size. Defaults to 1 (n-of-1)."
-        },
-        "concluded": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "experiment only. YYYY-MM-DD when it ended (absent while ongoing)."
-        },
-        "medium": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "production-log only. Subfolder, e.g. \"Posts\", \"Articles\"."
-        },
-        "recorded": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "production-log only. YYYY-MM-DD of recording session."
-        },
-        "published": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "production-log only. YYYY-MM-DD of publication."
-        },
-        "host": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "production-log only. Creator/talent name."
-        },
-        "editor": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "production-log only. Producer/editor name."
-        },
-        "suggestions": {
-          "default": true,
-          "type": "boolean",
-          "description": "When true (default), the result carries a `suggestions`\nblock — existing pages this note should probably link to, ranked\nby the retrieval stack. Set false for a faster write when you\nalready know the note's links; the near-duplicate/overlap\nwarnings stay ON either way (dedupe is a guardrail, not a\nsuggestion)."
-        },
-        "project_category": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
+        "scope": {
+          "default": "kb",
+          "type": "string",
+          "description": "\"kb\" for Knowledge Base first, or \"vault\" to search the broader vault."
         }
       },
-      "required": [
-        "content",
-        "note_type",
-        "title"
-      ],
       "type": "object"
     }
   },
-  "mint_upload_token": {
-    "description": "Mint a short-lived bearer token for the HTTP `/upload` endpoint.\n\nThis is how you file BINARY evidence (images, PDFs, any file) from a\nclaude.ai web session — the bytes travel out-of-band, never through the\nmodel. Steps:\n\n1. Call this tool → `{token, ttl_seconds, upload_url[, large_upload_url]}`.\n2. In the code sandbox, multipart-POST the user's ATTACHED files to\n   `upload_url` with header `Authorization: Bearer <token>` and form\n   fields `file`, `scope`, `category` (optional `filename`, `description`,\n   `text`). Files must be ATTACHMENTS — inline-pasted images never reach\n   the sandbox disk and cannot be sent.\n3. To make the binary SEARCHABLE, extract its text in the sandbox (OCR an\n   image/scan, read a PDF, transcribe audio/video) and pass it as the\n   `text` field above — it lands in an embedded sidecar so the otherwise-\n   opaque file is findable by its content.\n\n**Large files (>100 MB):** `upload_url` is fronted by Cloudflare, which\n413s any body over ~100 MB at the edge. If a file exceeds ~100 MB (or a\nPOST to `upload_url` returns 413), send it to `large_upload_url` instead\nwhen that field is present — same token, same form fields, an alternate\nhost with no edge cap. If `large_upload_url` is absent, only `upload_url`\nis available and >100 MB must go desk-side.\n\nThe token is Evidence-write only and expires after `ttl_seconds`; the\nserver's long-lived secret never leaves the server.\n\nReturns: {token, ttl_seconds, upload_url, large_upload_url?}.\nRaises: UPLOAD_DISABLED if the server has no upload token configured.",
+  "suggest_links": {
+    "description": "Suggest existing KB pages a note should link to. Read-only.\n\nCloses the corpus-blind-write gap: surfaces the related prior work a\ndraft (or an existing page) should connect to, so the graph gets denser\nwith every write instead of just bigger. For link suggestions only — it\nreuses the same hybrid ranker as `find`, prefers well-connected hubs, and excludes\nthe page itself plus anything it already links. Suggestions are\nnon-binding: YOU decide which to wire in (e.g. via a follow-up `edit`).\n\nTwo call shapes:\n- `path`: suggest links for an EXISTING page (densify it retroactively).\n  Same path conventions as `get`/`find`.\n- `draft_title` + `draft_body`: suggest links for a note you're about to\n  create, BEFORE calling `note` — so you can cite/connect on first write.",
     "inputSchema": {
       "additionalProperties": false,
-      "properties": {},
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Existing page to suggest links for. Mutually exclusive with\nthe draft_* args."
+        },
+        "draft_title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Title of a not-yet-written note."
+        },
+        "draft_body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Body (markdown) of a not-yet-written note. Wikilinks\nalready present in it are treated as \"already linked\" and excluded."
+        },
+        "limit": {
+          "default": 8,
+          "type": "integer",
+          "description": "Max suggestions (default 8)."
+        },
+        "scope": {
+          "default": "kb",
+          "type": "string",
+          "description": "\"kb\" (default) or \"vault\" — same meaning as `find`."
+        }
+      },
       "type": "object"
     }
   },
-  "mint_download_token": {
-    "description": "Mint a short-lived bearer token for the HTTP `/download` endpoint.\n\nUse to PULL a vault file into the sandbox — a dataset, an evidence\nbinary, a scan — so you can analyze it. Call this, then from the code\nsandbox GET `download_url?path=<vault-relative path>` with header\n`Authorization: Bearer <token>`. Read-only; the token is download-scoped\n(can't write) and expires after `ttl_seconds`.\n\nReturns: {token, ttl_seconds, download_url}.\nRaises: DOWNLOAD_DISABLED if the server has no upload token configured.",
+  "suggest_relations": {
+    "description": "Suggest candidate typed graph relations. Read-only and proposal-only.\n\nUses deterministic signals from wikilinks, frontmatter sources, shared\nsources/entities, supersession, and optional embedding proximity when\navailable. Model-backed suggestions are default-off and soft-fail as\nwarnings; accepted relations still require an explicit `note` or `edit`\nwrite. This operation never mutates Markdown or the graph sidecar.",
     "inputSchema": {
       "additionalProperties": false,
-      "properties": {},
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Existing page to inspect. Mutually exclusive with draft-only use."
+        },
+        "draft_title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional title for a not-yet-written draft."
+        },
+        "draft_body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Draft body; wikilinks in it become proposal candidates."
+        },
+        "include_model_suggestions": {
+          "default": false,
+          "type": "boolean",
+          "description": "Request optional model-backed suggestion\npaths. Default false; unavailable paths soft-fail with warnings."
+        },
+        "limit": {
+          "default": 10,
+          "type": "integer",
+          "description": "Max candidates to return. Default 10."
+        }
+      },
       "type": "object"
     }
   }

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -5,16 +5,16 @@
       "additionalProperties": false,
       "properties": {
         "content": {
-          "type": "string",
-          "description": "Full text body to capture (markdown / plain text). For\nfiles or binaries, use the /upload endpoint instead."
+          "description": "Full text body to capture (markdown / plain text). For files or binaries, use the /upload endpoint instead.",
+          "type": "string"
         },
         "source_type": {
-          "type": "string",
-          "description": "One of article, session, book, paper, video, other."
+          "description": "One of article, session, book, paper, video, other.",
+          "type": "string"
         },
         "title": {
-          "type": "string",
-          "description": "Human title; used to derive the filename slug."
+          "description": "Human title; used to derive the filename slug.",
+          "type": "string"
         },
         "url": {
           "anyOf": [
@@ -53,7 +53,7 @@
             }
           ],
           "default": null,
-          "description": "One short paragraph on why this is worth keeping.\nRendered as a leading blockquote in the source body, between\nthe `# Source: ...` header and the `## Capture` section."
+          "description": "One short paragraph on why this is worth keeping. Rendered as a leading blockquote in the source body, between the `# Source: ...` header and the `## Capture` section."
         }
       },
       "required": [
@@ -71,33 +71,33 @@
       "properties": {
         "path": {
           "default": "",
-          "type": "string",
-          "description": "Optional vault subtree to scan. Defaults to the vault root."
+          "description": "Optional vault subtree to scan. Defaults to the vault root.",
+          "type": "string"
         },
         "mode": {
           "default": "scan-only",
-          "type": "string",
-          "description": "Adoption mode: scan-only, save-manifest, copy-as-sources, or compile-selected."
+          "description": "Adoption mode: scan-only, save-manifest, copy-as-sources, or compile-selected.",
+          "type": "string"
         },
         "max_depth": {
           "default": 3,
-          "type": "integer",
-          "description": "Folder-tree depth cap for the scan."
+          "description": "Folder-tree depth cap for the scan.",
+          "type": "integer"
         },
         "include_hidden": {
           "default": false,
-          "type": "boolean",
-          "description": "Include hidden files/directories in the scan."
+          "description": "Include hidden files/directories in the scan.",
+          "type": "boolean"
         },
         "samples": {
           "default": 5,
-          "type": "integer",
-          "description": "Sample filename count per folder."
+          "description": "Sample filename count per folder.",
+          "type": "integer"
         },
         "pack_limit": {
           "default": 6,
-          "type": "integer",
-          "description": "Maximum knowledge-pack suggestions to return."
+          "description": "Maximum knowledge-pack suggestions to return.",
+          "type": "integer"
         },
         "manifest_path": {
           "anyOf": [
@@ -109,7 +109,7 @@
             }
           ],
           "default": null,
-          "description": "Optional markdown destination under Knowledge Base/ for\nsave-manifest. A default under _Adoption/ is used when omitted."
+          "description": "Optional markdown destination under Knowledge Base/ for save-manifest. A default under _Adoption/ is used when omitted."
         },
         "selected_paths": {
           "anyOf": [
@@ -136,17 +136,17 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative."
+          "description": "Vault-relative.",
+          "type": "string"
         },
         "content": {
-          "type": "string",
-          "description": "Text to append (text only; binaries go via /upload)."
+          "description": "Text to append (text only; binaries go via /upload).",
+          "type": "string"
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Required under curated trees."
+          "description": "Required under curated trees.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -174,12 +174,12 @@
             }
           ],
           "default": null,
-          "description": "Optional subset of {corpus_contradictions, stale_review,\nunprocessed_source}. Omit to include all three."
+          "description": "Optional subset of {corpus_contradictions, stale_review, unprocessed_source}. Omit to include all three."
         },
         "limit": {
           "default": 25,
-          "type": "integer",
-          "description": "Max items to surface (default 25; 0 or negative = uncapped,\nsurface all). Lower-priority items beyond the cap are summarized in\na \"N more not shown\" note, never dropped silently."
+          "description": "Max items to surface (default 25; 0 or negative = uncapped, surface all). Lower-priority items beyond the cap are summarized in a \"N more not shown\" note, never dropped silently.",
+          "type": "integer"
         }
       },
       "type": "object"
@@ -203,7 +203,7 @@
             }
           ],
           "default": null,
-          "description": "Optional filter; only run these checks. Each must be\none of the categories above. Omit to run all."
+          "description": "Optional filter; only run these checks. Each must be one of the categories above. Omit to run all."
         }
       },
       "type": "object"
@@ -216,13 +216,13 @@
       "properties": {
         "dry_run": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, compute what would change without writing.\nDefault false."
+          "description": "If true, compute what would change without writing. Default false.",
+          "type": "boolean"
         },
         "rebuild_embeddings": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, wipe and rebuild the vector sidecar\nat `<vault>/Knowledge Base/.embeddings.sqlite` after the fix\nsweep. Use on first run, after a machine swap, or when the\nsidecar has drifted from disk. Ignored when `dry_run=true`."
+          "description": "If true, wipe and rebuild the vector sidecar at `<vault>/Knowledge Base/.embeddings.sqlite` after the fix sweep. Use on first run, after a machine swap, or when the sidecar has drifted from disk. Ignored when `dry_run=true`.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -235,8 +235,8 @@
       "properties": {
         "profile": {
           "default": "compact",
-          "type": "string",
-          "description": "\"compact\" (default), \"full\", or \"diagnostics\". Compact is\nenough for normal clients. Full adds examples. Diagnostics adds\nperformance interpretation guidance."
+          "description": "\"compact\" (default), \"full\", or \"diagnostics\". Compact is enough for normal clients. Full adds examples. Diagnostics adds performance interpretation guidance.",
+          "type": "string"
         },
         "workflow": {
           "anyOf": [
@@ -248,7 +248,7 @@
             }
           ],
           "default": null,
-          "description": "Optional caller-selected workflow label. Returned as context\nonly; it does not change server behavior."
+          "description": "Optional caller-selected workflow label. Returned as context only; it does not change server behavior."
         }
       },
       "type": "object"
@@ -260,13 +260,13 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative, e.g. `Knowledge Base/Identity/Career.md`.\nForward or back slashes accepted. Path-escape guarded."
+          "description": "Vault-relative, e.g. `Knowledge Base/Identity/Career.md`. Forward or back slashes accepted. Path-escape guarded.",
+          "type": "string"
         },
         "content": {
           "default": "",
-          "type": "string",
-          "description": "File body (or full file if `frontmatter` is None). Text\nonly; for binaries use the /upload endpoint."
+          "description": "File body (or full file if `frontmatter` is None). Text only; for binaries use the /upload endpoint.",
+          "type": "string"
         },
         "frontmatter": {
           "anyOf": [
@@ -283,23 +283,23 @@
         },
         "overwrite": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, replace existing file. Default false."
+          "description": "If true, replace existing file. Default false.",
+          "type": "boolean"
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Required to write under a curated tree. Default false."
+          "description": "Required to write under a curated tree. Default false.",
+          "type": "boolean"
         },
         "kind": {
           "default": "file",
-          "type": "string",
-          "description": "\"file\" (default) or \"dir\". With \"dir\", creates a folder\ninstead of a file (former `create_directory`)."
+          "description": "\"file\" (default) or \"dir\". With \"dir\", creates a folder instead of a file (former `create_directory`).",
+          "type": "string"
         },
         "parents": {
           "default": true,
-          "type": "boolean",
-          "description": "In \"dir\" mode, create intermediate folders (mkdir -p).\nDefault true."
+          "description": "In \"dir\" mode, create intermediate folders (mkdir -p). Default true.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -314,32 +314,32 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative."
+          "description": "Vault-relative.",
+          "type": "string"
         },
         "confirm": {
-          "type": "boolean",
-          "description": "Must be `true` explicitly. Marks the action deliberate."
+          "description": "Must be `true` explicitly. Marks the action deliberate.",
+          "type": "boolean"
         },
         "recursive": {
           "default": false,
-          "type": "boolean",
-          "description": "For a non-empty FOLDER, required to confirm you know it\nhas contents. Ignored for files."
+          "description": "For a non-empty FOLDER, required to confirm you know it has contents. Ignored for files.",
+          "type": "boolean"
         },
         "force_orphan": {
           "default": false,
-          "type": "boolean",
-          "description": "Allow trash even if inbound wikilinks exist."
+          "description": "Allow trash even if inbound wikilinks exist.",
+          "type": "boolean"
         },
         "force_superseded": {
           "default": false,
-          "type": "boolean",
-          "description": "Allow trash of a file in the supersession chain."
+          "description": "Allow trash of a file in the supersession chain.",
+          "type": "boolean"
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Required to trash under a curated tree."
+          "description": "Required to trash under a curated tree.",
+          "type": "boolean"
         },
         "expected_dead_inbound": {
           "anyOf": [
@@ -354,7 +354,7 @@
             }
           ],
           "default": null,
-          "description": "Vault-relative paths whose inbound links\nto this file should be ignored. Use when you're trashing\nmultiple files in one workflow (e.g. cleaning a supersession\nchain) and don't want each step to false-positive on\nlinks that will die in the same batch."
+          "description": "Vault-relative paths whose inbound links to this file should be ignored. Use when you're trashing multiple files in one workflow (e.g. cleaning a supersession chain) and don't want each step to false-positive on links that will die in the same batch."
         }
       },
       "required": [
@@ -370,12 +370,12 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative path to the compiled page (same shape as\n`get` accepts)."
+          "description": "Vault-relative path to the compiled page (same shape as `get` accepts).",
+          "type": "string"
         },
         "why": {
-          "type": "string",
-          "description": "One-line rationale for the edit. Required — lands in the\nlog entry so the change is auditable."
+          "description": "One-line rationale for the edit. Required — lands in the log entry so the change is auditable.",
+          "type": "string"
         },
         "new_body": {
           "anyOf": [
@@ -387,7 +387,7 @@
             }
           ],
           "default": null,
-          "description": "New markdown body (everything after frontmatter).\nOmit to keep the existing body."
+          "description": "New markdown body (everything after frontmatter). Omit to keep the existing body."
         },
         "tags": {
           "anyOf": [
@@ -402,7 +402,7 @@
             }
           ],
           "default": null,
-          "description": "New tags list (replaces existing). Lowercase dash-\nseparated; the server normalizes. Omit to keep existing tags."
+          "description": "New tags list (replaces existing). Lowercase dash- separated; the server normalizes. Omit to keep existing tags."
         },
         "old_string": {
           "anyOf": [
@@ -426,12 +426,12 @@
             }
           ],
           "default": null,
-          "description": "Replacement snippet (required with old_string; must\ndiffer from it)."
+          "description": "Replacement snippet (required with old_string; must differ from it)."
         },
         "replace_all": {
           "default": false,
-          "type": "boolean",
-          "description": "Replace every occurrence instead of requiring a\nunique match. Default False."
+          "description": "Replace every occurrence instead of requiring a unique match. Default False.",
+          "type": "boolean"
         },
         "heading": {
           "anyOf": [
@@ -443,12 +443,12 @@
             }
           ],
           "default": null,
-          "description": "Section-targeted mode — the `## Heading` (the `#` markers\nare optional) under which to place `new_string`. The section\nspans from that heading to the next heading of equal-or-higher\nlevel (or EOF). Mutually exclusive with new_body/old_string.\nRaises HEADING_NOT_FOUND if absent."
+          "description": "Section-targeted mode — the `## Heading` (the `#` markers are optional) under which to place `new_string`. The section spans from that heading to the next heading of equal-or-higher level (or EOF). Mutually exclusive with new_body/old_string. Raises HEADING_NOT_FOUND if absent."
         },
         "section_position": {
           "default": "append",
-          "type": "string",
-          "description": "With `heading`, where to put `new_string`:\n\"append\" (default), \"prepend\", or \"replace\" the section body."
+          "description": "With `heading`, where to put `new_string`: \"append\" (default), \"prepend\", or \"replace\" the section body.",
+          "type": "string"
         },
         "edits": {
           "anyOf": [
@@ -464,7 +464,7 @@
             }
           ],
           "default": null,
-          "description": "Batch-surgical mode — list of {old_string, new_string,\nreplace_all?} applied sequentially in one atomic commit."
+          "description": "Batch-surgical mode — list of {old_string, new_string, replace_all?} applied sequentially in one atomic commit."
         },
         "row_key": {
           "anyOf": [
@@ -476,7 +476,7 @@
             }
           ],
           "default": null,
-          "description": "Take-row mode — natural leading text of the row to fill\n(e.g. \"Whiplash (2014)\"). Requires `take`."
+          "description": "Take-row mode — natural leading text of the row to fill (e.g. \"Whiplash (2014)\"). Requires `take`."
         },
         "take": {
           "anyOf": [
@@ -492,8 +492,8 @@
         },
         "overwrite": {
           "default": false,
-          "type": "boolean",
-          "description": "In take-row mode, also replace an already-filled take."
+          "description": "In take-row mode, also replace an already-filled take.",
+          "type": "boolean"
         },
         "field": {
           "anyOf": [
@@ -505,7 +505,7 @@
             }
           ],
           "default": null,
-          "description": "Frontmatter-patch mode — the single frontmatter key to set\n(cannot be `updated`, which is auto-bumped)."
+          "description": "Frontmatter-patch mode — the single frontmatter key to set (cannot be `updated`, which is auto-bumped)."
         },
         "value": {
           "anyOf": [
@@ -538,8 +538,8 @@
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Allow a frontmatter patch under a curated tree."
+          "description": "Allow a frontmatter patch under a curated tree.",
+          "type": "boolean"
         },
         "expected_hash": {
           "anyOf": [
@@ -551,12 +551,12 @@
             }
           ],
           "default": null,
-          "description": "Optional drift guard. Pass the `content_hash` you\ngot from `get`; the edit refuses (STALE_EDIT) if the file\nchanged on disk since, so you never clobber another writer."
+          "description": "Optional drift guard. Pass the `content_hash` you got from `get`; the edit refuses (STALE_EDIT) if the file changed on disk since, so you never clobber another writer."
         },
         "validate_only": {
           "default": false,
-          "type": "boolean",
-          "description": "Preview a surgical match without writing. Needs\n`old_string`. Reports how many rows would be hit instead of\ncommitting — use it before a `replace_all` to avoid an\nambiguous match silently touching more rows than intended."
+          "description": "Preview a surgical match without writing. Needs `old_string`. Reports how many rows would be hit instead of committing — use it before a `replace_all` to avoid an ambiguous match silently touching more rows than intended.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -573,14 +573,17 @@
       "properties": {
         "query": {
           "default": "",
+          "description": "The topic to trace (free text, like `find`).",
           "type": "string"
         },
         "limit": {
           "default": 10,
+          "description": "Max chains (timelines) to return, by find relevance (default 10; 0 or negative = uncapped). Chains beyond the cap are reported in `truncation`, never dropped silently.",
           "type": "integer"
         },
         "scope": {
           "default": "kb",
+          "description": "Search scope passed to `find` — \"kb\" (default) / \"vault\" / \"kb-only\".",
           "type": "string"
         },
         "projects": {
@@ -595,7 +598,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Optional project-key filter passed to `find`."
         },
         "tags": {
           "anyOf": [
@@ -609,7 +613,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Optional tag filter passed to `find`."
         }
       },
       "type": "object"
@@ -621,13 +626,13 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string",
-          "description": "A result `id` returned by `search` (the canonical vault-relative path)."
+          "description": "A result `id` returned by `search` (the canonical vault-relative path).",
+          "type": "string"
         },
         "max_chars": {
           "default": 3000,
-          "type": "integer",
-          "description": "Maximum body characters to return. Values below 500 are raised\nto 500; values above 6000 are capped server-side."
+          "description": "Maximum body characters to return. Values below 500 are raised to 500; values above 6000 are capped server-side.",
+          "type": "integer"
         }
       },
       "required": [
@@ -643,8 +648,8 @@
       "properties": {
         "query": {
           "default": "",
-          "type": "string",
-          "description": "Free-text search string. In \"hybrid\"/\"vector\" mode it's\nembedded with bge-base for semantic recall. In \"keyword\" mode\nit's tokenized on whitespace and every token must appear in\ntitle or body (any order) — `contract employment` matches a\npage about \"employment contract\". Empty string always falls\nback to \"most-recent filtered\" behaviour regardless of mode."
+          "description": "Free-text search string. In \"hybrid\"/\"vector\" mode it's embedded with bge-base for semantic recall. In \"keyword\" mode it's tokenized on whitespace and every token must appear in title or body (any order) — `contract employment` matches a page about \"employment contract\". Empty string always falls back to \"most-recent filtered\" behaviour regardless of mode.",
+          "type": "string"
         },
         "types": {
           "anyOf": [
@@ -704,7 +709,7 @@
             }
           ],
           "default": null,
-          "description": "Filter to diarized media whose `speakers:` frontmatter includes any of\nthese named speakers (case-insensitive) — e.g. \"what did Alice say about X\".\nAND'd with the query/other filters; OR'd within the list."
+          "description": "Filter to diarized media whose `speakers:` frontmatter includes any of these named speakers (case-insensitive) — e.g. \"what did Alice say about X\". AND'd with the query/other filters; OR'd within the list."
         },
         "file_types": {
           "anyOf": [
@@ -719,7 +724,7 @@
             }
           ],
           "default": null,
-          "description": "Scope results to these artifact kinds — note, pdf, image,\naudio, video, csv, json, tsv. A binary surfaces under its media\nkind (pdf/image/...); a data file under its dataset card's format\n(csv/json). Omit to return ALL kinds (the default — search never\nhides a type unless you ask)."
+          "description": "Scope results to these artifact kinds — note, pdf, image, audio, video, csv, json, tsv. A binary surfaces under its media kind (pdf/image/...); a data file under its dataset card's format (csv/json). Omit to return ALL kinds (the default — search never hides a type unless you ask)."
         },
         "exclude_file_types": {
           "anyOf": [
@@ -738,23 +743,23 @@
         },
         "limit": {
           "default": 15,
-          "type": "integer",
-          "description": "Max hits to return. Default 15, hard cap 100."
+          "description": "Max hits to return. Default 15, hard cap 100.",
+          "type": "integer"
         },
         "scope": {
           "default": "kb",
-          "type": "string",
-          "description": "\"kb\" (default) searches Knowledge Base/ first and\nAUTO-WIDENS to the whole vault when the KB doesn't fill\n`limit` — so content in sibling folders (Tracking/,\nReference/, Finance/, ... and curated, read-only trees kept\noutside Knowledge Base/) is never silently invisible. Widened\nhits carry `outside_kb: true`. \"vault\" always walks the\nwhole vault. \"kb-only\" is the strict opt-out: KB only,\nnever widens. Outside-KB recall is BM25/keyword (the\nvector sidecar is KB-scoped), with a relaxed gate so terse\nfiles (e.g. a numbers-heavy tracker) surface on a partial\ntoken match. `_Schema/`, `_trash/`, `_attachments/`, and\n`.obsidian/` are excluded under every scope. NOTE: an\nempty result means \"not found in what I searched,\" NOT\n\"doesn't exist\" — say so, and try \"vault\" before\nconcluding absence."
+          "description": "\"kb\" (default) searches Knowledge Base/ first and AUTO-WIDENS to the whole vault when the KB doesn't fill `limit` — so content in sibling folders (Tracking/, Reference/, Finance/, ... and curated, read-only trees kept outside Knowledge Base/) is never silently invisible. Widened hits carry `outside_kb: true`. \"vault\" always walks the whole vault. \"kb-only\" is the strict opt-out: KB only, never widens. Outside-KB recall is BM25/keyword (the vector sidecar is KB-scoped), with a relaxed gate so terse files (e.g. a numbers-heavy tracker) surface on a partial token match. `_Schema/`, `_trash/`, `_attachments/`, and `.obsidian/` are excluded under every scope. NOTE: an empty result means \"not found in what I searched,\" NOT \"doesn't exist\" — say so, and try \"vault\" before concluding absence.",
+          "type": "string"
         },
         "mode": {
           "default": "hybrid",
-          "type": "string",
-          "description": "Ranker. \"hybrid\" (default) fuses BM25 + local vector\nembeddings via reciprocal rank fusion — best recall on\nnatural-language queries. \"keyword\" preserves the original\ncase-insensitive substring matching, sorted by `updated:`.\n\"vector\" is vector-only (testing aid). BM25 corpus is\nSnowball-stemmed so \"regulation\" reaches pages with\n\"regulator\"; keyword mode stays strict-substring. If the\nembedding sidecar hasn't been built yet, hybrid degrades\nto BM25-only; run `audit_fix(rebuild_embeddings=true)` to\npopulate it."
+          "description": "Ranker. \"hybrid\" (default) fuses BM25 + local vector embeddings via reciprocal rank fusion — best recall on natural-language queries. \"keyword\" preserves the original case-insensitive substring matching, sorted by `updated:`. \"vector\" is vector-only (testing aid). BM25 corpus is Snowball-stemmed so \"regulation\" reaches pages with \"regulator\"; keyword mode stays strict-substring. If the embedding sidecar hasn't been built yet, hybrid degrades to BM25-only; run `audit_fix(rebuild_embeddings=true)` to populate it.",
+          "type": "string"
         },
         "graph": {
           "default": true,
-          "type": "boolean",
-          "description": "When true (default) and mode is hybrid/vector, outbound\nwikilinks of top BM25/vector candidates contribute a third\nranking — surfaces 1-hop neighbours of strong matches."
+          "description": "When true (default) and mode is hybrid/vector, outbound wikilinks of top BM25/vector candidates contribute a third ranking — surfaces 1-hop neighbours of strong matches.",
+          "type": "boolean"
         },
         "rerank": {
           "anyOf": [
@@ -766,42 +771,42 @@
             }
           ],
           "default": null,
-          "description": "Cross-encoder re-sort of the top fused candidates\n(bge-reranker-base) for higher-precision ordering. Default\n(unset) is mode-aware AUTO: in CPU steady-state modes it stays\noff for predictable latency; when the text/reranker device is\naccelerated, the server reranks only when ranking lanes\ndisagree or the query is long. Pass true to force reranking\nfor a high-value query, including on CPU; pass false to skip\nit entirely."
+          "description": "Cross-encoder re-sort of the top fused candidates (bge-reranker-base) for higher-precision ordering. Default (unset) is mode-aware AUTO: in CPU steady-state modes it stays off for predictable latency; when the text/reranker device is accelerated, the server reranks only when ranking lanes disagree or the query is long. Pass true to force reranking for a high-value query, including on CPU; pass false to skip it entirely."
         },
         "prefer_compiled": {
           "default": true,
-          "type": "boolean",
-          "description": "When true (default), applies a small boost to\ncompiled types (insight, pattern, failure, research-note,\nentity) and a small penalty to raw `source` after fusion\nAND rerank. Reflects the KB's epistemic hierarchy. Set\nfalse to retrieve raw source discussion verbatim (e.g.\n\"what did I capture from Dr. X\")."
+          "description": "When true (default), applies a small boost to compiled types (insight, pattern, failure, research-note, entity) and a small penalty to raw `source` after fusion AND rerank. Reflects the KB's epistemic hierarchy. Set false to retrieve raw source discussion verbatim (e.g. \"what did I capture from Dr. X\").",
+          "type": "boolean"
         },
         "prefer_active": {
           "default": true,
-          "type": "boolean",
-          "description": "When true (default), soft-demotes `status:\nsuperseded` pages so a replaced conclusion can't outrank the\npage that superseded it. The tombstone stays findable and its\nhit still carries `status` + `superseded_by` (the forward\npointer) so you can see it's superseded. Set false to rank a\nsuperseded page on its content alone (e.g. \"what did I used to\nthink about X\")."
+          "description": "When true (default), soft-demotes `status: superseded` pages so a replaced conclusion can't outrank the page that superseded it. The tombstone stays findable and its hit still carries `status` + `superseded_by` (the forward pointer) so you can see it's superseded. Set false to rank a superseded page on its content alone (e.g. \"what did I used to think about X\").",
+          "type": "boolean"
         },
         "prefer_used": {
           "default": false,
-          "type": "boolean",
-          "description": "When true (OFF by default — default ranking is\nusage-blind), applies a bounded, positive-only usage boost:\npages you actually read (`get`) and cite in written notes rank\nslightly higher, from ACT-R activation over the server's own\naccess logs. Capped below the compiled boost so usage breaks\nties but never overrides the epistemic hierarchy; never a\npenalty; never ADDS results — it only reorders pages the\ncontent lanes already matched. Boosted hits expose\n`signals.activation` + `signals.usage_boost` so you can see\nexactly why. Reading and citing pages IS the feedback loop —\nno separate feedback call exists or is needed. Use for \"what\nhave I been working with lately\" recall; leave off for\nneutral knowledge lookup."
+          "description": "When true (OFF by default — default ranking is usage-blind), applies a bounded, positive-only usage boost: pages you actually read (`get`) and cite in written notes rank slightly higher, from ACT-R activation over the server's own access logs. Capped below the compiled boost so usage breaks ties but never overrides the epistemic hierarchy; never a penalty; never ADDS results — it only reorders pages the content lanes already matched. Boosted hits expose `signals.activation` + `signals.usage_boost` so you can see exactly why. Reading and citing pages IS the feedback loop — no separate feedback call exists or is needed. Use for \"what have I been working with lately\" recall; leave off for neutral knowledge lookup.",
+          "type": "boolean"
         },
         "pack": {
           "default": false,
-          "type": "boolean",
-          "description": "When true (off by default), ALSO assemble a reasoning-ready\ncontext pack from the top hits and change the return to\n{\"hits\": [...], \"pack\": {...}} (with pack off, the return is the\nusual hit list, unchanged). The pack is PURE MEASUREMENT over the\nnotes you already wrote — no server-side reasoning: each top note's\nstructurally-extracted key claims (lede + headline-section lines +\nheading outline), the 1-hop wikilink neighbourhood of those notes\nranked by co-citation, and the contradictions among them (recorded\nsupersession edges + proximity \"tension\" pairs in the embedding\nband, surfaced for you to judge — proximity, not polarity). Lets you\nreason over the matches in one shot instead of fanning out `get`\ncalls. Bounded with explicit `truncation`; the tension part needs\nthe embedding sidecar and reports `embeddings_available`."
+          "description": "When true (off by default), ALSO assemble a reasoning-ready context pack from the top hits and change the return to {\"hits\": [...], \"pack\": {...}} (with pack off, the return is the usual hit list, unchanged). The pack is PURE MEASUREMENT over the notes you already wrote — no server-side reasoning: each top note's structurally-extracted key claims (lede + headline-section lines + heading outline), the 1-hop wikilink neighbourhood of those notes ranked by co-citation, and the contradictions among them (recorded supersession edges + proximity \"tension\" pairs in the embedding band, surfaced for you to judge — proximity, not polarity). Lets you reason over the matches in one shot instead of fanning out `get` calls. Bounded with explicit `truncation`; the tension part needs the embedding sidecar and reports `embeddings_available`.",
+          "type": "boolean"
         },
         "graph_enrich": {
           "default": false,
-          "type": "boolean",
-          "description": "When true with `pack=true`, add typed graph neighborhood\ndata from the derived epistemic graph sidecar to the pack. Default\nfalse; missing/disabled/stale graph state soft-fails inside\n`pack.graph.available` without changing hits, hit ordering, or the\ndefault pack contract."
+          "description": "When true with `pack=true`, add typed graph neighborhood data from the derived epistemic graph sidecar to the pack. Default false; missing/disabled/stale graph state soft-fails inside `pack.graph.available` without changing hits, hit ordering, or the default pack contract.",
+          "type": "boolean"
         },
         "detail": {
           "default": "full",
-          "type": "string",
-          "description": "Result verbosity. \"full\" (default) keeps the current hit\nshape including `excerpt` and `signals`. \"compact\" returns the\nSAME ranked hits as token-cheap routing stubs — path, title,\ntype, scope, updated, plus lifecycle/media/outside_kb markers\nwhen present — omitting `excerpt` and `signals`. Use compact\nfor cheap proactive recall, then `get` a chosen page (or rerun\nwith detail=\"full\") when you need the why."
+          "description": "Result verbosity. \"full\" (default) keeps the current hit shape including `excerpt` and `signals`. \"compact\" returns the SAME ranked hits as token-cheap routing stubs — path, title, type, scope, updated, plus lifecycle/media/outside_kb markers when present — omitting `excerpt` and `signals`. Use compact for cheap proactive recall, then `get` a chosen page (or rerun with detail=\"full\") when you need the why.",
+          "type": "string"
         },
         "include_timings": {
           "default": false,
-          "type": "boolean",
-          "description": "When true (off by default), the return becomes an\nenvelope {\"hits\": [...], \"timings\": {...}} (with pack=true the\nenvelope also carries \"pack\"). `timings` reports total_ms,\nhot-cache status, and per-stage milliseconds for the retrieval\nlanes (skipped/failed optional lanes are marked, never fatal).\nDiagnostics only — timings never include note content. Omitted\n→ the response shape is unchanged."
+          "description": "When true (off by default), the return becomes an envelope {\"hits\": [...], \"timings\": {...}} (with pack=true the envelope also carries \"pack\"). `timings` reports total_ms, hot-cache status, and per-stage milliseconds for the retrieval lanes (skipped/failed optional lanes are marked, never fatal). Diagnostics only — timings never include note content. Omitted → the response shape is unchanged.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -813,28 +818,28 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative path. Accepted shapes:\n- `Knowledge Base/Notes/Insights/foo.md`\n- `Reference/Strategy.md`\n- `Notes/Insights/foo` (auto-prepends `Knowledge Base/` if\n  literal path doesn't resolve; auto-adds `.md`)."
+          "description": "Vault-relative path. Accepted shapes: - `Knowledge Base/Notes/Insights/foo.md` - `Reference/Strategy.md` - `Notes/Insights/foo` (auto-prepends `Knowledge Base/` if literal path doesn't resolve; auto-adds `.md`).",
+          "type": "string"
         },
         "frontmatter_only": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, return ONLY the frontmatter (no body) —\ncheap for scanning many files by field (folds in the former\n`get_frontmatter` tool). Returns {path, frontmatter,\nhas_frontmatter} instead of the full page below."
+          "description": "If true, return ONLY the frontmatter (no body) — cheap for scanning many files by field (folds in the former `get_frontmatter` tool). Returns {path, frontmatter, has_frontmatter} instead of the full page below.",
+          "type": "boolean"
         },
         "include_history": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, attach a `history` list — the page's\nchange log from the append-only `log.md`, newest-first\n(`[{date, op, summary}]`, where `summary` is the `why:`\nrationale recorded at write time). Use this to answer \"why was\nthis note changed / what was the old version / show its history\"\nand to verify an edit's rationale. `[]` when the page has no\nrecorded edits."
+          "description": "If true, attach a `history` list — the page's change log from the append-only `log.md`, newest-first (`[{date, op, summary}]`, where `summary` is the `why:` rationale recorded at write time). Use this to answer \"why was this note changed / what was the old version / show its history\" and to verify an edit's rationale. `[]` when the page has no recorded edits.",
+          "type": "boolean"
         },
         "links": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, attach a `links` summary —\n`{inbound: [...], outbound: [...]}`. `inbound` lists files whose\nwikilinks resolve to this page (each\n`{path, line_number, context, raw_target}`); `outbound` lists\nthe distinct wikilink targets in this page's body. Use it to\nsee a note's graph neighbourhood in one call. Default off (no\nbehaviour change)."
+          "description": "If true, attach a `links` summary — `{inbound: [...], outbound: [...]}`. `inbound` lists files whose wikilinks resolve to this page (each `{path, line_number, context, raw_target}`); `outbound` lists the distinct wikilink targets in this page's body. Use it to see a note's graph neighbourhood in one call. Default off (no behaviour change).",
+          "type": "boolean"
         },
         "include_raw": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, ALSO return `content` — the raw file text\nincluding the frontmatter delimiters. Off by default because it\nduplicates `frontmatter` + `body` (double the tokens on every\nread) and nothing in the normal workflow needs it: edits\nround-trip `body`, and the drift guard uses `content_hash`,\nwhich the server always computes over the raw bytes for you."
+          "description": "If true, ALSO return `content` — the raw file text including the frontmatter delimiters. Off by default because it duplicates `frontmatter` + `body` (double the tokens on every read) and nothing in the normal workflow needs it: edits round-trip `body`, and the drift guard uses `content_hash`, which the server always computes over the raw bytes for you.",
+          "type": "boolean"
         },
         "max_body_chars": {
           "anyOf": [
@@ -846,7 +851,7 @@
             }
           ],
           "default": null,
-          "description": "Optional cap for the returned `body`. Use this when a\nclient wants bounded content instead of an arbitrary full-page read.\nValues above 12000 are capped server-side; negative values are rejected."
+          "description": "Optional cap for the returned `body`. Use this when a client wants bounded content instead of an arbitrary full-page read. Values above 12000 are capped server-side; negative values are rejected."
         }
       },
       "required": [
@@ -861,13 +866,13 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "Vault-relative path to a video file\n(`.mp4 .mov .mkv .webm .avi .m4v .wmv .flv .mpeg .mpg`)."
+          "description": "Vault-relative path to a video file (`.mp4 .mov .mkv .webm .avi .m4v .wmv .flv .mpeg .mpg`).",
+          "type": "string"
         },
         "max_frames": {
           "default": 8,
-          "type": "integer",
-          "description": "Maximum frames to return. Default 8, hard-capped\nserver-side (16); out-of-range values clamp silently and the\nmetadata reports `max_frames_effective`. Each frame costs\nimage tokens — prefer a time window over raising this."
+          "description": "Maximum frames to return. Default 8, hard-capped server-side (16); out-of-range values clamp silently and the metadata reports `max_frames_effective`. Each frame costs image tokens — prefer a time window over raising this.",
+          "type": "integer"
         },
         "start_sec": {
           "anyOf": [
@@ -879,7 +884,7 @@
             }
           ],
           "default": null,
-          "description": "Optional window start in seconds — sample at/after this\ntimestamp only."
+          "description": "Optional window start in seconds — sample at/after this timestamp only."
         },
         "end_sec": {
           "anyOf": [
@@ -891,7 +896,7 @@
             }
           ],
           "default": null,
-          "description": "Optional window end in seconds — sample before this\ntimestamp only (clamped to the video's duration)."
+          "description": "Optional window end in seconds — sample before this timestamp only (clamped to the video's duration)."
         }
       },
       "required": [
@@ -915,7 +920,7 @@
             }
           ],
           "default": null,
-          "description": "Existing page path to use as the graph seed. Optional when `query`\nis supplied."
+          "description": "Existing page path to use as the graph seed. Optional when `query` is supplied."
         },
         "query": {
           "anyOf": [
@@ -927,12 +932,12 @@
             }
           ],
           "default": null,
-          "description": "Text seed for matching graph node titles/content. Optional when\n`path` is supplied."
+          "description": "Text seed for matching graph node titles/content. Optional when `path` is supplied."
         },
         "depth": {
           "default": 1,
-          "type": "integer",
-          "description": "Traversal depth from seed nodes. Default 1."
+          "description": "Traversal depth from seed nodes. Default 1.",
+          "type": "integer"
         },
         "relation_types": {
           "anyOf": [
@@ -947,7 +952,7 @@
             }
           ],
           "default": null,
-          "description": "Optional allowlist of relation types, e.g.\n`derived_from`, `evidenced_by`, `supports`, `contradicts`,\n`supersedes`, `links_to`."
+          "description": "Optional allowlist of relation types, e.g. `derived_from`, `evidenced_by`, `supports`, `contradicts`, `supersedes`, `links_to`."
         },
         "node_types": {
           "anyOf": [
@@ -962,17 +967,17 @@
             }
           ],
           "default": null,
-          "description": "Optional allowlist of node kinds, e.g. `file`, `decision`,\n`finding`, `risk`, `action`, `claim`, `evidence`."
+          "description": "Optional allowlist of node kinds, e.g. `file`, `decision`, `finding`, `risk`, `action`, `claim`, `evidence`."
         },
         "max_nodes": {
           "default": 40,
-          "type": "integer",
-          "description": "Cap returned nodes. Default 40."
+          "description": "Cap returned nodes. Default 40.",
+          "type": "integer"
         },
         "max_edges": {
           "default": 80,
-          "type": "integer",
-          "description": "Cap returned edges. Default 80."
+          "description": "Cap returned edges. Default 80.",
+          "type": "integer"
         }
       },
       "type": "object"
@@ -984,16 +989,16 @@
       "additionalProperties": false,
       "properties": {
         "entity_type": {
-          "type": "string",
-          "description": "One of person, concept, library, decision."
+          "description": "One of person, concept, library, decision.",
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Title Case, the entity's actual name. Will be the filename."
+          "description": "Title Case, the entity's actual name. Will be the filename.",
+          "type": "string"
         },
         "summary": {
-          "type": "string",
-          "description": "One-paragraph description for the `## Summary` section."
+          "description": "One-paragraph description for the `## Summary` section.",
+          "type": "string"
         },
         "why_in_kb": {
           "anyOf": [
@@ -1005,7 +1010,7 @@
             }
           ],
           "default": null,
-          "description": "Optional `## Why in the KB` paragraph — explains what\nthis entity is relevant to in your work."
+          "description": "Optional `## Why in the KB` paragraph — explains what this entity is relevant to in your work."
         },
         "tags": {
           "anyOf": [
@@ -1035,7 +1040,7 @@
             }
           ],
           "default": null,
-          "description": "List of vault-relative wikilink targets to put under\n`## Connections`. Same path conventions as `note.sources`."
+          "description": "List of vault-relative wikilink targets to put under `## Connections`. Same path conventions as `note.sources`. (per-type fields): see the bullet list above."
         },
         "affiliation": {
           "anyOf": [
@@ -1166,18 +1171,18 @@
       "properties": {
         "path": {
           "default": "",
-          "type": "string",
-          "description": "Vault-relative. Empty string lists vault root. Auto-handles\nforward/back slashes."
+          "description": "Vault-relative. Empty string lists vault root. Auto-handles forward/back slashes.",
+          "type": "string"
         },
         "recursive": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, walk subfolders. Default false."
+          "description": "If true, walk subfolders. Default false.",
+          "type": "boolean"
         },
         "include_hidden": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, include dotfiles and _attachments/.\nDefault false."
+          "description": "If true, include dotfiles and _attachments/. Default false.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -1189,8 +1194,8 @@
       "additionalProperties": false,
       "properties": {
         "target": {
-          "type": "string",
-          "description": "Vault-relative path or bare basename. `.md` optional."
+          "description": "Vault-relative path or bare basename. `.md` optional.",
+          "type": "string"
         }
       },
       "required": [
@@ -1242,22 +1247,22 @@
       "additionalProperties": false,
       "properties": {
         "old_path": {
-          "type": "string",
-          "description": "Vault-relative source."
+          "description": "Vault-relative source.",
+          "type": "string"
         },
         "new_path": {
-          "type": "string",
-          "description": "Vault-relative destination (must not exist)."
+          "description": "Vault-relative destination (must not exist).",
+          "type": "string"
         },
         "update_wikilinks": {
           "default": true,
-          "type": "boolean",
-          "description": "Default true."
+          "description": "Default true.",
+          "type": "boolean"
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Required if either end is in a curated tree."
+          "description": "Required if either end is in a curated tree.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1273,12 +1278,15 @@
       "additionalProperties": false,
       "properties": {
         "content": {
+          "description": "Full markdown body, written verbatim after the frontmatter. Should start with `# <title>` (the H1 matching the title arg) followed by the section conventions per type: research-note: `## Question`/`## Findings`/`## Connections`.",
           "type": "string"
         },
         "note_type": {
+          "description": "One of research-note, insight, failure, pattern, experiment, production-log.",
           "type": "string"
         },
         "title": {
+          "description": "Human title; used to derive a kebab-case filename slug. Experiments and production-logs auto-prefix with YYYY-MM.",
           "type": "string"
         },
         "project": {
@@ -1290,7 +1298,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "REQUIRED for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
         },
         "projects": {
           "anyOf": [
@@ -1304,7 +1313,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "List of project keys (plural). Optional for insight, failure, pattern, production-log. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
         },
         "sources": {
           "anyOf": [
@@ -1318,7 +1328,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Vault-relative wikilinks to existing pages this note draws from, e.g. `[\"Knowledge Base/Sources/Articles/2026-05-18-foo\"]` or `[\"[[Knowledge Base/Sources/Articles/2026-05-18-foo]]\"]`. Brackets and the leading `Knowledge Base/` are tolerated."
         },
         "tags": {
           "anyOf": [
@@ -1332,7 +1343,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Lowercase dash-separated; the server normalizes case/spacing."
         },
         "status": {
           "anyOf": [
@@ -1343,7 +1355,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Defaults to `active` for most types, `planned` for production-log. Valid set varies by type."
         },
         "severity": {
           "anyOf": [
@@ -1354,7 +1367,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "failure only. {minor, moderate, serious, critical}."
         },
         "pattern_type": {
           "anyOf": [
@@ -1365,7 +1379,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "pattern only. {architectural, workflow, prompting, governance, pedagogical}."
         },
         "domain": {
           "anyOf": [
@@ -1376,7 +1391,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. Becomes the subfolder name (lowercased)."
         },
         "started": {
           "anyOf": [
@@ -1387,7 +1403,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. YYYY-MM-DD when the experiment began."
         },
         "duration": {
           "anyOf": [
@@ -1398,7 +1415,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. Freeform, e.g. \"30 days\", \"ongoing\"."
         },
         "hypothesis": {
           "anyOf": [
@@ -1409,7 +1427,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. One-line claim being tested."
         },
         "n": {
           "anyOf": [
@@ -1420,7 +1439,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. Sample size. Defaults to 1 (n-of-1)."
         },
         "concluded": {
           "anyOf": [
@@ -1431,7 +1451,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "experiment only. YYYY-MM-DD when it ended (absent while ongoing)."
         },
         "medium": {
           "anyOf": [
@@ -1442,7 +1463,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "production-log only. Subfolder, e.g. \"Posts\", \"Articles\"."
         },
         "recorded": {
           "anyOf": [
@@ -1453,7 +1475,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "production-log only. YYYY-MM-DD of recording session."
         },
         "published": {
           "anyOf": [
@@ -1464,7 +1487,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "production-log only. YYYY-MM-DD of publication."
         },
         "host": {
           "anyOf": [
@@ -1475,7 +1499,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "production-log only. Creator/talent name."
         },
         "editor": {
           "anyOf": [
@@ -1486,10 +1511,12 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "production-log only. Producer/editor name."
         },
         "suggestions": {
           "default": true,
+          "description": "When true (default), the result carries a `suggestions`",
           "type": "boolean"
         },
         "project_category": {
@@ -1519,23 +1546,23 @@
       "properties": {
         "path": {
           "default": "",
-          "type": "string",
-          "description": "Vault-relative subtree to report on. Empty string (default)\nreports the whole vault. Auto-handles forward/back slashes."
+          "description": "Vault-relative subtree to report on. Empty string (default) reports the whole vault. Auto-handles forward/back slashes.",
+          "type": "string"
         },
         "max_depth": {
           "default": 3,
-          "type": "integer",
-          "description": "Tree depth cap; deeper folders roll up into their\nancestors (counts stay exact). Default 3."
+          "description": "Tree depth cap; deeper folders roll up into their ancestors (counts stay exact). Default 3.",
+          "type": "integer"
         },
         "include_hidden": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, include dot-directories/dotfiles and\n`_trash`/`_attachments`. Default false."
+          "description": "If true, include dot-directories/dotfiles and `_trash`/`_attachments`. Default false.",
+          "type": "boolean"
         },
         "samples": {
           "default": 5,
-          "type": "integer",
-          "description": "Filename samples listed per folder. Default 5."
+          "description": "Filename samples listed per folder. Default 5.",
+          "type": "integer"
         }
       },
       "type": "object"
@@ -1547,20 +1574,20 @@
       "additionalProperties": false,
       "properties": {
         "scope": {
-          "type": "string",
-          "description": "Incident or domain key (e.g. \"project-alpha\", \"incident-2026-04\").\nCreates the subfolder if it doesn't exist."
+          "description": "Incident or domain key (e.g. \"project-alpha\", \"incident-2026-04\"). Creates the subfolder if it doesn't exist.",
+          "type": "string"
         },
         "category": {
-          "type": "string",
-          "description": "Sub-category within scope (e.g. \"letters\", \"labs\",\n\"court-docs\"). Creates the subfolder if it doesn't exist."
+          "description": "Sub-category within scope (e.g. \"letters\", \"labs\", \"court-docs\"). Creates the subfolder if it doesn't exist.",
+          "type": "string"
         },
         "filename": {
-          "type": "string",
-          "description": "The artifact's filename including extension\n(e.g. `2026-04-15-statement.txt`)."
+          "description": "The artifact's filename including extension (e.g. `2026-04-15-statement.txt`).",
+          "type": "string"
         },
         "content": {
-          "type": "string",
-          "description": "UTF-8 text to preserve as-received."
+          "description": "UTF-8 text to preserve as-received.",
+          "type": "string"
         },
         "description": {
           "anyOf": [
@@ -1572,7 +1599,7 @@
             }
           ],
           "default": null,
-          "description": "Optional. If supplied, a sidecar `<filename>.md`\nis written alongside the artifact with frontmatter and the\ndescription under `## Description`."
+          "description": "Optional. If supplied, a sidecar `<filename>.md` is written alongside the artifact with frontmatter and the description under `## Description`."
         }
       },
       "required": [
@@ -1590,11 +1617,11 @@
       "additionalProperties": false,
       "properties": {
         "sources": {
+          "description": "Vault-relative paths/wikilinks to the source(s) to compile. Same path conventions as `note.sources` (brackets and the leading `Knowledge Base/` are tolerated).",
           "items": {
             "type": "string"
           },
-          "type": "array",
-          "description": "Vault-relative paths/wikilinks to the source(s) to compile.\nSame path conventions as `note.sources` (brackets and the\nleading `Knowledge Base/` are tolerated)."
+          "type": "array"
         },
         "suggested_title": {
           "anyOf": [
@@ -1606,7 +1633,7 @@
             }
           ],
           "default": null,
-          "description": "Optional title override; otherwise one is derived\nfrom the source titles."
+          "description": "Optional title override; otherwise one is derived from the source titles."
         }
       },
       "required": [
@@ -1666,7 +1693,7 @@
             }
           ],
           "default": null,
-          "description": "Restrict the scan to one vault-relative file (else the whole\nKnowledge Base is walked)."
+          "description": "Restrict the scan to one vault-relative file (else the whole Knowledge Base is walked)."
         }
       },
       "type": "object"
@@ -1678,8 +1705,8 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "type": "string",
-          "description": "vault-relative path to the `.csv` / `.tsv` / `.json` file."
+          "description": "vault-relative path to the `.csv` / `.tsv` / `.json` file.",
+          "type": "string"
         },
         "record_path": {
           "anyOf": [
@@ -1691,7 +1718,7 @@
             }
           ],
           "default": null,
-          "description": "(JSON) dotted path to the array inside a nested\nobject, e.g. \"sections.work_incapacity\". Omit for a top-level\narray or the common keys result/results/data/rows/items/entries."
+          "description": "(JSON) dotted path to the array inside a nested object, e.g. \"sections.work_incapacity\". Omit for a top-level array or the common keys result/results/data/rows/items/entries."
         },
         "filters": {
           "anyOf": [
@@ -1707,7 +1734,7 @@
             }
           ],
           "default": null,
-          "description": "list of `{column, op, value}`. `op` ∈ eq, ne, gt, gte, lt,\nlte, contains, icontains, startswith, in, nin, exists, missing.\nNumeric compares coerce tolerantly (comma decimals; lab\noperators like \"<0.4\"/\">75\" are stripped for the comparison)."
+          "description": "list of `{column, op, value}`. `op` ∈ eq, ne, gt, gte, lt, lte, contains, icontains, startswith, in, nin, exists, missing. Numeric compares coerce tolerantly (comma decimals; lab operators like \"<0.4\"/\">75\" are stripped for the comparison)."
         },
         "columns": {
           "anyOf": [
@@ -1722,7 +1749,7 @@
             }
           ],
           "default": null,
-          "description": "project to these columns (dotted ok). Omit for all."
+          "description": "project to these columns (dotted ok). Omit for all. sort_by / descending: sort by a column (numeric-aware). limit / offset: pagination (limit default 100, hard cap 1000)."
         },
         "sort_by": {
           "anyOf": [
@@ -1757,7 +1784,7 @@
             }
           ],
           "default": null,
-          "description": "instead of rows — \"count\"; \"func:column\" where func ∈\nmin, max, sum, avg, latest, distinct; or \"profile\" to get a\ndeterministic content profile (per-column kind, distinct values,\nnumeric ranges, date span) under `aggregate.profile` PLUS a\nready-to-write markdown dataset card under `aggregate.dataset_card`.\nUse \"profile\" to make a CSV/JSON findable — write the card into\nthe KB (fill in its \"What this holds\" line) so the dataset is\ndiscoverable by content without ever embedding its raw rows."
+          "description": "instead of rows — \"count\"; \"func:column\" where func ∈ min, max, sum, avg, latest, distinct; or \"profile\" to get a deterministic content profile (per-column kind, distinct values, numeric ranges, date span) under `aggregate.profile` PLUS a ready-to-write markdown dataset card under `aggregate.dataset_card`. Use \"profile\" to make a CSV/JSON findable — write the card into the KB (fill in its \"What this holds\" line) so the dataset is discoverable by content without ever embedding its raw rows. date_from / date_to / date_column: convenience date-range filter on `date_column` (defaults to a \"date\" column if present); ISO date strings, compared lexicographically."
         },
         "date_from": {
           "anyOf": [
@@ -1806,8 +1833,8 @@
       "properties": {
         "dry_run": {
           "default": false,
-          "type": "boolean",
-          "description": "If true, compute what would change without writing.\nDefault false."
+          "description": "If true, compute what would change without writing. Default false.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -1819,8 +1846,8 @@
       "additionalProperties": false,
       "properties": {
         "trash_path": {
-          "type": "string",
-          "description": "Vault-relative path to the trashed entry\n(under `Knowledge Base/_trash/...`)."
+          "description": "Vault-relative path to the trashed entry (under `Knowledge Base/_trash/...`).",
+          "type": "string"
         },
         "restore_path": {
           "anyOf": [
@@ -1832,12 +1859,12 @@
             }
           ],
           "default": null,
-          "description": "Optional override; defaults to the original\nlocation from the sidecar."
+          "description": "Optional override; defaults to the original location from the sidecar."
         },
         "allow_curated": {
           "default": false,
-          "type": "boolean",
-          "description": "Required if restoring into a curated tree."
+          "description": "Required if restoring into a curated tree.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1852,8 +1879,8 @@
       "additionalProperties": false,
       "properties": {
         "old_path": {
-          "type": "string",
-          "description": "Vault-relative path of the page being superseded.\nSame path conventions as `get` and `find`."
+          "description": "Vault-relative path of the page being superseded. Same path conventions as `get` and `find`.",
+          "type": "string"
         },
         "content": {
           "type": "string"
@@ -1874,7 +1901,7 @@
             }
           ],
           "default": null,
-          "description": "Optional one-line explanation of why this replacement is\nhappening; lands in the log entry body."
+          "description": "Optional one-line explanation of why this replacement is happening; lands in the log entry body. (all other args): Same as the `note` tool — define the new page's content, type, project/projects, sources, etc."
         },
         "project": {
           "anyOf": [
@@ -2111,8 +2138,8 @@
       "properties": {
         "query": {
           "default": "",
-          "type": "string",
-          "description": "Free-text search string."
+          "description": "Free-text search string.",
+          "type": "string"
         },
         "types": {
           "anyOf": [
@@ -2161,13 +2188,13 @@
         },
         "limit": {
           "default": 10,
-          "type": "integer",
-          "description": "Maximum number of results. Capped to 50."
+          "description": "Maximum number of results. Capped to 50.",
+          "type": "integer"
         },
         "scope": {
           "default": "kb",
-          "type": "string",
-          "description": "\"kb\" for Knowledge Base first, or \"vault\" to search the broader vault."
+          "description": "\"kb\" for Knowledge Base first, or \"vault\" to search the broader vault.",
+          "type": "string"
         }
       },
       "type": "object"
@@ -2188,7 +2215,7 @@
             }
           ],
           "default": null,
-          "description": "Existing page to suggest links for. Mutually exclusive with\nthe draft_* args."
+          "description": "Existing page to suggest links for. Mutually exclusive with the draft_* args."
         },
         "draft_title": {
           "anyOf": [
@@ -2212,17 +2239,17 @@
             }
           ],
           "default": null,
-          "description": "Body (markdown) of a not-yet-written note. Wikilinks\nalready present in it are treated as \"already linked\" and excluded."
+          "description": "Body (markdown) of a not-yet-written note. Wikilinks already present in it are treated as \"already linked\" and excluded."
         },
         "limit": {
           "default": 8,
-          "type": "integer",
-          "description": "Max suggestions (default 8)."
+          "description": "Max suggestions (default 8).",
+          "type": "integer"
         },
         "scope": {
           "default": "kb",
-          "type": "string",
-          "description": "\"kb\" (default) or \"vault\" — same meaning as `find`."
+          "description": "\"kb\" (default) or \"vault\" — same meaning as `find`.",
+          "type": "string"
         }
       },
       "type": "object"
@@ -2271,13 +2298,13 @@
         },
         "include_model_suggestions": {
           "default": false,
-          "type": "boolean",
-          "description": "Request optional model-backed suggestion\npaths. Default false; unavailable paths soft-fail with warnings."
+          "description": "Request optional model-backed suggestion paths. Default false; unavailable paths soft-fail with warnings.",
+          "type": "boolean"
         },
         "limit": {
           "default": 10,
-          "type": "integer",
-          "description": "Max candidates to return. Default 10."
+          "description": "Max candidates to return. Default 10.",
+          "type": "integer"
         }
       },
       "type": "object"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -41,6 +41,7 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
         "performance_profiles",
         "memory_model",
         "knowledge_packs",
+        "authoring_contract",
     } <= set(out)
     assert "durable governed knowledge" in out["memory_model"]["exomem"]
     assert [s["name"] for s in out["workflow_skills"]] == [
@@ -59,11 +60,22 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
     assert out["knowledge_packs"]["available"][0]["beginner_description"]
     assert out["front_door_actions"]["save"]["selected_pack_guidance"][0]["pack_id"] == "personal-records"
     assert out["tool_defaults"]["adopt_existing_vault"]["tool"] == "adopt"
+    authoring = out["authoring_contract"]
+    assert "suggest_links" in " ".join(authoring["canonical_loop"])
+    assert authoring["route_by_intent"]["new_durable_conclusion"] == "note"
+    assert authoring["route_by_intent"]["small_correction"] == "edit"
+    assert authoring["route_by_intent"]["substantial_rewrite"] == "replace"
+    assert "near_duplicate_warnings" in authoring["preflight"]
+    assert "write_feedback" in authoring["post_write"]
+    assert "insight" in authoring["note_type_recipes"]
+    assert any("write_feedback" in step for step in out["workflow"]["loop"])
     assert "adopt" in out["common_tools"]
-    assert out["tool_defaults"]["normal_lookup"]["args"] == {
-        "detail": "compact",
-        "rerank": False,
-    }
+    assert "search" in out["common_tools"]
+    assert "fetch" in out["common_tools"]
+    assert "find" in out["common_tools"]
+    assert "get" in out["common_tools"]
+    assert out["tool_defaults"]["normal_lookup"] == {"tool": "search", "args": {}}
+    assert out["tool_defaults"]["read_bounded_page"]["tool"] == "fetch"
     serialized = json.dumps(out)
     assert str(vault) not in serialized
     assert "Progressive disclosure" not in serialized
@@ -88,7 +100,10 @@ def test_product_front_door_metadata_is_registry_derived() -> None:
 
     assert {"save", "adopt", "ask", "prove", "review", "update", "connect"} <= set(front_door)
     assert "adopt" in catalog["primary"]
+    assert "search" in catalog["primary"]
+    assert "fetch" in catalog["primary"]
     assert "find" in catalog["primary"]
+    assert "get" in catalog["primary"]
     assert "preserve" in front_door["prove"]["primary_tools"]
     assert "audit" in front_door["review"]["primary_tools"]
     assert "create_file" in catalog["advanced"]

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -58,6 +58,29 @@ def test_note_body_with_no_h1_is_written_verbatim(vault: Path) -> None:
     assert body.lstrip().startswith("## Claim")
 
 
+def test_note_returns_structural_write_feedback(vault: Path) -> None:
+    result = note_module.note(
+        vault,
+        content=(
+            "# Feedback note\n\n"
+            "## Claim\n\n"
+            "The writer should report the note structure.\n\n"
+            "## Connections\n\n"
+            "This relates to [[Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation]].\n"
+        ),
+        note_type="insight",
+        title="Feedback note",
+        today=TODAY,
+    )
+
+    feedback = result.write_feedback
+    assert feedback["contract"] == "compiled-note"
+    assert feedback["note_type"] == "insight"
+    assert feedback["semantic_blocks"]["by_kind"]["claim"] >= 1
+    assert feedback["links"]["body_wikilinks"] == 1
+    assert feedback["links"]["unresolved_count"] == 0
+    assert "write_feedback" in result.as_dict()
+
 def test_note_slug_truncation_emits_warning(vault: Path) -> None:
     """A title that exceeds SLUG_MAX_LENGTH should produce a slug_warning."""
     very_long_title = (

--- a/tests/test_portable_retrieval.py
+++ b/tests/test_portable_retrieval.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import commands
+from exomem import find as find_module
+from exomem import server as server_module
+
+
+def _build_server(monkeypatch: pytest.MonkeyPatch, vault: Path):
+    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_RELEVANCE_CHECK", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_CLIP", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_FILE_WATCHER", "1")
+    monkeypatch.setenv("EXOMEM_DISABLE_WARMUP", "1")
+    monkeypatch.delenv("EXOMEM_DISABLE_TIER2", raising=False)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    return server_module.build_server(require_auth=False)
+
+
+def _mcp_tools(mcp) -> dict[str, dict]:
+    tools = asyncio.run(mcp.list_tools())
+    return {t.name: t.to_mcp_tool().model_dump(mode="json") for t in tools}
+
+
+def test_search_returns_metadata_only(vault: Path) -> None:
+    out = commands.op_search(vault, query="jitter", limit=5)
+
+    assert set(out) == {"results"}
+    assert out["results"]
+    serialized = json.dumps(out)
+    assert "breathing room" not in serialized
+    assert "excerpt" not in serialized
+    assert "signals" not in serialized
+    assert "pack" not in serialized
+    assert "timings" not in serialized
+    assert "body" not in serialized
+
+    first = out["results"][0]
+    assert set(first) == {"id", "title", "url", "metadata"}
+    assert first["id"].startswith("Knowledge Base/")
+    assert first["metadata"]["path"] == first["id"]
+    assert all(isinstance(value, str) for value in first["metadata"].values())
+
+
+def test_fetch_returns_bounded_document_text(vault: Path) -> None:
+    rel = Path("Knowledge Base/Notes/Patterns/long-fetch-test.md")
+    body = "# Long Fetch\n\n" + "alpha beta gamma delta " * 120
+    (vault / rel).write_text(
+        "---\n"
+        "type: pattern\n"
+        "status: active\n"
+        "title: Long Fetch\n"
+        "tags: [portable, retrieval]\n"
+        "---\n\n"
+        + body,
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+
+    out = commands.op_fetch(vault, id=rel.as_posix(), max_chars=600)
+
+    assert out["id"] == rel.as_posix()
+    assert out["title"] == "Long Fetch"
+    assert len(out["text"]) <= 600
+    assert out["text"].endswith("[truncated]")
+    assert out["metadata"]["truncated"] == "true"
+    assert out["metadata"]["path"] == rel.as_posix()
+    assert "frontmatter" not in out
+    assert "content_hash" not in out
+    assert "content" not in out
+
+
+def test_search_fetch_mcp_shape_is_portable(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    for name in ("search", "fetch"):
+        annotations = tools[name]["annotations"]
+        assert annotations["readOnlyHint"] is True
+        assert annotations["destructiveHint"] is False
+        assert annotations["openWorldHint"] is False
+
+    search_schema = tools["search"]["outputSchema"]
+    assert search_schema["type"] == "object"
+    assert search_schema["required"] == ["results"]
+    result_schema = search_schema["properties"]["results"]["items"]
+    assert result_schema["required"] == ["id", "title", "url", "metadata"]
+    assert set(result_schema["properties"]) == {"id", "title", "url", "metadata"}
+    assert result_schema["properties"]["metadata"]["additionalProperties"] == {
+        "type": "string"
+    }
+
+    fetch_schema = tools["fetch"]["outputSchema"]
+    assert fetch_schema["type"] == "object"
+    assert fetch_schema["required"] == ["id", "title", "text", "url"]
+    assert set(fetch_schema["properties"]) == {"id", "title", "text", "url", "metadata"}
+    assert fetch_schema["properties"]["metadata"]["additionalProperties"] == {
+        "type": "string"
+    }
+
+    search_inputs = tools["search"]["inputSchema"]["properties"]
+    fetch_inputs = tools["fetch"]["inputSchema"]["properties"]
+    for forbidden in ("pack", "detail", "include_timings", "include_raw", "frontmatter_only"):
+        assert forbidden not in search_inputs
+        assert forbidden not in fetch_inputs

--- a/tests/test_retrieval_surface_safety.py
+++ b/tests/test_retrieval_surface_safety.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import commands
+from exomem import find as find_module
+from exomem import server as server_module
+
+
+def _build_server(monkeypatch: pytest.MonkeyPatch, vault: Path):
+    monkeypatch.setattr(server_module, "load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    return server_module.build_server(require_auth=False)
+
+
+def _mcp_tools(mcp) -> dict[str, dict]:
+    tools = asyncio.run(mcp.list_tools())
+    return {t.name: t.to_mcp_tool().model_dump(mode="json") for t in tools}
+
+
+def test_find_compact_is_metadata_only(vault: Path) -> None:
+    out = commands.op_find(vault, query="metabolism", detail="compact")
+
+    assert isinstance(out, list)
+    assert out, "fixture vault should match 'metabolism'"
+    for hit in out:
+        assert {"path", "type", "scope", "title", "updated"} <= set(hit)
+        serialized = json.dumps(hit)
+        assert "excerpt" not in serialized
+        assert "signals" not in serialized
+        assert "body" not in serialized
+
+
+def test_get_can_return_bounded_body(vault: Path) -> None:
+    path = vault / "Knowledge Base" / "Notes" / "Insights" / "long-safe-get.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "type: insight\n"
+        "title: Long Safe Get\n"
+        "status: active\n"
+        "created: 2026-07-08\n"
+        "updated: 2026-07-08\n"
+        "sources: []\n"
+        "tags: [chatgpt-safe]\n"
+        "---\n\n"
+        + ("alpha beta gamma delta\n" * 200),
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+
+    out = commands.op_get(
+        vault,
+        path="Knowledge Base/Notes/Insights/long-safe-get.md",
+        max_body_chars=600,
+    )
+
+    assert out["path"] == "Knowledge Base/Notes/Insights/long-safe-get.md"
+    assert len(out["body"]) <= 600
+    assert out["body"].endswith("[truncated]")
+    assert out["body_truncated"] is True
+    assert out["body_chars"] == len(out["body"])
+
+
+def test_find_get_mcp_output_schemas_are_concrete(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    find_schema = tools["find"]["outputSchema"]
+    find_result = find_schema["properties"]["result"]
+    first_shape = find_result["anyOf"][0]
+    hit_schema = first_shape["items"]
+    assert {"path", "type", "scope", "title", "updated"} <= set(
+        hit_schema["required"]
+    )
+    assert "excerpt" in hit_schema["properties"]
+    assert hit_schema["type"] == "object"
+
+    get_schema = tools["get"]["outputSchema"]
+    assert get_schema["type"] == "object"
+    assert get_schema["required"] == ["path", "frontmatter"]
+    assert "body" in get_schema["properties"]
+    assert "body_truncated" in get_schema["properties"]
+    assert "max_body_chars" in tools["get"]["inputSchema"]["properties"]

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- add a bootstrap authoring contract and workflow-skill summary for generic MCP clients
- add portable `search`/`fetch` retrieval surfaces alongside richer `find`/`get`
- return deterministic `write_feedback` from compiled `note()` writes and document the loop

## Validation
- `uv run pytest tests\test_bootstrap.py tests\test_mcp_schema_fidelity.py tests\test_note_suggestions_knob.py tests\test_note.py tests\test_portable_retrieval.py tests\test_retrieval_surface_safety.py`
- `uv run python scripts\generate-capabilities.py --check`

Both validation commands passed in a clean detached worktree at `925de61`.