### PR TITLE
perf: lazy-load server imports on the CLI path

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -31,7 +31,6 @@ import os
 import sys
 from pathlib import Path
 
-from . import server
 from .kbdir import kb_dirname, kb_prefix
 
 
@@ -76,13 +75,18 @@ def main(argv: list[str] | None = None) -> int:
     # Registry-driven product operations (reads + writes): `exomem ask_memory "..."`,
     # `exomem remember ...`, etc. Product commands take precedence over old
     # short aliases when a name overlaps.
-    if raw and raw[0] in _core_op_names():
+    if raw and not raw[0].startswith("-") and raw[0] in _core_op_names():
         return _core_op_main(raw)
     if raw and raw[0] in _simple_cli_action_names():
         return _simple_action_main(raw)
     # A real tier-2 op invoked while EXOMEM_DISABLE_TIER2 is set would otherwise fall
     # through to the serve parser and emit a confusing argparse error — name it instead.
-    if raw and not _expose_tier2() and raw[0] in _core_op_names(expose_tier2=True):
+    if (
+        raw
+        and not raw[0].startswith("-")
+        and not _expose_tier2()
+        and raw[0] in _core_op_names(expose_tier2=True)
+    ):
         print(
             f"Error [UNAVAILABLE]: operation {raw[0]!r} is unavailable (tier-2 disabled)",
             file=sys.stderr,
@@ -112,6 +116,8 @@ def _serve_main(argv: list[str]) -> int:
         help="Bind port for HTTP transports (default: 8765).",
     )
     args = parser.parse_args(argv)
+
+    from . import server
 
     try:
         server.run(transport=args.transport, host=args.host, port=args.port)

--- a/tests/test_cli_lazy_imports.py
+++ b/tests/test_cli_lazy_imports.py
@@ -1,0 +1,77 @@
+"""Regression coverage for the CLI's model-free import paths."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_VAULT = ROOT / "tests" / "fixtures"
+HEAVY_MODULES = ("torch", "sentence_transformers", "fastmcp")
+
+
+def _run_cli_with_module_probe(tmp_path: Path, *args: str) -> tuple[subprocess.CompletedProcess[str], set[str]]:
+    modules_path = tmp_path / "modules.json"
+    (tmp_path / "sitecustomize.py").write_text(
+        """
+import atexit
+import json
+import os
+import sys
+
+
+def dump_modules():
+    with open(os.environ["EXOMEM_MODULES_PATH"], "w", encoding="utf-8") as output:
+        json.dump(sorted(sys.modules), output)
+
+
+atexit.register(dump_modules)
+""",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "EXOMEM_DISABLE_EMBEDDINGS": "1",
+            "EXOMEM_MODULES_PATH": str(modules_path),
+            "EXOMEM_VAULT_PATH": str(FIXTURE_VAULT),
+            "PYTHONPATH": os.pathsep.join(
+                part for part in (str(tmp_path), str(ROOT / "src"), env.get("PYTHONPATH")) if part
+            ),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "exomem", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, set(json.loads(modules_path.read_text(encoding="utf-8")))
+
+
+def _assert_no_heavy_modules(modules: set[str]) -> None:
+    for module in HEAVY_MODULES:
+        assert module not in modules
+        assert not any(name.startswith(f"{module}.") for name in modules)
+    assert "exomem.server" not in modules
+
+
+def test_help_does_not_import_heavy_stacks(tmp_path: Path) -> None:
+    result, modules = _run_cli_with_module_probe(tmp_path, "--help")
+
+    assert result.returncode == 0, result.stderr
+    assert "MCP transport to serve" in result.stdout
+    _assert_no_heavy_modules(modules)
+
+
+def test_status_one_shot_does_not_import_heavy_stacks(tmp_path: Path) -> None:
+    result, modules = _run_cli_with_module_probe(tmp_path, "status", "--json", "--vault", str(FIXTURE_VAULT))
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["models"]["module_loaded"] is False
+    _assert_no_heavy_modules(modules)


### PR DESCRIPTION
Third lane of OpenSpec `reduce-memory-and-startup-overhead` (Codex worker: `gpt-5.6-terra`, orchestrator-gated).

- Defers the FastMCP/server import until `_serve_main()` actually serves; option-led invocations (`--help`) reach argparse without touching the product registry's server imports.
- Measured on this host: `import exomem.__main__` cumulative import time **2,621,746 µs → 57,065 µs (−97.8%)** — `scripts/startup_benchmark.py` (lane A4, separate PR) shows `fastmcp`/`mcp` were the dominant import cost.
- New `tests/test_cli_lazy_imports.py`: subprocess regressions assert `torch`, `sentence_transformers`, `fastmcp`, and `exomem.server` are never loaded for `--help` and a model-free one-shot.

Gate evidence: lean suite 1781 passed; latency gate 2 passed; ruff findings identical to main (111 pre-existing, none new); diff confined to the brief's allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)