### PR TITLE
fix: make remote MCP sessions restart-safe

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -565,6 +565,12 @@ Pick the strongest option that fits the situation:
 
 ## Restarting the service
 
+Remote Streamable HTTP runs statelessly: authenticated tool calls do not rely
+on a process-local `Mcp-Session-Id`. A service restart or active/passive route
+change therefore cannot strand a transport session on the old process. OAuth
+is still enforced on every request; a genuinely expired, revoked, or invalid
+credential still requires authorization, but a normal restart does not.
+
 **macOS / Linux:** `bash scripts/restart.sh` — launchd `kickstart -k` on macOS,
 `systemctl --user restart` on Linux. It truncates `logs/exomem.log` and tails it.
 

--- a/openspec/changes/make-mcp-restarts-session-safe/.openspec.yaml
+++ b/openspec/changes/make-mcp-restarts-session-safe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/make-mcp-restarts-session-safe/design.md
+++ b/openspec/changes/make-mcp-restarts-session-safe/design.md
@@ -1,0 +1,43 @@
+## Context
+
+FastMCP's default Streamable HTTP transport is stateful: initialization creates a process-local transport session and later requests carry `Mcp-Session-Id`. Exomem's OAuth and writer state are durable and shared across replicas, but the transport session is not. A Windows service restart or HA route change therefore returns 404 for a previously valid session and can push clients into unnecessary connection and authorization recovery.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove process-local MCP transport sessions from remote HTTP operation.
+- Preserve OAuth enforcement, tool semantics, retry safety, and writer fencing.
+- Make the behavior an Exomem product default rather than a private deployment tweak.
+
+**Non-Goals:**
+
+- Persist FastMCP transport sessions externally.
+- Change token lifetime, signing, shared OAuth storage, or the MCP endpoint.
+- Change stdio transport behavior.
+
+## Decisions
+
+Pass `stateless_http=True` explicitly when Exomem runs an HTTP transport. FastMCP then creates a fresh transport for each request and does not require a process-local session record. Explicit construction is preferable to relying on `FASTMCP_STATELESS_HTTP` because restart/failover safety is part of Exomem's remote-server contract and should not depend on operator configuration.
+
+Preserve GET/SSE compatibility on the same OAuth-protected MCP route. FastMCP omits GET from stateless routes because server-initiated notifications are optional, but Codex and Claude still open that channel. The underlying MCP SDK stateless transport already handles GET without issuing a session ID, so an Exomem FastMCP subclass adds GET back to the protected route rather than implementing a parallel or unauthenticated endpoint.
+
+Keep OAuth unchanged. Stateless transport removes only the MCP session dependency; every request still passes through the existing OAuth middleware and durable token swap.
+
+Expose `/.well-known/openid-configuration` as an RFC 8414-compatible alias of Exomem's authorization-server metadata. Live Codex evidence showed a successful `/token` response immediately followed by a 404 at this alias, after which the client abandoned the connection. The alias contains OAuth endpoint metadata only; Exomem does not claim to issue OIDC ID tokens.
+
+Cover construction with a focused fake-server test that asserts remote runs enable stateless mode and stdio runs do not receive the option. Integration verification will exercise repeated authenticated calls before and after one controlled service restart.
+
+## Risks / Trade-offs
+
+- [FastMCP changes its internal route shape] → Keep a focused route-method regression test and fail construction visibly if the protected MCP route cannot be found.
+- [Per-request transport setup adds overhead] → FastMCP exposes this mode for horizontally scaled deployments; measure consecutive call latency during live verification.
+- [Stateless mode does not repair an actually invalid OAuth token] → OAuth remains independently diagnosable; the change targets the observed 404/reconnect cascade after restart.
+
+## Migration Plan
+
+Deploy as a normal Exomem service update and perform one controlled restart. Existing clients should establish a stateless request on their next call. Roll back by removing the explicit option if a supported connector proves incompatible.
+
+## Open Questions
+
+None before implementation.

--- a/openspec/changes/make-mcp-restarts-session-safe/proposal.md
+++ b/openspec/changes/make-mcp-restarts-session-safe/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Remote MCP clients currently depend on process-local Streamable HTTP session IDs. A normal Exomem restart or HA failover invalidates those IDs, causing repeated 404/reconnect/authentication churn even though the OAuth credential and shared state remain valid.
+
+## What Changes
+
+- Run remote Streamable HTTP in FastMCP stateless mode so each request gets a fresh transport and no process-local session survives between calls.
+- Serve the OIDC discovery alias used by Codex after OAuth token exchange.
+- Preserve OAuth, shared encrypted token storage, writer fencing, and tool behavior.
+- Add regression coverage proving remote HTTP construction is stateless while stdio remains unchanged.
+- Document restart/failover continuity for self-hosted deployments.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-session-continuity`: Remote MCP calls do not depend on process-local transport session state and can recover cleanly across Exomem restart or replica failover.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Affected areas are `src/exomem/server.py`, `src/exomem/server_assets.py`, focused server transport tests, and deployment documentation. No MCP tool schema, OAuth token semantics, vault format, dependency, or stdio behavior changes.

--- a/openspec/changes/make-mcp-restarts-session-safe/specs/mcp-session-continuity/spec.md
+++ b/openspec/changes/make-mcp-restarts-session-safe/specs/mcp-session-continuity/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Remote MCP requests are process-session independent
+The system SHALL run remote Streamable HTTP without requiring a process-local MCP transport session to survive between requests.
+
+#### Scenario: Consecutive remote calls
+- **WHEN** an authenticated client makes multiple MCP calls to the remote endpoint
+- **THEN** each call is handled without depending on a previously allocated process-local transport session
+
+#### Scenario: Client opens the optional GET stream
+- **WHEN** an authenticated client opens the Streamable HTTP GET/SSE channel
+- **THEN** the server accepts the connection without allocating or requiring a process-local session ID
+- **AND** the GET endpoint remains protected by the same OAuth middleware as POST
+
+#### Scenario: Service restart or replica failover
+- **WHEN** the Exomem process serving the endpoint changes between authenticated MCP calls
+- **THEN** the next call can establish transport handling without a stale `Mcp-Session-Id` lookup
+- **AND** OAuth authentication remains required
+
+### Requirement: Local stdio behavior remains unchanged
+The system SHALL preserve the existing stdio transport behavior for local MCP clients.
+
+#### Scenario: Stdio server start
+- **WHEN** Exomem starts with the stdio transport
+- **THEN** it does not apply HTTP stateless transport configuration
+
+### Requirement: Codex discovery completes after OAuth exchange
+The system SHALL expose OAuth authorization-server metadata at the OIDC well-known alias used by compatible MCP clients.
+
+#### Scenario: Client probes OIDC discovery after token exchange
+- **WHEN** a client requests `/.well-known/openid-configuration`
+- **THEN** the server returns the issuer, authorization, token, registration, grant, client-authentication, and PKCE metadata for Exomem's OAuth server
+- **AND** the response does not claim that Exomem issues OIDC ID tokens

--- a/openspec/changes/make-mcp-restarts-session-safe/tasks.md
+++ b/openspec/changes/make-mcp-restarts-session-safe/tasks.md
@@ -1,0 +1,21 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add focused server-run tests proving HTTP transports enable stateless mode.
+- [x] 1.2 Prove stdio construction remains unchanged.
+
+## 2. Restart-safe transport
+
+- [x] 2.1 Configure remote HTTP runs with explicit FastMCP stateless transport.
+- [x] 2.2 Document restart/failover continuity and the remaining OAuth boundary.
+- [x] 2.3 Serve and test the OIDC discovery alias observed in the Codex reconnect flow.
+
+## 3. Verification
+
+- [x] 3.1 Run focused tests, Ruff, and strict OpenSpec validation.
+- [x] 3.2 Run the lean suite (2,010 passed; eight unrelated Windows harness/encoding failures documented).
+- [x] 3.3 Deploy once and prove repeated authenticated calls before and after a controlled restart.
+
+### Live verification evidence
+
+- Before restart, a freshly reopened Codex connection completed initialization and repeated authenticated `POST /mcp` requests with `200 OK` / `202 Accepted` responses.
+- After the controlled 2026-07-12 19:00 Europe/Tallinn service restart, Exomem started in stateless mode and the client reopened five authenticated `GET /mcp` streams with `200 OK`; there was no `401`, stale-session `404`, discovery loop, or reauthorization prompt.

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -41,6 +41,35 @@ _GUARDED_WRITE_FIELDS = commands_module.GUARDED_WRITE_FIELDS
 _link_summary = commands_module._link_summary
 
 
+class ExomemFastMCP(FastMCP):
+    """FastMCP with stateless POST plus authenticated GET/SSE compatibility.
+
+    FastMCP normally omits GET from a stateless Streamable HTTP route because
+    stateless servers do not need server-initiated notifications. Codex and
+    Claude still open the optional GET/SSE channel, though. The MCP SDK's
+    stateless transport supports that channel without allocating a session ID,
+    so expose the method on the same OAuth-protected route.
+    """
+
+    def http_app(self, *args, stateless_http=None, **kwargs):
+        app = super().http_app(*args, stateless_http=stateless_http, **kwargs)
+        if stateless_http:
+            endpoint_found = False
+            for route in app.routes:
+                methods = getattr(route, "methods", None)
+                if (
+                    getattr(route, "path", None) == app.state.path
+                    and methods is not None
+                    and {"POST", "DELETE"}.issubset(methods)
+                ):
+                    methods.add("GET")
+                    endpoint_found = True
+                    break
+            if not endpoint_found:
+                raise RuntimeError("FastMCP stateless endpoint route was not found")
+        return app
+
+
 class CallTraceMiddleware(Middleware):
     """Per-call traceability: log every tool invocation with name + duration."""
 
@@ -132,7 +161,7 @@ def build_server(*, require_auth: bool) -> FastMCP:
     start_server_lifecycle()
     auth = build_oauth(require_auth=require_auth, base_url=runtime.base_url)
 
-    mcp = FastMCP("exomem", auth=auth, icons=server_icons())
+    mcp = ExomemFastMCP("exomem", auth=auth, icons=server_icons())
     mcp.add_middleware(CallTraceMiddleware())
 
     register_asset_routes(mcp)
@@ -262,4 +291,10 @@ def run(
             host=host,
             port=port,
             middleware=[ASGIMiddleware(PrimeMcpSSEMiddleware)],
+            # Remote clients may be routed to another replica or outlive this
+            # process.  A process-local Mcp-Session-Id turns either event into
+            # a 404/reconnect cascade; each Exomem operation is already an
+            # independently authenticated request, so use FastMCP's transport
+            # mode designed for horizontally scaled/restartable servers.
+            stateless_http=True,
         )

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -144,12 +144,39 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
 def register_oauth_metadata_route(
     mcp_app: FastMCP, *, base_url: str, auth_enabled: bool
 ) -> None:
-    """Mirror OAuth protected-resource metadata at the bare well-known path."""
+    """Expose compatibility aliases for OAuth/OIDC discovery."""
     if not auth_enabled:
         return
 
+    base_url = base_url.rstrip("/")
     resource_url = f"{base_url}/mcp"
     issuer_url = f"{base_url}/"
+
+    @mcp_app.custom_route("/.well-known/openid-configuration", methods=["GET"])
+    async def _openid_configuration(request: Request) -> JSONResponse:  # noqa: ARG001
+        # Some MCP clients probe the OIDC alias after a successful OAuth token
+        # exchange. Exomem uses OAuth (not ID tokens), so return the same RFC
+        # 8414 authorization-server metadata shape as the canonical endpoint.
+        return JSONResponse(
+            {
+                "issuer": issuer_url,
+                "authorization_endpoint": f"{base_url}/authorize",
+                "token_endpoint": f"{base_url}/token",
+                "registration_endpoint": f"{base_url}/register",
+                "scopes_supported": [],
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "token_endpoint_auth_methods_supported": [
+                    "client_secret_post",
+                    "client_secret_basic",
+                    "private_key_jwt",
+                    "none",
+                ],
+                "code_challenge_methods_supported": ["S256"],
+                "client_id_metadata_document_supported": True,
+            },
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
 
     @mcp_app.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
     async def _oauth_protected_resource_bare(request: Request) -> JSONResponse:  # noqa: ARG001

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from typing import Any
 
+import pytest
+
+from exomem import logging_config, server
+from exomem.server_assets import register_oauth_metadata_route
 from exomem.server_transport import PrimeMcpSSEMiddleware
 
 
@@ -90,3 +96,81 @@ def test_non_sse_or_failed_response_is_not_primed() -> None:
             )
         )
     ) == 2
+
+
+class _FakeMcp:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def run(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.fixture
+def fake_mcp(monkeypatch: pytest.MonkeyPatch) -> _FakeMcp:
+    fake = _FakeMcp()
+    monkeypatch.setattr(server, "build_server", lambda **_kwargs: fake)
+    monkeypatch.setattr(logging_config, "configure_logging", lambda *_args, **_kwargs: None)
+    return fake
+
+
+@pytest.mark.parametrize("transport", ["http", "streamable-http"])
+def test_remote_http_runs_stateless(
+    fake_mcp: _FakeMcp,
+    monkeypatch: pytest.MonkeyPatch,
+    transport: str,
+) -> None:
+    monkeypatch.delenv("EXOMEM_HOST", raising=False)
+
+    server.run(transport=transport, host="127.0.0.1", port=9876)
+
+    assert len(fake_mcp.calls) == 1
+    call = fake_mcp.calls[0]
+    middleware = call.pop("middleware")
+    assert call == {
+        "transport": transport,
+        "host": "127.0.0.1",
+        "port": 9876,
+        "stateless_http": True,
+    }
+    assert len(middleware) == 1
+    assert middleware[0].cls is server.PrimeMcpSSEMiddleware
+
+
+def test_stdio_does_not_apply_http_stateless_configuration(fake_mcp: _FakeMcp) -> None:
+    server.run(transport="stdio")
+
+    assert fake_mcp.calls == [{"transport": "stdio"}]
+
+
+def test_stateless_http_keeps_get_sse_compatibility() -> None:
+    mcp = server.ExomemFastMCP("transport-test")
+
+    app = mcp.http_app(transport="streamable-http", stateless_http=True)
+
+    endpoint = next(route for route in app.routes if getattr(route, "path", None) == "/mcp")
+    assert endpoint.methods == {"GET", "POST", "DELETE"}
+
+
+def test_openid_discovery_alias_returns_oauth_metadata() -> None:
+    mcp = server.ExomemFastMCP("discovery-test")
+    register_oauth_metadata_route(
+        mcp,
+        base_url="https://memory.example",
+        auth_enabled=True,
+    )
+    app = mcp.http_app(transport="streamable-http", stateless_http=True)
+    route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/.well-known/openid-configuration"
+    )
+
+    response = asyncio.run(route.endpoint(None))
+    metadata = json.loads(response.body)
+
+    assert metadata["issuer"] == "https://memory.example/"
+    assert metadata["authorization_endpoint"] == "https://memory.example/authorize"
+    assert metadata["token_endpoint"] == "https://memory.example/token"
+    assert metadata["registration_endpoint"] == "https://memory.example/register"
+    assert metadata["code_challenge_methods_supported"] == ["S256"]


### PR DESCRIPTION
## Summary

- run remote Streamable HTTP in FastMCP stateless mode
- preserve authenticated GET/SSE compatibility for Codex and Claude
- expose the OIDC discovery alias Codex probes after OAuth exchange
- document restart/failover continuity and add regression coverage

## Verification

- `uv run pytest tests/test_server_transport.py -q` — 7 passed
- `uvx ruff check src/exomem/server.py src/exomem/server_assets.py tests/test_server_transport.py` — clean
- `openspec validate make-mcp-restarts-session-safe --strict` — valid
- lean suite — 2,010 passed, 16 skipped; eight unrelated pre-existing Windows installer/console-encoding failures
- live Codex proof — authenticated POST calls succeeded before restart; after a controlled service restart, Codex reopened five authenticated GET streams with 200 responses and no 401, stale-session 404, discovery loop, or reauthorization prompt