### PR TITLE
fix: normalize piped Worker secrets

### DIFF
--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -223,5 +223,5 @@ function stateValue(body) {
 
 function authorized(request, expected) {
   if (!expected) return false;
-  return request.headers.get("authorization") === `Bearer ${expected}`;
+  return request.headers.get("authorization") === `Bearer ${String(expected).trim()}`;
 }

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -73,3 +73,21 @@ test("edge rejects unauthenticated coordinator access", async () => {
   const response = await worker.fetch(post("/v1/vaults/main/lease/acquire", { replica_id: "desktop", ttl_seconds: 30 }), env);
   assert.equal(response.status, 401);
 });
+
+test("edge accepts a piped Worker secret with trailing transport whitespace", async () => {
+  const request = post("/v1/vaults/main/lease/acquire", {
+    replica_id: "desktop",
+    ttl_seconds: 30,
+  });
+  request.headers.set("authorization", "Bearer secret");
+  const env = {
+    STATE_TOKEN: "secret\r\n",
+    EXOMEM_STATE: {
+      idFromName: (name) => name,
+      get: () => ({ fetch: async () => new Response('{"granted":true}') }),
+    },
+  };
+  const response = await worker.fetch(request, env);
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).granted, true);
+});


### PR DESCRIPTION
PowerShell pipelines can preserve trailing CRLF in Wrangler secrets. Trim transport whitespace before exact bearer comparison and cover the production-shaped case.

Verified with Node syntax check and 4 Worker tests.