### PR TITLE
perf: bound the parsed-page FrontmatterCache with LRU eviction

### DIFF
--- a/src/exomem/find_corpus.py
+++ b/src/exomem/find_corpus.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -18,13 +20,25 @@ EXCLUDED_DIR_NAMES = frozenset({"_Schema", "_attachments", "_archive", "_trash"}
 NAVIGATION_BASENAMES = frozenset({"index.md", "log.md"})
 FRONTMATTER_PATTERN = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
 H1_PATTERN = re.compile(r"^# (.+)$", re.MULTILINE)
+_DEFAULT_PAGE_CACHE_SIZE = 4096
+
+
+def _page_cache_size() -> int:
+    raw = os.environ.get("EXOMEM_PAGE_CACHE_SIZE")
+    if raw is None or not raw.strip():
+        return _DEFAULT_PAGE_CACHE_SIZE
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        log.warning("EXOMEM_PAGE_CACHE_SIZE=%r is not an int; using default", raw)
+        return _DEFAULT_PAGE_CACHE_SIZE
 
 
 @dataclass
 class FrontmatterCache:
     """Per-process cache of parsed pages, invalidated by mtime."""
 
-    entries: dict[Path, ParsedPage] = field(default_factory=dict)
+    entries: OrderedDict[Path, ParsedPage] = field(default_factory=OrderedDict)
 
     def get(self, path: Path, vault_root: Path) -> ParsedPage | None:
         try:
@@ -34,10 +48,14 @@ class FrontmatterCache:
             return None
         cached = self.entries.get(path)
         if cached and cached.mtime == mtime:
+            self.entries.move_to_end(path)
             return cached
         parsed = parse_page(path, mtime, vault_root)
         if parsed is not None:
             self.entries[path] = parsed
+            self.entries.move_to_end(path)
+            while len(self.entries) > _page_cache_size():
+                self.entries.popitem(last=False)
         return parsed
 
 

--- a/tests/test_frontmatter_cache_bound.py
+++ b/tests/test_frontmatter_cache_bound.py
@@ -1,0 +1,81 @@
+"""Bounded-LRU behavior for the parsed-page frontmatter cache."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from exomem import find_corpus
+
+
+def _page(path: Path, title: str) -> None:
+    path.write_text(f"---\ntype: research-note\n---\n# {title}\n", encoding="utf-8")
+
+
+def test_cache_respects_bound_and_evicts_least_recently_used(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_PAGE_CACHE_SIZE", "2")
+    cache = find_corpus.FrontmatterCache()
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    third = tmp_path / "third.md"
+    for page in (first, second, third):
+        _page(page, page.stem)
+
+    cache.get(first, tmp_path)
+    cache.get(second, tmp_path)
+    cache.get(first, tmp_path)
+    cache.get(third, tmp_path)
+
+    assert len(cache.entries) == 2
+    assert list(cache.entries) == [first, third]
+
+
+def test_cache_hit_within_bound_does_not_parse_again(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_PAGE_CACHE_SIZE", "2")
+    page = tmp_path / "page.md"
+    _page(page, "First title")
+    cache = find_corpus.FrontmatterCache()
+    parse_calls = 0
+    original_parse_page = find_corpus.parse_page
+
+    def count_parses(path: Path, mtime: float, vault_root: Path):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse_page(path, mtime, vault_root)
+
+    monkeypatch.setattr(find_corpus, "parse_page", count_parses)
+
+    first = cache.get(page, tmp_path)
+    second = cache.get(page, tmp_path)
+
+    assert first is second
+    assert parse_calls == 1
+
+
+def test_mtime_change_invalidates_entry_within_bound(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("EXOMEM_PAGE_CACHE_SIZE", "2")
+    page = tmp_path / "page.md"
+    _page(page, "Original title")
+    cache = find_corpus.FrontmatterCache()
+    parse_calls = 0
+    original_parse_page = find_corpus.parse_page
+
+    def count_parses(path: Path, mtime: float, vault_root: Path):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse_page(path, mtime, vault_root)
+
+    monkeypatch.setattr(find_corpus, "parse_page", count_parses)
+
+    first = cache.get(page, tmp_path)
+    old_stat = page.stat()
+    _page(page, "Updated title")
+    os.utime(page, (old_stat.st_atime, old_stat.st_mtime + 1))
+    updated = cache.get(page, tmp_path)
+
+    assert first is not updated
+    assert updated is not None
+    assert updated.title == "Updated title"
+    assert parse_calls == 2


### PR DESCRIPTION
First lane of OpenSpec `reduce-memory-and-startup-overhead` (merged in #185) — and the pilot run of the Codex worker protocol (implemented by a `gpt-5.6-terra` worker, gated by the orchestrator).

- `FrontmatterCache` becomes an `OrderedDict` LRU bounded by `EXOMEM_PAGE_CACHE_SIZE` (default 4096; `0` disables retention); recency refreshed on hits and reparses; mtime invalidation semantics unchanged.
- New `tests/test_frontmatter_cache_bound.py`: bound respected, LRU eviction order, warm hits within bound, mtime invalidation.

Gate evidence: lean suite 1782 passed; `tests/test_latency_gate.py` 2 passed; ruff findings identical to main (111 pre-existing, none new); diff confined to the brief's allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)