### PR TITLE
feat: activate and prove the governed graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,10 @@ store. exomem works the other way around: agents come to your vault.
 | Memory hidden inside one assistant | exomem is client-agnostic: use the same vault from Claude Code, Codex, Cursor, scripts, or a custom chatbot. |
 
 For a deeper point-in-time comparison, see
-[docs/comparison-engraph.md](docs/comparison-engraph.md). For the practical
-boundary with chat products' own memory features, see
+[docs/comparison-engraph.md](docs/comparison-engraph.md). The reproducible
+graph-only comparison with Basic Memory is in
+[docs/comparison-basic-memory-graph.md](docs/comparison-basic-memory-graph.md).
+For the practical boundary with chat products' own memory features, see
 [docs/vs-built-in-memory.md](docs/vs-built-in-memory.md).
 
 **Measured retrieval quality — and speed.** Retrieval is graded by a

--- a/docs/comparison-basic-memory-graph.md
+++ b/docs/comparison-basic-memory-graph.md
@@ -1,0 +1,115 @@
+# Exomem vs Basic Memory: graph-value comparison
+
+Measured 2026-07-11 against Exomem revision `6ce9499bfe6b` and Basic Memory
+`v0.22.1-17-g0e59bbff` at revision `0e59bbffaf7d`.
+
+## Verdict
+
+Exomem is demonstrably superior on the graph-dependent tasks in this benchmark.
+It matches Basic Memory's native graph on ordinary one-hop reachability,
+multi-hop reachability, and relation-type fidelity, then wins on direction,
+distractor exclusion, traversal lenses, provenance traceability, active versus
+superseded state, and relation-bearing semantic blocks.
+
+That is a graph claim, not a claim that Exomem is globally the better product.
+This benchmark says nothing about cloud onboarding, generic search UX, canvas
+workflows, imports, or ecosystem breadth.
+
+## Recorded result
+
+| Independent dimension | Exomem | Basic Memory | Reading |
+|---|---:|---:|---|
+| One-hop reachability | 1/1 | 1/1 | Parity |
+| Multi-hop reachability | 2/2 | 2/2 | Parity |
+| Relation-type fidelity | 1/1 | 1/1 | Parity |
+| Direction fidelity | 2/2 | 1/2 | Exomem excludes the incoming neighbor under an outgoing traversal |
+| Distractor precision | 1/1 | 1/2 | Exomem's typed filter excludes the unrelated edge |
+| Traversal-lens filtering | 2/2 | 0/1 unsupported | Exomem exposes relation-family traversal profiles |
+| Provenance traceability | 2/2 | 0/1 unsupported | Exomem returns authored origin and source anchor |
+| Supersession handling | 3/3 | 0/1 unsupported | Exomem returns the edge plus active/superseded state |
+| Semantic-block precision | 2/2 | 0/1 unsupported | Exomem returns the claim block anchor and its edge |
+
+The dominance gate passed. It has no weighted aggregate: Exomem must be no worse
+on every common graph dimension, pass every fixture invariant, and strictly win
+provenance, supersession, and semantic-block precision. A future Exomem
+reachability regression makes the result false even if all governance dimensions
+still pass.
+
+The generated Markdown trees were unchanged by both contenders. Recorded corpus
+hashes were `b993b570bfaa96cb8fa18bc532390a4a17091263f9aac7aa7268bb8a5f7ab106`
+for Exomem and `5c528f82eb7e1385c4865cdc9920a2a30e802a6303735912ee02a508685fdd10`
+for Basic Memory.
+
+## Fairness contract
+
+The benchmark starts from one versioned, product-neutral manifest: 17 notes,
+seven ordinary directed relations, two provenance relations, one lifecycle
+replacement pair, one relation-bearing claim block, deliberate distractors, and
+nine graph tasks. It then renders each product's documented native Markdown:
+
+- Exomem receives its generic schema scaffold, governed frontmatter, semantic
+  blocks, and canonical `## Relations` bullets.
+- Basic Memory receives native frontmatter, atomic observations, and open
+  relation bullets. Lifecycle and block facts are represented as far as its
+  format allows; missing return contracts are reported as unsupported rather
+  than silently removed.
+
+The direct comparison explicitly performs a full Basic Memory filesystem index
+before measurement. Both products then serve every task through one persistent
+stdio MCP session. Semantic/model features are off, Basic Memory uses an isolated
+home/config/SQLite state with file mutation disabled, and versions plus revisions
+are recorded. Response bytes and latency are emitted separately but do not affect
+correctness or dominance.
+
+## Reproduce
+
+The fast Exomem-only fixture gate requires no Basic Memory checkout or model:
+
+```bash
+uv run python scripts/graph_value_benchmark.py
+```
+
+For the direct comparison, place a current Basic Memory checkout beside Exomem:
+
+```bash
+uv run python scripts/graph_value_benchmark.py \
+  --direct \
+  --basic-memory-root ../basic-memory \
+  --output-json /tmp/graph-value.json \
+  --output-markdown /tmp/graph-value.md
+```
+
+Direct mode is intentionally desk-side. A highly restricted process sandbox may
+block asynchronous stdio even when both servers are healthy.
+
+## What to improve next
+
+The next target is graph activation and product use, not a larger schema.
+
+1. Activate existing corpora through a governed propose/review/apply loop. Graph
+   quality is currently constrained more by missing authored relationships than
+   by missing relation vocabulary.
+2. Make the graph advantage visible in normal recall and review: show the path,
+   relation family, provenance anchor, and active/superseded state when they
+   materially change the answer.
+3. Add a medium public corpus and user-task tier after observing real activation
+   output. Keep the same independent dimensions and dominance rule.
+4. Improve relation authoring and maintenance ergonomics: acceptance queues,
+   unresolved-target repair, stale-edge review, and useful coverage telemetry.
+5. Expand schema only when evidence shows a repeated semantic collision that
+   changes traversal or review outcomes. A new relation should have a clear
+   parent, a demonstrated task distinction, and enough observed examples to
+   justify authoring and migration cost.
+
+Schema remains strategically important as the graph's governance layer. It is
+not the current bottleneck, and growing it speculatively would optimize the
+easiest surface to expand rather than the hardest value to deliver.
+
+## Limits
+
+This is a small adversarial fixture, not an independent third-party benchmark or
+a statistical sample of real vaults. Unsupported means the tested public
+`build_context` response cannot return the required fact; it does not mean Basic
+Memory has no graph or cannot store a similarly named relation. Basic Memory may
+change, which is why the runner records its exact revision and keeps the direct
+comparison optional.

--- a/docs/product-gap-matrix.md
+++ b/docs/product-gap-matrix.md
@@ -1,8 +1,12 @@
 # Product gap matrix: Exomem vs Basic Memory
 
-Generated from local product-flow benchmarking on 2026-07-09.
+Product-flow baseline measured 2026-07-09; direct graph comparison added
+2026-07-11.
 
-This is a product benchmark, not an internals comparison. Basic Memory was inspected only through public/product-facing surfaces in the sibling checkout: README/docs/tool names. No Basic Memory implementation or benchmark code was copied.
+This is a product benchmark, not an internals comparison. The product-flow
+baseline reads Basic Memory's public README/docs/tool names; the graph row adds a
+direct run through its public `build_context` MCP tool over native Markdown. No
+Basic Memory implementation or benchmark code is copied.
 
 Run locally:
 
@@ -22,8 +26,10 @@ hash-guarded schema contracts, and safe copied-source preservation. Basic Memory
 is stronger where the product needs low-friction adoption and breadth:
 cloud/no-install paths, sync, importers, multi-project UX, canvas workflows, and
 the packaged assistant ecosystem. The earlier technical schema and unified
-context gaps are now closed; the remaining lead is primarily product surface,
-not knowledge-substrate depth.
+context gaps are now closed. Exomem's graph is now directly benchmarked as ahead
+on graph-dependent tasks; Basic Memory's remaining lead is primarily product
+surface, not knowledge-substrate depth. See
+[the graph-value comparison](comparison-basic-memory-graph.md).
 
 The earlier largest product gap was first-run adoption: direct CLI scans of a messy uninitialized vault failed before they could report anything useful. That is now fixed for the product surface: `browse_memory(mode="overview")` and `adopt_vault(mode="scan-only")` can inspect a pre-init vault, while write-capable adoption modes still require an initialized governed KB.
 
@@ -38,18 +44,24 @@ The earlier largest product gap was first-run adoption: direct CLI scans of a me
 | Source preservation | Ahead | Pass | Basic Memory importers cover more formats. | Exomem `adopt_vault(mode="copy-as-sources")` preserves the original file, records `imported_from`, SHA-256, and byte count. |
 | Evidence / provenance | Ahead | Pass | Basic Memory is primarily note/knowledge-graph oriented. | Exomem has an explicit Evidence tree plus `review_memory(mode="provenance")` over durable `<!-- key:value -->` markers. The marker workflow is still hidden. |
 | Schema inference / validation | Comparable | Pass | Basic Memory publicly exposes `schema_infer`, `schema_validate`, and `schema_diff`. | Exomem's `schema_memory` now infers from corpus frequencies, saves optional contracts with hash-guarded overwrite, validates with strict CI status, and diffs corpus or contract drift. |
-| Graph / context building | Comparable | Pass | Basic Memory still exposes a broader canvas workflow. | Exomem now has one bounded `connect_memory(operation="context")` response over stored documents, semantic blocks, typed graph edges, provenance, evidence, supersession, history, unresolved targets, and explicit truncation. |
+| Graph / context building | Ahead | Pass | Basic Memory still exposes a broader canvas workflow. | The direct graph-value benchmark matches Basic Memory on one-hop, multi-hop, and relation typing, then wins direction, distractor precision, traversal lenses, provenance, lifecycle, and semantic-block precision. |
 | Review / stale / contradiction workflow | Ahead | Pass | Basic Memory has recent activity and graph navigation, but less explicit epistemic review. | Exomem `review_memory` surfaces unprocessed source work, audit findings, attention queues, provenance, and compilation scaffolds. |
 | Assistant onboarding | Comparable | Pass | Basic Memory has broader packaged plugins, skills, and public docs across clients. | Exomem `bootstrap` exposes front-door actions and product commands; `demo --json` proves doctor/retrieval/review against a sample vault. |
 
-Current harness summary: 10 flows; 4 ahead, 5 comparable, 1 behind, 0 missing.
+Current harness summary: 10 flows; 5 ahead, 4 comparable, 1 behind, 0 missing.
 Status: 10 pass.
 
 ## Prioritized backlog
 
-1. **Keep first-run adoption polished across surfaces.** The CLI now lets `browse_memory(mode="overview")` and `adopt_vault(mode="scan-only")` scan a raw messy vault before `Knowledge Base/_Schema/SKILL.md` exists. Keep MCP and REST aligned with that contract, and make the safe next action obvious.
+1. **Turn graph superiority into habitual product value.** Use
+   `review_memory(mode="activation")` to measure and rank relationship debt in
+   existing vaults, make propose/review/apply easy, and show graph paths,
+   provenance anchors, and active/superseded state when they improve an answer.
 
-2. **Collapse onboarding into one obvious first action.** Keep `setup`'s safety, but reduce the user's mental model to: demo, choose vault, scan, initialize. Basic Memory is ahead because its first-run story is easier to explain and it has a cloud escape hatch.
+2. **Keep first-run adoption polished across surfaces.** The CLI now lets
+   `browse_memory(mode="overview")` and `adopt_vault(mode="scan-only")` scan a
+   raw messy vault before initialization. Keep MCP and REST aligned and reduce
+   the first-run mental model to: demo, choose vault, scan, initialize.
 
 3. **Make evidence/provenance discoverable.** The Evidence tree and
    `review_memory(mode="provenance")` are a real differentiator, but the
@@ -61,10 +73,10 @@ Status: 10 pass.
    The product remember flow should guide the assistant through Source vs Note vs
    Evidence without requiring the user to name page types.
 
-5. **Keep the heavy proof lanes operational.** Lean stdio/HTTP product E2E now
-   runs on every pull request; real embeddings/reranking remain in the model job,
-   and OCR/PDF/ASR/CLIP/video run scheduled or on demand. Treat failures in those
-   configured lanes as product regressions, not optional noise.
+5. **Grow schema from observed graph pressure, not in advance.** Add relation
+   vocabulary or constraints only when activation and user-task evidence shows a
+   repeated semantic collision that changes traversal or review outcomes. Keep
+   the graph benchmark and heavy proof lanes operational as the promotion gate.
 
 ## Harness coverage notes
 

--- a/openspec/changes/activate-existing-corpus/.openspec.yaml
+++ b/openspec/changes/activate-existing-corpus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/activate-existing-corpus/design.md
+++ b/openspec/changes/activate-existing-corpus/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The graph substrate already indexes wikilinks, canonical note relations, semantic-block relations, and frontmatter provenance. The default attention queue can surface pages with no outbound Markdown connection, but it cannot distinguish a generic-only page from a typed page, measure provenance coverage, or expose explicit relation vocabulary that the registry does not govern. Existing review state already provides portable item references, fingerprint-bound dismiss/snooze decisions, and deterministic RRF composition.
+
+The change must remain a pure substrate. It may parse and count explicit Markdown structure, but it cannot infer that one note supports, contradicts, or causes another. Sources, Evidence, excluded content, read-only content, inactive conclusions, and navigation pages are not activation write targets.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give an existing vault an objective activation baseline with explicit denominators.
+- Rank individual, reviewable deficits without changing the normal daily attention queue.
+- Route review toward the existing relation-proposal, schema, read, and governed edit operations.
+- Reuse stable review identity and triage so the backlog can be worked incrementally.
+- Keep the whole read path deterministic, dependency-light, and non-mutating.
+
+**Non-Goals:**
+
+- Automatically inventing, accepting, or writing semantic relationships.
+- Treating graph density as truth, authority, confidence, or note quality.
+- Requiring every claim to have block-level evidence or every wikilink to become typed.
+- Modifying retrieval ranking, graph traversal profiles, or the relation registry.
+- Adding a server-side reasoning model or an activation sidecar/database.
+
+## Decisions
+
+### Use a dedicated corpus activation scanner
+
+A new `activation` module will walk the parsed KB once and classify active, read-write compiled pages using the same eligibility conventions as relation-debt review. It will return `AuditFinding`-compatible measurements plus a coverage object. This keeps the general audit response stable while still reusing the existing finding/ranking contracts.
+
+Alternative: add several audit categories and derive coverage from their findings. Rejected because findings cannot express clean denominators, and independent audit checks would repeatedly parse the same page.
+
+### Measure four explicit deficits
+
+The scanner will emit, in fixed priority order:
+
+1. `unregistered_relation`: an explicitly authored relation observation is not governed by the loaded relation registry.
+2. `provenance_debt`: a page contains assertion-bearing semantic blocks but has no explicit page-level provenance edge (`derived_from`, `evidenced_by`, or `cites`, including supported frontmatter origins).
+3. `typed_relation_debt`: a page has generic graph connections but no registered typed semantic relation.
+4. `relation_debt`: a page has no explicit outbound graph connection.
+
+These are structural measurements, not judgments. In particular, page-level provenance is intentionally coarse: its presence does not prove that every block is supported.
+
+### Return counts with denominators, not a quality score
+
+Coverage will report eligible pages, connected pages, typed-relation pages, generic-only pages, disconnected pages, provenance-candidate pages, provenance-linked pages, and unregistered observations. It will not collapse these into a single score. A single score would imply an unsupported quality ordering and would hide why the corpus needs work.
+
+### Reuse attention ranking and review state under a dedicated mode
+
+`review_memory(mode="activation")` will compose activation findings with equal-weight RRF, deterministic category/path tie-breaking, path deduplication, stable references, fingerprint-bound state, and explicit truncation. The default `attention` category set and order remain unchanged. Item lookup and triage will resolve both default-attention and activation-only items.
+
+Alternative: add activation categories to the default attention inbox. Rejected for the first release because a mature existing corpus can produce a large backlog that would drown time-sensitive contradiction, staleness, and source work.
+
+### Put action routes in measured finding metadata
+
+Each reason will carry deterministic `next_actions` describing existing tool calls, such as relation suggestions, schema review, read, or governed edit. Routes are guidance only and do not execute during activation. Model-assisted suggestions remain an explicit downstream request and retain their existing default-off/soft-fail behavior.
+
+### Inherit MCP, REST, and CLI exposure from `review_memory`
+
+No new top-level command is required. Extending the shared `review_memory` leaf makes activation reachable through its generated MCP tool, `/api/review_memory`, OpenAPI schema, and CLI subcommand with no duplicated surface logic.
+
+## Risks / Trade-offs
+
+- [Large legacy backlog makes scans or responses noisy] -> Scan only eligible pages, cap surfaced items with explicit truncation, and keep the mode opt-in.
+- [Generic links are sometimes exactly right] -> Label the signal as review debt, not an error, and never auto-convert links.
+- [Page-level provenance overstates block-level support] -> Name the metric precisely and state the limitation in the response guidance.
+- [Unknown relation syntax may be intentional vocabulary] -> Route it to `schema_memory`; do not silently map it to a core relation.
+- [A dismissed activation item changes meaning after edits] -> Bind decisions to content-derived signal fingerprints so changed pages resurface.
+- [Unreadable or malformed pages interrupt a corpus scan] -> Reuse tolerant page parsing and skip individual unreadable pages with logging; return the measurements that completed.
+
+## Migration Plan
+
+Ship as an additive `review_memory` mode with no data migration. Existing review-state files remain compatible because identity is path-based and fingerprints already include categories and signal versions. Rollback removes the mode and scanner; no vault content or sidecar requires reversal.
+
+## Open Questions
+
+None for the first slice. Future evidence-block granularity and project-specific activation lenses should be driven by real queue usage rather than hard-coded now.

--- a/openspec/changes/activate-existing-corpus/design.md
+++ b/openspec/changes/activate-existing-corpus/design.md
@@ -49,6 +49,8 @@ Coverage will report eligible pages, connected pages, typed-relation pages, gene
 
 `review_memory(mode="activation")` will compose activation findings with equal-weight RRF, deterministic category/path tie-breaking, path deduplication, stable references, fingerprint-bound state, and explicit truncation. The default `attention` category set and order remain unchanged. Item lookup and triage will resolve both default-attention and activation-only items.
 
+Activation review identities are deterministically namespaced from daily-attention identities. A page may legitimately appear in both queues with different reasons and fingerprints; distinct stable references keep triage of one queue from resolving to or changing the other. Existing daily-attention references remain unchanged.
+
 Alternative: add activation categories to the default attention inbox. Rejected for the first release because a mature existing corpus can produce a large backlog that would drown time-sensitive contradiction, staleness, and source work.
 
 ### Put action routes in measured finding metadata

--- a/openspec/changes/activate-existing-corpus/proposal.md
+++ b/openspec/changes/activate-existing-corpus/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exomem can already represent deep epistemic relationships, but an existing vault can remain mostly connected by generic wikilinks with little typed relation or provenance structure. The system needs a safe, low-friction way to measure that dormant potential and turn it into a reviewable improvement loop without bulk inference or automatic rewriting.
+
+## What Changes
+
+- Add a read-only corpus-activation report that measures graph and epistemic coverage across eligible compiled knowledge.
+- Add a dedicated ranked activation queue for disconnected notes, generic-link-only notes, provenance gaps, and unregistered relation observations.
+- Give every activation item stable review identity, measured reasons, and concrete routes into existing proposal and governed edit operations.
+- Preserve human judgment: activation never asserts a semantic relationship, changes a note, or mutates Sources, Evidence, or read-only content.
+- Keep model-assisted relation suggestions explicit and optional; the activation measurement and ranking path is deterministic, dependency-light, and soft-fails individual unreadable notes.
+- Verify the full lifecycle across the shared MCP, REST, and CLI command surface, including triage persistence and non-mutation.
+
+## Capabilities
+
+### New Capabilities
+
+- `corpus-activation`: Measures existing-corpus coverage and provides a deterministic, governed queue for progressively activating deeper epistemic structure.
+
+### Modified Capabilities
+
+- `attention-queue`: Adds a dedicated activation review composition that reuses stable item identity, deterministic ranking, triage, and read-only guarantees without changing the default daily attention categories.
+
+## Impact
+
+This affects audit/coverage measurement, attention queue composition, `review_memory` routing, command documentation, and focused product E2E tests. It adds no required service, model, storage migration, or automatic write path; existing generated MCP, REST, and CLI surfaces inherit the behavior from the shared command implementation.

--- a/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
+++ b/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Dedicated Corpus Activation Review Composition
+
+The system SHALL expose corpus activation through `review_memory(mode="activation")`. It SHALL rank activation findings by equal-weight Reciprocal Rank Fusion with fixed category preference `unregistered_relation` > `provenance_debt` > `typed_relation_debt` > `relation_debt`, deduplicate by anchor path, preserve all contributing reasons, apply the requested cap with explicit truncation, and return the corpus coverage counts alongside the queue. The default `attention` operation and its default categories SHALL remain unchanged.
+
+#### Scenario: Activation backlog stays out of daily attention
+
+- **WHEN** a vault contains activation findings and `review_memory(mode="attention")` is called without categories
+- **THEN** the existing daily attention categories and ordering are used unchanged
+- **AND** `review_memory(mode="activation")` returns the separately ranked activation backlog and coverage
+
+#### Scenario: Multiple activation deficits deduplicate and rise
+
+- **WHEN** one page has both provenance and typed-relation debt while another has only typed-relation debt at the same intra-category rank
+- **THEN** the first page appears once with both reasons and the sum of its RRF votes
+- **AND** it ranks above the page with one signal
+
+### Requirement: Activation Items Use Stable Review Lifecycle
+
+Activation items SHALL receive the same stable review reference, content-bound signal fingerprint, open/all/snoozed/dismissed filtering, and triage behavior as daily attention items. Item lookup and triage SHALL resolve activation-only references. A materially changed signal SHALL resurface even if its previous fingerprint was dismissed.
+
+#### Scenario: Activation-only item can be triaged
+
+- **WHEN** an activation item that is absent from default attention is dismissed through `triage_memory`
+- **THEN** it is hidden from the open activation view and visible in the dismissed or all view
+- **AND** default attention behavior is unaffected
+
+#### Scenario: Changed knowledge resurfaces
+
+- **WHEN** a dismissed page is edited so its measured activation signal version changes while a deficit remains
+- **THEN** the new activation fingerprint is open again
+
+### Requirement: Activation Mode Is Shared Across Product Surfaces
+
+The activation mode SHALL be implemented in the shared `review_memory` leaf and SHALL therefore be reachable through the generated MCP tool, REST route, OpenAPI operation, and CLI command without surface-specific activation logic.
+
+#### Scenario: Same activation contract on every surface
+
+- **WHEN** activation is invoked through MCP, `/api/review_memory`, and `kb review_memory --mode activation --json` over the same vault state
+- **THEN** each surface returns the same coverage, ordered item paths, categories, and stable references
+

--- a/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
+++ b/openspec/changes/activate-existing-corpus/specs/attention-queue/spec.md
@@ -18,7 +18,7 @@ The system SHALL expose corpus activation through `review_memory(mode="activatio
 
 ### Requirement: Activation Items Use Stable Review Lifecycle
 
-Activation items SHALL receive the same stable review reference, content-bound signal fingerprint, open/all/snoozed/dismissed filtering, and triage behavior as daily attention items. Item lookup and triage SHALL resolve activation-only references. A materially changed signal SHALL resurface even if its previous fingerprint was dismissed.
+Activation items SHALL receive the same stable review reference, content-bound signal fingerprint, open/all/snoozed/dismissed filtering, and triage behavior as daily attention items. Activation references SHALL be deterministically distinct from daily-attention references for the same target so item lookup and triage resolve the intended queue. Item lookup and triage SHALL resolve activation-only references. A materially changed signal SHALL resurface even if its previous fingerprint was dismissed.
 
 #### Scenario: Activation-only item can be triaged
 
@@ -31,6 +31,12 @@ Activation items SHALL receive the same stable review reference, content-bound s
 - **WHEN** a dismissed page is edited so its measured activation signal version changes while a deficit remains
 - **THEN** the new activation fingerprint is open again
 
+#### Scenario: Overlapping queues retain independent triage
+
+- **WHEN** the same page appears in both daily attention and corpus activation
+- **THEN** the two items have distinct stable review references
+- **AND** dismissing the activation item does not dismiss or resolve to the daily-attention item
+
 ### Requirement: Activation Mode Is Shared Across Product Surfaces
 
 The activation mode SHALL be implemented in the shared `review_memory` leaf and SHALL therefore be reachable through the generated MCP tool, REST route, OpenAPI operation, and CLI command without surface-specific activation logic.
@@ -39,4 +45,3 @@ The activation mode SHALL be implemented in the shared `review_memory` leaf and 
 
 - **WHEN** activation is invoked through MCP, `/api/review_memory`, and `kb review_memory --mode activation --json` over the same vault state
 - **THEN** each surface returns the same coverage, ordered item paths, categories, and stable references
-

--- a/openspec/changes/activate-existing-corpus/specs/corpus-activation/spec.md
+++ b/openspec/changes/activate-existing-corpus/specs/corpus-activation/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Existing-Corpus Coverage
+
+The system SHALL scan active, read-write compiled knowledge and return explicit coverage counts for eligible pages, connected pages, typed-relation pages, generic-only pages, disconnected pages, provenance-candidate pages, provenance-linked pages, and unregistered relation observations. It MUST NOT combine the counts into a confidence, authority, or quality score.
+
+#### Scenario: Mixed corpus produces denominator-backed coverage
+
+- **WHEN** the corpus contains a disconnected compiled page, a generic-link-only compiled page, a typed-relation page, and an assertion-bearing page with provenance
+- **THEN** each page is counted in the applicable coverage fields with `eligible_pages` as the page denominator
+- **AND** no aggregate quality score is returned
+
+#### Scenario: Protected and inactive material is excluded
+
+- **WHEN** Sources, Evidence, read-only pages, excluded pages, navigation pages, drafts, archived pages, or superseded pages are present
+- **THEN** they are not counted as eligible activation targets
+- **AND** the scan does not modify them
+
+### Requirement: Structural Activation Signals
+
+The system SHALL surface four explicit structural signals: `relation_debt` for an eligible page with no outbound graph connection, `typed_relation_debt` for one with generic connections but no registered typed semantic relation, `provenance_debt` for one with assertion-bearing semantic blocks but no explicit page-level provenance relation, and `unregistered_relation` for authored relation observations outside the loaded registry. Every signal SHALL carry the page content version and measured counts needed for stable review fingerprinting.
+
+#### Scenario: Generic links do not masquerade as typed epistemic structure
+
+- **WHEN** an eligible page contains ordinary body wikilinks but no registered typed relation
+- **THEN** it produces `typed_relation_debt`, not `relation_debt`
+- **AND** its metadata reports the observed generic and typed connection counts
+
+#### Scenario: Assertion-bearing page lacks page-level provenance
+
+- **WHEN** an eligible page contains a claim, finding, inference, hypothesis, or result semantic block and has no `derived_from`, `evidenced_by`, or `cites` relation through supported Markdown or frontmatter origins
+- **THEN** it produces a `provenance_debt` measurement
+- **AND** the guidance states that page-level provenance does not establish support for every block
+
+#### Scenario: Explicit unknown vocabulary remains unassigned
+
+- **WHEN** an authored relation observation cannot be resolved by the loaded relation registry
+- **THEN** the page produces an `unregistered_relation` measurement containing the observed labels and anchors
+- **AND** the system does not map, register, or rewrite the relation automatically
+
+### Requirement: Governed Activation Actions
+
+Every activation reason SHALL include deterministic next-action routes into existing read, relation-proposal, schema-review, or governed edit operations. Running activation MUST NOT execute those routes, write a relation, change the registry, mutate a note, update graph data, or alter retrieval ranking. Any model-assisted relation suggestion remains explicit, default-off, response-only, and soft-failing under its existing contract.
+
+#### Scenario: Reviewing an activation item is non-mutating
+
+- **WHEN** an activation report is requested
+- **THEN** each item includes review guidance and applicable existing-tool routes
+- **AND** vault file content, graph sidecars, registry files, and find ordering remain unchanged
+
+### Requirement: Dependency-Light Soft Failure
+
+Corpus activation SHALL require no embedding, reranking, media, or reasoning-model dependency. An unreadable individual page MUST NOT fail the whole scan; it SHALL be skipped using the existing tolerant corpus parsing behavior while the completed measurements are returned.
+
+#### Scenario: Embeddings are disabled
+
+- **WHEN** activation runs with embeddings and optional model features disabled
+- **THEN** the same Markdown-derived findings and deterministic ordering are available
+

--- a/openspec/changes/activate-existing-corpus/tasks.md
+++ b/openspec/changes/activate-existing-corpus/tasks.md
@@ -1,0 +1,19 @@
+## 1. Corpus Measurement
+
+- [x] 1.1 Implement the dependency-light activation scanner, eligibility rules, coverage counts, and four structural findings.
+- [x] 1.2 Add deterministic next-action metadata, content signal versions, and non-mutating behavior tests.
+
+## 2. Review Workflow
+
+- [x] 2.1 Generalize attention composition for a fixed activation category order while preserving default attention output.
+- [x] 2.2 Add `review_memory(mode="activation")`, coverage output, activation item lookup, and triage lifecycle support.
+
+## 3. Surface And Lifecycle Verification
+
+- [x] 3.1 Add focused scanner, ranking, review-state, and default-attention regression tests.
+- [x] 3.2 Verify matching activation behavior through MCP, REST, and CLI and update command-schema fixtures where required.
+- [x] 3.3 Run lint, the focused suite, the full dependency-light suite, and an installed-wheel full-lifecycle E2E.
+
+## 4. Completion
+
+- [x] 4.1 Validate the OpenSpec change against implementation and mark all completed tasks.

--- a/openspec/changes/activate-existing-corpus/tasks.md
+++ b/openspec/changes/activate-existing-corpus/tasks.md
@@ -7,6 +7,7 @@
 
 - [x] 2.1 Generalize attention composition for a fixed activation category order while preserving default attention output.
 - [x] 2.2 Add `review_memory(mode="activation")`, coverage output, activation item lookup, and triage lifecycle support.
+- [x] 2.3 Keep activation and daily-attention identities distinct for overlapping pages and verify independent triage.
 
 ## 3. Surface And Lifecycle Verification
 

--- a/openspec/changes/add-graph-value-benchmark/.openspec.yaml
+++ b/openspec/changes/add-graph-value-benchmark/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/add-graph-value-benchmark/design.md
+++ b/openspec/changes/add-graph-value-benchmark/design.md
@@ -1,0 +1,87 @@
+## Context
+
+Exomem and Basic Memory both derive graphs from owned Markdown, but their native abstractions differ. Basic Memory indexes note entities, atomic observations, and open-vocabulary relations, then traverses connected entities through `build_context`. Exomem indexes files plus semantic blocks, resolves relations through a governed registry, records origin/anchor/hash metadata, and exposes bounded traversal profiles for epistemic, provenance, causal, decision, or all-relation context.
+
+A comparison that feeds one product the other's syntax, counts raw edge density, or collapses every outcome into one score would be easy to game. The benchmark must instead start from product-neutral facts and tasks, render equivalent native corpora, invoke public graph behavior, and report each claimed advantage independently. No reasoning model is needed: the harness measures deterministic reachability and returned structure while the evaluator compares it with explicit expected facts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make “Exomem's graph is superior” a reproducible, falsifiable graph-only claim.
+- Protect ordinary note-level reachability while testing the governed dimensions Exomem adds.
+- Compare current product-facing behavior over equivalent semantics and native authoring grammar.
+- Keep a fast model-free Exomem gate in normal tests and a direct persistent-MCP comparison for desk-side evidence.
+- Produce failure details precise enough to drive narrow runtime fixes.
+
+**Non-Goals:**
+
+- No claim that Exomem is globally superior on onboarding, generic note search, canvas UX, or ecosystem breadth.
+- No weighted composite, graph-density target, private-vault leaderboard, or benchmark-specific runtime branch.
+- No server-side reasoning model, graph database migration, schema expansion, or new relation vocabulary.
+- No required Basic Memory dependency in Exomem's package or lean CI.
+
+## Decisions
+
+### Use one semantic manifest with native corpus renderers
+
+The benchmark manifest will define neutral note identities, facts, directed relations, lifecycle state, provenance targets, semantic-block anchors, distractors, and graph tasks. An Exomem renderer will express those facts through governed frontmatter, semantic blocks, `## Relations`, Sources, and Evidence. A Basic Memory renderer will use its documented frontmatter, observations, and open relation bullets.
+
+This is preferable to sharing byte-identical Markdown, which would privilege one parser, or maintaining unrelated hand-written corpora, which would allow semantic drift. The generated trees will be hashed before and after contender runs to detect mutation.
+
+### Normalize public outputs before scoring
+
+Each contender adapter will return a small normalized result: reached note identities, typed directed edges, observations/blocks, provenance fields, lifecycle fields, response bytes, latency, contender version, and unsupported capabilities. Scoring will operate only on that contract, not internal SQLite tables.
+
+Exomem's fast gate may call its shared graph leaf in-process because that is the implementation behind MCP/REST/CLI. The direct comparison will call both products through persistent MCP servers. The Basic Memory adapter will run from an explicit checkout or executable, use an isolated home/config/database, disable semantic search and file mutation, and record its version and git revision. It is default-off and returns actionable unavailable status rather than failing lean tests when the external contender is absent.
+
+### Score independent graph dimensions
+
+Cases will cover:
+
+- note-level one-hop and multi-hop target reachability;
+- distractor exclusion under bounded results;
+- exact relation-type and edge-direction fidelity;
+- traversal-lens filtering;
+- provenance traceability including relation origin and source anchor;
+- supersession and active-conclusion selection;
+- semantic-block precision, including block kind/anchor and its relation;
+- response bytes and latency as informational efficiency measurements.
+
+Every case reports numerator, denominator, ratio, and concrete missing or unexpected normalized facts. Latency and response size remain visible but do not override correctness.
+
+### Define superiority as dominance, not an average
+
+The comparison passes only when all of these are true:
+
+1. Exomem is no worse than Basic Memory on common one-hop and multi-hop reachability.
+2. Exomem is no worse on distractor precision, relation-type fidelity, and direction fidelity.
+3. Exomem passes every Exomem graph invariant in the fixture gate.
+4. Exomem strictly exceeds Basic Memory on provenance traceability, supersession handling, and semantic-block relational precision.
+
+An unsupported contender capability scores as unsupported/zero for that dimension with an explanation; it is never silently omitted. The report contains no overall weighted score, so a governance win cannot hide a reachability regression.
+
+### Separate benchmark construction from measured fixes
+
+The first run establishes the baseline. If Exomem fails a criterion, the same OpenSpec change may add a narrowly scoped graph fix only after the failure is recorded and a regression case exists. The fix must improve public graph behavior, not inspect benchmark identifiers or special-case fixture content.
+
+### Keep reports aggregate and reproducible
+
+JSON contains the manifest version, corpus hashes, contender versions, dimension totals, dominance checks, and sanitized case IDs. Markdown renders the same aggregate facts and reproduction commands. Neither format contains private paths, private note text, query text from a personal vault, or environment secrets.
+
+## Risks / Trade-offs
+
+- [Risk] Native renderers accidentally give one contender more semantic information. -> Keep facts in one manifest, test renderer parity, and publish the mapping table.
+- [Risk] A small synthetic corpus overstates real-world value. -> Use adversarial distractors and multi-hop cases now; add a separate public medium tier later without changing metrics.
+- [Risk] External Basic Memory setup drifts. -> Record the executable version, git revision when available, tool schemas, and generated corpus hash on every run.
+- [Risk] Product adapters normalize away meaningful differences. -> Preserve unsupported fields and raw counts, and make normalization rules part of the report.
+- [Risk] Cross-product latency is noisy. -> Treat it as informational and keep correctness dominance independent of timing.
+- [Risk] The benchmark becomes a feature wishlist. -> Require a measured failed criterion and regression case before changing runtime behavior.
+
+## Migration Plan
+
+This is additive. Land the deterministic Exomem gate and report tooling, run the optional direct comparison desk-side, then publish the recorded report. Rollback removes benchmark files and any benchmark-justified runtime fix; no vault or sidecar migration is involved.
+
+## Open Questions
+
+None for the fixture tier. A public medium corpus can be added after the first direct comparison identifies which dimensions need more statistical depth.

--- a/openspec/changes/add-graph-value-benchmark/proposal.md
+++ b/openspec/changes/add-graph-value-benchmark/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Exomem now has a richer governed graph than Basic Memory, but the repository cannot yet prove that this produces better task outcomes. Before expanding schema or adding graph machinery, the project needs a reproducible comparison that fails when Exomem loses reachability and demonstrates strict advantages in semantic precision, provenance, lifecycle, and block-level context.
+
+## What Changes
+
+- Add a deterministic graph-value benchmark built from one product-neutral task manifest and semantically equivalent corpora rendered in each contender's native Markdown grammar.
+- Measure graph-dependent outcomes separately: reachable-target recall, distractor precision, relation-type and direction fidelity, provenance traceability, supersession/active-conclusion handling, semantic-block precision, multi-hop completeness, response size, and latency.
+- Define superiority as Pareto-style dominance rather than a weighted vanity score: Exomem must not lose baseline reachability and must be strictly better on the governed graph dimensions it claims as its moat.
+- Provide a fast in-repository Exomem regression gate plus an optional desk-side Basic Memory MCP adapter pinned to a recorded version/commit. The external contender remains default-off and soft-fails with clear setup guidance when unavailable.
+- Emit machine-readable JSON and aggregate Markdown reports containing the fairness contract, contender versions, per-dimension results, and any failed superiority criteria without including private vault content.
+- Use benchmark failures to drive narrowly scoped graph fixes; do not add relation vocabulary, schema surface, models, or storage backends merely to improve the score.
+
+## Capabilities
+
+### New Capabilities
+
+- `graph-value-benchmark`: Defines equivalent graph tasks, contender adapters, per-dimension metrics, dominance criteria, privacy-safe reporting, and regression behavior for demonstrating Exomem's graph advantage.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: new benchmark/evaluation modules under `scripts/`, deterministic fixtures and tests, and benchmark documentation; graph runtime code changes only if a measured failure requires a focused fix.
+- APIs: no public MCP, REST, or CLI contract change for the benchmark itself.
+- Dependencies: no new required runtime dependency or reasoning model. Direct Basic Memory execution is an explicit desk-side option using an isolated home/config and recorded contender revision.
+- CI: the small Exomem-only fixture gate remains model-free and dependency-light; cross-product and larger-corpus runs stay explicit desk-side jobs.

--- a/openspec/changes/add-graph-value-benchmark/specs/graph-value-benchmark/spec.md
+++ b/openspec/changes/add-graph-value-benchmark/specs/graph-value-benchmark/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Product-Neutral Graph Task Corpus
+
+The repository SHALL define a deterministic product-neutral manifest of graph facts and tasks and SHALL render semantically equivalent Exomem and Basic Memory corpora using each product's documented native Markdown grammar. The renderers MUST preserve note identities, observations, directed relation facts, lifecycle facts, provenance facts, block facts, expected targets, and distractors, and MUST verify that contender execution does not mutate either generated corpus.
+
+#### Scenario: Native renderers preserve one semantic manifest
+
+- **WHEN** the fixture corpus is generated for both contenders
+- **THEN** both rendered trees identify the same neutral notes and note-level relation facts
+- **AND** contender-specific provenance, lifecycle, or block representations are declared explicitly rather than silently dropped
+
+#### Scenario: Benchmark corpus is deterministic and non-mutating
+
+- **WHEN** the same manifest version is rendered twice and exercised by a contender
+- **THEN** its pre-run corpus hashes are identical across renders
+- **AND** its pre-run and post-run Markdown hashes are identical
+
+### Requirement: Independent Graph-Value Metrics
+
+The evaluator SHALL report separate numerator, denominator, and ratio values for one-hop reachability, multi-hop reachability, distractor precision, relation-type fidelity, direction fidelity, traversal-lens filtering, provenance traceability, supersession/active-conclusion handling, and semantic-block relational precision. It MUST report response bytes and latency separately and MUST NOT collapse correctness dimensions into a weighted aggregate score.
+
+#### Scenario: A graph mistake remains visible
+
+- **WHEN** a contender reaches the expected target but returns the wrong relation type, wrong direction, or forbidden distractor
+- **THEN** reachability, semantic fidelity, and precision are scored independently
+- **AND** a high value in one dimension does not erase the failed dimension
+
+#### Scenario: Unsupported capability is explicit
+
+- **WHEN** a contender cannot represent or return a required provenance, lifecycle, or semantic-block fact
+- **THEN** the dimension records unsupported status and a zero result with a reason
+- **AND** the denominator is not silently removed
+
+### Requirement: Falsifiable Graph Superiority Contract
+
+The comparison SHALL declare Exomem dominant only when Exomem is no worse than Basic Memory on common note-level one-hop and multi-hop reachability, distractor precision, relation-type fidelity, and direction fidelity; passes every Exomem fixture invariant; and strictly exceeds Basic Memory on provenance traceability, supersession handling, and semantic-block relational precision. Every failed criterion MUST identify the affected dimensions and cases.
+
+#### Scenario: Governance cannot hide a reachability regression
+
+- **WHEN** Exomem wins provenance and lifecycle dimensions but misses a note-level target that Basic Memory reaches
+- **THEN** the dominance result is false
+- **AND** the report names the reachability criterion and failed case
+
+#### Scenario: Strict governed-graph advantage is demonstrated
+
+- **WHEN** Exomem matches or exceeds all common graph dimensions and exceeds Basic Memory on all three governed dimensions
+- **THEN** the dominance result is true
+- **AND** the report scopes the claim to graph-dependent tasks
+
+### Requirement: Fast Exomem Gate And Optional Direct Contender
+
+The repository SHALL provide a model-free Exomem fixture gate suitable for the lean test suite and an explicit desk-side mode that invokes current Exomem and Basic Memory through persistent MCP server sessions. The Basic Memory session MUST use an isolated home, config, and database; disable semantic/model features and corpus mutation; and record its executable version and git revision when available. Basic Memory unavailability MUST soft-fail with setup guidance outside direct-comparison mode and MUST NOT add a required Exomem dependency.
+
+#### Scenario: Lean tests require no external contender
+
+- **WHEN** the normal Exomem test suite runs without Basic Memory installed
+- **THEN** deterministic Exomem graph cases and evaluator tests run successfully
+- **AND** no network, embedding model, or external database is required
+
+#### Scenario: Direct comparison uses persistent isolated servers
+
+- **WHEN** desk-side direct comparison is explicitly requested
+- **THEN** each contender is invoked through one persistent MCP session over its generated corpus
+- **AND** Basic Memory state is confined to an isolated benchmark directory with mutation-disabled configuration
+
+#### Scenario: Missing Basic Memory is actionable
+
+- **WHEN** direct comparison is not requested and no Basic Memory executable or checkout is available
+- **THEN** the report marks the contender unavailable and prints the exact opt-in setup requirement
+- **AND** the Exomem fixture gate still completes
+
+### Requirement: Privacy-Safe Reproducible Reports
+
+The benchmark SHALL emit JSON and Markdown reports containing manifest and corpus versions, contender versions/revisions, aggregate per-dimension results, dominance criteria, response-size and latency measurements, fairness notes, and reproduction commands. Reports MUST NOT contain private vault paths, personal note content, environment values, or personal-vault query text.
+
+#### Scenario: Report is safe to commit
+
+- **WHEN** a fixture or direct comparison report is rendered
+- **THEN** it contains only fixture case identifiers and aggregate measurements
+- **AND** repository tests reject absolute home paths, environment secrets, or generated note bodies in the report
+
+### Requirement: Benchmark-Driven Runtime Changes
+
+Any runtime graph change made in this work SHALL be tied to a recorded failed benchmark criterion and SHALL add a regression case demonstrating the public graph behavior. Runtime code MUST NOT branch on benchmark case identifiers, fixture paths, or benchmark execution state.
+
+#### Scenario: Measured failure drives a general fix
+
+- **WHEN** the initial benchmark reveals an Exomem graph failure
+- **THEN** the change records the failed criterion, adds a regression case, and implements a content-agnostic fix
+- **AND** the benchmark passes without special-casing fixture identifiers

--- a/openspec/changes/add-graph-value-benchmark/tasks.md
+++ b/openspec/changes/add-graph-value-benchmark/tasks.md
@@ -1,0 +1,29 @@
+## 1. Neutral Corpus And Renderers
+
+- [x] 1.1 Define versioned neutral note, relation, lifecycle, provenance, block, distractor, and task manifests for the fixture tier.
+- [x] 1.2 Implement deterministic Exomem and Basic Memory native Markdown renderers with declared parity metadata and corpus hashing.
+- [x] 1.3 Verify renderer determinism and pre/post contender non-mutation.
+
+## 2. Metrics And Dominance
+
+- [x] 2.1 Implement the normalized contender-result contract and independent graph-dimension scoring with concrete missing/unexpected facts.
+- [x] 2.2 Implement the no-regression plus strict-governed-win dominance contract without a weighted aggregate.
+- [x] 2.3 Implement privacy-safe JSON and aggregate Markdown reports with versions, fairness notes, corpus hashes, and reproduction commands.
+
+## 3. Contender Adapters
+
+- [x] 3.1 Implement the model-free in-process Exomem adapter and fixture regression gate over the shared graph leaf.
+- [x] 3.2 Implement explicit persistent-MCP desk-side adapters for Exomem and an isolated, mutation-disabled Basic Memory checkout/executable.
+- [x] 3.3 Add CLI selection, contender revision capture, actionable soft-failure outside direct mode, and strict failure when direct comparison was requested.
+
+## 4. Benchmark Evidence And Measured Fixes
+
+- [x] 4.1 Add focused tests for corpus parity, every metric, dominance failures, unsupported capabilities, privacy, adapter normalization, and non-mutation.
+- [x] 4.2 Run the initial Exomem fixture and direct Basic Memory comparison, recording per-dimension baseline evidence and failed criteria.
+- [x] 4.3 For each Exomem failure, add a public-behavior regression and implement only the content-agnostic graph fix required to satisfy the criterion. (The initial Exomem run had no failed criteria, so no benchmark-driven runtime change was required.)
+- [x] 4.4 Publish the graph-scoped comparison methodology, results, limitations, and reproduction commands in repository docs.
+
+## 5. Verification
+
+- [x] 5.1 Run changed-area lint, focused graph/benchmark tests, the latency gate, OpenSpec validation, and the available dependency-light suite.
+- [x] 5.2 Verify implementation completeness, correctness, and design coherence against every graph-value benchmark requirement.

--- a/openspec/changes/fix-graph-semantic-integrity/.openspec.yaml
+++ b/openspec/changes/fix-graph-semantic-integrity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/fix-graph-semantic-integrity/design.md
+++ b/openspec/changes/fix-graph-semantic-integrity/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Exomem has two authoring layers for durable typed relationships: block-level relation metadata indexed as `semantic_relation` and canonical note-level `## Relations` bullets indexed as `markdown_relation`. Memory contracts currently retain only the former origin, so the recommended note-level syntax disappears from schema inference, validation, and diff.
+
+Relation suggestions have a separate integrity defect. Explicit wikilinks and frontmatter sources have observed semantics, but shared-source and embedding-neighbour candidates are currently emitted as `refines`. Those measurements establish adjacency or similarity, not a directional refinement claim. Suggestions are proposal-only, which prevents durable corruption, but the proposed type still misleads the reviewing agent.
+
+The change must preserve the pure-substrate boundary: deterministic measurements may surface candidates, but semantic direction remains an authored, reviewed decision.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make canonical note-level and block-level typed relations participate consistently in memory-contract inference, validation, and diff.
+- Keep similarity-only suggestions useful while representing their semantics conservatively.
+- Preserve response shape, ordering, evidence payloads, and proposal-only/non-mutating behavior.
+- Cover both fixes with focused regression tests.
+
+**Non-Goals:**
+
+- No new relation vocabulary, schema language, graph node type, model, or sidecar migration.
+- No automatic relation acceptance or conversion of generic links into durable typed edges.
+- No change to frontmatter-derived provenance semantics, graph traversal, or retrieval ranking.
+- No broader schema expansion such as relation cardinality or target-type constraints; those remain evidence-driven follow-on work.
+
+## Decisions
+
+### Treat both authored semantic origins as contract relations
+
+Memory-contract relation collection will accept edges whose origin is either `semantic_relation` or `markdown_relation`, provided the edge resolved to a canonical relation type. This is the narrowest change that aligns contracts with the documented authoring contract while retaining legacy/block behavior.
+
+Including every graph origin was rejected. Frontmatter provenance and generic wikilinks have distinct authoring and validation semantics and broadening contracts to them would create unrelated schema drift.
+
+### Use `relates_to` for similarity-only candidates
+
+Shared-source and embedding-proximity candidates will retain their methods and evidence but propose the symmetric core relation `relates_to`. Explicit wikilinks remain `links_to`; frontmatter sources remain `derived_from`.
+
+Returning `relation_type=null` would be semantically pure but needlessly breaks callers that expect a registered candidate type. `relates_to` is the existing governed, symmetric fallback for a potentially meaningful association. It remains a proposal requiring review; callers may replace it with a more precise relation only when the note content supports that choice.
+
+### Test public behavior through existing command leaves
+
+Regression tests will exercise contract inference/validation through `schema_memory` behavior and suggestion output through the existing graph helper/command path. No surface-specific logic or new API is introduced.
+
+## Risks / Trade-offs
+
+- [Risk] `relates_to` candidates may still be low-value semantic neighbours. -> Preserve similarity evidence and proposal-only behavior; graph-value benchmarking and acceptance rates decide whether the candidate method remains useful.
+- [Risk] Existing consumers expect `refines` from proximity. -> The old value is semantically incorrect; keep the response shape and method stable while changing only the proposed type.
+- [Risk] Canonical relations alter inferred contract output for corpora that already use them. -> This is the intended correction; conservative requiredness rules and explicit contract saving remain unchanged.
+
+## Migration Plan
+
+No data migration is required. Deploy the code and rebuild nothing: contracts are inferred from Markdown on demand, and suggestions are response-only. Rollback restores the two prior classifications without modifying Markdown or sidecars.
+
+## Open Questions
+
+None for this slice. Relation target types, cardinality, and first-class semantic-block retrieval should be considered only after corpus activation and graph-value measurement.

--- a/openspec/changes/fix-graph-semantic-integrity/proposal.md
+++ b/openspec/changes/fix-graph-semantic-integrity/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exomem's canonical note-level relation syntax is currently omitted from corpus-contract inference and validation, while similarity-only relation suggestions overstate semantic direction by labelling nearby notes as `refines`. These two defects undermine the governed meaning the graph is intended to preserve and should be corrected before expanding schema or graph surface area.
+
+## What Changes
+
+- Make memory-contract inference, validation, and diff treat canonical `## Relations` edges as observed typed relations alongside block-level semantic relations.
+- Make similarity-only and shared-source relation suggestions semantically neutral; they may propose related candidates but must not assert `refines` without directional evidence.
+- Preserve explicit wikilink and frontmatter-derived suggestion behavior, proposal-only semantics, graph ordering, and all existing write contracts.
+- Add regression coverage for canonical relation contracts and neutral similarity/shared-source candidates.
+
+## Capabilities
+
+### New Capabilities
+
+- `graph-semantic-integrity`: Ensures schema observation and relation proposals preserve the meaning and provenance of canonical graph relations without laundering proximity into directional claims.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: `memory_schema.py`, `epistemic_graph.py`, and focused schema/graph tests.
+- APIs: existing `schema_memory` and `connect_memory(operation="suggest-relations")` response shapes remain compatible; only incorrect relation classification changes.
+- Dependencies and runtime: no new dependency, model, background task, or sidecar migration.

--- a/openspec/changes/fix-graph-semantic-integrity/specs/graph-semantic-integrity/spec.md
+++ b/openspec/changes/fix-graph-semantic-integrity/specs/graph-semantic-integrity/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Canonical authored relations participate in memory contracts
+
+The system SHALL treat resolved canonical note-level `## Relations` edges and resolved block-level semantic relations as observed typed relations when inferring, validating, or diffing memory contracts. It MUST NOT treat generic wikilinks or unregistered relation labels as canonical contract relations.
+
+#### Scenario: Canonical note relation is inferred
+
+- **WHEN** every eligible page in a contract corpus contains a canonical `## Relations` edge of the same registered type
+- **THEN** contract inference reports that relation type with full occurrence frequency and applies the existing conservative requiredness rule
+
+#### Scenario: Canonical relation satisfies validation
+
+- **WHEN** a saved contract requires a registered relation and a matching page expresses it through canonical `## Relations` syntax
+- **THEN** contract validation considers the requirement satisfied
+
+#### Scenario: Relation drift includes canonical syntax
+
+- **WHEN** canonical note-level relation usage is added to or removed from the current corpus
+- **THEN** contract diff reports the corresponding relation change without modifying any page or contract
+
+### Requirement: Similarity-only suggestions remain semantically neutral
+
+The system SHALL represent candidates produced only by shared-source or embedding-proximity measurement as the registered symmetric relation `relates_to`. It MUST NOT propose `refines`, `supports`, `contradicts`, or another directional epistemic relation unless the candidate method observes evidence for that meaning.
+
+#### Scenario: Embedding proximity does not assert refinement
+
+- **WHEN** an embedding-neighbour candidate is returned without directional evidence
+- **THEN** its proposed relation type is `relates_to`, its method remains `embedding_proximity`, and its similarity evidence is retained
+
+#### Scenario: Shared source does not assert refinement
+
+- **WHEN** two notes cite the same source and no directional relation is observed
+- **THEN** the shared-source candidate proposes `relates_to` and identifies the shared source in its evidence
+
+#### Scenario: Explicit evidence keeps its observed semantics
+
+- **WHEN** a candidate comes from an explicit wikilink or frontmatter source field
+- **THEN** it retains the existing `links_to` or `derived_from` relation type respectively
+
+### Requirement: Relation suggestions remain proposal-only
+
+Changing similarity candidate types SHALL NOT write Markdown, mutate accepted graph edges, change retrieval ranking, invoke a reasoning model, or alter candidate ordering beyond deterministic deduplication caused by the corrected type.
+
+#### Scenario: Neutral suggestion call is non-mutating
+
+- **WHEN** relation suggestions return shared-source or embedding-proximity candidates
+- **THEN** the response reports `mutated=false` and the vault and graph sidecar remain unchanged

--- a/openspec/changes/fix-graph-semantic-integrity/tasks.md
+++ b/openspec/changes/fix-graph-semantic-integrity/tasks.md
@@ -1,0 +1,14 @@
+## 1. Canonical Relation Contracts
+
+- [x] 1.1 Add regression coverage proving canonical `## Relations` edges participate in contract inference, validation, and diff while generic links and unknown labels do not.
+- [x] 1.2 Update memory-contract relation collection to include resolved `markdown_relation` edges without broadening to generic wikilinks or frontmatter edges.
+
+## 2. Semantically Neutral Suggestions
+
+- [x] 2.1 Add regression coverage for neutral shared-source and embedding-proximity candidates, preserved evidence/methods, explicit-source semantics, and non-mutation.
+- [x] 2.2 Change similarity-only candidate types from `refines` to the governed symmetric `relates_to` relation without changing candidate ordering or response shape.
+
+## 3. Verification
+
+- [x] 3.1 Run focused schema, graph, registry, and relation-parser tests with embeddings disabled.
+- [x] 3.2 Run lint, OpenSpec validation, and the broad lean test suite available in the worktree environment.

--- a/scripts/graph_value_benchmark.py
+++ b/scripts/graph_value_benchmark.py
@@ -1,0 +1,1516 @@
+#!/usr/bin/env python
+"""Deterministic graph-value benchmark for Exomem and Basic Memory."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "tests" / "fixtures" / "graph_value" / "manifest.json"
+COMMON_DIMENSIONS = (
+    "one_hop_reachability",
+    "multi_hop_reachability",
+    "distractor_precision",
+    "relation_type_fidelity",
+    "direction_fidelity",
+)
+GOVERNED_DIMENSIONS = (
+    "provenance_traceability",
+    "supersession_handling",
+    "semantic_block_precision",
+)
+ALL_DIMENSIONS = (*COMMON_DIMENSIONS, "traversal_lens_filtering", *GOVERNED_DIMENSIONS)
+
+
+@dataclass(frozen=True)
+class EdgeFact:
+    source: str
+    target: str
+    relation_type: str
+    origin: str | None = None
+    source_anchor: str | None = None
+
+
+@dataclass(frozen=True)
+class BlockFact:
+    note: str
+    block_id: str
+    kind: str
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    dimension: str
+    reached_nodes: list[str]
+    edges: list[EdgeFact]
+    blocks: list[BlockFact]
+    statuses: dict[str, str]
+    response_bytes: int
+    latency_ms: float
+    unsupported: dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "dimension": self.dimension,
+            "reached_nodes": sorted(self.reached_nodes),
+            "edges": [asdict(item) for item in sorted(self.edges, key=_edge_sort_key)],
+            "blocks": [asdict(item) for item in sorted(self.blocks, key=_block_sort_key)],
+            "statuses": dict(sorted(self.statuses.items())),
+            "response_bytes": self.response_bytes,
+            "latency_ms": round(self.latency_ms, 3),
+            "unsupported": dict(sorted(self.unsupported.items())),
+        }
+
+
+@dataclass
+class ContenderRun:
+    contender: str
+    available: bool
+    version: str
+    revision: str
+    corpus_hash: str
+    mutation_safe: bool
+    cases: dict[str, CaseResult] = field(default_factory=dict)
+    unavailable_reason: str | None = None
+    notes: list[str] = field(default_factory=list)
+    renderer_parity: dict[str, str] = field(default_factory=dict)
+
+    def public_dict(self) -> dict[str, Any]:
+        return {
+            "contender": self.contender,
+            "available": self.available,
+            "version": self.version,
+            "revision": self.revision,
+            "corpus_hash": self.corpus_hash,
+            "mutation_safe": self.mutation_safe,
+            "unavailable_reason": self.unavailable_reason,
+            "notes": list(self.notes),
+            "renderer_parity": dict(sorted(self.renderer_parity.items())),
+        }
+
+
+@dataclass
+class MetricResult:
+    dimension: str
+    numerator: int
+    denominator: int
+    ratio: float
+    supported: bool
+    missing: list[str] = field(default_factory=list)
+    unexpected: list[str] = field(default_factory=list)
+    reason: str | None = None
+    case_ids: list[str] = field(default_factory=list)
+    failed_case_ids: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dimension": self.dimension,
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "ratio": round(self.ratio, 6),
+            "supported": self.supported,
+            "missing": sorted(self.missing),
+            "unexpected": sorted(self.unexpected),
+            "reason": self.reason,
+            "case_ids": sorted(self.case_ids),
+            "failed_case_ids": sorted(self.failed_case_ids),
+        }
+
+
+@dataclass(frozen=True)
+class RenderedCorpus:
+    contender: str
+    root: Path
+    manifest_version: int
+    id_to_path: dict[str, str]
+    title_to_id: dict[str, str]
+    id_to_permalink: dict[str, str]
+    parity: dict[str, str]
+    corpus_hash: str
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    required = {"manifest_version", "notes", "relations", "provenance", "blocks", "tasks"}
+    missing = required - set(data)
+    if missing:
+        raise ValueError(f"graph manifest missing fields: {sorted(missing)}")
+    note_ids = [str(note["id"]) for note in data["notes"]]
+    task_ids = [str(task["id"]) for task in data["tasks"]]
+    if len(note_ids) != len(set(note_ids)):
+        raise ValueError("graph manifest note ids must be unique")
+    if len(task_ids) != len(set(task_ids)):
+        raise ValueError("graph manifest task ids must be unique")
+    unknown_dimensions = {str(task["dimension"]) for task in data["tasks"]} - set(ALL_DIMENSIONS)
+    if unknown_dimensions:
+        raise ValueError(f"graph manifest has unknown dimensions: {sorted(unknown_dimensions)}")
+    known = set(note_ids)
+    for edge in [*data["relations"], *data["provenance"]]:
+        if str(edge["from"]) not in known or str(edge["to"]) not in known:
+            raise ValueError(f"graph manifest edge references unknown note: {edge}")
+    return data
+
+
+def render_exomem(manifest: dict[str, Any], root: Path) -> RenderedCorpus:
+    root = Path(root)
+    shutil.copytree(
+        REPO_ROOT / "src" / "exomem" / "_scaffold",
+        root / "Knowledge Base",
+        dirs_exist_ok=True,
+    )
+    notes = {str(note["id"]): note for note in manifest["notes"]}
+    id_to_path = {note_id: _exomem_path(note) for note_id, note in notes.items()}
+    title_to_id = {str(note["title"]): note_id for note_id, note in notes.items()}
+    id_to_permalink = dict(id_to_path)
+    relations_by_source = _group_by_source(manifest["relations"])
+    provenance_by_source = _group_by_source(manifest["provenance"])
+    blocks_by_note = _group_by(manifest["blocks"], "note")
+
+    for note_id, note in notes.items():
+        rel_path = id_to_path[note_id]
+        path = root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frontmatter = [
+            "---",
+            f"type: {_exomem_page_type(note)}",
+            f"status: {note['status']}",
+            "created: 2026-01-01",
+            "updated: 2026-01-01",
+            f"benchmark_id: {note_id}",
+        ]
+        for edge in provenance_by_source.get(note_id, []):
+            frontmatter.extend(
+                [
+                    f"{edge['channel']}:",
+                    f'  - "[[{id_to_path[str(edge["to"])]}]]"',
+                ]
+            )
+        if note.get("supersedes"):
+            frontmatter.extend(
+                [
+                    "supersedes:",
+                    f'  - "[[{id_to_path[str(note["supersedes"])]}]]"',
+                ]
+            )
+        if note.get("superseded_by"):
+            frontmatter.extend(
+                [
+                    "superseded_by:",
+                    f'  - "[[{id_to_path[str(note["superseded_by"])]}]]"',
+                ]
+            )
+        frontmatter.append("---")
+        body = [*frontmatter, "", f"# {note['title']}", "", "## Overview", "", note["text"]]
+        for block in blocks_by_note.get(note_id, []):
+            relation_text = ", ".join(
+                f"{edge['type']}: [[{id_to_path[str(edge['to'])]}]]"
+                for edge in block.get("relations", [])
+            )
+            body.extend(
+                [
+                    "",
+                    f"## {str(block['kind']).replace('_', ' ').title()}",
+                    f"- id: {block['id']}",
+                ]
+            )
+            if relation_text:
+                body.append(f"- relations: {relation_text}")
+            body.extend(["", str(block["text"])])
+        note_relations = relations_by_source.get(note_id, [])
+        if note_relations:
+            body.extend(["", "## Relations"])
+            body.extend(
+                f"- {edge['type']} [[{id_to_path[str(edge['to'])]}]]" for edge in note_relations
+            )
+        path.write_text("\n".join(body).rstrip() + "\n", encoding="utf-8")
+
+    profile_path = root / "Knowledge Base" / "_Schema" / "traversal-profiles.yaml"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    profile_path.write_text(
+        """schema_version: 1
+profiles:
+  benchmark-outgoing:
+    extends: all
+    direction: outgoing
+  benchmark-dependency:
+    extends: all
+    remove_families: [support, contradiction, refinement, duplication, supersession, derivation, evidence, implementation, mitigation, causality, blocking, resolution, answer, question, use, observation, mention, entity, relation, link, citation, testing, ownership]
+    add_families: [dependency]
+    direction: outgoing
+""",
+        encoding="utf-8",
+    )
+    return RenderedCorpus(
+        contender="exomem",
+        root=root,
+        manifest_version=int(manifest["manifest_version"]),
+        id_to_path=id_to_path,
+        title_to_id=title_to_id,
+        id_to_permalink=id_to_permalink,
+        parity={
+            "note_relations": "canonical ## Relations bullets",
+            "provenance": "sources/evidence frontmatter with governed origin metadata",
+            "lifecycle": "status plus supersedes/superseded_by frontmatter",
+            "blocks": "semantic blocks with anchored relation metadata",
+            "scaffold": "generic Exomem schema scaffold; excluded from neutral note identities",
+        },
+        corpus_hash=corpus_hash(root),
+    )
+
+
+def render_basic_memory(manifest: dict[str, Any], root: Path) -> RenderedCorpus:
+    root = Path(root)
+    notes = {str(note["id"]): note for note in manifest["notes"]}
+    id_to_path = {note_id: f"notes/{note_id}.md" for note_id in notes}
+    title_to_id = {str(note["title"]): note_id for note_id, note in notes.items()}
+    id_to_permalink = {note_id: note_id for note_id in notes}
+    relations_by_source = _group_by_source(manifest["relations"])
+    provenance_by_source = _group_by_source(manifest["provenance"])
+    blocks_by_note = _group_by(manifest["blocks"], "note")
+
+    for note_id, note in notes.items():
+        path = root / id_to_path[note_id]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = [
+            "---",
+            f"title: {note['title']}",
+            f"type: {note['kind']}",
+            f"permalink: {note_id}",
+            f"status: {note['status']}",
+            f"benchmark_id: {note_id}",
+            "---",
+            "",
+            f"# {note['title']}",
+            "",
+            "## Observations",
+            f"- [{note['kind']}] {note['text']}",
+        ]
+        for block in blocks_by_note.get(note_id, []):
+            body.append(f"- [{block['kind']}] {block['text']}")
+        edges = [*relations_by_source.get(note_id, []), *provenance_by_source.get(note_id, [])]
+        if note.get("supersedes"):
+            edges.append({"from": note_id, "to": str(note["supersedes"]), "type": "supersedes"})
+        for block in blocks_by_note.get(note_id, []):
+            edges.extend(
+                {"from": note_id, "to": str(edge["to"]), "type": str(edge["type"])}
+                for edge in block.get("relations", [])
+            )
+        if edges:
+            body.extend(["", "## Relations"])
+            body.extend(f"- {edge['type']} [[{notes[str(edge['to'])]['title']}]]" for edge in edges)
+        path.write_text("\n".join(body).rstrip() + "\n", encoding="utf-8")
+
+    return RenderedCorpus(
+        contender="basic-memory",
+        root=root,
+        manifest_version=int(manifest["manifest_version"]),
+        id_to_path=id_to_path,
+        title_to_id=title_to_id,
+        id_to_permalink=id_to_permalink,
+        parity={
+            "note_relations": "documented open relation bullets",
+            "provenance": "closest native typed relation; no origin/source-anchor contract",
+            "lifecycle": "custom status metadata plus supersedes relation",
+            "blocks": "atomic observation plus page-level relation; no relation-bearing block anchor",
+        },
+        corpus_hash=corpus_hash(root),
+    )
+
+
+def corpus_hash(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(Path(root).rglob("*.md")):
+        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def run_exomem_fixture(
+    manifest: dict[str, Any], corpus: RenderedCorpus, *, revision: str = ""
+) -> ContenderRun:
+    from exomem import epistemic_graph
+
+    before = corpus_hash(corpus.root)
+    epistemic_graph.EpistemicGraphIndex(corpus.root).rebuild_all()
+    cases: dict[str, CaseResult] = {}
+    for task in manifest["tasks"]:
+        started = time.perf_counter()
+        payload = epistemic_graph.graph_context(
+            corpus.root,
+            path=corpus.id_to_path[str(task["seed"])],
+            depth=int(task.get("depth", 1)),
+            relation_types=list(task.get("relation_types") or []) or None,
+            max_nodes=100,
+            max_edges=200,
+            traversal_profile=task.get("profile"),
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        cases[str(task["id"])] = normalize_exomem_context(
+            task, payload, corpus, elapsed_ms=elapsed_ms
+        )
+    after = corpus_hash(corpus.root)
+    return ContenderRun(
+        contender="exomem",
+        available=True,
+        version=_package_version("exomem"),
+        revision=revision or git_revision(REPO_ROOT),
+        corpus_hash=before,
+        mutation_safe=before == after,
+        cases=cases,
+        notes=["model-free in-process shared graph leaf"],
+        renderer_parity=corpus.parity,
+    )
+
+
+def normalize_exomem_context(
+    task: dict[str, Any], payload: dict[str, Any], corpus: RenderedCorpus, *, elapsed_ms: float
+) -> CaseResult:
+    path_to_id = {path: note_id for note_id, path in corpus.id_to_path.items()}
+    node_by_key = {str(node["node_key"]): node for node in payload.get("nodes", [])}
+    key_to_neutral: dict[str, str] = {}
+    reached: set[str] = set()
+    statuses: dict[str, str] = {}
+    blocks: set[BlockFact] = set()
+    seed = str(task["seed"])
+    for key, node in node_by_key.items():
+        note_id = path_to_id.get(str(node.get("path") or ""))
+        if note_id is None:
+            continue
+        kind = str(node.get("kind") or "")
+        if kind == "file":
+            key_to_neutral[key] = note_id
+            if note_id != seed:
+                reached.add(note_id)
+            metadata = node.get("metadata") or {}
+            if metadata.get("status"):
+                statuses[note_id] = str(metadata["status"])
+        elif kind != "unresolved":
+            anchor = str(node.get("anchor") or "")
+            key_to_neutral[key] = f"{note_id}#{anchor}"
+            blocks.add(BlockFact(note_id, anchor, kind))
+    edges: set[EdgeFact] = set()
+    for edge in payload.get("edges", []):
+        source = key_to_neutral.get(str(edge.get("src_key") or ""))
+        target = key_to_neutral.get(str(edge.get("dst_key") or ""))
+        relation_type = edge.get("relation_type")
+        if source and target and relation_type:
+            edges.add(
+                EdgeFact(
+                    source,
+                    target,
+                    str(relation_type),
+                    str(edge["origin"]) if edge.get("origin") else None,
+                    str(edge["source_anchor"]) if edge.get("source_anchor") else None,
+                )
+            )
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return CaseResult(
+        case_id=str(task["id"]),
+        dimension=str(task["dimension"]),
+        reached_nodes=sorted(reached),
+        edges=sorted(edges, key=_edge_sort_key),
+        blocks=sorted(blocks, key=_block_sort_key),
+        statuses=statuses,
+        response_bytes=len(encoded),
+        latency_ms=elapsed_ms,
+    )
+
+
+def normalize_basic_memory_context(
+    task: dict[str, Any], payload: dict[str, Any], corpus: RenderedCorpus, *, elapsed_ms: float
+) -> CaseResult:
+    reached: set[str] = set()
+    edges: set[EdgeFact] = set()
+    seed = str(task["seed"])
+    for result in payload.get("results", []):
+        primary = result.get("primary_result") or {}
+        primary_id = corpus.title_to_id.get(str(primary.get("title") or ""), seed)
+        for related in result.get("related_results", []):
+            item_type = related.get("type")
+            if item_type == "entity":
+                note_id = corpus.title_to_id.get(str(related.get("title") or ""))
+                if note_id and note_id != seed:
+                    reached.add(note_id)
+            elif item_type == "relation":
+                source = corpus.title_to_id.get(str(related.get("from_entity") or ""))
+                target = corpus.title_to_id.get(
+                    str(related.get("to_entity") or related.get("to_name") or "")
+                )
+                relation_type = related.get("relation_type")
+                if source and target and relation_type:
+                    edges.add(EdgeFact(source, target, str(relation_type)))
+        if primary_id != seed:
+            reached.add(primary_id)
+    unsupported: dict[str, str] = {}
+    dimension = str(task["dimension"])
+    if dimension == "provenance_traceability":
+        unsupported[dimension] = "build_context relations omit authored origin and source anchor"
+    elif dimension == "supersession_handling":
+        unsupported[dimension] = "build_context entities omit lifecycle status metadata"
+    elif dimension == "semantic_block_precision":
+        unsupported[dimension] = "observations cannot own graph relations or stable block anchors"
+    elif dimension == "traversal_lens_filtering":
+        unsupported[dimension] = "build_context exposes no relation-family traversal lens"
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return CaseResult(
+        case_id=str(task["id"]),
+        dimension=dimension,
+        reached_nodes=sorted(reached),
+        edges=sorted(edges, key=_edge_sort_key),
+        blocks=[],
+        statuses={},
+        response_bytes=len(encoded),
+        latency_ms=elapsed_ms,
+        unsupported=unsupported,
+    )
+
+
+def score_run(manifest: dict[str, Any], run: ContenderRun) -> dict[str, MetricResult]:
+    grouped: dict[str, list[MetricResult]] = {dimension: [] for dimension in ALL_DIMENSIONS}
+    tasks = {str(task["id"]): task for task in manifest["tasks"]}
+    for case_id, task in tasks.items():
+        result = run.cases.get(case_id)
+        if result is None:
+            grouped[str(task["dimension"])].append(
+                MetricResult(
+                    str(task["dimension"]),
+                    0,
+                    1,
+                    0.0,
+                    False,
+                    missing=[f"{case_id}:missing-result"],
+                    reason=run.unavailable_reason or "contender returned no case result",
+                    case_ids=[case_id],
+                    failed_case_ids=[case_id],
+                )
+            )
+        else:
+            metric = score_case(task, result)
+            metric.case_ids = [case_id]
+            if metric.ratio < 1.0 or not metric.supported:
+                metric.failed_case_ids = [case_id]
+            grouped[result.dimension].append(metric)
+    return {
+        dimension: _aggregate_dimension(dimension, values)
+        for dimension, values in grouped.items()
+        if values
+    }
+
+
+def score_case(task: dict[str, Any], result: CaseResult) -> MetricResult:
+    dimension = str(task["dimension"])
+    if dimension in result.unsupported:
+        return MetricResult(
+            dimension,
+            0,
+            1,
+            0.0,
+            False,
+            missing=[str(task["id"])],
+            reason=result.unsupported[dimension],
+        )
+    if dimension in {"one_hop_reachability", "multi_hop_reachability"}:
+        expected = set(map(str, task.get("expected_nodes") or []))
+        reached = set(result.reached_nodes)
+        return _metric_from_checks(
+            dimension, expected, expected & reached, expected - reached, set()
+        )
+    if dimension == "distractor_precision":
+        expected = set(map(str, task.get("expected_nodes") or []))
+        reached = set(result.reached_nodes)
+        denominator = max(1, len(reached))
+        numerator = len(reached & expected)
+        return MetricResult(
+            dimension,
+            numerator,
+            denominator,
+            numerator / denominator,
+            True,
+            missing=sorted(expected - reached),
+            unexpected=sorted(reached - expected),
+        )
+    if dimension == "relation_type_fidelity":
+        expected = [_expected_edge(edge) for edge in task.get("expected_edges") or []]
+        checks = [
+            any(
+                {item.source, item.target} == {edge.source, edge.target}
+                and item.relation_type == edge.relation_type
+                for item in result.edges
+            )
+            for edge in expected
+        ]
+        metric = _metric_from_bools(dimension, checks, expected)
+        metric.unexpected = [
+            str(item)
+            for expected_edge in expected
+            for item in result.edges
+            if {item.source, item.target} == {expected_edge.source, expected_edge.target}
+            and item.relation_type != expected_edge.relation_type
+        ]
+        return metric
+    if dimension == "direction_fidelity":
+        expected = [_expected_edge(edge) for edge in task.get("expected_edges") or []]
+        edge_checks = [
+            any(item.source == edge.source and item.target == edge.target for item in result.edges)
+            for edge in expected
+        ]
+        forbidden = list(map(str, task.get("forbidden_nodes") or []))
+        forbidden_checks = [node not in result.reached_nodes for node in forbidden]
+        checks = [*edge_checks, *forbidden_checks]
+        denominator = max(1, len(checks))
+        numerator = sum(checks)
+        return MetricResult(
+            dimension,
+            numerator,
+            denominator,
+            numerator / denominator,
+            True,
+            missing=[
+                str(edge) for edge, passed in zip(expected, edge_checks, strict=False) if not passed
+            ],
+            unexpected=[
+                node
+                for node, passed in zip(forbidden, forbidden_checks, strict=False)
+                if not passed
+            ],
+        )
+    if dimension == "traversal_lens_filtering":
+        observed = {edge.relation_type for edge in result.edges}
+        expected_types = list(map(str, task.get("expected_relation_types") or []))
+        forbidden_types = list(map(str, task.get("forbidden_relation_types") or []))
+        expected_checks = [item in observed for item in expected_types]
+        forbidden_checks = [item not in observed for item in forbidden_types]
+        checks = [*expected_checks, *forbidden_checks]
+        denominator = max(1, len(checks))
+        numerator = sum(checks)
+        return MetricResult(
+            dimension,
+            numerator,
+            denominator,
+            numerator / denominator,
+            True,
+            missing=[
+                item
+                for item, passed in zip(expected_types, expected_checks, strict=False)
+                if not passed
+            ],
+            unexpected=[
+                item
+                for item, passed in zip(forbidden_types, forbidden_checks, strict=False)
+                if not passed
+            ],
+        )
+    if dimension == "provenance_traceability":
+        requirements = task.get("edge_requirements") or []
+        checks = [
+            _matching_edge_requirement(requirement, result.edges) for requirement in requirements
+        ]
+        return _metric_from_bools(dimension, checks, requirements)
+    if dimension == "supersession_handling":
+        expected_edges = [_expected_edge(edge) for edge in task.get("expected_edges") or []]
+        checks = [_matching_expected_edge(edge, result.edges) for edge in expected_edges]
+        labels: list[Any] = list(expected_edges)
+        for note_id, status in (task.get("expected_statuses") or {}).items():
+            checks.append(result.statuses.get(str(note_id)) == str(status))
+            labels.append(f"{note_id}:{status}")
+        return _metric_from_bools(dimension, checks, labels)
+    if dimension == "semantic_block_precision":
+        expected_blocks = [
+            BlockFact(str(item["note"]), str(item["id"]), str(item["kind"]))
+            for item in task.get("expected_blocks") or []
+        ]
+        expected_edges = [_expected_edge(edge) for edge in task.get("expected_edges") or []]
+        checks = [block in result.blocks for block in expected_blocks]
+        checks.extend(_matching_expected_edge(edge, result.edges) for edge in expected_edges)
+        return _metric_from_bools(dimension, checks, [*expected_blocks, *expected_edges])
+    raise ValueError(f"unsupported graph benchmark dimension: {dimension}")
+
+
+def dominance_report(
+    exomem_scores: dict[str, MetricResult],
+    basic_scores: dict[str, MetricResult] | None,
+) -> dict[str, Any]:
+    fixture_failures = [
+        dimension
+        for dimension, metric in exomem_scores.items()
+        if metric.ratio < 1.0 or not metric.supported
+    ]
+    if basic_scores is None:
+        return {
+            "dominant": None,
+            "scope": "graph-dependent fixture tasks",
+            "fixture_passed": not fixture_failures,
+            "failed_criteria": [*fixture_failures, "basic-memory-unavailable"],
+            "checks": [],
+        }
+    checks: list[dict[str, Any]] = []
+    for dimension in COMMON_DIMENSIONS:
+        left_metric = exomem_scores[dimension]
+        right_metric = basic_scores[dimension]
+        left = left_metric.ratio
+        right = right_metric.ratio
+        passed = left >= right
+        checks.append(
+            {
+                "criterion": f"no-regression:{dimension}",
+                "passed": passed,
+                "exomem": round(left, 6),
+                "basic_memory": round(right, 6),
+                "cases": []
+                if passed
+                else sorted(set(left_metric.failed_case_ids or left_metric.case_ids)),
+            }
+        )
+    for dimension in GOVERNED_DIMENSIONS:
+        left_metric = exomem_scores[dimension]
+        right_metric = basic_scores[dimension]
+        left = left_metric.ratio
+        right = right_metric.ratio
+        passed = left > right
+        checks.append(
+            {
+                "criterion": f"strict-win:{dimension}",
+                "passed": passed,
+                "exomem": round(left, 6),
+                "basic_memory": round(right, 6),
+                "cases": [] if passed else sorted(set(left_metric.case_ids)),
+            }
+        )
+    failed = [item["criterion"] for item in checks if not item["passed"]]
+    failed.extend(f"fixture:{dimension}" for dimension in fixture_failures)
+    return {
+        "dominant": not failed,
+        "scope": "graph-dependent fixture tasks",
+        "fixture_passed": not fixture_failures,
+        "failed_criteria": failed,
+        "checks": checks,
+    }
+
+
+def build_report(
+    manifest: dict[str, Any],
+    exomem_run: ContenderRun,
+    basic_run: ContenderRun | None = None,
+) -> dict[str, Any]:
+    exomem_scores = score_run(manifest, exomem_run)
+    basic_scores = score_run(manifest, basic_run) if basic_run and basic_run.available else None
+    return {
+        "report_version": 1,
+        "manifest_version": int(manifest["manifest_version"]),
+        "claim_scope": "graph-dependent fixture tasks only",
+        "fairness": {
+            "one_manifest": True,
+            "native_markdown_renderers": True,
+            "persistent_mcp_direct_mode": True,
+            "model_free": True,
+            "weighted_aggregate": False,
+            "latency_is_informational": True,
+        },
+        "contenders": {
+            "exomem": exomem_run.public_dict(),
+            "basic_memory": (
+                basic_run.public_dict()
+                if basic_run
+                else {
+                    "contender": "basic-memory",
+                    "available": False,
+                    "unavailable_reason": "run with --direct and provide a checkout or executable",
+                }
+            ),
+        },
+        "dimensions": {
+            "exomem": {key: value.as_dict() for key, value in sorted(exomem_scores.items())},
+            "basic_memory": (
+                {key: value.as_dict() for key, value in sorted(basic_scores.items())}
+                if basic_scores
+                else None
+            ),
+        },
+        "dominance": dominance_report(exomem_scores, basic_scores),
+        "efficiency": {
+            "exomem": _efficiency(exomem_run),
+            "basic_memory": _efficiency(basic_run) if basic_run and basic_run.available else None,
+        },
+        "reproduce": {
+            "fixture": "python scripts/graph_value_benchmark.py",
+            "direct": "python scripts/graph_value_benchmark.py --direct --basic-memory-root ../basic-memory",
+        },
+    }
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Graph value benchmark",
+        "",
+        f"Claim scope: **{report['claim_scope']}**",
+        "",
+        f"Report version: `{report['report_version']}`  ",
+        f"Manifest version: `{report['manifest_version']}`",
+        "",
+        "No weighted aggregate is used. Correctness dimensions remain independent.",
+        "",
+        "## Contenders",
+        "",
+        "| Contender | Available | Version | Revision | Corpus hash | Markdown unchanged |",
+        "|---|---:|---|---|---|---:|",
+    ]
+    for key in ("exomem", "basic_memory"):
+        item = report["contenders"][key]
+        lines.append(
+            "| {name} | {available} | {version} | {revision} | {corpus_hash} | {safe} |".format(
+                name=item.get("contender", key),
+                available="yes" if item.get("available") else "no",
+                version=item.get("version") or "—",
+                revision=item.get("revision") or "—",
+                corpus_hash=item.get("corpus_hash") or "—",
+                safe=("yes" if item.get("mutation_safe") else "no")
+                if item.get("available")
+                else "—",
+            )
+        )
+    for key in ("exomem", "basic_memory"):
+        item = report["contenders"][key]
+        if not item.get("available") and item.get("unavailable_reason"):
+            lines.extend(
+                [
+                    "",
+                    f"{item.get('contender', key)} unavailable: {item['unavailable_reason']}",
+                ]
+            )
+    lines.extend(
+        [
+            "",
+            "## Fairness",
+            "",
+            "- One product-neutral manifest is rendered through native Markdown grammars.",
+            "- Direct mode uses one persistent MCP session per contender.",
+            "- Model features are disabled; latency and response size are informational.",
+            "- Correctness dimensions are independent; no weighted aggregate is computed.",
+            "",
+            "| Representation | Exomem renderer | Basic Memory renderer |",
+            "|---|---|---|",
+        ]
+    )
+    exomem_parity = report["contenders"]["exomem"].get("renderer_parity") or {}
+    basic_parity = report["contenders"]["basic_memory"].get("renderer_parity") or {}
+    for concern in sorted(set(exomem_parity) | set(basic_parity)):
+        lines.append(
+            f"| {concern} | {exomem_parity.get(concern, '—')} | {basic_parity.get(concern, '—')} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Independent dimensions",
+            "",
+            "| Dimension | Exomem | Basic Memory |",
+            "|---|---:|---:|",
+        ]
+    )
+    basic = report["dimensions"]["basic_memory"] or {}
+    for dimension, metric in report["dimensions"]["exomem"].items():
+        basic_metric = basic.get(dimension)
+        right = (
+            f"{basic_metric['numerator']}/{basic_metric['denominator']}" if basic_metric else "—"
+        )
+        lines.append(f"| {dimension} | {metric['numerator']}/{metric['denominator']} | {right} |")
+    lines.extend(
+        [
+            "",
+            "## Informational efficiency",
+            "",
+            "| Contender | Response bytes | Total latency (ms) |",
+            "|---|---:|---:|",
+        ]
+    )
+    for key in ("exomem", "basic_memory"):
+        efficiency = report["efficiency"].get(key)
+        name = report["contenders"][key].get("contender", key)
+        if efficiency:
+            lines.append(
+                f"| {name} | {efficiency['response_bytes']} | {efficiency['latency_ms']} |"
+            )
+        else:
+            lines.append(f"| {name} | — | — |")
+    dominance = report["dominance"]
+    lines.extend(
+        [
+            "",
+            "## Dominance",
+            "",
+            f"Result: **{_dominance_label(dominance['dominant'])}**",
+            "",
+        ]
+    )
+    if dominance.get("checks"):
+        lines.extend(
+            [
+                "| Criterion | Exomem | Basic Memory | Passed |",
+                "|---|---:|---:|---:|",
+            ]
+        )
+        for check in dominance["checks"]:
+            lines.append(
+                f"| {check['criterion']} | {check['exomem']:.3f} | "
+                f"{check['basic_memory']:.3f} | {'yes' if check['passed'] else 'no'} |"
+            )
+        lines.append("")
+    if dominance["failed_criteria"]:
+        lines.append("Failed or unavailable criteria:")
+        failed_checks = {
+            item["criterion"]: item for item in dominance.get("checks", []) if not item["passed"]
+        }
+        for criterion in dominance["failed_criteria"]:
+            cases = failed_checks.get(criterion, {}).get("cases") or []
+            suffix = f" (cases: {', '.join(cases)})" if cases else ""
+            lines.append(f"- `{criterion}`{suffix}")
+    else:
+        lines.append("All no-regression and strict governed-graph criteria passed.")
+    lines.extend(
+        [
+            "",
+            "## Reproduce",
+            "",
+            f"- Fixture: `{report['reproduce']['fixture']}`",
+            f"- Direct: `{report['reproduce']['direct']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def unavailable_basic_memory(reason: str, corpus: RenderedCorpus) -> ContenderRun:
+    return ContenderRun(
+        contender="basic-memory",
+        available=False,
+        version="",
+        revision="",
+        corpus_hash=corpus.corpus_hash,
+        mutation_safe=True,
+        unavailable_reason=reason,
+        renderer_parity=corpus.parity,
+    )
+
+
+def git_revision(root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _package_version(name: str) -> str:
+    try:
+        from importlib.metadata import version
+
+        return version(name)
+    except Exception:  # noqa: BLE001 - benchmark metadata is best-effort
+        return "source"
+
+
+def _group_by_source(values: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    return _group_by(values, "from")
+
+
+def _group_by(values: list[dict[str, Any]], key: str) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for value in values:
+        grouped.setdefault(str(value[key]), []).append(value)
+    return grouped
+
+
+def _exomem_path(note: dict[str, Any]) -> str:
+    note_id = str(note["id"])
+    if note["kind"] == "source":
+        return f"Knowledge Base/Sources/Articles/{note_id}.md"
+    if note["kind"] == "evidence":
+        return f"Knowledge Base/Evidence/Cases/{note_id}.md"
+    return f"Knowledge Base/Notes/Insights/{note_id}.md"
+
+
+def _exomem_page_type(note: dict[str, Any]) -> str:
+    if note["kind"] in {"source", "evidence"}:
+        return str(note["kind"])
+    return "insight"
+
+
+def _expected_edge(value: dict[str, Any]) -> EdgeFact:
+    return EdgeFact(
+        str(value["from"]),
+        str(value["to"]),
+        str(value["type"]),
+        str(value["origin"]) if value.get("origin") else None,
+        str(value["source_anchor"]) if value.get("source_anchor") else None,
+    )
+
+
+def _matching_edge_requirement(value: dict[str, Any], edges: list[EdgeFact]) -> bool:
+    expected = _expected_edge(value)
+    return any(
+        edge.source == expected.source
+        and edge.target == expected.target
+        and edge.relation_type == expected.relation_type
+        and (expected.origin is None or edge.origin == expected.origin)
+        and (expected.source_anchor is None or edge.source_anchor == expected.source_anchor)
+        for edge in edges
+    )
+
+
+def _matching_expected_edge(expected: EdgeFact, edges: list[EdgeFact]) -> bool:
+    return any(
+        edge.source == expected.source
+        and edge.target == expected.target
+        and edge.relation_type == expected.relation_type
+        and (expected.origin is None or edge.origin == expected.origin)
+        and (expected.source_anchor is None or edge.source_anchor == expected.source_anchor)
+        for edge in edges
+    )
+
+
+def _metric_from_checks(
+    dimension: str,
+    expected: set[str],
+    matched: set[str],
+    missing: set[str],
+    unexpected: set[str],
+) -> MetricResult:
+    denominator = max(1, len(expected))
+    numerator = len(matched)
+    return MetricResult(
+        dimension,
+        numerator,
+        denominator,
+        numerator / denominator,
+        True,
+        missing=sorted(missing),
+        unexpected=sorted(unexpected),
+    )
+
+
+def _metric_from_bools(dimension: str, checks: list[bool], labels: list[Any]) -> MetricResult:
+    denominator = max(1, len(checks))
+    numerator = sum(bool(item) for item in checks)
+    missing = [str(label) for label, passed in zip(labels, checks, strict=False) if not passed]
+    return MetricResult(
+        dimension,
+        numerator,
+        denominator,
+        numerator / denominator,
+        True,
+        missing=missing,
+    )
+
+
+def _aggregate_dimension(dimension: str, values: list[MetricResult]) -> MetricResult:
+    numerator = sum(value.numerator for value in values)
+    denominator = max(1, sum(value.denominator for value in values))
+    supported = all(value.supported for value in values)
+    reasons = sorted({value.reason for value in values if value.reason})
+    return MetricResult(
+        dimension,
+        numerator,
+        denominator,
+        numerator / denominator,
+        supported,
+        missing=[item for value in values for item in value.missing],
+        unexpected=[item for value in values for item in value.unexpected],
+        reason="; ".join(reasons) if reasons else None,
+        case_ids=sorted({item for value in values for item in value.case_ids}),
+        failed_case_ids=sorted({item for value in values for item in value.failed_case_ids}),
+    )
+
+
+def _efficiency(run: ContenderRun | None) -> dict[str, float] | None:
+    if run is None or not run.available or not run.cases:
+        return None
+    return {
+        "response_bytes": sum(item.response_bytes for item in run.cases.values()),
+        "latency_ms": round(sum(item.latency_ms for item in run.cases.values()), 3),
+    }
+
+
+def _edge_sort_key(edge: EdgeFact) -> tuple[str, str, str, str, str]:
+    return (
+        edge.source,
+        edge.target,
+        edge.relation_type,
+        edge.origin or "",
+        edge.source_anchor or "",
+    )
+
+
+def _block_sort_key(block: BlockFact) -> tuple[str, str, str]:
+    return (block.note, block.block_id, block.kind)
+
+
+def _dominance_label(value: bool | None) -> str:
+    if value is True:
+        return "EXOMEM DOMINATES"
+    if value is False:
+        return "NOT DOMINANT"
+    return "DIRECT CONTENDER NOT RUN"
+
+
+async def run_direct_comparison(
+    manifest: dict[str, Any],
+    exomem_corpus: RenderedCorpus,
+    basic_corpus: RenderedCorpus,
+    args: argparse.Namespace,
+) -> tuple[ContenderRun, ContenderRun]:
+    exomem_run = await _run_exomem_mcp(
+        manifest,
+        exomem_corpus,
+        python=Path(args.exomem_python),
+        timeout=float(args.request_timeout),
+    )
+    basic_run = await _run_basic_memory_mcp(
+        manifest,
+        basic_corpus,
+        root=args.basic_memory_root,
+        executable=args.basic_memory_executable,
+        uv=str(args.uv),
+        timeout=float(args.request_timeout),
+    )
+    return exomem_run, basic_run
+
+
+async def _run_exomem_mcp(
+    manifest: dict[str, Any],
+    corpus: RenderedCorpus,
+    *,
+    python: Path,
+    timeout: float,
+) -> ContenderRun:
+    from fastmcp import Client
+    from fastmcp.client.transports import StdioTransport
+
+    from exomem import epistemic_graph
+
+    before = corpus_hash(corpus.root)
+    epistemic_graph.EpistemicGraphIndex(corpus.root).rebuild_all()
+    state = corpus.root.parent / "exomem-state"
+    state.mkdir(parents=True, exist_ok=True)
+    env = _child_env(state)
+    env.update(
+        {
+            "EXOMEM_VAULT_PATH": str(corpus.root),
+            "EXOMEM_DISABLE_EMBEDDINGS": "1",
+            "EXOMEM_DISABLE_MEDIA_EXTRACTION": "1",
+            "EXOMEM_DISABLE_CLIP": "1",
+            "EXOMEM_DISABLE_RELEVANCE_CHECK": "1",
+            "EXOMEM_DISABLE_QUERY_LOG": "1",
+            "EXOMEM_DISABLE_RANKING_CONFIG": "1",
+            "EXOMEM_DISABLE_WARMUP": "1",
+            "EXOMEM_DISABLE_FILE_WATCHER": "1",
+            "EXOMEM_DISABLE_MODE_WATCH": "1",
+            "EXOMEM_CONFIG_PATH": str(state / "config.json"),
+            "EXOMEM_LOG_DIR": str(state / "logs"),
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+        }
+    )
+    transport = StdioTransport(
+        command=str(python),
+        args=["-m", "exomem", "--transport", "stdio"],
+        env=env,
+        cwd=str(REPO_ROOT),
+        keep_alive=False,
+        log_file=state / "stdio.log",
+    )
+    cases: dict[str, CaseResult] = {}
+    client = Client(transport, timeout=timeout, init_timeout=max(timeout, 60.0))
+    async with asyncio.timeout(max(timeout * (len(manifest["tasks"]) + 4), 120.0)):
+        async with client:
+            tools = {tool.name for tool in await asyncio.wait_for(client.list_tools(), timeout)}
+            if "connect_memory" not in tools:
+                raise RuntimeError("Exomem MCP server does not expose connect_memory")
+            for task in manifest["tasks"]:
+                arguments: dict[str, Any] = {
+                    "operation": "context",
+                    "path": corpus.id_to_path[str(task["seed"])],
+                    "depth": int(task.get("depth", 1)),
+                    "max_nodes": 100,
+                    "max_edges": 200,
+                }
+                if task.get("relation_types"):
+                    arguments["relation_types"] = list(task["relation_types"])
+                if task.get("profile"):
+                    arguments["traversal_profile"] = str(task["profile"])
+                started = time.perf_counter()
+                payload = await _mcp_call(client, "connect_memory", arguments, timeout)
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                graph = payload.get("graph", payload) if isinstance(payload, dict) else {}
+                cases[str(task["id"])] = normalize_exomem_context(
+                    task, graph, corpus, elapsed_ms=elapsed_ms
+                )
+    after = corpus_hash(corpus.root)
+    return ContenderRun(
+        contender="exomem",
+        available=True,
+        version=_package_version("exomem"),
+        revision=git_revision(REPO_ROOT),
+        corpus_hash=before,
+        mutation_safe=before == after,
+        cases=cases,
+        notes=["persistent stdio MCP", "model features disabled"],
+        renderer_parity=corpus.parity,
+    )
+
+
+async def _run_basic_memory_mcp(
+    manifest: dict[str, Any],
+    corpus: RenderedCorpus,
+    *,
+    root: Path | None,
+    executable: Path | None,
+    uv: str,
+    timeout: float,
+) -> ContenderRun:
+    from fastmcp import Client
+    from fastmcp.client.transports import StdioTransport
+
+    if executable is None and root is None:
+        raise RuntimeError(
+            "direct comparison requires --basic-memory-root or --basic-memory-executable"
+        )
+    if executable is not None and not executable.is_file():
+        raise RuntimeError(f"Basic Memory executable not found: {executable}")
+    if root is not None and not (root / "pyproject.toml").is_file():
+        raise RuntimeError(f"Basic Memory checkout is invalid: {root}")
+
+    state = corpus.root.parent / "basic-memory-state"
+    home = state / "home"
+    state.mkdir(parents=True, exist_ok=True)
+    home.mkdir(parents=True, exist_ok=True)
+    config = _basic_memory_config(corpus)
+    (state / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    env = _child_env(home)
+    env.update(
+        {
+            "BASIC_MEMORY_CONFIG_DIR": str(state),
+            "BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED": "false",
+            "BASIC_MEMORY_SYNC_CHANGES": "false",
+            "BASIC_MEMORY_DISABLE_PERMALINKS": "true",
+            "BASIC_MEMORY_ENSURE_FRONTMATTER_ON_SYNC": "false",
+            "BASIC_MEMORY_FORCE_LOCAL": "true",
+            "BASIC_MEMORY_EXPLICIT_ROUTING": "true",
+        }
+    )
+    if executable is not None:
+        command = str(executable)
+        launcher_args: list[str] = []
+        command_args = [
+            "mcp",
+            "--transport",
+            "stdio",
+            "--project",
+            "graph-benchmark",
+        ]
+        cwd = state
+        version = _command_version(executable)
+        revision = git_revision(root) if root is not None else "installed"
+    else:
+        assert root is not None
+        uv_path = shutil.which(uv) if not Path(uv).is_file() else uv
+        if not uv_path:
+            raise RuntimeError(
+                "uv is required for --basic-memory-root; pass --uv /path/to/uv or "
+                "--basic-memory-executable"
+            )
+        command = str(uv_path)
+        launcher_args = [
+            "run",
+            "--frozen",
+            "--project",
+            str(root),
+            "basic-memory",
+        ]
+        command_args = [
+            *launcher_args,
+            "mcp",
+            "--transport",
+            "stdio",
+            "--project",
+            "graph-benchmark",
+        ]
+        cwd = root
+        version = _git_describe(root)
+        revision = git_revision(root)
+
+    before = corpus_hash(corpus.root)
+    _index_basic_memory_corpus(
+        command=command,
+        launcher_args=launcher_args,
+        env=env,
+        cwd=cwd,
+        project="graph-benchmark",
+        timeout=timeout,
+    )
+    transport = StdioTransport(
+        command=command,
+        args=command_args,
+        env=env,
+        cwd=str(cwd),
+        keep_alive=False,
+        log_file=state / "stdio.log",
+    )
+    cases: dict[str, CaseResult] = {}
+    client = Client(transport, timeout=timeout, init_timeout=max(timeout, 120.0))
+    async with asyncio.timeout(max(timeout * (len(manifest["tasks"]) + 8), 180.0)):
+        async with client:
+            tools = {tool.name for tool in await asyncio.wait_for(client.list_tools(), timeout)}
+            if "build_context" not in tools:
+                raise RuntimeError("Basic Memory MCP server does not expose build_context")
+            for task in manifest["tasks"]:
+                arguments = {
+                    "url": f"memory://{corpus.id_to_permalink[str(task['seed'])]}",
+                    "project": "graph-benchmark",
+                    "depth": int(task.get("depth", 1)),
+                    "timeframe": None,
+                    "page_size": 10,
+                    "max_related": 200,
+                }
+                started = time.perf_counter()
+                payload = await _mcp_call(client, "build_context", arguments, timeout)
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                cases[str(task["id"])] = normalize_basic_memory_context(
+                    task,
+                    payload if isinstance(payload, dict) else {},
+                    corpus,
+                    elapsed_ms=elapsed_ms,
+                )
+    after = corpus_hash(corpus.root)
+    return ContenderRun(
+        contender="basic-memory",
+        available=True,
+        version=version,
+        revision=revision,
+        corpus_hash=before,
+        mutation_safe=before == after,
+        cases=cases,
+        notes=[
+            "explicit full filesystem index before measurement",
+            "persistent stdio MCP",
+            "semantic search disabled",
+            "isolated config and SQLite state",
+            "file mutation disabled",
+        ],
+        renderer_parity=corpus.parity,
+    )
+
+
+def _basic_memory_config(corpus: RenderedCorpus) -> dict[str, Any]:
+    return {
+        "env": "test",
+        "projects": {"graph-benchmark": {"path": str(corpus.root), "mode": "local"}},
+        "default_project": "graph-benchmark",
+        "semantic_search_enabled": False,
+        "default_search_type": "text",
+        "sync_changes": False,
+        "disable_permalinks": True,
+        "ensure_frontmatter_on_sync": False,
+        "auto_update": False,
+        "log_level": "WARNING",
+    }
+
+
+def _index_basic_memory_corpus(
+    *,
+    command: str,
+    launcher_args: list[str],
+    env: dict[str, str],
+    cwd: Path,
+    project: str,
+    timeout: float,
+) -> None:
+    """Populate Basic Memory's rebuildable DB before measuring graph queries."""
+    try:
+        result = subprocess.run(
+            [
+                command,
+                *launcher_args,
+                "reindex",
+                "--full",
+                "--search",
+                "--project",
+                project,
+            ],
+            cwd=cwd,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=max(timeout, 60.0),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError("Basic Memory corpus indexing failed to start") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        summary = detail[-1] if detail else f"exit {result.returncode}"
+        raise RuntimeError(f"Basic Memory corpus indexing failed: {summary}")
+
+
+async def _mcp_call(client: Any, name: str, arguments: dict[str, Any], timeout: float) -> Any:
+    result = await asyncio.wait_for(client.call_tool(name, arguments), timeout=timeout)
+    if getattr(result, "is_error", False):
+        raise RuntimeError(f"MCP tool {name} returned an error: {result}")
+    data = getattr(result, "data", None)
+    if data is not None:
+        return _unwrap_result(data)
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        return _unwrap_result(structured)
+    for block in getattr(result, "content", []):
+        text = getattr(block, "text", None)
+        if text:
+            try:
+                return _unwrap_result(json.loads(text))
+            except json.JSONDecodeError:
+                continue
+    raise RuntimeError(f"MCP tool {name} returned no structured result")
+
+
+def _unwrap_result(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    if isinstance(value, dict) and "result" in value:
+        return value["result"]
+    return value
+
+
+def _child_env(home: Path) -> dict[str, str]:
+    env = {
+        "HOME": str(home),
+        "PATH": os.environ.get("PATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "PYTHONUTF8": "1",
+        "NO_COLOR": "1",
+    }
+    if sys.platform == "win32":
+        env["USERPROFILE"] = str(home)
+        if os.environ.get("SYSTEMROOT"):
+            env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+    return env
+
+
+def _command_version(executable: Path) -> str:
+    try:
+        result = subprocess.run(
+            [str(executable), "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "installed"
+    return (result.stdout or result.stderr).strip().splitlines()[0] or "installed"
+
+
+def _git_describe(root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "source"
+    return result.stdout.strip() or "source"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--output-markdown", type=Path)
+    parser.add_argument("--direct", action="store_true")
+    parser.add_argument("--basic-memory-root", type=Path)
+    parser.add_argument("--basic-memory-executable", type=Path)
+    parser.add_argument("--exomem-python", default=sys.executable)
+    parser.add_argument("--uv", default=shutil.which("uv") or "uv")
+    parser.add_argument("--request-timeout", type=float, default=30.0)
+    parser.add_argument("--work-dir", type=Path)
+    return parser.parse_args(argv)
+
+
+def _execute(args: argparse.Namespace, manifest: dict[str, Any], work: Path) -> int:
+    if args.direct and args.basic_memory_root is None and args.basic_memory_executable is None:
+        raise ValueError("--direct requires --basic-memory-root or --basic-memory-executable")
+    exomem_corpus = render_exomem(manifest, work / "exomem-vault")
+    basic_corpus = render_basic_memory(manifest, work / "basic-memory-project")
+    if args.direct:
+        exomem_run, basic_run = asyncio.run(
+            run_direct_comparison(manifest, exomem_corpus, basic_corpus, args)
+        )
+    else:
+        exomem_run = run_exomem_fixture(manifest, exomem_corpus)
+        basic_run = unavailable_basic_memory(
+            "direct comparison not requested; pass --direct with --basic-memory-root or "
+            "--basic-memory-executable",
+            basic_corpus,
+        )
+    report = build_report(manifest, exomem_run, basic_run)
+    rendered = render_markdown_report(report)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if args.output_markdown:
+        args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.output_markdown.write_text(rendered, encoding="utf-8")
+    print(rendered)
+    fixture_passed = bool(report["dominance"]["fixture_passed"])
+    if not fixture_passed:
+        return 1
+    if args.direct and report["dominance"]["dominant"] is not True:
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    if args.work_dir:
+        work = args.work_dir.resolve()
+        work.mkdir(parents=True, exist_ok=True)
+        occupied = [
+            name for name in ("exomem-vault", "basic-memory-project") if (work / name).exists()
+        ]
+        if occupied:
+            raise ValueError(f"benchmark work directory is not empty: {occupied}")
+        return _execute(args, manifest, work)
+    with tempfile.TemporaryDirectory(prefix="exomem-graph-value-") as raw:
+        return _execute(args, manifest, Path(raw))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/activation.py
+++ b/src/exomem/activation.py
@@ -1,0 +1,323 @@
+"""Deterministic measurements for progressively activating an existing corpus.
+
+This module measures explicit Markdown structure only. It does not infer semantic
+relationships, score knowledge quality, or write to the vault.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from . import access, markdown_relations, relation_registry, semantic_blocks
+from . import find as find_module
+from .audit import AuditFinding
+from .vault import content_hash, find_body_wikilinks, kb_root
+
+ACTIVATION_CATEGORIES: tuple[str, ...] = (
+    "unregistered_relation",
+    "provenance_debt",
+    "typed_relation_debt",
+    "relation_debt",
+)
+
+_ELIGIBLE_TYPES = frozenset(
+    {
+        "research-note",
+        "insight",
+        "pattern",
+        "failure",
+        "experiment",
+        "production-log",
+        "entity",
+    }
+)
+_INACTIVE_STATUSES = frozenset({"superseded", "archived", "draft", "dropped"})
+_SKIP_SLUG_SUFFIXES = ("-architecture", "-snapshot", "-catalog-snapshot")
+_SKIP_TAGS = frozenset({"hub", "snapshot"})
+_ASSERTION_BLOCK_TYPES = frozenset({"claim", "finding", "inference", "hypothesis", "result"})
+_PROVENANCE_RELATIONS = frozenset({"derived_from", "evidenced_by", "cites"})
+_FRONTMATTER_TYPED_FIELDS: dict[str, str] = {
+    "sources": "derived_from",
+    "evidence": "evidenced_by",
+    "evidences": "evidenced_by",
+    "evidence_paths": "evidenced_by",
+    "supersedes": "supersedes",
+    "superseded_by": "supersedes",
+}
+_WIKILINK_RE = re.compile(r"\[\[([^\]|\n]+)(?:\|[^\]\n]+)?\]\]")
+
+
+@dataclass(frozen=True)
+class ActivationScan:
+    findings: list[AuditFinding]
+    coverage: dict[str, int]
+
+
+def scan(vault_root: Path) -> ActivationScan:
+    """Measure activation coverage and review deficits in one tolerant vault walk."""
+    vault_root = Path(vault_root)
+    registry = relation_registry.load_registry(vault_root)
+    findings: list[AuditFinding] = []
+    coverage = {
+        "eligible_pages": 0,
+        "connected_pages": 0,
+        "typed_relation_pages": 0,
+        "generic_only_pages": 0,
+        "disconnected_pages": 0,
+        "provenance_candidate_pages": 0,
+        "provenance_linked_pages": 0,
+        "unregistered_relation_observations": 0,
+    }
+
+    kb = kb_root(vault_root)
+    if not kb.is_dir():
+        return ActivationScan(findings=findings, coverage=coverage)
+
+    for path in find_module._walk_md(kb):
+        try:
+            page = find_module._parse_page(path, path.stat().st_mtime, vault_root)
+        except OSError:
+            continue
+        if page is None or not _eligible(vault_root, page):
+            continue
+
+        coverage["eligible_pages"] += 1
+        measurement = _measure_page(page, registry)
+        meta = {
+            "signal_version": _signal_version(page),
+            "typed_relations": measurement["typed_relations"],
+            "body_wikilinks": measurement["body_wikilinks"],
+            "frontmatter_links": measurement["frontmatter_links"],
+            "assertion_blocks": measurement["assertion_blocks"],
+            "provenance_relations": measurement["provenance_relations"],
+        }
+
+        if measurement["connected"]:
+            coverage["connected_pages"] += 1
+        else:
+            coverage["disconnected_pages"] += 1
+            findings.append(_relation_debt(page.rel_path, meta))
+
+        if measurement["typed_relations"]:
+            coverage["typed_relation_pages"] += 1
+        elif measurement["connected"]:
+            coverage["generic_only_pages"] += 1
+            findings.append(_typed_relation_debt(page.rel_path, meta))
+
+        if measurement["assertion_blocks"]:
+            coverage["provenance_candidate_pages"] += 1
+            if measurement["provenance_relations"]:
+                coverage["provenance_linked_pages"] += 1
+            else:
+                findings.append(_provenance_debt(page.rel_path, meta))
+
+        unknown = measurement["unregistered"]
+        if unknown:
+            coverage["unregistered_relation_observations"] += len(unknown)
+            findings.append(_unregistered_relation(page.rel_path, meta, unknown))
+
+    return ActivationScan(
+        findings=sorted(
+            findings,
+            key=lambda item: (ACTIVATION_CATEGORIES.index(item.category), item.path),
+        ),
+        coverage=coverage,
+    )
+
+
+def _eligible(vault_root: Path, page: Any) -> bool:
+    if page.page_type not in _ELIGIBLE_TYPES:
+        return False
+    if page.path.name in {"index.md", "log.md"}:
+        return False
+    if page.status in _INACTIVE_STATUSES:
+        return False
+    if access.access_tier(vault_root, page.rel_path) != access.TIER_READ_WRITE:
+        return False
+    stem = page.path.stem.lower()
+    if any(stem.endswith(suffix) for suffix in _SKIP_SLUG_SUFFIXES):
+        return False
+    return not bool(_SKIP_TAGS & set(page.tags))
+
+
+def _measure_page(page: Any, registry: relation_registry.RelationRegistry) -> dict[str, Any]:
+    project = _page_project(page.frontmatter)
+    note_doc = markdown_relations.parse_markdown_relations(
+        page.body,
+        include_legacy=True,
+        relation_types=registry.keys | frozenset(registry.aliases),
+        retain_unknown=True,
+    )
+    block_doc = semantic_blocks.parse_semantic_blocks(
+        page.body, validate=False, registry=registry
+    )
+
+    registered: list[str] = []
+    unregistered: list[dict[str, str | int]] = []
+    for relation in note_doc.relations:
+        resolution = registry.resolve(
+            relation.kind,
+            project=project,
+            page_type=page.page_type,
+            source_kind="file",
+            origin="semantic_relation",
+        )
+        if resolution.canonical is None:
+            unregistered.append(
+                {"label": relation.kind, "anchor": f"line-{relation.line}"}
+            )
+        else:
+            registered.append(resolution.canonical)
+
+    for block in block_doc.blocks:
+        for relation in block.relations:
+            raw = relation.raw.split(":", 1)[0].strip()
+            resolution = registry.resolve(
+                raw,
+                project=project,
+                page_type=page.page_type,
+                source_kind=block.type,
+                origin="semantic_relation",
+            )
+            if resolution.canonical is None:
+                unregistered.append(
+                    {"label": relation_registry.normalize_relation(raw), "anchor": block.id or f"line-{relation.line}"}
+                )
+            else:
+                registered.append(resolution.canonical)
+
+    frontmatter_links = 0
+    for field, relation_kind in _FRONTMATTER_TYPED_FIELDS.items():
+        count = len(_frontmatter_links(page.frontmatter.get(field)))
+        frontmatter_links += count
+        registered.extend([relation_kind] * count)
+    related_count = len(_frontmatter_links(page.frontmatter.get("related")))
+    frontmatter_links += related_count
+
+    body_wikilinks = sum(1 for _ in find_body_wikilinks(page.body))
+    assertion_blocks = sum(
+        1 for block in block_doc.blocks if block.type in _ASSERTION_BLOCK_TYPES
+    )
+    provenance_relations = sum(1 for kind in registered if kind in _PROVENANCE_RELATIONS)
+    unique_unknown = {
+        (str(item["label"]), str(item["anchor"])): item for item in unregistered
+    }
+    authored_relations = len(note_doc.relations) + sum(
+        len(block.relations) for block in block_doc.blocks
+    )
+    return {
+        "connected": bool(body_wikilinks or frontmatter_links or authored_relations),
+        "typed_relations": len(registered),
+        "body_wikilinks": body_wikilinks,
+        "frontmatter_links": frontmatter_links,
+        "assertion_blocks": assertion_blocks,
+        "provenance_relations": provenance_relations,
+        "unregistered": list(unique_unknown.values()),
+    }
+
+
+def _frontmatter_links(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        matches = _WIKILINK_RE.findall(value)
+        return [item.strip() for item in matches] if matches else ([value.strip()] if value.strip() else [])
+    if isinstance(value, list):
+        return [link for item in value for link in _frontmatter_links(item)]
+    if isinstance(value, dict):
+        return [link for item in value.values() for link in _frontmatter_links(item)]
+    return []
+
+
+def _page_project(frontmatter: dict[str, Any]) -> str | None:
+    if frontmatter.get("project") not in (None, ""):
+        return str(frontmatter["project"])
+    projects = frontmatter.get("projects")
+    if isinstance(projects, list) and len(projects) == 1:
+        return str(projects[0])
+    return None
+
+
+def _signal_version(page: Any) -> str:
+    frontmatter = yaml.safe_dump(page.frontmatter, sort_keys=True, allow_unicode=True)
+    return content_hash(frontmatter + "\n" + page.body)[:16]
+
+
+def _relation_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="relation_debt",
+        severity="info",
+        path=path,
+        detail="Active compiled page has no explicit outbound graph connection.",
+        proposed_fix="Review candidate neighbours; accept only meaningful durable edges.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "connect_memory", "args": {"operation": "suggest-links", "path": path}},
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+            ],
+        },
+    )
+
+
+def _typed_relation_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="typed_relation_debt",
+        severity="info",
+        path=path,
+        detail="Page has generic connections but no registered typed semantic relation.",
+        proposed_fix="Review relation proposals; generic links may remain generic when that is accurate.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+                {"tool": "read_memory", "args": {"identifier": path}},
+            ],
+        },
+    )
+
+
+def _provenance_debt(path: str, meta: dict[str, Any]) -> AuditFinding:
+    return AuditFinding(
+        category="provenance_debt",
+        severity="info",
+        path=path,
+        detail=(
+            "Page has assertion-bearing semantic blocks but no explicit page-level provenance; "
+            "page-level provenance would not by itself establish support for every block."
+        ),
+        proposed_fix="Review the assertions and add only provenance that the stored sources or evidence support.",
+        meta={
+            **meta,
+            "next_actions": [
+                {"tool": "read_memory", "args": {"identifier": path}},
+                {"tool": "connect_memory", "args": {"operation": "suggest-relations", "path": path}},
+            ],
+        },
+    )
+
+
+def _unregistered_relation(
+    path: str, meta: dict[str, Any], observations: list[dict[str, str | int]]
+) -> AuditFinding:
+    labels = sorted({str(item["label"]) for item in observations})
+    return AuditFinding(
+        category="unregistered_relation",
+        severity="warn",
+        path=path,
+        detail=f"Page uses relation vocabulary not governed by the loaded registry: {labels}.",
+        proposed_fix="Review corpus-wide usage before registering, aliasing, replacing, or removing the vocabulary.",
+        meta={
+            **meta,
+            "unregistered": observations,
+            "next_actions": [
+                {"tool": "schema_memory", "args": {"operation": "infer", "subject": "relations"}},
+                {"tool": "read_memory", "args": {"identifier": path}},
+            ],
+        },
+    )

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from . import activation as activation_module
 from . import audit as audit_module
 from . import fusion
 from . import review_state as review_state_module
@@ -31,12 +32,8 @@ ATTENTION_CATEGORIES: tuple[str, ...] = (
     "unprocessed_source",
     "relation_debt",
 )
-_CATEGORY_ORDER: dict[str, int] = {c: i for i, c in enumerate(ATTENTION_CATEGORIES)}
 _SEVERITY_RANK: dict[str, int] = {"info": 0, "warn": 1, "error": 2}
 _SEVERITY_BY_RANK: dict[int, str] = {v: k for k, v in _SEVERITY_RANK.items()}
-# Equal default weights — the order is then a clean rank-major interleave, except a note
-# flagged by >1 queue accumulates votes and rises. Weights are a seam, not env-exposed.
-_DEFAULT_WEIGHTS: dict[str, float] = {c: 1.0 for c in ATTENTION_CATEGORIES}
 _RRF_K: int = 60  # the conventional default `fusion` and `find` use
 
 _PROPOSED_FIX: str = (
@@ -45,6 +42,12 @@ _PROPOSED_FIX: str = (
     "`replace` (supersede) / `reconcile` / `propose_compilation` / "
     "`connect_memory` / archive. Nothing is "
     "auto-acted; `find` ordering is unchanged."
+)
+
+_ACTIVATION_FIX: str = (
+    "Surfaced for REVIEW only. Coverage and ranking measure explicit Markdown "
+    "structure; they do not judge truth or quality. Follow a reason's `next_actions` "
+    "only after review. Nothing is auto-written or auto-registered."
 )
 
 
@@ -100,6 +103,7 @@ class AttentionReport:
     note: str | None
     all_total: int | None = None
     state_summary: dict[str, int] | None = None
+    coverage: dict[str, int] | None = None
 
     def as_dict(self) -> dict:
         out = {
@@ -114,6 +118,8 @@ class AttentionReport:
         if self.all_total is not None:
             out["all_total"] = self.all_total
             out["state_summary"] = self.state_summary or {}
+        if self.coverage is not None:
+            out["coverage"] = self.coverage
         return out
 
 
@@ -153,6 +159,8 @@ def _rank(
     categories: set[str] | None = None,
     limit: int = 25,
     weights: dict[str, float] | None = None,
+    category_order: tuple[str, ...] = ATTENTION_CATEGORIES,
+    proposed_fix: str = _PROPOSED_FIX,
 ) -> AttentionReport:
     """Compose findings into one ranked, deduped review surface. Pure — no vault access.
 
@@ -160,12 +168,13 @@ def _rank(
     by anchor path (votes add → multi-flagged notes rise), drop+fold the contradiction
     queue's trailing summary finding, then cap at `limit` with an explicit count.
     """
-    selected = set(ATTENTION_CATEGORIES) if categories is None else (
-        set(categories) & set(ATTENTION_CATEGORIES)
+    selected = set(category_order) if categories is None else (
+        set(categories) & set(category_order)
     )
-    weights = _DEFAULT_WEIGHTS if weights is None else weights
+    weights = ({c: 1.0 for c in category_order} if weights is None else weights)
+    category_rank = {category: rank for rank, category in enumerate(category_order)}
 
-    per_cat: dict[str, list[AuditFinding]] = {c: [] for c in ATTENTION_CATEGORIES}
+    per_cat: dict[str, list[AuditFinding]] = {c: [] for c in category_order}
     upstream_truncated = 0
     for f in findings:
         if f.category not in selected:
@@ -180,7 +189,7 @@ def _rank(
     # One best-first anchor-path list per populated category, plus aligned weights.
     result_lists: list[list[str]] = []
     weight_list: list[float] = []
-    for c in ATTENTION_CATEGORIES:
+    for c in category_order:
         if c in selected and per_cat[c]:
             result_lists.append([f.path for f in per_cat[c]])
             weight_list.append(float(weights.get(c, 1.0)))
@@ -195,7 +204,7 @@ def _rank(
     # All reasons (every contributing finding) + max severity per anchor path.
     reasons_by_path: dict[str, list[dict]] = {}
     severity_by_path: dict[str, int] = {}
-    for c in ATTENTION_CATEGORIES:
+    for c in category_order:
         if c not in selected:
             continue
         for rank, f in enumerate(per_cat[c], start=1):
@@ -209,7 +218,7 @@ def _rank(
         scores,
         key=lambda p: (
             -scores[p],
-            min(_CATEGORY_ORDER[r["category"]] for r in reasons_by_path[p]),
+            min(category_rank[r["category"]] for r in reasons_by_path[p]),
             p,
         ),
     )
@@ -220,22 +229,22 @@ def _rank(
     for p in shown_paths:
         reasons = sorted(
             reasons_by_path[p],
-            key=lambda r: (r["rank"], _CATEGORY_ORDER[r["category"]]),
+            key=lambda r: (r["rank"], category_rank[r["category"]]),
         )
-        cats = sorted({r["category"] for r in reasons}, key=lambda c: _CATEGORY_ORDER[c])
+        cats = sorted({r["category"] for r in reasons}, key=lambda c: category_rank[c])
         items.append(AttentionItem(
             path=p,
             score=round(scores[p], 6),
             severity=_SEVERITY_BY_RANK[severity_by_path[p]],
             categories=cats,
             reasons=reasons,
-            proposed_fix=_PROPOSED_FIX,
+            proposed_fix=proposed_fix,
         ))
 
     truncated = total - len(items)
     summary = {
         c: len(per_cat[c])
-        for c in ATTENTION_CATEGORIES
+        for c in category_order
         if c in selected and per_cat[c]
     }
     note = _build_note(len(items), total, truncated, upstream_truncated)
@@ -287,6 +296,44 @@ def attention(
     )
 
 
+def activation(
+    vault_root: Path,
+    *,
+    categories: list[str] | None = None,
+    limit: int = 25,
+    today=None,
+    state: str = "open",
+) -> AttentionReport:
+    """Rank deterministic existing-corpus activation measurements. Read-only."""
+    resolved = (
+        set(activation_module.ACTIVATION_CATEGORIES)
+        if not categories
+        else set(categories)
+    )
+    invalid = resolved - set(activation_module.ACTIVATION_CATEGORIES)
+    if invalid:
+        raise ValueError(
+            f"unknown activation categories: {sorted(invalid)}. "
+            f"Valid: {list(activation_module.ACTIVATION_CATEGORIES)}"
+        )
+    state = str(state or "open").strip().lower()
+    if state not in review_state_module.VALID_VIEWS:
+        raise ValueError(
+            f"INVALID_REVIEW_STATE: state must be one of "
+            f"{sorted(review_state_module.VALID_VIEWS)}"
+        )
+    scan = activation_module.scan(vault_root)
+    ranked = _rank(
+        scan.findings,
+        categories=resolved,
+        limit=0,
+        category_order=activation_module.ACTIVATION_CATEGORIES,
+        proposed_fix=_ACTIVATION_FIX,
+    )
+    ranked.coverage = scan.coverage
+    return _apply_review_state(vault_root, ranked, state=state, limit=limit, today=today)
+
+
 def item_by_ref(
     vault_root: Path,
     reference: str,
@@ -295,10 +342,13 @@ def item_by_ref(
 ) -> AttentionItem:
     """Resolve one current review item by its stable review reference."""
     wanted = review_state_module.parse_review_ref(reference)
-    report = attention(vault_root, limit=0, state="all", today=today)
-    for item in report.items:
-        if item.item_id == wanted:
-            return item
+    for report in (
+        attention(vault_root, limit=0, state="all", today=today),
+        activation(vault_root, limit=0, state="all", today=today),
+    ):
+        for item in report.items:
+            if item.item_id == wanted:
+                return item
     raise ValueError(f"REVIEW_ITEM_NOT_FOUND: no current review item for {reference}")
 
 
@@ -376,4 +426,5 @@ def _apply_review_state(
         note=note,
         all_total=len(report.items),
         state_summary=state_summary,
+        coverage=report.coverage,
     )

--- a/src/exomem/attention.py
+++ b/src/exomem/attention.py
@@ -331,7 +331,14 @@ def activation(
         proposed_fix=_ACTIVATION_FIX,
     )
     ranked.coverage = scan.coverage
-    return _apply_review_state(vault_root, ranked, state=state, limit=limit, today=today)
+    return _apply_review_state(
+        vault_root,
+        ranked,
+        state=state,
+        limit=limit,
+        today=today,
+        identity_namespace="activation",
+    )
 
 
 def item_by_ref(
@@ -342,10 +349,8 @@ def item_by_ref(
 ) -> AttentionItem:
     """Resolve one current review item by its stable review reference."""
     wanted = review_state_module.parse_review_ref(reference)
-    for report in (
-        attention(vault_root, limit=0, state="all", today=today),
-        activation(vault_root, limit=0, state="all", today=today),
-    ):
+    for resolver in (attention, activation):
+        report = resolver(vault_root, limit=0, state="all", today=today)
         for item in report.items:
             if item.item_id == wanted:
                 return item
@@ -359,6 +364,7 @@ def _apply_review_state(
     state: str,
     limit: int,
     today=None,
+    identity_namespace: str | None = None,
 ) -> AttentionReport:
     all_paths: list[str] = []
     for item in report.items:
@@ -372,7 +378,12 @@ def _apply_review_state(
 
     for item in report.items:
         target_ref = refs[item.path]
-        review_id = review_state_module.item_id(target_ref)
+        identity = (
+            f"{identity_namespace}:{target_ref}"
+            if identity_namespace
+            else target_ref
+        )
+        review_id = review_state_module.item_id(identity)
         related_paths = sorted(
             {
                 path

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -3379,10 +3379,10 @@ def op_review_memory(
     `maintain_memory`, not here.
 
     Args:
-        mode: attention, item, audit, provenance, evolution, compilation, stale,
-            contradiction, unprocessed-sources, or relation-debt.
-        categories: Optional category filter for attention/audit.
-        limit: Attention/evolution result cap.
+        mode: attention, activation, item, audit, provenance, evolution,
+            compilation, stale, contradiction, unprocessed-sources, or relation-debt.
+        categories: Optional category filter for attention/activation/audit.
+        limit: Attention/activation/evolution result cap.
         query: Topic for evolution review.
         sources: Source paths for compilation mode.
         suggested_title: Optional compilation title hint.
@@ -3390,13 +3390,20 @@ def op_review_memory(
         key: Provenance key filter.
         value: Provenance value filter.
         path: Restrict provenance scan to one path.
-        state: For attention, open (default), all, snoozed, or dismissed.
+        state: For attention/activation, open (default), all, snoozed, or dismissed.
         ref: Stable `exomem://review/<id>` reference for item mode.
     """
     if path:
         path = _resolve_memory_identifier(vault_root, path)
     if mode == "attention":
         return op_attention(vault_root, categories=categories, limit=limit, state=state)
+    if mode == "activation":
+        return attention_module.activation(
+            vault_root,
+            categories=categories,
+            limit=limit,
+            state=state,
+        ).as_dict()
     if mode == "item":
         if not ref:
             raise ValueError("INVALID_REVIEW: item mode requires `ref`")
@@ -3434,8 +3441,9 @@ def op_review_memory(
             raise ValueError("INVALID_REVIEW: compilation mode requires `sources`")
         return op_propose_compilation(vault_root, sources=sources, suggested_title=suggested_title)
     raise ValueError(
-        "INVALID_MODE: review_memory mode must be attention, item, audit, provenance, "
-        "evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt"
+        "INVALID_MODE: review_memory mode must be attention, activation, item, audit, "
+        "provenance, evolution, compilation, stale, contradiction, "
+        "unprocessed-sources, or relation-debt"
     )
 
 

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -65,10 +65,10 @@ from . import overview as overview_module
 from . import provenance as provenance_module
 from . import query_data as query_data_module
 from . import query_log, upload_tokens, vault
-from . import relation_registry as relation_registry_module
 from . import readiness as readiness_module
 from . import reconcile as reconcile_module
 from . import recover_from_trash as recover_from_trash_module
+from . import relation_registry as relation_registry_module
 from . import replace as replace_module
 from . import review_state as review_state_module
 from . import set_frontmatter_field as set_frontmatter_field_module

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -1223,7 +1223,7 @@ def _shared_source_candidates(vault_root: Path, rel_path: str) -> list[dict[str,
             {
                 "from": rel_path,
                 "to": other_key.removeprefix("file:"),
-                "relation_type": "refines",
+                "relation_type": "relates_to",
                 "method": "shared_sources",
                 "evidence": {"shared_source": shared_key.removeprefix("file:")},
             }
@@ -1251,7 +1251,7 @@ def _embedding_proximity_candidates(vault_root: Path, page) -> list[dict[str, An
             {
                 "from": self_path,
                 "to": target_path,
-                "relation_type": "refines",
+                "relation_type": "relates_to",
                 "method": "embedding_proximity",
                 "evidence": {"cosine": round(float(score), 4)},
             }

--- a/src/exomem/memory_schema.py
+++ b/src/exomem/memory_schema.py
@@ -24,6 +24,7 @@ from .kbdir import kb_dirname
 
 SCHEMA_VERSION = 1
 MIN_REQUIRED_SAMPLE = 5
+CONTRACT_RELATION_ORIGINS = frozenset({"semantic_relation", "markdown_relation"})
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
 
@@ -635,7 +636,7 @@ def _page_relations(vault_root: Path, page, document) -> set[str]:
     return {
         edge.relation_type
         for edge in epistemic_graph._edges_for_page(vault_root, page, tuple(document.blocks))
-        if edge.origin == "semantic_relation" and edge.relation_type is not None
+        if edge.origin in CONTRACT_RELATION_ORIGINS and edge.relation_type is not None
     }
 
 

--- a/tests/fixtures/graph_value/manifest.json
+++ b/tests/fixtures/graph_value/manifest.json
@@ -1,0 +1,49 @@
+{
+  "manifest_version": 1,
+  "notes": [
+    {"id": "common-start", "title": "Common Start", "kind": "insight", "status": "active", "text": "The common graph path begins here."},
+    {"id": "common-target", "title": "Common Target", "kind": "insight", "status": "active", "text": "The common one-hop target is reachable."},
+    {"id": "chain-start", "title": "Chain Start", "kind": "insight", "status": "active", "text": "The multi-hop chain begins here."},
+    {"id": "chain-middle", "title": "Chain Middle", "kind": "insight", "status": "active", "text": "The chain continues through this note."},
+    {"id": "chain-end", "title": "Chain End", "kind": "insight", "status": "active", "text": "The multi-hop target ends here."},
+    {"id": "filter-start", "title": "Filter Start", "kind": "insight", "status": "active", "text": "One edge is a dependency and one is merely adjacent."},
+    {"id": "filter-target", "title": "Filter Target", "kind": "insight", "status": "active", "text": "This dependency is relevant to the filtered traversal."},
+    {"id": "filter-distractor", "title": "Filter Distractor", "kind": "insight", "status": "active", "text": "This adjacent note is a deliberate distractor."},
+    {"id": "direction-source", "title": "Direction Source", "kind": "insight", "status": "active", "text": "This note points into the direction center."},
+    {"id": "direction-center", "title": "Direction Center", "kind": "insight", "status": "active", "text": "Outgoing traversal should not follow the incoming edge."},
+    {"id": "direction-target", "title": "Direction Target", "kind": "insight", "status": "active", "text": "This note is the outgoing dependency."},
+    {"id": "governed-claim", "title": "Governed Claim", "kind": "insight", "status": "active", "text": "The governed conclusion is tied to source, evidence, and a precise claim."},
+    {"id": "architecture-source", "title": "Architecture Source", "kind": "source", "status": "active", "text": "The architecture record is the source for the governed claim."},
+    {"id": "test-evidence", "title": "Test Evidence", "kind": "evidence", "status": "active", "text": "The preserved receipt verifies the governed claim."},
+    {"id": "verified-result", "title": "Verified Result", "kind": "insight", "status": "active", "text": "The result is supported by a specific claim block."},
+    {"id": "old-policy", "title": "Old Policy", "kind": "insight", "status": "superseded", "text": "This policy is retained as history but is no longer current.", "superseded_by": "current-policy"},
+    {"id": "current-policy", "title": "Current Policy", "kind": "insight", "status": "active", "text": "This policy is the active replacement.", "supersedes": "old-policy"}
+  ],
+  "relations": [
+    {"from": "common-start", "to": "common-target", "type": "relates_to"},
+    {"from": "chain-start", "to": "chain-middle", "type": "depends_on"},
+    {"from": "chain-middle", "to": "chain-end", "type": "depends_on"},
+    {"from": "filter-start", "to": "filter-target", "type": "depends_on"},
+    {"from": "filter-start", "to": "filter-distractor", "type": "relates_to"},
+    {"from": "direction-source", "to": "direction-center", "type": "depends_on"},
+    {"from": "direction-center", "to": "direction-target", "type": "depends_on"}
+  ],
+  "provenance": [
+    {"from": "governed-claim", "to": "architecture-source", "type": "derived_from", "channel": "sources"},
+    {"from": "governed-claim", "to": "test-evidence", "type": "evidenced_by", "channel": "evidence"}
+  ],
+  "blocks": [
+    {"note": "governed-claim", "id": "claim-anchor", "kind": "claim", "text": "A precise claim supports the verified result.", "relations": [{"to": "verified-result", "type": "supports"}]}
+  ],
+  "tasks": [
+    {"id": "common-one-hop", "dimension": "one_hop_reachability", "seed": "common-start", "depth": 1, "expected_nodes": ["common-target"]},
+    {"id": "common-multi-hop", "dimension": "multi_hop_reachability", "seed": "chain-start", "depth": 2, "expected_nodes": ["chain-middle", "chain-end"]},
+    {"id": "typed-distractor-filter", "dimension": "distractor_precision", "seed": "filter-start", "depth": 1, "relation_types": ["depends_on"], "expected_nodes": ["filter-target"], "forbidden_nodes": ["filter-distractor"]},
+    {"id": "relation-type-fidelity", "dimension": "relation_type_fidelity", "seed": "filter-start", "depth": 1, "expected_edges": [{"from": "filter-start", "to": "filter-target", "type": "depends_on"}]},
+    {"id": "outgoing-direction", "dimension": "direction_fidelity", "seed": "direction-center", "depth": 1, "profile": "benchmark-outgoing", "expected_nodes": ["direction-target"], "forbidden_nodes": ["direction-source"], "expected_edges": [{"from": "direction-center", "to": "direction-target", "type": "depends_on"}]},
+    {"id": "dependency-lens", "dimension": "traversal_lens_filtering", "seed": "filter-start", "depth": 1, "profile": "benchmark-dependency", "expected_relation_types": ["depends_on"], "forbidden_relation_types": ["relates_to"]},
+    {"id": "provenance-trace", "dimension": "provenance_traceability", "seed": "governed-claim", "depth": 1, "profile": "provenance", "edge_requirements": [{"from": "governed-claim", "to": "architecture-source", "type": "derived_from", "origin": "frontmatter", "source_anchor": "sources"}, {"from": "governed-claim", "to": "test-evidence", "type": "evidenced_by", "origin": "frontmatter", "source_anchor": "evidence"}]},
+    {"id": "active-supersession", "dimension": "supersession_handling", "seed": "current-policy", "depth": 1, "profile": "epistemic", "expected_edges": [{"from": "current-policy", "to": "old-policy", "type": "supersedes"}], "expected_statuses": {"current-policy": "active", "old-policy": "superseded"}},
+    {"id": "block-relational-precision", "dimension": "semantic_block_precision", "seed": "governed-claim", "depth": 1, "profile": "epistemic", "expected_blocks": [{"note": "governed-claim", "id": "claim-anchor", "kind": "claim"}], "expected_edges": [{"from": "governed-claim#claim-anchor", "to": "verified-result", "type": "supports"}]}
+  ]
+}

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -1982,7 +1982,7 @@
       "properties": {
         "mode": {
           "default": "attention",
-          "description": "attention, item, audit, provenance, evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt.",
+          "description": "attention, activation, item, audit, provenance, evolution, compilation, stale, contradiction, unprocessed-sources, or relation-debt.",
           "type": "string"
         },
         "categories": {
@@ -1998,11 +1998,11 @@
             }
           ],
           "default": null,
-          "description": "Optional category filter for attention/audit."
+          "description": "Optional category filter for attention/activation/audit."
         },
         "limit": {
           "default": 25,
-          "description": "Attention/evolution result cap.",
+          "description": "Attention/activation/evolution result cap.",
           "type": "integer"
         },
         "query": {
@@ -2087,7 +2087,7 @@
         },
         "state": {
           "default": "open",
-          "description": "For attention, open (default), all, snoozed, or dismissed.",
+          "description": "For attention/activation, open (default), all, snoozed, or dismissed.",
           "type": "string"
         },
         "ref": {

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exomem import activation, attention, commands, review_state
+
+
+def _write_page(
+    vault: Path,
+    name: str,
+    body: str,
+    *,
+    page_type: str = "insight",
+    status: str = "active",
+    folder: str = "Notes/Insights",
+) -> Path:
+    path = vault / "Knowledge Base" / folder / f"{name}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\ntype: {page_type}\nstatus: {status}\n---\n# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_activation_corpus(vault: Path) -> dict[str, Path]:
+    paths = {
+        "disconnected": _write_page(vault, "disconnected", "## Finding\n\nMeasured result."),
+        "generic": _write_page(
+            vault,
+            "generic",
+            "## Overview\n\nSee [[Knowledge Base/Notes/Insights/typed]].",
+        ),
+        "typed": _write_page(
+            vault,
+            "typed",
+            "## Relations\n\n- supports [[Knowledge Base/Notes/Insights/generic]]",
+        ),
+        "provenance": _write_page(
+            vault,
+            "provenance",
+            "## Claim\n\n- relations: evidenced_by: [[Knowledge Base/Sources/source]]\n\nSupported claim.",
+        ),
+        "unknown": _write_page(
+            vault,
+            "unknown",
+            "## Relations\n\n- science.replicates [[Knowledge Base/Notes/Insights/typed]]",
+        ),
+    }
+    _write_page(
+        vault,
+        "raw",
+        "## Finding\n\nRaw input.",
+        page_type="source",
+        folder="Sources",
+    )
+    _write_page(vault, "archived", "## Finding\n\nOld.", status="archived")
+    _write_page(vault, "readonly", "## Finding\n\nProtected.", folder="Reference")
+    (vault / "Knowledge Base/_access.yaml").write_text(
+        "readonly:\n  - Reference\n", encoding="utf-8"
+    )
+    return paths
+
+
+def test_scan_measures_coverage_and_four_structural_deficits(tmp_path: Path) -> None:
+    paths = _seed_activation_corpus(tmp_path)
+
+    report = activation.scan(tmp_path)
+    by_category = {category: [] for category in activation.ACTIVATION_CATEGORIES}
+    for finding in report.findings:
+        by_category[finding.category].append(finding.path)
+
+    assert report.coverage == {
+        "eligible_pages": 5,
+        "connected_pages": 4,
+        "typed_relation_pages": 2,
+        "generic_only_pages": 2,
+        "disconnected_pages": 1,
+        "provenance_candidate_pages": 2,
+        "provenance_linked_pages": 1,
+        "unregistered_relation_observations": 1,
+    }
+    assert paths["disconnected"].relative_to(tmp_path).as_posix() in by_category["relation_debt"]
+    assert paths["generic"].relative_to(tmp_path).as_posix() in by_category["typed_relation_debt"]
+    assert paths["disconnected"].relative_to(tmp_path).as_posix() in by_category["provenance_debt"]
+    assert paths["unknown"].relative_to(tmp_path).as_posix() in by_category["unregistered_relation"]
+    assert not any("Sources/" in finding.path or "Reference/" in finding.path for finding in report.findings)
+
+
+def test_scan_is_deterministic_non_mutating_and_routes_existing_tools(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+    before = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    first = activation.scan(tmp_path)
+    second = activation.scan(tmp_path)
+    after = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    assert first == second
+    assert after == before
+    for finding in first.findings:
+        assert finding.meta and finding.meta["signal_version"]
+        assert finding.meta["next_actions"]
+        assert {action["tool"] for action in finding.meta["next_actions"]} <= {
+            "connect_memory",
+            "read_memory",
+            "schema_memory",
+        }
+
+
+def test_activation_queue_ranks_dedups_and_preserves_default_attention(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+
+    default_categories = attention.ATTENTION_CATEGORIES
+    activation_report = attention.activation(tmp_path, limit=0)
+
+    assert attention.ATTENTION_CATEGORIES == default_categories
+    assert activation_report.coverage["eligible_pages"] == 5
+    assert len({item.path for item in activation_report.items}) == len(activation_report.items)
+    disconnected = next(item for item in activation_report.items if item.path.endswith("disconnected.md"))
+    assert disconnected.categories == ["provenance_debt", "relation_debt"]
+    assert disconnected.score > next(
+        item.score for item in activation_report.items if item.path.endswith("generic.md")
+    )
+    assert "quality" in disconnected.proposed_fix.lower()
+
+
+def test_activation_only_item_supports_item_lookup_and_triage(tmp_path: Path) -> None:
+    paths = _seed_activation_corpus(tmp_path)
+    item = next(
+        item
+        for item in attention.activation(tmp_path, limit=0).items
+        if item.path == paths["generic"].relative_to(tmp_path).as_posix()
+    )
+    assert item.categories == ["typed_relation_debt"]
+    assert commands.op_review_memory(tmp_path, mode="item", ref=item.ref)["ref"] == item.ref
+
+    dismissed = commands.op_triage_memory(tmp_path, ref=item.ref, action="dismiss")
+    assert dismissed["state"] == "dismissed"
+    assert item.ref not in {
+        current.ref for current in attention.activation(tmp_path, limit=0).items
+    }
+    assert item.ref in {
+        current.ref
+        for current in attention.activation(tmp_path, limit=0, state="dismissed").items
+    }
+
+    paths["generic"].write_text(
+        paths["generic"].read_text(encoding="utf-8") + "\nChanged context.\n",
+        encoding="utf-8",
+    )
+    resurfaced = next(
+        current
+        for current in attention.activation(tmp_path, limit=0).items
+        if current.ref == item.ref
+    )
+    assert resurfaced.fingerprint != item.fingerprint
+    assert resurfaced.state == "open"
+    assert review_state.state_path(tmp_path).exists()
+
+
+def test_review_memory_activation_response_is_json_serializable(tmp_path: Path) -> None:
+    _seed_activation_corpus(tmp_path)
+
+    result = commands.op_review_memory(tmp_path, mode="activation", limit=2)
+
+    assert result["shown"] == len(result["items"]) == 2
+    assert result["truncated"] > 0
+    assert result["coverage"]["eligible_pages"] == 5
+    assert json.loads(json.dumps(result))["coverage"] == result["coverage"]

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -167,6 +167,42 @@ def test_activation_only_item_supports_item_lookup_and_triage(tmp_path: Path) ->
     assert review_state.state_path(tmp_path).exists()
 
 
+def test_activation_identity_does_not_collide_with_daily_attention(tmp_path: Path) -> None:
+    paths = _seed_activation_corpus(tmp_path)
+    rel_path = paths["disconnected"].relative_to(tmp_path).as_posix()
+    daily_item = next(
+        item
+        for item in attention.attention(
+            tmp_path, categories=["relation_debt"], limit=0
+        ).items
+        if item.path == rel_path
+    )
+    activation_item = next(
+        item
+        for item in attention.activation(tmp_path, limit=0).items
+        if item.path == rel_path
+    )
+
+    assert activation_item.ref != daily_item.ref
+    resolved = attention.item_by_ref(tmp_path, activation_item.ref)
+    assert resolved.ref == activation_item.ref
+    assert resolved.categories == activation_item.categories
+
+    commands.op_triage_memory(
+        tmp_path, ref=activation_item.ref, action="dismiss"
+    )
+
+    assert activation_item.ref not in {
+        item.ref for item in attention.activation(tmp_path, limit=0).items
+    }
+    assert daily_item.ref in {
+        item.ref
+        for item in attention.attention(
+            tmp_path, categories=["relation_debt"], limit=0
+        ).items
+    }
+
+
 def test_review_memory_activation_response_is_json_serializable(tmp_path: Path) -> None:
     _seed_activation_corpus(tmp_path)
 

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -70,6 +70,19 @@ def test_review_memory_attention_runs(vault: Path, capsys) -> None:
     assert surfaced <= {"stale_review"}
 
 
+def test_review_memory_activation_runs(vault: Path, capsys) -> None:
+    code, out, _ = _run(
+        ["review_memory", "--mode", "activation", "--limit", "3", "--json"],
+        capsys,
+    )
+
+    assert code == 0
+    data = json.loads(out.strip().splitlines()[-1])["data"]
+    assert data["coverage"]["eligible_pages"] > 0
+    assert data["shown"] == len(data["items"]) <= 3
+    assert all(item["ref"].startswith("exomem://review/") for item in data["items"])
+
+
 def test_review_memory_audit_runs(vault: Path, capsys) -> None:
     code, out, _ = _run(["review_memory", "--mode", "audit", "--json"], capsys)
     assert code == 0

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -249,6 +249,23 @@ def test_review_memory_attention_mode_composes_review_surface(vault: Path, monke
     assert surfaced <= {"unprocessed_source"}
 
 
+def test_review_memory_activation_mode_surfaces_corpus_coverage(vault: Path, monkeypatch) -> None:
+    rel = _make_page(
+        vault,
+        "# Activation-only\n\n## Overview\n\nSee [[Knowledge Base/Notes/Insights/other]].\n",
+        name="activation-only.md",
+    )
+    mcp = _build(monkeypatch)
+
+    out = _call(mcp, "review_memory", {"mode": "activation", "limit": 0})
+
+    assert out["coverage"]["eligible_pages"] > 0
+    item = next(item for item in out["items"] if item["path"] == rel)
+    assert item["categories"] == ["typed_relation_debt"]
+    assert item["ref"].startswith("exomem://review/")
+    assert item["reasons"][0]["meta"]["next_actions"]
+
+
 def test_triage_memory_mcp_write_is_explicit_and_reversible(vault: Path, monkeypatch) -> None:
     mcp = _build(monkeypatch)
     review = _call(mcp, "review_memory", {"mode": "attention", "limit": 1})

--- a/tests/test_epistemic_graph.py
+++ b/tests/test_epistemic_graph.py
@@ -6,7 +6,7 @@ import builtins
 from pathlib import Path
 from types import SimpleNamespace
 
-from exomem import epistemic_graph
+from exomem import corpus_aware, epistemic_graph
 
 SOURCE = "Knowledge Base/Sources/Articles/2026-07-08-source.md"
 EVIDENCE = "Knowledge Base/Evidence/Cases/receipt.md"
@@ -261,6 +261,54 @@ def test_optional_model_suggestion_failure_does_not_break_context(tmp_path: Path
     assert suggestions["model_suggestions_available"] is False
     assert any("unavailable" in warning for warning in suggestions["warnings"])
     assert any(c["method"] == "wikilink" for c in suggestions["candidates"])
+
+
+def test_similarity_suggestions_are_neutral_evidenced_and_read_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = _seed_graph_vault(tmp_path)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    before_markdown = {
+        path.relative_to(vault).as_posix(): path.read_text(encoding="utf-8")
+        for path in vault.rglob("*.md")
+    }
+    before_edges = index.edges()
+    monkeypatch.setattr(
+        corpus_aware,
+        "_best_cosine_per_file",
+        lambda *_args, **_kwargs: {RELATED: 0.91234},
+    )
+
+    suggestions = epistemic_graph.suggest_relations(vault, path=CURRENT, limit=30)
+    candidates = suggestions["candidates"]
+    shared = next(candidate for candidate in candidates if candidate["method"] == "shared_sources")
+    proximity = next(
+        candidate for candidate in candidates if candidate["method"] == "embedding_proximity"
+    )
+    wikilink = next(candidate for candidate in candidates if candidate["method"] == "wikilink")
+    frontmatter = next(
+        candidate for candidate in candidates if candidate["method"] == "frontmatter_sources"
+    )
+
+    assert shared["relation_type"] == "relates_to"
+    assert shared["evidence"]["shared_source"].endswith("2026-07-08-source.md")
+    assert proximity == {
+        "from": CURRENT,
+        "to": RELATED,
+        "relation_type": "relates_to",
+        "method": "embedding_proximity",
+        "evidence": {"cosine": 0.9123},
+    }
+    assert wikilink["relation_type"] == "links_to"
+    assert frontmatter["relation_type"] == "derived_from"
+    assert suggestions["mutated"] is False
+    assert index.edges() == before_edges
+    assert {
+        path.relative_to(vault).as_posix(): path.read_text(encoding="utf-8")
+        for path in vault.rglob("*.md")
+    } == before_markdown
+
 
 def test_command_leaves_return_graph_context_and_suggestions(tmp_path: Path) -> None:
     from exomem import commands

--- a/tests/test_graph_value_benchmark.py
+++ b/tests/test_graph_value_benchmark.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "graph_value_benchmark.py"
+spec = importlib.util.spec_from_file_location("graph_value_benchmark", MODULE_PATH)
+bench = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = bench
+spec.loader.exec_module(bench)
+
+
+@pytest.fixture(scope="module")
+def perfect_fixture(tmp_path_factory: pytest.TempPathFactory):
+    manifest = bench.load_manifest()
+    corpus = bench.render_exomem(manifest, tmp_path_factory.mktemp("graph-value") / "exomem")
+    before = bench.corpus_hash(corpus.root)
+    run = bench.run_exomem_fixture(manifest, corpus, revision="fixture-revision")
+    return manifest, corpus, before, run
+
+
+def _case(
+    task: dict,
+    *,
+    reached: list[str] | None = None,
+    edges: list | None = None,
+) -> object:
+    return bench.CaseResult(
+        case_id=str(task["id"]),
+        dimension=str(task["dimension"]),
+        reached_nodes=reached or [],
+        edges=edges or [],
+        blocks=[],
+        statuses={},
+        response_bytes=0,
+        latency_ms=0.0,
+    )
+
+
+def test_native_renderers_are_deterministic_and_preserve_neutral_relations(
+    tmp_path: Path,
+) -> None:
+    manifest = bench.load_manifest()
+    exomem_a = bench.render_exomem(manifest, tmp_path / "exomem-a")
+    exomem_b = bench.render_exomem(manifest, tmp_path / "exomem-b")
+    basic_a = bench.render_basic_memory(manifest, tmp_path / "basic-a")
+    basic_b = bench.render_basic_memory(manifest, tmp_path / "basic-b")
+
+    assert exomem_a.corpus_hash == exomem_b.corpus_hash
+    assert basic_a.corpus_hash == basic_b.corpus_hash
+    assert set(exomem_a.id_to_path) == set(basic_a.id_to_path)
+    assert exomem_a.title_to_id == basic_a.title_to_id
+
+    notes = {str(item["id"]): item for item in manifest["notes"]}
+    for edge in manifest["relations"]:
+        source = str(edge["from"])
+        target = str(edge["to"])
+        exomem_text = (exomem_a.root / exomem_a.id_to_path[source]).read_text()
+        basic_text = (basic_a.root / basic_a.id_to_path[source]).read_text()
+        assert f"- {edge['type']} [[{exomem_a.id_to_path[target]}]]" in exomem_text
+        assert f"- {edge['type']} [[{notes[target]['title']}]]" in basic_text
+
+    assert "origin" in exomem_a.parity["provenance"]
+    assert "no origin" in basic_a.parity["provenance"]
+    assert "semantic blocks" in exomem_a.parity["blocks"]
+    assert "no relation-bearing block anchor" in basic_a.parity["blocks"]
+
+
+def test_exomem_fixture_passes_every_dimension_without_mutating_markdown(
+    perfect_fixture,
+) -> None:
+    manifest, corpus, before, run = perfect_fixture
+    scores = bench.score_run(manifest, run)
+
+    assert set(scores) == set(bench.ALL_DIMENSIONS)
+    assert all(metric.supported for metric in scores.values())
+    assert all(metric.ratio == 1.0 for metric in scores.values())
+    assert run.mutation_safe is True
+    assert before == bench.corpus_hash(corpus.root)
+    assert run.renderer_parity == corpus.parity
+    assert {case for metric in scores.values() for case in metric.case_ids} == {
+        str(task["id"]) for task in manifest["tasks"]
+    }
+
+
+def test_graph_mistakes_remain_independent(perfect_fixture) -> None:
+    manifest, _, _, _ = perfect_fixture
+    tasks = {str(task["id"]): task for task in manifest["tasks"]}
+
+    reachability = bench.score_case(
+        tasks["common-one-hop"],
+        _case(tasks["common-one-hop"], reached=["common-target"]),
+    )
+    wrong_type = bench.score_case(
+        tasks["relation-type-fidelity"],
+        _case(
+            tasks["relation-type-fidelity"],
+            edges=[bench.EdgeFact("filter-start", "filter-target", "relates_to")],
+        ),
+    )
+    distracted = bench.score_case(
+        tasks["typed-distractor-filter"],
+        _case(
+            tasks["typed-distractor-filter"],
+            reached=["filter-target", "filter-distractor"],
+        ),
+    )
+    wrong_direction = bench.score_case(
+        tasks["outgoing-direction"],
+        _case(
+            tasks["outgoing-direction"],
+            reached=["direction-target", "direction-source"],
+            edges=[bench.EdgeFact("direction-center", "direction-target", "depends_on")],
+        ),
+    )
+
+    assert reachability.ratio == 1.0
+    assert wrong_type.ratio == 0.0
+    assert distracted.ratio == 0.5
+    assert distracted.unexpected == ["filter-distractor"]
+    assert wrong_direction.ratio == 0.5
+    assert wrong_direction.unexpected == ["direction-source"]
+
+
+def test_basic_memory_normalization_preserves_public_typed_edges_and_marks_gaps(
+    tmp_path: Path,
+) -> None:
+    manifest = bench.load_manifest()
+    corpus = bench.render_basic_memory(manifest, tmp_path / "basic")
+    tasks = {str(task["id"]): task for task in manifest["tasks"]}
+    payload = {
+        "results": [
+            {
+                "primary_result": {"title": "Filter Start"},
+                "related_results": [
+                    {"type": "entity", "title": "Filter Target"},
+                    {
+                        "type": "relation",
+                        "from_entity": "Filter Start",
+                        "to_entity": "Filter Target",
+                        "relation_type": "depends_on",
+                    },
+                ],
+            }
+        ]
+    }
+
+    normalized = bench.normalize_basic_memory_context(
+        tasks["relation-type-fidelity"], payload, corpus, elapsed_ms=1.0
+    )
+    governed = bench.normalize_basic_memory_context(
+        tasks["provenance-trace"], payload, corpus, elapsed_ms=1.0
+    )
+
+    assert normalized.reached_nodes == ["filter-target"]
+    assert normalized.edges == [bench.EdgeFact("filter-start", "filter-target", "depends_on")]
+    assert governed.unsupported["provenance_traceability"].startswith(
+        "build_context relations omit"
+    )
+    unsupported = bench.score_case(tasks["provenance-trace"], governed)
+    assert unsupported.supported is False
+    assert unsupported.ratio == 0.0
+    assert unsupported.denominator == 1
+
+
+def test_dominance_flips_on_common_regression_and_names_the_case(perfect_fixture) -> None:
+    manifest, _, _, run = perfect_fixture
+    exomem_scores = bench.score_run(manifest, run)
+    basic_scores = {
+        dimension: bench.MetricResult(
+            dimension,
+            0 if dimension in bench.GOVERNED_DIMENSIONS else 1,
+            1,
+            0.0 if dimension in bench.GOVERNED_DIMENSIONS else 1.0,
+            dimension not in bench.GOVERNED_DIMENSIONS,
+            case_ids=list(metric.case_ids),
+        )
+        for dimension, metric in exomem_scores.items()
+    }
+
+    assert bench.dominance_report(exomem_scores, basic_scores)["dominant"] is True
+
+    degraded = dict(exomem_scores)
+    degraded["one_hop_reachability"] = bench.MetricResult(
+        "one_hop_reachability",
+        0,
+        1,
+        0.0,
+        True,
+        missing=["common-target"],
+        case_ids=["common-one-hop"],
+        failed_case_ids=["common-one-hop"],
+    )
+    report = bench.dominance_report(degraded, basic_scores)
+    failed = next(
+        item
+        for item in report["checks"]
+        if item["criterion"] == "no-regression:one_hop_reachability"
+    )
+
+    assert report["dominant"] is False
+    assert "no-regression:one_hop_reachability" in report["failed_criteria"]
+    assert failed["cases"] == ["common-one-hop"]
+
+
+def test_reports_are_aggregate_reproducible_and_privacy_safe(perfect_fixture) -> None:
+    manifest, corpus, _, run = perfect_fixture
+    basic_corpus = bench.render_basic_memory(manifest, corpus.root.parent / "basic-report")
+    basic = bench.unavailable_basic_memory(
+        "direct comparison not requested; pass --direct with --basic-memory-root or "
+        "--basic-memory-executable",
+        basic_corpus,
+    )
+    report = bench.build_report(manifest, run, basic)
+    markdown = bench.render_markdown_report(report)
+    encoded = json.dumps(report, sort_keys=True)
+
+    assert report["manifest_version"] == manifest["manifest_version"]
+    assert report["fairness"]["weighted_aggregate"] is False
+    assert "overall_score" not in encoded
+    assert run.corpus_hash in encoded
+    assert "renderer_parity" in encoded
+    assert str(corpus.root) not in encoded
+    assert "/home/" not in encoded
+    assert "C:\\" not in encoded
+    assert "PRIVATE_API_KEY" not in encoded
+    assert "The common graph path begins here." not in encoded
+    assert "Manifest version: `1`" in markdown
+    assert "## Fairness" in markdown
+    assert "Corpus hash" in markdown
+    assert "## Informational efficiency" in markdown
+    assert "No weighted aggregate is used" in markdown
+    assert "DIRECT CONTENDER NOT RUN" in markdown
+    assert "pass --direct with --basic-memory-root or --basic-memory-executable" in markdown
+
+
+def test_basic_memory_adapter_configuration_is_isolated_and_mutation_disabled(
+    tmp_path: Path,
+) -> None:
+    corpus = bench.render_basic_memory(bench.load_manifest(), tmp_path / "basic")
+    config = bench._basic_memory_config(corpus)
+
+    assert config["projects"] == {"graph-benchmark": {"path": str(corpus.root), "mode": "local"}}
+    assert config["semantic_search_enabled"] is False
+    assert config["sync_changes"] is False
+    assert config["disable_permalinks"] is True
+    assert config["ensure_frontmatter_on_sync"] is False
+    assert config["auto_update"] is False
+
+
+def test_index_command_keeps_frozen_launcher_prefix(monkeypatch, tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        observed["command"] = command
+        observed["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(bench.subprocess, "run", fake_run)
+    bench._index_basic_memory_corpus(
+        command="uv",
+        launcher_args=["run", "--frozen", "--project", "checkout", "basic-memory"],
+        env={"HOME": str(tmp_path)},
+        cwd=tmp_path,
+        project="graph-benchmark",
+        timeout=1.0,
+    )
+
+    assert observed["command"] == [
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        "checkout",
+        "basic-memory",
+        "reindex",
+        "--full",
+        "--search",
+        "--project",
+        "graph-benchmark",
+    ]
+
+
+def test_child_environment_does_not_forward_unrelated_secrets(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PRIVATE_API_KEY", "must-not-be-forwarded")
+    monkeypatch.setenv("UNRELATED_SECRET", "must-not-be-forwarded")
+
+    child = bench._child_env(tmp_path)
+
+    assert child["HOME"] == str(tmp_path)
+    assert "PRIVATE_API_KEY" not in child
+    assert "UNRELATED_SECRET" not in child
+
+
+def test_direct_mode_requires_an_explicit_basic_memory_target(tmp_path: Path) -> None:
+    args = bench.parse_args(["--direct"])
+
+    with pytest.raises(ValueError, match="--basic-memory-root"):
+        bench._execute(args, bench.load_manifest(), tmp_path)

--- a/tests/test_memory_schema.py
+++ b/tests/test_memory_schema.py
@@ -69,6 +69,60 @@ def test_inference_profiles_fields_blocks_relations_and_enums(tmp_path: Path) ->
     assert proposal["unknown_fields"] == "allow"
 
 
+def test_canonical_relations_drive_contract_inference_validation_and_diff(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    pages = _seed_pages(vault)
+    target = "Knowledge Base/Notes/future"
+    for page in pages:
+        body = page.read_text(encoding="utf-8").replace(
+            f"- supports [[{target}]]\n",
+            "A generic reference remains [[Knowledge Base/Notes/other]].\n\n"
+            "## Relations\n\n"
+            f"- supports [[{target}]]\n"
+            "- science.unreviewed [[Knowledge Base/Notes/unknown]]\n",
+        )
+        page.write_text(body, encoding="utf-8")
+
+    inferred = commands.op_schema_memory(
+        vault,
+        operation="infer",
+        name="canonical-relations",
+        project="atlas",
+        page_type="insight",
+        save=True,
+    )
+    proposal = inferred["proposal"]
+
+    assert proposal["relations"] == {"supports": {"required": True}}
+    assert inferred["frequencies"]["relations"]["supports"] == {
+        "count": 5,
+        "frequency": 1.0,
+    }
+    assert commands.op_schema_memory(
+        vault, operation="validate", name="canonical-relations", strict=True
+    )["valid"] is True
+
+    pages[0].write_text(
+        pages[0].read_text(encoding="utf-8").replace(
+            f"- supports [[{target}]]\n", ""
+        ),
+        encoding="utf-8",
+    )
+    validation = commands.op_schema_memory(
+        vault, operation="validate", name="canonical-relations", strict=True
+    )
+    diff = commands.op_schema_memory(
+        vault, operation="diff", name="canonical-relations"
+    )
+
+    assert "body.relation:supports" in {
+        finding["span"] for finding in validation["findings"]
+    }
+    assert diff["changes"]["relations"]["required_removed"] == ["supports"]
+
+
 def test_contract_save_requires_hash_for_overwrite(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _seed_pages(vault)

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -221,6 +221,21 @@ def test_review_memory_route_and_openapi_params(vault, monkeypatch: pytest.Monke
     assert {"ref", "action"} <= set(triage_schema.get("required", []))
 
 
+def test_review_memory_activation_route(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
+    response = client.post(
+        "/api/review_memory",
+        json={"mode": "activation", "limit": 3},
+        headers=_auth(),
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["coverage"]["eligible_pages"] > 0
+    assert data["shown"] == len(data["items"]) <= 3
+    assert all(item["ref"].startswith("exomem://review/") for item in data["items"])
+
+
 def test_openapi_has_no_hand_list(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     client = _client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
     doc = client.get("/api/openapi.json").json()


### PR DESCRIPTION
## Summary

- preserve canonical authored relation semantics and keep similarity suggestions neutral
- add a read-only `review_memory(mode="activation")` coverage report and governed activation queue for existing corpora
- isolate activation review identities from the daily attention queue
- add a deterministic native-Markdown graph benchmark against current Basic Memory, with independent metrics and a falsifiable dominance gate
- publish the measured result and make activation/product use the priority ahead of speculative schema growth

## Measured graph result

Direct persistent-MCP comparison against Basic Memory `v0.22.1-17-g0e59bbff` (`0e59bbffaf7d`):

| Dimension | Exomem | Basic Memory |
|---|---:|---:|
| one-hop reachability | 1/1 | 1/1 |
| multi-hop reachability | 2/2 | 2/2 |
| relation-type fidelity | 1/1 | 1/1 |
| direction fidelity | 2/2 | 1/2 |
| distractor precision | 1/1 | 1/2 |
| traversal-lens filtering | 2/2 | 0/1 unsupported |
| provenance traceability | 2/2 | 0/1 unsupported |
| supersession handling | 3/3 | 0/1 unsupported |
| semantic-block precision | 2/2 | 0/1 unsupported |

The gate uses no weighted aggregate. Exomem must be no worse on every common graph dimension, pass every fixture invariant, and strictly win provenance, supersession, and semantic-block precision. Both generated Markdown corpora remained unchanged.

The claim is deliberately scoped to graph-dependent tasks; it does not claim superiority in onboarding, generic search UX, canvas workflows, imports, or ecosystem breadth.

## Verification

- `1868 passed, 19 skipped` — full lean suite
- `90 passed` — changed-area graph, activation, schema, CLI/MCP/REST suite
- `10 passed` — graph benchmark contract tests
- `2 passed` — 2,000-note latency gate
- scaffold leak gate: `4 passed`
- changed-area Ruff and repository `--select F`: clean
- all three OpenSpec changes and all 18 main specs: strict-valid
- capabilities doc: current
- direct Exomem/Basic Memory dominance run: pass
- sdist and wheel build: pass
