### PR TITLE
fix: flush MCP SSE sessions immediately

### DIFF
--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.server.middleware.middleware import Middleware, MiddlewareContext
+from starlette.middleware import Middleware as ASGIMiddleware
 
 from . import commands as commands_module
 from . import guards
@@ -31,6 +32,7 @@ from .server_auth import (  # noqa: F401 - re-exported for compatibility
 from .server_rest import register_rest_facade
 from .server_runtime import initialize_runtime
 from .server_transfer import register_transfer_routes
+from .server_transport import PrimeMcpSSEMiddleware
 
 log = logging.getLogger(__name__)
 _call_log = logging.getLogger("exomem.calls")
@@ -255,4 +257,9 @@ def run(
     else:
         host = os.environ.get("EXOMEM_HOST") or host or "127.0.0.1"
         log.info("exomem starting on %s host=%s port=%s", transport, host, port)
-        mcp.run(transport=transport, host=host, port=port)
+        mcp.run(
+            transport=transport,
+            host=host,
+            port=port,
+            middleware=[ASGIMiddleware(PrimeMcpSSEMiddleware)],
+        )

--- a/src/exomem/server_transport.py
+++ b/src/exomem/server_transport.py
@@ -1,0 +1,69 @@
+"""Transport-level ASGI behavior for the public MCP endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+ASGIMessage = dict[str, Any]
+Receive = Callable[[], Awaitable[ASGIMessage]]
+Send = Callable[[ASGIMessage], Awaitable[None]]
+
+_SSE_CONTENT_TYPE = b"text/event-stream"
+_INITIAL_SSE_COMMENT = b": stream-ready\r\n\r\n"
+
+
+class PrimeMcpSSEMiddleware:
+    """Flush the standalone MCP SSE stream before its first keepalive.
+
+    Some reverse proxies buffer an SSE response until body bytes arrive. The
+    SDK's standalone GET stream is initially idle and its first ping is 15
+    seconds later, which can serialize an authenticated client's first request
+    behind that wait. An SSE comment is protocol-neutral and forces an
+    immediate flush without becoming an MCP message.
+    """
+
+    def __init__(self, app: Any, *, path: str = "/mcp") -> None:
+        self.app = app
+        self.path = path.rstrip("/") or "/"
+
+    async def __call__(self, scope: ASGIMessage, receive: Receive, send: Send) -> None:
+        if not self._is_standalone_stream(scope):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_prime(message: ASGIMessage) -> None:
+            await send(message)
+            if message.get("type") != "http.response.start":
+                return
+            if int(message.get("status", 0)) != 200:
+                return
+            headers = message.get("headers") or []
+            content_type = next(
+                (value for name, value in headers if name.lower() == b"content-type"),
+                b"",
+            )
+            if _SSE_CONTENT_TYPE not in content_type.lower():
+                return
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": _INITIAL_SSE_COMMENT,
+                    "more_body": True,
+                }
+            )
+
+        await self.app(scope, receive, send_with_prime)
+
+    def _is_standalone_stream(self, scope: ASGIMessage) -> bool:
+        if scope.get("type") != "http" or scope.get("method") != "GET":
+            return False
+        request_path = str(scope.get("path") or "").rstrip("/") or "/"
+        if request_path != self.path:
+            return False
+        headers = scope.get("headers") or []
+        accept = next(
+            (value for name, value in headers if name.lower() == b"accept"),
+            b"",
+        )
+        return _SSE_CONTENT_TYPE in accept.lower()

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+
+from exomem.server_transport import PrimeMcpSSEMiddleware
+
+
+async def _receive() -> dict:
+    return {"type": "http.disconnect"}
+
+
+def test_mcp_get_sse_is_primed_immediately() -> None:
+    async def scenario() -> list[dict]:
+        sent: list[dict] = []
+
+        async def capture(message: dict) -> None:
+            sent.append(message)
+
+        async def app(scope, receive, send) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream; charset=utf-8")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"data: later\r\n\r\n"})
+
+        middleware = PrimeMcpSSEMiddleware(app)
+        await middleware(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/mcp",
+                "headers": [(b"accept", b"text/event-stream")],
+            },
+            _receive,
+            capture,
+        )
+        return sent
+
+    sent = asyncio.run(scenario())
+
+    assert [message["type"] for message in sent] == [
+        "http.response.start",
+        "http.response.body",
+        "http.response.body",
+    ]
+    assert sent[1] == {
+        "type": "http.response.body",
+        "body": b": stream-ready\r\n\r\n",
+        "more_body": True,
+    }
+
+
+def test_non_sse_or_failed_response_is_not_primed() -> None:
+    async def run(scope: dict, *, status: int, content_type: bytes) -> list[dict]:
+        sent: list[dict] = []
+
+        async def capture(message: dict) -> None:
+            sent.append(message)
+
+        async def app(inner_scope, receive, send) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": status,
+                    "headers": [(b"content-type", content_type)],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"original"})
+
+        await PrimeMcpSSEMiddleware(app)(scope, _receive, capture)
+        return sent
+
+    base = {
+        "type": "http",
+        "method": "GET",
+        "path": "/mcp",
+        "headers": [(b"accept", b"text/event-stream")],
+    }
+    assert len(asyncio.run(run(base, status=401, content_type=b"text/event-stream"))) == 2
+    assert len(asyncio.run(run(base, status=200, content_type=b"application/json"))) == 2
+    assert len(
+        asyncio.run(
+            run(
+                {**base, "method": "POST"},
+                status=200,
+                content_type=b"text/event-stream",
+            )
+        )
+    ) == 2


### PR DESCRIPTION
## Summary
- send an immediate protocol-neutral SSE comment on authenticated standalone MCP GET streams
- force reverse proxies to flush the stream instead of waiting for sse-starlette's 15-second default ping
- leave POSTs, errors, non-SSE responses, REST, and tool schemas unchanged

## Measured cause
- public authenticated reconnect/initialize: 42-56 ms
- first tools/list on every fresh session: 15.108-15.123 s
- second tools/list: 42-55 ms
- Exomem in-process tools/list: 1.1-4.2 ms
- server log shows the first public ListToolsRequest arriving only after the 15-second gap
- sse-starlette EventSourceResponse.DEFAULT_PING_INTERVAL is exactly 15 seconds

## Verification
- 21 focused transport/server tests pass
- ruff and diff checks pass
- public OAuth benchmark will be repeated after deployment using the same persisted benchmark token