### PR TITLE
Fix Mac import memory pressure and adoption collisions

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -407,7 +407,7 @@ re-runs ASR; combine with `--rediarize` to gain both markers in one pass).
 
 **Install:** `uv sync --extra media --extra diarization`, then build the isolated
 sidecar with `pwsh -File scripts/setup-diarizer.ps1 -Prewarm` on Windows or
-`uv sync --directory sidecar/diarizer` on Linux/macOS.
+`sh scripts/setup-diarizer.sh --prewarm` on Linux/macOS.
 
 Named-speaker diarization's ECAPA voice embedder (`diarization` extra) runs on
 torch and follows the same precedent: it defaults to **CPU when ASR is active** (and

--- a/env.example
+++ b/env.example
@@ -24,6 +24,10 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # Search profile — optional
 # ---------------------------------------------------------------------------
 
+# Capability profile for `exomem doctor` when --profile is omitted.
+# lean | hybrid | media | remote
+# EXOMEM_PROFILE=hybrid
+#
 # Set to 1 for a lean, keyword/BM25-only install (no embeddings, no torch).
 # Leave unset for hybrid semantic search (needs `uv sync --extra embeddings`).
 # EXOMEM_DISABLE_EMBEDDINGS=1
@@ -46,6 +50,11 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 #   performance - use the GPU when a capable one is present (aliases: gpu, turbo).
 # EXOMEM_MODE=normal
 #
+# Startup model preload. On Apple Silicon normal mode defaults to lazy model load
+# to avoid multiplying multi-GB resident models across local stdio sessions.
+# Set 1 to restore eager preload; set 0 to force lazy preload everywhere.
+# EXOMEM_PRELOAD_MODELS=1
+#
 # Explicit device override (wins over the mode). cpu | gpu | auto | cuda | cuda:1 | mps
 #   'gpu'/'auto' opt in with a marginal-VRAM guard; 'cuda' forces it (legacy behavior).
 # EXOMEM_DEVICE=            # global; legacy alias EXOMEM_TORCH_DEVICE
@@ -53,6 +62,11 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # EXOMEM_CLIP_DEVICE=       # CLIP image/text only
 # EXOMEM_ASR_DEVICE=        # faster-whisper ASR (cpu|cuda|auto); own path, not via the above
 # EXOMEM_GPU_MIN_FREE_GB=2  # min free VRAM to accept a GPU (the marginal-VRAM guard)
+#
+# ASR startup preload. On Apple Silicon this defaults off so each local stdio
+# session does not eagerly load a multi-GB Whisper model. Set 1 to preload.
+# EXOMEM_ASR_PREWARM=1
+# EXOMEM_DISABLE_ASR_PREWARM=1
 #
 # Idle-unload reaper (performance/quiet): release resident models after N idle minutes.
 # EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off; default on for quiet/performance, off for normal
@@ -67,6 +81,12 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # extras): hybrid embeddings ON, reranker + image search OFF.
 #   EXOMEM_DISABLE_RANKING=1
 #   EXOMEM_DISABLE_CLIP=1
+#
+# Live write/import semantic indexing. Ordinary note writes embed immediately.
+# Larger watcher batches keep lexical/freshness indexes current and defer
+# semantic embeddings so imports do not load the full vector stack in every
+# local client process. Run `exomem index --scope vault` after a bulk import.
+# EXOMEM_WATCHER_MAX_EMBED_FILES=32
 
 # ---------------------------------------------------------------------------
 # HTTP transport bind — optional (remote / service use)

--- a/scripts/setup-diarizer.sh
+++ b/scripts/setup-diarizer.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+# Build the isolated speaker-diarization sidecar venv (sidecar/diarizer/.venv).
+#
+# Run once per machine at deploy time. Requires uv on PATH. The running service
+# later invokes this sidecar Python by path; it never builds the venv at runtime.
+#
+# Usage:
+#   sh scripts/setup-diarizer.sh
+#   sh scripts/setup-diarizer.sh --prewarm
+
+set -eu
+
+prewarm=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prewarm|-p)
+      prewarm=1
+      ;;
+    --help|-h)
+      sed -n '2,10p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      echo "usage: sh scripts/setup-diarizer.sh [--prewarm]" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found on PATH; install uv first: https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+diarize_dir="$repo_root/sidecar/diarizer"
+
+if [ ! -d "$diarize_dir" ]; then
+  echo "diarizer sidecar directory not found: $diarize_dir" >&2
+  exit 1
+fi
+
+echo "Building diarizer sidecar venv in $diarize_dir ..."
+uv sync --directory "$diarize_dir"
+
+py="$diarize_dir/.venv/bin/python"
+if [ ! -x "$py" ]; then
+  echo "sidecar venv build failed: $py missing" >&2
+  exit 1
+fi
+
+"$py" - <<'PY'
+import warnings
+warnings.filterwarnings("ignore")
+import torch
+from pyannote.audio import Pipeline
+from faster_whisper.audio import decode_audio
+print(
+    "diarizer sidecar OK | torch",
+    torch.__version__,
+    "| cuda",
+    torch.cuda.is_available(),
+    torch.cuda.get_device_name(0) if torch.cuda.is_available() else "CPU",
+)
+PY
+
+if [ "$prewarm" -eq 1 ]; then
+  if [ -z "${HUGGINGFACE_TOKEN:-}${HF_TOKEN:-}" ]; then
+    echo "HUGGINGFACE_TOKEN/HF_TOKEN not set; skipping prewarm (gated download would fail)." >&2
+  else
+    echo "Prewarming pyannote weights (downloads to the shared HF cache)..."
+    "$py" - <<'PY'
+import os
+from pyannote.audio import Pipeline
+model = os.environ.get("EXOMEM_DIARIZE_MODEL", "pyannote/speaker-diarization-3.1")
+token = os.environ.get("HUGGINGFACE_TOKEN") or os.environ.get("HF_TOKEN")
+Pipeline.from_pretrained(model, token=token)
+print("weights cached")
+PY
+  fi
+fi
+
+echo "Done. Sidecar python: $py"
+echo "Next: set HUGGINGFACE_TOKEN, EXOMEM_DIARIZE=1, enroll a speaker, then restart the service."

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -369,8 +369,8 @@ def _doctor_main(argv: list[str]) -> int:
     parser.add_argument(
         "--profile",
         choices=("lean", "hybrid", "media", "remote"),
-        default="lean",
-        help="capability profile to validate (default: lean)",
+        default=None,
+        help="capability profile to validate (default: infer from EXOMEM_PROFILE, else lean)",
     )
     parser.add_argument("--json", action="store_true", help="emit stable JSON")
     parser.add_argument(

--- a/src/exomem/adopt.py
+++ b/src/exomem/adopt.py
@@ -369,6 +369,19 @@ def _resolve_selected_text_file(root: Path, raw: str) -> tuple[Path, str] | dict
     return abs_path, rel
 
 
+def _unique_import_path(folder: Path, stem: str, reserved: set[Path]) -> Path:
+    """Return a path unique on disk and within the pending batch."""
+    i = 1
+    while True:
+        suffix = "" if i == 1 else f"-{i}"
+        candidate = folder / f"{stem}{suffix}.md"
+        if not candidate.exists() and candidate not in reserved:
+            reserved.add(candidate)
+            return candidate
+        i += 1
+
+
+
 def _copy_as_sources(
     root: Path,
     *,
@@ -389,6 +402,7 @@ def _copy_as_sources(
     copied: list[dict] = []
     skipped: list[dict] = []
     writes: list[PlannedWrite] = []
+    reserved_targets: set[Path] = set()
 
     for raw in selected_paths:
         resolved = _resolve_selected_text_file(root, raw)
@@ -401,7 +415,7 @@ def _copy_as_sources(
         text = data.decode("utf-8", errors="replace")
         title = _title_from_text(abs_path, text)
         slug, slug_warning = slugify_with_truncation_check(title)
-        target = unique_path(folder, f"{date_iso}-{slug}")
+        target = _unique_import_path(folder, f"{date_iso}-{slug}", reserved_targets)
         rel_target = target.relative_to(root).as_posix()
         if slug_warning:
             skipped.append({"path": rel, "code": "SLUG_TRUNCATED", "reason": slug_warning})

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -27,6 +27,7 @@ import importlib.util
 import os
 import shutil
 import sqlite3
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,6 +38,7 @@ from .kbdir import kb_dirname, kb_prefix
 Status = Literal["pass", "warn", "fail"]
 Profile = Literal["lean", "hybrid", "media", "remote"]
 VALID_PROFILES: tuple[Profile, ...] = ("lean", "hybrid", "media", "remote")
+PROFILE_ENV = "EXOMEM_PROFILE"
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -97,6 +99,18 @@ def _check(
 
 def _module_available(module: str) -> bool:
     return importlib.util.find_spec(module) is not None
+
+
+def infer_profile() -> Profile:
+    """Infer the doctor capability profile when --profile is omitted."""
+    raw = (os.environ.get(PROFILE_ENV) or "").strip().lower()
+    if raw:
+        if raw not in VALID_PROFILES:
+            raise ValueError(f"unknown {PROFILE_ENV}: {raw!r}. Valid: {list(VALID_PROFILES)}")
+        return raw  # type: ignore[return-value]
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        return "lean"
+    return "lean"
 
 
 def _resolve_vault(vault: str | None) -> tuple[Path | None, DoctorCheck]:
@@ -464,6 +478,116 @@ def _check_asr_backend() -> DoctorCheck:
     )
 
 
+def _mps_available_for_doctor() -> bool:
+    if sys.platform != "darwin" or not _module_available("torch"):
+        return False
+    try:
+        import torch
+
+        mps = getattr(torch.backends, "mps", None)
+        return bool(mps is not None and mps.is_available() and mps.is_built())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _check_mps_headroom() -> DoctorCheck | None:
+    if not _mps_available_for_doctor():
+        return None
+    from . import extract, mode, warmup
+
+    policy = mode.watcher_policy()
+    return _check(
+        "mps.headroom",
+        "pass",
+        "Apple Silicon MPS is available. macOS does not expose a stable non-torch "
+        "free-memory probe for Metal, so Exomem uses policy controls: lazy model "
+        "preload by default, live-write burst deferral, and explicit indexing for imports.",
+        details={
+            "model_preload_allowed": warmup.model_preload_allowed(mode.resolve_mode()),
+            "asr_prewarm_enabled": extract.asr_prewarm_enabled(),
+            "watcher_max_embed_files": policy.max_embed_files_per_batch,
+        },
+    )
+
+
+def _check_asr_prewarm() -> DoctorCheck:
+    from . import extract
+
+    enabled = extract.asr_prewarm_enabled()
+    if enabled:
+        return _check(
+            "asr.prewarm",
+            "pass",
+            "ASR prewarm is enabled; the media worker may load the ASR model at startup.",
+            "Set EXOMEM_ASR_PREWARM=0 to lazy-load ASR on the first media job.",
+        )
+    return _check(
+        "asr.prewarm",
+        "pass",
+        "ASR prewarm is disabled by policy; the model lazy-loads on the first media job.",
+    )
+
+
+def _list_exomem_processes() -> list[dict[str, object]]:
+    if os.name == "nt":
+        return []
+    ps = shutil.which("ps")
+    if not ps:
+        return []
+    try:
+        result = subprocess.run(
+            [ps, "-axo", "pid=,rss=,command="],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=2.0,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if result.returncode != 0:
+        return []
+    rows: list[dict[str, object]] = []
+    current_pid = os.getpid()
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            rss_kb = int(parts[1])
+        except ValueError:
+            continue
+        command = parts[2]
+        if pid == current_pid:
+            continue
+        command_l = command.lower()
+        if "exomem" not in command_l:
+            continue
+        if "--transport" not in command_l and "python -m exomem" not in command_l:
+            continue
+        rows.append({"pid": pid, "rss_mb": round(rss_kb / 1024, 1), "command": command[:180]})
+    return rows
+
+
+def _check_runtime_processes() -> DoctorCheck | None:
+    rows = _list_exomem_processes()
+    if not rows:
+        return None
+    total = round(sum(float(row.get("rss_mb") or 0.0) for row in rows), 1)
+    count = len(rows)
+    status: Status = "warn" if count > 1 else "pass"
+    return _check(
+        "runtime.processes",
+        status,
+        f"Detected {count} other exomem server process(es) using about {total} MB RSS total. "
+        "Each stdio MCP client/session launches its own process; use HTTP service mode "
+        "or lazy/quiet policies on small-memory Macs.",
+        details={"count": count, "rss_mb_total": total, "processes": rows[:8]},
+    )
+
+
 def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
     """LIVE embed+search probe of the embedding sidecar.
 
@@ -772,7 +896,8 @@ def _check_remote_probes() -> list[DoctorCheck]:
     return checks
 
 
-def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool = False) -> DoctorReport:
+def doctor(*, vault: str | None = None, profile: Profile | None = None, probe: bool = False) -> DoctorReport:
+    profile = profile or infer_profile()
     if profile not in VALID_PROFILES:
         raise ValueError(f"unknown profile: {profile!r}. Valid: {list(VALID_PROFILES)}")
 
@@ -789,6 +914,9 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
         _check_resource_posture(profile),
         _check_lexical(vault_root),
     ]
+    runtime_processes = _check_runtime_processes()
+    if runtime_processes is not None:
+        checks.append(runtime_processes)
 
     if profile in ("hybrid", "media"):
         checks.extend([
@@ -801,6 +929,9 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
             _check_models_cache(),
             _check_sqlite_vec(),
         ])
+        mps_headroom = _check_mps_headroom()
+        if mps_headroom is not None:
+            checks.append(mps_headroom)
         sidecar = _check_embedding_sidecar(vault_root)
         if sidecar is not None:
             checks.append(sidecar)
@@ -813,6 +944,7 @@ def doctor(*, vault: str | None = None, profile: Profile = "lean", probe: bool =
             _check_dependency("markitdown", "media"),
             _check_tesseract(),
             _check_asr_backend(),
+            _check_asr_prewarm(),
         ])
 
     if profile == "remote":

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -36,8 +36,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import platform
 import re
 import subprocess
+import sys
 import tempfile
 import threading
 from collections.abc import Iterable
@@ -262,6 +264,21 @@ def _get_whisper():
     return _WHISPER
 
 
+def asr_prewarm_enabled() -> bool:
+    """Whether the media worker should eagerly load the ASR backend at start."""
+    if _env_flag("EXOMEM_DISABLE_ASR_PREWARM"):
+        return False
+    override = os.environ.get("EXOMEM_ASR_PREWARM")
+    if override is not None:
+        return _env_flag("EXOMEM_ASR_PREWARM")
+    legacy_enable = os.environ.get("EXOMEM_ENABLE_ASR_PREWARM")
+    if legacy_enable is not None:
+        return _env_flag("EXOMEM_ENABLE_ASR_PREWARM")
+    if sys.platform == "darwin" and platform.machine() == "arm64":
+        return False
+    return True
+
+
 def prewarm() -> None:
     """Eagerly load the ASR model so the first real transcription isn't a cold-start.
 
@@ -273,6 +290,9 @@ def prewarm() -> None:
     just stays lazy and transcribes nothing until configured.
     """
     if not extraction_enabled():
+        return
+    if not asr_prewarm_enabled():
+        log.info("ASR prewarm skipped by policy; model will lazy-load on first media job")
         return
     try:
         get_transcriber().prewarm()

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -535,6 +535,7 @@ class FileWatcher:
         kb_ups = [p for p in ups if self._is_kb(p)]
         kb_del_rels = [r for r in del_rels if r.startswith(kb_prefix())]
         policy = self._watcher_policy()
+        defer_semantic = False
         if cap and not policy.defer_expensive_indexes:
             max_files = policy.max_reconcile_embed_files
             if max_files is not None and len(kb_ups) > max_files:
@@ -545,6 +546,17 @@ class FileWatcher:
                     max_files, len(kb_ups),
                 )
                 kb_ups = kb_ups[:max_files]
+        elif not cap and not policy.defer_expensive_indexes:
+            max_files = policy.max_embed_files_per_batch
+            if max_files is not None and len(kb_ups) > max_files:
+                log.warning(
+                    "file watcher: live import/sync burst has %d KB file(s), above "
+                    "EXOMEM_WATCHER_MAX_EMBED_FILES=%d; lexical indexes updated but "
+                    "semantic indexing deferred. Run `exomem index --scope vault` "
+                    "after the import.",
+                    len(kb_ups), max_files,
+                )
+                defer_semantic = True
         elif policy.defer_expensive_indexes and kb_ups:
             log.info(
                 "file watcher: quiet mode deferring semantic indexing for %d KB file(s)",
@@ -552,7 +564,9 @@ class FileWatcher:
             )
         if kb_ups:
             try:
-                index_sync.upsert_after_write(self._vault_root, kb_ups)
+                index_sync.upsert_after_write(
+                    self._vault_root, kb_ups, defer_semantic=defer_semantic
+                )
             except Exception:  # noqa: BLE001
                 log.exception("file watcher: upsert_after_write failed for %d file(s)", len(kb_ups))
         if kb_del_rels:

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -140,7 +140,9 @@ def drain_deferred_work(vault_root: Path, *, limit: int | None = None) -> int:
     return clear_deferred_work(vault_root, paths=paths)
 
 
-def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
+def upsert_after_write(
+    vault_root: Path, written_paths: list[Path], *, defer_semantic: bool = False
+) -> None:
     """Fan a writer's markdown change out to every index sidecar.
 
     Paths under excluded scan dirs (`_trash/`, `_archive/`, `_Schema/`, ...) are
@@ -175,7 +177,7 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
     except Exception:  # noqa: BLE001 -- resolver sync must never fail a write
         log.debug("resolver re-sync after write failed", exc_info=True)
     epistemic_graph.upsert_after_write(vault_root, eligible)
-    if mode.defer_expensive_indexes():
+    if defer_semantic or mode.defer_expensive_indexes():
         added = _record_deferred_semantic_upserts(vault_root, eligible)
         if added:
             log.info("deferred semantic indexing for %d markdown file(s)", added)

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -61,12 +61,15 @@ class MediaWorker:
             )
             self._thread.start()
             log.info("media extraction worker started")
-            # Warm the ASR model off the request path so the first audio/video upload
-            # isn't a multi-minute cold-start (large-v3 ~3 GB loads lazily on first use).
-            # Separate daemon thread so image/PDF/CLIP jobs aren't blocked while it loads.
-            threading.Thread(
-                target=extract.prewarm, name="kb-asr-prewarm", daemon=True
-            ).start()
+            # Warm the ASR model off the request path only when policy allows it.
+            # On Apple Silicon this defaults to lazy load to avoid multiplying
+            # multi-GB model residency across local stdio client processes.
+            if extract.asr_prewarm_enabled():
+                threading.Thread(
+                    target=extract.prewarm, name="kb-asr-prewarm", daemon=True
+                ).start()
+            else:
+                log.info("ASR prewarm disabled by policy; first media job will lazy-load")
             # Boot-time diarization readiness line (cheap: a path check + small JSON
             # read) — the soft-fail design otherwise hides a broken stack entirely.
             extract.log_diarization_readiness(self._vault_root)

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -52,6 +52,7 @@ _DEFAULT_DEBOUNCE_SECONDS = 0.5
 _QUIET_DEBOUNCE_SECONDS = 2.0
 _DEFAULT_RECONCILE_INTERVAL_SECONDS = 300.0
 _QUIET_RECONCILE_INTERVAL_SECONDS = 900.0
+_DEFAULT_LIVE_MAX_EMBED_FILES = 32
 _DEFAULT_RECONCILE_MAX_EMBED_FILES = 500
 _QUIET_EXPENSIVE_INDEX_CAP = 0
 
@@ -59,6 +60,7 @@ _MODE_ENV = "EXOMEM_MODE"
 _QUIET_ALIAS_ENV = "EXOMEM_QUIET_MODE"
 _CONFIG_PATH_ENV = "EXOMEM_CONFIG_PATH"
 _RELEASE_ENV = "EXOMEM_RELEASE_GPU_WHEN_IDLE"
+_WATCHER_MAX_EMBED_FILES_ENV = "EXOMEM_WATCHER_MAX_EMBED_FILES"
 
 
 @dataclass(frozen=True)
@@ -78,6 +80,17 @@ class WatcherPolicy:
 def _truthy(value: str | None) -> bool:
     """Shared truthiness convention (mirrors `freshness._truthy`)."""
     return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        log.warning("ignoring invalid %s=%r; using %d", name, raw, default)
+        return default
 
 
 def normalize(value: str | None) -> str | None:
@@ -167,7 +180,9 @@ def watcher_policy() -> WatcherPolicy:
     return WatcherPolicy(
         debounce_seconds=_DEFAULT_DEBOUNCE_SECONDS,
         reconcile_interval_seconds=_DEFAULT_RECONCILE_INTERVAL_SECONDS,
-        max_embed_files_per_batch=None,
+        max_embed_files_per_batch=_int_env(
+            _WATCHER_MAX_EMBED_FILES_ENV, _DEFAULT_LIVE_MAX_EMBED_FILES
+        ),
         max_reconcile_embed_files=_DEFAULT_RECONCILE_MAX_EMBED_FILES,
         defer_expensive_indexes=False,
     )

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -36,6 +36,7 @@ from . import personalize as personalize_module
 from .kbdir import kb_dirname, kb_prefix
 
 _SKILL_NAME_MARKER = "name: exomem"
+_CLAUDE_SCOPES = ("user", "local", "project")
 
 
 def _format_pack_suggestions(packs: list[dict], *, limit: int = 3) -> str:
@@ -131,6 +132,33 @@ def _server_command(which_fn) -> list[str]:
     if console_script:
         return [console_script, "--transport", "stdio"]
     return ["uvx", "exomem", "--transport", "stdio"]
+
+
+def _output_mentions_exomem(output: str) -> bool:
+    for line in output.splitlines():
+        stripped = line.strip().lower()
+        if not stripped:
+            continue
+        if stripped.startswith("exomem") or '"exomem"' in stripped or "name: exomem" in stripped:
+            return True
+    return False
+
+
+def _claude_registered_scopes(claude: str, run_fn, run_kwargs: dict) -> list[str]:
+    scopes: list[str] = []
+    for item in _CLAUDE_SCOPES:
+        try:
+            result = run_fn([claude, "mcp", "list", "--scope", item], **run_kwargs)
+        except Exception:  # noqa: BLE001 - registration can still try the requested add
+            continue
+        output = (result.stdout or "") + (result.stderr or "")
+        if result.returncode == 0 and _output_mentions_exomem(output):
+            scopes.append(item)
+    return scopes
+
+
+def _format_scopes(scopes: list[str]) -> str:
+    return ", ".join(scopes) if scopes else "none"
 
 
 def run_setup(
@@ -352,23 +380,39 @@ def run_setup(
             # encoding pinned: Windows-native Python otherwise decodes pipes as
             # cp1252 and multibyte output crashes the reader thread
             run_kwargs = dict(capture_output=True, text=True, encoding="utf-8", errors="replace")
-            result = run_fn(argv, **run_kwargs)
-            output = (result.stderr or "") + (result.stdout or "")
-            if result.returncode == 0:
-                report("register", f"[done] registered with Claude Code (scope {scope})")
-            elif "already exists" in output:
-                if not yes and _ask_yn(input_fn, "exomem is already registered. Replace it?", False):
-                    run_fn([claude, "mcp", "remove", "exomem", "--scope", scope], **run_kwargs)
+            existing_scopes = _claude_registered_scopes(claude, run_fn, run_kwargs)
+            if existing_scopes:
+                scope_text = _format_scopes(existing_scopes)
+                if yes:
+                    report("register", f"[skipped: already registered in {scope_text}]")
+                elif _ask_yn(input_fn, f"exomem is already registered in {scope_text}. Replace it?", False):
+                    for existing_scope in existing_scopes:
+                        run_fn([claude, "mcp", "remove", "exomem", "--scope", existing_scope], **run_kwargs)
                     result = run_fn(argv, **run_kwargs)
                     if result.returncode == 0:
-                        report("register", "[done] re-registered")
+                        report("register", f"[done] re-registered with Claude Code (scope {scope})")
                     else:
                         report("register", f"[failed: {(result.stderr or '').strip()}]")
                 else:
-                    report("register", "[skipped: already registered]")
+                    report("register", f"[skipped: already registered in {scope_text}]")
             else:
-                detail = (result.stderr or "").strip() or f"claude mcp add exited {result.returncode}"
-                report("register", f"[failed: {detail}]")
+                result = run_fn(argv, **run_kwargs)
+                output = (result.stderr or "") + (result.stdout or "")
+                if result.returncode == 0:
+                    report("register", f"[done] registered with Claude Code (scope {scope})")
+                elif "already exists" in output:
+                    if not yes and _ask_yn(input_fn, "exomem is already registered. Replace it?", False):
+                        run_fn([claude, "mcp", "remove", "exomem", "--scope", scope], **run_kwargs)
+                        result = run_fn(argv, **run_kwargs)
+                        if result.returncode == 0:
+                            report("register", "[done] re-registered")
+                        else:
+                            report("register", f"[failed: {(result.stderr or '').strip()}]")
+                    else:
+                        report("register", "[skipped: already registered]")
+                else:
+                    detail = (result.stderr or "").strip() or f"claude mcp add exited {result.returncode}"
+                    report("register", f"[failed: {detail}]")
 
     # 7. skill — the brain; without it the tools sit unused
     skill_target = (home / "skills" / "exomem") if home else None

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
+import platform
 import threading
 import time
 from pathlib import Path
@@ -41,6 +42,23 @@ _WARM_THREAD: threading.Thread | None = None
 
 def warmup_enabled() -> bool:
     return not os.environ.get("EXOMEM_DISABLE_WARMUP")
+
+
+def model_preload_allowed(mode_name: str | None = None) -> bool:
+    """Whether startup may eagerly load model weights in this process.
+
+    Normal-mode Apple Silicon defaults to lazy model loads. Multiple local stdio
+    clients naturally mean multiple Python processes, and eager BGE/CLIP/ASR
+    preloads can multiply into a multi-GB-per-chat footprint during imports.
+    `EXOMEM_PRELOAD_MODELS=1` opts back into the old eager behavior.
+    """
+    override = os.environ.get("EXOMEM_PRELOAD_MODELS")
+    if override is not None and override.strip() != "":
+        return override.strip().lower() not in {"0", "false", "no", "off"}
+    resolved_mode = mode_name or "normal"
+    if resolved_mode == "normal" and platform.system() == "Darwin" and platform.machine() == "arm64":
+        return False
+    return True
 
 
 def warm_caches(
@@ -139,7 +157,8 @@ def warm_all(vault_root: Path) -> dict[str, float]:
     """
     from . import mode, readiness
 
-    preload = mode.preload_models()
+    mode_name = mode.resolve_mode()
+    preload = mode.preload_models() and model_preload_allowed(mode_name)
     durations = warm_caches(
         vault_root,
         preload_models=preload,
@@ -183,7 +202,7 @@ def warm_all(vault_root: Path) -> dict[str, float]:
         # idle-unload reaper reclaims them). Mark the model components ready either
         # way so finds during the lexical warm don't carry a "warming" marker for
         # models that won't preload, and writers stop deferring.
-        reason = "EXOMEM_DISABLE_EMBEDDINGS" if disabled else "quiet mode"
+        reason = "EXOMEM_DISABLE_EMBEDDINGS" if disabled else "mode/preload policy"
         log.info("model preloads skipped (%s); models lazy-load on first use", reason)
         readiness.mark_ready("reranker")
         readiness.mark_ready("clip")

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -136,6 +136,37 @@ def test_adopt_copy_as_sources_preserves_original_and_records_provenance(tmp_pat
     assert "# Laptop receipt" in source_text
 
 
+def test_adopt_copy_as_sources_disambiguates_same_basename_batch(tmp_path: Path) -> None:
+    vault = _legacy_vault(tmp_path, kb=True)
+    for folder, body in (("Mercor A", "alpha answer"), ("Mercor B", "beta answer")):
+        target = vault / folder / "Task1.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"# Task1\n\n{body}\n", encoding="utf-8")
+
+    report = adopt_module.adopt(
+        vault,
+        mode="copy-as-sources",
+        selected_paths=["Mercor A/Task1.md", "Mercor B/Task1.md"],
+        today=dt.date(2026, 7, 7),
+    )
+
+    copied = report["copy"]["copied_sources"]
+    source_paths = [item["source_path"] for item in copied]
+    assert len(copied) == 2
+    assert len(set(source_paths)) == 2
+    assert source_paths == [
+        "Knowledge Base/Sources/Imported/2026-07-07-task1.md",
+        "Knowledge Base/Sources/Imported/2026-07-07-task1-2.md",
+    ]
+    source_texts = {
+        item["original_path"]: (vault / item["source_path"]).read_text(encoding="utf-8")
+        for item in copied
+    }
+    assert "alpha answer" in source_texts["Mercor A/Task1.md"]
+    assert "beta answer" in source_texts["Mercor B/Task1.md"]
+
+
+
 def test_adopt_compile_selected_copies_and_returns_reviewable_plan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -10,11 +10,17 @@ import io
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from exomem import doctor as doctor_module
 from exomem.__main__ import main
+
+
+@pytest.fixture(autouse=True)
+def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_PROFILE", raising=False)
 
 
 def _run(argv: list[str], capsys) -> tuple[int, str, str]:
@@ -45,6 +51,13 @@ def test_doctor_json_cli(vault: Path, capsys) -> None:
     assert payload["success"] is True
     assert payload["profile"] == "lean"
     assert {"id", "status", "message", "remediation"} <= set(payload["checks"][0])
+
+
+def test_doctor_infers_profile_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_PROFILE", "hybrid")
+
+    assert doctor_module.infer_profile() == "hybrid"
+
 
 
 def test_doctor_missing_vault_fails(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -309,3 +322,47 @@ def test_resource_posture_reports_container_variant_without_cuda_import(
     assert details["runtime"]["kind"] == "container"
     assert details["runtime"]["variant"] == "cuda"
     assert details["cuda"] == {"torch_imported": False, "initialized": False, "memory": None}
+
+
+def test_runtime_process_check_warns_for_multiple_stdio_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        doctor_module,
+        "_list_exomem_processes",
+        lambda: [
+            {"pid": 101, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+            {"pid": 102, "rss_mb": 4096.0, "command": "python -m exomem --transport stdio"},
+        ],
+    )
+
+    check = doctor_module._check_runtime_processes()
+
+    assert check is not None
+    assert check.status == "warn"
+    assert "Each stdio MCP client/session launches its own process" in check.message
+    assert check.details["count"] == 2
+
+
+
+def test_mps_headroom_reports_policy_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import extract, mode, warmup
+
+    monkeypatch.setattr(doctor_module, "_mps_available_for_doctor", lambda: True)
+    monkeypatch.setattr(mode, "resolve_mode", lambda: "normal")
+    monkeypatch.setattr(
+        mode,
+        "watcher_policy",
+        lambda: SimpleNamespace(max_embed_files_per_batch=32),
+    )
+    monkeypatch.setattr(warmup, "model_preload_allowed", lambda _mode: False)
+    monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: False)
+
+    check = doctor_module._check_mps_headroom()
+
+    assert check is not None
+    assert check.status == "pass"
+    assert "macOS does not expose" in check.message
+    assert check.details["model_preload_allowed"] is False
+    assert check.details["asr_prewarm_enabled"] is False
+    assert check.details["watcher_max_embed_files"] == 32

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -51,19 +51,27 @@ def test_extraction_enabled_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_prewarm_loads_the_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+    monkeypatch.setenv("EXOMEM_ASR_PREWARM", "1")
     called: list[bool] = []
-    monkeypatch.setattr(extract, "_get_whisper", lambda: called.append(True))
+
+    class _FakeTranscriber:
+        def prewarm(self) -> None:
+            called.append(True)
+
+    monkeypatch.setattr(extract, "get_transcriber", lambda: _FakeTranscriber())
     extract.prewarm()
     assert called == [True]  # warmed eagerly
 
 
 def test_prewarm_soft_fails_when_engine_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+    monkeypatch.setenv("EXOMEM_ASR_PREWARM", "1")
 
-    def unavailable():
-        raise extract.ExtractionUnavailable("faster-whisper not installed")
+    class _UnavailableTranscriber:
+        def prewarm(self) -> None:
+            raise extract.ExtractionUnavailable("faster-whisper not installed")
 
-    monkeypatch.setattr(extract, "_get_whisper", unavailable)
+    monkeypatch.setattr(extract, "get_transcriber", lambda: _UnavailableTranscriber())
     extract.prewarm()  # must not raise — a lean box just stays lazy
 
 
@@ -73,6 +81,20 @@ def test_prewarm_skipped_when_extraction_disabled(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(extract, "_get_whisper", lambda: called.append(True))
     extract.prewarm()
     assert called == []  # disabled → never touches the model
+
+
+def test_asr_prewarm_defaults_off_on_apple_silicon(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_ASR_PREWARM", raising=False)
+    monkeypatch.delenv("EXOMEM_ENABLE_ASR_PREWARM", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_ASR_PREWARM", raising=False)
+    monkeypatch.setattr(extract.sys, "platform", "darwin")
+    monkeypatch.setattr(extract.platform, "machine", lambda: "arm64")
+
+    assert extract.asr_prewarm_enabled() is False
+
+    monkeypatch.setenv("EXOMEM_ASR_PREWARM", "1")
+    assert extract.asr_prewarm_enabled() is True
+
 
 
 def test_extract_text_routes_by_media_type(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -8,6 +8,7 @@ the lazy import.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -118,6 +119,41 @@ def test_file_watcher_reads_policy_without_restart(vault, monkeypatch: pytest.Mo
     assert w._reconcile_interval_seconds() == pytest.approx(300.0)
 
 
+def test_live_import_burst_defers_semantic_indexing(
+    vault, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    calls: list[tuple[list[Path], dict]] = []
+    monkeypatch.setattr(
+        file_watcher.index_sync,
+        "upsert_after_write",
+        lambda root, paths, **kw: calls.append((list(paths), dict(kw))),
+    )
+    monkeypatch.setattr(
+        file_watcher.mode,
+        "watcher_policy",
+        lambda: file_watcher.mode.WatcherPolicy(
+            debounce_seconds=0.05,
+            reconcile_interval_seconds=999.0,
+            max_embed_files_per_batch=1,
+            max_reconcile_embed_files=500,
+            defer_expensive_indexes=False,
+        ),
+    )
+    w = file_watcher.FileWatcher(vault)
+    a = vault / "Knowledge Base" / "Notes" / "burst-a.md"
+    b = vault / "Knowledge Base" / "Notes" / "burst-b.md"
+    with caplog.at_level(logging.WARNING, logger="exomem.file_watcher"):
+        w._record(a, deleted=False)
+        w._record(b, deleted=False)
+        w._flush()
+
+    assert len(calls) == 1
+    assert sorted(calls[0][0]) == sorted([a, b])
+    assert calls[0][1] == {"defer_semantic": True}
+    assert "live import/sync burst" in caplog.text
+
+
+
 def test_dispatch_thread_uses_quiet_policy_for_burst_coalescing(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -125,7 +161,7 @@ def test_dispatch_thread_uses_quiet_policy_for_burst_coalescing(
     monkeypatch.setattr(
         file_watcher.index_sync,
         "upsert_after_write",
-        lambda root, paths: calls.append(list(paths)),
+        lambda root, paths, **_kw: calls.append(list(paths)),
     )
     monkeypatch.setattr(
         file_watcher.mode,
@@ -300,7 +336,7 @@ def _spy_reconcile_fanout(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
     )
     monkeypatch.setattr(
         file_watcher.index_sync, "upsert_after_write",
-        lambda root, paths: calls["upsert"].append(list(paths)),
+        lambda root, paths, **_kw: calls["upsert"].append(list(paths)),
     )
     monkeypatch.setattr(
         file_watcher.index_sync, "delete_after_remove",

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -145,6 +145,50 @@ def test_index_sync_quiet_defers_semantic_upserts(
         index_sync.clear_deferred_work(vault)
 
 
+def test_index_sync_explicit_defer_semantic_upserts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    index_sync.clear_deferred_work(vault)
+    from exomem import embeddings, find, lexstore
+
+    seen: dict[str, list] = {"lexstore": [], "embeddings": [], "resolver": []}
+    monkeypatch.setattr(
+        lexstore,
+        "upsert_after_write",
+        lambda root, paths: seen["lexstore"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write",
+        lambda root, paths: seen["embeddings"].append(list(paths)),
+    )
+    monkeypatch.setattr(
+        find,
+        "on_resolver_files_changed",
+        lambda root, changed, deleted: seen["resolver"].append(
+            (list(changed), list(deleted))
+        ),
+    )
+
+    good = vault / "Knowledge Base" / "Notes" / "Insights" / "defer-explicit.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text("# defer\n", encoding="utf-8")
+
+    try:
+        index_sync.upsert_after_write(vault, [good], defer_semantic=True)
+
+        assert seen["lexstore"] == [[good]]
+        assert seen["embeddings"] == []
+        assert seen["resolver"] == [(["Knowledge Base/Notes/Insights/defer-explicit.md"], [])]
+        status = index_sync.deferred_work_status(vault)["semantic_upserts"]
+        assert status["count"] == 1
+        assert status["paths"] == ["Knowledge Base/Notes/Insights/defer-explicit.md"]
+    finally:
+        index_sync.clear_deferred_work(vault)
+
+
+
 def test_index_sync_nonquiet_keeps_immediate_embedding_upsert(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -39,7 +39,8 @@ from exomem.__main__ import main
 
 
 @pytest.fixture(autouse=True)
-def _reset_readiness():
+def _reset_readiness(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EXOMEM_PRELOAD_MODELS", "1")
     readiness.reset()
     yield
     readiness.reset()
@@ -218,6 +219,20 @@ def test_defer_and_mark_ready_race_no_loss_no_duplication() -> None:
 # ============================================================================
 # exomem.warmup.warm_all — lexical caches, then model preloads
 # ============================================================================
+
+
+def test_model_preload_allowed_defaults_lazy_on_apple_silicon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_PRELOAD_MODELS", raising=False)
+    monkeypatch.setattr(warmup.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(warmup.platform, "machine", lambda: "arm64")
+
+    assert warmup.model_preload_allowed("normal") is False
+
+    monkeypatch.setenv("EXOMEM_PRELOAD_MODELS", "1")
+    assert warmup.model_preload_allowed("normal") is True
+
 
 
 def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_order(

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -100,6 +100,7 @@ def test_start_prewarms_asr_off_the_request_path(vault, monkeypatch: pytest.Monk
     import threading
 
     warmed = threading.Event()
+    monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: True)
     monkeypatch.setattr(extract, "prewarm", warmed.set)
     w = media_worker.MediaWorker(vault)
     w.start()
@@ -107,6 +108,20 @@ def test_start_prewarms_asr_off_the_request_path(vault, monkeypatch: pytest.Monk
         assert warmed.wait(timeout=5.0), "start() should warm ASR in a background thread"
     finally:
         w.stop()
+
+
+def test_start_skips_asr_prewarm_when_policy_disables_it(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: False)
+    monkeypatch.setattr(extract, "prewarm", lambda: pytest.fail("prewarm should be skipped"))
+    w = media_worker.MediaWorker(vault)
+    w.start()
+    try:
+        pass
+    finally:
+        w.stop()
+
 
 
 def test_start_logs_diarization_readiness(vault, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -162,7 +162,7 @@ def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> 
                 "watcher_policy": {
                     "debounce_seconds": 0.5,
                     "reconcile_interval_seconds": 300.0,
-                    "max_embed_files_per_batch": None,
+                    "max_embed_files_per_batch": 32,
                     "max_reconcile_embed_files": 500,
                     "defer_expensive_indexes": False,
                 },
@@ -179,7 +179,7 @@ def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> 
                 "watcher_policy": {
                     "debounce_seconds": 0.5,
                     "reconcile_interval_seconds": 300.0,
-                    "max_embed_files_per_batch": None,
+                    "max_embed_files_per_batch": 32,
                     "max_reconcile_embed_files": 500,
                     "defer_expensive_indexes": False,
                 },
@@ -200,6 +200,13 @@ def test_resolved_resource_policy_fields(
     assert mode.retain_cpu_caches() is expected["retain_cpu_caches"]
     assert mode.defer_expensive_indexes() is expected["defer_expensive_indexes"]
     assert mode.watcher_policy().as_dict() == expected["watcher_policy"]
+
+
+def test_watcher_live_embed_cap_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    monkeypatch.setenv("EXOMEM_WATCHER_MAX_EMBED_FILES", "7")
+
+    assert mode.watcher_policy().max_embed_files_per_batch == 7
 
 
 def test_policy_helpers_do_not_import_torch(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -170,6 +170,18 @@ def test_setup_generates_access_policy(tmp_path: Path) -> None:
     assert "[skipped: no sibling folders need governing]" in out2
 
 
+def test_setup_skips_registration_when_exomem_exists_in_another_scope(tmp_path: Path) -> None:
+    vault, home = _messy_vault(tmp_path), tmp_path / "home"
+    recorder = Recorder(results={"mcp list --scope local": (0, "exomem\n", "")})
+
+    code, out = _setup(vault, home, recorder, scope="user")
+
+    assert code == 0
+    assert "[skipped: already registered in local]" in out
+    assert not [c for c in recorder.calls if "add" in c]
+
+
+
 def test_no_claude_cli_prints_snippet(tmp_path: Path) -> None:
     vault, home = _messy_vault(tmp_path), tmp_path / "home"
     recorder = Recorder()


### PR DESCRIPTION
## Summary
- bound live watcher import bursts so lexical/freshness indexes update while semantic embeddings defer for explicit indexing
- make Apple Silicon model/ASR prewarm lazy by default and surface profile/process/MPS policy in doctor
- avoid duplicate Claude MCP registrations across scopes and add POSIX diarizer setup
- reserve adopt copy-as-sources destinations within a batch to prevent same-title overwrites

## Tests
- uv run pytest -q tests/test_adopt.py tests/test_mode.py tests/test_index_trash_exclusion.py tests/test_file_watcher.py tests/test_doctor.py tests/test_setup_wizard.py tests/test_extract.py tests/test_media_worker.py tests/test_instant_start.py tests/test_resource_status.py
  - 253 passed, 1 skipped (sentence_transformers optional doctor probe missing locally)