### PR TITLE
ci: test Python compatibility boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # Compatibility boundaries are sufficient here: 3.11 is the minimum
+        # supported runtime and 3.13 is the newest. Testing the middle release
+        # duplicated the full lean suite without expanding the support range.
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv


### PR DESCRIPTION
Run the lean suite on the supported minimum and maximum runtimes (3.11 and 3.13). Python 3.12 remains supported but no longer duplicates the full matrix in the middle of the tested range.