### PR TITLE
fix(config): load packaged service dotenv from working directory

### DIFF
--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -39,5 +39,5 @@
 - [x] 6.1 Pin `fastmcp==3.4.4`, refresh the lockfile, and add adapter contract tests for every private callback, transaction/code-store, token, revocation, initialization, and exception seam Exomem relies on.
 - [x] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
 - [ ] 6.3 Run the equivalent supported hosted-connector smoke test and record the rollout result; block deployment if omitted `expires_in` is not persisted correctly.
-- [ ] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.
+- [x] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.
 - [ ] 6.5 Have an independent reviewer verify the implementation against every scenario in `durable-mcp-auth-sessions`, including zero post-issuance GitHub calls and 503-vs-401 behavior.

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -38,7 +38,10 @@ def initialize_runtime(*, load_dotenv_func: Callable[..., object]) -> ServerRunt
     ``exomem.server.load_dotenv`` still neutralize dotenv loading exactly as they
     did before this extraction.
     """
-    load_dotenv_func(override=True)
+    # An installed package lives under site-packages, so python-dotenv's implicit
+    # caller-relative search misses the service working directory. The documented
+    # repo-root .env is explicitly cwd-relative for both checkout and wheel installs.
+    load_dotenv_func(dotenv_path=Path.cwd() / ".env", override=True)
     env_compat.promote_legacy()
 
     vault_root = resolve_vault()

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import server_runtime
+
+
+def test_initialize_runtime_loads_dotenv_from_service_working_directory(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[tuple[object, bool]] = []
+
+    def load_dotenv(*, dotenv_path, override):
+        calls.append((dotenv_path, override))
+
+    monkeypatch.setattr(server_runtime, "resolve_vault", lambda: vault)
+    monkeypatch.setattr(
+        server_runtime.schema,
+        "load_source_schema",
+        lambda _vault: SimpleNamespace(source_types=("session",)),
+    )
+    monkeypatch.setattr(server_runtime.project_keys, "keys_hint", lambda _vault: "")
+    monkeypatch.setattr(server_runtime, "_start_compute_runtime", lambda _vault: None)
+    monkeypatch.setattr(server_runtime, "_start_media_worker", lambda _vault: None)
+    monkeypatch.setattr(server_runtime, "_start_file_watcher", lambda _vault: None)
+
+    runtime = server_runtime.initialize_runtime(load_dotenv_func=load_dotenv)
+
+    assert calls == [(tmp_path / ".env", True)]
+    assert runtime.vault_root == vault


### PR DESCRIPTION
## Summary

- explicitly load `.env` from the service working directory instead of python-dotenv's caller-relative site-packages search
- make release-wheel/NSSM restarts pick up documented repo-root `.env` edits
- add focused runtime regression coverage

## Verification

- 8 focused tests passed
- Ruff clean
- live durable-auth rollout exposed and confirmed this packaged-service path mismatch
