### PR TITLE
Fix Windows release service setup

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -232,7 +232,9 @@ loginctl enable-linger "$USER"   # keep it running without an active login sessi
 # or download from https://nssm.cc/download and add nssm.exe to PATH
 # (or pass -NssmPath "C:\path\to\nssm.exe" to the script below).
 # The script self-elevates; approve the UAC prompt.
-pwsh -File scripts/install-service.ps1
+pwsh -File scripts/install-service.ps1 -Release
+# Developer checkout mode is still available when .venv already exists:
+#   pwsh -File scripts/install-service.ps1
 # Uninstall:
 #   nssm stop exomem && nssm remove exomem confirm
 # Restart (after .env edits): elevated shell required

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -2,14 +2,18 @@
 #
 # Prereqs:
 #   - NSSM installed (https://nssm.cc/download) and on PATH, OR pass -NssmPath.
-#   - uv has been run (`uv sync` in repo root) so .venv exists.
+#   - uv installed and on PATH.
+#   - For repo-mode installs, `uv sync` has been run in repo root so .venv exists.
+#     For release installs, pass -Release and the script creates/updates a sibling
+#     PyPI-backed service venv.
 #   - .env exists in the repo root with the GitHub OAuth vars set
 #     (EXOMEM_BASE_URL, EXOMEM_GITHUB_USERNAME, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET).
 #
 # Usage:
-#   pwsh -File scripts/install-service.ps1
+#   pwsh -File scripts/install-service.ps1 -Release
 #   pwsh -File scripts/install-service.ps1 -NssmPath "C:\nssm\nssm.exe"
-#   pwsh -File scripts/install-service.ps1 -Profile lean    # lexical-only service
+#   pwsh -File scripts/install-service.ps1 -Release -Profile lean    # lexical-only service
+#   pwsh -File scripts/install-service.ps1 -Release -Profile media
 #
 # Uninstall:
 #   nssm stop exomem
@@ -21,7 +25,13 @@ param(
     [string]$BindHost = "127.0.0.1",
     [int]$Port = 8765,
     [ValidateSet("lean", "hybrid", "media")]
-    [string]$Profile = "hybrid"
+    [string]$Profile = "hybrid",
+    [switch]$Release,
+    [string]$ServiceRoot = "",
+    [string]$PackageVersion = "",
+    [ValidateSet("auto", "always", "never")]
+    [string]$CudaTorch = "auto",
+    [switch]$LegacyMcpCompat
 )
 
 $ErrorActionPreference = "Stop"
@@ -43,19 +53,20 @@ if (-not $isAdmin) {
         "-ServiceName", $ServiceName,
         "-BindHost", $BindHost,
         "-Port", $Port,
-        "-Profile", $Profile
+        "-Profile", $Profile,
+        "-CudaTorch", $CudaTorch
     )
+    if ($Release) { $relaunchArgs += "-Release" }
+    if ($ServiceRoot) { $relaunchArgs += @("-ServiceRoot", "`"$ServiceRoot`"") }
+    if ($PackageVersion) { $relaunchArgs += @("-PackageVersion", "`"$PackageVersion`"") }
+    if ($LegacyMcpCompat) { $relaunchArgs += "-LegacyMcpCompat" }
     Start-Process -FilePath $hostExe -Verb RunAs -ArgumentList $relaunchArgs
     exit
 }
 
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
-$python = Join-Path $repoRoot ".venv\Scripts\python.exe"
 $logDir = Join-Path $repoRoot "logs"
 
-if (-not (Test-Path $python)) {
-    throw "Python venv not found at $python. Run 'uv sync' in $repoRoot first."
-}
 if (-not (Test-Path (Join-Path $repoRoot ".env"))) {
     throw ".env file missing in $repoRoot. See the Install section of README.md for the required GitHub OAuth vars."
 }
@@ -76,6 +87,108 @@ function Get-DotenvValue {
     }
     return $null
 }
+
+function Read-DotenvMap {
+    $envPath = Join-Path $repoRoot ".env"
+    $map = [ordered]@{}
+    foreach ($line in Get-Content $envPath) {
+        if ($line -match '^\s*([^#][A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$') {
+            $name = $Matches[1].Trim()
+            $value = $Matches[2].Trim()
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+            $map[$name] = $value
+        }
+    }
+    if ($LegacyMcpCompat) {
+        $map["EXOMEM_MCP_LEGACY_COMPAT"] = "1"
+    }
+    return $map
+}
+
+function Set-ProcessEnvFromMap {
+    param([System.Collections.IDictionary]$Map)
+    foreach ($entry in $Map.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, "Process")
+    }
+}
+
+function Set-NssmEnvironment {
+    param([System.Collections.IDictionary]$Map)
+    $args = @("set", $ServiceName, "AppEnvironmentExtra")
+    foreach ($entry in $Map.GetEnumerator()) {
+        $args += "$($entry.Key)=$($entry.Value)"
+    }
+    & $NssmPath @args
+}
+
+function Invoke-LoggedNative {
+    param([string[]]$CommandArgs)
+    $out = & $CommandArgs[0] @($CommandArgs[1..($CommandArgs.Count - 1)]) 2>&1
+    foreach ($line in $out) { Write-Host $line }
+    return $LASTEXITCODE
+}
+
+function Install-ReleaseVenv {
+    $root = if ($ServiceRoot) {
+        $ServiceRoot
+    } else {
+        Join-Path (Split-Path -Parent $repoRoot) "exomem-service-release"
+    }
+    if (-not (Test-Path $root)) { New-Item -ItemType Directory -Path $root | Out-Null }
+    $venvPython = Join-Path $root ".venv\Scripts\python.exe"
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "Creating release service venv at $root\.venv..."
+        $code = Invoke-LoggedNative @("uv", "venv", (Join-Path $root ".venv"), "--python", "3.13")
+        if ($code -ne 0) { throw "uv venv failed" }
+    }
+
+    $pkg = if ($PackageVersion) { "exomem==$PackageVersion" } else { "exomem" }
+    if ($Profile -eq "hybrid") {
+        $pkg = if ($PackageVersion) { "exomem[embeddings]==$PackageVersion" } else { "exomem[embeddings]" }
+    } elseif ($Profile -eq "media") {
+        $pkg = if ($PackageVersion) { "exomem[embeddings,media,vision,diarization]==$PackageVersion" } else { "exomem[embeddings,media,vision,diarization]" }
+    }
+
+    Write-Host "Installing $pkg into release service venv..."
+    $code = Invoke-LoggedNative @("uv", "pip", "install", "--python", $venvPython, $pkg)
+    if ($code -ne 0) { throw "uv pip install failed for $pkg" }
+
+    $shouldCuda = $false
+    if ($CudaTorch -eq "always") {
+        $shouldCuda = $true
+    } elseif ($CudaTorch -eq "auto" -and (Get-Command nvidia-smi -ErrorAction SilentlyContinue)) {
+        $shouldCuda = $true
+    }
+    if ($shouldCuda -and $Profile -ne "lean") {
+        Write-Host "Installing CUDA 13.2 Torch for Windows NVIDIA GPU support..."
+        $code = Invoke-LoggedNative @(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            $venvPython,
+            "--default-index",
+            "https://download.pytorch.org/whl/cu132",
+            "torch==2.12.0+cu132"
+        )
+        if ($code -ne 0) { throw "CUDA Torch install failed" }
+    }
+    return $venvPython
+}
+
+if ($Release) {
+    $python = Install-ReleaseVenv
+} else {
+    $python = Join-Path $repoRoot ".venv\Scripts\python.exe"
+    if (-not (Test-Path $python)) {
+        throw "Python venv not found at $python. Run 'uv sync' in $repoRoot first, or pass -Release to install a PyPI-backed service venv."
+    }
+}
+
+$serviceEnv = Read-DotenvMap
+Set-ProcessEnvFromMap -Map $serviceEnv
 
 $doctorArgs = @("-m", "exomem", "doctor", "--profile", $Profile)
 $vault = Get-DotenvValue "EXOMEM_VAULT_PATH"
@@ -98,6 +211,7 @@ if ($LASTEXITCODE -ne 0) {
 & $NssmPath set $ServiceName AppRestartDelay 5000
 & $NssmPath set $ServiceName AppThrottle 10000
 & $NssmPath set $ServiceName Description "exomem: Obsidian Knowledge Base MCP server for mobile claude.ai"
+Set-NssmEnvironment -Map $serviceEnv
 
 & $NssmPath start $ServiceName
 

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -162,7 +162,72 @@ def build_server(*, require_auth: bool) -> FastMCP:
             annotations=cmd.mcp_annotations,
         )
 
+    if _legacy_mcp_compat_enabled():
+        _register_legacy_mcp_tools(
+            mcp,
+            vault_root=runtime.vault_root,
+            source_schema=runtime.source_schema,
+            expose_tier2=expose_tier2,
+            project_keys_hint=runtime.project_keys_hint,
+        )
+
     return mcp
+
+
+def _legacy_mcp_compat_enabled() -> bool:
+    """Register canonical MCP leaf names for stale connector caches.
+
+    The product MCP surface is the default. This opt-in exists for clients that
+    cached the old tool list and still call names such as `note` or
+    `create_file` after a service upgrade. It is intentionally environment
+    gated so fresh clients do not see the primitive leaves unless an operator
+    chooses compatibility over a smaller tool list.
+    """
+    return os.environ.get("EXOMEM_MCP_LEGACY_COMPAT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _register_legacy_mcp_tools(
+    mcp: FastMCP,
+    *,
+    vault_root: Path,
+    source_schema: object,
+    expose_tier2: bool,
+    project_keys_hint: str,
+) -> None:
+    product_names = {
+        c.name for c in commands_module.product_commands_for("mcp", expose_tier2=expose_tier2)
+    }
+    legacy = list(commands_module.commands_for("mcp", expose_tier2=expose_tier2))
+    legacy += [c for c in commands_module.COMMANDS if c.name == "note"]
+
+    for cmd in legacy:
+        if cmd.name in product_names:
+            continue
+        if "mcp" not in cmd.surfaces and cmd.name != "note":
+            continue
+        injected = (
+            (vault_root, source_schema)
+            if cmd.needs_schema
+            else (vault_root,)
+        )
+        description = cmd.doc
+        if cmd.name == "note":
+            description = commands_module.remember_description(project_keys_hint)
+        mcp.tool(
+            commands_module.bind_vault(
+                cmd.leaf,
+                *injected,
+                name=cmd.name,
+                description="[Deprecated compatibility alias; prefer product commands.] "
+                + description,
+            ),
+            annotations=cmd.mcp_annotations,
+        )
 
 
 def run(

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -63,3 +63,15 @@ def test_windows_service_scripts_gate_selected_profile_before_success() -> None:
     assert '"-Profile", $Profile' in install
     assert "exomem\", \"doctor\", \"--profile\", $Profile" in install
     assert install.index("exomem\", \"doctor\", \"--profile\", $Profile") < install.index("& $NssmPath install")
+
+
+def test_windows_service_installer_supports_release_env_and_cuda() -> None:
+    install = _read("scripts/install-service.ps1")
+
+    assert "[switch]$Release" in install
+    assert "exomem-service-release" in install
+    assert '"pip", "install", "--python", $venvPython, $pkg' in install
+    assert "AppEnvironmentExtra" in install
+    assert "EXOMEM_MCP_LEGACY_COMPAT" in install
+    assert "https://download.pytorch.org/whl/cu132" in install
+    assert "torch==2.12.0+cu132" in install

--- a/tests/test_retrieval_surface_safety.py
+++ b/tests/test_retrieval_surface_safety.py
@@ -84,3 +84,24 @@ def test_product_mcp_retrieval_schemas_are_safe(
     assert read_schema["type"] == "object"
     assert read_schema["additionalProperties"] is True
     assert "path" in tools["read_memory"]["inputSchema"]["properties"]
+
+
+def test_legacy_mcp_leaf_names_are_opt_in(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_MCP_LEGACY_COMPAT", raising=False)
+    tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    assert "note" not in tools
+    assert "create_file" not in tools
+
+    monkeypatch.setenv("EXOMEM_MCP_LEGACY_COMPAT", "1")
+    compat_tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    assert "remember" in compat_tools
+    assert "manage_memory_file" in compat_tools
+    assert "note" in compat_tools
+    assert "create_file" in compat_tools
+    assert compat_tools["note"]["description"].startswith(
+        "[Deprecated compatibility alias; prefer product commands.]"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- add `scripts/install-service.ps1 -Release` for PyPI-backed Windows service installs instead of requiring a repo `.venv`
- load `.env` into NSSM `AppEnvironmentExtra` so service restarts keep vault/auth/runtime config
- install CUDA Torch automatically for NVIDIA Windows hosts on hybrid/media profiles
- add opt-in `EXOMEM_MCP_LEGACY_COMPAT=1` aliases for stale MCP clients still calling old leaf tools like `note` or `create_file`
- document the release-service path in deployment docs

## Validation
- `uv run pytest tests/test_retrieval_surface_safety.py tests/test_container_distribution.py tests/test_rest_api.py tests/test_rest_registry.py` -> 35 passed
- `uv run pytest tests/test_mcp_schema_fidelity.py tests/test_setup_wizard.py tests/test_remote_setup_wizard.py` -> 43 passed
- `uv run pytest` -> 1740 passed, 16 skipped
- `pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw scripts/install-service.ps1)); "install-service.ps1 parses"'`
- `git diff --check` -> only local CRLF warning for `scripts/install-service.ps1`, no whitespace errors

## Live service benchmark notes
Current Windows service on `C:\Users\hugoa\Documents\Obsidian` returns `ask_memory` in ~176-362 ms cold for unique hybrid queries, and ~5-7 ms server-side for exact-query cache hits. `/mcp` unauth challenge is ~1-8 ms. Native Windows vault stat walks are fast on both C and D; the real performance win is avoiding WSL walking a mounted Windows vault.