### PR TITLE
feat: simplify command surface

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -73,6 +73,26 @@ Existing vault material remains read-only input. Exomem writes governed knowledg
 under `Knowledge Base/` unless you deliberately configure a different governed
 folder.
 
+After setup, you can use simple action aliases instead of learning every
+canonical operation first:
+
+```bash
+exomem ask "what do I know about this project?"
+exomem ask "what supports this decision?" --deep --graph-enrich --json
+exomem remember "# Setup succeeded\n\n## Claim\n\nExomem setup completed today." --title "Setup succeeded today" --json
+exomem capture "raw source text" --title "Source title" --source-type other --json
+exomem capture "receipt text" --as evidence --scope warranty --category receipts --filename receipt.txt --json
+exomem review --json
+exomem connect --path "Notes/Insights/example" --json
+exomem maintain --json
+```
+
+These aliases are thin routes over the governed operations: `ask` -> `find`,
+`remember` -> `note`, `capture` -> `add`/`preserve`, `review` ->
+`attention`/`audit`, `connect` -> `suggest_links`/`suggest_relations`, and
+`maintain` -> `audit` unless a fix flag is explicit. The full command registry
+remains available for advanced work.
+
 The numbered steps below are the **manual path** — exactly what `setup` does
 under the hood, kept for troubleshooting and for people who prefer explicit
 steps.

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -43,24 +43,39 @@ Capture raw material separately when provenance matters.
 
 ## Simple actions for agents
 
-| User intent | What the agent should do | Typical Exomem action |
-| --- | --- | --- |
-| "Remember this" | Decide whether it is raw material, a durable conclusion, or both. Save the conclusion as a compiled note; preserve the raw input if it matters. | `note`, sometimes `add` first |
-| "Find what I concluded" | Search first, cite relevant hits, and treat misses as scoped misses. Read full pages only when needed. | `find`, then `get` or `find(pack=true)` |
-| "Preserve this source" | Keep the raw material with provenance. Do not rewrite it into a conclusion unless asked or clearly useful. | `add` |
-| "Preserve this proof/record" | Store as proof-bearing material for a case, claim, receipt, warranty, dispute, or record. | `preserve` or upload |
-| "Compile this evidence" | Turn raw sources/evidence into a concise conclusion with links back to the originals. | `note` with citations |
-| "Review stale knowledge" | Surface old or low-use conclusions for human review; do not hide, decay, or auto-rank them down. | `audit`, stale-review checks |
-| "This replaces the old conclusion" | Supersede the old compiled page instead of creating an unlinked duplicate. | `replace` |
-| "Update this small detail" | Patch a compiled page when the claim is still the same. | `edit` |
-| "Connect these ideas" | Add links or entity pages only when they clarify retrieval and future reasoning. | `suggest_links`, `link` |
+Use the simple product actions as the first mental model. The canonical tool is
+still the implementation route.
 
-Use internal names only as implementation details. With the user, say "save the
-source," "write the conclusion," "preserve the record," "review stale notes," or
-"replace the old conclusion."
+| Simple action | User intent | Canonical route |
+| --- | --- | --- |
+| `ask` | "What do I know?", "find what I concluded", "show the context" | `find(detail="compact", rerank=false)`, then `get`; use `find(pack=true)` for synthesis |
+| `remember` | "remember this conclusion", "save this decision", "write this up" | `note`; use `replace` when it supersedes an old conclusion |
+| `capture` | "save this source", "preserve this receipt", "keep this proof" | `add` for raw sources; `preserve` or upload for Evidence |
+| `review` | "what needs review?", "show stale knowledge", "what is unprocessed?" | `attention`, `audit`, `propose_compilation` |
+| `connect` | "what should this link to?", "suggest relations", "show related ideas" | `suggest_links`, `suggest_relations`, `graph_context`; `link` only for explicit writes |
+| `adopt` | "import/adopt this existing vault safely" | `adopt(mode="scan-only")`; explicit modes for manifest/copy/compile planning |
+| `maintain` | "check/fix vault health" | `audit` by default; `audit_fix`/`reconcile` only when explicitly requested |
+
+Do not make the user choose `Sources`, `Evidence`, `Notes`, `Entities`, pack
+metadata, graph sidecars, or schema terms unless the distinction changes the
+outcome. With the user, say "ask", "remember", "capture", "review", "connect",
+"adopt", or "maintain"; use canonical tool names only when reporting exact
+implementation steps or debugging.
+
+For CLI use, these actions are also available as friendly aliases:
+
+```bash
+exomem ask "what did I conclude about onboarding?" --json
+exomem ask "warranty dispute context" --deep --graph-enrich --json
+exomem remember "# Decision\n\n## Claim\n\nUse simple actions first." --title "Use simple actions first" --json
+exomem capture "raw article excerpt" --title "Article title" --source-type article --url "https://example.com" --json
+exomem capture "receipt text" --as evidence --scope warranty --category receipts --filename receipt.txt --json
+exomem review --json
+exomem connect --path "Notes/Insights/example" --json
+exomem maintain --json
+```
 
 ## Examples
-
 ### Remember this
 
 User:

--- a/docs/knowledge-packs.md
+++ b/docs/knowledge-packs.md
@@ -43,7 +43,7 @@ Each pack is a JSON object with these required fields:
 | `suggested_folders` | Governed KB locations the pack commonly uses; selection does not create them. |
 | `suggested_workflows` | Beginner-facing workflows with `title`, `intent`, `route`, and `example`. |
 | `primitives` | Durable primitives the pack commonly uses. |
-| `actions` | Simple actions the pack supports: `save`, `adopt`, `ask`, `prove`, `review`, `update`, `connect`. |
+| `actions` | Simple actions the pack supports. Existing packs may use legacy product verbs `save`, `adopt`, `ask`, `prove`, `review`, `update`, `connect`; new packs may also use `remember`, `capture`, and `maintain`. |
 | `examples` | User-facing prompts that should route to this pack. |
 | `signals` | Structural tokens used by adoption scans to suggest the pack. |
 
@@ -108,13 +108,13 @@ Packs do not bypass governance. They help agents choose existing typed tools:
 
 | Simple action | Typed operation |
 | --- | --- |
-| Save raw material | `add` |
-| Save durable conclusion | `note` or `link` |
-| Preserve proof | `preserve` or upload to Evidence |
-| Ask | `find` and `get` |
-| Review | `audit`, `attention`, `propose_compilation` |
-| Update | `edit`, `replace`, `reconcile` |
-| Connect | `link`, `suggest_links` |
+| `capture` raw material | `add`; use `preserve` or upload for Evidence |
+| `remember` durable conclusion | `note` or `link`; use `replace` for supersession |
+| `ask` | `find`, optionally `get` or `find(pack=true)` |
+| `review` | `attention`, `audit`, `propose_compilation` |
+| `connect` | `suggest_links`, `suggest_relations`, `graph_context`, `link` |
+| `adopt` | `adopt(mode="scan-only")` before copy/compile modes |
+| `maintain` | `audit`; explicit `audit_fix` or `reconcile` for repairs |
 
 Agents should speak in product language. The user can say "save this warranty
 receipt"; the agent chooses the evidence/proof route and reports the saved path.

--- a/openspec/changes/simplify-command-surface/.openspec.yaml
+++ b/openspec/changes/simplify-command-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/simplify-command-surface/design.md
+++ b/openspec/changes/simplify-command-surface/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Exomem's command registry is now the correct source of truth: MCP, REST, CLI, docs, and OpenAPI derive from the same leaf functions. That architecture should not be replaced. The problem is product shape: the canonical tools expose Exomem's internal architecture directly, so first-use agents and humans see a broad technical menu before they understand the few common actions.
+
+The latest main includes adoption, knowledge packs, semantic blocks, compile planning, agent memory boundary docs, and the epistemic graph sidecar. The next gap is the front door: "ask", "remember", "capture", "review", "connect", "adopt", and "maintain" should be obvious before users learn `find`, `note`, `add`, `propose_compilation`, `graph_context`, or `audit_fix`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a simple action layer that maps common user intent to canonical registry commands.
+- Keep the registry as the only operation contract; simple actions are aliases/routing metadata, not duplicate implementations.
+- Make CLI use easier without hiding advanced commands from power users.
+- Make bootstrap and scaffold docs teach actions first and tools second.
+- Preserve MCP schema stability unless a canonical tool intentionally changes.
+
+**Non-Goals:**
+
+- Do not remove, rename, or break existing registry commands.
+- Do not add server-side reasoning or LLM selection.
+- Do not make graph enrichment, model-backed relation suggestions, or repair operations automatic.
+- Do not replace existing REST endpoints or OpenAPI paths.
+- Do not copy Basic Memory's implementation or syntax.
+
+## Decisions
+
+1. Simple actions are metadata plus thin dispatch, not new storage primitives.
+
+   Rationale: Exomem's moat depends on governed layers, but those layers already exist behind canonical commands. A new action model should choose the right existing tool and defaults, not create another source of truth.
+
+   Alternative considered: add independent `remember`, `ask`, and `review` operations with their own logic. Rejected because it would duplicate validation, drift from MCP/REST/CLI parity, and blur the pure-substrate boundary.
+
+2. CLI aliases are allowed; MCP aliases are optional and conservative.
+
+   Rationale: CLI aliases such as `exomem ask` and `exomem remember` improve human ergonomics without changing MCP schema snapshots. MCP clients already benefit from bootstrap action metadata, and existing canonical tools remain stable.
+
+   Alternative considered: add many new MCP tools. Rejected for the first pass because more MCP tools may make tool selection noisier unless the aliases are extremely well scoped and separately schema-pinned.
+
+3. `ask` should route to `find` with safe defaults and expose an explicit enriched mode.
+
+   Rationale: Normal recall should be cheap and predictable. Rich graph/pack behavior is valuable, but it should be selected by an action option such as `--deep` rather than hidden behind every lookup.
+
+4. `remember` should route to compiled notes; `capture` should route to raw sources/evidence.
+
+   Rationale: This preserves the epistemic hierarchy in product language. Durable conclusions belong in `note`; raw material belongs in `add` or upload/preserve flows.
+
+5. Bootstrap should emit a first-class action catalog.
+
+   Rationale: Generic agents need a small map from intent to route. They do not need to learn every canonical tool before doing useful work.
+
+## Risks / Trade-offs
+
+- Alias semantics become vague -> Keep aliases small and map each one to a canonical operation plus explicit defaults.
+- MCP tool count grows too large -> First pass can avoid MCP aliases and expose action guidance through bootstrap/scaffold docs.
+- Users think simple actions are less capable -> CLI help and docs should point from aliases to canonical advanced tools.
+- Hidden writes become risky -> Write aliases must require the same required fields and safety checks as the underlying canonical command.
+- Graph/pack calls become slow by default -> Keep deep graph enrichment explicit and soft-failing; missing sidecars must return guidance rather than failing unrelated lookup.
+
+## Migration Plan
+
+1. Add action metadata and routing helpers over the existing command registry.
+2. Add CLI aliases with human-readable help and JSON support where practical.
+3. Update bootstrap/action catalog and scaffold guidance to teach actions first.
+4. Regenerate capabilities docs and fixtures as needed.
+5. Validate with focused CLI/bootstrap/schema tests before running the broader suite.
+
+Rollback is simple: aliases and metadata can be removed without changing canonical commands or stored vault data.
+
+## Open Questions
+
+- Should MCP expose actual alias tools in this change, or should bootstrap guidance remain the first MCP simplification step?
+- Should `remember` support only compiled notes in the first pass, or also a guided "raw plus compiled" mode?
+- Should `maintain` be read-only by default (`audit`, `attention`) with an explicit `--fix` for `audit_fix`?

--- a/openspec/changes/simplify-command-surface/proposal.md
+++ b/openspec/changes/simplify-command-surface/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Exomem's registry is now powerful enough to express the full governed-knowledge architecture, but the first-use MCP and CLI surface still asks users and agents to reason in tool names such as `propose_compilation`, `graph_context`, `suggest_relations`, and `audit_fix`. Basic Memory's simpler product surface shows the gap: Exomem needs an approachable front door without weakening the underlying governance model.
+
+## What Changes
+
+- Add a small set of product verbs for humans and generic agents: `ask`, `remember`, `capture`, `review`, `connect`, `adopt`, and `maintain`.
+- Map those verbs deterministically onto existing registry commands instead of duplicating command logic.
+- Expose the simple verbs through bootstrap metadata, docs, and CLI aliases.
+- Keep the full registry available for advanced users, tests, REST, and MCP clients that already call canonical tools.
+- Keep optional/heavy behavior default-off and soft-failing: graph enrichment remains explicit, model-backed relation suggestions remain opt-in, and the server continues to measure rather than reason.
+- No breaking changes: existing command names, schemas, REST endpoints, and MCP tools remain valid.
+
+## Capabilities
+
+### New Capabilities
+- `simple-command-surface`: A beginner-safe, product-oriented action layer that routes common knowledge intents to canonical Exomem operations.
+
+### Modified Capabilities
+- `command-surface`: The command registry exposes simple action metadata and CLI aliases while preserving canonical operations as the source of truth.
+- `agent-bootstrap-contract`: Bootstrap and scaffold guidance present simple actions first, then disclose advanced tools when needed.
+
+## Impact
+
+- Affected code: `src/exomem/commands.py`, `src/exomem/command_surface.py`, `src/exomem/__main__.py`, CLI rendering helpers, bootstrap payloads, and scaffold docs.
+- Affected tests: bootstrap contract tests, CLI tests, command-registry metadata tests, MCP schema fidelity tests if any MCP descriptions are intentionally changed.
+- Affected docs: `docs/ai-assistant-guide.md`, `docs/capabilities.md`, `QUICKSTART.md`, and `_Schema` scaffold references.
+- No new runtime dependency and no server-side reasoning model.

--- a/openspec/changes/simplify-command-surface/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/simplify-command-surface/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Bootstrap Presents Simple Actions First
+The bootstrap contract SHALL present simple product actions before the full technical tool catalog, so generic agents can route common user intents without learning every command.
+
+#### Scenario: Compact bootstrap includes action routing
+- **WHEN** `bootstrap(profile="compact")` is called
+- **THEN** the response includes a simple action catalog with action names, intent descriptions, default canonical routes, and safety notes
+- **AND** the response still avoids note bodies, private vault paths, and private project names
+
+#### Scenario: Bootstrap distinguishes simple and advanced tools
+- **WHEN** an agent reads the bootstrap response
+- **THEN** it can identify the normal route for ask, remember, capture, review, connect, adopt, and maintain
+- **AND** it can identify when to fall through to advanced canonical commands
+
+### Requirement: Scaffold Guidance Uses Intent Language
+The installed Exomem skill and operation references SHALL teach agents simple user-intent language before listing canonical tools.
+
+#### Scenario: Agent maps user words to actions
+- **WHEN** a generic agent reads the scaffolded skill or operation reference
+- **THEN** it sees examples such as "ask what I know", "remember this conclusion", "capture this source", "review stale knowledge", "connect this note", and "adopt this vault"
+- **AND** each example names the canonical operation route to use

--- a/openspec/changes/simplify-command-surface/specs/command-surface/spec.md
+++ b/openspec/changes/simplify-command-surface/specs/command-surface/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Command Registry Carries Simple Action Metadata
+The command registry SHALL expose enough metadata to derive the simple product action catalog without maintaining a separate operation list.
+
+#### Scenario: Action metadata is registry-derived
+- **WHEN** the product action catalog is built
+- **THEN** it derives command routes from registry metadata
+- **AND** canonical commands remain available on their original MCP, REST, and CLI surfaces
+
+#### Scenario: Advanced tools remain discoverable
+- **WHEN** a tool is not part of the primary simple action flow
+- **THEN** it remains listed as advanced rather than hidden or removed
+- **AND** tier-2 and destructive-operation controls continue to apply
+
+### Requirement: CLI Exposes Simple Aliases Without Breaking Canonical Commands
+The CLI SHALL expose simple action aliases for common workflows while preserving every canonical registry subcommand.
+
+#### Scenario: Simple alias and canonical command both work
+- **WHEN** a user invokes a supported simple CLI action
+- **THEN** the action routes to the same canonical leaf used by the equivalent registry command
+- **AND** invoking the canonical command directly still works with the same behavior as before
+
+#### Scenario: JSON envelopes stay consistent
+- **WHEN** a user invokes a simple CLI action in JSON mode
+- **THEN** the output uses the same success/error envelope semantics as canonical CLI operations
+- **AND** failures carry stable error codes and remediation where the canonical operation provides them

--- a/openspec/changes/simplify-command-surface/specs/simple-command-surface/spec.md
+++ b/openspec/changes/simplify-command-surface/specs/simple-command-surface/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Simple Product Actions
+The system SHALL define a small set of simple product actions that route common knowledge-base intents to canonical Exomem operations without duplicating command logic.
+
+#### Scenario: Action catalog names the simple actions
+- **WHEN** the action catalog is requested by bootstrap, docs generation, or CLI help
+- **THEN** it lists `ask`, `remember`, `capture`, `review`, `connect`, `adopt`, and `maintain`
+- **AND** each action identifies its canonical operation route and default safety posture
+
+#### Scenario: Canonical operations remain the source of truth
+- **WHEN** a simple action invokes an Exomem operation
+- **THEN** it uses the existing registry leaf and validation path
+- **AND** it does not bypass guarded fields, destructive-operation metadata, schema validation, or vault path checks
+
+### Requirement: Ask Action
+The system SHALL provide an `ask` action for recall-oriented lookup over durable knowledge.
+
+#### Scenario: Ask performs cheap recall by default
+- **WHEN** a user runs the ask action with a query
+- **THEN** it routes to `find` with compact lookup defaults suitable for first-pass recall
+- **AND** it does not force reranking, pack assembly, or graph enrichment by default
+
+#### Scenario: Ask can request deeper reasoning context
+- **WHEN** a user runs the ask action with an explicit deep/context option
+- **THEN** it routes to `find` with packed reasoning context
+- **AND** graph enrichment remains explicit and soft-fails if the graph sidecar is unavailable
+
+### Requirement: Remember And Capture Actions
+The system SHALL distinguish durable conclusions from raw captured material in the simple action layer.
+
+#### Scenario: Remember routes to compiled knowledge
+- **WHEN** a user runs the remember action
+- **THEN** the action routes to the compiled-note path
+- **AND** the required fields and type-specific validation are the same as the canonical `note` operation
+
+#### Scenario: Capture routes to raw material
+- **WHEN** a user runs the capture action
+- **THEN** the action routes to raw source or evidence preservation paths
+- **AND** raw provenance is preserved rather than silently converted into a compiled conclusion
+
+### Requirement: Review Connect Adopt And Maintain Actions
+The system SHALL expose simple actions for knowledge hygiene, graph building, adoption, and maintenance while preserving existing safety contracts.
+
+#### Scenario: Review stays proposal-oriented
+- **WHEN** a user runs the review action
+- **THEN** it routes to review queues or audit reports
+- **AND** it does not mutate vault content unless the user explicitly selects a write-capable maintenance path
+
+#### Scenario: Connect stays proposal-oriented by default
+- **WHEN** a user runs the connect action
+- **THEN** it routes to link or relation suggestion paths by default
+- **AND** suggested graph relations remain review-only until accepted through an explicit write
+
+#### Scenario: Adopt remains safe by default
+- **WHEN** a user runs the adopt action
+- **THEN** it uses scan-only adoption by default
+- **AND** copy or compile planning modes require explicit options and preserve originals
+
+#### Scenario: Maintain separates audit from fix
+- **WHEN** a user runs the maintain action without a fix option
+- **THEN** it performs read-only diagnostics
+- **AND** write-capable fixes remain explicit and use the canonical `audit_fix` or reconcile paths

--- a/openspec/changes/simplify-command-surface/tasks.md
+++ b/openspec/changes/simplify-command-surface/tasks.md
@@ -1,0 +1,30 @@
+## 1. Action Catalog
+
+- [x] 1.1 Add a registry-derived simple action catalog for `ask`, `remember`, `capture`, `review`, `connect`, `adopt`, and `maintain`.
+- [x] 1.2 Define canonical routes, default arguments, safety notes, and advanced fallbacks for each simple action.
+- [x] 1.3 Add tests proving the action catalog is derived from canonical command metadata and has no orphan routes.
+
+## 2. CLI Aliases
+
+- [x] 2.1 Add `exomem ask` as a thin alias over `find` with compact recall defaults and an explicit deep/context option.
+- [x] 2.2 Add write aliases for `remember` and `capture` that route through `note`, `add`, or `preserve` without bypassing validation.
+- [x] 2.3 Add read/proposal aliases for `review`, `connect`, `adopt`, and `maintain`, with write-capable behavior explicit.
+- [x] 2.4 Preserve canonical registry commands and JSON envelope behavior for aliases.
+
+## 3. Bootstrap And Scaffold Guidance
+
+- [x] 3.1 Update bootstrap to expose simple actions first, with canonical routes and safety posture.
+- [x] 3.2 Update `common_tools` or equivalent guidance so generic agents can start with actions and fall through to advanced tools.
+- [x] 3.3 Update `_Schema` scaffold guidance and operation references to use user-intent language before tool names.
+
+## 4. Documentation And Generated Artifacts
+
+- [x] 4.1 Update `docs/ai-assistant-guide.md` and `QUICKSTART.md` with the simple action model.
+- [x] 4.2 Regenerate `docs/capabilities.md` if command metadata or docs generation changes.
+- [x] 4.3 Update MCP schema fixtures only if canonical MCP tool schemas intentionally change.
+
+## 5. Verification
+
+- [x] 5.1 Run focused tests for bootstrap, CLI aliases, command metadata, scaffold leak checks, and MCP schema fidelity.
+- [x] 5.2 Run `openspec validate simplify-command-surface`.
+- [x] 5.3 Run `git diff --check`.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -73,6 +73,8 @@ def main(argv: list[str] | None = None) -> int:
         return _list_speakers_main(raw[1:])
     if raw and raw[0] == "remove-speaker":
         return _remove_speaker_main(raw[1:])
+    if raw and raw[0] in _simple_cli_action_names():
+        return _simple_action_main(raw)
     # Registry-driven core operations (reads + writes): `kb find "…"`, `kb get …`,
     # `kb note …`, etc. — every command on the `cli` surface.
     if raw and raw[0] in _core_op_names():
@@ -780,6 +782,273 @@ def _install_hook_main(argv: list[str]) -> int:
         print(hook_module.snippet(report["installed"]))
     return 0
 
+
+# --------------------------------------------------------------------------- #
+# Simple product actions (friendly CLI aliases over canonical registry commands)
+# --------------------------------------------------------------------------- #
+_SIMPLE_CLI_ACTIONS = frozenset({"ask", "remember", "capture", "review", "connect", "maintain"})
+
+
+def _simple_cli_action_names() -> frozenset[str]:
+    return _SIMPLE_CLI_ACTIONS
+
+
+def _with_json(argv: list[str], enabled: bool) -> list[str]:
+    return argv + (["--json"] if enabled else [])
+
+
+def _append_repeated(argv: list[str], flag: str, values: list[str] | None) -> None:
+    for value in values or []:
+        argv.extend([flag, value])
+
+
+def _field(argv: list[str], name: str, value: object | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, list):
+        if not value:
+            return
+        value = ",".join(str(item) for item in value)
+    argv.extend(["--field", f"{name}={value}"])
+
+
+def _simple_action_main(argv: list[str]) -> int:
+    action = argv[0]
+    rest = argv[1:]
+    if action == "ask":
+        return _simple_ask_main(rest)
+    if action == "remember":
+        return _simple_remember_main(rest)
+    if action == "capture":
+        return _simple_capture_main(rest)
+    if action == "review":
+        return _simple_review_main(rest)
+    if action == "connect":
+        return _simple_connect_main(rest)
+    if action == "maintain":
+        return _simple_maintain_main(rest)
+    raise AssertionError(f"unhandled simple action: {action}")
+
+
+def _simple_ask_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem ask",
+        description="Ask Exomem what it knows. Thin alias over find with compact recall defaults.",
+    )
+    parser.add_argument("query", help="question or search phrase")
+    parser.add_argument("--deep", action="store_true", help="include a packed reasoning context")
+    parser.add_argument(
+        "--graph-enrich",
+        action="store_true",
+        help="with --deep, include typed graph neighborhood data when available",
+    )
+    parser.add_argument("--limit", type=int, default=15, help="maximum hits to return")
+    parser.add_argument(
+        "--scope",
+        choices=("kb", "vault", "kb-only"),
+        default="kb",
+        help="search scope (default: kb, which can auto-widen)",
+    )
+    parser.add_argument("--type", dest="types", action="append", default=None, help="page type filter (repeatable)")
+    parser.add_argument("--project", dest="projects", action="append", default=None, help="project filter (repeatable)")
+    parser.add_argument("--tag", dest="tags", action="append", default=None, help="tag filter (repeatable)")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    core = [
+        "find",
+        args.query,
+        "--detail",
+        "compact",
+        "--no-rerank",
+        "--limit",
+        str(args.limit),
+        "--scope",
+        args.scope,
+    ]
+    _append_repeated(core, "--types", args.types)
+    _append_repeated(core, "--projects", args.projects)
+    _append_repeated(core, "--tags", args.tags)
+    if args.deep or args.graph_enrich:
+        core.append("--pack")
+    if args.graph_enrich:
+        core.append("--graph-enrich")
+    return _core_op_main(_with_json(core, args.json))
+
+
+def _simple_remember_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem remember",
+        description="Remember a durable conclusion. Thin alias over note.",
+    )
+    parser.add_argument("content", help="compiled note body markdown")
+    parser.add_argument("--title", required=True, help="note title")
+    parser.add_argument("--type", dest="note_type", default="insight", help="note type (default: insight)")
+    parser.add_argument("--project", help="research-note project key")
+    parser.add_argument("--project-ref", dest="projects", action="append", default=None, help="projects list entry (repeatable)")
+    parser.add_argument("--source", dest="sources", action="append", default=None, help="source/evidence path (repeatable)")
+    parser.add_argument("--tag", dest="tags", action="append", default=None, help="tag (repeatable)")
+    parser.add_argument("--status", help="status override")
+    parser.add_argument("--severity", help="failure severity")
+    parser.add_argument("--pattern-type", help="pattern subtype")
+    parser.add_argument("--domain", help="experiment domain")
+    parser.add_argument("--started", help="experiment start date")
+    parser.add_argument("--duration", help="experiment duration")
+    parser.add_argument("--medium", help="production-log medium")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    core = [
+        "note",
+        "--content",
+        args.content,
+        "--note-type",
+        args.note_type,
+        "--title",
+        args.title,
+    ]
+    _field(core, "project", args.project)
+    _field(core, "projects", args.projects)
+    _field(core, "sources", args.sources)
+    _field(core, "tags", args.tags)
+    _field(core, "status", args.status)
+    _field(core, "severity", args.severity)
+    _field(core, "pattern_type", args.pattern_type)
+    _field(core, "domain", args.domain)
+    _field(core, "started", args.started)
+    _field(core, "duration", args.duration)
+    _field(core, "medium", args.medium)
+    return _core_op_main(_with_json(core, args.json))
+
+
+def _simple_capture_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem capture",
+        description="Capture raw source or proof-bearing text. Thin alias over add/preserve.",
+    )
+    parser.add_argument("content", help="raw text to capture")
+    parser.add_argument("--as", dest="capture_kind", choices=("source", "evidence"), default="source")
+    parser.add_argument("--title", help="source title (required for --as source)")
+    parser.add_argument("--source-type", default="other", help="source type for --as source")
+    parser.add_argument("--url", help="source URL")
+    parser.add_argument("--tag", dest="tags", action="append", default=None, help="tag (repeatable)")
+    parser.add_argument("--why-captured", help="why this source is worth keeping")
+    parser.add_argument("--scope", help="evidence scope for --as evidence")
+    parser.add_argument("--category", help="evidence category for --as evidence")
+    parser.add_argument("--filename", help="evidence filename for --as evidence")
+    parser.add_argument("--description", help="evidence sidecar description")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    if args.capture_kind == "source":
+        if not args.title:
+            parser.error("--title is required when --as source")
+        core = [
+            "add",
+            "--content",
+            args.content,
+            "--source-type",
+            args.source_type,
+            "--title",
+            args.title,
+        ]
+        if args.url:
+            core.extend(["--url", args.url])
+        _append_repeated(core, "--tags", args.tags)
+        if args.why_captured:
+            core.extend(["--why-captured", args.why_captured])
+    else:
+        missing = [name for name in ("scope", "category", "filename") if not getattr(args, name)]
+        if missing:
+            parser.error("--as evidence requires " + ", ".join(f"--{name}" for name in missing))
+        core = [
+            "preserve",
+            "--scope",
+            args.scope,
+            "--category",
+            args.category,
+            "--filename",
+            args.filename,
+            "--content",
+            args.content,
+        ]
+        if args.description:
+            core.extend(["--description", args.description])
+    return _core_op_main(_with_json(core, args.json))
+
+
+def _simple_review_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem review",
+        description="Review knowledge needing attention. Thin alias over attention/audit.",
+    )
+    parser.add_argument("--audit", action="store_true", help="run the full audit report instead of attention queue")
+    parser.add_argument("--category", dest="categories", action="append", default=None, help="review/audit category (repeatable)")
+    parser.add_argument("--limit", type=int, default=25, help="attention item cap")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    core = ["audit"] if args.audit else ["attention", "--limit", str(args.limit)]
+    _append_repeated(core, "--categories", args.categories)
+    return _core_op_main(_with_json(core, args.json))
+
+
+def _simple_connect_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem connect",
+        description="Suggest links or typed graph relations. Proposal-only by default.",
+    )
+    parser.add_argument("--path", help="existing page path")
+    parser.add_argument("--draft-title", help="draft title")
+    parser.add_argument("--draft-body", help="draft body")
+    parser.add_argument("--relations", action="store_true", help="suggest typed graph relations instead of wikilinks")
+    parser.add_argument("--model-suggestions", action="store_true", help="opt into model-backed relation suggestions")
+    parser.add_argument("--limit", type=int, default=8, help="candidate cap")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    core = ["suggest_relations" if args.relations else "suggest_links"]
+    if args.path:
+        core.extend(["--path", args.path])
+    if args.draft_title:
+        core.extend(["--draft-title", args.draft_title])
+    if args.draft_body:
+        core.extend(["--draft-body", args.draft_body])
+    core.extend(["--limit", str(args.limit)])
+    if args.relations and args.model_suggestions:
+        core.append("--include-model-suggestions")
+    return _core_op_main(_with_json(core, args.json))
+
+
+def _simple_maintain_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem maintain",
+        description="Check vault health; write-capable fixes require explicit flags.",
+    )
+    parser.add_argument("--fix", action="store_true", help="run audit_fix instead of read-only audit")
+    parser.add_argument("--reconcile", action="store_true", help="run reconcile instead of read-only audit")
+    parser.add_argument("--dry-run", action="store_true", help="with --fix/--reconcile, report without writing")
+    parser.add_argument("--rebuild-embeddings", action="store_true", help="with --fix, rebuild text embeddings")
+    parser.add_argument("--category", dest="categories", action="append", default=None, help="audit category (repeatable)")
+    parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
+    args = parser.parse_args(argv)
+
+    if args.fix and args.reconcile:
+        parser.error("choose only one of --fix or --reconcile")
+    if args.fix:
+        core = ["audit_fix"]
+        if args.dry_run:
+            core.append("--dry-run")
+        if args.rebuild_embeddings:
+            core.append("--rebuild-embeddings")
+    elif args.reconcile:
+        core = ["reconcile"]
+        if args.dry_run:
+            core.append("--dry-run")
+    else:
+        core = ["audit"]
+        _append_repeated(core, "--categories", args.categories)
+    return _core_op_main(_with_json(core, args.json))
 
 # --------------------------------------------------------------------------- #
 # Registry-driven core operations (reads + writes)

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -189,37 +189,35 @@ The Tier 2 filesystem ops below may be turned off on lean deployments
 ## Simple front door
 
 Speak to users in simple actions first. Use the typed operations underneath.
-Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
-`replace` unless that implementation detail changes what will happen.
+Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, graph
+sidecars, schema blocks, or `replace` unless that implementation detail changes
+what will happen.
 
 Native assistant memory is for preferences, style, identity facts, and routing
 rules such as "use Exomem for my project knowledge." Exomem is for durable
 governed knowledge: sourced conclusions, project context, decisions, failures,
 experiments, proof-bearing records, review, and supersession.
 
-| User phrasing | User-facing action | Preferred route |
+| Simple action | User phrasing | Preferred route |
 |---|---|---|
-| "remember this," "save this conclusion" | Save durable knowledge | `note` for the conclusion; `add` first if raw provenance matters |
-| "find what I concluded," "what do I know about X" | Search prior knowledge | `find` first, then `get` or `find(pack=true)` when synthesis needs context |
-| "save this article/source/transcript" | Preserve raw source | `add`; offer compilation only when there is a stable conclusion |
-| "keep this receipt/record/proof" | Preserve proof-bearing material | `preserve` or upload to Evidence for cases, claims, warranties, disputes, and records |
-| "compile this evidence" | Write a sourced conclusion | `note` with source/evidence links; run `suggest_links` before writing |
-| "review stale knowledge" | Surface review candidates | `attention`, `audit`, or stale-review checks; never auto-decay or down-rank |
-| "this replaces the old conclusion" | Supersede old knowledge | `replace`; do not create an unlinked duplicate |
-| "fix this small detail" | Patch an existing conclusion | `edit` when the core claim is unchanged |
-| "connect these ideas" | Improve the graph | `suggest_links` and `link` |
-| "what does this existing vault contain" | Assess before writing | `overview` or `adopt(mode="scan-only")` |
+| `ask` | "what do I know," "find what I concluded," "show the context" | `find(detail="compact", rerank=false)` first; `get` or `find(pack=true)` when synthesis needs context |
+| `remember` | "remember this," "save this conclusion," "write this decision" | `note`; use `replace` when it supersedes old knowledge |
+| `capture` | "save this article/source/transcript," "keep this receipt/record/proof" | `add` for Sources; `preserve` or upload for Evidence |
+| `review` | "review stale knowledge," "what needs attention," "what sources are unprocessed" | `attention`, `audit`, `propose_compilation` |
+| `connect` | "connect these ideas," "suggest relations," "what does this link to" | `suggest_links`, `suggest_relations`, `graph_context`; `link` only for explicit writes |
+| `adopt` | "what does this existing vault contain," "import/adopt this vault safely" | `adopt(mode="scan-only")` first; explicit modes for manifest/copy/compile planning |
+| `maintain` | "check vault health," "fix safe drift" | `audit` by default; `audit_fix` or `reconcile` only with explicit fix intent |
 
 Examples:
 
 - "Remember this decision" -> write a concise compiled note and report
   `Saved -> <path>`.
-- "What did I conclude about onboarding?" -> `find` first, cite hits, and retry
-  with adjacent terms before treating a miss as meaningful.
-- "Save this article" -> `add` the source with provenance; ask about compiling
+- "What did I conclude about onboarding?" -> `ask`/`find` first, cite hits, and
+  retry with adjacent terms before treating a miss as meaningful.
+- "Save this article" -> `capture` via `add` with provenance; ask about compiling
   only if a conclusion is present.
-- "Keep this receipt for the warranty case" -> preserve it as proof-bearing
-  evidence, not as a general note.
+- "Keep this receipt for the warranty case" -> `capture` via Evidence, not as a
+  general note.
 - "Compile these three sources" -> draft a sourced note, run `suggest_links`,
   then write after the applicable approval rule.
 - "Show stale conclusions" -> run the review path and present candidates for
@@ -228,7 +226,6 @@ Examples:
   visible.
 
 ## Operations
-
 Operations split into two tiers. **Tier 1 is primary** — every typed-note
 workflow goes through it because the type-routing IS the discipline. **Tier 2 is
 the escape hatch** for cases that don't fit a Tier 1 shape. If a write fits Tier

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -4,24 +4,25 @@ Detailed specs for the Knowledge Base operations. Read on first use of an operat
 
 ## Plain-language routing
 
-Agents should hear user intent first and choose the operation second:
+Agents should hear user intent first and choose the operation second. Use the
+simple action names as the routing layer; canonical tools remain the exact
+implementation.
 
-| User intent | Operation path |
-|---|---|
-| Remember a durable conclusion | `note`; use `add` first when raw provenance matters |
-| Find a prior conclusion | `find`, then `get` or `find(pack=true)` if needed |
-| Preserve a source | `add` |
-| Preserve proof or a record | `preserve` or upload |
-| Compile evidence into a conclusion | `note` with source/evidence links |
-| Review stale knowledge | `audit` / stale-review checks |
-| Supersede old knowledge | `replace` |
-| Patch a small detail | `edit` |
+| Simple action | User intent | Operation path |
+|---|---|---|
+| `ask` | Ask what Exomem knows, find a prior conclusion, gather context | `find`, then `get`; use `find(pack=true)` for synthesis |
+| `remember` | Remember a durable conclusion, decision, solved problem, or pattern | `note`; use `replace` if it supersedes old knowledge |
+| `capture` | Preserve raw material, a source, proof, receipt, or record | `add` for Sources; `preserve` or upload for Evidence |
+| `review` | Review stale, contradictory, or unprocessed knowledge | `attention`, `audit`, `propose_compilation` |
+| `connect` | Suggest links, relations, or graph context | `suggest_links`, `suggest_relations`, `graph_context`; `link` only for explicit writes |
+| `adopt` | Assess or import an existing vault safely | `adopt(mode="scan-only")` first; explicit modes for manifest/copy/compile planning |
+| `maintain` | Check or repair vault health | `audit` by default; `audit_fix`/`reconcile` only with explicit fix intent |
 
-Do not ask users to choose internal folders or page types unless the distinction
-changes the write. Translate back to simple language when reporting results.
+Do not ask users to choose internal folders, graph sidecars, or page types unless
+the distinction changes the write. Translate back to simple language when
+reporting results.
 
 ## Index and log discipline (applies to every write)
-
 Every confirmed write that creates, moves, or supersedes a page performs two
 bookkeeping updates:
 

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -268,6 +268,8 @@ def op_bootstrap(
                 "try pack=true for synthesis instead of many get calls",
             ],
         },
+        "simple_actions": simple_action_catalog(selected_packs),
+        "common_actions": list(simple_action_names()),
         "front_door_actions": product_front_door_catalog(selected_packs),
         "tool_catalog": product_tool_catalog(),
         "common_tools": [
@@ -2440,6 +2442,77 @@ def note_description(project_keys_hint: str) -> str:
 # --------------------------------------------------------------------------- #
 # (name, leaf, tier, cli_writes, needs_schema, cli_positional, surfaces)
 _PRODUCT_ACTIONS: tuple[str, ...] = ("save", "adopt", "ask", "prove", "review", "update", "connect")
+_SIMPLE_ACTIONS: tuple[str, ...] = (
+    "ask",
+    "remember",
+    "capture",
+    "review",
+    "connect",
+    "adopt",
+    "maintain",
+)
+_SIMPLE_ACTION_PACK_ALIASES: dict[str, tuple[str, ...]] = {
+    "ask": ("ask",),
+    "remember": ("save", "update"),
+    "capture": ("save", "prove"),
+    "review": ("review",),
+    "connect": ("connect",),
+    "adopt": ("adopt",),
+    "maintain": ("review", "update"),
+}
+_SIMPLE_ACTION_DEFS: dict[str, dict] = {
+    "ask": {
+        "intent": "Recall durable knowledge and cite useful context.",
+        "route": {"tool": "find", "args": {"detail": "compact", "rerank": False}},
+        "deep_route": {
+            "tool": "find",
+            "args": {"detail": "compact", "rerank": False, "pack": True},
+        },
+        "safety": "read-only; deep mode assembles context and graph enrichment stays explicit",
+        "advanced": ["get", "graph_context", "evolution"],
+    },
+    "remember": {
+        "intent": "Save a durable conclusion as compiled governed knowledge.",
+        "route": {"tool": "note", "args": {"note_type": "insight"}},
+        "safety": "additive write; uses note validation and does not preserve raw provenance unless sources are provided",
+        "advanced": ["replace", "edit", "link"],
+    },
+    "capture": {
+        "intent": "Capture raw material or proof-bearing text without turning it into a conclusion.",
+        "route": {"tool": "add", "args": {"source_type": "other"}},
+        "evidence_route": {"tool": "preserve", "args": {}},
+        "safety": "additive write; Sources and Evidence preserve originals/provenance",
+        "advanced": ["mint_upload_token", "propose_compilation"],
+    },
+    "review": {
+        "intent": "Review stale, contradictory, or unprocessed knowledge before acting.",
+        "route": {"tool": "attention", "args": {}},
+        "audit_route": {"tool": "audit", "args": {}},
+        "safety": "read-only by default; surfaces candidates for human judgment",
+        "advanced": ["audit", "propose_compilation", "evolution"],
+    },
+    "connect": {
+        "intent": "Find links or typed relations that make the knowledge graph denser.",
+        "route": {"tool": "suggest_links", "args": {}},
+        "relations_route": {"tool": "suggest_relations", "args": {}},
+        "safety": "proposal-only by default; suggested relations never write automatically",
+        "advanced": ["graph_context", "link"],
+    },
+    "adopt": {
+        "intent": "Assess or import an existing vault safely.",
+        "route": {"tool": "adopt", "args": {"mode": "scan-only"}},
+        "safety": "scan-only by default; copy/compile modes require explicit options and preserve originals",
+        "advanced": ["overview", "propose_compilation"],
+    },
+    "maintain": {
+        "intent": "Check vault health and repair drift only when explicitly requested.",
+        "route": {"tool": "audit", "args": {}},
+        "fix_route": {"tool": "audit_fix", "args": {"dry_run": False}},
+        "reconcile_route": {"tool": "reconcile", "args": {"dry_run": False}},
+        "safety": "read-only by default; write-capable fixes require explicit flags",
+        "advanced": ["audit_fix", "reconcile", "doctor"],
+    },
+}
 _PRODUCT_METADATA: dict[str, dict] = {
     "bootstrap": {"surface": "primary", "actions": (), "first_run_safe": True},
     "adopt": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
@@ -2564,6 +2637,74 @@ def product_tool_catalog() -> dict:
         "advanced": advanced,
         "first_run_safe": [c.name for c in COMMANDS if c.first_run_safe],
     }
+
+
+def _catalog_route_tools(entry: dict) -> set[str]:
+    tools: set[str] = set()
+    for key, value in entry.items():
+        if key == "route" or key.endswith("_route"):
+            if isinstance(value, dict) and value.get("tool"):
+                tools.add(str(value["tool"]))
+    for value in entry.get("advanced", []):
+        tools.add(str(value))
+    return tools
+
+
+def simple_action_names() -> tuple[str, ...]:
+    """The stable, beginner-facing action vocabulary."""
+    return _SIMPLE_ACTIONS
+
+
+def simple_action_catalog(selected_packs: dict | None = None) -> dict:
+    """Product action map over canonical commands; no duplicate command logic."""
+    known_commands = {command.name for command in COMMANDS} | {
+        "doctor",
+        "mint_upload_token",
+    }
+    out: dict[str, dict] = {}
+    for action in _SIMPLE_ACTIONS:
+        definition = _SIMPLE_ACTION_DEFS[action]
+        missing = sorted(_catalog_route_tools(definition) - known_commands)
+        if missing:
+            raise RuntimeError(
+                f"simple action {action!r} references unknown route(s): {missing}"
+            )
+        out[action] = {
+            "intent": definition["intent"],
+            "route": definition["route"],
+            "safety": definition["safety"],
+            "advanced": definition.get("advanced", []),
+        }
+        for key in (
+            "deep_route",
+            "evidence_route",
+            "audit_route",
+            "relations_route",
+            "fix_route",
+            "reconcile_route",
+        ):
+            if key in definition:
+                out[action][key] = definition[key]
+
+    packs = (selected_packs or {}).get("packs") or []
+    if packs:
+        for action, aliases in _SIMPLE_ACTION_PACK_ALIASES.items():
+            alias_set = set(aliases)
+            guidance = []
+            for pack in packs:
+                if not (alias_set & set(pack.get("actions") or [])):
+                    continue
+                guidance.append(
+                    {
+                        "pack_id": pack.get("id"),
+                        "name": pack.get("name"),
+                        "agent_instructions": pack.get("agent_instructions"),
+                        "suggested_workflows": pack.get("suggested_workflows") or [],
+                    }
+                )
+            if guidance:
+                out[action]["selected_pack_guidance"] = guidance
+    return out
 
 
 def product_front_door_catalog(selected_packs: dict | None = None) -> dict:

--- a/src/exomem/knowledge_packs.py
+++ b/src/exomem/knowledge_packs.py
@@ -19,7 +19,6 @@ from typing import Any
 from .kbdir import kb_dirname, kb_prefix
 from .vault import PlannedWrite, batch_atomic_write, kb_root
 
-
 PACK_DIRECTORY = "packs"
 PACK_SELECTION_DIR = "_Packs"
 PACK_SELECTION_FILE = "selected-packs.json"
@@ -67,7 +66,18 @@ PACK_ALLOWED_PRIMITIVES: frozenset[str] = frozenset(
     }
 )
 PACK_ALLOWED_ACTIONS: frozenset[str] = frozenset(
-    {"save", "adopt", "ask", "prove", "review", "update", "connect"}
+    {
+        "save",
+        "adopt",
+        "ask",
+        "prove",
+        "review",
+        "update",
+        "connect",
+        "remember",
+        "capture",
+        "maintain",
+    }
 )
 
 

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -164,37 +164,35 @@ The Tier 2 filesystem ops below may be turned off on lean deployments
 ## Simple front door
 
 Speak to users in simple actions first. Use the typed operations underneath.
-Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
-`replace` unless that implementation detail changes what will happen.
+Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, graph
+sidecars, schema blocks, or `replace` unless that implementation detail changes
+what will happen.
 
 Native assistant memory is for preferences, style, identity facts, and routing
 rules such as "use Exomem for my project knowledge." Exomem is for durable
 governed knowledge: sourced conclusions, project context, decisions, failures,
 experiments, proof-bearing records, review, and supersession.
 
-| User phrasing | User-facing action | Preferred route |
+| Simple action | User phrasing | Preferred route |
 |---|---|---|
-| "remember this," "save this conclusion" | Save durable knowledge | `note` for the conclusion; `add` first if raw provenance matters |
-| "find what I concluded," "what do I know about X" | Search prior knowledge | `find` first, then `get` or `find(pack=true)` when synthesis needs context |
-| "save this article/source/transcript" | Preserve raw source | `add`; offer compilation only when there is a stable conclusion |
-| "keep this receipt/record/proof" | Preserve proof-bearing material | `preserve` or upload to Evidence for cases, claims, warranties, disputes, and records |
-| "compile this evidence" | Write a sourced conclusion | `note` with source/evidence links; run `suggest_links` before writing |
-| "review stale knowledge" | Surface review candidates | `attention`, `audit`, or stale-review checks; never auto-decay or down-rank |
-| "this replaces the old conclusion" | Supersede old knowledge | `replace`; do not create an unlinked duplicate |
-| "fix this small detail" | Patch an existing conclusion | `edit` when the core claim is unchanged |
-| "connect these ideas" | Improve the graph | `suggest_links` and `link` |
-| "what does this existing vault contain" | Assess before writing | `overview` or `adopt(mode="scan-only")` |
+| `ask` | "what do I know," "find what I concluded," "show the context" | `find(detail="compact", rerank=false)` first; `get` or `find(pack=true)` when synthesis needs context |
+| `remember` | "remember this," "save this conclusion," "write this decision" | `note`; use `replace` when it supersedes old knowledge |
+| `capture` | "save this article/source/transcript," "keep this receipt/record/proof" | `add` for Sources; `preserve` or upload for Evidence |
+| `review` | "review stale knowledge," "what needs attention," "what sources are unprocessed" | `attention`, `audit`, `propose_compilation` |
+| `connect` | "connect these ideas," "suggest relations," "what does this link to" | `suggest_links`, `suggest_relations`, `graph_context`; `link` only for explicit writes |
+| `adopt` | "what does this existing vault contain," "import/adopt this vault safely" | `adopt(mode="scan-only")` first; explicit modes for manifest/copy/compile planning |
+| `maintain` | "check vault health," "fix safe drift" | `audit` by default; `audit_fix` or `reconcile` only with explicit fix intent |
 
 Examples:
 
 - "Remember this decision" -> write a concise compiled note and report
   `Saved -> <path>`.
-- "What did I conclude about onboarding?" -> `find` first, cite hits, and retry
-  with adjacent terms before treating a miss as meaningful.
-- "Save this article" -> `add` the source with provenance; ask about compiling
+- "What did I conclude about onboarding?" -> `ask`/`find` first, cite hits, and
+  retry with adjacent terms before treating a miss as meaningful.
+- "Save this article" -> `capture` via `add` with provenance; ask about compiling
   only if a conclusion is present.
-- "Keep this receipt for the warranty case" -> preserve it as proof-bearing
-  evidence, not as a general note.
+- "Keep this receipt for the warranty case" -> `capture` via Evidence, not as a
+  general note.
 - "Compile these three sources" -> draft a sourced note, run `suggest_links`,
   then write after the applicable approval rule.
 - "Show stale conclusions" -> run the review path and present candidates for
@@ -203,7 +201,6 @@ Examples:
   visible.
 
 ## Operations
-
 Operations split into two tiers. **Tier 1 is primary** — every typed-note
 workflow goes through it because the type-routing IS the discipline. **Tier 2 is
 the escape hatch** for cases that don't fit a Tier 1 shape. If a write fits Tier

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -42,6 +42,10 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
         "memory_model",
         "knowledge_packs",
     } <= set(out)
+    assert set(out["common_actions"]) == set(commands.simple_action_names())
+    assert out["simple_actions"]["ask"]["route"]["tool"] == "find"
+    assert out["simple_actions"]["remember"]["route"]["tool"] == "note"
+    assert out["simple_actions"]["capture"]["evidence_route"]["tool"] == "preserve"
     assert "durable governed knowledge" in out["memory_model"]["exomem"]
     assert [s["name"] for s in out["workflow_skills"]] == [
         "exomem-continue",
@@ -116,6 +120,59 @@ def test_product_front_door_metadata_is_registry_derived() -> None:
         assert command.product_surface in {"primary", "advanced"}
         assert set(command.product_actions) <= actions
 
+def test_simple_action_catalog_is_registry_routed() -> None:
+    catalog = commands.simple_action_catalog()
+
+    assert set(catalog) == {
+        "ask",
+        "remember",
+        "capture",
+        "review",
+        "connect",
+        "adopt",
+        "maintain",
+    }
+    assert catalog["ask"]["route"] == {
+        "tool": "find",
+        "args": {"detail": "compact", "rerank": False},
+    }
+    assert catalog["ask"]["deep_route"]["args"]["pack"] is True
+    assert catalog["remember"]["route"]["tool"] == "note"
+    assert catalog["capture"]["route"]["tool"] == "add"
+    assert catalog["capture"]["evidence_route"]["tool"] == "preserve"
+    assert catalog["review"]["route"]["tool"] == "attention"
+    assert catalog["connect"]["relations_route"]["tool"] == "suggest_relations"
+    assert catalog["adopt"]["route"]["args"] == {"mode": "scan-only"}
+    assert catalog["maintain"]["fix_route"]["tool"] == "audit_fix"
+
+    known = {command.name for command in commands.COMMANDS} | {"doctor", "mint_upload_token"}
+    for action, item in catalog.items():
+        routes = [item["route"]]
+        routes.extend(
+            value for key, value in item.items()
+            if key.endswith("_route") and isinstance(value, dict)
+        )
+        for route in routes:
+            assert route["tool"] in known, (action, route)
+        for tool in item["advanced"]:
+            assert tool in known, (action, tool)
+
+    selected = {
+        "packs": [
+            {
+                "id": "legal-warranty",
+                "name": "Legal and warranty",
+                "actions": ["save", "prove", "review"],
+                "agent_instructions": "Preserve proof before compiling claims.",
+                "suggested_workflows": [],
+            }
+        ]
+    }
+    guided = commands.simple_action_catalog(selected)
+    assert guided["remember"]["selected_pack_guidance"][0]["pack_id"] == "legal-warranty"
+    assert guided["capture"]["selected_pack_guidance"][0]["pack_id"] == "legal-warranty"
+    assert guided["review"]["selected_pack_guidance"][0]["pack_id"] == "legal-warranty"
+    assert "selected_pack_guidance" not in guided["connect"]
 
 def test_bootstrap_is_registry_generated_on_public_surfaces(
     vault: Path, monkeypatch: pytest.MonkeyPatch, capsys

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -195,3 +195,107 @@ def test_unknown_field_key_rejected(vault: Path, capsys) -> None:
     )
     assert code == 1
     assert "UNKNOWN_PARAM" in err
+
+def test_simple_ask_alias_uses_compact_find_defaults(vault: Path, capsys) -> None:
+    code, out, err = _run(["ask", "metabolism", "--json"], capsys)
+    assert code == 0, err
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert isinstance(payload["data"], list)
+    assert payload["data"], "ask should surface fixture notes"
+    assert "excerpt" not in payload["data"][0]
+
+
+def test_simple_ask_alias_can_request_deep_context(vault: Path, capsys) -> None:
+    code, out, err = _run(["ask", "metabolism", "--deep", "--json"], capsys)
+    assert code == 0, err
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert {"hits", "pack"} <= set(payload["data"])
+
+
+def test_simple_remember_alias_routes_to_note(vault: Path, capsys) -> None:
+    code, out, err = _run(
+        [
+            "remember",
+            "# Simple action memory\n\n## Claim\n\nSimple aliases write through note.\n",
+            "--title",
+            "Simple action memory",
+            "--json",
+        ],
+        capsys,
+    )
+    assert code == 0, err
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    written = vault / payload["data"]["path"]
+    assert written.exists()
+    assert "Simple aliases write through note" in written.read_text(encoding="utf-8")
+
+
+def test_simple_capture_alias_routes_to_source_and_evidence(vault: Path, capsys) -> None:
+    code, out, err = _run(
+        [
+            "capture",
+            "raw source body",
+            "--title",
+            "Simple raw source",
+            "--source-type",
+            "other",
+            "--json",
+        ],
+        capsys,
+    )
+    assert code == 0, err
+    source_payload = json.loads(out.strip().splitlines()[-1])
+    assert source_payload["success"] is True
+    assert "/Sources/Other/" in source_payload["data"]["path"]
+
+    code2, out2, err2 = _run(
+        [
+            "capture",
+            "proof body",
+            "--as",
+            "evidence",
+            "--scope",
+            "simple-case",
+            "--category",
+            "receipts",
+            "--filename",
+            "proof.txt",
+            "--json",
+        ],
+        capsys,
+    )
+    assert code2 == 0, err2
+    evidence_payload = json.loads(out2.strip().splitlines()[-1])
+    assert evidence_payload["success"] is True
+    assert "Evidence/simple-case/receipts/proof.txt" in evidence_payload["data"]["path"]
+
+
+def test_simple_review_connect_and_maintain_aliases(vault: Path, capsys) -> None:
+    code, out, err = _run(["review", "--limit", "3", "--json"], capsys)
+    assert code == 0, err
+    review_payload = json.loads(out.strip().splitlines()[-1])
+    assert review_payload["success"] is True
+    assert "items" in review_payload["data"]
+
+    code2, out2, err2 = _run(["maintain", "--json"], capsys)
+    assert code2 == 0, err2
+    maintain_payload = json.loads(out2.strip().splitlines()[-1])
+    assert maintain_payload["success"] is True
+    assert "findings" in maintain_payload["data"]
+
+    code3, out3, err3 = _run(
+        [
+            "connect",
+            "--path",
+            "Notes/Insights/progressive-disclosure-without-mode-fragmentation",
+            "--json",
+        ],
+        capsys,
+    )
+    assert code3 == 0, err3
+    connect_payload = json.loads(out3.strip().splitlines()[-1])
+    assert connect_payload["success"] is True
+    assert isinstance(connect_payload["data"], list)

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+def test_lf_governed_files_are_normalized_in_git_index() -> None:
+    result = subprocess.run(
+        ["git", "ls-files", "--eol"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip("git metadata is unavailable")
+
+    offenders: list[str] = []
+    for line in result.stdout.splitlines():
+        metadata, _, path = line.partition("\t")
+        fields = metadata.split()
+        if "eol=lf" not in fields:
+            continue
+
+        index_eol = next((field for field in fields if field.startswith("i/")), "")
+        if index_eol in {"i/crlf", "i/mixed"}:
+            offenders.append(f"{path} ({index_eol})")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- Adds a simple action catalog for ask, remember, capture, review, connect, adopt, and maintain, routed through canonical Exomem commands.
- Adds CLI aliases for the simple actions while preserving the existing registry/MCP/REST command surface.
- Updates bootstrap, scaffold guidance, quickstart, assistant docs, knowledge-pack docs, OpenSpec artifacts, and tests.
- Adds a regression test for normalized LF-governed Git index entries so EOL churn does not recur.

## Validation
- `openspec validate simplify-command-surface`
- `git diff --check origin/main..HEAD`
- `git ls-files --eol | Select-String ... i/(crlf|mixed)` returned no offenders
- `uv run python -m py_compile src/exomem/commands.py src/exomem/__main__.py src/exomem/knowledge_packs.py`
- `uvx ruff check src/exomem/commands.py src/exomem/__main__.py src/exomem/knowledge_packs.py tests/test_bootstrap.py tests/test_cli_core_ops.py tests/test_line_endings.py`
- `uv run python scripts/generate-capabilities.py --check`
- `uv run python -m pytest tests/test_bootstrap.py tests/test_cli_core_ops.py tests/test_line_endings.py tests/test_scaffold_no_leak.py tests/test_mcp_schema_fidelity.py -q` -> 31 passed
- `uv run python -m pytest -q` -> 1713 passed, 16 skipped