### PR TITLE
docs: design governed epistemic relations

### DIFF
--- a/openspec/changes/add-governed-relation-registry/.openspec.yaml
+++ b/openspec/changes/add-governed-relation-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/add-governed-relation-registry/design.md
+++ b/openspec/changes/add-governed-relation-registry/design.md
@@ -24,6 +24,8 @@ unified-context, and schema-governance surfaces this design extends.
 **Goals:**
 
 - Establish one versioned source of truth for portable core relation semantics.
+- Preserve a zero-configuration experience and current behavior for users who
+  never create an extension or custom profile.
 - Permit precise namespaced extension relations without fragmenting
   cross-domain traversal.
 - Preserve unknown observed relation labels and their provenance for review.
@@ -63,6 +65,25 @@ vault. The core must mean the same thing across installations and must not be
 silently overridden by vault configuration. A Python-only enum was rejected
 because the registry needs structured metadata and stable serialization for
 API responses and tests.
+
+### Adoption is universal at the core and opt-in at the precision layer
+
+Every installation uses the consolidated core internally, but this requires no
+setup and preserves current parsing and broad-context defaults. The scaffold
+contains an empty extension registry and no domain assumptions. Built-in
+profiles are available without configuration; `all` remains the omitted-profile
+behavior.
+
+Custom extensions, custom profiles, corpus inference, registry persistence, and
+Markdown migration are opt-in actions. No startup prompt, automatic ontology
+wizard, mandatory schema validation, or background corpus rewrite is added.
+Unregistered observations remain advisory and do not enter the default
+attention queue or make otherwise healthy ordinary writes fail.
+
+This gradient was selected because most users need portable graph behavior, not
+ontology administration. Advanced broad-corpus users can add precision as the
+corpus demonstrates a need, while every other user receives internal
+consistency with effectively no new product surface.
 
 ### Extensions are namespaced refinements of a core parent
 
@@ -116,16 +137,21 @@ reviewable.
 
 ### Unknown relation observations are preserved but semantically inert
 
-The parser recognizes syntactically valid typed-relation observations even when
-their label is not registered. The graph stores the observed edge with
+The parser recognizes unregistered labels only where typed intent is explicit:
+semantic-block relation metadata or a relation bullet with a colon, such as
+`- medicine.replicates: [[Target]]`. Existing registered labels keep their
+backward-compatible colon-optional grammar. This prevents ordinary navigation
+bullets such as `- See [[Target]]` from becoming ontology findings merely because
+they begin with a word and a link. The graph stores an explicit unknown edge with
 `registry_status="unregistered"`, its raw label, target resolution, and source
 provenance. It does not assign a core parent, inverse, symmetry, or epistemic
 meaning.
 
 Normal traversal profiles exclude unregistered edges. Unified context reports
-their count and examples as warnings; the unrestricted diagnostic profile may
-include them explicitly. Audit reports them, and corpus inference can propose
-registry skeletons.
+their bounded count and examples as advisory warnings; the unrestricted
+diagnostic profile may include them explicitly. A dedicated registry audit and
+explicit corpus inference report them, but they do not enter default attention
+or change ordinary write validity.
 
 Preservation was selected over the current ignore behavior because dropped
 observations cannot be governed later. Treating unknown labels as generic

--- a/openspec/changes/add-governed-relation-registry/design.md
+++ b/openspec/changes/add-governed-relation-registry/design.md
@@ -1,0 +1,263 @@
+## Context
+
+Exomem already derives a graph from Markdown files, semantic blocks,
+frontmatter, wikilinks, and explicit typed relation bullets. The current
+relation vocabulary is duplicated in `semantic_blocks.py` and
+`epistemic_graph.py`; unsupported labels are ignored. That works for a compact
+global ontology but loses useful observations in broad corpora and makes adding
+domain precision a code release rather than a governed knowledge decision.
+
+The intended corpus spans science, medicine, technology, health, fitness,
+wellbeing, entertainment, and future domains. Those domains need precise terms
+such as `medicine.contraindicates`, `science.replicates`, or
+`software.regressed_by`, while cross-domain context still needs to understand
+that these refine core contradiction, support, and causality families.
+
+Markdown remains canonical. SQLite graph state remains rebuildable. Exomem may
+parse, normalize, count, validate, and traverse relations deterministically, but
+it does not decide whether a claim is true, infer logical closure, or silently
+accept model-suggested semantics. Merged PR #182 supplies the stable-reference,
+unified-context, and schema-governance surfaces this design extends.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one versioned source of truth for portable core relation semantics.
+- Permit precise namespaced extension relations without fragmenting
+  cross-domain traversal.
+- Preserve unknown observed relation labels and their provenance for review.
+- Infer corpus relation usage and propose registry additions without automatic
+  adoption.
+- Offer deterministic traversal lenses over the same stored graph.
+- Keep registry/profile changes explicit, hash-guarded, auditable, rebuildable,
+  and consistent across every product surface.
+
+**Non-Goals:**
+
+- No server-side reasoning model, ontology-generation agent, or automatic
+  relation acceptance.
+- No automatic transitive closure, causal inference, contradiction judgment,
+  or truth/confidence score.
+- No canonical graph database and no required rewrite of existing Markdown.
+- No per-project redefinition of a relation's meaning.
+- No full ontology editor, OWL/RDF compatibility layer, or public taxonomy
+  marketplace in this change.
+- No change to default `find` ordering or retrieval ranking.
+
+## Decisions
+
+### One immutable core registry replaces duplicated enums
+
+Add a small `relation_registry` module backed by one packaged, versioned core
+definition. Semantic parsing, graph indexing, validation, suggestions, context,
+and tests consume this registry rather than maintaining separate sets.
+
+Each core definition carries a canonical key, description, family, directed or
+symmetric behavior, optional inverse key, permitted deterministic origins, and
+deprecation metadata. The first registry version preserves every currently
+accepted relation and its behavior.
+
+A packaged registry was selected over copying the core definitions into every
+vault. The core must mean the same thing across installations and must not be
+silently overridden by vault configuration. A Python-only enum was rejected
+because the registry needs structured metadata and stable serialization for
+API responses and tests.
+
+### Extensions are namespaced refinements of a core parent
+
+Vault-owned extensions live in
+`Knowledge Base/_Schema/relation-registry.yaml`. The generic scaffold starts
+with a versioned empty extension list and examples only in comments/guidance.
+An extension definition contains:
+
+- a namespaced canonical key such as `medicine.contraindicates`;
+- exactly one core parent such as `contradicts`;
+- a human-readable description;
+- optional aliases and inverse display key;
+- allowed source and target node/block kinds;
+- an applicability scope over project keys and/or page types;
+- `active` or `deprecated` status and optional `replaced_by`;
+- allowed observation origins, defaulting to explicit semantic relations.
+
+Keys use a strict lowercase `<namespace>.<name>` form. Core keys, extension
+keys, and aliases are globally unique within a vault. Extensions cannot replace
+or shadow core definitions. Applicability scope controls where an extension is
+valid; it never changes the extension's meaning. A use outside scope remains
+observable but receives a scope-violation finding.
+
+Parent mapping was selected over unrelated custom labels because it gives a
+portable graph view: an epistemic traversal that includes `contradicts` can also
+include `medicine.contraindicates`. A fully fixed global enum was rejected as
+too shallow for the corpus. Arbitrary free-form registered labels were rejected
+because synonyms would fragment the graph and make cross-domain queries
+unreliable.
+
+### Edges retain raw observation and registry resolution separately
+
+The derived graph edge schema records:
+
+- `raw_relation`, exactly as observed in Markdown;
+- `relation_type`, the canonical core or extension key when resolved;
+- `parent_relation`, populated for extensions;
+- `registry_status`: `core`, `extension`, `alias`, `unregistered`,
+  `deprecated`, or `scope_violation`;
+- `registry_version` and extension-registry content hash;
+- existing origin, source path, source anchor, source hash, and metadata.
+
+Alias resolution changes only derived canonicalization; Markdown is not
+rewritten automatically. Deprecated relations remain resolvable and visible.
+Rebuilds are deterministic for a given Markdown corpus plus registry version and
+extension hash.
+
+Keeping the raw observation separate avoids laundering an author-provided word
+into a stronger canonical claim. It also makes migrations and alias changes
+reviewable.
+
+### Unknown relation observations are preserved but semantically inert
+
+The parser recognizes syntactically valid typed-relation observations even when
+their label is not registered. The graph stores the observed edge with
+`registry_status="unregistered"`, its raw label, target resolution, and source
+provenance. It does not assign a core parent, inverse, symmetry, or epistemic
+meaning.
+
+Normal traversal profiles exclude unregistered edges. Unified context reports
+their count and examples as warnings; the unrestricted diagnostic profile may
+include them explicitly. Audit reports them, and corpus inference can propose
+registry skeletons.
+
+Preservation was selected over the current ignore behavior because dropped
+observations cannot be governed later. Treating unknown labels as generic
+`links_to` was rejected because that erases the author's typed intent and makes
+the graph appear more certain than it is.
+
+### Corpus inference proposes registry skeletons, never semantics
+
+Schema governance gains relation-registry as a subject alongside corpus
+contracts. Deterministic inference reports registered, deprecated,
+out-of-scope, and unregistered relation frequencies for a project/page-type
+scope, with bounded example paths and anchors. An unregistered label produces a
+proposal skeleton whose parent and description remain unset unless a unique
+declared alias resolves them.
+
+Saving is explicit and requires a complete caller-reviewed proposal. Existing
+registry overwrite requires the current content hash. The write refuses missing
+parents, alias collisions, core shadowing, invalid scope keys, inverse cycles,
+and deprecation targets that do not resolve.
+
+An optional model may suggest a description or parent only when explicitly
+requested. This is pure-substrate-safe because the suggestion is response-only,
+default-off, clearly attributed, and soft-fails when unavailable. It can never
+populate the saved proposal without the caller sending the reviewed definition
+back through the guarded save path.
+
+### Traversal profiles are deterministic query policy, not graph truth
+
+Ship these built-in profiles:
+
+- `epistemic`: support, contradiction, refinement, duplication,
+  supersession, questions, and answers;
+- `provenance`: derivation, evidence, citation, and observation;
+- `causal`: causes, caused-by, dependency, mitigation, blocking, and
+  resolution;
+- `decision`: evidence/derivation, dependency, implementation, use,
+  mitigation, and resolution;
+- `all`: every registered relation, preserving current broad graph-context
+  behavior.
+
+Custom profiles live in
+`Knowledge Base/_Schema/traversal-profiles.yaml`. A custom profile extends one
+built-in profile and may add/remove core families or exact relation keys, set
+edge direction, choose whether parent matches include extensions, provide a
+deterministic relation-priority order, and lower default depth/node/edge caps.
+It cannot exceed server hard caps or include unregistered relations except in an
+explicit diagnostic mode.
+
+`connect_memory(operation="context")` accepts `traversal_profile`; omission
+uses `all` for compatibility. Explicit `relation_types` intersect the profile
+rather than expanding it. Runtime depth and caps may further restrict the
+profile. The response names the resolved profile, registry version/hash,
+included relation families, unknown counts, and every applied truncation.
+
+Profiles do not mutate Markdown, accept relations, change default `find`
+ranking, or express epistemic confidence. Deterministic priority exists only to
+choose which edges fit inside a context cap.
+
+### Schema governance is extended instead of adding another top-level tool
+
+After PR #182, `schema_memory` remains the advanced governance surface. Add a
+backward-compatible `subject` parameter with default `contract` and values
+`relations` and `traversal-profiles`. Existing infer/validate/diff, `save`,
+`expected_hash`, scope, strict-exit, and proposal-first behavior are reused.
+A structured `proposal` parameter lets MCP/REST callers return a reviewed
+inference proposal for guarded persistence; CLI accepts the same JSON object.
+
+`connect_memory` remains the read surface. This avoids a new graph-admin tool
+while keeping registry and profile semantics identical across MCP, REST, CLI,
+OpenAPI, and generated docs.
+
+### Registry/profile changes invalidate graph state by content hash
+
+The graph sidecar metadata stores core registry version, extension-registry
+hash, and traversal-profile hash. Only the first two affect indexed edge
+resolution; a mismatch makes graph data stale and triggers rebuild through the
+existing writer/watcher/reconcile paths. Profile-only changes invalidate cached
+context plans but do not require reindexing edges.
+
+Audit detects missing, malformed, stale, conflicting, or out-of-scope registry
+state. Reconcile rebuilds derived graph state without modifying Markdown or
+registry files.
+
+## Risks / Trade-offs
+
+- [Risk] Domain extensions create synonyms and ontology sprawl. -> Require a
+  core parent, namespace, description, global alias uniqueness, corpus evidence,
+  and explicit adoption; surface near-duplicate names during inference.
+- [Risk] Parent mappings imply more semantics than authors intended. -> Preserve
+  raw labels, show parent expansion in context metadata, and never rewrite or
+  infer logical conclusions from ancestry.
+- [Risk] Unknown-edge preservation increases graph size and noise. -> Bound
+  examples, exclude unknown edges from normal profiles, and keep their payload
+  compact and derived.
+- [Risk] A custom profile hides important opposing evidence. -> Always report
+  the active profile and excluded/unknown counts; provide `all` and
+  `epistemic` comparison in diagnostics; never call a profile exhaustive.
+- [Risk] Registry edits make sidecars stale. -> Hash registry inputs into graph
+  metadata, audit drift, and rebuild deterministically through reconcile.
+- [Risk] Scope rules become another closed taxonomy. -> Projects/page types
+  remain open sets governed by existing schema rules; scope is optional and
+  unknown content stays allowed by default.
+- [Risk] Optional model parent suggestions violate the substrate boundary. ->
+  Default off, response-only, explicitly attributed, soft-failing, and
+  impossible to persist without a reviewed proposal echoed through save.
+- [Trade-off] V1 deliberately excludes transitivity and rule inference. This
+  sacrifices automatic deductions to preserve epistemic honesty and avoid
+  domain-invalid closure.
+
+## Migration Plan
+
+1. Start from the merged PR #182 stable-reference, unified-context, and
+   schema-governance foundation.
+2. Introduce the core registry with parity tests proving every existing
+   relation still parses and indexes identically.
+3. Add the empty generic extension/profile scaffold and validation without
+   changing graph behavior.
+4. Bump the graph sidecar schema, preserve raw/unknown observations, and rebuild
+   derived state through reconcile.
+5. Add relation inference and guarded persistence to `schema_memory`.
+6. Add built-in/custom profile resolution to unified context, then update
+   generated schemas, docs, and product E2E.
+7. Run dry-run inference on real broad corpora before registering any extension;
+   ship no personal/domain-specific extensions in the generic scaffold.
+
+Rollback ignores the optional extension/profile files, restores the prior core
+registry version, and rebuilds the derived graph. Markdown observations remain
+unchanged, so no content migration or destructive rollback is required.
+
+## Open Questions
+
+None for implementation start. The core-vs-extension boundary, namespace form,
+unknown-edge behavior, profile semantics, write guard, and PR #182 dependency
+are selected here; proposed real-world extensions remain corpus decisions made
+after inference and review.

--- a/openspec/changes/add-governed-relation-registry/proposal.md
+++ b/openspec/changes/add-governed-relation-registry/proposal.md
@@ -11,10 +11,14 @@ without turning relation labels into unreviewed truth.
 
 - Replace duplicated hard-coded relation enums with one versioned core relation
   registry shared by semantic parsing, graph indexing, validation, and context.
+- Keep ordinary use zero-config: the portable core and current broad traversal
+  remain the defaults, while custom extensions, profiles, and corpus inference
+  are explicitly opt-in.
 - Add optional vault- and project-scoped relation extensions using namespaced
   identifiers and explicit mappings to a core parent relation.
 - Preserve unregistered observed relation labels in derived graph state with
-  source provenance and audit findings instead of silently dropping them.
+  source provenance and advisory governance findings instead of silently
+  dropping them or adding them to default attention queues.
 - Infer relation frequencies and extension candidates from a selected corpus,
   but require explicit, hash-guarded adoption before an extension becomes
   registered.

--- a/openspec/changes/add-governed-relation-registry/proposal.md
+++ b/openspec/changes/add-governed-relation-registry/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Exomem's broad epistemic corpus spans domains whose useful relation vocabulary
+cannot fit one permanent global enum, while unconstrained free-form labels would
+fragment meaning and make traversal unreliable. The graph needs a governed
+extension model that preserves a portable epistemic core, learns what each
+corpus actually uses, and lets callers select deterministic traversal lenses
+without turning relation labels into unreviewed truth.
+
+## What Changes
+
+- Replace duplicated hard-coded relation enums with one versioned core relation
+  registry shared by semantic parsing, graph indexing, validation, and context.
+- Add optional vault- and project-scoped relation extensions using namespaced
+  identifiers and explicit mappings to a core parent relation.
+- Preserve unregistered observed relation labels in derived graph state with
+  source provenance and audit findings instead of silently dropping them.
+- Infer relation frequencies and extension candidates from a selected corpus,
+  but require explicit, hash-guarded adoption before an extension becomes
+  registered.
+- Add built-in and user-governed traversal profiles for epistemic, provenance,
+  causal, decision, and unrestricted graph context.
+- Extend schema governance and context routes through the shared product
+  registry; normal writes remain permissive and existing relation syntax stays
+  compatible.
+- Keep deterministic parsing and traversal inside the pure substrate. Any
+  optional model-backed parent suggestion is default-off, response-only,
+  soft-failing, and can never register a relation automatically.
+
+## Capabilities
+
+### New Capabilities
+
+- `epistemic-relation-registry`: Versioned core relations, governed scoped
+  extensions, alias/deprecation behavior, unknown-observation preservation,
+  corpus inference, and registry validation.
+- `graph-traversal-profiles`: Built-in and governed traversal lenses that select
+  relation families, directions, priorities, depth, and hard bounds without
+  changing stored knowledge or default retrieval ranking.
+
+### Modified Capabilities
+
+- `context-packs`: Context assembly can apply a traversal profile and reports
+  canonical relation definitions, extension ancestry, unknown relations, and
+  profile truncation.
+- `live-index-freshness`: Registry/profile changes invalidate derived graph
+  state and are detectable and repairable through audit/reconcile.
+- `command-surface`: Schema governance and context parameters remain identical
+  across MCP, REST, CLI, OpenAPI, annotations, and generated capability docs.
+
+## Impact
+
+The change affects semantic relation parsing, epistemic graph schema/rebuilds,
+schema inference and persistence, context assembly, audit/reconcile, the command
+registry, generated schemas/docs, the generic scaffold, and graph-quality tests.
+It adds generic governed YAML under `Knowledge Base/_Schema/` while leaving
+Markdown canonical and graph databases derived. The change builds on merged PR
+#182 (`close technical memory gaps`) for stable references, unified context, and
+schema-governance surface integration.

--- a/openspec/changes/add-governed-relation-registry/specs/command-surface/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/command-surface/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Relation governance preserves registry-generated surface parity
+The product registry SHALL expose relation registry and traversal-profile
+infer/validate/diff/save behavior through the schema-governance command, and
+traversal profile selection through the context command, with identical
+parameters and error semantics across MCP, REST, CLI, OpenAPI, generated docs,
+annotations, and schema-fidelity fixtures. Existing schema/context calls SHALL
+remain compatible when the new subject/profile parameters are omitted.
+
+#### Scenario: One registry definition exposes relation governance everywhere
+- **WHEN** the generated surfaces are inspected after this change
+- **THEN** schema governance accepts relation/profile subjects and reviewed
+  proposals, context accepts traversal profiles, and every surface exposes the
+  same defaults, bounds, hash guards, and validation codes
+
+#### Scenario: Existing callers retain prior behavior
+- **WHEN** callers omit relation-governance subjects and traversal profiles
+- **THEN** existing schema contract behavior and broad context traversal remain
+  unchanged

--- a/openspec/changes/add-governed-relation-registry/specs/context-packs/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/context-packs/spec.md
@@ -15,9 +15,10 @@ their more precise canonical key in the response.
 
 ### Requirement: Context never hides unknown relation observations
 Normal context SHALL exclude unregistered edges from traversal but SHALL report
-their bounded count and source examples as warnings. An explicit diagnostic view
-MAY include the semantically inert observed edges while clearly marking them
-unregistered.
+their bounded count and source examples as advisory warnings when they occur in
+the selected neighborhood. An explicit diagnostic view MAY include the
+semantically inert observed edges while clearly marking them unregistered. These
+warnings MUST NOT add items to default attention or alter ordinary retrieval.
 
 #### Scenario: Unknown edge is warned without semantic promotion
 - **WHEN** a seed page contains a valid but unregistered typed relation

--- a/openspec/changes/add-governed-relation-registry/specs/context-packs/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/context-packs/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Unified context exposes registry-aware traversal
+Unified context SHALL accept a traversal profile and return the resolved profile,
+core registry version, extension-registry hash, included relation families,
+canonical/raw relation metadata, unknown/out-of-scope counts, warnings, and
+explicit truncation. Extension edges selected through a core parent SHALL retain
+their more precise canonical key in the response.
+
+#### Scenario: Cross-domain support remains precise and portable
+- **WHEN** epistemic context encounters a registered domain extension whose core
+  parent is `supports`
+- **THEN** the edge is included as its namespaced canonical type, reports parent
+  `supports`, and carries its raw label and source provenance
+
+### Requirement: Context never hides unknown relation observations
+Normal context SHALL exclude unregistered edges from traversal but SHALL report
+their bounded count and source examples as warnings. An explicit diagnostic view
+MAY include the semantically inert observed edges while clearly marking them
+unregistered.
+
+#### Scenario: Unknown edge is warned without semantic promotion
+- **WHEN** a seed page contains a valid but unregistered typed relation
+- **THEN** context reports the observation in warnings and does not treat it as a
+  core or extension family edge

--- a/openspec/changes/add-governed-relation-registry/specs/epistemic-relation-registry/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/epistemic-relation-registry/spec.md
@@ -23,6 +23,11 @@ alias, inverse, node-kind, origin, status, and scope validation. Extension scope
 MAY restrict valid projects or page types but MUST NOT redefine the extension's
 meaning.
 
+#### Scenario: Empty registry requires no user action
+- **WHEN** a user never registers an extension or custom traversal profile
+- **THEN** existing Markdown parsing and broad graph-context behavior remain
+  compatible without setup prompts, mandatory validation, or corpus rewrites
+
 #### Scenario: Domain relation refines a portable parent
 - **WHEN** a valid extension `medicine.contraindicates` declares parent
   `contradicts` and is used inside its allowed scope
@@ -49,11 +54,13 @@ Alias resolution and registry updates MUST NOT rewrite Markdown automatically.
 - **AND** context can report how the observation was normalized
 
 ### Requirement: Unregistered observations are preserved without semantics
-The parser SHALL preserve syntactically valid relation observations whose labels
-are unregistered. Their derived edges SHALL carry raw label, target, and source
-provenance with `registry_status="unregistered"`, but MUST NOT receive a core
-parent, inverse, symmetry, confidence, or inferred epistemic meaning. Normal
-traversal profiles SHALL exclude them and audit SHALL surface them.
+The parser SHALL preserve unregistered relation labels only in explicit typed
+locations: semantic-block relation metadata or colon-bearing relation bullets.
+Their derived edges SHALL carry raw label, target, and source provenance with
+`registry_status="unregistered"`, but MUST NOT receive a core parent, inverse,
+symmetry, confidence, or inferred epistemic meaning. Normal traversal profiles
+SHALL exclude them; dedicated registry audit and explicit inference SHALL surface
+them as advisory findings without adding them to default attention.
 
 #### Scenario: Unknown relation is reviewable rather than dropped
 - **WHEN** a page contains `- medicine.replicates [[Target]]` before that label is
@@ -62,6 +69,12 @@ traversal profiles SHALL exclude them and audit SHALL surface them.
   exact source anchor
 - **AND** normal context warns about but does not traverse the edge as support or
   any other known family
+
+#### Scenario: Navigation bullet does not become ontology noise
+- **WHEN** ordinary Markdown contains `- See [[Target]]` with no registered `see`
+  relation and no explicit typed-relation colon
+- **THEN** normal wikilink indexing may retain the generic link but the registry
+  does not create an unregistered typed edge or audit finding for `See`
 
 ### Requirement: Corpus relation inference is proposal-first
 Relation inference SHALL report bounded frequency and example evidence for core,

--- a/openspec/changes/add-governed-relation-registry/specs/epistemic-relation-registry/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/epistemic-relation-registry/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: One versioned core relation registry
+The system SHALL define every portable core relation in one versioned registry
+consumed by semantic parsing, graph indexing, validation, suggestions, context,
+and schema generation. A core relation definition SHALL include canonical key,
+description, family, directionality, optional inverse, permitted origins, and
+deprecation metadata. Vault configuration MUST NOT override or shadow a core
+definition.
+
+#### Scenario: Existing relation behavior survives consolidation
+- **WHEN** the registry replaces the duplicated relation enums
+- **THEN** every relation accepted before the change parses and indexes with the
+  same canonical key and edge direction
+- **AND** a parity test fails if parser and graph consumers expose different core
+  sets
+
+### Requirement: Governed namespaced relation extensions
+The system SHALL load optional relation extensions from a generic governed YAML
+file under `Knowledge Base/_Schema/`. Each extension MUST use a lowercase
+namespaced key, map to exactly one core parent, describe its meaning, and pass
+alias, inverse, node-kind, origin, status, and scope validation. Extension scope
+MAY restrict valid projects or page types but MUST NOT redefine the extension's
+meaning.
+
+#### Scenario: Domain relation refines a portable parent
+- **WHEN** a valid extension `medicine.contraindicates` declares parent
+  `contradicts` and is used inside its allowed scope
+- **THEN** the graph records the extension key and its `contradicts` ancestry
+- **AND** a traversal selecting the core parent can include the extension without
+  treating the two labels as identical observations
+
+#### Scenario: Extension cannot shadow the core
+- **WHEN** a proposed extension key or alias collides with a core key or another
+  active canonical key
+- **THEN** validation refuses persistence with a stable collision finding and
+  leaves the current registry unchanged
+
+### Requirement: Raw and canonical relation identity remain distinct
+Every derived typed edge SHALL retain the raw observed label, resolved canonical
+relation when available, core parent for extensions, registry status, registry
+version/hash, origin, source path, source anchor, and target-resolution status.
+Alias resolution and registry updates MUST NOT rewrite Markdown automatically.
+
+#### Scenario: Alias resolution remains inspectable
+- **WHEN** Markdown uses a registered alias for an extension relation
+- **THEN** the edge carries both the raw alias and canonical extension key with
+  `registry_status="alias"`
+- **AND** context can report how the observation was normalized
+
+### Requirement: Unregistered observations are preserved without semantics
+The parser SHALL preserve syntactically valid relation observations whose labels
+are unregistered. Their derived edges SHALL carry raw label, target, and source
+provenance with `registry_status="unregistered"`, but MUST NOT receive a core
+parent, inverse, symmetry, confidence, or inferred epistemic meaning. Normal
+traversal profiles SHALL exclude them and audit SHALL surface them.
+
+#### Scenario: Unknown relation is reviewable rather than dropped
+- **WHEN** a page contains `- medicine.replicates [[Target]]` before that label is
+  registered
+- **THEN** graph diagnostics and corpus inference retain the observed edge and
+  exact source anchor
+- **AND** normal context warns about but does not traverse the edge as support or
+  any other known family
+
+### Requirement: Corpus relation inference is proposal-first
+Relation inference SHALL report bounded frequency and example evidence for core,
+extension, alias, deprecated, out-of-scope, and unregistered labels over an
+optional project/page-type scope. An unregistered candidate SHALL have no parent
+or description unless deterministic alias resolution supplies them. Saving a
+registry proposal SHALL be explicit, complete, atomic, and expected-hash guarded
+on overwrite.
+
+#### Scenario: Broad corpus proposes but does not adopt vocabulary
+- **WHEN** inference observes an unregistered relation repeatedly across a
+  selected corpus
+- **THEN** it returns counts, example paths/anchors, and an incomplete extension
+  skeleton without changing the registry or graph meaning
+
+#### Scenario: Incomplete or stale proposal cannot persist
+- **WHEN** save is requested with an unset core parent or a stale expected hash
+- **THEN** the write is refused atomically and the existing registry remains
+  byte-identical
+
+### Requirement: Optional model suggestions remain outside graph truth
+The system SHALL permit an optional model to suggest an extension description
+or core parent only when explicitly requested. The capability SHALL be
+default-off, response-only,
+attributed, and soft-failing. It MUST NOT write registry files, resolve an edge,
+change graph traversal, or populate a saved proposal without the reviewed data
+being sent back through the guarded deterministic save path.
+
+#### Scenario: Model unavailable does not block deterministic inference
+- **WHEN** model suggestions are requested but the optional model dependency is
+  absent
+- **THEN** deterministic frequencies and proposal skeletons are returned with an
+  unavailable warning and no mutation
+
+### Requirement: Deprecation preserves historical observations
+Registry definitions SHALL support `active` and `deprecated` status plus an
+optional valid `replaced_by`. Deprecated keys and aliases SHALL remain
+resolvable for historical Markdown and SHALL surface review findings; deleting a
+relation still observed by the corpus MUST be refused or represented as
+deprecation.
+
+#### Scenario: Deprecated relation remains readable
+- **WHEN** existing Markdown uses a relation later deprecated in favor of another
+  key
+- **THEN** graph rebuild preserves the historical edge, marks it deprecated, and
+  reports the replacement without rewriting the page

--- a/openspec/changes/add-governed-relation-registry/specs/graph-traversal-profiles/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/graph-traversal-profiles/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Built-in deterministic traversal profiles
+The system SHALL provide immutable built-in `epistemic`, `provenance`, `causal`,
+`decision`, and `all` profiles. Each profile SHALL define relation families,
+edge directions, extension-parent expansion, deterministic priority, and bounded
+defaults. Omitting a profile SHALL preserve current broad context behavior by
+using `all`.
+
+#### Scenario: Epistemic lens excludes unrelated operational edges
+- **WHEN** context is requested with `traversal_profile="epistemic"`
+- **THEN** support, contradiction, refinement, duplication, supersession,
+  question, and answer families are traversed within bounds
+- **AND** unrelated implementation or generic link edges are excluded and the
+  resolved profile is named in the response
+
+### Requirement: Governed custom traversal profiles
+The system SHALL load optional custom profiles from a governed YAML file under
+`Knowledge Base/_Schema/`. A custom profile MUST extend one built-in profile and
+MAY add/remove registered families or exact keys, set direction and deterministic
+priority, choose parent-extension expansion, and lower depth/node/edge defaults.
+It MUST NOT exceed server hard caps, redefine relations, include unknown edges in
+normal mode, or form inheritance cycles.
+
+#### Scenario: Project profile specializes provenance safely
+- **WHEN** a valid custom profile extends `provenance` and adds a registered
+  domain evidence relation
+- **THEN** context includes that extension while retaining the built-in
+  provenance bounds and relation semantics
+
+#### Scenario: Invalid profile fails without affecting context
+- **WHEN** a custom profile names an unregistered key or requests caps above the
+  server maximum
+- **THEN** validation reports stable path/span findings and the invalid profile
+  is not selected or persisted
+
+### Requirement: Runtime filters only narrow a selected profile
+Explicit relation filters SHALL intersect the selected profile. Runtime depth
+and node/edge caps SHALL be clamped by server maxima and MAY further narrow the
+profile. The system MUST NOT let an explicit filter silently expand a profile or
+include an unregistered relation.
+
+#### Scenario: Explicit filter narrows causal context
+- **WHEN** the causal profile is selected with `relation_types=["causes"]`
+- **THEN** only registered `causes` edges and permitted child extensions are
+  traversed, subject to the profile and global caps
+
+### Requirement: Traversal profiles do not alter stored knowledge or ranking
+Profile resolution and traversal SHALL be deterministic and read-only. Profiles
+MUST NOT write relations, accept suggestions, infer transitive edges, assign
+truth/confidence, or change default `find` ordering. Priority SHALL only choose
+which otherwise eligible edges fit inside a bounded context response.
+
+#### Scenario: Two lenses leave the corpus unchanged
+- **WHEN** the same seed is queried through epistemic and provenance profiles
+- **THEN** the returned edge sets may differ, both responses report their lens
+  and truncation, and no Markdown, registry, or stored graph edge changes

--- a/openspec/changes/add-governed-relation-registry/specs/live-index-freshness/spec.md
+++ b/openspec/changes/add-governed-relation-registry/specs/live-index-freshness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Relation registry changes invalidate derived graph resolution
+The graph sidecar SHALL record core registry version and extension-registry
+content hash. A mismatch SHALL be detectable as graph drift and SHALL cause the
+next explicit rebuild/reconcile path to re-resolve every edge deterministically.
+Registry invalidation MUST NOT modify Markdown.
+
+#### Scenario: Alias change rebuilds canonical edge identity
+- **WHEN** a valid extension registry alias changes and reconcile runs
+- **THEN** the graph sidecar is rebuilt against the new registry hash, raw
+  observations remain unchanged, and canonical relation metadata reflects the
+  new valid resolution
+
+### Requirement: Traversal profile changes invalidate context plans only
+The system SHALL hash governed traversal profiles for cache freshness. A
+profile-only change SHALL invalidate cached profile/context plans but MUST NOT
+force graph edge reindexing because stored edge resolution is unchanged.
+
+#### Scenario: Profile edit avoids unnecessary graph rebuild
+- **WHEN** a valid custom profile changes its included relation families
+- **THEN** the next context call uses the new profile and no Markdown or graph
+  edge rows are rewritten solely because of that profile edit

--- a/openspec/changes/add-governed-relation-registry/tasks.md
+++ b/openspec/changes/add-governed-relation-registry/tasks.md
@@ -1,0 +1,45 @@
+## 1. Dependency and compatibility baseline
+
+- [x] 1.1 Confirm merged PR #182 provides stable references, unified context, and `schema_memory` as the implementation foundation
+- [ ] 1.2 Add a golden snapshot of every current relation definition, parser acceptance rule, edge direction, origin, and graph-context result
+- [ ] 1.3 Add migration tests proving existing Markdown and graph fixtures remain behaviorally identical after registry consolidation
+
+## 2. Core and extension registry
+
+- [ ] 2.1 Implement typed core relation definitions and one versioned packaged registry consumed by semantic parsing and graph indexing
+- [ ] 2.2 Remove duplicated relation enums and add parity checks that every consumer resolves the same core registry
+- [ ] 2.3 Implement generic extension-registry loading, namespaced key validation, core-parent mapping, scope checks, aliases, inverse metadata, and deprecation
+- [ ] 2.4 Add hash-aware registry caching plus stable validation findings for collisions, invalid parents/scopes, inverse cycles, and bad replacements
+- [ ] 2.5 Add the leak-guarded empty extension registry and generic guidance to the shipped scaffold
+
+## 3. Registry-aware graph state
+
+- [ ] 3.1 Bump the graph sidecar schema and persist raw/canonical relation identity, parent, registry status/version/hash, and existing source provenance
+- [ ] 3.2 Preserve syntactically valid unregistered observations as semantically inert derived edges with resolved or placeholder targets
+- [ ] 3.3 Resolve aliases, deprecated keys, and scope violations deterministically without rewriting Markdown
+- [ ] 3.4 Extend graph audit and reconcile for unknown, deprecated, out-of-scope, invalid, and registry-hash drift
+- [ ] 3.5 Add rebuild, edit, move, watcher, delete, and registry-change tests for incremental and full graph freshness
+
+## 4. Corpus relation governance
+
+- [ ] 4.1 Extend `schema_memory` with backward-compatible relation-registry subject selection and structured reviewed proposals
+- [ ] 4.2 Implement scoped frequency/example inference for core, extension, alias, deprecated, scope-violating, and unregistered observations
+- [ ] 4.3 Implement atomic expected-hash persistence that refuses incomplete semantics, collisions, invalid scopes, or observed-key deletion
+- [ ] 4.4 Implement registry validation and diff against corpus reality or another reviewed proposal
+- [ ] 4.5 Add default-off response-only optional parent/description suggestions with attribution and soft-fail tests
+
+## 5. Traversal profiles and unified context
+
+- [ ] 5.1 Implement immutable `epistemic`, `provenance`, `causal`, `decision`, and `all` built-in profiles with deterministic priorities and bounds
+- [ ] 5.2 Implement governed custom profile loading, built-in extension, add/remove rules, parent expansion, direction, caps, validation, and cache hashing
+- [ ] 5.3 Apply profile resolution and narrowing filters to bounded graph traversal without changing graph rows or default `find` ranking
+- [ ] 5.4 Extend unified context with resolved profile, registry metadata, extension ancestry, unknown/scope warnings, excluded counts, and truncation
+- [ ] 5.5 Add cross-domain golden tests proving precise extensions remain queryable through portable core families and different lenses remain read-only
+
+## 6. Product surfaces and proof
+
+- [ ] 6.1 Register every new schema/context parameter once and regenerate MCP, REST, CLI, OpenAPI, annotations, capability docs, and fidelity fixtures
+- [ ] 6.2 Update the generic skill guidance for core versus extension semantics, proposal-first adoption, deprecation, and traversal lenses
+- [ ] 6.3 Add an installed-wheel product E2E that registers reviewed domain extensions, rebuilds after restart, and queries epistemic/provenance/causal profiles
+- [ ] 6.4 Run focused and full lean suites, registry/profile golden checks, Ruff, targeted typing, generated-doc checks, and strict OpenSpec validation
+- [ ] 6.5 Run dry-run inference over a broad real corpus and document proposed vocabulary without shipping personal extensions in the scaffold

--- a/openspec/changes/add-governed-relation-registry/tasks.md
+++ b/openspec/changes/add-governed-relation-registry/tasks.md
@@ -16,9 +16,10 @@
 
 - [ ] 3.1 Bump the graph sidecar schema and persist raw/canonical relation identity, parent, registry status/version/hash, and existing source provenance
 - [ ] 3.2 Preserve syntactically valid unregistered observations as semantically inert derived edges with resolved or placeholder targets
-- [ ] 3.3 Resolve aliases, deprecated keys, and scope violations deterministically without rewriting Markdown
-- [ ] 3.4 Extend graph audit and reconcile for unknown, deprecated, out-of-scope, invalid, and registry-hash drift
-- [ ] 3.5 Add rebuild, edit, move, watcher, delete, and registry-change tests for incremental and full graph freshness
+- [ ] 3.3 Restrict unknown capture to explicit typed intent and add regression tests proving navigation bullets do not create ontology or attention noise
+- [ ] 3.4 Resolve aliases, deprecated keys, and scope violations deterministically without rewriting Markdown
+- [ ] 3.5 Extend opt-in graph governance audit and reconcile for unknown, deprecated, out-of-scope, invalid, and registry-hash drift
+- [ ] 3.6 Add rebuild, edit, move, watcher, delete, and registry-change tests for incremental and full graph freshness
 
 ## 4. Corpus relation governance
 


### PR DESCRIPTION
## Summary
- add a complete OpenSpec change for a versioned core relation registry plus governed namespaced extensions
- keep ordinary use zero-config: current core parsing and broad context stay default; extensions, custom profiles, and inference are opt-in
- preserve explicitly typed unknown relation labels as provenance-bearing but semantically inert graph edges
- prevent ordinary navigation bullets from creating ontology or default-attention noise
- add corpus-derived proposal-first relation governance with explicit hash-guarded adoption
- design built-in and custom epistemic, provenance, causal, decision, and all traversal profiles
- extend unified context, graph freshness, and generated product surfaces without changing Markdown canonicality or default find ranking

## Key decisions
- common portable core ontology; vault/project scopes may refine but never redefine it
- extension keys map to exactly one core parent for cross-domain traversal
- raw observations remain distinct from canonical resolution
- unknown capture requires explicit typed intent and stays advisory
- no automatic transitive closure, confidence scores, ontology generation, or model-accepted relations
- optional model parent suggestions remain default-off, response-only, attributed, and soft-failing

## Artifacts
- proposal and detailed architecture design
- five capability delta specs
- 29 implementation tasks, with merged PR #182 foundation already complete

## Verification
- OpenSpec strict validation passes
- design branch rebased onto v0.15.0 main
- actual broad-vault review informed the zero-config and unknown-noise rules

This PR is design-only; implementation begins through the OpenSpec apply workflow after review.