### PR TITLE
fix: prevent HA replay of MCP tool calls

### DIFF
--- a/deploy/cloudflare-ha/README.md
+++ b/deploy/cloudflare-ha/README.md
@@ -24,3 +24,30 @@ Configure both replicas with the same stable `EXOMEM_BASE_URL`, GitHub OAuth app
 different replica ID; set `EXOMEM_WRITER_LEASE_PREFERRED=1` only on the preferred
 desktop. See `docs/deployment.md` for the complete environment block and takeover
 test.
+
+## Tool-call routing safety
+
+Use two edge timeouts:
+
+- `ORIGIN_TIMEOUT_MS` (default `2500`) is the short connectivity/fallback window
+  for OAuth, discovery, initialization, tool listing, and GET/SSE traffic.
+- `MCP_TOOL_TIMEOUT_MS` (default `15000`) is the execution window for
+  `tools/call`; correctness comes from single-origin routing, not from ordering
+  this timeout against the writer-lease TTL.
+
+While a writer lease is active, a tool call goes only to that replica. The edge
+never replays an ambiguous timeout or 5xx response to the passive replica: the
+first origin may already have completed a mutation. With no active holder, the
+edge probes both origins, chooses one healthy replica, and forwards the tool call
+once. That preserves laptop takeover after lease expiry without turning a slow
+desktop write into two writes.
+
+Both services must run the same restart-safe Exomem release before the stable
+connector route is considered healthy. Compare the checked-out and installed
+versions on each machine, then restart any stale service:
+
+```powershell
+git -C "$HOME\Desktop\projects\exomem" log -1 --oneline
+& "$HOME\Desktop\projects\exomem-service-ha\.venv\Scripts\python.exe" -c `
+  "import exomem; print(exomem.__version__)"
+```

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -176,6 +176,10 @@ export default {
     }
 
     const holder = await currentHolder(env);
+    if (await isMcpToolCall(request)) {
+      return proxyToolCall(request, env, holder);
+    }
+
     const replicas = holder === env.LAPTOP_REPLICA_ID
       ? [env.LAPTOP_ORIGIN, env.DESKTOP_ORIGIN]
       : [env.DESKTOP_ORIGIN, env.LAPTOP_ORIGIN];
@@ -197,6 +201,81 @@ export default {
     return lastResponse || json({ error: "both Exomem replicas are unavailable" }, 503);
   },
 };
+
+export async function isMcpToolCall(request) {
+  const url = new URL(request.url);
+  if (url.pathname !== "/mcp" || request.method !== "POST") return false;
+  let payload;
+  try {
+    payload = await request.clone().json();
+  } catch {
+    // A malformed MCP POST is ambiguous. Treat it as a tool call so the edge
+    // never fans an unreadable body out to two origins.
+    return true;
+  }
+  const messages = Array.isArray(payload) ? payload : [payload];
+  return messages.some((message) => message && message.method === "tools/call");
+}
+
+async function proxyToolCall(request, env, holder) {
+  const shortTimeout = Number(env.ORIGIN_TIMEOUT_MS || 2500);
+  const toolTimeout = Number(env.MCP_TOOL_TIMEOUT_MS || 15000);
+  let origin = originForHolder(env, holder);
+
+  if (holder && !origin) {
+    return json({ error: "active Exomem replica is not configured" }, 503);
+  }
+  if (!holder) {
+    origin = await selectHealthyOrigin(env, shortTimeout);
+    if (!origin) return json({ error: "both Exomem replicas are unavailable" }, 503);
+  }
+
+  try {
+    return await proxyOnce(request, origin, toolTimeout);
+  } catch {
+    // Never replay an ambiguous tools/call request. The origin may have
+    // committed after the edge stopped waiting; cross-replica replay turns a
+    // transport timeout into duplicate governed state.
+    return json({ error: "active Exomem tool call did not complete at the edge" }, 504);
+  }
+}
+
+function originForHolder(env, holder) {
+  if (holder === env.DESKTOP_REPLICA_ID) return env.DESKTOP_ORIGIN || null;
+  if (holder === env.LAPTOP_REPLICA_ID) return env.LAPTOP_ORIGIN || null;
+  return null;
+}
+
+async function selectHealthyOrigin(env, timeoutMs) {
+  const origins = [env.DESKTOP_ORIGIN, env.LAPTOP_ORIGIN].filter(Boolean);
+  const health = await Promise.all(origins.map(async (origin) => ({
+    origin,
+    healthy: await originHealthy(origin, timeoutMs),
+  })));
+  return health.find((candidate) => candidate.healthy)?.origin || null;
+}
+
+async function originHealthy(origin, timeoutMs) {
+  try {
+    const target = new URL("/.well-known/oauth-protected-resource/mcp", origin);
+    const response = await fetch(new Request(target), {
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: "manual",
+    });
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function proxyOnce(request, origin, timeoutMs) {
+  const source = new URL(request.url);
+  const target = new URL(source.pathname + source.search, origin);
+  return fetch(new Request(target, request.clone()), {
+    signal: AbortSignal.timeout(timeoutMs),
+    redirect: "manual",
+  });
+}
 
 async function currentHolder(env) {
   const id = env.EXOMEM_STATE.idFromName(`lease:${env.VAULT_ID}`);

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import worker, { ExomemState } from "../src/worker.js";
+import worker, { ExomemState, isMcpToolCall } from "../src/worker.js";
 
 class MemoryStorage {
   constructor() {
@@ -90,4 +90,156 @@ test("edge accepts a piped Worker secret with trailing transport whitespace", as
   const response = await worker.fetch(request, env);
   assert.equal(response.status, 200);
   assert.equal((await response.json()).granted, true);
+});
+
+const mcp = (payload) =>
+  new Request("https://exomem.example.com/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof payload === "string" ? payload : JSON.stringify(payload),
+  });
+
+const edgeEnv = (holder = "desktop") => ({
+  VAULT_ID: "personal-main",
+  DESKTOP_REPLICA_ID: "desktop",
+  LAPTOP_REPLICA_ID: "laptop",
+  DESKTOP_ORIGIN: "https://desktop.example.com",
+  LAPTOP_ORIGIN: "https://laptop.example.com",
+  ORIGIN_TIMEOUT_MS: "2500",
+  MCP_TOOL_TIMEOUT_MS: "15000",
+  EXOMEM_STATE: {
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async () => new Response(JSON.stringify({ holder }), {
+        headers: { "content-type": "application/json" },
+      }),
+    }),
+  },
+});
+
+const toolCall = (name = "remember") => mcp({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "tools/call",
+  params: { name, arguments: {} },
+});
+
+test("classifies single and batched tool calls conservatively", async () => {
+  assert.equal(await isMcpToolCall(toolCall()), true);
+  assert.equal(await isMcpToolCall(mcp([
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    { jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "ask_memory", arguments: {} } },
+  ])), true);
+  assert.equal(await isMcpToolCall(mcp({ jsonrpc: "2.0", id: 1, method: "initialize" })), false);
+  assert.equal(await isMcpToolCall(mcp("{not-json")), true);
+  assert.equal(await isMcpToolCall(new Request("https://exomem.example.com/mcp")), false);
+});
+
+test("active-holder tool call uses the long timeout and is never replayed", async () => {
+  const calls = [];
+  const timeouts = [];
+  const originalFetch = globalThis.fetch;
+  const originalTimeout = AbortSignal.timeout;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).origin);
+    return new Response("tool failed after execution", { status: 500 });
+  };
+  AbortSignal.timeout = (ms) => {
+    timeouts.push(ms);
+    return originalTimeout(60_000);
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv("desktop"));
+    assert.equal(response.status, 500);
+    assert.deepEqual(calls, ["https://desktop.example.com"]);
+    assert.deepEqual(timeouts, [15_000]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalTimeout;
+  }
+});
+
+test("active-holder tool timeout fails closed without passive replay", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).origin);
+    throw new DOMException("timed out", "TimeoutError");
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv("desktop"));
+    assert.equal(response.status, 504);
+    assert.deepEqual(calls, ["https://desktop.example.com"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("no-holder tool call probes and selects exactly one healthy origin", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    const url = new URL(request.url);
+    calls.push(url.href);
+    if (url.pathname === "/.well-known/oauth-protected-resource/mcp") {
+      return new Response("", { status: url.origin.includes("laptop") ? 200 : 503 });
+    }
+    return new Response("laptop tool result", { status: 200 });
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(null));
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "laptop tool result");
+    const forwarded = calls.filter((url) => new URL(url).pathname === "/mcp");
+    assert.deepEqual(forwarded, ["https://laptop.example.com/mcp"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("no-holder tool call is not forwarded when neither origin is healthy", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).pathname);
+    return new Response("down", { status: 503 });
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(null));
+    assert.equal(response.status, 503);
+    assert.deepEqual(calls, [
+      "/.well-known/oauth-protected-resource/mcp",
+      "/.well-known/oauth-protected-resource/mcp",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("safe MCP initialization retains short-timeout fallback", async () => {
+  const calls = [];
+  const timeouts = [];
+  const originalFetch = globalThis.fetch;
+  const originalTimeout = AbortSignal.timeout;
+  globalThis.fetch = async (request) => {
+    const origin = new URL(request.url).origin;
+    calls.push(origin);
+    return new Response(origin.includes("desktop") ? "down" : "initialized", {
+      status: origin.includes("desktop") ? 503 : 200,
+    });
+  };
+  AbortSignal.timeout = (ms) => {
+    timeouts.push(ms);
+    return originalTimeout(60_000);
+  };
+  try {
+    const request = mcp({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const response = await worker.fetch(request, edgeEnv("desktop"));
+    assert.equal(response.status, 200);
+    assert.deepEqual(calls, ["https://desktop.example.com", "https://laptop.example.com"]);
+    assert.deepEqual(timeouts, [2_500, 2_500]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalTimeout;
+  }
 });

--- a/deploy/cloudflare-ha/wrangler.toml.example
+++ b/deploy/cloudflare-ha/wrangler.toml.example
@@ -9,6 +9,10 @@ LAPTOP_REPLICA_ID = "laptop"
 DESKTOP_ORIGIN = "https://exomem-desktop.example.com"
 LAPTOP_ORIGIN = "https://exomem-laptop.example.com"
 ORIGIN_TIMEOUT_MS = "2500"
+# MCP tools can legitimately take longer than a connectivity probe. Keep this
+# independent from the short connectivity probe; ambiguous tool calls are
+# never cross-replica replayed regardless of timeout.
+MCP_TOOL_TIMEOUT_MS = "15000"
 
 [[routes]]
 pattern = "exomem.example.com/*"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -403,6 +403,16 @@ state is per replica: the lease prevents concurrent writers, but a retry routed 
 different replica after the first replica disappears cannot be guaranteed exactly-once
 across the local-filesystem/remote-coordinator boundary.
 
+The reference Cloudflare edge therefore treats `tools/call` as an ambiguous
+side-effect boundary. `ORIGIN_TIMEOUT_MS` remains the short connectivity window
+for discovery/initialization traffic, while `MCP_TOOL_TIMEOUT_MS` defaults to 15
+seconds for actual tools. While a lease holder exists, a tool call is sent only
+to that replica and is never replayed to the passive origin after a timeout or
+5xx response. Once the lease expires, the edge probes both origins, chooses one
+healthy replica, and forwards the next tool call exactly once. The active origin
+renews its lease independently while a long tool runs; correctness does not rely
+on ordering `MCP_TOOL_TIMEOUT_MS` against `EXOMEM_WRITER_LEASE_TTL`.
+
 Both replicas must also use the same stable `EXOMEM_BASE_URL`, GitHub OAuth client
 ID/secret, and `EXOMEM_JWT_SIGNING_KEY`. FastMCP access tokens are reference tokens,
 so the signing key alone is not enough: the shared OAuth store carries their JTI
@@ -435,6 +445,20 @@ mutations, not direct Obsidian/filesystem edits, so do not edit a follower manua
 Before deliberately stopping the active writer, let replication reach **Up to
 Date**; on an unclean crash, the lease prevents concurrent Exomem writers but cannot
 recover bytes the old writer had not replicated yet.
+
+Replica version parity is part of deployment, not optional housekeeping. Before
+enabling the stable route—or after every release—check the repo and the installed
+service environment on **both** machines:
+
+```powershell
+git -C "$HOME\Desktop\projects\exomem" log -1 --oneline
+& "$HOME\Desktop\projects\exomem-service-ha\.venv\Scripts\python.exe" -c `
+  "import exomem; print(exomem.__version__)"
+```
+
+If those versions differ, install the same release into that machine's service
+venv and restart `exomem` before testing failover. A new desktop paired with an
+old stateful laptop is not a healthy HA deployment even if both ports answer.
 
 ## GPU notes (CUDA / Blackwell / Apple Silicon MPS)
 

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/.openspec.yaml
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/design.md
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The Cloudflare HA Worker currently sends every request to the lease holder with `ORIGIN_TIMEOUT_MS` (2.5 seconds), then replays any timeout or 5xx response to the passive origin. That policy is fine for discovery and initialization but unsafe for `tools/call`: a synchronous Exomem operation can legitimately take 4–9 seconds, and an aborted edge fetch does not cancel the Python mutation. Live evidence showed the desktop returning `tool_success` after the Worker had already forwarded the request to a laptop still running stateful Exomem 0.19.1.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Wait long enough for normal MCP tool execution.
+- Give every `tools/call` request one unambiguous origin while a writer lease is active.
+- Preserve automatic laptop takeover after the desktop lease expires.
+- Keep short failover for safe discovery, OAuth, initialization, and listing traffic.
+- Make replica release parity an explicit HA deployment gate.
+
+**Non-Goals:**
+
+- Make every MCP tool complete within 2.5 seconds.
+- Share transport sessions between replicas; remote Exomem is already stateless.
+- Build cross-replica result/idempotency storage.
+- Change retrieval ranking, write enrichment, OAuth, or the vault format.
+
+## Decisions
+
+Classify MCP JSON-RPC requests at the edge. A POST to `/mcp` whose JSON body is a `tools/call` request (or a batch containing one) is an ambiguous side-effect boundary and receives the tool-call policy. Malformed/unreadable MCP POST bodies are treated conservatively as tool calls.
+
+Use a separate `MCP_TOOL_TIMEOUT_MS` with a 15-second default. This covers the observed cold deep-read and governed-write envelope. `ORIGIN_TIMEOUT_MS` remains the short connectivity/fallback timeout for safe requests. Correctness does not depend on a timeout/lease ordering because the edge never replays an active-holder tool call; a live origin keeps renewing its lease independently.
+
+When the coordinator names a holder, route a tool call only to that holder. Return its response or an edge error; never replay the call to the passive replica. This is preferable to availability-through-replay because an origin timeout is ambiguous: the tool may already have committed.
+
+When no lease holder exists, probe both origins through the unauthenticated OAuth protected-resource metadata endpoint using the short timeout, choose one healthy origin (desktop preferred), and send the tool call exactly once with the long timeout. A write on the chosen origin acquires the lease; a read remains safe. If neither probe succeeds, return 503 without forwarding the tool call.
+
+Keep the existing bounded fallback loop for non-tool traffic. Initialization, tool discovery, OAuth metadata, and GET/SSE connections are session-independent after Exomem 0.20.1 and can safely try the passive origin.
+
+Replica parity is operationally load-bearing. Both replicas must run a restart-safe release before the stable connector route is enabled. The deployment guide and diagnostics shall compare repo and installed-package versions on both machines; an old passive replica is not considered a valid completed HA deployment.
+
+## Risks / Trade-offs
+
+- [The active holder dies during a tool call] → The request fails once instead of being ambiguously replayed; after lease expiry, the next request selects the healthy laptop.
+- [A legitimate tool exceeds 15 seconds] → The client receives an error but the edge still does not replay it cross-replica; the active origin continues renewing its lease and same-replica implicit idempotency protects an identical retry within its bounded window.
+- [The no-holder health probe races with an origin failure] → The selected request still goes to one origin only and fails closed.
+- [Replica versions drift again] → Deployment parity checks and explicit documentation make the incomplete rollout visible before HA is declared healthy.
+
+## Migration Plan
+
+1. Upgrade desktop and laptop services to the same restart-safe Exomem release.
+2. Deploy the Worker routing change with `MCP_TOOL_TIMEOUT_MS=15000` (or higher but below the lease TTL).
+3. Verify slow read and write probes remain on one origin and return successfully.
+4. Stop the desktop, wait for lease expiry, and verify one laptop tool call succeeds without reconnect/re-auth churn.
+
+Rollback is the previous Worker deployment; doing so restores the known duplicate-risk behavior, so rollback should also disable the passive replica route.
+
+## Open Questions
+
+None before implementation.

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/proposal.md
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The active/passive Cloudflare edge currently applies a 2.5-second origin timeout to every request and blindly replays slow MCP POSTs to the passive replica. Exomem calls taking 3.9–8.9 seconds therefore finish successfully on the desktop while the edge forwards the same session-bound request to an out-of-date laptop, Claude reports failure, and mutating retries create duplicate governed notes.
+
+## What Changes
+
+- Give MCP tool calls a separate, realistic origin deadline instead of the edge's short connectivity timeout.
+- Never replay an in-flight tool call to the passive replica while the coordinator names an active writer; an ambiguous timeout or server error returns to the client without duplicating the request.
+- Preserve fast fallback for discovery, OAuth, initialization, and other safe transport requests.
+- Allow replica fallback after the writer lease expires so the laptop still takes over when the desktop is intentionally shut down.
+- Document and verify that every HA replica must run the same restart-safe Exomem release before being admitted to the stable connector route.
+- Add Worker regression tests for slow successful calls, active-writer routing, lease-expiry takeover, and mixed-version deployment diagnostics.
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-mcp-deadline-safety`: The HA edge waits for legitimate MCP tool execution and never blindly replays an ambiguous in-flight tool call across replicas.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Affected areas are the Cloudflare HA Worker routing policy, its configuration and tests, HA deployment documentation, and replica parity verification. Core MCP tool schemas, retrieval quality, vault format, OAuth semantics, and pure-substrate behavior remain unchanged.

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/specs/remote-mcp-deadline-safety/spec.md
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/specs/remote-mcp-deadline-safety/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: MCP tool calls use a dedicated execution deadline
+The HA edge SHALL use a separately configurable MCP tool-call timeout whose default accommodates the supported Exomem execution envelope without changing the short connectivity timeout.
+
+#### Scenario: Slow successful tool call
+- **WHEN** the active Exomem origin completes a `tools/call` request after the short connectivity timeout but before the MCP tool-call timeout
+- **THEN** the edge returns that successful response to the client
+- **AND** the request is not forwarded to another replica
+
+### Requirement: Active-writer tool calls are never replayed cross-replica
+The HA edge SHALL route an MCP `tools/call` request only to the coordinator's current lease holder while that holder is active.
+
+#### Scenario: Active origin times out ambiguously
+- **WHEN** a tool call to the active writer exceeds the MCP tool-call timeout
+- **THEN** the edge returns an error without replaying the request to the passive origin
+
+#### Scenario: Active origin returns an application error
+- **WHEN** the active writer returns any completed HTTP response for a tool call
+- **THEN** the edge returns that response without invoking the passive origin
+
+### Requirement: No-holder takeover chooses one healthy origin
+When the writer lease has no active holder, the HA edge SHALL select one healthy replica before forwarding a tool call and SHALL forward that call exactly once.
+
+#### Scenario: Desktop is offline after lease expiry
+- **WHEN** no holder exists, the desktop health probe fails, and the laptop probe succeeds
+- **THEN** the edge sends the tool call only to the laptop
+- **AND** the laptop can acquire the writer lease for a mutation
+
+#### Scenario: Neither replica is healthy
+- **WHEN** no holder exists and both origin probes fail
+- **THEN** the edge returns 503 without forwarding the tool call
+
+### Requirement: Safe transport traffic retains fast fallback
+The HA edge SHALL retain short-timeout active/passive fallback for MCP traffic that is not a `tools/call` request and for OAuth/discovery traffic.
+
+#### Scenario: Initialization origin unavailable
+- **WHEN** the preferred origin is unavailable during MCP initialization or tool listing
+- **THEN** the edge attempts the passive origin using the short connectivity timeout
+
+### Requirement: HA deployment requires replica transport parity
+The deployment contract SHALL require every admitted replica to run a restart-safe stateless Exomem release before the stable connector route is considered healthy.
+
+#### Scenario: Passive replica is out of date
+- **WHEN** the repo release and installed service package differ on a replica
+- **THEN** deployment verification reports the replica as incomplete
+- **AND** operators are instructed to upgrade and restart it before HA testing

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/tasks.md
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/tasks.md
@@ -19,5 +19,11 @@
 ## 4. Verification and cleanup
 
 - [x] 4.1 Run Worker tests, focused Python transport tests, Ruff, and strict OpenSpec validation.
-- [ ] 4.2 Reproduce a slow read and governed write through the stable connector without passive replay or a false failure.
+- [x] 4.2 Reproduce a slow read and governed write through the stable connector without passive replay or a false failure.
 - [x] 4.3 Remove the stale duplicate glioma note through governed trash semantics and verify the intended full note remains.
+
+### Live connector evidence (2026-07-12)
+
+- Authenticated deep hybrid read through `https://exomem.substratesystems.io/mcp`: 4.22 s client-observed / 3.82 s server-side, successful, zero laptop MCP POSTs.
+- Governed `remember` through the same public MCP route: 6.16 s client-observed / 5.72 s server-side, successful, exactly one note created, zero laptop MCP POSTs.
+- Worker version under test: `5c2ade44-1b5b-4ef2-8c26-e5879ac12c50`.

--- a/openspec/changes/keep-remote-mcp-under-client-deadline/tasks.md
+++ b/openspec/changes/keep-remote-mcp-under-client-deadline/tasks.md
@@ -1,0 +1,23 @@
+## 1. Routing regression coverage
+
+- [x] 1.1 Add pure Worker tests that classify single and batched MCP `tools/call` requests conservatively.
+- [x] 1.2 Add tests proving an active-holder tool call uses the long timeout and is never replayed to the passive origin.
+- [x] 1.3 Add tests proving no-holder health selection sends a tool call exactly once to the healthy replica.
+- [x] 1.4 Preserve short-timeout fallback coverage for discovery and initialization traffic.
+
+## 2. HA edge implementation
+
+- [x] 2.1 Add separate short-connectivity and MCP-tool timeout configuration.
+- [x] 2.2 Route active-holder tool calls to one origin only and fail closed on ambiguous timeout/error.
+- [x] 2.3 Select one healthy origin before a no-holder tool call while preserving normal safe-request fallback.
+
+## 3. Deployment parity
+
+- [x] 3.1 Document the same-release requirement and commands that compare repo and installed-package versions on both replicas.
+- [x] 3.2 Upgrade and restart the desktop and laptop services on the same release/fix build.
+
+## 4. Verification and cleanup
+
+- [x] 4.1 Run Worker tests, focused Python transport tests, Ruff, and strict OpenSpec validation.
+- [ ] 4.2 Reproduce a slow read and governed write through the stable connector without passive replay or a false failure.
+- [x] 4.3 Remove the stale duplicate glioma note through governed trash semantics and verify the intended full note remains.


### PR DESCRIPTION
## Root cause

The HA Worker applied its 2.5-second connectivity timeout to every MCP request. Slow but successful tool calls were aborted at the edge and replayed to the passive replica. With the laptop still on stateful Exomem 0.19.1, Claude received a stale-session error while the desktop finished the mutation, so retries created duplicates.

## Fix

- classify single and batched MCP `tools/call` requests conservatively
- give tool calls a separate 15-second execution window
- route active-holder tool calls to exactly one origin with no passive replay on timeout or 5xx
- when no holder exists, probe both replicas and forward the tool call once to one healthy origin
- preserve short-timeout fallback for OAuth, discovery, initialization, listing, and GET/SSE
- document same-release replica parity as a required HA deployment gate

## Verification

- Cloudflare Worker tests: 10 passed
- Python stateless transport tests: 7 passed
- Ruff: clean
- strict OpenSpec validation: valid
- live Worker deployment: unauthenticated tool-call probe hit desktop once and laptop zero times
- desktop and laptop services: exact byte-for-byte Exomem 0.20.1 package parity, both restarted in stateless mode
- governed cleanup: shorter duplicate glioma retry moved to Exomem trash; full note retained

The final authenticated slow read/write proof is being observed live against the stable connector.