### PR TITLE
Fix wikilinks for nested Obsidian vault roots

### DIFF
--- a/scripts/normalize_vault_wikilinks.py
+++ b/scripts/normalize_vault_wikilinks.py
@@ -1,5 +1,5 @@
 """One-shot cleanup: rewrite every wikilink under `Knowledge Base/` to the
-canonical full vault-rooted form, plus refresh sub-folder indexes.
+preferred form for the detected Obsidian vault root, plus refresh indexes.
 
 This is the "drain the lake" Phase 5 step from the plan. The exomem writer
 now enforces canonical form on every write going forward (Phase 1), but
@@ -12,7 +12,7 @@ Usage:
 By default runs against the vault resolved via `exomem.vault.resolve_vault()`
 (the `EXOMEM_VAULT_PATH` env var). Use --vault to override.
 
-The script:
+Canonical path resolution remains vault-rooted internally. The script:
 1. Builds a WikilinkResolver against the vault (one walk; includes
    frontmatter `title:` index for date-prefixed bare-name resolution).
 2. Walks every `.md` under `Knowledge Base/`, normalizes wikilinks in both
@@ -51,6 +51,7 @@ from exomem.vault import (  # noqa: E402
     normalize_body_wikilinks,
     normalize_wikilink,
     parse_frontmatter,
+    render_wikilink_target,
     resolve_vault,
 )
 
@@ -106,12 +107,13 @@ def normalize_frontmatter_wikilinks(
         if warning:
             warnings.append(warning)
             continue
-        if canonical == target and not alias:
+        rendered = render_wikilink_target(canonical, vault_root)
+        if rendered == target and not alias:
             continue
         if alias:
-            replacement = f"[[{canonical}{alias}]]"
+            replacement = f"[[{rendered}{alias}]]"
         else:
-            replacement = f"[[{canonical}]]"
+            replacement = f"[[{rendered}]]"
         if replacement != m.group(0):
             new_text = new_text[: m.start()] + replacement + new_text[m.end():]
     return new_text, warnings

--- a/src/exomem/audit_fix.py
+++ b/src/exomem/audit_fix.py
@@ -61,6 +61,7 @@ from .vault import (
     normalize_body_wikilinks,
     normalize_wikilink,
     parse_frontmatter,
+    render_wikilink_target,
 )
 
 
@@ -130,9 +131,10 @@ def _normalize_frontmatter_wikilinks(
         if warning:
             warnings.append(warning)
             continue
-        if canonical == target and not alias:
+        rendered = render_wikilink_target(canonical, vault_root)
+        if rendered == target and not alias:
             continue
-        replacement = f"[[{canonical}{alias}]]" if alias else f"[[{canonical}]]"
+        replacement = f"[[{rendered}{alias}]]" if alias else f"[[{rendered}]]"
         if replacement != m.group(0):
             new_text = new_text[: m.start()] + replacement + new_text[m.end():]
     return new_text, warnings

--- a/src/exomem/indexes.py
+++ b/src/exomem/indexes.py
@@ -17,7 +17,12 @@ from functools import cache
 from pathlib import Path
 
 from .kbdir import kb_prefix
-from .vault import PlannedWrite, escape_wikilinks_for_log, kb_root
+from .vault import (
+    PlannedWrite,
+    escape_wikilinks_for_log,
+    kb_root,
+    render_wikilinks_for_vault,
+)
 
 
 RECENT_ACTIVITY_CAP = 50
@@ -94,9 +99,9 @@ def compute_updates(
     )
 
     return IndexUpdate(
-        sources_index_content=sources_index_new,
-        top_index_content=top_index_new,
-        log_content=log_new,
+        sources_index_content=render_wikilinks_for_vault(sources_index_new, vault_root),
+        top_index_content=render_wikilinks_for_vault(top_index_new, vault_root),
+        log_content=render_wikilinks_for_vault(log_new, vault_root),
         trim_note=trim_note,
     )
 
@@ -403,7 +408,7 @@ _NOTES_H3_COUNT = re.compile(
 @cache
 def _notes_subfolder_bullet_re(kb_prefix_str: str) -> re.Pattern[str]:
     return re.compile(
-        r"^(- \[\[" + re.escape(kb_prefix_str)
+        r"^(- \[\[(?:" + re.escape(kb_prefix_str) + r")?"
         + r"Notes/(?P<typef>[A-Za-z]+)/(?P<sub>[^|\]/]+)/?(?:\|[^\]]+)?\]\])"
         r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
         re.MULTILINE,
@@ -414,7 +419,7 @@ def _notes_subfolder_bullet_re(kb_prefix_str: str) -> re.Pattern[str]:
 @cache
 def _entities_bullet_re(kb_prefix_str: str) -> re.Pattern[str]:
     return re.compile(
-        r"^(- \[\[" + re.escape(kb_prefix_str)
+        r"^(- \[\[(?:" + re.escape(kb_prefix_str) + r")?"
         + r"Entities/(?P<folder>People|Concepts|Libraries|Decisions)/?(?:\|[^\]]+)?\]\])"
         r"( \((?P<count>\d+)\))?(?P<rest>(?:\s+—[^\n]*)?)\s*$",
         re.MULTILINE,
@@ -611,6 +616,7 @@ def compute_subindex_writes(
             notes_counts=notes_counts,
             entities_counts=entities_counts,
         )
+        new_top_text = render_wikilinks_for_vault(new_top_text, vault_root)
 
     # Notes/index.md refresh.
     notes_index = notes_dir / "index.md"
@@ -625,6 +631,7 @@ def compute_subindex_writes(
                 counts_by_type=notes_counts,
                 counts_by_subfolder=notes_by_subfolder,
             )
+            new = render_wikilinks_for_vault(new, vault_root)
             if new != current:
                 writes.append(PlannedWrite(path=notes_index, content=new))
 
@@ -639,6 +646,7 @@ def compute_subindex_writes(
             new = _refresh_entities_subindex_text(
                 current, counts_by_type=entities_counts
             )
+            new = render_wikilinks_for_vault(new, vault_root)
             if new != current:
                 writes.append(PlannedWrite(path=entities_index, content=new))
 

--- a/src/exomem/link.py
+++ b/src/exomem/link.py
@@ -34,6 +34,7 @@ from .vault import (
     kb_root,
     normalize_body_wikilinks,
     normalize_wikilink,
+    render_wikilink_target,
     rotate_log_if_needed,
 )
 
@@ -181,7 +182,10 @@ def link(
         why_in_kb=why_clean,
         date_iso=date_iso,
         tags=tags_clean,
-        connections=connections_norm,
+        connections=[
+            render_wikilink_target(connection, vault_root)
+            for connection in connections_norm
+        ],
         affiliation=affiliation,
         relationship=relationship,
         domain=domain,

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -47,6 +47,7 @@ from .vault import (
     kb_root,
     normalize_body_wikilinks,
     normalize_wikilink,
+    render_wikilink_target,
     rotate_log_if_needed,
     slugify_with_truncation_check,
     unique_path,
@@ -331,7 +332,7 @@ def note(
         date_iso=date_iso,
     )
     rel_note_no_ext = note_path.relative_to(vault_root).with_suffix("").as_posix()
-    new_note_wikilink = f"[[{rel_note_no_ext}]]"
+    new_note_wikilink = f"[[{render_wikilink_target(rel_note_no_ext, vault_root)}]]"
 
     # Resolver: the process-shared, freshness-checked instance (find's graph-
     # lane cache) — a fresh build reads + YAML-parses the whole vault per
@@ -422,7 +423,7 @@ def note(
         projects=projects,
         status=status,
         date_iso=date_iso,
-        sources=sources_norm,
+        sources=[render_wikilink_target(source, vault_root) for source in sources_norm],
         tags=tags_clean,
         content=body_clean,
         severity=severity,

--- a/src/exomem/replace.py
+++ b/src/exomem/replace.py
@@ -29,7 +29,7 @@ from . import indexes
 from . import note as note_module
 from . import memory_refs
 from .kbdir import kb_prefix
-from .vault import PlannedWrite, batch_atomic_write, kb_root
+from .vault import PlannedWrite, batch_atomic_write, kb_root, render_wikilink_target
 
 
 log = logging.getLogger(__name__)
@@ -139,7 +139,8 @@ def replace(
 
     # Inject `supersedes:` into the freshly-written new page's frontmatter.
     new_text = new_resolved.read_text(encoding="utf-8")
-    new_text_updated = _inject_supersedes(new_text, rel_old_no_ext)
+    old_link_target = render_wikilink_target(rel_old_no_ext, vault_root)
+    new_text_updated = _inject_supersedes(new_text, old_link_target)
     if new_text_updated == new_text:
         warnings.append(
             "could not inject supersedes: into new page frontmatter — "
@@ -148,7 +149,8 @@ def replace(
 
     # Patch old page: status -> superseded, add superseded_by, refresh updated.
     old_text = old_resolved.read_text(encoding="utf-8")
-    old_text_updated = _mark_superseded(old_text, rel_new_no_ext, date_iso)
+    new_link_target = render_wikilink_target(rel_new_no_ext, vault_root)
+    old_text_updated = _mark_superseded(old_text, new_link_target, date_iso)
     if old_text_updated == old_text:
         warnings.append(
             "could not patch old page frontmatter (status/superseded_by/updated) — "

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -1000,6 +1000,43 @@ def _strip_wikilink_brackets(s: str) -> str:
     return s
 
 
+def obsidian_uses_kb_root(vault_root: Path) -> bool:
+    """Whether Obsidian opens the managed KB directory as its vault root.
+
+    Exomem's API paths stay vault-rooted (``Knowledge Base/...``). Markdown
+    targets must instead be relative to the directory containing ``.obsidian``
+    or Obsidian interprets the KB prefix as a nested folder.
+    """
+    return (kb_root(vault_root) / ".obsidian").is_dir()
+
+
+def render_wikilink_target(target: str, vault_root: Path) -> str:
+    """Render a canonical target for the detected Obsidian vault root."""
+    if obsidian_uses_kb_root(vault_root) and target.startswith(kb_prefix()):
+        return target.removeprefix(kb_prefix())
+    return target
+
+
+def render_wikilinks_for_vault(text: str, vault_root: Path) -> str:
+    """Render canonical wikilinks in generated Markdown for this vault root.
+
+    Unlike :func:`normalize_body_wikilinks`, this does not resolve targets. It
+    only converts already-canonical ``Knowledge Base/...`` targets to their
+    KB-relative display form when Obsidian opens the managed directory itself.
+    """
+    new_text = text
+    for match in reversed(find_body_wikilinks(text)):
+        full = match.group(0)
+        inner = full[2:-2]
+        target, separator, alias = inner.partition("|")
+        rendered = render_wikilink_target(target.strip(), vault_root)
+        if rendered == target.strip():
+            continue
+        replacement = f"[[{rendered}|{alias}]]" if separator else f"[[{rendered}]]"
+        new_text = new_text[: match.start()] + replacement + new_text[match.end() :]
+    return new_text
+
+
 def normalize_wikilink(
     target: str,
     vault_root: Path,
@@ -1164,11 +1201,14 @@ def normalize_body_wikilinks(
     *,
     resolver: WikilinkResolver | None = None,
 ) -> tuple[str, list[str]]:
-    """Rewrite every `[[X]]` in `body` to canonical full vault-rooted form.
+    """Rewrite every `[[X]]` to the preferred Obsidian-visible form.
 
     Preserves `[[X|alias]]` aliases. Skips matches inside fenced code blocks
-    and inline code spans. Returns `(new_body, warnings)`. Unresolvable links
-    are left as-is with a warning — forward references are intentional.
+    and inline code spans. Internal resolution remains canonical vault-rooted;
+    emitted Markdown is KB-relative when ``Knowledge Base/.obsidian`` marks the
+    managed directory as the Obsidian vault root. Returns `(new_body, warnings)`.
+    Unresolvable links are left as-is with a warning — forward references are
+    intentional.
     """
     if resolver is None:
         resolver = WikilinkResolver(vault_root)
@@ -1195,10 +1235,11 @@ def normalize_body_wikilinks(
         if warning:
             warnings.append(warning)
             continue
-        if canonical == target_only:
+        rendered = render_wikilink_target(canonical, vault_root)
+        if rendered == target_only:
             continue  # already canonical
         replacement = (
-            f"[[{canonical}|{alias}]]" if alias is not None else f"[[{canonical}]]"
+            f"[[{rendered}|{alias}]]" if alias is not None else f"[[{rendered}]]"
         )
         new_body = new_body[: m.start()] + replacement + new_body[m.end():]
     return new_body, warnings

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -181,6 +181,27 @@ def test_add_updates_sources_index_count(
     assert "2026-05-18 — [[Knowledge Base/Sources/Articles/2026-05-18-new-article]]" in after
 
 
+def test_add_renders_generated_indexes_for_nested_obsidian_root(
+    vault: Path, source_schema: schema_module.SourceSchema
+) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+
+    add_module.add(
+        vault,
+        source_schema,
+        content="body",
+        source_type="article",
+        title="Nested root article",
+        url="https://example.com/nested",
+        today=TODAY,
+    )
+
+    sources_index = _read(vault / "Knowledge Base" / "Sources" / "index.md")
+    assert "[[Sources/Articles/|Articles]]" in sources_index
+    assert "[[Sources/Articles/2026-05-18-nested-root-article]]" in sources_index
+    assert "[[Knowledge Base/" not in sources_index
+
+
 def test_add_updates_sources_index_for_new_folder(
     vault: Path, source_schema: schema_module.SourceSchema
 ) -> None:

--- a/tests/test_audit_fix.py
+++ b/tests/test_audit_fix.py
@@ -39,6 +39,28 @@ def test_audit_fix_canonicalizes_wikilinks_in_body(vault: Path) -> None:
     assert report.files_rewritten >= 1
 
 
+def test_audit_fix_uses_kb_relative_links_for_nested_obsidian_root(vault: Path) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    target = (
+        "Knowledge Base/Notes/Insights/"
+        "progressive-disclosure-without-mode-fragmentation"
+    )
+    path = vault / "Knowledge Base" / "Notes" / "Insights" / "nested-root-linker.md"
+    _seed(
+        path,
+        "---\ntype: insight\nstatus: active\ncreated: 2026-05-28\n"
+        "updated: 2026-05-28\ntags: []\n"
+        f'sources:\n  - "[[{target}]]"\n---\n'
+        f"# Linker\n\nSee [[{target}]].\n",
+    )
+
+    audit_fix_module.audit_fix(vault, today=TODAY)
+
+    text = path.read_text(encoding="utf-8")
+    assert "[[Notes/Insights/progressive-disclosure-without-mode-fragmentation]]" in text
+    assert "[[Knowledge Base/" not in text
+
+
 def test_audit_fix_skips_sources_and_evidence(vault: Path) -> None:
     """Append-only trees are never touched even if they contain stale wikilinks."""
     # Plant a KB-relative wikilink in an existing source (which would normally

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -224,3 +224,22 @@ def test_link_connections_normalize_and_render(vault: Path) -> None:
     assert "- relates_to [[Knowledge Base/Notes/Insights/foo]]" in text
     assert "- relates_to [[Knowledge Base/Notes/Patterns/bar]]" in text
     assert "- relates_to [[Reference/Strategy]]" in text
+
+
+def test_link_connections_use_kb_relative_form_for_nested_obsidian_root(
+    vault: Path,
+) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+
+    result = link_module.link(
+        vault,
+        entity_type="concept",
+        name="Nested Root Connection",
+        summary="x",
+        connections=["Knowledge Base/Notes/Insights/foo"],
+        today=TODAY,
+    )
+
+    text = _read(vault / result.path)
+    assert "- relates_to [[Notes/Insights/foo]]" in text
+    assert "[[Knowledge Base/" not in text

--- a/tests/test_normalize_wikilink.py
+++ b/tests/test_normalize_wikilink.py
@@ -18,6 +18,9 @@ from exomem.vault import (
     find_body_wikilinks,
     normalize_body_wikilinks,
     normalize_wikilink,
+    obsidian_uses_kb_root,
+    render_wikilink_target,
+    render_wikilinks_for_vault,
 )
 
 
@@ -219,6 +222,58 @@ def test_body_normalization_rewrites_kb_relative_to_full(vault: Path) -> None:
         in new_body
     )
     assert warnings == []
+
+
+def test_body_normalization_uses_kb_relative_links_for_nested_obsidian_root(
+    vault: Path,
+) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    target = (
+        "Knowledge Base/Notes/Insights/"
+        "progressive-disclosure-without-mode-fragmentation"
+    )
+
+    new_body, warnings = normalize_body_wikilinks(
+        f"See [[{target}#mechanism|the mechanism]].", vault
+    )
+
+    assert obsidian_uses_kb_root(vault) is True
+    assert warnings == []
+    assert (
+        "[[Notes/Insights/progressive-disclosure-without-mode-fragmentation"
+        "#mechanism|the mechanism]]"
+    ) in new_body
+    assert "[[Knowledge Base/" not in new_body
+    canonical, warning = normalize_wikilink(
+        "Notes/Insights/progressive-disclosure-without-mode-fragmentation", vault
+    )
+    assert warning is None
+    assert canonical.startswith("Knowledge Base/")
+    assert render_wikilink_target(canonical, vault).startswith("Notes/")
+
+
+def test_parent_obsidian_root_keeps_full_vault_rooted_links(vault: Path) -> None:
+    (vault / ".obsidian").mkdir()
+    target = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation"
+
+    new_body, warnings = normalize_body_wikilinks(f"See [[{target}]].", vault)
+
+    assert obsidian_uses_kb_root(vault) is False
+    assert warnings == []
+    assert f"[[{target}]]" in new_body
+
+
+def test_generated_markdown_renderer_preserves_code_and_aliases(vault: Path) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    text = (
+        "[[Knowledge Base/Notes/Insights/foo|Foo]]\n"
+        "`[[Knowledge Base/Notes/Insights/in-code]]`\n"
+    )
+
+    rendered = render_wikilinks_for_vault(text, vault)
+
+    assert "[[Notes/Insights/foo|Foo]]" in rendered
+    assert "`[[Knowledge Base/Notes/Insights/in-code]]`" in rendered
 
 
 def test_body_normalization_preserves_alias(vault: Path) -> None:

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -39,6 +39,31 @@ def test_note_writes_caller_h1_verbatim_no_duplicate(vault: Path) -> None:
     assert body.lstrip().startswith("# A note about retrieval pipelines")
 
 
+def test_note_renders_links_for_kb_rooted_obsidian_vault(vault: Path) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    source = "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements"
+    target = (
+        "Knowledge Base/Notes/Insights/"
+        "progressive-disclosure-without-mode-fragmentation"
+    )
+
+    result = note_module.note(
+        vault,
+        content=f"## Claim\n\nSee [[{target}]].\n",
+        note_type="insight",
+        title="KB-rooted Obsidian links",
+        sources=[source],
+        today=TODAY,
+    )
+
+    written = (vault / result.path).read_text(encoding="utf-8")
+    assert "[[Notes/Insights/progressive-disclosure" in written
+    assert "[[Sources/Articles/2026-05-04-best-egcg-supplements]]" in written
+    assert "[[Knowledge Base/" not in written
+    source_text = (vault / f"{source}.md").read_text(encoding="utf-8")
+    assert "[[Notes/Insights/kb-rooted-obsidian-links]]" in source_text
+
+
 def test_note_body_with_no_h1_is_written_verbatim(vault: Path) -> None:
     """If the caller declines to supply an H1, the tool doesn't invent one."""
     result = note_module.note(

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -63,6 +63,26 @@ def test_replace_writes_new_and_flips_old(vault: Path) -> None:
     assert old_rel.removesuffix(".md") in str(supersedes)
 
 
+def test_replace_renders_supersession_links_for_kb_rooted_obsidian(vault: Path) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    old_rel = _make_insight(vault, "Nested Root Old")
+
+    result = replace_module.replace(
+        vault,
+        old_path=old_rel,
+        content="# Nested Root New\n\nrevised.\n",
+        note_type="insight",
+        title="Nested Root New",
+        today=TODAY,
+    )
+
+    old_text = _read(vault / result.old_path)
+    new_text = _read(vault / result.new_path)
+    assert "[[Notes/Insights/nested-root-new]]" in old_text
+    assert "[[Notes/Insights/nested-root-old]]" in new_text
+    assert "[[Knowledge Base/" not in old_text + new_text
+
+
 def test_replace_bumps_old_updated_date(vault: Path) -> None:
     old_rel = _make_insight(vault, "Bumped Insight")
     later = dt.date(2026, 6, 1)

--- a/tests/test_subindex_refresh.py
+++ b/tests/test_subindex_refresh.py
@@ -136,6 +136,34 @@ def test_link_updates_entities_subindex_bullet(vault: Path) -> None:
     assert "- [[Knowledge Base/Entities/Concepts/|Concepts]] (4)" in text, text
 
 
+def test_subindex_refresh_supports_nested_obsidian_root(vault: Path) -> None:
+    (vault / "Knowledge Base" / ".obsidian").mkdir()
+    notes_idx = _seed_notes_index(vault)
+    entities_idx = _seed_entities_index(vault)
+
+    note_module.note(
+        vault,
+        content="# t\n\n## Question\n\nBody.\n",
+        note_type="research-note",
+        title="Nested root subindex note",
+        project="project-alpha",
+        today=TODAY,
+    )
+    link_module.link(
+        vault,
+        entity_type="concept",
+        name="Nested Root Subindex Concept",
+        summary="x",
+        today=TODAY,
+    )
+
+    notes_text = notes_idx.read_text(encoding="utf-8")
+    entities_text = entities_idx.read_text(encoding="utf-8")
+    assert "[[Notes/Research/Project Alpha/|Project Alpha]] (2)" in notes_text
+    assert "[[Entities/Concepts/|Concepts]] (4)" in entities_text
+    assert "[[Knowledge Base/" not in notes_text + entities_text
+
+
 def test_subindex_preserves_hand_curated_descriptions(vault: Path) -> None:
     """The auto-refresh must not touch the `— description` tail on bullets."""
     notes_idx = _seed_notes_index(vault)


### PR DESCRIPTION
## Summary
- keep Exomem paths canonical internally while rendering Markdown relative to the detected Obsidian vault root
- cover bodies, frontmatter, backlinks, relations, supersession, and generated indexes
- make the existing normalization script migrate either supported vault layout

## Verification
- 104 focused lifecycle tests passed
- required Ruff correctness gate passed
- exact live target rendered from Knowledge Base/Notes/... to Notes/... and exists on disk

The full mounted-corpus dry-run was stopped after six minutes because WSL filesystem traversal was too slow; it made no writes.