### PR TITLE
feat: add multi-host writer lease

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,18 +6,19 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Product commands: 21
-- Tier 1 commands: 18
+- Product commands: 22
+- Tier 1 commands: 19
 - Tier 2 commands: 3
-- Registry-generated MCP commands: 21
-- REST commands: 20
-- CLI commands: 20
+- Registry-generated MCP commands: 22
+- REST commands: 21
+- CLI commands: 21
 - Hand-registered MCP tools: none
 
 ## Product Command Registry
 
 | Command | Tier | Surfaces | Mode | Destructive | CLI positional | Routes | Parameters | Summary |
 | --- | ---: | --- | --- | --- | --- | --- | --- | --- |
+| coordination_status | 1 | MCP, REST, CLI | read | no | - | coordination_status | - | Report this replica's writer-lease role and coordinator health. |
 | bootstrap | 1 | MCP, REST, CLI | read | no | - | bootstrap | profile, workflow | Return Exomem's versioned operating contract for generic MCP clients. |
 | ask_memory | 1 | MCP, REST, CLI | read | no | query | search, find | query, types, projects, tags, speakers, file_types, exclude_file_types, limit, scope, mode, detail, deep, graph, rerank, prefer_compiled, prefer_active, prefer_used, graph_enrich, include_timings | Recall durable knowledge from Exomem with product defaults. |
 | read_memory | 1 | MCP, REST, CLI | read | no | path | fetch, get | path*, frontmatter_only, include_history, links, include_raw | Read one memory page or curated vault file by path. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -289,9 +289,10 @@ service name, so it keeps working across the rename. Verify with
 
 ## Deploying on a second machine (multi-host)
 
-Each machine is an independent deployment — there is no shared state. To run exomem
-on a second box (e.g. a laptop alongside a desktop), repeat the install with that
-host's *own* values. The non-obvious parts:
+Each machine runs its own Exomem process and local vault replica. If both replicas
+can mutate a Syncthing-replicated vault, enable the writer lease below: Syncthing
+replicates files, while the coordinator guarantees that only one Exomem host writes.
+Without a lease, keep exactly one host writable. The non-obvious per-host parts:
 
 - **Its own public hostname.** `EXOMEM_BASE_URL` and the connector URL are
   per-host. Tailscale gives each node a distinct `<node>.<tailnet>.ts.net`
@@ -322,9 +323,82 @@ host's *own* values. The non-obvious parts:
   `embedding model ready ... on cuda`. (Default PyPI Windows torch is CPU-only,
   which is why the explicit CUDA index in `pyproject.toml` exists.)
 
-The deployments coexist — claude.ai talks to whichever host's connector you invoke,
-and only that host needs to be awake. After editing `.env`, restart the service so
-it reloads.
+### Single-writer lease and automatic laptop takeover
+
+The lease is replication-agnostic. It decides which replica may mutate; it does
+not copy vault files. This desktop/laptop example uses Syncthing, but self-hosters
+can use shared storage, Unison, rsync automation, Git-based replication, or another
+external mechanism. Followers can only serve content that mechanism has delivered,
+and its convergence/recovery behavior remains an operator concern.
+
+Network reachability is a third, separate layer. In a LAN-only Syncthing setup,
+an isolated laptop can take the lease and write its last local vault copy, but its
+changes do not reach the desktop until the machines share a network again. If
+takeover must work while the laptop is away from home, the coordinator must also
+be reachable from both networks (for example through public TLS, a small VPS, a
+managed linearizable service, or a private overlay network). Never put the only
+coordinator on the desktop whose shutdown is meant to trigger failover.
+
+Run one strongly consistent coordinator. The included reference service uses a
+transactional SQLite database on one always-on node:
+
+```powershell
+$env:EXOMEM_LEASE_COORDINATOR_TOKEN = '<long-random-secret>'
+uv run python -m exomem.lease_coordinator --host 0.0.0.0 --port 8770 `
+  --database C:\exomem-state\writer-leases.sqlite
+```
+
+Expose that service over private TLS or a protected tunnel. SQLite is consistent
+on a single coordinator node but not highly available; for HA, implement the same
+HTTP contract on a linearizable store such as a Durable Object, transactional SQL,
+Consul, or etcd.
+
+Configure both Exomem hosts with the same vault ID and coordinator, but unique
+replica IDs. Desktop example:
+
+```dotenv
+EXOMEM_WRITER_LEASE_URL=https://lease.example.com
+EXOMEM_WRITER_LEASE_VAULT_ID=personal-main
+EXOMEM_WRITER_LEASE_REPLICA_ID=desktop
+EXOMEM_WRITER_LEASE_TOKEN=<long-random-secret>
+EXOMEM_WRITER_LEASE_TTL=30
+EXOMEM_WRITER_LEASE_PREFERRED=1
+```
+
+Laptop uses the same values except
+`EXOMEM_WRITER_LEASE_REPLICA_ID=laptop` and omits the preferred flag. Both remain
+readable. The first write acquires the lease; the server renews it while alive.
+After a crash or sleep, another host can take over after the TTL. Writes fail closed
+with `WRITER_COORDINATOR_UNAVAILABLE` if authority cannot be confirmed, but reads
+continue locally. Check any replica with:
+
+```powershell
+uv run python -m exomem coordination_status --json
+```
+
+REST callers can attach `Idempotency-Key`; CLI callers can set
+`EXOMEM_IDEMPOTENCY_KEY` for retry-safe mutations. Idempotency records and lease
+credentials stay in per-machine runtime state, outside the synced vault.
+
+The coordinator contract is:
+
+- `POST /v1/vaults/{vault}/lease/acquire`
+- `POST /v1/vaults/{vault}/lease/renew`
+- `POST /v1/vaults/{vault}/lease/release`
+- `GET /v1/vaults/{vault}/lease`
+
+POST bodies carry `replica_id`, `ttl_seconds`, and, for renew/release,
+`fencing_token`. Responses carry only `holder`, `expires_at`, `fencing_token`, and
+`granted`; no vault content is sent. Use bearer authentication in any networked
+deployment.
+
+The deployments coexist — claude.ai can use either connector. After editing `.env`,
+restart each service so it reloads the coordination settings. Automatic two-way
+failover requires the vault folder to be Syncthing **Send & Receive on both hosts**;
+the writer lease is the write guard. Avoid direct Obsidian/filesystem edits on a
+follower because those bypass Exomem. Before deliberately stopping the active
+writer, let Syncthing reach **Up to Date**; on an unclean crash, the lease prevents
+split brain but cannot recover bytes the old writer had not replicated yet.
 
 ## GPU notes (CUDA / Blackwell / Apple Silicon MPS)
 
@@ -518,7 +592,7 @@ The remote tier is intentionally minimal. Not included:
   RBAC).
 - Monitoring/metrics/observability beyond rotating file logs.
 - Web UI.
-- Multi-host failover / always-on home server (each host is independent; you pick
-  which connector to invoke).
+- Highly available coordinator hosting (the bundled SQLite coordinator is a
+  strongly consistent single-node reference).
 - Compiled-note creation from mobile (`add` only captures raw sources;
   compilation stays a desk-side / Claude Code flow).

--- a/openspec/changes/add-multi-host-writer-lease/.openspec.yaml
+++ b/openspec/changes/add-multi-host-writer-lease/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/add-multi-host-writer-lease/design.md
+++ b/openspec/changes/add-multi-host-writer-lease/design.md
@@ -1,0 +1,101 @@
+## Context
+
+Exomem stores its canonical state as Markdown plus derived indexes and logs. Syncthing is excellent replication but does not provide a strongly consistent distributed lock. With two writable replicas, simultaneous command execution can create conflict copies or diverging index/log state even when most human edits are rare. The command registry already marks every exposed operation as read-only or write-capable and generates MCP, REST, and CLI adapters, giving us one reliable policy boundary.
+
+The personal topology is a desktop and laptop that both expose Exomem connectors and replicate the vault. The desktop should normally write; the laptop should take over after the desktop disappears. The mechanism must also work for ordinary self-hosted replicas and must not depend on a language model making coordination decisions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep all replicas readable while permitting exactly one active writer per vault.
+- Automatically renew, expire, release, and transfer writer authority.
+- Gate every registry-declared mutation consistently across MCP, REST, and CLI.
+- Fail closed for writes when authority cannot be proven, while preserving reads.
+- Make retries safe and expose clear role/health diagnostics.
+- Use a small provider-neutral HTTP contract suitable for a strongly consistent cloud primitive or self-hosted service.
+- Remain independent of the operator's vault replication or shared-storage product.
+- Leave existing single-host installs unchanged unless explicitly enabled.
+
+**Non-Goals:**
+
+- Building a CRDT, offline multi-writer merge engine, or conflict resolver.
+- Treating Syncthing folder modes or filesystem lock files as distributed consensus.
+- Implementing or prescribing a vault replication engine.
+- Replicating coordinator credentials or runtime state inside the vault.
+- Moving vault content through the coordinator.
+
+## Decisions
+
+### A registry-level invocation boundary owns coordination
+
+Add a shared `CommandInvoker` used by generated MCP, REST, and CLI adapters. It receives a `Command`, injected leaf arguments, keyword arguments, and optional idempotency key. For read-only commands it directly invokes the leaf. For write-capable commands it validates/acquires the lease, then invokes through the idempotency store. This avoids duplicating policy in dozens of leaves and makes command metadata the auditable source of truth.
+
+### The coordinator contract is HTTP JSON and strongly consistent by contract
+
+The client uses a base URL plus bearer token and the following conceptual operations:
+
+- `POST /v1/vaults/{vault}/lease/acquire` with replica ID and TTL.
+- `POST /v1/vaults/{vault}/lease/renew` with replica ID and fencing token.
+- `POST /v1/vaults/{vault}/lease/release` with replica ID and fencing token.
+- `GET /v1/vaults/{vault}/lease` for authoritative status.
+
+The coordinator atomically grants one unexpired holder and increments a persistent fencing token on each new acquisition. Exomem validates ownership at each mutation boundary; it never relies only on cached role state. The contract, not a particular vendor, is normative. A reference coordinator service backed by SQLite transactions will be included for self-hosting and tests; managed implementations can use Durable Objects, transactional SQL, Consul, etcd, or an equivalent linearizable primitive.
+
+### Replication remains an external substrate
+
+The lease service elects a writer; it does not copy the vault. Syncthing is one
+deployment example, not a dependency. Self-hosters may use shared storage, Unison,
+rsync automation, Git-based replication, or another mechanism whose consistency
+and recovery trade-offs they understand. Followers can only read data their chosen
+replication layer has delivered.
+
+Coordinator reachability is independent again: automatic takeover across different
+networks requires a coordinator endpoint both replicas can reach. A LAN-only
+replication link may converge later; until it does, the active replica operates on
+its latest local copy.
+
+### Acquisition is demand-driven with optional background renewal
+
+On a write request, a replica asks to acquire or validate authority. The server process renews a held lease in the background and releases it during graceful shutdown where possible. Demand-driven acquisition keeps CLI invocations correct even though they are short-lived. Preferred-writer configuration affects who proactively acquires; it never overrides an existing valid holder.
+
+### Coordination failure is explicit and safe
+
+An authoritative response naming another holder produces `WRITER_LEASE_REQUIRED`; transport failure, malformed responses, or coordinator server errors produce `WRITER_COORDINATOR_UNAVAILABLE`. Both occur before the leaf runs. REST maps these errors to 409 and 503 respectively; CLI uses its existing structured envelope; MCP receives the stable code in the raised operation error. Reads never call the coordinator.
+
+### Idempotency is local, durable, and scoped to the vault
+
+The invoker hashes the command name and normalized arguments. When an idempotency key is provided, it stores pending/completed records in an Exomem runtime sidecar outside the replicated vault content. Identical completed calls return the saved result; mismatched reuse fails. The key is optional because existing callers do not supply it. Cross-replica failover safety requires clients to retry against the new writer with the same key and the coordinator-backed implementation may later centralize records; this slice prevents the common same-writer/network retry duplication and defines the boundary without pretending local files are distributed consensus.
+
+### Configuration is explicit and default-off
+
+Coordination enables only when `EXOMEM_WRITER_LEASE_URL` is set. `EXOMEM_WRITER_LEASE_VAULT_ID`, `EXOMEM_WRITER_LEASE_REPLICA_ID`, bearer token, TTL, request timeout, preferred role, and state directory are independently configurable. Missing required identity values while a URL is set is a startup/configuration error. Secrets are read from the environment and excluded from status output.
+
+### Status is a read-only product command
+
+Add a `coordination_status` read command to MCP, REST, and CLI. It reports standalone/writer/follower/unknown, identifiers, holder, expiry, fencing token, and coordinator health. It performs a bounded status lookup when enabled but never blocks unrelated reads.
+
+## Risks / Trade-offs
+
+- **Coordinator availability becomes a write dependency.** This is intentional: uncertain authority must not produce split brain. Mitigation: reads remain local and available; operators can deploy a highly available strongly consistent coordinator.
+- **Lease expiry during a long mutation.** The invoker validates immediately before execution, and the server renewer maintains the lease. Some batch operations may outlive a TTL. Mitigation: configure TTL comfortably above worst-case leaf duration and renew while the process owns the lease; future storage-level fencing can strengthen this further.
+- **A fencing token cannot stop arbitrary direct filesystem edits.** The guarantee covers Exomem command surfaces. Mitigation: operational docs keep Syncthing followers receive-only and discourage direct edits outside the active writer.
+- **Local idempotency does not deduplicate across replicas.** It still solves ordinary transport retries and establishes a stable API. Full cross-replica idempotency would need coordinator storage and is deferred rather than falsely claimed.
+- **SQLite reference service is a single coordinator node.** It is strongly consistent on one node but not highly available. It is appropriate for self-hosting; managed linearizable backends provide HA.
+
+## Migration Plan
+
+1. Ship the capability disabled by default; existing deployments require no changes.
+2. Deploy a compatible coordinator and create a bearer token.
+3. Assign the same vault ID and distinct replica IDs on desktop and laptop.
+4. Configure both replicas with the coordinator URL; set the desktop as preferred writer and laptop as follower candidate.
+5. Verify `coordination_status`, perform a desktop write, stop the desktop, wait one TTL, and verify laptop takeover.
+6. For automatic two-way failover, set the replicated vault folder to Send & Receive on both hosts. Avoid direct Obsidian/filesystem edits on the follower because those bypass Exomem's lease gate.
+
+Rollback is setting `EXOMEM_WRITER_LEASE_URL` empty and restarting. That restores legacy standalone behavior; operators must first ensure only one replica is writable to avoid reintroducing split brain.
+
+## Open Questions
+
+- Should a later version store idempotency records in the coordinator to guarantee deduplication across failover?
+- Should preferred-writer priority include a voluntary hand-back policy, or remain sticky until expiry/release to avoid unnecessary churn?
+- Which managed coordinator adapter should be documented first: Cloudflare Durable Objects or transactional Postgres?

--- a/openspec/changes/add-multi-host-writer-lease/proposal.md
+++ b/openspec/changes/add-multi-host-writer-lease/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Exomem can run against Syncthing-replicated vaults on multiple hosts, but each server currently assumes it may write locally; concurrent mutations can therefore fork canonical Markdown, `index.md`, and `log.md` before Syncthing detects the conflict. Multi-host and self-hosted deployments need automatic failover without allowing two replicas to become writers at the same time.
+
+## What Changes
+
+- Add an opt-in, strongly consistent writer lease that elects exactly one writable Exomem replica per vault while allowing every healthy replica to continue serving reads.
+- Gate every mutation through the shared command leaf so MCP, REST, and CLI enforce the same leader/follower contract without duplicated surface logic.
+- Renew leases with a bounded TTL, release them on graceful shutdown, and allow another replica to take over automatically after expiry.
+- Make follower and coordinator-unavailable write failures stable and machine-readable, including retry/leader metadata where available; reads remain available when coordination fails.
+- Add durable per-replica idempotency protection for transport/process retries and a stable idempotency boundary that can later move to shared coordinator storage for cross-replica failover.
+- Expose replica role and lease health for reverse proxies, tunnels, health checks, and operators so one stable MCP endpoint can route to the active writer.
+- Keep coordination default-off: ordinary single-host installations retain current behavior and gain no required external service. When explicitly enabled but unavailable, coordination soft-fails operationally—reads stay healthy and writes fail closed rather than risking split brain.
+- Document provider-neutral self-hosting requirements and a reference coordination deployment; the lease carries only vault/replica identity and expiry metadata, never vault content.
+- Explicitly exclude offline multi-writer merging, CRDT conversion, and Syncthing lockfiles from this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `multi-host-writer-lease`: Opt-in single-writer election, lease lifecycle, mutation gating, idempotent failover, role health, and provider-neutral self-hosted coordination for replicated Exomem vaults.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects command dispatch around write-capable registry leaves, MCP/REST/CLI error envelopes, service startup/shutdown lifecycle, and health/readiness reporting.
+- Adds a coordination abstraction plus at least one strongly consistent shared backend suitable for Desktop/laptop and general self-hosted deployments.
+- Adds configuration for vault identity, replica identity, lease TTL/renewal, coordinator selection, and optional leader routing metadata.
+- Requires concurrency, expiry, takeover, local idempotency, coordinator-outage, and single-host compatibility tests.
+- Requires deployment and operator documentation for stable-endpoint routing and safe multi-replica setup.

--- a/openspec/changes/add-multi-host-writer-lease/specs/multi-host-writer-lease/spec.md
+++ b/openspec/changes/add-multi-host-writer-lease/specs/multi-host-writer-lease/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Opt-in multi-host coordination
+Exomem SHALL preserve its current single-host behavior unless writer-lease coordination is explicitly configured. When coordination is enabled, every replica SHALL use a stable vault identifier and a unique replica identifier when requesting authority to mutate the vault.
+
+#### Scenario: Existing single-host installation
+- **WHEN** no writer-lease coordinator is configured
+- **THEN** reads and writes behave as they did before this capability was added
+
+#### Scenario: Coordinated replica starts
+- **WHEN** a coordinator URL, vault identifier, and replica identifier are configured
+- **THEN** the replica participates in writer-lease coordination for that vault
+
+### Requirement: Exactly one active writer
+The coordination service SHALL grant at most one unexpired writer lease for a vault at a time. All replicas MAY serve reads, but only the replica holding the current lease SHALL execute mutations.
+
+#### Scenario: Two replicas request authority
+- **WHEN** two replicas concurrently request the writer lease for the same vault
+- **THEN** at most one receives writer authority and the other remains a readable follower
+
+#### Scenario: Independent vaults
+- **WHEN** replicas request leases for different vault identifiers
+- **THEN** the leases do not block one another
+
+### Requirement: Lease lifecycle and automatic takeover
+The active writer SHALL renew its bounded lease before expiry. A follower SHALL be able to acquire the lease after the previous lease expires or is explicitly released, without manual Syncthing mode changes.
+
+#### Scenario: Healthy writer renews
+- **WHEN** the active writer renews before the lease deadline
+- **THEN** it remains the writer and the lease deadline advances
+
+#### Scenario: Writer disappears
+- **WHEN** the active writer stops renewing and its lease expires
+- **THEN** another replica can acquire a new lease and become writer
+
+#### Scenario: Graceful shutdown
+- **WHEN** the active writer explicitly releases its lease
+- **THEN** another replica can acquire immediately
+
+### Requirement: Stale-writer fencing
+Every successful acquisition SHALL return a monotonically increasing fencing token for that vault. A replica SHALL validate current lease ownership at the mutation boundary and SHALL refuse a mutation when its token or ownership is stale.
+
+#### Scenario: Former writer returns after failover
+- **WHEN** a former writer attempts a mutation after another replica acquired a newer lease
+- **THEN** the former writer is rejected before the mutation leaf executes
+
+### Requirement: Uniform mutation gate
+Every command declared as write-capable in the shared command registry SHALL pass through the same lease gate on MCP, REST, and CLI surfaces before its leaf executes. Read-only commands SHALL not require a lease.
+
+#### Scenario: Follower invokes a write through any surface
+- **WHEN** a follower invokes a registry command whose write metadata is true through MCP, REST, or CLI
+- **THEN** Exomem rejects it before calling the command leaf with a stable `WRITER_LEASE_REQUIRED` error
+
+#### Scenario: Follower invokes a read
+- **WHEN** a follower invokes a read-only command
+- **THEN** Exomem executes it without acquiring writer authority
+
+### Requirement: Fail-closed mutations and available reads
+When coordination is enabled and the coordinator cannot authoritatively confirm ownership, Exomem SHALL fail closed for mutations while continuing to serve local reads.
+
+#### Scenario: Coordinator is unreachable
+- **WHEN** a mutation is requested while the coordinator is unreachable
+- **THEN** Exomem rejects it with a stable `WRITER_COORDINATOR_UNAVAILABLE` error and does not execute the leaf
+
+#### Scenario: Read during coordinator outage
+- **WHEN** a read-only command is requested while the coordinator is unreachable
+- **THEN** Exomem serves the read from the local replica
+
+### Requirement: Retry-safe mutation identity
+Coordinated mutations SHALL accept an optional idempotency key at the common mutation boundary. A replica SHALL reject reuse of a key for a different command or payload and SHALL return the recorded result for an identical completed mutation without executing the leaf again.
+
+#### Scenario: Client retries the same mutation
+- **WHEN** an identical mutation with the same idempotency key is retried on the current writer
+- **THEN** Exomem returns the recorded result without applying the mutation twice
+
+#### Scenario: Key is reused for different input
+- **WHEN** an idempotency key is reused with a different command or payload
+- **THEN** Exomem rejects it with `IDEMPOTENCY_KEY_REUSED`
+
+### Requirement: Role and lease health visibility
+Exomem SHALL expose machine-readable coordination status containing whether coordination is enabled, the local role, vault and replica identifiers, current holder, lease expiry, fencing token, and coordinator health without exposing vault content or coordinator credentials.
+
+#### Scenario: Operator checks a follower
+- **WHEN** coordination status is requested on a healthy follower
+- **THEN** the response identifies the current writer and reports the local role as `follower`
+
+#### Scenario: Operator checks an uncoordinated instance
+- **WHEN** status is requested without coordination configured
+- **THEN** the response reports coordination disabled and the local role as `standalone`
+
+### Requirement: Provider-neutral coordinator contract
+The lease client SHALL communicate through a documented HTTP JSON contract that can be implemented by a strongly consistent managed service or a self-hosted service. Requests SHALL authenticate when a token is configured, and the contract SHALL exchange coordination metadata only, never vault content.
+
+#### Scenario: Self-hosted coordinator
+- **WHEN** an operator supplies a compatible self-hosted coordinator URL and credentials
+- **THEN** Exomem coordinates writers without depending on a specific cloud provider
+
+### Requirement: Replication-mechanism independence
+Writer coordination SHALL NOT depend on Syncthing or any other specific vault replication product. The operator SHALL remain responsible for providing shared storage or an external replication mechanism appropriate to the deployment.
+
+#### Scenario: Self-hoster uses a different replication layer
+- **WHEN** replicas receive the same canonical vault through shared storage, Unison, rsync, Git-based automation, or another external mechanism
+- **THEN** Exomem applies the same writer-lease behavior without requiring Syncthing APIs or configuration

--- a/openspec/changes/add-multi-host-writer-lease/tasks.md
+++ b/openspec/changes/add-multi-host-writer-lease/tasks.md
@@ -1,0 +1,22 @@
+## 1. Coordination Core
+
+- [x] 1.1 Add pure-logic tests for lease configuration, coordinator responses, ownership errors, fencing, and default-off behavior
+- [x] 1.2 Implement environment-backed lease configuration and the provider-neutral HTTP coordinator client
+- [x] 1.3 Implement a transactional SQLite reference coordinator with acquire, renew, release, and status operations
+
+## 2. Common Mutation Boundary
+
+- [x] 2.1 Add tests for read bypass, writer execution, follower refusal, coordinator outage, and stale-token refusal
+- [x] 2.2 Implement the shared command invoker and durable local idempotency records
+- [x] 2.3 Route MCP, REST, and CLI registry commands through the shared invoker and map stable error statuses
+
+## 3. Operations and Lifecycle
+
+- [x] 3.1 Add the read-only `coordination_status` command consistently across MCP, REST, and CLI
+- [x] 3.2 Add server lease renewal and graceful release lifecycle behavior
+- [x] 3.3 Add the runnable self-hosted reference coordinator service and document its HTTP contract and deployment configuration
+
+## 4. Verification
+
+- [x] 4.1 Add integration tests covering single-writer exclusivity, expiry takeover, retry idempotency, surface metadata, and status redaction
+- [x] 4.2 Run targeted tests, full non-embedding tests, and Ruff; resolve regressions

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -1446,7 +1446,14 @@ def _core_op_main(argv: list[str]) -> int:
             injected = (vault_root, schema_module.load_source_schema(vault_root))
         else:
             injected = (vault_root,)
-        result = cmd.leaf(*injected, **kwargs)
+        from .writer_lease import invoke_command
+
+        result = invoke_command(
+            cmd,
+            *injected,
+            idempotency_key=os.environ.get("EXOMEM_IDEMPOTENCY_KEY") or None,
+            **kwargs,
+        )
     except (cli_ops.OpError, ValueError, TypeError, RuntimeError) as e:
         err = cli_ops.error_dict(e)
         if as_json:

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -39,6 +39,8 @@ _REMEDIATION: dict[str, str] = {
     "BAD_JSON": "Pass valid JSON for this field.",
     "BINARY_BLOB_REJECTED": "Don't push binaries through text fields; use the /upload endpoint.",
     "NOT_FOUND": "Check the path; try `ask_memory` to locate it.",
+    "WRITER_LEASE_REQUIRED": "Send the mutation to the current writer or retry after its lease expires.",
+    "WRITER_COORDINATOR_UNAVAILABLE": "Check the coordinator URL, credentials, and service health; reads remain available.",
 }
 
 # Error codes whose HTTP status is NOT the default 400.
@@ -56,6 +58,9 @@ _CONFLICT_CODES = frozenset(
         "STALE_EDIT",
         "STALE_CONTRACT",
         "CONTRACT_EXISTS",
+        "WRITER_LEASE_REQUIRED",
+        "IDEMPOTENCY_KEY_REUSED",
+        "IDEMPOTENCY_IN_PROGRESS",
     }
 )
 
@@ -105,6 +110,8 @@ def http_status_for(code: str) -> int:
         return 404
     if code in _CONFLICT_CODES or code.endswith("_EXISTS"):
         return 409
+    if code == "WRITER_COORDINATOR_UNAVAILABLE":
+        return 503
     return 400
 
 

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -114,6 +114,7 @@ def bind_vault(
     *injected: object,
     name: str | None = None,
     description: str | None = None,
+    command: Command | None = None,
 ) -> Callable:
     """Return a callable FastMCP introspects exactly like a hand-written wrapper."""
     sig = inspect.signature(leaf)
@@ -137,7 +138,11 @@ def bind_vault(
     new_sig = sig.replace(parameters=visible)
 
     def wrapper(**kwargs):
-        return leaf(*injected, **kwargs)
+        if command is None:
+            return leaf(*injected, **kwargs)
+        from .writer_lease import invoke_command
+
+        return invoke_command(command, *injected, **kwargs)
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
     wrapper.__name__ = name or leaf.__name__

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -4097,6 +4097,17 @@ def remember_description(project_keys_hint: str) -> str:
     """The `remember` MCP description with the live project-key hint substituted."""
     return (op_remember.__doc__ or "").replace("__PROJECT_KEYS_HINT__", project_keys_hint)
 
+
+def op_coordination_status(vault_root: Path) -> dict:  # noqa: ARG001
+    """Report this replica's writer-lease role and coordinator health.
+
+    Read-only and safe during coordinator outages. Credentials and vault content
+    are never included.
+    """
+    from .writer_lease import coordination_status
+
+    return coordination_status()
+
 def note_description(project_keys_hint: str) -> str:
     """The `note` MCP description with the live project-key hint substituted in.
 
@@ -4189,6 +4200,7 @@ _SIMPLE_ACTION_DEFS: dict[str, dict] = {
     },
 }
 _PRODUCT_METADATA: dict[str, dict] = {
+    "coordination_status": {"surface": "advanced", "actions": ("review",), "first_run_safe": True},
     "bootstrap": {"surface": "primary", "actions": (), "first_run_safe": True},
     "adopt": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
     "overview": {"surface": "primary", "actions": ("adopt",), "first_run_safe": True},
@@ -4224,6 +4236,7 @@ _RC = frozenset({"rest", "cli"})
 # meaningless through the REST/CLI JSON envelopes, so it is mcp-only.
 _M = frozenset({"mcp"})
 _SPEC: tuple[tuple, ...] = (
+    ("coordination_status", op_coordination_status, 1, False, False, None, _MCRC),
     ("bootstrap", op_bootstrap, 1, False, False, None, _MCRC),
     ("search", op_search, 1, False, False, "query", _MCRC),
     ("fetch", op_fetch, 1, False, False, "id", _MCRC),
@@ -4295,6 +4308,17 @@ def _build_commands() -> tuple[Command, ...]:
 COMMANDS: tuple[Command, ...] = _build_commands()
 
 _PRODUCT_SPEC: tuple[tuple, ...] = (
+    (
+        "coordination_status",
+        op_coordination_status,
+        1,
+        False,
+        False,
+        None,
+        _MCRC,
+        ("coordination_status",),
+        {"surface": "advanced", "actions": ("review",), "first_run_safe": True},
+    ),
     (
         "bootstrap",
         op_bootstrap,

--- a/src/exomem/lease_coordinator.py
+++ b/src/exomem/lease_coordinator.py
@@ -1,0 +1,190 @@
+"""Reference strongly-consistent writer-lease coordinator.
+
+Run with ``python -m exomem.lease_coordinator``. SQLite ``BEGIN IMMEDIATE``
+serializes grants on one coordinator node; deploy a linearizable managed backend
+behind the same HTTP contract when coordinator high availability is required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+import sqlite3
+import time
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+class SQLiteLeaseStore:
+    def __init__(self, path: Path, *, clock=time.time):
+        self.path = path
+        self.clock = clock
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS leases ("
+                "vault_id TEXT PRIMARY KEY, holder TEXT, expires_at REAL, "
+                "fencing_token INTEGER NOT NULL DEFAULT 0)"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=10, isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    @staticmethod
+    def _record(row, *, granted: bool = False) -> dict:  # noqa: ANN001
+        return {
+            "holder": row[0] if row else None,
+            "expires_at": row[1] if row and row[0] else None,
+            "fencing_token": int(row[2]) if row else 0,
+            "granted": granted,
+        }
+
+    def acquire(self, vault_id: str, replica_id: str, ttl_seconds: float) -> dict:
+        now = self.clock()
+        expires = now + ttl_seconds
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
+                (vault_id,),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO leases(vault_id, holder, expires_at, fencing_token) VALUES (?, ?, ?, 1)",
+                    (vault_id, replica_id, expires),
+                )
+                conn.execute("COMMIT")
+                return {"holder": replica_id, "expires_at": expires, "fencing_token": 1, "granted": True}
+            holder, old_expiry, token = row
+            active = holder is not None and old_expiry is not None and old_expiry > now
+            if active and holder != replica_id:
+                conn.execute("COMMIT")
+                return self._record(row)
+            new_token = token if active and holder == replica_id else token + 1
+            conn.execute(
+                "UPDATE leases SET holder = ?, expires_at = ?, fencing_token = ? WHERE vault_id = ?",
+                (replica_id, expires, new_token, vault_id),
+            )
+            conn.execute("COMMIT")
+            return {"holder": replica_id, "expires_at": expires, "fencing_token": new_token, "granted": True}
+
+    def renew(self, vault_id: str, replica_id: str, fencing_token: int, ttl_seconds: float) -> dict:
+        now = self.clock()
+        expires = now + ttl_seconds
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
+                (vault_id,),
+            ).fetchone()
+            valid = bool(
+                row
+                and row[0] == replica_id
+                and row[1] is not None
+                and row[1] > now
+                and row[2] == fencing_token
+            )
+            if valid:
+                conn.execute("UPDATE leases SET expires_at = ? WHERE vault_id = ?", (expires, vault_id))
+                row = (replica_id, expires, fencing_token)
+            conn.execute("COMMIT")
+            return self._record(row, granted=valid)
+
+    def release(self, vault_id: str, replica_id: str, fencing_token: int) -> dict:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
+                (vault_id,),
+            ).fetchone()
+            valid = bool(row and row[0] == replica_id and row[2] == fencing_token)
+            if valid:
+                conn.execute("UPDATE leases SET holder = NULL, expires_at = NULL WHERE vault_id = ?", (vault_id,))
+                row = (None, None, fencing_token)
+            conn.execute("COMMIT")
+            return self._record(row, granted=valid)
+
+    def status(self, vault_id: str) -> dict:
+        now = self.clock()
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT holder, expires_at, fencing_token FROM leases WHERE vault_id = ?",
+                (vault_id,),
+            ).fetchone()
+            if row and row[0] is not None and (row[1] is None or row[1] <= now):
+                conn.execute("UPDATE leases SET holder = NULL, expires_at = NULL WHERE vault_id = ?", (vault_id,))
+                row = (None, None, row[2])
+            conn.execute("COMMIT")
+            return self._record(row)
+
+
+def create_app(*, database: Path | None = None, bearer_token: str | None = None, clock=time.time) -> Starlette:
+    database = database or Path(os.environ.get("EXOMEM_LEASE_COORDINATOR_DB", "writer-leases.sqlite"))
+    bearer_token = bearer_token if bearer_token is not None else (os.environ.get("EXOMEM_LEASE_COORDINATOR_TOKEN", "").strip() or None)
+    store = SQLiteLeaseStore(database, clock=clock)
+
+    def authorized(request: Request) -> bool:
+        if not bearer_token:
+            return True
+        header = request.headers.get("authorization", "")
+        return header.startswith("Bearer ") and secrets.compare_digest(header[7:].strip(), bearer_token)
+
+    async def lease(request: Request) -> JSONResponse:
+        if not authorized(request):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        vault_id = request.path_params["vault_id"]
+        operation = request.path_params.get("operation")
+        if request.method == "GET":
+            return JSONResponse(store.status(vault_id))
+        try:
+            body = await request.json()
+            replica_id = str(body["replica_id"])
+            if operation == "acquire":
+                result = store.acquire(vault_id, replica_id, _ttl(body))
+            elif operation == "renew":
+                result = store.renew(vault_id, replica_id, int(body["fencing_token"]), _ttl(body))
+            elif operation == "release":
+                result = store.release(vault_id, replica_id, int(body["fencing_token"]))
+            else:
+                return JSONResponse({"error": "unknown operation"}, status_code=404)
+        except (KeyError, TypeError, ValueError):
+            return JSONResponse({"error": "invalid request"}, status_code=400)
+        return JSONResponse(result)
+
+    return Starlette(
+        routes=[
+            Route("/v1/vaults/{vault_id:str}/lease", lease, methods=["GET"]),
+            Route("/v1/vaults/{vault_id:str}/lease/{operation:str}", lease, methods=["POST"]),
+        ]
+    )
+
+
+def _ttl(body: dict) -> float:
+    ttl = float(body["ttl_seconds"])
+    if ttl <= 0 or ttl > 3600:
+        raise ValueError("ttl_seconds must be between 0 and 3600")
+    return ttl
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Exomem SQLite writer-lease coordinator")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8770)
+    parser.add_argument("--database", type=Path, default=None)
+    args = parser.parse_args(argv)
+    import uvicorn
+
+    uvicorn.run(create_app(database=args.database), host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -125,6 +125,9 @@ def _find_call_summary(message) -> str:
 def build_server(*, require_auth: bool) -> FastMCP:
     """Construct and return the FastMCP app, ready to run."""
     runtime = initialize_runtime(load_dotenv_func=load_dotenv)
+    from .writer_lease import start_server_lifecycle
+
+    start_server_lifecycle()
     auth = build_oauth(require_auth=require_auth, base_url=runtime.base_url)
 
     mcp = FastMCP("exomem", auth=auth, icons=server_icons())
@@ -157,7 +160,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
             description = commands_module.remember_description(runtime.project_keys_hint)
         mcp.tool(
             commands_module.bind_vault(
-                cmd.leaf, *injected, name=cmd.name, description=description
+                cmd.leaf, *injected, name=cmd.name, description=description, command=cmd
             ),
             annotations=cmd.mcp_annotations,
         )
@@ -225,6 +228,7 @@ def _register_legacy_mcp_tools(
                 name=cmd.name,
                 description="[Deprecated compatibility alias; prefer product commands.] "
                 + description,
+                command=cmd,
             ),
             annotations=cmd.mcp_annotations,
         )

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -119,7 +119,15 @@ def register_rest_facade(
                     _cmd.params, body, guarded_fields=_cmd.guarded_fields, tool=_cmd.name
                 )
                 injected = (vault_root, source_schema) if _cmd.needs_schema else (vault_root,)
-                result = await run_in_threadpool(_cmd.leaf, *injected, **kwargs)
+                from .writer_lease import invoke_command
+
+                result = await run_in_threadpool(
+                    invoke_command,
+                    _cmd,
+                    *injected,
+                    idempotency_key=request.headers.get("idempotency-key"),
+                    **kwargs,
+                )
             except (cli_ops.OpError, ValueError, TypeError) as exc:
                 err = cli_ops.error_dict(exc)
                 return RestJSONResponse(

--- a/src/exomem/server_transfer.py
+++ b/src/exomem/server_transfer.py
@@ -114,6 +114,17 @@ def register_transfer_routes(
                 {"code": "UNAUTHORIZED", "reason": "missing or invalid upload credential"},
                 status_code=401,
             )
+        from .cli_ops import OpError, error_dict, http_status_for
+        from .writer_lease import get_manager
+
+        try:
+            get_manager().ensure_writer()
+        except (OpError, ValueError) as exc:
+            error = error_dict(exc)
+            return JSONResponse(
+                {"code": error["code"], "reason": error["message"]},
+                status_code=http_status_for(error["code"]),
+            )
         try:
             form = await request.form(max_part_size=config.upload_max_bytes)
         except MultiPartException as exc:

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -1,0 +1,343 @@
+"""Single-writer lease coordination for replicated Exomem vaults.
+
+The coordinator carries identity and timing metadata only. Vault content never
+leaves the replica. Coordination is opt-in through ``EXOMEM_WRITER_LEASE_URL``;
+without it the invocation path is the legacy standalone path.
+"""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import pickle
+import sqlite3
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .cli_ops import OpError
+
+
+@dataclass(frozen=True)
+class LeaseConfig:
+    url: str | None = None
+    vault_id: str | None = None
+    replica_id: str | None = None
+    token: str | None = None
+    ttl_seconds: float = 30.0
+    timeout_seconds: float = 3.0
+    preferred_writer: bool = False
+    state_dir: Path = Path.home() / ".cache" / "exomem"
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.url)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> LeaseConfig:
+        values = os.environ if env is None else env
+        url = values.get("EXOMEM_WRITER_LEASE_URL", "").strip() or None
+        state_raw = values.get("EXOMEM_WRITER_LEASE_STATE_DIR", "").strip()
+        config = cls(
+            url=url.rstrip("/") if url else None,
+            vault_id=values.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip() or None,
+            replica_id=values.get("EXOMEM_WRITER_LEASE_REPLICA_ID", "").strip() or None,
+            token=values.get("EXOMEM_WRITER_LEASE_TOKEN", "").strip() or None,
+            ttl_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TTL", 30.0),
+            timeout_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TIMEOUT", 3.0),
+            preferred_writer=_truthy(values.get("EXOMEM_WRITER_LEASE_PREFERRED", "")),
+            state_dir=Path(state_raw).expanduser() if state_raw else cls.state_dir,
+        )
+        if config.enabled and (not config.vault_id or not config.replica_id):
+            raise ValueError(
+                "WRITER_LEASE_CONFIG: EXOMEM_WRITER_LEASE_VAULT_ID and "
+                "EXOMEM_WRITER_LEASE_REPLICA_ID are required when coordination is enabled"
+            )
+        return config
+
+
+def _positive_float(values: Mapping[str, str], name: str, default: float) -> float:
+    raw = values.get(name, "").strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be a number") from None
+    if value <= 0:
+        raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be positive")
+    return value
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class LeaseRecord:
+    holder: str | None
+    expires_at: float | None
+    fencing_token: int
+    granted: bool = False
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, Any]) -> LeaseRecord:
+        holder = data.get("holder")
+        expires = data.get("expires_at")
+        token = data.get("fencing_token", 0)
+        if holder is not None and not isinstance(holder, str):
+            raise ValueError("holder must be a string or null")
+        if expires is not None and not isinstance(expires, (int, float)):
+            raise ValueError("expires_at must be a number or null")
+        if isinstance(token, bool) or not isinstance(token, int):
+            raise ValueError("fencing_token must be an integer")
+        return cls(holder, float(expires) if expires is not None else None, token, bool(data.get("granted")))
+
+
+class LeaseCoordinatorClient:
+    """Small stdlib HTTP client for the provider-neutral lease contract."""
+
+    def __init__(self, config: LeaseConfig):
+        if not config.enabled:
+            raise ValueError("coordinator client requires enabled configuration")
+        self.config = config
+
+    def acquire(self) -> LeaseRecord:
+        return self._request("POST", "acquire", {"replica_id": self.config.replica_id, "ttl_seconds": self.config.ttl_seconds})
+
+    def renew(self, fencing_token: int) -> LeaseRecord:
+        return self._request("POST", "renew", {"replica_id": self.config.replica_id, "fencing_token": fencing_token, "ttl_seconds": self.config.ttl_seconds})
+
+    def release(self, fencing_token: int) -> LeaseRecord:
+        return self._request("POST", "release", {"replica_id": self.config.replica_id, "fencing_token": fencing_token})
+
+    def status(self) -> LeaseRecord:
+        return self._request("GET", "", None)
+
+    def _request(self, method: str, operation: str, body: dict | None) -> LeaseRecord:
+        vault = urllib.parse.quote(str(self.config.vault_id), safe="")
+        suffix = f"/{operation}" if operation else ""
+        url = f"{self.config.url}/v1/vaults/{vault}/lease{suffix}"
+        headers = {"Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.config.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("response is not an object")
+            return LeaseRecord.from_json(payload)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError, ValueError) as exc:
+            raise OpError(
+                "WRITER_COORDINATOR_UNAVAILABLE",
+                f"writer coordinator could not confirm authority: {exc}",
+                "Check the coordinator URL, credentials, and service health; reads remain available.",
+            ) from None
+
+
+class IdempotencyStore:
+    """Durable per-replica retry cache, deliberately outside the synced vault."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS mutations ("
+                "key TEXT PRIMARY KEY, digest TEXT NOT NULL, state TEXT NOT NULL, "
+                "result BLOB, updated_at REAL NOT NULL)"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=10)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def run(self, key: str | None, digest: str, operation) -> Any:  # noqa: ANN001
+        if not key:
+            return operation()
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT digest, state, result FROM mutations WHERE key = ?", (key,)).fetchone()
+            if row:
+                if row[0] != digest:
+                    raise OpError("IDEMPOTENCY_KEY_REUSED", "idempotency key was already used for different input")
+                if row[1] == "completed":
+                    return pickle.loads(row[2])  # noqa: S301 - local trusted runtime state
+                raise OpError("IDEMPOTENCY_IN_PROGRESS", "an identical mutation with this key is already in progress")
+            conn.execute(
+                "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
+                (key, digest, time.time()),
+            )
+        try:
+            result = operation()
+        except Exception:
+            with self._connect() as conn:
+                conn.execute("DELETE FROM mutations WHERE key = ? AND digest = ? AND state = 'pending'", (key, digest))
+            raise
+        payload = pickle.dumps(result)
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE mutations SET state = 'completed', result = ?, updated_at = ? WHERE key = ? AND digest = ?",
+                (payload, time.time(), key, digest),
+            )
+        return result
+
+
+class LeaseManager:
+    def __init__(self, config: LeaseConfig, *, client: LeaseCoordinatorClient | None = None):
+        self.config = config
+        self.client = client if client is not None else (LeaseCoordinatorClient(config) if config.enabled else None)
+        replica = config.replica_id or "standalone"
+        vault = config.vault_id or "standalone"
+        safe_name = hashlib.sha256(f"{vault}\0{replica}".encode()).hexdigest()[:20]
+        self.idempotency = IdempotencyStore(config.state_dir / f"idempotency-{safe_name}.sqlite") if config.enabled else None
+        self._fencing_token: int | None = None
+        self._expires_at: float | None = None
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._renewer: threading.Thread | None = None
+
+    def ensure_writer(self) -> LeaseRecord:
+        if not self.config.enabled:
+            return LeaseRecord(self.config.replica_id, None, 0, True)
+        assert self.client is not None
+        with self._lock:
+            record = self.client.acquire()
+            if not record.granted or record.holder != self.config.replica_id:
+                raise OpError(
+                    "WRITER_LEASE_REQUIRED",
+                    f"replica is read-only; current writer is {record.holder or 'unassigned'}",
+                    "Send the mutation to the current writer or retry after its lease expires.",
+                )
+            self._fencing_token = record.fencing_token
+            self._expires_at = record.expires_at
+            return record
+
+    def invoke(self, command: Any, injected: tuple[Any, ...], kwargs: dict[str, Any], *, idempotency_key: str | None = None) -> Any:
+        if command.read_only or not self.config.enabled:
+            return command.leaf(*injected, **kwargs)
+        self.ensure_writer()
+        digest = hashlib.sha256(
+            json.dumps({"command": command.name, "kwargs": kwargs}, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        ).hexdigest()
+        assert self.idempotency is not None
+        return self.idempotency.run(idempotency_key, digest, lambda: command.leaf(*injected, **kwargs))
+
+    def status(self) -> dict[str, Any]:
+        base = {
+            "enabled": self.config.enabled,
+            "role": "standalone" if not self.config.enabled else "unknown",
+            "vault_id": self.config.vault_id,
+            "replica_id": self.config.replica_id,
+            "holder": None,
+            "expires_at": None,
+            "fencing_token": None,
+            "coordinator_healthy": True if not self.config.enabled else False,
+        }
+        if not self.config.enabled:
+            return base
+        assert self.client is not None
+        try:
+            record = self.client.status()
+        except OpError:
+            return base
+        base.update(
+            role="writer" if record.holder == self.config.replica_id else "follower",
+            holder=record.holder,
+            expires_at=record.expires_at,
+            fencing_token=record.fencing_token,
+            coordinator_healthy=True,
+        )
+        return base
+
+    def start_renewer(self) -> None:
+        if not self.config.enabled or self._renewer is not None:
+            return
+        self._renewer = threading.Thread(target=self._renew_loop, name="exomem-writer-lease", daemon=True)
+        self._renewer.start()
+
+    def _renew_loop(self) -> None:
+        interval = max(1.0, self.config.ttl_seconds / 3)
+        while not self._stop.wait(interval):
+            with self._lock:
+                token = self._fencing_token
+            if token is None or self.client is None:
+                continue
+            try:
+                record = self.client.renew(token)
+                with self._lock:
+                    if record.granted and record.holder == self.config.replica_id:
+                        self._expires_at = record.expires_at
+                    else:
+                        self._fencing_token = None
+                        self._expires_at = None
+            except OpError:
+                # Mutations still revalidate synchronously and fail closed.
+                continue
+
+    def close(self) -> None:
+        self._stop.set()
+        with self._lock:
+            token = self._fencing_token
+            self._fencing_token = None
+        if token is not None and self.client is not None:
+            try:
+                self.client.release(token)
+            except OpError:
+                pass
+
+
+_MANAGERS: dict[LeaseConfig, LeaseManager] = {}
+_MANAGERS_LOCK = threading.Lock()
+
+
+def get_manager() -> LeaseManager:
+    config = LeaseConfig.from_env()
+    with _MANAGERS_LOCK:
+        manager = _MANAGERS.get(config)
+        if manager is None:
+            manager = LeaseManager(config)
+            _MANAGERS[config] = manager
+        return manager
+
+
+def invoke_command(command: Any, *injected: Any, idempotency_key: str | None = None, **kwargs: Any) -> Any:
+    return get_manager().invoke(command, injected, kwargs, idempotency_key=idempotency_key)
+
+
+def coordination_status() -> dict[str, Any]:
+    return get_manager().status()
+
+
+def start_server_lifecycle() -> LeaseManager:
+    manager = get_manager()
+    if manager.config.enabled and manager.config.preferred_writer:
+        try:
+            manager.ensure_writer()
+        except OpError:
+            # Startup remains readable. Mutations will retry authoritatively.
+            pass
+    manager.start_renewer()
+    atexit.register(manager.close)
+    return manager
+
+
+def reset_managers_for_tests() -> None:
+    """Close and clear process globals; intentionally public for deterministic tests."""
+    with _MANAGERS_LOCK:
+        managers = list(_MANAGERS.values())
+        _MANAGERS.clear()
+    for manager in managers:
+        manager.close()

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -1,4 +1,12 @@
 {
+  "coordination_status": {
+    "description": "Report this replica's writer-lease role and coordinator health.\n\nRead-only and safe during coordinator outages. Credentials and vault content\nare never included.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    }
+  },
   "adopt_vault": {
     "description": "Adopt an existing vault safely without replacing originals.\n\nDefault mode scans only. Copy/compile modes write under the governed\nKnowledge Base layer and preserve original path/hash provenance.",
     "inputSchema": {

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem.cli_ops import OpError, http_status_for
+from exomem.lease_coordinator import SQLiteLeaseStore
+from exomem.writer_lease import LeaseConfig, LeaseManager, LeaseRecord
+
+
+def test_config_is_default_off_and_requires_identities() -> None:
+    assert LeaseConfig.from_env({}).enabled is False
+    with pytest.raises(ValueError, match="WRITER_LEASE_CONFIG"):
+        LeaseConfig.from_env({"EXOMEM_WRITER_LEASE_URL": "https://lease.example"})
+
+
+def test_config_loads_without_exposing_token_in_status(tmp_path: Path) -> None:
+    config = LeaseConfig.from_env(
+        {
+            "EXOMEM_WRITER_LEASE_URL": "https://lease.example/",
+            "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+            "EXOMEM_WRITER_LEASE_REPLICA_ID": "desktop",
+            "EXOMEM_WRITER_LEASE_TOKEN": "secret",
+            "EXOMEM_WRITER_LEASE_STATE_DIR": str(tmp_path),
+        }
+    )
+    manager = LeaseManager(config, client=FakeClient(LeaseRecord("desktop", 99, 7)))
+    status = manager.status()
+    assert status["role"] == "writer"
+    assert "secret" not in repr(status)
+    assert "url" not in status
+
+
+class FakeClient:
+    def __init__(self, record: LeaseRecord | Exception):
+        self.record = record
+        self.releases: list[int] = []
+
+    def _get(self) -> LeaseRecord:
+        if isinstance(self.record, Exception):
+            raise self.record
+        return self.record
+
+    def acquire(self) -> LeaseRecord:
+        record = self._get()
+        return LeaseRecord(record.holder, record.expires_at, record.fencing_token, record.holder == "desktop")
+
+    def status(self) -> LeaseRecord:
+        return self._get()
+
+    def renew(self, fencing_token: int) -> LeaseRecord:
+        return self.acquire()
+
+    def release(self, fencing_token: int) -> LeaseRecord:
+        self.releases.append(fencing_token)
+        return LeaseRecord(None, None, fencing_token, True)
+
+
+def _command(*, writes: bool, leaf):  # noqa: ANN001
+    return SimpleNamespace(name="mutate" if writes else "read", read_only=not writes, leaf=leaf)
+
+
+def _manager(tmp_path: Path, record: LeaseRecord | Exception) -> LeaseManager:
+    return LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=FakeClient(record),
+    )
+
+
+def test_reads_bypass_unavailable_coordinator(tmp_path: Path) -> None:
+    manager = _manager(tmp_path, OpError("WRITER_COORDINATOR_UNAVAILABLE", "down"))
+    assert manager.invoke(_command(writes=False, leaf=lambda value: value + 1), (), {"value": 2}) == 3
+
+
+def test_writer_executes_but_follower_and_outage_fail_closed(tmp_path: Path) -> None:
+    calls: list[str] = []
+    command = _command(writes=True, leaf=lambda: calls.append("write") or "ok")
+    assert _manager(tmp_path / "a", LeaseRecord("desktop", 99, 4)).invoke(command, (), {}) == "ok"
+    with pytest.raises(OpError, match="WRITER_LEASE_REQUIRED"):
+        _manager(tmp_path / "b", LeaseRecord("laptop", 99, 5)).invoke(command, (), {})
+    with pytest.raises(OpError, match="WRITER_COORDINATOR_UNAVAILABLE"):
+        _manager(tmp_path / "c", OpError("WRITER_COORDINATOR_UNAVAILABLE", "down")).invoke(command, (), {})
+    assert calls == ["write"]
+    assert http_status_for("WRITER_LEASE_REQUIRED") == 409
+    assert http_status_for("WRITER_COORDINATOR_UNAVAILABLE") == 503
+
+
+def test_idempotency_returns_saved_result_and_rejects_mismatch(tmp_path: Path) -> None:
+    calls: list[int] = []
+    manager = _manager(tmp_path, LeaseRecord("desktop", 99, 4))
+    command = _command(writes=True, leaf=lambda value: calls.append(value) or {"value": value})
+    assert manager.invoke(command, (), {"value": 1}, idempotency_key="request-1") == {"value": 1}
+    assert manager.invoke(command, (), {"value": 1}, idempotency_key="request-1") == {"value": 1}
+    with pytest.raises(OpError, match="IDEMPOTENCY_KEY_REUSED"):
+        manager.invoke(command, (), {"value": 2}, idempotency_key="request-1")
+    assert calls == [1]
+
+
+@dataclass
+class Clock:
+    value: float = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def test_sqlite_coordinator_exclusivity_expiry_takeover_and_fencing(tmp_path: Path) -> None:
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    desktop = store.acquire("main", "desktop", 10)
+    assert desktop["granted"] and desktop["fencing_token"] == 1
+    laptop = store.acquire("main", "laptop", 10)
+    assert not laptop["granted"] and laptop["holder"] == "desktop"
+
+    clock.value = 111
+    laptop = store.acquire("main", "laptop", 10)
+    assert laptop["granted"] and laptop["fencing_token"] == 2
+    stale = store.renew("main", "desktop", desktop["fencing_token"], 10)
+    assert not stale["granted"] and stale["holder"] == "laptop"
+
+
+def test_release_allows_immediate_takeover_and_vaults_are_independent(tmp_path: Path) -> None:
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite")
+    first = store.acquire("main", "desktop", 30)
+    assert store.acquire("other", "laptop", 30)["granted"]
+    assert store.release("main", "desktop", first["fencing_token"])["granted"]
+    assert store.acquire("main", "laptop", 30)["granted"]
+
+
+def test_coordination_status_is_a_read_only_public_command() -> None:
+    from exomem.commands import product_commands_for
+
+    for surface in ("mcp", "rest", "cli"):
+        command = next(c for c in product_commands_for(surface) if c.name == "coordination_status")
+        assert command.read_only


### PR DESCRIPTION
## Summary
- add an opt-in provider-neutral HTTP writer lease with fencing, renewal, release, and fail-closed mutation gating
- route MCP, REST, CLI, and upload writes through the same authority boundary while keeping reads available
- include a transactional SQLite reference coordinator, local retry idempotency, coordination status, and replication-agnostic deployment docs

## Verification
- 50 targeted tests passed
- touched-file Ruff passed
- OpenSpec strict validation passed
- full non-embedding suite was attempted; the existing latency gate exceeded the 5-minute harness timeout at 53% with no feature failure
- repo-wide Ruff retains pre-existing violations outside this diff