### PR TITLE
fix: stop forcing OAuth session expiry

### DIFF
--- a/openspec/changes/remove-forced-oauth-expiry/.openspec.yaml
+++ b/openspec/changes/remove-forced-oauth-expiry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/remove-forced-oauth-expiry/design.md
+++ b/openspec/changes/remove-forced-oauth-expiry/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`build_oauth()` constructs FastMCP's `OAuthProxy` over a GitHub OAuth App. GitHub OAuth App access tokens normally omit both `expires_in` and `refresh_token`. FastMCP already detects that shape and selects its no-refresh fallback, but Exomem currently overrides the decision with `fallback_access_token_expiry_seconds=30 * 24 * 60 * 60`. The resulting FastMCP access token expires after 30 days with no refresh token available, forcing users through reauthorization.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove Exomem's arbitrary 30-day session cutoff.
+- Preserve FastMCP's upstream-aware handling when an identity provider supplies expiry or refresh metadata.
+- Lock the behavior with a focused construction-level regression test.
+
+**Non-Goals:**
+
+- Change the canonical MCP hostname or OAuth callback.
+- Replace GitHub OAuth, patch FastMCP internals, or migrate existing client tokens.
+- Make expired app links recoverable inside ChatGPT/Codex; one clean reconnect remains necessary.
+
+## Decisions
+
+Pass no `fallback_access_token_expiry_seconds` argument to `OAuthProxy`. This is preferable to replacing 30 days with another Exomem-owned constant: FastMCP's default explicitly distinguishes upstream expiry, refresh-capable providers, and non-refreshable token providers such as GitHub OAuth Apps.
+
+Test the constructor call by replacing `OAuthProxy` with a recording stub and asserting that the fallback override is absent while stable signing and shared storage inputs remain intact. This avoids binding the test to FastMCP's private token-exchange implementation.
+
+Keep public deployment documentation generic. The personal production hostname is operational configuration, not a value that belongs under `src/exomem/` or the shipped scaffold; user-facing diagnosis should nevertheless use `https://exomem.substratesystems.io` for this deployment.
+
+## Risks / Trade-offs
+
+- [Longer-lived downstream token when GitHub supplies no refresh token] → FastMCP's no-refresh default is intentionally designed for this provider shape; GitHub revocation and Exomem's verifier still gate access.
+- [Existing expired sessions remain broken] → document that deployment fixes newly issued sessions and requires one fresh reconnect.
+- [A future FastMCP default changes] → the design intentionally delegates provider policy upstream; tests assert absence of an Exomem override rather than pinning FastMCP's current duration.

--- a/openspec/changes/remove-forced-oauth-expiry/proposal.md
+++ b/openspec/changes/remove-forced-oauth-expiry/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Exomem currently overrides FastMCP's provider-aware OAuth lifetime with a forced 30-day access-token expiry. GitHub OAuth Apps do not issue refresh tokens, so otherwise healthy ChatGPT/Codex connections become unrecoverable on that schedule and fall into a broken reauthentication flow.
+
+## What Changes
+
+- Stop forcing a 30-day fallback lifetime in the GitHub OAuth proxy.
+- Let FastMCP choose its provider-aware fallback: upstream `expires_in` when supplied, refresh-aware behavior when available, and its long-lived no-refresh fallback for GitHub OAuth App tokens.
+- Add regression coverage that rejects reintroducing a fixed fallback expiry.
+- Document `https://exomem.substratesystems.io` as the canonical deployed host while keeping deployment examples generic.
+
+## Capabilities
+
+### New Capabilities
+
+- `oauth-session-longevity`: Remote OAuth sessions inherit provider-aware token lifetime and refresh behavior instead of an Exomem-imposed recurring expiry.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Affected areas are `src/exomem/server_auth.py`, OAuth unit tests, and remote deployment documentation. There are no MCP, CLI, REST, vault-format, or dependency changes. Existing expired client connections still require one clean reconnect; newly issued sessions no longer inherit Exomem's forced 30-day cutoff.

--- a/openspec/changes/remove-forced-oauth-expiry/specs/oauth-session-longevity/spec.md
+++ b/openspec/changes/remove-forced-oauth-expiry/specs/oauth-session-longevity/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: OAuth session lifetime follows provider capabilities
+The system SHALL construct the remote OAuth proxy without imposing an Exomem-specific fallback access-token expiry, allowing the OAuth implementation to select lifetime and refresh behavior from the upstream token response.
+
+#### Scenario: GitHub OAuth token has no refresh metadata
+- **WHEN** the upstream GitHub OAuth token response omits `expires_in` and `refresh_token`
+- **THEN** Exomem does not force the downstream connection to expire after 30 days
+- **AND** the OAuth implementation's no-refresh fallback policy applies
+
+#### Scenario: Upstream provider supplies expiry or refresh metadata
+- **WHEN** the upstream token response supplies an expiry or refresh token
+- **THEN** the OAuth implementation uses that provider metadata without an Exomem fallback overriding it
+
+### Requirement: Existing authentication safeguards remain intact
+The system SHALL preserve the configured GitHub account verifier, stable JWT signing key, and optional shared OAuth storage when removing the forced expiry.
+
+#### Scenario: Authenticated remote server is constructed
+- **WHEN** required GitHub and Exomem authentication settings are present
+- **THEN** the proxy retains the single-user verifier and existing signing/storage configuration
+- **AND** only the fixed fallback-expiry override is absent

--- a/openspec/changes/remove-forced-oauth-expiry/tasks.md
+++ b/openspec/changes/remove-forced-oauth-expiry/tasks.md
@@ -1,0 +1,14 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a focused OAuth construction test proving no fixed fallback access-token expiry is passed.
+- [x] 1.2 Preserve assertions for the existing verifier, signing key, and shared-storage wiring.
+
+## 2. OAuth Lifetime Fix
+
+- [x] 2.1 Remove Exomem's forced 30-day `fallback_access_token_expiry_seconds` override.
+- [x] 2.2 Add a concise code comment explaining why provider-aware FastMCP behavior is required for GitHub OAuth Apps.
+
+## 3. Verification
+
+- [x] 3.1 Run focused OAuth tests and Ruff on changed Python files.
+- [x] 3.2 Run strict OpenSpec validation and the lean test suite in proportion to the change.

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -161,6 +161,10 @@ def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
             raise_on_decryption_error=False,
         )
 
+    # Do not impose a fallback access-token lifetime here. GitHub OAuth Apps
+    # normally issue long-lived access tokens without refresh tokens; forcing a
+    # shorter downstream expiry creates an unrecoverable refresh gap. FastMCP
+    # already selects provider-aware defaults from the upstream token response.
     return OAuthProxy(
         upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
         upstream_token_endpoint="https://github.com/login/oauth/access_token",
@@ -170,5 +174,4 @@ def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
         base_url=base_url,
         jwt_signing_key=jwt_signing_key,
         client_storage=client_storage,
-        fallback_access_token_expiry_seconds=30 * 24 * 60 * 60,
     )

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from exomem import server_auth
+
+
+def test_build_oauth_delegates_token_lifetime_to_fastmcp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    for key, value in {
+        "GITHUB_CLIENT_ID": "client",
+        "GITHUB_CLIENT_SECRET": "secret",
+        "EXOMEM_GITHUB_USERNAME": "person",
+        "EXOMEM_JWT_SIGNING_KEY": "stable-signing-key",
+        "EXOMEM_OAUTH_STORAGE_URL": "https://coordinator.example",
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE": "vault",
+        "EXOMEM_OAUTH_STORAGE_TOKEN": "state-token",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    from fastmcp import settings
+
+    monkeypatch.setattr(settings, "home", tmp_path)
+    captured: dict[str, Any] = {}
+
+    class RecordingOAuthProxy:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(server_auth, "OAuthProxy", RecordingOAuthProxy)
+
+    result = server_auth.build_oauth(
+        require_auth=True,
+        base_url="https://memory.example",
+    )
+
+    assert isinstance(result, RecordingOAuthProxy)
+    assert "fallback_access_token_expiry_seconds" not in captured
+    assert captured["jwt_signing_key"] == "stable-signing-key"
+    assert isinstance(captured["token_verifier"], server_auth.SingleUserGitHubVerifier)
+    assert captured["token_verifier"]._allowed_login == "person"
+    assert captured["client_storage"] is not None


### PR DESCRIPTION
## Summary

- remove Exomem's forced 30-day FastMCP access-token fallback
- delegate access lifetime and refresh behavior to FastMCP's upstream-aware policy
- preserve GitHub account verification, stable JWT signing, and shared OAuth storage
- add a constructor-level regression test and OpenSpec contract

## Why

GitHub OAuth Apps normally issue long-lived access tokens without refresh tokens. Exomem's 30-day override therefore expired otherwise healthy ChatGPT/Codex connections without giving clients a usable refresh path.

Existing expired connections still need one clean reconnect. Newly issued sessions no longer inherit Exomem's arbitrary 30-day cutoff.

## Testing

- 42 OAuth, shared-storage, remote-probe, and setup-wizard tests pass
- Ruff passes on changed Python files
- strict OpenSpec validation passes; 6/6 tasks complete
- repo-wide local suite reaches the existing FastMCP/Starlette `TestClient` timeout at `tests/test_bootstrap.py::test_bootstrap_is_registry_generated_on_public_surfaces` before assertions; CI remains the clean full-suite gate
