### PR TITLE
feat: gate HA failover on runtime readiness

### DIFF
--- a/deploy/cloudflare-ha/README.md
+++ b/deploy/cloudflare-ha/README.md
@@ -37,17 +37,38 @@ Use two edge timeouts:
 
 While a writer lease is active, a tool call goes only to that replica. The edge
 never replays an ambiguous timeout or 5xx response to the passive replica: the
-first origin may already have completed a mutation. With no active holder, the
-edge probes both origins, chooses one healthy replica, and forwards the tool call
-once. That preserves laptop takeover after lease expiry without turning a slow
-desktop write into two writes.
+first origin may already have completed a mutation. Before routing, it admits the
+runtime through `/health/ready`: supported runtime contract, stateless transport,
+expected replica identity, healthy coordination, and takeover eligibility. The
+admission is bound to the lease fencing token in the Durable Object, so steady
+state does not add a readiness round trip to every MCP call.
 
-Both services must run the same restart-safe Exomem release before the stable
-connector route is considered healthy. Compare the checked-out and installed
-versions on each machine, then restart any stale service:
+With no holder, both origins are probed concurrently and the call is forwarded
+exactly once to the first eligible replica. A live but stale service that lacks
+the readiness contract is skipped instead of becoming the failover writer.
+
+Configure `SUPPORTED_RUNTIME_CONTRACTS` with behavioral contract versions, not
+package versions. Compatible releases can differ during a rolling deployment.
+Before enabling enforcement, compare the checked-out and installed versions and
+probe readiness on each machine:
 
 ```powershell
 git -C "$HOME\Desktop\projects\exomem" log -1 --oneline
 & "$HOME\Desktop\projects\exomem-service-ha\.venv\Scripts\python.exe" -c `
   "import exomem; print(exomem.__version__)"
+curl.exe -fsS https://exomem-desktop.example.com/health/ready
+curl.exe -fsS https://exomem-laptop.example.com/health/ready
 ```
+
+Run the combined read-only gate from either checkout:
+
+```powershell
+uv run python -m exomem doctor --profile ha --probe `
+  --replica-url https://exomem-desktop.example.com `
+  --replica-url https://exomem-laptop.example.com
+```
+
+For a future incompatible contract bump, use expand-roll-contract: temporarily
+accept both contracts (`"1,2"`), roll every replica, verify doctor, then remove
+the old contract. Deployment infrastructure owns release pinning and rollback;
+Exomem does not update another machine and does not depend on Syncthing.

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -20,6 +20,7 @@ export class ExomemState {
   async fetch(request) {
     const url = new URL(request.url);
     if (url.pathname === "/lease") return this.lease(request);
+    if (url.pathname === "/admission") return this.admission(request);
     if (url.pathname.startsWith("/state/")) return this.sharedState(request, url.pathname.slice(7));
     return json({ error: "not found" }, 404);
   }
@@ -58,6 +59,9 @@ export class ExomemState {
               ? current.fencing_token
               : current.fencing_token + 1,
         };
+        if (active && current.holder === replica && current.admission) {
+          next.admission = current.admission;
+        }
         await tx.put("lease", next);
         return json({ ...next, granted: true });
       }
@@ -76,6 +80,7 @@ export class ExomemState {
         if (valid) {
           current.holder = null;
           current.expires_at = null;
+          delete current.admission;
           await tx.put("lease", current);
         }
         return json({ ...normalizeLease(current, now), granted: Boolean(valid) });
@@ -93,6 +98,48 @@ export class ExomemState {
     const normalized = normalizeLease(current, now);
     if (current.holder && !normalized.holder) await this.state.storage.put("lease", normalized);
     return { ...normalized, granted: false };
+  }
+
+  async admission(request) {
+    if (request.method !== "POST") return json({ error: "method not allowed" }, 405);
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "invalid request" }, 400);
+    }
+    const holder = String(body.holder || "");
+    const fencingToken = Number(body.fencing_token);
+    const readiness = body.readiness;
+    if (
+      !holder
+      || !Number.isInteger(fencingToken)
+      || !readiness
+      || typeof readiness !== "object"
+      || Array.isArray(readiness)
+    ) {
+      return json({ error: "invalid request" }, 400);
+    }
+    const now = Date.now() / 1000;
+    return this.state.storage.transaction(async (tx) => {
+      const current = (await tx.get("lease")) || {
+        holder: null,
+        expires_at: null,
+        fencing_token: 0,
+      };
+      const matches = current.holder === holder
+        && current.expires_at > now
+        && current.fencing_token === fencingToken;
+      if (!matches) return json({ stored: false, error: "lease changed" }, 409);
+      current.admission = {
+        holder,
+        fencing_token: fencingToken,
+        readiness,
+        admitted_at: now,
+      };
+      await tx.put("lease", current);
+      return json({ stored: true });
+    });
   }
 
   async sharedState(request, operation) {
@@ -175,9 +222,10 @@ export default {
       );
     }
 
-    const holder = await currentHolder(env);
+    const lease = await currentLease(env);
+    const holder = lease.holder;
     if (await isMcpToolCall(request)) {
-      return proxyToolCall(request, env, holder);
+      return proxyToolCall(request, env, lease);
     }
 
     const replicas = holder === env.LAPTOP_REPLICA_ID
@@ -217,21 +265,31 @@ export async function isMcpToolCall(request) {
   return messages.some((message) => message && message.method === "tools/call");
 }
 
-async function proxyToolCall(request, env, holder) {
+async function proxyToolCall(request, env, lease) {
   const shortTimeout = Number(env.ORIGIN_TIMEOUT_MS || 2500);
   const toolTimeout = Number(env.MCP_TOOL_TIMEOUT_MS || 15000);
-  let origin = originForHolder(env, holder);
+  const holder = lease.holder;
+  let candidate = candidateForHolder(env, holder);
 
-  if (holder && !origin) {
+  if (holder && !candidate) {
     return json({ error: "active Exomem replica is not configured" }, 503);
   }
-  if (!holder) {
-    origin = await selectHealthyOrigin(env, shortTimeout);
-    if (!origin) return json({ error: "both Exomem replicas are unavailable" }, 503);
+  if (holder) {
+    if (!admissionEligible(lease.admission, env, holder, lease.fencing_token)) {
+      candidate = await probeCandidateReadiness(candidate, env, shortTimeout);
+      if (!candidate) {
+        return json({ error: "active Exomem replica is not runtime-ready" }, 503);
+      }
+      const stored = await recordAdmission(env, lease, candidate.readiness);
+      if (!stored) return json({ error: "writer lease changed during runtime admission" }, 503);
+    }
+  } else {
+    candidate = await selectEligibleOrigin(env, shortTimeout);
+    if (!candidate) return json({ error: "both Exomem replicas are ineligible" }, 503);
   }
 
   try {
-    return await proxyOnce(request, origin, toolTimeout);
+    return await proxyOnce(request, candidate.origin, toolTimeout);
   } catch {
     // Never replay an ambiguous tools/call request. The origin may have
     // committed after the edge stopped waiting; cross-replica replay turns a
@@ -240,32 +298,137 @@ async function proxyToolCall(request, env, holder) {
   }
 }
 
-function originForHolder(env, holder) {
-  if (holder === env.DESKTOP_REPLICA_ID) return env.DESKTOP_ORIGIN || null;
-  if (holder === env.LAPTOP_REPLICA_ID) return env.LAPTOP_ORIGIN || null;
+function candidateForHolder(env, holder) {
+  if (holder === env.DESKTOP_REPLICA_ID && env.DESKTOP_ORIGIN) {
+    return { origin: env.DESKTOP_ORIGIN, replicaId: env.DESKTOP_REPLICA_ID };
+  }
+  if (holder === env.LAPTOP_REPLICA_ID && env.LAPTOP_ORIGIN) {
+    return { origin: env.LAPTOP_ORIGIN, replicaId: env.LAPTOP_REPLICA_ID };
+  }
   return null;
 }
 
-async function selectHealthyOrigin(env, timeoutMs) {
-  const origins = [env.DESKTOP_ORIGIN, env.LAPTOP_ORIGIN].filter(Boolean);
-  const health = await Promise.all(origins.map(async (origin) => ({
-    origin,
-    healthy: await originHealthy(origin, timeoutMs),
-  })));
-  return health.find((candidate) => candidate.healthy)?.origin || null;
+function configuredCandidates(env) {
+  return [
+    env.DESKTOP_ORIGIN && env.DESKTOP_REPLICA_ID
+      ? { origin: env.DESKTOP_ORIGIN, replicaId: env.DESKTOP_REPLICA_ID }
+      : null,
+    env.LAPTOP_ORIGIN && env.LAPTOP_REPLICA_ID
+      ? { origin: env.LAPTOP_ORIGIN, replicaId: env.LAPTOP_REPLICA_ID }
+      : null,
+  ].filter(Boolean);
 }
 
-async function originHealthy(origin, timeoutMs) {
+async function selectEligibleOrigin(env, timeoutMs) {
+  const checked = await Promise.all(
+    configuredCandidates(env).map((candidate) => probeCandidateReadiness(candidate, env, timeoutMs)),
+  );
+  return checked.find(Boolean) || null;
+}
+
+async function probeCandidateReadiness(candidate, env, timeoutMs) {
   try {
-    const target = new URL("/.well-known/oauth-protected-resource/mcp", origin);
+    const target = new URL("/health/ready", candidate.origin);
     const response = await fetch(new Request(target), {
       signal: AbortSignal.timeout(timeoutMs),
       redirect: "manual",
     });
-    return response.status < 500;
+    if (response.status !== 200) return null;
+    const readiness = await response.json();
+    const evaluation = evaluateReadiness(readiness, env, candidate.replicaId);
+    return evaluation.eligible ? { ...candidate, readiness } : null;
   } catch {
+    return null;
+  }
+}
+
+export function evaluateReadiness(readiness, env, expectedReplicaId) {
+  if (!readiness || typeof readiness !== "object" || Array.isArray(readiness)) {
+    return { eligible: false, reason: "invalid_readiness_payload" };
+  }
+  if (readiness.status !== "ready" || readiness.service !== "exomem") {
+    return { eligible: false, reason: "runtime_not_ready" };
+  }
+  if (typeof readiness.release !== "string" || !readiness.release) {
+    return { eligible: false, reason: "release_identity_missing" };
+  }
+  const runtimeContract = Number(readiness.runtime_contract);
+  if (!Number.isInteger(runtimeContract) || !supportedRuntimeContracts(env).has(runtimeContract)) {
+    return { eligible: false, reason: "unsupported_runtime_contract" };
+  }
+  const requiredTransport = env.REQUIRED_RUNTIME_TRANSPORT || "streamable-http-stateless";
+  if (readiness.transport !== requiredTransport) {
+    return { eligible: false, reason: "unsupported_transport" };
+  }
+  if (readiness.replica_id !== expectedReplicaId) {
+    return { eligible: false, reason: "replica_identity_mismatch" };
+  }
+  if (readiness.takeover_eligible !== true) {
+    return { eligible: false, reason: "takeover_ineligible" };
+  }
+  const coordination = readiness.coordination;
+  if (requireCoordination(env)) {
+    if (!coordination || coordination.enabled !== true) {
+      return { eligible: false, reason: "coordination_required" };
+    }
+    if (coordination.coordinator_healthy !== true) {
+      return { eligible: false, reason: "coordinator_unavailable" };
+    }
+  }
+  return { eligible: true, reason: null };
+}
+
+function supportedRuntimeContracts(env) {
+  const values = String(env.SUPPORTED_RUNTIME_CONTRACTS || "1")
+    .split(",")
+    .map((value) => Number(value.trim()))
+    .filter(Number.isInteger);
+  return new Set(values);
+}
+
+function requireCoordination(env) {
+  return !["0", "false", "no", "off"].includes(
+    String(env.REQUIRE_COORDINATION ?? "true").trim().toLowerCase(),
+  );
+}
+
+function admissionEligible(admission, env, holder, fencingToken) {
+  if (!admission || admission.holder !== holder || admission.fencing_token !== fencingToken) {
     return false;
   }
+  return evaluateReadiness(admission.readiness, env, holder).eligible;
+}
+
+async function recordAdmission(env, lease, readiness) {
+  const id = env.EXOMEM_STATE.idFromName(`lease:${env.VAULT_ID}`);
+  const response = await env.EXOMEM_STATE.get(id).fetch(new Request("https://state/admission", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      holder: lease.holder,
+      fencing_token: lease.fencing_token,
+      readiness: readinessSummary(readiness),
+    }),
+  }));
+  return response.status === 200;
+}
+
+function readinessSummary(readiness) {
+  return {
+    status: readiness.status,
+    service: readiness.service,
+    release: readiness.release,
+    runtime_contract: readiness.runtime_contract,
+    transport: readiness.transport,
+    replica_id: readiness.replica_id,
+    coordination: {
+      enabled: readiness.coordination?.enabled === true,
+      role: readiness.coordination?.role || "unknown",
+      coordinator_healthy: readiness.coordination?.coordinator_healthy === true,
+    },
+    takeover_eligible: readiness.takeover_eligible === true,
+    reasons: Array.isArray(readiness.reasons) ? readiness.reasons.map(String).slice(0, 8) : [],
+  };
 }
 
 function proxyOnce(request, origin, timeoutMs) {
@@ -277,10 +440,10 @@ function proxyOnce(request, origin, timeoutMs) {
   });
 }
 
-async function currentHolder(env) {
+async function currentLease(env) {
   const id = env.EXOMEM_STATE.idFromName(`lease:${env.VAULT_ID}`);
-  const response = await env.EXOMEM_STATE.get(id).fetch("https://state/lease");
-  return (await response.json()).holder;
+  const response = await env.EXOMEM_STATE.get(id).fetch(new Request("https://state/lease"));
+  return response.json();
 }
 
 function normalizeLease(lease, now) {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import worker, { ExomemState, isMcpToolCall } from "../src/worker.js";
+import worker, {
+  ExomemState,
+  evaluateReadiness,
+  isMcpToolCall,
+} from "../src/worker.js";
 
 class MemoryStorage {
   constructor() {
@@ -99,7 +103,37 @@ const mcp = (payload) =>
     body: typeof payload === "string" ? payload : JSON.stringify(payload),
   });
 
-const edgeEnv = (holder = "desktop") => ({
+const readiness = (replicaId, overrides = {}) => ({
+  status: "ready",
+  service: "exomem",
+  release: "0.20.2",
+  runtime_contract: 1,
+  transport: "streamable-http-stateless",
+  replica_id: replicaId,
+  coordination: { enabled: true, role: "follower", coordinator_healthy: true },
+  takeover_eligible: true,
+  reasons: [],
+  ...overrides,
+});
+
+const admission = (replicaId, fencingToken = 7) => ({
+  holder: replicaId,
+  fencing_token: fencingToken,
+  readiness: readiness(replicaId),
+});
+
+const leaseRecord = (value) => {
+  if (value && typeof value === "object") return value;
+  if (value == null) return { holder: null, expires_at: null, fencing_token: 7 };
+  return {
+    holder: value,
+    expires_at: Date.now() / 1000 + 30,
+    fencing_token: 7,
+    admission: admission(value),
+  };
+};
+
+const edgeEnv = (lease = "desktop", stateFetch = null) => ({
   VAULT_ID: "personal-main",
   DESKTOP_REPLICA_ID: "desktop",
   LAPTOP_REPLICA_ID: "laptop",
@@ -107,12 +141,14 @@ const edgeEnv = (holder = "desktop") => ({
   LAPTOP_ORIGIN: "https://laptop.example.com",
   ORIGIN_TIMEOUT_MS: "2500",
   MCP_TOOL_TIMEOUT_MS: "15000",
+  SUPPORTED_RUNTIME_CONTRACTS: "1",
+  REQUIRE_COORDINATION: "true",
   EXOMEM_STATE: {
     idFromName: (name) => name,
     get: () => ({
-      fetch: async () => new Response(JSON.stringify({ holder }), {
+      fetch: stateFetch || (async () => new Response(JSON.stringify(leaseRecord(lease)), {
         headers: { "content-type": "application/json" },
-      }),
+      })),
     }),
   },
 });
@@ -133,6 +169,68 @@ test("classifies single and batched tool calls conservatively", async () => {
   assert.equal(await isMcpToolCall(mcp({ jsonrpc: "2.0", id: 1, method: "initialize" })), false);
   assert.equal(await isMcpToolCall(mcp("{not-json")), true);
   assert.equal(await isMcpToolCall(new Request("https://exomem.example.com/mcp")), false);
+});
+
+test("readiness admission uses compatibility rather than exact release equality", () => {
+  const env = edgeEnv();
+  assert.deepEqual(evaluateReadiness(readiness("desktop", { release: "0.20.99" }), env, "desktop"), {
+    eligible: true,
+    reason: null,
+  });
+  assert.equal(
+    evaluateReadiness(readiness("desktop", { runtime_contract: 2 }), env, "desktop").reason,
+    "unsupported_runtime_contract",
+  );
+  assert.equal(
+    evaluateReadiness(readiness("desktop", { transport: "streamable-http-stateful" }), env, "desktop").reason,
+    "unsupported_transport",
+  );
+  assert.equal(
+    evaluateReadiness(readiness("laptop"), env, "desktop").reason,
+    "replica_identity_mismatch",
+  );
+  assert.equal(
+    evaluateReadiness(readiness("desktop", {
+      coordination: { enabled: false, role: "standalone", coordinator_healthy: true },
+    }), env, "desktop").reason,
+    "coordination_required",
+  );
+});
+
+test("lease admission is bound to holder and fencing token and cleared on takeover", async () => {
+  const object = new ExomemState({ storage: new MemoryStorage() });
+  const desktop = await body(await object.fetch(post("/lease?operation=acquire", {
+    replica_id: "desktop",
+    ttl_seconds: 30,
+  })));
+  const admitted = await object.fetch(post("/admission", {
+    holder: "desktop",
+    fencing_token: desktop.fencing_token,
+    readiness: readiness("desktop"),
+  }));
+  assert.equal(admitted.status, 200);
+  let status = await body(await object.fetch(new Request("https://state/lease")));
+  assert.equal(status.admission.fencing_token, desktop.fencing_token);
+
+  await object.fetch(post("/lease?operation=release", {
+    replica_id: "desktop",
+    fencing_token: desktop.fencing_token,
+  }));
+  const laptop = await body(await object.fetch(post("/lease?operation=acquire", {
+    replica_id: "laptop",
+    ttl_seconds: 30,
+  })));
+  status = await body(await object.fetch(new Request("https://state/lease")));
+  assert.equal(status.holder, "laptop");
+  assert.equal(status.admission, undefined);
+
+  const stale = await object.fetch(post("/admission", {
+    holder: "desktop",
+    fencing_token: desktop.fencing_token,
+    readiness: readiness("desktop"),
+  }));
+  assert.equal(stale.status, 409);
+  assert.equal(laptop.fencing_token, 2);
 });
 
 test("active-holder tool call uses the long timeout and is never replayed", async () => {
@@ -175,14 +273,77 @@ test("active-holder tool timeout fails closed without passive replay", async () 
   }
 });
 
+test("active holder without cached admission is probed once and recorded", async () => {
+  const calls = [];
+  const stateCalls = [];
+  const lease = {
+    holder: "desktop",
+    expires_at: Date.now() / 1000 + 30,
+    fencing_token: 12,
+  };
+  const stateFetch = async (request) => {
+    const url = new URL(request.url);
+    stateCalls.push({ path: url.pathname, method: request.method });
+    if (url.pathname === "/admission") return new Response('{"stored":true}', { status: 200 });
+    return new Response(JSON.stringify(lease), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    const url = new URL(request.url);
+    calls.push(url.pathname);
+    if (url.pathname === "/health/ready") {
+      return Response.json(readiness("desktop"));
+    }
+    return new Response("ok", { status: 200 });
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(lease, stateFetch));
+    assert.equal(response.status, 200);
+    assert.deepEqual(calls, ["/health/ready", "/mcp"]);
+    assert.deepEqual(stateCalls, [
+      { path: "/lease", method: "GET" },
+      { path: "/admission", method: "POST" },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ineligible active holder fails closed without invoking either MCP origin", async () => {
+  const calls = [];
+  const lease = {
+    holder: "desktop",
+    expires_at: Date.now() / 1000 + 30,
+    fencing_token: 12,
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).pathname);
+    return Response.json(readiness("desktop", { runtime_contract: 99 }));
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv(lease));
+    assert.equal(response.status, 503);
+    assert.deepEqual(calls, ["/health/ready"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("no-holder tool call probes and selects exactly one healthy origin", async () => {
   const calls = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (request) => {
     const url = new URL(request.url);
     calls.push(url.href);
-    if (url.pathname === "/.well-known/oauth-protected-resource/mcp") {
-      return new Response("", { status: url.origin.includes("laptop") ? 200 : 503 });
+    if (url.pathname === "/health/ready") {
+      return Response.json(
+        url.origin.includes("laptop")
+          ? readiness("laptop")
+          : readiness("desktop", { runtime_contract: 99 }),
+      );
     }
     return new Response("laptop tool result", { status: 200 });
   };
@@ -208,9 +369,26 @@ test("no-holder tool call is not forwarded when neither origin is healthy", asyn
     const response = await worker.fetch(toolCall(), edgeEnv(null));
     assert.equal(response.status, 503);
     assert.deepEqual(calls, [
-      "/.well-known/oauth-protected-resource/mcp",
-      "/.well-known/oauth-protected-resource/mcp",
+      "/health/ready",
+      "/health/ready",
     ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("cached active-holder admission preserves the steady-state single-fetch path", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).pathname);
+    return new Response("cached writer", { status: 200 });
+  };
+  try {
+    const response = await worker.fetch(toolCall(), edgeEnv("desktop"));
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "cached writer");
+    assert.deepEqual(calls, ["/mcp"]);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/deploy/cloudflare-ha/wrangler.toml.example
+++ b/deploy/cloudflare-ha/wrangler.toml.example
@@ -1,6 +1,6 @@
 name = "exomem-ha-edge"
 main = "src/worker.js"
-compatibility_date = "2026-07-11"
+compatibility_date = "2026-07-12"
 
 [vars]
 VAULT_ID = "personal-main"
@@ -13,6 +13,11 @@ ORIGIN_TIMEOUT_MS = "2500"
 # independent from the short connectivity probe; ambiguous tool calls are
 # never cross-replica replayed regardless of timeout.
 MCP_TOOL_TIMEOUT_MS = "15000"
+# Behavioral compatibility, not exact package versions. During an incompatible
+# rolling deployment, expand to "1,2", roll every replica, then contract to "2".
+SUPPORTED_RUNTIME_CONTRACTS = "1"
+REQUIRED_RUNTIME_TRANSPORT = "streamable-http-stateless"
+REQUIRE_COORDINATION = "true"
 
 [[routes]]
 pattern = "exomem.example.com/*"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -409,7 +409,12 @@ for discovery/initialization traffic, while `MCP_TOOL_TIMEOUT_MS` defaults to 15
 seconds for actual tools. While a lease holder exists, a tool call is sent only
 to that replica and is never replayed to the passive origin after a timeout or
 5xx response. Once the lease expires, the edge probes both origins, chooses one
-healthy replica, and forwards the next tool call exactly once. The active origin
+runtime-compatible replica, and forwards the next tool call exactly once. Runtime
+admission uses the content-free `/health/ready` contract: supported behavioral
+contract, stateless HTTP transport, expected replica identity, healthy writer
+coordination, and takeover eligibility. Admission is cached in the Durable Object
+against the active lease holder and fencing token, so steady-state tool calls do
+not pay another origin probe. The active origin
 renews its lease independently while a long tool runs; correctness does not rely
 on ordering `MCP_TOOL_TIMEOUT_MS` against `EXOMEM_WRITER_LEASE_TTL`.
 
@@ -446,19 +451,41 @@ Before deliberately stopping the active writer, let replication reach **Up to
 Date**; on an unclean crash, the lease prevents concurrent Exomem writers but cannot
 recover bytes the old writer had not replicated yet.
 
-Replica version parity is part of deployment, not optional housekeeping. Before
-enabling the stable route—or after every release—check the repo and the installed
-service environment on **both** machines:
+Replica release drift remains deployment housekeeping, but runtime compatibility
+is now enforced independently. Before enabling the stable route—or after every
+release—check the repo, installed service environment, and readiness contract on
+**both** machines:
 
 ```powershell
 git -C "$HOME\Desktop\projects\exomem" log -1 --oneline
 & "$HOME\Desktop\projects\exomem-service-ha\.venv\Scripts\python.exe" -c `
   "import exomem; print(exomem.__version__)"
+curl.exe -fsS https://exomem-desktop.example.com/health/ready
+curl.exe -fsS https://exomem-laptop.example.com/health/ready
 ```
 
-If those versions differ, install the same release into that machine's service
-venv and restart `exomem` before testing failover. A new desktop paired with an
-old stateful laptop is not a healthy HA deployment even if both ports answer.
+Then run the combined read-only diagnostic:
+
+```powershell
+uv run python -m exomem doctor --profile ha --probe `
+  --replica-url https://exomem-desktop.example.com `
+  --replica-url https://exomem-laptop.example.com
+```
+
+Different package releases are allowed when they advertise a supported common
+runtime contract. A missing readiness route, unsupported contract, stateful
+transport, duplicate replica identity, unhealthy coordinator, or takeover
+ineligibility fails the HA gate. An old stateful laptop is therefore excluded
+even if its port answers.
+
+The Worker example sets `SUPPORTED_RUNTIME_CONTRACTS="1"`,
+`REQUIRED_RUNTIME_TRANSPORT="streamable-http-stateless"`, and
+`REQUIRE_COORDINATION="true"`. For an incompatible contract bump, first expand
+the accepted set (for example `"1,2"`), roll every replica, confirm doctor passes,
+then contract the set to the new version. The deployment platform owns immutable
+release pinning, rollout, and rollback. Exomem deliberately has no cross-machine
+auto-updater, and the readiness contract is independent of Syncthing or any other
+replication product.
 
 ## GPU notes (CUDA / Blackwell / Apple Silicon MPS)
 

--- a/openspec/changes/add-runtime-readiness-contract/.openspec.yaml
+++ b/openspec/changes/add-runtime-readiness-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/add-runtime-readiness-contract/design.md
+++ b/openspec/changes/add-runtime-readiness-contract/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The HA edge already asks a Durable Object for the active writer lease before routing MCP tool calls. It currently treats OAuth metadata as health when no holder exists and trusts any active holder without knowing which Exomem runtime is installed. Repository state and the installed service package can drift, while hosted rolling deployments legitimately run different releases for a bounded period.
+
+The existing `/health` route is liveness only and must remain cheap and independent of vault, coordinator, or model state. The existing writer lease provides a fencing token that changes whenever ownership transfers, which is a natural generation key for cached runtime admission.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose a small, non-secret readiness contract usable by self-hosted and hosted orchestration.
+- Distinguish release identity from behavioral compatibility.
+- Prevent an incompatible, stateful, or coordination-broken replica from receiving an HA tool call.
+- Preserve the steady-state MCP latency path after one admission probe per lease generation.
+- Give operators a read-only doctor workflow that detects drift before failover.
+
+**Non-Goals:**
+
+- Automatically update Exomem, Windows services, containers, or repositories.
+- Require exact release equality across replicas.
+- Couple Exomem to Syncthing or a particular deployment platform.
+- Turn readiness into a model, retrieval, or vault-content check.
+- Replay a failed or ambiguous MCP tool call to another replica.
+
+## Decisions
+
+### Separate liveness from readiness
+
+Keep `/health` unchanged. Add `GET /health/ready`, returning HTTP 200 when the runtime can be admitted and 503 when it cannot. The JSON contains only service/release metadata, integer `runtime_contract`, stateless HTTP transport identity, replica identity, coordination health/role, `takeover_eligible`, and stable reason codes. It never returns vault paths, vault IDs, credentials, or content.
+
+Alternative considered: extend `/health`. Rejected because liveness must continue answering during coordinator outages so supervisors do not restart a healthy process merely because it cannot safely take writes.
+
+### Gate on a compatibility contract, not semantic version
+
+`release` is diagnostic. `runtime_contract` is the routing contract and changes only for incompatible runtime/edge behavior. The Worker accepts a configurable comma-separated set of contracts so a rolling deployment can temporarily admit old and new contracts together.
+
+Alternative considered: require matching Exomem versions. Rejected because patch releases and compatible rolling deployments should not cause downtime.
+
+### Require HA-specific eligibility at the edge
+
+The Worker validates readiness status, supported contract, stateless transport, expected replica ID, takeover eligibility, and (by default) enabled/healthy coordination. Standalone Exomem remains ready for single-host deployments; the HA Worker applies the stricter coordination requirement through configuration.
+
+### Cache admission by lease fencing token
+
+The Durable Object stores the admitted readiness summary only when its holder and fencing token still match the active lease. Subsequent tool calls reuse that admission after re-evaluating it against the Worker's current supported-contract configuration. Lease expiry, release, or ownership change clears the admission.
+
+If an active lease has no admission, the Worker probes that holder once and records the result. With no holder, it probes replicas concurrently, chooses one eligible origin, and forwards the tool call exactly once. The next request admits the newly acquired lease generation. This avoids a readiness network round trip on the steady-state path without using unsafe module-global request state.
+
+Alternative considered: probe readiness on every tool call. Rejected because it adds avoidable origin latency to cached retrievals. Module-global caching was also rejected because Workers reuse isolates across requests and it would not be authoritative across isolates.
+
+### Keep doctor network access explicit
+
+Add `ha` as a doctor profile. Local HA configuration checks run offline. Cross-replica readiness checks run only with `--probe` and explicit repeatable `--replica-url` values (or `EXOMEM_HA_REPLICA_URLS`). Release differences produce warnings; unsupported contracts, non-stateless transport, disabled/unhealthy coordination, duplicate replica IDs, or ineligible replicas fail.
+
+## Risks / Trade-offs
+
+- **A cached admission can outlive a process restart briefly** → admission is bound to the lease fencing token; normal release/expiry invalidates it, and ambiguous tool calls still never replay.
+- **A direct-origin caller could acquire a lease before edge admission** → the first stable-edge tool call to that holder must admit its readiness or fail closed.
+- **Public readiness metadata can fingerprint a release** → the payload is intentionally content-free and small; deployments that require secrecy can keep origin routes private.
+- **Contract bumps require rollout choreography** → configure the Worker to accept both contracts, roll replicas, then remove the old contract.
+- **Coordinator outage makes a coordinated replica unready for takeover** → this is intentional fail-closed behavior; `/health` remains live and reads through already-routed safe traffic remain available.
+
+## Migration Plan
+
+1. Ship the readiness endpoint and HA doctor support with runtime contract `1`.
+2. Upgrade every replica and verify `/health/ready` directly while the Worker still runs the previous routing release.
+3. Deploy the Worker with `SUPPORTED_RUNTIME_CONTRACTS = "1"` and coordination enforcement enabled.
+4. Run the HA doctor probe and a live MCP read/write test.
+5. Roll back the Worker if admission unexpectedly rejects a replica; `/health` and the existing services remain untouched.
+
+## Open Questions
+
+None for contract version 1. Future hosted infrastructure may move the same readiness checks behind private service bindings or platform-native readiness probes without changing the payload semantics.

--- a/openspec/changes/add-runtime-readiness-contract/proposal.md
+++ b/openspec/changes/add-runtime-readiness-contract/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Exomem's HA edge can now avoid ambiguous tool-call replay, but a replica whose checkout and installed runtime have drifted can still be selected during failover. Hosted rollout needs the same protection without requiring exact release equality during normal rolling deployments.
+
+## What Changes
+
+- Add a small, unauthenticated runtime readiness endpoint distinct from the existing liveness endpoint.
+- Report non-secret release identity, a compatibility contract version, HTTP transport mode, coordination state, and whether the replica is eligible for takeover.
+- Gate HA tool-call origin selection on readiness and compatibility instead of OAuth discovery alone.
+- Fail closed when an active holder is unavailable, incompatible, or ineligible; never replay the tool call to another replica.
+- Add an HA doctor profile that compares configured replica readiness and explains release drift versus true incompatibility.
+- Document that deployment infrastructure owns image pinning, rollout, and rollback; Exomem does not auto-update replicas or require exact release equality.
+
+## Capabilities
+
+### New Capabilities
+- `runtime-readiness-contract`: Machine-readable runtime readiness, compatibility-aware HA admission, and fail-closed routing behavior for self-hosted and hosted deployments.
+
+### Modified Capabilities
+- `install-readiness`: Extend the read-only doctor command with an HA profile that validates replica readiness and compatibility without mutating services or vaults.
+
+## Impact
+
+- Exomem HTTP server routes and runtime metadata.
+- Writer-lease/coordination status used to determine takeover eligibility.
+- Cloudflare HA Worker origin probes and routing tests.
+- Doctor CLI, tests, deployment documentation, and Worker example configuration.
+- No new model, storage backend, updater, or Syncthing dependency.

--- a/openspec/changes/add-runtime-readiness-contract/specs/install-readiness/spec.md
+++ b/openspec/changes/add-runtime-readiness-contract/specs/install-readiness/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Read-Only Doctor Command
+The system SHALL provide a CLI-only `doctor` admin command that checks installation readiness without mutating the repo, vault, environment, service state, model caches, or remote replicas. It SHALL support `--profile lean|hybrid|standard|media|remote|ha`, `--vault PATH`, `--json`, explicit `--probe`, and repeatable `--replica-url URL`. Documentation SHALL point users to the matching profile before wiring a client, optional capability, or HA failover route.
+
+#### Scenario: Lean doctor over a valid vault
+- **WHEN** `python -m exomem doctor --vault <valid-vault> --json` is run
+- **THEN** it returns JSON containing `success`, `profile`, and a `checks` list
+- **AND** each check contains `id`, `status`, `message`, and `remediation`
+- **AND** no vault file is created, modified, moved, or deleted
+
+#### Scenario: Missing required lean setup
+- **WHEN** `doctor` cannot resolve a vault containing `Knowledge Base/_Schema/SKILL.md`
+- **THEN** it exits non-zero
+- **AND** it reports a remediation that tells the user to set `EXOMEM_VAULT_PATH` or pass `--vault` and run `init` if needed
+
+#### Scenario: HA doctor stays offline by default
+- **WHEN** `doctor --profile ha` runs without `--probe`
+- **THEN** it validates local HA configuration without making network calls
+
+### Requirement: Profile-Specific Readiness
+The doctor command SHALL validate the requested capability profile. `lean` SHALL check Python/package/vault/registry basics. `hybrid` SHALL additionally check embeddings dependencies and embedding sidecar state. `standard` SHALL additionally check the normal optional media stack with soft degradation. `media` SHALL require the media extraction dependencies and Tesseract discovery. `remote` SHALL additionally check public URL and OAuth-related environment variables. `ha` SHALL additionally check local writer-coordination configuration and, only with `--probe`, compare explicit replica runtime-readiness endpoints.
+
+#### Scenario: Optional capability profile is requested
+- **WHEN** `doctor --profile media` is run without media extraction dependencies
+- **THEN** the report marks the missing media components as failures
+- **AND** the remediation names `uv sync --extra media` and any required system tool such as Tesseract
+
+#### Scenario: Compatible HA releases differ
+- **WHEN** HA replica probes report different releases with the same supported runtime contract, stateless transport, unique replica identities, healthy coordination, and takeover eligibility
+- **THEN** doctor reports compatibility as passing
+- **AND** reports release drift as a warning rather than a failure
+
+#### Scenario: HA runtime is incompatible
+- **WHEN** a replica probe reports an unsupported runtime contract, stateful transport, duplicate identity, unhealthy coordination, or takeover ineligibility
+- **THEN** doctor fails with remediation to upgrade or repair that replica before enabling failover

--- a/openspec/changes/add-runtime-readiness-contract/specs/runtime-readiness-contract/spec.md
+++ b/openspec/changes/add-runtime-readiness-contract/specs/runtime-readiness-contract/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Liveness and readiness are separate contracts
+Exomem SHALL preserve the unauthenticated `/health` liveness route and SHALL expose an unauthenticated `GET /health/ready` route for runtime admission. Readiness MUST NOT expose vault paths, vault identifiers, credentials, tokens, or vault content.
+
+#### Scenario: Coordinator outage does not change liveness
+- **WHEN** a coordinated replica cannot reach its writer coordinator
+- **THEN** `/health` still returns its normal successful liveness response
+- **AND** `/health/ready` returns 503 with content-free reason codes
+
+### Requirement: Readiness reports behavioral compatibility
+The readiness payload SHALL report service identity, release identity, an integer runtime compatibility contract, HTTP transport identity, replica identity, coordination state, takeover eligibility, and stable reason codes. Release identity SHALL be diagnostic and SHALL NOT itself determine compatibility.
+
+#### Scenario: Compatible releases differ
+- **WHEN** two replicas run different Exomem releases that advertise the same supported runtime contract and transport
+- **THEN** both can be admitted for a rolling deployment
+- **AND** the release mismatch remains visible for operator diagnosis
+
+#### Scenario: Runtime contract is unsupported
+- **WHEN** a replica advertises a runtime contract outside the deployment's supported set
+- **THEN** the replica is not eligible to receive an HA tool call
+
+### Requirement: Readiness reflects takeover safety
+Standalone Exomem SHALL remain ready without multi-host coordination. A coordinated replica SHALL report takeover eligibility only when its coordinator is healthy, its replica identity is configured, and its role is authoritatively known.
+
+#### Scenario: Healthy coordinated follower
+- **WHEN** a follower can confirm the current lease state
+- **THEN** readiness returns 200 and reports takeover eligibility true
+
+#### Scenario: Coordinator is unavailable
+- **WHEN** a coordinated replica cannot confirm lease state
+- **THEN** readiness returns 503 and reports takeover eligibility false
+
+### Requirement: HA edge admits a runtime before tool-call routing
+The HA edge SHALL validate readiness status, runtime contract, stateless HTTP transport, expected replica identity, takeover eligibility, and configured coordination requirements before admitting a replica for MCP tool calls.
+
+#### Scenario: Stale service lacks the readiness contract
+- **WHEN** a candidate origin does not serve a valid readiness payload
+- **THEN** the edge does not forward the tool call to that origin
+
+#### Scenario: Origin mapping is swapped
+- **WHEN** an origin's readiness replica identity does not match the configured replica identity for that origin
+- **THEN** the edge rejects that origin for tool calls
+
+### Requirement: Runtime admission is bound to the writer generation
+The HA edge SHALL bind a successful runtime admission to the active lease holder and fencing token. It SHALL re-evaluate stored admission against current policy and SHALL require new admission after lease expiry, release, or ownership change.
+
+#### Scenario: Steady-state writer remains admitted
+- **WHEN** successive tool calls observe the same active holder and fencing token
+- **THEN** the edge reuses the stored compatible admission without another origin readiness probe
+
+#### Scenario: Ownership changes
+- **WHEN** a different replica acquires a newer fencing token
+- **THEN** the previous admission is discarded
+- **AND** the new holder must pass runtime admission
+
+### Requirement: Ineligible active writers fail closed
+The HA edge SHALL return 503 when an active holder cannot be admitted and SHALL NOT replay the tool call to another replica.
+
+#### Scenario: Active holder becomes unverifiable
+- **WHEN** the active holder has no valid stored admission and its readiness probe fails
+- **THEN** the edge returns 503 without invoking either replica's MCP tool endpoint
+
+### Requirement: No-holder selection chooses one eligible runtime
+When no writer lease is active, the HA edge SHALL probe configured replicas concurrently, select one eligible runtime in deterministic preference order, and forward the tool call exactly once.
+
+#### Scenario: Preferred replica is incompatible
+- **WHEN** no holder exists, the preferred replica is live but incompatible, and the passive replica is compatible
+- **THEN** the edge sends the tool call only to the compatible passive replica
+
+#### Scenario: No replica is eligible
+- **WHEN** no holder exists and every configured replica fails readiness admission
+- **THEN** the edge returns 503 without forwarding the tool call
+
+### Requirement: Compatibility rollout is deployment-owned
+The deployment contract SHALL support an explicit set of accepted runtime contracts and SHALL document expand-roll-contract rollout. Exomem SHALL NOT auto-update replicas or require a specific replication product.
+
+#### Scenario: Incompatible contract migration
+- **WHEN** a new release requires runtime contract 2 while contract 1 replicas are still serving
+- **THEN** deployment infrastructure can temporarily admit contracts 1 and 2
+- **AND** remove contract 1 only after the replica rollout completes

--- a/openspec/changes/add-runtime-readiness-contract/tasks.md
+++ b/openspec/changes/add-runtime-readiness-contract/tasks.md
@@ -1,0 +1,25 @@
+## 1. Runtime readiness contract
+
+- [x] 1.1 Add pure readiness snapshot tests for standalone, healthy coordinated, and coordinator-unavailable replicas.
+- [x] 1.2 Implement the content-free runtime compatibility/readiness snapshot.
+- [x] 1.3 Expose `/health/ready` separately from unchanged `/health` liveness and cover authenticated-server routing.
+
+## 2. Compatibility-aware HA edge
+
+- [x] 2.1 Add Worker tests for readiness payload validation, expected replica identity, supported contract sets, and coordination requirements.
+- [x] 2.2 Add Durable Object tests for admission bound to holder and fencing token, including invalidation on release/expiry/takeover.
+- [x] 2.3 Gate active-holder and no-holder tool-call routing on readiness while preserving exact-once forwarding and safe non-tool fallback.
+- [x] 2.4 Reuse compatible admission on the steady-state lease generation without repeated readiness probes.
+
+## 3. HA operator diagnostics
+
+- [x] 3.1 Add doctor tests for offline HA configuration checks and explicit cross-replica probes.
+- [x] 3.2 Implement `doctor --profile ha`, repeatable `--replica-url`, compatibility comparison, and release-drift warnings.
+- [x] 3.3 Document expand-roll-contract deployment, runtime parity verification, and the boundary between Exomem readiness and deployment-owned updates.
+
+## 4. Verification and rollout
+
+- [x] 4.1 Run focused Python, Worker, Ruff, and strict OpenSpec validation.
+- [ ] 4.2 Run the broader CI-relevant test set and package checks.
+- [ ] 4.3 Upgrade both live replicas to the compatible release/build before enabling Worker enforcement.
+- [ ] 4.4 Deploy the Worker, prove steady-state admission reuse and incompatible-replica fail-closed behavior, then verify a live MCP read and governed write.

--- a/openspec/changes/add-runtime-readiness-contract/tasks.md
+++ b/openspec/changes/add-runtime-readiness-contract/tasks.md
@@ -20,6 +20,6 @@
 ## 4. Verification and rollout
 
 - [x] 4.1 Run focused Python, Worker, Ruff, and strict OpenSpec validation.
-- [ ] 4.2 Run the broader CI-relevant test set and package checks.
+- [x] 4.2 Run the broader CI-relevant test set and package checks.
 - [ ] 4.3 Upgrade both live replicas to the compatible release/build before enabling Worker enforcement.
 - [ ] 4.4 Deploy the Worker, prove steady-state admission reuse and incompatible-replica fail-closed behavior, then verify a live MCP read and governed write.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -420,7 +420,7 @@ def _doctor_main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--profile",
-        choices=("lean", "hybrid", "standard", "media", "remote"),
+        choices=("lean", "hybrid", "standard", "media", "remote", "ha"),
         default=None,
         help="capability profile to validate (default: infer from EXOMEM_PROFILE, else lean)",
     )
@@ -428,16 +428,25 @@ def _doctor_main(argv: list[str]) -> int:
     parser.add_argument(
         "--probe",
         action="store_true",
-        help="with --profile remote: also verify the live endpoints (three "
-        "read-only GETs — local /mcp expects 401, OAuth discovery expects 200, "
-        "the bare oauth-protected-resource path expects 200; the last one is "
-        "the claude.ai registration gate). Default is fully offline.",
+        help="with --profile remote or ha: also verify live endpoints using read-only GETs. "
+        "Default is fully offline.",
+    )
+    parser.add_argument(
+        "--replica-url",
+        action="append",
+        default=None,
+        help="with --profile ha --probe: replica origin to inspect; repeat once per replica",
     )
     args = parser.parse_args(argv)
 
     from . import doctor as doctor_module
 
-    report = doctor_module.doctor(vault=args.vault, profile=args.profile, probe=args.probe)
+    report = doctor_module.doctor(
+        vault=args.vault,
+        profile=args.profile,
+        probe=args.probe,
+        replica_urls=args.replica_url,
+    )
     if args.json:
         print(json.dumps(report.as_dict(), ensure_ascii=False, default=str))
     else:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -13,11 +13,9 @@ the other guarantees — it loads only an ALREADY-CACHED model (skips the probe
 rather than trigger a download) and the search is read-only (never mutates the
 sidecar).
 
-The one network exception is explicit opt-in: `--probe` (remote profile only)
-performs three read-only GETs to verify the live connector endpoints — local
-/mcp expects 401, OAuth discovery expects 200, and the bare
-oauth-protected-resource path expects 200 (the claude.ai registration gate).
-Without the flag, doctor performs zero network calls.
+The one network exception is explicit opt-in: `--probe`. The remote profile
+verifies the live connector endpoints; the HA profile verifies explicit replica
+readiness origins. Without the flag, doctor performs zero network calls.
 """
 
 from __future__ import annotations
@@ -29,6 +27,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -36,8 +35,15 @@ from typing import Literal
 from .kbdir import kb_dirname, kb_prefix
 
 Status = Literal["pass", "warn", "fail"]
-Profile = Literal["lean", "hybrid", "standard", "media", "remote"]
-VALID_PROFILES: tuple[Profile, ...] = ("lean", "hybrid", "standard", "media", "remote")
+Profile = Literal["lean", "hybrid", "standard", "media", "remote", "ha"]
+VALID_PROFILES: tuple[Profile, ...] = (
+    "lean",
+    "hybrid",
+    "standard",
+    "media",
+    "remote",
+    "ha",
+)
 PROFILE_ENV = "EXOMEM_PROFILE"
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -817,6 +823,222 @@ def _check_remote_env() -> list[DoctorCheck]:
     return checks
 
 
+def _check_ha_env() -> list[DoctorCheck]:
+    required = {
+        "EXOMEM_WRITER_LEASE_URL": "Set the provider-neutral writer coordinator URL.",
+        "EXOMEM_WRITER_LEASE_VAULT_ID": "Set the stable vault coordination identifier.",
+        "EXOMEM_WRITER_LEASE_REPLICA_ID": "Set a unique identifier for this replica.",
+    }
+    checks: list[DoctorCheck] = []
+    for key, remediation in required.items():
+        if os.environ.get(key, "").strip():
+            checks.append(_check(f"ha.env.{key}", "pass", f"{key} is set."))
+        else:
+            checks.append(_check(f"ha.env.{key}", "fail", f"{key} is not set.", remediation))
+    if os.environ.get("EXOMEM_WRITER_LEASE_TOKEN", "").strip():
+        checks.append(_check("ha.env.EXOMEM_WRITER_LEASE_TOKEN", "pass", "Writer lease token is set."))
+    else:
+        checks.append(_check(
+            "ha.env.EXOMEM_WRITER_LEASE_TOKEN",
+            "warn",
+            "Writer lease token is not set.",
+            "Set EXOMEM_WRITER_LEASE_TOKEN unless the coordinator is private and explicitly unauthenticated.",
+        ))
+    raw_contracts = os.environ.get("EXOMEM_HA_SUPPORTED_RUNTIME_CONTRACTS", "").strip()
+    try:
+        contracts = _parse_runtime_contracts(raw_contracts)
+    except ValueError as exc:
+        checks.append(_check(
+            "ha.supported_contracts",
+            "fail",
+            str(exc),
+            "Set EXOMEM_HA_SUPPORTED_RUNTIME_CONTRACTS to comma-separated positive integers.",
+        ))
+    else:
+        checks.append(_check(
+            "ha.supported_contracts",
+            "pass",
+            f"Accepted runtime contracts: {', '.join(map(str, sorted(contracts)))}.",
+        ))
+    return checks
+
+
+def _parse_runtime_contracts(raw: str = "") -> set[int]:
+    from .runtime_readiness import RUNTIME_CONTRACT
+
+    if not raw:
+        return {RUNTIME_CONTRACT}
+    values: set[int] = set()
+    for part in raw.split(","):
+        text = part.strip()
+        if not text:
+            continue
+        try:
+            value = int(text)
+        except ValueError:
+            raise ValueError(f"Invalid HA runtime contract {text!r}.") from None
+        if value <= 0:
+            raise ValueError(f"Invalid HA runtime contract {text!r}.")
+        values.add(value)
+    if not values:
+        raise ValueError("No valid HA runtime contracts were configured.")
+    return values
+
+
+def _ha_replica_urls(explicit: list[str] | tuple[str, ...] | None) -> list[str]:
+    raw_values = list(explicit or ())
+    if not raw_values:
+        raw_values = os.environ.get("EXOMEM_HA_REPLICA_URLS", "").split(",")
+    urls: list[str] = []
+    for raw in raw_values:
+        value = raw.strip().rstrip("/")
+        if not value:
+            continue
+        parsed = urllib.parse.urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"Invalid HA replica URL {value!r}.")
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ValueError(f"HA replica URL must be a credential-free origin: {value!r}.")
+        if parsed.path not in {"", "/"}:
+            raise ValueError(f"HA replica URL must not include a path: {value!r}.")
+        origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+        if origin not in urls:
+            urls.append(origin)
+    return urls
+
+
+def _evaluate_ha_readiness(
+    body: object, *, supported_contracts: set[int]
+) -> tuple[list[str], dict[str, object]]:
+    from .runtime_readiness import HTTP_TRANSPORT
+
+    if not isinstance(body, dict):
+        return ["invalid readiness payload"], {}
+    reasons: list[str] = []
+    if body.get("status") != "ready" or body.get("service") != "exomem":
+        reasons.append("runtime is not ready")
+    contract = body.get("runtime_contract")
+    if isinstance(contract, bool) or not isinstance(contract, int) or contract not in supported_contracts:
+        reasons.append("runtime contract is unsupported")
+    if body.get("transport") != HTTP_TRANSPORT:
+        reasons.append("HTTP transport is not stateless")
+    replica_id = body.get("replica_id")
+    if not isinstance(replica_id, str) or not replica_id:
+        reasons.append("replica identity is missing")
+    coordination = body.get("coordination")
+    if not isinstance(coordination, dict) or coordination.get("enabled") is not True:
+        reasons.append("writer coordination is disabled")
+    elif coordination.get("coordinator_healthy") is not True:
+        reasons.append("writer coordinator is unavailable")
+    if body.get("takeover_eligible") is not True:
+        reasons.append("replica is not takeover eligible")
+    release = body.get("release")
+    if not isinstance(release, str) or not release:
+        reasons.append("release identity is missing")
+    return reasons, {
+        "replica_id": replica_id,
+        "release": release,
+        "runtime_contract": contract,
+        "transport": body.get("transport"),
+    }
+
+
+def _check_ha_probes(replica_urls: list[str]) -> list[DoctorCheck]:
+    if len(replica_urls) < 2:
+        return [_check(
+            "ha.replica_urls",
+            "fail",
+            "HA probing requires at least two explicit replica origins.",
+            "Pass --replica-url once per replica or set EXOMEM_HA_REPLICA_URLS.",
+        )]
+    try:
+        supported = _parse_runtime_contracts(
+            os.environ.get("EXOMEM_HA_SUPPORTED_RUNTIME_CONTRACTS", "").strip()
+        )
+    except ValueError as exc:
+        return [_check("ha.compatibility", "fail", str(exc))]
+
+    checks: list[DoctorCheck] = []
+    identities: list[str] = []
+    releases: list[str] = []
+    failed = False
+    for index, origin in enumerate(replica_urls, start=1):
+        url = f"{origin}/health/ready"
+        try:
+            status, body = _probe_get(url)
+        except Exception as exc:  # noqa: BLE001 - network failure is a diagnostic result
+            checks.append(_check(
+                f"ha.replica.{index}",
+                "fail",
+                f"Could not reach runtime readiness at {origin}: {exc}",
+                "Start or upgrade the replica and verify its private/public origin routing.",
+            ))
+            failed = True
+            continue
+        reasons, details = _evaluate_ha_readiness(body, supported_contracts=supported)
+        if status != 200:
+            reasons.insert(0, f"readiness returned HTTP {status}")
+        if reasons:
+            checks.append(_check(
+                f"ha.replica.{index}",
+                "fail",
+                f"Replica {origin} is ineligible: {', '.join(reasons)}.",
+                "Upgrade or repair this replica before enabling HA failover.",
+                details=details,
+            ))
+            failed = True
+            continue
+        replica_id = str(details["replica_id"])
+        release = str(details["release"])
+        identities.append(replica_id)
+        releases.append(release)
+        checks.append(_check(
+            f"ha.replica.{index}",
+            "pass",
+            f"Replica {replica_id} at {origin} is runtime-compatible (release {release}).",
+            details=details,
+        ))
+
+    duplicates = len(identities) != len(set(identities))
+    if duplicates:
+        failed = True
+    checks.append(_check(
+        "ha.compatibility",
+        "fail" if failed else "pass",
+        (
+            "HA replicas are not safely compatible."
+            if failed
+            else "All HA replicas are compatible and have unique identities."
+        ),
+        (
+            "Fix failing replica checks and ensure every replica ID is unique."
+            if failed
+            else None
+        ),
+    ))
+    if duplicates:
+        checks.append(_check(
+            "ha.replica_identity",
+            "fail",
+            "Two or more ready replicas report the same replica identity.",
+            "Set a unique EXOMEM_WRITER_LEASE_REPLICA_ID on every replica.",
+        ))
+    if len(set(releases)) > 1:
+        checks.append(_check(
+            "ha.release_drift",
+            "warn",
+            f"Compatible replicas run different releases: {', '.join(sorted(set(releases)))}.",
+            "Finish the rolling deployment when convenient; exact release equality is not required.",
+        ))
+    elif releases:
+        checks.append(_check(
+            "ha.release_drift",
+            "pass",
+            f"All ready replicas run release {releases[0]}.",
+        ))
+    return checks
+
+
 def _probe_get(url: str) -> tuple[int, object]:
     """GET `url` with a short timeout; returns (status, parsed-JSON-or-text).
 
@@ -945,7 +1167,13 @@ def _check_remote_probes() -> list[DoctorCheck]:
     return checks
 
 
-def doctor(*, vault: str | None = None, profile: Profile | None = None, probe: bool = False) -> DoctorReport:
+def doctor(
+    *,
+    vault: str | None = None,
+    profile: Profile | None = None,
+    probe: bool = False,
+    replica_urls: list[str] | tuple[str, ...] | None = None,
+) -> DoctorReport:
     profile = profile or infer_profile()
     if profile not in VALID_PROFILES:
         raise ValueError(f"unknown profile: {profile!r}. Valid: {list(VALID_PROFILES)}")
@@ -1006,6 +1234,21 @@ def doctor(*, vault: str | None = None, profile: Profile | None = None, probe: b
         # unless --probe is passed explicitly.
         if probe:
             checks.extend(_check_remote_probes())
+
+    if profile == "ha":
+        checks.extend(_check_ha_env())
+        if probe:
+            try:
+                urls = _ha_replica_urls(replica_urls)
+            except ValueError as exc:
+                checks.append(_check(
+                    "ha.replica_urls",
+                    "fail",
+                    str(exc),
+                    "Pass credential-free replica origins such as https://replica.example.com.",
+                ))
+            else:
+                checks.extend(_check_ha_probes(urls))
 
     return DoctorReport(profile=profile, checks=checks)
 

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -1,0 +1,74 @@
+"""Content-free runtime admission metadata for HA and hosted orchestration."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+RUNTIME_CONTRACT = 1
+HTTP_TRANSPORT = "streamable-http-stateless"
+
+
+def package_release() -> str:
+    """Return the installed distribution release without making readiness fragile."""
+    try:
+        return version("exomem")
+    except PackageNotFoundError:
+        return "0+unknown"
+    except Exception:  # noqa: BLE001 - metadata failure must become diagnostic state
+        return "0+unknown"
+
+
+def build_runtime_readiness(
+    *, coordination: Mapping[str, Any], release: str
+) -> dict[str, Any]:
+    """Build the public readiness payload from already-measured coordination state."""
+    enabled = bool(coordination.get("enabled"))
+    healthy = bool(coordination.get("coordinator_healthy"))
+    role = str(coordination.get("role") or "unknown")
+    replica_raw = coordination.get("replica_id")
+    replica_id = replica_raw if isinstance(replica_raw, str) and replica_raw else None
+
+    reasons: list[str] = []
+    if enabled:
+        if not healthy:
+            reasons.append("coordinator_unavailable")
+        if role not in {"writer", "follower"}:
+            reasons.append("coordination_role_unknown")
+        if replica_id is None:
+            reasons.append("replica_identity_missing")
+
+    takeover_eligible = not reasons
+    return {
+        "status": "ready" if takeover_eligible else "not_ready",
+        "service": "exomem",
+        "release": release,
+        "runtime_contract": RUNTIME_CONTRACT,
+        "transport": HTTP_TRANSPORT,
+        "replica_id": replica_id,
+        "coordination": {
+            "enabled": enabled,
+            "role": role,
+            "coordinator_healthy": healthy,
+        },
+        "takeover_eligible": takeover_eligible,
+        "reasons": reasons,
+    }
+
+
+def runtime_readiness() -> dict[str, Any]:
+    """Measure this process's eligibility without exposing vault or credential state."""
+    from .writer_lease import coordination_status
+
+    try:
+        coordination = coordination_status()
+    except Exception:  # noqa: BLE001 - readiness must return structured 503 state
+        coordination = {
+            "enabled": bool(os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip()),
+            "role": "unknown",
+            "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
+            "coordinator_healthy": False,
+        }
+    return build_runtime_readiness(coordination=coordination, release=package_release())

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -11,6 +11,8 @@ from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 
+from . import runtime_readiness as runtime_readiness_module
+
 _STUDIO_SECURITY_HEADERS = {
     "Content-Security-Policy": (
         "default-src 'none'; base-uri 'none'; connect-src 'self'; "
@@ -96,6 +98,17 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
             ver = "unknown"
         return JSONResponse(
             {"status": "ok", "service": "exomem", "version": ver},
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @mcp_app.custom_route("/health/ready", methods=["GET"])
+    async def _runtime_ready(request: Request) -> JSONResponse:  # noqa: ARG001
+        """Content-free admission probe; liveness remains the separate /health route."""
+        snapshot = runtime_readiness_module.runtime_readiness()
+        status_code = 200 if snapshot["status"] == "ready" else 503
+        return JSONResponse(
+            snapshot,
+            status_code=status_code,
             headers={"Cache-Control": "no-store"},
         )
 

--- a/tests/test_doctor_ha.py
+++ b/tests/test_doctor_ha.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import doctor as doctor_module
+from exomem.__main__ import main
+from exomem.runtime_readiness import HTTP_TRANSPORT, RUNTIME_CONTRACT
+
+
+def _set_ha_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://coordinator.example.com")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", "secret")
+
+
+def _ready(replica_id: str, release: str, *, contract: int = RUNTIME_CONTRACT) -> dict:
+    return {
+        "status": "ready",
+        "service": "exomem",
+        "release": release,
+        "runtime_contract": contract,
+        "transport": HTTP_TRANSPORT,
+        "replica_id": replica_id,
+        "coordination": {
+            "enabled": True,
+            "role": "writer" if replica_id == "desktop" else "follower",
+            "coordinator_healthy": True,
+        },
+        "takeover_eligible": True,
+        "reasons": [],
+    }
+
+
+def test_ha_profile_is_offline_by_default(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+
+    def fail_network(url: str):  # noqa: ANN202
+        raise AssertionError(f"HA doctor made an unexpected network call: {url}")
+
+    monkeypatch.setattr(doctor_module, "_probe_get", fail_network)
+    report = doctor_module.doctor(vault=str(vault), profile="ha")
+
+    assert report.profile == "ha"
+    checks = {check.id: check for check in report.checks}
+    assert checks["ha.env.EXOMEM_WRITER_LEASE_URL"].status == "pass"
+    assert not any(check_id.startswith("ha.replica.") for check_id in checks)
+
+
+def test_ha_profile_reports_missing_coordination_configuration(vault: Path) -> None:
+    report = doctor_module.doctor(vault=str(vault), profile="ha")
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.env.EXOMEM_WRITER_LEASE_URL"].status == "fail"
+    assert checks["ha.env.EXOMEM_WRITER_LEASE_VAULT_ID"].status == "fail"
+    assert checks["ha.env.EXOMEM_WRITER_LEASE_REPLICA_ID"].status == "fail"
+
+
+def test_ha_probe_accepts_compatible_release_drift(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    responses = {
+        "https://desktop.example.com/health/ready": (200, _ready("desktop", "0.20.1")),
+        "https://laptop.example.com/health/ready": (200, _ready("laptop", "0.20.2")),
+    }
+    monkeypatch.setattr(doctor_module, "_probe_get", lambda url: responses[url])
+
+    report = doctor_module.doctor(
+        vault=str(vault),
+        profile="ha",
+        probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com/"],
+    )
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.replica.1"].status == "pass"
+    assert checks["ha.replica.2"].status == "pass"
+    assert checks["ha.compatibility"].status == "pass"
+    assert checks["ha.release_drift"].status == "warn"
+    assert report.success is True
+
+
+def test_ha_probe_rejects_incompatible_or_duplicate_replicas(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    responses = {
+        "https://desktop.example.com/health/ready": (200, _ready("desktop", "0.20.1")),
+        "https://laptop.example.com/health/ready": (
+            200,
+            _ready("desktop", "0.21.0", contract=RUNTIME_CONTRACT + 1),
+        ),
+    }
+    monkeypatch.setattr(doctor_module, "_probe_get", lambda url: responses[url])
+
+    report = doctor_module.doctor(
+        vault=str(vault),
+        profile="ha",
+        probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.replica.2"].status == "fail"
+    assert checks["ha.compatibility"].status == "fail"
+    assert report.success is False
+
+
+def test_ha_probe_requires_explicit_replica_urls(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.delenv("EXOMEM_HA_REPLICA_URLS", raising=False)
+    report = doctor_module.doctor(vault=str(vault), profile="ha", probe=True)
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.replica_urls"].status == "fail"
+
+
+def test_ha_cli_passes_repeatable_replica_urls(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    seen = {}
+
+    def fake_doctor(**kwargs):  # noqa: ANN202
+        seen.update(kwargs)
+        return doctor_module.DoctorReport(profile="ha", checks=[])
+
+    monkeypatch.setattr(doctor_module, "doctor", fake_doctor)
+    code = main(
+        [
+            "doctor",
+            "--profile",
+            "ha",
+            "--vault",
+            str(vault),
+            "--replica-url",
+            "https://desktop.example.com",
+            "--replica-url",
+            "https://laptop.example.com",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    assert seen["replica_urls"] == [
+        "https://desktop.example.com",
+        "https://laptop.example.com",
+    ]
+    assert json.loads(capsys.readouterr().out)["profile"] == "ha"

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -55,3 +55,67 @@ def test_health_endpoint_public_and_reports_version(vault, monkeypatch: pytest.M
     # Public even with OAuth enabled.
     r2 = _client(vault, monkeypatch, require_auth=True).get("/health")
     assert r2.status_code == 200, r2.text
+
+
+def test_readiness_endpoint_is_public_and_content_free(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import runtime_readiness
+
+    monkeypatch.setattr(
+        runtime_readiness,
+        "runtime_readiness",
+        lambda: {
+            "status": "ready",
+            "service": "exomem",
+            "release": "1.2.3",
+            "runtime_contract": 1,
+            "transport": "streamable-http-stateless",
+            "replica_id": "desktop",
+            "coordination": {
+                "enabled": True,
+                "role": "writer",
+                "coordinator_healthy": True,
+            },
+            "takeover_eligible": True,
+            "reasons": [],
+        },
+    )
+
+    response = _client(vault, monkeypatch, require_auth=True).get("/health/ready")
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json()["runtime_contract"] == 1
+    rendered = response.text.lower()
+    assert "vault" not in rendered
+    assert "token" not in rendered
+
+
+def test_readiness_endpoint_returns_503_without_changing_liveness(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import runtime_readiness
+
+    monkeypatch.setattr(
+        runtime_readiness,
+        "runtime_readiness",
+        lambda: {
+            "status": "not_ready",
+            "service": "exomem",
+            "release": "1.2.3",
+            "runtime_contract": 1,
+            "transport": "streamable-http-stateless",
+            "replica_id": "desktop",
+            "coordination": {
+                "enabled": True,
+                "role": "unknown",
+                "coordinator_healthy": False,
+            },
+            "takeover_eligible": False,
+            "reasons": ["coordinator_unavailable"],
+        },
+    )
+    client = _client(vault, monkeypatch)
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/health/ready").status_code == 503

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from exomem.runtime_readiness import (
+    HTTP_TRANSPORT,
+    RUNTIME_CONTRACT,
+    build_runtime_readiness,
+)
+
+
+def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+    )
+
+    assert snapshot == {
+        "status": "ready",
+        "service": "exomem",
+        "release": "1.2.3",
+        "runtime_contract": RUNTIME_CONTRACT,
+        "transport": HTTP_TRANSPORT,
+        "replica_id": None,
+        "coordination": {
+            "enabled": False,
+            "role": "standalone",
+            "coordinator_healthy": True,
+        },
+        "takeover_eligible": True,
+        "reasons": [],
+    }
+
+
+def test_healthy_coordinated_follower_is_takeover_eligible() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": True,
+            "role": "follower",
+            "vault_id": "must-not-leak",
+            "replica_id": "laptop",
+            "holder": "desktop",
+            "fencing_token": 9,
+            "coordinator_healthy": True,
+        },
+        release="1.2.4",
+    )
+
+    assert snapshot["status"] == "ready"
+    assert snapshot["takeover_eligible"] is True
+    assert snapshot["replica_id"] == "laptop"
+    assert snapshot["coordination"] == {
+        "enabled": True,
+        "role": "follower",
+        "coordinator_healthy": True,
+    }
+    rendered = repr(snapshot).lower()
+    assert "must-not-leak" not in rendered
+    assert "vault_id" not in rendered
+    assert "fencing_token" not in rendered
+
+
+def test_coordinator_outage_is_not_ready_and_uses_stable_reason() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": True,
+            "role": "unknown",
+            "replica_id": "desktop",
+            "coordinator_healthy": False,
+        },
+        release="1.2.3",
+    )
+
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["takeover_eligible"] is False
+    assert snapshot["reasons"] == ["coordinator_unavailable", "coordination_role_unknown"]
+
+
+def test_missing_replica_identity_is_not_ready_when_coordination_enabled() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": True,
+            "role": "follower",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+    )
+
+    assert snapshot["status"] == "not_ready"
+    assert snapshot["reasons"] == ["replica_identity_missing"]


### PR DESCRIPTION
## Summary
- add a content-free /health/ready runtime compatibility contract without changing /health liveness
- admit HA origins by contract, transport, replica identity, coordination health, and takeover eligibility
- cache admission by lease fencing token so steady-state MCP calls add no readiness probe
- add doctor --profile ha --probe and expand-roll-contract deployment guidance

## Verification
- 68 focused Python tests passed (1 optional embeddings skip)
- 15 Cloudflare Worker tests passed
- focused Ruff and repo-wide --select F passed
- strict OpenSpec validation passed
- wheel/sdist built and the wheel readiness import smoke passed
- full Windows suite reached the pre-existing synthetic lexical latency gate, which exceeded its 60 s per-test timeout both in-suite and isolated; this change does not touch retrieval/lexstore and CI's Linux latency gate is authoritative
