### PR TITLE
fix(auth): issue durable local MCP sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,12 @@
 #   Tailscale Funnel (legacy):    https://<device>.<tailnet>.ts.net
 KB_MCP_BASE_URL=https://kb.example.com
 KB_MCP_GITHUB_USERNAME=your-github-login
+KB_MCP_GITHUB_USER_ID=12345678
 # GitHub OAuth App (per host — its ONE callback must be {KB_MCP_BASE_URL}/auth/callback).
 GITHUB_CLIENT_ID=ovXXXXXXXXXXXXXXXXXX
 GITHUB_CLIENT_SECRET=replace-with-secret
-# Recommended: pins the OAuth signing key so the connector survives upgrades / secret
-# rotation without re-auth. Generate: python -c "import secrets;print(secrets.token_urlsafe(48))"
+# Required durable-session root. Rotation revokes all sessions. Generate:
+# python -c "import secrets;print(secrets.token_urlsafe(48))"
 KB_MCP_JWT_SIGNING_KEY=replace-with-long-random-string
 KB_MCP_VAULT_PATH=D:\path\to\your\Obsidian
 KB_MCP_UPLOAD_MAX_BYTES=104857600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,8 @@ jobs:
             -v /tmp/vault:/vault -e EXOMEM_VAULT_PATH=/vault \
             -e EXOMEM_BASE_URL=http://127.0.0.1:8765 \
             -e GITHUB_CLIENT_ID=dummy -e GITHUB_CLIENT_SECRET=dummy \
-            -e EXOMEM_GITHUB_USERNAME=dummy -e EXOMEM_JWT_SIGNING_KEY=dummy \
+            -e EXOMEM_GITHUB_USERNAME=dummy -e EXOMEM_GITHUB_USER_ID=1 \
+            -e EXOMEM_JWT_SIGNING_KEY=dummy \
             exomem:pr-smoke
           for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/mcp || true)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Full local setup is in [QUICKSTART.md](QUICKSTART.md). Remote/mobile setup is
 in [docs/remote-quickstart.md](docs/remote-quickstart.md) and
 [docs/deployment.md](docs/deployment.md).
 
+Remote OAuth uses GitHub once to prove the configured login plus immutable user
+ID, then issues an Exomem-owned durable session. Operators can inspect and revoke
+those sessions with `exomem auth sessions`, `exomem auth revoke <session-id>`,
+and `exomem auth revoke --all`; session administration is never an MCP tool.
+
 The product model is intentionally simple: built-in AI memory remembers preferences and routing, while Exomem stores durable governed knowledge with sources, proof, history, decisions, records, and review. See [docs/product-model.md](docs/product-model.md) for the full mental model, [docs/review-studio.md](docs/review-studio.md) for the packaged browser review loop, [docs/epistemic-inbox.md](docs/epistemic-inbox.md) for daily review and relation repair, [docs/knowledge-packs.md](docs/knowledge-packs.md) for pack/admin details, and [docs/workflow-skills.md](docs/workflow-skills.md) for the named agent workflows.
 
 For development, or to run the sample vault from a checkout instead of a

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -325,3 +325,8 @@ search/save workflow. Ask one known vault question next and confirm it uses
 
 For remote connectors, use [remote-quickstart.md](remote-quickstart.md). For the
 memory boundary, see [vs-built-in-memory.md](vs-built-in-memory.md).
+
+After a durable-auth upgrade, keep the existing connector URL and complete its
+one final GitHub login. New conversations should reuse the stored Exomem bearer;
+a repeated login prompt is a failed client-compatibility gate, while a `503`
+means the session authority is unavailable and should not trigger reauthorization.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -460,13 +460,18 @@ login, then starts several fresh ephemeral processes:
 python scripts/codex_auth_session_harness.py \
   --url https://kb.example.com/mcp \
   --codex-home .rollout/codex-auth-gate \
+  --codex-auth-source ~/.codex/auth.json \
   --runs 3 \
   --acknowledge-disposable-target
 ```
 
 Run this only against a disposable staged KB. The harness refuses a non-empty
-`CODEX_HOME`, so its one interactive authorization cannot accidentally reuse a
-personal Codex login; the acknowledgement is deliberately mandatory.
+target `CODEX_HOME`, copies only the invoking Codex OpenAI `auth.json` into it
+with owner-only permissions, and verifies `codex login status` before registering
+Exomem. It never copies `config.toml`, `.credentials.json`, or prior MCP state.
+When `--codex-auth-source` is omitted, it resolves to `$CODEX_HOME/auth.json` for
+the invoking process, or `~/.codex/auth.json` when `CODEX_HOME` is unset. The
+acknowledgement is deliberately mandatory.
 
 Keep legacy JTI/upstream-token collections untouched for a bounded rollback
 window, but never dual-read them while the new provider is active. Rollback means

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -460,8 +460,13 @@ login, then starts several fresh ephemeral processes:
 python scripts/codex_auth_session_harness.py \
   --url https://kb.example.com/mcp \
   --codex-home .rollout/codex-auth-gate \
-  --runs 3
+  --runs 3 \
+  --acknowledge-disposable-target
 ```
+
+Run this only against a disposable staged KB. The harness refuses a non-empty
+`CODEX_HOME`, so its one interactive authorization cannot accidentally reuse a
+personal Codex login; the acknowledgement is deliberately mandatory.
 
 Keep legacy JTI/upstream-token collections untouched for a bounded rollback
 window, but never dual-read them while the new provider is active. Rollback means

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,11 +152,11 @@ Create `.env` in the repo root:
 ```
 EXOMEM_BASE_URL=https://kb.example.com
 EXOMEM_GITHUB_USERNAME=<your-github-login>
+EXOMEM_GITHUB_USER_ID=<positive-numeric-id-from-GitHub>
 GITHUB_CLIENT_ID=<from step 3>
 GITHUB_CLIENT_SECRET=<from step 3>
-# Recommended: a long random string that pins the OAuth signing key, so the
-# claude.ai connector survives FastMCP upgrades / client-secret rotation without
-# re-authorizing. Generate: python -c "import secrets;print(secrets.token_urlsafe(48))"
+# Required root for durable opaque sessions. Rotation revokes every session.
+# Generate: python -c "import secrets;print(secrets.token_urlsafe(48))"
 EXOMEM_JWT_SIGNING_KEY=<long-random-string>
 # Required: vault root — the folder that contains Knowledge Base/
 EXOMEM_VAULT_PATH=<your-Obsidian-vault-root>
@@ -164,7 +164,9 @@ EXOMEM_VAULT_PATH=<your-Obsidian-vault-root>
 
 `EXOMEM_BASE_URL` must match your public hostname (from step 2) exactly — no
 trailing slash, no `/mcp` suffix. `EXOMEM_GITHUB_USERNAME` is case-insensitive but
-must be the *login*, not the display name. `EXOMEM_VAULT_PATH` is **required**:
+must be the *login*, not the display name. `EXOMEM_GITHUB_USER_ID` is the positive
+numeric `id` returned by `GET https://api.github.com/users/<login>`; authorization
+must match both values. `EXOMEM_VAULT_PATH` is **required**:
 claude.ai connects over HTTP and passes no environment, so the service resolves the
 vault solely from this line in `.env` at startup.
 
@@ -378,6 +380,12 @@ EXOMEM_OAUTH_STORAGE_NAMESPACE=personal-main
 EXOMEM_OAUTH_STORAGE_TOKEN=<same-edge-secret>
 ```
 
+The coordinator's `EXOMEM_LEASE_COORDINATOR_TOKEN`, each replica's
+`EXOMEM_WRITER_LEASE_TOKEN`, and `EXOMEM_OAUTH_STORAGE_TOKEN` must be the same
+non-empty value. `exomem doctor --profile ha --probe` proves that anonymous
+state reads receive `401` and an authenticated absent-key read succeeds; a
+coordinator that accepts anonymous state access is not safe for session authority.
+
 Laptop uses the same values except
 `EXOMEM_WRITER_LEASE_REPLICA_ID=laptop` and omits the preferred flag. Both remain
 readable. The first write acquires the lease; the server renews it while alive.
@@ -419,13 +427,53 @@ renews its lease independently while a long tool runs; correctness does not rely
 on ordering `MCP_TOOL_TIMEOUT_MS` against `EXOMEM_WRITER_LEASE_TTL`.
 
 Both replicas must also use the same stable `EXOMEM_BASE_URL`, GitHub OAuth client
-ID/secret, and `EXOMEM_JWT_SIGNING_KEY`. FastMCP access tokens are reference tokens,
-so the signing key alone is not enough: the shared OAuth store carries their JTI
-and upstream-token mappings. Values are Fernet-encrypted on the replica before
-leaving it. On first enablement, the preferred replica reads through its existing
-encrypted local FastMCP store and migrates live records on demand, while mirroring
-new writes locally for rollback. Existing connectors therefore migrate in place
-instead of requiring removal and re-registration.
+ID/secret, `EXOMEM_GITHUB_USERNAME`, `EXOMEM_GITHUB_USER_ID`, and
+`EXOMEM_JWT_SIGNING_KEY`. Durable session records are Fernet-encrypted on the
+replica before leaving it. Session and auth-generation reads are always direct to
+the coordinator: there is no read-through mirror or stale local fallback that
+could resurrect a revoked session.
+
+### Durable-session cutover and rollback
+
+Treat the upgrade from FastMCP reference tokens as a coordinated HA cutover, not
+a rolling mixed-provider deployment:
+
+1. Back up `.env`, the coordinator database/shared OAuth state, and both service
+   installations. Preserve the existing `EXOMEM_JWT_SIGNING_KEY`; add the
+   immutable GitHub ID and matching coordinator/storage credentials.
+2. Quiesce connector traffic. Upgrade active and passive replicas together so no
+   request can alternate between the legacy and durable token formats.
+3. Run offline and probed doctor on both replicas, then bring up only the new
+   provider. Keep the public connector URL and connector registrations unchanged.
+4. Each existing client receives one expected `401` for its legacy reference JWT
+   and completes one final GitHub authorization. It then holds an Exomem-owned
+   opaque session with no advertised expiry. Do not delete/recreate connectors.
+5. Prove a session issued through one replica validates through the other. Run
+   single-session and `--all` revocation checks. Run the Codex harness and the
+   supported hosted-connector smoke test; block rollout if either client asks for
+   another login or discards the response because `expires_in` is omitted.
+
+The Codex gate uses an isolated persistent home, performs exactly one interactive
+login, then starts several fresh ephemeral processes:
+
+```bash
+python scripts/codex_auth_session_harness.py \
+  --url https://kb.example.com/mcp \
+  --codex-home .rollout/codex-auth-gate \
+  --runs 3
+```
+
+Keep legacy JTI/upstream-token collections untouched for a bounded rollback
+window, but never dual-read them while the new provider is active. Rollback means
+deploying the prior provider as another coordinated cutover; clients already on
+durable sessions authorize once into the old format. Only after the window closes
+should obsolete JTI/upstream GitHub-token records be removed. New durable-session
+collections can remain inert during rollback.
+
+For troubleshooting, a malformed, unknown, revoked, or legacy bearer returns the
+normal `401 invalid_token` challenge. A coordinator/network failure or current
+session-namespace decryption problem returns `503` with no OAuth challenge. Repair
+the authority and retry a 503; logging in again cannot fix an availability outage.
 
 The coordinator contract is:
 
@@ -668,6 +716,8 @@ sc.exe start exomem
 | GitHub redirects to "The redirect_uri MUST match…" error | OAuth App callback URL mismatch | At github.com/settings/developers → exomem, set the callback to exactly `https://<your-host>/auth/callback` (no trailing slash). |
 | GitHub: "The redirect_uri is not associated with this application" on a *second* machine | Reused another host's OAuth App client ID/secret (the app's one callback points at the other host) | Create a per-host OAuth App with callback `https://<this-host>.example.com/auth/callback`, put its client ID/secret in this `.env`, restart the service. See § Deploying on a second machine. |
 | claude.ai connector connects but every tool call returns 401 | Wrong GitHub user | `EXOMEM_GITHUB_USERNAME` must equal the login of the GitHub account you authorized with. Check the exomem log for `rejecting token for github login=...`. |
+| Existing client receives one `401 invalid_token` after the durable-session cutover | Legacy FastMCP reference JWT is intentionally not dual-read | Complete one final login without deleting or changing the connector URL. If a durable session later gets 401, inspect it with `exomem auth sessions`. |
+| Authenticated tools return `503` without `WWW-Authenticate` | Authoritative session storage is unavailable or corrupt | Repair the coordinator/network/storage path. Do not reauthorize: a fresh login uses the same unavailable authority. |
 | claude.ai shows "connector failed" | service down (host asleep, service stopped, crash loop) | Check the service status; tail `logs/service.err.log` and `logs/exomem.log`. Multiple startup banners within seconds = orphan python processes — kill them and force-restart. |
 | Edits to `.env` not picked up | service didn't restart | Restart the service (elevated on Windows). Confirm the python process restarted. |
 | 404 / Funnel "no service" | Tunnel disabled or pointing at the wrong port | `tailscale funnel status` (or check `cloudflared`); re-run the tunnel command from step 2. |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,7 +95,9 @@ documented in [deployment.md](deployment.md).
    compose-only ones below — uncomment the ones you need):
    - The OAuth vars from [deployment.md](deployment.md): `EXOMEM_BASE_URL`,
      `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `EXOMEM_GITHUB_USERNAME`,
-     `EXOMEM_JWT_SIGNING_KEY`.
+     `EXOMEM_GITHUB_USER_ID`, and `EXOMEM_JWT_SIGNING_KEY`. HA deployments also
+     require matching non-empty `EXOMEM_LEASE_COORDINATOR_TOKEN`,
+     `EXOMEM_WRITER_LEASE_TOKEN`, and `EXOMEM_OAUTH_STORAGE_TOKEN` values.
    - `EXOMEM_VAULT_HOST_PATH` is the **host** path bind-mounted to `/vault`
      (`compose.yaml` maps it in; the container always sees `/vault`). Compose
      fails fast with `set in .env` if it is missing.

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -72,6 +72,7 @@ EXOMEM_BASE_URL=https://<host>
 GITHUB_CLIENT_ID=<from step 1>
 GITHUB_CLIENT_SECRET=<from step 1>
 EXOMEM_GITHUB_USERNAME=<your-github-login>
+EXOMEM_GITHUB_USER_ID=<positive-numeric-id-from-GitHub>
 EXOMEM_JWT_SIGNING_KEY=<long-random-string>
 EXOMEM_VAULT_PATH=<your-Obsidian-vault-root>
 ```
@@ -81,6 +82,11 @@ Generate `EXOMEM_JWT_SIGNING_KEY`:
 ```bash
 python -c "import secrets;print(secrets.token_urlsafe(48))"
 ```
+
+Resolve the immutable account ID with `GET https://api.github.com/users/<login>`
+and copy its numeric `id`, or let `exomem setup --remote` resolve it. For an
+offline/headless run, pass `--github-user-id <id>`. The login comparison is
+case-insensitive; the numeric ID is the durable trust anchor.
 
 `EXOMEM_BASE_URL` has no trailing slash and no `/mcp` suffix. `EXOMEM_VAULT_PATH`
 is required: claude.ai connects over HTTP and passes no environment of its
@@ -199,7 +205,10 @@ just importable.
 
 claude.ai → **Settings** → **Connectors** → **Add custom connector** →
 `https://<host>/mcp` → log in with GitHub as the account named in
-`EXOMEM_GITHUB_USERNAME`.
+`EXOMEM_GITHUB_USERNAME`. A newly upgraded installation asks each existing
+client to do this once. Keep the connector definition and URL unchanged: after
+that final login, Codex/Claude reuse the Exomem-owned session across fresh chats
+and processes without depending on the temporary GitHub token.
 
 Then add Exomem behavior to the hosted client. Paste the instruction block from
 [ai-assistant-guide.md](ai-assistant-guide.md), or at minimum start new chats by
@@ -223,6 +232,8 @@ asking it to call `bootstrap(profile="compact")` once before using the KB.
 | ngrok setup stalls, then a `429` shows in the ngrok dashboard | Free-tier burst limit (120 req/min) hit during registration | Wait a minute and retry, or switch to Cloudflare Tunnel. |
 | GitHub OAuth redirect never completes on first ngrok use | The one-time ngrok browser interstitial intercepted the redirect | Open the ngrok URL directly once, click through the interstitial, then retry the connector add. |
 | "Couldn't reach the MCP server" during connector add | OAuth discovery failed | See [deployment.md's troubleshooting table](deployment.md#troubleshooting) — the rest of the fixes there apply regardless of ingress profile. |
+| An existing connector gets one `401 invalid_token` immediately after the durable-session cutover | Its legacy FastMCP reference token is intentionally no longer accepted | Complete one final browser login. Do not delete or recreate the connector. |
+| Tools return `503` without an OAuth challenge | The authoritative session store is unavailable, not the login | Repair coordinator/network/storage health and retry. Re-authorizing cannot fix a 503. |
 
 For everything else — service management, GPU/CUDA, revoking access,
 restarting, logs, multi-host setups — see [deployment.md](deployment.md).

--- a/env.example
+++ b/env.example
@@ -118,11 +118,20 @@ GITHUB_CLIENT_SECRET=
 
 # The single GitHub login allowed to authenticate to this connector.
 EXOMEM_GITHUB_USERNAME=
+# Immutable positive numeric ID for that login (`GET /users/<login>` -> `id`).
+# This prevents a renamed/recycled login from becoming the trusted account.
+EXOMEM_GITHUB_USER_ID=
 
-# Stable JWT signing key — pins the OAuth token store so connector re-auth does
-# NOT recur on client-secret rotation or FastMCP upgrades. Generate with:
+# Required stable root for opaque durable sessions. Rotating it intentionally
+# invalidates every Exomem session. Generate with:
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
 EXOMEM_JWT_SIGNING_KEY=
+
+# HA only: all three values must be the SAME non-empty random bearer. The
+# coordinator enforces it; replicas use it for leases and authoritative auth state.
+# EXOMEM_LEASE_COORDINATOR_TOKEN=
+# EXOMEM_WRITER_LEASE_TOKEN=
+# EXOMEM_OAUTH_STORAGE_TOKEN=
 
 # ---------------------------------------------------------------------------
 # Remote extras — optional

--- a/openspec/changes/durable-local-auth-sessions/.openspec.yaml
+++ b/openspec/changes/durable-local-auth-sessions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/durable-local-auth-sessions/design.md
+++ b/openspec/changes/durable-local-auth-sessions/design.md
@@ -1,0 +1,126 @@
+## Context
+
+FastMCP's `OAuthProxy` currently treats its downstream JWT as a reference to an upstream GitHub token. Authorization-code exchange stores one GitHub token set per MCP client, and `load_access_token()` resolves the JWT's JTI and revalidates the GitHub token on ordinary requests. Exomem's shared signing key, encrypted JTI mapping, and upstream-token record are all healthy in the reproduced incident; GitHub rejects the retained upstream credential.
+
+The store contains 44 upstream-token records. GitHub permits only ten OAuth tokens per user/application/scope combination and revokes the oldest when another is created. A reconnect therefore repairs one MCP client by invalidating another. The approved security boundary is that GitHub proves the configured user's identity once and Exomem owns session continuity thereafter.
+
+Exomem runs in both single-node and active/passive HA configurations. HA already has an encrypted remote OAuth state store plus a local read-through mirror. That mirror is appropriate for recoverable OAuth bookkeeping, but it is unsafe as a revocation authority because a remote miss can repopulate stale local data.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the standard MCP OAuth browser flow while using GitHub only as an authorization-time identity proof.
+- Give Codex, Claude, and other MCP clients an Exomem session that does not expire with inactivity, conversation boundaries, GitHub token eviction, or ordinary service restarts.
+- Make explicit Exomem revocation and signing-key rotation the only session-ending mechanisms after issuance.
+- Keep session secrets encrypted at rest, absent from logs, and independently revocable.
+- Make revocation immediate and consistent across replicas without stale fallback resurrection.
+- Distinguish unavailable auth infrastructure from invalid credentials so an outage does not trigger a login loop.
+- Require only one final login during migration, without changing connector URLs or registrations.
+
+**Non-Goals:**
+
+- Automatically terminate an Exomem session when GitHub later revokes the temporary authorization token or the account changes.
+- Add multi-user authorization, roles, or vault-level permissions.
+- Depend on client refresh-token behavior for continuity.
+- Preserve legacy FastMCP reference JWTs indefinitely or dual-read legacy GitHub token records.
+- Expose privileged session administration as an MCP knowledge-base tool.
+
+## Decisions
+
+### 1. Issue an opaque, non-expiring Exomem bearer session
+
+During the normal IdP callback, `ExomemSessionOAuthProxy` exchanges the GitHub code, validates the access token exactly once with a cache-disabled `SingleUserGitHubVerifier`, and requires both the configured normalized login and the configured `EXOMEM_GITHUB_USER_ID`. The callback extracts a minimal verified identity proof, revokes/discards the GitHub token, and stores only that proof in the short-lived downstream client code. Downstream authorization-code exchange consumes the proof and never sees an upstream credential.
+
+The provider then creates a bearer token with a versioned opaque format containing a random session ID and at least 256 bits of secret entropy. The session ID is only a lookup/revocation handle; possession of it is not sufficient to authenticate. The token response omits `expires_in` and `refresh_token`, which the OAuth response model and MCP SDK represent as optional. `AccessToken.expires_at` is also unset.
+
+The server stores an HMAC of the complete bearer token, never the raw token. The HMAC key is derived from `EXOMEM_JWT_SIGNING_KEY` with an Exomem-session-specific purpose salt distinct from FastMCP JWT signing and storage encryption salts. Rotation therefore makes old token proofs unusable even though the bearer is opaque.
+
+HTTP OAuth startup requires explicit `EXOMEM_JWT_SIGNING_KEY` and `EXOMEM_GITHUB_USER_ID` values. The current fallback that derives keys from the GitHub client secret is rejected with an actionable configuration error: a non-expiring Exomem session needs a deliberate, independently rotatable root of trust. The setup flow resolves and records the numeric GitHub ID for the configured login; subsequent authorization requires both values, preventing a renamed or recycled login from becoming a different trusted subject.
+
+This is preferred over short access JWTs plus local refresh tokens because refresh rotation adds client persistence assumptions and race conditions to the exact path whose reliability matters. It is preferred over one canonical GitHub token because a canonical token still couples every Exomem session to GitHub availability and revocation.
+
+### 2. Keep authorization data in an encrypted server-side session record
+
+Each record is keyed by the random session ID and contains:
+
+- schema version and session ID;
+- HMAC token digest;
+- MCP client ID and MCP scopes from the downstream authorization code;
+- Exomem issuer and protected-resource audience;
+- GitHub immutable user ID and normalized login captured at issuance;
+- issue time and current random auth-generation ID;
+- `active` or `revoked` status plus revocation time/reason.
+
+GitHub-returned scopes are never reused as MCP scopes. Ordinary requests verify the token HMAC with constant-time comparison plus record status, generation, issuer, audience, stored issuing-client context, scopes, and stored account identity. They return the stored issuing-client context in `AccessToken`; an ordinary bearer request provides no independent sender proof. They do not re-check GitHub or current login configuration; changing authorization policy requires explicit revocation.
+
+### 3. Make the session authority remote-canonical and fail closed in HA
+
+A small `SessionAuthority` abstraction owns session records and the auth-generation record.
+
+- In HA, it wraps the coordinator-backed store directly in Fernet encryption. Session and generation reads are uncached and never use `ReadThroughMirrorStorage`. Both the Exomem replica and coordinator must have a non-empty, matching OAuth-storage bearer credential; HA startup fails if `EXOMEM_OAUTH_STORAGE_TOKEN` is absent.
+- In a single-node deployment, it uses an encrypted `FileTreeStore` under the stable FastMCP home.
+- Session and generation collection names include a non-secret fingerprint of the current signing root. Signing-key rotation therefore reads a fresh namespace where old session IDs are unknown, yielding 401 rather than attempting to decrypt old ciphertext.
+- Revoked sessions are overwritten with permanent tombstones, never deleted.
+- `revoke --all` replaces the shared generation with a new random value. Existing records remain auditable but no longer validate.
+
+The first generation in a fresh key namespace is initialized atomically so two replicas cannot establish competing roots. Later generation replacement is one authoritative write; issuance always re-reads it before returning a bearer.
+
+Issuance reads the current generation, writes the session, and re-reads the generation before returning the bearer. If a concurrent global revocation changed it, issuance tombstones the provisional record and retries against the new generation. A revocation immediately after the final check is allowed to invalidate the newly returned session, which is the intended outcome of concurrent operator revocation.
+
+Unknown, malformed, mismatched, revoked, wrong-generation, and prior-key-namespace tokens return the normal invalid-token result. Coordinator/network failures and decryption corruption inside the current key namespace raise a distinct auth-store-unavailable error that the HTTP boundary maps to 503 with retry guidance and no `WWW-Authenticate: invalid_token` challenge; they must not be collapsed into `None`/401 by a broad exception handler.
+
+### 4. Provide explicit local and protocol revocation
+
+The operator surface is:
+
+- `exomem auth sessions` — list non-secret session metadata;
+- `exomem auth revoke <session-id>` — overwrite one record with a tombstone;
+- `exomem auth revoke --all` — rotate the auth generation.
+
+The HA coordinator state API gains the minimal collection enumeration needed for the authenticated operator command. The route requires the existing coordinator bearer credential, which is mandatory for HA auth storage. The session values remain Fernet-encrypted; listing never returns bearer material. Single-session revocation addresses the record directly by its random session ID.
+
+FastMCP's local RFC 7009 revocation endpoint is enabled and maps a client-presented token to the same tombstone operation. The management commands remain CLI/operator-plane only rather than MCP tools: a vault session must not grant authority to enumerate or revoke unrelated sessions.
+
+### 5. Dispose of the temporary GitHub credential in the callback
+
+The overridden IdP callback exchanges the upstream code, validates the configured login and immutable ID, extracts a minimal proof, and then calls GitHub's OAuth application token-deletion endpoint for that exact token using the configured application credentials. Both FastMCP's token cache and Exomem's former login cache are disabled for this one-shot proof. No raw GitHub token or `AccessToken` object enters a cache.
+
+Cleanup is attempted on every callback path after a token is obtained, including identity rejection and failures to persist or redirect the downstream code. On success or best-effort cleanup failure, the raw token is discarded before the callback stores only the verified proof. A transient GitHub cleanup outage is logged and surfaced as an operational alert, but it cannot affect later local session validation. A client that abandons the downstream code therefore leaves no GitHub credential in Exomem storage.
+
+### 6. Isolate the FastMCP private seam
+
+`ExomemSessionOAuthProxy` preserves FastMCP's public provider behavior while overriding the IdP callback lifecycle, downstream authorization-code exchange, access-token loading, and revocation. Provider initialization also enables local RFC 7009 behavior, and the outer HTTP boundary maps session-authority failures to 503. Access to FastMCP's private transaction/code stores and callback helpers is isolated in this adapter instead of leaking through Exomem modules.
+
+The implementation pins exactly `fastmcp==3.4.4`, the inspected production version, and updates the lockfile. Contract tests cover every private callback, transaction/code-store, response, revocation, and exception seam used by the adapter. A FastMCP change requires an explicit pin update plus a green contract suite before deployment.
+
+### 7. Preserve protocol and connector compatibility
+
+OAuth discovery, protected-resource metadata, DCR, consent, callback routes, PKCE, authorization codes, scopes, and connector URLs remain unchanged. The token endpoint returns a normal bearer response with optional lifetime fields omitted.
+
+A black-box Codex CLI acceptance test is a rollout gate: log in once, restart several fresh Codex conversations/processes, and confirm the persisted bearer is reused without a browser prompt. The supported hosted connector receives an equivalent smoke test. If a supported client cannot persist an OAuth token without `expires_in`, implementation stops and returns to design; it does not substitute an arbitrary far-future expiry.
+
+## Risks / Trade-offs
+
+- **A stolen bearer remains valid until explicit revocation** → Use at least 256 bits of secret entropy, HMAC-only storage, encryption at rest, secret-safe logs, per-session revocation, and global generation rotation. This is an accepted trade-off for a single-user service.
+- **The auth authority becomes an availability dependency** → Fail with 503 rather than 401, keep the coordinator strongly consistent, and retain encrypted local storage for single-node mode only.
+- **FastMCP private internals can change** → Keep one adapter, pin exactly FastMCP 3.4.4, and require explicit pin updates with green contract tests.
+- **A client may mishandle omitted `expires_in`** → Gate rollout on black-box Codex and hosted-connector tests; redesign around fully local refresh tokens if required.
+- **GitHub token cleanup can fail transiently** → Alert without coupling the local session to cleanup; never retain the credential as session state.
+- **Mixed old/new replicas disagree on token format** → Use a coordinated active/passive rollout with no mixed-version serving window.
+- **Session enumeration adds an internal coordinator operation** → Require the existing coordinator bearer credential, return only encrypted values/opaque keys, and keep it outside the public MCP/REST knowledge surfaces.
+
+## Migration Plan
+
+1. Implement and test the adapter, session authority, revocation commands, 503 mapping, and client compatibility in an isolated environment.
+2. Back up the existing production environment and shared OAuth state. Resolve and persist `EXOMEM_GITHUB_USER_ID`, verify matching non-empty coordinator OAuth-storage credentials, and preserve the existing `EXOMEM_JWT_SIGNING_KEY`; do not rotate it or change the connector URL during this rollout.
+3. Quiesce connector traffic or otherwise ensure only the new provider serves requests, then update both active/passive replicas as one coordinated change.
+4. Existing FastMCP reference JWTs intentionally receive 401 once. Each client completes one final GitHub authorization and receives a durable Exomem session. Do not delete or recreate connector definitions.
+5. Verify a session issued by one replica works on the other, then verify single-session and global revocation across replicas.
+6. After the rollback window, remove obsolete JTI/upstream-token records. Do not dual-read them during normal operation.
+
+Rollback deploys the prior provider and leaves the new encrypted session collection inert. Clients that already migrated will need to authorize once into the prior token format. Legacy OAuth records remain untouched until the rollback window closes, so rollback does not require reconstructing them.
+
+## Open Questions
+
+There are no blocking product decisions. Omitted-`expires_in` interoperability with the exact production Codex and hosted connector versions is an implementation acceptance gate rather than an architectural assumption.

--- a/openspec/changes/durable-local-auth-sessions/proposal.md
+++ b/openspec/changes/durable-local-auth-sessions/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Exomem currently retains one upstream GitHub OAuth token per MCP client and asks GitHub to validate that token during ordinary MCP requests. GitHub revokes older tokens after ten authorizations for the same user, application, and scopes, so reconnecting one Codex or Claude client can invalidate another and create an endless login loop.
+
+## What Changes
+
+- **BREAKING** Replace existing FastMCP reference JWTs backed by per-client GitHub tokens with Exomem-owned, opaque MCP sessions. Existing clients perform one final OAuth authorization after deployment.
+- **BREAKING** Require an explicit `EXOMEM_JWT_SIGNING_KEY` whenever HTTP OAuth is enabled; startup fails with remediation instead of deriving durable-session keys from the GitHub client secret.
+- **BREAKING** Require `EXOMEM_GITHUB_USER_ID` to anchor the configured login to GitHub's immutable numeric subject, and require `EXOMEM_OAUTH_STORAGE_TOKEN` whenever shared HA auth storage is enabled.
+- Use GitHub only during authorization-code exchange to prove the configured account's login and immutable user ID.
+- Issue a high-entropy Exomem bearer token with no advertised expiry or refresh token, backed by a durable encrypted server-side session record.
+- Validate ordinary MCP requests entirely against Exomem's authoritative session store, with no GitHub API call or retained upstream GitHub credential.
+- Add immediate single-session and global Exomem revocation, plus invalidation on signing-key rotation.
+- Make HA session validation uncached, remote-authoritative, and fail closed without allowing stale local state to resurrect revoked sessions.
+- Return service-unavailable failures for authoritative-store outages instead of `401 invalid_token`, preventing infrastructure failures from triggering fresh authorization loops.
+- Validate and revoke each short-lived GitHub token inside the IdP callback before persisting the downstream client code, so abandoned or failed client exchanges retain no upstream credential.
+- Preserve the existing connector URL, OAuth discovery, DCR, consent, callback, PKCE, and authorization-code behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `durable-mcp-auth-sessions`: GitHub-backed one-time identity proof, durable Exomem session issuance and validation, HA-safe revocation, operator management, migration, and failure semantics.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects OAuth wiring and token exchange in `src/exomem/server_auth.py`, shared auth storage, the internal HA coordinator state API, auth-related CLI commands, remote setup/doctor documentation, and auth tests.
+- Introduces no new external dependency; it pins the production-tested FastMCP 3.4.4 seam and continues to use `httpx`, Fernet-encrypted storage, and the now-required stable `EXOMEM_JWT_SIGNING_KEY`.
+- Requires a coordinated replica rollout because old and new auth providers intentionally accept different token formats.
+- Requires one final OAuth login for every existing MCP client. Connector definitions and URLs remain unchanged.

--- a/openspec/changes/durable-local-auth-sessions/specs/durable-mcp-auth-sessions/spec.md
+++ b/openspec/changes/durable-local-auth-sessions/specs/durable-mcp-auth-sessions/spec.md
@@ -1,0 +1,195 @@
+## ADDED Requirements
+
+### Requirement: GitHub is a one-time identity proof
+The system SHALL use the upstream GitHub OAuth token only inside the IdP callback for identity proof and exact-token disposal. It MUST match both the configured normalized login and configured `EXOMEM_GITHUB_USER_ID`, MUST disable raw-token verification caches, and MUST persist only a minimal verified identity proof in the downstream client code.
+
+#### Scenario: Configured GitHub account authorizes successfully
+- **WHEN** the callback token resolves to the configured login and configured immutable user ID
+- **THEN** the callback stores a token-free identity proof that can issue an Exomem-owned MCP session
+
+#### Scenario: Wrong or unverifiable GitHub account is rejected
+- **WHEN** GitHub rejects the token, the login differs, or the immutable user ID is absent or differs from `EXOMEM_GITHUB_USER_ID`
+- **THEN** the system issues no Exomem session and returns an OAuth authorization failure
+
+#### Scenario: Identity proof is not cached with the raw token
+- **WHEN** the callback finishes verification on any success or failure path
+- **THEN** neither FastMCP nor Exomem retains the raw GitHub bearer in a verifier cache
+
+### Requirement: Durable sessions require an explicit root of trust
+The system MUST require non-empty `EXOMEM_JWT_SIGNING_KEY` and `EXOMEM_GITHUB_USER_ID` values whenever HTTP OAuth is enabled. It SHALL derive session HMAC and encryption keys from the signing value with distinct purpose salts and MUST NOT fall back to the GitHub client secret.
+
+#### Scenario: HTTP OAuth starts with explicit trust anchors
+- **WHEN** all OAuth settings including `EXOMEM_JWT_SIGNING_KEY` and `EXOMEM_GITHUB_USER_ID` are present
+- **THEN** the system derives purpose-separated session keys and starts the protected HTTP server
+
+#### Scenario: Trust anchor is missing
+- **WHEN** HTTP OAuth is enabled without `EXOMEM_JWT_SIGNING_KEY` or `EXOMEM_GITHUB_USER_ID`
+- **THEN** startup fails with an actionable configuration error before accepting requests
+
+### Requirement: Remote setup provisions durable auth settings
+The remote setup flow SHALL generate and preserve `EXOMEM_JWT_SIGNING_KEY`, resolve and persist `EXOMEM_GITHUB_USER_ID` for the configured login, and configure matching non-empty coordinator and Exomem OAuth-storage bearer credentials for HA. Remote doctor SHALL validate the settings offline and SHALL verify the coordinator credential when run with `--probe`.
+
+#### Scenario: New remote setup provisions trust anchors
+- **WHEN** a user completes a new authenticated remote setup
+- **THEN** the resulting environment contains the signing key, immutable GitHub user ID, and any required matching HA storage credentials
+
+#### Scenario: Existing signing key is upgraded safely
+- **WHEN** remote setup runs against an existing installation with `EXOMEM_JWT_SIGNING_KEY`
+- **THEN** it preserves that value instead of rotating all existing sessions implicitly
+
+#### Scenario: Doctor finds incomplete HA authentication
+- **WHEN** shared OAuth storage is configured with a missing or rejected coordinator token
+- **THEN** offline doctor reports the missing setting or probed doctor reports the rejected credential with remediation
+
+### Requirement: Exomem issues a durable opaque session
+The system SHALL issue a versioned opaque bearer containing at least 256 bits of secret entropy. It MUST omit `expires_in` and `refresh_token`, MUST store only an HMAC proof rather than the raw bearer, and MUST persist an encrypted session record containing the MCP client, MCP scopes, issuer, protected-resource audience, issuance identity, issue time, status, and auth generation.
+
+#### Scenario: Successful token response has no time-based expiry
+- **WHEN** authorization-code exchange succeeds
+- **THEN** the token response contains an opaque bearer and no access-token expiry or refresh token
+
+#### Scenario: Stored state cannot reveal the bearer
+- **WHEN** an operator or test inspects decrypted session fields
+- **THEN** the raw bearer secret is absent and only its keyed HMAC proof is present
+
+#### Scenario: GitHub scopes do not become MCP scopes
+- **WHEN** GitHub's token response includes upstream scopes that differ from the downstream authorization code's scopes
+- **THEN** the Exomem session contains and returns only the authorized MCP scopes
+
+### Requirement: Ordinary requests are independent of GitHub
+The system SHALL validate ordinary MCP bearer requests only against the Exomem session authority. It MUST NOT call GitHub, load a retained upstream GitHub token, or depend on a FastMCP JTI-to-upstream-token mapping after session issuance.
+
+#### Scenario: Repeated requests make zero GitHub calls
+- **WHEN** an active Exomem session performs any number of MCP requests
+- **THEN** every request validates locally and the GitHub verifier and GitHub API receive zero calls
+
+#### Scenario: GitHub later revokes or evicts the authorization token
+- **WHEN** GitHub invalidates the temporary token after the Exomem session was issued
+- **THEN** the Exomem session remains valid until Exomem revokes it or the signing key rotates
+
+#### Scenario: More than ten clients authorize
+- **WHEN** more than ten downstream MCP clients authorize through the same GitHub user, application, and scopes
+- **THEN** every previously issued active Exomem session remains valid
+
+### Requirement: Session validation is cryptographically and contextually bound
+The system MUST verify the bearer HMAC using a key derived from `EXOMEM_JWT_SIGNING_KEY` with a distinct purpose salt and constant-time comparison. It SHALL also require an active record whose schema, generation, issuer, audience, stored issuing-client context, scopes, and issuance identity are valid for the current Exomem deployment.
+
+#### Scenario: Unknown or modified token is rejected
+- **WHEN** a bearer is malformed, unknown, or differs from the issued secret
+- **THEN** the system returns invalid token without revealing which proof check failed
+
+#### Scenario: Token record belongs to another deployment context
+- **WHEN** a record's issuer or protected-resource audience differs from the current deployment
+- **THEN** the system rejects the bearer as invalid
+
+#### Scenario: Signing key rotates
+- **WHEN** `EXOMEM_JWT_SIGNING_KEY` changes
+- **THEN** the authority selects a fresh fingerprinted collection namespace and rejects prior sessions as unknown without decrypting old ciphertext
+
+### Requirement: HA session state is authoritative and revocation-safe
+In HA mode, the system SHALL read encrypted session and generation state from a bearer-authenticated remote coordinator as the sole authority, without read cache or local fallback. It MUST require a non-empty `EXOMEM_OAUTH_STORAGE_TOKEN`, use key-fingerprinted collection namespaces and permanent revoked tombstones, and MUST NOT resurrect a session from replica-local state.
+
+#### Scenario: HA storage credential is missing
+- **WHEN** a shared OAuth storage URL is configured without `EXOMEM_OAUTH_STORAGE_TOKEN`
+- **THEN** startup fails before exposing the protected HTTP server
+
+#### Scenario: Session crosses replicas
+- **WHEN** replica A issues a session and replica B receives its bearer
+- **THEN** replica B validates the session from the shared authoritative state
+
+#### Scenario: Revocation propagates immediately
+- **WHEN** replica A revokes a session that replica B previously accepted
+- **THEN** replica B rejects the next request without waiting for cache expiry
+
+#### Scenario: Stale local copy exists after revocation
+- **WHEN** the authoritative record is a revoked tombstone and a replica has an older active local copy
+- **THEN** the replica rejects the session and never restores the active copy
+
+### Requirement: Auth-store outages are not authentication failures
+The system MUST distinguish authoritative session-store unavailability from an invalid bearer. Invalid, unknown, or revoked sessions SHALL return 401 with the normal invalid-token challenge, while coordinator/network failures or decryption corruption in the current key namespace SHALL produce 503 without `WWW-Authenticate: invalid_token` or any OAuth authorization challenge.
+
+#### Scenario: Coordinator is unavailable for an otherwise valid session
+- **WHEN** session validation cannot reach the authoritative coordinator
+- **THEN** the MCP endpoint returns 503 without an invalid-token challenge
+
+#### Scenario: Revoked session is available in the authority
+- **WHEN** the authoritative store successfully returns a revoked tombstone
+- **THEN** the MCP endpoint returns invalid token
+
+### Requirement: Operators can inspect and revoke Exomem sessions
+The system SHALL provide authenticated operator commands to list non-secret session metadata, revoke one session by session ID, and revoke all sessions by replacing the shared auth generation. The system MUST NOT expose raw bearer material or privileged session enumeration through MCP knowledge tools.
+
+#### Scenario: Operator lists sessions
+- **WHEN** an authorized operator runs `exomem auth sessions`
+- **THEN** the command returns session IDs, client metadata, login, issue time, and status without bearer secrets
+
+#### Scenario: Operator revokes one session
+- **WHEN** an authorized operator runs `exomem auth revoke <session-id>`
+- **THEN** the authority overwrites that session with a permanent revoked tombstone and all replicas reject it
+
+#### Scenario: Operator revokes all sessions
+- **WHEN** an authorized operator runs `exomem auth revoke --all`
+- **THEN** the authority replaces the auth generation and every session from the prior generation is rejected
+
+#### Scenario: Revoke-all races with issuance
+- **WHEN** global revocation changes the generation while a new session is being committed
+- **THEN** the system never returns a session that remains active under the revoked generation
+
+### Requirement: Client-initiated revocation uses the same authority
+The system SHALL enable local OAuth token revocation and SHALL map a client-presented active bearer to the same permanent session tombstone used by operator revocation.
+
+#### Scenario: Client revokes its bearer
+- **WHEN** an authenticated OAuth client submits its bearer to the revocation endpoint
+- **THEN** all replicas reject subsequent use of that session
+
+### Requirement: Temporary GitHub credentials are disposed
+After identity proof in the IdP callback, the system MUST NOT retain the GitHub access token in the verifier cache, downstream client code, or session state. Before storing the client code, it SHALL attempt to revoke the exact token with GitHub and SHALL emit a secret-safe operational alert if cleanup fails.
+
+#### Scenario: GitHub cleanup succeeds
+- **WHEN** the callback verifies identity and GitHub accepts exact-token deletion
+- **THEN** the downstream client code contains only the verified proof and no upstream token
+
+#### Scenario: GitHub cleanup fails after identity proof
+- **WHEN** GitHub token deletion fails because GitHub is unavailable
+- **THEN** the callback discards the raw token, stores only the verified proof, and emits a secret-safe cleanup alert
+
+#### Scenario: Client abandons or fails downstream exchange
+- **WHEN** the client never redeems the downstream code or fails its PKCE check
+- **THEN** no GitHub credential remains in Exomem storage and no Exomem bearer is issued
+
+#### Scenario: Callback fails after GitHub issued a token
+- **WHEN** identity validation, proof persistence, or redirect handling fails after a GitHub token is available
+- **THEN** the callback attempts exact-token cleanup and does not retain the raw credential
+
+### Requirement: Existing OAuth protocol behavior remains compatible
+The system SHALL preserve the current connector URL, OAuth discovery, protected-resource metadata, DCR, consent, callback, PKCE, authorization-code, and MCP scope behavior. The implementation MUST prove that supported clients persist and reuse a token response with omitted lifetime fields before production rollout.
+
+#### Scenario: Existing connector performs final migration login
+- **WHEN** an existing client presents a legacy FastMCP reference JWT after deployment
+- **THEN** the server rejects it once, the client completes the unchanged browser authorization flow, and the connector receives a durable local session without being deleted or re-registered
+
+#### Scenario: Fresh Codex conversations reuse one login
+- **WHEN** Codex has stored a newly issued Exomem session and starts multiple fresh conversations or processes
+- **THEN** each process reuses that bearer without launching the browser authorization flow
+
+#### Scenario: Supported client mishandles omitted expiry
+- **WHEN** a black-box compatibility test shows that a supported client discards or refuses a token without `expires_in`
+- **THEN** production rollout is blocked and the implementation returns to design instead of adding an arbitrary far-future expiry
+
+### Requirement: FastMCP integration failures are detected before deployment
+The implementation SHALL isolate private FastMCP dependencies in one adapter, pin exactly `fastmcp==3.4.4`, and provide contract tests that fail when required callback, transaction/code-store, authorization-code, token-loading, revocation, or exception behavior changes.
+
+#### Scenario: FastMCP upgrade changes a required private seam
+- **WHEN** dependency resolution selects any FastMCP version other than 3.4.4 or the pinned internals no longer satisfy the adapter contract
+- **THEN** dependency or contract validation fails before deployment
+
+### Requirement: Migration does not preserve the faulty dependency
+The deployment MUST use a coordinated replica cutover and MUST NOT dual-read legacy JTI/upstream-token records during normal operation. Legacy records MAY remain untouched for a bounded rollback window and SHALL be removed only after the new provider is verified.
+
+#### Scenario: Old and new providers would otherwise serve together
+- **WHEN** the HA rollout could route requests to both token formats
+- **THEN** traffic is quiesced or replica routing is coordinated so only the new provider serves after cutover
+
+#### Scenario: Rollback is required
+- **WHEN** the deployment rolls back during the bounded rollback window
+- **THEN** legacy records are still available, new session records remain inert, and migrated clients can authorize once into the prior format

--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Session Token and Record Contract
 
 - [ ] 1.1 Add failing pure-logic tests for versioned bearer parsing, entropy shape, HMAC verification, constant-time mismatch handling, record context validation, fingerprinted signing-key rotation, and refusal to start HTTP OAuth without explicit signing-key and immutable-user-ID anchors.
-- [ ] 1.2 Implement the opaque token codec, purpose-separated key derivation, and typed session/generation records without storing raw bearer material.
-- [ ] 1.3 Add failing tests that distinguish invalid/revoked records from session-authority failures and cover the concurrent revoke-all/issuance generation race.
+- [x] 1.2 Implement the opaque token codec, purpose-separated key derivation, and typed session/generation records without storing raw bearer material.
+- [x] 1.3 Add failing tests that distinguish invalid/revoked records from session-authority failures and cover the concurrent revoke-all/issuance generation race.
 
 ## 2. Authoritative Session Storage
 
-- [ ] 2.1 Add failing storage tests for encrypted single-node persistence, fingerprinted namespaces, remote cross-replica reads, uncached generation checks, permanent tombstones, key-rotation 401 behavior, and stale-local non-resurrection.
-- [ ] 2.2 Implement `SessionAuthority` with encrypted local and remote-canonical HA backends, fingerprinted collections, permanent tombstones, atomically initialized/randomly replaced generations, and fail-closed exceptions.
-- [ ] 2.3 Add bearer-authenticated collection enumeration to the internal coordinator state API and remote storage adapter, with tests proving HA refuses an empty storage credential and enumeration exposes no decrypted bearer material.
+- [x] 2.1 Add failing storage tests for encrypted single-node persistence, fingerprinted namespaces, remote cross-replica reads, uncached generation checks, permanent tombstones, key-rotation 401 behavior, and stale-local non-resurrection.
+- [x] 2.2 Implement `SessionAuthority` with encrypted local and remote-canonical HA backends, fingerprinted collections, permanent tombstones, atomically initialized/randomly replaced generations, and fail-closed exceptions.
+- [x] 2.3 Add bearer-authenticated collection enumeration to the internal coordinator state API and remote storage adapter, with tests proving HA refuses an empty storage credential and enumeration exposes no decrypted bearer material.
 
 ## 3. OAuth Exchange and Request Validation
 

--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -28,16 +28,16 @@
 
 ## 5. Operator Surface and Migration Controls
 
-- [ ] 5.1 Add CLI tests for `exomem auth sessions`, `exomem auth revoke <session-id>`, and `exomem auth revoke --all`, including authorization/config errors and secret-free output.
-- [ ] 5.2 Implement the operator-only auth commands over the local or remote session authority without registering them as MCP knowledge tools.
+- [x] 5.1 Add CLI tests for `exomem auth sessions`, `exomem auth revoke <session-id>`, and `exomem auth revoke --all`, including authorization/config errors and secret-free output.
+- [x] 5.2 Implement the operator-only auth commands over the local or remote session authority without registering them as MCP knowledge tools.
 - [x] 5.3 Add migration tests proving legacy FastMCP JWTs are not dual-read, connector URLs/discovery/DCR/PKCE remain unchanged, and rollback can use preserved legacy state during a bounded window.
-- [ ] 5.4 Extend remote setup to generate/preserve `EXOMEM_JWT_SIGNING_KEY`, resolve/persist `EXOMEM_GITHUB_USER_ID`, and generate/configure matching non-empty coordinator OAuth-storage credentials; add offline and probed doctor validation.
-- [ ] 5.5 Document the coordinated replica cutover, one-final-login expectation, new required settings, rollback procedure, post-window legacy JTI/upstream-record cleanup, and updated troubleshooting semantics.
+- [x] 5.4 Extend remote setup to generate/preserve `EXOMEM_JWT_SIGNING_KEY`, resolve/persist `EXOMEM_GITHUB_USER_ID`, and generate/configure matching non-empty coordinator OAuth-storage credentials; add offline and probed doctor validation.
+- [x] 5.5 Document the coordinated replica cutover, one-final-login expectation, new required settings, rollback procedure, post-window legacy JTI/upstream-record cleanup, and updated troubleshooting semantics.
 
 ## 6. Dependency and Client Compatibility Gates
 
 - [x] 6.1 Pin `fastmcp==3.4.4`, refresh the lockfile, and add adapter contract tests for every private callback, transaction/code-store, token, revocation, initialization, and exception seam Exomem relies on.
-- [ ] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
+- [x] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
 - [ ] 6.3 Run the equivalent supported hosted-connector smoke test and record the rollout result; block deployment if omitted `expires_in` is not persisted correctly.
 - [ ] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.
 - [ ] 6.5 Have an independent reviewer verify the implementation against every scenario in `durable-mcp-auth-sessions`, including zero post-issuance GitHub calls and 503-vs-401 behavior.

--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Session Token and Record Contract
 
-- [ ] 1.1 Add failing pure-logic tests for versioned bearer parsing, entropy shape, HMAC verification, constant-time mismatch handling, record context validation, fingerprinted signing-key rotation, and refusal to start HTTP OAuth without explicit signing-key and immutable-user-ID anchors.
+- [x] 1.1 Add failing pure-logic tests for versioned bearer parsing, entropy shape, HMAC verification, constant-time mismatch handling, record context validation, fingerprinted signing-key rotation, and refusal to start HTTP OAuth without explicit signing-key and immutable-user-ID anchors.
 - [x] 1.2 Implement the opaque token codec, purpose-separated key derivation, and typed session/generation records without storing raw bearer material.
 - [x] 1.3 Add failing tests that distinguish invalid/revoked records from session-authority failures and cover the concurrent revoke-all/issuance generation race.
 
@@ -12,31 +12,31 @@
 
 ## 3. OAuth Exchange and Request Validation
 
-- [ ] 3.1 Add failing IdP-callback and authorization-code tests for configured GitHub login plus configured immutable ID, disabled verifier caches, wrong/missing identity rejection, token-free client codes, downstream MCP scope preservation, omitted lifetime fields, abandoned/invalid-PKCE flows, and one-time code use.
-- [ ] 3.2 Implement `ExomemSessionOAuthProxy` callback proof extraction plus authorization-code exchange so the callback stores no GitHub token and exchange commits a generation-stable local session without upstream-token/JTI state.
-- [ ] 3.3 Add failing request-validation tests proving repeated active-session requests make zero GitHub calls, survive simulated GitHub revocation and more than ten authorizations, and reject malformed/context-mismatched tokens.
-- [ ] 3.4 Implement opaque bearer loading against `SessionAuthority`, returning an `AccessToken` from stored MCP context without checking GitHub or current login configuration.
-- [ ] 3.5 Add failing tests for callback cleanup success, identity/proof/redirect failure, abandoned downstream code, already-revoked tokens, transient cleanup failure, disabled raw-token caches, and secret-safe logs.
-- [ ] 3.6 Implement exact-token GitHub cleanup inside the callback, treating already-invalid tokens as cleaned, discarding raw credentials before client-code persistence, and alerting on transient cleanup failure.
+- [x] 3.1 Add failing IdP-callback and authorization-code tests for configured GitHub login plus configured immutable ID, disabled verifier caches, wrong/missing identity rejection, token-free client codes, downstream MCP scope preservation, omitted lifetime fields, abandoned/invalid-PKCE flows, and one-time code use.
+- [x] 3.2 Implement `ExomemSessionOAuthProxy` callback proof extraction plus authorization-code exchange so the callback stores no GitHub token and exchange commits a generation-stable local session without upstream-token/JTI state.
+- [x] 3.3 Add failing request-validation tests proving repeated active-session requests make zero GitHub calls, survive simulated GitHub revocation and more than ten authorizations, and reject malformed/context-mismatched tokens.
+- [x] 3.4 Implement opaque bearer loading against `SessionAuthority`, returning an `AccessToken` from stored MCP context without checking GitHub or current login configuration.
+- [x] 3.5 Add failing tests for callback cleanup success, identity/proof/redirect failure, abandoned downstream code, already-revoked tokens, transient cleanup failure, disabled raw-token caches, and secret-safe logs.
+- [x] 3.6 Implement exact-token GitHub cleanup inside the callback, treating already-invalid tokens as cleaned, discarding raw credentials before client-code persistence, and alerting on transient cleanup failure.
 
 ## 4. Revocation and Availability Semantics
 
-- [ ] 4.1 Add failing tests for RFC 7009 client revocation, single-session operator revocation, global generation replacement, immediate cross-replica propagation, and concurrent issuance safety.
-- [ ] 4.2 Enable local OAuth revocation and implement client, single-session, and revoke-all operations through the same session authority.
-- [ ] 4.3 Add failing HTTP-boundary tests proving invalid/revoked/prior-key tokens return 401 with the normal challenge while current-authority network or corruption failures return 503 without `WWW-Authenticate: invalid_token` or another OAuth challenge.
-- [ ] 4.4 Implement the narrow auth-store-unavailable mapping at the HTTP boundary and ensure FastMCP's adapter does not swallow infrastructure exceptions.
+- [x] 4.1 Add failing tests for RFC 7009 client revocation, single-session operator revocation, global generation replacement, immediate cross-replica propagation, and concurrent issuance safety.
+- [x] 4.2 Enable local OAuth revocation and implement client, single-session, and revoke-all operations through the same session authority.
+- [x] 4.3 Add failing HTTP-boundary tests proving invalid/revoked/prior-key tokens return 401 with the normal challenge while current-authority network or corruption failures return 503 without `WWW-Authenticate: invalid_token` or another OAuth challenge.
+- [x] 4.4 Implement the narrow auth-store-unavailable mapping at the HTTP boundary and ensure FastMCP's adapter does not swallow infrastructure exceptions.
 
 ## 5. Operator Surface and Migration Controls
 
 - [ ] 5.1 Add CLI tests for `exomem auth sessions`, `exomem auth revoke <session-id>`, and `exomem auth revoke --all`, including authorization/config errors and secret-free output.
 - [ ] 5.2 Implement the operator-only auth commands over the local or remote session authority without registering them as MCP knowledge tools.
-- [ ] 5.3 Add migration tests proving legacy FastMCP JWTs are not dual-read, connector URLs/discovery/DCR/PKCE remain unchanged, and rollback can use preserved legacy state during a bounded window.
+- [x] 5.3 Add migration tests proving legacy FastMCP JWTs are not dual-read, connector URLs/discovery/DCR/PKCE remain unchanged, and rollback can use preserved legacy state during a bounded window.
 - [ ] 5.4 Extend remote setup to generate/preserve `EXOMEM_JWT_SIGNING_KEY`, resolve/persist `EXOMEM_GITHUB_USER_ID`, and generate/configure matching non-empty coordinator OAuth-storage credentials; add offline and probed doctor validation.
 - [ ] 5.5 Document the coordinated replica cutover, one-final-login expectation, new required settings, rollback procedure, post-window legacy JTI/upstream-record cleanup, and updated troubleshooting semantics.
 
 ## 6. Dependency and Client Compatibility Gates
 
-- [ ] 6.1 Pin `fastmcp==3.4.4`, refresh the lockfile, and add adapter contract tests for every private callback, transaction/code-store, token, revocation, initialization, and exception seam Exomem relies on.
+- [x] 6.1 Pin `fastmcp==3.4.4`, refresh the lockfile, and add adapter contract tests for every private callback, transaction/code-store, token, revocation, initialization, and exception seam Exomem relies on.
 - [ ] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
 - [ ] 6.3 Run the equivalent supported hosted-connector smoke test and record the rollout result; block deployment if omitted `expires_in` is not persisted correctly.
 - [ ] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.

--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -1,0 +1,43 @@
+## 1. Session Token and Record Contract
+
+- [ ] 1.1 Add failing pure-logic tests for versioned bearer parsing, entropy shape, HMAC verification, constant-time mismatch handling, record context validation, fingerprinted signing-key rotation, and refusal to start HTTP OAuth without explicit signing-key and immutable-user-ID anchors.
+- [ ] 1.2 Implement the opaque token codec, purpose-separated key derivation, and typed session/generation records without storing raw bearer material.
+- [ ] 1.3 Add failing tests that distinguish invalid/revoked records from session-authority failures and cover the concurrent revoke-all/issuance generation race.
+
+## 2. Authoritative Session Storage
+
+- [ ] 2.1 Add failing storage tests for encrypted single-node persistence, fingerprinted namespaces, remote cross-replica reads, uncached generation checks, permanent tombstones, key-rotation 401 behavior, and stale-local non-resurrection.
+- [ ] 2.2 Implement `SessionAuthority` with encrypted local and remote-canonical HA backends, fingerprinted collections, permanent tombstones, atomically initialized/randomly replaced generations, and fail-closed exceptions.
+- [ ] 2.3 Add bearer-authenticated collection enumeration to the internal coordinator state API and remote storage adapter, with tests proving HA refuses an empty storage credential and enumeration exposes no decrypted bearer material.
+
+## 3. OAuth Exchange and Request Validation
+
+- [ ] 3.1 Add failing IdP-callback and authorization-code tests for configured GitHub login plus configured immutable ID, disabled verifier caches, wrong/missing identity rejection, token-free client codes, downstream MCP scope preservation, omitted lifetime fields, abandoned/invalid-PKCE flows, and one-time code use.
+- [ ] 3.2 Implement `ExomemSessionOAuthProxy` callback proof extraction plus authorization-code exchange so the callback stores no GitHub token and exchange commits a generation-stable local session without upstream-token/JTI state.
+- [ ] 3.3 Add failing request-validation tests proving repeated active-session requests make zero GitHub calls, survive simulated GitHub revocation and more than ten authorizations, and reject malformed/context-mismatched tokens.
+- [ ] 3.4 Implement opaque bearer loading against `SessionAuthority`, returning an `AccessToken` from stored MCP context without checking GitHub or current login configuration.
+- [ ] 3.5 Add failing tests for callback cleanup success, identity/proof/redirect failure, abandoned downstream code, already-revoked tokens, transient cleanup failure, disabled raw-token caches, and secret-safe logs.
+- [ ] 3.6 Implement exact-token GitHub cleanup inside the callback, treating already-invalid tokens as cleaned, discarding raw credentials before client-code persistence, and alerting on transient cleanup failure.
+
+## 4. Revocation and Availability Semantics
+
+- [ ] 4.1 Add failing tests for RFC 7009 client revocation, single-session operator revocation, global generation replacement, immediate cross-replica propagation, and concurrent issuance safety.
+- [ ] 4.2 Enable local OAuth revocation and implement client, single-session, and revoke-all operations through the same session authority.
+- [ ] 4.3 Add failing HTTP-boundary tests proving invalid/revoked/prior-key tokens return 401 with the normal challenge while current-authority network or corruption failures return 503 without `WWW-Authenticate: invalid_token` or another OAuth challenge.
+- [ ] 4.4 Implement the narrow auth-store-unavailable mapping at the HTTP boundary and ensure FastMCP's adapter does not swallow infrastructure exceptions.
+
+## 5. Operator Surface and Migration Controls
+
+- [ ] 5.1 Add CLI tests for `exomem auth sessions`, `exomem auth revoke <session-id>`, and `exomem auth revoke --all`, including authorization/config errors and secret-free output.
+- [ ] 5.2 Implement the operator-only auth commands over the local or remote session authority without registering them as MCP knowledge tools.
+- [ ] 5.3 Add migration tests proving legacy FastMCP JWTs are not dual-read, connector URLs/discovery/DCR/PKCE remain unchanged, and rollback can use preserved legacy state during a bounded window.
+- [ ] 5.4 Extend remote setup to generate/preserve `EXOMEM_JWT_SIGNING_KEY`, resolve/persist `EXOMEM_GITHUB_USER_ID`, and generate/configure matching non-empty coordinator OAuth-storage credentials; add offline and probed doctor validation.
+- [ ] 5.5 Document the coordinated replica cutover, one-final-login expectation, new required settings, rollback procedure, post-window legacy JTI/upstream-record cleanup, and updated troubleshooting semantics.
+
+## 6. Dependency and Client Compatibility Gates
+
+- [ ] 6.1 Pin `fastmcp==3.4.4`, refresh the lockfile, and add adapter contract tests for every private callback, transaction/code-store, token, revocation, initialization, and exception seam Exomem relies on.
+- [ ] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
+- [ ] 6.3 Run the equivalent supported hosted-connector smoke test and record the rollout result; block deployment if omitted `expires_in` is not persisted correctly.
+- [ ] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.
+- [ ] 6.5 Have an independent reviewer verify the implementation against every scenario in `durable-mcp-auth-sessions`, including zero post-issuance GitHub calls and 503-vs-401 behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=2.10",
+    "fastmcp==3.4.4",
     "httpx>=0.27",
     "pyyaml>=6.0",
     "python-slugify>=8.0",

--- a/scripts/codex_auth_session_harness.py
+++ b/scripts/codex_auth_session_harness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Rollout gate for durable Codex MCP login persistence.
+
+This is intentionally a manual/live harness. Unit tests inject a subprocess
+runner; operators run this script once against the staged connector URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+class HarnessFailure(RuntimeError):
+    """The live client gate observed registration, login, or reuse failure."""
+
+
+_FORBIDDEN = (
+    re.compile(r"not\s+logged\s+in", re.IGNORECASE),
+    re.compile(r"MCP\s+startup\s+incomplete", re.IGNORECASE),
+    re.compile(r"codex\s+mcp\s+login", re.IGNORECASE),
+    re.compile(r"(?:open(?:ing)?|launch(?:ing)?)\b.{0,40}\bbrowser", re.IGNORECASE),
+    re.compile(r"browser\b.{0,40}\b(?:login|log\s*in|authenticat)", re.IGNORECASE),
+)
+
+
+def classify_exec_output(stdout: str, stderr: str) -> None:
+    """Raise unless one fresh process completed an Exomem MCP tool call."""
+    combined = f"{stdout}\n{stderr}"
+    for pattern in _FORBIDDEN:
+        if pattern.search(combined):
+            raise HarnessFailure("fresh Codex process attempted or requested a new login")
+
+    completed = False
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "item.completed":
+            continue
+        item = event.get("item")
+        if not isinstance(item, dict) or item.get("type") != "mcp_tool_call":
+            continue
+        server = str(item.get("server") or item.get("server_name") or "")
+        tool = str(item.get("tool") or item.get("name") or "")
+        status = str(item.get("status") or "completed").casefold()
+        if (
+            (server.casefold() == "exomem" or tool.casefold().startswith("mcp__exomem__"))
+            and status not in {"failed", "error", "cancelled"}
+        ):
+            completed = True
+            break
+    if not completed:
+        raise HarnessFailure("fresh Codex process did not complete an Exomem MCP call")
+
+
+def _run_checked(
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+    command: list[str],
+    *,
+    env: dict[str, str],
+    action: str,
+    interactive: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    kwargs: dict[str, object] = {"env": env, "check": False, "text": True}
+    if not interactive:
+        kwargs["capture_output"] = True
+    result = runner(command, **kwargs)
+    if result.returncode != 0:
+        raise HarnessFailure(f"Codex failed to {action} (exit {result.returncode})")
+    return result
+
+
+def run_harness(
+    *,
+    url: str,
+    codex_home: Path,
+    runs: int = 3,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> int:
+    parsed = urlsplit(url.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise HarnessFailure("connector URL must be a credential-free HTTP(S) URL")
+    if runs < 2:
+        raise HarnessFailure("at least two fresh Codex processes are required")
+
+    codex_home = codex_home.expanduser().resolve()
+    codex_home.mkdir(parents=True, exist_ok=True)
+    try:
+        codex_home.chmod(0o700)
+    except OSError:
+        pass
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    _run_checked(
+        runner,
+        ["codex", "mcp", "add", "exomem", "--url", url.strip()],
+        env=env,
+        action="register the Exomem MCP server",
+    )
+    _run_checked(
+        runner,
+        ["codex", "mcp", "login", "exomem"],
+        env=env,
+        action="complete the one interactive Exomem login",
+        interactive=True,
+    )
+
+    prompt = (
+        "Use the exomem MCP server now. Make exactly one harmless read-only "
+        "ask_memory call with query '__exomem_codex_session_smoke_absent__'. "
+        "Do not use shell commands."
+    )
+    for index in range(1, runs + 1):
+        result = _run_checked(
+            runner,
+            [
+                "codex",
+                "exec",
+                "--ephemeral",
+                "--json",
+                "--sandbox",
+                "read-only",
+                "--skip-git-repo-check",
+                prompt,
+            ],
+            env=env,
+            action=f"run fresh compatibility process {index}",
+        )
+        classify_exec_output(result.stdout or "", result.stderr or "")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True, help="Exomem MCP connector URL")
+    parser.add_argument(
+        "--codex-home",
+        type=Path,
+        required=True,
+        help="isolated persistent CODEX_HOME used only by this rollout gate",
+    )
+    parser.add_argument("--runs", type=int, default=3, help="fresh process count (minimum 2)")
+    args = parser.parse_args(argv)
+    try:
+        return run_harness(url=args.url, codex_home=args.codex_home, runs=args.runs)
+    except HarnessFailure as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_auth_session_harness.py
+++ b/scripts/codex_auth_session_harness.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -25,6 +26,9 @@ class HarnessFailure(RuntimeError):
 SENTINEL_QUERY = "__exomem_codex_session_smoke_absent__"
 _SUCCESS_STATUSES = {"completed", "success", "succeeded"}
 _ERROR_STATUSES = {"cancelled", "error", "failed", "failure"}
+_ERROR_LIKE_STDERR = re.compile(
+    r"\b(?:error|failed|failure|fatal|panic|traceback)\b", re.IGNORECASE
+)
 
 
 _FORBIDDEN = (
@@ -77,26 +81,48 @@ def _arguments(value: object) -> dict[str, object] | None:
     return None
 
 
+def _is_command_lifecycle(value: object) -> bool:
+    normalized = re.sub(r"[.\s-]+", "_", str(value or "").casefold())
+    return (
+        "command_execution" in normalized
+        or normalized == "command"
+        or normalized.startswith("shell_")
+        or normalized.endswith("_shell")
+    )
+
+
 def classify_exec_output(stdout: str, stderr: str) -> None:
     """Require exactly one explicit successful sentinel ``ask_memory`` call."""
     combined = f"{stdout}\n{stderr}"
     for pattern in _FORBIDDEN:
         if pattern.search(combined):
             raise HarnessFailure("fresh Codex process attempted or requested a new login")
+    if _ERROR_LIKE_STDERR.search(stderr):
+        raise HarnessFailure("fresh Codex process emitted error-like stderr")
 
     observed_call_ids: set[str] = set()
     completed_call_ids: list[str] = []
     for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
         try:
             event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as error:
+            raise HarnessFailure(
+                "fresh Codex process emitted non-JSON stdout"
+            ) from error
         if not isinstance(event, dict):
             continue
         if _has_error_marker(event):
             raise HarnessFailure("fresh Codex process emitted an error event")
         item = event.get("item")
-        if not isinstance(item, dict) or item.get("type") != "mcp_tool_call":
+        if _is_command_lifecycle(event.get("type")):
+            raise HarnessFailure("fresh Codex process attempted shell execution")
+        if not isinstance(item, dict):
+            continue
+        if _is_command_lifecycle(item.get("type")):
+            raise HarnessFailure("fresh Codex process attempted shell execution")
+        if item.get("type") != "mcp_tool_call":
             continue
         server = str(item.get("server") or item.get("server_name") or "")
         tool = str(item.get("tool") or item.get("name") or "")
@@ -104,7 +130,7 @@ def classify_exec_output(stdout: str, stderr: str) -> None:
             server.casefold() == "exomem"
             or tool.casefold().startswith("mcp__exomem__")
         ):
-            continue
+            raise HarnessFailure("fresh Codex process called an unexpected MCP tool")
         if tool.casefold() not in {"ask_memory", "mcp__exomem__ask_memory"}:
             raise HarnessFailure("fresh Codex process called an unexpected Exomem tool")
         if _arguments(item.get("arguments")) != {"query": SENTINEL_QUERY}:
@@ -162,6 +188,7 @@ def run_harness(
     *,
     url: str,
     codex_home: Path,
+    codex_auth_source: Path | None = None,
     runs: int = 3,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     acknowledge_disposable_target: bool = False,
@@ -190,14 +217,42 @@ def run_harness(
         raise HarnessFailure(
             "CODEX_HOME must be a new or empty isolated directory for the initial login"
         )
+
+    if codex_auth_source is None:
+        invoking_home = os.environ.get("CODEX_HOME", "").strip()
+        source_home = Path(invoking_home) if invoking_home else Path.home() / ".codex"
+        codex_auth_source = source_home / "auth.json"
+    codex_auth_source = codex_auth_source.expanduser().resolve()
+    if not codex_auth_source.is_file():
+        raise HarnessFailure(
+            "Codex OpenAI auth source must be an existing auth.json file"
+        )
+
     codex_home.mkdir(parents=True, exist_ok=True)
     try:
         codex_home.chmod(0o700)
     except OSError:
         pass
+    auth_destination = codex_home / "auth.json"
+    if codex_auth_source == auth_destination:
+        raise HarnessFailure("Codex OpenAI auth source must be outside isolated CODEX_HOME")
+    try:
+        shutil.copyfile(codex_auth_source, auth_destination)
+        auth_destination.chmod(0o600)
+    except OSError as error:
+        raise HarnessFailure(
+            "could not seed isolated Codex OpenAI auth.json"
+        ) from error
     env = os.environ.copy()
     env["CODEX_HOME"] = str(codex_home)
 
+    _run_checked(
+        runner,
+        ["codex", "login", "status"],
+        env=env,
+        action="verify the isolated Codex OpenAI login",
+        timeout=30.0,
+    )
     _run_checked(
         runner,
         ["codex", "mcp", "add", "exomem", "--url", url.strip()],
@@ -249,6 +304,14 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="isolated persistent CODEX_HOME used only by this rollout gate",
     )
+    parser.add_argument(
+        "--codex-auth-source",
+        type=Path,
+        help=(
+            "source auth.json for the invoking Codex OpenAI login; defaults to "
+            "$CODEX_HOME/auth.json (or ~/.codex/auth.json)"
+        ),
+    )
     parser.add_argument("--runs", type=int, default=3, help="fresh process count (minimum 2)")
     parser.add_argument(
         "--acknowledge-disposable-target",
@@ -261,6 +324,7 @@ def main(argv: list[str] | None = None) -> int:
         return run_harness(
             url=args.url,
             codex_home=args.codex_home,
+            codex_auth_source=args.codex_auth_source,
             runs=args.runs,
             acknowledge_disposable_target=args.acknowledge_disposable_target,
         )

--- a/scripts/codex_auth_session_harness.py
+++ b/scripts/codex_auth_session_harness.py
@@ -22,6 +22,11 @@ class HarnessFailure(RuntimeError):
     """The live client gate observed registration, login, or reuse failure."""
 
 
+SENTINEL_QUERY = "__exomem_codex_session_smoke_absent__"
+_SUCCESS_STATUSES = {"completed", "success", "succeeded"}
+_ERROR_STATUSES = {"cancelled", "error", "failed", "failure"}
+
+
 _FORBIDDEN = (
     re.compile(r"not\s+logged\s+in", re.IGNORECASE),
     re.compile(r"MCP\s+startup\s+incomplete", re.IGNORECASE),
@@ -31,35 +36,100 @@ _FORBIDDEN = (
 )
 
 
+def _has_error_marker(value: object) -> bool:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized_key = str(key).casefold()
+            if normalized_key in {"iserror", "is_error"} and item is True:
+                return True
+            if (
+                normalized_key in {"error", "errors"}
+                and item is not None
+                and item is not False
+                and item != ""
+                and item != []
+            ):
+                return True
+            if normalized_key == "status" and str(item).casefold() in _ERROR_STATUSES:
+                return True
+            if normalized_key == "type" and str(item).casefold() in {
+                "error",
+                "item.failed",
+                "turn.failed",
+            }:
+                return True
+            if _has_error_marker(item):
+                return True
+    elif isinstance(value, list):
+        return any(_has_error_marker(item) for item in value)
+    return False
+
+
+def _arguments(value: object) -> dict[str, object] | None:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return decoded if isinstance(decoded, dict) else None
+    return None
+
+
 def classify_exec_output(stdout: str, stderr: str) -> None:
-    """Raise unless one fresh process completed an Exomem MCP tool call."""
+    """Require exactly one explicit successful sentinel ``ask_memory`` call."""
     combined = f"{stdout}\n{stderr}"
     for pattern in _FORBIDDEN:
         if pattern.search(combined):
             raise HarnessFailure("fresh Codex process attempted or requested a new login")
 
-    completed = False
-    for line in stdout.splitlines():
+    observed_call_ids: set[str] = set()
+    completed_call_ids: list[str] = []
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if not isinstance(event, dict) or event.get("type") != "item.completed":
+        if not isinstance(event, dict):
             continue
+        if _has_error_marker(event):
+            raise HarnessFailure("fresh Codex process emitted an error event")
         item = event.get("item")
         if not isinstance(item, dict) or item.get("type") != "mcp_tool_call":
             continue
         server = str(item.get("server") or item.get("server_name") or "")
         tool = str(item.get("tool") or item.get("name") or "")
-        status = str(item.get("status") or "completed").casefold()
-        if (
-            (server.casefold() == "exomem" or tool.casefold().startswith("mcp__exomem__"))
-            and status not in {"failed", "error", "cancelled"}
+        if not (
+            server.casefold() == "exomem"
+            or tool.casefold().startswith("mcp__exomem__")
         ):
-            completed = True
-            break
-    if not completed:
-        raise HarnessFailure("fresh Codex process did not complete an Exomem MCP call")
+            continue
+        if tool.casefold() not in {"ask_memory", "mcp__exomem__ask_memory"}:
+            raise HarnessFailure("fresh Codex process called an unexpected Exomem tool")
+        if _arguments(item.get("arguments")) != {"query": SENTINEL_QUERY}:
+            raise HarnessFailure("Exomem ask_memory call used unexpected arguments")
+        if _has_error_marker(item):
+            raise HarnessFailure("Exomem ask_memory call returned an error")
+
+        raw_id = item.get("id")
+        call_id = (
+            str(raw_id)
+            if raw_id is not None and str(raw_id)
+            else f"ambiguous-event-{line_number}"
+        )
+        observed_call_ids.add(call_id)
+        if event.get("type") == "item.completed":
+            if str(item.get("status") or "").casefold() not in _SUCCESS_STATUSES:
+                raise HarnessFailure(
+                    "Exomem ask_memory call lacked explicit success status"
+                )
+            completed_call_ids.append(call_id)
+
+    if len(observed_call_ids) != 1 or len(completed_call_ids) != 1:
+        raise HarnessFailure(
+            "fresh Codex process must contain one unambiguous completed Exomem call"
+        )
 
 
 def _run_checked(
@@ -68,12 +138,21 @@ def _run_checked(
     *,
     env: dict[str, str],
     action: str,
+    timeout: float,
     interactive: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    kwargs: dict[str, object] = {"env": env, "check": False, "text": True}
+    kwargs: dict[str, object] = {
+        "env": env,
+        "check": False,
+        "text": True,
+        "timeout": timeout,
+    }
     if not interactive:
         kwargs["capture_output"] = True
-    result = runner(command, **kwargs)
+    try:
+        result = runner(command, **kwargs)
+    except subprocess.TimeoutExpired as error:
+        raise HarnessFailure(f"Codex timed out while trying to {action}") from error
     if result.returncode != 0:
         raise HarnessFailure(f"Codex failed to {action} (exit {result.returncode})")
     return result
@@ -85,7 +164,12 @@ def run_harness(
     codex_home: Path,
     runs: int = 3,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    acknowledge_disposable_target: bool = False,
 ) -> int:
+    if not acknowledge_disposable_target:
+        raise HarnessFailure(
+            "explicit acknowledgement of a disposable staged target is required"
+        )
     parsed = urlsplit(url.strip())
     if (
         parsed.scheme not in {"http", "https"}
@@ -100,6 +184,12 @@ def run_harness(
         raise HarnessFailure("at least two fresh Codex processes are required")
 
     codex_home = codex_home.expanduser().resolve()
+    if codex_home.exists() and (
+        not codex_home.is_dir() or any(codex_home.iterdir())
+    ):
+        raise HarnessFailure(
+            "CODEX_HOME must be a new or empty isolated directory for the initial login"
+        )
     codex_home.mkdir(parents=True, exist_ok=True)
     try:
         codex_home.chmod(0o700)
@@ -113,19 +203,21 @@ def run_harness(
         ["codex", "mcp", "add", "exomem", "--url", url.strip()],
         env=env,
         action="register the Exomem MCP server",
+        timeout=30.0,
     )
     _run_checked(
         runner,
         ["codex", "mcp", "login", "exomem"],
         env=env,
         action="complete the one interactive Exomem login",
+        timeout=300.0,
         interactive=True,
     )
 
     prompt = (
         "Use the exomem MCP server now. Make exactly one harmless read-only "
-        "ask_memory call with query '__exomem_codex_session_smoke_absent__'. "
-        "Do not use shell commands."
+        f"ask_memory call with query '{SENTINEL_QUERY}'. Do not call any other "
+        "Exomem tool. Do not use shell commands."
     )
     for index in range(1, runs + 1):
         result = _run_checked(
@@ -142,6 +234,7 @@ def run_harness(
             ],
             env=env,
             action=f"run fresh compatibility process {index}",
+            timeout=300.0,
         )
         classify_exec_output(result.stdout or "", result.stderr or "")
     return 0
@@ -157,9 +250,20 @@ def main(argv: list[str] | None = None) -> int:
         help="isolated persistent CODEX_HOME used only by this rollout gate",
     )
     parser.add_argument("--runs", type=int, default=3, help="fresh process count (minimum 2)")
+    parser.add_argument(
+        "--acknowledge-disposable-target",
+        action="store_true",
+        required=True,
+        help="confirm the URL is a disposable staged KB where this live gate is safe",
+    )
     args = parser.parse_args(argv)
     try:
-        return run_harness(url=args.url, codex_home=args.codex_home, runs=args.runs)
+        return run_harness(
+            url=args.url,
+            codex_home=args.codex_home,
+            runs=args.runs,
+            acknowledge_disposable_target=args.acknowledge_disposable_target,
+        )
     except HarnessFailure as error:
         print(f"FAIL: {error}", file=sys.stderr)
         return 1

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -13,6 +13,7 @@ Subcommands:
   bundled sample vault, no clone/config/vault needed (`uvx exomem demo`)
 - `studio` — print the local Review Studio URL; `--open` launches it explicitly
 - `doctor` — read-only local install/setup preflight
+- `auth sessions|revoke` — operator-only durable MCP session administration
 - `status` — resource posture/residency diagnostics without loading models
 - `warm` — pre-download/load the search models (bge, reranker, CLIP) so the first
   server start doesn't pay the download in the background; optional `--vault`
@@ -27,6 +28,7 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
 import sys
@@ -59,6 +61,8 @@ def main(argv: list[str] | None = None) -> int:
         return _studio_main(raw[1:])
     if raw and raw[0] == "doctor":
         return _doctor_main(raw[1:])
+    if raw and raw[0] == "auth":
+        return _auth_main(raw[1:])
     if raw and raw[0] == "status":
         return _status_main(raw[1:])
     if raw and raw[0] == "warm":
@@ -96,6 +100,119 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
     return _serve_main(raw)
+
+
+def _build_auth_session_authority():
+    """Load operator configuration and reuse the HTTP auth authority factory.
+
+    Keeping this adapter tiny makes the CLI and HTTP paths share the exact same
+    issuer, audience, storage namespace, and local-vs-HA selection without
+    importing server auth during unrelated CLI startup.
+    """
+    from dotenv import load_dotenv
+
+    load_dotenv(override=True)
+    base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
+    if not base_url:
+        raise ValueError("EXOMEM_BASE_URL is required for session administration")
+    from .server_auth import build_session_authority
+
+    return build_session_authority(base_url=base_url)
+
+
+def _session_metadata(record, *, current_generation: str) -> dict[str, object]:
+    effective_status = record.status
+    if effective_status == "active" and record.generation != current_generation:
+        effective_status = "generation_revoked"
+    return {
+        "session_id": record.session_id,
+        "client_id": record.client_id,
+        "scopes": list(record.scopes),
+        "github_login": record.github_login,
+        "github_user_id": record.github_user_id,
+        "issued_at": record.issued_at,
+        "status": effective_status,
+    }
+
+
+def _auth_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem auth",
+        description="Inspect and revoke durable MCP sessions (operator-only).",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    sessions = subcommands.add_parser("sessions", help="list non-secret session metadata")
+    sessions.add_argument("--json", action="store_true", help="emit stable JSON")
+
+    revoke = subcommands.add_parser("revoke", help="revoke one session or every session")
+    revoke.add_argument("session_id", nargs="?", help="opaque session ID (not the bearer)")
+    revoke.add_argument("--all", action="store_true", dest="revoke_all")
+    revoke.add_argument("--reason", default=None, help="operator audit reason")
+    revoke.add_argument("--json", action="store_true", help="emit stable JSON")
+    args = parser.parse_args(argv)
+
+    if args.command == "revoke":
+        if bool(args.session_id) == bool(args.revoke_all):
+            parser.error("revoke requires exactly one session ID or --all")
+        if args.reason is not None and not args.reason.strip():
+            parser.error("--reason must not be empty")
+
+    try:
+        authority = _build_auth_session_authority()
+    except (ValueError, RuntimeError) as error:
+        print(f"auth configuration error: {error}", file=sys.stderr)
+        return 2
+
+    async def run() -> dict[str, object]:
+        if args.command == "sessions":
+            records = await authority.list_sessions()
+            current_generation = await authority.current_generation()
+            return {
+                "sessions": [
+                    _session_metadata(record, current_generation=current_generation)
+                    for record in records
+                ]
+            }
+        reason = (
+            args.reason
+            or ("operator-revoke-all" if args.revoke_all else "operator-revocation")
+        ).strip()
+        if args.revoke_all:
+            await authority.replace_generation()
+            return {"revoked_all": True}
+        revoked = await authority.tombstone(args.session_id, reason=reason)
+        return {"revoked": revoked, "session_id": args.session_id}
+
+    from .auth_sessions import SessionStoreUnavailable
+
+    try:
+        result = asyncio.run(run())
+    except SessionStoreUnavailable:
+        print(
+            "session authority unavailable; check storage configuration and connectivity",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False))
+    elif args.command == "sessions":
+        rows = result["sessions"]
+        if not rows:
+            print("No durable MCP sessions.")
+        else:
+            for row in rows:
+                print(
+                    f"{row['session_id']}  {row['status']}  {row['client_id']}  "
+                    f"{row['github_login']}  {row['issued_at']}"
+                )
+    elif result.get("revoked_all"):
+        print("Revoked all durable MCP sessions.")
+    elif result.get("revoked"):
+        print(f"Revoked session {result['session_id']}.")
+    else:
+        print(f"Session {result['session_id']} was not found.")
+    return 0
 
 
 def _serve_main(argv: list[str]) -> int:

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -112,6 +112,9 @@ def _build_auth_session_authority():
     from dotenv import load_dotenv
 
     load_dotenv(override=True)
+    from . import env_compat
+
+    env_compat.promote_legacy()
     base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
     if not base_url:
         raise ValueError("EXOMEM_BASE_URL is required for session administration")
@@ -157,9 +160,17 @@ def _auth_main(argv: list[str]) -> int:
         if args.reason is not None and not args.reason.strip():
             parser.error("--reason must not be empty")
 
+    from .auth_sessions import SessionStoreUnavailable
+
     try:
         authority = _build_auth_session_authority()
-    except (ValueError, RuntimeError) as error:
+    except (SessionStoreUnavailable, OSError):
+        print(
+            "session authority unavailable; check storage configuration and connectivity",
+            file=sys.stderr,
+        )
+        return 1
+    except ValueError as error:
         print(f"auth configuration error: {error}", file=sys.stderr)
         return 2
 
@@ -182,8 +193,6 @@ def _auth_main(argv: list[str]) -> int:
             return {"revoked_all": True}
         revoked = await authority.tombstone(args.session_id, reason=reason)
         return {"revoked": revoked, "session_id": args.session_id}
-
-    from .auth_sessions import SessionStoreUnavailable
 
     try:
         result = asyncio.run(run())

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -170,7 +170,7 @@ def _auth_main(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
-    except ValueError as error:
+    except (ValueError, RuntimeError) as error:
         print(f"auth configuration error: {error}", file=sys.stderr)
         return 2
 

--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -8,17 +8,24 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import errno
 import hashlib
 import hmac
 import json
 import math
+import os
 import re
 import secrets
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, BinaryIO, Literal
+
+if os.name == "nt":  # pragma: no cover - exercised on Windows deployments
+    import msvcrt
+else:  # pragma: no cover - branch selection is platform-specific
+    import fcntl
 
 import httpx
 from cryptography.fernet import Fernet, InvalidToken
@@ -44,8 +51,8 @@ class SessionStoreUnavailable(RuntimeError):
 
 @dataclass(frozen=True)
 class SessionKeys:
-    hmac_key: bytes
-    storage_key: bytes
+    hmac_key: bytes = field(repr=False)
+    storage_key: bytes = field(repr=False)
     fingerprint: str
 
 
@@ -83,7 +90,7 @@ def derive_session_keys(signing_root: str) -> SessionKeys:
 @dataclass(frozen=True)
 class ParsedSessionToken:
     session_id: str
-    secret: str
+    secret: str = field(repr=False)
 
 
 class SessionTokenCodec:
@@ -249,7 +256,6 @@ class _EncryptedStorage:
     def __init__(self, storage: Any, storage_key: bytes):
         self.raw = storage
         self._fernet = Fernet(base64.urlsafe_b64encode(storage_key))
-        self._fallback_lock = asyncio.Lock()
 
     @staticmethod
     def _unavailable(action: str, error: Exception) -> SessionStoreUnavailable:
@@ -298,13 +304,11 @@ class _EncryptedStorage:
         encrypted = self._encrypt(value)
         try:
             operation = getattr(self.raw, "put_if_absent", None)
-            if operation is not None:
-                return bool(await operation(key, encrypted, collection=collection))
-            async with self._fallback_lock:
-                if await self.raw.get(key, collection=collection) is not None:
-                    return False
-                await self.raw.put(key, encrypted, collection=collection)
-                return True
+            if operation is None:
+                raise SessionStoreUnavailable(
+                    "session store lacks atomic put-if-absent support"
+                )
+            return bool(await operation(key, encrypted, collection=collection))
         except Exception as error:
             if isinstance(error, SessionStoreUnavailable):
                 raise
@@ -323,7 +327,60 @@ class _EncryptedStorage:
             raise self._unavailable("enumeration", error) from error
 
 
-_LOCAL_ATOMIC_LOCKS: dict[tuple[str, str, str], asyncio.Lock] = {}
+class _InterprocessFileLock:
+    """Portable advisory lock automatically released when its process exits."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        timeout: float = 10.0,
+    ):
+        self.path = path
+        self.timeout = timeout
+        self._handle: BinaryIO | None = None
+
+    def _try_acquire(self) -> bool:
+        handle = self.path.open("a+b")
+        try:
+            if os.name == "nt":  # pragma: no cover - exercised on Windows deployments
+                handle.seek(0)
+                if not handle.read(1):
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as error:
+            handle.close()
+            if error.errno in {errno.EACCES, errno.EAGAIN}:
+                return False
+            raise
+        self._handle = handle
+        return True
+
+    async def __aenter__(self) -> _InterprocessFileLock:
+        deadline = time.monotonic() + self.timeout
+        while True:
+            if self._try_acquire():
+                return self
+            if time.monotonic() >= deadline:
+                raise SessionStoreUnavailable(
+                    "timed out acquiring the local session-store lock"
+                ) from None
+            await asyncio.sleep(0.01)
+
+    async def __aexit__(self, *_: object) -> None:
+        if self._handle is None:
+            return
+        if os.name == "nt":  # pragma: no cover - exercised on Windows deployments
+            self._handle.seek(0)
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        self._handle.close()
+        self._handle = None
 
 
 class _LocalFileBackend:
@@ -332,6 +389,8 @@ class _LocalFileBackend:
     def __init__(self, directory: Path):
         self.directory = directory.resolve()
         self.directory.mkdir(parents=True, exist_ok=True)
+        self._lock_directory = self.directory / ".exomem-session-locks"
+        self._lock_directory.mkdir(parents=True, exist_ok=True)
         self.store = FileTreeStore(data_directory=self.directory)
 
     async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
@@ -356,8 +415,8 @@ class _LocalFileBackend:
         ttl: float | None = None,
     ) -> bool:
         collection_name = collection or "default"
-        lock_key = (str(self.directory), collection_name, key)
-        lock = _LOCAL_ATOMIC_LOCKS.setdefault(lock_key, asyncio.Lock())
+        lock_name = hashlib.sha256(f"{collection_name}\0{key}".encode()).hexdigest()
+        lock = _InterprocessFileLock(self._lock_directory / f"{lock_name}.lock")
         async with lock:
             if await self.store.get(key, collection=collection) is not None:
                 return False
@@ -386,14 +445,15 @@ class SessionAuthority:
     ):
         if not issuer or not audience:
             raise ValueError("session issuer and audience are required")
-        self.keys = derive_session_keys(signing_root)
+        keys = derive_session_keys(signing_root)
+        self.fingerprint = keys.fingerprint
         self.issuer = issuer
         self.audience = audience
         self.clock = clock
-        self.codec = SessionTokenCodec(self.keys.hmac_key)
-        self.sessions_collection = f"exomem-auth-sessions-v1-{self.keys.fingerprint}"
-        self.generations_collection = f"exomem-auth-generations-v1-{self.keys.fingerprint}"
-        self._storage = _EncryptedStorage(storage, self.keys.storage_key)
+        self.codec = SessionTokenCodec(keys.hmac_key)
+        self.sessions_collection = f"exomem-auth-sessions-v1-{keys.fingerprint}"
+        self.generations_collection = f"exomem-auth-generations-v1-{keys.fingerprint}"
+        self._storage = _EncryptedStorage(storage, keys.storage_key)
 
     @classmethod
     def local(
@@ -550,11 +610,14 @@ class SessionAuthority:
             record = SessionRecord.from_dict(raw)
         except ValueError:
             return None
+        if record.session_id != parsed.session_id:
+            raise SessionStoreUnavailable(
+                "session record does not match its authoritative storage key"
+            )
         if not self.codec.verify(bearer, record.token_digest):
             return None
         if (
-            record.session_id != parsed.session_id
-            or record.status != "active"
+            record.status != "active"
             or record.issuer != self.issuer
             or record.audience != self.audience
         ):
@@ -587,6 +650,10 @@ class SessionAuthority:
             record = SessionRecord.from_dict(raw)
         except ValueError as error:
             raise SessionStoreUnavailable("session record is corrupt") from error
+        if record.session_id != session_id:
+            raise SessionStoreUnavailable(
+                "session record does not match its authoritative storage key"
+            )
         if record.status == "revoked":
             return True
         await self._write_tombstone(record, reason=reason)
@@ -600,7 +667,12 @@ class SessionAuthority:
             if raw is None:
                 continue
             try:
-                records.append(SessionRecord.from_dict(raw))
+                record = SessionRecord.from_dict(raw)
             except ValueError as error:
                 raise SessionStoreUnavailable("session record is corrupt") from error
+            if record.session_id != key:
+                raise SessionStoreUnavailable(
+                    "session record does not match its authoritative storage key"
+                )
+            records.append(record)
         return sorted(records, key=lambda record: (record.issued_at, record.session_id))

--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -1,0 +1,606 @@
+"""Durable, Exomem-owned MCP session records.
+
+GitHub proves identity before this module is called.  Session validation is
+deliberately local to Exomem and never retains or revalidates an upstream token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import math
+import re
+import secrets
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from key_value.aio.stores.filetree import FileTreeStore
+
+from .remote_oauth_storage import RemoteOAuthStorage
+
+_TOKEN_VERSION = "exo_s1"
+_SCHEMA_VERSION = 1
+_TOKEN_PATTERN = re.compile(
+    rf"^{_TOKEN_VERSION}\.(?P<session_id>[A-Za-z0-9_-]{{16,64}})\."
+    r"(?P<secret>[A-Za-z0-9_-]{43,128})$"
+)
+_GENERATION_KEY = "current"
+_MAX_ISSUANCE_ATTEMPTS = 8
+
+
+class SessionStoreUnavailable(RuntimeError):
+    """The authoritative session store or its cipher could not be used."""
+
+
+@dataclass(frozen=True)
+class SessionKeys:
+    hmac_key: bytes
+    storage_key: bytes
+    fingerprint: str
+
+
+def _derive(root: bytes, *, salt: bytes, info: bytes) -> bytes:
+    return HKDF(algorithm=hashes.SHA256(), length=32, salt=salt, info=info).derive(root)
+
+
+def derive_session_keys(signing_root: str) -> SessionKeys:
+    """Derive purpose-separated proof and storage keys from an explicit root."""
+    if not signing_root or not signing_root.strip():
+        raise ValueError("an explicit signing root is required")
+    material = signing_root.encode("utf-8")
+    hmac_key = _derive(
+        material,
+        salt=b"exomem-session-proof-v1",
+        info=b"opaque MCP bearer HMAC",
+    )
+    storage_key = _derive(
+        material,
+        salt=b"exomem-session-storage-v1",
+        info=b"session record Fernet encryption",
+    )
+    fingerprint_key = _derive(
+        material,
+        salt=b"exomem-session-namespace-v1",
+        info=b"non-secret root namespace fingerprint",
+    )
+    return SessionKeys(
+        hmac_key=hmac_key,
+        storage_key=storage_key,
+        fingerprint=hashlib.sha256(fingerprint_key).hexdigest()[:16],
+    )
+
+
+@dataclass(frozen=True)
+class ParsedSessionToken:
+    session_id: str
+    secret: str
+
+
+class SessionTokenCodec:
+    """Issue and verify versioned opaque session bearers."""
+
+    def __init__(self, hmac_key: bytes):
+        if len(hmac_key) < 32:
+            raise ValueError("session HMAC key must contain at least 256 bits")
+        self._hmac_key = hmac_key
+
+    def issue(self) -> tuple[str, str, str]:
+        session_id = secrets.token_urlsafe(18)
+        secret = secrets.token_urlsafe(32)
+        bearer = f"{_TOKEN_VERSION}.{session_id}.{secret}"
+        return bearer, session_id, self.digest(bearer)
+
+    @staticmethod
+    def parse(bearer: str) -> ParsedSessionToken | None:
+        if not isinstance(bearer, str):
+            return None
+        match = _TOKEN_PATTERN.fullmatch(bearer)
+        if match is None:
+            return None
+        return ParsedSessionToken(
+            session_id=match.group("session_id"),
+            secret=match.group("secret"),
+        )
+
+    def digest(self, bearer: str) -> str:
+        return hmac.new(self._hmac_key, bearer.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    def verify(self, bearer: str, expected_digest: str) -> bool:
+        calculated = self.digest(bearer)
+        return hmac.compare_digest(calculated, expected_digest)
+
+
+@dataclass(frozen=True)
+class SessionIdentity:
+    github_user_id: int
+    github_login: str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.github_user_id, bool) or self.github_user_id <= 0:
+            raise ValueError("GitHub identity requires a positive numeric user ID")
+        login = self.github_login.strip().casefold()
+        if not login:
+            raise ValueError("GitHub identity requires a login")
+        object.__setattr__(self, "github_login", login)
+
+
+SessionStatus = Literal["active", "revoked"]
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    schema_version: int
+    session_id: str
+    token_digest: str
+    client_id: str
+    scopes: tuple[str, ...]
+    issuer: str
+    audience: str
+    github_user_id: int
+    github_login: str
+    issued_at: float
+    generation: str
+    status: SessionStatus
+    revoked_at: float | None = None
+    revocation_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["scopes"] = list(self.scopes)
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SessionRecord:
+        try:
+            record = cls(
+                schema_version=int(value["schema_version"]),
+                session_id=str(value["session_id"]),
+                token_digest=str(value["token_digest"]),
+                client_id=str(value["client_id"]),
+                scopes=tuple(str(scope) for scope in value["scopes"]),
+                issuer=str(value["issuer"]),
+                audience=str(value["audience"]),
+                github_user_id=int(value["github_user_id"]),
+                github_login=str(value["github_login"]),
+                issued_at=float(value["issued_at"]),
+                generation=str(value["generation"]),
+                status=str(value["status"]),  # type: ignore[arg-type]
+                revoked_at=(
+                    None if value.get("revoked_at") is None else float(value["revoked_at"])
+                ),
+                revocation_reason=(
+                    None
+                    if value.get("revocation_reason") is None
+                    else str(value["revocation_reason"])
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid session record") from error
+        if not record.structurally_valid():
+            raise ValueError("invalid session record")
+        return record
+
+    def structurally_valid(self) -> bool:
+        if self.schema_version != _SCHEMA_VERSION:
+            return False
+        if SessionTokenCodec.parse(f"{_TOKEN_VERSION}.{self.session_id}.{'a' * 43}") is None:
+            return False
+        if not re.fullmatch(r"[0-9a-f]{64}", self.token_digest):
+            return False
+        if not self.client_id or not self.issuer or not self.audience or not self.generation:
+            return False
+        if any(not scope for scope in self.scopes) or len(set(self.scopes)) != len(self.scopes):
+            return False
+        if self.github_user_id <= 0 or self.github_login != self.github_login.strip().casefold():
+            return False
+        if not self.github_login or not math.isfinite(self.issued_at) or self.issued_at <= 0:
+            return False
+        if self.status == "active":
+            return self.revoked_at is None and self.revocation_reason is None
+        if self.status == "revoked":
+            return (
+                self.revoked_at is not None
+                and math.isfinite(self.revoked_at)
+                and bool(self.revocation_reason)
+            )
+        return False
+
+
+@dataclass(frozen=True)
+class GenerationRecord:
+    schema_version: int
+    generation: str
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> GenerationRecord:
+        try:
+            record = cls(
+                schema_version=int(value["schema_version"]),
+                generation=str(value["generation"]),
+                created_at=float(value["created_at"]),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid generation record") from error
+        if (
+            record.schema_version != _SCHEMA_VERSION
+            or not record.generation
+            or not math.isfinite(record.created_at)
+            or record.created_at <= 0
+        ):
+            raise ValueError("invalid generation record")
+        return record
+
+
+class _EncryptedStorage:
+    def __init__(self, storage: Any, storage_key: bytes):
+        self.raw = storage
+        self._fernet = Fernet(base64.urlsafe_b64encode(storage_key))
+        self._fallback_lock = asyncio.Lock()
+
+    @staticmethod
+    def _unavailable(action: str, error: Exception) -> SessionStoreUnavailable:
+        return SessionStoreUnavailable(f"session store {action} unavailable: {error}")
+
+    def _encrypt(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            payload = json.dumps(dict(value), separators=(",", ":"), sort_keys=True).encode()
+            ciphertext = self._fernet.encrypt(payload).decode("ascii")
+        except Exception as error:  # pragma: no cover - defensive cipher boundary
+            raise SessionStoreUnavailable("session record encryption failed") from error
+        return {"__encrypted_data__": ciphertext, "__encryption_version__": 1}
+
+    def _decrypt(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            if value.get("__encryption_version__") != 1:
+                raise ValueError("unsupported encryption version")
+            ciphertext = value["__encrypted_data__"]
+            if not isinstance(ciphertext, str):
+                raise TypeError("ciphertext must be text")
+            decoded = self._fernet.decrypt(ciphertext.encode("ascii"))
+            result = json.loads(decoded)
+            if not isinstance(result, dict):
+                raise TypeError("decrypted record must be an object")
+            return result
+        except (InvalidToken, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise SessionStoreUnavailable("session record decrypt failed") from error
+
+    async def get(self, key: str, *, collection: str) -> dict[str, Any] | None:
+        try:
+            value = await self.raw.get(key, collection=collection)
+        except Exception as error:
+            raise self._unavailable("read", error) from error
+        return None if value is None else self._decrypt(value)
+
+    async def put(self, key: str, value: Mapping[str, Any], *, collection: str) -> None:
+        encrypted = self._encrypt(value)
+        try:
+            await self.raw.put(key, encrypted, collection=collection)
+        except Exception as error:
+            raise self._unavailable("write", error) from error
+
+    async def put_if_absent(
+        self, key: str, value: Mapping[str, Any], *, collection: str
+    ) -> bool:
+        encrypted = self._encrypt(value)
+        try:
+            operation = getattr(self.raw, "put_if_absent", None)
+            if operation is not None:
+                return bool(await operation(key, encrypted, collection=collection))
+            async with self._fallback_lock:
+                if await self.raw.get(key, collection=collection) is not None:
+                    return False
+                await self.raw.put(key, encrypted, collection=collection)
+                return True
+        except Exception as error:
+            if isinstance(error, SessionStoreUnavailable):
+                raise
+            raise self._unavailable("atomic write", error) from error
+
+    async def list_keys(self, *, collection: str) -> list[str]:
+        operation = getattr(self.raw, "list_keys", None)
+        if operation is None:
+            operation = getattr(self.raw, "keys", None)
+        if operation is None:
+            raise SessionStoreUnavailable("session store does not support key enumeration")
+        try:
+            keys = await operation(collection=collection)
+            return [str(key) for key in keys]
+        except Exception as error:
+            raise self._unavailable("enumeration", error) from error
+
+
+_LOCAL_ATOMIC_LOCKS: dict[tuple[str, str, str], asyncio.Lock] = {}
+
+
+class _LocalFileBackend:
+    """FileTreeStore with single-node atomic initialization and key listing."""
+
+    def __init__(self, directory: Path):
+        self.directory = directory.resolve()
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.store = FileTreeStore(data_directory=self.directory)
+
+    async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
+        return await self.store.get(key, collection=collection)
+
+    async def put(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        await self.store.put(key, value, collection=collection, ttl=ttl)
+
+    async def put_if_absent(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> bool:
+        collection_name = collection or "default"
+        lock_key = (str(self.directory), collection_name, key)
+        lock = _LOCAL_ATOMIC_LOCKS.setdefault(lock_key, asyncio.Lock())
+        async with lock:
+            if await self.store.get(key, collection=collection) is not None:
+                return False
+            await self.store.put(key, value, collection=collection, ttl=ttl)
+            return True
+
+    async def list_keys(self, *, collection: str | None = None) -> list[str]:
+        collection_name = collection or "default"
+        directory = self.directory / collection_name
+        if not directory.exists():
+            return []
+        return sorted(path.stem for path in directory.glob("*.json") if path.is_file())
+
+
+class SessionAuthority:
+    """Authoritative encrypted store for durable Exomem MCP sessions."""
+
+    def __init__(
+        self,
+        *,
+        storage: Any,
+        signing_root: str,
+        issuer: str,
+        audience: str,
+        clock: Callable[[], float] = time.time,
+    ):
+        if not issuer or not audience:
+            raise ValueError("session issuer and audience are required")
+        self.keys = derive_session_keys(signing_root)
+        self.issuer = issuer
+        self.audience = audience
+        self.clock = clock
+        self.codec = SessionTokenCodec(self.keys.hmac_key)
+        self.sessions_collection = f"exomem-auth-sessions-v1-{self.keys.fingerprint}"
+        self.generations_collection = f"exomem-auth-generations-v1-{self.keys.fingerprint}"
+        self._storage = _EncryptedStorage(storage, self.keys.storage_key)
+
+    @classmethod
+    def local(
+        cls,
+        *,
+        directory: Path,
+        signing_root: str,
+        issuer: str,
+        audience: str,
+        clock: Callable[[], float] = time.time,
+    ) -> SessionAuthority:
+        return cls(
+            storage=_LocalFileBackend(directory),
+            signing_root=signing_root,
+            issuer=issuer,
+            audience=audience,
+            clock=clock,
+        )
+
+    @classmethod
+    def remote(
+        cls,
+        *,
+        url: str,
+        namespace: str,
+        storage_token: str,
+        signing_root: str,
+        issuer: str,
+        audience: str,
+        timeout: float = 5.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> SessionAuthority:
+        if not storage_token or not storage_token.strip():
+            raise ValueError("a non-empty OAuth storage token is required for HA sessions")
+        storage = RemoteOAuthStorage(
+            url=url,
+            namespace=namespace,
+            token=storage_token.strip(),
+            timeout=timeout,
+            cache_ttl=0,
+            transport=transport,
+        )
+        return cls(
+            storage=storage,
+            signing_root=signing_root,
+            issuer=issuer,
+            audience=audience,
+            clock=clock,
+        )
+
+    def _new_generation(self) -> GenerationRecord:
+        return GenerationRecord(
+            schema_version=_SCHEMA_VERSION,
+            generation=secrets.token_urlsafe(24),
+            created_at=float(self.clock()),
+        )
+
+    async def current_generation(self) -> str:
+        raw = await self._storage.get(
+            _GENERATION_KEY, collection=self.generations_collection
+        )
+        if raw is not None:
+            try:
+                return GenerationRecord.from_dict(raw).generation
+            except ValueError as error:
+                raise SessionStoreUnavailable("session generation record is corrupt") from error
+
+        proposed = self._new_generation()
+        created = await self._storage.put_if_absent(
+            _GENERATION_KEY,
+            proposed.to_dict(),
+            collection=self.generations_collection,
+        )
+        if created:
+            return proposed.generation
+        raw = await self._storage.get(
+            _GENERATION_KEY, collection=self.generations_collection
+        )
+        if raw is None:
+            raise SessionStoreUnavailable("session generation disappeared during initialization")
+        try:
+            return GenerationRecord.from_dict(raw).generation
+        except ValueError as error:
+            raise SessionStoreUnavailable("session generation record is corrupt") from error
+
+    async def replace_generation(self) -> str:
+        replacement = self._new_generation()
+        await self._storage.put(
+            _GENERATION_KEY,
+            replacement.to_dict(),
+            collection=self.generations_collection,
+        )
+        return replacement.generation
+
+    @staticmethod
+    def _normalize_scopes(scopes: Sequence[str]) -> tuple[str, ...]:
+        normalized = tuple(str(scope) for scope in scopes)
+        if any(not scope for scope in normalized) or len(set(normalized)) != len(normalized):
+            raise ValueError("session scopes must be non-empty and unique")
+        return normalized
+
+    async def issue(
+        self,
+        *,
+        client_id: str,
+        scopes: Sequence[str],
+        identity: SessionIdentity,
+    ) -> tuple[str, SessionRecord]:
+        if not client_id:
+            raise ValueError("session client ID is required")
+        normalized_scopes = self._normalize_scopes(scopes)
+        if not isinstance(identity, SessionIdentity):
+            raise TypeError("session identity is required")
+
+        for _ in range(_MAX_ISSUANCE_ATTEMPTS):
+            generation = await self.current_generation()
+            bearer, session_id, digest = self.codec.issue()
+            record = SessionRecord(
+                schema_version=_SCHEMA_VERSION,
+                session_id=session_id,
+                token_digest=digest,
+                client_id=client_id,
+                scopes=normalized_scopes,
+                issuer=self.issuer,
+                audience=self.audience,
+                github_user_id=identity.github_user_id,
+                github_login=identity.github_login,
+                issued_at=float(self.clock()),
+                generation=generation,
+                status="active",
+            )
+            created = await self._storage.put_if_absent(
+                session_id,
+                record.to_dict(),
+                collection=self.sessions_collection,
+            )
+            if not created:  # astronomically unlikely random session-ID collision
+                continue
+            observed_generation = await self.current_generation()
+            if observed_generation == generation:
+                return bearer, record
+            await self._write_tombstone(record, reason="generation-changed-during-issuance")
+        raise SessionStoreUnavailable("could not issue a generation-stable session")
+
+    async def validate(self, bearer: str) -> SessionRecord | None:
+        parsed = self.codec.parse(bearer)
+        if parsed is None:
+            return None
+        raw = await self._storage.get(parsed.session_id, collection=self.sessions_collection)
+        if raw is None:
+            return None
+        try:
+            record = SessionRecord.from_dict(raw)
+        except ValueError:
+            return None
+        if not self.codec.verify(bearer, record.token_digest):
+            return None
+        if (
+            record.session_id != parsed.session_id
+            or record.status != "active"
+            or record.issuer != self.issuer
+            or record.audience != self.audience
+        ):
+            return None
+        if record.generation != await self.current_generation():
+            return None
+        return record
+
+    async def _write_tombstone(self, record: SessionRecord, *, reason: str) -> SessionRecord:
+        tombstone = replace(
+            record,
+            status="revoked",
+            revoked_at=float(self.clock()),
+            revocation_reason=reason,
+        )
+        await self._storage.put(
+            record.session_id,
+            tombstone.to_dict(),
+            collection=self.sessions_collection,
+        )
+        return tombstone
+
+    async def tombstone(self, session_id: str, *, reason: str) -> bool:
+        if not session_id or not reason:
+            raise ValueError("session ID and revocation reason are required")
+        raw = await self._storage.get(session_id, collection=self.sessions_collection)
+        if raw is None:
+            return False
+        try:
+            record = SessionRecord.from_dict(raw)
+        except ValueError as error:
+            raise SessionStoreUnavailable("session record is corrupt") from error
+        if record.status == "revoked":
+            return True
+        await self._write_tombstone(record, reason=reason)
+        return True
+
+    async def list_sessions(self) -> list[SessionRecord]:
+        keys = await self._storage.list_keys(collection=self.sessions_collection)
+        records: list[SessionRecord] = []
+        for key in keys:
+            raw = await self._storage.get(key, collection=self.sessions_collection)
+            if raw is None:
+                continue
+            try:
+                records.append(SessionRecord.from_dict(raw))
+            except ValueError as error:
+                raise SessionStoreUnavailable("session record is corrupt") from error
+        return sorted(records, key=lambda record: (record.issued_at, record.session_id))

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -852,6 +852,7 @@ def _check_ha_env() -> list[DoctorCheck]:
         "EXOMEM_WRITER_LEASE_REPLICA_ID": "Set a unique identifier for this replica.",
         "EXOMEM_OAUTH_STORAGE_URL": "Set the authoritative coordinator state URL.",
         "EXOMEM_OAUTH_STORAGE_TOKEN": "Set the coordinator bearer credential for auth state.",
+        "EXOMEM_LEASE_COORDINATOR_TOKEN": "Set the bearer enforced by the coordinator service.",
     }
     checks: list[DoctorCheck] = []
     for key, remediation in required.items():
@@ -896,12 +897,10 @@ def _check_ha_env() -> list[DoctorCheck]:
         None if valid_user_id else "Set a positive numeric EXOMEM_GITHUB_USER_ID.",
     ))
     credential_values = [
+        os.environ.get("EXOMEM_LEASE_COORDINATOR_TOKEN", "").strip(),
         os.environ.get("EXOMEM_WRITER_LEASE_TOKEN", "").strip(),
         os.environ.get("EXOMEM_OAUTH_STORAGE_TOKEN", "").strip(),
     ]
-    coordinator_token = os.environ.get("EXOMEM_LEASE_COORDINATOR_TOKEN", "").strip()
-    if coordinator_token:
-        credential_values.append(coordinator_token)
     credentials_match = all(credential_values) and len(set(credential_values)) == 1
     checks.append(_check(
         "ha.auth.credentials_match",
@@ -1230,6 +1229,24 @@ def _check_ha_auth_probes(*, prefix: str = "ha.auth") -> list[DoctorCheck]:
     return checks
 
 
+def _ha_auth_configured() -> bool:
+    """Whether this environment declares any part of a replica/HA topology."""
+    return any(
+        os.environ.get(key, "").strip()
+        for key in (
+            "EXOMEM_WRITER_LEASE_URL",
+            "EXOMEM_WRITER_LEASE_VAULT_ID",
+            "EXOMEM_WRITER_LEASE_REPLICA_ID",
+            "EXOMEM_WRITER_LEASE_TOKEN",
+            "EXOMEM_LEASE_COORDINATOR_TOKEN",
+            "EXOMEM_OAUTH_STORAGE_URL",
+            "EXOMEM_OAUTH_STORAGE_NAMESPACE",
+            "EXOMEM_OAUTH_STORAGE_TOKEN",
+            "EXOMEM_HA_REPLICA_URLS",
+        )
+    )
+
+
 def _check_probe_local(port: int = 8765) -> DoctorCheck:
     url = f"http://127.0.0.1:{port}/mcp"
     try:
@@ -1404,12 +1421,14 @@ def doctor(
 
     if profile == "remote":
         checks.extend(_check_remote_env())
+        if _ha_auth_configured():
+            checks.extend(_check_ha_env())
         # Opt-in live-endpoint verification (three read-only GETs). The
         # default stays fully offline — doctor never touches the network
         # unless --probe is passed explicitly.
         if probe:
             checks.extend(_check_remote_probes())
-            if os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip():
+            if _ha_auth_configured():
                 checks.extend(_check_ha_auth_probes(prefix="probe.auth"))
 
     if profile == "ha":

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -800,6 +800,26 @@ def _check_remote_env() -> list[DoctorCheck]:
         else:
             checks.append(_check(f"env.{key}", "fail", f"{key} is not set.", remediation))
 
+    raw_user_id = os.environ.get("EXOMEM_GITHUB_USER_ID", "").strip()
+    try:
+        user_id = int(raw_user_id)
+        valid_user_id = user_id > 0 and raw_user_id.isdecimal()
+    except ValueError:
+        valid_user_id = False
+    if valid_user_id:
+        checks.append(_check(
+            "env.EXOMEM_GITHUB_USER_ID",
+            "pass",
+            "EXOMEM_GITHUB_USER_ID is a positive immutable GitHub subject.",
+        ))
+    else:
+        checks.append(_check(
+            "env.EXOMEM_GITHUB_USER_ID",
+            "fail",
+            "EXOMEM_GITHUB_USER_ID is missing or invalid.",
+            "Set EXOMEM_GITHUB_USER_ID to the positive numeric ID returned by GitHub.",
+        ))
+
     host = os.environ.get("EXOMEM_HOST", "127.0.0.1")
     checks.append(_check("env.EXOMEM_HOST", "pass", f"EXOMEM_HOST resolves to {host}."))
     if os.environ.get("EXOMEM_REST_API_KEY"):
@@ -825,9 +845,13 @@ def _check_remote_env() -> list[DoctorCheck]:
 
 def _check_ha_env() -> list[DoctorCheck]:
     required = {
+        "EXOMEM_BASE_URL": "Set the stable public OAuth origin.",
+        "EXOMEM_JWT_SIGNING_KEY": "Set the stable durable-session signing root.",
         "EXOMEM_WRITER_LEASE_URL": "Set the provider-neutral writer coordinator URL.",
         "EXOMEM_WRITER_LEASE_VAULT_ID": "Set the stable vault coordination identifier.",
         "EXOMEM_WRITER_LEASE_REPLICA_ID": "Set a unique identifier for this replica.",
+        "EXOMEM_OAUTH_STORAGE_URL": "Set the authoritative coordinator state URL.",
+        "EXOMEM_OAUTH_STORAGE_TOKEN": "Set the coordinator bearer credential for auth state.",
     }
     checks: list[DoctorCheck] = []
     for key, remediation in required.items():
@@ -840,10 +864,55 @@ def _check_ha_env() -> list[DoctorCheck]:
     else:
         checks.append(_check(
             "ha.env.EXOMEM_WRITER_LEASE_TOKEN",
-            "warn",
+            "fail",
             "Writer lease token is not set.",
-            "Set EXOMEM_WRITER_LEASE_TOKEN unless the coordinator is private and explicitly unauthenticated.",
+            "Set EXOMEM_WRITER_LEASE_TOKEN to the same bearer as EXOMEM_OAUTH_STORAGE_TOKEN.",
         ))
+    namespace = (
+        os.environ.get("EXOMEM_OAUTH_STORAGE_NAMESPACE", "").strip()
+        or os.environ.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip()
+    )
+    checks.append(_check(
+        "ha.env.EXOMEM_OAUTH_STORAGE_NAMESPACE",
+        "pass" if namespace else "fail",
+        "OAuth storage namespace is set."
+        if namespace
+        else "OAuth storage namespace is not set.",
+        None if namespace else (
+            "Set EXOMEM_OAUTH_STORAGE_NAMESPACE or EXOMEM_WRITER_LEASE_VAULT_ID."
+        ),
+    ))
+    raw_user_id = os.environ.get("EXOMEM_GITHUB_USER_ID", "").strip()
+    try:
+        valid_user_id = raw_user_id.isdecimal() and int(raw_user_id) > 0
+    except ValueError:
+        valid_user_id = False
+    checks.append(_check(
+        "ha.env.EXOMEM_GITHUB_USER_ID",
+        "pass" if valid_user_id else "fail",
+        "Immutable GitHub user ID is valid."
+        if valid_user_id
+        else "EXOMEM_GITHUB_USER_ID is missing or invalid.",
+        None if valid_user_id else "Set a positive numeric EXOMEM_GITHUB_USER_ID.",
+    ))
+    credential_values = [
+        os.environ.get("EXOMEM_WRITER_LEASE_TOKEN", "").strip(),
+        os.environ.get("EXOMEM_OAUTH_STORAGE_TOKEN", "").strip(),
+    ]
+    coordinator_token = os.environ.get("EXOMEM_LEASE_COORDINATOR_TOKEN", "").strip()
+    if coordinator_token:
+        credential_values.append(coordinator_token)
+    credentials_match = all(credential_values) and len(set(credential_values)) == 1
+    checks.append(_check(
+        "ha.auth.credentials_match",
+        "pass" if credentials_match else "fail",
+        "HA coordinator credentials are present and match."
+        if credentials_match
+        else "HA coordinator credentials are missing or do not match.",
+        None if credentials_match else (
+            "Use one bearer value for writer lease, OAuth storage, and the coordinator."
+        ),
+    ))
     raw_contracts = os.environ.get("EXOMEM_HA_SUPPORTED_RUNTIME_CONTRACTS", "").strip()
     try:
         contracts = _parse_runtime_contracts(raw_contracts)
@@ -1055,6 +1124,112 @@ def _probe_get(url: str) -> tuple[int, object]:
     return resp.status_code, body
 
 
+def _probe_state(url: str, namespace: str, token: str | None) -> tuple[int, object]:
+    """Read a deliberately absent coordinator key, optionally authenticated."""
+    import httpx
+
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = httpx.post(
+        f"{url.rstrip('/')}/v1/state/{namespace}/get",
+        json={
+            "key": "__exomem_doctor_absent_sentinel__",
+            "collection": "exomem-doctor-auth-probe",
+        },
+        headers=headers,
+        timeout=5.0,
+        follow_redirects=False,
+    )
+    try:
+        body: object = response.json()
+    except Exception:  # noqa: BLE001 - non-JSON error bodies are diagnostic only
+        body = response.text
+    return response.status_code, body
+
+
+def _check_ha_auth_probes(*, prefix: str = "ha.auth") -> list[DoctorCheck]:
+    url = os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip().rstrip("/")
+    namespace = (
+        os.environ.get("EXOMEM_OAUTH_STORAGE_NAMESPACE", "").strip()
+        or os.environ.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip()
+    )
+    token = os.environ.get("EXOMEM_OAUTH_STORAGE_TOKEN", "").strip()
+    if not (url and namespace and token):
+        return [_check(
+            f"{prefix}.storage_credential",
+            "fail",
+            "Cannot probe authoritative auth storage because its URL, namespace, or token is missing.",
+            "Set EXOMEM_OAUTH_STORAGE_URL, its namespace, and EXOMEM_OAUTH_STORAGE_TOKEN.",
+        )]
+
+    checks: list[DoctorCheck] = []
+    try:
+        anonymous_status, _ = _probe_state(url, namespace, None)
+    except Exception as error:  # noqa: BLE001 - network diagnostic boundary
+        checks.append(_check(
+            f"{prefix}.anonymous_rejected",
+            "fail",
+            f"Could not reach coordinator for anonymous auth enforcement probe: {error}",
+            "Check coordinator routing and availability.",
+        ))
+    else:
+        checks.append(_check(
+            f"{prefix}.anonymous_rejected",
+            "pass" if anonymous_status == 401 else "fail",
+            "Coordinator rejects anonymous state access with 401."
+            if anonymous_status == 401
+            else f"Coordinator anonymous state probe returned HTTP {anonymous_status}, expected 401.",
+            None if anonymous_status == 401 else (
+                "Require bearer authentication on every coordinator state route."
+            ),
+        ))
+
+    try:
+        authenticated_status, authenticated_body = _probe_state(url, namespace, token)
+    except Exception:  # noqa: BLE001 - network diagnostic boundary
+        checks.append(_check(
+            f"{prefix}.storage_credential",
+            "fail",
+            "Could not reach authoritative auth storage.",
+            "Check coordinator routing and availability; the configured token was not printed.",
+        ))
+    else:
+        sentinel_absent = (
+            isinstance(authenticated_body, dict)
+            and "result" in authenticated_body
+            and authenticated_body.get("result") is None
+        )
+        if authenticated_status == 200 and sentinel_absent:
+            checks.append(_check(
+                f"{prefix}.storage_credential",
+                "pass",
+                "Authenticated read-only auth-storage probe succeeded.",
+            ))
+        elif authenticated_status in {401, 403}:
+            checks.append(_check(
+                f"{prefix}.storage_credential",
+                "fail",
+                "Coordinator rejected the configured auth-storage credential.",
+                "Set the same bearer on coordinator, writer lease, and OAuth storage.",
+            ))
+        elif authenticated_status == 200:
+            checks.append(_check(
+                f"{prefix}.storage_credential",
+                "fail",
+                "Authenticated auth-storage probe returned an unexpected sentinel value.",
+                "Check coordinator state routing and namespace configuration.",
+            ))
+        else:
+            checks.append(_check(
+                f"{prefix}.storage_credential",
+                "fail",
+                f"Authoritative auth storage returned HTTP {authenticated_status}.",
+                "Repair coordinator availability before serving authenticated traffic.",
+            ))
+    return checks
+
+
 def _check_probe_local(port: int = 8765) -> DoctorCheck:
     url = f"http://127.0.0.1:{port}/mcp"
     try:
@@ -1234,10 +1409,13 @@ def doctor(
         # unless --probe is passed explicitly.
         if probe:
             checks.extend(_check_remote_probes())
+            if os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip():
+                checks.extend(_check_ha_auth_probes(prefix="probe.auth"))
 
     if profile == "ha":
         checks.extend(_check_ha_env())
         if probe:
+            checks.extend(_check_ha_auth_probes())
             try:
                 urls = _ha_replica_urls(replica_urls)
             except ValueError as exc:

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -45,6 +45,17 @@ VALID_PROFILES: tuple[Profile, ...] = (
     "ha",
 )
 PROFILE_ENV = "EXOMEM_PROFILE"
+HA_AUTH_ENV_KEYS = (
+    "EXOMEM_WRITER_LEASE_URL",
+    "EXOMEM_WRITER_LEASE_VAULT_ID",
+    "EXOMEM_WRITER_LEASE_REPLICA_ID",
+    "EXOMEM_WRITER_LEASE_TOKEN",
+    "EXOMEM_LEASE_COORDINATOR_TOKEN",
+    "EXOMEM_OAUTH_STORAGE_URL",
+    "EXOMEM_OAUTH_STORAGE_NAMESPACE",
+    "EXOMEM_OAUTH_STORAGE_TOKEN",
+    "EXOMEM_HA_REPLICA_URLS",
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -1233,17 +1244,7 @@ def _ha_auth_configured() -> bool:
     """Whether this environment declares any part of a replica/HA topology."""
     return any(
         os.environ.get(key, "").strip()
-        for key in (
-            "EXOMEM_WRITER_LEASE_URL",
-            "EXOMEM_WRITER_LEASE_VAULT_ID",
-            "EXOMEM_WRITER_LEASE_REPLICA_ID",
-            "EXOMEM_WRITER_LEASE_TOKEN",
-            "EXOMEM_LEASE_COORDINATOR_TOKEN",
-            "EXOMEM_OAUTH_STORAGE_URL",
-            "EXOMEM_OAUTH_STORAGE_NAMESPACE",
-            "EXOMEM_OAUTH_STORAGE_TOKEN",
-            "EXOMEM_HA_REPLICA_URLS",
-        )
+        for key in HA_AUTH_ENV_KEYS
     )
 
 

--- a/src/exomem/lease_coordinator.py
+++ b/src/exomem/lease_coordinator.py
@@ -208,6 +208,55 @@ class SQLiteStateStore:
             )
             conn.execute("COMMIT")
 
+    def put_if_absent(
+        self, namespace: str, collection: object, key: str, value: dict, ttl: float | None
+    ) -> bool:
+        """Atomically insert a state value unless a live value already exists."""
+        now = self.clock()
+        expires = None if ttl is None else now + ttl
+        coll = self._collection(collection)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "DELETE FROM shared_state "
+                "WHERE namespace=? AND collection=? AND key=? "
+                "AND expires_at IS NOT NULL AND expires_at <= ?",
+                (namespace, coll, key, now),
+            )
+            result = conn.execute(
+                "INSERT OR IGNORE INTO shared_state"
+                "(namespace, collection, key, value, expires_at) VALUES(?,?,?,?,?)",
+                (
+                    namespace,
+                    coll,
+                    key,
+                    json.dumps(value, separators=(",", ":")),
+                    expires,
+                ),
+            )
+            conn.execute("COMMIT")
+        return bool(result.rowcount)
+
+    def list_keys(self, namespace: str, collection: object) -> list[str]:
+        """List live opaque keys without returning encrypted values."""
+        now = self.clock()
+        coll = self._collection(collection)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "DELETE FROM shared_state "
+                "WHERE namespace=? AND collection=? "
+                "AND expires_at IS NOT NULL AND expires_at <= ?",
+                (namespace, coll, now),
+            )
+            rows = conn.execute(
+                "SELECT key FROM shared_state "
+                "WHERE namespace=? AND collection=? ORDER BY key",
+                (namespace, coll),
+            ).fetchall()
+            conn.execute("COMMIT")
+        return [str(row[0]) for row in rows]
+
     def delete(self, namespace: str, collection: object, key: str) -> bool:
         with self._connect() as conn:
             result = conn.execute(
@@ -279,6 +328,16 @@ def create_app(
                     namespace, collection, str(body["key"]), dict(body["value"]), _state_ttl(body)
                 )
                 result = None
+            elif operation == "put-if-absent":
+                result = state_store.put_if_absent(
+                    namespace,
+                    collection,
+                    str(body["key"]),
+                    dict(body["value"]),
+                    _state_ttl(body),
+                )
+            elif operation == "list-keys":
+                result = state_store.list_keys(namespace, collection)
             elif operation == "delete":
                 result = state_store.delete(namespace, collection, str(body["key"]))
             elif operation == "get-many":

--- a/src/exomem/remote_oauth_storage.py
+++ b/src/exomem/remote_oauth_storage.py
@@ -1,9 +1,8 @@
-"""Encrypted shared OAuth state for active/passive Exomem replicas.
+"""Shared OAuth and session state for active/passive Exomem replicas.
 
-FastMCP access tokens are reference tokens: each request needs durable JTI and
-upstream-token records.  This adapter keeps those records in an always-on HTTP
-coordinator while FastMCP's Fernet wrapper encrypts every value before it leaves
-the replica.
+This adapter carries already-encrypted values to an always-on HTTP coordinator.
+Legacy FastMCP OAuth bookkeeping may use its bounded cache; durable Exomem
+session collections bypass that cache and remain remote-canonical.
 """
 
 from __future__ import annotations
@@ -118,6 +117,35 @@ class RemoteOAuthStorage:
             },
         )
         self._remember(collection, key, value, float(ttl) if ttl is not None else None)
+
+    async def put_if_absent(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: SupportsFloat | None = None,
+    ) -> bool:
+        """Atomically create a value without replacing an existing one."""
+        created = bool(
+            await self._request(
+                "put-if-absent",
+                {
+                    "key": key,
+                    "value": dict(value),
+                    "collection": collection,
+                    "ttl": float(ttl) if ttl is not None else None,
+                },
+            )
+        )
+        if created:
+            self._remember(collection, key, value, float(ttl) if ttl is not None else None)
+        return created
+
+    async def list_keys(self, *, collection: str | None = None) -> list[str]:
+        """Return opaque keys in a coordinator collection."""
+        result = await self._request("list-keys", {"collection": collection})
+        return [str(key) for key in result]
 
     async def delete(self, key: str, *, collection: str | None = None) -> bool:
         deleted = bool(await self._request("delete", {"key": key, "collection": collection}))

--- a/src/exomem/remote_setup_wizard.py
+++ b/src/exomem/remote_setup_wizard.py
@@ -338,12 +338,19 @@ def run_remote_setup(
             return 2
         github_client_id = _ask(input_fn, "GitHub Client ID", _existing("GITHUB_CLIENT_ID"))
     if not github_client_secret:
+        existing_secret = _existing("GITHUB_CLIENT_SECRET")
         if yes:
-            print_fn("setup --remote: --yes requires --github-client-secret.")
-            return 2
-        github_client_secret = _ask(
-            input_fn, "GitHub Client Secret", _existing("GITHUB_CLIENT_SECRET")
-        )
+            if not existing_secret:
+                print_fn("setup --remote: --yes requires --github-client-secret.")
+                return 2
+            github_client_secret = existing_secret
+        elif existing_secret:
+            entered = input_fn(
+                "GitHub Client Secret [press Enter to keep existing]: "
+            ).strip()
+            github_client_secret = entered or existing_secret
+        else:
+            github_client_secret = _ask(input_fn, "GitHub Client Secret")
     if not github_username:
         if yes:
             print_fn("setup --remote: --yes requires --github-username.")
@@ -361,15 +368,18 @@ def run_remote_setup(
     # confirms the same value. Otherwise resolve it once from GitHub.
     existing_user_id = _existing("EXOMEM_GITHUB_USER_ID").strip()
     try:
-        if existing_user_id:
-            resolved_user_id = _positive_user_id(existing_user_id)
-            if github_user_id is not None and _positive_user_id(github_user_id) != resolved_user_id:
+        preserved_user_id = (
+            _positive_user_id(existing_user_id) if existing_user_id else None
+        )
+        if github_user_id is not None:
+            resolved_user_id = _positive_user_id(github_user_id)
+            if (
+                preserved_user_id is not None
+                and resolved_user_id != preserved_user_id
+            ):
                 raise ValueError(
                     "--github-user-id conflicts with existing EXOMEM_GITHUB_USER_ID"
                 )
-            report("github_id", "[skipped: already set — kept stable]")
-        elif github_user_id is not None:
-            resolved_user_id = _positive_user_id(github_user_id)
             report("github_id", "[done] supplied explicitly")
         else:
             identity = github_user_resolver(github_username)
@@ -379,8 +389,22 @@ def run_remote_setup(
                     "GitHub resolved a different login; use the canonical login or "
                     "provide --github-user-id for offline setup"
                 )
-            resolved_user_id = _positive_user_id(identity.get("id"))
-            report("github_id", "[done] resolved immutable ID")
+            online_user_id = _positive_user_id(identity.get("id"))
+            if (
+                preserved_user_id is not None
+                and online_user_id != preserved_user_id
+            ):
+                raise ValueError(
+                    "GitHub login resolves to a different immutable user ID than "
+                    "the existing EXOMEM_GITHUB_USER_ID"
+                )
+            resolved_user_id = preserved_user_id or online_user_id
+            report(
+                "github_id",
+                "[skipped: existing ID verified and kept stable]"
+                if preserved_user_id is not None
+                else "[done] resolved immutable ID",
+            )
     except Exception as error:  # noqa: BLE001 - setup boundary, before any write
         print_fn(f"setup --remote: could not establish GitHub identity: {error}")
         return 2
@@ -396,12 +420,34 @@ def run_remote_setup(
     # Active/passive auth state and the writer lease share one authenticated
     # coordinator. If HA is configured, converge all three credential views to
     # one value. Reject conflicts before touching the environment file.
+    writer_url = _existing("EXOMEM_WRITER_LEASE_URL").strip()
+    storage_url = _existing("EXOMEM_OAUTH_STORAGE_URL").strip()
+    storage_namespace = (
+        _existing("EXOMEM_OAUTH_STORAGE_NAMESPACE").strip()
+        or _existing("EXOMEM_WRITER_LEASE_VAULT_ID").strip()
+    )
     ha_enabled = bool(
-        _existing("EXOMEM_WRITER_LEASE_URL").strip()
-        or _existing("EXOMEM_OAUTH_STORAGE_URL").strip()
+        writer_url
+        or storage_url
+        or _existing("EXOMEM_WRITER_LEASE_REPLICA_ID").strip()
     )
     storage_credential: str | None = None
     if ha_enabled:
+        missing_ha = [
+            name
+            for name, value in (
+                ("EXOMEM_WRITER_LEASE_URL", writer_url),
+                ("EXOMEM_OAUTH_STORAGE_URL", storage_url),
+                ("EXOMEM_OAUTH_STORAGE_NAMESPACE or EXOMEM_WRITER_LEASE_VAULT_ID", storage_namespace),
+            )
+            if not value
+        ]
+        if missing_ha:
+            print_fn(
+                "setup --remote: HA durable sessions require "
+                f"{', '.join(missing_ha)}. No changes were written."
+            )
+            return 2
         token_keys = (
             "EXOMEM_LEASE_COORDINATOR_TOKEN",
             "EXOMEM_WRITER_LEASE_TOKEN",

--- a/src/exomem/remote_setup_wizard.py
+++ b/src/exomem/remote_setup_wizard.py
@@ -421,15 +421,15 @@ def run_remote_setup(
     # coordinator. If HA is configured, converge all three credential views to
     # one value. Reject conflicts before touching the environment file.
     writer_url = _existing("EXOMEM_WRITER_LEASE_URL").strip()
+    writer_vault_id = _existing("EXOMEM_WRITER_LEASE_VAULT_ID").strip()
+    writer_replica_id = _existing("EXOMEM_WRITER_LEASE_REPLICA_ID").strip()
     storage_url = _existing("EXOMEM_OAUTH_STORAGE_URL").strip()
     storage_namespace = (
         _existing("EXOMEM_OAUTH_STORAGE_NAMESPACE").strip()
-        or _existing("EXOMEM_WRITER_LEASE_VAULT_ID").strip()
+        or writer_vault_id
     )
-    ha_enabled = bool(
-        writer_url
-        or storage_url
-        or _existing("EXOMEM_WRITER_LEASE_REPLICA_ID").strip()
+    ha_enabled = any(
+        _existing(key).strip() for key in doctor_module.HA_AUTH_ENV_KEYS
     )
     storage_credential: str | None = None
     if ha_enabled:
@@ -437,6 +437,8 @@ def run_remote_setup(
             name
             for name, value in (
                 ("EXOMEM_WRITER_LEASE_URL", writer_url),
+                ("EXOMEM_WRITER_LEASE_VAULT_ID", writer_vault_id),
+                ("EXOMEM_WRITER_LEASE_REPLICA_ID", writer_replica_id),
                 ("EXOMEM_OAUTH_STORAGE_URL", storage_url),
                 ("EXOMEM_OAUTH_STORAGE_NAMESPACE or EXOMEM_WRITER_LEASE_VAULT_ID", storage_namespace),
             )

--- a/src/exomem/remote_setup_wizard.py
+++ b/src/exomem/remote_setup_wizard.py
@@ -12,7 +12,8 @@ server.build_server). Re-running is always safe.
 
 The env-var contract is the source of truth in `server.build_server`
 (require_auth branch): EXOMEM_BASE_URL, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET,
-EXOMEM_GITHUB_USERNAME, EXOMEM_JWT_SIGNING_KEY, plus EXOMEM_VAULT_PATH.
+EXOMEM_GITHUB_USERNAME, EXOMEM_GITHUB_USER_ID, EXOMEM_JWT_SIGNING_KEY, plus
+EXOMEM_VAULT_PATH and matching coordinator credentials when HA is configured.
 
 CLI-only by design: it writes `.env` (secrets), reloads the environment, and
 runs doctor's live probes. All side-effect seams (`input_fn`, `print_fn`,
@@ -25,7 +26,9 @@ from __future__ import annotations
 import argparse
 import os
 import secrets
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from . import doctor as doctor_module
 
@@ -36,7 +39,11 @@ _OAUTH_KEYS = (
     "GITHUB_CLIENT_ID",
     "GITHUB_CLIENT_SECRET",
     "EXOMEM_GITHUB_USERNAME",
+    "EXOMEM_GITHUB_USER_ID",
     "EXOMEM_JWT_SIGNING_KEY",
+    "EXOMEM_LEASE_COORDINATOR_TOKEN",
+    "EXOMEM_WRITER_LEASE_TOKEN",
+    "EXOMEM_OAUTH_STORAGE_TOKEN",
     "EXOMEM_VAULT_PATH",
 )
 
@@ -55,6 +62,40 @@ class BaseUrlError(ValueError):
 def generate_signing_key() -> str:
     """A fresh, stable JWT signing key — `secrets.token_urlsafe(48)` (64 chars)."""
     return secrets.token_urlsafe(48)
+
+
+def generate_storage_credential() -> str:
+    """Generate one shared bearer for coordinator, lease, and OAuth state."""
+    return secrets.token_urlsafe(48)
+
+
+def resolve_github_user(username: str) -> dict[str, Any]:
+    """Resolve GitHub's immutable numeric user ID for a login."""
+    import httpx
+
+    response = httpx.get(
+        f"https://api.github.com/users/{username}",
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=10.0,
+        follow_redirects=False,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub returned an invalid user response")
+    return payload
+
+
+def _positive_user_id(value: object) -> int:
+    if isinstance(value, bool):
+        raise ValueError("GitHub user ID must be a positive integer")
+    try:
+        user_id = int(str(value).strip())
+    except (TypeError, ValueError):
+        raise ValueError("GitHub user ID must be a positive integer") from None
+    if user_id <= 0:
+        raise ValueError("GitHub user ID must be a positive integer")
+    return user_id
 
 
 def validate_base_url(raw: str) -> str:
@@ -212,6 +253,7 @@ def run_remote_setup(
     github_client_id: str | None = None,
     github_client_secret: str | None = None,
     github_username: str | None = None,
+    github_user_id: str | int | None = None,
     yes: bool = False,
     probe: bool = True,
     env_path: Path | None = None,
@@ -219,9 +261,11 @@ def run_remote_setup(
     print_fn=print,
     doctor_fn=None,
     load_env_fn=None,
+    github_user_resolver: Callable[[str], dict[str, Any]] | None = None,
 ) -> int:
     doctor_fn = doctor_fn or doctor_module.doctor
     load_env_fn = load_env_fn or _load_env
+    github_user_resolver = github_user_resolver or resolve_github_user
     env_path = env_path or _default_env_path()
 
     steps: list[tuple[str, str]] = []
@@ -312,6 +356,35 @@ def run_remote_setup(
         return 2
     report("oauth_app", "[done] fields printed + credentials captured")
 
+    # GitHub login names are mutable; pin authorization to GitHub's immutable
+    # positive numeric subject. Preserve a prior ID unless an explicit flag
+    # confirms the same value. Otherwise resolve it once from GitHub.
+    existing_user_id = _existing("EXOMEM_GITHUB_USER_ID").strip()
+    try:
+        if existing_user_id:
+            resolved_user_id = _positive_user_id(existing_user_id)
+            if github_user_id is not None and _positive_user_id(github_user_id) != resolved_user_id:
+                raise ValueError(
+                    "--github-user-id conflicts with existing EXOMEM_GITHUB_USER_ID"
+                )
+            report("github_id", "[skipped: already set — kept stable]")
+        elif github_user_id is not None:
+            resolved_user_id = _positive_user_id(github_user_id)
+            report("github_id", "[done] supplied explicitly")
+        else:
+            identity = github_user_resolver(github_username)
+            resolved_login = str(identity.get("login") or "").strip().casefold()
+            if resolved_login != github_username.strip().casefold():
+                raise ValueError(
+                    "GitHub resolved a different login; use the canonical login or "
+                    "provide --github-user-id for offline setup"
+                )
+            resolved_user_id = _positive_user_id(identity.get("id"))
+            report("github_id", "[done] resolved immutable ID")
+    except Exception as error:  # noqa: BLE001 - setup boundary, before any write
+        print_fn(f"setup --remote: could not establish GitHub identity: {error}")
+        return 2
+
     # 5. JWT signing key — generate ONCE and keep it (rotating orphans the store).
     signing_key = _existing("EXOMEM_JWT_SIGNING_KEY")
     if signing_key:
@@ -320,6 +393,35 @@ def run_remote_setup(
         signing_key = generate_signing_key()
         report("signing_key", "[done] generated")
 
+    # Active/passive auth state and the writer lease share one authenticated
+    # coordinator. If HA is configured, converge all three credential views to
+    # one value. Reject conflicts before touching the environment file.
+    ha_enabled = bool(
+        _existing("EXOMEM_WRITER_LEASE_URL").strip()
+        or _existing("EXOMEM_OAUTH_STORAGE_URL").strip()
+    )
+    storage_credential: str | None = None
+    if ha_enabled:
+        token_keys = (
+            "EXOMEM_LEASE_COORDINATOR_TOKEN",
+            "EXOMEM_WRITER_LEASE_TOKEN",
+            "EXOMEM_OAUTH_STORAGE_TOKEN",
+        )
+        configured = {value for key in token_keys if (value := _existing(key).strip())}
+        if len(configured) > 1:
+            print_fn(
+                "setup --remote: HA credential conflict; coordinator, writer lease, "
+                "and OAuth storage tokens must match. No changes were written."
+            )
+            return 2
+        storage_credential = next(iter(configured), None) or generate_storage_credential()
+        report(
+            "ha_auth",
+            "[skipped: existing matching credential preserved]"
+            if configured
+            else "[done] generated matching coordinator credential",
+        )
+
     # 6. Patch .env in place, preserving every other line.
     updates = {
         "EXOMEM_VAULT_PATH": vault_path,
@@ -327,8 +429,17 @@ def run_remote_setup(
         "GITHUB_CLIENT_ID": github_client_id,
         "GITHUB_CLIENT_SECRET": github_client_secret,
         "EXOMEM_GITHUB_USERNAME": github_username,
+        "EXOMEM_GITHUB_USER_ID": str(resolved_user_id),
         "EXOMEM_JWT_SIGNING_KEY": signing_key,
     }
+    if storage_credential is not None:
+        updates.update(
+            {
+                "EXOMEM_LEASE_COORDINATOR_TOKEN": storage_credential,
+                "EXOMEM_WRITER_LEASE_TOKEN": storage_credential,
+                "EXOMEM_OAUTH_STORAGE_TOKEN": storage_credential,
+            }
+        )
     env_path.write_text(patch_env(existing_text, updates), encoding="utf-8")
     try:
         env_path.chmod(0o600)  # secrets — owner-only on POSIX; near-no-op on Windows
@@ -404,6 +515,11 @@ def remote_setup_main(argv: list[str]) -> int:
     parser.add_argument("--github-client-secret", dest="github_client_secret", help="GitHub OAuth App Client Secret.")
     parser.add_argument("--github-username", dest="github_username", help="The single GitHub login allowed to sign in.")
     parser.add_argument(
+        "--github-user-id",
+        dest="github_user_id",
+        help="Immutable positive numeric GitHub user ID (avoids the setup lookup).",
+    )
+    parser.add_argument(
         "--yes", action="store_true",
         help="Non-interactive; requires --vault, --base-url, --tunnel, and the three --github-* flags.",
     )
@@ -435,6 +551,7 @@ def remote_setup_main(argv: list[str]) -> int:
         github_client_id=args.github_client_id,
         github_client_secret=args.github_client_secret,
         github_username=args.github_username,
+        github_user_id=args.github_user_id,
         yes=args.yes,
         probe=args.probe,
     )

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-import time
+from typing import Any
 
 from cryptography.fernet import Fernet
 from fastmcp.server.auth.auth import AccessToken
@@ -19,86 +19,181 @@ from key_value.aio.stores.filetree import (
 )
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
+from .auth_sessions import SessionAuthority
 from .remote_oauth_storage import ReadThroughMirrorStorage, RemoteOAuthStorage
+from .session_oauth import ExomemSessionOAuthProxy
 
 log = logging.getLogger(__name__)
 
 
 class SingleUserGitHubVerifier(GitHubTokenVerifier):
-    """Reject any GitHub token whose login is not the allowed user.
+    """Use GitHub once to prove the configured login and immutable user ID."""
 
-    Caches validated tokens for a short TTL (``EXOMEM_AUTH_CACHE_TTL`` seconds,
-    default 300). Without it every MCP request, and a single connector operation
-    fires several, re-hits the GitHub API to revalidate the same token.
-    """
+    def __init__(
+        self,
+        *,
+        allowed_login: str,
+        allowed_user_id: int,
+        **kwargs: Any,
+    ) -> None:
+        login = allowed_login.strip().casefold()
+        if not login:
+            raise ValueError("an allowed GitHub login is required")
+        if isinstance(allowed_user_id, bool) or allowed_user_id <= 0:
+            raise ValueError("GitHub identity requires a positive numeric user ID")
 
-    _DEFAULT_TTL = 300.0
-    _MAX_ENTRIES = 64
-
-    def __init__(self, *, allowed_login: str, **kwargs):
-        super().__init__(**kwargs)
-        self._allowed_login = allowed_login.lower()
-        # Do not name this ``_cache``. The parent GitHubTokenVerifier owns that
-        # attribute and expects a fastmcp TokenCache instance.
-        self._login_cache: dict[str, tuple[float, AccessToken]] = {}
-
-    def _ttl(self) -> float:
-        raw = os.environ.get("EXOMEM_AUTH_CACHE_TTL")
-        if raw is None:
-            return self._DEFAULT_TTL
-        try:
-            return max(0.0, float(raw))
-        except ValueError:
-            return self._DEFAULT_TTL
+        # A GitHub bearer is one-time identity proof. FastMCP's verifier cache
+        # must stay disabled so no bearer material survives the callback.
+        kwargs.pop("cache_ttl_seconds", None)
+        super().__init__(cache_ttl_seconds=None, **kwargs)
+        self._allowed_login = login
+        self._allowed_user_id = allowed_user_id
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        ttl = self._ttl()
-        key = hashlib.sha256(token.encode("utf-8")).hexdigest() if token else ""
-        if ttl > 0 and key:
-            hit = self._login_cache.get(key)
-            if hit is not None:
-                ts, cached = hit
-                if time.monotonic() - ts < ttl:
-                    return cached
-                del self._login_cache[key]
-
         access = await super().verify_token(token)
         if access is None:
-            log.info(
-                "exomem auth: token rejected by GitHub (expired/revoked/invalid); "
-                "client will re-authorize"
-            )
-            return None
-        login = (access.claims.get("login") or "").lower()
-        if login != self._allowed_login:
-            log.warning("rejecting token for github login=%r", login)
             return None
 
-        if ttl > 0 and key:
-            now = time.monotonic()
-            if len(self._login_cache) >= self._MAX_ENTRIES:
-                self._login_cache = {k: v for k, v in self._login_cache.items() if now - v[0] < ttl}
-            self._login_cache[key] = (now, access)
+        claims = access.claims or {}
+        login = str(claims.get("login") or "").strip().casefold()
+        raw_user_id = claims.get("sub") or access.client_id
+        if isinstance(raw_user_id, bool):
+            return None
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            return None
+        if login != self._allowed_login or user_id != self._allowed_user_id:
+            log.warning("rejecting GitHub token for an unexpected identity")
+            return None
         return access
 
 
+def _required_signing_root() -> str:
+    signing_root = os.environ.get("EXOMEM_JWT_SIGNING_KEY", "").strip()
+    if not signing_root:
+        raise RuntimeError("EXOMEM_JWT_SIGNING_KEY is required for durable OAuth sessions")
+    return signing_root
+
+
+def _shared_storage_settings() -> tuple[str, str, str, float] | None:
+    storage_url = os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip()
+    if not storage_url:
+        return None
+    namespace = (
+        os.environ.get("EXOMEM_OAUTH_STORAGE_NAMESPACE", "").strip()
+        or os.environ.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip()
+    )
+    if not namespace:
+        raise RuntimeError(
+            "EXOMEM_OAUTH_STORAGE_NAMESPACE or EXOMEM_WRITER_LEASE_VAULT_ID "
+            "is required for shared OAuth storage"
+        )
+    storage_token = os.environ.get("EXOMEM_OAUTH_STORAGE_TOKEN", "").strip()
+    if not storage_token:
+        raise RuntimeError(
+            "EXOMEM_OAUTH_STORAGE_TOKEN is required for shared OAuth storage"
+        )
+    timeout = float(os.environ.get("EXOMEM_OAUTH_STORAGE_TIMEOUT", "5"))
+    return storage_url, namespace, storage_token, timeout
+
+
+def build_session_authority(*, base_url: str) -> SessionAuthority:
+    """Build the authoritative durable session store for this deployment."""
+    signing_root = _required_signing_root()
+    issuer = base_url.rstrip("/")
+    audience = f"{issuer}/mcp"
+    shared = _shared_storage_settings()
+    if shared is not None:
+        storage_url, namespace, storage_token, timeout = shared
+        return SessionAuthority.remote(
+            url=storage_url,
+            namespace=namespace,
+            storage_token=storage_token,
+            signing_root=signing_root,
+            issuer=issuer,
+            audience=audience,
+            timeout=timeout,
+        )
+
+    from fastmcp import settings
+
+    return SessionAuthority.local(
+        directory=settings.home / "oauth-sessions",
+        signing_root=signing_root,
+        issuer=issuer,
+        audience=audience,
+    )
+
+
+def _build_oauth_client_storage(*, signing_root: str) -> Any | None:
+    """Preserve FastMCP's DCR/transaction/code storage behavior in HA mode."""
+    shared = _shared_storage_settings()
+    if shared is None:
+        return None
+    storage_url, namespace, storage_token, timeout = shared
+    signing_key = derive_jwt_key(
+        low_entropy_material=signing_root,
+        salt="fastmcp-jwt-signing-key",
+    )
+    storage_key = derive_jwt_key(
+        high_entropy_material=signing_key.decode(),
+        salt="fastmcp-storage-encryption-key",
+    )
+    remote = RemoteOAuthStorage(
+        url=storage_url,
+        namespace=namespace,
+        token=storage_token,
+        timeout=timeout,
+        cache_ttl=float(os.environ.get("EXOMEM_OAUTH_STORAGE_CACHE_TTL", "300")),
+    )
+
+    from fastmcp import settings
+
+    key_fingerprint = hashlib.sha256(storage_key).hexdigest()[:12]
+    storage_dir = settings.home / "oauth-proxy" / key_fingerprint
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    local = FileTreeStore(
+        data_directory=storage_dir,
+        key_sanitization_strategy=FileTreeV1KeySanitizationStrategy(storage_dir),
+        collection_sanitization_strategy=FileTreeV1CollectionSanitizationStrategy(
+            storage_dir
+        ),
+    )
+    return FernetEncryptionWrapper(
+        key_value=ReadThroughMirrorStorage(primary=remote, fallback=local),
+        fernet=Fernet(key=storage_key),
+        raise_on_decryption_error=False,
+    )
+
+
 def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
-    """Return the GitHub OAuth proxy for HTTP transports, or None for stdio."""
+    """Return the durable GitHub-bootstrap OAuth proxy, or None for stdio."""
     if not require_auth:
         return None
 
     gh_id = os.environ.get("GITHUB_CLIENT_ID", "").strip()
     gh_secret = os.environ.get("GITHUB_CLIENT_SECRET", "").strip()
     gh_username = os.environ.get("EXOMEM_GITHUB_USERNAME", "").strip()
+    raw_user_id = os.environ.get("EXOMEM_GITHUB_USER_ID", "").strip()
+    signing_root = os.environ.get("EXOMEM_JWT_SIGNING_KEY", "").strip()
+    # Validate shared-storage trust anchors in dependency order so startup
+    # reports the broken coordinator boundary directly.
+    if not signing_root:
+        _required_signing_root()
+    if os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip():
+        _shared_storage_settings()
     missing = [
-        k
-        for k, v in {
+        key
+        for key, value in {
             "EXOMEM_BASE_URL": base_url,
             "GITHUB_CLIENT_ID": gh_id,
             "GITHUB_CLIENT_SECRET": gh_secret,
             "EXOMEM_GITHUB_USERNAME": gh_username,
+            "EXOMEM_GITHUB_USER_ID": raw_user_id,
+            "EXOMEM_JWT_SIGNING_KEY": signing_root,
         }.items()
-        if not v
+        if not value
     ]
     if missing:
         raise RuntimeError(
@@ -106,72 +201,32 @@ def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
             "See README.md section Install for setup steps."
         )
 
-    jwt_signing_key = os.environ.get("EXOMEM_JWT_SIGNING_KEY", "").strip() or None
-    if jwt_signing_key is None:
-        log.info(
-            "EXOMEM_JWT_SIGNING_KEY not set; OAuth signing key derives from the "
-            "GitHub client secret, so connector re-auth can recur on secret "
-            "rotation or FastMCP upgrades. Set it in .env for a stable connector."
+    try:
+        github_user_id = int(raw_user_id)
+    except ValueError as error:
+        raise RuntimeError(
+            "EXOMEM_GITHUB_USER_ID must be a positive numeric GitHub user ID"
+        ) from error
+    if github_user_id <= 0:
+        raise RuntimeError(
+            "EXOMEM_GITHUB_USER_ID must be a positive numeric GitHub user ID"
         )
 
-    client_storage = None
-    storage_url = os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip()
-    if storage_url:
-        if jwt_signing_key is None:
-            raise RuntimeError(
-                "EXOMEM_JWT_SIGNING_KEY is required when EXOMEM_OAUTH_STORAGE_URL is set"
-            )
-        namespace = (
-            os.environ.get("EXOMEM_OAUTH_STORAGE_NAMESPACE", "").strip()
-            or os.environ.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip()
-        )
-        if not namespace:
-            raise RuntimeError(
-                "EXOMEM_OAUTH_STORAGE_NAMESPACE or EXOMEM_WRITER_LEASE_VAULT_ID "
-                "is required for shared OAuth storage"
-            )
-        signing_key = derive_jwt_key(
-            low_entropy_material=jwt_signing_key,
-            salt="fastmcp-jwt-signing-key",
-        )
-        storage_key = derive_jwt_key(
-            high_entropy_material=signing_key.decode(),
-            salt="fastmcp-storage-encryption-key",
-        )
-        remote = RemoteOAuthStorage(
-            url=storage_url,
-            namespace=namespace,
-            token=os.environ.get("EXOMEM_OAUTH_STORAGE_TOKEN", "").strip() or None,
-            timeout=float(os.environ.get("EXOMEM_OAUTH_STORAGE_TIMEOUT", "5")),
-            cache_ttl=float(os.environ.get("EXOMEM_OAUTH_STORAGE_CACHE_TTL", "300")),
-        )
-        from fastmcp import settings
-
-        key_fingerprint = hashlib.sha256(storage_key).hexdigest()[:12]
-        storage_dir = settings.home / "oauth-proxy" / key_fingerprint
-        storage_dir.mkdir(parents=True, exist_ok=True)
-        local = FileTreeStore(
-            data_directory=storage_dir,
-            key_sanitization_strategy=FileTreeV1KeySanitizationStrategy(storage_dir),
-            collection_sanitization_strategy=FileTreeV1CollectionSanitizationStrategy(storage_dir),
-        )
-        client_storage = FernetEncryptionWrapper(
-            key_value=ReadThroughMirrorStorage(primary=remote, fallback=local),
-            fernet=Fernet(key=storage_key),
-            raise_on_decryption_error=False,
-        )
-
-    # Do not impose a fallback access-token lifetime here. GitHub OAuth Apps
-    # normally issue long-lived access tokens without refresh tokens; forcing a
-    # shorter downstream expiry creates an unrecoverable refresh gap. FastMCP
-    # already selects provider-aware defaults from the upstream token response.
-    return OAuthProxy(
+    authority = build_session_authority(base_url=base_url)
+    client_storage = _build_oauth_client_storage(signing_root=signing_root)
+    verifier = SingleUserGitHubVerifier(
+        allowed_login=gh_username,
+        allowed_user_id=github_user_id,
+    )
+    return ExomemSessionOAuthProxy(
+        session_authority=authority,
         upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
         upstream_token_endpoint="https://github.com/login/oauth/access_token",
         upstream_client_id=gh_id,
         upstream_client_secret=gh_secret,
-        token_verifier=SingleUserGitHubVerifier(allowed_login=gh_username),
+        upstream_revocation_endpoint=None,
+        token_verifier=verifier,
         base_url=base_url,
-        jwt_signing_key=jwt_signing_key,
+        jwt_signing_key=signing_root,
         client_storage=client_storage,
     )

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+from contextlib import nullcontext
 from typing import Any
 
+import httpx
 from cryptography.fernet import Fernet
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.jwt_issuer import derive_jwt_key
@@ -50,13 +52,38 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
         self._allowed_user_id = allowed_user_id
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        access = await super().verify_token(token)
-        if access is None:
+        try:
+            async with (
+                nullcontext(self._http_client)
+                if self._http_client is not None
+                else httpx.AsyncClient(timeout=self.timeout_seconds)
+            ) as client:
+                response = await client.get(
+                    "https://api.github.com/user",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                        "User-Agent": "Exomem-GitHub-OAuth",
+                    },
+                )
+            if response.status_code != 200:
+                log.warning(
+                    "GitHub identity proof failed with status %d",
+                    response.status_code,
+                )
+                return None
+            user_data = response.json()
+            if not isinstance(user_data, dict):
+                raise ValueError("GitHub user response must be an object")
+        except (httpx.HTTPError, TypeError, ValueError) as error:
+            log.warning(
+                "GitHub identity proof failed due to %s",
+                type(error).__name__,
+            )
             return None
 
-        claims = access.claims or {}
-        login = str(claims.get("login") or "").strip().casefold()
-        raw_user_id = claims.get("sub") or access.client_id
+        login = str(user_data.get("login") or "").strip().casefold()
+        raw_user_id = user_data.get("id")
         if isinstance(raw_user_id, bool):
             return None
         try:
@@ -66,7 +93,13 @@ class SingleUserGitHubVerifier(GitHubTokenVerifier):
         if login != self._allowed_login or user_id != self._allowed_user_id:
             log.warning("rejecting GitHub token for an unexpected identity")
             return None
-        return access
+        return AccessToken(
+            token=token,
+            client_id=str(user_id),
+            scopes=[],
+            expires_at=None,
+            claims={"sub": str(user_id), "login": login},
+        )
 
 
 def _required_signing_root() -> str:
@@ -79,6 +112,11 @@ def _required_signing_root() -> str:
 def _shared_storage_settings() -> tuple[str, str, str, float] | None:
     storage_url = os.environ.get("EXOMEM_OAUTH_STORAGE_URL", "").strip()
     if not storage_url:
+        if os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip():
+            raise RuntimeError(
+                "EXOMEM_OAUTH_STORAGE_URL is required when "
+                "EXOMEM_WRITER_LEASE_URL enables HA coordination"
+            )
         return None
     namespace = (
         os.environ.get("EXOMEM_OAUTH_STORAGE_NAMESPACE", "").strip()

--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -1,0 +1,396 @@
+"""FastMCP 3.4.4 adapter for durable Exomem-owned OAuth sessions."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import (
+    DEFAULT_AUTH_CODE_EXPIRY_SECONDS,
+    HTTP_TIMEOUT_SECONDS,
+    ClientCode,
+)
+from fastmcp.server.auth.oauth_proxy.ui import create_error_html
+from mcp.server.auth.provider import AuthorizationCode, RefreshToken, TokenError
+from mcp.server.auth.settings import RevocationOptions
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
+from typing_extensions import override
+
+from .auth_sessions import SessionAuthority, SessionIdentity, SessionStoreUnavailable
+
+logger = logging.getLogger(__name__)
+
+
+class SessionStoreUnavailableMiddleware:
+    """Map only authoritative session-store failures to retryable HTTP 503."""
+
+    def __init__(self, app: Any):
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        try:
+            await self.app(scope, receive, send)
+        except SessionStoreUnavailable:
+            if scope.get("type") != "http":
+                raise
+            logger.warning("durable auth session store unavailable")
+            response = JSONResponse(
+                {
+                    "error": "temporarily_unavailable",
+                    "error_description": (
+                        "The authentication session store is temporarily unavailable; retry shortly."
+                    ),
+                },
+                status_code=503,
+                headers={"Retry-After": "5"},
+            )
+            await response(scope, receive, send)
+
+
+class ExomemSessionOAuthProxy(OAuthProxy):
+    """Use GitHub once for identity, then issue and validate Exomem sessions."""
+
+    def __init__(
+        self,
+        *,
+        session_authority: SessionAuthority,
+        github_cleanup_transport: httpx.AsyncBaseTransport | None = None,
+        **kwargs: Any,
+    ):
+        if kwargs.get("upstream_revocation_endpoint") is not None:
+            raise ValueError(
+                "durable sessions use local RFC 7009 revocation, not an upstream endpoint"
+            )
+        kwargs["upstream_revocation_endpoint"] = None
+        super().__init__(**kwargs)
+        self._session_authority = session_authority
+        self._github_cleanup_transport = github_cleanup_transport
+        self.revocation_options = RevocationOptions(enabled=True)
+
+    @override
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        code_model = await self._code_store.get(key=authorization_code.code)
+        if code_model is None:
+            raise TokenError("invalid_grant", "Authorization code not found")
+        if code_model.client_id != client.client_id:
+            raise TokenError("invalid_grant", "Authorization code client mismatch")
+
+        consumed = await self._code_store.delete(key=authorization_code.code)
+        if not consumed:
+            raise TokenError("invalid_grant", "Authorization code not found")
+
+        proof = code_model.idp_tokens.get("exomem_identity")
+        if not isinstance(proof, dict):
+            raise TokenError("invalid_grant", "Authorization identity proof is missing")
+        try:
+            raw_user_id = proof["github_user_id"]
+            if isinstance(raw_user_id, bool):
+                raise ValueError("boolean identity IDs are invalid")
+            identity = SessionIdentity(
+                github_user_id=int(raw_user_id),
+                github_login=str(proof["github_login"]),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise TokenError(
+                "invalid_grant", "Authorization identity proof is invalid"
+            ) from error
+
+        if client.client_id is None:
+            raise TokenError("invalid_client", "Client ID is required")
+        scopes = list(code_model.scopes)
+        bearer, _ = await self._session_authority.issue(
+            client_id=client.client_id,
+            scopes=scopes,
+            identity=identity,
+        )
+        return OAuthToken(
+            access_token=bearer,
+            token_type="Bearer",
+            expires_in=None,
+            scope=" ".join(scopes) or None,
+            refresh_token=None,
+        )
+
+    @override
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        record = await self._session_authority.validate(token)
+        if record is None:
+            return None
+        return AccessToken(
+            token=token,
+            client_id=record.client_id,
+            scopes=list(record.scopes),
+            expires_at=None,
+            resource=record.audience,
+            claims={
+                "sub": str(record.github_user_id),
+                "github_user_id": record.github_user_id,
+                "github_login": record.github_login,
+                "iss": record.issuer,
+                "aud": record.audience,
+            },
+        )
+
+    @override
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        record = await self._session_authority.validate(token.token)
+        if record is None:
+            return
+        await self._session_authority.tombstone(
+            record.session_id,
+            reason="oauth-client-revocation",
+        )
+
+    @override
+    def get_middleware(self) -> list:
+        return [
+            Middleware(SessionStoreUnavailableMiddleware),
+            *super().get_middleware(),
+        ]
+
+    async def _cleanup_github_token(self, access_token: str) -> None:
+        if self._upstream_client_secret is None:
+            logger.warning("GitHub OAuth token cleanup skipped: missing application secret")
+            return
+        endpoint = (
+            "https://api.github.com/applications/"
+            f"{self._upstream_client_id}/token"
+        )
+        try:
+            async with httpx.AsyncClient(
+                timeout=HTTP_TIMEOUT_SECONDS,
+                transport=self._github_cleanup_transport,
+            ) as client:
+                response = await client.request(
+                    "DELETE",
+                    endpoint,
+                    auth=(
+                        self._upstream_client_id,
+                        self._upstream_client_secret.get_secret_value(),
+                    ),
+                    json={"access_token": access_token},
+                    headers={"Accept": "application/vnd.github+json"},
+                )
+            if response.status_code in {204, 404, 422}:
+                return
+            logger.warning(
+                "GitHub OAuth token cleanup failed with status %d",
+                response.status_code,
+            )
+        except httpx.HTTPError as error:
+            logger.warning(
+                "GitHub OAuth token cleanup failed due to %s",
+                type(error).__name__,
+            )
+
+    @staticmethod
+    def _verified_identity_proof(verified: AccessToken | None) -> dict[str, Any] | None:
+        if verified is None:
+            return None
+        claims = verified.claims or {}
+        login = str(claims.get("login") or "").strip().casefold()
+        raw_user_id = claims.get("sub") or verified.client_id
+        if isinstance(raw_user_id, bool):
+            return None
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            return None
+        if not login or user_id <= 0:
+            return None
+        return {
+            "exomem_identity": {
+                "github_user_id": user_id,
+                "github_login": login,
+            }
+        }
+
+    @staticmethod
+    def _error_response(message: str, *, status_code: int) -> HTMLResponse:
+        return HTMLResponse(
+            content=create_error_html(
+                error_title="OAuth Error",
+                error_message=message,
+            ),
+            status_code=status_code,
+        )
+
+    @override
+    async def _handle_idp_callback(
+        self, request: Request
+    ) -> HTMLResponse | RedirectResponse:
+        """Exchange, verify, dispose, and retain only a minimal identity proof."""
+        try:
+            idp_code = request.query_params.get("code")
+            txn_id = request.query_params.get("state")
+            error = request.query_params.get("error")
+
+            if not idp_code and not error:
+                return self._error_response(
+                    "Missing authorization code or transaction ID from the identity provider.",
+                    status_code=400,
+                )
+
+            transaction_model = (
+                await self._transaction_store.get(key=txn_id) if txn_id else None
+            )
+
+            if error:
+                error_description = request.query_params.get("error_description")
+                if transaction_model:
+                    client_redirect_uri = transaction_model.client_redirect_uri
+                    if not self._validate_client_redirect_uri(client_redirect_uri):
+                        return self._error_response(
+                            "Invalid redirect URI",
+                            status_code=400,
+                        )
+                    error_params: dict[str, str] = {
+                        "error": error,
+                        "state": transaction_model.client_state,
+                    }
+                    if error_description:
+                        error_params["error_description"] = error_description
+                    separator = "&" if "?" in client_redirect_uri else "?"
+                    return RedirectResponse(
+                        url=f"{client_redirect_uri}{separator}{urlencode(error_params)}",
+                        status_code=302,
+                    )
+                return self._error_response(
+                    f"Authentication failed: {error_description or 'Unknown error'}",
+                    status_code=400,
+                )
+
+            if not txn_id or transaction_model is None:
+                return self._error_response(
+                    "Invalid or expired authorization transaction. Please try authenticating again.",
+                    status_code=400,
+                )
+            if not self._validate_client_redirect_uri(
+                transaction_model.client_redirect_uri
+            ):
+                return self._error_response("Invalid redirect URI", status_code=400)
+
+            if self._require_authorization_consent in (True, "remember"):
+                consent_token = transaction_model.consent_token
+                if not consent_token:
+                    return self._error_response(
+                        "Invalid authorization flow. Please try authenticating again.",
+                        status_code=403,
+                    )
+                if not self._verify_consent_binding_cookie(
+                    request, txn_id, consent_token
+                ):
+                    return self._error_response(
+                        "Authorization session mismatch. Please try authenticating again.",
+                        status_code=403,
+                    )
+
+            transaction = transaction_model.model_dump()
+            idp_redirect_uri = f"{str(self.base_url).rstrip('/')}{self._redirect_path}"
+            token_params: dict[str, Any] = {
+                "url": self._upstream_token_endpoint,
+                "code": idp_code,
+                "redirect_uri": idp_redirect_uri,
+            }
+            proxy_code_verifier = transaction.get("proxy_code_verifier")
+            if proxy_code_verifier:
+                token_params["code_verifier"] = proxy_code_verifier
+            exchange_scopes = self._prepare_scopes_for_token_exchange(
+                transaction.get("scopes") or []
+            )
+            if exchange_scopes:
+                token_params["scope"] = " ".join(exchange_scopes)
+            token_params.update(self._extra_token_params)
+
+            try:
+                async with self._upstream_oauth_client() as oauth_client:
+                    idp_tokens: dict[str, Any] = await oauth_client.fetch_token(
+                        **token_params
+                    )
+            except Exception as exchange_error:  # noqa: BLE001 - OAuth callback boundary
+                logger.error(
+                    "IdP token exchange failed due to %s",
+                    type(exchange_error).__name__,
+                )
+                return self._error_response(
+                    "Token exchange with identity provider failed.",
+                    status_code=500,
+                )
+
+            raw_access_token = idp_tokens.get("access_token")
+            if not isinstance(raw_access_token, str) or not raw_access_token:
+                idp_tokens.clear()
+                return self._error_response(
+                    "Identity provider returned no usable access token.",
+                    status_code=403,
+                )
+
+            proof: dict[str, Any] | None = None
+            try:
+                verified = await self._token_validator.verify_token(raw_access_token)
+                proof = self._verified_identity_proof(verified)
+            except Exception as verification_error:  # noqa: BLE001 - reject verifier failures
+                logger.warning(
+                    "GitHub identity verification failed due to %s",
+                    type(verification_error).__name__,
+                )
+            finally:
+                await self._cleanup_github_token(raw_access_token)
+                idp_tokens.clear()
+
+            if proof is None:
+                return self._error_response(
+                    "The authorized GitHub identity is not permitted.",
+                    status_code=403,
+                )
+
+            client_code = secrets.token_urlsafe(32)
+            code_expires_at = int(time.time() + DEFAULT_AUTH_CODE_EXPIRY_SECONDS)
+            await self._code_store.put(
+                key=client_code,
+                value=ClientCode(
+                    code=client_code,
+                    client_id=transaction["client_id"],
+                    redirect_uri=transaction["client_redirect_uri"],
+                    code_challenge=transaction["code_challenge"],
+                    code_challenge_method=transaction["code_challenge_method"],
+                    scopes=transaction["scopes"],
+                    idp_tokens=proof,
+                    expires_at=code_expires_at,
+                    created_at=time.time(),
+                ),
+                ttl=DEFAULT_AUTH_CODE_EXPIRY_SECONDS,
+            )
+            await self._transaction_store.delete(key=txn_id)
+
+            client_redirect_uri = transaction["client_redirect_uri"]
+            separator = "&" if "?" in client_redirect_uri else "?"
+            callback_url = (
+                f"{client_redirect_uri}{separator}"
+                f"{urlencode({'code': client_code, 'state': transaction['client_state']})}"
+            )
+            response = RedirectResponse(url=callback_url, status_code=302)
+            self._clear_consent_binding_cookie(request, response, txn_id)
+            return response
+        except Exception as callback_error:  # noqa: BLE001 - preserve callback error page
+            logger.error(
+                "OAuth callback processing failed due to %s",
+                type(callback_error).__name__,
+            )
+            return self._error_response(
+                "Internal server error during OAuth callback processing. Please try again.",
+                status_code=500,
+            )

--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -17,12 +17,15 @@ from fastmcp.server.auth.oauth_proxy.models import (
     ClientCode,
 )
 from fastmcp.server.auth.oauth_proxy.ui import create_error_html
+from mcp.server.auth.handlers.metadata import MetadataHandler
 from mcp.server.auth.provider import AuthorizationCode, RefreshToken, TokenError
-from mcp.server.auth.settings import RevocationOptions
+from mcp.server.auth.routes import build_metadata, cors_middleware
+from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
+from starlette.routing import Route
 from typing_extensions import override
 
 from .auth_sessions import SessionAuthority, SessionIdentity, SessionStoreUnavailable
@@ -145,6 +148,41 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         )
 
     @override
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        """Refuse refresh without consulting preserved FastMCP legacy state."""
+        del client, refresh_token
+        return None
+
+    @override
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        """Defensively prevent callers from re-entering FastMCP's legacy flow."""
+        del client, refresh_token, scopes
+        raise TokenError("invalid_grant", "Refresh tokens are not supported")
+
+    @override
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        """Register authorization-code-only downstream clients."""
+        client_info.grant_types = ["authorization_code"]
+        await super().register_client(client_info)
+
+    @override
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        """Hide refresh grants retained in bounded rollback client records."""
+        client = await super().get_client(client_id)
+        if client is None:
+            return None
+        return client.model_copy(update={"grant_types": ["authorization_code"]})
+
+    @override
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         record = await self._session_authority.validate(token.token)
         if record is None:
@@ -160,6 +198,46 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             Middleware(SessionStoreUnavailableMiddleware),
             *super().get_middleware(),
         ]
+
+    @override
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        """Preserve FastMCP routes while advertising no refresh-token grant."""
+        routes = super().get_routes(mcp_path)
+        rewritten: list[Route] = []
+        for route in routes:
+            if not route.path.startswith("/.well-known/oauth-authorization-server"):
+                rewritten.append(route)
+                continue
+
+            client_options = (
+                self.client_registration_options or ClientRegistrationOptions()
+            )
+            metadata = build_metadata(
+                self.base_url,
+                self.service_documentation_url,
+                client_options,
+                self.revocation_options or RevocationOptions(),
+            )
+            metadata.grant_types_supported = ["authorization_code"]
+            if self._cimd_manager is not None:
+                metadata.client_id_metadata_document_supported = True
+                existing = metadata.token_endpoint_auth_methods_supported or []
+                metadata.token_endpoint_auth_methods_supported = [
+                    *existing,
+                    "private_key_jwt",
+                    "none",
+                ]
+            handler = MetadataHandler(metadata)
+            rewritten.append(
+                Route(
+                    path=route.path,
+                    endpoint=cors_middleware(handler.handle, ["GET", "OPTIONS"]),
+                    methods=route.methods or ["GET", "OPTIONS"],
+                    name=route.name,
+                    include_in_schema=route.include_in_schema,
+                )
+            )
+        return rewritten
 
     async def _cleanup_github_token(self, access_token: str) -> None:
         if self._upstream_client_secret is None:
@@ -184,7 +262,7 @@ class ExomemSessionOAuthProxy(OAuthProxy):
                     json={"access_token": access_token},
                     headers={"Accept": "application/vnd.github+json"},
                 )
-            if response.status_code in {204, 404, 422}:
+            if response.status_code in {204, 404}:
                 return
             logger.warning(
                 "GitHub OAuth token cleanup failed with status %d",

--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -17,15 +17,12 @@ from fastmcp.server.auth.oauth_proxy.models import (
     ClientCode,
 )
 from fastmcp.server.auth.oauth_proxy.ui import create_error_html
-from mcp.server.auth.handlers.metadata import MetadataHandler
 from mcp.server.auth.provider import AuthorizationCode, RefreshToken, TokenError
-from mcp.server.auth.routes import build_metadata, cors_middleware
-from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
+from mcp.server.auth.settings import RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
-from starlette.routing import Route
 from typing_extensions import override
 
 from .auth_sessions import SessionAuthority, SessionIdentity, SessionStoreUnavailable
@@ -169,20 +166,6 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         raise TokenError("invalid_grant", "Refresh tokens are not supported")
 
     @override
-    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
-        """Register authorization-code-only downstream clients."""
-        client_info.grant_types = ["authorization_code"]
-        await super().register_client(client_info)
-
-    @override
-    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        """Hide refresh grants retained in bounded rollback client records."""
-        client = await super().get_client(client_id)
-        if client is None:
-            return None
-        return client.model_copy(update={"grant_types": ["authorization_code"]})
-
-    @override
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         record = await self._session_authority.validate(token.token)
         if record is None:
@@ -198,46 +181,6 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             Middleware(SessionStoreUnavailableMiddleware),
             *super().get_middleware(),
         ]
-
-    @override
-    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
-        """Preserve FastMCP routes while advertising no refresh-token grant."""
-        routes = super().get_routes(mcp_path)
-        rewritten: list[Route] = []
-        for route in routes:
-            if not route.path.startswith("/.well-known/oauth-authorization-server"):
-                rewritten.append(route)
-                continue
-
-            client_options = (
-                self.client_registration_options or ClientRegistrationOptions()
-            )
-            metadata = build_metadata(
-                self.base_url,
-                self.service_documentation_url,
-                client_options,
-                self.revocation_options or RevocationOptions(),
-            )
-            metadata.grant_types_supported = ["authorization_code"]
-            if self._cimd_manager is not None:
-                metadata.client_id_metadata_document_supported = True
-                existing = metadata.token_endpoint_auth_methods_supported or []
-                metadata.token_endpoint_auth_methods_supported = [
-                    *existing,
-                    "private_key_jwt",
-                    "none",
-                ]
-            handler = MetadataHandler(metadata)
-            rewritten.append(
-                Route(
-                    path=route.path,
-                    endpoint=cors_middleware(handler.handle, ["GET", "OPTIONS"]),
-                    methods=route.methods or ["GET", "OPTIONS"],
-                    name=route.name,
-                    include_in_schema=route.include_in_schema,
-                )
-            )
-        return rewritten
 
     async def _cleanup_github_token(self, access_token: str) -> None:
         if self._upstream_client_secret is None:

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
-from types import SimpleNamespace
+from typing import Any
 
+import httpx
 import pytest
-from fastmcp.server.auth.providers.github import GitHubTokenVerifier
 
 from exomem.server_auth import SingleUserGitHubVerifier
 
@@ -14,46 +13,50 @@ ALLOWED_LOGIN = "person"
 ALLOWED_ID = 123456
 
 
-def _verifier() -> SingleUserGitHubVerifier:
-    return SingleUserGitHubVerifier(
-        allowed_login=ALLOWED_LOGIN,
-        allowed_user_id=ALLOWED_ID,
+def _response(
+    request: httpx.Request,
+    *,
+    login: str | None = ALLOWED_LOGIN,
+    user_id: Any = ALLOWED_ID,
+    status_code: int = 200,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json={"login": login, "id": user_id},
+        request=request,
     )
 
 
-def _stub_super(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    login: str | None = ALLOWED_LOGIN,
-    user_id: object = ALLOWED_ID,
-) -> dict[str, int]:
-    calls = {"count": 0}
+@pytest.mark.anyio
+async def test_exact_identity_uses_exactly_one_uncached_github_user_request() -> None:
+    requests: list[httpx.Request] = []
 
-    async def fake(self, token):  # noqa: ANN001
-        del self
-        calls["count"] += 1
-        if login is None:
-            return None
-        return SimpleNamespace(
-            claims={"login": login, "sub": str(user_id)},
-            client_id=str(user_id),
-            token=token,
+    def github(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _response(request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(github)) as client:
+        verifier = SingleUserGitHubVerifier(
+            allowed_login=ALLOWED_LOGIN,
+            allowed_user_id=ALLOWED_ID,
+            http_client=client,
         )
-
-    monkeypatch.setattr(GitHubTokenVerifier, "verify_token", fake)
-    return calls
-
-
-def test_exact_login_and_immutable_id_are_required(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch)
-    verifier = _verifier()
-
-    result = asyncio.run(verifier.verify_token("temporary-github-token"))
+        result = await verifier.verify_token("temporary-github-token")
 
     assert result is not None
-    assert calls["count"] == 1
+    assert result.client_id == str(ALLOWED_ID)
+    assert result.scopes == []
+    assert result.claims == {"sub": str(ALLOWED_ID), "login": ALLOWED_LOGIN}
+    assert len(requests) == 1
+    assert requests[0].method == "GET"
+    assert requests[0].url == "https://api.github.com/user"
+    assert requests[0].headers["authorization"] == "Bearer temporary-github-token"
+    assert verifier._cache.enabled is False
+    assert verifier._cache._entries == {}
+    assert not hasattr(verifier, "_login_cache")
 
 
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("login", "user_id"),
     [
@@ -62,49 +65,79 @@ def test_exact_login_and_immutable_id_are_required(monkeypatch: pytest.MonkeyPat
         (ALLOWED_LOGIN, 999),
         (ALLOWED_LOGIN, None),
         (ALLOWED_LOGIN, "not-numeric"),
+        (ALLOWED_LOGIN, True),
     ],
 )
-def test_wrong_or_missing_identity_is_rejected(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_wrong_missing_or_non_numeric_identity_is_rejected(
     login: str | None,
-    user_id: object,
+    user_id: Any,
 ) -> None:
-    _stub_super(monkeypatch, login=login, user_id=user_id)
+    requests = 0
 
-    assert asyncio.run(_verifier().verify_token("temporary-github-token")) is None
+    def github(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return _response(request, login=login, user_id=user_id)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(github)) as client:
+        verifier = SingleUserGitHubVerifier(
+            allowed_login=ALLOWED_LOGIN,
+            allowed_user_id=ALLOWED_ID,
+            http_client=client,
+        )
+        assert await verifier.verify_token("temporary-github-token") is None
+
+    assert requests == 1
 
 
-def test_verification_cache_is_disabled_and_no_exomem_cache_exists(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls = _stub_super(monkeypatch)
-    verifier = _verifier()
+@pytest.mark.anyio
+async def test_same_proof_is_fetched_once_per_verification_without_scope_request() -> None:
+    paths: list[str] = []
 
-    first = asyncio.run(verifier.verify_token("same-token"))
-    second = asyncio.run(verifier.verify_token("same-token"))
+    def github(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return _response(request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(github)) as client:
+        verifier = SingleUserGitHubVerifier(
+            allowed_login=ALLOWED_LOGIN,
+            allowed_user_id=ALLOWED_ID,
+            http_client=client,
+        )
+        first = await verifier.verify_token("same-token")
+        second = await verifier.verify_token("same-token")
 
     assert first is not None and second is not None
-    assert calls["count"] == 2
+    assert paths == ["/user", "/user"]
     assert verifier._cache.enabled is False
     assert verifier._cache._entries == {}
-    assert not hasattr(verifier, "_login_cache")
 
 
-def test_boolean_claim_is_not_accepted_as_numeric_user_id(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.anyio
+@pytest.mark.parametrize("status_code", [401, 403, 429, 503])
+async def test_github_failure_alert_is_secret_safe(
+    status_code: int,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    async def fake(self, token):  # noqa: ANN001
-        del self
-        return SimpleNamespace(
-            claims={"login": ALLOWED_LOGIN, "sub": True},
-            client_id="1",
-            token=token,
+    bearer = "temporary-github-token-must-not-be-logged"
+
+    def github(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            text=f"provider echoed {bearer}",
+            request=request,
         )
 
-    monkeypatch.setattr(GitHubTokenVerifier, "verify_token", fake)
-    verifier = SingleUserGitHubVerifier(allowed_login=ALLOWED_LOGIN, allowed_user_id=1)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(github)) as client:
+        verifier = SingleUserGitHubVerifier(
+            allowed_login=ALLOWED_LOGIN,
+            allowed_user_id=ALLOWED_ID,
+            http_client=client,
+        )
+        assert await verifier.verify_token(bearer) is None
 
-    assert asyncio.run(verifier.verify_token("temporary-github-token")) is None
+    assert bearer not in caplog.text
+    assert str(status_code) in caplog.text
 
 
 @pytest.mark.parametrize("user_id", [0, -1, True])

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -1,147 +1,113 @@
-"""SingleUserGitHubVerifier's TTL cache for validated GitHub tokens.
-
-Most tests stub the real GitHub round-trip (`super().verify_token`) with a call-counter
-so they assert the *caching contract* without any network: a validated token is served
-from cache within the TTL, distinct tokens validate independently, rejections are never
-cached (instant recovery), and TTL=0 disables caching. The final test deliberately does
-*not* stub `super().verify_token` (only the HTTP call) so the real parent code path runs
-— a regression guard for the `_cache` attribute-shadowing bug those stubbed tests missed.
-"""
+"""One-shot GitHub identity verification must never cache bearer material."""
 
 from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
 
-import httpx
 import pytest
 from fastmcp.server.auth.providers.github import GitHubTokenVerifier
-from fastmcp.utilities.token_cache import TokenCache
 
-from exomem.server import SingleUserGitHubVerifier
+from exomem.server_auth import SingleUserGitHubVerifier
 
-ALLOWED = "artexis10"
+ALLOWED_LOGIN = "person"
+ALLOWED_ID = 123456
 
 
 def _verifier() -> SingleUserGitHubVerifier:
-    return SingleUserGitHubVerifier(allowed_login=ALLOWED)
+    return SingleUserGitHubVerifier(
+        allowed_login=ALLOWED_LOGIN,
+        allowed_user_id=ALLOWED_ID,
+    )
 
 
-def _stub_super(monkeypatch: pytest.MonkeyPatch, *, login: str | None):
-    """Patch the parent verify_token to count calls; returns the call counter.
+def _stub_super(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    login: str | None = ALLOWED_LOGIN,
+    user_id: object = ALLOWED_ID,
+) -> dict[str, int]:
+    calls = {"count": 0}
 
-    `login=None` simulates GitHub rejecting the token (returns None)."""
-    calls = {"n": 0}
-
-    async def fake(self, token):  # noqa: ANN001 — test stub
-        calls["n"] += 1
+    async def fake(self, token):  # noqa: ANN001
+        del self
+        calls["count"] += 1
         if login is None:
             return None
-        return SimpleNamespace(claims={"login": login}, token=token)
+        return SimpleNamespace(
+            claims={"login": login, "sub": str(user_id)},
+            client_id=str(user_id),
+            token=token,
+        )
 
     monkeypatch.setattr(GitHubTokenVerifier, "verify_token", fake)
     return calls
 
 
-def test_validated_token_is_served_from_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch, login=ALLOWED)
-    v = _verifier()
+def test_exact_login_and_immutable_id_are_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_super(monkeypatch)
+    verifier = _verifier()
 
-    a1 = asyncio.run(v.verify_token("tok"))
-    a2 = asyncio.run(v.verify_token("tok"))
+    result = asyncio.run(verifier.verify_token("temporary-github-token"))
 
-    assert a1 is not None and a2 is a1  # same cached object
-    assert calls["n"] == 1  # second call hit the cache, not GitHub
-
-
-def test_distinct_tokens_validate_independently(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch, login=ALLOWED)
-    v = _verifier()
-
-    asyncio.run(v.verify_token("tok-a"))
-    asyncio.run(v.verify_token("tok-b"))
-
-    assert calls["n"] == 2  # different cache keys → each validated once
+    assert result is not None
+    assert calls["count"] == 1
 
 
-def test_expired_entry_revalidates(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch, login=ALLOWED)
-    v = _verifier()
+@pytest.mark.parametrize(
+    ("login", "user_id"),
+    [
+        ("someone-else", ALLOWED_ID),
+        (None, ALLOWED_ID),
+        (ALLOWED_LOGIN, 999),
+        (ALLOWED_LOGIN, None),
+        (ALLOWED_LOGIN, "not-numeric"),
+    ],
+)
+def test_wrong_or_missing_identity_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    login: str | None,
+    user_id: object,
+) -> None:
+    _stub_super(monkeypatch, login=login, user_id=user_id)
 
-    asyncio.run(v.verify_token("tok"))
-    # Rewind the cached timestamp well past the TTL to simulate expiry.
-    (key,) = v._login_cache.keys()
-    ts, access = v._login_cache[key]
-    v._login_cache[key] = (ts - 10_000.0, access)
-    asyncio.run(v.verify_token("tok"))
-
-    assert calls["n"] == 2  # expired → re-hit GitHub
-
-
-def test_github_rejection_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch, login=None)  # GitHub says no
-    v = _verifier()
-
-    assert asyncio.run(v.verify_token("tok")) is None
-    assert asyncio.run(v.verify_token("tok")) is None
-    assert calls["n"] == 2  # re-checked each time — recovery is instant after re-auth
-    assert not v._login_cache
+    assert asyncio.run(_verifier().verify_token("temporary-github-token")) is None
 
 
-def test_wrong_login_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _stub_super(monkeypatch, login="someone-else")
-    v = _verifier()
-
-    assert asyncio.run(v.verify_token("tok")) is None
-    assert asyncio.run(v.verify_token("tok")) is None
-    assert calls["n"] == 2  # only the *allowed* login is ever cached
-    assert not v._login_cache
-
-
-def test_ttl_zero_disables_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("EXOMEM_AUTH_CACHE_TTL", "0")
-    calls = _stub_super(monkeypatch, login=ALLOWED)
-    v = _verifier()
-
-    asyncio.run(v.verify_token("tok"))
-    asyncio.run(v.verify_token("tok"))
-
-    assert calls["n"] == 2  # caching off → every call revalidates
-    assert not v._login_cache
-
-
-def test_real_super_verify_does_not_crash_on_cache_miss(
+def test_verification_cache_is_disabled_and_no_exomem_cache_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression: do NOT shadow the parent GitHubTokenVerifier's ``_cache``.
+    calls = _stub_super(monkeypatch)
+    verifier = _verifier()
 
-    Every other test in this file replaces ``GitHubTokenVerifier.verify_token``
-    wholesale, so none of them exercise the parent's first line —
-    ``is_cached, cached_result = self._cache.get(token)``. When exomem's verifier
-    overwrote ``self._cache`` with a plain ``dict``, that line unpacked
-    ``dict.get(token)``'s ``None`` return → ``TypeError: cannot unpack
-    non-iterable NoneType object`` → the OAuth token-swap failed → every
-    authenticated ``/mcp`` request returned 401. This test runs the REAL
-    ``super().verify_token`` (only the GitHub HTTP call is stubbed) so the
-    regression is caught locally.
-    """
+    first = asyncio.run(verifier.verify_token("same-token"))
+    second = asyncio.run(verifier.verify_token("same-token"))
 
-    class _FakeResp:
-        status_code = 401
-        text = "unauthorized"
-        headers: dict[str, str] = {}
+    assert first is not None and second is not None
+    assert calls["count"] == 2
+    assert verifier._cache.enabled is False
+    assert verifier._cache._entries == {}
+    assert not hasattr(verifier, "_login_cache")
 
-        def json(self) -> dict[str, object]:  # pragma: no cover — 401 path returns early
-            return {}
 
-    async def _fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
-        return _FakeResp()
+def test_boolean_claim_is_not_accepted_as_numeric_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(self, token):  # noqa: ANN001
+        del self
+        return SimpleNamespace(
+            claims={"login": ALLOWED_LOGIN, "sub": True},
+            client_id="1",
+            token=token,
+        )
 
-    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    monkeypatch.setattr(GitHubTokenVerifier, "verify_token", fake)
+    verifier = SingleUserGitHubVerifier(allowed_login=ALLOWED_LOGIN, allowed_user_id=1)
 
-    v = _verifier()
-    # A GitHub-rejected token must resolve to None, not raise the unpack TypeError
-    # the parent's `self._cache.get(token)` throws when `_cache` is a plain dict.
-    assert asyncio.run(v.verify_token("tok")) is None
-    # And the parent class must still own ``_cache`` as its TokenCache.
-    assert isinstance(v._cache, TokenCache)
+    assert asyncio.run(verifier.verify_token("temporary-github-token")) is None
+
+
+@pytest.mark.parametrize("user_id", [0, -1, True])
+def test_verifier_refuses_non_positive_immutable_id(user_id: object) -> None:
+    with pytest.raises(ValueError, match="positive numeric"):
+        SingleUserGitHubVerifier(allowed_login=ALLOWED_LOGIN, allowed_user_id=user_id)

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import replace
 
 import pytest
 
-from exomem import server_auth
+from exomem import env_compat, server_auth
 from exomem.__main__ import main
 from exomem.auth_sessions import SessionRecord, SessionStoreUnavailable
 
@@ -31,7 +32,7 @@ def _record(*, generation: str = "current", status: str = "active") -> SessionRe
 
 class FakeAuthority:
     def __init__(self, records: list[SessionRecord] | None = None) -> None:
-        self.records = records or [_record()]
+        self.records = [_record()] if records is None else records
         self.tombstone_calls: list[tuple[str, str]] = []
         self.replace_calls = 0
 
@@ -167,6 +168,52 @@ def test_auth_missing_config_exits_two(
 
     assert main(["auth", "sessions"]) == 2
     assert "EXOMEM_BASE_URL" in capsys.readouterr().err
+
+
+def test_auth_promotes_legacy_env_after_loading_dotenv(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    authority = FakeAuthority([])
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+    monkeypatch.delenv("KB_MCP_BASE_URL", raising=False)
+
+    def load_env(*, override: bool) -> None:
+        assert override is True
+        monkeypatch.setenv("KB_MCP_BASE_URL", "https://legacy.example.com")
+
+    seen: list[str] = []
+    monkeypatch.setattr("dotenv.load_dotenv", load_env)
+    monkeypatch.setattr(env_compat, "_advised", False)
+    monkeypatch.setattr(
+        server_auth,
+        "build_session_authority",
+        lambda *, base_url: seen.append(base_url) or authority,
+        raising=False,
+    )
+
+    assert main(["auth", "sessions", "--json"]) == 0
+    assert seen == ["https://legacy.example.com"]
+    assert json.loads(capsys.readouterr().out) == {"sessions": []}
+    os.environ.pop("EXOMEM_BASE_URL", None)
+
+
+def test_auth_factory_storage_failure_exits_one_without_details(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com")
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+
+    def fail_factory(*, base_url: str):
+        raise OSError(f"cannot create store for {base_url} with secret-token")
+
+    monkeypatch.setattr(
+        server_auth, "build_session_authority", fail_factory, raising=False
+    )
+
+    assert main(["auth", "sessions"]) == 1
+    error = capsys.readouterr().err
+    assert "session authority unavailable" in error
+    assert "secret-token" not in error
 
 
 def test_auth_authority_failure_exits_one(

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -216,6 +216,34 @@ def test_auth_factory_storage_failure_exits_one_without_details(
     assert "secret-token" not in error
 
 
+def test_auth_real_oauth_configuration_error_exits_two(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The merged session helper uses RuntimeError for invalid OAuth env."""
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com")
+    monkeypatch.setenv("GITHUB_CLIENT_ID", "github-client")
+    monkeypatch.setenv("GITHUB_CLIENT_SECRET", "github-secret")
+    monkeypatch.setenv("EXOMEM_GITHUB_USERNAME", "octocat")
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_URL", "https://coordinator.example")
+    monkeypatch.delenv("EXOMEM_JWT_SIGNING_KEY", raising=False)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+
+    def representative_session_helper(*, base_url: str):
+        return server_auth.build_oauth(require_auth=True, base_url=base_url)
+
+    monkeypatch.setattr(
+        server_auth,
+        "build_session_authority",
+        representative_session_helper,
+        raising=False,
+    )
+
+    assert main(["auth", "sessions"]) == 2
+    error = capsys.readouterr().err
+    assert "auth configuration error" in error
+    assert "EXOMEM_JWT_SIGNING_KEY" in error
+
+
 def test_auth_authority_failure_exits_one(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from exomem import server_auth
+from exomem.__main__ import main
+from exomem.auth_sessions import SessionRecord, SessionStoreUnavailable
+
+
+def _record(*, generation: str = "current", status: str = "active") -> SessionRecord:
+    return SessionRecord(
+        schema_version=1,
+        session_id="abcdefghijklmnop",
+        token_digest="0" * 64,
+        client_id="codex-client",
+        scopes=("read",),
+        issuer="https://kb.example.com",
+        audience="https://kb.example.com/mcp",
+        github_user_id=1234,
+        github_login="octocat",
+        issued_at=1_700_000_000.0,
+        generation=generation,
+        status=status,  # type: ignore[arg-type]
+        revoked_at=1_700_000_001.0 if status == "revoked" else None,
+        revocation_reason="operator" if status == "revoked" else None,
+    )
+
+
+class FakeAuthority:
+    def __init__(self, records: list[SessionRecord] | None = None) -> None:
+        self.records = records or [_record()]
+        self.tombstone_calls: list[tuple[str, str]] = []
+        self.replace_calls = 0
+
+    async def list_sessions(self) -> list[SessionRecord]:
+        return self.records
+
+    async def current_generation(self) -> str:
+        return "current"
+
+    async def tombstone(self, session_id: str, *, reason: str) -> bool:
+        self.tombstone_calls.append((session_id, reason))
+        return session_id == "abcdefghijklmnop"
+
+    async def replace_generation(self) -> str:
+        self.replace_calls += 1
+        return "new-secret-generation"
+
+
+def _install_authority(
+    monkeypatch: pytest.MonkeyPatch, authority: FakeAuthority
+) -> list[str]:
+    dotenv_calls: list[str] = []
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com/")
+    monkeypatch.setattr(
+        "dotenv.load_dotenv",
+        lambda *, override: dotenv_calls.append(f"override={override}"),
+    )
+    monkeypatch.setattr(
+        server_auth,
+        "build_session_authority",
+        lambda *, base_url: (
+            authority
+            if base_url == "https://kb.example.com"
+            else pytest.fail(f"unexpected base URL: {base_url}")
+        ),
+        raising=False,
+    )
+    return dotenv_calls
+
+
+def test_auth_sessions_json_is_secret_free_and_marks_generation_revoked(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    records = [
+        _record(),
+        replace(_record(), session_id="qrstuvwxyzABCDEF", generation="old"),
+    ]
+    authority = FakeAuthority(records)
+    dotenv_calls = _install_authority(monkeypatch, authority)
+
+    assert main(["auth", "sessions", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert dotenv_calls == ["override=True"]
+    assert payload == {
+        "sessions": [
+            {
+                "session_id": "abcdefghijklmnop",
+                "client_id": "codex-client",
+                "scopes": ["read"],
+                "github_login": "octocat",
+                "github_user_id": 1234,
+                "issued_at": 1_700_000_000.0,
+                "status": "active",
+            },
+            {
+                "session_id": "qrstuvwxyzABCDEF",
+                "client_id": "codex-client",
+                "scopes": ["read"],
+                "github_login": "octocat",
+                "github_user_id": 1234,
+                "issued_at": 1_700_000_000.0,
+                "status": "generation_revoked",
+            },
+        ]
+    }
+    rendered = json.dumps(payload)
+    assert "token_digest" not in rendered
+    assert '"generation":' not in rendered
+    assert "new-secret-generation" not in rendered
+
+
+def test_auth_revoke_one_uses_tombstone_and_custom_reason(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    authority = FakeAuthority()
+    _install_authority(monkeypatch, authority)
+
+    assert main([
+        "auth", "revoke", "abcdefghijklmnop", "--reason", "lost laptop", "--json"
+    ]) == 0
+
+    assert authority.tombstone_calls == [("abcdefghijklmnop", "lost laptop")]
+    assert json.loads(capsys.readouterr().out) == {
+        "revoked": True,
+        "session_id": "abcdefghijklmnop",
+    }
+
+
+def test_auth_revoke_all_replaces_generation_without_printing_it(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    authority = FakeAuthority()
+    _install_authority(monkeypatch, authority)
+
+    assert main(["auth", "revoke", "--all", "--json"]) == 0
+
+    assert authority.replace_calls == 1
+    output = capsys.readouterr().out
+    assert json.loads(output) == {"revoked_all": True}
+    assert "new-secret-generation" not in output
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["auth", "revoke"],
+        ["auth", "revoke", "abcdefghijklmnop", "--all"],
+        ["auth", "revoke", "--all", "--reason", ""],
+    ],
+)
+def test_auth_usage_errors_exit_two(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(argv)
+    assert exc.value.code == 2
+
+
+def test_auth_missing_config_exits_two(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+
+    assert main(["auth", "sessions"]) == 2
+    assert "EXOMEM_BASE_URL" in capsys.readouterr().err
+
+
+def test_auth_authority_failure_exits_one(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    authority = FakeAuthority()
+
+    async def unavailable() -> list[SessionRecord]:
+        raise SessionStoreUnavailable("coordinator rejected request with secret-token")
+
+    authority.list_sessions = unavailable  # type: ignore[method-assign]
+    _install_authority(monkeypatch, authority)
+
+    assert main(["auth", "sessions"]) == 1
+    error = capsys.readouterr().err
+    assert "session authority unavailable" in error
+    assert "secret-token" not in error

--- a/tests/test_auth_http_boundary.py
+++ b/tests/test_auth_http_boundary.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.middleware import RequireAuthMiddleware
+from key_value.aio.stores.memory import MemoryStore
+from pydantic import AnyHttpUrl
+from starlette.responses import JSONResponse
+
+from exomem.auth_sessions import SessionAuthority, SessionIdentity, SessionStoreUnavailable
+from exomem.session_oauth import ExomemSessionOAuthProxy, SessionStoreUnavailableMiddleware
+
+
+class Authority:
+    def __init__(self, result: Any = None) -> None:
+        self.result = result
+
+    async def validate(self, token: str) -> Any:
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class Verifier:
+    required_scopes: list[str] = []
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        raise AssertionError("ordinary session requests must not call GitHub")
+
+
+def _proxy(authority: Authority) -> ExomemSessionOAuthProxy:
+    return ExomemSessionOAuthProxy(
+        session_authority=authority,
+        upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
+        upstream_token_endpoint="https://github.com/login/oauth/access_token",
+        upstream_client_id="github-client",
+        upstream_client_secret="github-secret",
+        token_verifier=Verifier(),
+        base_url="https://memory.example",
+        client_storage=MemoryStore(),
+        jwt_signing_key="stable-signing-root",
+        require_authorization_consent=False,
+    )
+
+
+def _protected_app(proxy: ExomemSessionOAuthProxy) -> Any:
+    async def endpoint(scope: Any, receive: Any, send: Any) -> None:
+        await JSONResponse({"ok": True})(scope, receive, send)
+
+    app: Any = RequireAuthMiddleware(
+        endpoint,
+        required_scopes=[],
+        resource_metadata_url=AnyHttpUrl(
+            "https://memory.example/.well-known/oauth-protected-resource/mcp"
+        ),
+    )
+    for middleware in reversed(proxy.get_middleware()):
+        app = middleware.cls(app, *middleware.args, **middleware.kwargs)
+    return app
+
+
+@pytest.mark.anyio
+async def test_invalid_revoked_and_prior_format_tokens_keep_normal_401_challenge(
+    tmp_path: Path,
+) -> None:
+    current = SessionAuthority.local(
+        directory=tmp_path / "current",
+        signing_root="current-signing-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+    )
+    revoked, revoked_record = await current.issue(
+        client_id="codex-client",
+        scopes=["exomem:read"],
+        identity=SessionIdentity(github_user_id=123456, github_login="person"),
+    )
+    await current.tombstone(revoked_record.session_id, reason="test")
+
+    prior = SessionAuthority.local(
+        directory=tmp_path / "current",
+        signing_root="prior-signing-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+    )
+    prior_key_token, _ = await prior.issue(
+        client_id="codex-client",
+        scopes=["exomem:read"],
+        identity=SessionIdentity(github_user_id=123456, github_login="person"),
+    )
+    app = _protected_app(_proxy(current))
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://memory.example"
+    ) as client:
+        for presented in ("malformed", "legacy.jwt.token", revoked, prior_key_token):
+            response = await client.get(
+                "/mcp", headers={"Authorization": f"Bearer {presented}"}
+            )
+
+            assert response.status_code == 401
+            assert "invalid_token" in response.headers["www-authenticate"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        SessionStoreUnavailable("coordinator unavailable"),
+        SessionStoreUnavailable("session record decrypt failed"),
+    ],
+)
+async def test_authority_outage_or_corruption_returns_503_without_oauth_challenge(
+    failure: SessionStoreUnavailable,
+) -> None:
+    app = _protected_app(_proxy(Authority(failure)))
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://memory.example"
+    ) as client:
+        response = await client.get(
+            "/mcp", headers={"Authorization": "Bearer session-token"}
+        )
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "temporarily_unavailable"
+    assert "retry" in response.json()["error_description"].lower()
+    assert "www-authenticate" not in response.headers
+    assert response.headers["retry-after"] == "5"
+
+
+@pytest.mark.anyio
+async def test_boundary_does_not_reclassify_unrelated_exceptions() -> None:
+    app = _protected_app(_proxy(Authority(RuntimeError("programming error"))))
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app, raise_app_exceptions=True),
+        base_url="https://memory.example",
+    ) as client:
+        with pytest.raises(RuntimeError, match="programming error"):
+            await client.get("/mcp", headers={"Authorization": "Bearer session-token"})
+
+
+def test_store_unavailable_middleware_is_outermost() -> None:
+    middleware = _proxy(Authority(None)).get_middleware()
+
+    assert middleware[0].cls is SessionStoreUnavailableMiddleware

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from exomem.session_oauth import ExomemSessionOAuthProxy
+
+
+class Verifier:
+    required_scopes = ["exomem:read"]
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return None
+
+
+class Authority:
+    def __init__(self) -> None:
+        self.validations: list[str] = []
+        self.sessions = {"new-session": object()}
+
+    async def validate(self, token: str) -> Any:
+        self.validations.append(token)
+        return None
+
+
+def _kwargs(storage: MemoryStore) -> dict[str, Any]:
+    return {
+        "upstream_authorization_endpoint": "https://github.com/login/oauth/authorize",
+        "upstream_token_endpoint": "https://github.com/login/oauth/access_token",
+        "upstream_client_id": "github-client",
+        "upstream_client_secret": "github-secret",
+        "token_verifier": Verifier(),
+        "base_url": "https://memory.example",
+        "allowed_client_redirect_uris": ["http://127.0.0.1:*"],
+        "client_storage": storage,
+        "jwt_signing_key": "stable-signing-root",
+        "require_authorization_consent": False,
+    }
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="codex-client",
+        client_secret="client-secret",
+        redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
+        token_endpoint_auth_method="client_secret_post",
+    )
+
+
+def test_connector_routes_discovery_dcr_callback_and_consent_remain_compatible() -> None:
+    legacy = OAuthProxy(**_kwargs(MemoryStore()))
+    durable = ExomemSessionOAuthProxy(
+        session_authority=Authority(),
+        **_kwargs(MemoryStore()),
+    )
+
+    legacy_routes = legacy.get_routes("/mcp")
+    durable_routes = durable.get_routes("/mcp")
+    legacy_paths = {route.path for route in legacy_routes}
+    durable_paths = {route.path for route in durable_routes}
+    compatibility_paths = {
+        "/authorize",
+        "/token",
+        "/register",
+        "/auth/callback",
+        "/consent",
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-protected-resource/mcp",
+    }
+
+    assert compatibility_paths <= legacy_paths
+    assert compatibility_paths <= durable_paths
+    assert str(durable.base_url).rstrip("/") == "https://memory.example"
+    assert durable._redirect_path == legacy._redirect_path == "/auth/callback"
+    assert durable._forward_pkce is legacy._forward_pkce is True
+    assert durable._forward_resource is legacy._forward_resource is True
+
+
+@pytest.mark.anyio
+async def test_authorize_preserves_downstream_state_pkce_resource_and_redirect() -> None:
+    proxy = ExomemSessionOAuthProxy(
+        session_authority=Authority(),
+        **_kwargs(MemoryStore()),
+    )
+    proxy.get_routes("/mcp")
+    params = AuthorizationParams(
+        state="downstream-state",
+        scopes=["exomem:read"],
+        code_challenge="downstream-code-challenge",
+        redirect_uri=AnyUrl("http://127.0.0.1:8765/callback"),
+        redirect_uri_provided_explicitly=True,
+        resource="https://memory.example/mcp",
+    )
+
+    upstream_url = await proxy.authorize(_client(), params)
+
+    upstream_query = parse_qs(urlparse(upstream_url).query)
+    transaction_id = upstream_query["state"][0]
+    transaction = await proxy._transaction_store.get(key=transaction_id)
+    assert transaction is not None
+    assert transaction.client_state == "downstream-state"
+    assert transaction.client_redirect_uri == "http://127.0.0.1:8765/callback"
+    assert transaction.code_challenge == "downstream-code-challenge"
+    assert transaction.resource == "https://memory.example/mcp"
+    assert transaction.proxy_code_verifier
+    assert upstream_query["code_challenge"][0] != "downstream-code-challenge"
+
+
+@pytest.mark.anyio
+async def test_legacy_jti_and_upstream_records_are_not_dual_read_or_mutated() -> None:
+    storage = MemoryStore()
+    await storage.put(
+        "legacy-jti",
+        {"sentinel": "jti-preserved"},
+        collection="mcp-jti-mappings",
+    )
+    await storage.put(
+        "legacy-upstream",
+        {"sentinel": "upstream-preserved"},
+        collection="mcp-upstream-tokens",
+    )
+    authority = Authority()
+    proxy = ExomemSessionOAuthProxy(
+        session_authority=authority,
+        **_kwargs(storage),
+    )
+
+    assert await proxy.load_access_token("legacy.fastmcp.jwt") is None
+
+    assert authority.validations == ["legacy.fastmcp.jwt"]
+    assert await storage.get("legacy-jti", collection="mcp-jti-mappings") == {
+        "sentinel": "jti-preserved"
+    }
+    assert await storage.get("legacy-upstream", collection="mcp-upstream-tokens") == {
+        "sentinel": "upstream-preserved"
+    }
+
+
+@pytest.mark.anyio
+async def test_rollback_provider_leaves_new_session_state_inert_and_legacy_state_available() -> None:
+    storage = MemoryStore()
+    await storage.put(
+        "legacy-record",
+        {"sentinel": "rollback"},
+        collection="mcp-upstream-tokens",
+    )
+    authority = Authority()
+    legacy = OAuthProxy(**_kwargs(storage))
+    legacy.get_routes("/mcp")
+
+    assert await legacy.load_access_token("new-session") is None
+
+    assert authority.sessions == {"new-session": authority.sessions["new-session"]}
+    assert await storage.get("legacy-record", collection="mcp-upstream-tokens") == {
+        "sentinel": "rollback"
+    }

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -140,35 +140,95 @@ def test_connector_routes_discovery_dcr_callback_and_consent_remain_compatible()
     assert durable._forward_resource is legacy._forward_resource is True
 
 
+def _registration_payload(grant_types: list[str]) -> dict[str, Any]:
+    return {
+        "client_name": "Codex compatibility client",
+        "redirect_uris": ["http://127.0.0.1:8765/callback"],
+        "token_endpoint_auth_method": "none",
+        "grant_types": grant_types,
+        "response_types": ["code"],
+        "scope": "exomem:read",
+    }
+
+
+def _stable_registration_fields(body: dict[str, Any]) -> dict[str, Any]:
+    unstable = {
+        "client_id",
+        "client_secret",
+        "client_id_issued_at",
+        "client_secret_expires_at",
+    }
+    return {key: value for key, value in body.items() if key not in unstable}
+
+
 @pytest.mark.anyio
-async def test_discovery_and_dcr_advertise_authorization_code_without_refresh() -> None:
-    proxy = ExomemSessionOAuthProxy(
+async def test_discovery_and_real_http_dcr_match_legacy_fastmcp() -> None:
+    legacy = OAuthProxy(**_kwargs(MemoryStore()))
+    durable = ExomemSessionOAuthProxy(
         session_authority=Authority(),
         **_kwargs(MemoryStore()),
     )
-    app = Starlette(routes=proxy.get_routes("/mcp"))
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="https://memory.example",
-    ) as client:
-        metadata = await client.get("/.well-known/oauth-authorization-server")
+    legacy_app = Starlette(routes=legacy.get_routes("/mcp"))
+    durable_app = Starlette(routes=durable.get_routes("/mcp"))
+    async with (
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=legacy_app),
+            base_url="https://memory.example",
+        ) as legacy_client,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=durable_app),
+            base_url="https://memory.example",
+        ) as durable_client,
+    ):
+        legacy_metadata = await legacy_client.get(
+            "/.well-known/oauth-authorization-server"
+        )
+        durable_metadata = await durable_client.get(
+            "/.well-known/oauth-authorization-server"
+        )
+        auth_code_only = _registration_payload(["authorization_code"])
+        legacy_auth_code_only = await legacy_client.post(
+            "/register", json=auth_code_only
+        )
+        durable_auth_code_only = await durable_client.post(
+            "/register", json=auth_code_only
+        )
+        both_grants = _registration_payload(
+            ["authorization_code", "refresh_token"]
+        )
+        legacy_both = await legacy_client.post("/register", json=both_grants)
+        durable_both = await durable_client.post("/register", json=both_grants)
 
-    assert metadata.status_code == 200
-    assert metadata.json()["grant_types_supported"] == ["authorization_code"]
-
-    registered = _client("registered-client")
-    await proxy.register_client(registered)
-    assert registered.grant_types == ["authorization_code"]
-    assert (await proxy.get_client("registered-client")).grant_types == [
-        "authorization_code"
+    assert legacy_metadata.status_code == durable_metadata.status_code == 200
+    assert durable_metadata.json()["grant_types_supported"] == legacy_metadata.json()[
+        "grant_types_supported"
     ]
-
-    legacy = _client("legacy-client")
-    await OAuthProxy.register_client(proxy, legacy)
-    assert "refresh_token" in (await proxy._client_store.get(key="legacy-client")).grant_types
-    assert (await proxy.get_client("legacy-client")).grant_types == [
-        "authorization_code"
+    assert durable_metadata.json()["grant_types_supported"] == [
+        "authorization_code",
+        "refresh_token",
     ]
+    durable_metadata_without_local_revocation = durable_metadata.json()
+    durable_metadata_without_local_revocation.pop("revocation_endpoint")
+    durable_metadata_without_local_revocation.pop(
+        "revocation_endpoint_auth_methods_supported"
+    )
+    assert durable_metadata_without_local_revocation == legacy_metadata.json()
+
+    assert durable_auth_code_only.status_code == legacy_auth_code_only.status_code
+    assert durable_auth_code_only.json() == legacy_auth_code_only.json()
+
+    assert durable_both.status_code == legacy_both.status_code == 201
+    durable_registration = durable_both.json()
+    legacy_registration = legacy_both.json()
+    assert _stable_registration_fields(durable_registration) == (
+        _stable_registration_fields(legacy_registration)
+    )
+    assert durable_registration["grant_types"] == legacy_registration["grant_types"] == [
+        "authorization_code",
+        "refresh_token",
+    ]
+    assert durable_registration["client_id"]
+    assert legacy_registration["client_id"]
 
 
 @pytest.mark.anyio

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
+import json
+import time
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
+import httpx
 import pytest
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import (
+    JTIMapping,
+    RefreshTokenMetadata,
+    UpstreamTokenSet,
+    _hash_token,
+)
 from key_value.aio.stores.memory import MemoryStore
-from mcp.server.auth.provider import AuthorizationParams
+from mcp.server.auth.provider import (
+    AuthorizationParams,
+    RefreshToken,
+    TokenError,
+)
+from mcp.server.auth.routes import RevocationHandler, TokenHandler
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
+from starlette.applications import Starlette
+from starlette.requests import Request
 
 from exomem.session_oauth import ExomemSessionOAuthProxy
 
@@ -17,7 +33,11 @@ from exomem.session_oauth import ExomemSessionOAuthProxy
 class Verifier:
     required_scopes = ["exomem:read"]
 
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
     async def verify_token(self, token: str) -> AccessToken | None:
+        self.calls.append(token)
         return None
 
 
@@ -46,12 +66,48 @@ def _kwargs(storage: MemoryStore) -> dict[str, Any]:
     }
 
 
-def _client() -> OAuthClientInformationFull:
+def _client(client_id: str = "codex-client") -> OAuthClientInformationFull:
     return OAuthClientInformationFull(
-        client_id="codex-client",
+        client_id=client_id,
         client_secret="client-secret",
         redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
         token_endpoint_auth_method="client_secret_post",
+    )
+
+
+class ClientAuthenticator:
+    async def authenticate_request(self, request: Request) -> OAuthClientInformationFull:
+        return _client()
+
+
+def _form_request(path: str, values: dict[str, str]) -> Request:
+    body = urlencode(values).encode()
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [
+                (b"content-type", b"application/x-www-form-urlencoded"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("memory.example", 443),
+        },
+        receive,
     )
 
 
@@ -82,6 +138,37 @@ def test_connector_routes_discovery_dcr_callback_and_consent_remain_compatible()
     assert durable._redirect_path == legacy._redirect_path == "/auth/callback"
     assert durable._forward_pkce is legacy._forward_pkce is True
     assert durable._forward_resource is legacy._forward_resource is True
+
+
+@pytest.mark.anyio
+async def test_discovery_and_dcr_advertise_authorization_code_without_refresh() -> None:
+    proxy = ExomemSessionOAuthProxy(
+        session_authority=Authority(),
+        **_kwargs(MemoryStore()),
+    )
+    app = Starlette(routes=proxy.get_routes("/mcp"))
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="https://memory.example",
+    ) as client:
+        metadata = await client.get("/.well-known/oauth-authorization-server")
+
+    assert metadata.status_code == 200
+    assert metadata.json()["grant_types_supported"] == ["authorization_code"]
+
+    registered = _client("registered-client")
+    await proxy.register_client(registered)
+    assert registered.grant_types == ["authorization_code"]
+    assert (await proxy.get_client("registered-client")).grant_types == [
+        "authorization_code"
+    ]
+
+    legacy = _client("legacy-client")
+    await OAuthProxy.register_client(proxy, legacy)
+    assert "refresh_token" in (await proxy._client_store.get(key="legacy-client")).grant_types
+    assert (await proxy.get_client("legacy-client")).grant_types == [
+        "authorization_code"
+    ]
 
 
 @pytest.mark.anyio
@@ -142,6 +229,134 @@ async def test_legacy_jti_and_upstream_records_are_not_dual_read_or_mutated() ->
     assert await storage.get("legacy-upstream", collection="mcp-upstream-tokens") == {
         "sentinel": "upstream-preserved"
     }
+
+
+@pytest.mark.anyio
+async def test_refresh_and_revocation_paths_never_read_or_mutate_legacy_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryStore()
+    authority = Authority()
+    proxy = ExomemSessionOAuthProxy(
+        session_authority=authority,
+        **_kwargs(storage),
+    )
+    proxy.get_routes("/mcp")
+    refresh_jti = "legacy-refresh-jti"
+    refresh_token = proxy.jwt_issuer.issue_refresh_token(
+        client_id="codex-client",
+        scopes=["exomem:read"],
+        jti=refresh_jti,
+        expires_in=3600,
+    )
+    real_refresh_key = _hash_token(refresh_token)
+    await proxy._refresh_token_store.put(
+        key=real_refresh_key,
+        value=RefreshTokenMetadata(
+            client_id="codex-client",
+            scopes=["exomem:read"],
+            expires_at=int(time.time() + 3600),
+            created_at=time.time(),
+        ),
+        ttl=3600,
+    )
+    # Seed recognizable preserved records in every legacy collection.
+    await proxy._jti_mapping_store.put(
+        key=refresh_jti,
+        value=JTIMapping(
+            jti=refresh_jti,
+            upstream_token_id="legacy-upstream",
+            created_at=time.time(),
+        ),
+        ttl=3600,
+    )
+    await proxy._upstream_token_store.put(
+        key="legacy-upstream",
+        value=UpstreamTokenSet(
+            upstream_token_id="legacy-upstream",
+            access_token="legacy-access-secret",
+            refresh_token="legacy-refresh-secret",
+            refresh_token_expires_at=time.time() + 3600,
+            expires_at=time.time() + 3600,
+            token_type="Bearer",
+            scope="exomem:read",
+            client_id="codex-client",
+            created_at=time.time(),
+            raw_token_data={"access_token": "legacy-access-secret"},
+        ),
+        ttl=3600,
+    )
+
+    before = {
+        "refresh": await storage.get(real_refresh_key, collection="mcp-refresh-tokens"),
+        "jti": await storage.get(refresh_jti, collection="mcp-jti-mappings"),
+        "upstream": await storage.get(
+            "legacy-upstream", collection="mcp-upstream-tokens"
+        ),
+    }
+
+    async def forbidden_legacy_access(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("durable provider touched a preserved legacy OAuth store")
+
+    for adapter in (
+        proxy._refresh_token_store,
+        proxy._jti_mapping_store,
+        proxy._upstream_token_store,
+    ):
+        monkeypatch.setattr(adapter, "get", forbidden_legacy_access)
+        monkeypatch.setattr(adapter, "put", forbidden_legacy_access)
+        monkeypatch.setattr(adapter, "delete", forbidden_legacy_access)
+
+    assert await proxy.load_refresh_token(_client(), refresh_token) is None
+    with pytest.raises(TokenError, match="Refresh tokens are not supported"):
+        await proxy.exchange_refresh_token(
+            _client(),
+            RefreshToken(
+                token=refresh_token,
+                client_id="codex-client",
+                scopes=["exomem:read"],
+                expires_at=int(time.time() + 3600),
+            ),
+            ["exomem:read"],
+        )
+
+    token_response = await TokenHandler(proxy, ClientAuthenticator()).handle(
+        _form_request(
+            "/token",
+            {
+                "grant_type": "refresh_token",
+                "client_id": "codex-client",
+                "client_secret": "client-secret",
+                "refresh_token": refresh_token,
+            },
+        )
+    )
+    assert token_response.status_code == 400
+    assert json.loads(token_response.body)["error"] == "invalid_grant"
+
+    revoke_response = await RevocationHandler(proxy, ClientAuthenticator()).handle(
+        _form_request(
+            "/revoke",
+            {
+                "token": refresh_token,
+                "token_type_hint": "refresh_token",
+                "client_id": "codex-client",
+                "client_secret": "client-secret",
+            },
+        )
+    )
+    assert revoke_response.status_code == 200
+    assert authority.validations == [refresh_token]
+    assert proxy._token_validator.calls == []
+
+    after = {
+        "refresh": await storage.get(real_refresh_key, collection="mcp-refresh-tokens"),
+        "jti": await storage.get(refresh_jti, collection="mcp-jti-mappings"),
+        "upstream": await storage.get(
+            "legacy-upstream", collection="mcp-upstream-tokens"
+        ),
+    }
+    assert after == before
 
 
 @pytest.mark.anyio

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import multiprocessing
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ from exomem.auth_sessions import (
     SessionIdentity,
     SessionStoreUnavailable,
     SessionTokenCodec,
+    _InterprocessFileLock,
     derive_session_keys,
 )
 
@@ -71,6 +73,77 @@ class AtomicMemoryStore:
 
     async def list_keys(self, *, collection: str | None = None) -> list[str]:
         return sorted(key for coll, key in self.data if coll == collection)
+
+
+class NonAtomicMemoryStore:
+    def __init__(self) -> None:
+        self.data: dict[tuple[str | None, str], dict[str, Any]] = {}
+
+    async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
+        return self.data.get((collection, key))
+
+    async def put(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        del ttl
+        self.data[(collection, key)] = dict(value)
+
+    async def list_keys(self, *, collection: str | None = None) -> list[str]:
+        return sorted(key for coll, key in self.data if coll == collection)
+
+
+def _multiprocess_generation_worker(
+    directory: str,
+    start: Any,
+    barrier: Any,
+    results: Any,
+) -> None:
+    async def run() -> None:
+        authority = SessionAuthority.local(
+            directory=Path(directory),
+            signing_root="stable-root",
+            issuer="https://memory.example",
+            audience="https://memory.example/mcp",
+        )
+        backend = authority._storage.raw
+        original_get = backend.get
+        original_put = backend.store.put
+        first_generation_read = True
+
+        async def synchronized_get(
+            key: str, *, collection: str | None = None
+        ) -> dict[str, Any] | None:
+            nonlocal first_generation_read
+            value = await original_get(key, collection=collection)
+            if first_generation_read and key == "current":
+                first_generation_read = False
+                await asyncio.to_thread(barrier.wait)
+            return value
+
+        async def delayed_put(*args: Any, **kwargs: Any) -> None:
+            await asyncio.sleep(0.2)
+            await original_put(*args, **kwargs)
+
+        backend.get = synchronized_get
+        backend.store.put = delayed_put
+        await asyncio.to_thread(start.wait)
+        results.put(await authority.current_generation())
+
+    asyncio.run(run())
+
+
+def _multiprocess_lock_holder(path: str, ready: Any, release: Any) -> None:
+    async def run() -> None:
+        async with _InterprocessFileLock(Path(path), timeout=2):
+            ready.set()
+            await asyncio.to_thread(release.wait)
+
+    asyncio.run(run())
 
 
 def _authority(
@@ -137,6 +210,25 @@ def test_key_derivation_is_purpose_separated_and_fingerprinted() -> None:
     assert first.hmac_key != first.storage_key
     assert first.fingerprint != rotated.fingerprint
     assert "explicit-root" not in repr(first)
+
+
+def test_key_and_parsed_token_repr_do_not_expose_secret_material() -> None:
+    keys = derive_session_keys("explicit-root")
+    codec = SessionTokenCodec(keys.hmac_key)
+    bearer, _, _ = codec.issue()
+    parsed = codec.parse(bearer)
+
+    assert parsed is not None
+    assert "hmac_key=" not in repr(keys)
+    assert "storage_key=" not in repr(keys)
+    assert parsed.secret not in repr(parsed)
+
+
+def test_session_authority_exposes_only_nonsecret_key_fingerprint() -> None:
+    authority = _authority(AtomicMemoryStore())
+
+    assert not hasattr(authority, "keys")
+    assert authority.fingerprint == derive_session_keys("test-signing-root").fingerprint
 
 
 def test_identity_normalizes_login_and_rejects_invalid_values() -> None:
@@ -228,6 +320,19 @@ async def test_store_and_cipher_failures_are_distinct_from_invalid_sessions() ->
 
 
 @pytest.mark.anyio
+async def test_generation_initialization_refuses_non_atomic_storage() -> None:
+    authority = SessionAuthority(
+        storage=NonAtomicMemoryStore(),
+        signing_root="stable-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+    )
+
+    with pytest.raises(SessionStoreUnavailable, match="atomic put-if-absent"):
+        await authority.current_generation()
+
+
+@pytest.mark.anyio
 async def test_replace_generation_invalidates_every_existing_session() -> None:
     raw = AtomicMemoryStore()
     authority = _authority(raw)
@@ -254,6 +359,62 @@ async def test_generation_initialization_is_atomic_across_authorities() -> None:
 
     assert first_result[1].generation == second_result[1].generation
     assert await first.validate(second_result[0]) == second_result[1]
+
+
+def test_local_generation_initialization_is_atomic_across_processes(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    barrier = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_multiprocess_generation_worker,
+            args=(str(tmp_path), start, barrier, results),
+        )
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(timeout=20)
+    try:
+        assert [process.exitcode for process in processes] == [0, 0]
+        generations = [results.get(timeout=2) for _ in processes]
+        assert generations[0] == generations[1]
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+
+@pytest.mark.anyio
+async def test_live_interprocess_lock_is_never_reclaimed_by_elapsed_time(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    lock_path = tmp_path / "authority.lock"
+    holder = context.Process(
+        target=_multiprocess_lock_holder,
+        args=(str(lock_path), ready, release),
+    )
+    holder.start()
+    try:
+        assert await asyncio.to_thread(ready.wait, 15)
+        with pytest.raises(SessionStoreUnavailable, match="timed out"):
+            async with _InterprocessFileLock(lock_path, timeout=0.1):
+                pytest.fail("a live interprocess lock was stolen")
+    finally:
+        release.set()
+        holder.join(timeout=5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(timeout=5)
+    assert holder.exitcode == 0
+
+    async with _InterprocessFileLock(lock_path, timeout=1):
+        pass
 
 
 @pytest.mark.anyio
@@ -303,3 +464,41 @@ async def test_local_authority_encrypts_and_persists_sessions(tmp_path: Path) ->
     disk_text = "".join(path.read_text(encoding="utf-8") for path in tmp_path.rglob("*.json"))
     assert bearer not in disk_text
     assert "person" not in disk_text
+
+
+@pytest.mark.anyio
+async def test_swapped_ciphertext_fails_closed_for_validation_and_tombstone() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    bearer, first = await authority.issue(
+        client_id="first", scopes=("exomem:read",), identity=_identity()
+    )
+    _, second = await authority.issue(
+        client_id="second", scopes=("exomem:read",), identity=_identity()
+    )
+    raw.data[(authority.sessions_collection, first.session_id)] = raw.data[
+        (authority.sessions_collection, second.session_id)
+    ]
+
+    with pytest.raises(SessionStoreUnavailable, match="storage key"):
+        await authority.validate(bearer)
+    with pytest.raises(SessionStoreUnavailable, match="storage key"):
+        await authority.tombstone(first.session_id, reason="operator")
+
+
+@pytest.mark.anyio
+async def test_swapped_ciphertext_fails_closed_during_session_listing() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    _, first = await authority.issue(
+        client_id="first", scopes=("exomem:read",), identity=_identity()
+    )
+    _, second = await authority.issue(
+        client_id="second", scopes=("exomem:read",), identity=_identity()
+    )
+    first_key = (authority.sessions_collection, first.session_id)
+    second_key = (authority.sessions_collection, second.session_id)
+    raw.data[first_key], raw.data[second_key] = raw.data[second_key], raw.data[first_key]
+
+    with pytest.raises(SessionStoreUnavailable, match="storage key"):
+        await authority.list_sessions()

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from exomem.auth_sessions import (
+    SessionAuthority,
+    SessionIdentity,
+    SessionStoreUnavailable,
+    SessionTokenCodec,
+    derive_session_keys,
+)
+
+
+class AtomicMemoryStore:
+    def __init__(self) -> None:
+        self.data: dict[tuple[str | None, str], dict[str, Any]] = {}
+        self.calls: list[tuple[str, str | None, str]] = []
+        self.pause_after_session_put = False
+        self.session_written = asyncio.Event()
+        self.resume_session_put = asyncio.Event()
+        self.fail_get = False
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
+        self.calls.append(("get", collection, key))
+        if self.fail_get:
+            raise OSError("store unavailable")
+        value = self.data.get((collection, key))
+        return dict(value) if value is not None else None
+
+    async def put(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        del ttl
+        self.calls.append(("put", collection, key))
+        self.data[(collection, key)] = dict(value)
+        if self.pause_after_session_put and collection and "sessions" in collection:
+            self.pause_after_session_put = False
+            self.session_written.set()
+            await self.resume_session_put.wait()
+
+    async def put_if_absent(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> bool:
+        del ttl
+        async with self._lock:
+            if (collection, key) in self.data:
+                return False
+            self.data[(collection, key)] = dict(value)
+        if self.pause_after_session_put and collection and "sessions" in collection:
+            self.pause_after_session_put = False
+            self.session_written.set()
+            await self.resume_session_put.wait()
+        return True
+
+    async def list_keys(self, *, collection: str | None = None) -> list[str]:
+        return sorted(key for coll, key in self.data if coll == collection)
+
+
+def _authority(
+    store: AtomicMemoryStore,
+    *,
+    signing_root: str = "test-signing-root",
+    issuer: str = "https://memory.example",
+    audience: str = "https://memory.example/mcp",
+) -> SessionAuthority:
+    return SessionAuthority(
+        storage=store,
+        signing_root=signing_root,
+        issuer=issuer,
+        audience=audience,
+        clock=lambda: 1_800_000_000.0,
+    )
+
+
+def _identity() -> SessionIdentity:
+    return SessionIdentity(github_user_id=123456, github_login="Person")
+
+
+def test_token_codec_issues_versioned_opaque_token_with_256_secret_bits() -> None:
+    keys = derive_session_keys("explicit-root")
+    codec = SessionTokenCodec(keys.hmac_key)
+
+    bearer, session_id, digest = codec.issue()
+    parsed = codec.parse(bearer)
+
+    assert bearer.startswith("exo_s1.")
+    assert parsed is not None and parsed.session_id == session_id
+    secret = parsed.secret + "=" * (-len(parsed.secret) % 4)
+    assert len(base64.urlsafe_b64decode(secret)) >= 32
+    assert bearer not in digest
+    assert codec.verify(bearer, digest)
+
+
+def test_token_codec_rejects_malformed_and_uses_constant_time_comparison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    keys = derive_session_keys("explicit-root")
+    codec = SessionTokenCodec(keys.hmac_key)
+    bearer, _, digest = codec.issue()
+    compared: list[tuple[str, str]] = []
+
+    def recording_compare(left: str, right: str) -> bool:
+        compared.append((left, right))
+        return left == right
+
+    monkeypatch.setattr("exomem.auth_sessions.hmac.compare_digest", recording_compare)
+
+    assert codec.parse("not-a-session") is None
+    assert codec.parse("exo_s1.bad/identifier.secret") is None
+    assert not codec.verify(bearer + "x", digest)
+    assert compared and compared[-1][1] == digest
+
+
+def test_key_derivation_is_purpose_separated_and_fingerprinted() -> None:
+    first = derive_session_keys("explicit-root")
+    same = derive_session_keys("explicit-root")
+    rotated = derive_session_keys("rotated-root")
+
+    assert first == same
+    assert first.hmac_key != first.storage_key
+    assert first.fingerprint != rotated.fingerprint
+    assert "explicit-root" not in repr(first)
+
+
+def test_identity_normalizes_login_and_rejects_invalid_values() -> None:
+    assert SessionIdentity(github_user_id=7, github_login="  SomeUser  ").github_login == "someuser"
+    with pytest.raises(ValueError, match="numeric"):
+        SessionIdentity(github_user_id=0, github_login="person")
+    with pytest.raises(ValueError, match="login"):
+        SessionIdentity(github_user_id=7, github_login="   ")
+
+
+@pytest.mark.anyio
+async def test_issue_validate_list_and_tombstone_without_storing_bearer() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+
+    bearer, issued = await authority.issue(
+        client_id="codex",
+        scopes=("exomem:read", "exomem:write"),
+        identity=_identity(),
+    )
+
+    assert await authority.validate(bearer) == issued
+    assert await authority.list_sessions() == [issued]
+    assert issued.github_login == "person"
+    assert issued.token_digest not in bearer
+    assert bearer not in repr(raw.data)
+    assert all("__encrypted_data__" in value for value in raw.data.values())
+
+    assert await authority.tombstone(issued.session_id, reason="operator")
+    assert await authority.validate(bearer) is None
+    [revoked] = await authority.list_sessions()
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at == 1_800_000_000.0
+    assert revoked.revocation_reason == "operator"
+
+
+@pytest.mark.anyio
+async def test_validation_rejects_malformed_unknown_and_context_mismatch() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    bearer, _ = await authority.issue(
+        client_id="codex", scopes=("exomem:read",), identity=_identity()
+    )
+    calls_before = len(raw.calls)
+
+    assert await authority.validate("malformed") is None
+    assert len(raw.calls) == calls_before
+    unknown, _, _ = SessionTokenCodec(derive_session_keys("test-signing-root").hmac_key).issue()
+    assert await authority.validate(unknown) is None
+    assert await _authority(raw, issuer="https://other.example").validate(bearer) is None
+    assert await _authority(raw, audience="https://other.example/mcp").validate(bearer) is None
+
+
+@pytest.mark.anyio
+async def test_signing_key_rotation_selects_fresh_namespace_without_decrypting_old_data() -> None:
+    raw = AtomicMemoryStore()
+    old = _authority(raw)
+    bearer, issued = await old.issue(
+        client_id="codex", scopes=("exomem:read",), identity=_identity()
+    )
+    old_collection = old.sessions_collection
+    raw.data[(old_collection, issued.session_id)] = {"__encrypted_data__": "corrupt"}
+
+    rotated = _authority(raw, signing_root="rotated-root")
+
+    assert rotated.sessions_collection != old_collection
+    assert await rotated.validate(bearer) is None
+    assert not any(call[1] == old_collection for call in raw.calls[-2:])
+
+
+@pytest.mark.anyio
+async def test_store_and_cipher_failures_are_distinct_from_invalid_sessions() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    bearer, issued = await authority.issue(
+        client_id="codex", scopes=("exomem:read",), identity=_identity()
+    )
+
+    raw.fail_get = True
+    with pytest.raises(SessionStoreUnavailable, match="unavailable"):
+        await authority.validate(bearer)
+    raw.fail_get = False
+    raw.data[(authority.sessions_collection, issued.session_id)] = {
+        "__encrypted_data__": "not-fernet",
+        "__encryption_version__": 1,
+    }
+    with pytest.raises(SessionStoreUnavailable, match="decrypt"):
+        await authority.validate(bearer)
+
+
+@pytest.mark.anyio
+async def test_replace_generation_invalidates_every_existing_session() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    bearer, issued = await authority.issue(
+        client_id="codex", scopes=("exomem:read",), identity=_identity()
+    )
+
+    replacement = await authority.replace_generation()
+
+    assert replacement != issued.generation
+    assert await authority.validate(bearer) is None
+
+
+@pytest.mark.anyio
+async def test_generation_initialization_is_atomic_across_authorities() -> None:
+    raw = AtomicMemoryStore()
+    first = _authority(raw)
+    second = _authority(raw)
+
+    (first_result, second_result) = await asyncio.gather(
+        first.issue(client_id="a", scopes=("exomem:read",), identity=_identity()),
+        second.issue(client_id="b", scopes=("exomem:read",), identity=_identity()),
+    )
+
+    assert first_result[1].generation == second_result[1].generation
+    assert await first.validate(second_result[0]) == second_result[1]
+
+
+@pytest.mark.anyio
+async def test_issuance_retries_and_tombstones_when_revoke_all_wins_race() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    await authority.current_generation()
+    raw.pause_after_session_put = True
+
+    issue_task = asyncio.create_task(
+        authority.issue(client_id="codex", scopes=("exomem:read",), identity=_identity())
+    )
+    await raw.session_written.wait()
+    replacement = await authority.replace_generation()
+    raw.resume_session_put.set()
+    bearer, issued = await issue_task
+
+    assert issued.generation == replacement
+    assert await authority.validate(bearer) == issued
+    sessions = await authority.list_sessions()
+    assert [record.status for record in sessions].count("revoked") == 1
+    assert [record.status for record in sessions].count("active") == 1
+
+
+@pytest.mark.anyio
+async def test_local_authority_encrypts_and_persists_sessions(tmp_path: Path) -> None:
+    first = SessionAuthority.local(
+        directory=tmp_path,
+        signing_root="stable-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+        clock=lambda: 1_800_000_000.0,
+    )
+    bearer, issued = await first.issue(
+        client_id="codex", scopes=("exomem:read",), identity=_identity()
+    )
+    second = SessionAuthority.local(
+        directory=tmp_path,
+        signing_root="stable-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+        clock=lambda: 1_800_000_000.0,
+    )
+
+    assert await second.validate(bearer) == issued
+    assert await second.list_sessions() == [issued]
+    disk_text = "".join(path.read_text(encoding="utf-8") for path in tmp_path.rglob("*.json"))
+    assert bearer not in disk_text
+    assert "person" not in disk_text

--- a/tests/test_codex_auth_session_harness.py
+++ b/tests/test_codex_auth_session_harness.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "codex_auth_session_harness.py"
+_SPEC = importlib.util.spec_from_file_location("codex_auth_session_harness", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+harness = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = harness
+_SPEC.loader.exec_module(harness)
+
+
+def _mcp_success() -> str:
+    return json.dumps(
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "mcp_tool_call",
+                "server": "exomem",
+                "tool": "ask_memory",
+                "status": "completed",
+            },
+        }
+    )
+
+
+class FakeRunner:
+    def __init__(self, exec_outputs: list[str] | None = None) -> None:
+        self.calls: list[tuple[list[str], dict]] = []
+        self.exec_outputs = list(exec_outputs or [_mcp_success()] * 3)
+
+    def __call__(self, command: list[str], **kwargs):
+        self.calls.append((command, kwargs))
+        if command[1:3] == ["mcp", "add"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[1:3] == ["mcp", "login"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return subprocess.CompletedProcess(command, 0, self.exec_outputs.pop(0), "")
+
+
+def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner()
+    codex_home = tmp_path / "isolated-codex"
+
+    result = harness.run_harness(
+        url="https://kb.example.com/mcp",
+        codex_home=codex_home,
+        runs=3,
+        runner=runner,
+    )
+
+    assert result == 0
+    commands = [call[0] for call in runner.calls]
+    assert commands[0] == [
+        "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
+    ]
+    assert commands.count(["codex", "mcp", "login", "exomem"]) == 1
+    exec_commands = [command for command in commands if command[:2] == ["codex", "exec"]]
+    assert len(exec_commands) == 3
+    assert all("--ephemeral" in command and "--json" in command for command in exec_commands)
+    assert all(call[1]["env"]["CODEX_HOME"] == str(codex_home) for call in runner.calls)
+    assert codex_home.is_dir()
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "The exomem MCP server is not logged in",
+        "MCP startup incomplete (failed: exomem)",
+        "Opening your browser to authenticate",
+        "Run codex mcp login exomem",
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message"}}),
+    ],
+)
+def test_exec_classification_rejects_reauth_or_missing_success(output: str) -> None:
+    with pytest.raises(harness.HarnessFailure):
+        harness.classify_exec_output(output, "")
+
+
+def test_exec_classification_accepts_only_completed_exomem_mcp_call() -> None:
+    assert harness.classify_exec_output(_mcp_success(), "diagnostic noise") is None
+
+
+def test_harness_stops_if_registration_fails(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 7, "", "bad")
+
+    with pytest.raises(harness.HarnessFailure, match="register"):
+        harness.run_harness(
+            url="https://kb.example.com/mcp",
+            codex_home=tmp_path / "codex",
+            runs=3,
+            runner=runner,
+        )
+
+    assert calls == [[
+        "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
+    ]]
+
+
+def test_unit_suite_never_invokes_live_codex(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("unit test attempted live Codex"),
+    )
+    assert harness.classify_exec_output(_mcp_success(), "") is None

--- a/tests/test_codex_auth_session_harness.py
+++ b/tests/test_codex_auth_session_harness.py
@@ -15,31 +15,39 @@ harness = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = harness
 _SPEC.loader.exec_module(harness)
 
+SENTINEL_QUERY = "__exomem_codex_session_smoke_absent__"
+
+
+def _mcp_event(*, event_type: str = "item.completed", **item_overrides) -> str:
+    item = {
+        "id": "sentinel-call",
+        "type": "mcp_tool_call",
+        "server": "exomem",
+        "tool": "ask_memory",
+        "arguments": {"query": SENTINEL_QUERY},
+        "status": "completed",
+        "isError": False,
+    }
+    item.update(item_overrides)
+    return json.dumps({"type": event_type, "item": item})
+
 
 def _mcp_success() -> str:
-    return json.dumps(
-        {
-            "type": "item.completed",
-            "item": {
-                "type": "mcp_tool_call",
-                "server": "exomem",
-                "tool": "ask_memory",
-                "status": "completed",
-            },
-        }
-    )
+    return _mcp_event()
 
 
 class FakeRunner:
     def __init__(self, exec_outputs: list[str] | None = None) -> None:
         self.calls: list[tuple[list[str], dict]] = []
         self.exec_outputs = list(exec_outputs or [_mcp_success()] * 3)
+        self.browser_launches = 0
 
     def __call__(self, command: list[str], **kwargs):
         self.calls.append((command, kwargs))
         if command[1:3] == ["mcp", "add"]:
             return subprocess.CompletedProcess(command, 0, "", "")
         if command[1:3] == ["mcp", "login"]:
+            self.browser_launches += 1
             return subprocess.CompletedProcess(command, 0, "", "")
         return subprocess.CompletedProcess(command, 0, self.exec_outputs.pop(0), "")
 
@@ -55,6 +63,7 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
         codex_home=codex_home,
         runs=3,
         runner=runner,
+        acknowledge_disposable_target=True,
     )
 
     assert result == 0
@@ -63,10 +72,12 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
         "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
     ]
     assert commands.count(["codex", "mcp", "login", "exomem"]) == 1
+    assert runner.browser_launches == 1
     exec_commands = [command for command in commands if command[:2] == ["codex", "exec"]]
     assert len(exec_commands) == 3
     assert all("--ephemeral" in command and "--json" in command for command in exec_commands)
     assert all(call[1]["env"]["CODEX_HOME"] == str(codex_home) for call in runner.calls)
+    assert all(call[1]["timeout"] > 0 for call in runner.calls)
     assert codex_home.is_dir()
 
 
@@ -78,6 +89,22 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
         "Opening your browser to authenticate",
         "Run codex mcp login exomem",
         json.dumps({"type": "item.completed", "item": {"type": "agent_message"}}),
+        _mcp_event(status=None),
+        _mcp_event(isError=True),
+        _mcp_event(result={"error": "tool failed"}),
+        _mcp_event(tool="remember"),
+        _mcp_event(arguments={"query": "wrong"}),
+        _mcp_success() + "\n" + _mcp_success(),
+        json.dumps({"type": "error", "message": "turn failed"}) + "\n" + _mcp_success(),
+        _mcp_event(
+            event_type="item.started",
+            id="write-call",
+            tool="remember",
+            arguments={"content": "must not run"},
+            status="in_progress",
+        )
+        + "\n"
+        + _mcp_success(),
     ],
 )
 def test_exec_classification_rejects_reauth_or_missing_success(output: str) -> None:
@@ -87,6 +114,15 @@ def test_exec_classification_rejects_reauth_or_missing_success(output: str) -> N
 
 def test_exec_classification_accepts_only_completed_exomem_mcp_call() -> None:
     assert harness.classify_exec_output(_mcp_success(), "diagnostic noise") is None
+
+
+def test_exec_classification_deduplicates_one_sentinel_call_lifecycle() -> None:
+    output = (
+        _mcp_event(event_type="item.started", status="in_progress")
+        + "\n"
+        + _mcp_success()
+    )
+    assert harness.classify_exec_output(output, "") is None
 
 
 def test_harness_stops_if_registration_fails(tmp_path: Path) -> None:
@@ -102,11 +138,44 @@ def test_harness_stops_if_registration_fails(tmp_path: Path) -> None:
             codex_home=tmp_path / "codex",
             runs=3,
             runner=runner,
+            acknowledge_disposable_target=True,
         )
 
     assert calls == [[
         "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
     ]]
+
+
+def test_harness_requires_explicit_disposable_target_acknowledgement(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner()
+    with pytest.raises(harness.HarnessFailure, match="disposable"):
+        harness.run_harness(
+            url="https://kb.example.com/mcp",
+            codex_home=tmp_path / "codex",
+            runs=3,
+            runner=runner,
+        )
+    assert runner.calls == []
+
+
+def test_harness_refuses_nonempty_codex_home_before_initial_login(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("existing-auth")
+    runner = FakeRunner()
+
+    with pytest.raises(harness.HarnessFailure, match="empty"):
+        harness.run_harness(
+            url="https://kb.example.com/mcp",
+            codex_home=codex_home,
+            runs=3,
+            runner=runner,
+            acknowledge_disposable_target=True,
+        )
+
+    assert runner.calls == []
 
 
 def test_unit_suite_never_invokes_live_codex(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_codex_auth_session_harness.py
+++ b/tests/test_codex_auth_session_harness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -44,6 +45,8 @@ class FakeRunner:
 
     def __call__(self, command: list[str], **kwargs):
         self.calls.append((command, kwargs))
+        if command[1:3] == ["login", "status"]:
+            return subprocess.CompletedProcess(command, 0, "Logged in", "")
         if command[1:3] == ["mcp", "add"]:
             return subprocess.CompletedProcess(command, 0, "", "")
         if command[1:3] == ["mcp", "login"]:
@@ -52,15 +55,27 @@ class FakeRunner:
         return subprocess.CompletedProcess(command, 0, self.exec_outputs.pop(0), "")
 
 
+def _auth_source(tmp_path: Path) -> Path:
+    source_home = tmp_path / "invoking-codex"
+    source_home.mkdir()
+    source = source_home / "auth.json"
+    source.write_text('{"OPENAI_API_KEY":"unit-test-only"}')
+    (source_home / ".credentials.json").write_text("must-not-copy")
+    (source_home / "config.toml").write_text("must-not-copy")
+    return source
+
+
 def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
     tmp_path: Path,
 ) -> None:
     runner = FakeRunner()
     codex_home = tmp_path / "isolated-codex"
+    auth_source = _auth_source(tmp_path)
 
     result = harness.run_harness(
         url="https://kb.example.com/mcp",
         codex_home=codex_home,
+        codex_auth_source=auth_source,
         runs=3,
         runner=runner,
         acknowledge_disposable_target=True,
@@ -68,7 +83,8 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
 
     assert result == 0
     commands = [call[0] for call in runner.calls]
-    assert commands[0] == [
+    assert commands[0] == ["codex", "login", "status"]
+    assert commands[1] == [
         "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
     ]
     assert commands.count(["codex", "mcp", "login", "exomem"]) == 1
@@ -79,6 +95,10 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
     assert all(call[1]["env"]["CODEX_HOME"] == str(codex_home) for call in runner.calls)
     assert all(call[1]["timeout"] > 0 for call in runner.calls)
     assert codex_home.is_dir()
+    assert (codex_home / "auth.json").read_text() == auth_source.read_text()
+    assert stat.S_IMODE((codex_home / "auth.json").stat().st_mode) == 0o600
+    assert not (codex_home / ".credentials.json").exists()
+    assert not (codex_home / "config.toml").exists()
 
 
 @pytest.mark.parametrize(
@@ -105,6 +125,49 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
         )
         + "\n"
         + _mcp_success(),
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "shell-call",
+                    "type": "shell_command",
+                    "command": "pwd",
+                    "status": "completed",
+                },
+            }
+        )
+        + "\n"
+        + _mcp_success(),
+        json.dumps(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "shell-call",
+                    "type": "command_execution",
+                    "command": "echo forbidden",
+                    "status": "in_progress",
+                },
+            }
+        )
+        + "\n"
+        + _mcp_success(),
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "other-mcp",
+                    "type": "mcp_tool_call",
+                    "server": "context7",
+                    "tool": "resolve-library-id",
+                    "arguments": {},
+                    "status": "completed",
+                },
+            }
+        )
+        + "\n"
+        + _mcp_success(),
+        "plain text before JSON\n" + _mcp_success(),
+        _mcp_success() + "\nplain text after JSON",
     ],
 )
 def test_exec_classification_rejects_reauth_or_missing_success(output: str) -> None:
@@ -114,6 +177,30 @@ def test_exec_classification_rejects_reauth_or_missing_success(output: str) -> N
 
 def test_exec_classification_accepts_only_completed_exomem_mcp_call() -> None:
     assert harness.classify_exec_output(_mcp_success(), "diagnostic noise") is None
+
+
+def test_exec_classification_rejects_error_like_stderr() -> None:
+    with pytest.raises(harness.HarnessFailure, match="stderr"):
+        harness.classify_exec_output(_mcp_success(), "ERROR connector crashed")
+
+
+def test_exec_classification_preserves_normal_json_agent_lifecycle() -> None:
+    output = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "thread-1"}),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "calling memory"},
+                }
+            ),
+            _mcp_event(event_type="item.started", status="in_progress"),
+            _mcp_success(),
+            json.dumps({"type": "turn.completed", "usage": {"input_tokens": 1}}),
+        ]
+    )
+
+    assert harness.classify_exec_output(output, "diagnostic noise") is None
 
 
 def test_exec_classification_deduplicates_one_sentinel_call_lifecycle() -> None:
@@ -127,23 +214,92 @@ def test_exec_classification_deduplicates_one_sentinel_call_lifecycle() -> None:
 
 def test_harness_stops_if_registration_fails(tmp_path: Path) -> None:
     calls: list[list[str]] = []
+    auth_source = _auth_source(tmp_path)
 
     def runner(command: list[str], **_kwargs):
         calls.append(command)
+        if command[1:3] == ["login", "status"]:
+            return subprocess.CompletedProcess(command, 0, "Logged in", "")
         return subprocess.CompletedProcess(command, 7, "", "bad")
 
     with pytest.raises(harness.HarnessFailure, match="register"):
         harness.run_harness(
             url="https://kb.example.com/mcp",
             codex_home=tmp_path / "codex",
+            codex_auth_source=auth_source,
             runs=3,
             runner=runner,
             acknowledge_disposable_target=True,
         )
 
-    assert calls == [[
-        "codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"
-    ]]
+    assert calls == [
+        ["codex", "login", "status"],
+        ["codex", "mcp", "add", "exomem", "--url", "https://kb.example.com/mcp"],
+    ]
+
+
+def test_harness_checks_isolated_openai_login_before_mcp_registration(
+    tmp_path: Path,
+) -> None:
+    auth_source = _auth_source(tmp_path)
+    calls: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, "", "Not logged in")
+
+    with pytest.raises(harness.HarnessFailure, match="OpenAI login"):
+        harness.run_harness(
+            url="https://kb.example.com/mcp",
+            codex_home=tmp_path / "isolated-codex",
+            codex_auth_source=auth_source,
+            runs=3,
+            runner=runner,
+            acknowledge_disposable_target=True,
+        )
+
+    assert calls == [["codex", "login", "status"]]
+
+
+@pytest.mark.parametrize("source_kind", ["missing", "directory"])
+def test_harness_rejects_invalid_codex_auth_source_before_subprocesses(
+    tmp_path: Path, source_kind: str
+) -> None:
+    source = tmp_path / "source-auth.json"
+    if source_kind == "directory":
+        source.mkdir()
+    runner = FakeRunner()
+
+    with pytest.raises(harness.HarnessFailure, match="auth source"):
+        harness.run_harness(
+            url="https://kb.example.com/mcp",
+            codex_home=tmp_path / "isolated-codex",
+            codex_auth_source=source,
+            runs=3,
+            runner=runner,
+            acknowledge_disposable_target=True,
+        )
+
+    assert runner.calls == []
+
+
+def test_harness_defaults_auth_source_to_invoking_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_source = _auth_source(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(auth_source.parent))
+    target = tmp_path / "isolated-codex"
+
+    assert harness.run_harness(
+        url="https://kb.example.com/mcp",
+        codex_home=target,
+        runs=2,
+        runner=FakeRunner(exec_outputs=[_mcp_success()] * 2),
+        acknowledge_disposable_target=True,
+    ) == 0
+
+    assert (target / "auth.json").read_text() == auth_source.read_text()
+    assert not (target / ".credentials.json").exists()
 
 
 def test_harness_requires_explicit_disposable_target_acknowledgement(

--- a/tests/test_codex_auth_session_harness.py
+++ b/tests/test_codex_auth_session_harness.py
@@ -96,7 +96,12 @@ def test_harness_adds_and_logs_in_once_then_runs_fresh_ephemeral_processes(
     assert all(call[1]["timeout"] > 0 for call in runner.calls)
     assert codex_home.is_dir()
     assert (codex_home / "auth.json").read_text() == auth_source.read_text()
-    assert stat.S_IMODE((codex_home / "auth.json").stat().st_mode) == 0o600
+    auth_mode = stat.S_IMODE((codex_home / "auth.json").stat().st_mode)
+    if auth_mode != 0o600:
+        pytest.skip(
+            "filesystem does not expose POSIX chmod semantics; "
+            "Windows ACLs remain authoritative"
+        )
     assert not (codex_home / ".credentials.json").exists()
     assert not (codex_home / "config.toml").exists()
 

--- a/tests/test_doctor_ha.py
+++ b/tests/test_doctor_ha.py
@@ -15,6 +15,7 @@ def _set_ha_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_LEASE_COORDINATOR_TOKEN", "secret")
     monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_URL", "https://coordinator.example.com")
     monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_NAMESPACE", "main")
     monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_TOKEN", "secret")
@@ -63,7 +64,23 @@ def test_ha_profile_is_offline_by_default(
     assert not any(check_id.startswith("ha.replica.") for check_id in checks)
 
 
-def test_ha_profile_reports_missing_coordination_configuration(vault: Path) -> None:
+def test_ha_profile_reports_missing_coordination_configuration(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in (
+        "EXOMEM_BASE_URL",
+        "EXOMEM_JWT_SIGNING_KEY",
+        "EXOMEM_WRITER_LEASE_URL",
+        "EXOMEM_WRITER_LEASE_VAULT_ID",
+        "EXOMEM_WRITER_LEASE_REPLICA_ID",
+        "EXOMEM_WRITER_LEASE_TOKEN",
+        "EXOMEM_OAUTH_STORAGE_URL",
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE",
+        "EXOMEM_OAUTH_STORAGE_TOKEN",
+        "EXOMEM_LEASE_COORDINATOR_TOKEN",
+        "EXOMEM_GITHUB_USER_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
     report = doctor_module.doctor(vault=str(vault), profile="ha")
     checks = {check.id: check for check in report.checks}
 
@@ -90,6 +107,21 @@ def test_ha_profile_rejects_mismatched_storage_credentials(
     rendered = doctor_module.render_human(report)
     assert "different-secret" not in rendered
     assert "secret" not in rendered
+
+
+def test_ha_profile_requires_coordinator_token_even_when_replica_tokens_match(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.delenv("EXOMEM_LEASE_COORDINATOR_TOKEN")
+
+    checks = {
+        check.id: check
+        for check in doctor_module.doctor(vault=str(vault), profile="ha").checks
+    }
+
+    assert checks["ha.env.EXOMEM_LEASE_COORDINATOR_TOKEN"].status == "fail"
+    assert checks["ha.auth.credentials_match"].status == "fail"
 
 
 def test_ha_probe_proves_coordinator_requires_and_accepts_auth(

--- a/tests/test_doctor_ha.py
+++ b/tests/test_doctor_ha.py
@@ -15,6 +15,17 @@ def _set_ha_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_URL", "https://coordinator.example.com")
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_NAMESPACE", "main")
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_GITHUB_USER_ID", "1234")
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com")
+    monkeypatch.setenv("EXOMEM_JWT_SIGNING_KEY", "stable-signing-root")
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_state",
+        lambda _url, _namespace, token: (401, {}) if token is None else (200, {"result": None}),
+    )
 
 
 def _ready(replica_id: str, release: str, *, contract: int = RUNTIME_CONTRACT) -> dict:
@@ -59,6 +70,148 @@ def test_ha_profile_reports_missing_coordination_configuration(vault: Path) -> N
     assert checks["ha.env.EXOMEM_WRITER_LEASE_URL"].status == "fail"
     assert checks["ha.env.EXOMEM_WRITER_LEASE_VAULT_ID"].status == "fail"
     assert checks["ha.env.EXOMEM_WRITER_LEASE_REPLICA_ID"].status == "fail"
+    assert checks["ha.env.EXOMEM_OAUTH_STORAGE_URL"].status == "fail"
+    assert checks["ha.env.EXOMEM_OAUTH_STORAGE_TOKEN"].status == "fail"
+    assert checks["ha.env.EXOMEM_GITHUB_USER_ID"].status == "fail"
+    assert checks["ha.env.EXOMEM_BASE_URL"].status == "fail"
+    assert checks["ha.env.EXOMEM_JWT_SIGNING_KEY"].status == "fail"
+
+
+def test_ha_profile_rejects_mismatched_storage_credentials(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_TOKEN", "different-secret")
+
+    report = doctor_module.doctor(vault=str(vault), profile="ha")
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.auth.credentials_match"].status == "fail"
+    rendered = doctor_module.render_human(report)
+    assert "different-secret" not in rendered
+    assert "secret" not in rendered
+
+
+def test_ha_probe_proves_coordinator_requires_and_accepts_auth(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    calls: list[tuple[str, str, str | None]] = []
+
+    def probe_state(url: str, namespace: str, token: str | None):
+        calls.append((url, namespace, token))
+        return (401, {"error": "unauthorized"}) if token is None else (200, {"result": None})
+
+    monkeypatch.setattr(doctor_module, "_probe_state", probe_state, raising=False)
+    monkeypatch.setattr(doctor_module, "_check_ha_probes", lambda _urls: [])
+
+    report = doctor_module.doctor(
+        vault=str(vault),
+        profile="ha",
+        probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+    checks = {check.id: check for check in report.checks}
+
+    assert checks["ha.auth.anonymous_rejected"].status == "pass"
+    assert checks["ha.auth.storage_credential"].status == "pass"
+    assert calls == [
+        ("https://coordinator.example.com", "main", None),
+        ("https://coordinator.example.com", "main", "secret"),
+    ]
+
+
+def test_ha_probe_rejects_anonymous_state_access(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_state",
+        lambda _url, _namespace, token: (200, {"result": None}),
+        raising=False,
+    )
+    monkeypatch.setattr(doctor_module, "_check_ha_probes", lambda _urls: [])
+
+    report = doctor_module.doctor(
+        vault=str(vault), profile="ha", probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+
+    assert next(
+        c for c in report.checks if c.id == "ha.auth.anonymous_rejected"
+    ).status == "fail"
+
+
+def test_ha_probe_requires_absent_sentinel_result(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_state",
+        lambda _url, _namespace, token: (
+            (401, {}) if token is None else (200, {"result": {"unexpected": True}})
+        ),
+    )
+    monkeypatch.setattr(doctor_module, "_check_ha_probes", lambda _urls: [])
+
+    report = doctor_module.doctor(
+        vault=str(vault), profile="ha", probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+
+    assert next(
+        c for c in report.checks if c.id == "ha.auth.storage_credential"
+    ).status == "fail"
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_ha_probe_distinguishes_rejected_storage_credential(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    _set_ha_env(monkeypatch)
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_state",
+        lambda _url, _namespace, token: (
+            (401, {}) if token is None else (status, {})
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(doctor_module, "_check_ha_probes", lambda _urls: [])
+
+    report = doctor_module.doctor(
+        vault=str(vault), profile="ha", probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+    check = next(c for c in report.checks if c.id == "ha.auth.storage_credential")
+
+    assert check.status == "fail"
+    assert "rejected" in check.message.lower()
+    assert "secret" not in doctor_module.render_human(report)
+
+
+def test_ha_probe_distinguishes_storage_outage(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_ha_env(monkeypatch)
+
+    def probe_state(_url: str, _namespace: str, token: str | None):
+        if token is None:
+            return 401, {}
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr(doctor_module, "_probe_state", probe_state, raising=False)
+    monkeypatch.setattr(doctor_module, "_check_ha_probes", lambda _urls: [])
+    report = doctor_module.doctor(
+        vault=str(vault), profile="ha", probe=True,
+        replica_urls=["https://desktop.example.com", "https://laptop.example.com"],
+    )
+    check = next(c for c in report.checks if c.id == "ha.auth.storage_credential")
+
+    assert check.status == "fail"
+    assert "reach" in check.message.lower()
 
 
 def test_ha_probe_accepts_compatible_release_drift(

--- a/tests/test_doctor_probe.py
+++ b/tests/test_doctor_probe.py
@@ -55,6 +55,65 @@ def test_remote_doctor_requires_positive_immutable_github_id(
     assert "positive" in (checks["env.EXOMEM_GITHUB_USER_ID"].remediation or "")
 
 
+def test_remote_ha_mode_requires_shared_session_url_and_namespace_offline(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_remote_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://coordinator.example.com")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_LEASE_COORDINATOR_TOKEN", "secret")
+    monkeypatch.setenv(
+        "EXOMEM_HA_REPLICA_URLS",
+        "https://desktop.example.com,https://laptop.example.com",
+    )
+    monkeypatch.delenv("EXOMEM_OAUTH_STORAGE_URL", raising=False)
+    monkeypatch.delenv("EXOMEM_OAUTH_STORAGE_NAMESPACE", raising=False)
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_TOKEN", "secret")
+
+    checks = {
+        check.id: check
+        for check in doctor_module.doctor(vault=str(vault), profile="remote").checks
+    }
+
+    assert checks["ha.env.EXOMEM_OAUTH_STORAGE_URL"].status == "fail"
+    assert checks["ha.env.EXOMEM_OAUTH_STORAGE_NAMESPACE"].status == "fail"
+
+
+def test_remote_ha_probe_runs_even_when_shared_storage_url_is_missing(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_remote_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://coordinator.example.com")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_LEASE_COORDINATOR_TOKEN", "secret")
+    monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_TOKEN", "secret")
+    monkeypatch.delenv("EXOMEM_OAUTH_STORAGE_URL", raising=False)
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_get",
+        _make_probe_get(
+            {
+                LOCAL_MCP_URL: (401, "unauthorized"),
+                OAUTH_DISCOVERY_URL: (200, {"issuer": f"{BASE_URL}/"}),
+                PROTECTED_RESOURCE_URL: (200, {"resource": f"{BASE_URL}/mcp"}),
+            }
+        ),
+    )
+
+    checks = {
+        check.id: check
+        for check in doctor_module.doctor(
+            vault=str(vault), profile="remote", probe=True
+        ).checks
+    }
+
+    assert checks["probe.auth.storage_credential"].status == "fail"
+
+
 def _make_probe_get(
     responses: dict[str, tuple[int, dict | str] | BaseException],
 ) -> Callable[[str], tuple[int, dict | str]]:

--- a/tests/test_doctor_probe.py
+++ b/tests/test_doctor_probe.py
@@ -36,7 +36,23 @@ def _set_remote_env(monkeypatch: pytest.MonkeyPatch, *, base_url: str | None = B
     monkeypatch.setenv("GITHUB_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("GITHUB_CLIENT_SECRET", "test-client-secret")
     monkeypatch.setenv("EXOMEM_GITHUB_USERNAME", "octocat")
+    monkeypatch.setenv("EXOMEM_GITHUB_USER_ID", "1234")
     monkeypatch.setenv("EXOMEM_JWT_SIGNING_KEY", "test-signing-key")
+
+
+def test_remote_doctor_requires_positive_immutable_github_id(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_remote_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_GITHUB_USER_ID", "not-numeric")
+
+    checks = {
+        check.id: check
+        for check in doctor_module.doctor(vault=str(vault), profile="remote").checks
+    }
+
+    assert checks["env.EXOMEM_GITHUB_USER_ID"].status == "fail"
+    assert "positive" in (checks["env.EXOMEM_GITHUB_USER_ID"].remediation or "")
 
 
 def _make_probe_get(

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -19,6 +19,8 @@ def _client(vault, monkeypatch: pytest.MonkeyPatch, *, require_auth: bool = Fals
         monkeypatch.setenv("GITHUB_CLIENT_ID", "x")
         monkeypatch.setenv("GITHUB_CLIENT_SECRET", "y")
         monkeypatch.setenv("EXOMEM_GITHUB_USERNAME", "z")
+        monkeypatch.setenv("EXOMEM_GITHUB_USER_ID", "123456")
+        monkeypatch.setenv("EXOMEM_JWT_SIGNING_KEY", "stable-test-signing-root")
     return TestClient(server.build_server(require_auth=require_auth).http_app())
 
 

--- a/tests/test_lease_coordinator.py
+++ b/tests/test_lease_coordinator.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from exomem.lease_coordinator import create_app
+
+
+@pytest.mark.anyio
+async def test_state_atomic_put_and_list_keys_require_bearer(tmp_path: Path) -> None:
+    app = create_app(database=tmp_path / "coordinator.sqlite", bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="https://coordinator.example") as client:
+        denied = await client.post(
+            "/v1/state/main/list-keys", json={"collection": "auth"}
+        )
+        assert denied.status_code == 401
+
+        headers = {"Authorization": "Bearer secret"}
+        first = await client.post(
+            "/v1/state/main/put-if-absent",
+            json={
+                "collection": "auth",
+                "key": "generation",
+                "value": {"__encrypted_data__": "ciphertext"},
+                "ttl": None,
+            },
+            headers=headers,
+        )
+        second = await client.post(
+            "/v1/state/main/put-if-absent",
+            json={
+                "collection": "auth",
+                "key": "generation",
+                "value": {"__encrypted_data__": "replacement"},
+                "ttl": None,
+            },
+            headers=headers,
+        )
+        listed = await client.post(
+            "/v1/state/main/list-keys", json={"collection": "auth"}, headers=headers
+        )
+
+    assert first.json() == {"result": True}
+    assert second.json() == {"result": False}
+    assert listed.json() == {"result": ["generation"]}
+    assert "ciphertext" not in listed.text
+    assert "replacement" not in listed.text

--- a/tests/test_remote_setup_wizard.py
+++ b/tests/test_remote_setup_wizard.py
@@ -231,17 +231,57 @@ def test_existing_github_user_id_is_preserved_without_network(tmp_path: Path) ->
     env_path = tmp_path / ".env"
     env_path.write_text("EXOMEM_GITHUB_USER_ID=1234\n", encoding="utf-8")
 
-    def fail_resolver(_username: str):
-        pytest.fail("existing immutable user ID should not be resolved again")
+    calls: list[str] = []
+
+    def resolver(username: str):
+        calls.append(username)
+        return {"id": 1234, "login": "octocat"}
 
     code, _, _ = _run(
         env_path,
         github_user_id=None,
-        github_user_resolver=fail_resolver,
+        github_user_resolver=resolver,
     )
 
     assert code == 0
+    assert calls == ["octocat"]
     assert rsw.parse_env(env_path.read_text())["EXOMEM_GITHUB_USER_ID"] == "1234"
+
+
+def test_existing_id_rejects_changed_login_resolving_to_another_account(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / ".env"
+    original = "EXOMEM_GITHUB_USERNAME=old-login\nEXOMEM_GITHUB_USER_ID=1234\n"
+    env_path.write_text(original, encoding="utf-8")
+
+    code, output, doctor_calls = _run(
+        env_path,
+        github_username="new-login",
+        github_user_id=None,
+        github_user_resolver=lambda _username: {"id": 9999, "login": "new-login"},
+    )
+
+    assert code == 2
+    assert "identity" in output.lower()
+    assert doctor_calls == []
+    assert env_path.read_text() == original
+
+
+def test_existing_id_accepts_online_resolution_of_same_account(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXOMEM_GITHUB_USER_ID=1234\n", encoding="utf-8")
+
+    code, _, _ = _run(
+        env_path,
+        github_user_id=None,
+        github_user_resolver=lambda _username: {"id": 1234, "login": "OctoCat"},
+    )
+
+    assert code == 0
+    values = rsw.parse_env(env_path.read_text())
+    assert values["EXOMEM_GITHUB_USER_ID"] == "1234"
+    assert values["EXOMEM_GITHUB_USERNAME"] == "octocat"
 
 
 def test_setup_resolves_numeric_id_and_requires_normalized_login_match(tmp_path: Path) -> None:
@@ -290,9 +330,9 @@ def test_invalid_or_mismatched_github_identity_fails_before_write(
 @pytest.mark.parametrize(
     ("existing", "expected"),
     [
-        ("EXOMEM_WRITER_LEASE_TOKEN=writer-only\nEXOMEM_WRITER_LEASE_URL=https://c\n", "writer-only"),
-        ("EXOMEM_OAUTH_STORAGE_TOKEN=oauth-only\nEXOMEM_OAUTH_STORAGE_URL=https://c\n", "oauth-only"),
-        ("EXOMEM_WRITER_LEASE_URL=https://c\n", None),
+        ("EXOMEM_WRITER_LEASE_TOKEN=writer-only\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "writer-only"),
+        ("EXOMEM_OAUTH_STORAGE_TOKEN=oauth-only\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "oauth-only"),
+        ("EXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", None),
     ],
 )
 def test_ha_setup_preserves_or_generates_one_matching_storage_credential(
@@ -317,6 +357,8 @@ def test_ha_setup_conflicting_credentials_fail_before_any_write(tmp_path: Path) 
     env_path = tmp_path / ".env"
     original = (
         "EXOMEM_WRITER_LEASE_URL=https://c\n"
+        "EXOMEM_OAUTH_STORAGE_URL=https://c\n"
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE=main\n"
         "EXOMEM_WRITER_LEASE_TOKEN=one\n"
         "EXOMEM_OAUTH_STORAGE_TOKEN=two\n"
     )
@@ -328,6 +370,63 @@ def test_ha_setup_conflicting_credentials_fail_before_any_write(tmp_path: Path) 
     assert "conflict" in output.lower()
     assert doctor_calls == []
     assert env_path.read_text() == original
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        "EXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_WRITER_LEASE_VAULT_ID=main\n",
+        "EXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_URL=https://c\n",
+    ],
+)
+def test_ha_setup_requires_shared_session_url_and_namespace_before_write(
+    tmp_path: Path, existing: str
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(existing, encoding="utf-8")
+
+    code, output, doctor_calls = _run(env_path)
+
+    assert code == 2
+    assert "HA" in output
+    assert doctor_calls == []
+    assert env_path.read_text() == existing
+
+
+def test_interactive_existing_client_secret_is_preserved_without_rendering_it(
+    tmp_path: Path,
+) -> None:
+    env_path = tmp_path / ".env"
+    secret = "existing-super-secret"
+    env_path.write_text(f"GITHUB_CLIENT_SECRET={secret}\n", encoding="utf-8")
+    prompts: list[str] = []
+    output: list[str] = []
+
+    def input_fn(prompt: str = "") -> str:
+        prompts.append(prompt)
+        return ""
+
+    code = rsw.run_remote_setup(
+        vault="/vault",
+        base_url="https://kb.example.com",
+        tunnel="ngrok",
+        github_client_id="client-id",
+        github_client_secret=None,
+        github_username="octocat",
+        github_user_id="1234",
+        yes=False,
+        probe=False,
+        env_path=env_path,
+        input_fn=input_fn,
+        print_fn=output.append,
+        doctor_fn=lambda **_kwargs: SimpleNamespace(success=True),
+        load_env_fn=lambda _path: None,
+    )
+
+    assert code == 0
+    assert rsw.parse_env(env_path.read_text())["GITHUB_CLIENT_SECRET"] == secret
+    assert secret not in "\n".join(prompts + output)
+    assert any("keep existing" in prompt.lower() for prompt in prompts)
 
 
 def test_doctor_failure_is_a_hard_gate(tmp_path: Path) -> None:

--- a/tests/test_remote_setup_wizard.py
+++ b/tests/test_remote_setup_wizard.py
@@ -20,7 +20,6 @@ import pytest
 from exomem import remote_setup_wizard as rsw
 from exomem.__main__ import main
 
-
 # ============================================================================
 # generate_signing_key
 # ============================================================================
@@ -178,6 +177,7 @@ def _run(env_path: Path, doctor_success: bool = True, **overrides):
         github_client_id="Iv1.abc",
         github_client_secret="secret-xyz",
         github_username="octocat",
+        github_user_id="1234",
         yes=True,
         env_path=env_path,
         input_fn=lambda prompt="": pytest.fail(f"unexpected prompt: {prompt}"),
@@ -201,6 +201,7 @@ def test_happy_path_writes_env_and_prints_connector(tmp_path: Path) -> None:
     assert written["GITHUB_CLIENT_ID"] == "Iv1.abc"
     assert written["GITHUB_CLIENT_SECRET"] == "secret-xyz"
     assert written["EXOMEM_GITHUB_USERNAME"] == "octocat"
+    assert written["EXOMEM_GITHUB_USER_ID"] == "1234"
     assert len(written["EXOMEM_JWT_SIGNING_KEY"]) >= 64  # freshly generated
 
     # doctor ran as the remote gate, with the live probe on
@@ -224,6 +225,109 @@ def test_existing_signing_key_is_preserved(tmp_path: Path) -> None:
     assert written["EXOMEM_JWT_SIGNING_KEY"] == "keep-this-stable-key"
     assert written["UNRELATED"] == "x"  # unrelated key preserved
     assert "[skipped: already set" in out
+
+
+def test_existing_github_user_id_is_preserved_without_network(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXOMEM_GITHUB_USER_ID=1234\n", encoding="utf-8")
+
+    def fail_resolver(_username: str):
+        pytest.fail("existing immutable user ID should not be resolved again")
+
+    code, _, _ = _run(
+        env_path,
+        github_user_id=None,
+        github_user_resolver=fail_resolver,
+    )
+
+    assert code == 0
+    assert rsw.parse_env(env_path.read_text())["EXOMEM_GITHUB_USER_ID"] == "1234"
+
+
+def test_setup_resolves_numeric_id_and_requires_normalized_login_match(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    calls: list[str] = []
+
+    def resolver(username: str):
+        calls.append(username)
+        return {"id": 1234, "login": "OctoCat"}
+
+    code, _, _ = _run(
+        env_path,
+        github_user_id=None,
+        github_user_resolver=resolver,
+    )
+
+    assert code == 0
+    assert calls == ["octocat"]
+    assert rsw.parse_env(env_path.read_text())["EXOMEM_GITHUB_USER_ID"] == "1234"
+
+
+@pytest.mark.parametrize(
+    ("github_user_id", "resolver_result"),
+    [
+        ("0", None),
+        ("not-a-number", None),
+        (None, {"id": 1234, "login": "someone-else"}),
+        (None, {"id": None, "login": "octocat"}),
+    ],
+)
+def test_invalid_or_mismatched_github_identity_fails_before_write(
+    tmp_path: Path, github_user_id, resolver_result
+) -> None:
+    env_path = tmp_path / ".env"
+    code, _, doctor_calls = _run(
+        env_path,
+        github_user_id=github_user_id,
+        github_user_resolver=lambda _username: resolver_result,
+    )
+
+    assert code == 2
+    assert doctor_calls == []
+    assert not env_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("existing", "expected"),
+    [
+        ("EXOMEM_WRITER_LEASE_TOKEN=writer-only\nEXOMEM_WRITER_LEASE_URL=https://c\n", "writer-only"),
+        ("EXOMEM_OAUTH_STORAGE_TOKEN=oauth-only\nEXOMEM_OAUTH_STORAGE_URL=https://c\n", "oauth-only"),
+        ("EXOMEM_WRITER_LEASE_URL=https://c\n", None),
+    ],
+)
+def test_ha_setup_preserves_or_generates_one_matching_storage_credential(
+    tmp_path: Path, existing: str, expected: str | None
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(existing, encoding="utf-8")
+
+    code, output, _ = _run(env_path)
+
+    assert code == 0
+    values = rsw.parse_env(env_path.read_text())
+    assert values["EXOMEM_WRITER_LEASE_TOKEN"]
+    assert values["EXOMEM_WRITER_LEASE_TOKEN"] == values["EXOMEM_OAUTH_STORAGE_TOKEN"]
+    assert values["EXOMEM_WRITER_LEASE_TOKEN"] == values["EXOMEM_LEASE_COORDINATOR_TOKEN"]
+    if expected is not None:
+        assert values["EXOMEM_WRITER_LEASE_TOKEN"] == expected
+    assert values["EXOMEM_WRITER_LEASE_TOKEN"] not in output
+
+
+def test_ha_setup_conflicting_credentials_fail_before_any_write(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    original = (
+        "EXOMEM_WRITER_LEASE_URL=https://c\n"
+        "EXOMEM_WRITER_LEASE_TOKEN=one\n"
+        "EXOMEM_OAUTH_STORAGE_TOKEN=two\n"
+    )
+    env_path.write_text(original, encoding="utf-8")
+
+    code, output, doctor_calls = _run(env_path)
+
+    assert code == 2
+    assert "conflict" in output.lower()
+    assert doctor_calls == []
+    assert env_path.read_text() == original
 
 
 def test_doctor_failure_is_a_hard_gate(tmp_path: Path) -> None:
@@ -266,11 +370,13 @@ def test_setup_remote_dispatches_from_main(monkeypatch: pytest.MonkeyPatch) -> N
         "--tunnel", "cloudflare",
         "--github-client-id", "id", "--github-client-secret", "sec",
         "--github-username", "octocat", "--yes",
+        "--github-user-id", "1234",
     ])
     assert code == 0
     assert called["base_url"] == "https://kb.example.com"
     assert called["tunnel"] == "cloudflare"
     assert called["probe"] is True
+    assert called["github_user_id"] == "1234"
 
 
 def test_setup_remote_yes_without_required_flags_is_usage_error() -> None:

--- a/tests/test_remote_setup_wizard.py
+++ b/tests/test_remote_setup_wizard.py
@@ -330,9 +330,9 @@ def test_invalid_or_mismatched_github_identity_fails_before_write(
 @pytest.mark.parametrize(
     ("existing", "expected"),
     [
-        ("EXOMEM_WRITER_LEASE_TOKEN=writer-only\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "writer-only"),
-        ("EXOMEM_OAUTH_STORAGE_TOKEN=oauth-only\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "oauth-only"),
-        ("EXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", None),
+        ("EXOMEM_WRITER_LEASE_TOKEN=writer-only\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_WRITER_LEASE_VAULT_ID=main\nEXOMEM_WRITER_LEASE_REPLICA_ID=replica-a\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "writer-only"),
+        ("EXOMEM_OAUTH_STORAGE_TOKEN=oauth-only\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_WRITER_LEASE_VAULT_ID=main\nEXOMEM_WRITER_LEASE_REPLICA_ID=replica-a\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", "oauth-only"),
+        ("EXOMEM_WRITER_LEASE_URL=https://c\nEXOMEM_WRITER_LEASE_VAULT_ID=main\nEXOMEM_WRITER_LEASE_REPLICA_ID=replica-a\nEXOMEM_OAUTH_STORAGE_URL=https://c\nEXOMEM_OAUTH_STORAGE_NAMESPACE=main\n", None),
     ],
 )
 def test_ha_setup_preserves_or_generates_one_matching_storage_credential(
@@ -357,6 +357,8 @@ def test_ha_setup_conflicting_credentials_fail_before_any_write(tmp_path: Path) 
     env_path = tmp_path / ".env"
     original = (
         "EXOMEM_WRITER_LEASE_URL=https://c\n"
+        "EXOMEM_WRITER_LEASE_VAULT_ID=main\n"
+        "EXOMEM_WRITER_LEASE_REPLICA_ID=replica-a\n"
         "EXOMEM_OAUTH_STORAGE_URL=https://c\n"
         "EXOMEM_OAUTH_STORAGE_NAMESPACE=main\n"
         "EXOMEM_WRITER_LEASE_TOKEN=one\n"
@@ -391,6 +393,62 @@ def test_ha_setup_requires_shared_session_url_and_namespace_before_write(
     assert "HA" in output
     assert doctor_calls == []
     assert env_path.read_text() == existing
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        (
+            "EXOMEM_WRITER_LEASE_URL=https://c\n"
+            "EXOMEM_OAUTH_STORAGE_URL=https://c\n"
+            "EXOMEM_OAUTH_STORAGE_NAMESPACE=main\n"
+        ),
+        (
+            "EXOMEM_WRITER_LEASE_URL=https://c\n"
+            "EXOMEM_WRITER_LEASE_VAULT_ID=main\n"
+            "EXOMEM_OAUTH_STORAGE_URL=https://c\n"
+        ),
+    ],
+)
+def test_ha_setup_requires_complete_writer_topology_before_write(
+    tmp_path: Path, existing: str
+) -> None:
+    env_path = tmp_path / ".env"
+    original = existing.encode()
+    env_path.write_bytes(original)
+
+    code, output, doctor_calls = _run(env_path)
+
+    assert code == 2
+    assert "HA" in output
+    assert doctor_calls == []
+    assert env_path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        "EXOMEM_WRITER_LEASE_TOKEN=token-only\n",
+        "EXOMEM_LEASE_COORDINATOR_TOKEN=token-only\n",
+        "EXOMEM_OAUTH_STORAGE_TOKEN=token-only\n",
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE=namespace-only\n",
+        "EXOMEM_WRITER_LEASE_VAULT_ID=vault-only\n",
+        "EXOMEM_HA_REPLICA_URLS=https://replica.example\n",
+    ],
+)
+def test_partial_ha_signal_fails_before_writing_env(
+    tmp_path: Path, existing: str
+) -> None:
+    env_path = tmp_path / ".env"
+    original = existing.encode()
+    env_path.write_bytes(original)
+
+    code, output, doctor_calls = _run(env_path)
+
+    assert code == 2
+    assert "HA" in output
+    assert doctor_calls == []
+    assert env_path.read_bytes() == original
 
 
 def test_interactive_existing_client_secret_is_preserved_without_rendering_it(

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -123,6 +123,17 @@ def test_shared_session_authority_refuses_missing_storage_bearer(
         server_auth.build_session_authority(base_url="https://memory.example")
 
 
+def test_ha_runtime_refuses_replica_local_session_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_oauth_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://coordinator.example")
+    monkeypatch.delenv("EXOMEM_OAUTH_STORAGE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="EXOMEM_OAUTH_STORAGE_URL"):
+        server_auth.build_session_authority(base_url="https://memory.example")
+
+
 def test_build_oauth_constructs_durable_proxy_and_cache_disabled_verifier(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -3,45 +3,180 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
 from exomem import server_auth
+from exomem.auth_sessions import SessionAuthority
+from exomem.lease_coordinator import create_app
+from exomem.remote_oauth_storage import RemoteOAuthStorage
 
 
-def test_build_oauth_delegates_token_lifetime_to_fastmcp(
+def _set_oauth_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    values = {
+        "GITHUB_CLIENT_ID": "github-client",
+        "GITHUB_CLIENT_SECRET": "github-secret",
+        "EXOMEM_GITHUB_USERNAME": "Person",
+        "EXOMEM_GITHUB_USER_ID": "123456",
+        "EXOMEM_JWT_SIGNING_KEY": "stable-signing-root",
+    }
+    values.update(overrides)
+    for key, value in values.items():
+        if value:
+            monkeypatch.setenv(key, value)
+        else:
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_stdio_auth_disabled_needs_no_oauth_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key in (
+        "GITHUB_CLIENT_ID",
+        "GITHUB_CLIENT_SECRET",
+        "EXOMEM_GITHUB_USERNAME",
+        "EXOMEM_GITHUB_USER_ID",
+        "EXOMEM_JWT_SIGNING_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    assert server_auth.build_oauth(require_auth=False, base_url="http://localhost") is None
+
+
+@pytest.mark.parametrize(
+    ("missing_key", "message"),
+    [
+        ("EXOMEM_JWT_SIGNING_KEY", "EXOMEM_JWT_SIGNING_KEY"),
+        ("EXOMEM_GITHUB_USER_ID", "EXOMEM_GITHUB_USER_ID"),
+    ],
+)
+def test_http_oauth_requires_explicit_trust_anchors(
+    monkeypatch: pytest.MonkeyPatch,
+    missing_key: str,
+    message: str,
+) -> None:
+    _set_oauth_env(monkeypatch)
+    monkeypatch.delenv(missing_key)
+
+    with pytest.raises(RuntimeError, match=message):
+        server_auth.build_oauth(require_auth=True, base_url="https://memory.example")
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "not-numeric"])
+def test_http_oauth_rejects_invalid_immutable_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    _set_oauth_env(monkeypatch, EXOMEM_GITHUB_USER_ID=raw)
+
+    with pytest.raises(RuntimeError, match="positive numeric"):
+        server_auth.build_oauth(require_auth=True, base_url="https://memory.example")
+
+
+def test_build_session_authority_uses_encrypted_local_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    for key, value in {
-        "GITHUB_CLIENT_ID": "client",
-        "GITHUB_CLIENT_SECRET": "secret",
-        "EXOMEM_GITHUB_USERNAME": "person",
-        "EXOMEM_JWT_SIGNING_KEY": "stable-signing-key",
-        "EXOMEM_OAUTH_STORAGE_URL": "https://coordinator.example",
-        "EXOMEM_OAUTH_STORAGE_NAMESPACE": "vault",
-        "EXOMEM_OAUTH_STORAGE_TOKEN": "state-token",
-    }.items():
-        monkeypatch.setenv(key, value)
+    _set_oauth_env(monkeypatch)
+    monkeypatch.delenv("EXOMEM_OAUTH_STORAGE_URL", raising=False)
+    from fastmcp import settings
 
+    monkeypatch.setattr(settings, "home", tmp_path)
+
+    authority = server_auth.build_session_authority(base_url="https://memory.example/")
+
+    assert isinstance(authority, SessionAuthority)
+    assert authority.issuer == "https://memory.example"
+    assert authority.audience == "https://memory.example/mcp"
+    assert (tmp_path / "oauth-sessions").is_dir()
+
+
+def test_build_session_authority_uses_authenticated_uncached_remote_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_oauth_env(
+        monkeypatch,
+        EXOMEM_OAUTH_STORAGE_URL="https://coordinator.example",
+        EXOMEM_OAUTH_STORAGE_NAMESPACE="vault",
+        EXOMEM_OAUTH_STORAGE_TOKEN="coordinator-secret",
+    )
+
+    authority = server_auth.build_session_authority(base_url="https://memory.example")
+    raw_store = authority._storage.raw
+
+    assert isinstance(raw_store, RemoteOAuthStorage)
+    assert raw_store.token == "coordinator-secret"
+    assert raw_store.cache_ttl == 0
+
+
+def test_shared_session_authority_refuses_missing_storage_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_oauth_env(
+        monkeypatch,
+        EXOMEM_OAUTH_STORAGE_URL="https://coordinator.example",
+        EXOMEM_OAUTH_STORAGE_NAMESPACE="vault",
+        EXOMEM_OAUTH_STORAGE_TOKEN="",
+    )
+
+    with pytest.raises(RuntimeError, match="EXOMEM_OAUTH_STORAGE_TOKEN"):
+        server_auth.build_session_authority(base_url="https://memory.example")
+
+
+def test_build_oauth_constructs_durable_proxy_and_cache_disabled_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _set_oauth_env(monkeypatch)
     from fastmcp import settings
 
     monkeypatch.setattr(settings, "home", tmp_path)
     captured: dict[str, Any] = {}
 
-    class RecordingOAuthProxy:
+    class RecordingProxy:
         def __init__(self, **kwargs: Any) -> None:
             captured.update(kwargs)
 
-    monkeypatch.setattr(server_auth, "OAuthProxy", RecordingOAuthProxy)
+    monkeypatch.setattr(server_auth, "ExomemSessionOAuthProxy", RecordingProxy)
 
     result = server_auth.build_oauth(
         require_auth=True,
         base_url="https://memory.example",
     )
 
-    assert isinstance(result, RecordingOAuthProxy)
-    assert "fallback_access_token_expiry_seconds" not in captured
-    assert captured["jwt_signing_key"] == "stable-signing-key"
-    assert isinstance(captured["token_verifier"], server_auth.SingleUserGitHubVerifier)
-    assert captured["token_verifier"]._allowed_login == "person"
-    assert captured["client_storage"] is not None
+    assert isinstance(result, RecordingProxy)
+    assert isinstance(captured["session_authority"], SessionAuthority)
+    assert captured["jwt_signing_key"] == "stable-signing-root"
+    assert captured["upstream_revocation_endpoint"] is None
+    verifier = captured["token_verifier"]
+    assert isinstance(verifier, server_auth.SingleUserGitHubVerifier)
+    assert verifier._allowed_login == "person"
+    assert verifier._allowed_user_id == 123456
+    assert verifier._cache.enabled is False
+
+
+@pytest.mark.anyio
+async def test_coordinator_state_rejects_unauthenticated_and_accepts_configured_bearer(
+    tmp_path: Path,
+) -> None:
+    app = create_app(database=tmp_path / "coordinator.sqlite", bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+    denied = RemoteOAuthStorage(
+        url="https://coordinator.example",
+        namespace="main",
+        token=None,
+        cache_ttl=0,
+        transport=transport,
+    )
+    configured = RemoteOAuthStorage(
+        url="https://coordinator.example",
+        namespace="main",
+        token="secret",
+        cache_ttl=0,
+        transport=transport,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as error:
+        await denied.get("current", collection="auth")
+    assert error.value.response.status_code == 401
+    assert await configured.get("current", collection="auth") is None

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -1,0 +1,750 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import inspect
+import json
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from importlib.metadata import version
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+import pytest
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.oauth_proxy.models import (
+    ClientCode,
+    OAuthTransaction,
+)
+from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.provider import AuthorizationCode, TokenError
+from mcp.server.auth.routes import TokenHandler
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+from starlette.requests import Request
+
+from exomem.auth_sessions import SessionIdentity, SessionStoreUnavailable
+from exomem.session_oauth import ExomemSessionOAuthProxy
+
+
+def test_fastmcp_private_adapter_contract_is_pinned() -> None:
+    assert version("fastmcp") == "3.4.4"
+    assert list(inspect.signature(OAuthProxy._handle_idp_callback).parameters) == [
+        "self",
+        "request",
+    ]
+    assert list(inspect.signature(OAuthProxy.exchange_authorization_code).parameters) == [
+        "self",
+        "client",
+        "authorization_code",
+    ]
+    assert list(inspect.signature(OAuthProxy.load_access_token).parameters) == ["self", "token"]
+    assert list(inspect.signature(OAuthProxy.revoke_token).parameters) == ["self", "token"]
+    assert list(inspect.signature(OAuthProxy.get_middleware).parameters) == ["self"]
+    assert list(
+        inspect.signature(OAuthProxy._validate_client_redirect_uri).parameters
+    ) == ["self", "redirect_uri"]
+    assert list(
+        inspect.signature(OAuthProxy._verify_consent_binding_cookie).parameters
+    ) == ["self", "request", "txn_id", "expected_token"]
+    assert list(
+        inspect.signature(OAuthProxy._clear_consent_binding_cookie).parameters
+    ) == ["self", "request", "response", "txn_id"]
+    assert list(
+        inspect.signature(OAuthProxy._prepare_scopes_for_token_exchange).parameters
+    ) == ["self", "scopes"]
+    assert list(inspect.signature(OAuthProxy._upstream_oauth_client).parameters) == [
+        "self"
+    ]
+    assert set(AccessToken.model_fields) == {
+        "token",
+        "client_id",
+        "scopes",
+        "expires_at",
+        "resource",
+        "claims",
+    }
+    assert set(OAuthToken.model_fields) == {
+        "access_token",
+        "token_type",
+        "expires_in",
+        "scope",
+        "refresh_token",
+    }
+    assert {
+        "code",
+        "client_id",
+        "redirect_uri",
+        "code_challenge",
+        "code_challenge_method",
+        "scopes",
+        "idp_tokens",
+        "expires_at",
+        "created_at",
+    } == set(ClientCode.model_fields)
+    assert {
+        "txn_id",
+        "client_id",
+        "client_redirect_uri",
+        "client_state",
+        "code_challenge",
+        "code_challenge_method",
+        "scopes",
+        "created_at",
+        "resource",
+        "proxy_code_verifier",
+        "csrf_token",
+        "csrf_expires_at",
+        "consent_token",
+    } == set(OAuthTransaction.model_fields)
+
+
+@dataclass
+class FakeRecord:
+    session_id: str
+    client_id: str
+    scopes: tuple[str, ...]
+    issuer: str = "https://memory.example"
+    audience: str = "https://memory.example/mcp"
+    github_user_id: int = 123456
+    github_login: str = "person"
+
+
+class FakeAuthority:
+    def __init__(self) -> None:
+        self.sessions: dict[str, FakeRecord] = {}
+        self.issue_calls: list[dict[str, Any]] = []
+        self.tombstones: list[tuple[str, str]] = []
+        self.validation_error: Exception | None = None
+
+    async def issue(
+        self,
+        *,
+        client_id: str,
+        scopes: list[str],
+        identity: SessionIdentity,
+    ) -> tuple[str, FakeRecord]:
+        token = f"local-session-{len(self.issue_calls)}"
+        record = FakeRecord(
+            session_id=f"session-{len(self.issue_calls)}",
+            client_id=client_id,
+            scopes=tuple(scopes),
+            github_user_id=identity.github_user_id,
+            github_login=identity.github_login,
+        )
+        self.issue_calls.append(
+            {"client_id": client_id, "scopes": list(scopes), "identity": identity}
+        )
+        self.sessions[token] = record
+        return token, record
+
+    async def validate(self, token: str) -> FakeRecord | None:
+        if self.validation_error is not None:
+            raise self.validation_error
+        return self.sessions.get(token)
+
+    async def tombstone(self, session_id: str, *, reason: str) -> bool:
+        self.tombstones.append((session_id, reason))
+        for token, record in list(self.sessions.items()):
+            if record.session_id == session_id:
+                del self.sessions[token]
+                return True
+        return False
+
+
+class StubVerifier:
+    required_scopes: list[str] = []
+
+    def __init__(self, result: AccessToken | None) -> None:
+        self.result = result
+        self.calls: list[str] = []
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        self.calls.append(token)
+        return self.result
+
+
+def _verified_identity() -> AccessToken:
+    return AccessToken(
+        token="temporary-github-token",
+        client_id="123456",
+        scopes=["user"],
+        expires_at=None,
+        claims={"sub": "123456", "login": "person"},
+    )
+
+
+def _proxy(
+    *,
+    authority: FakeAuthority | None = None,
+    verifier: StubVerifier | None = None,
+    cleanup_transport: httpx.AsyncBaseTransport | None = None,
+    require_consent: bool = False,
+) -> ExomemSessionOAuthProxy:
+    return ExomemSessionOAuthProxy(
+        session_authority=authority or FakeAuthority(),
+        github_cleanup_transport=cleanup_transport,
+        upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
+        upstream_token_endpoint="https://github.com/login/oauth/access_token",
+        upstream_client_id="github-client",
+        upstream_client_secret="github-secret",
+        upstream_revocation_endpoint=None,
+        token_verifier=verifier or StubVerifier(_verified_identity()),
+        base_url="https://memory.example",
+        allowed_client_redirect_uris=["http://127.0.0.1:*"],
+        client_storage=MemoryStore(),
+        jwt_signing_key="stable-signing-root",
+        require_authorization_consent=require_consent,
+    )
+
+
+async def _seed_transaction(
+    proxy: ExomemSessionOAuthProxy,
+    *,
+    consent_token: str | None = None,
+) -> OAuthTransaction:
+    transaction = OAuthTransaction(
+        txn_id="transaction-id",
+        client_id="codex-client",
+        client_redirect_uri="http://127.0.0.1:8765/callback",
+        client_state="client-state",
+        code_challenge="downstream-pkce-challenge",
+        code_challenge_method="S256",
+        scopes=["exomem:read", "exomem:write"],
+        created_at=time.time(),
+        resource="https://memory.example/mcp",
+        proxy_code_verifier="forwarded-upstream-verifier",
+        consent_token=consent_token,
+    )
+    await proxy._transaction_store.put(key=transaction.txn_id, value=transaction, ttl=900)
+    return transaction
+
+
+def _callback_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "https",
+            "path": "/auth/callback",
+            "raw_path": b"/auth/callback",
+            "query_string": b"code=github-code&state=transaction-id",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+            "server": ("memory.example", 443),
+        }
+    )
+
+
+def _install_token_exchange(
+    proxy: ExomemSessionOAuthProxy,
+    tokens: dict[str, Any],
+) -> None:
+    class Client:
+        async def fetch_token(self, **params: Any) -> dict[str, Any]:
+            assert params["code"] == "github-code"
+            assert params["redirect_uri"] == "https://memory.example/auth/callback"
+            assert params["code_verifier"] == "forwarded-upstream-verifier"
+            return dict(tokens)
+
+    @asynccontextmanager
+    async def client_factory():
+        yield Client()
+
+    proxy._upstream_oauth_client = client_factory
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="codex-client",
+        client_secret="client-secret",
+        redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
+        token_endpoint_auth_method="client_secret_post",
+    )
+
+
+def _authorization_code(code: str) -> AuthorizationCode:
+    return AuthorizationCode(
+        code=code,
+        scopes=["exomem:read", "exomem:write"],
+        expires_at=time.time() + 300,
+        client_id="codex-client",
+        code_challenge="downstream-pkce-challenge",
+        redirect_uri=AnyUrl("http://127.0.0.1:8765/callback"),
+        redirect_uri_provided_explicitly=True,
+        resource="https://memory.example/mcp",
+    )
+
+
+class _ClientAuthenticator:
+    async def authenticate_request(self, request: Request) -> OAuthClientInformationFull:
+        return _client()
+
+
+def _token_request(*, code: str, code_verifier: str) -> Request:
+    body = urlencode(
+        {
+            "grant_type": "authorization_code",
+            "client_id": "codex-client",
+            "client_secret": "client-secret",
+            "code": code,
+            "redirect_uri": "http://127.0.0.1:8765/callback",
+            "code_verifier": code_verifier,
+        }
+    ).encode()
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/token",
+            "raw_path": b"/token",
+            "query_string": b"",
+            "headers": [
+                (b"content-type", b"application/x-www-form-urlencoded"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("memory.example", 443),
+        },
+        receive,
+    )
+
+
+def _contains_credentials(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(
+            key in {"access_token", "refresh_token"} or _contains_credentials(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_credentials(item) for item in value)
+    return False
+
+
+@pytest.mark.anyio
+async def test_callback_stores_token_free_proof_then_exchange_issues_local_session() -> None:
+    cleanup_requests: list[httpx.Request] = []
+
+    def cleanup(request: httpx.Request) -> httpx.Response:
+        cleanup_requests.append(request)
+        return httpx.Response(204)
+
+    authority = FakeAuthority()
+    verifier = StubVerifier(_verified_identity())
+    proxy = _proxy(
+        authority=authority,
+        verifier=verifier,
+        cleanup_transport=httpx.MockTransport(cleanup),
+    )
+    await _seed_transaction(proxy)
+    _install_token_exchange(
+        proxy,
+        {
+            "access_token": "temporary-github-token",
+            "refresh_token": "must-not-survive",
+            "scope": "repo user",
+            "token_type": "bearer",
+        },
+    )
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    params = parse_qs(urlparse(location).query)
+    code = params["code"][0]
+    assert params["state"] == ["client-state"]
+    stored_code = await proxy._code_store.get(key=code)
+    assert stored_code is not None
+    assert not _contains_credentials(stored_code.idp_tokens)
+    assert stored_code.idp_tokens == {
+        "exomem_identity": {"github_user_id": 123456, "github_login": "person"}
+    }
+    assert await proxy._transaction_store.get(key="transaction-id") is None
+    assert verifier.calls == ["temporary-github-token"]
+    [request] = cleanup_requests
+    assert request.method == "DELETE"
+    assert request.url == "https://api.github.com/applications/github-client/token"
+    assert request.headers["authorization"].startswith("Basic ")
+    assert json.loads(request.content) == {"access_token": "temporary-github-token"}
+    assert authority.issue_calls == []  # an abandoned downstream code issues no session
+
+    loaded = await proxy.load_authorization_code(_client(), code)
+    assert loaded is not None
+    assert loaded.code_challenge == "downstream-pkce-challenge"
+    token = await proxy.exchange_authorization_code(_client(), _authorization_code(code))
+
+    assert token.access_token.startswith("local-session-")
+    assert token.expires_in is None
+    assert token.refresh_token is None
+    assert token.scope == "exomem:read exomem:write"
+    assert authority.issue_calls == [
+        {
+            "client_id": "codex-client",
+            "scopes": ["exomem:read", "exomem:write"],
+            "identity": SessionIdentity(github_user_id=123456, github_login="person"),
+        }
+    ]
+    assert await proxy._client_storage.keys(collection="mcp-upstream-tokens") == []
+    assert await proxy._client_storage.keys(collection="mcp-jti-mappings") == []
+    with pytest.raises(TokenError, match="Authorization code not found"):
+        await proxy.exchange_authorization_code(_client(), _authorization_code(code))
+
+
+@pytest.mark.anyio
+async def test_callback_preserves_consent_binding_verification_and_cookie_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proxy = _proxy(
+        cleanup_transport=httpx.MockTransport(lambda request: httpx.Response(204)),
+        require_consent=True,
+    )
+    await _seed_transaction(proxy, consent_token="consent-token")
+    _install_token_exchange(proxy, {"access_token": "temporary-github-token"})
+    calls: list[tuple[str, str]] = []
+
+    def verify(request: Request, txn_id: str, expected_token: str) -> bool:
+        calls.append((txn_id, expected_token))
+        return True
+
+    def clear(request: Request, response: Any, txn_id: str) -> None:
+        calls.append((txn_id, "cleared"))
+
+    monkeypatch.setattr(proxy, "_verify_consent_binding_cookie", verify)
+    monkeypatch.setattr(proxy, "_clear_consent_binding_cookie", clear)
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 302
+    assert calls == [
+        ("transaction-id", "consent-token"),
+        ("transaction-id", "cleared"),
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "verified",
+    [
+        None,
+        AccessToken(token="t", client_id="x", scopes=[], claims={"login": "person"}),
+        AccessToken(token="t", client_id="x", scopes=[], claims={"sub": "123456"}),
+        AccessToken(
+            token="t",
+            client_id="1",
+            scopes=[],
+            claims={"login": "person", "sub": True},
+        ),
+    ],
+)
+async def test_callback_rejects_unverifiable_or_incomplete_identity_and_cleans_token(
+    verified: AccessToken | None,
+) -> None:
+    cleanup_calls = 0
+
+    def cleanup(request: httpx.Request) -> httpx.Response:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return httpx.Response(204)
+
+    proxy = _proxy(
+        verifier=StubVerifier(verified),
+        cleanup_transport=httpx.MockTransport(cleanup),
+    )
+    await _seed_transaction(proxy)
+    _install_token_exchange(proxy, {"access_token": "temporary-github-token"})
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 403
+    assert cleanup_calls == 1
+    assert await proxy._client_storage.keys(collection="mcp-authorization-codes") == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("cleanup_status", [404, 422, 503])
+async def test_cleanup_already_gone_or_transient_failure_never_retains_token_or_blocks_code(
+    cleanup_status: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def cleanup(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(cleanup_status)
+
+    proxy = _proxy(cleanup_transport=httpx.MockTransport(cleanup))
+    await _seed_transaction(proxy)
+    _install_token_exchange(proxy, {"access_token": "temporary-github-token"})
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 302
+    code = parse_qs(urlparse(response.headers["location"]).query)["code"][0]
+    stored = await proxy._code_store.get(key=code)
+    assert stored is not None and not _contains_credentials(stored.idp_tokens)
+    assert "temporary-github-token" not in caplog.text
+    if cleanup_status == 503:
+        assert "cleanup" in caplog.text.lower()
+
+
+@pytest.mark.anyio
+async def test_cleanup_occurs_before_proof_persistence_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_calls = 0
+
+    def cleanup(request: httpx.Request) -> httpx.Response:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return httpx.Response(204)
+
+    proxy = _proxy(cleanup_transport=httpx.MockTransport(cleanup))
+    await _seed_transaction(proxy)
+    _install_token_exchange(proxy, {"access_token": "temporary-github-token"})
+
+    async def fail_put(*args: Any, **kwargs: Any) -> None:
+        raise OSError("code store unavailable")
+
+    monkeypatch.setattr(proxy._code_store, "put", fail_put)
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 500
+    assert cleanup_calls == 1
+
+
+@pytest.mark.anyio
+async def test_cleanup_already_happened_when_redirect_handling_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_calls = 0
+
+    def cleanup(request: httpx.Request) -> httpx.Response:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return httpx.Response(204)
+
+    proxy = _proxy(cleanup_transport=httpx.MockTransport(cleanup))
+    await _seed_transaction(proxy)
+    _install_token_exchange(proxy, {"access_token": "temporary-github-token"})
+
+    def fail_redirect(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("redirect construction failed")
+
+    monkeypatch.setattr("exomem.session_oauth.RedirectResponse", fail_redirect)
+
+    response = await proxy._handle_idp_callback(_callback_request())
+
+    assert response.status_code == 500
+    assert cleanup_calls == 1
+    keys = await proxy._client_storage.keys(collection="mcp-authorization-codes")
+    assert len(keys) == 1
+    stored = await proxy._code_store.get(key=keys[0])
+    assert stored is not None and not _contains_credentials(stored.idp_tokens)
+
+
+@pytest.mark.anyio
+async def test_invalid_pkce_issues_no_session_and_retains_no_github_credential() -> None:
+    authority = FakeAuthority()
+    proxy = _proxy(authority=authority)
+    code = "downstream-code"
+    valid_verifier = "correct-verifier"
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(valid_verifier.encode()).digest()
+    ).decode().rstrip("=")
+    await proxy._code_store.put(
+        key=code,
+        value=ClientCode(
+            code=code,
+            client_id="codex-client",
+            redirect_uri="http://127.0.0.1:8765/callback",
+            code_challenge=challenge,
+            code_challenge_method="S256",
+            scopes=["exomem:read"],
+            idp_tokens={
+                "exomem_identity": {
+                    "github_user_id": 123456,
+                    "github_login": "person",
+                }
+            },
+            expires_at=int(time.time() + 300),
+            created_at=time.time(),
+        ),
+        ttl=300,
+    )
+
+    response = await TokenHandler(proxy, _ClientAuthenticator()).handle(
+        _token_request(code=code, code_verifier="incorrect-verifier")
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "invalid_grant"
+    assert authority.issue_calls == []
+    stored = await proxy._code_store.get(key=code)
+    assert stored is not None and not _contains_credentials(stored.idp_tokens)
+
+
+@pytest.mark.anyio
+async def test_token_endpoint_omits_expiry_and_refresh_fields() -> None:
+    authority = FakeAuthority()
+    proxy = _proxy(authority=authority)
+    code = "successful-downstream-code"
+    verifier = "correct-verifier"
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    await proxy._code_store.put(
+        key=code,
+        value=ClientCode(
+            code=code,
+            client_id="codex-client",
+            redirect_uri="http://127.0.0.1:8765/callback",
+            code_challenge=challenge,
+            code_challenge_method="S256",
+            scopes=["exomem:read"],
+            idp_tokens={
+                "exomem_identity": {
+                    "github_user_id": 123456,
+                    "github_login": "person",
+                }
+            },
+            expires_at=int(time.time() + 300),
+            created_at=time.time(),
+        ),
+        ttl=300,
+    )
+
+    response = await TokenHandler(proxy, _ClientAuthenticator()).handle(
+        _token_request(code=code, code_verifier=verifier)
+    )
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "access_token": "local-session-0",
+        "token_type": "Bearer",
+        "scope": "exomem:read",
+    }
+    assert len(authority.issue_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_exchange_rejects_corrupt_boolean_identity_proof() -> None:
+    authority = FakeAuthority()
+    proxy = _proxy(authority=authority)
+    code = "corrupt-proof-code"
+    await proxy._code_store.put(
+        key=code,
+        value=ClientCode(
+            code=code,
+            client_id="codex-client",
+            redirect_uri="http://127.0.0.1:8765/callback",
+            code_challenge="downstream-pkce-challenge",
+            code_challenge_method="S256",
+            scopes=["exomem:read"],
+            idp_tokens={
+                "exomem_identity": {
+                    "github_user_id": True,
+                    "github_login": "person",
+                }
+            },
+            expires_at=int(time.time() + 300),
+            created_at=time.time(),
+        ),
+        ttl=300,
+    )
+
+    with pytest.raises(TokenError, match="identity proof is invalid"):
+        await proxy.exchange_authorization_code(_client(), _authorization_code(code))
+
+    assert authority.issue_calls == []
+
+
+@pytest.mark.anyio
+async def test_load_access_token_uses_only_session_authority_for_repeated_requests() -> None:
+    authority = FakeAuthority()
+    verifier = StubVerifier(None)  # simulates GitHub revocation after issuance
+    proxy = _proxy(authority=authority, verifier=verifier)
+    for index in range(12):
+        code = f"authorization-code-{index}"
+        await proxy._code_store.put(
+            key=code,
+            value=ClientCode(
+                code=code,
+                client_id="codex-client",
+                redirect_uri="http://127.0.0.1:8765/callback",
+                code_challenge="downstream-pkce-challenge",
+                code_challenge_method="S256",
+                scopes=["exomem:read"],
+                idp_tokens={
+                    "exomem_identity": {
+                        "github_user_id": 123456,
+                        "github_login": "person",
+                    }
+                },
+                expires_at=int(time.time() + 300),
+                created_at=time.time(),
+            ),
+            ttl=300,
+        )
+        issued = await proxy.exchange_authorization_code(
+            _client(), _authorization_code(code)
+        )
+        assert issued.access_token == f"local-session-{index}"
+
+    for index in range(12):
+        first = await proxy.load_access_token(f"local-session-{index}")
+        second = await proxy.load_access_token(f"local-session-{index}")
+        assert first is not None and second is not None
+        assert first.client_id == "codex-client"
+        assert first.scopes == ["exomem:read"]
+        assert first.expires_at is None
+        assert first.resource == "https://memory.example/mcp"
+        assert first.claims["github_user_id"] == 123456
+
+    assert verifier.calls == []
+    assert await proxy.load_access_token("malformed-or-legacy-token") is None
+
+
+@pytest.mark.anyio
+async def test_load_access_token_propagates_authority_failure() -> None:
+    authority = FakeAuthority()
+    authority.validation_error = SessionStoreUnavailable("coordinator down")
+    proxy = _proxy(authority=authority)
+
+    with pytest.raises(SessionStoreUnavailable, match="coordinator down"):
+        await proxy.load_access_token("session-token")
+
+
+@pytest.mark.anyio
+async def test_rfc7009_revocation_tombstones_shared_session_and_unknown_is_success() -> None:
+    authority = FakeAuthority()
+    authority.sessions["session-token"] = FakeRecord(
+        session_id="session-id",
+        client_id="codex-client",
+        scopes=("exomem:read",),
+    )
+    proxy = _proxy(authority=authority)
+
+    assert proxy.revocation_options is not None and proxy.revocation_options.enabled
+    await proxy.revoke_token(
+        AccessToken(token="session-token", client_id="codex-client", scopes=["exomem:read"])
+    )
+
+    assert authority.tombstones == [("session-id", "oauth-client-revocation")]
+    assert await proxy.load_access_token("session-token") is None
+    await proxy.revoke_token(
+        AccessToken(token="unknown", client_id="codex-client", scopes=["exomem:read"])
+    )
+    assert authority.tombstones == [("session-id", "oauth-client-revocation")]

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -44,6 +44,40 @@ def test_fastmcp_private_adapter_contract_is_pinned() -> None:
     assert list(inspect.signature(OAuthProxy.load_access_token).parameters) == ["self", "token"]
     assert list(inspect.signature(OAuthProxy.revoke_token).parameters) == ["self", "token"]
     assert list(inspect.signature(OAuthProxy.get_middleware).parameters) == ["self"]
+    assert list(inspect.signature(OAuthProxy.get_routes).parameters) == [
+        "self",
+        "mcp_path",
+    ]
+    assert list(inspect.signature(OAuthProxy.load_refresh_token).parameters) == [
+        "self",
+        "client",
+        "refresh_token",
+    ]
+    assert list(inspect.signature(OAuthProxy.exchange_refresh_token).parameters) == [
+        "self",
+        "client",
+        "refresh_token",
+        "scopes",
+    ]
+    assert list(inspect.signature(OAuthProxy.register_client).parameters) == [
+        "self",
+        "client_info",
+    ]
+    assert list(inspect.signature(OAuthProxy.get_client).parameters) == [
+        "self",
+        "client_id",
+    ]
+    for seam in (
+        "load_refresh_token",
+        "exchange_refresh_token",
+        "register_client",
+        "get_client",
+        "get_routes",
+    ):
+        assert seam in ExomemSessionOAuthProxy.__dict__
+        assert list(
+            inspect.signature(getattr(ExomemSessionOAuthProxy, seam)).parameters
+        ) == list(inspect.signature(getattr(OAuthProxy, seam)).parameters)
     assert list(
         inspect.signature(OAuthProxy._validate_client_redirect_uri).parameters
     ) == ["self", "redirect_uri"]
@@ -478,7 +512,7 @@ async def test_callback_rejects_unverifiable_or_incomplete_identity_and_cleans_t
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("cleanup_status", [404, 422, 503])
-async def test_cleanup_already_gone_or_transient_failure_never_retains_token_or_blocks_code(
+async def test_cleanup_already_gone_or_failed_never_retains_token_or_blocks_code(
     cleanup_status: int,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -496,7 +530,7 @@ async def test_cleanup_already_gone_or_transient_failure_never_retains_token_or_
     stored = await proxy._code_store.get(key=code)
     assert stored is not None and not _contains_credentials(stored.idp_tokens)
     assert "temporary-github-token" not in caplog.text
-    if cleanup_status == 503:
+    if cleanup_status in {422, 503}:
         assert "cleanup" in caplog.text.lower()
 
 

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -44,10 +44,6 @@ def test_fastmcp_private_adapter_contract_is_pinned() -> None:
     assert list(inspect.signature(OAuthProxy.load_access_token).parameters) == ["self", "token"]
     assert list(inspect.signature(OAuthProxy.revoke_token).parameters) == ["self", "token"]
     assert list(inspect.signature(OAuthProxy.get_middleware).parameters) == ["self"]
-    assert list(inspect.signature(OAuthProxy.get_routes).parameters) == [
-        "self",
-        "mcp_path",
-    ]
     assert list(inspect.signature(OAuthProxy.load_refresh_token).parameters) == [
         "self",
         "client",
@@ -59,25 +55,16 @@ def test_fastmcp_private_adapter_contract_is_pinned() -> None:
         "refresh_token",
         "scopes",
     ]
-    assert list(inspect.signature(OAuthProxy.register_client).parameters) == [
-        "self",
-        "client_info",
-    ]
-    assert list(inspect.signature(OAuthProxy.get_client).parameters) == [
-        "self",
-        "client_id",
-    ]
     for seam in (
         "load_refresh_token",
         "exchange_refresh_token",
-        "register_client",
-        "get_client",
-        "get_routes",
     ):
         assert seam in ExomemSessionOAuthProxy.__dict__
         assert list(
             inspect.signature(getattr(ExomemSessionOAuthProxy, seam)).parameters
         ) == list(inspect.signature(getattr(OAuthProxy, seam)).parameters)
+    for inherited_compatibility_seam in ("register_client", "get_client", "get_routes"):
+        assert inherited_compatibility_seam not in ExomemSessionOAuthProxy.__dict__
     assert list(
         inspect.signature(OAuthProxy._validate_client_redirect_uri).parameters
     ) == ["self", "redirect_uri"]

--- a/tests/test_shared_oauth_storage.py
+++ b/tests/test_shared_oauth_storage.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from key_value.aio.stores.memory import MemoryStore
 
+from exomem.auth_sessions import SessionAuthority, SessionIdentity
 from exomem.lease_coordinator import SQLiteStateStore, create_app
 from exomem.remote_oauth_storage import ReadThroughMirrorStorage, RemoteOAuthStorage
 
@@ -39,6 +40,14 @@ async def test_remote_storage_round_trip_bulk_ttl_and_auth(tmp_path: Path) -> No
         None,
     ]
     assert await store.delete_many(["one", "two", "missing"], collection="tokens") == 2
+    assert await store.put_if_absent(
+        "generation", {"ciphertext": "first"}, collection="auth"
+    )
+    assert not await store.put_if_absent(
+        "generation", {"ciphertext": "second"}, collection="auth"
+    )
+    assert await store.get("generation", collection="auth") == {"ciphertext": "first"}
+    assert await store.list_keys(collection="tokens") == ["three"]
 
     denied = RemoteOAuthStorage(
         url="https://coordinator.example",
@@ -85,6 +94,24 @@ def test_sqlite_state_store_expires_and_isolates_namespaces(tmp_path: Path) -> N
     assert store.get("b", "tokens", "same")[0] == {"value": "b"}
 
 
+def test_sqlite_state_store_put_if_absent_and_key_enumeration(tmp_path: Path) -> None:
+    now = [100.0]
+    store = SQLiteStateStore(tmp_path / "coordinator.sqlite", clock=lambda: now[0])
+
+    assert store.put_if_absent("main", "auth", "generation", {"ciphertext": "first"}, None)
+    assert not store.put_if_absent(
+        "main", "auth", "generation", {"ciphertext": "second"}, None
+    )
+    store.put("main", "auth", "expiring", {"ciphertext": "soon"}, 5)
+    store.put("other", "auth", "hidden", {"ciphertext": "other"}, None)
+    assert store.list_keys("main", "auth") == ["expiring", "generation"]
+
+    now[0] = 106.0
+
+    assert store.list_keys("main", "auth") == ["generation"]
+    assert store.get("main", "auth", "generation")[0] == {"ciphertext": "first"}
+
+
 @pytest.mark.anyio
 async def test_read_through_migrates_existing_local_state_and_mirrors_writes() -> None:
     remote = MemoryStore()
@@ -98,6 +125,46 @@ async def test_read_through_migrates_existing_local_state_and_mirrors_writes() -
     await store.put("new", {"ciphertext": "new"}, collection="tokens")
     assert await remote.get("new", collection="tokens") == {"ciphertext": "new"}
     assert await local.get("new", collection="tokens") == {"ciphertext": "new"}
+
+
+@pytest.mark.anyio
+async def test_remote_session_authority_is_cross_replica_and_revocation_safe(tmp_path: Path) -> None:
+    app = create_app(database=tmp_path / "coordinator.sqlite", bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+    kwargs = {
+        "url": "https://coordinator.example",
+        "namespace": "main",
+        "storage_token": "secret",
+        "signing_root": "stable-root",
+        "issuer": "https://memory.example",
+        "audience": "https://memory.example/mcp",
+        "transport": transport,
+    }
+    first = SessionAuthority.remote(**kwargs)
+    second = SessionAuthority.remote(**kwargs)
+    bearer, issued = await first.issue(
+        client_id="codex",
+        scopes=("exomem:read",),
+        identity=SessionIdentity(github_user_id=123, github_login="person"),
+    )
+
+    assert await second.validate(bearer) == issued
+    assert await second.tombstone(issued.session_id, reason="operator")
+    assert await first.validate(bearer) is None
+    [listed] = await first.list_sessions()
+    assert listed.status == "revoked"
+
+
+def test_remote_session_authority_requires_storage_bearer() -> None:
+    with pytest.raises(ValueError, match="storage token"):
+        SessionAuthority.remote(
+            url="https://coordinator.example",
+            namespace="main",
+            storage_token="",
+            signing_root="stable-root",
+            issuer="https://memory.example",
+            audience="https://memory.example/mcp",
+        )
 
 
 def test_shared_storage_requires_stable_key_and_namespace(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.19.1"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -685,7 +685,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faster-whisper", marker = "extra == 'media'", specifier = ">=1.0" },
-    { name = "fastmcp", specifier = ">=2.10" },
+    { name = "fastmcp", specifier = "==3.4.4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "markitdown", extras = ["docx", "xlsx", "pptx"], marker = "extra == 'media'", specifier = ">=0.1.1" },
     { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'media-mlx'", specifier = ">=0.4" },
@@ -738,19 +738,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -760,9 +760,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -773,6 +773,7 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 server = [
     { name = "authlib" },
@@ -780,6 +781,7 @@ server = [
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -790,6 +792,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -3181,15 +3184,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace GitHub-backed reference JWTs with durable Exomem-owned opaque sessions
- use GitHub once for login plus immutable user-ID proof, then discard the upstream token
- make HA session validation remote-authoritative with explicit revocation and 503 outage semantics
- add operator commands, setup/doctor validation, coordinated rollout docs, and a Codex reuse harness

## Root cause
GitHub retains at most ten OAuth tokens per user/application/scope combination. Production had accumulated 44 upstream-token records, so each new authorization could revoke another active MCP client's token and create the reauthentication loop.

## Verification
- focused auth/HA/setup gate: 201 passed, 1 skipped (NTFS does not expose POSIX chmod bits under WSL)
- Ruff: clean
- strict OpenSpec validation: clean
- live hosted-client smoke and coordinated two-replica rollout remain the deployment gate