### PR TITLE
test: pin numpy vector backend's text-free cache residency

### DIFF
--- a/tests/test_numpy_lite_residency.py
+++ b/tests/test_numpy_lite_residency.py
@@ -1,0 +1,77 @@
+"""Regression coverage for the numpy backend's text-free resident cache."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exomem.embeddings import VECTOR_DIM, EmbeddingIndex
+
+
+@pytest.fixture(autouse=True)
+def _numpy_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_VEC_BACKEND", "numpy")
+
+
+def _vector(*values: float) -> np.ndarray:
+    vector = np.zeros(VECTOR_DIM, dtype=np.float32)
+    vector[: len(values)] = values
+    return vector / np.linalg.norm(vector)
+
+
+def _uncached_top_k(index: EmbeddingIndex, query: np.ndarray, k: int) -> list[tuple[str, int, str, float]]:
+    """Reference the former tuple-with-text scan straight from the sidecar."""
+    conn = sqlite3.connect(index.path)
+    try:
+        rows = conn.execute(
+            "SELECT file_path, chunk_idx, chunk_text, vector FROM chunks "
+            "ORDER BY file_path, chunk_idx"
+        ).fetchall()
+    finally:
+        conn.close()
+    scored = [
+        (path, chunk_idx, text, float(np.frombuffer(blob, dtype=np.float32) @ query))
+        for path, chunk_idx, text, blob in rows
+    ]
+    return sorted(scored, key=lambda hit: -hit[3])[:k]
+
+
+def test_numpy_query_hydrates_top_k_without_retaining_chunk_text(tmp_path: Path) -> None:
+    index = EmbeddingIndex(tmp_path)
+    secret_texts = [
+        "resident-text-probe-alpha",
+        "resident-text-probe-beta",
+        "resident-text-probe-gamma",
+    ]
+    index.upsert_file(
+        "Knowledge Base/Notes/probe.md",
+        secret_texts,
+        np.stack([_vector(1, 0), _vector(0.9, 0.1), _vector(0, 1)]),
+        mtime=1.0,
+    )
+    query = _vector(1, 0)
+
+    before = _uncached_top_k(index, query, k=2)
+    after = index.search(query, k=2)
+
+    # Same ordered top-k, text, and scores as the pre-cache tuple scan.
+    assert [(path, chunk, text) for path, chunk, text, _ in after] == [
+        (path, chunk, text) for path, chunk, text, _ in before
+    ]
+    np.testing.assert_allclose(
+        [score for *_rest, score in after],
+        [score for *_rest, score in before],
+    )
+
+    assert index._cache is not None
+    metadata = index._cache.metadata
+    assert metadata == [("Knowledge Base/Notes/probe.md", 0), ("Knowledge Base/Notes/probe.md", 1), ("Knowledge Base/Notes/probe.md", 2)]
+    assert all(
+        text not in value
+        for text in secret_texts
+        for path, _chunk_idx in metadata
+        for value in (path,)
+    )


### PR DESCRIPTION
Lane B1 of OpenSpec `reduce-memory-and-startup-overhead` (Codex worker: `gpt-5.6-terra`, orchestrator-gated) — with a finding.

**Finding:** the pre-scoped "numpy-lite" RSS fix already shipped on 2026-07-04 (see the `numpy-lite` comment at `src/exomem/embedding_index.py:72`): the resident cache holds only `(file_path, chunk_idx)` metadata + the float32 matrix, and top-k text hydrates from the sidecar by primary key. The decision-record text in `docs/benchmarks.md` (and the planning KB note) predated that and read as if unimplemented.

This PR therefore adds only `tests/test_numpy_lite_residency.py`, converting the property into a gated invariant: ordered top-k + hydrated text + scores match a sidecar-backed reference, and the warmed cache contains no chunk text. bf16 matrix storage was evaluated and deferred (no clean ≤10-line optional that preserves the float32 ranking path).

Gate evidence: lean suite 1780 passed; latency gate 2 passed; ruff identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)