### PR TITLE
fix(auth): close durable-session rollout gaps

### DIFF
--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -171,6 +171,38 @@ export class ExomemState {
         await this.state.storage.put(itemKey(body.key), stateValue(body));
         return json({ result: null });
       }
+      if (operation === "put-if-absent") {
+        if (!Object.hasOwn(body, "key")) throw new Error("missing key");
+        const key = itemKey(body.key);
+        const value = stateValue(body);
+        const created = await this.state.storage.transaction(async (tx) => {
+          const stored = await tx.get(key);
+          const now = Date.now() / 1000;
+          if (stored && (stored.expires_at == null || stored.expires_at > now)) {
+            return false;
+          }
+          if (stored) await tx.delete(key);
+          await tx.put(key, value);
+          return true;
+        });
+        return json({ result: created });
+      }
+      if (operation === "list-keys") {
+        const prefix = itemKey("");
+        const keys = await this.state.storage.transaction(async (tx) => {
+          const entries = await tx.list({ prefix });
+          const now = Date.now() / 1000;
+          const expired = [];
+          const live = [];
+          for (const [key, stored] of entries) {
+            if (stored.expires_at != null && stored.expires_at <= now) expired.push(key);
+            else live.push(key.slice(prefix.length));
+          }
+          if (expired.length) await tx.delete(expired);
+          return live.sort();
+        });
+        return json({ result: keys });
+      }
       if (operation === "delete") {
         const existed = (await this.state.storage.get(itemKey(body.key))) !== undefined;
         await this.state.storage.delete(itemKey(body.key));

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -149,6 +149,9 @@ export class ExomemState {
     } catch {
       return json({ error: "invalid request" }, 400);
     }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return json({ error: "invalid request" }, 400);
+    }
     const collection = body.collection == null ? "" : String(body.collection);
     const itemKey = (key) => `state\0${collection}\0${String(key)}`;
     const read = async (key) => {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -79,6 +79,15 @@ test("opaque shared state supports TTL and bulk operations", async () => {
   assert.deepEqual(values.result, [{ ciphertext: "one" }, { ciphertext: "two" }, null]);
 });
 
+test("shared state rejects a JSON null body with the documented response", async () => {
+  const object = new ExomemState({ storage: new MemoryStorage() });
+
+  const response = await object.fetch(post("/state/list-keys", null));
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await body(response), { error: "invalid request" });
+});
+
 test("atomic state creation never replaces a live existing value", async () => {
   const object = new ExomemState({ storage: new MemoryStorage() });
   const first = await object.fetch(post("/state/put-if-absent", {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -23,6 +23,13 @@ class MemoryStorage {
     if (Array.isArray(key)) return key.map((k) => this.data.delete(k)).filter(Boolean).length;
     return this.data.delete(key);
   }
+  async list({ prefix = "" } = {}) {
+    return new Map(
+      [...this.data.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .sort(([left], [right]) => left.localeCompare(right)),
+    );
+  }
   async transaction(fn) {
     return fn(this);
   }
@@ -72,10 +79,121 @@ test("opaque shared state supports TTL and bulk operations", async () => {
   assert.deepEqual(values.result, [{ ciphertext: "one" }, { ciphertext: "two" }, null]);
 });
 
-test("edge rejects unauthenticated coordinator access", async () => {
+test("atomic state creation never replaces a live existing value", async () => {
+  const object = new ExomemState({ storage: new MemoryStorage() });
+  const first = await object.fetch(post("/state/put-if-absent", {
+    collection: "auth",
+    key: "generation",
+    value: { __encrypted_data__: "first-ciphertext" },
+    ttl: null,
+  }));
+  const second = await object.fetch(post("/state/put-if-absent", {
+    collection: "auth",
+    key: "generation",
+    value: { __encrypted_data__: "replacement-ciphertext" },
+    ttl: null,
+  }));
+  const stored = await body(await object.fetch(post("/state/get", {
+    collection: "auth",
+    key: "generation",
+  })));
+
+  assert.equal(first.status, 200);
+  assert.deepEqual(await body(first), { result: true });
+  assert.equal(second.status, 200);
+  assert.deepEqual(await body(second), { result: false });
+  assert.deepEqual(stored.result, { __encrypted_data__: "first-ciphertext" });
+});
+
+test("atomic state creation replaces a TTL-expired value", async () => {
+  const object = new ExomemState({ storage: new MemoryStorage() });
+  const originalNow = Date.now;
+  let now = 100_000;
+  Date.now = () => now;
+  try {
+    const first = await body(await object.fetch(post("/state/put-if-absent", {
+      collection: "auth",
+      key: "generation",
+      value: { __encrypted_data__: "expired-ciphertext" },
+      ttl: 1,
+    })));
+    now += 2_000;
+    const replacement = await body(await object.fetch(post("/state/put-if-absent", {
+      collection: "auth",
+      key: "generation",
+      value: { __encrypted_data__: "current-ciphertext" },
+      ttl: null,
+    })));
+    const stored = await body(await object.fetch(post("/state/get", {
+      collection: "auth",
+      key: "generation",
+    })));
+
+    assert.deepEqual(first, { result: true });
+    assert.deepEqual(replacement, { result: true });
+    assert.deepEqual(stored.result, { __encrypted_data__: "current-ciphertext" });
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("state key enumeration returns sorted live keys without encrypted values", async () => {
+  const object = new ExomemState({ storage: new MemoryStorage() });
+  const originalNow = Date.now;
+  let now = 100_000;
+  Date.now = () => now;
+  try {
+    await object.fetch(post("/state/put", {
+      collection: "auth",
+      key: "permanent",
+      value: { __encrypted_data__: "permanent-secret-ciphertext" },
+    }));
+    await object.fetch(post("/state/put", {
+      collection: "auth",
+      key: "expired",
+      value: { __encrypted_data__: "expired-secret-ciphertext" },
+      ttl: 1,
+    }));
+    await object.fetch(post("/state/put", {
+      collection: "other",
+      key: "hidden",
+      value: { __encrypted_data__: "other-secret-ciphertext" },
+    }));
+    await object.fetch(post("/state/put", {
+      collection: "auth",
+      key: "alpha",
+      value: { __encrypted_data__: "alpha-secret-ciphertext" },
+    }));
+    now += 2_000;
+
+    const response = await object.fetch(post("/state/list-keys", { collection: "auth" }));
+    const rendered = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(JSON.parse(rendered), { result: ["alpha", "permanent"] });
+    assert.equal(rendered.includes("ciphertext"), false);
+    assert.equal(rendered.includes("secret"), false);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("edge rejects unauthenticated lease and state coordinator access", async () => {
   const env = { STATE_TOKEN: "secret", EXOMEM_STATE: { idFromName: (name) => name, get: () => { throw new Error("must not reach state"); } } };
-  const response = await worker.fetch(post("/v1/vaults/main/lease/acquire", { replica_id: "desktop", ttl_seconds: 30 }), env);
-  assert.equal(response.status, 401);
+  const requests = [
+    post("/v1/vaults/main/lease/acquire", { replica_id: "desktop", ttl_seconds: 30 }),
+    post("/v1/state/main/put-if-absent", {
+      collection: "auth",
+      key: "generation",
+      value: { __encrypted_data__: "ciphertext" },
+    }),
+    post("/v1/state/main/list-keys", { collection: "auth" }),
+  ];
+  for (const request of requests) {
+    const response = await worker.fetch(request, env);
+    assert.equal(response.status, 401);
+    assert.deepEqual(await body(response), { error: "unauthorized" });
+  }
 });
 
 test("edge accepts a piped Worker secret with trailing transport whitespace", async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -491,12 +491,23 @@ The coordinator contract is:
 - `POST /v1/vaults/{vault}/lease/renew`
 - `POST /v1/vaults/{vault}/lease/release`
 - `GET /v1/vaults/{vault}/lease`
-- `POST /v1/state/{namespace}/{get|ttl|put|delete|get-many|ttl-many|put-many|delete-many}`
+- `POST /v1/state/{namespace}/{get|ttl|put|put-if-absent|list-keys|delete|get-many|ttl-many|put-many|delete-many}`
 
-POST bodies carry `replica_id`, `ttl_seconds`, and, for renew/release,
-`fencing_token`. Responses carry only `holder`, `expires_at`, `fencing_token`, and
-`granted`; no vault content is sent. Use bearer authentication in any networked
-deployment.
+Lease POST bodies carry `replica_id`, `ttl_seconds`, and, for renew/release,
+`fencing_token`. Lease responses carry only `holder`, `expires_at`,
+`fencing_token`, and `granted`; no vault content is sent.
+
+State POST bodies carry `collection` plus the operation's `key`, `keys`, `value`,
+`values`, and optional positive `ttl`. Every successful state response uses the
+`{"result": ...}` envelope. `put-if-absent` is transactional: it returns `true`
+only when it creates the key, never replaces a live value, and treats a
+TTL-expired value as absent. `list-keys` returns sorted live key strings for the
+requested collection, removes expired entries, and never returns encrypted
+values. Networked coordinator deployments require `Authorization: Bearer
+<token>` on every lease and state operation. Missing or rejected credentials
+return `401 {"error":"unauthorized"}`, malformed bodies return `400
+{"error":"invalid request"}`, and unknown operations return `404
+{"error":"unknown operation"}`.
 
 With the edge deployment, clients register only the stable connector URL; the two
 origin hostnames are operational endpoints, not separate connectors. After editing

--- a/openspec/changes/durable-local-auth-sessions/tasks.md
+++ b/openspec/changes/durable-local-auth-sessions/tasks.md
@@ -40,4 +40,4 @@
 - [x] 6.2 Add an automated black-box Codex CLI acceptance test or reproducible harness that logs in once and reuses the stored bearer across fresh processes without a browser prompt.
 - [ ] 6.3 Run the equivalent supported hosted-connector smoke test and record the rollout result; block deployment if omitted `expires_in` is not persisted correctly.
 - [x] 6.4 Run focused auth/coordinator/CLI tests, the full lean pytest suite, strict OpenSpec validation, and Ruff; resolve every failure before review.
-- [ ] 6.5 Have an independent reviewer verify the implementation against every scenario in `durable-mcp-auth-sessions`, including zero post-issuance GitHub calls and 503-vs-401 behavior.
+- [x] 6.5 Have an independent reviewer verify the implementation against every scenario in `durable-mcp-auth-sessions`, including zero post-issuance GitHub calls and 503-vs-401 behavior.

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -111,7 +111,7 @@ def _build_auth_session_authority():
     """
     from dotenv import load_dotenv
 
-    load_dotenv(override=True)
+    load_dotenv(dotenv_path=Path.cwd() / ".env", override=True)
     from . import env_compat
 
     env_compat.promote_legacy()
@@ -565,6 +565,12 @@ def _doctor_main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=Path.cwd() / ".env", override=True)
+    from . import env_compat
+
+    env_compat.promote_legacy()
     from . import doctor as doctor_module
 
     report = doctor_module.doctor(

--- a/src/exomem/remote_setup_wizard.py
+++ b/src/exomem/remote_setup_wizard.py
@@ -207,7 +207,7 @@ def render_oauth_fields(base_url: str) -> str:
 
 
 def _default_env_path() -> Path:
-    return Path(__file__).resolve().parents[2] / ".env"
+    return Path.cwd() / ".env"
 
 
 def _ask(input_fn, prompt: str, default: str = "") -> str:

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -58,7 +58,7 @@ def _install_authority(
     monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com/")
     monkeypatch.setattr(
         "dotenv.load_dotenv",
-        lambda *, override: dotenv_calls.append(f"override={override}"),
+        lambda **kwargs: dotenv_calls.append(f"override={kwargs['override']}"),
     )
     monkeypatch.setattr(
         server_auth,
@@ -163,11 +163,32 @@ def test_auth_usage_errors_exit_two(argv: list[str]) -> None:
 def test_auth_missing_config_exits_two(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda **_kwargs: None)
     monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
 
     assert main(["auth", "sessions"]) == 2
     assert "EXOMEM_BASE_URL" in capsys.readouterr().err
+
+
+def test_auth_authority_loads_dotenv_from_service_working_directory(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com")
+    calls: list[tuple[object, bool]] = []
+
+    def load_env(*, dotenv_path=None, override: bool) -> None:
+        calls.append((dotenv_path, override))
+
+    monkeypatch.setattr("dotenv.load_dotenv", load_env)
+    monkeypatch.setattr(
+        server_auth,
+        "build_session_authority",
+        lambda *, base_url: FakeAuthority([]),
+    )
+
+    assert main(["auth", "sessions", "--json"]) == 0
+    assert calls == [(tmp_path / ".env", True)]
 
 
 def test_auth_promotes_legacy_env_after_loading_dotenv(
@@ -177,7 +198,8 @@ def test_auth_promotes_legacy_env_after_loading_dotenv(
     monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
     monkeypatch.delenv("KB_MCP_BASE_URL", raising=False)
 
-    def load_env(*, override: bool) -> None:
+    def load_env(*, dotenv_path, override: bool) -> None:
+        assert dotenv_path is not None
         assert override is True
         monkeypatch.setenv("KB_MCP_BASE_URL", "https://legacy.example.com")
 
@@ -201,7 +223,7 @@ def test_auth_factory_storage_failure_exits_one_without_details(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("EXOMEM_BASE_URL", "https://kb.example.com")
-    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda **_kwargs: None)
 
     def fail_factory(*, base_url: str):
         raise OSError(f"cannot create store for {base_url} with secret-token")
@@ -226,7 +248,7 @@ def test_auth_real_oauth_configuration_error_exits_two(
     monkeypatch.setenv("EXOMEM_GITHUB_USERNAME", "octocat")
     monkeypatch.setenv("EXOMEM_OAUTH_STORAGE_URL", "https://coordinator.example")
     monkeypatch.delenv("EXOMEM_JWT_SIGNING_KEY", raising=False)
-    monkeypatch.setattr("dotenv.load_dotenv", lambda *, override: None)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda **_kwargs: None)
 
     def representative_session_helper(*, base_url: str):
         return server_auth.build_oauth(require_auth=True, base_url=base_url)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -51,6 +52,33 @@ def test_doctor_json_cli(vault: Path, capsys) -> None:
     assert payload["success"] is True
     assert payload["profile"] == "lean"
     assert {"id", "status", "message", "remediation"} <= set(payload["checks"][0])
+
+
+def test_doctor_cli_loads_cwd_dotenv_and_promotes_loaded_legacy_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("EXOMEM_PROFILE", raising=False)
+    monkeypatch.delenv("KB_MCP_PROFILE", raising=False)
+    calls: list[tuple[object, bool]] = []
+    seen: dict[str, str | None] = {}
+
+    def load_env(*, dotenv_path=None, override: bool) -> None:
+        calls.append((dotenv_path, override))
+        monkeypatch.setenv("KB_MCP_PROFILE", "remote")
+
+    def fake_doctor(**_kwargs):
+        seen["profile"] = os.environ.get("EXOMEM_PROFILE")
+        return doctor_module.DoctorReport(profile="remote", checks=[])
+
+    monkeypatch.setattr("dotenv.load_dotenv", load_env)
+    monkeypatch.setattr(doctor_module, "doctor", fake_doctor)
+
+    code, _out, err = _run(["doctor", "--json"], capsys)
+
+    assert code == 0, err
+    assert calls == [(tmp_path / ".env", True)]
+    assert seen == {"profile": "remote"}
 
 
 def test_doctor_infers_profile_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_remote_setup_wizard.py
+++ b/tests/test_remote_setup_wizard.py
@@ -162,6 +162,14 @@ def test_render_oauth_fields_contains_homepage_and_callback() -> None:
 # ============================================================================
 
 
+def test_default_env_path_is_service_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert rsw._default_env_path() == tmp_path / ".env"
+
+
 def _run(env_path: Path, doctor_success: bool = True, **overrides):
     lines: list[str] = []
     doctor_calls: list[dict] = []


### PR DESCRIPTION
## Summary

- load operator CLI, doctor, and remote setup configuration from the service working directory
- complete the supported Cloudflare Durable Object state contract with atomic put-if-absent and secret-free key enumeration
- reject malformed non-object coordinator bodies with the documented 400 response
- record the independent OpenSpec review

## Verification

- 2,195 passed, 19 expected skips
- latency gate: 2/2
- Cloudflare Worker: 19/19
- Ruff, compileall, lockfile, Node syntax, strict OpenSpec, and diff checks green
- independent reviewer: ready to merge, no blocker or Important findings