### PR TITLE
feat: activate existing corpus through governed review

### DIFF
--- a/openspec/changes/activate-existing-corpus/.openspec.yaml
+++ b/openspec/changes/activate-existing-corpus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/activate-existing-corpus/design.md
+++ b/openspec/changes/activate-existing-corpus/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The graph substrate already indexes wikilinks, canonical note relations, semantic-block relations, and frontmatter provenance. The default attention queue can surface pages with no outbound Markdown connection, but it cannot distinguish a generic-only page from a typed page, measure provenance coverage, or expose explicit relation vocabulary that the registry does not govern. Existing review state already provides portable item references, fingerprint-bound dismiss/snooze decisions, and deterministic RRF composition.
+
+The change must remain a pure substrate. It may parse and count explicit Markdown structure, but it cannot infer that one note supports, contradicts, or causes another. Sources, Evidence, excluded content, read-only content, inactive conclusions, and navigation pages are not activation write targets.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give an existing vault an objective activation baseline with explicit denominators.
+- Rank individual, reviewable deficits without changing the normal daily attention queue.
+- Route review toward the existing relation-proposal, schema, read, and governed edit operations.
+- Reuse stable review identity and triage so the backlog can be worked incrementally.
+- Keep the whole read path deterministic, dependency-light, and non-mutating.
+
+**Non-Goals:**
+
+- Automatically inventing, accepting, or writing semantic relationships.
+- Treating graph density as truth, authority, confidence, or note quality.
+- Requiring every claim to have block-level evidence or every wikilink to become typed.
+- Modifying retrieval ranking, graph traversal profiles, or the relation registry.
+- Adding a server-side reasoning model or an activation sidecar/database.
+
+## Decisions
+
+### Use a dedicated corpus activation scanner
+
+A new `activation` module will walk the parsed KB once and classify active, read-write compiled pages using the same eligibility conventions as relation-debt review. It will return `AuditFinding`-compatible measurements plus a coverage object. This keeps the general audit response stable while still reusing the existing finding/ranking contracts.
+
+Alternative: add several audit categories and derive coverage from their findings. Rejected because findings cannot express clean denominators, and independent audit checks would repeatedly parse the same page.
+
+### Measure four explicit deficits
+
+The scanner will emit, in fixed priority order:
+
+1. `unregistered_relation`: an explicitly authored relation observation is not governed by the loaded relation registry.
+2. `provenance_debt`: a page contains assertion-bearing semantic blocks but has no explicit page-level provenance edge (`derived_from`, `evidenced_by`, or `cites`, including supported frontmatter origins).
+3. `typed_relation_debt`: a page has generic graph connections but no registered typed semantic relation.
+4. `relation_debt`: a page has no explicit outbound graph connection.
+
+These are structural measurements, not judgments. In particular, page-level provenance is intentionally coarse: its presence does not prove that every block is supported.
+
+### Return counts with denominators, not a quality score
+
+Coverage will report eligible pages, connected pages, typed-relation pages, generic-only pages, disconnected pages, provenance-candidate pages, provenance-linked pages, and unregistered observations. It will not collapse these into a single score. A single score would imply an unsupported quality ordering and would hide why the corpus needs work.
+
+### Reuse attention ranking and review state under a dedicated mode
+
+`review_memory(mode="activation")` will compose activation findings with equal-weight RRF, deterministic category/path tie-breaking, path deduplication, stable references, fingerprint-bound state, and explicit truncation. The default `attention` category set and order remain unchanged. Item lookup and triage will resolve both default-attention and activation-only items.
+
+Alternative: add activation categories to the default attention inbox. Rejected for the first release because a mature existing corpus can produce a large backlog that would drown time-sensitive contradiction, staleness, and source work.
+
+### Put action routes in measured finding metadata
+
+Each reason will carry deterministic `next_actions` describing existing tool calls, such as relation suggestions, schema review, read, or governed edit. Routes are guidance only and do not execute during activation. Model-assisted suggestions remain an explicit downstream request and retain their existing default-off/soft-fail behavior.
+
+### Inherit MCP, REST, and CLI exposure from `review_memory`
+
+No new top-level command is required. Extending the shared `review_memory` leaf makes activation reachable through its generated MCP tool, `/api/review_memory`, OpenAPI schema, and CLI subcommand with no duplicated surface logic.
+
+## Risks / Trade-offs
+
+- [Large legacy backlog makes scans or responses noisy] -> Scan only eligible pages, cap surfaced items with explicit truncation, and keep the mode opt-in.
+- [Generic links are sometimes exactly right] -> Label the signal as review debt, not an error, and never auto-convert links.
+- [Page-level provenance overstates block-level support] -> Name the metric precisely and state the limitation in the response guidance.
+- [Unknown relation syntax may be intentional vocabulary] -> Route it to `schema_memory`; do not silently map it to a core relation.
+- [A dismissed activation item changes meaning after edits] -> Bind decisions to content-derived signal fingerprints so changed pages resurface.
+- [Unreadable or malformed pages interrupt a corpus scan] -> Reuse tolerant page parsing and skip individual unreadable pages with logging; return the measurements that completed.
+
+## Migration Plan
+
+Ship as an additive `review_memory` mode with no data migration. Existing review-state files remain compatible because identity is path-based and fingerprints already include categories and signal versions. Rollback removes the mode and scanner; no vault content or sidecar requires reversal.
+
+## Open Questions
+
+None for the first slice. Future evidence-block granularity and project-specific activation lenses should be driven by real queue usage rather than hard-coded now.

--- a/openspec/changes/activate-existing-corpus/proposal.md
+++ b/openspec/changes/activate-existing-corpus/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exomem can already represent deep epistemic relationships, but an existing vault can remain mostly connected by generic wikilinks with little typed relation or provenance structure. The system needs a safe, low-friction way to measure that dormant potential and turn it into a reviewable improvement loop without bulk inference or automatic rewriting.
+
+## What Changes
+
+- Add a read-only corpus-activation report that measures graph and epistemic coverage across eligible compiled knowledge.
+- Add a dedicated ranked activation queue for disconnected notes, generic-link-only notes, provenance gaps, and unregistered relation observations.
+- Give every activation item stable review identity, measured reasons, and concrete routes into existing proposal and governed edit operations.
+- Preserve human judgment: activation never asserts a semantic relationship, changes a note, or mutates Sources, Evidence, or read-only content.
+- Keep model-assisted relation suggestions explicit and optional; the activation measurement and ranking path is deterministic, dependency-light, and soft-fails individual unreadable notes.
+- Verify the full lifecycle across the shared MCP, REST, and CLI command surface, including triage persistence and non-mutation.
+
+## Capabilities
+
+### New Capabilities
+
+- `corpus-activation`: Measures existing-corpus coverage and provides a deterministic, governed queue for progressively activating deeper epistemic structure.
+
+### Modified Capabilities
+
+- `attention-queue`: Adds a dedicated activation review composition that reuses stable item identity, deterministic ranking, triage, and read-only guarantees without changing the default daily attention categories.
+
+## Impact
+
+This affects audit/coverage measurement, attention queue composition, `review_memory` routing, command documentation, and focused product E2E tests. It adds no required service, model, storage migration, or automatic write path; existing generated MCP, REST, and CLI surfaces inherit the behavior from the shared command implementation.

--- a/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
+++ b/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Dedicated Corpus Activation Review Composition
+
+The system SHALL expose corpus activation through `review_memory(mode="activation")`. It SHALL rank activation findings by equal-weight Reciprocal Rank Fusion with fixed category preference `unregistered_relation` > `provenance_debt` > `typed_relation_debt` > `relation_debt`, deduplicate by anchor path, preserve all contributing reasons, apply the requested cap with explicit truncation, and return the corpus coverage counts alongside the queue. The default `attention` operation and its default categories SHALL remain unchanged.
+
+#### Scenario: Activation backlog stays out of daily attention
+
+- **WHEN** a vault contains activation findings and `review_memory(mode="attention")` is called without categories
+- **THEN** the existing daily attention categories and ordering are used unchanged
+- **AND** `review_memory(mode="activation")` returns the separately ranked activation backlog and coverage
+
+#### Scenario: Multiple activation deficits deduplicate and rise
+
+- **WHEN** one page has both provenance and typed-relation debt while another has only typed-relation debt at the same intra-category rank
+- **THEN** the first page appears once with both reasons and the sum of its RRF votes
+- **AND** it ranks above the page with one signal
+
+### Requirement: Activation Items Use Stable Review Lifecycle
+
+Activation items SHALL receive the same stable review reference, content-bound signal fingerprint, open/all/snoozed/dismissed filtering, and triage behavior as daily attention items. Item lookup and triage SHALL resolve activation-only references. A materially changed signal SHALL resurface even if its previous fingerprint was dismissed.
+
+#### Scenario: Activation-only item can be triaged
+
+- **WHEN** an activation item that is absent from default attention is dismissed through `triage_memory`
+- **THEN** it is hidden from the open activation view and visible in the dismissed or all view
+- **AND** default attention behavior is unaffected
+
+#### Scenario: Changed knowledge resurfaces
+
+- **WHEN** a dismissed page is edited so its measured activation signal version changes while a deficit remains
+- **THEN** the new activation fingerprint is open again
+
+### Requirement: Activation Mode Is Shared Across Product Surfaces
+
+The activation mode SHALL be implemented in the shared `review_memory` leaf and SHALL therefore be reachable through the generated MCP tool, REST route, OpenAPI operation, and CLI command without surface-specific activation logic.
+
+#### Scenario: Same activation contract on every surface
+
+- **WHEN** activation is invoked through MCP, `/api/review_memory`, and `kb review_memory --mode activation --json` over the same vault state
+- **THEN** each surface returns the same coverage, ordered item paths, categories, and stable references
+

--- a/openspec/changes/activate-existing-corpus/specs/corpus-activation/spec.md
+++ b/openspec/changes/activate-existing-corpus/specs/corpus-activation/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Existing-Corpus Coverage
+
+The system SHALL scan active, read-write compiled knowledge and return explicit coverage counts for eligible pages, connected pages, typed-relation pages, generic-only pages, disconnected pages, provenance-candidate pages, provenance-linked pages, and unregistered relation observations. It MUST NOT combine the counts into a confidence, authority, or quality score.
+
+#### Scenario: Mixed corpus produces denominator-backed coverage
+
+- **WHEN** the corpus contains a disconnected compiled page, a generic-link-only compiled page, a typed-relation page, and an assertion-bearing page with provenance
+- **THEN** each page is counted in the applicable coverage fields with `eligible_pages` as the page denominator
+- **AND** no aggregate quality score is returned
+
+#### Scenario: Protected and inactive material is excluded
+
+- **WHEN** Sources, Evidence, read-only pages, excluded pages, navigation pages, drafts, archived pages, or superseded pages are present
+- **THEN** they are not counted as eligible activation targets
+- **AND** the scan does not modify them
+
+### Requirement: Structural Activation Signals
+
+The system SHALL surface four explicit structural signals: `relation_debt` for an eligible page with no outbound graph connection, `typed_relation_debt` for one with generic connections but no registered typed semantic relation, `provenance_debt` for one with assertion-bearing semantic blocks but no explicit page-level provenance relation, and `unregistered_relation` for authored relation observations outside the loaded registry. Every signal SHALL carry the page content version and measured counts needed for stable review fingerprinting.
+
+#### Scenario: Generic links do not masquerade as typed epistemic structure
+
+- **WHEN** an eligible page contains ordinary body wikilinks but no registered typed relation
+- **THEN** it produces `typed_relation_debt`, not `relation_debt`
+- **AND** its metadata reports the observed generic and typed connection counts
+
+#### Scenario: Assertion-bearing page lacks page-level provenance
+
+- **WHEN** an eligible page contains a claim, finding, inference, hypothesis, or result semantic block and has no `derived_from`, `evidenced_by`, or `cites` relation through supported Markdown or frontmatter origins
+- **THEN** it produces a `provenance_debt` measurement
+- **AND** the guidance states that page-level provenance does not establish support for every block
+
+#### Scenario: Explicit unknown vocabulary remains unassigned
+
+- **WHEN** an authored relation observation cannot be resolved by the loaded relation registry
+- **THEN** the page produces an `unregistered_relation` measurement containing the observed labels and anchors
+- **AND** the system does not map, register, or rewrite the relation automatically
+
+### Requirement: Governed Activation Actions
+
+Every activation reason SHALL include deterministic next-action routes into existing read, relation-proposal, schema-review, or governed edit operations. Running activation MUST NOT execute those routes, write a relation, change the registry, mutate a note, update graph data, or alter retrieval ranking. Any model-assisted relation suggestion remains explicit, default-off, response-only, and soft-failing under its existing contract.
+
+#### Scenario: Reviewing an activation item is non-mutating
+
+- **WHEN** an activation report is requested
+- **THEN** each item includes review guidance and applicable existing-tool routes
+- **AND** vault file content, graph sidecars, registry files, and find ordering remain unchanged
+
+### Requirement: Dependency-Light Soft Failure
+
+Corpus activation SHALL require no embedding, reranking, media, or reasoning-model dependency. An unreadable individual page MUST NOT fail the whole scan; it SHALL be skipped using the existing tolerant corpus parsing behavior while the completed measurements are returned.
+
+#### Scenario: Embeddings are disabled
+
+- **WHEN** activation runs with embeddings and optional model features disabled
+- **THEN** the same Markdown-derived findings and deterministic ordering are available
+

--- a/openspec/changes/activate-existing-corpus/tasks.md
+++ b/openspec/changes/activate-existing-corpus/tasks.md
@@ -1,0 +1,19 @@
+## 1. Corpus Measurement
+
+- [x] 1.1 Implement the dependency-light activation scanner, eligibility rules, coverage counts, and four structural findings.
+- [x] 1.2 Add deterministic next-action metadata, content signal versions, and non-mutating behavior tests.
+
+## 2. Review Workflow
+
+- [x] 2.1 Generalize attention composition for a fixed activation category order while preserving default attention output.
+- [x] 2.2 Add `review_memory(mode="activation")`, coverage output, activation item lookup, and triage lifecycle support.
+
+## 3. Surface And Lifecycle Verification
+
+- [x] 3.1 Add focused scanner, ranking, review-state, and default-attention regression tests.
+- [x] 3.2 Verify matching activation behavior through MCP, REST, and CLI and update command-schema fixtures where required.
+- [x] 3.3 Run lint, the focused suite, the full dependency-light suite, and an installed-wheel full-lifecycle E2E.
+
+## 4. Completion
+
+- [x] 4.1 Validate the OpenSpec change against implementation and mark all completed tasks.

--- a/src/exomem/activation.py
+++ b/src/exomem/activation.py
@@ -1,0 +1,323 @@
+"""Deterministic measurements for progressively activating an existing corpus.
+
+This module measures explicit Markdown structure only. It does not infer semantic
+relationships, score knowledge quality, or write to the vault.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from . import access, markdown_relations, relation_registry, semantic_blocks
+from . import find as find_module
+from .audit import AuditFinding
+from .vault import content_hash, find_body_wikilinks, kb_root
+
+ACTIVATION_CATEGORIES: tuple[str, ...] = (
+    "unregistered_relation",
+    "provenance_debt",
+    "typed_relation_debt",
+    "relation_debt",
+)
+
+_ELIGIBLE_TYPES = frozenset(
+    {
+        "research-note",
+        "insight",
+        "pattern",
+        "failure",
+        "experiment",
+        "production-log",
+        "entity",
+    }
+)
+_INACTIVE_STATUSES = frozenset({"superseded", "archived", "draft", "dropped"})
+_SKIP_SLUG_SUFFIXES = ("-architecture", "-snapshot", "-catalog-snapshot")
+_SKIP_TAGS = frozenset({"hub", "snapshot"})
+_ASSERTION_BLOCK_TYPES = frozenset({"claim", "finding", "inference", "hypothesis", "result"})
+_PROVENANCE_RELATIONS = frozenset({"derived_from", "evidenced_by", "cites"})
+_FRONTMATTER_TYPED_FIELDS: dict[str, str] = {
+    "sources": "derived_from",
+    "evidence": "evidenced_by",
+    "evidences": "evidenced_by",
+    "evidence_paths": "evidenced_by",
+    "supersedes": "supersedes",
+    "superseded_by": "supersedes",
+}
+_WIKILINK_RE = re.compile(r"\[\[([^\]|\n]+)(?:\|[^\]\n]+)?\]\]")
+
+
+@dataclass(frozen=True)
+class ActivationScan:
+    findings: list[AuditFinding]
+    coverage: dict[str, int]
+
+
+def scan(vault_root: Path) -> ActivationScan:
+    """Measure activation coverage and review deficits in one tolerant vault walk."""
+    vault_root = Path(vault_root)
+    registry = relation_registry.load_registry(vault_root)
+    findings: list[AuditFinding] = []
+    coverage = {
+        "eligible_pages": 0,
+        "connected_pages": 0,
+        "typed_relation_pages": 0,
+        "generic_only_pages": 0,
+        "disconnected_pages": 0,
+        "provenance_candidate_pages": 0,
+        "provenance_linked_pages": 0,
+        "unregistered_relation_observations": 0,
+    }
+
+    kb = kb_root(vault_root)
+    if not kb.is_dir():
+        return ActivationScan(findings=findings, coverage=coverage)
+
+    for path in find_module._walk_md(kb):
+        try:
+            page = find_module._parse_page(path, path.stat().st_mtime, vault_root)
+        except OSError:
+            continue
+        if page is None or not _eligible(vault_root, page):
+            continue
+
+        coverage["eligible_pages"] += 1
+        measurement = _measure_page(page, registry)
+        meta = {
+            "signal_version": _signal_version(page),
+            "typed_relations": measurement["typed_relations"],
+            "body_wikilinks": measurement["body_wikilinks"],
+            "frontmatter_links": measurement["frontmatter_links"],
+            "assertion_blocks": measurement["assertion_blocks"],
+            "provenance_relations": measurement["provenance_relations"],
+        }
+
+        if measurement["connected"]:
+            coverage["connected_pages"] += 1
+        else:
+            coverage["disconnected_pages"] += 1
+            findings.append(_relation_debt(page.rel_path, meta))
+
+        if measurement["typed_relations"]:
+            coverage["typed_relation_pages"] += 1
+        elif measurement["connected"]:
+            coverage["generic_only_pages"] += 1
+            findings.append(_typed_relation_debt(page.rel_path, meta))
+
+        if measurement["assertion_blocks"]:
+            coverage["provenance_candidate_pages"] += 1
+            if measurement["provenance_relations"]:
+                coverage["provenance_linked_pages"] += 1
+            else:
+                findings.append(_provenance_debt(page.rel_path, meta))
+
+        unknown = measurement["unregistered"]
+        if unknown:
+            coverage["unregistered_relation_observations"] += len(unknown)
+            findings.append(_unregistered_relation(page.rel_path, meta, unknown))
+
+    return ActivationScan(
+        findings=sorted(
+            findings,
+            key=lambda item: (ACTIVATION_CATEGORIES.index(item.category), item.path),
+        ),
+        coverage=coverage,
+    )
+
+
+def _eligible(vault_root: Path, page: Any) -> bool:
+    if page.page_type not in _ELIGIBLE_TYPES:
+        return False
+    if page.path.name in {"index.md", "log.md"}:
+        return False
+    if page.status in _INACTIVE_STATUSES:
+        return False
+    if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
+        return False
+    stem = page.path.stem.lower()
+    if any(stem.endswith(suffix) for suffix in _SKIP_SLUG_SUFFIXES):
+        return False
+    return not bool(_SKIP_TAGS & set(page.tags))
+
+
+def _measure_page(page: Any, registry: relation_registry.RelationRegistry) -> dict[str, Any]:
+    project = _page_project(page.frontmatter)
+    note_doc = markdown_relations.parse_markdown_relations(
+        page.body,
+        include_legacy=True,
+        relation_types=registry.keys | frozenset(registry.aliases),
+        retain_unknown=True,
+    )
+    block_doc = semantic_blocks.parse_semantic_blocks(
+        page.body, validate=False, registry=registry
+    )
+
+    registered: list[str] = []
+    unregistered: list[dict[str, str | int]] = []
+    for relation in note_doc.relations:
+        resolution = registry.resolve(
+            relation.kind,
+            project=project,
+            page_type=page.page_type,
+            source_kind="file",
+            origin="semantic_relation",
+        )
+        if resolution.canonical is None:
+            unregistered.append(
+                {"label": relation.kind, "anchor": f"line-{relation.line}"}
+            )
+        else:
+            registered.append(resolution.canonical)
+
+    for block in block_doc.blocks:
+        for relation in block.relations:
+            raw = relation.raw.split(":", 1)[0].strip()
+            resolution = registry.resolve(
+                raw,
+                project=project,
+                page_type=page.page_type,
+                source_kind=block.type,
+                origin="semantic_relation",
+            )
+            if resolution.canonical is None:
+                unregistered.append(
+                    {"label": relation_registry.normalize_relation(raw), "anchor": block.id or f"line-{relation.line}"}
+                )
+            else:
+                registered.append(resolution.canonical)
+
+    frontmatter_links = 0
+    for field, relation_kind in _FRONTMATTER_TYPED_FIELDS.items():
+        count = len(_frontmatter_links(page.frontmatter.get(field)))
+        frontmatter_links += count
+        registered.extend([relation_kind] * count)
+    related_count = len(_frontmatter_links(page.frontmatter.get("related")))
+    frontmatter_links += related_count
+
+    body_wikilinks = sum(1 for _ in find_body_wikilinks(page.body))
+    assertion_blocks = sum(
+        1 for block in block_doc.blocks if block.type in _ASSERTION_BLOCK_TYPES
+    )
+    provenance_relations = sum(1 for kind in registered if kind in _PROVENANCE_RELATIONS)
+    unique_unknown = {
+        (str(item["label"]), str(item["anchor"])): item for item in unregistered
+    }
+    authored_relations = len(note_doc.relations) + sum(
+        len(block.relations) for block in block_doc.blocks
+    )
+    return {
+        "connected": bool(body_wikilinks or frontmatter_links or authored_relations),
+        "typed_relations": len(registered),
+        "body_wikilinks": body_wikilinks,
+        "frontmatter_links": frontmatter_links,
+        "assertion_blocks": assertion_blocks,
+        "provenance_relations": provenance_relations,
+        "unregistered": list(unique_unknown.values()),
+    }
+
+
+def _frontmatter_links(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        matches = _WIKILINK_RE.findall(value)
+        return [item.strip() for item in matches] if matches else ([value.strip()] if value.strip() else [])
+    if isinstance(value, list):
+        return [link for item in value for link in _frontmatter_links(item)]
+    if isinstance(value, dict):
+        return [link for item in value.values() for link in _frontmatter_links(item)]
+    return []
+
+
+def _page_project(frontmatter: dict[str, Any]) -> str | None:
+    if frontmatter.get("project") not in (None, ""):
+        return str(frontmatter["project"])
+    projects = frontmatter.get("projects")
+    if isinstance(projects, list) and len(projects) == 1:
+        return str(projects[0])
+    return None
+
+
+def _signal_version(page: Any) -> str:
+    frontmatter = yaml.safe_dump(page.frontmatter, sort_keys=True, allow_unicode=True)
+    return content_hash(frontmatter + "\n" + page.body)[:16]
+
+
+def _relation_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="relation_debt",
+        severity="info",
+        path=path,
+        detail="Active compiled page has no explicit outbound graph connection.",
+        proposed_fix="Review candidate neighbours; accept only meaningful durable edges.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "connect_memory", "args": {"operation": "suggest-links", "path": path}},
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+            ],
+        },
+    )
+
+
+def _typed_relation_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="typed_relation_debt",
+        severity="info",
+        path=path,
+        detail="Page has generic connections but no registered typed semantic relation.",
+        proposed_fix="Review relation proposals; generic links may remain generic when that is accurate.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+                {"tool": "read_memory", "args": {"identifier": path}},
+            ],
+        },
+    )
+
+
+def _provenance_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="provenance_debt",
+        severity="info",
+        path=path,
+        detail=(
+            "Page has assertion-bearing semantic blocks but no explicit page-level provenance; "
+            "page-level provenance would not by itself establish support for every block."
+        ),
+        proposed_fix="Review the assertions and add only provenance that the stored sources or evidence support.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "read_memory", "args": {"identifier": path}},
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+            ],
+        },
+    )
+
+
+def _unregistered_relation(
+    path: str, meta: dict[str, Any], observations: list[dict[str, str | int]]
+) -> AuditFinding:
+    labels = sorted({str(item["label"]) for item in observations})
+    return AuditFinding(
+        category="unregistered_relation",
+        severity="warn",
+        path=path,
+        detail=f"Page uses relation vocabulary not governed by the loaded registry: {labels}.",
+        proposed_fix="Review corpus-wide usage before registering, aliasing, replacing, or removing the vocabulary.",
+        meta={
+            **meta,
+            "unregistered": observations,
+            "next_actions": [
+                {"tool": "schema_memory", "args": {"operation": "infer", "subject": "relations"}},
+                {"tool": "read_memory", "args": {"identifier": path}},
+            ],
+        },
+    )

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import activation as activation_module
 from . import audit as audit_module
 from . import fusion
 from . import review_state as review_state_module
@@ -31,12 +32,8 @@ ATTENTION_CATEGORIES: tuple[str, ...] = (
     "unprocessed_source",
     "relation_debt",
 )
-_CATEGORY_ORDER: dict[str, int] = {c: i for i, c in enumerate(ATTENTION_CATEGORIES)}
 _SEVERITY_RANK: dict[str, int] = {"info": 0, "warn": 1, "error": 2}
 _SEVERITY_BY_RANK: dict[int, str] = {v: k for k, v in _SEVERITY_RANK.items()}
-# Equal default weights — the order is then a clean rank-major interleave, except a note
-# flagged by >1 queue accumulates votes and rises. Weights are a seam, not env-exposed.
-_DEFAULT_WEIGHTS: dict[str, float] = {c: 1.0 for c in ATTENTION_CATEGORIES}
 _RRF_K: int = 60  # the conventional default `fusion` and `find` use
 
 _PROPOSED_FIX: str = (
@@ -45,6 +42,12 @@ _PROPOSED_FIX: str = (
     "`replace` (supersede) / `reconcile` / `propose_compilation` / "
     "`connect_memory` / archive. Nothing is "
     "auto-acted; `find` ordering is unchanged."
+)
+
+_ACTIVATION_FIX: str = (
+    "Surfaced for REVIEW only. Coverage and ranking measure explicit Markdown "
+    "structure; they do not judge truth or quality. Follow a reason's `next_actions` "
+    "only after review. Nothing is auto-written or auto-registered."
 )
 
 
@@ -100,6 +103,7 @@ class AttentionReport:
     note: str | None
     all_total: int | None = None
     state_summary: dict[str, int] | None = None
+    coverage: dict[str, int] | None = None
 
     def as_dict(self) -> dict:
         out = {
@@ -114,6 +118,8 @@ class AttentionReport:
         if self.all_total is not None:
             out["all_total"] = self.all_total
             out["state_summary"] = self.state_summary or {}
+        if self.coverage is not None:
+            out["coverage"] = self.coverage
         return out
 
 
@@ -153,6 +159,8 @@ def _rank(
     categories: set[str] | None = None,
     limit: int = 25,
     weights: dict[str, float] | None = None,
+    category_order: tuple[str, ...] = ATTENTION_CATEGORIES,
+    proposed_fix: str = _PROPOSED_FIX,
 ) -> AttentionReport:
     """Compose findings into one ranked, deduped review surface. Pure — no vault access.
 
@@ -160,12 +168,13 @@ def _rank(
     by anchor path (votes add → multi-flagged notes rise), drop+fold the contradiction
     queue's trailing summary finding, then cap at `limit` with an explicit count.
     """
-    selected = set(ATTENTION_CATEGORIES) if categories is None else (
-        set(categories) & set(ATTENTION_CATEGORIES)
+    selected = set(category_order) if categories is None else (
+        set(categories) & set(category_order)
     )
-    weights = _DEFAULT_WEIGHTS if weights is None else weights
+    weights = ({c: 1.0 for c in category_order} if weights is None else weights)
+    category_rank = {category: rank for rank, category in enumerate(category_order)}
 
-    per_cat: dict[str, list[AuditFinding]] = {c: [] for c in ATTENTION_CATEGORIES}
+    per_cat: dict[str, list[AuditFinding]] = {c: [] for c in category_order}
     upstream_truncated = 0
     for f in findings:
         if f.category not in selected:
@@ -180,7 +189,7 @@ def _rank(
     # One best-first anchor-path list per populated category, plus aligned weights.
     result_lists: list[list[str]] = []
     weight_list: list[float] = []
-    for c in ATTENTION_CATEGORIES:
+    for c in category_order:
         if c in selected and per_cat[c]:
             result_lists.append([f.path for f in per_cat[c]])
             weight_list.append(float(weights.get(c, 1.0)))
@@ -195,7 +204,7 @@ def _rank(
     # All reasons (every contributing finding) + max severity per anchor path.
     reasons_by_path: dict[str, list[dict]] = {}
     severity_by_path: dict[str, int] = {}
-    for c in ATTENTION_CATEGORIES:
+    for c in category_order:
         if c not in selected:
             continue
         for rank, f in enumerate(per_cat[c], start=1):
@@ -209,7 +218,7 @@ def _rank(
         scores,
         key=lambda p: (
             -scores[p],
-            min(_CATEGORY_ORDER[r["category"]] for r in reasons_by_path[p]),
+            min(category_rank[r["category"]] for r in reasons_by_path[p]),
             p,
         ),
     )
@@ -220,22 +229,22 @@ def _rank(
     for p in shown_paths:
         reasons = sorted(
             reasons_by_path[p],
-            key=lambda r: (r["rank"], _CATEGORY_ORDER[r["category"]]),
+            key=lambda r: (r["rank"], category_rank[r["category"]]),
         )
-        cats = sorted({r["category"] for r in reasons}, key=lambda c: _CATEGORY_ORDER[c])
+        cats = sorted({r["category"] for r in reasons}, key=lambda c: category_rank[c])
         items.append(AttentionItem(
             path=p,
             score=round(scores[p], 6),
             severity=_SEVERITY_BY_RANK[severity_by_path[p]],
             categories=cats,
             reasons=reasons,
-            proposed_fix=_PROPOSED_FIX,
+            proposed_fix=proposed_fix,
         ))
 
     truncated = total - len(items)
     summary = {
         c: len(per_cat[c])
-        for c in ATTENTION_CATEGORIES
+        for c in category_order
         if c in selected and per_cat[c]
     }
     note = _build_note(len(items), total, truncated, upstream_truncated)
@@ -287,6 +296,44 @@ def attention(
     )
 
 
+def activation(
+    vault_root: Path,
+    *,
+    categories: list[str] | None = None,
+    limit: int = 25,
+    today=None,
+    state: str = "open",
+) -> AttentionReport:
+    """Rank deterministic existing-corpus activation measurements. Read-only."""
+    resolved = (
+        set(activation_module.ACTIVATION_CATEGORIES)
+        if not categories
+        else set(categories)
+    )
+    invalid = resolved - set(activation_module.ACTIVATION_CATEGORIES)
+    if invalid:
+        raise ValueError(
+            f"unknown activation categories: {sorted(invalid)}. "
+            f"Valid: {list(activation_module.ACTIVATION_CATEGORIES)}"
+        )
+    state = str(state or "open").strip().lower()
+    if state not in review_state_module.VALID_VIEWS:
+        raise ValueError(
+            f"INVALID_REVIEW_STATE: state must be one of "
+            f"{sorted(review_state_module.VALID_VIEWS)}"
+        )
+    scan = activation_module.scan(vault_root)
+    ranked = _rank(
+        scan.findings,
+        categories=resolved,
+        limit=0,
+        category_order=activation_module.ACTIVATION_CATEGORIES,
+        proposed_fix=_ACTIVATION_FIX,
+    )
+    ranked.coverage = scan.coverage
+    return _apply_review_state(vault_root, ranked, state=state, limit=limit, today=today)
+
+
 def item_by_ref(
     vault_root: Path,
     reference: str,
@@ -295,10 +342,13 @@ def item_by_ref(
 ) -> AttentionItem:
     """Resolve one current review item by its stable review reference."""
     wanted = review_state_module.parse_review_ref(reference)
-    report = attention(vault_root, limit=0, state="all", today=today)
-    for item in report.items:
-        if item.item_id == wanted:
-            return item
+    for report in (
+        attention(vault_root, limit=0, state="all", today=today),
+        activation(vault_root, limit=0, state="all", today=today),
+    ):
+        for item in report.items:
+            if item.item_id == wanted:
+                return item
     raise ValueError(f"REVIEW_ITEM_NOT_FOUND: no current review item for {reference}")
 
 
@@ -376,4 +426,5 @@ def _apply_review_state(
         note=note,
         all_total=len(report.items),
         state_summary=state_summary,
+        coverage=report.coverage,
     )

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -3379,10 +3379,10 @@ def op_review_memory(
     `maintain_memory`, not here.
 
     Args:
-        mode: attention, item, audit, provenance, evolution, compilation, stale,
-            contradiction, unprocessed-sources, or relation-debt.
-        categories: Optional category filter for attention/audit.
-        limit: Attention/evolution result cap.
+        mode: attention, activation, item, audit, provenance, evolution,
+            compilation, stale, contradiction, unprocessed-sources, or relation-debt.
+        categories: Optional category filter for attention/activation/audit.
+        limit: Attention/activation/evolution result cap.
         query: Topic for evolution review.
         sources: Source paths for compilation mode.
         suggested_title: Optional compilation title hint.
@@ -3390,13 +3390,20 @@ def op_review_memory(
         key: Provenance key filter.
         value: Provenance value filter.
         path: Restrict provenance scan to one path.
-        state: For attention, open (default), all, snoozed, or dismissed.
+        state: For attention/activation, open (default), all, snoozed, or dismissed.
         ref: Stable `exomem://review/<id>` reference for item mode.
     """
     if path:
         path = _resolve_memory_identifier(vault_root, path)
     if mode == "attention":
         return op_attention(vault_root, categories=categories, limit=limit, state=state)
+    if mode == "activation":
+        return attention_module.activation(
+            vault_root,
+            categories=categories,
+            limit=limit,
+            state=state,
+        ).as_dict()
     if mode == "item":
         if not ref:
             raise ValueError("INVALID_REVIEW: item mode requires `ref`")
@@ -3434,8 +3441,9 @@ def op_review_memory(
             raise ValueError("INVALID_REVIEW: compilation mode requires `sources`")
         return op_propose_compilation(vault_root, sources=sources, suggested_title=suggested_title)
     raise ValueError(
-        "INVALID_MODE: review_memory mode must be attention, item, audit, provenance, "
-        "evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt"
+        "INVALID_MODE: review_memory mode must be attention, activation, item, audit, "
+        "provenance, evolution, compilation, stale, contradiction, "
+        "unprocessed-sources, or relation-debt"
     )
 
 

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -1982,7 +1982,7 @@
       "properties": {
         "mode": {
           "default": "attention",
-          "description": "attention, item, audit, provenance, evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt.",
+          "description": "attention, activation, item, audit, provenance, evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt.",
           "type": "string"
         },
         "categories": {
@@ -1998,11 +1998,11 @@
             }
           ],
           "default": null,
-          "description": "Optional category filter for attention/audit."
+          "description": "Optional category filter for attention/activation/audit."
         },
         "limit": {
           "default": 25,
-          "description": "Attention/evolution result cap.",
+          "description": "Attention/activation/evolution result cap.",
           "type": "integer"
         },
         "query": {
@@ -2087,7 +2087,7 @@
         },
         "state": {
           "default": "open",
-          "description": "For attention, open (default), all, snoozed, or dismissed.",
+          "description": "For attention/activation, open (default), all, snoozed, or dismissed.",
           "type": "string"
         },
         "ref": {

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exomem import activation, attention, commands, review_state
+
+
+def _write_page(
+    vault: Path,
+    name: str,
+    body: str,
+    *,
+    page_type: str = "insight",
+    status: str = "active",
+    folder: str = "Notes/Insights",
+) -> Path:
+    path = vault / "Knowledge Base" / folder / f"{name}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\ntype: {page_type}\nstatus: {status}\n---\n# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_activation_corpus(vault: Path) -> dict[str, Path]:
+    paths = {
+        "disconnected": _write_page(vault, "disconnected", "## Finding\n\nMeasured result."),
+        "generic": _write_page(
+            vault,
+            "generic",
+            "## Overview\n\nSee [[Knowledge Base/Notes/Insights/typed]].",
+        ),
+        "typed": _write_page(
+            vault,
+            "typed",
+            "## Relations\n\n- supports [[Knowledge Base/Notes/Insights/generic]]",
+        ),
+        "provenance": _write_page(
+            vault,
+            "provenance",
+            "## Claim\n\n- relations: evidenced_by: [[Knowledge Base/Sources/source]]\n\nSupported claim.",
+        ),
+        "unknown": _write_page(
+            vault,
+            "unknown",
+            "## Relations\n\n- science.replicates [[Knowledge Base/Notes/Insights/typed]]",
+        ),
+    }
+    _write_page(
+        vault,
+        "raw",
+        "## Finding\n\nRaw input.",
+        page_type="source",
+        folder="Sources",
+    )
+    _write_page(vault, "archived", "## Finding\n\nOld.", status="archived")
+    _write_page(vault, "readonly", "## Finding\n\nProtected.", folder="Reference")
+    (vault / "Knowledge Base/_access.yaml").write_text(
+        "readonly:\n  - Reference\n", encoding="utf-8"
+    )
+    return paths
+
+
+def test_scan_measures_coverage_and_four_structural_deficits(tmp_path: Path) -> None:
+    paths = _seed_activation_corpus(tmp_path)
+
+    report = activation.scan(tmp_path)
+    by_category = {category: [] for category in activation.ACTIVATION_CATEGORIES}
+    for finding in report.findings:
+        by_category[finding.category].append(finding.path)
+
+    assert report.coverage == {
+        "eligible_pages": 5,
+        "connected_pages": 4,
+        "typed_relation_pages": 2,
+        "generic_only_pages": 2,
+        "disconnected_pages": 1,
+        "provenance_candidate_pages": 2,
+        "provenance_linked_pages": 1,
+        "unregistered_relation_observations": 1,
+    }
+    assert paths["disconnected"].relative_to(tmp_path).as_posix() in by_category["relation_debt"]
+    assert paths["generic"].relative_to(tmp_path).as_posix() in by_category["typed_relation_debt"]
+    assert paths["disconnected"].relative_to(tmp_path).as_posix() in by_category["provenance_debt"]
+    assert paths["unknown"].relative_to(tmp_path).as_posix() in by_category["unregistered_relation"]
+    assert not any("Sources/" in finding.path or "Reference/" in finding.path for finding in report.findings)
+
+
+def test_scan_is_deterministic_non_mutating_and_routes_existing_tools(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+    before = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    first = activation.scan(tmp_path)
+    second = activation.scan(tmp_path)
+    after = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    assert first == second
+    assert after == before
+    for finding in first.findings:
+        assert finding.meta and finding.meta["signal_version"]
+        assert finding.meta["next_actions"]
+        assert {action["tool"] for action in finding.meta["next_actions"]} <= {
+            "connect_memory",
+            "read_memory",
+            "schema_memory",
+        }
+
+
+def test_activation_queue_ranks_dedups_and_preserves_default_attention(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+
+    default_categories = attention.ATTENTION_CATEGORIES
+    activation_report = attention.activation(tmp_path, limit=0)
+
+    assert attention.ATTENTION_CATEGORIES == default_categories
+    assert activation_report.coverage["eligible_pages"] == 5
+    assert len({item.path for item in activation_report.items}) == len(activation_report.items)
+    disconnected = next(item for item in activation_report.items if item.path.endswith("disconnected.md"))
+    assert disconnected.categories == ["provenance_debt", "relation_debt"]
+    assert disconnected.score > next(
+        item.score for item in activation_report.items if item.path.endswith("generic.md")
+    )
+    assert "quality" in disconnected.proposed_fix.lower()
+
+
+def test_activation_only_item_supports_item_lookup_and_triage(tmp_path: Path) -> None:
+    paths = _seed_activation_corpus(tmp_path)
+    item = next(
+        item
+        for item in attention.activation(tmp_path, limit=0).items
+        if item.path == paths["generic"].relative_to(tmp_path).as_posix()
+    )
+    assert item.categories == ["typed_relation_debt"]
+    assert commands.op_review_memory(tmp_path, mode="item", ref=item.ref)["ref"] == item.ref
+
+    dismissed = commands.op_triage_memory(tmp_path, ref=item.ref, action="dismiss")
+    assert dismissed["state"] == "dismissed"
+    assert item.ref not in {
+        current.ref for current in attention.activation(tmp_path, limit=0).items
+    }
+    assert item.ref in {
+        current.ref
+        for current in attention.activation(tmp_path, limit=0, state="dismissed").items
+    }
+
+    paths["generic"].write_text(
+        paths["generic"].read_text(encoding="utf-8") + "\nChanged context.\n",
+        encoding="utf-8",
+    )
+    resurfaced = next(
+        current
+        for current in attention.activation(tmp_path, limit=0).items
+        if current.ref == item.ref
+    )
+    assert resurfaced.fingerprint != item.fingerprint
+    assert resurfaced.state == "open"
+    assert review_state.state_path(tmp_path).exists()
+
+
+def test_review_memory_activation_response_is_json_serializable(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+
+    result = commands.op_review_memory(tmp_path, mode="activation", limit=2)
+
+    assert result["shown"] == len(result["items"]) == 2
+    assert result["truncated"] > 0
+    assert result["coverage"]["eligible_pages"] == 5
+    assert json.loads(json.dumps(result))["coverage"] == result["coverage"]

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -70,6 +70,19 @@ def test_review_memory_attention_runs(vault: Path, capsys) -> None:
     assert surfaced <= {"stale_review"}
 
 
+def test_review_memory_activation_runs(vault: Path, capsys) -> None:
+    code, out, _ = _run(
+        ["review_memory", "--mode", "activation", "--limit", "3", "--json"],
+        capsys,
+    )
+
+    assert code == 0
+    data = json.loads(out.strip().splitlines()[-1])["data"]
+    assert data["coverage"]["eligible_pages"] > 0
+    assert data["shown"] == len(data["items"]) <= 3
+    assert all(item["ref"].startswith("exomem://review/") for item in data["items"])
+
+
 def test_review_memory_audit_runs(vault: Path, capsys) -> None:
     code, out, _ = _run(["review_memory", "--mode", "audit", "--json"], capsys)
     assert code == 0

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -249,6 +249,23 @@ def test_review_memory_attention_mode_composes_review_surface(vault: Path, monke
     assert surfaced <= {"unprocessed_source"}
 
 
+def test_review_memory_activation_mode_surfaces_corpus_coverage(vault: Path, monkeypatch) -> None:
+    rel = _make_page(
+        vault,
+        "# Activation-only\n\n## Overview\n\nSee [[Knowledge Base/Notes/Insights/other]].\n",
+        name="activation-only.md",
+    )
+    mcp = _build(monkeypatch)
+
+    out = _call(mcp, "review_memory", {"mode": "activation", "limit": 0})
+
+    assert out["coverage"]["eligible_pages"] > 0
+    item = next(item for item in out["items"] if item["path"] == rel)
+    assert item["categories"] == ["typed_relation_debt"]
+    assert item["ref"].startswith("exomem://review/")
+    assert item["reasons"][0]["meta"]["next_actions"]
+
+
 def test_triage_memory_mcp_write_is_explicit_and_reversible(vault: Path, monkeypatch) -> None:
     mcp = _build(monkeypatch)
     review = _call(mcp, "review_memory", {"mode": "attention", "limit": 1})

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -221,6 +221,21 @@ def test_review_memory_route_and_openapi_params(vault, monkeypatch: pytest.Monke
     assert {"ref", "action"} <= set(triage_schema.get("required", []))
 
 
+def test_review_memory_activation_route(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
+    response = client.post(
+        "/api/review_memory",
+        json={"mode": "activation", "limit": 3},
+        headers=_auth(),
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["coverage"]["eligible_pages"] > 0
+    assert data["shown"] == len(data["items"]) <= 3
+    assert all(item["ref"].startswith("exomem://review/") for item in data["items"])
+
+
 def test_openapi_has_no_hand_list(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
     doc = client.get("/api/openapi.json").json()


### PR DESCRIPTION
## Summary
- add deterministic corpus activation coverage and four structural review signals
- expose an opt-in `review_memory(mode=activation)` queue with stable refs, triage, and content-change resurfacing
- preserve the default Epistemic Inbox and route all action through existing governed proposal/edit tools
- add and complete the `activate-existing-corpus` OpenSpec change

## Verification
- `33 passed` focused scanner/ranking/review/CLI/schema suite
- broad local dependency-light run: `1747 passed, 16 skipped` outside transport-harness files; the single generated-fixture sidecar failure was cleaned and rechecked
- real local HTTP server: `POST /api/review_memory` returned 200 with coverage, ranked items, stable refs, and explicit truncation
- installed-wheel lifecycle: activate -> dismiss -> hidden from open view -> packaged edit -> same ref resurfaced with a new fingerprint
- Ruff clean for all changed implementation/test files; `git diff --check` clean; OpenSpec strict validation clean
- CI: all 11 jobs pass, including Python 3.11-3.13, installed-wheel stdio/HTTP E2E, retrieval golden gate, Docker, lint, packaging, capabilities, and OpenSpec validation

## Local harness note
The sandbox's borrowed FastMCP/Starlette in-process `TestClient/call_tool` environment timed out even on untouched bootstrap/attention tests. Real HTTP passed locally and the complete GitHub CI transport suite passes on every supported Python version.