### PR TITLE
Preserve protected trees during wikilink migration

### DIFF
--- a/scripts/fix_wikilink_residuals.py
+++ b/scripts/fix_wikilink_residuals.py
@@ -171,7 +171,7 @@ def main() -> int:
     if writes and not args.dry_run:
         BATCH = 100
         for i in range(0, len(writes), BATCH):
-            batch_atomic_write(writes[i : i + BATCH])
+            batch_atomic_write(writes[i : i + BATCH], vault_root=vault_root)
         print(f"Applied {len(writes)} file writes.")
 
     return 0

--- a/scripts/normalize_vault_wikilinks.py
+++ b/scripts/normalize_vault_wikilinks.py
@@ -41,6 +41,7 @@ SRC = HERE.parent / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from exomem import access  # noqa: E402
 from exomem import audit as audit_module  # noqa: E402
 from exomem import indexes  # noqa: E402
 from exomem.vault import (  # noqa: E402
@@ -56,28 +57,45 @@ from exomem.vault import (  # noqa: E402
 )
 
 
-# Skip these subtrees of Knowledge Base/ entirely.
-SKIP_KB_SUBDIRS = frozenset({"_Schema", "_trash", "_archive", "_attachments"})
+# Skip append-only and infrastructure subtrees entirely. Per-vault readonly and
+# excluded policy is checked separately through ``access_tier`` below.
+SKIP_KB_SUBDIRS = frozenset({
+    "Sources", "Evidence", "_Schema", "_trash", "_archive", "_attachments",
+})
+
+
+def _is_writable_tree(vault_root: Path, path: Path) -> bool:
+    rel = path.relative_to(vault_root).as_posix()
+    return access.access_tier(vault_root, rel) == access.TIER_READ_WRITE
 
 
 def walk_kb_md(kb_dir: Path):
-    """Yield every .md under Knowledge Base/, skipping infra/archive subtrees."""
+    """Yield writable compiled Markdown, preserving protected provenance trees."""
+    vault_root = kb_dir.parent
     for child in sorted(kb_dir.iterdir()):
         if child.is_dir():
-            if child.name in SKIP_KB_SUBDIRS:
+            if child.name in SKIP_KB_SUBDIRS or not _is_writable_tree(vault_root, child):
                 continue
-            yield from _walk(child)
-        elif child.is_file() and child.suffix.lower() == ".md":
+            yield from _walk(child, vault_root)
+        elif (
+            child.is_file()
+            and child.suffix.lower() == ".md"
+            and _is_writable_tree(vault_root, child)
+        ):
             yield child
 
 
-def _walk(dir_: Path):
+def _walk(dir_: Path, vault_root: Path):
     for child in sorted(dir_.iterdir()):
         if child.is_dir():
-            if child.name in SKIP_KB_SUBDIRS:
+            if child.name in SKIP_KB_SUBDIRS or not _is_writable_tree(vault_root, child):
                 continue
-            yield from _walk(child)
-        elif child.is_file() and child.suffix.lower() == ".md":
+            yield from _walk(child, vault_root)
+        elif (
+            child.is_file()
+            and child.suffix.lower() == ".md"
+            and _is_writable_tree(vault_root, child)
+        ):
             yield child
 
 
@@ -238,7 +256,7 @@ def main() -> int:
         # Split into batches to keep the atomic-write tempfile count reasonable.
         BATCH = 100
         for i in range(0, len(writes), BATCH):
-            batch_atomic_write(writes[i : i + BATCH])
+            batch_atomic_write(writes[i : i + BATCH], vault_root=vault_root)
         print(f"  wrote {len(writes)} files.")
         print()
 

--- a/tests/test_normalize_vault_wikilinks_script.py
+++ b/tests/test_normalize_vault_wikilinks_script.py
@@ -1,0 +1,43 @@
+"""Safety boundaries for the one-time wikilink migration scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "normalize_vault_wikilinks.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "normalize_vault_wikilinks_under_test", SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+normalize_script = _load_script_module()
+
+
+def test_walk_only_returns_writable_compiled_markdown(vault: Path) -> None:
+    kb = vault / "Knowledge Base"
+    protected = {
+        kb / "Sources" / "Articles" / "protected-source.md",
+        kb / "Evidence" / "Case" / "protected-evidence.md",
+        kb / "Products" / "protected-curated.md",
+    }
+    writable = kb / "Notes" / "Insights" / "writable-note.md"
+    for path in protected | {writable}:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# test\n", encoding="utf-8")
+    (kb / "_access.yaml").write_text(
+        "readonly:\n  - Products\nexcluded: []\n", encoding="utf-8"
+    )
+
+    walked = set(normalize_script.walk_kb_md(kb))
+
+    assert writable in walked
+    assert walked.isdisjoint(protected)


### PR DESCRIPTION
## Summary
- skip append-only Sources and Evidence during wikilink migration
- honor readonly and excluded subtrees from _access.yaml
- pass the vault root into the central write-policy backstop for both migration scripts

## Verification
- 44 focused tests passed
- required Ruff correctness gate passed

Found during the native Windows dry-run for v0.16.1: the old script proposed 1,161 rewrites, including protected provenance files, so no corpus writes were applied.