### PR TITLE
Refresh Exomem skill command guidance

### DIFF
--- a/docs/workflow-skills.md
+++ b/docs/workflow-skills.md
@@ -9,8 +9,8 @@ to return.
 
 | Layer | What it is | Example |
 | --- | --- | --- |
-| Exomem tools | Typed MCP/REST/CLI operations that read and write the KB | `find`, `get`, `note`, `add`, `replace`, `attention` |
-| Context packs | Retrieval-time evidence bundles returned by `find(pack=true)` | top hits, extracted claims, graph neighborhood, contradiction signals |
+| Exomem tools | Product MCP/REST/CLI commands that read and write the KB | `ask_memory`, `read_memory`, `remember`, `capture_source`, `review_memory` |
+| Context packs | Retrieval-time evidence bundles returned by `ask_memory(deep=true)` | top hits, extracted claims, graph neighborhood, contradiction signals |
 | Knowledge packs | Product/domain guidance selected during setup | technical, creative, legal/warranty, personal records |
 | Workflow skills | Agent-visible workflows for common user intent | `exomem-continue`, `exomem-capture`, `exomem-review` |
 
@@ -26,7 +26,7 @@ agent is doing right now.
 - `exomem-reflect` - extract decisions, failures, patterns, open questions, and next actions.
 - `exomem-curate` - improve links and compiled-note quality safely.
 - `exomem-defrag` - reconcile duplicate, stale, or conflicting memory.
-- `exomem-review` - drain attention and audit queues.
+- `exomem-review` - drain review and audit queues.
 - `exomem-media` - search and inspect PDFs, images, audio, video, and other artifacts.
 
 ## Installation and discovery
@@ -55,6 +55,6 @@ Every workflow skill preserves the same Exomem contract:
 - Search before claiming prior context.
 - Keep raw `Sources/` and `Evidence/` separate from compiled notes.
 - Use compiled notes for durable conclusions only.
-- Prefer `replace` over silent rewrites when a conclusion changes.
+- Prefer `replace_memory` over silent rewrites when a conclusion changes.
 - Treat review, stale, and contradiction signals as measurement, not judgment.
 - Cite the pages, sources, or artifacts used.

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -41,10 +41,10 @@ triggers.)
 **Proactive retrieval (read) — quiet, surface only hits.** When a turn
 references something the KB plausibly holds — a project, a domain, a named
 entity, or phrasings like "what did I conclude about X," "have I looked at Y,"
-"where did we land on Z" — run a quiet `find` **first** and fold what you find
+"where did we land on Z" — run a quiet `ask_memory` **first** and fold what you find
 into the answer. Don't narrate the search; mention the KB only when it returned
 something relevant, and cite the page(s) you used. A miss means "not found in
-what I searched," never "it doesn't exist" — an empty find means *no coverage
+what I searched," never "it doesn't exist" — an empty `ask_memory` result means *no coverage
 yet*, which is a reason to consider capturing, not to disengage.
 
 **Stepping-stone capture (write) — then report.** When the conversation reaches
@@ -54,11 +54,12 @@ diagnosed, a pattern is recognized — capture it:
 - Capture whether or not the KB already holds the topic. A durable conclusion on
   brand-new ground is first-class: it becomes the first page on that topic, which
   is how the corpus grows.
-- Raw material → **add**. A durable conclusion → draft the compiled
-  **note**/**link**, run **suggest_links** and the near-duplicate check first,
+- Raw material -> `capture_source`. A durable conclusion -> draft with
+  `remember` or `connect_memory`, run
+  `connect_memory(operation="suggest-links")` and the near-duplicate check first,
   then write and report one line: `Saved -> <path>`.
 - The guardrails that remain are the ones that matter: dedupe (prefer
-  **edit**/**replace** over a parallel page; surface a near-duplicate warning when
+  **edit_memory**/**replace_memory** over a parallel page; surface a near-duplicate warning when
   it fires) and clean links.
 - Pause and ask only when type or scope is genuinely ambiguous (research vs.
   insight vs. experiment; which `Notes/Research/<scope>`).
@@ -70,12 +71,12 @@ questions. Capture at the landing, not during the flight.
 
 Use this loop whenever a durable conclusion should enter Exomem:
 
-1. `find` relevant prior notes and sources.
-2. `get` the chosen pages, or use `find(pack=true)` when synthesis needs a bounded context pack.
-3. Draft the typed page at the right layer: `add` for raw source, `note` for compiled conclusion, `link` for entity, `edit` for small correction, `replace` for supersession.
-4. Run `suggest_links` on the draft before writing; accept only links that genuinely clarify provenance or context.
+1. `ask_memory` for relevant prior notes and sources.
+2. `read_memory` for chosen pages, or use `ask_memory(deep=true)` when synthesis needs bounded context.
+3. Draft the typed page at the right layer: `capture_source` for raw source, `remember` for a compiled conclusion, `connect_memory` for entity/link work, `edit_memory` for small correction, `replace_memory` for supersession.
+4. Run `connect_memory(operation="suggest-links")` on the draft before writing; accept only links that genuinely clarify provenance or context.
 5. Write, then inspect the returned `warnings` and optional `suggestions`.
-6. If a near-duplicate warning fires, prefer `edit` or `replace` over a parallel page. If suggestions are useful, add them with a follow-up `edit`.
+6. If a near-duplicate warning fires, prefer `edit_memory` or `replace_memory` over a parallel page. If suggestions are useful, add them with a follow-up `edit_memory`.
 7. Report one line: `Saved -> <path>`.
 
 **Comprehensive coverage, minimal expression.** Capturing at the landing is about
@@ -135,7 +136,7 @@ notes stay distilled in form but never context-pruned.
 The vault around it is yours: any top-level folders you keep (`Daily/`, `Projects/`,
 `Reference/`, a journal — whatever) sit *beside* `Knowledge Base/` and are **read-only
 input** to this skill. Don't infer a fixed vault shape from the tree above. On your
-first engagement in a vault, run `overview` once to learn its real top-level layout
+first engagement in a vault, run `browse_memory` once to learn its real top-level layout
 (see § Assessing a vault you didn't build), then treat everything outside
 `Knowledge Base/` as read-only. Only `Knowledge Base/` is governed and writeable.
 
@@ -151,12 +152,14 @@ small set (e.g. `personal`, `project-alpha`, `work`) and add their own.
 
 The KB tools may be **deferred** — the client lists them by name and you load a
 tool's schema before you can call it. Load the product surface up front, in one
-shot: you'll almost always need `ask_memory` (recall), `read_memory` (open a
-page), `remember` (compiled conclusions), `capture_source`, `preserve_evidence`,
-`review_memory`, `connect_memory`, `adopt_vault`, and `maintain_memory`. In
-Claude Code, load them by exact name in a single call:
+shot: you'll almost always need `bootstrap`, `ask_memory` (recall),
+`read_memory` (open a page), `browse_memory` (vault shape), `remember`
+(compiled conclusions), `edit_memory`, `replace_memory`, `capture_source`,
+`compile_source`, `preserve_evidence`, `transfer_artifact`, `review_memory`,
+`connect_memory`, `adopt_vault`, `maintain_memory`, `query_dataset`, and
+`read_media`. In Claude Code, load them by exact name in a single call:
 
-`ToolSearch("select:bootstrap,ask_memory,read_memory,remember,capture_source,preserve_evidence,review_memory,connect_memory,adopt_vault,maintain_memory")`
+`ToolSearch("select:bootstrap,ask_memory,read_memory,browse_memory,remember,edit_memory,replace_memory,capture_source,compile_source,preserve_evidence,transfer_artifact,review_memory,connect_memory,adopt_vault,maintain_memory,query_dataset,read_media")`
 
 On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 "search the knowledge base", "read a KB page", "compile a note" — and each
@@ -229,8 +232,9 @@ Examples:
 Product commands are the public interface. The operations below are canonical
 implementation leaves: product commands route here so filenames, folders,
 frontmatter, supersession, indexes, append-only rules, and binary guards stay in
-one place. Use them as reference material, not as the first mental model for a
-new user.
+one place. Agents should call product commands by default; use the leaf names
+below for debugging internals, interpreting old notes, or understanding exactly
+what a product command routes to.
 
 Operations split into two tiers. **Tier 1 is primary** — every typed-note
 workflow goes through it because the type-routing IS the discipline. **Tier 2 is
@@ -346,7 +350,10 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   `delete` refuses on files with inbound links unless `force_orphan=true`. The KB
   is a graph; ops that fragment it are explicit.
 
-### Phrasing → operation mapping (heuristic, not exhaustive)
+### Phrasing → operation mapping (canonical leaf reference)
+
+For normal agent work, use the Simple front door table above. This mapping is a
+reference for the canonical operation leaves that product commands route to.
 
 - "save this," "log this," "capture this," "add to my KB" → **add**
 - "compile this into a note," "make a note on this," "write this up," "distill this" → **note** (typically preceded by an implicit **add**)
@@ -380,15 +387,17 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "what's in the trash," "undelete," "put it back" → **list_trash** / **recover_from_trash** (Tier 2)
 
 **Implicit (no explicit ask) — proactive engagement:**
-- topic maps to a project/domain/entity, or "what did I conclude about X" → proactive **find** first, fold the hits into the answer
-- a decision is made or a problem just got solved → stepping-stone: capture via **add**/**note**, then report the path
+- topic maps to a project/domain/entity, or "what did I conclude about X" -> proactive **ask_memory** first, fold the hits into the answer
+- a decision is made or a problem just got solved -> stepping-stone: capture via **capture_source**/**remember**, then report the path
 
-When you say something oblique like "interesting, save it," default to **add** +
-ask whether to compile a note.
+When you say something oblique like "interesting, save it," default to
+**capture_source** and ask whether to compile only if there is a durable
+conclusion.
 
 ## Search
 
-`find` runs in **hybrid mode** by default: BM25 + local vector embeddings
+`ask_memory` is the normal product command for recall. Underneath, `find` runs in
+**hybrid mode** by default: BM25 + local vector embeddings
 (BAAI/bge-base-en-v1.5, 768-dim) fused via reciprocal rank fusion.
 Natural-language queries reach pages that don't contain the literal terms.
 
@@ -412,9 +421,9 @@ Empty queries degrade to filtered-most-recent regardless of mode.
   opt-out (KB only, never widens).
 - **Never report a search-miss as absence.** An empty result means *"not found in
   what I searched,"* not *"it doesn't exist."* If you're sure something exists,
-  try `scope="vault"`, vary the query terms, or `get` a path you suspect.
+  try `scope="vault"`, vary the query terms, or `read_memory` a path you suspect.
 
-Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
+Additional knobs exposed through `ask_memory`/`find`: `graph=true` (1-hop neighbours of strong matches),
 `rerank=true` (CrossEncoder re-sort, explicit precision spend),
 `prefer_compiled=true` (default; favours compiled types over raw `source`),
 `prefer_active=true` (default; soft-demotes superseded pages), `file_types` /
@@ -426,11 +435,11 @@ mode-aware auto: CPU steady-state modes keep it off; accelerated/performance
 mode may auto-rerank when lanes strongly disagree or the query is long.
 
 Performance presets:
-- Normal lookup: `detail="compact"`, `rerank=false`.
-- Reasoning context: `pack=true` when you need a compressed evidence bundle;
+- Normal lookup: `ask_memory(detail="compact", rerank=false)`.
+- Reasoning context: `ask_memory(deep=true)` when you need a compressed evidence bundle;
   add `graph_enrich=true` only when you need typed graph neighborhoods alongside
   the normal pack contract.
-- Diagnostics: `include_timings=true`; add `rerank=true` only when you are
+- Diagnostics: `ask_memory(include_timings=true)`; add `rerank=true` only when you are
   intentionally measuring reranking or spending latency for precision. Interpret
   timing output with the returned compute mode, embedding backend, cache state,
   rerank flag, and search profile.
@@ -439,8 +448,8 @@ Performance presets:
 data files aren't `find`-searchable. To make a dataset findable, write a
 **dataset card** — a small `type: dataset` page (frontmatter `data_file:` +
 `format:`, a one-line "What this holds", and a column profile) via `create_file`.
-`query_data(aggregate="profile")` emits a ready-to-write card; pull exact rows
-from the `data_file` with `query_data`.
+`query_dataset(aggregate="profile")` emits a ready-to-write card; pull exact rows
+from the `data_file` with `query_dataset`.
 
 Vector embeddings live in a per-machine sidecar at
 `<vault>/Knowledge Base/.embeddings.sqlite` (a dotfile that file-sync tools like Obsidian Sync ignore).
@@ -449,18 +458,18 @@ drift, call `audit_fix(rebuild_embeddings=true)`.
 
 ### Assessing or adopting a vault you didn't build
 
-**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
+**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt_vault(mode="scan-only")** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
 
 For structural questions —
 "what does this vault look like," "how is this vault organized," "is there junk in
-here" — and simply to learn the layout before you write, run **overview** first: one bounded,
+here" — and simply to learn the layout before you write, run **browse_memory** first: one bounded,
 read-only report of folder structure, counts, frontmatter coverage, naming
 patterns, and junk candidates (zero-byte files, sync-conflict duplicates). It
 works on any folder under the vault root, including trees outside
 `Knowledge Base/` (a `Daily/` or `Journal/` folder), and on vaults with no KB at
 all. The folders it reports *outside* `Knowledge Base/` are read-only input — link
-to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `list_directory` on folders of interest,
-`find scope="vault"` for content, targeted `get` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
+to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `browse_memory` on folders of interest,
+`ask_memory scope="vault"` for content, targeted `read_memory` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
 bulk-read a vault file-by-file to answer a structural question** — the report
 answers in one call what would otherwise cost hundreds of reads.
 
@@ -518,10 +527,11 @@ These rules are non-negotiable.
    the same append-only tree (into a themed sub-folder) is allowed via
    `move_file`; crossing the boundary is forbidden.
 
-3. **Propose before writing compiled material.** For `note`, `link`, and
-   `replace` (and any hand-edit of `_Schema/` files), show the proposed content
-   (or diff) and wait for confirmation. The exception is `add` (raw capture),
-   `preserve` (raw evidence), and `find`/`audit` (read-only).
+3. **Propose before writing compiled material.** For `remember`,
+   `connect_memory` entity writes, and `replace_memory` (and any hand-edit of
+   `_Schema/` files), show the proposed content (or diff) and wait for
+   confirmation. The exception is `capture_source` (raw capture),
+   `preserve_evidence` (raw evidence), and read-only recall/review operations.
 
     **Batch waiver:** you may approve a *scope* of multiple files upfront ("draft
     all Tier 1," "write all four hubs + concepts") rather than each individually.
@@ -586,8 +596,9 @@ most-specific scope first. A typical starter set:
 For **patterns** that apply across multiple projects, use `projects:` (plural
 list) instead of `project:` (singular), e.g. `projects: [project-alpha, project-beta]`.
 
-**Auto-registration of new project keys.** The `note`, `replace`, `edit`
-(frontmatter-patch), and `link` (decision-entity) writers auto-append unknown
+**Auto-registration of new project keys.** The `remember`, `replace_memory`,
+`edit_memory` (frontmatter-patch), and `connect_memory` (decision-entity)
+writers auto-append unknown
 slug-shaped project keys to `_Schema/project-keys.yaml` and create the matching
 `Notes/Research/<Folder>/` directory on first use — no manual YAML edit needed.
 Pass `project_category` to bucket the new key (product / activity / domain /
@@ -608,7 +619,7 @@ out to *learn whether X is true* (experiment) or to *make a thing the world sees
 ## Workflow: typical add-then-compile session
 
 1. **You paste raw material or ask to log something.**
-2. **Skill creates a `source` file.** Picks the subfolder from the input shape —
+2. **Skill calls `capture_source` to create a source file.** Picks the subfolder from the input shape —
    `Sources/Articles/`, `Sources/Sessions/`, `Sources/Books/`, `Sources/Papers/`,
    `Sources/Videos/`, or `Sources/Other/`. Filename: ISO-date + slug. Updates
    `Sources/index.md`.
@@ -616,13 +627,15 @@ out to *learn whether X is true* (experiment) or to *make a thing the world sees
    insight, failure, pattern, experiment, production-log? And what scope?"** Skip
    if you already specified.
 4. **Skill drafts the compiled page** with frontmatter, a sources block linking
-   back to the source file, and a Connections section. **Run `suggest_links` on
-   the draft first** — it surfaces related existing pages you'd otherwise miss.
+   back to the source file, and a Connections section. **Run
+   `connect_memory(operation="suggest-links")` on the draft first** — it surfaces
+   related existing pages you'd otherwise miss.
 5. **Skill shows the draft, waits for confirmation.** You can revise inline.
-6. **On confirm: writes the page**, updates the relevant `index.md`, appends to
-   `log.md`, and reports paths. The `note` result carries a `suggestions` block
-   and any near-duplicate `warning` — wire in the relevant links via **edit** (or,
-   for a genuine duplicate, prefer `replace`/`append` over a parallel page).
+6. **On confirm: calls `remember` to write the page**, updates the relevant
+   `index.md`, appends to `log.md`, and reports paths. The write result carries a
+   `suggestions` block and any near-duplicate `warning` — wire in the relevant
+   links via **edit_memory** (or, for a genuine duplicate, prefer
+   `replace_memory` over a parallel page).
 
 When you approve a scope of multiple files upfront, the workflow collapses to a
 single batch write (see Write discipline § 3, batch waiver).
@@ -643,9 +656,9 @@ through `vault.normalize_wikilink()` before writing — bare names, KB-relative
 paths, `.md` suffixes, and stale paths get rewritten to canonical full form. You
 can write in any form; the on-disk file lands canonical.
 
-If a wikilink target doesn't exist yet, prefer creating the entity stub via the
-**link** operation rather than leaving a dangling link. Dangling links accumulate
-and surface in **audit** as `broken_wikilink`.
+If a wikilink target doesn't exist yet, prefer creating the entity stub via
+**connect_memory** rather than leaving a dangling link. Dangling links accumulate
+and surface in **review_memory(mode="audit")** as `broken_wikilink`.
 
 When creating an entity that points at a **currently-evolving external artifact**
 (a live spec, a code library, a service config), use **pointer-style** — summary
@@ -654,7 +667,7 @@ file inventories, command lines copied verbatim). Mirroring guarantees drift.
 
 ## Audit (lint) checks
 
-The **audit** operation runs read-only checks and proposes fixes (never
+The **review_memory(mode="audit")** operation runs read-only checks and proposes fixes (never
 auto-fixes); the report is reviewed before anything is written. It covers:
 orphans, broken wikilinks, supersession integrity, stale frontmatter,
 `index.md`/`log.md` drift, aged unprocessed sources (oldest-first — pair with
@@ -679,10 +692,10 @@ is in **`references/audit-checks.md`**.
 - Assign numeric confidence scores. Use citation count and recency as the trust
   signal.
 - Apply retention decay or "forgetting curves." Old material stays. If superseded,
-  mark it; if irrelevant, archive into an `_archive/` subfolder. (`audit`'s
+  mark it; if irrelevant, archive into an `_archive/` subfolder. (`review_memory`'s
   `stale_review` check **surfaces** old/cold/low-inbound conclusions as *review
   candidates* for you to judge — but never auto-decays, down-ranks, hides, or moves
-  anything; `find` ordering is unchanged. Surfacing a candidate ≠ a forgetting curve.)
+  anything; `ask_memory`/`find` ordering is unchanged. Surfacing a candidate ≠ a forgetting curve.)
 - Run on hooks, schedules, or background triggers. Operations happen because you
   asked, or because the conversation reached a point where consulting or capturing
   is clearly warranted.
@@ -704,11 +717,11 @@ is in **`references/audit-checks.md`**.
 - Marking an existing page `superseded`.
 
 **Proceed without asking:**
-- Proactive `find` for context (read-only).
+- Proactive `ask_memory` for context (read-only).
 - Capturing a clear stepping-stone conclusion whose type and scope are
   unambiguous — write under the standing waiver and report the path.
-- `add` and `preserve` operations — raw capture.
-- `find` and `audit` — read-only.
+- `capture_source` and `preserve_evidence` operations — raw capture.
+- `ask_memory`, `read_memory`, `browse_memory`, and `review_memory` — read-only.
 - Updating `index.md`, `log.md`, and `ingested_into:` frontmatter after a
   confirmed write.
 - Resolving obvious wikilink targets when the entity exists exactly.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-capture/SKILL.md
@@ -14,10 +14,10 @@ Use when the user says to save, remember, file, capture, or when the session lan
 
 ## Workflow
 1. Decide whether the material is raw evidence or a compiled conclusion.
-2. Use `add` for raw captured text or source material.
-3. Use `preserve` or upload flow for factual artifacts and binary evidence.
-4. Use `note` for distilled conclusions: `research-note`, `insight`, `failure`, or `pattern`.
-5. Run `suggest_links` before writing compiled notes; prefer `edit` or `replace` for near-duplicates.
+2. Use `capture_source` for raw captured text or source material.
+3. Use `preserve_evidence` for factual text artifacts and `transfer_artifact` for binary evidence.
+4. Use `remember` for distilled conclusions: `research-note`, `insight`, `failure`, or `pattern`.
+5. Run `connect_memory(operation="suggest-links")` before writing compiled notes; prefer `edit_memory` or `replace_memory` for near-duplicates.
 
 ## Output contract
 After writing, report exactly `Saved -> <path>` plus one short phrase if needed. If nothing durable was saved, say why.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-continue/SKILL.md
@@ -13,9 +13,9 @@ Resume prior context without guessing from chat history alone.
 Use when the user asks to continue, resume, pick up a project, recover prior state, or asks what they were doing on a topic.
 
 ## Workflow
-1. Search first with `find`, preferring active compiled notes and project-relevant terms from the prompt.
-2. Use `find(pack=true)` when several hits matter or the state needs synthesis.
-3. Read only the top relevant pages with `get` when excerpts are not enough.
+1. Search first with `ask_memory(detail="compact", rerank=false)`, preferring active compiled notes and project-relevant terms from the prompt.
+2. Use `ask_memory(deep=true)` when several hits matter or the state needs synthesis.
+3. Read only the top relevant pages with `read_memory` when excerpts are not enough.
 4. Prefer recent active compiled notes, then linked sources/evidence when provenance is needed.
 5. Summarize current state, decisions already made, blockers, and likely next actions.
 
@@ -23,7 +23,7 @@ Use when the user asks to continue, resume, pick up a project, recover prior sta
 Return a compact continuation brief with cited Exomem pages and a short next-action list. Say when the search missed or was thin.
 
 ## Save rules
-Save only if the resumed work produces a new durable decision, solved problem, failure, pattern, or research finding. Use `note`, `edit`, or `replace` as appropriate.
+Save only if the resumed work produces a new durable decision, solved problem, failure, pattern, or research finding. Use `remember`, `edit_memory`, or `replace_memory` as appropriate.
 
 ## Mistakes to avoid
 Do not invent prior context from memory. Do not treat a scoped miss as absence. Do not dump long note bodies when a state brief is enough.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-curate/SKILL.md
@@ -13,10 +13,10 @@ Improve the KB graph and compiled-note quality without damaging provenance.
 Use when the user asks to clean up, organize, link, tidy, or improve a set of Exomem notes.
 
 ## Workflow
-1. Search related notes with `find`; use `graph_context`, inbound links, or `suggest_links` when graph shape matters.
+1. Search related notes with `ask_memory`; use `connect_memory` for graph context, inbound links, or link suggestions when graph shape matters.
 2. Identify safe improvements: missing links, stale wording, weak titles, duplicate tags, or unlinked entities.
-3. Use `edit` for small compiled-note fixes.
-4. Use `replace` for substantial rewrites or changed conclusions.
+3. Use `edit_memory` for small compiled-note fixes.
+4. Use `replace_memory` for substantial rewrites or changed conclusions.
 5. Leave raw `Sources/` and `Evidence/` untouched except for metadata the core contract explicitly allows.
 
 ## Output contract

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-defrag/SKILL.md
@@ -13,10 +13,10 @@ Reduce duplicate, stale, or conflicting memory without losing provenance.
 Use when the user asks to defrag a topic, reconcile notes, resolve contradictions, merge duplicates, or inspect what is stale.
 
 ## Workflow
-1. Search the topic with `find`, using `pack=true`, `graph_context`, `attention`, `audit`, or `evolution` when useful.
+1. Search the topic with `ask_memory`, using `ask_memory(deep=true)`, `connect_memory`, or `review_memory` when graph, stale, audit, or evolution context matters.
 2. Group findings into keep, merge, supersede, or leave alone.
-3. Read candidate pages with `get`, including history when needed.
-4. Use `replace` for changed conclusions and `edit` only for minor corrections.
+3. Read candidate pages with `read_memory`, including history when needed.
+4. Use `replace_memory` for changed conclusions and `edit_memory` only for minor corrections.
 5. Preserve raw sources and evidence; keep superseded history visible.
 
 ## Output contract

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-ingest/SKILL.md
@@ -14,10 +14,10 @@ Use when the user asks to ingest, add, import, process, or preserve an external 
 
 ## Workflow
 1. Identify the artifact type: text, article, PDF, dataset, image, audio, video, or mixed media.
-2. Preserve the raw source first with `add`, `preserve`, or the upload flow.
-3. For media, use extraction and media-aware retrieval paths; do not pretend the artifact is plain text.
-4. If the source is worth distilling, compile a linked note with `note` or use `propose_compilation` for unprocessed sources.
-5. Link related prior notes with `suggest_links`.
+2. Preserve the raw source first with `capture_source`, `preserve_evidence`, or `transfer_artifact`.
+3. For media, use `read_media`, extracted text/OCR/transcripts, or media-aware `ask_memory`; do not pretend the artifact is plain text.
+4. If the source is worth distilling, use `compile_source` for planning and `remember` for the compiled note.
+5. Link related prior notes with `connect_memory(operation="suggest-links")`.
 
 ## Output contract
 Report the stored source/evidence path, any compiled note path, and what remains unprocessed.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-media/SKILL.md
@@ -13,11 +13,11 @@ Use Exomem's multimodal substrate without flattening every artifact into text.
 Use when the user asks to find media evidence, look inside a recording, inspect a PDF/image/audio/video, or recall where something appeared.
 
 ## Workflow
-1. Search with media-aware filters or artifact terms using `find`.
-2. Use artifact-specific tools: extracted text/OCR/transcripts, `get_video_frames`, upload metadata, or preserved evidence paths.
+1. Search with media-aware filters or artifact terms using `ask_memory`.
+2. Use artifact-specific product tools: extracted text/OCR/transcripts, `read_media`, `transfer_artifact`, upload metadata, or preserved evidence paths.
 3. Cite raw artifact paths and timestamps/pages/frames when available.
-4. Compile textual conclusions only when there is a durable finding.
-5. Preserve new raw artifacts before analyzing them.
+4. Compile textual conclusions with `remember` only when there is a durable finding.
+5. Preserve new raw artifacts with `capture_source`, `preserve_evidence`, or `transfer_artifact` before analyzing them.
 
 ## Output contract
 Return matching artifacts, what was inspected, citations, and any compiled conclusion path.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-reflect/SKILL.md
@@ -13,11 +13,11 @@ Convert experience into reusable memory.
 Use when the user asks what was learned, asks to reflect, closes a project episode, or wants patterns extracted from a session.
 
 ## Workflow
-1. Search Exomem for the project/topic so reflection builds on existing memory.
+1. Search Exomem with `ask_memory` for the project/topic so reflection builds on existing memory.
 2. Extract durable decisions, solved problems, diagnosed failures, reusable patterns, open questions, and next actions.
-3. Save each durable conclusion at the right type: `insight`, `failure`, `pattern`, or `research-note`.
+3. Save each durable conclusion with `remember` at the right type: `insight`, `failure`, `pattern`, or `research-note`.
 4. Prefer one strong note over many weak notes unless the conclusions are genuinely different.
-5. Link related pages with `suggest_links`.
+5. Link related pages with `connect_memory(operation="suggest-links")`.
 
 ## Output contract
 Return what was saved, what was intentionally not saved, and remaining open questions.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-research/SKILL.md
@@ -13,14 +13,14 @@ Answer a focused question and save what should compound.
 Use when the user asks to research a topic, compare options, investigate a claim, or save findings from a research pass.
 
 ## Workflow
-1. Search Exomem first for prior conclusions and related sources.
-2. Gather external sources only as needed; preserve important raw sources with `add` or `preserve`.
+1. Search Exomem first with `ask_memory` for prior conclusions and related sources.
+2. Gather external sources only as needed; preserve important raw sources with `capture_source`, `preserve_evidence`, or `transfer_artifact`.
 3. Attribute findings to sources and distinguish evidence from interpretation.
-4. Compile the result with `note` as a `research-note` unless another type clearly fits.
-5. Use `suggest_links` and connect related prior notes.
+4. Compile the result with `remember` as a `research-note` unless another type clearly fits.
+5. Use `connect_memory(operation="suggest-links")` and connect related prior notes.
 
 ## Output contract
-Return findings, cited sources, confidence/limits, saved path, and follow-up questions.
+Return findings, cited sources, limits, saved path, and follow-up questions.
 
 ## Save rules
 Save findings that answer the question, change a decision, or create reusable context. Keep source attribution explicit.

--- a/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/exomem-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exomem-review
-description: Use Exomem attention and audit queues to surface stale conclusions, contradictions, and unprocessed sources safely.
+description: Use Exomem review and audit queues to surface stale conclusions, contradictions, and unprocessed sources safely.
 version: 0.1.0
 ---
 
@@ -13,10 +13,10 @@ Drain Exomem review queues into safe next actions.
 Use when the user asks to review the KB, see what needs attention, drain backlog, or inspect stale/contradictory/unprocessed material.
 
 ## Workflow
-1. Start with `attention` for the ranked review queue.
-2. Use `audit` when the user asks for broader health checks or specific categories.
-3. For unprocessed sources, use `propose_compilation` before writing a compiled note.
-4. For stale or contradictory compiled notes, read the relevant pages and decide keep, edit, replace, reconcile, or leave alone.
+1. Start with `review_memory(mode="attention")` for the ranked review queue.
+2. Use `review_memory(mode="audit")` when the user asks for broader health checks or specific categories.
+3. For unprocessed sources, use `compile_source` before writing a compiled note with `remember`.
+4. For stale or contradictory compiled notes, read the relevant pages with `read_memory` and decide keep, `edit_memory`, `replace_memory`, `maintain_memory`, or leave alone.
 5. Propose risky actions before mutating.
 
 ## Output contract

--- a/src/exomem/_scaffold/_Schema/workflow-skills/index.yaml
+++ b/src/exomem/_scaffold/_Schema/workflow-skills/index.yaml
@@ -43,7 +43,7 @@ skills:
       - reconcile these notes
       - what's stale?
   - name: exomem-review
-    purpose: Drain Exomem attention and review queues safely.
+    purpose: Drain Exomem review and audit queues safely.
     triggers:
       - review my KB
       - what needs attention?

--- a/tests/fixtures/Knowledge Base/_Schema/SKILL.md
+++ b/tests/fixtures/Knowledge Base/_Schema/SKILL.md
@@ -41,10 +41,10 @@ triggers.)
 **Proactive retrieval (read) — quiet, surface only hits.** When a turn
 references something the KB plausibly holds — a project, a domain, a named
 entity, or phrasings like "what did I conclude about X," "have I looked at Y,"
-"where did we land on Z" — run a quiet `find` **first** and fold what you find
+"where did we land on Z" — run a quiet `ask_memory` **first** and fold what you find
 into the answer. Don't narrate the search; mention the KB only when it returned
 something relevant, and cite the page(s) you used. A miss means "not found in
-what I searched," never "it doesn't exist" — an empty find means *no coverage
+what I searched," never "it doesn't exist" — an empty `ask_memory` result means *no coverage
 yet*, which is a reason to consider capturing, not to disengage.
 
 **Stepping-stone capture (write) — then report.** When the conversation reaches
@@ -54,17 +54,30 @@ diagnosed, a pattern is recognized — capture it:
 - Capture whether or not the KB already holds the topic. A durable conclusion on
   brand-new ground is first-class: it becomes the first page on that topic, which
   is how the corpus grows.
-- Raw material → **add**. A durable conclusion → draft the compiled
-  **note**/**link**, run **suggest_links** and the near-duplicate check first,
+- Raw material -> `capture_source`. A durable conclusion -> draft with
+  `remember` or `connect_memory`, run
+  `connect_memory(operation="suggest-links")` and the near-duplicate check first,
   then write and report one line: `Saved -> <path>`.
 - The guardrails that remain are the ones that matter: dedupe (prefer
-  **edit**/**replace** over a parallel page; surface a near-duplicate warning when
+  **edit_memory**/**replace_memory** over a parallel page; surface a near-duplicate warning when
   it fires) and clean links.
 - Pause and ask only when type or scope is genuinely ambiguous (research vs.
   insight vs. experiment; which `Notes/Research/<scope>`).
 
 Not a stepping-stone: mid-thought exploration, brainstorm tangents, unresolved
 questions. Capture at the landing, not during the flight.
+
+## Agent write loop
+
+Use this loop whenever a durable conclusion should enter Exomem:
+
+1. `ask_memory` for relevant prior notes and sources.
+2. `read_memory` for chosen pages, or use `ask_memory(deep=true)` when synthesis needs bounded context.
+3. Draft the typed page at the right layer: `capture_source` for raw source, `remember` for a compiled conclusion, `connect_memory` for entity/link work, `edit_memory` for small correction, `replace_memory` for supersession.
+4. Run `connect_memory(operation="suggest-links")` on the draft before writing; accept only links that genuinely clarify provenance or context.
+5. Write, then inspect the returned `warnings` and optional `suggestions`.
+6. If a near-duplicate warning fires, prefer `edit_memory` or `replace_memory` over a parallel page. If suggestions are useful, add them with a follow-up `edit_memory`.
+7. Report one line: `Saved -> <path>`.
 
 **Comprehensive coverage, minimal expression.** Capturing at the landing is about
 *timing*, not *volume* — it never means keep less. Minimality is a property of
@@ -88,6 +101,7 @@ notes stay distilled in form but never context-pruned.
 ├── _Schema/
 │   ├── SKILL.md                  This file (canonical)
 │   ├── project-keys.yaml         Registered research scope keys
+│   ├── workflow-skills/          Named agent workflows built on the core contract
 │   └── references/
 │       ├── page-types.md         Page-type taxonomy
 │       ├── frontmatter.md        Frontmatter spec for each page type
@@ -122,7 +136,7 @@ notes stay distilled in form but never context-pruned.
 The vault around it is yours: any top-level folders you keep (`Daily/`, `Projects/`,
 `Reference/`, a journal — whatever) sit *beside* `Knowledge Base/` and are **read-only
 input** to this skill. Don't infer a fixed vault shape from the tree above. On your
-first engagement in a vault, run `overview` once to learn its real top-level layout
+first engagement in a vault, run `browse_memory` once to learn its real top-level layout
 (see § Assessing a vault you didn't build), then treat everything outside
 `Knowledge Base/` as read-only. Only `Knowledge Base/` is governed and writeable.
 
@@ -137,18 +151,19 @@ small set (e.g. `personal`, `project-alpha`, `work`) and add their own.
 ## Loading the tools
 
 The KB tools may be **deferred** — the client lists them by name and you load a
-tool's schema before you can call it. Load the core set up front, in one shot:
-you'll almost always need `find` (search), `get` (read a page), and one or more
-of `note`, `add`, `link`, `suggest_links`, `graph_context`,
-`suggest_relations`, `edit`, `audit`. In Claude Code, load
-them by exact name in a single call:
+tool's schema before you can call it. Load the product surface up front, in one
+shot: you'll almost always need `bootstrap`, `ask_memory` (recall),
+`read_memory` (open a page), `browse_memory` (vault shape), `remember`
+(compiled conclusions), `edit_memory`, `replace_memory`, `capture_source`,
+`compile_source`, `preserve_evidence`, `transfer_artifact`, `review_memory`,
+`connect_memory`, `adopt_vault`, `maintain_memory`, `query_dataset`, and
+`read_media`. In Claude Code, load them by exact name in a single call:
 
-`ToolSearch("select:adopt,overview,find,get,note,add,link,suggest_links,edit,audit")`
+`ToolSearch("select:bootstrap,ask_memory,read_memory,browse_memory,remember,edit_memory,replace_memory,capture_source,compile_source,preserve_evidence,transfer_artifact,review_memory,connect_memory,adopt_vault,maintain_memory,query_dataset,read_media")`
 
 On clients without a `select:` syntax (e.g. claude.ai), search by capability —
 "search the knowledge base", "read a KB page", "compile a note" — and each
-resolves to the right tool. `find` is the read-only hybrid (semantic + keyword)
-search and your default entry point.
+resolves to the right product command. `ask_memory` is the normal first read.
 
 This skill is the rich behavioural contract for Exomem-aware agents. If this
 file has been read, routine KB work does not need a separate `bootstrap()` call.
@@ -157,55 +172,74 @@ start to get the portable operating contract. Skill-aware agents may still use
 `bootstrap(profile="diagnostics")` when interpreting retrieval speed, compute
 mode, reranking, `pack`, or `include_timings`.
 
+## Workflow skills
+
+Named workflow skills live under `_Schema/workflow-skills/` and are installed as
+agent-visible sibling skills when `exomem install-skill` runs. They do not replace
+this contract; they route common user intents into the right Exomem tool loop:
+continue, capture, ingest, research, reflect, curate, defrag, review, and media.
+
+Use the workflow skill when its trigger matches the user's intent, then preserve
+the same invariants from this file: search before claiming prior context, keep
+raw Sources/Evidence separate from compiled notes, prefer `replace_memory` for changed
+conclusions, and cite the pages or artifacts used.
+
 The Tier 2 filesystem ops below may be turned off on lean deployments
 (`EXOMEM_DISABLE_TIER2`), in which case only the Tier 1 ops are registered.
 
 
 ## Simple front door
 
-Speak to users in simple actions first. Use the typed operations underneath.
-Do not ask the user to choose `Sources`, `Notes`, `Entities`, `Evidence`, graph
-sidecars, schema blocks, or `replace` unless that implementation detail changes
-what will happen.
+Speak to users in simple actions first. Call product commands by default; the
+canonical operations are implementation leaves underneath them. Do not ask the
+user to choose `Sources`, `Notes`, `Entities`, `Evidence`, graph sidecars, schema
+blocks, or supersession internals unless that detail changes what will happen.
 
-Native assistant memory is for preferences, style, identity facts, and routing
-rules such as "use Exomem for my project knowledge." Exomem is for durable
-governed knowledge: sourced conclusions, project context, decisions, failures,
+Native assistant memory (Claude, ChatGPT, Codex, and similar) is short-term or
+behavioural memory for preferences, style, identity facts, working context, and
+routing rules such as "use Exomem for my project knowledge." Exomem is long-term
+governed memory for sourced conclusions, project context, decisions, failures,
 experiments, proof-bearing records, review, and supersession.
 
-| Simple action | User phrasing | Preferred route |
+| Simple action | User phrasing | Product route |
 |---|---|---|
-| `ask` | "what do I know," "find what I concluded," "show the context" | `find(detail="compact", rerank=false)` first; `get` or `find(pack=true)` when synthesis needs context |
-| `remember` | "remember this," "save this conclusion," "write this decision" | `note`; use `replace` when it supersedes old knowledge |
-| `capture` | "save this article/source/transcript," "keep this receipt/record/proof" | `add` for Sources; `preserve` or upload for Evidence |
-| `review` | "review stale knowledge," "what needs attention," "what sources are unprocessed" | `attention`, `audit`, `propose_compilation` |
-| `connect` | "connect these ideas," "suggest relations," "what does this link to" | `suggest_links`, `suggest_relations`, `graph_context`; `link` only for explicit writes |
-| `adopt` | "what does this existing vault contain," "import/adopt this vault safely" | `adopt(mode="scan-only")` first; explicit modes for manifest/copy/compile planning |
-| `maintain` | "check vault health," "fix safe drift" | `audit` by default; `audit_fix` or `reconcile` only with explicit fix intent |
+| `ask` | "what do I know," "find what I concluded," "show the context" | `ask_memory(detail="compact", rerank=false)` first; `read_memory` or `ask_memory(deep=true)` when synthesis needs context |
+| `remember` | "remember this," "save this conclusion," "write this decision" | `remember`; use `replace_memory` when it supersedes old knowledge |
+| `capture` | "save this article/source/transcript," "keep this receipt/record/proof" | `capture_source` for Sources; `preserve_evidence` or `transfer_artifact` for Evidence |
+| `review` | "review stale knowledge," "what needs attention," "what sources are unprocessed" | `review_memory` |
+| `connect` | "connect these ideas," "suggest relations," "what does this link to" | `connect_memory` |
+| `adopt` | "what does this existing vault contain," "import/adopt this vault safely" | `adopt_vault(mode="scan-only")` first; explicit modes for manifest/copy/compile planning |
+| `maintain` | "check vault health," "fix safe drift" | `maintain_memory(mode="audit")`; explicit `fix` or `reconcile` modes only with fix intent |
 
 Examples:
 
 - "Remember this decision" -> write a concise compiled note and report
   `Saved -> <path>`.
-- "What did I conclude about onboarding?" -> `ask`/`find` first, cite hits, and
+- "What did I conclude about onboarding?" -> `ask_memory` first, cite hits, and
   retry with adjacent terms before treating a miss as meaningful.
-- "Save this article" -> `capture` via `add` with provenance; ask about compiling
+- "Save this article" -> `capture_source` with provenance; ask about compiling
   only if a conclusion is present.
-- "Keep this receipt for the warranty case" -> `capture` via Evidence, not as a
+- "Keep this receipt for the warranty case" -> `preserve_evidence` or `transfer_artifact`, not as a
   general note.
-- "Compile these three sources" -> draft a sourced note, run `suggest_links`,
+- "Compile these three sources" -> draft a sourced note with `remember` link suggestions,
   then write after the applicable approval rule.
 - "Show stale conclusions" -> run the review path and present candidates for
   keep/edit/supersede/archive.
 - "This new strategy replaces the old one" -> use supersession so history stays
   visible.
 
-## Operations
+## Canonical Operations
+Product commands are the public interface. The operations below are canonical
+implementation leaves: product commands route here so filenames, folders,
+frontmatter, supersession, indexes, append-only rules, and binary guards stay in
+one place. Agents should call product commands by default; use the leaf names
+below for debugging internals, interpreting old notes, or understanding exactly
+what a product command routes to.
+
 Operations split into two tiers. **Tier 1 is primary** — every typed-note
 workflow goes through it because the type-routing IS the discipline. **Tier 2 is
 the escape hatch** for cases that don't fit a Tier 1 shape. If a write fits Tier
-1, use it. Operations are dispatched by intent — you phrase the request; the
-skill matches one of these.
+1, use it.
 
 ### Tier 1 — type-routed (primary)
 
@@ -266,7 +300,7 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - **Binaries go out-of-band — never inline through a tool argument.** Transcribe
   what's relevant into the note/evidence *text* (that's the queryable part), and
   deliver the *original file* separately. On claude.ai web, call
-  **`mint_upload_token`** for a short-lived `{token, upload_url}`, then have the
+  **`transfer_artifact(mode="upload")`** for a short-lived `{token, upload_url}`, then have the
   code sandbox multipart-`curl` the attached files to `upload_url`.
   **Searchable binaries are automatic:** the server transcribes audio/video
   (Whisper), OCRs images (Tesseract), reads PDFs (pymupdf), extracts office/web
@@ -278,22 +312,22 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   inline byte blobs (`BINARY_BLOB_REJECTED`). Full workflow:
   `references/operations.md` § preserve.
 - **Pull a vault file back out — the download channel.** Call
-  **`mint_download_token`** for a short-lived `{token, download_url}`, then GET
+  **`transfer_artifact(mode="download")`** for a short-lived `{token, download_url}`, then GET
   `download_url?path=<vault-relative path>` with `Authorization: Bearer <token>`.
   Read-only, download-scoped, path confined to the vault root.
 - **Media hits in `find` are first-class.** An extracted media sidecar carries
   `media_type` and `media_file` (a pointer to the original binary). Treat the
   *file* as the result and the matched transcript/OCR snippet as the "why"; offer
-  to pull the original via `mint_download_token`. Images and video are also
+  to pull the original via `transfer_artifact(mode="download")`. Images and video are also
   searchable by *visual content* (CLIP), not just text — a purely-visual hit
   carries a `clip_score`; a video visual hit also carries `clip_match_at` (e.g.
   `"14:32"`), the timestamp of the matching keyframe.
-- **View a video's frames on demand — `get_video_frames`.** To *see* what a vault
+- **View a video's frames on demand — `read_media`.** To *see* what a vault
   video shows (slides, screen recordings, meetings), call
-  `get_video_frames(path, max_frames=8, start_sec=?, end_sec=?)` — it returns
+  `read_media(path, max_frames=8, start_sec=?, end_sec=?)` — it returns
   sampled keyframes INLINE as JPEG image blocks (no download round-trip needed),
   preceded by per-frame timestamps. The comprehension companion to visual search:
-  `find` locates the moment (`clip_match_at`), `get_video_frames` shows it — an
+  `ask_memory` locates the moment (`clip_match_at`), `read_media` shows it — an
   overview call first, then zoom with `start_sec`/`end_sec` around that timestamp.
   Bounded and read-only (default 8 frames, hard cap 16, JPEG ≤768px); soft-fails
   with a clear code when the server lacks the media extra.
@@ -316,7 +350,10 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
   `delete` refuses on files with inbound links unless `force_orphan=true`. The KB
   is a graph; ops that fragment it are explicit.
 
-### Phrasing → operation mapping (heuristic, not exhaustive)
+### Phrasing → operation mapping (canonical leaf reference)
+
+For normal agent work, use the Simple front door table above. This mapping is a
+reference for the canonical operation leaves that product commands route to.
 
 - "save this," "log this," "capture this," "add to my KB" → **add**
 - "compile this into a note," "make a note on this," "write this up," "distill this" → **note** (typically preceded by an implicit **add**)
@@ -350,15 +387,17 @@ These constraints apply equally to Tier 1 and Tier 2 — no escape hatch around 
 - "what's in the trash," "undelete," "put it back" → **list_trash** / **recover_from_trash** (Tier 2)
 
 **Implicit (no explicit ask) — proactive engagement:**
-- topic maps to a project/domain/entity, or "what did I conclude about X" → proactive **find** first, fold the hits into the answer
-- a decision is made or a problem just got solved → stepping-stone: capture via **add**/**note**, then report the path
+- topic maps to a project/domain/entity, or "what did I conclude about X" -> proactive **ask_memory** first, fold the hits into the answer
+- a decision is made or a problem just got solved -> stepping-stone: capture via **capture_source**/**remember**, then report the path
 
-When you say something oblique like "interesting, save it," default to **add** +
-ask whether to compile a note.
+When you say something oblique like "interesting, save it," default to
+**capture_source** and ask whether to compile only if there is a durable
+conclusion.
 
 ## Search
 
-`find` runs in **hybrid mode** by default: BM25 + local vector embeddings
+`ask_memory` is the normal product command for recall. Underneath, `find` runs in
+**hybrid mode** by default: BM25 + local vector embeddings
 (BAAI/bge-base-en-v1.5, 768-dim) fused via reciprocal rank fusion.
 Natural-language queries reach pages that don't contain the literal terms.
 
@@ -382,9 +421,9 @@ Empty queries degrade to filtered-most-recent regardless of mode.
   opt-out (KB only, never widens).
 - **Never report a search-miss as absence.** An empty result means *"not found in
   what I searched,"* not *"it doesn't exist."* If you're sure something exists,
-  try `scope="vault"`, vary the query terms, or `get` a path you suspect.
+  try `scope="vault"`, vary the query terms, or `read_memory` a path you suspect.
 
-Additional knobs on `find`: `graph=true` (1-hop neighbours of strong matches),
+Additional knobs exposed through `ask_memory`/`find`: `graph=true` (1-hop neighbours of strong matches),
 `rerank=true` (CrossEncoder re-sort, explicit precision spend),
 `prefer_compiled=true` (default; favours compiled types over raw `source`),
 `prefer_active=true` (default; soft-demotes superseded pages), `file_types` /
@@ -396,11 +435,11 @@ mode-aware auto: CPU steady-state modes keep it off; accelerated/performance
 mode may auto-rerank when lanes strongly disagree or the query is long.
 
 Performance presets:
-- Normal lookup: `detail="compact"`, `rerank=false`.
-- Reasoning context: `pack=true` when you need a compressed evidence bundle;
+- Normal lookup: `ask_memory(detail="compact", rerank=false)`.
+- Reasoning context: `ask_memory(deep=true)` when you need a compressed evidence bundle;
   add `graph_enrich=true` only when you need typed graph neighborhoods alongside
   the normal pack contract.
-- Diagnostics: `include_timings=true`; add `rerank=true` only when you are
+- Diagnostics: `ask_memory(include_timings=true)`; add `rerank=true` only when you are
   intentionally measuring reranking or spending latency for precision. Interpret
   timing output with the returned compute mode, embedding backend, cache state,
   rerank flag, and search profile.
@@ -409,8 +448,8 @@ Performance presets:
 data files aren't `find`-searchable. To make a dataset findable, write a
 **dataset card** — a small `type: dataset` page (frontmatter `data_file:` +
 `format:`, a one-line "What this holds", and a column profile) via `create_file`.
-`query_data(aggregate="profile")` emits a ready-to-write card; pull exact rows
-from the `data_file` with `query_data`.
+`query_dataset(aggregate="profile")` emits a ready-to-write card; pull exact rows
+from the `data_file` with `query_dataset`.
 
 Vector embeddings live in a per-machine sidecar at
 `<vault>/Knowledge Base/.embeddings.sqlite` (a dotfile that file-sync tools like Obsidian Sync ignore).
@@ -419,18 +458,18 @@ drift, call `audit_fix(rebuild_embeddings=true)`.
 
 ### Assessing or adopting a vault you didn't build
 
-**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
+**Make this your first move in any unfamiliar vault.** For import/adoption questions, run **adopt_vault(mode="scan-only")** first: it wraps the bounded scan, states the read-only contract, suggests likely knowledge packs, and lists safe next actions. It never rewrites originals in scan-only mode; explicit write modes stay under `Knowledge Base/` and either save the manifest or copy selected legacy text files as Sources with original path/hash provenance.
 
 For structural questions —
 "what does this vault look like," "how is this vault organized," "is there junk in
-here" — and simply to learn the layout before you write, run **overview** first: one bounded,
+here" — and simply to learn the layout before you write, run **browse_memory** first: one bounded,
 read-only report of folder structure, counts, frontmatter coverage, naming
 patterns, and junk candidates (zero-byte files, sync-conflict duplicates). It
 works on any folder under the vault root, including trees outside
 `Knowledge Base/` (a `Daily/` or `Journal/` folder), and on vaults with no KB at
 all. The folders it reports *outside* `Knowledge Base/` are read-only input — link
-to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `list_directory` on folders of interest,
-`find scope="vault"` for content, targeted `get` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
+to them, never write them; only `Knowledge Base/` is governed. Drill down from there: `browse_memory` on folders of interest,
+`ask_memory scope="vault"` for content, targeted `read_memory` for individual files. Use adoption output to decide whether to save a manifest, copy selected originals into Sources, or compile selected material into governed notes; do not rewrite the old vault by default. **Never
 bulk-read a vault file-by-file to answer a structural question** — the report
 answers in one call what would otherwise cost hundreds of reads.
 
@@ -488,10 +527,11 @@ These rules are non-negotiable.
    the same append-only tree (into a themed sub-folder) is allowed via
    `move_file`; crossing the boundary is forbidden.
 
-3. **Propose before writing compiled material.** For `note`, `link`, and
-   `replace` (and any hand-edit of `_Schema/` files), show the proposed content
-   (or diff) and wait for confirmation. The exception is `add` (raw capture),
-   `preserve` (raw evidence), and `find`/`audit` (read-only).
+3. **Propose before writing compiled material.** For `remember`,
+   `connect_memory` entity writes, and `replace_memory` (and any hand-edit of
+   `_Schema/` files), show the proposed content (or diff) and wait for
+   confirmation. The exception is `capture_source` (raw capture),
+   `preserve_evidence` (raw evidence), and read-only recall/review operations.
 
     **Batch waiver:** you may approve a *scope* of multiple files upfront ("draft
     all Tier 1," "write all four hubs + concepts") rather than each individually.
@@ -556,8 +596,9 @@ most-specific scope first. A typical starter set:
 For **patterns** that apply across multiple projects, use `projects:` (plural
 list) instead of `project:` (singular), e.g. `projects: [project-alpha, project-beta]`.
 
-**Auto-registration of new project keys.** The `note`, `replace`, `edit`
-(frontmatter-patch), and `link` (decision-entity) writers auto-append unknown
+**Auto-registration of new project keys.** The `remember`, `replace_memory`,
+`edit_memory` (frontmatter-patch), and `connect_memory` (decision-entity)
+writers auto-append unknown
 slug-shaped project keys to `_Schema/project-keys.yaml` and create the matching
 `Notes/Research/<Folder>/` directory on first use — no manual YAML edit needed.
 Pass `project_category` to bucket the new key (product / activity / domain /
@@ -578,7 +619,7 @@ out to *learn whether X is true* (experiment) or to *make a thing the world sees
 ## Workflow: typical add-then-compile session
 
 1. **You paste raw material or ask to log something.**
-2. **Skill creates a `source` file.** Picks the subfolder from the input shape —
+2. **Skill calls `capture_source` to create a source file.** Picks the subfolder from the input shape —
    `Sources/Articles/`, `Sources/Sessions/`, `Sources/Books/`, `Sources/Papers/`,
    `Sources/Videos/`, or `Sources/Other/`. Filename: ISO-date + slug. Updates
    `Sources/index.md`.
@@ -586,13 +627,15 @@ out to *learn whether X is true* (experiment) or to *make a thing the world sees
    insight, failure, pattern, experiment, production-log? And what scope?"** Skip
    if you already specified.
 4. **Skill drafts the compiled page** with frontmatter, a sources block linking
-   back to the source file, and a Connections section. **Run `suggest_links` on
-   the draft first** — it surfaces related existing pages you'd otherwise miss.
+   back to the source file, and a Connections section. **Run
+   `connect_memory(operation="suggest-links")` on the draft first** — it surfaces
+   related existing pages you'd otherwise miss.
 5. **Skill shows the draft, waits for confirmation.** You can revise inline.
-6. **On confirm: writes the page**, updates the relevant `index.md`, appends to
-   `log.md`, and reports paths. The `note` result carries a `suggestions` block
-   and any near-duplicate `warning` — wire in the relevant links via **edit** (or,
-   for a genuine duplicate, prefer `replace`/`append` over a parallel page).
+6. **On confirm: calls `remember` to write the page**, updates the relevant
+   `index.md`, appends to `log.md`, and reports paths. The write result carries a
+   `suggestions` block and any near-duplicate `warning` — wire in the relevant
+   links via **edit_memory** (or, for a genuine duplicate, prefer
+   `replace_memory` over a parallel page).
 
 When you approve a scope of multiple files upfront, the workflow collapses to a
 single batch write (see Write discipline § 3, batch waiver).
@@ -613,9 +656,9 @@ through `vault.normalize_wikilink()` before writing — bare names, KB-relative
 paths, `.md` suffixes, and stale paths get rewritten to canonical full form. You
 can write in any form; the on-disk file lands canonical.
 
-If a wikilink target doesn't exist yet, prefer creating the entity stub via the
-**link** operation rather than leaving a dangling link. Dangling links accumulate
-and surface in **audit** as `broken_wikilink`.
+If a wikilink target doesn't exist yet, prefer creating the entity stub via
+**connect_memory** rather than leaving a dangling link. Dangling links accumulate
+and surface in **review_memory(mode="audit")** as `broken_wikilink`.
 
 When creating an entity that points at a **currently-evolving external artifact**
 (a live spec, a code library, a service config), use **pointer-style** — summary
@@ -624,7 +667,7 @@ file inventories, command lines copied verbatim). Mirroring guarantees drift.
 
 ## Audit (lint) checks
 
-The **audit** operation runs read-only checks and proposes fixes (never
+The **review_memory(mode="audit")** operation runs read-only checks and proposes fixes (never
 auto-fixes); the report is reviewed before anything is written. It covers:
 orphans, broken wikilinks, supersession integrity, stale frontmatter,
 `index.md`/`log.md` drift, aged unprocessed sources (oldest-first — pair with
@@ -649,10 +692,10 @@ is in **`references/audit-checks.md`**.
 - Assign numeric confidence scores. Use citation count and recency as the trust
   signal.
 - Apply retention decay or "forgetting curves." Old material stays. If superseded,
-  mark it; if irrelevant, archive into an `_archive/` subfolder. (`audit`'s
+  mark it; if irrelevant, archive into an `_archive/` subfolder. (`review_memory`'s
   `stale_review` check **surfaces** old/cold/low-inbound conclusions as *review
   candidates* for you to judge — but never auto-decays, down-ranks, hides, or moves
-  anything; `find` ordering is unchanged. Surfacing a candidate ≠ a forgetting curve.)
+  anything; `ask_memory`/`find` ordering is unchanged. Surfacing a candidate ≠ a forgetting curve.)
 - Run on hooks, schedules, or background triggers. Operations happen because you
   asked, or because the conversation reached a point where consulting or capturing
   is clearly warranted.
@@ -674,11 +717,11 @@ is in **`references/audit-checks.md`**.
 - Marking an existing page `superseded`.
 
 **Proceed without asking:**
-- Proactive `find` for context (read-only).
+- Proactive `ask_memory` for context (read-only).
 - Capturing a clear stepping-stone conclusion whose type and scope are
   unambiguous — write under the standing waiver and report the path.
-- `add` and `preserve` operations — raw capture.
-- `find` and `audit` — read-only.
+- `capture_source` and `preserve_evidence` operations — raw capture.
+- `ask_memory`, `read_memory`, `browse_memory`, and `review_memory` — read-only.
 - Updating `index.md`, `log.md`, and `ingested_into:` frontmatter after a
   confirmed write.
 - Resolving obvious wikilink targets when the entity exists exactly.

--- a/tests/test_workflow_skills.py
+++ b/tests/test_workflow_skills.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from exomem import workflow_skills
 
 EXPECTED_WORKFLOW_SKILLS = [
@@ -23,6 +25,42 @@ REQUIRED_SECTIONS = [
     "## Mistakes to avoid",
 ]
 
+PRODUCT_COMMAND_HINTS = [
+    "ask_memory",
+    "read_memory",
+    "remember",
+    "edit_memory",
+    "replace_memory",
+    "capture_source",
+    "compile_source",
+    "preserve_evidence",
+    "transfer_artifact",
+    "review_memory",
+    "connect_memory",
+    "maintain_memory",
+    "read_media",
+]
+
+LEAF_COMMANDS_THAT_SHOULD_NOT_DRIVE_WORKFLOW_SKILLS = [
+    "find",
+    "get",
+    "add",
+    "note",
+    "preserve",
+    "edit",
+    "replace",
+    "suggest_links",
+    "graph_context",
+    "attention",
+    "audit",
+    "evolution",
+    "propose_compilation",
+    "get_video_frames",
+    "query_data",
+    "overview",
+    "adopt",
+]
+
 
 def test_workflow_skill_index_lists_first_pass_skills() -> None:
     skills = workflow_skills.list_skills()
@@ -41,3 +79,48 @@ def test_workflow_skill_docs_have_required_contract_sections() -> None:
         assert f"name: {name}" in text
         for section in REQUIRED_SECTIONS:
             assert section in text, f"{name} missing {section}"
+
+
+def test_workflow_skill_docs_route_through_product_commands() -> None:
+    for name in EXPECTED_WORKFLOW_SKILLS:
+        skill_md = workflow_skills.source_dir(name) / "SKILL.md"
+        text = skill_md.read_text(encoding="utf-8")
+
+        assert any(f"`{command}" in text for command in PRODUCT_COMMAND_HINTS), (
+            f"{name} should mention at least one product command"
+        )
+
+        for command in LEAF_COMMANDS_THAT_SHOULD_NOT_DRIVE_WORKFLOW_SKILLS:
+            pattern = rf"`{re.escape(command)}(?:`|\()"
+            assert not re.search(pattern, text), (
+                f"{name} should not route agents through leaf command `{command}`"
+            )
+
+
+def test_core_skill_tool_loading_mentions_current_product_surface() -> None:
+    skill_md = workflow_skills.WORKFLOW_SKILLS_DIR.parent / "SKILL.md"
+    text = skill_md.read_text(encoding="utf-8")
+    loading_section = text.split("## Loading the tools", maxsplit=1)[1].split(
+        "## Workflow skills", maxsplit=1
+    )[0]
+
+    for command in [
+        "bootstrap",
+        "ask_memory",
+        "read_memory",
+        "browse_memory",
+        "remember",
+        "edit_memory",
+        "replace_memory",
+        "capture_source",
+        "compile_source",
+        "preserve_evidence",
+        "transfer_artifact",
+        "review_memory",
+        "connect_memory",
+        "adopt_vault",
+        "maintain_memory",
+        "query_dataset",
+        "read_media",
+    ]:
+        assert command in loading_section


### PR DESCRIPTION
## Summary
- Update the core Exomem skill scaffold and workflow skills to prefer product command names.
- Sync the fixture schema copy and workflow-skill docs.
- Add regression tests to keep workflow skills from routing agents through old leaf commands.

## Tests
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_workflow_skills.py tests/test_scaffold_no_leak.py tests/test_bootstrap.py tests/test_schema.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_add.py tests/test_init.py tests/test_cli_core_ops.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_install_skill.py tests/test_install_hook.py tests/test_workflow_skills.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_doctor.py tests/test_find.py::test_excludes_schema_dir tests/test_find.py::test_scope_vault_excludes_schema_and_trash tests/test_index_trash_exclusion.py
  - 27 passed, 1 skipped: sentence_transformers not installed
- env UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/generate-capabilities.py --check
- sh tests/scripts/test_install_sh.sh
- git diff --check

Note: ruff was not available in this environment.