### PR TITLE
Fix product command adoption flow

### DIFF
--- a/docs/product-gap-matrix.md
+++ b/docs/product-gap-matrix.md
@@ -1,6 +1,6 @@
 # Product gap matrix: Exomem vs Basic Memory
 
-Generated from local product-flow benchmarking on 2026-07-08.
+Generated from local product-flow benchmarking on 2026-07-09.
 
 This is a product benchmark, not an internals comparison. Basic Memory was inspected only through public/product-facing surfaces in the sibling checkout: README/docs/tool names. No Basic Memory implementation or benchmark code was copied.
 
@@ -18,43 +18,43 @@ The harness creates temporary vaults under `.pytest-tmp/product-flow-benchmark/`
 
 Exomem is stronger where the product needs governance: source/evidence separation, provenance, review queues, and safe copied-source preservation. Basic Memory is stronger where the product needs low-friction adoption: cloud/no-install path, sync, importers, schema tools, multi-project UX, context/canvas workflows, and packaged assistant ecosystem.
 
-The most important finding is not philosophical: **Exomem's direct `overview` and `adopt` CLI paths currently fail on a messy uninitialized vault before they can scan it**, even though setup uses the adoption scan internally. That makes the existing-vault story weaker than the product model promises.
+The earlier largest product gap was first-run adoption: direct CLI scans of a messy uninitialized vault failed before they could report anything useful. That is now fixed for the product surface: `browse_memory(mode="overview")` and `adopt_vault(mode="scan-only")` can inspect a pre-init vault, while write-capable adoption modes still require an initialized governed KB.
 
 ## Matrix
 
 | Flow | Exomem rating | Harness status | Basic Memory comparison | Evidence / gap |
 | --- | --- | --- | --- | --- |
 | Fresh vault setup | Behind | Pass | Basic Memory has simpler public local install (`uv tool install basic-memory`) and cloud/no-install onboarding. | Exomem `setup --yes --lean --no-hooks --skip-claude-register` works and initializes the scaffold, but still feels like configuration rather than immediate product use. |
-| Existing messy vault adoption | Behind | Partial | Basic Memory has importers and project setup paths that are more discoverable. | Exomem's product model is safer, but direct `overview`/`adopt --mode scan-only` reject a pre-init vault because the registry CLI resolves only initialized vaults first. |
-| Search / recall | Comparable | Pass | Basic Memory has polished text/vector/hybrid search docs and richer search-result UX. | Exomem `find` recalls seeded notes with vault-relative cited paths. Lean benchmark uses keyword mode to avoid model downloads. |
+| Existing messy vault adoption | Comparable | Pass | Basic Memory has importers and project setup paths that are more discoverable. | Exomem's product model is safer: `browse_memory` and `adopt_vault(mode="scan-only")` scan before initialization, and write modes preserve originals under governed source/adoption folders. |
+| Search / recall | Comparable | Pass | Basic Memory has polished text/vector/hybrid search docs and richer search-result UX. | Exomem `ask_memory` recalls seeded notes with vault-relative cited paths. Lean benchmark uses keyword mode to avoid model downloads. |
 | Write / remember | Ahead | Pass | Basic Memory `write_note` is easier; Exomem is more governed. | Exomem writes raw Sources and compiled notes separately, canonicalizes the source citation, and updates the source `ingested_into` backlink. |
-| Source preservation | Ahead | Pass | Basic Memory importers cover more formats. | Exomem `adopt --mode copy-as-sources` preserves the original file, records `imported_from`, SHA-256, and byte count. |
-| Evidence / provenance | Ahead | Pass | Basic Memory is primarily note/knowledge-graph oriented. | Exomem has an explicit Evidence tree plus `provenance_report` over durable `<!-- key:value -->` markers. The marker workflow is still hidden. |
+| Source preservation | Ahead | Pass | Basic Memory importers cover more formats. | Exomem `adopt_vault(mode="copy-as-sources")` preserves the original file, records `imported_from`, SHA-256, and byte count. |
+| Evidence / provenance | Ahead | Pass | Basic Memory is primarily note/knowledge-graph oriented. | Exomem has an explicit Evidence tree plus `review_memory(mode="provenance")` over durable `<!-- key:value -->` markers. The marker workflow is still hidden. |
 | Schema inference / validation | Missing | Not measured | Basic Memory publicly exposes `schema_infer`, `schema_validate`, and `schema_diff`. | Exomem validates its own page types but has no comparable user-facing schema inference/validation flow. |
-| Graph / context building | Behind | Pass | Basic Memory exposes `build_context` and `canvas` as clearer user/assistant workflows. | Exomem can do inbound links and `find(pack=true)`, and `suggest_links` returns a list, but the product flow is fragmented and less legible. |
-| Review / stale / contradiction workflow | Ahead | Pass | Basic Memory has recent activity and graph navigation, but less explicit epistemic review. | Exomem `audit`, `attention`, and `propose_compilation` surface unprocessed source work and scaffold compilation. |
-| Assistant onboarding | Comparable | Pass | Basic Memory has broader packaged plugins, skills, and public docs across clients. | Exomem `bootstrap` exposes front-door actions and `demo --json` proves doctor/find/get/audit against a sample vault. |
+| Graph / context building | Behind | Pass | Basic Memory exposes `build_context` and `canvas` as clearer user/assistant workflows. | Exomem can do inbound links, `ask_memory(deep=true)`, and `connect_memory(operation="suggest-links")`, but Basic Memory's context/canvas story is still easier to explain. |
+| Review / stale / contradiction workflow | Ahead | Pass | Basic Memory has recent activity and graph navigation, but less explicit epistemic review. | Exomem `review_memory` surfaces unprocessed source work, audit findings, attention queues, provenance, and compilation scaffolds. |
+| Assistant onboarding | Comparable | Pass | Basic Memory has broader packaged plugins, skills, and public docs across clients. | Exomem `bootstrap` exposes front-door actions and product commands; `demo --json` proves doctor/retrieval/review against a sample vault. |
 
-Current harness summary: 10 flows; 4 ahead, 2 comparable, 3 behind, 1 missing. Status: 8 pass, 1 partial, 1 not measured.
+Current harness summary: 10 flows; 4 ahead, 3 comparable, 2 behind, 1 missing. Status: 9 pass, 1 not measured.
 
 ## Prioritized backlog
 
-1. **Fix pre-init adoption through the public CLI/MCP surface.** `overview` and `adopt --mode scan-only` must be able to scan a raw messy vault before `Knowledge Base/_Schema/SKILL.md` exists. This is the largest product trust gap because it breaks the exact first-run scenario Exomem claims to handle safely.
+1. **Keep first-run adoption polished across surfaces.** The CLI now lets `browse_memory(mode="overview")` and `adopt_vault(mode="scan-only")` scan a raw messy vault before `Knowledge Base/_Schema/SKILL.md` exists. Keep MCP and REST aligned with that contract, and make the safe next action obvious.
 
 2. **Collapse onboarding into one obvious first action.** Keep `setup`'s safety, but reduce the user's mental model to: demo, choose vault, scan, initialize. Basic Memory is ahead because its first-run story is easier to explain and it has a cloud escape hatch.
 
-3. **Make graph/context a single product verb.** Exomem has good pieces (`find(pack=true)`, inbound links, suggestions), but Basic Memory's `build_context`/canvas story is easier to use. Add or document one front-door context command that returns the relevant notes, links, and surrounding graph.
+3. **Make graph/context a single product story.** Exomem has good pieces (`ask_memory(deep=true)`, inbound links, suggestions), but Basic Memory's `build_context`/canvas story is easier to use. Document the front-door `connect_memory`/deep-context flow so it returns the relevant notes, links, and surrounding graph.
 
 4. **Decide whether schema inference belongs in Exomem.** Basic Memory is plainly ahead here. If Exomem wants this capability, expose it as a governed validation/audit flow, not as a Basic Memory clone.
 
-5. **Make evidence/provenance discoverable.** The Evidence tree and `provenance_report` are a real differentiator, but the HTML-comment marker workflow is too implicit. Add assistant guidance and maybe a small `prove`/`trace` wrapper so users do not need to know the comment syntax.
+5. **Make evidence/provenance discoverable.** The Evidence tree and `review_memory(mode="provenance")` are a real differentiator, but the HTML-comment marker workflow is too implicit. Add assistant guidance so users do not need to know the comment syntax.
 
-6. **Polish write ergonomics without dropping governance.** `add` + `note --field sources=...` is safer than a plain note write, but heavier. A product-level remember flow should guide the assistant through Source vs Note vs Evidence without requiring the user to name page types.
+6. **Polish write ergonomics without dropping governance.** `capture_source` + `remember --field sources=...` is safer than a plain note write, but heavier. The product remember flow should guide the assistant through Source vs Note vs Evidence without requiring the user to name page types.
 
 ## Harness coverage notes
 
 - The benchmark intentionally runs real Exomem CLI commands through subprocesses.
 - Heavy embedding/media paths are disabled so the harness stays local, fast, and deterministic.
 - `schema_inference_validation` is rated `missing` rather than failed because there is no Exomem command to run.
-- `messy_vault_adoption` is partial by design until the pre-init CLI resolution bug is fixed.
+- `messy_vault_adoption` covers the fixed pre-init scan path and confirms scan-only leaves originals untouched.
 - The Basic Memory reference detector reads public-facing README/docs text and records observed product promises; it does not execute or copy Basic Memory code.

--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -15,13 +15,13 @@ Users and agents should think in verbs first. Exomem's internal page types still
 
 | User action | What it means | Backed by |
 | --- | --- | --- |
-| Save | Keep raw material or a durable conclusion | `add`, `note`, `link`, sometimes `preserve` |
-| Adopt/import | Understand an existing vault safely before changing anything | `adopt`, `overview` |
-| Ask | Retrieve what the vault already knows with citations | `find`, `get`, `find(pack=true)` |
-| Prove | Show or preserve proof for a claim, case, warranty, dispute, record, or receipt | `preserve`, `find`, `get`, upload/download tools |
-| Review | Surface stale, unprocessed, broken, or contradictory areas | `attention`, `audit`, `propose_compilation` |
-| Update | Correct, edit, or supersede knowledge while preserving history | `edit`, `replace`, `reconcile` |
-| Connect | Link related notes, entities, decisions, and sources | `link`, `suggest_links` |
+| Save | Keep raw material or a durable conclusion | `capture_source` for raw material; `remember` for compiled conclusions; `preserve_evidence` for proof |
+| Adopt/import | Understand an existing vault safely before changing anything | `adopt_vault(mode="scan-only")`, then explicit copy/manifest/compile modes |
+| Ask | Retrieve what the vault already knows with citations | `ask_memory`, then `read_memory`; `ask_memory(deep=true)` for bounded context |
+| Prove | Show or preserve proof for a claim, case, warranty, dispute, record, or receipt | `preserve_evidence`, `transfer_artifact`, `review_memory(mode="provenance")` |
+| Review | Surface stale, unprocessed, broken, or contradictory areas | `review_memory` |
+| Update | Correct, edit, or supersede knowledge while preserving history | `edit_memory`, `replace_memory`, `maintain_memory` |
+| Connect | Link related notes, entities, decisions, and sources | `connect_memory` |
 
 ## Existing vaults
 
@@ -34,9 +34,9 @@ The adoption modes are explicit:
 | `scan-only` | No | Report structure, likely packs, governed vs read-only areas, and next actions |
 | `save-manifest` | Yes, under `Knowledge Base/_Adoption/` only | Save the scan as a durable onboarding artifact |
 | `copy-as-sources` | Yes, under `Knowledge Base/Sources/Imported/` only | Copy selected legacy text files with original path and SHA-256 provenance |
-| `compile-selected` | Yes, under `Knowledge Base/Sources/Imported/` when legacy files need source copies | Copy selected legacy text files when needed, then return a reviewable compile plan; compiled notes are written later through `note` |
+| `compile-selected` | Yes, under `Knowledge Base/Sources/Imported/` when legacy files need source copies | Copy selected legacy text files when needed, then return a reviewable compile plan; compiled notes are written later through `remember` |
 
-There is no rewrite-in-place onboarding path in the normal product flow. `compile-selected` is a planning step, not auto-migration: it prepares governed sources and a note scaffold so the user or agent can deliberately compile with `note`.
+There is no rewrite-in-place onboarding path in the normal product flow. `compile-selected` is a planning step, not auto-migration: it prepares governed sources and a note scaffold so the user or agent can deliberately compile with `remember`.
 
 ## Sources versus evidence
 

--- a/docs/workflow-skills.md
+++ b/docs/workflow-skills.md
@@ -9,7 +9,7 @@ to return.
 
 | Layer | What it is | Example |
 | --- | --- | --- |
-| Exomem tools | Product MCP/REST/CLI commands that read and write the KB | `ask_memory`, `read_memory`, `remember`, `capture_source`, `review_memory` |
+| Exomem product commands | Product MCP/REST/CLI commands that read and write the KB | `ask_memory`, `read_memory`, `remember`, `capture_source`, `review_memory` |
 | Context packs | Retrieval-time evidence bundles returned by `ask_memory(deep=true)` | top hits, extracted claims, graph neighborhood, contradiction signals |
 | Knowledge packs | Product/domain guidance selected during setup | technical, creative, legal/warranty, personal records |
 | Workflow skills | Agent-visible workflows for common user intent | `exomem-continue`, `exomem-capture`, `exomem-review` |

--- a/scripts/product_flow_benchmark.py
+++ b/scripts/product_flow_benchmark.py
@@ -427,8 +427,12 @@ def flow_messy_vault_adoption(ctx: HarnessContext, runner: FlowRunner, bm: dict)
     vault = _mk_vault(ctx, "messy-adoption")
     _seed_messy_vault(vault)
     before = _snapshot_files(vault)
-    overview_run, overview_payload = runner.run(vault, "overview", "--json")
-    adopt_run, adopt_payload = runner.run(vault, "adopt", ".", "--mode", "scan-only", "--json")
+    overview_run, overview_payload = runner.run(
+        vault, "browse_memory", ".", "--mode", "overview", "--json"
+    )
+    adopt_run, adopt_payload = runner.run(
+        vault, "adopt_vault", ".", "--mode", "scan-only", "--json"
+    )
     after = _snapshot_files(vault)
     data = (adopt_payload or {}).get("data", {})
     totals = data.get("summary", {}).get("totals", {})
@@ -441,14 +445,13 @@ def flow_messy_vault_adoption(ctx: HarnessContext, runner: FlowRunner, bm: dict)
     return runner.flow(
         flow_id="messy_vault_adoption",
         name="Existing messy vault adoption",
-        rating="behind",
+        rating="comparable",
         checks=checks,
         evidence=[
             "The product model has an explicit scan-only adoption contract.",
-            "The direct CLI path currently rejects an uninitialized messy vault before it can scan.",
+            "The product CLI can scan a messy existing vault before any copy/adoption write.",
         ],
         gaps=[
-            "Fix CLI/MCP adoption so `adopt` and `overview` can scan a pre-init vault directly, matching setup wizard behavior.",
             "Basic Memory has richer importers for common AI exports; Exomem adoption is safer in design but less usable today.",
         ],
     )
@@ -459,7 +462,7 @@ def flow_search_recall(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> Flo
     path = _write_recall_note(vault)
     run, payload = runner.run(
         vault,
-        "find",
+        "ask_memory",
         "rotating token",
         "--mode",
         "keyword",
@@ -470,7 +473,7 @@ def flow_search_recall(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> Flo
     hits = (payload or {}).get("data") or []
     paths = [hit.get("path", "") for hit in hits if isinstance(hit, dict)]
     checks = [
-        Check("find exits successfully", run.ok, f"exit={run.returncode}"),
+        Check("ask_memory exits successfully", run.ok, f"exit={run.returncode}"),
         Check("seed note is recalled", path.as_posix() in paths, ", ".join(paths)),
         Check("results carry paths for citation", all(".md" in p for p in paths[:1]), paths[0] if paths else "none"),
     ]
@@ -493,7 +496,7 @@ def flow_write_remember(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> Fl
     vault = _prepared_vault(ctx, runner, "write-remember")
     add_run, add_payload = runner.run(
         vault,
-        "add",
+        "capture_source",
         "--content",
         "Session capture: durable benchmark memory should cite raw source material.",
         "--source-type",
@@ -504,16 +507,17 @@ def flow_write_remember(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> Fl
         "product flow benchmark",
         "--json",
     )
-    source_path = ((add_payload or {}).get("data") or {}).get("path", "")
+    add_data = (add_payload or {}).get("data") or {}
+    source_path = ((add_data.get("source") or {}).get("path")) or add_data.get("path", "")
     note_run, note_payload = runner.run(
         vault,
-        "note",
-        "--note-type",
-        "insight",
+        "remember",
         "--title",
         "Benchmark source-backed insight",
         "--content",
         "# Benchmark source-backed insight\n\n## Claim\n\nDurable product memories should cite raw source material.\n\n## Why it holds\n\nThe benchmark writes a raw Source first, then a compiled note that cites it.\n",
+        "--field",
+        "note_type=insight",
         "--field",
         f"sources={source_path}",
         "--json",
@@ -521,9 +525,9 @@ def flow_write_remember(ctx: HarnessContext, runner: FlowRunner, bm: dict) -> Fl
     note_path = ((note_payload or {}).get("data") or {}).get("path", "")
     source_text = (vault / source_path).read_text(encoding="utf-8", errors="replace") if source_path else ""
     checks = [
-        Check("add source succeeds", add_run.ok and bool(source_path), source_path or f"exit={add_run.returncode}"),
-        Check("note succeeds", note_run.ok and bool(note_path), note_path or f"exit={note_run.returncode}"),
-        Check("note cites source", source_path.removesuffix(".md") in (vault / note_path).read_text(encoding="utf-8", errors="replace") if note_path else False, source_path),
+        Check("capture_source succeeds", add_run.ok and bool(source_path), source_path or f"exit={add_run.returncode}"),
+        Check("remember succeeds", note_run.ok and bool(note_path), note_path or f"exit={note_run.returncode}"),
+        Check("note cites source", bool(source_path) and source_path.removesuffix(".md") in (vault / note_path).read_text(encoding="utf-8", errors="replace") if note_path else False, source_path),
         Check("source has ingestion backlink", "ingested_into" in source_text and "benchmark-source-backed-insight" in source_text, "source frontmatter backlink"),
     ]
     return runner.flow(
@@ -556,7 +560,7 @@ def flow_source_preservation(ctx: HarnessContext, runner: FlowRunner, bm: dict) 
     runner.commands.extend(setup_runner.commands)
     run, payload = runner.run(
         vault,
-        "adopt",
+        "adopt_vault",
         ".",
         "--mode",
         "copy-as-sources",
@@ -593,7 +597,7 @@ def flow_evidence_provenance(ctx: HarnessContext, runner: FlowRunner, bm: dict) 
     vault = _prepared_vault(ctx, runner, "evidence-provenance")
     preserve_run, preserve_payload = runner.run(
         vault,
-        "preserve",
+        "preserve_evidence",
         "--scope",
         "warranty",
         "--category",
@@ -609,18 +613,20 @@ def flow_evidence_provenance(ctx: HarnessContext, runner: FlowRunner, bm: dict) 
     evidence_path = ((preserve_payload or {}).get("data") or {}).get("path", "")
     note_run, note_payload = runner.run(
         vault,
-        "note",
-        "--note-type",
-        "insight",
+        "remember",
         "--title",
         "Benchmark warranty proof",
         "--content",
         "# Benchmark warranty proof\n\n## Claim\n\nThe benchmark receipt is preserved as proof. <!-- evidence:R-1001 -->\n\n## Why it holds\n\nThe Evidence artifact stores the receipt text separately from this compiled claim.\n",
+        "--field",
+        "note_type=insight",
         "--json",
     )
     prov_run, prov_payload = runner.run(
         vault,
-        "provenance_report",
+        "review_memory",
+        "--mode",
+        "provenance",
         "--key",
         "evidence",
         "--value",
@@ -632,8 +638,8 @@ def flow_evidence_provenance(ctx: HarnessContext, runner: FlowRunner, bm: dict) 
     checks = [
         Check("preserve succeeds", preserve_run.ok and bool(evidence_path), evidence_path),
         Check("evidence artifact exists", bool(evidence_path) and (vault / evidence_path).is_file(), evidence_path),
-        Check("provenance note succeeds", note_run.ok, f"exit={note_run.returncode}"),
-        Check("provenance report finds marker", bool(findings), json.dumps(findings[:1], default=str)),
+        Check("remember proof note succeeds", note_run.ok, f"exit={note_run.returncode}"),
+        Check("review_memory provenance finds marker", bool(findings), json.dumps(findings[:1], default=str)),
     ]
     return runner.flow(
         flow_id="evidence_provenance",
@@ -681,7 +687,9 @@ def flow_graph_context_building(ctx: HarnessContext, runner: FlowRunner, bm: dic
     source = _write_context_notes(vault)
     suggest_run, suggest_payload = runner.run(
         vault,
-        "suggest_links",
+        "connect_memory",
+        "--operation",
+        "suggest-links",
         "--draft-title",
         "Rotating token rollout",
         "--draft-body",
@@ -692,27 +700,31 @@ def flow_graph_context_building(ctx: HarnessContext, runner: FlowRunner, bm: dic
     )
     inbound_run, inbound_payload = runner.run(
         vault,
-        "list_inbound_links",
+        "connect_memory",
+        "--operation",
+        "inbound-links",
+        "--target",
         source.as_posix(),
         "--json",
     )
     pack_run, pack_payload = runner.run(
         vault,
-        "find",
+        "ask_memory",
         "rotating token",
         "--mode",
         "keyword",
-        "--pack",
+        "--deep",
         "--json",
     )
     suggestions = (suggest_payload or {}).get("data") or []
     inbound_count = (((inbound_payload or {}).get("data") or {}).get("count")) or 0
-    pack = ((pack_payload or {}).get("data") or {}).get("pack")
+    pack_data = (pack_payload or {}).get("data") or {}
+    context = pack_data.get("context") or pack_data.get("pack")
     checks = [
-        Check("suggest_links succeeds", suggest_run.ok, f"exit={suggest_run.returncode}"),
-        Check("suggest_links returns a list", isinstance(suggestions, list), json.dumps(suggestions[:1], default=str)),
-        Check("list_inbound_links detects links", inbound_run.ok and inbound_count >= 1, f"count={inbound_count}"),
-        Check("find(pack=true) returns pack", pack_run.ok and isinstance(pack, dict), "pack present" if isinstance(pack, dict) else "missing"),
+        Check("connect_memory suggest-links succeeds", suggest_run.ok, f"exit={suggest_run.returncode}"),
+        Check("connect_memory suggest-links returns a list", isinstance(suggestions, list), json.dumps(suggestions[:1], default=str)),
+        Check("connect_memory inbound-links detects links", inbound_run.ok and inbound_count >= 1, f"count={inbound_count}"),
+        Check("ask_memory deep returns context", pack_run.ok and isinstance(context, dict), "context present" if isinstance(context, dict) else "missing"),
     ]
     return runner.flow(
         flow_id="graph_context_building",
@@ -733,7 +745,7 @@ def flow_review_stale_contradiction(ctx: HarnessContext, runner: FlowRunner, bm:
     vault = _prepared_vault(ctx, runner, "review")
     add_run, add_payload = runner.run(
         vault,
-        "add",
+        "capture_source",
         "--content",
         "Unprocessed source: review queues should surface captured material that has not been compiled.",
         "--source-type",
@@ -742,12 +754,17 @@ def flow_review_stale_contradiction(ctx: HarnessContext, runner: FlowRunner, bm:
         "Unprocessed benchmark source",
         "--json",
     )
-    source_path = ((add_payload or {}).get("data") or {}).get("path", "")
-    audit_run, audit_payload = runner.run(vault, "audit", "--json")
-    attention_run, attention_payload = runner.run(vault, "attention", "--limit", "5", "--json")
+    add_data = (add_payload or {}).get("data") or {}
+    source_path = ((add_data.get("source") or {}).get("path")) or add_data.get("path", "")
+    audit_run, audit_payload = runner.run(vault, "review_memory", "--mode", "audit", "--json")
+    attention_run, attention_payload = runner.run(
+        vault, "review_memory", "--mode", "attention", "--limit", "5", "--json"
+    )
     propose_run, propose_payload = runner.run(
         vault,
-        "propose_compilation",
+        "review_memory",
+        "--mode",
+        "compilation",
         "--sources",
         source_path,
         "--json",
@@ -756,10 +773,10 @@ def flow_review_stale_contradiction(ctx: HarnessContext, runner: FlowRunner, bm:
     proposal = (propose_payload or {}).get("data") or {}
     checks = [
         Check("seed source succeeds", add_run.ok and bool(source_path), source_path),
-        Check("audit succeeds", audit_run.ok, f"exit={audit_run.returncode}"),
+        Check("review_memory audit succeeds", audit_run.ok, f"exit={audit_run.returncode}"),
         Check("audit surfaces review data", isinstance(audit_findings, list), f"{len(audit_findings)} findings"),
-        Check("attention succeeds", attention_run.ok, f"exit={attention_run.returncode}"),
-        Check("propose_compilation returns scaffold", propose_run.ok and bool(proposal.get("outline_markdown")), json.dumps(proposal, default=str)[:240]),
+        Check("review_memory attention succeeds", attention_run.ok, f"exit={attention_run.returncode}"),
+        Check("review_memory compilation returns scaffold", propose_run.ok and bool(proposal.get("outline_markdown")), json.dumps(proposal, default=str)[:240]),
     ]
     return runner.flow(
         flow_id="review_stale_contradiction",

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -1301,17 +1301,17 @@ def _core_op_main(argv: list[str]) -> int:
     as_json = getattr(args, "json", False)
 
     try:
-        vault_root = resolve_vault()
         raw = _collect_raw_args(cmd, args, parser)
         kwargs = cli_ops.coerce(
             cmd.params, raw, guarded_fields=cmd.guarded_fields, tool=cmd.name, cli=True
         )
+        vault_root = _resolve_core_op_vault(cmd.name, kwargs, resolve_vault)
         if cmd.needs_schema:
             injected = (vault_root, schema_module.load_source_schema(vault_root))
         else:
             injected = (vault_root,)
         result = cmd.leaf(*injected, **kwargs)
-    except (cli_ops.OpError, ValueError, TypeError) as e:
+    except (cli_ops.OpError, ValueError, TypeError, RuntimeError) as e:
         err = cli_ops.error_dict(e)
         if as_json:
             print(json.dumps(cli_ops.envelope(False, error=err), default=str))
@@ -1326,6 +1326,30 @@ def _core_op_main(argv: list[str]) -> int:
     else:
         _print_human(result, op=cmd.name)
     return 0
+
+
+def _resolve_core_op_vault(op: str, kwargs: dict, resolve_vault_func) -> Path:
+    """Resolve the CLI vault root, allowing read-only first-run scans pre-init."""
+    try:
+        return resolve_vault_func()
+    except RuntimeError:
+        if not _core_op_allows_uninitialized_vault(op, kwargs):
+            raise
+        override = os.environ.get("EXOMEM_VAULT_PATH")
+        if not override:
+            raise
+        path = Path(override)
+        if not path.is_dir():
+            raise
+        return path
+
+
+def _core_op_allows_uninitialized_vault(op: str, kwargs: dict) -> bool:
+    if op == "browse_memory":
+        return True
+    if op == "adopt_vault":
+        return (kwargs.get("mode") or "scan-only") == "scan-only"
+    return False
 
 
 if __name__ == "__main__":

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -88,7 +88,7 @@ def error_dict(exc: Exception) -> dict:
     if isinstance(exc, OpError):
         return {"code": exc.code, "message": exc.message, "remediation": exc.remediation}
     text = str(exc)
-    if isinstance(exc, (ValueError, TypeError)):
+    if isinstance(exc, (ValueError, TypeError, RuntimeError)):
         m = _CODE_PREFIX.match(text)
         if m:
             code, message = m.group(1), m.group(2).strip()

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -358,6 +358,53 @@ def test_adopt_cli_door(vault: Path, capsys) -> None:
     assert payload["data"]["summary"]["kb"]["present"] is True
 
 
+def test_product_cli_scan_only_adoption_allows_pre_init_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    vault = _legacy_vault(tmp_path, kb=False)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+
+    code = main(["adopt_vault", ".", "--mode", "scan-only", "--json"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"]["mode"] == "scan-only"
+    assert payload["data"]["summary"]["kb"]["present"] is False
+
+
+def test_product_cli_browse_memory_allows_pre_init_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    vault = _legacy_vault(tmp_path, kb=False)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+
+    code = main(["browse_memory", ".", "--mode", "overview", "--json"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"]["kb"]["present"] is False
+    assert payload["data"]["totals"]["markdown"] >= 3
+
+
+def test_product_cli_write_adoption_still_requires_initialized_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    vault = _legacy_vault(tmp_path, kb=False)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+
+    code = main(["adopt_vault", ".", "--mode", "copy-as-sources", "--json"])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is False
+    assert "does not look like a vault" in payload["error"]["message"]
+
+
 def test_adopt_cli_human_output_is_product_shaped(vault: Path, capsys) -> None:
     code = main(["adopt"])
     out = capsys.readouterr().out
@@ -368,4 +415,3 @@ def test_adopt_cli_human_output_is_product_shaped(vault: Path, capsys) -> None:
     assert "Safe next actions" in out
     assert "Originals: untouched" in out
     assert '"mode"' not in out
-


### PR DESCRIPTION
## Summary
- update product-flow benchmark/docs to use product commands instead of primitive CLI names
- allow browse_memory and adopt_vault scan-only to inspect pre-init vaults
- keep write adoption blocked until the governed KB scaffold exists

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run --locked pytest tests/test_adopt.py tests/test_product_flow_benchmark.py tests/test_cli_core_ops.py tests/test_mcp_schema_fidelity.py tests/test_tool_annotations.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --locked pytest tests/test_product_flow_benchmark.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --locked python scripts/product_flow_benchmark.py --json --timeout-seconds 120
- scratch localhost REST smoke against copied /tmp vault: bootstrap, adopt_vault, capture_source, compile_source, remember, preserve_evidence, ask_memory, read_memory, review_memory, connect_memory, maintain_memory, delete refusal without confirm

## Notes
- Existing FastMCP/Starlette TestClient REST tests hang under the current HTTP app lifespan; the live scratch HTTP smoke was used for REST validation instead.
- uv.lock and the untracked FastMCP cache directory were left out of this PR.