### PR TITLE
fix: make MCP mutations retry-safe

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -393,6 +393,16 @@ REST callers can attach `Idempotency-Key`; CLI callers can set
 `EXOMEM_IDEMPOTENCY_KEY` for retry-safe mutations. Idempotency records and lease
 credentials stay in per-machine runtime state, outside the synced vault.
 
+MCP clients do not currently provide a caller-controlled idempotency header. Exomem
+therefore replays a successful mutation when the same authenticated bearer repeats
+the exact command and arguments within 60 seconds. This bounded guard covers the
+common "commit succeeded but the acknowledgement was lost" retry without changing
+tool result shapes or suppressing later intentional calls. The credential is hashed
+before it contributes to the local cache key and is never stored or logged. Replay
+state is per replica: the lease prevents concurrent writers, but a retry routed to a
+different replica after the first replica disappears cannot be guaranteed exactly-once
+across the local-filesystem/remote-coordinator boundary.
+
 Both replicas must also use the same stable `EXOMEM_BASE_URL`, GitHub OAuth client
 ID/secret, and `EXOMEM_JWT_SIGNING_KEY`. FastMCP access tokens are reference tokens,
 so the signing key alone is not enough: the shared OAuth store carries their JTI

--- a/openspec/changes/make-mcp-mutations-retry-safe/.openspec.yaml
+++ b/openspec/changes/make-mcp-mutations-retry-safe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/make-mcp-mutations-retry-safe/design.md
+++ b/openspec/changes/make-mcp-mutations-retry-safe/design.md
@@ -1,0 +1,53 @@
+## Context
+
+FastMCP tool calls currently reach the shared command leaf through `bind_vault`, but that adapter supplies no idempotency key. If an authenticated MCP client loses a successful acknowledgement and repeats identical arguments, the writer lease correctly authorizes both calls and additive commands create duplicates. The existing SQLite idempotency store is durable but only used when REST or CLI callers explicitly supply a key, and only while lease coordination is enabled.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replay successful, identical MCP mutation results when the same authenticated client retries promptly.
+- Keep failed calls retryable and intentional later repetitions executable.
+- Preserve the existing response schema and explicit idempotency contract.
+- Apply explicit and implicit idempotency in standalone as well as coordinated deployments.
+
+**Non-Goals:**
+
+- Promise distributed exactly-once filesystem transactions across a replica crash at every possible instruction boundary.
+- Deduplicate read operations or calls from different authenticated principals.
+- Store vault content or mutation results in the lease coordinator.
+
+## Decisions
+
+### Derive an implicit key from authenticated principal, command, and arguments
+
+The MCP adapter will hash the bearer credential (never persist the credential itself) to create a caller scope. The lease manager will combine that scope with its existing canonical command/argument digest. This catches a retry even if FastMCP allocates a new JSON-RPC request ID or MCP session after a lost acknowledgement. If no bearer credential is available, the adapter falls back to FastMCP's session ID; outside MCP it supplies no implicit scope.
+
+Using only request ID was rejected because a retry may receive a new ID. Global argument-only deduplication was rejected because one user's call could suppress another's.
+
+### Use a bounded implicit retry window
+
+Implicit completed entries expire after 60 seconds. Exact repeats within that window replay the stored result; after it they execute normally. Explicit idempotency keys retain their existing durable semantics and mismatch protection. Failed operations remove their pending entry immediately and are never cached.
+
+An unbounded implicit cache was rejected because identical user-intended actions must remain possible. A very short transport-only window was rejected because agent retries can include model/tool round trips.
+
+### Reuse the local durable SQLite store
+
+The existing per-replica idempotency store will support expiring implicit entries and work even when writer leasing is disabled. Results remain in trusted local runtime state, outside the synced vault. Replay emits an informational log without altering the returned leaf result.
+
+Remote shared result storage was rejected for this change because it would export serialized mutation results, expand the coordinator contract, and still could not make a local filesystem mutation and remote acknowledgement atomic. The writer lease continues to provide cross-replica exclusion; this change addresses the observed same-writer acknowledgement-loss retry.
+
+## Risks / Trade-offs
+
+- [A user intentionally repeats exactly the same mutation within 60 seconds] → The second call replays; callers needing deliberate rapid repetition can vary the operation input or use a later call after the bounded window.
+- [A retry lands on another replica after the first replica disappears] → Per-replica replay state cannot prove the first local commit; the lease prevents concurrency but distributed exactly-once semantics remain a documented non-goal.
+- [Bearer credentials appear in runtime state] → Only a one-way SHA-256 scope digest is persisted as part of another hashed key; raw credentials are never logged or stored.
+- [SQLite accumulates expired implicit rows] → Opportunistically prune expired implicit entries during mutation calls.
+
+## Migration Plan
+
+Ship as an in-place runtime behavior improvement with no vault migration. Restart Exomem to load it. Rollback restores the previous invocation behavior; the local SQLite table remains schema-compatible.
+
+## Open Questions
+
+None for this scoped fix.

--- a/openspec/changes/make-mcp-mutations-retry-safe/proposal.md
+++ b/openspec/changes/make-mcp-mutations-retry-safe/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+An MCP client can lose or misclassify a successful mutation response and retry the same tool call. Exomem currently commits each retry independently when MCP supplies no explicit idempotency key, producing duplicate notes and misleading `NOT_FOUND` errors after successful deletes.
+
+## What Changes
+
+- Make retried MCP mutations replay the original result instead of executing the filesystem mutation again.
+- Scope implicit retry detection narrowly by caller session, command, and canonical arguments, with a bounded lifetime so intentional later repetitions still execute.
+- Preserve explicit `Idempotency-Key` behavior for REST and CLI callers as the stronger caller-controlled contract.
+- Make replay decisions observable in server logs and tests without changing tool result shapes or storing vault content in coordination services.
+
+## Capabilities
+
+### New Capabilities
+
+- `retry-safe-mutations`: Bounded, session-scoped deduplication and result replay for ambiguous MCP mutation retries.
+
+### Modified Capabilities
+
+<!-- None. -->
+
+## Impact
+
+- MCP command registration and invocation context
+- Writer-lease idempotency storage and replay behavior
+- Mutation regression tests across save and delete operations
+- Deployment/runtime state only; no vault schema or external dependency changes

--- a/openspec/changes/make-mcp-mutations-retry-safe/specs/retry-safe-mutations/spec.md
+++ b/openspec/changes/make-mcp-mutations-retry-safe/specs/retry-safe-mutations/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Prompt MCP retries replay successful mutations
+The system SHALL detect a successful mutation repeated through MCP by the same authenticated principal with the same command and canonical arguments within a bounded retry window, and SHALL return the original result without executing the mutation leaf again.
+
+#### Scenario: Lost save acknowledgement is retried
+- **WHEN** an authenticated MCP client repeats an identical successful additive save within the retry window
+- **THEN** the system returns the first save result and creates only one vault artifact
+
+#### Scenario: Lost delete acknowledgement is retried
+- **WHEN** an authenticated MCP client repeats an identical successful delete within the retry window
+- **THEN** the system returns the first delete result instead of executing a second delete that reports `NOT_FOUND`
+
+### Requirement: Implicit retry detection is narrowly scoped and bounded
+The system MUST scope implicit retry detection to the authenticated caller when available, MUST compare canonical command arguments, and MUST expire implicit completed entries after 60 seconds. Calls from another authenticated principal or after the window SHALL execute normally.
+
+#### Scenario: Different principals submit identical mutations
+- **WHEN** two authenticated principals submit the same command and arguments within 60 seconds
+- **THEN** neither principal's call suppresses the other's mutation
+
+#### Scenario: Intentional later repetition
+- **WHEN** the same principal repeats identical mutation arguments after 60 seconds
+- **THEN** the mutation leaf executes again
+
+### Requirement: Failed mutations remain retryable
+The system SHALL NOT cache a failed mutation as a successful replay result and SHALL remove its pending implicit entry so a later identical call can execute.
+
+#### Scenario: First attempt fails before completion
+- **WHEN** an implicitly keyed MCP mutation raises an error and the client retries it
+- **THEN** the retry executes the mutation leaf instead of replaying the error
+
+### Requirement: Explicit idempotency remains authoritative across surfaces
+The system SHALL preserve durable caller-supplied idempotency keys and mismatch rejection for REST and CLI callers, and SHALL honor them whether or not writer-lease coordination is enabled.
+
+#### Scenario: Standalone REST retry with explicit key
+- **WHEN** a standalone deployment receives two identical mutations with the same explicit idempotency key
+- **THEN** it executes the mutation once and replays the saved result
+
+#### Scenario: Explicit key reused with different input
+- **WHEN** a caller reuses an explicit idempotency key for different canonical arguments
+- **THEN** the system rejects the call with `IDEMPOTENCY_KEY_REUSED`

--- a/openspec/changes/make-mcp-mutations-retry-safe/tasks.md
+++ b/openspec/changes/make-mcp-mutations-retry-safe/tasks.md
@@ -1,0 +1,18 @@
+## 1. Retry Semantics Tests
+
+- [x] 1.1 Add unit tests for bounded implicit replay, expiry, principal isolation, and failure retry
+- [x] 1.2 Add regression coverage for explicit idempotency when writer leasing is disabled
+- [x] 1.3 Add MCP adapter tests proving bearer-derived scope without credential leakage
+
+## 2. Core Implementation
+
+- [x] 2.1 Extend the durable idempotency store with expiring implicit entries and opportunistic cleanup
+- [x] 2.2 Apply idempotency to standalone mutations while preserving lease gating for coordinated deployments
+- [x] 2.3 Derive and pass an authenticated MCP retry scope from the FastMCP request context
+- [x] 2.4 Log implicit replay decisions without changing tool result shapes
+
+## 3. Verification and Documentation
+
+- [x] 3.1 Run focused retry, command-surface, REST, and writer-lease tests
+- [x] 3.2 Run Ruff and the full non-embedding test suite
+- [x] 3.3 Document bounded MCP retry behavior and its cross-replica limitation

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import types
 import typing
@@ -142,7 +143,12 @@ def bind_vault(
             return leaf(*injected, **kwargs)
         from .writer_lease import invoke_command
 
-        return invoke_command(command, *injected, **kwargs)
+        return invoke_command(
+            command,
+            *injected,
+            implicit_idempotency_scope=(None if command.read_only else mcp_retry_scope()),
+            **kwargs,
+        )
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
     wrapper.__name__ = name or leaf.__name__
@@ -157,6 +163,22 @@ def bind_vault(
         ann["return"] = resolved["return"]
     wrapper.__annotations__ = ann
     return wrapper
+
+
+def mcp_retry_scope() -> str | None:
+    """Return a credential-safe caller scope for bounded MCP retry replay."""
+    try:
+        from fastmcp.server.dependencies import get_context, get_http_headers
+
+        headers = get_http_headers(include={"authorization"})
+        authorization = headers.get("authorization", "").strip()
+        scheme, separator, credential = authorization.partition(" ")
+        if separator and scheme.lower() == "bearer" and credential.strip():
+            digest = hashlib.sha256(credential.strip().encode("utf-8")).hexdigest()
+            return f"bearer:{digest}"
+        return f"session:{get_context().session_id}"
+    except (LookupError, RuntimeError):
+        return None
 
 
 def _annotate_description(annotation: object, description: str) -> object:

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import hashlib
 import json
+import logging
 import os
 import pickle
 import sqlite3
@@ -28,6 +29,8 @@ from .cli_ops import OpError
 _COORDINATOR_USER_AGENT = (
     "Mozilla/5.0 (compatible; Exomem-Coordinator/1.0; +https://github.com/Artexis10/exomem)"
 )
+_IMPLICIT_RETRY_TTL_SECONDS = 60.0
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -181,8 +184,9 @@ class LeaseCoordinatorClient:
 class IdempotencyStore:
     """Durable per-replica retry cache, deliberately outside the synced vault."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, *, clock=time.time):  # noqa: ANN001
         self.path = path
+        self.clock = clock
         path.parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as conn:
             conn.execute(
@@ -196,14 +200,32 @@ class IdempotencyStore:
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
 
-    def run(self, key: str | None, digest: str, operation) -> Any:  # noqa: ANN001
+    def run(
+        self,
+        key: str | None,
+        digest: str,
+        operation,  # noqa: ANN001
+        *,
+        expires_after: float | None = None,
+        on_replay=None,  # noqa: ANN001
+    ) -> Any:
         if not key:
             return operation()
+        now = self.clock()
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            if expires_after is not None:
+                conn.execute(
+                    "DELETE FROM mutations WHERE key LIKE 'implicit:%' "
+                    "AND state = 'completed' AND updated_at <= ?",
+                    (now - expires_after,),
+                )
             row = conn.execute(
-                "SELECT digest, state, result FROM mutations WHERE key = ?", (key,)
+                "SELECT digest, state, result, updated_at FROM mutations WHERE key = ?", (key,)
             ).fetchone()
+            if row and expires_after is not None and row[3] <= now - expires_after:
+                conn.execute("DELETE FROM mutations WHERE key = ?", (key,))
+                row = None
             if row:
                 if row[0] != digest:
                     raise OpError(
@@ -211,6 +233,8 @@ class IdempotencyStore:
                         "idempotency key was already used for different input",
                     )
                 if row[1] == "completed":
+                    if on_replay is not None:
+                        on_replay()
                     return pickle.loads(row[2])  # noqa: S301 - local trusted runtime state
                 raise OpError(
                     "IDEMPOTENCY_IN_PROGRESS",
@@ -218,7 +242,7 @@ class IdempotencyStore:
                 )
             conn.execute(
                 "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
-                (key, digest, time.time()),
+                (key, digest, now),
             )
         try:
             result = operation()
@@ -233,13 +257,19 @@ class IdempotencyStore:
         with self._connect() as conn:
             conn.execute(
                 "UPDATE mutations SET state = 'completed', result = ?, updated_at = ? WHERE key = ? AND digest = ?",
-                (payload, time.time(), key, digest),
+                (payload, self.clock(), key, digest),
             )
         return result
 
 
 class LeaseManager:
-    def __init__(self, config: LeaseConfig, *, client: LeaseCoordinatorClient | None = None):
+    def __init__(
+        self,
+        config: LeaseConfig,
+        *,
+        client: LeaseCoordinatorClient | None = None,
+        clock=time.time,  # noqa: ANN001
+    ):
         self.config = config
         self.client = (
             client
@@ -249,10 +279,8 @@ class LeaseManager:
         replica = config.replica_id or "standalone"
         vault = config.vault_id or "standalone"
         safe_name = hashlib.sha256(f"{vault}\0{replica}".encode()).hexdigest()[:20]
-        self.idempotency = (
-            IdempotencyStore(config.state_dir / f"idempotency-{safe_name}.sqlite")
-            if config.enabled
-            else None
+        self.idempotency = IdempotencyStore(
+            config.state_dir / f"idempotency-{safe_name}.sqlite", clock=clock
         )
         self._fencing_token: int | None = None
         self._expires_at: float | None = None
@@ -283,10 +311,12 @@ class LeaseManager:
         kwargs: dict[str, Any],
         *,
         idempotency_key: str | None = None,
+        implicit_idempotency_scope: str | None = None,
     ) -> Any:
-        if command.read_only or not self.config.enabled:
+        if command.read_only:
             return command.leaf(*injected, **kwargs)
-        self.ensure_writer()
+        if self.config.enabled:
+            self.ensure_writer()
         digest = hashlib.sha256(
             json.dumps(
                 {"command": command.name, "kwargs": kwargs},
@@ -295,9 +325,26 @@ class LeaseManager:
                 default=str,
             ).encode("utf-8")
         ).hexdigest()
-        assert self.idempotency is not None
+        key = idempotency_key
+        expires_after = None
+        on_replay = None
+        if key is None and implicit_idempotency_scope:
+            scoped = hashlib.sha256(
+                f"{implicit_idempotency_scope}\0{digest}".encode()
+            ).hexdigest()
+            key = f"implicit:{scoped}"
+            expires_after = _IMPLICIT_RETRY_TTL_SECONDS
+
+            def log_replay() -> None:
+                logger.info("Replayed retry-safe MCP mutation command=%s", command.name)
+
+            on_replay = log_replay
         return self.idempotency.run(
-            idempotency_key, digest, lambda: command.leaf(*injected, **kwargs)
+            key,
+            digest,
+            lambda: command.leaf(*injected, **kwargs),
+            expires_after=expires_after,
+            on_replay=on_replay,
         )
 
     def status(self) -> dict[str, Any]:
@@ -381,9 +428,19 @@ def get_manager() -> LeaseManager:
 
 
 def invoke_command(
-    command: Any, *injected: Any, idempotency_key: str | None = None, **kwargs: Any
+    command: Any,
+    *injected: Any,
+    idempotency_key: str | None = None,
+    implicit_idempotency_scope: str | None = None,
+    **kwargs: Any,
 ) -> Any:
-    return get_manager().invoke(command, injected, kwargs, idempotency_key=idempotency_key)
+    return get_manager().invoke(
+        command,
+        injected,
+        kwargs,
+        idempotency_key=idempotency_key,
+        implicit_idempotency_scope=implicit_idempotency_scope,
+    )
 
 
 def coordination_status() -> dict[str, Any]:

--- a/tests/test_command_surface_retry.py
+++ b/tests/test_command_surface_retry.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from exomem import command_surface
+
+
+def test_mcp_retry_scope_hashes_bearer_and_falls_back_to_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers",
+        lambda **kwargs: {"authorization": "Bearer super-secret-token"},
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_context",
+        lambda: SimpleNamespace(session_id="session-1"),
+    )
+    scope = command_surface.mcp_retry_scope()
+    assert scope.startswith("bearer:")
+    assert "super-secret-token" not in scope
+
+    monkeypatch.setattr("fastmcp.server.dependencies.get_http_headers", lambda **kwargs: {})
+    assert command_surface.mcp_retry_scope() == "session:session-1"
+
+
+def test_bound_mcp_tool_passes_retry_scope(monkeypatch) -> None:
+    seen = {}
+
+    def leaf(vault, *, value: int):  # noqa: ANN001
+        return value
+
+    command = SimpleNamespace(name="mutate", leaf=leaf, read_only=False)
+    bound = command_surface.bind_vault(leaf, object(), command=command)
+    monkeypatch.setattr(command_surface, "mcp_retry_scope", lambda: "bearer:abc")
+
+    def fake_invoke(cmd, *injected, **kwargs):  # noqa: ANN001
+        seen.update(command=cmd, injected=injected, kwargs=kwargs)
+        return "ok"
+
+    monkeypatch.setattr("exomem.writer_lease.invoke_command", fake_invoke)
+    assert bound(value=1) == "ok"
+    assert seen["kwargs"] == {"value": 1, "implicit_idempotency_scope": "bearer:abc"}

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -138,6 +138,68 @@ def test_idempotency_returns_saved_result_and_rejects_mismatch(tmp_path: Path) -
     assert calls == [1]
 
 
+def test_implicit_idempotency_is_bounded_and_principal_scoped(tmp_path: Path) -> None:
+    clock = Clock()
+    calls: list[int] = []
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=FakeClient(LeaseRecord("desktop", 99, 4)),
+        clock=clock,
+    )
+    command = _command(writes=True, leaf=lambda value: calls.append(value) or {"value": value})
+
+    assert manager.invoke(command, (), {"value": 1}, implicit_idempotency_scope="alice") == {
+        "value": 1
+    }
+    assert manager.invoke(command, (), {"value": 1}, implicit_idempotency_scope="alice") == {
+        "value": 1
+    }
+    assert manager.invoke(command, (), {"value": 1}, implicit_idempotency_scope="bob") == {
+        "value": 1
+    }
+    assert calls == [1, 1]
+
+    clock.value += 61
+    assert manager.invoke(command, (), {"value": 1}, implicit_idempotency_scope="alice") == {
+        "value": 1
+    }
+    assert calls == [1, 1, 1]
+
+
+def test_failed_implicit_mutation_remains_retryable(tmp_path: Path) -> None:
+    attempts = 0
+
+    def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError("transient")
+        return "ok"
+
+    manager = _manager(tmp_path, LeaseRecord("desktop", 99, 4))
+    command = _command(writes=True, leaf=flaky)
+    with pytest.raises(ValueError, match="transient"):
+        manager.invoke(command, (), {}, implicit_idempotency_scope="alice")
+    assert manager.invoke(command, (), {}, implicit_idempotency_scope="alice") == "ok"
+    assert attempts == 2
+
+
+def test_explicit_idempotency_also_works_without_writer_lease(tmp_path: Path) -> None:
+    calls: list[int] = []
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path))
+    command = _command(writes=True, leaf=lambda value: calls.append(value) or value)
+    assert manager.invoke(command, (), {"value": 1}, idempotency_key="standalone-1") == 1
+    assert manager.invoke(command, (), {"value": 1}, idempotency_key="standalone-1") == 1
+    with pytest.raises(OpError, match="IDEMPOTENCY_KEY_REUSED"):
+        manager.invoke(command, (), {"value": 2}, idempotency_key="standalone-1")
+    assert calls == [1]
+
+
 @dataclass
 class Clock:
     value: float = 100.0


### PR DESCRIPTION
## Summary
- replay identical successful MCP mutations from the same authenticated caller for 60 seconds
- preserve failed-call retryability and explicit REST/CLI idempotency in standalone mode
- document the bounded per-replica guarantee and add OpenSpec coverage

## Verification
- 29 focused retry, REST, writer-lease, and MCP schema tests passed
- scoped Ruff passed
- isolated latency gate passed
- broad suite: 2114 passed, 1 skipped; 9 existing Windows path/encoding failures unrelated to this change