### PR TITLE
fix: write-governance & lifecycle hardening from the promise audit

### DIFF
--- a/env.example
+++ b/env.example
@@ -30,6 +30,10 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 #
 # Set to 1 for a lean, keyword/BM25-only install (no embeddings, no torch).
 # Leave unset for hybrid semantic search (needs `uv sync --extra embeddings`).
+# NOTE: this gates embedding WRITES + model warmup, not query-time reads. If a
+# `.embeddings.sqlite` sidecar already exists on disk, find() will still use the
+# vector lane for reads; to force a truly keyword-only comparison, query with
+# mode="keyword" (or remove/rename the sidecar).
 # EXOMEM_DISABLE_EMBEDDINGS=1
 
 # Path to the Tesseract OCR binary if it is not on PATH (media profile only).

--- a/openspec/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/specs/agent-bootstrap-contract/spec.md
@@ -1,7 +1,11 @@
 # agent-bootstrap-contract Specification
 
 ## Purpose
-TBD - created by archiving change add-agent-bootstrap-contract. Update Purpose after archive.
+Give a generic agent without a native Exomem skill a deterministic, versioned
+operating contract instead of guessing conventions: a read-only `bootstrap`
+operation that returns workflow guidance, tool defaults, performance profiles,
+and search guidance as structured JSON, without inspecting or summarizing any
+private vault content.
 ## Requirements
 ### Requirement: Agent Bootstrap Contract
 The system SHALL expose a read-only `bootstrap` operation that returns a

--- a/openspec/specs/attention-queue/spec.md
+++ b/openspec/specs/attention-queue/spec.md
@@ -1,7 +1,13 @@
 # attention-queue Specification
 
 ## Purpose
-TBD - created by archiving change add-attention-queue. Update Purpose after archive.
+Give reviewers a single daily front door instead of three separate audit
+queues: a unified `attention` operation that composes `stale_review`,
+`corpus_contradictions`, and `unprocessed_source` findings into one
+deterministically ranked, deduplicated list via Reciprocal Rank Fusion.
+Composition is measurement-only — it never mutates the vault, auto-supersedes,
+or changes `find` ranking — and any capped output reports an explicit count
+rather than silently truncating.
 ## Requirements
 ### Requirement: Unified Review Surface Composed From The Epistemic Queues
 

--- a/openspec/specs/command-surface/spec.md
+++ b/openspec/specs/command-surface/spec.md
@@ -1,7 +1,12 @@
 # command-surface Specification
 
 ## Purpose
-TBD - created by archiving change unify-command-surface. Update Purpose after archive.
+Keep every operation defined once instead of once per surface: a single
+declarative command registry generates the MCP tools, the REST facade, the
+OpenAPI document, and the CLI, so adding or removing an operation requires no
+per-surface code and MCP tool schemas stay byte-identical to their committed
+baseline. The CLI and REST facade share one result/error envelope so a given
+failure carries the same machine-readable code on both surfaces.
 ## Requirements
 ### Requirement: Single Command Registry Generates Every Surface
 

--- a/openspec/specs/context-packs/spec.md
+++ b/openspec/specs/context-packs/spec.md
@@ -1,7 +1,13 @@
 # context-packs Specification
 
 ## Purpose
-TBD - created by archiving change add-context-packs. Update Purpose after archive.
+Let a caller get more context from one `find` call instead of chaining several
+`get` calls: an optional `pack` parameter that assembles a bounded context
+pack — structurally extracted claims, a co-citation-ranked wikilink
+neighborhood, and recorded contradictions/supersessions — over the top hits.
+Assembly is purely structural and deterministic (no generative or reasoning
+model), never mutates the vault, and never changes `find`'s hits or ordering
+when `pack` is off.
 ## Requirements
 ### Requirement: Optional Context Pack Assembly From `find`
 

--- a/openspec/specs/contradiction-queue/spec.md
+++ b/openspec/specs/contradiction-queue/spec.md
@@ -1,7 +1,14 @@
 # contradiction-queue Specification
 
 ## Purpose
-TBD - created by archiving change order-contradiction-queue. Update Purpose after archive.
+Surface the contradiction pairs most worth reviewing first instead of in
+arbitrary order: the `corpus_contradictions` queue is sorted by a review
+priority derived from embedding cosine and note dormancy, with same-family
+pairs (noise from adjacent notes in the same research subfolder) demoted below
+cross-family pairs rather than dropped. Ordering is sort-only and
+measurement-only — it never changes which pairs are eligible, never mutates
+notes, and never affects `find` ranking — and the cap on surfaced pairs always
+reports an explicit omitted count.
 ## Requirements
 ### Requirement: Review-Priority Ordering by Cosine and Dormancy
 

--- a/openspec/specs/exomem-identity/spec.md
+++ b/openspec/specs/exomem-identity/spec.md
@@ -1,7 +1,13 @@
 # exomem-identity Specification
 
 ## Purpose
-TBD - created by archiving change rename-internals-to-exomem. Update Purpose after archive.
+Establish `exomem` as the canonical package name and `EXOMEM_*` as the
+canonical environment-variable prefix throughout the codebase, skill scaffold,
+tests, scripts, and docs, replacing the legacy `kb_mcp`/`KB_MCP_*` naming.
+Existing installations and integrations MUST keep working unchanged: legacy
+imports resolve to the same module objects and legacy environment variables
+are promoted to their new names automatically, with the new name always
+winning on conflict.
 ## Requirements
 ### Requirement: Exomem Is the Canonical Internal Name
 

--- a/openspec/specs/find-usage-activation/spec.md
+++ b/openspec/specs/find-usage-activation/spec.md
@@ -1,7 +1,14 @@
 # find-usage-activation Specification
 
 ## Purpose
-TBD - created by archiving change usage-aware-find-ranking. Update Purpose after archive.
+Let frequently-used notes rank a little higher without changing default
+retrieval behavior: an opt-in `prefer_used` parameter on `find` applies a
+bounded, positive-only usage-activation multiplier — derived from find
+surfacings, reads, and citing writes — to candidates that content-matching
+lanes already surfaced. The boost defaults off, is always weaker than the
+compiled-note boost, can never let a superseded page outrank its active
+successor, and never introduces a candidate that content matching didn't
+already find.
 ## Requirements
 ### Requirement: Opt-In Usage-Activation Boost Defaults Off
 

--- a/openspec/specs/get-payload-shape/spec.md
+++ b/openspec/specs/get-payload-shape/spec.md
@@ -1,7 +1,11 @@
 # get-payload-shape Specification
 
 ## Purpose
-TBD - created by archiving change dedupe-get-payload. Update Purpose after archive.
+Cut the token cost of `get` by dropping the redundant raw `content` field from
+its default response, since `frontmatter` plus `body` already reconstruct the
+file. Raw content stays available opt-in via `include_raw`, and `content_hash`
+continues to be computed over the full raw file text regardless of
+`include_raw`, so `edit`'s stale-write guard is unaffected.
 ## Requirements
 ### Requirement: Default Get Response Excludes Raw Content
 

--- a/openspec/specs/image-tags/spec.md
+++ b/openspec/specs/image-tags/spec.md
@@ -1,7 +1,13 @@
 # image-tags Specification
 
 ## Purpose
-TBD - created by archiving change image-zero-shot-tags. Update Purpose after archive.
+Make depicted concepts in images findable by keyword/BM25 search even when an
+image has no legible text: when enabled (`EXOMEM_IMAGE_TAGS`), the system
+scores an image's CLIP embedding against a fixed generic tag vocabulary and
+appends the top-scoring tags above a threshold as a `Tags:` line to the
+image's extracted text, reusing the already-loaded CLIP model. The feature is
+default-off (byte-identical output when unset), configurable in top-K and
+threshold, and soft-fails to no tags on any dependency or inference error.
 ## Requirements
 ### Requirement: Zero-Shot CLIP Image Tags
 

--- a/openspec/specs/live-index-freshness/spec.md
+++ b/openspec/specs/live-index-freshness/spec.md
@@ -1,7 +1,16 @@
 # live-index-freshness Specification
 
 ## Purpose
-TBD - created by archiving change improve-find-latency-token-cost. Update Purpose after archive.
+Keep `find` latency and reindex work from scaling with vault size and write
+volume: event-maintained in-memory registries for markdown freshness and
+inbound wikilinks are updated incrementally from the live file watcher and
+in-process writers, so most freshness checks and link lookups need no
+filesystem walk or full-vault rescan. Self-authored writer mutations are
+suppressed from re-triggering a duplicate embedding reindex through the
+watcher, while external edits (Obsidian, sync, git) still reindex live, and
+periodic reconciliation bounds how stale a registry can drift from a missed
+event. Every event-maintained path falls back to the prior walk/rescan
+behavior when the registry isn't live.
 ## Requirements
 ### Requirement: Suppress Exomem Self-Write Watcher Echo
 

--- a/openspec/specs/ranking-autotune/spec.md
+++ b/openspec/specs/ranking-autotune/spec.md
@@ -1,7 +1,14 @@
 # ranking-autotune Specification
 
 ## Purpose
-TBD - created by archiving change close-auto-tune-loop. Update Purpose after archive.
+Close the loop from real usage to better ranking without ever risking a silent
+regression: the tuner mines `(query → cited_path)` pairs from usage logs as
+binary relevance labels (guarded off until enough real pairs exist), scores
+candidate configs against a combined pairs-plus-golden objective, and treats
+the golden-set NDCG floor as a hard constraint on both selection and adoption.
+The loop is deterministic and reasoning-model-free throughout, tuning only
+ever writes a reviewable candidate config and report, and adoption is an
+explicit, reversible step that never happens automatically.
 ## Requirements
 ### Requirement: Mined Pairs Enter the Tuning Objective as Binary Labels
 

--- a/openspec/specs/retrieve-inject-hook/spec.md
+++ b/openspec/specs/retrieve-inject-hook/spec.md
@@ -1,7 +1,15 @@
 # retrieve-inject-hook Specification
 
 ## Purpose
-TBD - created by archiving change retrieve-inject-hook. Update Purpose after archive.
+Let the `UserPromptSubmit` retrieve hook proactively surface relevant Exomem
+hits into the conversation instead of only reminding the agent to search,
+without changing its default reminder-only behavior. When explicitly opted in
+(`EXOMEM_RETRIEVE_INJECT`), the hook attempts a REST call and falls back to an
+opt-in CLI invocation to fetch a few compact hits, injecting only a small,
+bounded routing-stub block (paths and metadata, never excerpts or note
+content) into `additionalContext`. The hook reuses the existing prompt-length
+gate and cooldown, stays silent on obvious control prompts and zero-hit
+results, and never blocks indefinitely or raises.
 ## Requirements
 ### Requirement: Recall Injection Defaults Off
 

--- a/openspec/specs/semantic-video-segments/spec.md
+++ b/openspec/specs/semantic-video-segments/spec.md
@@ -1,7 +1,15 @@
 # semantic-video-segments Specification
 
 ## Purpose
-TBD - created by archiving change add-semantic-video-segments. Update Purpose after archive.
+Make long audio/video transcripts retrievable at the moment a topic was
+discussed rather than as one undifferentiated blob: when enabled
+(`EXOMEM_SEMANTIC_SEGMENTS`), transcripts render one timestamped line per ASR
+segment, and the embedding chunker segments them at boundaries fused from
+topic shifts, visual-change events, speaker turns, and OCR changes, so `find`
+can surface a matched hit's timestamp and nearest scene frame. The feature is
+default-off (byte-identical output when unset), degrades through a soft-fail
+ladder to the existing paragraph chunker on missing signals or errors, and
+relies only on deterministic measurements — no reasoning model is invoked.
 ## Requirements
 ### Requirement: Timed Transcript Rendering
 

--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -1,7 +1,16 @@
 # speaker-diarization Specification
 
 ## Purpose
-TBD - created by archiving change add-named-speaker-diarization. Update Purpose after archive.
+Turn anonymous diarization clusters (`Speaker A`, `Speaker B`) into named
+turns when the speaker is known: when diarization is enabled and at least one
+voice profile is enrolled, each cluster's ECAPA voice embedding is matched
+against enrolled profile centroids by cosine similarity, and only a match that
+clears a configured threshold, margin, and standout rule is named — the system
+prefers leaving a cluster anonymous over mis-naming it. Profiles are managed
+via CLI enrollment and persisted in a local JSON store outside the vault's
+note trees, and the whole path is a deterministic, reasoning-model-free
+measurement that soft-fails to anonymous diarization or a plain transcript on
+any dependency or inference error.
 ## Requirements
 ### Requirement: Named-Speaker Attribution via Voice Profiles
 

--- a/openspec/specs/thinking-evolution/spec.md
+++ b/openspec/specs/thinking-evolution/spec.md
@@ -1,7 +1,14 @@
 # thinking-evolution Specification
 
 ## Purpose
-TBD - created by archiving change add-thinking-evolution. Update Purpose after archive.
+Let a reader see how a conclusion changed over time instead of only its
+current state: an `evolution` operation resolves a topic query's matching
+notes into their supersession chains — walking `supersedes`/`superseded_by`
+frontmatter pointers — and returns one ordered timeline per chain (oldest to
+newest), with each version's structurally-extracted claims and, for
+non-terminal versions, the recorded transition reason. The operation is
+measurement-only (no vault mutation, no change to `find` ranking), invents
+nothing beyond the notes' own text, and reports any truncation explicitly.
 ## Requirements
 ### Requirement: Topic-Driven Thinking-Evolution Timelines
 

--- a/openspec/specs/video-scene-frames/spec.md
+++ b/openspec/specs/video-scene-frames/spec.md
@@ -1,7 +1,15 @@
 # video-scene-frames Specification
 
 ## Purpose
-TBD - created by archiving change add-video-scene-frames. Update Purpose after archive.
+Make a video's CLIP keyframes track what actually changes on screen instead of
+sampling at uniform intervals: when enabled
+(`EXOMEM_VIDEO_SCENE_FRAMES`), a cheap visual-change metrics pass detects
+scene boundaries, persists one representative, OCR'd JPEG per scene as an
+ordinary vault file, and `find` collapses a video's multiple scene-frame
+matches into a single hit enriched with the matched scene's frame and
+timestamp. The feature is default-off (byte-identical output when unset),
+falls back to the existing uniform sampler on detection failure, and a frame
+write failure never blocks the video's CLIP vectors from being indexed.
 ## Requirements
 ### Requirement: Visual-Change Scene Detection
 

--- a/src/exomem/access.py
+++ b/src/exomem/access.py
@@ -90,7 +90,7 @@ def _kb_relative(rel_path: str) -> str:
     """
     rel = rel_path.replace("\\", "/").strip("/")
     parts = rel.split("/")
-    if parts and parts[0] == kb_dirname():
+    if parts and parts[0].casefold() == kb_dirname().casefold():
         return "/".join(parts[1:])
     return rel
 
@@ -118,7 +118,9 @@ def access_tier(vault_root: Path, rel_path: str) -> str:
     if _matches(cfg["readonly"], kb_rel):
         return TIER_READONLY
     head = kb_rel.split("/", 1)[0]
-    if head in _APPEND_ONLY:
+    # Case-insensitive: an uppercase `SOURCES/` aliases the real `Sources/` on a
+    # case-insensitive filesystem, and the tier must not depend on path casing.
+    if any(head.casefold() == a.casefold() for a in _APPEND_ONLY):
         return TIER_APPEND_ONLY
     return TIER_READ_WRITE
 

--- a/src/exomem/append_to_file.py
+++ b/src/exomem/append_to_file.py
@@ -11,7 +11,6 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from .kbdir import kb_dirname
 from .vault import (
     PlannedWrite,
     VaultPathError,
@@ -21,7 +20,6 @@ from .vault import (
     resolve_under_vault,
     write_log_entry,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -70,9 +68,9 @@ def append_to_file(
     # Sources/ is fully immutable. Evidence/ allows appends to sidecars and
     # description files (description.md style); the raw artifacts there are
     # binary and wouldn't be markdown-appended anyway.
-    parts = rel_path.split("/")
-    head = parts[1] if parts[0] == kb_dirname() and len(parts) > 1 else parts[0]
-    if head == "Sources":
+    # Canonical, case-insensitive match (an uppercase `SOURCES/` aliases the real
+    # `Sources/` on a case-insensitive filesystem). Evidence/ appends stay allowed.
+    if in_append_only_tree(rel_path) == "Sources":
         raise AppendError(
             code="APPEND_ONLY",
             reason=(
@@ -131,8 +129,3 @@ def append_to_file(
     return AppendResult(
         path=rel_path, bytes_appended=bytes_appended, warnings=warnings
     )
-
-# `in_append_only_tree` import kept available for callers/tests that want
-# the consistent guard; the local `head` check above is narrower because
-# Evidence/ sidecars are intentionally allowed here.
-_ = in_append_only_tree

--- a/src/exomem/append_to_file.py
+++ b/src/exomem/append_to_file.py
@@ -60,7 +60,7 @@ def append_to_file(
 
     try:
         abs_path, rel_path = resolve_under_vault(
-            vault_root, path, must_exist=True, must_be_file=True
+            vault_root, path, must_exist=True, must_be_file=True, must_be_under_kb=True
         )
     except VaultPathError as e:
         raise AppendError(code=e.code, reason=e.reason) from e

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -3663,13 +3663,33 @@ def op_connect_memory(
     if operation == "accept-relation":
         if not ref:
             raise ValueError("INVALID_MODE: accept-relation requires `ref`")
+
+        def _accept_relations_edit(vault_root: Path, **kw: Any) -> dict:
+            """`edit_memory` for the relation queue: identical to op_edit_memory,
+            but creates the canonical `## Relations` section when a note has none
+            (remember() doesn't emit one), so accepting the first relation into a
+            note doesn't fail HEADING_NOT_FOUND. create_missing stays server-side
+            only — it is not exposed on the edit_memory MCP tool."""
+            try:
+                result = edit_module.edit(
+                    vault_root, create_missing_section=True, **kw
+                )
+            except edit_module.EditError as e:
+                msg = f"{e.code}: {e.reason}"
+                if getattr(e, "missing", None):
+                    msg += f" (missing: {e.missing})"
+                if getattr(e, "candidates", None):
+                    msg += f" (candidates: {e.candidates})"
+                raise ValueError(msg) from e
+            return result.as_dict()
+
         return relation_queue_module.accept(
             vault_root,
             ref=ref,
             expected_hash=expected_hash,
             why=why,
             expected_fingerprint=expected_fingerprint,
-            edit_memory=op_edit_memory,
+            edit_memory=_accept_relations_edit,
         )
     if path:
         path = _resolve_memory_identifier(vault_root, path)

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -3810,29 +3810,40 @@ def op_maintain_memory(
     vault_root: Path,
     mode: str = "audit",
     categories: list[str] | None = None,
-    dry_run: bool = True,
+    dry_run: bool | None = None,
     rebuild_embeddings: bool = False,
 ) -> dict:
     """Maintain vault health with explicit write-capable modes.
 
-    Default mode is read-only audit. `mode="fix"`, `mode="reconcile"`, and
-    `mode="backfill-ids"`
-    preserve the canonical dry-run/write semantics and default to dry-run here.
+    Default mode is read-only audit. `mode="fix"` and `mode="backfill-ids"`
+    rewrite content (wikilinks, frontmatter, stable IDs) and default to
+    dry-run here as a safety net. `mode="reconcile"` only heals index-count
+    and sidecar drift from out-of-band edits — the same canonical default as
+    `op_reconcile` itself (idempotent, non-destructive) — so it defaults to
+    writing; pass `dry_run=true` to preview instead.
 
     Args:
         mode: audit, fix, reconcile, or backfill-ids.
         categories: Optional audit category filter.
-        dry_run: For fix/reconcile, report without writing when true.
+        dry_run: Report without writing when true. Defaults to true for
+            fix/backfill-ids (safety net) and false for reconcile (matches
+            `op_reconcile`'s own default). Pass explicitly to override either way.
         rebuild_embeddings: For fix mode, rebuild embeddings when explicitly requested.
     """
     if mode == "audit":
         return op_audit(vault_root, categories=categories)
     if mode == "fix":
-        return op_audit_fix(vault_root, dry_run=dry_run, rebuild_embeddings=rebuild_embeddings)
+        return op_audit_fix(
+            vault_root,
+            dry_run=True if dry_run is None else dry_run,
+            rebuild_embeddings=rebuild_embeddings,
+        )
     if mode == "reconcile":
-        return op_reconcile(vault_root, dry_run=dry_run)
+        return op_reconcile(vault_root, dry_run=False if dry_run is None else dry_run)
     if mode == "backfill-ids":
-        return memory_refs_module.backfill_ids(vault_root, dry_run=dry_run)
+        return memory_refs_module.backfill_ids(
+            vault_root, dry_run=True if dry_run is None else dry_run
+        )
     raise ValueError(
         "INVALID_MODE: maintain_memory mode must be audit, fix, reconcile, or backfill-ids"
     )

--- a/src/exomem/corpus_aware.py
+++ b/src/exomem/corpus_aware.py
@@ -148,6 +148,26 @@ def _why(hit) -> str:
     return ", ".join(bits) or "related"
 
 
+def _is_relation_target_eligible(vault_root: Path, rel_path: str) -> bool:
+    """False for out-of-KB, readonly, or excluded targets.
+
+    A `relates_to` suggestion has to be actionable: the reader can review and
+    wire it in via `note()`/`edit()`. Read-only, excluded, and out-of-KB
+    material (e.g. `find()`'s scope="kb" auto-widen reaching sibling trees
+    like `Handbooks/`/`Reference/`) fails that bar — you can't act on the
+    edge, so surfacing it just pollutes the graph (audit finding 2-02).
+    """
+    from . import access
+
+    normalized = (rel_path or "").replace("\\", "/").lstrip("/")
+    if not normalized.casefold().startswith(kb_prefix().casefold()):
+        return False
+    return access.access_tier(vault_root, rel_path) not in (
+        access.TIER_READONLY,
+        access.TIER_EXCLUDED,
+    )
+
+
 def suggest_related(
     vault_root: Path,
     *,
@@ -163,7 +183,10 @@ def suggest_related(
     Excludes the draft itself (`self_path`) and anything in `existing_links`
     (cited sources + wikilinks already in the body). Re-ranks find()'s order
     with a small log-scaled graph-in-degree bonus so well-connected hubs float
-    up — linking a hub compounds more than linking a leaf.
+    up — linking a hub compounds more than linking a leaf. Also excludes any
+    hit that isn't a governed, in-KB target (see `_is_relation_target_eligible`)
+    — `find()`'s auto-widen is correct for retrieval but wrong for a
+    suggested edge, since you can't act on a read-only/out-of-KB link.
     """
     from . import find as find_module
 
@@ -195,6 +218,8 @@ def suggest_related(
         if self_canon and hc == self_canon:
             continue
         if hc in excluded:
+            continue
+        if not _is_relation_target_eligible(vault_root, h.path):
             continue
         eligible.append(h)
 

--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -36,7 +36,6 @@ from .vault import (
     write_log_entry,
 )
 
-
 log = logging.getLogger(__name__)
 
 
@@ -69,7 +68,9 @@ def create_file(
     today: dt.date | None = None,
 ) -> CreateFileResult:
     try:
-        abs_path, rel_path = resolve_under_vault(vault_root, path)
+        abs_path, rel_path = resolve_under_vault(
+            vault_root, path, must_be_under_kb=True
+        )
     except VaultPathError as e:
         raise CreateFileError(code=e.code, reason=e.reason) from e
 

--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -28,6 +28,7 @@ from .vault import (
     PlannedWrite,
     VaultPathError,
     batch_atomic_write,
+    excluded_frontmatter_reason,
     in_append_only_tree,
     in_curated_tree,
     normalize_body_wikilinks,
@@ -67,6 +68,12 @@ def create_file(
     allow_curated: bool = False,
     today: dt.date | None = None,
 ) -> CreateFileResult:
+    if frontmatter:
+        for key in frontmatter:
+            reason = excluded_frontmatter_reason(str(key))
+            if reason is not None:
+                raise CreateFileError(code="EXCLUDED_FIELD", reason=reason)
+
     try:
         abs_path, rel_path = resolve_under_vault(
             vault_root, path, must_be_under_kb=True

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -108,6 +108,7 @@ def edit(
     section_position: str = "append",
     expected_hash: str | None = None,
     validate_only: bool = False,
+    create_missing_section: bool = False,
     today: dt.date | None = None,
 ) -> EditResult | EditValidation:
     """Edit a compiled page in place. Bumps `updated:`.
@@ -249,6 +250,7 @@ def edit(
             new_string,  # type: ignore[arg-type]
             vault_root,
             rel_path=rel_path,
+            create_missing=create_missing_section,
         )
         body_changed = True
     elif new_body is not None:
@@ -503,6 +505,7 @@ def apply_section_edit(
     *,
     rel_path: str = "",
     resolver: WikilinkResolver | None = None,
+    create_missing: bool = False,
 ) -> tuple[str, list[str]]:
     """Replace/prepend/append `content` within the section under `heading`.
 
@@ -510,9 +513,15 @@ def apply_section_edit(
     EQUAL-OR-HIGHER level (or EOF). The heading line itself is preserved; only
     its body is rewritten. Returns `(new_body, warnings)`.
 
-    Raises EditError(code="HEADING_NOT_FOUND") if the heading is absent. Only
-    the inserted `content` is wikilink-normalized — the rest of the body is left
-    byte-for-byte untouched (matching `apply_surgical_replace`).
+    Raises EditError(code="HEADING_NOT_FOUND") if the heading is absent — UNLESS
+    `create_missing` is set, in which case a new `## <heading>` section is
+    appended at the end of the body with `content`. `create_missing` is off by
+    default so an interactive caller's heading typo still errors rather than
+    silently spawning a section; server-side authors that must be able to write
+    the first entry into an absent section (e.g. the relation-acceptance queue
+    writing `## Relations` into a note that has none) opt in. Only the inserted
+    `content` is wikilink-normalized — the rest of the body is left byte-for-byte
+    untouched (matching `apply_surgical_replace`).
     """
     where = f" in {rel_path}" if rel_path else ""
     want = _normalize_heading(heading)
@@ -527,14 +536,25 @@ def apply_section_edit(
             h_level = len(m.group(1))
             break
     if h_idx == -1:
-        raise EditError(
-            code="HEADING_NOT_FOUND",
-            missing=["heading"],
-            reason=(
-                f"heading {heading!r} not found{where}. Match an existing `## Heading` "
-                "(the `#` markers are optional in the arg); read the page first."
-            ),
+        if not create_missing:
+            raise EditError(
+                code="HEADING_NOT_FOUND",
+                missing=["heading"],
+                reason=(
+                    f"heading {heading!r} not found{where}. Match an existing `## Heading` "
+                    "(the `#` markers are optional in the arg); read the page first."
+                ),
+            )
+        # Append a new level-2 section (the scaffold's convention) with `content`.
+        if resolver is None:
+            resolver = find_module.shared_resolver(vault_root)
+        content_norm, warnings = normalize_body_wikilinks(
+            content, vault_root, resolver=resolver
         )
+        prefix = body.rstrip("\n")
+        joiner = "\n\n" if prefix else ""
+        new_body = f"{prefix}{joiner}## {want}\n\n{content_norm}\n"
+        return new_body, warnings
 
     end = len(lines)
     for j in range(h_idx + 1, len(lines)):

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -38,9 +38,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import corpus_aware
+from . import corpus_aware, indexes
 from . import find as find_module
-from . import indexes
 from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
@@ -48,10 +47,10 @@ from .vault import (
     batch_atomic_write,
     content_hash,
     escape_wikilinks_for_log,
+    in_append_only_tree,
     kb_root,
     normalize_body_wikilinks,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -364,12 +363,13 @@ def load_editable(
     """
     abs_path, rel_path = _resolve(vault_root, path)
 
-    if "/Sources/" in "/" + rel_path or "/Evidence/" in "/" + rel_path:
+    append_only = in_append_only_tree(rel_path)
+    if append_only is not None:
         raise EditError(
             code="INVALID_EDIT",
             missing=["path"],
             reason=(
-                f"{rel_path} is in Sources/ or Evidence/, which are append-only "
+                f"{rel_path} is in {append_only}/, which is append-only "
                 "(SKILL.md rule 2). Add a corrective source instead, or compile "
                 "a downstream note that supersedes the framing."
             ),

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -84,6 +84,21 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
     """Serve inert public assets outside MCP auth; vault data stays behind REST."""
     asset_dir = Path(__file__).parent
 
+    @mcp_app.custom_route("/health", methods=["GET"])
+    async def _health(request: Request) -> JSONResponse:  # noqa: ARG001
+        """Unauthenticated liveness probe for tunnels/orchestrators. Reports only
+        that the process is up + its version — no vault data, no auth required."""
+        try:
+            from importlib.metadata import version
+
+            ver = version("exomem")
+        except Exception:  # noqa: BLE001 — version lookup must never fail the probe
+            ver = "unknown"
+        return JSONResponse(
+            {"status": "ok", "service": "exomem", "version": ver},
+            headers={"Cache-Control": "no-store"},
+        )
+
     @mcp_app.custom_route("/favicon.ico", methods=["GET"])
     async def _favicon_ico(request: Request):  # noqa: ARG001
         return FileResponse(

--- a/src/exomem/set_frontmatter_field.py
+++ b/src/exomem/set_frontmatter_field.py
@@ -21,12 +21,12 @@ from .vault import (
     VaultPathError,
     _format_yaml_line,
     batch_atomic_write,
+    excluded_frontmatter_reason,
     in_append_only_tree,
     in_curated_tree,
     resolve_under_vault,
     write_log_entry,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -84,6 +84,9 @@ def set_frontmatter_field(
             code="INVALID_SET",
             reason="cannot set `updated:` directly — it's always bumped to today by this op",
         )
+    excluded_reason = excluded_frontmatter_reason(field)
+    if excluded_reason is not None:
+        raise SetFrontmatterError(code="EXCLUDED_FIELD", reason=excluded_reason)
 
     # Project-key guard: route project/projects values through the same
     # auto-register + typo-distance check that note() uses. Without this,

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -54,6 +54,27 @@ APPEND_ONLY_KB_SUBPATHS: tuple[str, ...] = (
     "Evidence",
 )
 
+# Frontmatter keys the schema deliberately excludes (see _scaffold's
+# references/frontmatter.md): numeric confidence scores misrepresent the signal
+# (trust is citations + link count), and knowledge does not expire on a schedule.
+# Governed write paths refuse them so the documented "no confidence floats / no
+# retention decay" stance is actually enforced, not just described.
+EXCLUDED_FRONTMATTER_FIELDS: frozenset[str] = frozenset(
+    {"confidence", "decay_at", "expires_at"}
+)
+
+
+def excluded_frontmatter_reason(field: str) -> str | None:
+    """A refusal reason if `field` is a schema-excluded frontmatter key, else None."""
+    if field.strip().casefold() in EXCLUDED_FRONTMATTER_FIELDS:
+        return (
+            f"`{field}` is a schema-excluded frontmatter field. Exomem does not "
+            "record numeric confidence scores or time-based decay/expiry — trust "
+            "is conveyed by citations and link count, and old material is never "
+            "auto-decayed (see SKILL.md). Omit this field."
+        )
+    return None
+
 # When scanning the full vault for inbound wikilinks, skip these.
 VAULT_SCAN_SKIP_DIRS = frozenset({
     ".obsidian", ".git", ".trash", "_attachments", "_archive", "_trash",

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -262,8 +262,13 @@ def batch_atomic_write(
         for w in writes:
             try:
                 rel = w.path.resolve().relative_to(vault_resolved).as_posix()
-            except (ValueError, OSError):
-                continue  # not under the vault (shouldn't happen) — don't block
+            except (ValueError, OSError) as e:
+                # Fail CLOSED: a staged write that resolves outside the vault must
+                # never proceed (callers resolve paths first, so this is a
+                # defense-in-depth backstop, not a normal path).
+                raise ValueError(
+                    f"WRITE_REFUSED: {w.path} resolves outside the vault root"
+                ) from e
             reason = access.writable_reason(vault_root, rel)
             if reason is not None:
                 raise ValueError(f"WRITE_REFUSED: {rel}: {reason}")
@@ -396,6 +401,7 @@ def resolve_under_vault(
     must_exist: bool = False,
     must_be_file: bool = False,
     must_be_dir: bool = False,
+    must_be_under_kb: bool = False,
 ) -> tuple[Path, str]:
     """Resolve a vault-relative path; guard against escape; normalize.
 
@@ -403,6 +409,11 @@ def resolve_under_vault(
     always forward-slashed, never starts with `/`. The leading
     `Knowledge Base/` is preserved as-is (we don't auto-strip it like
     `get_page` does — Tier 2 ops take explicit paths).
+
+    `must_be_under_kb` additionally refuses any target that resolves OUTSIDE
+    `Knowledge Base/` (checked on the resolved path, so `Knowledge Base/../x`
+    can't sneak a write to a vault-root sibling of KB). Governed content writers
+    (`create`/`append`) set it — exomem only ever authors under `Knowledge Base/`.
 
     Raises VaultPathError with code in {INVALID_PATH, NOT_FOUND,
     NOT_A_FILE, NOT_A_DIR}.
@@ -421,6 +432,17 @@ def resolve_under_vault(
             reason=f"absolute paths are not allowed: {raw!r}",
         )
 
+    if must_be_under_kb:
+        # Governed writes are KB-relative: a bare `Reference/x.md` means
+        # `Knowledge Base/Reference/x.md` (matching how access tiers are keyed),
+        # so root it under KB unless it already is (any case) or leads with `..`
+        # (left for the escape guards below to reject). This makes bare and
+        # prefixed paths resolve to the SAME governed location instead of a bare
+        # path silently writing to a vault-root sibling of Knowledge Base/.
+        first = rel.split("/", 1)[0]
+        if first.casefold() != kb_dirname().casefold() and first != "..":
+            rel = f"{kb_dirname()}/{rel}"
+
     candidate = vault_root / rel
     try:
         resolved = candidate.resolve()
@@ -431,6 +453,19 @@ def resolve_under_vault(
             code="INVALID_PATH",
             reason=f"path escapes vault root: {raw!r} ({e})",
         ) from None
+
+    if must_be_under_kb:
+        kb_resolved = (vault_root / kb_dirname()).resolve()
+        try:
+            resolved.relative_to(kb_resolved)
+        except ValueError:
+            raise VaultPathError(
+                code="INVALID_PATH",
+                reason=(
+                    f"path is outside Knowledge Base/: {raw!r} — exomem only "
+                    "writes governed content under Knowledge Base/"
+                ),
+            ) from None
 
     if must_exist and not candidate.exists():
         raise VaultPathError(

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -490,20 +490,25 @@ def _is_curated_top_level(vault_root: Path, head: str) -> bool:
 
 
 def in_append_only_tree(rel_path: str) -> str | None:
-    """Return the subpath name ("Sources" or "Evidence") if matched.
+    """Return the canonical subpath name ("Sources" or "Evidence") if matched.
 
     Matches both `Knowledge Base/Sources/...` and bare `Sources/...` —
-    callers may pass either form.
+    callers may pass either form. Matching is case-insensitive (see below).
     """
-    parts = rel_path.split("/")
+    parts = rel_path.replace("\\", "/").split("/")
     if not parts:
         return None
-    if parts[0] == kb_dirname() and len(parts) > 1:
+    if len(parts) > 1 and parts[0].casefold() == kb_dirname().casefold():
         head = parts[1]
     else:
         head = parts[0]
-    if head in APPEND_ONLY_KB_SUBPATHS:
-        return head
+    # Case-insensitive match returning the CANONICAL name: on a case-insensitive
+    # filesystem (Windows/macOS) an uppercase `SOURCES/` aliases the real
+    # `Sources/` on disk, so a case-sensitive check would let raw Sources/Evidence
+    # be edited/appended/deleted through the alias.
+    for canonical in APPEND_ONLY_KB_SUBPATHS:
+        if head.casefold() == canonical.casefold():
+            return canonical
     return None
 
 

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -1049,7 +1049,7 @@
     }
   },
   "maintain_memory": {
-    "description": "Maintain vault health with explicit write-capable modes.\n\nDefault mode is read-only audit. `mode=\"fix\"`, `mode=\"reconcile\"`, and\n`mode=\"backfill-ids\"`\npreserve the canonical dry-run/write semantics and default to dry-run here.",
+    "description": "Maintain vault health with explicit write-capable modes.\n\nDefault mode is read-only audit. `mode=\"fix\"` and `mode=\"backfill-ids\"`\nrewrite content (wikilinks, frontmatter, stable IDs) and default to\ndry-run here as a safety net. `mode=\"reconcile\"` only heals index-count\nand sidecar drift from out-of-band edits — the same canonical default as\n`op_reconcile` itself (idempotent, non-destructive) — so it defaults to\nwriting; pass `dry_run=true` to preview instead.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
@@ -1074,9 +1074,16 @@
           "description": "Optional audit category filter."
         },
         "dry_run": {
-          "default": true,
-          "description": "For fix/reconcile, report without writing when true.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Report without writing when true. Defaults to true for fix/backfill-ids (safety net) and false for reconcile (matches `op_reconcile`'s own default). Pass explicitly to override either way."
         },
         "rebuild_embeddings": {
           "default": false,

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -26,6 +26,24 @@ def test_default_tiers_without_config(vault: Path) -> None:
     assert access.writable_reason(vault, "Knowledge Base/Notes/x.md") is None
 
 
+def test_append_only_tier_is_case_insensitive() -> None:
+    """On a case-insensitive filesystem (Windows/macOS) an uppercase `SOURCES/`
+    aliases the real `Sources/` on disk, so the append-only guard must match
+    regardless of case — else raw Sources/Evidence are editable via the alias.
+    Regression for the audit's confirmed HIGH."""
+    from exomem import vault as vault_module
+
+    for variant in ("SOURCES", "sources", "Sources", "SoUrCeS"):
+        assert vault_module.in_append_only_tree(f"Knowledge Base/{variant}/Articles/x.md") is not None, variant
+    for variant in ("EVIDENCE", "evidence", "Evidence"):
+        assert vault_module.in_append_only_tree(f"Knowledge Base/{variant}/Legal/x.pdf") is not None, variant
+    # access_tier (the batch-write backstop's source of truth) agrees.
+    assert access.access_tier(Path("/vault"), "Knowledge Base/SOURCES/Articles/x.md") == access.TIER_APPEND_ONLY
+    assert access.access_tier(Path("/vault"), "Knowledge Base/EVIDENCE/x.pdf") == access.TIER_APPEND_ONLY
+    # A folder that merely starts with the reserved name is NOT append-only.
+    assert vault_module.in_append_only_tree("Knowledge Base/Sources-of-truth/x.md") is None
+
+
 def test_readonly_from_config(vault: Path) -> None:
     _write_cfg(vault, "readonly:\n  - Reference\n  - Library\n")
     assert access.access_tier(vault, "Knowledge Base/Reference/Strategy.md") == access.TIER_READONLY

--- a/tests/test_compile_proposal.py
+++ b/tests/test_compile_proposal.py
@@ -13,6 +13,7 @@ import pytest
 
 from exomem import compile_proposal as cp
 from exomem import corpus_aware
+from exomem import find as find_module
 
 _ARTICLE = "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements"
 _SESSION = "Knowledge Base/Sources/Sessions/2026-05-05-metabolism-curriculum-design"
@@ -62,3 +63,87 @@ def test_errors(vault: Path) -> None:
         cp.propose_compilation(
             vault, sources=["Knowledge Base/Sources/Articles/does-not-exist-xyz"]
         )
+
+
+# ---------------- audit 2-02: relation targets must be governed KB material --
+#
+# compile_source proposes `relates_to` edges via corpus_aware.suggest_related's
+# candidate scan, which reuses find()'s scope="kb" auto-widen. Auto-widen is
+# correct for find() (surfacing out-of-KB content is the point), but a relation
+# TARGET must be governed, in-KB material — you can't act on a read-only or
+# out-of-KB edge, so it just pollutes the graph. These are torch-free (no
+# sentence_transformers needed) so they live here rather than
+# test_corpus_aware.py, whose semantic section import-skips without the
+# `embeddings` extra.
+
+
+def _hit(path: str):
+    return find_module.Hit(
+        path=path, type="insight", scope=None, title=path.rsplit("/", 1)[-1],
+        updated="", excerpt="ex",
+    )
+
+
+def test_suggest_related_excludes_out_of_kb_targets(monkeypatch) -> None:
+    # Handbooks/ and Reference/ are sibling trees of Knowledge Base/ — read-only
+    # INPUT surfaced by find()'s auto-widen, never governed notes a relates_to
+    # edge can point at.
+    fake = [
+        _hit("Handbooks/incident-severity-levels.md"),
+        _hit("Reference/sample-curated.md"),
+        _hit("Knowledge Base/Notes/Insights/fresh.md"),
+    ]
+    monkeypatch.setattr(find_module, "find", lambda *a, **k: fake)
+    out = corpus_aware.suggest_related(Path("/unused"), title="t", body="b", limit=8)
+    paths = {corpus_aware._canon(s.path) for s in out}
+    assert "handbooks/incident-severity-levels" not in paths
+    assert "reference/sample-curated" not in paths
+    assert paths == {"notes/insights/fresh"}
+
+
+def test_suggest_related_excludes_readonly_and_excluded_targets(
+    vault: Path, monkeypatch
+) -> None:
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly:\n  - Products\nexcluded:\n  - Private\n", encoding="utf-8"
+    )
+    fake = [
+        _hit("Knowledge Base/Products/ro-note.md"),
+        _hit("Knowledge Base/Private/secret.md"),
+        _hit("Knowledge Base/Notes/Insights/fresh.md"),
+    ]
+    monkeypatch.setattr(find_module, "find", lambda *a, **k: fake)
+    out = corpus_aware.suggest_related(vault, title="t", body="b", limit=8)
+    paths = {corpus_aware._canon(s.path) for s in out}
+    assert "products/ro-note" not in paths
+    assert "private/secret" not in paths
+    assert paths == {"notes/insights/fresh"}
+
+
+def test_suggest_related_excludes_out_of_kb_hits_end_to_end(vault: Path) -> None:
+    """Real fixture vault, no monkeypatch: find()'s scope='kb' auto-widen would
+    surface Reference/sample-curated.md (see test_find.py's
+    test_scope_kb_auto_widens_to_curated_trees) — suggest_related must drop it.
+    """
+    out = corpus_aware.suggest_related(
+        vault, title="reference-marker-xyz", body="reference-marker-xyz", limit=8
+    )
+    assert not any(s.path.startswith("Reference/") for s in out)
+
+
+def test_propose_compilation_never_suggests_out_of_kb_connections(
+    vault: Path,
+) -> None:
+    """End-to-end through op_compile_source's underlying call: on a cold-start
+    KB, suggested_connections must never point at Handbooks/ or Reference/
+    (audit finding 2-02) even though find()'s auto-widen would surface them
+    for a plain query.
+    """
+    res = cp.propose_compilation(
+        vault,
+        sources=[_ARTICLE],
+        suggested_title="reference-marker-xyz incident-severity-levels",
+    )
+    for conn in res["suggested_connections"]:
+        assert not conn.startswith("Reference/"), res["suggested_connections"]
+        assert not conn.startswith("Handbooks/"), res["suggested_connections"]

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -40,3 +40,18 @@ def test_favicon_public_even_with_auth_enabled(vault, monkeypatch: pytest.Monkey
     # The whole point: no bearer token, auth turned ON, favicon still 200.
     r = _client(vault, monkeypatch, require_auth=True).get("/favicon.ico")
     assert r.status_code == 200, r.text
+
+
+def test_health_endpoint_public_and_reports_version(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`/health` is an unauthenticated liveness probe (tunnels/orchestrators need
+    an HTTP readiness check; previously only CLI `doctor` existed). Public even
+    with auth on, returns status + version, and leaks no vault data."""
+    r = _client(vault, monkeypatch).get("/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "exomem"
+    assert "version" in body
+    # Public even with OAuth enabled.
+    r2 = _client(vault, monkeypatch, require_auth=True).get("/health")
+    assert r2.status_code == 200, r2.text

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from exomem import audit as audit_module
-from exomem import index_sync
+from exomem import commands, index_sync
 from exomem import reconcile as reconcile_module
 
 
@@ -43,6 +43,37 @@ def test_reconcile_heals_index_count_drift(vault: Path) -> None:
     assert not any(
         f["category"] == "index_drift" for f in rep.remaining_drift
     ), rep.as_dict()
+
+
+def test_reconcile_via_maintain_memory_heals_out_of_band_count_drift(vault: Path) -> None:
+    """`maintain_memory(mode="reconcile")` — the only MCP-exposed entry point for
+    reconcile — must actually heal per-type count drift by default, not just
+    report it in `remaining_drift` forever. Regression for audit finding 1B-14:
+    `op_maintain_memory`'s blanket `dry_run=True` default (shared with the
+    riskier `fix`/`backfill-ids` modes) was silently swallowing every write for
+    `mode="reconcile"` even though `op_reconcile` itself defaults to writing.
+    """
+    top = vault / "Knowledge Base" / "index.md"
+    notes_dir = vault / "Knowledge Base" / "Notes" / "Insights"
+    out_of_band = notes_dir / "manual-oob-note.md"
+    out_of_band.write_text(
+        "---\ntype: note\npage_type: insight\n---\n\n# Manual OOB\n", encoding="utf-8"
+    )
+
+    # Call exactly as an MCP client would: no explicit dry_run.
+    res = commands.op_maintain_memory(vault, mode="reconcile")
+
+    assert res["dry_run"] is False, res
+    assert "- Notes (insight): 5" in top.read_text(encoding="utf-8")
+    assert not any(
+        f["category"] == "index_drift" for f in res["remaining_drift"]
+    ), res
+
+    # Idempotent: a second call finds nothing left to heal for this drift.
+    res2 = commands.op_maintain_memory(vault, mode="reconcile")
+    assert not any(
+        f["category"] == "index_drift" for f in res2["remaining_drift"]
+    ), res2
 
 
 def test_reconcile_refreshes_source_indexes_and_total_rows(vault: Path) -> None:

--- a/tests/test_relation_queue_commands.py
+++ b/tests/test_relation_queue_commands.py
@@ -66,6 +66,72 @@ def test_review_memory_relation_queue_mode_is_read_only(tmp_path: Path) -> None:
     assert result["shown"] >= 1
 
 
+def test_edit_creates_missing_section_only_when_opted_in(tmp_path: Path) -> None:
+    """`edit()` must be able to author the first entry into an absent section
+    (create_missing_section=True), while the default still errors on a missing
+    heading so an interactive typo doesn't silently spawn a section. Regression
+    for the audit's accept-relation HIGH: remember() emits no `## Relations`."""
+    from exomem import edit as edit_module
+
+    p = tmp_path / "Knowledge Base" / "Notes" / "Insights" / "n.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("---\ntype: insight\n---\n# N\n\nA body line.\n", encoding="utf-8")
+    rel = "Knowledge Base/Notes/Insights/n.md"
+
+    with pytest.raises(edit_module.EditError) as ei:
+        edit_module.edit(
+            tmp_path, path=rel, why="x", heading="Relations",
+            section_position="append", new_string="- relates_to [[Foo]]",
+        )
+    assert ei.value.code == "HEADING_NOT_FOUND"
+
+    edit_module.edit(
+        tmp_path, path=rel, why="x", heading="Relations",
+        section_position="append", new_string="- relates_to [[Foo]]",
+        create_missing_section=True,
+    )
+    text = p.read_text(encoding="utf-8")
+    assert "## Relations" in text
+    assert "relates_to" in text
+    assert text.count("## Relations") == 1  # exactly one section created
+
+
+def test_accept_relation_creates_relations_section_when_absent(tmp_path: Path) -> None:
+    """accept-relation must succeed on a note that has no `## Relations` section
+    (the common case — remember() doesn't emit one), creating it. Previously it
+    failed HEADING_NOT_FOUND on ~90% of notes."""
+    # 'cedar' links to birch in its BODY, with NO ## Relations section.
+    _write_page(
+        tmp_path, "cedar",
+        "Body mentions [[Knowledge Base/Notes/Insights/birch]] inline.",
+    )
+    _write_page(tmp_path, "birch", "A measured fact.")
+    find.clear_cache()
+
+    result = commands.op_review_memory(tmp_path, mode="relation-queue")
+    item = next(
+        (it for g in result["groups"] for it in g["items"]
+         if it["from"].endswith("cedar.md") and it["to"].endswith("birch.md")),
+        None,
+    )
+    if item is None:
+        pytest.skip("relation queue surfaced no cedar->birch candidate in this env")
+    group_hash = next(
+        g["content_hash"] for g in result["groups"] if g["path"].endswith("cedar.md")
+    )
+    out = commands.op_connect_memory(
+        tmp_path,
+        operation="accept-relation",
+        ref=item["ref"],
+        expected_hash=group_hash,
+        why="Accepted reviewed relation",
+        expected_fingerprint=item["fingerprint"],
+    )
+    assert out["accepted"] is True
+    text = (tmp_path / "Knowledge Base/Notes/Insights/cedar.md").read_text(encoding="utf-8")
+    assert "## Relations" in text
+
+
 def test_accept_writes_bullet_byte_identical_to_studio_path(tmp_path: Path) -> None:
     studio_vault = tmp_path / "studio"
     accept_vault = tmp_path / "accept"

--- a/tests/test_tier2.py
+++ b/tests/test_tier2.py
@@ -159,6 +159,28 @@ def test_create_file_path_escape_guarded(vault: Path) -> None:
     assert exc.value.code == "INVALID_PATH"
 
 
+def test_create_file_refuses_escape_out_of_knowledge_base(vault: Path) -> None:
+    """Governed writes stay under Knowledge Base/: a `..` that escapes KB to a
+    vault-root sibling is refused, and a bare path is rooted under KB rather than
+    written to the vault root. Regression for the audit's KB-boundary finding."""
+    for escape in (
+        "Knowledge Base/../outside.md",
+        "Knowledge Base/Notes/Insights/../../../escape-deep.md",
+        "Knowledge Base\\..\\out.md",
+    ):
+        with pytest.raises(create_file_module.CreateFileError) as exc:
+            create_file_module.create_file(vault, path=escape, content="x", today=TODAY)
+        assert exc.value.code == "INVALID_PATH", escape
+    # No stray file landed at the vault root (outside Knowledge Base/).
+    assert not (vault / "outside.md").exists()
+    assert not (vault / "escape-deep.md").exists()
+    assert not (vault / "out.md").exists()
+    # A bare KB-relative path is rooted UNDER Knowledge Base/, not the vault root.
+    create_file_module.create_file(vault, path="Notes/Insights/bare.md", content="x", today=TODAY)
+    assert (vault / "Knowledge Base" / "Notes" / "Insights" / "bare.md").exists()
+    assert not (vault / "Notes" / "Insights" / "bare.md").exists()
+
+
 def test_create_file_logs_to_log_md(vault: Path) -> None:
     create_file_module.create_file(
         vault,

--- a/tests/test_tier2.py
+++ b/tests/test_tier2.py
@@ -903,3 +903,36 @@ def test_tier2_dropped_when_disabled(
     # Tier 1 stays fully registered — only the escape hatches drop.
     assert {"ask_memory", "read_memory", "remember", "capture_source", "edit_memory", "review_memory", "connect_memory"} <= names
     assert names.isdisjoint(TIER2_TOOLS)
+
+
+def test_excluded_frontmatter_fields_are_refused(vault: Path) -> None:
+    """The schema excludes `confidence`/`decay_at`/`expires_at`; the writers must
+    enforce that, not just document it. Regression for the audit's confidence-float
+    finding (edit_memory(field='confidence') previously persisted 0.99)."""
+    import asyncio
+
+    from exomem import server as server_module
+
+    mcp = server_module.build_server(require_auth=False)
+    note = vault / "Knowledge Base" / "Notes" / "Insights" / "conf.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("---\ntype: insight\n---\n# C\n\nBody.\n", encoding="utf-8")
+    rel = "Knowledge Base/Notes/Insights/conf.md"
+
+    with pytest.raises(Exception) as ei:  # ToolError wrapping EXCLUDED_FIELD
+        asyncio.run(mcp.call_tool(
+            "edit_memory",
+            {"path": rel, "why": "x", "field": "confidence", "value": 0.99},
+            run_middleware=True,
+        ))
+    assert "EXCLUDED_FIELD" in str(ei.value) or "confidence" in str(ei.value)
+    assert "confidence" not in note.read_text(encoding="utf-8")
+
+    # create_file with an excluded key in its frontmatter dict is refused too.
+    with pytest.raises(create_file_module.CreateFileError) as ce:
+        create_file_module.create_file(
+            vault, path="Notes/Insights/decay.md",
+            content="x", frontmatter={"type": "insight", "decay_at": "2030-01-01"},
+            today=TODAY,
+        )
+    assert ce.value.code == "EXCLUDED_FIELD"

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.18.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Remediation from the adversarial "do we live up to our promises" audit. Every fix has a regression test; the MCP schema-fidelity gate stays green throughout. Full suite in isolation: **2017 passed**, 0 new failures (the 8 fails are pre-existing Windows-host test-portability artifacts — bash path mangling + a CRLF diff — unrelated to these changes).

## Confirmed HIGHs
- **Append-only immutability was bypassable by path casing** (Windows/macOS): an uppercase `SOURCES/`/`EVIDENCE/` prefix defeated the case-sensitive guard, letting `edit`/`append`/`delete` mutate raw Sources/Evidence. Centralized on a canonical, case-insensitive `in_append_only_tree` and routed the scattered guards through it. (3e20a1c)
- **`accept-relation` failed on the common note**: it authored via `edit(heading="Relations")`, which raised `HEADING_NOT_FOUND` when the section was absent (and `remember()` emits none), so accepting a suggested relation errored on most notes. Added an internal `create_missing` (server-side only — public MCP schema untouched). (3fd89f7)

## Mediums
- **Writes could escape `Knowledge Base/`** to a vault-root sibling via `manage_memory_file`; `resolve_under_vault` now roots governed writes under KB and refuses escapes, and the `batch_atomic_write` backstop fails **closed**. (6f7245e)
- **`confidence`/`decay_at`/`expires_at`** frontmatter (schema-excluded, promised absent) now refused by the writers. (7492c01)
- **compile/suggest-links proposed relation edges into read-only/out-of-KB material**; added an eligibility filter. (2fa0279)

## Lows / docs
- **reconcile silently no-op'd** via `maintain_memory` (uniform dry-run default); reconcile now heals by default, matching `op_reconcile`. (009170f)
- Added a public **`/health`** liveness endpoint. (a2573d3)
- Filled the **16 "TBD" OpenSpec purposes**. (dff88d7)
- Clarified `EXOMEM_DISABLE_EMBEDDINGS` semantics. (11b0a3e)

## Deliberately deferred (need design / tuning / validation — not rushed here)
Lease fencing, supersession atomicity, and connect/adopt-reads-gated-by-lease (own OpenSpec change each); recency-ranking / contradiction-verdicts (deliberate opt-in, WAI); relation-precision threshold + lane-attribution (do with the golden eval gate in the loop); graph-lane-in-retrieval and 50k p90 tail (real-vault validation + perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)