### PR TITLE
fix: restore fast reference enrichment

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -688,8 +688,11 @@ def op_find(
         else:
             hit_dicts = [h.as_dict() for h in hits]
         ref_index = memory_refs_module.ReferenceIndex(vault_root)
+        refs = ref_index.refs_for_paths(
+            [str(hit.get("path") or "") for hit in hit_dicts]
+        )
         for hit in hit_dicts:
-            ref = ref_index.ref_for_path(str(hit.get("path") or ""))
+            ref = refs.get(str(hit.get("path") or ""))
             if ref:
                 hit["ref"] = ref
     timings_dict = timings.as_dict() if timings is not None else None
@@ -2885,13 +2888,6 @@ def op_ask_memory(
         detail=detail,
         include_timings=include_timings,
     )
-    hits = result.get("hits", []) if isinstance(result, dict) else result
-    ref_index = memory_refs_module.ReferenceIndex(vault_root)
-    for hit in hits:
-        if isinstance(hit, dict) and hit.get("path"):
-            ref = ref_index.ref_for_path(str(hit["path"]))
-            if ref:
-                hit["ref"] = ref
     return result
 
 

--- a/src/exomem/memory_refs.py
+++ b/src/exomem/memory_refs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,9 +12,10 @@ from urllib.parse import unquote
 from . import vault as vault_module
 from .kbdir import kb_dirname
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 REF_PREFIX = "exomem://memory/"
 ID_FIELD = "exomem_id"
+_REFERENCE_REBUILD_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -215,25 +217,7 @@ class ReferenceIndex:
 
     def ref_for_path(self, path: str) -> str | None:
         clean = str(path or "").replace("\\", "/").lstrip("/")
-        if not self.available():
-            return _ref_for_path_from_scan(self.vault_root, clean)
-        conn = self._connect()
-        try:
-            row = conn.execute(
-                "SELECT exomem_id FROM identities "
-                "WHERE path = ? AND status = 'valid'",
-                (clean,),
-            ).fetchone()
-            if row is None:
-                return _ref_for_path_from_scan(self.vault_root, clean)
-            count = conn.execute(
-                "SELECT COUNT(*) FROM identities "
-                "WHERE exomem_id = ? AND status = 'valid'",
-                (row[0],),
-            ).fetchone()[0]
-        finally:
-            conn.close()
-        return memory_ref(str(row[0])) if count == 1 else None
+        return self.refs_for_paths([clean]).get(clean)
 
     def refs_for_paths(self, paths: list[str]) -> dict[str, str | None]:
         """Resolve many paths with one sidecar query or one Markdown scan."""
@@ -243,32 +227,43 @@ class ReferenceIndex:
             return {}
 
         if not self.available():
-            scan_rows = _scan_pages(self.vault_root)
-            by_id: dict[str, list[str]] = {}
-            id_by_path: dict[str, str] = {}
-            for path, exomem_id, _raw, _hash, status in scan_rows:
-                if status != "valid" or exomem_id is None:
-                    continue
-                by_id.setdefault(exomem_id, []).append(path)
-                id_by_path[path] = exomem_id
-            return {
-                path: (
-                    memory_ref(id_by_path[path])
-                    if path in id_by_path and len(by_id[id_by_path[path]]) == 1
-                    else None
-                )
-                for path in wanted
-            }
+            # Schema upgrades and first use rebuild once. The lock prevents a
+            # burst of concurrent reads from all scanning the corpus together.
+            with _REFERENCE_REBUILD_LOCK:
+                if not self.available():
+                    try:
+                        self.rebuild_all()
+                    except (OSError, sqlite3.Error):
+                        # A read-only vault still works, with one scan per batch.
+                        return _refs_for_paths_from_scan(self.vault_root, wanted)
 
+        resolved, indexed_paths = self._refs_from_index(wanted)
+        # Rows absent from the index may be new external files whose watcher
+        # event has not landed yet. Refresh only those exact paths; never turn
+        # an ordinary negative lookup into a full-corpus scan.
+        missing = [path for path in wanted if path not in indexed_paths]
+        if missing:
+            self.refresh_paths([self.vault_root / path for path in missing])
+            refreshed, _ = self._refs_from_index(missing)
+            resolved.update(refreshed)
+        return resolved
+
+    def _refs_from_index(
+        self, wanted: list[str]
+    ) -> tuple[dict[str, str | None], set[str]]:
         placeholders = ",".join("?" for _ in wanted)
         conn = self._connect()
         try:
             db_rows = conn.execute(
-                f"SELECT path, exomem_id FROM identities "  # noqa: S608 - placeholders only
-                f"WHERE status = 'valid' AND path IN ({placeholders})",
+                f"SELECT path, exomem_id, status FROM identities "  # noqa: S608
+                f"WHERE path IN ({placeholders})",
                 wanted,
             ).fetchall()
-            ids = {str(row[1]) for row in db_rows}
+            ids = {
+                str(row[1])
+                for row in db_rows
+                if str(row[2]) == "valid" and row[1] is not None
+            }
             duplicate_ids: set[str] = set()
             if ids:
                 id_placeholders = ",".join("?" for _ in ids)
@@ -283,30 +278,24 @@ class ReferenceIndex:
                 }
         finally:
             conn.close()
-        id_by_path = {str(path): str(exomem_id) for path, exomem_id in db_rows}
-        resolved = {
-            path: (
-                memory_ref(id_by_path[path])
-                if path in id_by_path and id_by_path[path] not in duplicate_ids
-                else None
-            )
-            for path in wanted
+        indexed_paths = {str(row[0]) for row in db_rows}
+        id_by_path = {
+            str(path): str(exomem_id)
+            for path, exomem_id, status in db_rows
+            if str(status) == "valid" and exomem_id is not None
         }
-        missing = [path for path, ref in resolved.items() if ref is None]
-        if missing:
-            scan_rows = _scan_pages(self.vault_root)
-            scan_by_id: dict[str, list[str]] = {}
-            scan_id_by_path: dict[str, str] = {}
-            for path, exomem_id, _raw, _hash, status in scan_rows:
-                if status != "valid" or exomem_id is None:
-                    continue
-                scan_by_id.setdefault(exomem_id, []).append(path)
-                scan_id_by_path[path] = exomem_id
-            for path in missing:
-                exomem_id = scan_id_by_path.get(path)
-                if exomem_id and len(scan_by_id[exomem_id]) == 1:
-                    resolved[path] = memory_ref(exomem_id)
-        return resolved
+        return (
+            {
+                path: (
+                    memory_ref(id_by_path[path])
+                    if path in id_by_path
+                    and id_by_path[path] not in duplicate_ids
+                    else None
+                )
+                for path in wanted
+            },
+            indexed_paths,
+        )
 
     def issues(self) -> list[dict[str, str]]:
         if not self.available():
@@ -510,16 +499,28 @@ def _duplicate_ids(conn: sqlite3.Connection) -> list[str]:
 
 
 def _ref_for_path_from_scan(vault_root: Path, clean_path: str) -> str | None:
+    return _refs_for_paths_from_scan(vault_root, [clean_path]).get(clean_path)
+
+
+def _refs_for_paths_from_scan(
+    vault_root: Path, wanted: list[str]
+) -> dict[str, str | None]:
     entries = _scan_pages(vault_root)
-    row = next(
-        (entry for entry in entries if entry[0] == clean_path and entry[4] == "valid"),
-        None,
-    )
-    if row is None or row[1] is None:
-        return None
-    if sum(1 for entry in entries if entry[1] == row[1] and entry[4] == "valid") != 1:
-        return None
-    return memory_ref(row[1])
+    by_id: dict[str, list[str]] = {}
+    id_by_path: dict[str, str] = {}
+    for path, exomem_id, _raw, _hash, status in entries:
+        if status != "valid" or exomem_id is None:
+            continue
+        by_id.setdefault(exomem_id, []).append(path)
+        id_by_path[path] = exomem_id
+    return {
+        path: (
+            memory_ref(id_by_path[path])
+            if path in id_by_path and len(by_id[id_by_path[path]]) == 1
+            else None
+        )
+        for path in wanted
+    }
 
 
 def _relative_markdown(vault_root: Path, path: Path) -> str | None:
@@ -545,11 +546,9 @@ def _read_identity(vault_root: Path, path: Path) -> tuple[str, str | None, str, 
         return None
     fm, _, _ = vault_module.parse_frontmatter(raw)
     value = fm.get(ID_FIELD)
-    if value is None:
-        return None
-    raw_id = str(value)
+    raw_id = "" if value is None else str(value)
     normalized = normalize_id(value)
-    status = "valid" if normalized else "malformed"
+    status = "missing" if value is None else ("valid" if normalized else "malformed")
     return rel, normalized, raw_id, vault_module.content_hash(raw), status
 
 

--- a/tests/test_memory_refs.py
+++ b/tests/test_memory_refs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import yaml
@@ -40,7 +41,7 @@ def test_reference_round_trip_and_incremental_move(tmp_path: Path) -> None:
     assert index.resolve(identity) == "Knowledge Base/Notes/new.md"
 
 
-def test_bulk_reference_lookup_uses_index_and_scans_missing_paths(tmp_path: Path) -> None:
+def test_bulk_reference_lookup_uses_index_and_refreshes_only_missing_paths(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     notes = vault / "Knowledge Base" / "Notes"
     notes.mkdir(parents=True)
@@ -64,6 +65,130 @@ def test_bulk_reference_lookup_uses_index_and_scans_missing_paths(tmp_path: Path
         second_path: memory_refs.memory_ref(second_id),
         "missing.md": None,
     }
+
+
+def test_legacy_negative_reference_is_indexed_without_repeat_scan(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault"
+    legacy_path = "Knowledge Base/Notes/legacy.md"
+    legacy = vault / legacy_path
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(_page(None), encoding="utf-8")
+
+    calls = 0
+    original_scan = memory_refs._scan_pages
+
+    def counted_scan(root: Path):
+        nonlocal calls
+        calls += 1
+        return original_scan(root)
+
+    monkeypatch.setattr(memory_refs, "_scan_pages", counted_scan)
+    index = memory_refs.ReferenceIndex(vault)
+
+    assert index.refs_for_paths([legacy_path]) == {legacy_path: None}
+    assert index.refs_for_paths([legacy_path]) == {legacy_path: None}
+    assert index.ref_for_path(legacy_path) is None
+    assert calls == 1
+
+
+def test_bulk_reference_lookup_does_not_scan_per_result(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault"
+    notes = vault / "Knowledge Base" / "Notes"
+    notes.mkdir(parents=True)
+    paths = []
+    for number in range(30):
+        path = notes / f"legacy-{number}.md"
+        path.write_text(_page(None), encoding="utf-8")
+        paths.append(path.relative_to(vault).as_posix())
+
+    calls = 0
+    original_scan = memory_refs._scan_pages
+
+    def counted_scan(root: Path):
+        nonlocal calls
+        calls += 1
+        return original_scan(root)
+
+    monkeypatch.setattr(memory_refs, "_scan_pages", counted_scan)
+    index = memory_refs.ReferenceIndex(vault)
+
+    assert all(ref is None for ref in index.refs_for_paths(paths).values())
+    assert all(ref is None for ref in index.refs_for_paths(paths).values())
+    assert calls == 1
+
+
+def test_concurrent_reference_lookup_shares_initial_rebuild(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault"
+    legacy_path = "Knowledge Base/Notes/legacy.md"
+    legacy = vault / legacy_path
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(_page(None), encoding="utf-8")
+
+    calls = 0
+    original_scan = memory_refs._scan_pages
+
+    def counted_scan(root: Path):
+        nonlocal calls
+        calls += 1
+        return original_scan(root)
+
+    monkeypatch.setattr(memory_refs, "_scan_pages", counted_scan)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(
+            pool.map(
+                lambda _: memory_refs.ReferenceIndex(vault).ref_for_path(legacy_path),
+                range(16),
+            )
+        )
+
+    assert results == [None] * 16
+    assert calls == 1
+
+
+def test_legacy_negative_reference_refreshes_when_identity_is_added(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    legacy_path = "Knowledge Base/Notes/legacy.md"
+    legacy = vault / legacy_path
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(_page(None), encoding="utf-8")
+    index = memory_refs.ReferenceIndex(vault)
+
+    assert index.ref_for_path(legacy_path) is None
+    identity = memory_refs.new_id()
+    legacy.write_text(_page(identity), encoding="utf-8")
+    index.refresh_paths([legacy])
+
+    assert index.ref_for_path(legacy_path) == memory_refs.memory_ref(identity)
+
+
+def test_ask_memory_enriches_references_once(vault: Path, monkeypatch) -> None:
+    calls = 0
+    original = memory_refs.ReferenceIndex.refs_for_paths
+
+    def counted(self, paths: list[str]):
+        nonlocal calls
+        calls += 1
+        return original(self, paths)
+
+    monkeypatch.setattr(memory_refs.ReferenceIndex, "refs_for_paths", counted)
+
+    commands.op_ask_memory(
+        vault,
+        query="metabolism",
+        mode="keyword",
+        limit=5,
+        detail="compact",
+    )
+
+    assert calls == 1
 
 
 def test_duplicate_and_malformed_ids_are_diagnostic_and_self_healing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- batch stable-reference enrichment once per result set
- index legacy pages as negative reference entries instead of rescanning the vault
- serialize concurrent first-use rebuilds and target-refresh only genuinely new paths
- remove the duplicate ask_memory enrichment pass

## Verification
- 48 focused memory-reference, REST, and CLI tests pass
- ruff passes on changed files
- real 2,228-note desktop-vault copy: warm ask_memory 5/15 hits ~0.50-0.51s; reference serialization ~1.3-1.7ms (previously 2.7-17.6s)
- full suite reached 52% with no failures before the existing dense-vault latency test timed out while building its BM25 fixture (unrelated stack)