### PR TITLE
feat(bench): CLI startup benchmark (importtime offenders + one-shot wall times)

### DIFF
--- a/scripts/startup_benchmark.py
+++ b/scripts/startup_benchmark.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Measure one-shot startup costs for the Exomem CLI.
+
+The import profile deliberately uses the module entry point rather than a
+console-script wrapper so it is portable across development environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+IMPORTTIME_LINE = re.compile(
+    r"^import time:\s*(?P<self_us>\d+)\s*\|\s*"
+    r"(?P<cumulative_us>\d+)\s*\|\s*(?P<module>.+?)\s*$"
+)
+SAMPLES = 3
+FIXTURES_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+
+
+@dataclass(frozen=True)
+class ImportTiming:
+    """One row from Python's ``-X importtime`` output."""
+
+    module: str
+    self_us: int
+    cumulative_us: int
+
+
+def parse_importtime(stderr: str) -> list[ImportTiming]:
+    """Parse the import-time rows from stderr, ignoring non-profile output."""
+    timings = []
+    for line in stderr.splitlines():
+        match = IMPORTTIME_LINE.match(line)
+        if match:
+            timings.append(
+                ImportTiming(
+                    module=match.group("module"),
+                    self_us=int(match.group("self_us")),
+                    cumulative_us=int(match.group("cumulative_us")),
+                )
+            )
+    return timings
+
+
+def aggregate_by_top_level(timings: list[ImportTiming]) -> list[dict[str, float | str]]:
+    """Sum cumulative import time for each top-level import package."""
+    totals: defaultdict[str, int] = defaultdict(int)
+    for timing in timings:
+        top_level = timing.module.split(".", 1)[0]
+        totals[top_level] += timing.cumulative_us
+    return [
+        {"package": package, "cumulative_ms": round(cumulative_us / 1000, 3)}
+        for package, cumulative_us in sorted(totals.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def measure_import_time() -> tuple[float, list[dict[str, float | str]]]:
+    """Return total module import time and cumulative package totals."""
+    completed = subprocess.run(
+        [sys.executable, "-X", "importtime", "-c", "import exomem.__main__"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    timings = parse_importtime(completed.stderr)
+    if not timings:
+        raise RuntimeError("Python produced no importtime rows")
+    return max(timing.cumulative_us for timing in timings) / 1000, aggregate_by_top_level(timings)
+
+
+def command_environment() -> dict[str, str]:
+    """Build the deterministic environment for model-free product probes."""
+    environment = os.environ.copy()
+    environment["EXOMEM_DISABLE_EMBEDDINGS"] = "1"
+    environment["EXOMEM_VAULT_PATH"] = str(FIXTURES_DIR)
+    return environment
+
+
+def median_command_time(command: list[str], environment: dict[str, str]) -> float:
+    """Measure a command end-to-end three times and return its median in milliseconds."""
+    samples = []
+    for _ in range(SAMPLES):
+        started = time.perf_counter()
+        subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        samples.append((time.perf_counter() - started) * 1000)
+    return round(statistics.median(samples), 3)
+
+
+def benchmark(top: int) -> dict[str, object]:
+    """Run the import profile and both one-shot CLI probes."""
+    total_import_ms, package_totals = measure_import_time()
+    environment = command_environment()
+    commands = {
+        "exomem --help": [sys.executable, "-m", "exomem", "--help"],
+        "exomem browse_memory --samples 1": [
+            sys.executable,
+            "-m",
+            "exomem",
+            "browse_memory",
+            "--samples",
+            "1",
+        ],
+    }
+    return {
+        "import_time": {
+            "total_ms": round(total_import_ms, 3),
+            "top_packages": package_totals[:top],
+        },
+        "wall_time": {
+            label: median_command_time(command, environment) for label, command in commands.items()
+        },
+    }
+
+
+def print_markdown(result: dict[str, object]) -> None:
+    """Render a compact, copyable before/after comparison table."""
+    import_time = result["import_time"]
+    wall_time = result["wall_time"]
+    assert isinstance(import_time, dict)
+    assert isinstance(wall_time, dict)
+
+    print("# CLI startup benchmark")
+    print(f"\nTotal import time: {import_time['total_ms']:.3f} ms")
+    print("\n| Package | Cumulative import time (ms) |")
+    print("| --- | ---: |")
+    for item in import_time["top_packages"]:
+        assert isinstance(item, dict)
+        print(f"| {item['package']} | {item['cumulative_ms']:.3f} |")
+    print("\n| Command (median of 3) | Wall time (ms) |")
+    print("| --- | ---: |")
+    for label, milliseconds in wall_time.items():
+        print(f"| {label} | {milliseconds:.3f} |")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--top", type=int, default=15, help="number of import packages to show")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+    if args.top < 1:
+        parser.error("--top must be at least 1")
+
+    result = benchmark(args.top)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print_markdown(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_startup_benchmark.py
+++ b/tests/scripts/test_startup_benchmark.py
@@ -1,0 +1,37 @@
+"""Unit tests for the startup benchmark's importtime parser."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "startup_benchmark.py"
+SPEC = importlib.util.spec_from_file_location("startup_benchmark", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+startup_benchmark = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = startup_benchmark
+SPEC.loader.exec_module(startup_benchmark)
+
+
+def test_parse_importtime_and_aggregate_top_level_packages() -> None:
+    timings = startup_benchmark.parse_importtime(
+        """\
+import time: self [us] | cumulative | imported package
+import time:       120 |        120 | _io
+import time:        80 |        200 | exomem.kbdir
+import time:        30 |        230 | exomem.__main__
+unrelated stderr message
+"""
+    )
+
+    assert timings == [
+        startup_benchmark.ImportTiming(module="_io", self_us=120, cumulative_us=120),
+        startup_benchmark.ImportTiming(module="exomem.kbdir", self_us=80, cumulative_us=200),
+        startup_benchmark.ImportTiming(module="exomem.__main__", self_us=30, cumulative_us=230),
+    ]
+    assert startup_benchmark.aggregate_by_top_level(timings) == [
+        {"package": "exomem", "cumulative_ms": 0.43},
+        {"package": "_io", "cumulative_ms": 0.12},
+    ]


### PR DESCRIPTION
Lane A4 of OpenSpec `add-memory-server-comparison-benchmark` (Codex worker: `gpt-5.6-terra`, orchestrator-gated).

- New `scripts/startup_benchmark.py` (stdlib-only): parses `python -X importtime` for `exomem.__main__`, aggregates cumulative cost per top-level package, and reports median-of-3 wall times for `exomem --help` and a model-free one-shot. `--top`, `--json`.
- Sample run on this host fingered `fastmcp`/`mcp` as the dominant import cost — the evidence behind the lazy-import lane (#187).
- Canned-importtime parser test in `tests/scripts/`.

Gate evidence: lean suite 1780 passed; latency gate 2 passed; ruff identical to main (one auto-fixed import-sort in the new test, fixed by orchestrator at gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)