### PR TITLE
feat: add one-command native release service bootstrap

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -501,9 +501,12 @@ publicly-reachable, authenticated endpoint:
 3. **A GitHub OAuth app** (client id + secret) wired into the OAuthProxy —
    claude.ai connectors require OAuth; static tokens aren't accepted.
 4. **Lock it to your GitHub login** (the single-user verifier), then run it as a
-   background service with `--transport streamable-http` — `scripts/install-service.sh`
-   sets this up via **launchd** on macOS or **systemd** on Linux (the main
-   [docs/deployment.md](docs/deployment.md) covers all three platforms).
+   background service with `--transport streamable-http`. On macOS or Linux run
+   `bash scripts/install-service.sh --release --profile hybrid`; on Windows run
+   `pwsh -File scripts/install-service.ps1 -Release -Profile hybrid`. These
+   release commands create the PyPI service environment, load `.env`, doctor-gate,
+   start the OS service, and verify `/mcp` (the main
+   [docs/deployment.md](docs/deployment.md) covers all options, including repo-dev).
 5. **Add it as a custom connector** in claude.ai.
 
 [docs/deployment.md](docs/deployment.md) documents this path end-to-end. Rule of thumb: the **local path is ~90% of the value for ~20% of the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -232,7 +232,9 @@ loginctl enable-linger "$USER"   # keep it running without an active login sessi
 # or download from https://nssm.cc/download and add nssm.exe to PATH
 # (or pass -NssmPath "C:\path\to\nssm.exe" to the script below).
 # The script self-elevates; approve the UAC prompt.
-pwsh -File scripts/install-service.ps1
+pwsh -File scripts/install-service.ps1 -Release
+# Developer checkout mode is still available when .venv already exists:
+#   pwsh -File scripts/install-service.ps1
 # Uninstall:
 #   nssm stop exomem && nssm remove exomem confirm
 # Restart (after .env edits): elevated shell required

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,24 +204,28 @@ macOS Apple Silicon GPU paths (MPS/MLX are native-only), and hosts where Docker
 isn't wanted.
 
 Pick your platform — all three run the same `streamable-http` server and differ
-only in the OS service manager.
+only in the OS service manager. The release commands create or update a separate
+PyPI-backed service venv, load the repository `.env` into the service manager,
+doctor-gate the selected profile and remote configuration, start the service, and
+verify that local `/mcp` returns the expected OAuth `401`.
 
 **macOS (launchd):**
 
 ```bash
-bash scripts/install-service.sh
-# Restart after .env edits:  bash scripts/restart.sh
+bash scripts/install-service.sh --release --profile hybrid
+# Re-run after a package or .env change to update and restart the service.
+# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile hybrid
 # Uninstall:                 launchctl bootout gui/$(id -u)/com.exomem && rm ~/Library/LaunchAgents/com.exomem.plist
 ```
 
 **Linux (systemd --user):**
 
 ```bash
-mkdir -p ~/.config/systemd/user
-sed -e "s|__REPO_ROOT__|$PWD|g" -e "s|__VENV_PYTHON__|$PWD/.venv/bin/python|g" scripts/exomem.service > ~/.config/systemd/user/exomem.service
-systemctl --user daemon-reload && systemctl --user enable --now exomem
-loginctl enable-linger "$USER"   # keep it running without an active login session
-# Restart after .env edits:  systemctl --user restart exomem   (or: bash scripts/restart.sh)
+bash scripts/install-service.sh --release --profile hybrid
+# The installer attempts to enable user linger so the service survives logout.
+# Re-run after a package or .env change to update and restart the service.
+# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile hybrid
+# Uninstall: systemctl --user disable --now exomem && rm ~/.config/systemd/user/exomem.service
 ```
 
 **Windows (NSSM):**
@@ -233,6 +237,7 @@ loginctl enable-linger "$USER"   # keep it running without an active login sessi
 # (or pass -NssmPath "C:\path\to\nssm.exe" to the script below).
 # The script self-elevates; approve the UAC prompt.
 pwsh -File scripts/install-service.ps1 -Release
+# The installer creates/updates the PyPI service venv and verifies /mcp -> 401.
 # Developer checkout mode is still available when .venv already exists:
 #   pwsh -File scripts/install-service.ps1
 # Uninstall:

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -96,9 +96,11 @@ exomem doctor --profile remote
 
 For always-on service install (auto-start on boot), pick your OS — see
 [deployment.md § 6](deployment.md#6-install-as-a-service-auto-start-on-boot)
-for the full commands: macOS (`bash scripts/install-service.sh`), Linux
-(`systemctl --user enable --now exomem` after templating
-`scripts/exomem.service`), Windows (`pwsh -File scripts/install-service.ps1`).
+for the full commands. The blessed paths are macOS/Linux
+(`bash scripts/install-service.sh --release --profile hybrid`) and Windows
+(`pwsh -File scripts/install-service.ps1 -Release -Profile hybrid`). Each path
+installs the profile extras into a PyPI-backed service venv, loads `.env`, runs
+doctor, starts the native service, and verifies `/mcp` before reporting success.
 Or run it in the foreground for a first test:
 
 ```bash

--- a/openspec/changes/add-native-release-service-bootstrap/.openspec.yaml
+++ b/openspec/changes/add-native-release-service-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/add-native-release-service-bootstrap/design.md
+++ b/openspec/changes/add-native-release-service-bootstrap/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The macOS installer currently renders a launchd plist around the repository
+`.venv`; Linux requires users to render and install a systemd unit manually.
+Windows PR #178 introduces a separate PyPI release venv, dotenv propagation, and
+profile doctor gate, but does not verify the running endpoint. The Unix path must
+provide the same product guarantee without requiring root or coupling the service
+runtime to a checkout.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one rerunnable command create or update a native release service on Linux
+  and macOS.
+- Keep profile extras, service environment, preflight, and post-start health
+  semantics aligned across Windows, Linux, and macOS.
+- Preserve the existing repository-venv path for contributors.
+
+**Non-Goals:**
+
+- Replace Docker deployment or add a universal package-manager installer.
+- Add system-wide/root services; Unix installs remain per-user.
+- Automate public tunnel provisioning or GitHub OAuth application creation.
+
+## Decisions
+
+1. **One Unix entry point dispatches by OS.** `scripts/install-service.sh` handles
+   launchd and systemd user services. This keeps the product command and profile
+   mapping identical while retaining native templates.
+
+2. **Release mode is explicit and documented first.** `--release` creates an
+   external venv with `uv venv` and upgrades a PyPI requirement. `--repo-dev`
+   selects the checkout `.venv`; an invocation with no mode flag retains the
+   historical repo-dev behavior to avoid silently changing existing automation.
+
+3. **Release state uses per-user platform directories.** Linux uses
+   `${XDG_DATA_HOME:-~/.local/share}/exomem/service`; macOS uses
+   `~/Library/Application Support/Exomem/service`. `--service-root` overrides the
+   location. The venv and logs use the OS data root while generated environment
+   files use the OS config root, so the running release service does not depend
+   on repository files.
+
+4. **The installed package parses dotenv.** After the venv is ready, its Python
+   and `python-dotenv` parse the selected `.env`. The installer exports the map for
+   doctor, writes a `0600` systemd environment file, and emits escaped launchd
+   `EnvironmentVariables`. This avoids shell-sourcing arbitrary dotenv syntax and
+   avoids relying on service working directory discovery.
+
+5. **Preflight and endpoint checks define success.** The selected capability
+   doctor and `doctor --profile remote` run before any service-manager mutation.
+   After start, the installer polls `/mcp`; `401` is success, while `200` is an
+   authentication failure. A failed post-start check stops the service but leaves
+   its installed definition and logs for diagnosis.
+
+6. **Published extras mirror Windows.** Lean installs `exomem`, hybrid adds
+   `embeddings`, and media adds `embeddings,media,vision,diarization`; macOS arm64
+   also adds `media-mlx`. An optional package version pins the same requirement.
+
+## Risks / Trade-offs
+
+- **User systemd linger may require policy approval** -> attempt to enable linger
+  and warn with the exact command when the host refuses; the service still runs in
+  the active user session.
+- **Secrets are materialized for service managers** -> restrict generated files to
+  the current user and never print values.
+- **A package upgrade can fail before preflight** -> fail before changing the
+  service definition and retain the existing installed service for recovery.
+- **Platform services cannot be exercised in normal CI** -> test argument,
+  rendering, ordering, and status logic with temporary homes and command shims;
+  keep real-host verification as a documented release smoke.

--- a/openspec/changes/add-native-release-service-bootstrap/proposal.md
+++ b/openspec/changes/add-native-release-service-bootstrap/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Linux and macOS native service setup still depends on a repository `.venv`, manual
+systemd rendering, and implicit working-directory dotenv loading. Windows PR #178
+establishes a PyPI-backed `-Release` path; the native product needs the same
+one-command, doctor-gated guarantee on every supported desktop OS.
+
+## What Changes
+
+- Add `--release` and explicit `--repo-dev` modes to the Unix service installer,
+  with release mode creating or updating an external PyPI-backed service venv.
+- Make the same installer configure launchd on macOS and a systemd user service on
+  Linux, including `.env` propagation without relying on repository cwd discovery.
+- Map lean, hybrid, and media profiles to their published extras, including the
+  macOS arm64 MLX media extra.
+- Gate service-manager changes on dependency and remote-environment doctor checks,
+  then start the service and require an authenticated `401` response from `/mcp`.
+- Extend the Windows release installer with the same post-start `/mcp` verification.
+- Document release mode as the blessed product path while retaining repository
+  `.venv` mode for contributors.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `install-readiness`: native service installation gains cross-platform release
+  environments, explicit service environment propagation, preflight gates, and
+  post-start endpoint verification.
+
+## Impact
+
+- Service scripts and templates under `scripts/` for launchd, systemd, and NSSM.
+- Deployment and quickstart documentation for the three native platforms.
+- Installer contract tests and OpenSpec install-readiness requirements.
+- No runtime API or MCP tool schema changes and no new production dependency.

--- a/openspec/changes/add-native-release-service-bootstrap/specs/install-readiness/spec.md
+++ b/openspec/changes/add-native-release-service-bootstrap/specs/install-readiness/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Native release service bootstrap
+The project SHALL expose one blessed native service-install command per platform.
+Release mode MUST create or update a PyPI-backed service venv outside the checkout,
+install the selected profile extras, and install and start the platform service.
+Repository-venv mode SHALL remain available for development.
+
+#### Scenario: Linux or macOS release install
+- **WHEN** a user runs `bash scripts/install-service.sh --release --profile hybrid`
+- **THEN** the installer creates or updates an external venv with
+  `exomem[embeddings]` from PyPI
+- **AND** it installs and starts a systemd user service on Linux or a launchd user
+  agent on macOS
+
+#### Scenario: Repository development install
+- **WHEN** a contributor selects `--repo-dev` or uses the historical no-mode form
+- **THEN** the installer uses the checkout `.venv` without installing a PyPI
+  release package
+
+### Requirement: Profile-complete release environment
+The release installer SHALL map lean, hybrid, and media profiles to their published
+extras, load the selected dotenv file into preflight and service environments, and
+MUST NOT depend on the checkout working directory for runtime dotenv discovery.
+
+#### Scenario: Media profile on Apple Silicon
+- **WHEN** release mode selects the media profile on macOS arm64
+- **THEN** the PyPI requirement includes embeddings, media, vision, diarization,
+  and the macOS MLX media extra
+
+#### Scenario: Service receives dotenv values
+- **WHEN** the selected `.env` contains Exomem vault and OAuth settings
+- **THEN** those values are available to doctor and the installed service
+- **AND** generated files containing secrets are readable only by the current user
+
+### Requirement: Transactional readiness and endpoint verification
+Native installers SHALL run the selected capability doctor and remote-environment
+doctor before changing the service manager. They SHALL start the service only after
+both gates pass and SHALL verify `/mcp` before reporting success.
+
+#### Scenario: Doctor failure preserves service-manager state
+- **WHEN** either doctor gate fails
+- **THEN** the installer exits nonzero before invoking launchd, systemd, or NSSM
+  installation commands
+
+#### Scenario: Authenticated MCP endpoint is healthy
+- **WHEN** the started service returns HTTP `401` from its local `/mcp` endpoint
+- **THEN** the installer reports the service as installed and healthy
+
+#### Scenario: Unauthenticated MCP endpoint fails closed
+- **WHEN** the started service returns HTTP `200` from its local `/mcp` endpoint
+- **THEN** the installer stops the service, exits nonzero, and reports that OAuth
+  enforcement is missing

--- a/openspec/changes/add-native-release-service-bootstrap/tasks.md
+++ b/openspec/changes/add-native-release-service-bootstrap/tasks.md
@@ -1,0 +1,16 @@
+## 1. Unix release installer
+
+- [x] 1.1 Add release/repo-dev argument handling, PyPI venv creation, profile extras, and dotenv rendering to `install-service.sh`.
+- [x] 1.2 Add idempotent launchd and systemd user-service installation with platform state/log directories.
+- [x] 1.3 Gate service changes with capability and remote doctor checks, then verify authenticated `/mcp` health after start.
+
+## 2. Cross-platform parity
+
+- [x] 2.1 Update launchd and systemd templates for explicit service environment, release paths, and configurable bind settings.
+- [x] 2.2 Add post-start authenticated `/mcp` verification to the Windows release installer.
+
+## 3. Product guidance and verification
+
+- [x] 3.1 Document the blessed release commands and secondary repo-dev path in quickstart and deployment guidance.
+- [x] 3.2 Add installer tests for modes, extras, environment propagation, gate ordering, service-manager rendering, and endpoint status handling.
+- [x] 3.3 Run focused tests, syntax checks, OpenSpec validation, diff checks, and the full test suite (the full run reaches a pre-existing TestClient hang also reproducible on `main`).

--- a/scripts/com.exomem.plist
+++ b/scripts/com.exomem.plist
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-  launchd user-agent for exomem (macOS). This is a TEMPLATE: the placeholders
-  __VENV_PYTHON__, __REPO_ROOT__, __BIND_HOST__ and __PORT__ are substituted by
-  scripts/install-service.sh, which writes the rendered copy to
-  ~/Library/LaunchAgents/com.exomem.plist. Cross-platform counterpart to the
-  Windows NSSM service in scripts/install-service.ps1.
--->
+<!-- launchd template rendered and installed by scripts/install-service.sh. -->
 <plist version="1.0">
 <dict>
     <key>Label</key>
@@ -25,24 +19,22 @@
         <string>__PORT__</string>
     </array>
 
-    <!-- Run from the repo root so the app's load_dotenv() picks up ./.env. -->
     <key>WorkingDirectory</key>
-    <string>__REPO_ROOT__</string>
+    <string>__WORKING_DIRECTORY__</string>
 
-    <!-- Start at login and keep it alive (≈ NSSM SERVICE_AUTO_START + restart). -->
+    __ENVIRONMENT_VARIABLES__
+
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
-
-    <!-- Don't respawn faster than every 10s in a crash loop (≈ NSSM AppThrottle). -->
     <key>ThrottleInterval</key>
     <integer>10</integer>
 
     <key>StandardOutPath</key>
-    <string>__REPO_ROOT__/logs/service.out.log</string>
+    <string>__LOG_DIR__/service.out.log</string>
     <key>StandardErrorPath</key>
-    <string>__REPO_ROOT__/logs/service.err.log</string>
+    <string>__LOG_DIR__/service.err.log</string>
 
     <key>ProcessType</key>
     <string>Background</string>

--- a/scripts/exomem.service
+++ b/scripts/exomem.service
@@ -1,30 +1,16 @@
-# systemd --user unit for exomem (Linux). Cross-platform counterpart to the
-# macOS launchd agent (scripts/com.exomem.plist) and the Windows NSSM service
-# (scripts/install-service.ps1).
-#
-# This is a TEMPLATE: __REPO_ROOT__ and __VENV_PYTHON__ must be substituted with
-# absolute paths before installing. From the repo root:
-#
-#   mkdir -p ~/.config/systemd/user
-#   sed -e "s|__REPO_ROOT__|$PWD|g" -e "s|__VENV_PYTHON__|$PWD/.venv/bin/python|g" \
-#       scripts/exomem.service > ~/.config/systemd/user/exomem.service
-#   systemctl --user daemon-reload
-#   systemctl --user enable --now exomem
-#   loginctl enable-linger "$USER"     # so it runs without an active login session
-#
-# Restart after .env edits:  systemctl --user restart exomem   (or: bash scripts/restart.sh)
-# Logs:                       journalctl --user -u exomem -f   (plus logs/exomem.log)
-# Uninstall:                  systemctl --user disable --now exomem && rm ~/.config/systemd/user/exomem.service
+# systemd --user template for exomem. scripts/install-service.sh renders and
+# installs this unit; do not install the template directly.
 
 [Unit]
-Description=exomem: Obsidian Knowledge Base MCP server for mobile claude.ai
+Description=exomem: Obsidian Knowledge Base MCP server
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=__REPO_ROOT__
-ExecStart=__VENV_PYTHON__ -m exomem --transport streamable-http --host 127.0.0.1 --port 8765
+EnvironmentFile=__SERVICE_ENV_FILE__
+WorkingDirectory=__WORKING_DIRECTORY__
+ExecStart="__VENV_PYTHON__" -m exomem --transport streamable-http --host __BIND_HOST__ --port __PORT__
 Restart=always
 RestartSec=5
 

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -2,14 +2,18 @@
 #
 # Prereqs:
 #   - NSSM installed (https://nssm.cc/download) and on PATH, OR pass -NssmPath.
-#   - uv has been run (`uv sync` in repo root) so .venv exists.
+#   - uv installed and on PATH.
+#   - For repo-mode installs, `uv sync` has been run in repo root so .venv exists.
+#     For release installs, pass -Release and the script creates/updates a sibling
+#     PyPI-backed service venv.
 #   - .env exists in the repo root with the GitHub OAuth vars set
 #     (EXOMEM_BASE_URL, EXOMEM_GITHUB_USERNAME, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET).
 #
 # Usage:
-#   pwsh -File scripts/install-service.ps1
+#   pwsh -File scripts/install-service.ps1 -Release
 #   pwsh -File scripts/install-service.ps1 -NssmPath "C:\nssm\nssm.exe"
-#   pwsh -File scripts/install-service.ps1 -Profile lean    # lexical-only service
+#   pwsh -File scripts/install-service.ps1 -Release -Profile lean    # lexical-only service
+#   pwsh -File scripts/install-service.ps1 -Release -Profile media
 #
 # Uninstall:
 #   nssm stop exomem
@@ -21,7 +25,13 @@ param(
     [string]$BindHost = "127.0.0.1",
     [int]$Port = 8765,
     [ValidateSet("lean", "hybrid", "media")]
-    [string]$Profile = "hybrid"
+    [string]$Profile = "hybrid",
+    [switch]$Release,
+    [string]$ServiceRoot = "",
+    [string]$PackageVersion = "",
+    [ValidateSet("auto", "always", "never")]
+    [string]$CudaTorch = "auto",
+    [switch]$LegacyMcpCompat
 )
 
 $ErrorActionPreference = "Stop"
@@ -43,19 +53,20 @@ if (-not $isAdmin) {
         "-ServiceName", $ServiceName,
         "-BindHost", $BindHost,
         "-Port", $Port,
-        "-Profile", $Profile
+        "-Profile", $Profile,
+        "-CudaTorch", $CudaTorch
     )
+    if ($Release) { $relaunchArgs += "-Release" }
+    if ($ServiceRoot) { $relaunchArgs += @("-ServiceRoot", "`"$ServiceRoot`"") }
+    if ($PackageVersion) { $relaunchArgs += @("-PackageVersion", "`"$PackageVersion`"") }
+    if ($LegacyMcpCompat) { $relaunchArgs += "-LegacyMcpCompat" }
     Start-Process -FilePath $hostExe -Verb RunAs -ArgumentList $relaunchArgs
     exit
 }
 
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
-$python = Join-Path $repoRoot ".venv\Scripts\python.exe"
 $logDir = Join-Path $repoRoot "logs"
 
-if (-not (Test-Path $python)) {
-    throw "Python venv not found at $python. Run 'uv sync' in $repoRoot first."
-}
 if (-not (Test-Path (Join-Path $repoRoot ".env"))) {
     throw ".env file missing in $repoRoot. See the Install section of README.md for the required GitHub OAuth vars."
 }
@@ -76,6 +87,108 @@ function Get-DotenvValue {
     }
     return $null
 }
+
+function Read-DotenvMap {
+    $envPath = Join-Path $repoRoot ".env"
+    $map = [ordered]@{}
+    foreach ($line in Get-Content $envPath) {
+        if ($line -match '^\s*([^#][A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$') {
+            $name = $Matches[1].Trim()
+            $value = $Matches[2].Trim()
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+            $map[$name] = $value
+        }
+    }
+    if ($LegacyMcpCompat) {
+        $map["EXOMEM_MCP_LEGACY_COMPAT"] = "1"
+    }
+    return $map
+}
+
+function Set-ProcessEnvFromMap {
+    param([System.Collections.IDictionary]$Map)
+    foreach ($entry in $Map.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, "Process")
+    }
+}
+
+function Set-NssmEnvironment {
+    param([System.Collections.IDictionary]$Map)
+    $args = @("set", $ServiceName, "AppEnvironmentExtra")
+    foreach ($entry in $Map.GetEnumerator()) {
+        $args += "$($entry.Key)=$($entry.Value)"
+    }
+    & $NssmPath @args
+}
+
+function Invoke-LoggedNative {
+    param([string[]]$CommandArgs)
+    $out = & $CommandArgs[0] @($CommandArgs[1..($CommandArgs.Count - 1)]) 2>&1
+    foreach ($line in $out) { Write-Host $line }
+    return $LASTEXITCODE
+}
+
+function Install-ReleaseVenv {
+    $root = if ($ServiceRoot) {
+        $ServiceRoot
+    } else {
+        Join-Path (Split-Path -Parent $repoRoot) "exomem-service-release"
+    }
+    if (-not (Test-Path $root)) { New-Item -ItemType Directory -Path $root | Out-Null }
+    $venvPython = Join-Path $root ".venv\Scripts\python.exe"
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "Creating release service venv at $root\.venv..."
+        $code = Invoke-LoggedNative @("uv", "venv", (Join-Path $root ".venv"), "--python", "3.13")
+        if ($code -ne 0) { throw "uv venv failed" }
+    }
+
+    $pkg = if ($PackageVersion) { "exomem==$PackageVersion" } else { "exomem" }
+    if ($Profile -eq "hybrid") {
+        $pkg = if ($PackageVersion) { "exomem[embeddings]==$PackageVersion" } else { "exomem[embeddings]" }
+    } elseif ($Profile -eq "media") {
+        $pkg = if ($PackageVersion) { "exomem[embeddings,media,vision,diarization]==$PackageVersion" } else { "exomem[embeddings,media,vision,diarization]" }
+    }
+
+    Write-Host "Installing $pkg into release service venv..."
+    $code = Invoke-LoggedNative @("uv", "pip", "install", "--python", $venvPython, $pkg)
+    if ($code -ne 0) { throw "uv pip install failed for $pkg" }
+
+    $shouldCuda = $false
+    if ($CudaTorch -eq "always") {
+        $shouldCuda = $true
+    } elseif ($CudaTorch -eq "auto" -and (Get-Command nvidia-smi -ErrorAction SilentlyContinue)) {
+        $shouldCuda = $true
+    }
+    if ($shouldCuda -and $Profile -ne "lean") {
+        Write-Host "Installing CUDA 13.2 Torch for Windows NVIDIA GPU support..."
+        $code = Invoke-LoggedNative @(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            $venvPython,
+            "--default-index",
+            "https://download.pytorch.org/whl/cu132",
+            "torch==2.12.0+cu132"
+        )
+        if ($code -ne 0) { throw "CUDA Torch install failed" }
+    }
+    return $venvPython
+}
+
+if ($Release) {
+    $python = Install-ReleaseVenv
+} else {
+    $python = Join-Path $repoRoot ".venv\Scripts\python.exe"
+    if (-not (Test-Path $python)) {
+        throw "Python venv not found at $python. Run 'uv sync' in $repoRoot first, or pass -Release to install a PyPI-backed service venv."
+    }
+}
+
+$serviceEnv = Read-DotenvMap
+Set-ProcessEnvFromMap -Map $serviceEnv
 
 $doctorArgs = @("-m", "exomem", "doctor", "--profile", $Profile)
 $vault = Get-DotenvValue "EXOMEM_VAULT_PATH"
@@ -98,6 +211,7 @@ if ($LASTEXITCODE -ne 0) {
 & $NssmPath set $ServiceName AppRestartDelay 5000
 & $NssmPath set $ServiceName AppThrottle 10000
 & $NssmPath set $ServiceName Description "exomem: Obsidian Knowledge Base MCP server for mobile claude.ai"
+Set-NssmEnvironment -Map $serviceEnv
 
 & $NssmPath start $ServiceName
 

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -130,6 +130,35 @@ function Invoke-LoggedNative {
     return $LASTEXITCODE
 }
 
+function Test-McpEndpoint {
+    param(
+        [string]$HostName,
+        [int]$EndpointPort,
+        [int]$TimeoutSec = 60
+    )
+    $verifyHost = if ($HostName -in @("0.0.0.0", "::", "[::]")) { "127.0.0.1" } else { $HostName }
+    $url = "http://${verifyHost}:${EndpointPort}/mcp"
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    $lastStatus = 0
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -Uri $url -Method Get -SkipHttpErrorCheck -TimeoutSec 2
+            $lastStatus = [int]$response.StatusCode
+        } catch {
+            $lastStatus = 0
+        }
+        if ($lastStatus -eq 401) {
+            Write-Host "Verified $url -> 401 (healthy, OAuth enforced)."
+            return
+        }
+        if ($lastStatus -eq 200) {
+            throw "$url returned 200; OAuth is not enforced."
+        }
+        Start-Sleep -Seconds 1
+    }
+    throw "$url did not return the expected OAuth 401 (last status: $lastStatus)."
+}
+
 function Install-ReleaseVenv {
     $root = if ($ServiceRoot) {
         $ServiceRoot
@@ -152,7 +181,7 @@ function Install-ReleaseVenv {
     }
 
     Write-Host "Installing $pkg into release service venv..."
-    $code = Invoke-LoggedNative @("uv", "pip", "install", "--python", $venvPython, $pkg)
+    $code = Invoke-LoggedNative @("uv", "pip", "install", "--upgrade", "--python", $venvPython, $pkg)
     if ($code -ne 0) { throw "uv pip install failed for $pkg" }
 
     $shouldCuda = $false
@@ -199,6 +228,14 @@ if ($LASTEXITCODE -ne 0) {
     throw "Doctor preflight failed for profile '$Profile'. Install the missing extras (for example: uv sync --frozen --extra embeddings) before installing the service."
 }
 
+$remoteDoctorArgs = @("-m", "exomem", "doctor", "--profile", "remote")
+if ($vault) { $remoteDoctorArgs += @("--vault", $vault) }
+Write-Host "Preflight: exomem doctor --profile remote..."
+& $python @remoteDoctorArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Remote doctor preflight failed. Fix the vault and OAuth environment before installing the service."
+}
+
 # Install
 & $NssmPath install $ServiceName $python "-m" "exomem" "--transport" "streamable-http" "--host" $BindHost "--port" $Port
 & $NssmPath set $ServiceName AppDirectory $repoRoot
@@ -214,6 +251,13 @@ if ($LASTEXITCODE -ne 0) {
 Set-NssmEnvironment -Map $serviceEnv
 
 & $NssmPath start $ServiceName
+
+try {
+    Test-McpEndpoint -HostName $BindHost -EndpointPort $Port
+} catch {
+    & $NssmPath stop $ServiceName | Out-Null
+    throw "Service endpoint verification failed and '$ServiceName' was stopped: $_"
+}
 
 # Grant the invoking user start/stop rights on this service so future restarts
 # don't require UAC. The ACL keeps SYSTEM/Admins/AuthenticatedUsers as-is and

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,65 +1,433 @@
 #!/usr/bin/env bash
-# Install exomem as an always-on background service on macOS (launchd user agent).
+# Install or update exomem as a per-user service on macOS (launchd) or Linux
+# (systemd --user). Release mode is the product path; repo-dev keeps the checkout
+# .venv path available for contributors.
 #
-# This is the cross-platform counterpart to scripts/install-service.ps1
-# (Windows/NSSM). On Linux, use the systemd unit instead: scripts/exomem.service
-# (its header has the install steps). No sudo needed here — it's a per-user agent.
+# Product install:
+#   bash scripts/install-service.sh --release --profile hybrid
 #
-# Prereqs:
-#   - .venv exists with exomem installed, e.g.
-#       uv sync --extra embeddings
-#   - .env in the repo root with the GitHub OAuth vars (EXOMEM_BASE_URL,
-#     EXOMEM_GITHUB_USERNAME, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET) and
-#     EXOMEM_VAULT_PATH. See the Install section of README.md.
+# Developer install:
+#   bash scripts/install-service.sh --repo-dev --profile hybrid
 #
-# Usage:     bash scripts/install-service.sh
-# Override:  EXOMEM_BIND_HOST=127.0.0.1 EXOMEM_PORT=8765 bash scripts/install-service.sh
-# Restart:   bash scripts/restart.sh            # after .env edits
-# Uninstall: launchctl bootout gui/$(id -u)/com.exomem && rm ~/Library/LaunchAgents/com.exomem.plist
+# Re-run the same command after package or .env changes. No sudo is required.
 
 set -euo pipefail
 
 LABEL="com.exomem"
+SERVICE_NAME="exomem"
+MODE="repo-dev"
+PROFILE="hybrid"
 BIND_HOST="${EXOMEM_BIND_HOST:-127.0.0.1}"
 PORT="${EXOMEM_PORT:-8765}"
+SERVICE_ROOT=""
+PACKAGE_VERSION=""
+ENV_FILE=""
+LEGACY_MCP_COMPAT=0
 
-# Resolve repo root from this script's own location (scripts/..), so it works
-# regardless of the caller's working directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
-    echo "This installer targets macOS (launchd)." >&2
-    echo "On Linux, use the systemd unit: scripts/exomem.service" >&2
-    echo "  (see the 'Install as a service' section of README.md)." >&2
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/install-service.sh [options]
+
+Modes:
+  --release                 Create/update a PyPI-backed service venv (product path)
+  --repo-dev                Use the checkout .venv (default for compatibility)
+
+Options:
+  --profile lean|hybrid|media
+  --service-root PATH       Override release state/venv location
+  --package-version VERSION Pin the PyPI release version
+  --env-file PATH           Dotenv file (default: <repo>/.env)
+  --bind-host HOST          Service bind host (default: 127.0.0.1)
+  --port PORT               Service port (default: 8765)
+  --legacy-mcp-compat       Set EXOMEM_MCP_LEGACY_COMPAT=1 in the service
+  -h, --help                Show this help
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
     exit 1
+}
+
+require_value() {
+    [[ $# -ge 2 && -n "$2" ]] || die "$1 requires a value"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --release)
+            MODE="release"
+            shift
+            ;;
+        --repo-dev)
+            MODE="repo-dev"
+            shift
+            ;;
+        --profile)
+            require_value "$@"
+            PROFILE="$2"
+            shift 2
+            ;;
+        --service-root)
+            require_value "$@"
+            SERVICE_ROOT="$2"
+            shift 2
+            ;;
+        --package-version)
+            require_value "$@"
+            PACKAGE_VERSION="$2"
+            shift 2
+            ;;
+        --env-file)
+            require_value "$@"
+            ENV_FILE="$2"
+            shift 2
+            ;;
+        --bind-host)
+            require_value "$@"
+            BIND_HOST="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$@"
+            PORT="$2"
+            shift 2
+            ;;
+        --legacy-mcp-compat)
+            LEGACY_MCP_COMPAT=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1 (run with --help)"
+            ;;
+    esac
+done
+
+case "$PROFILE" in
+    lean|hybrid|media) ;;
+    *) die "--profile must be lean, hybrid, or media" ;;
+esac
+if [[ ! "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); then
+    die "--port must be an integer from 1 to 65535"
 fi
 
-VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
-LOG_DIR="$REPO_ROOT/logs"
-PLIST_SRC="$SCRIPT_DIR/com.exomem.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+CURRENT_USER="${USER:-$(id -un)}"
+case "$OS" in
+    Darwin)
+        CONFIG_ROOT="$HOME/Library/Application Support/Exomem"
+        DEFAULT_SERVICE_ROOT="$CONFIG_ROOT/service"
+        PLIST_SRC="$SCRIPT_DIR/com.exomem.plist"
+        PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+        require_command launchctl
+        ;;
+    Linux)
+        CONFIG_ROOT="${XDG_CONFIG_HOME:-$HOME/.config}/exomem"
+        DEFAULT_SERVICE_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/exomem/service"
+        UNIT_SRC="$SCRIPT_DIR/exomem.service"
+        UNIT_DEST="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$SERVICE_NAME.service"
+        require_command systemctl
+        ;;
+    *)
+        die "unsupported platform $OS; on Windows use scripts/install-service.ps1"
+        ;;
+esac
 
-[[ -x "$VENV_PYTHON" ]] || { echo "venv python not found at $VENV_PYTHON — create the venv and install exomem first (see README)." >&2; exit 1; }
-[[ -f "$REPO_ROOT/.env" ]] || { echo ".env missing in $REPO_ROOT — add the GitHub OAuth vars (see README Install)." >&2; exit 1; }
-[[ -f "$PLIST_SRC" ]] || { echo "plist template missing at $PLIST_SRC" >&2; exit 1; }
-mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+SERVICE_ROOT="${SERVICE_ROOT:-$DEFAULT_SERVICE_ROOT}"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+SERVICE_ENV_FILE="$CONFIG_ROOT/service.env"
+LAUNCHD_ENV_FILE="$CONFIG_ROOT/launchd-environment.xml"
 
-# Render the template: substitute absolute paths + bind host/port.
-sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
-    -e "s|__REPO_ROOT__|$REPO_ROOT|g" \
-    -e "s|__BIND_HOST__|$BIND_HOST|g" \
-    -e "s|__PORT__|$PORT|g" \
-    "$PLIST_SRC" > "$PLIST_DEST"
+[[ -f "$ENV_FILE" ]] || die "dotenv file not found: $ENV_FILE"
+require_command curl
 
-# Reload cleanly: bootout any prior instance (ignore if absent), then bootstrap.
-launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
-launchctl kickstart -k "gui/$(id -u)/$LABEL"
+if [[ "$MODE" == "release" ]]; then
+    require_command uv
+    VENV_DIR="$SERVICE_ROOT/.venv"
+    VENV_PYTHON="$VENV_DIR/bin/python"
+    LOG_DIR="$SERVICE_ROOT/logs"
+    WORKING_DIRECTORY="$SERVICE_ROOT"
+    mkdir -p "$SERVICE_ROOT" "$LOG_DIR" "$CONFIG_ROOT"
 
-echo "Installed and started '$LABEL' bound to ${BIND_HOST}:${PORT}."
-echo "  plist:   $PLIST_DEST"
-echo "  logs:    $LOG_DIR/service.out.log (stdout), service.err.log (stderr), exomem.log (app)"
-echo "  status:  launchctl print gui/$(id -u)/$LABEL | grep -i state"
-echo "  restart: bash scripts/restart.sh   (after .env edits)"
-echo "  remove:  launchctl bootout gui/$(id -u)/$LABEL && rm \"$PLIST_DEST\""
+    if [[ ! -x "$VENV_PYTHON" ]]; then
+        echo "Creating release service venv at $VENV_DIR..."
+        uv venv "$VENV_DIR" --python 3.13
+    fi
+
+    case "$PROFILE" in
+        lean)
+            EXTRAS=""
+            ;;
+        hybrid)
+            EXTRAS="embeddings"
+            ;;
+        media)
+            EXTRAS="embeddings,media,vision,diarization"
+            if [[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]]; then
+                EXTRAS="$EXTRAS,media-mlx"
+            fi
+            ;;
+    esac
+    PACKAGE_REQUIREMENT="exomem"
+    [[ -n "$EXTRAS" ]] && PACKAGE_REQUIREMENT="exomem[$EXTRAS]"
+    [[ -n "$PACKAGE_VERSION" ]] && PACKAGE_REQUIREMENT="$PACKAGE_REQUIREMENT==$PACKAGE_VERSION"
+
+    echo "Installing $PACKAGE_REQUIREMENT into the release service venv..."
+    uv pip install --upgrade --python "$VENV_PYTHON" "$PACKAGE_REQUIREMENT"
+else
+    VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+    LOG_DIR="$REPO_ROOT/logs"
+    WORKING_DIRECTORY="$REPO_ROOT"
+    PACKAGE_REQUIREMENT="repository .venv"
+    [[ -x "$VENV_PYTHON" ]] || die \
+        "venv python not found at $VENV_PYTHON; run uv sync or use --release"
+    mkdir -p "$LOG_DIR" "$CONFIG_ROOT"
+fi
+
+[[ -x "$VENV_PYTHON" ]] || die "service python is not executable: $VENV_PYTHON"
+
+PROCESS_ENV_FILE="$(mktemp "$CONFIG_ROOT/installer-env.XXXXXX")"
+cleanup() {
+    rm -f "$PROCESS_ENV_FILE"
+}
+trap cleanup EXIT
+
+# Parse dotenv with the package's own dependency, render systemd/launchd-safe
+# forms, and create a shell-quoted temporary export file for doctor.
+"$VENV_PYTHON" - \
+    "$ENV_FILE" \
+    "$SERVICE_ENV_FILE" \
+    "$PROCESS_ENV_FILE" \
+    "$LAUNCHD_ENV_FILE" \
+    "$LOG_DIR" \
+    "$LEGACY_MCP_COMPAT" <<'PY'
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from dotenv import dotenv_values
+
+env_path, systemd_path, process_path, xml_path, log_dir, legacy = sys.argv[1:]
+values = {
+    key: str(value)
+    for key, value in dotenv_values(env_path).items()
+    if value is not None
+}
+for key, value in values.items():
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+        raise SystemExit(f"invalid environment variable name in {env_path}: {key}")
+    if "\n" in value or "\r" in value:
+        raise SystemExit(f"multiline service environment values are not supported: {key}")
+
+if not values.get("EXOMEM_VAULT_PATH", "").strip():
+    raise SystemExit(f"EXOMEM_VAULT_PATH is required in {env_path}")
+values.setdefault("EXOMEM_LOG_DIR", log_dir)
+if os.environ.get("PATH"):
+    values.setdefault("PATH", os.environ["PATH"])
+if legacy == "1":
+    values["EXOMEM_MCP_LEGACY_COMPAT"] = "1"
+
+def systemd_quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+Path(systemd_path).write_text(
+    "".join(f"{key}={systemd_quote(value)}\n" for key, value in values.items()),
+    encoding="utf-8",
+)
+Path(process_path).write_text(
+    "".join(f"export {key}={shlex.quote(value)}\n" for key, value in values.items()),
+    encoding="utf-8",
+)
+xml_lines = ["    <key>EnvironmentVariables</key>", "    <dict>"]
+for key, value in values.items():
+    xml_lines.extend(
+        [f"        <key>{escape(key)}</key>", f"        <string>{escape(value)}</string>"]
+    )
+xml_lines.append("    </dict>")
+Path(xml_path).write_text("\n".join(xml_lines) + "\n", encoding="utf-8")
+for path in (systemd_path, process_path, xml_path):
+    os.chmod(path, 0o600)
+PY
+
+# This file is generated from parsed values with shlex quoting; it contains no
+# caller-provided shell syntax.
+# shellcheck disable=SC1090
+source "$PROCESS_ENV_FILE"
+rm -f "$PROCESS_ENV_FILE"
+
+echo "Preflight: exomem doctor --profile $PROFILE..."
+"$VENV_PYTHON" -m exomem doctor \
+    --profile "$PROFILE" \
+    --vault "$EXOMEM_VAULT_PATH"
+echo "Preflight: exomem doctor --profile remote..."
+"$VENV_PYTHON" -m exomem doctor \
+    --profile remote \
+    --vault "$EXOMEM_VAULT_PATH"
+
+render_launchd_plist() {
+    [[ -f "$PLIST_SRC" ]] || die "launchd template not found: $PLIST_SRC"
+    mkdir -p "$(dirname "$PLIST_DEST")"
+    "$VENV_PYTHON" - \
+        "$PLIST_SRC" \
+        "$PLIST_DEST" \
+        "$LAUNCHD_ENV_FILE" \
+        "$VENV_PYTHON" \
+        "$WORKING_DIRECTORY" \
+        "$BIND_HOST" \
+        "$PORT" \
+        "$LOG_DIR" <<'PY'
+from pathlib import Path
+from sys import argv
+from xml.sax.saxutils import escape
+
+src, dest, env_xml, python, working_dir, host, port, log_dir = argv[1:]
+text = Path(src).read_text(encoding="utf-8")
+replacements = {
+    "__VENV_PYTHON__": python,
+    "__WORKING_DIRECTORY__": working_dir,
+    "__BIND_HOST__": host,
+    "__PORT__": port,
+    "__LOG_DIR__": log_dir,
+}
+for marker, value in replacements.items():
+    text = text.replace(marker, escape(value))
+text = text.replace("    __ENVIRONMENT_VARIABLES__\n", Path(env_xml).read_text(encoding="utf-8"))
+Path(dest).write_text(text, encoding="utf-8")
+PY
+    chmod 600 "$PLIST_DEST"
+}
+
+render_systemd_unit() {
+    [[ -f "$UNIT_SRC" ]] || die "systemd template not found: $UNIT_SRC"
+    mkdir -p "$(dirname "$UNIT_DEST")"
+    "$VENV_PYTHON" - \
+        "$UNIT_SRC" \
+        "$UNIT_DEST" \
+        "$VENV_PYTHON" \
+        "$WORKING_DIRECTORY" \
+        "$SERVICE_ENV_FILE" \
+        "$BIND_HOST" \
+        "$PORT" <<'PY'
+from pathlib import Path
+from sys import argv
+
+src, dest, python, working_dir, env_file, host, port = argv[1:]
+
+def scalar_path(value: str) -> str:
+    escaped = {" ": "\\x20", "\t": "\\x09", "\n": "\\x0a", "\r": "\\x0d", "\\": "\\x5c"}
+    return "".join(escaped.get(char, char) for char in value)
+
+def exec_path(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+text = Path(src).read_text(encoding="utf-8")
+replacements = {
+    "__VENV_PYTHON__": exec_path(python),
+    "__WORKING_DIRECTORY__": scalar_path(working_dir),
+    "__SERVICE_ENV_FILE__": scalar_path(env_file),
+    "__BIND_HOST__": host,
+    "__PORT__": port,
+}
+for marker, value in replacements.items():
+    text = text.replace(marker, value)
+Path(dest).write_text(text, encoding="utf-8")
+PY
+}
+
+stop_service() {
+    case "$OS" in
+        Darwin)
+            launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+            ;;
+        Linux)
+            systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+            ;;
+    esac
+}
+
+case "$OS" in
+    Darwin)
+        render_launchd_plist
+        launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+        launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+        launchctl kickstart -k "gui/$(id -u)/$LABEL"
+        SERVICE_DEFINITION="$PLIST_DEST"
+        STATUS_COMMAND="launchctl print gui/$(id -u)/$LABEL"
+        LOG_COMMAND="tail -f '$LOG_DIR/service.out.log' '$LOG_DIR/service.err.log' '$LOG_DIR/exomem.log'"
+        ;;
+    Linux)
+        render_systemd_unit
+        systemctl --user daemon-reload
+        systemctl --user enable --now "$SERVICE_NAME"
+        if command -v loginctl >/dev/null 2>&1; then
+            LINGER="$(loginctl show-user "$CURRENT_USER" -p Linger --value 2>/dev/null || true)"
+            if [[ "$LINGER" != "yes" ]]; then
+                if ! loginctl enable-linger "$CURRENT_USER" >/dev/null 2>&1; then
+                    echo "warning: could not enable user linger; run: loginctl enable-linger '$CURRENT_USER'" >&2
+                fi
+            fi
+        fi
+        SERVICE_DEFINITION="$UNIT_DEST"
+        STATUS_COMMAND="systemctl --user status $SERVICE_NAME"
+        LOG_COMMAND="journalctl --user -u $SERVICE_NAME -f"
+        ;;
+esac
+
+VERIFY_HOST="$BIND_HOST"
+case "$VERIFY_HOST" in
+    0.0.0.0|::|'[::]') VERIFY_HOST="127.0.0.1" ;;
+esac
+MCP_URL="http://${VERIFY_HOST}:${PORT}/mcp"
+LAST_STATUS="000"
+for _attempt in $(seq 1 60); do
+    LAST_STATUS="$(curl --silent --show-error --output /dev/null \
+        --write-out '%{http_code}' --max-time 2 "$MCP_URL" 2>/dev/null || true)"
+    case "$LAST_STATUS" in
+        401)
+            break
+            ;;
+        200)
+            stop_service
+            die "$MCP_URL returned 200; OAuth is not enforced (service stopped)"
+            ;;
+        *)
+            sleep 1
+            ;;
+    esac
+done
+if [[ "$LAST_STATUS" != "401" ]]; then
+    stop_service
+    die "$MCP_URL did not return the expected OAuth 401 (last status: ${LAST_STATUS:-000}; service stopped)"
+fi
+
+echo "Installed and verified '$SERVICE_NAME' on $OS at ${BIND_HOST}:${PORT}."
+echo "  mode:       $MODE"
+echo "  package:    $PACKAGE_REQUIREMENT"
+echo "  python:     $VENV_PYTHON"
+echo "  service:    $SERVICE_DEFINITION"
+echo "  environment: $SERVICE_ENV_FILE"
+echo "  endpoint:   $MCP_URL -> 401 (healthy, OAuth enforced)"
+echo "  status:     $STATUS_COMMAND"
+echo "  logs:       $LOG_COMMAND"
+if [[ "$MODE" == "release" ]]; then
+    echo "  update:     re-run this --release command after package or .env changes"
+else
+    echo "  update:     re-run this --repo-dev command after .env changes"
+fi

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -162,7 +162,72 @@ def build_server(*, require_auth: bool) -> FastMCP:
             annotations=cmd.mcp_annotations,
         )
 
+    if _legacy_mcp_compat_enabled():
+        _register_legacy_mcp_tools(
+            mcp,
+            vault_root=runtime.vault_root,
+            source_schema=runtime.source_schema,
+            expose_tier2=expose_tier2,
+            project_keys_hint=runtime.project_keys_hint,
+        )
+
     return mcp
+
+
+def _legacy_mcp_compat_enabled() -> bool:
+    """Register canonical MCP leaf names for stale connector caches.
+
+    The product MCP surface is the default. This opt-in exists for clients that
+    cached the old tool list and still call names such as `note` or
+    `create_file` after a service upgrade. It is intentionally environment
+    gated so fresh clients do not see the primitive leaves unless an operator
+    chooses compatibility over a smaller tool list.
+    """
+    return os.environ.get("EXOMEM_MCP_LEGACY_COMPAT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _register_legacy_mcp_tools(
+    mcp: FastMCP,
+    *,
+    vault_root: Path,
+    source_schema: object,
+    expose_tier2: bool,
+    project_keys_hint: str,
+) -> None:
+    product_names = {
+        c.name for c in commands_module.product_commands_for("mcp", expose_tier2=expose_tier2)
+    }
+    legacy = list(commands_module.commands_for("mcp", expose_tier2=expose_tier2))
+    legacy += [c for c in commands_module.COMMANDS if c.name == "note"]
+
+    for cmd in legacy:
+        if cmd.name in product_names:
+            continue
+        if "mcp" not in cmd.surfaces and cmd.name != "note":
+            continue
+        injected = (
+            (vault_root, source_schema)
+            if cmd.needs_schema
+            else (vault_root,)
+        )
+        description = cmd.doc
+        if cmd.name == "note":
+            description = commands_module.remember_description(project_keys_hint)
+        mcp.tool(
+            commands_module.bind_vault(
+                cmd.leaf,
+                *injected,
+                name=cmd.name,
+                description="[Deprecated compatibility alias; prefer product commands.] "
+                + description,
+            ),
+            annotations=cmd.mcp_annotations,
+        )
 
 
 def run(

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -70,8 +69,9 @@ def test_windows_service_installer_supports_release_env_and_cuda() -> None:
 
     assert "[switch]$Release" in install
     assert "exomem-service-release" in install
-    assert '"pip", "install", "--python", $venvPython, $pkg' in install
+    assert '"pip", "install", "--upgrade", "--python", $venvPython, $pkg' in install
     assert "AppEnvironmentExtra" in install
     assert "EXOMEM_MCP_LEGACY_COMPAT" in install
     assert "https://download.pytorch.org/whl/cu132" in install
     assert "torch==2.12.0+cu132" in install
+    assert "Test-McpEndpoint -HostName $BindHost -EndpointPort $Port" in install

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -63,3 +63,15 @@ def test_windows_service_scripts_gate_selected_profile_before_success() -> None:
     assert '"-Profile", $Profile' in install
     assert "exomem\", \"doctor\", \"--profile\", $Profile" in install
     assert install.index("exomem\", \"doctor\", \"--profile\", $Profile") < install.index("& $NssmPath install")
+
+
+def test_windows_service_installer_supports_release_env_and_cuda() -> None:
+    install = _read("scripts/install-service.ps1")
+
+    assert "[switch]$Release" in install
+    assert "exomem-service-release" in install
+    assert '"pip", "install", "--python", $venvPython, $pkg' in install
+    assert "AppEnvironmentExtra" in install
+    assert "EXOMEM_MCP_LEGACY_COMPAT" in install
+    assert "https://download.pytorch.org/whl/cu132" in install
+    assert "torch==2.12.0+cu132" in install

--- a/tests/test_retrieval_surface_safety.py
+++ b/tests/test_retrieval_surface_safety.py
@@ -84,3 +84,24 @@ def test_product_mcp_retrieval_schemas_are_safe(
     assert read_schema["type"] == "object"
     assert read_schema["additionalProperties"] is True
     assert "path" in tools["read_memory"]["inputSchema"]["properties"]
+
+
+def test_legacy_mcp_leaf_names_are_opt_in(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_MCP_LEGACY_COMPAT", raising=False)
+    tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    assert "note" not in tools
+    assert "create_file" not in tools
+
+    monkeypatch.setenv("EXOMEM_MCP_LEGACY_COMPAT", "1")
+    compat_tools = _mcp_tools(_build_server(monkeypatch, vault))
+
+    assert "remember" in compat_tools
+    assert "manage_memory_file" in compat_tools
+    assert "note" in compat_tools
+    assert "create_file" in compat_tools
+    assert compat_tools["note"]["description"].startswith(
+        "[Deprecated compatibility alias; prefer product commands.]"
+    )

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -1,0 +1,368 @@
+"""Contract tests for native one-command service installation."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "scripts" / "install-service.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _fake_python(path: Path) -> None:
+    _write_executable(
+        path,
+        r'''
+        #!/usr/bin/python3
+        import html
+        import os
+        import shlex
+        import stat
+        import sys
+        from pathlib import Path
+
+        trace = Path(os.environ["TRACE_FILE"])
+
+        def log(message):
+            with trace.open("a", encoding="utf-8") as handle:
+                handle.write(message + "\n")
+
+        if len(sys.argv) > 1 and sys.argv[1] == "-" and len(sys.argv) == 8:
+            _, _, env_path, systemd_path, process_path, xml_path, log_dir, legacy = sys.argv
+            values = {}
+            for raw in Path(env_path).read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                values[key.strip()] = value.strip().strip("\"'")
+            values.setdefault("EXOMEM_LOG_DIR", log_dir)
+            values.setdefault("PATH", os.environ["PATH"])
+            if legacy == "1":
+                values["EXOMEM_MCP_LEGACY_COMPAT"] = "1"
+            Path(systemd_path).write_text(
+                "".join(f'{key}="{value}"\n' for key, value in values.items()),
+                encoding="utf-8",
+            )
+            Path(process_path).write_text(
+                "".join(f"export {key}={shlex.quote(value)}\n" for key, value in values.items()),
+                encoding="utf-8",
+            )
+            xml = ["    <key>EnvironmentVariables</key>", "    <dict>"]
+            for key, value in values.items():
+                xml += [f"        <key>{html.escape(key)}</key>", f"        <string>{html.escape(value)}</string>"]
+            xml.append("    </dict>")
+            Path(xml_path).write_text("\n".join(xml) + "\n", encoding="utf-8")
+            for output in (systemd_path, process_path, xml_path):
+                Path(output).chmod(stat.S_IRUSR | stat.S_IWUSR)
+            log("render environment")
+            raise SystemExit(0)
+
+        if len(sys.argv) > 1 and sys.argv[1] == "-" and len(sys.argv) == 10:
+            _, _, src, dest, env_xml, python, working_dir, host, port, log_dir = sys.argv
+            text = Path(src).read_text(encoding="utf-8")
+            replacements = {
+                "__VENV_PYTHON__": python,
+                "__WORKING_DIRECTORY__": working_dir,
+                "__BIND_HOST__": host,
+                "__PORT__": port,
+                "__LOG_DIR__": log_dir,
+            }
+            for marker, value in replacements.items():
+                text = text.replace(marker, html.escape(value))
+            text = text.replace("    __ENVIRONMENT_VARIABLES__\n", Path(env_xml).read_text(encoding="utf-8"))
+            Path(dest).write_text(text, encoding="utf-8")
+            log("render launchd")
+            raise SystemExit(0)
+
+        if len(sys.argv) > 1 and sys.argv[1] == "-" and len(sys.argv) == 9:
+            _, _, src, dest, python, working_dir, env_file, host, port = sys.argv
+            text = Path(src).read_text(encoding="utf-8")
+            def scalar_path(value):
+                escaped = {" ": "\\x20", "\t": "\\x09", "\n": "\\x0a", "\r": "\\x0d", "\\": "\\x5c"}
+                return "".join(escaped.get(char, char) for char in value)
+            replacements = {
+                "__VENV_PYTHON__": python.replace("\\", "\\\\").replace('"', '\\"'),
+                "__WORKING_DIRECTORY__": scalar_path(working_dir),
+                "__SERVICE_ENV_FILE__": scalar_path(env_file),
+                "__BIND_HOST__": host,
+                "__PORT__": port,
+            }
+            for marker, value in replacements.items():
+                text = text.replace(marker, value)
+            Path(dest).write_text(text, encoding="utf-8")
+            log("render systemd")
+            raise SystemExit(0)
+
+        if sys.argv[1:3] == ["-m", "exomem"] and "doctor" in sys.argv:
+            profile = sys.argv[sys.argv.index("--profile") + 1]
+            log(f"doctor {profile}")
+            if os.environ.get("FAKE_DOCTOR_FAIL_PROFILE") == profile:
+                raise SystemExit(1)
+            raise SystemExit(0)
+
+        raise SystemExit(0)
+        ''',
+    )
+
+
+def _fixture(tmp_path: Path, *, os_name: str = "Linux", arch: str = "x86_64") -> tuple[dict[str, str], Path, Path]:
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    service_root = tmp_path / "service root"
+    trace = tmp_path / "trace.log"
+    env_file = tmp_path / ".env"
+    home.mkdir()
+    bin_dir.mkdir()
+    (service_root / ".venv" / "bin").mkdir(parents=True)
+    trace.touch()
+    env_file.write_text(
+        "\n".join(
+            [
+                f"EXOMEM_VAULT_PATH={tmp_path / 'vault'}",
+                "EXOMEM_BASE_URL=https://memory.example.test",
+                "EXOMEM_GITHUB_USERNAME=test-user",
+                "GITHUB_CLIENT_ID=test-client",
+                "GITHUB_CLIENT_SECRET=secret&value",
+                "EXOMEM_JWT_SECRET=test-jwt-secret",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _fake_python(service_root / ".venv" / "bin" / "python")
+
+    _write_executable(
+        bin_dir / "uname",
+        f'''
+        #!/bin/sh
+        if [ "$1" = "-m" ]; then
+            printf '%s\n' "{arch}"
+        else
+            printf '%s\n' "{os_name}"
+        fi
+        ''',
+    )
+    for command in ("uv", "systemctl", "launchctl"):
+        _write_executable(
+            bin_dir / command,
+            f'''
+            #!/bin/sh
+            printf '%s %s\n' "{command}" "$*" >> "$TRACE_FILE"
+            exit 0
+            ''',
+        )
+    _write_executable(
+        bin_dir / "loginctl",
+        '''
+        #!/bin/sh
+        printf 'loginctl %s\n' "$*" >> "$TRACE_FILE"
+        if [ "$1" = "show-user" ]; then
+            printf 'yes\n'
+        fi
+        exit 0
+        ''',
+    )
+    _write_executable(
+        bin_dir / "curl",
+        '''
+        #!/bin/sh
+        printf 'curl %s\n' "$*" >> "$TRACE_FILE"
+        printf '%s' "${FAKE_HTTP_STATUS:-401}"
+        exit 0
+        ''',
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "USER": "test-user",
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "TRACE_FILE": str(trace),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+        }
+    )
+    return env, service_root, env_file
+
+
+def _run(tmp_path: Path, *args: str, os_name: str = "Linux", arch: str = "x86_64") -> tuple[subprocess.CompletedProcess[str], Path, Path, dict[str, str]]:
+    env, service_root, env_file = _fixture(tmp_path, os_name=os_name, arch=arch)
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--release",
+            "--service-root",
+            str(service_root),
+            "--env-file",
+            str(env_file),
+            *args,
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, service_root, Path(env["TRACE_FILE"]), env
+
+
+def test_linux_release_install_renders_env_gates_then_verifies(tmp_path: Path) -> None:
+    result, service_root, trace_path, env = _run(tmp_path, "--profile", "hybrid")
+
+    assert result.returncode == 0, result.stderr
+    trace = trace_path.read_text(encoding="utf-8")
+    assert "uv pip install --upgrade --python" in trace
+    assert "exomem[embeddings]" in trace
+    assert trace.index("doctor hybrid") < trace.index("doctor remote")
+    assert trace.index("doctor remote") < trace.index("systemctl --user daemon-reload")
+    assert trace.index("systemctl --user enable --now exomem") < trace.index("curl ")
+
+    unit = Path(env["XDG_CONFIG_HOME"]) / "systemd" / "user" / "exomem.service"
+    unit_text = unit.read_text(encoding="utf-8")
+    assert str(service_root / ".venv" / "bin" / "python") in unit_text
+    assert "EnvironmentFile=" in unit_text
+    assert "__" not in unit_text
+
+    if shutil.which("systemd-analyze"):
+        verified = subprocess.run(
+            ["systemd-analyze", "verify", str(unit)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert verified.returncode == 0, verified.stderr
+
+    service_env = Path(env["XDG_CONFIG_HOME"]) / "exomem" / "service.env"
+    assert "GITHUB_CLIENT_SECRET=" in service_env.read_text(encoding="utf-8")
+    assert stat.S_IMODE(service_env.stat().st_mode) == 0o600
+    assert "-> 401 (healthy, OAuth enforced)" in result.stdout
+
+
+def test_macos_arm64_media_adds_mlx_and_launchd_environment(tmp_path: Path) -> None:
+    result, _, trace_path, env = _run(
+        tmp_path,
+        "--profile",
+        "media",
+        os_name="Darwin",
+        arch="arm64",
+    )
+
+    assert result.returncode == 0, result.stderr
+    trace = trace_path.read_text(encoding="utf-8")
+    assert "exomem[embeddings,media,vision,diarization,media-mlx]" in trace
+    assert trace.index("doctor remote") < trace.index("launchctl bootstrap")
+    assert trace.index("launchctl kickstart") < trace.index("curl ")
+
+    plist = Path(env["HOME"]) / "Library" / "LaunchAgents" / "com.exomem.plist"
+    plist_text = plist.read_text(encoding="utf-8")
+    assert "<key>EnvironmentVariables</key>" in plist_text
+    assert "<key>PATH</key>" in plist_text
+    assert "secret&amp;value" in plist_text
+    assert "__" not in plist_text
+    assert stat.S_IMODE(plist.stat().st_mode) == 0o600
+
+
+def test_doctor_failure_does_not_touch_service_manager(tmp_path: Path) -> None:
+    env, service_root, env_file = _fixture(tmp_path)
+    env["FAKE_DOCTOR_FAIL_PROFILE"] = "hybrid"
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--release",
+            "--profile",
+            "hybrid",
+            "--service-root",
+            str(service_root),
+            "--env-file",
+            str(env_file),
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    trace = Path(env["TRACE_FILE"]).read_text(encoding="utf-8")
+    assert "doctor hybrid" in trace
+    assert "systemctl" not in trace
+    assert "launchctl" not in trace
+
+
+def test_http_200_stops_service_and_fails_closed(tmp_path: Path) -> None:
+    env, service_root, env_file = _fixture(tmp_path)
+    env["FAKE_HTTP_STATUS"] = "200"
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--release",
+            "--profile",
+            "lean",
+            "--service-root",
+            str(service_root),
+            "--env-file",
+            str(env_file),
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "OAuth is not enforced" in result.stderr
+    trace = Path(env["TRACE_FILE"]).read_text(encoding="utf-8")
+    assert "curl " in trace
+    assert "systemctl --user stop exomem" in trace
+
+
+def test_help_and_invalid_profile_are_non_mutating() -> None:
+    help_result = subprocess.run(
+        ["bash", str(INSTALL_SH), "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    invalid_result = subprocess.run(
+        ["bash", str(INSTALL_SH), "--profile", "invalid"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert help_result.returncode == 0
+    assert "--release" in help_result.stdout
+    assert "--repo-dev" in help_result.stdout
+    assert 'MODE="repo-dev"' in INSTALL_SH.read_text(encoding="utf-8")
+    assert invalid_result.returncode != 0
+    assert "lean, hybrid, or media" in invalid_result.stderr
+
+
+def test_windows_installer_gates_remote_and_verifies_before_success() -> None:
+    text = (ROOT / "scripts" / "install-service.ps1").read_text(encoding="utf-8")
+
+    assert '"pip", "install", "--upgrade", "--python", $venvPython, $pkg' in text
+    assert "Preflight: exomem doctor --profile remote" in text
+    assert "function Test-McpEndpoint" in text
+    assert "-SkipHttpErrorCheck" in text
+    assert "OAuth is not enforced" in text
+    assert text.index("Preflight: exomem doctor --profile remote") < text.index("& $NssmPath install")
+    assert text.index("Test-McpEndpoint -HostName") < text.index("Granted no-UAC")

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- supersede #178 by carrying its Windows PyPI release-service flow into a cross-platform native bootstrap
- add one blessed Linux/macOS command that creates or updates a release venv, installs profile extras, loads `.env`, doctor-gates, installs/starts launchd or systemd, and verifies `/mcp` returns the authenticated `401`
- retain explicit repo-dev mode, add the same post-start verification to Windows, and document release mode as the product path
- add OpenSpec requirements plus executable installer tests with fake service managers and HTTP responses

## Product commands

```bash
bash scripts/install-service.sh --release --profile hybrid
```

```powershell
pwsh -File scripts/install-service.ps1 -Release -Profile hybrid
```

## Validation

- `pytest -q tests/test_service_installers.py tests/test_container_distribution.py` - 12 passed
- `shellcheck scripts/install-service.sh`
- `bash -n scripts/install-service.sh`
- PowerShell parser validation for `scripts/install-service.ps1`
- `ruff check tests/test_service_installers.py tests/test_container_distribution.py`
- generated systemd unit passes `systemd-analyze verify`, including paths with spaces
- `openspec validate add-native-release-service-bootstrap --strict`
- `git diff --check`

The full suite was attempted with the repo's lightweight environment gates. It reaches the existing `tests/test_bootstrap.py::test_bootstrap_is_registry_generated_on_public_surfaces` TestClient hang; that same test times out on untouched `main` (exit 124), so it is not introduced by this branch.

## Relationship to #178

This branch includes #178's commit and extends it. Merge this PR instead of #178.
