### PR TITLE
Relax retrieval nudge across sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,13 @@ to an allowlist.
 `scripts/rebuild-schema-zip.py` **from this same scaffold**, overlaying only your real
 `project-keys.yaml` — no private canonical, no markers. Needs no version bump here.)
 
+## Memory boundary
+
+Treat Claude, ChatGPT, Codex, and other assistants' native memory as short-term
+or behavioural memory for preferences, routing, and working context. Exomem is
+the long-term governed store for project/domain knowledge, sources, evidence,
+decisions, and reusable conclusions.
+
 ## Connector triage ("MCP not working" / slow first call / forced reconnect)
 
 claude.ai connector problems are almost always **connection-side, not the service**.

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -3,9 +3,9 @@
 This guide is for agents using Exomem after the MCP server or connector is
 available. It keeps the contract simple:
 
-- Use the assistant's native memory or custom instructions for preferences and
-  routing rules.
-- Use Exomem for durable governed knowledge: project context, decisions, sourced
+- Use the assistant's native memory or custom instructions as short-term or
+  behavioural memory: preferences, routing rules, and working context.
+- Use Exomem as long-term governed memory: project context, decisions, sourced
   conclusions, failures, experiments, proof-bearing records, and anything that
   should be searchable, citeable, reviewable, or supersedable across clients.
 - Do not make the user choose internal folders or page types unless the choice
@@ -184,6 +184,11 @@ instructions. Trim the tone line to your preference.
 
 ```text
 Use Exomem as my durable Knowledge Base.
+
+Treat Claude, ChatGPT, Codex, and other assistants' native memory as short-term
+or behavioural memory for preferences, routing, and working context. Exomem is
+the long-term governed store for project/domain knowledge, sources, evidence,
+decisions, and reusable conclusions.
 
 If no Exomem skill is loaded, call bootstrap(profile="compact") once at the
 start of a session and follow the returned contract.

--- a/docs/vs-built-in-memory.md
+++ b/docs/vs-built-in-memory.md
@@ -5,11 +5,11 @@ when the boundary is explicit.
 
 ## Short version
 
-Use built-in memory or custom instructions for small preferences that should
-shape every chat. Use Exomem for durable governed knowledge: project context,
-sourced conclusions, decisions, failures, experiments, evidence, and anything you
-may need to inspect, cite, edit, review, supersede, or use from more than one
-client.
+Use built-in memory or custom instructions as short-term or behavioural memory:
+small preferences, routing rules, and working context that should shape every
+chat. Use Exomem as long-term governed memory: project context, sourced
+conclusions, decisions, failures, experiments, evidence, and anything you may
+need to inspect, cite, edit, review, supersede, or use from more than one client.
 
 Exomem is not a replacement for every native memory feature. It is the portable,
 user-owned knowledge layer behind Claude, Codex, ChatGPT, Cursor, hosted chat
@@ -34,8 +34,8 @@ clients, scripts, and future MCP clients.
 
 ## The boundary in one sentence
 
-Native assistant memory tells the assistant how to behave. Exomem tells the
-assistant what durable, governed knowledge the user has accumulated.
+Native assistant memory tells the assistant how to behave right now. Exomem tells
+the assistant what durable, governed knowledge the user has accumulated.
 
 A good native-memory entry is tiny:
 

--- a/src/exomem/_hooks/exomem_retrieve_nudge.py
+++ b/src/exomem/_hooks/exomem_retrieve_nudge.py
@@ -7,8 +7,8 @@ of a thread. This re-arms the read side: when the user submits a substantial
 prompt, it injects a one-line reminder to run `find` first and fold prior
 conclusions into the answer, so the KB actually functions as the source of truth.
 
-Cheap by default: gates on prompt length, an obvious-control-prompt filter, and
-a per-session cooldown. By default it injects only a *reminder* — Claude still
+Cheap by default: gates on prompt length, an obvious-control-prompt filter, a
+per-session cooldown, and a client-wide cooldown. By default it injects only a *reminder* — Claude still
 runs the real (semantic) find only when the prompt actually needs prior KB
 context — so it never stalls the prompt. (UserPromptSubmit blocks model start
 until the hook returns, so the hook must be fast: stdlib only, no search here by
@@ -27,12 +27,14 @@ EXOMEM_RETRIEVE_NUDGE_MIN_CHARS (default 20 — short, since prompts are short a
 a dense script like Japanese packs more per char),
 EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS (default 180 — only prompts at or below
 this length are eligible for the obvious-control-prompt skip gate),
-EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300), EXOMEM_RETRIEVE_INJECT (opt-in,
-default off — truthy-parsed: unset/""/"0"/"false"/"no"/"off", any case, count as
-off) to turn on retrieve-and-inject, and EXOMEM_RETRIEVE_INJECT_CLI (opt-in, same
-truthy parse) to additionally allow the slower CLI transport when REST isn't
-configured or fails. The legacy KB_RETRIEVE_* names (including KB_RETRIEVE_INJECT
-/ KB_RETRIEVE_INJECT_CLI) are still accepted for back-compat, aliased to the
+EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC (default 300),
+EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC (default 900; set 0 to disable),
+EXOMEM_RETRIEVE_INJECT (opt-in, default off — truthy-parsed:
+unset/""/"0"/"false"/"no"/"off", any case, count as off) to turn on
+retrieve-and-inject, and EXOMEM_RETRIEVE_INJECT_CLI (opt-in, same truthy parse)
+to additionally allow the slower CLI transport when REST isn't configured or
+fails. The legacy KB_RETRIEVE_* names (including KB_RETRIEVE_INJECT /
+KB_RETRIEVE_INJECT_CLI) are still accepted for back-compat, aliased to the
 EXOMEM_* names at startup.
 
 Contract (Claude Code / Codex UserPromptSubmit hook): read the event JSON on
@@ -124,6 +126,7 @@ _ENV_ALIASES = (
     ("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", "KB_RETRIEVE_NUDGE_MIN_CHARS"),
     ("EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS", "KB_RETRIEVE_NUDGE_CONTROL_MAX_CHARS"),
     ("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", "KB_RETRIEVE_NUDGE_COOLDOWN_SEC"),
+    ("EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC", "KB_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC"),
     ("EXOMEM_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT"),
     ("EXOMEM_RETRIEVE_INJECT_CLI", "KB_RETRIEVE_INJECT_CLI"),
 )
@@ -187,18 +190,31 @@ def _is_obvious_control_prompt(prompt: str, max_chars: int) -> bool:
     return bool(_CONTROL_PROMPT_RE.match(text))
 
 
-def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
-    """Per-session timestamp file (mtime-based). Namespaced so it never collides
-    with the capture hook's cooldown stamp for the same session."""
+def _cooldown_stamp_ok(key: str, cooldown: int) -> tuple[bool, Path]:
+    """Timestamp-file cooldown (mtime-based)."""
     state_dir = _hook_home() / ".cache" / "exomem-nudge"
-    key = "retrieve_" + re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:120]
     stamp = state_dir / key
+    if cooldown <= 0:
+        return True, stamp
     try:
         if stamp.exists() and (time.time() - stamp.stat().st_mtime) < cooldown:
             return False, stamp
     except OSError:
         pass
     return True, stamp
+
+
+def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
+    """Per-session timestamp file. Namespaced so it never collides with the
+    capture hook's cooldown stamp for the same session."""
+    key = "retrieve_" + re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "default")[:120]
+    return _cooldown_stamp_ok(key, cooldown)
+
+
+def _global_cooldown_ok(cooldown: int) -> tuple[bool, Path]:
+    """Client-wide retrieval nudge cooldown. This keeps multi-tab Codex/Claude
+    setups from seeing the same reminder in every fresh session."""
+    return _cooldown_stamp_ok("retrieve_global", cooldown)
 
 
 def _touch(stamp: Path) -> None:
@@ -356,6 +372,7 @@ def main() -> int:
     min_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_MIN_CHARS", 20)
     control_max_chars = _env_int("EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS", 180)
     cooldown = _env_int("EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC", 300)
+    global_cooldown = _env_int("EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC", 900)
 
     if len(prompt.strip()) < min_chars:  # trivial prompt ("yes", "go", "thanks")
         return 0
@@ -367,7 +384,13 @@ def main() -> int:
     if not ok:  # already nudged recently this session — keep it quiet
         return 0
 
+    global_ok, global_stamp = _global_cooldown_ok(global_cooldown)
+    if not global_ok:  # another tab/session already got the reminder recently
+        return 0
+
     _touch(stamp)
+    if global_cooldown > 0:
+        _touch(global_stamp)
     _log(prompt)
 
     additional_context = REMINDER

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -192,9 +192,10 @@ Speak to users in simple actions first. Use the typed operations underneath.
 Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, or
 `replace` unless that implementation detail changes what will happen.
 
-Native assistant memory is for preferences, style, identity facts, and routing
-rules such as "use Exomem for my project knowledge." Exomem is for durable
-governed knowledge: sourced conclusions, project context, decisions, failures,
+Native assistant memory (Claude, ChatGPT, Codex, and similar) is short-term or
+behavioural memory for preferences, style, identity facts, working context, and
+routing rules such as "use Exomem for my project knowledge." Exomem is long-term
+governed memory for sourced conclusions, project context, decisions, failures,
 experiments, proof-bearing records, review, and supersession.
 
 | User phrasing | User-facing action | Preferred route |

--- a/src/exomem/_scaffold/_Schema/references/write-scope.md
+++ b/src/exomem/_scaffold/_Schema/references/write-scope.md
@@ -5,11 +5,11 @@ to.** Everything else is downstream.
 
 ## Memory boundary
 
-Built-in assistant memory and custom instructions are the right place for small
-preferences, style rules, identity facts, and reminders to use Exomem. Exomem is
-the right place for durable governed knowledge: sourced conclusions, project
-context, decisions, failures, experiments, proof-bearing records, review, and
-supersession.
+Built-in assistant memory and custom instructions are short-term or behavioural
+memory for small preferences, style rules, identity facts, working context, and
+reminders to use Exomem. Exomem is long-term governed memory for durable
+knowledge: sourced conclusions, project context, decisions, failures,
+experiments, proof-bearing records, review, and supersession.
 
 Do not turn transient scratch, reminders, tasks, credentials, or every passing
 chat remark into KB material. Capture only raw material worth preserving or a

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -237,12 +237,13 @@ def op_bootstrap(
         },
         "memory_model": {
             "built_in_ai_memory": (
-                "Use for user preferences, working rules, and the instruction to route "
-                "durable knowledge into Exomem."
+                "Use as short-term or behavioural memory for user preferences, working "
+                "rules, routing instructions, and current working context."
             ),
             "exomem": (
-                "Use for durable governed knowledge: sources, proof/evidence, "
-                "history, decisions, records, review, and compiled conclusions."
+                "Use as long-term governed memory for durable governed knowledge: "
+                "sources, proof/evidence, history, decisions, records, review, and "
+                "compiled conclusions."
             ),
         },
         "knowledge_packs": {

--- a/tests/test_retrieve_inject.py
+++ b/tests/test_retrieve_inject.py
@@ -52,6 +52,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "EXOMEM_RETRIEVE_NUDGE_MIN_CHARS",
         "EXOMEM_RETRIEVE_NUDGE_CONTROL_MAX_CHARS",
         "EXOMEM_RETRIEVE_NUDGE_COOLDOWN_SEC",
+        "EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC",
         "EXOMEM_RETRIEVE_INJECT",
         "EXOMEM_RETRIEVE_INJECT_CLI",
         "EXOMEM_REST_API_KEY",
@@ -61,6 +62,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "KB_RETRIEVE_NUDGE_MIN_CHARS",
         "KB_RETRIEVE_NUDGE_CONTROL_MAX_CHARS",
         "KB_RETRIEVE_NUDGE_COOLDOWN_SEC",
+        "KB_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC",
         "KB_RETRIEVE_INJECT",
         "KB_RETRIEVE_INJECT_CLI",
     ):
@@ -612,6 +614,33 @@ def test_cooldown_gate_short_circuits_second_transport_attempt(
     assert call_count["n"] == 1
 
 
+def test_global_cooldown_suppresses_nearby_sessions(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    first = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "tab-a"}, home)
+    second = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "tab-b"}, home)
+
+    assert "additionalContext" in first
+    assert second.strip() == ""
+
+
+def test_global_cooldown_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC", "0")
+
+    first = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "tab-a"}, home)
+    second = _call_main(monkeypatch, capsys, {"prompt": PROMPT, "session_id": "tab-b"}, home)
+
+    assert "additionalContext" in first
+    assert "additionalContext" in second
+
+
 def test_exomem_retrieve_inject_zero_is_disabled_end_to_end(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
@@ -638,7 +667,9 @@ def _run_subprocess(event: dict, home: Path) -> subprocess.CompletedProcess:
     env = {**os.environ, "HOME": str(home), "USERPROFILE": str(home)}
     for key in (
         "EXOMEM_RETRIEVE_INJECT", "EXOMEM_RETRIEVE_INJECT_CLI", "EXOMEM_REST_API_KEY", "EXOMEM_HOST",
+        "EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC",
         "KB_RETRIEVE_INJECT", "KB_RETRIEVE_INJECT_CLI",  # legacy aliases, cleared too
+        "KB_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC",
     ):
         env.pop(key, None)
     return subprocess.run(


### PR DESCRIPTION
## Summary
- add a client-wide cooldown to the Exomem UserPromptSubmit retrieve nudge
- keep the existing per-session cooldown and control-prompt gates
- add tests for cross-session suppression and the opt-out knob

## Behavior
- default global cooldown is 900 seconds per client home (.codex or .claude)
- set EXOMEM_RETRIEVE_NUDGE_GLOBAL_COOLDOWN_SEC=0 to disable it

## Tests
- PYTHONPATH=src python -m pytest tests/test_retrieve_inject.py tests/test_install_hook.py -q
- git diff --check -- src/exomem/_hooks/exomem_retrieve_nudge.py tests/test_retrieve_inject.py