### PR TITLE
feat: make multimodal capability resource-bounded by default

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -281,8 +281,9 @@ uv run python -m exomem doctor --vault "/path/to/your/Obsidian" --profile hybrid
 
 ### Resource modes
 
-The safe default is `normal`: CPU steady-state, no automatic CUDA residency, and
-warm CPU caches allowed. For gaming or other foreground work, switch to quiet:
+The safe default is `normal`: no automatic CUDA residency, no startup model or
+whole-vault cache preload, and idle reclamation enabled. For gaming or other
+foreground work, quiet additionally defers expensive indexing:
 
 ```bash
 uv run python -m exomem mode quiet
@@ -502,8 +503,9 @@ publicly-reachable, authenticated endpoint:
    claude.ai connectors require OAuth; static tokens aren't accepted.
 4. **Lock it to your GitHub login** (the single-user verifier), then run it as a
    background service with `--transport streamable-http`. On macOS or Linux run
-   `bash scripts/install-service.sh --release --profile hybrid`; on Windows run
-   `pwsh -File scripts/install-service.ps1 -Release -Profile hybrid`. These
+   `bash scripts/install-service.sh --release`; on Windows run
+   `pwsh -File scripts/install-service.ps1 -Release`. These default to the
+   resource-bounded standard multimodal profile,
    release commands create the PyPI service environment, load `.env`, doctor-gate,
    start the OS service, and verify `/mcp` (the main
    [docs/deployment.md](docs/deployment.md) covers all options, including repo-dev).

--- a/README.md
+++ b/README.md
@@ -333,10 +333,15 @@ CLI and REST share the same JSON envelope:
 {"success": true, "data": []}
 ```
 
-## Optional multimodal stack
+## Multimodal by default, resident only while working
 
-The lean install works with keyword/BM25 search. Optional extras add local
-embedding search and media extraction:
+The native release-service command installs the `standard` profile: local
+embeddings, PDFs/Office documents, OCR bindings, ASR, and CLIP. Heavy models are
+not loaded at service startup. Media jobs enter a durable queue, run serially in
+one disposable child process, and the child exits after five idle minutes so its
+RAM and MPS/MLX/CUDA state return to the host.
+
+Manual/source installs can select the same capabilities directly:
 
 ```bash
 uv sync --extra embeddings
@@ -346,6 +351,10 @@ uv sync --extra media
 - `embeddings`: local text embeddings plus CLIP image search.
 - `media`: OCR for images, PDF extraction, Office document extraction, and
   faster-whisper ASR for audio/video.
+
+`lean` and `hybrid` remain available for constrained machines. Generated image
+captioning and speaker diarization are advanced opt-ins, not requirements for
+the standard multimodal path.
 
 System tools: Tesseract is required for image OCR. On Windows:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,22 +209,31 @@ PyPI-backed service venv, load the repository `.env` into the service manager,
 doctor-gate the selected profile and remote configuration, start the service, and
 verify that local `/mcp` returns the expected OAuth `401`.
 
+The default `standard` profile is multimodal but not permanently model-resident.
+Evidence work is durable and serialized through one disposable child; after
+`EXOMEM_MEDIA_IDLE_SECONDS` (default 300) without work, that child exits and returns
+its RAM plus MPS/MLX/CUDA state. After the deadline, maintainers can verify the
+persistent-core envelope with `python scripts/verify-resource-envelope.py` (targets:
+one service, zero media children, <=512 MiB pre-cache RSS, and <1% idle CPU). GPU
+acceptance is checked separately with `nvidia-smi` or Activity Monitor: the idle
+core must not be a CUDA compute process and targets <200 MiB GPU delta.
+
 **macOS (launchd):**
 
 ```bash
-bash scripts/install-service.sh --release --profile hybrid
+bash scripts/install-service.sh --release
 # Re-run after a package or .env change to update and restart the service.
-# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile hybrid
+# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile standard
 # Uninstall:                 launchctl bootout gui/$(id -u)/com.exomem && rm ~/Library/LaunchAgents/com.exomem.plist
 ```
 
 **Linux (systemd --user):**
 
 ```bash
-bash scripts/install-service.sh --release --profile hybrid
+bash scripts/install-service.sh --release
 # The installer attempts to enable user linger so the service survives logout.
 # Re-run after a package or .env change to update and restart the service.
-# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile hybrid
+# Developer checkout mode: bash scripts/install-service.sh --repo-dev --profile standard
 # Uninstall: systemctl --user disable --now exomem && rm ~/.config/systemd/user/exomem.service
 ```
 

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -97,8 +97,9 @@ exomem doctor --profile remote
 For always-on service install (auto-start on boot), pick your OS — see
 [deployment.md § 6](deployment.md#6-install-as-a-service-auto-start-on-boot)
 for the full commands. The blessed paths are macOS/Linux
-(`bash scripts/install-service.sh --release --profile hybrid`) and Windows
-(`pwsh -File scripts/install-service.ps1 -Release -Profile hybrid`). Each path
+(`bash scripts/install-service.sh --release`) and Windows
+(`pwsh -File scripts/install-service.ps1 -Release`). Each path defaults to the
+standard multimodal profile and
 installs the profile extras into a PyPI-backed service venv, loads `.env`, runs
 doctor, starts the native service, and verifies `/mcp` before reporting success.
 Or run it in the foreground for a first test:

--- a/env.example
+++ b/env.example
@@ -50,9 +50,8 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 #   performance - use the GPU when a capable one is present (aliases: gpu, turbo).
 # EXOMEM_MODE=normal
 #
-# Startup model preload. On Apple Silicon normal mode defaults to lazy model load
-# to avoid multiplying multi-GB resident models across local stdio sessions.
-# Set 1 to restore eager preload; set 0 to force lazy preload everywhere.
+# Startup model preload. Normal/quiet default to lazy model load on every OS;
+# performance may preload. Set 1 only when startup latency matters more than RAM.
 # EXOMEM_PRELOAD_MODELS=1
 #
 # Explicit device override (wins over the mode). cpu | gpu | auto | cuda | cuda:1 | mps
@@ -63,14 +62,16 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # EXOMEM_ASR_DEVICE=        # faster-whisper ASR (cpu|cuda|auto); own path, not via the above
 # EXOMEM_GPU_MIN_FREE_GB=2  # min free VRAM to accept a GPU (the marginal-VRAM guard)
 #
-# ASR startup preload. On Apple Silicon this defaults off so each local stdio
-# session does not eagerly load a multi-GB Whisper model. Set 1 to preload.
+# ASR startup preload defaults off on every OS. Product mode starts a disposable
+# media child only when work arrives. Set 1 to preload inside that child.
 # EXOMEM_ASR_PREWARM=1
 # EXOMEM_DISABLE_ASR_PREWARM=1
 #
-# Idle-unload reaper (performance/quiet): release resident models after N idle minutes.
-# EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off; default on for quiet/performance, off for normal
+# Idle-unload reaper: release resident models/caches after N idle minutes.
+# EXOMEM_RELEASE_GPU_WHEN_IDLE=   # on|off; default on in every mode
 # EXOMEM_IDLE_MINUTES=15
+# EXOMEM_MEDIA_IDLE_SECONDS=300   # disposable media child exits after this idle window
+# EXOMEM_MEDIA_WORKER_MODE=process # process (product default) | inline (debug rollback)
 #
 # Model selection & footprint (advanced). The reranker is a stateless scorer, so it
 # can be swapped or disabled with no re-index.
@@ -87,6 +88,7 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # semantic embeddings so imports do not load the full vector stack in every
 # local client process. Run `exomem index --scope vault` after a bulk import.
 # EXOMEM_WATCHER_MAX_EMBED_FILES=32
+# EXOMEM_LIVE_EMBED_MAX_CHUNKS=256 # maximum chunks passed to one live encode call
 
 # ---------------------------------------------------------------------------
 # HTTP transport bind — optional (remote / service use)

--- a/openspec/changes/add-resource-bounded-multimodal-workers/.openspec.yaml
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/add-resource-bounded-multimodal-workers/design.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/design.md
@@ -1,0 +1,191 @@
+## Context
+
+The server currently creates one in-process `MediaWorker` thread per Exomem process. The
+thread owns an in-memory queue and calls OCR, ASR, CLIP, frame persistence, and re-embedding
+directly. Pending sidecars reconstruct extraction work after restart, but queue state is not
+explicit, post-processing jobs are transient, and any model or accelerator context loaded by a
+job remains in the long-lived MCP process.
+
+That shape is particularly expensive under stdio process fan-out and on Apple Silicon, where
+each process can retain a separate MLX model in unified memory. It is also impossible to return
+CUDA to a near-zero idle footprint after first use from inside the same process because the
+primary context survives model unload. The native HTTP service reduces process fan-out, but the
+runtime must remain safe even when users have stale or duplicate clients.
+
+The pipeline is pure substrate: OCR, ASR, embeddings, CLIP, and frozen voice/caption models
+transduce user-owned evidence into deterministic searchable representations. No reasoning LLM
+or content judgment is introduced.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the product install multimodal by default without loading heavy models at service start.
+- Persist every queued media operation and recover safely after parent or child crashes.
+- Guarantee at most one heavy media worker per vault across HTTP and stdio server processes.
+- Keep models warm across a short burst, then reclaim RAM and accelerator contexts by exiting
+  the child process.
+- Preserve current sidecar/index output and current soft-fail semantics.
+- Make normal mode lazy at startup and reclaim idle model/cache residency.
+- Bound live text embedding calls by chunk count and persist deferred semantic paths.
+- Expose queue and worker state without importing model modules or creating accelerator state.
+- Preserve existing profile names and environment overrides.
+
+**Non-Goals:**
+
+- No cloud inference, hosted model service, reasoning model, or automatic note interpretation.
+- No parallel heavy media execution; serialization is deliberate resource governance.
+- No replacement of Whisper/CLIP/embedding model families in this change.
+- No requirement that optional image captioning or speaker diarization be enabled by default.
+- No guarantee of zero cold-start latency after the worker has returned resources.
+- No automatic installation of OS package-manager dependencies such as Tesseract.
+
+## Decisions
+
+### D1. Add a product-facing `standard` profile
+
+`standard` becomes the default profile for native release service installers. It maps to
+`exomem[embeddings,media]`, plus `media-mlx` on macOS arm64. This provides hybrid retrieval,
+PDF/Office extraction, OCR bindings, ASR, and CLIP. Missing optional OS tools such as Tesseract
+are warnings in `standard`, not a reason to deny the rest of the service; the existing `media`
+profile remains the strict/full compatibility profile and continues to install vision and
+diarization extras through the service installers.
+
+`lean`, `hybrid`, and `media` remain accepted. Advanced generated captioning and speaker
+diarization stay default-off because baseline OCR/ASR/CLIP already satisfies the multimodal
+product contract without pulling every specialized model into the default environment.
+
+Alternative: keep `hybrid` as the blessed default and describe media as optional. Rejected
+because it makes the advertised product experience false on first install.
+
+### D2. Use a rebuildable SQLite job ledger
+
+Add `.media-jobs.sqlite` under the KB root beside other derived sidecars. A job records the
+vault-relative binary and sidecar paths, media type, requested extraction/CLIP/re-embed stages,
+state, attempts, timestamps, and last error. Enqueue is idempotent: duplicate pending work
+merges stage flags rather than adding another heavy operation.
+
+The ledger supports atomic claim, complete/delete, blocked, failed, recovery of interrupted
+`running` rows, queue counts, and a bounded status sample. User-authored Markdown remains the
+source of truth; deleting the job DB is safe because startup scans reconstruct extraction and
+CLIP drift from pending sidecars and indexes.
+
+Alternative: continue relying only on pending sidecars. Rejected because CLIP and ordered
+post-frame re-embedding are not fully represented there and operators cannot inspect queue
+state.
+
+### D3. Split supervisor and child worker at a process boundary
+
+The long-lived `MediaWorker` becomes a stdlib-only supervisor. It writes jobs, starts a child
+with the current interpreter, and monitors it. The child claims jobs from SQLite, processes
+them serially with the existing extraction/index functions, and exits after
+`EXOMEM_MEDIA_IDLE_SECONDS` (default 300) with no pending work.
+
+One child processes an entire burst, preserving model reuse. Process exit is the reclamation
+primitive for Python heaps, CTranslate2, MLX caches, MPS state, and CUDA primary contexts. The
+parent never prewarms ASR and does not import model stacks merely to start media support.
+
+A per-vault OS file lock allows only one child to enter the processing loop. Competing children
+from duplicate server processes exit before importing heavy modules. The child checks parent
+liveness and the supervisor terminates it during orderly shutdown, limiting orphan overlap.
+
+Alternative: a process per media file. Rejected because repeated model loads make imports
+unacceptably slow. Alternative: `multiprocessing.Queue`. Rejected because queue state is not
+durable and ownership becomes ambiguous across multiple server processes.
+
+### D4. Keep processing idempotent and soft-fail
+
+The current stage functions become a child-side processor with an enqueue callback for scene
+frame OCR and parent re-embedding. Re-running after a crash is safe because sidecar updates and
+index upserts are idempotent. `ExtractionUnavailable` marks work blocked and visible instead of
+hot-looping; restart or explicit retry makes blocked work eligible again. Corrupt input retains
+the existing failed sidecar marker and does not kill the worker.
+
+The service starts and serves lexical retrieval even if the ledger is unavailable, the worker
+cannot spawn, a model is missing, or a child crashes. These are logged and surfaced through
+status/doctor.
+
+### D5. Make startup residency opt-in and normal-mode reclamation automatic
+
+Normal and quiet modes do not preload models or O(vault) CPU caches. Performance mode may
+preload for explicitly chosen low-latency behavior. The idle reaper runs in all modes by
+default; normal and quiet release model and large-cache slots after the configured idle window,
+while performance may retain CPU caches but still releases idle model weights unless overridden.
+
+Environment overrides remain authoritative for operators who deliberately want prewarm or
+retention. This makes the product default safe without depending on heuristic auto-quiet.
+
+### D6. Bound and persist semantic write work
+
+`embeddings.upsert_after_write` groups live writes by a configurable maximum chunk count
+(`EXOMEM_LIVE_EMBED_MAX_CHUNKS`, default 256) rather than flattening every chunk into one encode.
+Oversized single files are sliced into bounded encode calls before their rows are committed.
+
+The existing deferred semantic registry moves from process memory to a tiny SQLite table beside
+the embedding sidecar. Deferred paths survive restart, remain deduplicated, appear in resource
+status, and clear only after explicit or background processing dispatches them.
+
+### D7. Extend no-allocation observability
+
+Resource status reads the media and deferred-index SQLite metadata directly. It reports pending,
+running, blocked, and failed media counts, worker PID/active state when known, and semantic
+deferred counts. It must not import `torch`, `embeddings`, `extract`, MLX, or CTranslate2 solely
+to answer status.
+
+Doctor reports the selected profile, lazy/prewarm policy, job DB health, worker multiplicity,
+and the remediation for blocked jobs. The child process is identified separately from duplicate
+server processes so a healthy supervisor+worker pair does not produce a false fan-out warning.
+
+### D8. Treat resource budgets as release acceptance criteria
+
+On the maintained 2,000-note fixture after startup and after the media worker idle deadline:
+
+- the persistent core targets no CUDA compute process and less than 200 MiB GPU delta;
+- the worker process count is zero and the server process count is one in HTTP service mode;
+- persistent-core RSS targets 512 MiB or less before user-triggered cache growth;
+- idle CPU targets less than 1% averaged over 60 seconds;
+- queued work remains durable and visible while no worker is resident.
+
+Unit tests assert the deterministic lifecycle and no-allocation properties. Desk-side scripts
+record RSS/GPU/process results on Windows, Linux, and Apple Silicon because hosted Ubuntu-only
+CI cannot prove launchd/NSSM/MPS resource behavior.
+
+## Risks / Trade-offs
+
+- [First media job after idle is slower] -> Keep the child hot for a bounded burst, pre-download
+  models through explicit `exomem warm`, and expose `loading` rather than hiding the delay.
+- [SQLite claim or lock bugs strand work] -> Keep sidecars/index drift reconstructable, recover
+  `running` rows at startup, and make the ledger safely deletable.
+- [Two supervisors repeatedly race to spawn] -> Use the per-vault OS lock plus launch backoff;
+  losing children exit before model imports.
+- [Service termination can orphan a child briefly] -> Parent-liveness checks and a short idle
+  deadline bound the lifetime; orderly shutdown explicitly terminates the child.
+- [Standard profile increases install size] -> Keep a documented `lean` opt-out, avoid generated
+  caption/diarization extras, and distinguish disk-installed capability from memory residency.
+- [Missing Tesseract weakens image OCR] -> Warn with exact remediation while preserving CLIP,
+  ASR, PDF, Office, and core service operation.
+- [Lazy normal mode increases first query latency] -> Preserve performance mode and explicit
+  warm commands for users who choose latency over host coexistence.
+
+## Migration Plan
+
+1. Add the job ledger and child processor behind `EXOMEM_MEDIA_WORKER_MODE=process|inline`, with
+   `process` as product default and `inline` retained for deterministic tests/debugging.
+2. Move current stage methods without changing output contracts; convert enqueue and startup
+   scans to durable writes.
+3. Change prewarm/reaper defaults and add status/doctor reporting.
+4. Add `standard` across doctor, setup, installers, and docs; preserve old profile behavior.
+5. Add bounded live embedding and durable deferred semantic work.
+6. Run focused/full tests, OpenSpec validation, installer contract tests, and desk-side resource
+   verification where hosts are available.
+
+Rollback: set `EXOMEM_MEDIA_WORKER_MODE=inline` to restore in-process execution, select an
+existing profile explicitly, or revert the runtime change. The new SQLite sidecar is derived and
+can be removed without touching evidence or notes.
+
+## Open Questions
+
+- A future release may prefetch model files during installation, but this change keeps model
+  network downloads explicit because their size and availability vary by profile and host.
+- Byte-capped LRU caches are preferable to count-only caches, but the first implementation uses
+  the existing idle reaper; per-cache byte ceilings can follow after real-host measurements.

--- a/openspec/changes/add-resource-bounded-multimodal-workers/proposal.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Exomem's multimodal pipeline is a core product differentiator, but its current in-process
+media thread can retain multi-gigabyte ASR/CLIP/MPS/CUDA state for the lifetime of every
+server process. The default product path must accept and enrich multimodal evidence without
+making an idle machine materially worse to use or requiring users to understand model
+residency and service-process fan-out.
+
+## What Changes
+
+- Make a `standard` capability profile the default native product install: hybrid retrieval,
+  document/PDF extraction, OCR, ASR, and CLIP are available without a reinstall; `lean`,
+  `hybrid`, and `media` remain accepted compatibility profiles.
+- Replace the in-process media extraction thread with a lightweight supervisor, durable
+  SQLite job ledger, and one serialized child worker process that starts on demand, stays
+  warm for a bounded burst, and exits after idle to reclaim RAM plus MPS/MLX/CUDA state.
+- Keep model residency and prewarm off at startup on every OS. Model-backed extraction is
+  deterministic transduction (pure-substrate measurement), remains soft-fail, and never
+  prevents the core service from starting or serving lexical retrieval.
+- Make queued media state explicit and recoverable across worker/service crashes, including
+  extraction, CLIP, and post-frame re-embedding jobs.
+- Turn normal-mode model idle release on by default and expose media queue/worker residency
+  through the no-allocation resource status and doctor surfaces.
+- Bound live semantic indexing by chunk count and durable deferred work rather than flattening
+  an arbitrarily large write batch in one model call.
+- Keep advanced generated captioning and speaker diarization default-off; they remain optional
+  enrichments rather than requirements for the standard multimodal claim.
+
+## Capabilities
+
+### New Capabilities
+
+- `multimodal-job-runtime`: Durable multimodal jobs, serialized disposable worker lifecycle,
+  crash recovery, soft-fail behavior, and observable job/worker state.
+
+### Modified Capabilities
+
+- `install-readiness`: Native product installs default to the standard multimodal dependency
+  set while preserving explicit low-resource and compatibility profiles.
+- `resource-governance`: Normal mode releases idle model residency and defines a measurable
+  persistent-core resource envelope independent of transient worker usage.
+- `live-index-freshness`: Live semantic writes use bounded chunk batches and durable deferral
+  so imports cannot create unbounded model work.
+- `command-surface`: Resource status and doctor report media queue depth, active worker state,
+  and remediation without importing or loading model stacks.
+
+## Impact
+
+- Runtime: `media_worker.py`, a new durable job-store/child-worker boundary, server startup,
+  model/reaper policy, extraction/CLIP call sites, and resource status.
+- Installation: PyPI extras/profile mapping in Unix and Windows service installers, doctor
+  profile validation, setup defaults, and deployment documentation.
+- Storage: one rebuildable per-vault `.media-jobs.sqlite` sidecar under the governed KB root;
+  no user-authored Markdown schema changes.
+- Compatibility: current enqueue callers and legacy profile names remain supported; failed or
+  missing optional engines leave durable work visible and the core service operational.
+- Verification: deterministic unit/integration tests for queue recovery, one-worker
+  serialization, idle exit, process crash recovery, bounded embedding batches, profile mapping,
+  and no-allocation status, plus real-host macOS/Windows/Linux resource acceptance guidance.

--- a/openspec/changes/add-resource-bounded-multimodal-workers/specs/command-surface/spec.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/specs/command-surface/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Media runtime appears in resource diagnostics
+`exomem status --resources` SHALL include a stable media-runtime object with queue counts,
+worker-active state, worker PID when safely known, idle timeout, and job-store health. Doctor
+SHALL report blocked media jobs and profile remediation without loading a model.
+
+#### Scenario: JSON status remains no-allocation
+- **WHEN** resource status is requested before any media job has run
+- **THEN** it reports the media runtime and semantic deferred-work state
+- **AND** it does not create a job DB, load a model, or initialize an accelerator
+
+#### Scenario: Doctor finds blocked jobs
+- **WHEN** durable media jobs are blocked by a missing optional engine
+- **THEN** doctor reports a warning with the blocked count and remediation
+- **AND** the overall core service can still pass readiness

--- a/openspec/changes/add-resource-bounded-multimodal-workers/specs/install-readiness/spec.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/specs/install-readiness/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Standard multimodal product profile
+Native release installers SHALL default to a `standard` profile that installs embeddings and
+media extras, plus the MLX media extra on Apple Silicon. Existing `lean`, `hybrid`, and `media`
+profile names SHALL remain accepted. Missing optional OS-level OCR tooling SHALL be reported
+with remediation but MUST NOT prevent the remaining standard service from installing.
+
+#### Scenario: Default release install
+- **WHEN** a user runs a native release service command without an explicit profile
+- **THEN** the release venv contains the standard embeddings and media extras
+- **AND** the installed service uses demand-loaded disposable media workers
+
+#### Scenario: Apple Silicon standard install
+- **WHEN** the default release install runs on macOS arm64
+- **THEN** the package requirement includes the MLX media extra
+- **AND** ASR remains unloaded until media work arrives
+
+#### Scenario: Explicit compatibility profile
+- **WHEN** an existing automation selects lean, hybrid, or media
+- **THEN** the installer preserves that profile's existing dependency mapping
+- **AND** no profile name is silently reinterpreted

--- a/openspec/changes/add-resource-bounded-multimodal-workers/specs/live-index-freshness/spec.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/specs/live-index-freshness/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Bounded live semantic encoding
+Live semantic indexing SHALL split work by a configurable maximum chunk count. A single encode
+call MUST NOT receive more than that bound, including when one document alone exceeds it, and
+all chunks SHALL be committed under the existing file identity contract.
+
+#### Scenario: Large import batch
+- **WHEN** changed files produce more chunks than the live encode bound
+- **THEN** embedding runs as multiple bounded encode calls
+- **AND** every eligible file is indexed without one unbounded flattened allocation
+
+#### Scenario: One oversized document
+- **WHEN** one document produces more chunks than the live encode bound
+- **THEN** its chunks are encoded in bounded slices
+- **AND** the final file rows contain all slices in original order
+
+### Requirement: Deferred semantic work survives restart
+Deferred semantic paths SHALL be stored in a rebuildable per-vault SQLite sidecar, deduplicated,
+visible through resource status, and removed only after successful dispatch or explicit healing.
+
+#### Scenario: Restart with deferred paths
+- **WHEN** the server restarts after an import was deferred
+- **THEN** resource status still reports the deferred paths
+- **AND** an explicit index/reconcile can clear them after processing

--- a/openspec/changes/add-resource-bounded-multimodal-workers/specs/multimodal-job-runtime/spec.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/specs/multimodal-job-runtime/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Multimodal capability defaults on without startup model residency
+The standard product profile SHALL install hybrid retrieval, document/PDF extraction, OCR
+bindings, ASR, and CLIP capability. Starting the service MUST NOT load ASR, CLIP, embedding,
+MPS, MLX, or CUDA model state solely because those capabilities are installed. Model-backed
+extraction is deterministic transduction and SHALL soft-fail without preventing lexical
+retrieval or service startup.
+
+#### Scenario: Standard service starts idle
+- **WHEN** a standard-profile service starts with no queued media work
+- **THEN** no media child process is running
+- **AND** no ASR or CLIP model is loaded by startup
+
+#### Scenario: Optional engine is unavailable
+- **WHEN** queued evidence requires an optional engine that is missing
+- **THEN** the job remains visible as blocked with remediation context
+- **AND** the MCP service and lexical retrieval remain available
+
+### Requirement: Durable idempotent multimodal jobs
+Every extraction, CLIP, and post-processing operation SHALL be represented in a rebuildable
+SQLite ledger before execution. Enqueue MUST deduplicate equivalent pending work, claiming MUST
+be atomic, and interrupted running work MUST become eligible after recovery.
+
+#### Scenario: Service crashes after claim
+- **WHEN** a service or child process exits while a media job is running
+- **THEN** the next supervisor recovers the job to pending
+- **AND** processing may repeat without corrupting the sidecar or indexes
+
+#### Scenario: Duplicate clients enqueue the same evidence
+- **WHEN** two server processes enqueue the same pending stages for one evidence file
+- **THEN** the ledger contains one merged job
+- **AND** each requested stage runs at most once concurrently
+
+### Requirement: One serialized disposable worker per vault
+Heavy media work SHALL run in a child process, serialized to one active worker per vault across
+all server processes. The child SHALL reuse loaded models across a bounded burst and SHALL exit
+after the configured idle interval when no eligible jobs remain.
+
+#### Scenario: Worker returns resources after a burst
+- **WHEN** the final queued media job completes and the idle interval elapses
+- **THEN** the child process exits
+- **AND** its Python heap, native model state, and accelerator context are no longer resident
+
+#### Scenario: Duplicate supervisors race
+- **WHEN** multiple Exomem processes attempt to launch a worker for the same vault
+- **THEN** an OS-level vault lock permits only one child to process jobs
+- **AND** losing children exit before loading model stacks
+
+### Requirement: Observable job lifecycle
+No-allocation status SHALL report pending, running, blocked, and failed job counts plus active
+worker state without importing heavy model modules. Human-readable logs SHALL distinguish
+queued, loading/processing, blocked, failed, and idle-exit states.
+
+#### Scenario: Resource status with queued work
+- **WHEN** media work is queued while no worker is active
+- **THEN** resource status reports the durable queue depth and worker inactive state
+- **AND** collecting status does not import torch, MLX, CTranslate2, or model modules
+
+### Requirement: Multimodal advanced enrichments remain opt-in
+Generated image captioning and speaker diarization SHALL remain default-off optional
+enrichments. Their absence MUST NOT make the standard profile non-multimodal or prevent OCR,
+ASR, CLIP, PDF, and Office processing.
+
+#### Scenario: Standard profile without advanced enrichments
+- **WHEN** a standard installation processes image, audio, and video evidence
+- **THEN** baseline OCR/ASR/CLIP processing is available
+- **AND** no captioning or diarization model is loaded unless explicitly enabled

--- a/openspec/changes/add-resource-bounded-multimodal-workers/specs/resource-governance/spec.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/specs/resource-governance/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Safe normal-mode residency
+Normal mode SHALL avoid startup model and O(vault) cache preloads and SHALL run idle resource
+reclamation by default. Performance mode MAY preload when explicitly selected. Environment
+overrides SHALL remain available for deliberate operator choices.
+
+#### Scenario: Normal-mode startup
+- **WHEN** the service starts in normal mode
+- **THEN** models and O(vault) CPU caches remain lazy
+- **AND** the idle reaper is active
+
+#### Scenario: Explicit performance mode
+- **WHEN** an operator selects performance mode
+- **THEN** the service may preload latency-oriented resources
+- **AND** the choice is visible through resource status
+
+### Requirement: Persistent-core resource acceptance envelope
+Release verification SHALL measure the persistent service separately from transient workers.
+After worker idle exit on the maintained fixture, the acceptance targets SHALL be no active
+media worker, less than 200 MiB GPU delta/no CUDA compute process, no more than 512 MiB
+persistent-core RSS before user-triggered cache growth, and less than 1% idle CPU averaged over
+60 seconds.
+
+#### Scenario: Resource verification after media work
+- **WHEN** a representative media job completes and the worker idle interval elapses
+- **THEN** verification records zero media workers and the persistent-core RSS/CPU/GPU metrics
+- **AND** an exceeded target is treated as a release failure or explicitly documented blocker

--- a/openspec/changes/add-resource-bounded-multimodal-workers/tasks.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/tasks.md
@@ -39,5 +39,5 @@
 
 - [x] 6.1 Add a cross-platform desk-side resource verification script and document the acceptance envelope.
 - [x] 6.2 Run focused media/resource/profile tests, PowerShell and shell syntax checks, and installer tests.
-- [ ] 6.3 Run the full pytest suite, Ruff on touched Python, and strict OpenSpec validation.
+- [x] 6.3 Run the full pytest suite, Ruff on touched Python, and strict OpenSpec validation.
 - [x] 6.4 Review the final diff for compatibility and secret/personal-data leakage.

--- a/openspec/changes/add-resource-bounded-multimodal-workers/tasks.md
+++ b/openspec/changes/add-resource-bounded-multimodal-workers/tasks.md
@@ -1,0 +1,43 @@
+## 1. Durable Media Jobs
+
+- [x] 1.1 Add the per-vault media job SQLite path and schema with pending/running/blocked/failed states.
+- [x] 1.2 Implement idempotent enqueue, atomic claim, completion, failure, recovery, retry, and no-create status APIs.
+- [x] 1.3 Add job-store tests for deduplication, stage merging, crash recovery, and concurrent claims.
+
+## 2. Disposable Worker Runtime
+
+- [x] 2.1 Extract current media stage processing behind a child-safe processor with a durable enqueue callback.
+- [x] 2.2 Implement the child worker loop, per-vault OS lock, parent-liveness check, and idle exit.
+- [x] 2.3 Replace the in-process production thread with a supervisor that launches, monitors, joins, and stops the child.
+- [x] 2.4 Preserve an explicit inline execution mode for deterministic tests and emergency rollback.
+- [x] 2.5 Update startup scans so pending extraction, CLIP drift, and frame re-embedding enqueue durable jobs.
+- [x] 2.6 Add tests for one-worker serialization, idle exit, child crash recovery, soft-fail blocking, and scene-frame follow-up ordering.
+
+## 3. Safe Resource Defaults
+
+- [x] 3.1 Disable ASR prewarm by default on every platform while preserving explicit opt-in.
+- [x] 3.2 Make normal mode skip model and O(vault) cache preloads and run the idle reaper by default.
+- [x] 3.3 Ensure normal-mode model/cache slots reclaim after idle and update mode/warmup/reaper tests.
+- [x] 3.4 Add media queue/worker state to no-allocation resource status and doctor remediation.
+- [x] 3.5 Add tests proving status/doctor do not import heavy model modules or create sidecars.
+
+## 4. Bounded Semantic Work
+
+- [x] 4.1 Split live embedding encode calls by `EXOMEM_LIVE_EMBED_MAX_CHUNKS`, including oversized single files.
+- [x] 4.2 Persist deferred semantic paths in a rebuildable per-vault SQLite sidecar.
+- [x] 4.3 Update index dispatch, drain/clear/status, and explicit heal paths to use the durable registry.
+- [x] 4.4 Add tests for bounded ordering, restart durability, deduplication, and successful clearing.
+
+## 5. Standard Multimodal Profile
+
+- [x] 5.1 Add `standard` to doctor/CLI/setup profile handling with soft-fail OCR-tool remediation.
+- [x] 5.2 Make Unix and Windows release installers default to standard and map platform extras correctly.
+- [x] 5.3 Preserve lean/hybrid/media compatibility mappings and update installer/profile contract tests.
+- [x] 5.4 Update quickstart, deployment, README, and env guidance around capability versus residency.
+
+## 6. Verification And Delivery
+
+- [x] 6.1 Add a cross-platform desk-side resource verification script and document the acceptance envelope.
+- [x] 6.2 Run focused media/resource/profile tests, PowerShell and shell syntax checks, and installer tests.
+- [ ] 6.3 Run the full pytest suite, Ruff on touched Python, and strict OpenSpec validation.
+- [x] 6.4 Review the final diff for compatibility and secret/personal-data leakage.

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -24,8 +24,8 @@ param(
     [string]$ServiceName = "exomem",
     [string]$BindHost = "127.0.0.1",
     [int]$Port = 8765,
-    [ValidateSet("lean", "hybrid", "media")]
-    [string]$Profile = "hybrid",
+    [ValidateSet("lean", "hybrid", "standard", "media")]
+    [string]$Profile = "standard",
     [switch]$Release,
     [string]$ServiceRoot = "",
     [string]$PackageVersion = "",
@@ -176,6 +176,8 @@ function Install-ReleaseVenv {
     $pkg = if ($PackageVersion) { "exomem==$PackageVersion" } else { "exomem" }
     if ($Profile -eq "hybrid") {
         $pkg = if ($PackageVersion) { "exomem[embeddings]==$PackageVersion" } else { "exomem[embeddings]" }
+    } elseif ($Profile -eq "standard") {
+        $pkg = if ($PackageVersion) { "exomem[embeddings,media]==$PackageVersion" } else { "exomem[embeddings,media]" }
     } elseif ($Profile -eq "media") {
         $pkg = if ($PackageVersion) { "exomem[embeddings,media,vision,diarization]==$PackageVersion" } else { "exomem[embeddings,media,vision,diarization]" }
     }

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -4,10 +4,10 @@
 # .venv path available for contributors.
 #
 # Product install:
-#   bash scripts/install-service.sh --release --profile hybrid
+#   bash scripts/install-service.sh --release
 #
 # Developer install:
-#   bash scripts/install-service.sh --repo-dev --profile hybrid
+#   bash scripts/install-service.sh --repo-dev --profile standard
 #
 # Re-run the same command after package or .env changes. No sudo is required.
 
@@ -16,7 +16,7 @@ set -euo pipefail
 LABEL="com.exomem"
 SERVICE_NAME="exomem"
 MODE="repo-dev"
-PROFILE="hybrid"
+PROFILE="standard"
 BIND_HOST="${EXOMEM_BIND_HOST:-127.0.0.1}"
 PORT="${EXOMEM_PORT:-8765}"
 SERVICE_ROOT=""
@@ -36,7 +36,7 @@ Modes:
   --repo-dev                Use the checkout .venv (default for compatibility)
 
 Options:
-  --profile lean|hybrid|media
+  --profile lean|hybrid|standard|media
   --service-root PATH       Override release state/venv location
   --package-version VERSION Pin the PyPI release version
   --env-file PATH           Dotenv file (default: <repo>/.env)
@@ -115,8 +115,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$PROFILE" in
-    lean|hybrid|media) ;;
-    *) die "--profile must be lean, hybrid, or media" ;;
+    lean|hybrid|standard|media) ;;
+    *) die "--profile must be lean, hybrid, standard, or media" ;;
 esac
 if [[ ! "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); then
     die "--port must be an integer from 1 to 65535"
@@ -172,6 +172,12 @@ if [[ "$MODE" == "release" ]]; then
             ;;
         hybrid)
             EXTRAS="embeddings"
+            ;;
+        standard)
+            EXTRAS="embeddings,media"
+            if [[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]]; then
+                EXTRAS="$EXTRAS,media-mlx"
+            fi
             ;;
         media)
             EXTRAS="embeddings,media,vision,diarization"

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -9,7 +9,7 @@
 param(
     [switch]$Force,
     [string]$ServiceName = "exomem",
-    [ValidateSet("lean", "hybrid", "media")]
+    [ValidateSet("lean", "hybrid", "standard", "media")]
     [string]$Profile = "hybrid"
 )
 

--- a/scripts/verify-resource-envelope.py
+++ b/scripts/verify-resource-envelope.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Desk-side persistent-core resource acceptance check.
+
+Run after the media idle deadline. The script is stdlib-only and intentionally
+measures OS processes rather than importing Exomem or torch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class ProcessRow:
+    pid: int
+    rss_mb: float
+    cpu_percent: float
+    command: str
+
+
+def _posix_rows() -> list[ProcessRow]:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,rss=,%cpu=,command="],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    rows: list[ProcessRow] = []
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 3)
+        if len(parts) != 4:
+            continue
+        try:
+            rows.append(
+                ProcessRow(
+                    pid=int(parts[0]),
+                    rss_mb=round(int(parts[1]) / 1024, 1),
+                    cpu_percent=float(parts[2]),
+                    command=parts[3],
+                )
+            )
+        except ValueError:
+            continue
+    return rows
+
+
+def _windows_rows() -> list[ProcessRow]:
+    script = r"""
+$cmd = @{}
+Get-CimInstance Win32_Process | ForEach-Object { $cmd[[int]$_.ProcessId] = $_.CommandLine }
+Get-CimInstance Win32_PerfFormattedData_PerfProc_Process |
+  Where-Object { $_.IDProcess -gt 0 } |
+  ForEach-Object {
+    [pscustomobject]@{
+      pid = [int]$_.IDProcess
+      rss_mb = [math]::Round([double]$_.WorkingSetPrivate / 1MB, 1)
+      cpu_percent = [double]$_.PercentProcessorTime
+      command = [string]$cmd[[int]$_.IDProcess]
+    }
+  } | ConvertTo-Json -Compress
+"""
+    result = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    payload = json.loads(result.stdout)
+    if isinstance(payload, dict):
+        payload = [payload]
+    return [
+        ProcessRow(
+            pid=int(row["pid"]),
+            rss_mb=float(row["rss_mb"]),
+            cpu_percent=float(row["cpu_percent"]),
+            command=str(row.get("command") or ""),
+        )
+        for row in payload
+    ]
+
+
+def process_rows() -> list[ProcessRow]:
+    return _windows_rows() if os.name == "nt" else _posix_rows()
+
+
+def _is_server(row: ProcessRow) -> bool:
+    command = row.command.lower()
+    return "exomem" in command and "--transport" in command and "media_worker_child" not in command
+
+
+def _is_media_worker(row: ProcessRow) -> bool:
+    return "exomem.media_worker_child" in row.command.lower()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples", type=int, default=6)
+    parser.add_argument("--sample-seconds", type=float, default=10.0)
+    parser.add_argument("--max-rss-mb", type=float, default=512.0)
+    parser.add_argument("--max-cpu-percent", type=float, default=1.0)
+    parser.add_argument("--expected-servers", type=int, default=1)
+    args = parser.parse_args(argv)
+
+    cpu_samples: dict[int, list[float]] = {}
+    latest: list[ProcessRow] = []
+    for sample in range(max(1, args.samples)):
+        latest = process_rows()
+        for row in latest:
+            if _is_server(row):
+                cpu_samples.setdefault(row.pid, []).append(row.cpu_percent)
+        if sample + 1 < args.samples:
+            time.sleep(max(0.0, args.sample_seconds))
+
+    servers = [row for row in latest if _is_server(row)]
+    workers = [row for row in latest if _is_media_worker(row)]
+    failures: list[str] = []
+    if len(servers) != args.expected_servers:
+        failures.append(f"expected {args.expected_servers} server(s), found {len(servers)}")
+    if workers:
+        failures.append(f"expected no idle media worker, found {len(workers)}")
+    for row in servers:
+        average_cpu = sum(cpu_samples.get(row.pid, [row.cpu_percent])) / len(
+            cpu_samples.get(row.pid, [row.cpu_percent])
+        )
+        if row.rss_mb > args.max_rss_mb:
+            failures.append(f"pid {row.pid} RSS {row.rss_mb} MiB > {args.max_rss_mb} MiB")
+        if average_cpu > args.max_cpu_percent:
+            failures.append(
+                f"pid {row.pid} CPU {average_cpu:.2f}% > {args.max_cpu_percent:.2f}%"
+            )
+
+    payload = {
+        "success": not failures,
+        "servers": [asdict(row) for row in servers],
+        "media_workers": [asdict(row) for row in workers],
+        "limits": {
+            "max_rss_mb": args.max_rss_mb,
+            "max_cpu_percent": args.max_cpu_percent,
+            "expected_servers": args.expected_servers,
+        },
+        "failures": failures,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -355,6 +355,7 @@ def _status_main(argv: list[str]) -> int:
         print(f"mode: {status['mode']}  (source: {status['source']})")
         print(f"  config: {status['config_path']}")
         print(f"  models: {status['models']}")
+        print(f"  media: {status['media']}")
         print(f"  deferred_work: {status['deferred_work']}")
         print(f"  cuda: {status['cuda']}")
     return 0
@@ -371,7 +372,7 @@ def _doctor_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--profile",
-        choices=("lean", "hybrid", "media", "remote"),
+        choices=("lean", "hybrid", "standard", "media", "remote"),
         default=None,
         help="capability profile to validate (default: infer from EXOMEM_PROFILE, else lean)",
     )

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -1,0 +1,127 @@
+"""Durable registry for deferred semantic-index paths."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from .kbdir import kb_dirname
+
+
+def store_path(vault_root: Path) -> Path:
+    return vault_root / kb_dirname() / ".deferred-index.sqlite"
+
+
+def _connect(vault_root: Path, *, create: bool) -> sqlite3.Connection:
+    path = store_path(vault_root)
+    if not create:
+        return sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5.0)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS semantic_upserts (
+            rel_path TEXT PRIMARY KEY,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )
+        """
+    )
+    return conn
+
+
+def add(vault_root: Path, rel_paths: list[str]) -> int:
+    rels = sorted({rel.replace("\\", "/") for rel in rel_paths if rel.endswith(".md")})
+    if not rels:
+        return 0
+    now = time.time()
+    conn = _connect(vault_root, create=True)
+    try:
+        placeholders = ",".join("?" for _ in rels)
+        existing = int(
+            conn.execute(
+                f"SELECT count(*) FROM semantic_upserts WHERE rel_path IN ({placeholders})",
+                rels,
+            ).fetchone()[0]
+        )
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO semantic_upserts(rel_path, created_at, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(rel_path) DO UPDATE SET updated_at = excluded.updated_at
+                """,
+                [(rel, now, now) for rel in rels],
+            )
+        return len(rels) - existing
+    finally:
+        conn.close()
+
+
+def list_paths(vault_root: Path, *, limit: int | None = None) -> list[str]:
+    path = store_path(vault_root)
+    if not path.exists():
+        return []
+    conn = _connect(vault_root, create=False)
+    try:
+        sql = "SELECT rel_path FROM semantic_upserts ORDER BY rel_path"
+        params: tuple[Any, ...] = ()
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (max(0, limit),)
+        return [str(row[0]) for row in conn.execute(sql, params).fetchall()]
+    finally:
+        conn.close()
+
+
+def clear(vault_root: Path, rel_paths: list[str] | None = None) -> int:
+    path = store_path(vault_root)
+    if not path.exists():
+        return 0
+    conn = _connect(vault_root, create=True)
+    try:
+        with conn:
+            if rel_paths is None:
+                changed = conn.execute("DELETE FROM semantic_upserts").rowcount
+            else:
+                rels = sorted({rel.replace("\\", "/") for rel in rel_paths})
+                if not rels:
+                    return 0
+                changed = conn.execute(
+                    f"DELETE FROM semantic_upserts WHERE rel_path IN "
+                    f"({','.join('?' for _ in rels)})",
+                    rels,
+                ).rowcount
+        return int(changed)
+    finally:
+        conn.close()
+
+
+def status(vault_root: Path | None) -> dict[str, Any]:
+    empty = {"count": 0, "paths": [], "truncated": False, "roots": 0}
+    if vault_root is None or not store_path(vault_root).exists():
+        return empty
+    try:
+        conn = _connect(vault_root, create=False)
+        try:
+            count = int(conn.execute("SELECT count(*) FROM semantic_upserts").fetchone()[0])
+            paths = [
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT rel_path FROM semantic_upserts ORDER BY rel_path LIMIT 50"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        return {
+            "count": count,
+            "paths": paths,
+            "truncated": count > len(paths),
+            "roots": int(count > 0),
+        }
+    except (OSError, sqlite3.Error):
+        return empty

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -36,8 +36,8 @@ from typing import Literal
 from .kbdir import kb_dirname, kb_prefix
 
 Status = Literal["pass", "warn", "fail"]
-Profile = Literal["lean", "hybrid", "media", "remote"]
-VALID_PROFILES: tuple[Profile, ...] = ("lean", "hybrid", "media", "remote")
+Profile = Literal["lean", "hybrid", "standard", "media", "remote"]
+VALID_PROFILES: tuple[Profile, ...] = ("lean", "hybrid", "standard", "media", "remote")
 PROFILE_ENV = "EXOMEM_PROFILE"
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -528,6 +528,42 @@ def _check_asr_prewarm() -> DoctorCheck:
     )
 
 
+def _check_media_runtime(vault_root: Path | None) -> DoctorCheck | None:
+    if vault_root is None:
+        return None
+    from . import media_jobs
+
+    status = media_jobs.status(vault_root)
+    if not status["healthy"]:
+        return _check(
+            "media.runtime",
+            "warn",
+            "The durable media job store is unreadable.",
+            "Check permissions on Knowledge Base/.media-jobs.sqlite or remove the derived "
+            "sidecar and restart so pending evidence can be reconstructed.",
+            details=status,
+        )
+    counts = status["counts"]
+    blocked = int(counts.get("blocked", 0))
+    failed = int(counts.get("failed", 0))
+    if blocked or failed:
+        return _check(
+            "media.runtime",
+            "warn",
+            f"Media work needs attention: {blocked} blocked, {failed} failed.",
+            "Install the missing media engine or fix the failed input, then restart the "
+            "service to retry blocked work.",
+            details=status,
+        )
+    queued = int(counts.get("pending", 0)) + int(counts.get("running", 0))
+    return _check(
+        "media.runtime",
+        "pass",
+        f"Durable media runtime healthy ({queued} queued/running).",
+        details=status,
+    )
+
+
 def _list_exomem_processes() -> list[dict[str, object]]:
     if os.name == "nt":
         return []
@@ -564,6 +600,8 @@ def _list_exomem_processes() -> list[dict[str, object]]:
             continue
         command_l = command.lower()
         if "exomem" not in command_l:
+            continue
+        if "exomem.media_worker_child" in command_l:
             continue
         if "--transport" not in command_l and "python -m exomem" not in command_l:
             continue
@@ -714,7 +752,7 @@ def _check_models_cache() -> DoctorCheck:
     )
 
 
-def _check_tesseract() -> DoctorCheck:
+def _check_tesseract(*, required: bool = True) -> DoctorCheck:
     configured = os.environ.get("EXOMEM_TESSERACT_CMD")
     if configured and Path(configured).exists():
         return _check("tool.tesseract", "pass", f"Tesseract configured at {configured}.")
@@ -723,7 +761,7 @@ def _check_tesseract() -> DoctorCheck:
         return _check("tool.tesseract", "pass", f"Tesseract found at {found}.")
     return _check(
         "tool.tesseract",
-        "fail",
+        "fail" if required else "warn",
         "Tesseract OCR binary was not found.",
         "Install Tesseract (Windows: `winget install UB-Mannheim.TesseractOCR`) or set "
         "EXOMEM_TESSERACT_CMD.",
@@ -917,8 +955,11 @@ def doctor(*, vault: str | None = None, profile: Profile | None = None, probe: b
     runtime_processes = _check_runtime_processes()
     if runtime_processes is not None:
         checks.append(runtime_processes)
+    media_runtime = _check_media_runtime(vault_root)
+    if media_runtime is not None:
+        checks.append(media_runtime)
 
-    if profile in ("hybrid", "media"):
+    if profile in ("hybrid", "standard", "media"):
         checks.extend([
             _check_embeddings_disabled(),
             _check_dependency("sentence-transformers", "embeddings", import_name="sentence_transformers"),
@@ -936,13 +977,13 @@ def doctor(*, vault: str | None = None, profile: Profile | None = None, probe: b
         if sidecar is not None:
             checks.append(sidecar)
 
-    if profile == "media":
+    if profile in ("standard", "media"):
         checks.extend([
             _check_dependency("faster-whisper", "media", import_name="faster_whisper"),
             _check_dependency("pytesseract", "media"),
             _check_dependency("pymupdf", "media", import_name="fitz"),
             _check_dependency("markitdown", "media"),
-            _check_tesseract(),
+            _check_tesseract(required=profile == "media"),
             _check_asr_backend(),
             _check_asr_prewarm(),
         ])

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1001,23 +1001,24 @@ def index_cache_status() -> dict:
     }
 
 
-def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
+def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> bool:
     """Re-embed each markdown file in `written_paths` and refresh the sidecar.
 
     Soft no-op when sentence-transformers/torch aren't importable — keyword
     mode keeps working in stripped environments. Non-`.md` paths are skipped
-    silently (writers pass log.md, index.md, etc. through here too).
+    silently (writers pass log.md, index.md, etc. through here too). Returns
+    whether all eligible semantic writes completed, for durable queue draining.
     """
     global _IMPORT_FAILED
     if _IMPORT_FAILED:
-        return
+        return False
     # Test runs disable the heavy embedding path to keep the suite fast.
     # Production servers leave EXOMEM_DISABLE_EMBEDDINGS unset.
     if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
-        return
+        return False
     md_paths = [p for p in written_paths if index_paths.is_embeddable_path(p)]
     if not md_paths:
-        return
+        return True
 
     # While the background warm-up is loading the model, don't block this
     # write on the singleton lock — park the batch; the warm thread drains it
@@ -1026,7 +1027,7 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
     from . import readiness
     if readiness.defer("embeddings", (vault_root, tuple(md_paths))):
         log.info("write-embed deferred until the embedding model is warm (%d file(s))", len(md_paths))
-        return
+        return False
 
     try:
         get_model()  # triggers the heavy import; cheap thereafter.
@@ -1038,14 +1039,18 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
                 e,
             )
             _IMPORT_FAILED = True
-        return
-    except Exception as e:
+        return False
+    except Exception as e:  # noqa: BLE001 - model backends soft-fail by contract
         log.warning("embedding model load failed: %s; skipping upsert", e)
-        return
+        return False
 
     from . import find as find_module
 
-    index = get_embedding_index(vault_root)
+    try:
+        index = get_embedding_index(vault_root)
+    except Exception as e:  # noqa: BLE001 - derived index open is best-effort
+        log.warning("could not open embedding sidecar for upsert: %s", e)
+        return False
     per_file: list[tuple[str, list[str], float]] = []
     for md in md_paths:
         try:
@@ -1069,23 +1074,17 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
         per_file.append((page.rel_path, chunks, mtime))
 
     if not per_file:
-        return
+        return True
 
-    # Single batch encode across all files for throughput.
-    flat: list[str] = []
-    for _, chunks, _ in per_file:
-        flat.extend(chunks)
-    try:
-        vectors = embed_texts(flat, is_query=False)
-    except Exception as e:
-        log.warning("embedding encode failed: %s; sidecar left stale", e)
-        return
-
-    offset = 0
+    succeeded = True
     for rel_path, chunks, mtime in per_file:
-        n = len(chunks)
-        index.upsert_file(rel_path, chunks, vectors[offset:offset + n], mtime)
-        offset += n
+        try:
+            vectors = _embed_live_chunks(chunks)
+            index.upsert_file(rel_path, chunks, vectors, mtime)
+        except Exception as e:  # noqa: BLE001 - one bad encode must not fail the writer
+            log.warning("embedding encode failed for %s: %s; sidecar left stale", rel_path, e)
+            succeeded = False
+            continue
 
     # Claim-level sidecar (.claims.sqlite) rides the same write seam — opt-in via
     # EXOMEM_CLAIM_LEVEL, no-op otherwise. Local import avoids a module cycle
@@ -1098,6 +1097,28 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
             claims.upsert_claims_after_write(vault_root, md_paths)
     except Exception as e:  # noqa: BLE001
         log.debug("claim sidecar upsert skipped (%s)", e)
+    return succeeded
+
+
+def _live_embed_max_chunks() -> int:
+    try:
+        return max(1, int(os.environ.get("EXOMEM_LIVE_EMBED_MAX_CHUNKS") or "256"))
+    except ValueError:
+        return 256
+
+
+def _embed_live_chunks(chunks: list[str]) -> np.ndarray:
+    """Encode one file in bounded slices while preserving chunk order."""
+    limit = _live_embed_max_chunks()
+    parts = [
+        embed_texts(chunks[offset : offset + limit], is_query=False)
+        for offset in range(0, len(chunks), limit)
+    ]
+    if not parts:
+        return np.zeros((0, VECTOR_DIM), dtype=np.float32)
+    if len(parts) == 1:
+        return np.asarray(parts[0], dtype=np.float32)
+    return np.concatenate(parts, axis=0)
 
 
 def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
@@ -1110,13 +1131,13 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
         return
     try:
         index = get_embedding_index(vault_root)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - derived index deletion is best-effort
         log.warning("could not open embedding sidecar for delete: %s", e)
         return
     for rel in removed_rel_paths:
         try:
             index.delete_file(rel)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - derived index deletion is best-effort
             log.warning("delete_file(%s) failed in sidecar: %s", rel, e)
 
 

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -274,9 +274,7 @@ def asr_prewarm_enabled() -> bool:
     legacy_enable = os.environ.get("EXOMEM_ENABLE_ASR_PREWARM")
     if legacy_enable is not None:
         return _env_flag("EXOMEM_ENABLE_ASR_PREWARM")
-    if sys.platform == "darwin" and platform.machine() == "arm64":
-        return False
-    return True
+    return False
 
 
 def prewarm() -> None:
@@ -415,8 +413,6 @@ class MlxWhisperBackend:
 
 def _mlx_available() -> bool:
     """True on Apple Silicon with mlx-whisper importable (the [media-mlx] extra)."""
-    import platform
-    import sys
 
     if sys.platform != "darwin" or platform.machine() != "arm64":
         return False

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -24,21 +24,11 @@ wrappers as the outermost belt.
 from __future__ import annotations
 
 import logging
-import threading
 from pathlib import Path
 
+from . import deferred_index
+
 log = logging.getLogger(__name__)
-
-_DEFERRED_LOCK = threading.Lock()
-_DEFERRED_SEMANTIC_UPSERTS: dict[str, set[str]] = {}
-
-
-def _root_key(vault_root: Path) -> str:
-    try:
-        return str(vault_root.resolve())
-    except OSError:
-        return str(vault_root)
-
 
 def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
     """Vault-relative POSIX .md paths for `paths` (non-md / outside-vault skipped)."""
@@ -56,33 +46,14 @@ def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
 
 def _record_deferred_semantic_upserts(vault_root: Path, paths: list[Path]) -> int:
     rels = _rel_md_paths(vault_root, paths)
-    if not rels:
-        return 0
-    with _DEFERRED_LOCK:
-        pending = _DEFERRED_SEMANTIC_UPSERTS.setdefault(_root_key(vault_root), set())
-        before = len(pending)
-        pending.update(rels)
-        return len(pending) - before
+    before = deferred_index.status(vault_root)["count"]
+    deferred_index.add(vault_root, rels)
+    return max(0, deferred_index.status(vault_root)["count"] - before)
 
 
 def deferred_work_status(vault_root: Path | None = None) -> dict:
-    """No-allocation summary of expensive index work queued by quiet mode."""
-    with _DEFERRED_LOCK:
-        if vault_root is not None:
-            root = _root_key(vault_root)
-            roots = {root: set(_DEFERRED_SEMANTIC_UPSERTS.get(root, set()))}
-        else:
-            roots = {root: set(rels) for root, rels in _DEFERRED_SEMANTIC_UPSERTS.items()}
-    count = sum(len(rels) for rels in roots.values())
-    paths = sorted({rel for rels in roots.values() for rel in rels})
-    return {
-        "semantic_upserts": {
-            "count": count,
-            "paths": paths[:50],
-            "truncated": len(paths) > 50,
-            "roots": len([rels for rels in roots.values() if rels]),
-        }
-    }
+    """No-allocation summary of durable expensive index work."""
+    return {"semantic_upserts": deferred_index.status(vault_root)}
 
 
 def clear_deferred_work(
@@ -91,32 +62,19 @@ def clear_deferred_work(
     paths: list[Path] | list[str] | None = None,
 ) -> int:
     """Clear deferred semantic work after an explicit index/reconcile heal."""
-    with _DEFERRED_LOCK:
-        if vault_root is None:
-            count = sum(len(rels) for rels in _DEFERRED_SEMANTIC_UPSERTS.values())
-            _DEFERRED_SEMANTIC_UPSERTS.clear()
-            return count
-        root = _root_key(vault_root)
-        pending = _DEFERRED_SEMANTIC_UPSERTS.get(root)
-        if not pending:
-            return 0
-        if paths is None:
-            count = len(pending)
-            _DEFERRED_SEMANTIC_UPSERTS.pop(root, None)
-            return count
-        rels: set[str] = set()
-        for item in paths:
-            if isinstance(item, Path):
-                rels.update(_rel_md_paths(vault_root, [item]))
-            else:
-                rel = str(item).replace("\\", "/")
-                if rel.lower().endswith(".md"):
-                    rels.add(rel)
-        before = len(pending)
-        pending.difference_update(rels)
-        if not pending:
-            _DEFERRED_SEMANTIC_UPSERTS.pop(root, None)
-        return before - len(pending)
+    if vault_root is None:
+        return 0
+    if paths is None:
+        return deferred_index.clear(vault_root)
+    rels: list[str] = []
+    for item in paths:
+        if isinstance(item, Path):
+            rels.extend(_rel_md_paths(vault_root, [item]))
+        else:
+            rel = str(item).replace("\\", "/")
+            if rel.lower().endswith(".md"):
+                rels.append(rel)
+    return deferred_index.clear(vault_root, rels)
 
 
 def drain_deferred_work(vault_root: Path, *, limit: int | None = None) -> int:
@@ -126,17 +84,20 @@ def drain_deferred_work(vault_root: Path, *, limit: int | None = None) -> int:
     the normal writer path. Crash/restart recovery still comes from drift audit
     and explicit reconcile/index.
     """
-    root = _root_key(vault_root)
-    with _DEFERRED_LOCK:
-        pending = sorted(_DEFERRED_SEMANTIC_UPSERTS.get(root, set()))
-        if limit is not None:
-            pending = pending[:max(0, limit)]
+    pending = deferred_index.list_paths(vault_root, limit=limit)
     if not pending:
         return 0
     from . import embeddings
 
     paths = [vault_root / rel for rel in pending]
-    embeddings.upsert_after_write(vault_root, paths)
+    try:
+        dispatched = embeddings.upsert_after_write(vault_root, paths)
+    except Exception:  # noqa: BLE001 - durable work must survive a failed dispatch
+        log.warning("deferred semantic dispatch failed; work remains queued", exc_info=True)
+        return 0
+    if dispatched is False:
+        log.warning("deferred semantic dispatch incomplete; work remains queued")
+        return 0
     return clear_deferred_work(vault_root, paths=paths)
 
 

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -1,0 +1,462 @@
+"""Durable, rebuildable media-job ledger.
+
+The ledger is deliberately stdlib-only so the long-lived server and resource-status
+paths can inspect media work without importing torch, MLX, CTranslate2, or Exomem's
+model modules. User-authored evidence sidecars remain the source of truth; deleting
+this derived database is safe because startup scans reconstruct missing work.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .kbdir import kb_dirname
+
+PENDING = "pending"
+RUNNING = "running"
+BLOCKED = "blocked"
+FAILED = "failed"
+STATES = (PENDING, RUNNING, BLOCKED, FAILED)
+
+
+def job_store_path(vault_root: Path) -> Path:
+    return vault_root / kb_dirname() / ".media-jobs.sqlite"
+
+
+def worker_lock_path(vault_root: Path) -> Path:
+    return vault_root / kb_dirname() / ".media-worker.lock"
+
+
+@dataclass(frozen=True)
+class MediaJob:
+    binary_path: Path
+    sidecar_path: Path
+    media_type: str
+    do_ocr: bool = True
+    do_clip: bool = False
+    do_reembed: bool = False
+    id: int | None = None
+    attempts: int = 0
+    state: str = PENDING
+    last_error: str | None = None
+
+
+def pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    if os.name == "nt":
+        return _windows_pid_alive(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _windows_pid_alive(pid: int) -> bool:
+    """Query process state without using os.kill, which terminates on Windows."""
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    error_access_denied = 5
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+class MediaJobStore:
+    def __init__(self, vault_root: Path, *, create: bool = True) -> None:
+        self.vault_root = vault_root.resolve()
+        self.path = job_store_path(self.vault_root)
+        if create:
+            self._initialize()
+
+    def _connect(self, *, readonly: bool = False) -> sqlite3.Connection:
+        if readonly:
+            conn = sqlite3.connect(f"file:{self.path}?mode=ro", uri=True, timeout=5.0)
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(self.path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=5000")
+        if not readonly:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
+    def _initialize(self) -> None:
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS jobs (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        job_key TEXT NOT NULL UNIQUE,
+                        binary_rel TEXT NOT NULL,
+                        sidecar_rel TEXT NOT NULL,
+                        media_type TEXT NOT NULL,
+                        do_ocr INTEGER NOT NULL DEFAULT 0,
+                        do_clip INTEGER NOT NULL DEFAULT 0,
+                        do_reembed INTEGER NOT NULL DEFAULT 0,
+                        state TEXT NOT NULL DEFAULT 'pending',
+                        attempts INTEGER NOT NULL DEFAULT 0,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        last_error TEXT
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS jobs_state_id ON jobs(state, id)"
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS runtime (
+                        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                        worker_pid INTEGER,
+                        idle_seconds REAL,
+                        updated_at REAL NOT NULL
+                    )
+                    """
+                )
+        finally:
+            conn.close()
+
+    def _relative(self, path: Path) -> str:
+        return path.resolve().relative_to(self.vault_root).as_posix()
+
+    @staticmethod
+    def _key(binary_rel: str, sidecar_rel: str, media_type: str) -> str:
+        return "\0".join((binary_rel, sidecar_rel, media_type))
+
+    def enqueue(self, job: MediaJob) -> int:
+        binary_rel = self._relative(job.binary_path)
+        sidecar_rel = self._relative(job.sidecar_path)
+        key = self._key(binary_rel, sidecar_rel, job.media_type)
+        now = time.time()
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        job_key, binary_rel, sidecar_rel, media_type,
+                        do_ocr, do_clip, do_reembed, state,
+                        attempts, created_at, updated_at, last_error
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, NULL)
+                    ON CONFLICT(job_key) DO UPDATE SET
+                        do_ocr = MAX(jobs.do_ocr, excluded.do_ocr),
+                        do_clip = MAX(jobs.do_clip, excluded.do_clip),
+                        do_reembed = MAX(jobs.do_reembed, excluded.do_reembed),
+                        state = CASE
+                            WHEN jobs.state = 'running' THEN jobs.state
+                            ELSE 'pending'
+                        END,
+                        updated_at = excluded.updated_at,
+                        last_error = CASE
+                            WHEN jobs.state = 'running' THEN jobs.last_error
+                            ELSE NULL
+                        END
+                    """,
+                    (
+                        key,
+                        binary_rel,
+                        sidecar_rel,
+                        job.media_type,
+                        int(job.do_ocr),
+                        int(job.do_clip),
+                        int(job.do_reembed),
+                        now,
+                        now,
+                    ),
+                )
+                row = conn.execute("SELECT id FROM jobs WHERE job_key = ?", (key,)).fetchone()
+                return int(row[0])
+        finally:
+            conn.close()
+
+    def claim_next(self) -> MediaJob | None:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM jobs WHERE state = 'pending' ORDER BY id LIMIT 1"
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return None
+            now = time.time()
+            changed = conn.execute(
+                """
+                UPDATE jobs
+                SET state = 'running', attempts = attempts + 1,
+                    updated_at = ?, last_error = NULL
+                WHERE id = ? AND state = 'pending'
+                """,
+                (now, row["id"]),
+            ).rowcount
+            conn.commit()
+            if changed != 1:
+                return None
+            return self._row_to_job({**dict(row), "state": RUNNING, "attempts": row["attempts"] + 1})
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def complete(self, job: MediaJob) -> None:
+        """Clear stages this claim processed, preserving stages added mid-flight."""
+        if job.id is None:
+            return
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT do_ocr, do_clip, do_reembed FROM jobs WHERE id = ?", (job.id,)
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return
+            remaining = {
+                "do_ocr": bool(row["do_ocr"]) and not job.do_ocr,
+                "do_clip": bool(row["do_clip"]) and not job.do_clip,
+                "do_reembed": bool(row["do_reembed"]) and not job.do_reembed,
+            }
+            if any(remaining.values()):
+                conn.execute(
+                    """
+                    UPDATE jobs SET do_ocr = ?, do_clip = ?, do_reembed = ?,
+                        state = 'pending', updated_at = ?, last_error = NULL
+                    WHERE id = ?
+                    """,
+                    (
+                        int(remaining["do_ocr"]),
+                        int(remaining["do_clip"]),
+                        int(remaining["do_reembed"]),
+                        time.time(),
+                        job.id,
+                    ),
+                )
+            else:
+                conn.execute("DELETE FROM jobs WHERE id = ?", (job.id,))
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def mark(self, job_id: int, state: str, error: str | None = None) -> None:
+        if state not in STATES:
+            raise ValueError(f"unknown media job state: {state}")
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute(
+                    "UPDATE jobs SET state = ?, last_error = ?, updated_at = ? WHERE id = ?",
+                    (state, (error or "")[:1000] or None, time.time(), job_id),
+                )
+        finally:
+            conn.close()
+
+    def recover_interrupted(self, *, retry_blocked: bool = False) -> int:
+        states = [RUNNING]
+        if retry_blocked:
+            states.append(BLOCKED)
+        placeholders = ",".join("?" for _ in states)
+        conn = self._connect()
+        try:
+            with conn:
+                changed = conn.execute(
+                    f"UPDATE jobs SET state = 'pending', updated_at = ? "
+                    f"WHERE state IN ({placeholders})",
+                    (time.time(), *states),
+                ).rowcount
+                return int(changed)
+        finally:
+            conn.close()
+
+    def retry(self, *, include_failed: bool = False) -> int:
+        states = [BLOCKED]
+        if include_failed:
+            states.append(FAILED)
+        placeholders = ",".join("?" for _ in states)
+        conn = self._connect()
+        try:
+            with conn:
+                changed = conn.execute(
+                    f"UPDATE jobs SET state = 'pending', last_error = NULL, updated_at = ? "
+                    f"WHERE state IN ({placeholders})",
+                    (time.time(), *states),
+                ).rowcount
+                return int(changed)
+        finally:
+            conn.close()
+
+    def counts(self) -> dict[str, int]:
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT state, count(*) AS n FROM jobs GROUP BY state").fetchall()
+        finally:
+            conn.close()
+        out = {state: 0 for state in STATES}
+        out.update({str(row["state"]): int(row["n"]) for row in rows})
+        return out
+
+    def has_pending(self) -> bool:
+        conn = self._connect()
+        try:
+            return conn.execute(
+                "SELECT 1 FROM jobs WHERE state = 'pending' LIMIT 1"
+            ).fetchone() is not None
+        finally:
+            conn.close()
+
+    def worker_pid(self) -> int | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT worker_pid FROM runtime WHERE singleton = 1"
+            ).fetchone()
+            return int(row[0]) if row and row[0] else None
+        finally:
+            conn.close()
+
+    def needs_worker(self) -> bool:
+        """Whether work exists without another live child already owning the vault."""
+        conn = self._connect()
+        try:
+            work = conn.execute(
+                "SELECT 1 FROM jobs WHERE state IN ('pending', 'running') LIMIT 1"
+            ).fetchone()
+            row = conn.execute(
+                "SELECT worker_pid FROM runtime WHERE singleton = 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        active_pid = int(row[0]) if row and row[0] else None
+        return work is not None and not pid_alive(active_pid)
+
+    def set_worker(self, pid: int | None, idle_seconds: float | None = None) -> None:
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO runtime(singleton, worker_pid, idle_seconds, updated_at)
+                    VALUES (1, ?, ?, ?)
+                    ON CONFLICT(singleton) DO UPDATE SET
+                        worker_pid = excluded.worker_pid,
+                        idle_seconds = COALESCE(excluded.idle_seconds, runtime.idle_seconds),
+                        updated_at = excluded.updated_at
+                    """,
+                    (pid, idle_seconds, time.time()),
+                )
+        finally:
+            conn.close()
+
+    def clear_worker(self, pid: int) -> None:
+        conn = self._connect()
+        try:
+            with conn:
+                conn.execute(
+                    "UPDATE runtime SET worker_pid = NULL, updated_at = ? "
+                    "WHERE singleton = 1 AND worker_pid = ?",
+                    (time.time(), pid),
+                )
+        finally:
+            conn.close()
+
+    def _row_to_job(self, row: Any) -> MediaJob:
+        return MediaJob(
+            id=int(row["id"]),
+            binary_path=self.vault_root / str(row["binary_rel"]),
+            sidecar_path=self.vault_root / str(row["sidecar_rel"]),
+            media_type=str(row["media_type"]),
+            do_ocr=bool(row["do_ocr"]),
+            do_clip=bool(row["do_clip"]),
+            do_reembed=bool(row["do_reembed"]),
+            attempts=int(row["attempts"]),
+            state=str(row["state"]),
+            last_error=row["last_error"],
+        )
+
+
+def status(vault_root: Path | None) -> dict[str, Any]:
+    """Read ledger state without creating a DB or importing model modules."""
+    empty = {
+        "store": "missing",
+        "healthy": True,
+        "counts": {state: 0 for state in STATES},
+        "worker_active": False,
+        "worker_pid": None,
+        "idle_seconds": None,
+        "errors": [],
+    }
+    if vault_root is None:
+        return empty
+    path = job_store_path(vault_root)
+    if not path.exists():
+        return empty
+    try:
+        store = MediaJobStore(vault_root, create=False)
+        conn = store._connect(readonly=True)
+        try:
+            rows = conn.execute("SELECT state, count(*) AS n FROM jobs GROUP BY state").fetchall()
+            runtime = conn.execute(
+                "SELECT worker_pid, idle_seconds FROM runtime WHERE singleton = 1"
+            ).fetchone()
+            errors = conn.execute(
+                "SELECT state, last_error FROM jobs "
+                "WHERE state IN ('blocked', 'failed') ORDER BY updated_at DESC LIMIT 5"
+            ).fetchall()
+        finally:
+            conn.close()
+        counts = {state: 0 for state in STATES}
+        counts.update({str(row["state"]): int(row["n"]) for row in rows})
+        pid = int(runtime["worker_pid"]) if runtime and runtime["worker_pid"] else None
+        active = pid_alive(pid)
+        return {
+            "store": str(path),
+            "healthy": True,
+            "counts": counts,
+            "worker_active": active,
+            "worker_pid": pid if active else None,
+            "idle_seconds": float(runtime["idle_seconds"])
+            if runtime and runtime["idle_seconds"] is not None
+            else None,
+            "errors": [
+                {"state": str(row["state"]), "message": str(row["last_error"] or "")}
+                for row in errors
+            ],
+        }
+    except (OSError, sqlite3.Error) as exc:
+        return {**empty, "store": str(path), "healthy": False, "errors": [str(exc)]}

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -1,4 +1,4 @@
-"""Background media-extraction worker — fills pending media sidecars off the request path.
+"""Durable, disposable media extraction runtime.
 
 When a media binary is uploaded without text, `preserve()` writes a `pending` stub sidecar
 and the `/upload` route enqueues a job here. A single background thread (the GPU is
@@ -6,23 +6,37 @@ serialized) runs ASR/OCR/PDF extraction (`extract.extract_text`), writes the tra
 the sidecar (`preserve.update_sidecar_extraction`) and re-embeds it — so the 201 returns
 immediately and the binary becomes searchable shortly after.
 
-In-memory queue (no DB). A startup `scan_pending()` re-enqueues any `extracted_by: pending`
-sidecar so a restart doesn't strand jobs — mirroring exomem's reconcile-heals-drift approach.
-A genuine extraction error marks the sidecar `extracted_by: failed: …` so it won't loop.
+The long-lived service is a lightweight supervisor. Product mode records jobs in a
+SQLite ledger and starts one child process per vault on demand. The child serializes
+heavy work, stays warm for a bounded burst, then exits so RAM and accelerator contexts
+are returned to the host. Inline mode preserves a deterministic test/debug path.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
 import queue
 import re
+import subprocess
+import sys
 import threading
-from dataclasses import dataclass
+import time
 from pathlib import Path
 
 from . import embeddings, extract, index_sync, preserve, scene_frames, semantic_segments
 from .backfill import iter_kb_files
 from .kbdir import kb_dirname
+from .media_jobs import (
+    BLOCKED,
+    FAILED,
+    MediaJobStore,
+    pid_alive,
+)
+from .media_jobs import (
+    MediaJob as _Job,
+)
 
 log = logging.getLogger(__name__)
 
@@ -32,44 +46,57 @@ _PENDING_MARKER = "extracted_by: pending"
 _PARENT_MEDIA_MARKER = "\nparent_media:"
 
 
-@dataclass
-class _Job:
-    binary_path: Path
-    sidecar_path: Path
-    media_type: str
-    do_ocr: bool = True    # transcribe/OCR/read → fill the sidecar text
-    do_clip: bool = False  # CLIP-embed (images only) → ClipIndex
-    do_reembed: bool = False  # re-embed the sidecar (semantic re-segmentation)
-
-
 class MediaWorker:
-    """A single-thread extraction queue. One worker = the GPU is used serially."""
+    """Media supervisor with process-default and inline execution modes."""
 
-    def __init__(self, vault_root: Path) -> None:
+    def __init__(
+        self,
+        vault_root: Path,
+        *,
+        execution_mode: str | None = None,
+        idle_seconds: float | None = None,
+    ) -> None:
         self._vault_root = vault_root
+        selected = execution_mode or os.environ.get("EXOMEM_MEDIA_WORKER_MODE", "process")
+        if selected not in {"process", "inline"}:
+            raise ValueError("media worker mode must be process or inline")
+        self._execution_mode = selected
+        self._idle_seconds = idle_seconds if idle_seconds is not None else _idle_seconds()
         self._q: queue.Queue[_Job | None] = queue.Queue()
         self._thread: threading.Thread | None = None
         self._lock = threading.Lock()
         self._clip_index = embeddings.get_clip_index(vault_root)
+        self._store = MediaJobStore(vault_root) if selected == "process" else None
+        self._wake = threading.Event()
+        self._stop_event = threading.Event()
+        self._child: subprocess.Popen | None = None
 
     def start(self) -> None:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return
+            self._stop_event.clear()
+            if self._execution_mode == "process":
+                assert self._store is not None
+                retried = self._store.retry()
+                if retried:
+                    log.info("media worker: retried %d blocked job(s)", retried)
+                target = self._supervise
+                name = "exomem-media-supervisor"
+            else:
+                target = self._run
+                name = "exomem-media-inline"
             self._thread = threading.Thread(
-                target=self._run, name="kb-media-worker", daemon=True
+                target=target, name=name, daemon=True
             )
             self._thread.start()
-            log.info("media extraction worker started")
-            # Warm the ASR model off the request path only when policy allows it.
-            # On Apple Silicon this defaults to lazy load to avoid multiplying
-            # multi-GB model residency across local stdio client processes.
-            if extract.asr_prewarm_enabled():
+            log.info("media extraction %s runtime started", self._execution_mode)
+            # Explicit opt-in is honored only for inline/debug mode. Product process
+            # mode starts no child and loads no model until durable work exists.
+            if self._execution_mode == "inline" and extract.asr_prewarm_enabled():
                 threading.Thread(
-                    target=extract.prewarm, name="kb-asr-prewarm", daemon=True
+                    target=extract.prewarm, name="exomem-asr-prewarm", daemon=True
                 ).start()
-            else:
-                log.info("ASR prewarm disabled by policy; first media job will lazy-load")
             # Boot-time diarization readiness line (cheap: a path check + small JSON
             # read) — the soft-fail design otherwise hides a broken stack entirely.
             extract.log_diarization_readiness(self._vault_root)
@@ -84,23 +111,49 @@ class MediaWorker:
         do_clip: bool = False,
         do_reembed: bool = False,
     ) -> None:
-        self._q.put(
-            _Job(
-                binary_path=binary_path,
-                sidecar_path=sidecar_path,
-                media_type=media_type,
-                do_ocr=do_ocr,
-                do_clip=do_clip,
-                do_reembed=do_reembed,
-            )
+        job = _Job(
+            id=None,
+            binary_path=binary_path,
+            sidecar_path=sidecar_path,
+            media_type=media_type,
+            do_ocr=do_ocr,
+            do_clip=do_clip,
+            do_reembed=do_reembed,
         )
+        if self._execution_mode == "process":
+            assert self._store is not None
+            self._store.enqueue(job)
+            self._wake.set()
+        else:
+            self._q.put(job)
 
     def stop(self) -> None:
-        self._q.put(None)
+        self._stop_event.set()
+        self._wake.set()
+        if self._execution_mode == "inline":
+            self._q.put(None)
+        child = self._child
+        if child is not None and child.poll() is None:
+            with contextlib.suppress(OSError):
+                child.terminate()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=5)
 
     def join(self, timeout: float | None = None) -> None:
         """Block until the queue drains — used in tests."""
-        self._q.join() if timeout is None else _join_with_timeout(self._q, timeout)
+        if self._execution_mode == "inline":
+            self._q.join() if timeout is None else _join_with_timeout(self._q, timeout)
+            return
+        assert self._store is not None
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            counts = self._store.counts()
+            if counts["pending"] == 0 and counts["running"] == 0:
+                return
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError("media worker queue did not drain")
+            time.sleep(0.02)
 
     def _run(self) -> None:
         while True:
@@ -114,13 +167,15 @@ class MediaWorker:
             finally:
                 self._q.task_done()
 
-    def _process(self, job: _Job) -> None:
+    def _process(self, job: _Job) -> str:
+        blocked = False
         if job.do_ocr:
-            self._run_extraction(job)
+            blocked = not self._run_extraction(job)
         if job.do_clip:
             self._run_clip(job)
         if job.do_reembed:
             self._run_reembed(job)
+        return BLOCKED if blocked else "complete"
 
     def _run_reembed(self, job: _Job) -> None:
         """Re-embed a sidecar so semantic segmentation re-runs with late signals.
@@ -135,7 +190,7 @@ class MediaWorker:
         except Exception:  # noqa: BLE001 — enrichment, never fatal
             log.exception("re-embed failed for %s", job.sidecar_path.name)
 
-    def _run_extraction(self, job: _Job) -> None:
+    def _run_extraction(self, job: _Job) -> bool:
         try:
             result = extract.extract_text(
                 job.binary_path, media_type=job.media_type, vault_root=self._vault_root
@@ -144,13 +199,13 @@ class MediaWorker:
             # Engine not installed on this box right now — leave the sidecar `pending`
             # so a properly-provisioned box picks it up on its next restart scan.
             log.warning("extraction unavailable for %s: %s", job.binary_path.name, e)
-            return
+            return False
         except Exception as e:  # noqa: BLE001 — a corrupt file shouldn't re-loop forever
             log.exception("extraction failed for %s", job.binary_path.name)
             preserve.update_sidecar_extraction(
                 self._vault_root, job.sidecar_path, text="", engine=f"failed: {type(e).__name__}"
             )
-            return
+            return True
         text = result.text.strip() or "(no text detected)"
         preserve.update_sidecar_extraction(
             self._vault_root, job.sidecar_path, text=text, engine=result.engine,
@@ -159,6 +214,7 @@ class MediaWorker:
         log.info(
             "extracted %s via %s (%d chars)", job.binary_path.name, result.engine, len(result.text)
         )
+        return True
 
     def _run_clip(self, job: _Job) -> None:
         """CLIP-embed an image (one vector) or a video (per-keyframe vectors) so it's
@@ -232,6 +288,63 @@ class MediaWorker:
             log.info(
                 "scene frames: wrote %d frame(s) for %s", len(written), job.binary_path.name
             )
+
+    def _launch_child(self) -> subprocess.Popen:
+        args = [
+            sys.executable,
+            "-m",
+            "exomem.media_worker_child",
+            "--vault",
+            str(self._vault_root),
+            "--parent-pid",
+            str(os.getpid()),
+            "--idle-seconds",
+            str(self._idle_seconds),
+        ]
+        log.info("media worker: starting disposable child")
+        return subprocess.Popen(args)  # noqa: S603 - fixed interpreter/module command
+
+    def _supervise(self) -> None:
+        assert self._store is not None
+        relaunch_after = 0.0
+        try:
+            while not self._stop_event.is_set():
+                child = self._child
+                if child is not None and child.poll() is not None:
+                    returncode = child.returncode
+                    child_pid = child.pid
+                    self._child = None
+                    owns_runtime = self._store.worker_pid() == child_pid
+                    recovered = self._store.recover_interrupted() if owns_runtime else 0
+                    if owns_runtime:
+                        self._store.clear_worker(child_pid)
+                    if returncode:
+                        log.warning(
+                            "media child exited %s; recovered %d job(s)",
+                            returncode,
+                            recovered,
+                        )
+                    relaunch_after = time.monotonic() + (2.0 if returncode else 0.5)
+                if (
+                    self._child is None
+                    and time.monotonic() >= relaunch_after
+                    and self._store.needs_worker()
+                ):
+                    try:
+                        self._child = self._launch_child()
+                    except OSError:
+                        log.exception("media worker: could not start child")
+                        relaunch_after = time.monotonic() + 5.0
+                self._wake.wait(0.5)
+                self._wake.clear()
+        finally:
+            child = self._child
+            if child is not None and child.poll() is None:
+                with contextlib.suppress(OSError):
+                    child.terminate()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    child.wait(timeout=5)
+            self._child = None
 
     def scan_pending(self) -> int:
         """Restart recovery: re-enqueue pending OCR + CLIP-index un-indexed images."""
@@ -342,3 +455,56 @@ def _join_with_timeout(q: queue.Queue, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while q.unfinished_tasks and time.monotonic() < deadline:
         time.sleep(0.02)
+
+
+def _idle_seconds() -> float:
+    try:
+        return max(0.1, float(os.environ.get("EXOMEM_MEDIA_IDLE_SECONDS") or "300"))
+    except ValueError:
+        return 300.0
+
+
+def run_child(vault_root: Path, *, parent_pid: int, idle_seconds: float) -> int:
+    """Claim and process durable jobs until idle or the parent disappears."""
+    store = MediaJobStore(vault_root)
+    store.recover_interrupted()
+    store.set_worker(os.getpid(), idle_seconds)
+    # Process mode makes scene-frame follow-up enqueue durable in this same ledger;
+    # the nested supervisor is never started because the child calls _process directly.
+    worker = MediaWorker(vault_root, execution_mode="process", idle_seconds=idle_seconds)
+    last_work = time.monotonic()
+    try:
+        if extract.asr_prewarm_enabled():
+            extract.prewarm()
+        extract.log_diarization_readiness(vault_root)
+        while _parent_alive(parent_pid):
+            job = store.claim_next()
+            if job is None:
+                if time.monotonic() - last_work >= idle_seconds:
+                    log.info("media worker: idle deadline reached; child exiting")
+                    return 0
+                time.sleep(min(0.25, idle_seconds))
+                continue
+            last_work = time.monotonic()
+            try:
+                outcome = worker._process(job)
+            except Exception as exc:  # noqa: BLE001 - preserve worker availability
+                log.exception("media child job crashed: %s", job.binary_path)
+                assert job.id is not None
+                store.mark(job.id, FAILED, f"{type(exc).__name__}: {exc}")
+            else:
+                assert job.id is not None
+                if outcome == BLOCKED:
+                    store.mark(job.id, BLOCKED, "optional extraction engine unavailable")
+                else:
+                    store.complete(job)
+        log.info("media worker: parent exited; child stopping")
+        return 0
+    finally:
+        store.clear_worker(os.getpid())
+
+
+def _parent_alive(parent_pid: int) -> bool:
+    if parent_pid <= 0:
+        return True
+    return pid_alive(parent_pid)

--- a/src/exomem/media_worker_child.py
+++ b/src/exomem/media_worker_child.py
@@ -1,0 +1,83 @@
+"""Lightweight entrypoint that locks a vault before importing media model code."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+from pathlib import Path
+
+from .media_jobs import worker_lock_path
+
+
+class _VaultLock:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._handle = None
+
+    def acquire(self) -> bool:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.path.open("a+b")
+        handle.seek(0)
+        if handle.tell() == 0 and self.path.stat().st_size == 0:
+            handle.write(b"0")
+            handle.flush()
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (OSError, BlockingIOError):
+            handle.close()
+            return False
+        self._handle = handle
+        return True
+
+    def release(self) -> None:
+        handle = self._handle
+        if handle is None:
+            return
+        with contextlib.suppress(OSError):
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+        self._handle = None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m exomem.media_worker_child")
+    parser.add_argument("--vault", required=True)
+    parser.add_argument("--parent-pid", type=int, required=True)
+    parser.add_argument("--idle-seconds", type=float, required=True)
+    args = parser.parse_args(argv)
+
+    vault_root = Path(args.vault).resolve()
+    lock = _VaultLock(worker_lock_path(vault_root))
+    if not lock.acquire():
+        return 0
+    try:
+        from .media_worker import run_child
+
+        return run_child(
+            vault_root,
+            parent_pid=args.parent_pid,
+            idle_seconds=max(0.1, args.idle_seconds),
+        )
+    finally:
+        lock.release()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/mode.py
+++ b/src/exomem/mode.py
@@ -11,7 +11,7 @@ Three canonical modes (aliases in `_ALIASES` so whatever a user types works):
                    models when idle. Idle VRAM ~0. ("I'm gaming / low power.")
 - **normal**     — the safe default. CPU steady-state (MPS on Apple Silicon), never
                    auto-selects CUDA; bulk index may still use the GPU in a separate
-                   process. Boot preloads onto CPU RAM.
+                   process. Models and O(vault) caches stay lazy at boot.
 - **performance** — use my GPU for speed. Steady-state on CUDA when a capable GPU is
                    present; release when idle. Aliases: `gpu`, `turbo`.
 
@@ -148,18 +148,18 @@ def resolve_mode() -> str:
 
 
 def preload_models() -> bool:
-    """Whether boot should eagerly preload models. Off only in quiet mode."""
-    return resolve_mode() != "quiet"
+    """Whether policy permits eager model preload (performance only)."""
+    return resolve_mode() == "performance"
 
 
 def preload_cpu_caches() -> bool:
     """Whether startup warm-up may materialize O(vault) CPU caches."""
-    return resolve_mode() != "quiet"
+    return resolve_mode() == "performance"
 
 
 def retain_cpu_caches() -> bool:
     """Whether large CPU caches may stay resident after use."""
-    return resolve_mode() != "quiet"
+    return resolve_mode() == "performance"
 
 
 def defer_expensive_indexes() -> bool:
@@ -191,13 +191,13 @@ def watcher_policy() -> WatcherPolicy:
 def release_when_idle() -> bool:
     """Whether the idle-unload reaper should run.
 
-    `EXOMEM_RELEASE_GPU_WHEN_IDLE` (truthy/falsy) overrides; otherwise on for quiet
-    and performance (where a model may become resident and idle), off for normal.
+    `EXOMEM_RELEASE_GPU_WHEN_IDLE` (truthy/falsy) overrides; otherwise enabled in
+    every mode. Process exit/reaping is the default product resource contract.
     """
     override = os.environ.get(_RELEASE_ENV)
     if override is not None and override.strip() != "":
         return _truthy(override)
-    return resolve_mode() in ("quiet", "performance")
+    return True
 
 
 def bulk_gpu_opted() -> bool:

--- a/src/exomem/reconcile.py
+++ b/src/exomem/reconcile.py
@@ -112,12 +112,18 @@ def reconcile(vault_root: Path, *, dry_run: bool = False) -> ReconcileReport:
     else:
         drift = audit_module._check_embedding_drift(vault_root)
         drifted_abs = [vault_root / f.path for f in drift]
+        refresh_succeeded = True
         if drifted_abs and not dry_run:
             from . import embeddings, index_sync
-            embeddings.upsert_after_write(vault_root, drifted_abs)
-            index_sync.clear_deferred_work(vault_root, paths=drifted_abs)
-        report.embeddings_refreshed = len(drifted_abs)
-        report.embeddings_status = "refreshed" if drifted_abs else "current"
+
+            refresh_succeeded = embeddings.upsert_after_write(vault_root, drifted_abs) is not False
+            if refresh_succeeded:
+                index_sync.clear_deferred_work(vault_root, paths=drifted_abs)
+        report.embeddings_refreshed = len(drifted_abs) if refresh_succeeded else 0
+        if not refresh_succeeded:
+            report.embeddings_status = "deferred"
+        else:
+            report.embeddings_status = "refreshed" if drifted_abs else "current"
 
     # ---- 2b. Lexical sidecar (count/mtime reconcile against the walk) ----
     # NOT behind the embeddings gate: the lexical index is a lean-install

--- a/src/exomem/resource_status.py
+++ b/src/exomem/resource_status.py
@@ -80,17 +80,9 @@ def _cache_residency() -> dict[str, Any]:
 
 
 def _deferred_work(vault_root: Path | None) -> dict[str, Any]:
-    index_sync = sys.modules.get("exomem.index_sync")
-    if index_sync is None or not hasattr(index_sync, "deferred_work_status"):
-        return {
-            "semantic_upserts": {
-                "count": 0,
-                "paths": [],
-                "truncated": False,
-                "roots": 0,
-            }
-        }
-    return index_sync.deferred_work_status(vault_root)
+    from . import deferred_index
+
+    return {"semantic_upserts": deferred_index.status(vault_root)}
 
 
 def cuda_accounting_if_initialized() -> dict[str, Any]:
@@ -143,6 +135,8 @@ def runtime_info() -> dict[str, Any]:
 
 def collect(vault_root: Path | None = None) -> dict[str, Any]:
     """Collect process-local resource status without allocating heavy resources."""
+    from . import media_jobs
+
     policy = mode.resolved()
     return {
         "runtime": runtime_info(),
@@ -153,6 +147,7 @@ def collect(vault_root: Path | None = None) -> dict[str, Any]:
         "models": _model_residency(),
         "caches": _cache_residency(),
         "deferred_work": _deferred_work(vault_root),
+        "media": media_jobs.status(vault_root),
         "cuda": cuda_accounting_if_initialized(),
     }
 

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -91,8 +91,18 @@ def _start_media_worker(vault_root: Path) -> Any | None:
 
     from . import media_worker as media_worker_module
 
-    worker = media_worker_module.MediaWorker(vault_root)
-    worker.start()
+    worker = None
+    try:
+        worker = media_worker_module.MediaWorker(vault_root)
+        worker.start()
+    except Exception as exc:  # noqa: BLE001 - media must never deny the core service
+        if worker is not None:
+            try:
+                worker.stop()
+            except Exception:  # noqa: BLE001 - startup degradation must remain soft
+                pass
+        log.warning("media runtime unavailable; core service continuing: %s", exc)
+        return None
     try:
         worker.scan_pending()
     except Exception as exc:  # noqa: BLE001 - startup scan is best-effort

--- a/src/exomem/server_transfer.py
+++ b/src/exomem/server_transfer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import secrets
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from . import cf_access, upload_tokens
 from .vault import VaultPathError, resolve_under_vault
 
 DEFAULT_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
+log = logging.getLogger(__name__)
 
 
 def _extract_module():
@@ -170,13 +172,20 @@ def register_transfer_routes(
                     "EXOMEM_DISABLE_CLIP"
                 )
                 if do_ocr or do_clip:
-                    media_worker.enqueue(
-                        binary_path=vault_root / result.path,
-                        sidecar_path=vault_root / result.sidecar_path,
-                        media_type=media_type,
-                        do_ocr=do_ocr,
-                        do_clip=do_clip,
-                    )
+                    try:
+                        media_worker.enqueue(
+                            binary_path=vault_root / result.path,
+                            sidecar_path=vault_root / result.sidecar_path,
+                            media_type=media_type,
+                            do_ocr=do_ocr,
+                            do_clip=do_clip,
+                        )
+                    except Exception:  # noqa: BLE001 - pending sidecar enables later recovery
+                        log.warning(
+                            "media enqueue failed for %s; evidence remains pending",
+                            result.path,
+                            exc_info=True,
+                        )
         return JSONResponse(result.as_dict(), status_code=201)
 
     @mcp_app.custom_route("/upload", methods=["GET"])

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -299,8 +299,11 @@ def run_setup(
     # 4. profile
     if profile is None:
         has_embeddings = importlib.util.find_spec("sentence_transformers") is not None
+        has_media = importlib.util.find_spec("faster_whisper") is not None
         if yes or not has_embeddings:
-            profile = "hybrid" if has_embeddings else "lean"
+            profile = "standard" if has_embeddings and has_media else (
+                "hybrid" if has_embeddings else "lean"
+            )
             if not has_embeddings:
                 print_fn(
                     "  Lean profile (keyword/BM25 search). For semantic search later: "
@@ -502,6 +505,8 @@ def setup_main(argv: list[str]) -> int:
                          help="Keyword/BM25 search only (no embeddings).")
     profile.add_argument("--hybrid", action="store_const", const="hybrid", dest="profile",
                          help="Hybrid semantic search (needs the embeddings extra).")
+    profile.add_argument("--standard", action="store_const", const="standard", dest="profile",
+                         help="Default multimodal profile (embeddings + media extras).")
     hooks = parser.add_mutually_exclusive_group()
     hooks.add_argument("--with-hooks", action="store_const", const=True, dest="with_hooks",
                        help="Also install the capture/retrieval nudge hooks.")

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import logging
 import os
-import platform
 import threading
 import time
 from pathlib import Path
@@ -47,18 +46,14 @@ def warmup_enabled() -> bool:
 def model_preload_allowed(mode_name: str | None = None) -> bool:
     """Whether startup may eagerly load model weights in this process.
 
-    Normal-mode Apple Silicon defaults to lazy model loads. Multiple local stdio
-    clients naturally mean multiple Python processes, and eager BGE/CLIP/ASR
-    preloads can multiply into a multi-GB-per-chat footprint during imports.
-    `EXOMEM_PRELOAD_MODELS=1` opts back into the old eager behavior.
+    Normal and quiet modes default to lazy model loads on every OS. Multiple local
+    clients naturally mean multiple Python processes, and eager BGE/CLIP preloads
+    multiply memory residency. `EXOMEM_PRELOAD_MODELS=1` explicitly opts in.
     """
     override = os.environ.get("EXOMEM_PRELOAD_MODELS")
     if override is not None and override.strip() != "":
         return override.strip().lower() not in {"0", "false", "no", "off"}
-    resolved_mode = mode_name or "normal"
-    if resolved_mode == "normal" and platform.system() == "Darwin" and platform.machine() == "arm64":
-        return False
-    return True
+    return (mode_name or "normal") == "performance"
 
 
 def warm_caches(
@@ -158,7 +153,7 @@ def warm_all(vault_root: Path) -> dict[str, float]:
     from . import mode, readiness
 
     mode_name = mode.resolve_mode()
-    preload = mode.preload_models() and model_preload_allowed(mode_name)
+    preload = model_preload_allowed(mode_name)
     durations = warm_caches(
         vault_root,
         preload_models=preload,

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -58,7 +58,7 @@ def test_windows_service_scripts_gate_selected_profile_before_success() -> None:
     assert "Invoke-DoctorGate -Profile $Profile" in restart
     assert restart.index("Invoke-DoctorGate -Profile $Profile") < restart.index('Write-Host "Stopping $ServiceName..."')
 
-    assert '[string]$Profile = "hybrid"' in install
+    assert '[string]$Profile = "standard"' in install
     assert '"-Profile", $Profile' in install
     assert "exomem\", \"doctor\", \"--profile\", $Profile" in install
     assert install.index("exomem\", \"doctor\", \"--profile\", $Profile") < install.index("& $NssmPath install")

--- a/tests/test_deferred_index.py
+++ b/tests/test_deferred_index.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from exomem import deferred_index
+
+
+def test_deferred_paths_are_durable_deduplicated_and_clearable(vault: Path) -> None:
+    rel = "Knowledge Base/Notes/deferred.md"
+    assert deferred_index.add(vault, [rel, rel]) == 1
+    assert deferred_index.add(vault, [rel]) == 0
+    assert deferred_index.status(vault)["count"] == 1
+
+    # A fresh read from SQLite represents process restart recovery.
+    assert deferred_index.list_paths(vault) == [rel]
+    assert deferred_index.clear(vault, [rel]) == 1
+    assert deferred_index.status(vault)["count"] == 0
+
+
+def test_deferred_status_does_not_create_sidecar(vault: Path) -> None:
+    path = deferred_index.store_path(vault)
+    assert not path.exists()
+    assert deferred_index.status(vault)["count"] == 0
+    assert not path.exists()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -59,6 +59,23 @@ def test_doctor_infers_profile_from_env(monkeypatch: pytest.MonkeyPatch) -> None
     assert doctor_module.infer_profile() == "hybrid"
 
 
+def test_standard_profile_is_valid_for_env_inference(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_PROFILE", "standard")
+    assert doctor_module.infer_profile() == "standard"
+
+
+def test_standard_profile_accepts_missing_tesseract_as_degraded_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXOMEM_TESSERACT_CMD", raising=False)
+    monkeypatch.setattr(doctor_module.shutil, "which", lambda _name: None)
+
+    check = doctor_module._check_tesseract(required=False)
+
+    assert check.status == "warn"
+    assert "Tesseract" in check.message
+
+
 
 def test_doctor_missing_vault_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EXOMEM_VAULT_PATH", raising=False)

--- a/tests/test_find_overhead.py
+++ b/tests/test_find_overhead.py
@@ -221,7 +221,7 @@ def test_warm_caches_populates(vault: Path, monkeypatch) -> None:
     from exomem import lexstore
 
     monkeypatch.delenv("EXOMEM_DISABLE_WARMUP", raising=False)
-    warmup.warm_caches(vault)
+    warmup.warm_caches(vault, preload_cpu_caches=True)
     assert find_module._CACHE.entries  # pages parsed
     if lexstore.backend() != "python" and lexstore.fts5_available():
         assert lexstore.lexical_path(vault).exists()  # sidecar built by warm

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -258,3 +258,22 @@ def test_drain_deferred_work_processes_and_clears_semantic_upserts(
     assert processed == 1
     assert calls == [[good]]
     assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0
+
+
+def test_drain_deferred_work_preserves_failed_semantic_upserts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    index_sync.clear_deferred_work(vault)
+    from exomem import embeddings, find, lexstore
+
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda root, paths: None)
+    monkeypatch.setattr(find, "on_resolver_files_changed", lambda root, changed, deleted: None)
+    monkeypatch.setattr(embeddings, "upsert_after_write", lambda root, paths: False)
+    good = vault / "Knowledge Base" / "Notes" / "Insights" / "retry-me.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text("# retry\n", encoding="utf-8")
+
+    index_sync.upsert_after_write(vault, [good])
+    assert index_sync.drain_deferred_work(vault) == 0
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 1

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -221,12 +221,10 @@ def test_defer_and_mark_ready_race_no_loss_no_duplication() -> None:
 # ============================================================================
 
 
-def test_model_preload_allowed_defaults_lazy_on_apple_silicon(
+def test_model_preload_allowed_defaults_lazy_in_normal_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("EXOMEM_PRELOAD_MODELS", raising=False)
-    monkeypatch.setattr(warmup.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(warmup.platform, "machine", lambda: "arm64")
 
     assert warmup.model_preload_allowed("normal") is False
 
@@ -290,6 +288,7 @@ def test_warm_all_quiet_mode_skips_preloads_but_marks_ready(
     so finds during the lexical warm don't carry a bogus "warming" marker. This is
     the idle-VRAM win: no model touches CUDA at boot."""
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_PRELOAD_MODELS", raising=False)
     monkeypatch.setenv("EXOMEM_MODE", "quiet")
     cache_policy: dict = {}
     monkeypatch.setattr(warmup, "warm_caches", lambda vr, **kw: cache_policy.update(kw) or {})
@@ -358,7 +357,9 @@ def test_warm_caches_gates_matrix_warm_on_preload_models(
     assert "clip_matrix" not in d_quiet
     assert calls == []
 
-    d_default = warmup.warm_caches(tmp_path, preload_models=True)
+    d_default = warmup.warm_caches(
+        tmp_path, preload_models=True, preload_cpu_caches=True
+    )
     assert "embedding_matrix" in d_default
     assert "clip_matrix" in d_default
     assert calls == [1, 1]

--- a/tests/test_live_embedding_bounds.py
+++ b/tests/test_live_embedding_bounds.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from exomem import embeddings, readiness
+from exomem import find as find_module
+
+
+def test_live_embedding_slices_oversized_file_in_order(vault, monkeypatch) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_LIVE_EMBED_MAX_CHUNKS", "3")
+    monkeypatch.setattr(embeddings, "_IMPORT_FAILED", False)
+    monkeypatch.setattr(embeddings, "get_model", lambda: object())
+    readiness.reset()
+
+    path = vault / "Knowledge Base" / "Notes" / "large.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Large\n", encoding="utf-8")
+    page = SimpleNamespace(rel_path="Knowledge Base/Notes/large.md")
+    monkeypatch.setattr(find_module._CACHE, "get", lambda *_args: page)
+    chunks = [f"chunk-{i}" for i in range(7)]
+    monkeypatch.setattr(embeddings, "_chunks_for_page", lambda *_args: chunks)
+
+    calls: list[list[str]] = []
+
+    def _embed(texts, *, is_query):
+        assert is_query is False
+        calls.append(list(texts))
+        return np.asarray([[float(text.split("-")[1])] * embeddings.VECTOR_DIM for text in texts])
+
+    monkeypatch.setattr(embeddings, "embed_texts", _embed)
+    written: dict = {}
+
+    class _Index:
+        def upsert_file(self, rel_path, actual_chunks, vectors, mtime):
+            written.update(rel_path=rel_path, chunks=actual_chunks, vectors=vectors, mtime=mtime)
+
+        def delete_file(self, _rel_path):
+            raise AssertionError("existing file must not be deleted")
+
+    monkeypatch.setattr(embeddings, "get_embedding_index", lambda _root: _Index())
+    embeddings.upsert_after_write(vault, [path])
+
+    assert [len(batch) for batch in calls] == [3, 3, 1]
+    assert written["chunks"] == chunks
+    assert written["vectors"][:, 0].tolist() == list(map(float, range(7)))

--- a/tests/test_media_jobs.py
+++ b/tests/test_media_jobs.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from exomem import media_jobs
+from exomem.media_worker_child import _VaultLock
+
+
+def _job(vault: Path, *, ocr: bool = True, clip: bool = False) -> media_jobs.MediaJob:
+    binary = vault / "Knowledge Base" / "Evidence" / "item.mp4"
+    sidecar = binary.with_name(binary.name + ".md")
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.write_bytes(b"x")
+    sidecar.write_text("---\nmedia_type: video\n---\n", encoding="utf-8")
+    return media_jobs.MediaJob(
+        binary_path=binary,
+        sidecar_path=sidecar,
+        media_type="video",
+        do_ocr=ocr,
+        do_clip=clip,
+    )
+
+
+def test_status_does_not_create_store(vault: Path) -> None:
+    path = media_jobs.job_store_path(vault)
+    assert not path.exists()
+    status = media_jobs.status(vault)
+    assert status["counts"]["pending"] == 0
+    assert not path.exists()
+
+
+def test_pid_alive_handles_current_and_missing_processes() -> None:
+    assert media_jobs.pid_alive(os.getpid()) is True
+    assert media_jobs.pid_alive(2_147_483_647) is False
+
+
+def test_enqueue_deduplicates_and_merges_stages(vault: Path) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    first = store.enqueue(_job(vault, ocr=True, clip=False))
+    second = store.enqueue(_job(vault, ocr=False, clip=True))
+    assert first == second
+
+    claimed = store.claim_next()
+    assert claimed is not None
+    assert claimed.do_ocr is True
+    assert claimed.do_clip is True
+    assert store.claim_next() is None
+
+
+def test_recover_and_retry_states(vault: Path) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(_job(vault))
+    claimed = store.claim_next()
+    assert claimed is not None and claimed.id is not None
+
+    assert store.recover_interrupted() == 1
+    claimed = store.claim_next()
+    assert claimed is not None and claimed.id is not None
+    store.mark(claimed.id, media_jobs.BLOCKED, "missing engine")
+    assert store.counts()["blocked"] == 1
+    assert store.retry() == 1
+    assert store.counts()["pending"] == 1
+
+
+def test_live_worker_prevents_duplicate_recovery(vault: Path) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(_job(vault))
+    assert store.claim_next() is not None
+    store.set_worker(os.getpid(), 30.0)
+
+    assert store.needs_worker() is False
+    assert store.counts()["running"] == 1
+
+    store.clear_worker(os.getpid())
+    assert store.needs_worker() is True
+
+
+def test_atomic_claim_allows_one_winner(vault: Path) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(_job(vault))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        claimed = list(pool.map(lambda _: store.claim_next(), range(2)))
+
+    assert sum(job is not None for job in claimed) == 1
+
+
+def test_completion_preserves_new_stage_added_while_running(vault: Path) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(_job(vault, ocr=True, clip=False))
+    claimed = store.claim_next()
+    assert claimed is not None
+
+    store.enqueue(_job(vault, ocr=False, clip=True))
+    store.complete(claimed)
+
+    followup = store.claim_next()
+    assert followup is not None
+    assert followup.do_ocr is False
+    assert followup.do_clip is True
+
+
+def test_vault_lock_allows_one_worker(vault: Path) -> None:
+    first = _VaultLock(media_jobs.worker_lock_path(vault))
+    second = _VaultLock(media_jobs.worker_lock_path(vault))
+    assert first.acquire() is True
+    try:
+        assert second.acquire() is False
+    finally:
+        first.release()
+    assert second.acquire() is True
+    second.release()

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -1,11 +1,13 @@
 """media_worker — the async extraction pipeline (extract engines stubbed; no GPU)."""
 
-from __future__ import annotations
+import os
+import threading
+import time
 
 import numpy as np
 import pytest
 
-from exomem import embeddings, extract, media_worker, preserve
+from exomem import embeddings, extract, media_worker, preserve, server_runtime
 from exomem import find as find_module
 
 
@@ -42,7 +44,7 @@ def test_worker_fills_pending_sidecar(vault, monkeypatch: pytest.MonkeyPatch) ->
             text="discussion of the broken sink and water damage", media_type="audio", engine="faster-whisper:test"
         ),
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(binary_path=vault / result.path, sidecar_path=sidecar, media_type="audio"))
 
     body = sidecar.read_text(encoding="utf-8")
@@ -69,7 +71,7 @@ def test_worker_writes_speaker_labels_and_field(vault, monkeypatch: pytest.Monke
             ],
         ),
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(binary_path=vault / result.path, sidecar_path=sidecar, media_type="audio"))
 
     body = sidecar.read_text(encoding="utf-8")
@@ -88,7 +90,7 @@ def test_worker_marks_failed_on_extraction_error(vault, monkeypatch: pytest.Monk
         raise RuntimeError("corrupt container")
 
     monkeypatch.setattr(extract, "extract_text", boom)
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(binary_path=vault / result.path, sidecar_path=sidecar, media_type="audio"))
 
     body = sidecar.read_text(encoding="utf-8")
@@ -102,7 +104,7 @@ def test_start_prewarms_asr_off_the_request_path(vault, monkeypatch: pytest.Monk
     warmed = threading.Event()
     monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: True)
     monkeypatch.setattr(extract, "prewarm", warmed.set)
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w.start()
     try:
         assert warmed.wait(timeout=5.0), "start() should warm ASR in a background thread"
@@ -115,7 +117,7 @@ def test_start_skips_asr_prewarm_when_policy_disables_it(
 ) -> None:
     monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: False)
     monkeypatch.setattr(extract, "prewarm", lambda: pytest.fail("prewarm should be skipped"))
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w.start()
     try:
         pass
@@ -127,7 +129,7 @@ def test_start_skips_asr_prewarm_when_policy_disables_it(
 def test_start_logs_diarization_readiness(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list = []
     monkeypatch.setattr(extract, "log_diarization_readiness", lambda v=None: calls.append(v))
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w.start()
     try:
         assert calls == [vault]
@@ -201,6 +203,105 @@ def test_scan_unindexed_images_enqueues(vault, monkeypatch: pytest.MonkeyPatch) 
     preserve.preserve_bytes(vault, scope="Yolo", category="photos", filename="y.png", data=b"\x89PNG", text="t")
     w = media_worker.MediaWorker(vault)
     assert w._scan_unindexed_images() == 2  # both images queued for CLIP
+
+
+def test_process_worker_drains_and_exits_after_idle(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+    result = _preserve_media_stub(vault, filename="lifecycle.mp3")
+    w = media_worker.MediaWorker(vault, execution_mode="process", idle_seconds=0.15)
+    w.start()
+    try:
+        w.enqueue(
+            binary_path=vault / result.path,
+            sidecar_path=vault / result.sidecar_path,
+            media_type="audio",
+            do_ocr=False,
+        )
+        w.join(timeout=10)
+        deadline = time.monotonic() + 10
+        from exomem import media_jobs
+
+        while time.monotonic() < deadline and media_jobs.status(vault)["worker_active"]:
+            time.sleep(0.02)
+        assert media_jobs.status(vault)["worker_active"] is False
+    finally:
+        w.stop()
+
+
+def test_child_marks_unavailable_engine_blocked(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+    monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: False)
+    result = _preserve_media_stub(vault, filename="blocked.mp3")
+
+    def _unavailable(*_args, **_kwargs):
+        raise extract.ExtractionUnavailable("engine absent")
+
+    monkeypatch.setattr(extract, "extract_text", _unavailable)
+    from exomem import media_jobs
+
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(
+        media_jobs.MediaJob(
+            binary_path=vault / result.path,
+            sidecar_path=vault / result.sidecar_path,
+            media_type="audio",
+        )
+    )
+
+    assert media_worker.run_child(vault, parent_pid=os.getpid(), idle_seconds=0.1) == 0
+    assert store.counts()["blocked"] == 1
+
+
+def test_media_runtime_failure_does_not_deny_core_service(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+
+    class _BrokenWorker:
+        def __init__(self, _vault):
+            raise OSError("ledger unavailable")
+
+    monkeypatch.setattr(media_worker, "MediaWorker", _BrokenWorker)
+    assert server_runtime._start_media_worker(vault) is None
+
+
+def test_supervisor_recovers_jobs_owned_by_crashed_child(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_MEDIA_EXTRACTION", raising=False)
+    result = _preserve_media_stub(vault, filename="crash.mp3")
+    worker = media_worker.MediaWorker(vault, execution_mode="process")
+    assert worker._store is not None
+    worker.enqueue(
+        binary_path=vault / result.path,
+        sidecar_path=vault / result.sidecar_path,
+        media_type="audio",
+    )
+    assert worker._store.claim_next() is not None
+
+    class _CrashedChild:
+        pid = 2_147_483_646
+        returncode = 1
+
+        @staticmethod
+        def poll():
+            return 1
+
+    worker._store.set_worker(_CrashedChild.pid, 30.0)
+    worker._child = _CrashedChild()
+    thread = threading.Thread(target=worker._supervise)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and worker._store.counts()["pending"] == 0:
+            time.sleep(0.01)
+        assert worker._store.counts()["pending"] == 1
+        assert worker._store.counts()["running"] == 0
+    finally:
+        worker._stop_event.set()
+        worker._wake.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
 
 
 def test_find_surfaces_media_fields(vault, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -101,7 +101,7 @@ def test_invalid_env_mode_falls_through_to_default(monkeypatch: pytest.MonkeyPat
 # ---- derived policy booleans ----
 
 @pytest.mark.parametrize(
-    "m, preload", [("quiet", False), ("normal", True), ("performance", True)]
+    "m, preload", [("quiet", False), ("normal", False), ("performance", True)]
 )
 def test_preload_models(monkeypatch: pytest.MonkeyPatch, m: str, preload: bool) -> None:
     monkeypatch.setenv("EXOMEM_MODE", m)
@@ -109,7 +109,7 @@ def test_preload_models(monkeypatch: pytest.MonkeyPatch, m: str, preload: bool) 
 
 
 @pytest.mark.parametrize(
-    "m, release", [("quiet", True), ("normal", False), ("performance", True)]
+    "m, release", [("quiet", True), ("normal", True), ("performance", True)]
 )
 def test_release_when_idle_by_mode(monkeypatch: pytest.MonkeyPatch, m: str, release: bool) -> None:
     monkeypatch.setenv("EXOMEM_MODE", m)
@@ -117,7 +117,7 @@ def test_release_when_idle_by_mode(monkeypatch: pytest.MonkeyPatch, m: str, rele
 
 
 def test_release_when_idle_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("EXOMEM_MODE", "normal")  # default off
+    monkeypatch.setenv("EXOMEM_MODE", "normal")  # default on
     monkeypatch.setenv("EXOMEM_RELEASE_GPU_WHEN_IDLE", "on")
     assert mode.release_when_idle() is True
     monkeypatch.setenv("EXOMEM_MODE", "performance")  # default on
@@ -156,8 +156,8 @@ def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> 
         (
             "normal",
             {
-                "preload_cpu_caches": True,
-                "retain_cpu_caches": True,
+                "preload_cpu_caches": False,
+                "retain_cpu_caches": False,
                 "defer_expensive_indexes": False,
                 "watcher_policy": {
                     "debounce_seconds": 0.5,
@@ -166,7 +166,7 @@ def test_bulk_gpu_opted(monkeypatch: pytest.MonkeyPatch, m: str, bulk: bool) -> 
                     "max_reconcile_embed_files": 500,
                     "defer_expensive_indexes": False,
                 },
-                "release_when_idle": False,
+                "release_when_idle": True,
                 "bulk_gpu": False,
             },
         ),
@@ -301,12 +301,12 @@ def _patch_runtime(monkeypatch):
     return calls
 
 
-def test_apply_live_normal_unloads_and_stops_reaper(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_live_normal_unloads_and_starts_reaper(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _patch_runtime(monkeypatch)
     monkeypatch.setenv("EXOMEM_MODE", "normal")
     policy = mode.apply_live()
     assert calls["unload"] == 1  # models unloaded so they reload on the new device
-    assert calls["stop"] == 1 and calls["start"] == 0  # normal → reaper off
+    assert calls["start"] == 1 and calls["stop"] == 0
     assert policy["mode"] == "normal"
 
 

--- a/tests/test_model_unload.py
+++ b/tests/test_model_unload.py
@@ -251,14 +251,16 @@ def test_default_cache_slots_reap_only_when_cpu_caches_are_evictable(
 
     monkeypatch.setenv("EXOMEM_MODE", "normal")
     slots = [s for s in model_reaper.default_slots() if s.name.endswith("cache") or s.name.endswith("caches") or s.name == "index-matrices"]
-    model_reaper._reap_once(slots, now=time.monotonic() + 2.0, threshold=1.0)
-    assert calls == []
-
-    monkeypatch.setenv("EXOMEM_MODE", "quiet")
-    slots = [s for s in model_reaper.default_slots() if s.name.endswith("cache") or s.name.endswith("caches") or s.name == "index-matrices"]
     reaped = model_reaper._reap_once(slots, now=time.monotonic() + 2.0, threshold=1.0)
     assert reaped == ["index-matrices", "bm25-cache", "find-ram-caches"]
     assert calls == ["index", "bm25", "find"]
+
+    calls.clear()
+    monkeypatch.setenv("EXOMEM_MODE", "performance")
+    slots = [s for s in model_reaper.default_slots() if s.name.endswith("cache") or s.name.endswith("caches") or s.name == "index-matrices"]
+    reaped = model_reaper._reap_once(slots, now=time.monotonic() + 2.0, threshold=1.0)
+    assert reaped == []
+    assert calls == []
 
 
 # ---- reaper lifecycle ----

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -113,3 +113,44 @@ def test_reconcile_clears_deferred_semantic_work_after_embedding_refresh(
     assert rep.embeddings_status == "refreshed"
     assert calls == [[target]]
     assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0
+
+
+def test_reconcile_preserves_deferred_work_after_embedding_failure(
+    vault: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    index_sync.clear_deferred_work(vault)
+
+    from exomem import find, lexstore
+
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda root, paths: None)
+    monkeypatch.setattr(find, "on_resolver_files_changed", lambda root, changed, deleted: None)
+    target = vault / "Knowledge Base" / "Notes" / "reconcile-retry.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# reconcile retry\n", encoding="utf-8")
+    index_sync.upsert_after_write(vault, [target])
+
+    monkeypatch.setattr("exomem.embeddings.upsert_after_write", lambda root, paths: False)
+    monkeypatch.setattr(
+        audit_module,
+        "_check_embedding_drift",
+        lambda root: [SimpleNamespace(path=Path("Knowledge Base/Notes/reconcile-retry.md"))],
+    )
+    monkeypatch.setattr(
+        audit_module,
+        "audit",
+        lambda root, categories: SimpleNamespace(findings=[]),
+    )
+    monkeypatch.setattr(
+        reconcile_module.indexes,
+        "compute_subindex_writes",
+        lambda root, top_index_text: ([], top_index_text),
+    )
+    monkeypatch.setattr("exomem.lexstore.ensure_fresh", lambda root: None)
+
+    rep = reconcile_module.reconcile(vault)
+
+    assert rep.embeddings_status == "deferred"
+    assert rep.embeddings_refreshed == 0
+    assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 1

--- a/tests/test_resource_status.py
+++ b/tests/test_resource_status.py
@@ -46,6 +46,8 @@ def test_collect_does_not_import_torch_or_probe_cuda(monkeypatch, tmp_path: Path
         "reranker": False,
         "clip": False,
     }
+    assert status["media"]["worker_active"] is False
+    assert not (tmp_path / "Knowledge Base" / ".media-jobs.sqlite").exists()
 
 
 def test_collect_reports_already_loaded_modules_without_loading_missing_ones(
@@ -76,20 +78,12 @@ def test_collect_reports_already_loaded_modules_without_loading_missing_ones(
             "hot_results": {"entries": 1, "hits": 3},
         }
     )
-    fake_index_sync = types.SimpleNamespace(
-        deferred_work_status=lambda root: {
-            "semantic_upserts": {
-                "count": 1,
-                "paths": ["Knowledge Base/Notes/x.md"],
-                "truncated": False,
-                "roots": 1,
-            }
-        }
-    )
     monkeypatch.setitem(sys.modules, "exomem.embeddings", fake_embeddings)
     monkeypatch.setitem(sys.modules, "exomem.bm25", fake_bm25)
     monkeypatch.setitem(sys.modules, "exomem.find", fake_find)
-    monkeypatch.setitem(sys.modules, "exomem.index_sync", fake_index_sync)
+    from exomem import deferred_index
+
+    deferred_index.add(tmp_path, ["Knowledge Base/Notes/x.md"])
 
     status = resource_status.collect(tmp_path)
 
@@ -111,5 +105,5 @@ def test_status_cli_json_is_resource_status(monkeypatch, capsys, tmp_path: Path)
     assert main(["status", "--resources", "--json", "--vault", str(tmp_path)]) == 0
     data = json.loads(capsys.readouterr().out)
     assert data["mode"] == "normal"
-    assert data["policy"]["retain_cpu_caches"] is True
+    assert data["policy"]["retain_cpu_caches"] is False
     assert data["cuda"]["torch_imported"] is False

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -250,6 +250,22 @@ def test_linux_release_install_renders_env_gates_then_verifies(tmp_path: Path) -
     assert "-> 401 (healthy, OAuth enforced)" in result.stdout
 
 
+def test_default_release_profile_is_standard_multimodal(tmp_path: Path) -> None:
+    result, _, trace_path, _ = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    trace = trace_path.read_text(encoding="utf-8")
+    assert "exomem[embeddings,media]" in trace
+    assert "doctor standard" in trace
+
+
+def test_macos_arm64_standard_adds_mlx(tmp_path: Path) -> None:
+    result, _, trace_path, _ = _run(tmp_path, os_name="Darwin", arch="arm64")
+
+    assert result.returncode == 0, result.stderr
+    assert "exomem[embeddings,media,media-mlx]" in trace_path.read_text(encoding="utf-8")
+
+
 def test_macos_arm64_media_adds_mlx_and_launchd_environment(tmp_path: Path) -> None:
     result, _, trace_path, env = _run(
         tmp_path,
@@ -353,13 +369,15 @@ def test_help_and_invalid_profile_are_non_mutating() -> None:
     assert "--repo-dev" in help_result.stdout
     assert 'MODE="repo-dev"' in INSTALL_SH.read_text(encoding="utf-8")
     assert invalid_result.returncode != 0
-    assert "lean, hybrid, or media" in invalid_result.stderr
+    assert "lean, hybrid, standard, or media" in invalid_result.stderr
 
 
 def test_windows_installer_gates_remote_and_verifies_before_success() -> None:
     text = (ROOT / "scripts" / "install-service.ps1").read_text(encoding="utf-8")
 
     assert '"pip", "install", "--upgrade", "--python", $venvPython, $pkg' in text
+    assert '[string]$Profile = "standard"' in text
+    assert '"exomem[embeddings,media]"' in text
     assert "Preflight: exomem doctor --profile remote" in text
     assert "function Test-McpEndpoint" in text
     assert "-SkipHttpErrorCheck" in text

--- a/tests/test_video_visual.py
+++ b/tests/test_video_visual.py
@@ -49,7 +49,7 @@ def test_worker_clip_embeds_video_via_keyframes(vault, monkeypatch: pytest.Monke
     called = {}
     monkeypatch.setattr(embeddings, "embed_video_frames", lambda p: called.setdefault("v", _three_frames()))
     monkeypatch.setattr(embeddings, "embed_image", lambda p: (_ for _ in ()).throw(AssertionError("used embed_image for video")))
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -102,7 +102,7 @@ def test_worker_gate_on_writes_frames_and_queues_ocr(
         "embed_video_frames",
         lambda p: (_ for _ in ()).throw(AssertionError("uniform path used with gate on")),
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -135,7 +135,7 @@ def test_worker_gate_off_never_touches_scene_path(
         "embed_video_scenes",
         lambda p: (_ for _ in ()).throw(AssertionError("scene path used with gate off")),
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -158,7 +158,7 @@ def test_worker_frame_write_failure_still_upserts_vectors(
         "write_scene_frames",
         lambda *a, **k: (_ for _ in ()).throw(RuntimeError("disk on fire")),
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -187,7 +187,7 @@ def test_startup_scan_skips_frame_children(vault, monkeypatch: pytest.MonkeyPatc
         "---\ntype: source\nmedia_type: image\nparent_media: Knowledge Base/Evidence/Test/clips/demo.mp4\n---\n",
         encoding="utf-8",
     )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     n = w._scan_unindexed_images()
     assert n == 1
     job = w._q.get_nowait()
@@ -297,7 +297,7 @@ def test_worker_gate_on_enqueues_parent_reembed_after_ocr(
         vault, scope="Yolo", category="clips", filename="demo.mp4", data=b"\x00video", text="x",
     )
     monkeypatch.setattr(embeddings, "embed_video_scenes", lambda p: _two_scenes())
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -319,7 +319,7 @@ def test_worker_reembed_gate_off_not_enqueued(vault, monkeypatch: pytest.MonkeyP
         vault, scope="Yolo", category="clips", filename="demo.mp4", data=b"\x00video", text="x",
     )
     monkeypatch.setattr(embeddings, "embed_video_scenes", lambda p: _two_scenes())
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=vault / res.path, sidecar_path=vault / res.sidecar_path,
         media_type="video", do_ocr=False, do_clip=True,
@@ -339,7 +339,7 @@ def test_process_reembed_calls_upsert(vault, monkeypatch: pytest.MonkeyPatch) ->
     sidecar = vault / "Knowledge Base/Evidence/T/clips/demo.mp4.md"
     sidecar.parent.mkdir(parents=True, exist_ok=True)
     sidecar.write_text("---\nmedia_type: video\n---\n", encoding="utf-8")
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     w._process(media_worker._Job(
         binary_path=sidecar.with_suffix(""), sidecar_path=sidecar,
         media_type="video", do_ocr=False, do_clip=False, do_reembed=True,
@@ -371,7 +371,7 @@ def test_scan_pending_enqueues_deduped_parent_reembed(
             f"parent_media: {parent_rel}\n---\n",
             encoding="utf-8",
         )
-    w = media_worker.MediaWorker(vault)
+    w = media_worker.MediaWorker(vault, execution_mode="inline")
     n = w._scan_pending_ocr()
     jobs = []
     while not w._q.empty():


### PR DESCRIPTION
## Summary\n\n- make standard the default native release profile with embeddings and baseline media extras, plus media-mlx on Apple Silicon\n- replace the in-process media thread with a durable SQLite ledger and one lock-serialized disposable child per vault\n- keep startup model residency off, reclaim normal-mode caches after idle, and expose worker/queue state through status and doctor\n- bound live semantic encoding and persist deferred semantic paths across restarts\n- document capability versus residency and add a cross-platform resource-envelope check\n- include the completed OpenSpec proposal, design, delta specs, and 26/26 implementation checklist\n\n## Resource contract\n\nThe long-lived HTTP service stays lightweight. Heavy OCR, ASR, CLIP, and frame work starts only when durable work exists, runs serially in a child, and exits after the idle deadline so Python/native heaps and accelerator contexts are returned to the host. Duplicate service processes share the same per-vault lock and cannot fan out heavy workers.\n\nAdvanced generated captions and diarization remain opt-in. Missing optional engines block visible jobs without denying lexical retrieval, upload persistence, or service startup.\n\n## Verification\n\n- focused media/resource/profile/installer gate: 329 passed, 2 expected skips, plus direct supervisor crash-recovery regression coverage\n- broad local gate: 1,658 passed, 16 dependency/platform skips\n- full GitHub pytest matrix passed on Python 3.11, 3.12, and 3.13\n- real embedding retrieval gate, Docker HTTP smoke, onboarding wheel gate, package build, and capabilities check passed\n- Ruff on every touched Python file\n- strict OpenSpec validation passed\n- shell syntax, PowerShell parser, diff whitespace, and scaffold leakage checks passed\n- native Windows Python smoke passed for process liveness and the msvcrt vault lock\n- resource script smoke passed with zero expected local servers\n\nTen direct FastMCP/TestClient files were omitted from the local broad run because the same exact tests hang on unchanged main in this WSL environment. GitHub ran the complete suite successfully on all three supported Python versions.\n\n## Real-host acceptance\n\nInstaller mapping and PowerShell behavior are covered by contract tests, macOS arm64 simulation, and native Windows smoke. Real launchd/MPS and production Windows/Linux RSS, CPU, and GPU measurements still require the documented desk-side acceptance command before release; hosted Ubuntu CI cannot prove those OS service and accelerator properties.