### PR TITLE
fix: harden writer fencing and supersession atomicity

### DIFF
--- a/openspec/changes/harden-supersession-atomicity/.openspec.yaml
+++ b/openspec/changes/harden-supersession-atomicity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/harden-supersession-atomicity/design.md
+++ b/openspec/changes/harden-supersession-atomicity/design.md
@@ -1,0 +1,23 @@
+## Context
+
+`replace(old_path, new content)` today: check old page not already superseded → `note()` writes the NEW page (commit 1) → inject `supersedes`/flip old `status: superseded` + `superseded_by` (commit 2) → append log (commit 3). Three separate commits, no CAS on the old-status read. Failure modes: (a) two concurrent replaces both pass the check and produce competing successors, the later old-page write dropping the earlier's pointer; (b) a crash after commit 1 leaves a standalone new page with a dangling `supersedes` and an un-flipped old page.
+
+## Goals / Non-Goals
+
+- Goal: a supersession is all-or-nothing across new page + old-page chain flip + log.
+- Goal: concurrent supersession of the same active page → exactly one winner; the loser is refused (stale old page).
+- Non-goal: multi-page transactions beyond a single supersession; reworking `note()`'s own write.
+- Non-goal: changing the read/tombstone-demotion behavior of `find`.
+
+## Approach (to be finalized by the implementer)
+
+1. Capture the old page's `content_hash` at the status-read and require it unchanged through commit (optimistic concurrency): if the old page changed between read and write, refuse `REVIEW_ITEM_CHANGED`/`STALE_SUPERSEDE`.
+2. Build ONE `batch_atomic_write` containing the new page, the old page's flipped frontmatter (status + `superseded_by`), and the log update, so staging is all-or-nothing and a mid-flip failure leaves the whole set unapplied (or cleanly re-raises without a dangling new page).
+3. If `note()` cannot be folded into the same batch, restructure so the new-page content and the old-page flip are staged together and replaced together.
+
+Open questions for the implementer: whether `note()`'s index/log side effects can be composed into the single batch, or whether a compensating cleanup is needed if the batch can only cover the two page files + log.
+
+## Risks
+
+- Folding `note()` into a single atomic batch may require refactoring how `note()` stages its writes; keep the change minimal and covered by the existing supersession tests.
+- The CAS must not reject legitimate sequential re-reads (only genuine concurrent modification).

--- a/openspec/changes/harden-supersession-atomicity/proposal.md
+++ b/openspec/changes/harden-supersession-atomicity/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Supersession promises to preserve history — the old page stays readable and points to the new one. But `replace` reads the old page's status, then writes the new page, the old page, and the log SEQUENTIALLY with no lock or compare-and-swap. Two concurrent `replace` calls on the same active page can both pass the "already superseded?" check and race the pointer writes, and the last old-page write can drop the other successor pointer. A crash between the new-page write and the chain updates leaves a dangling standalone new page. (Audit finding CDX-04, HIGH-plausible; the common sequential path is correct — this is the concurrency/partial-commit edge.)
+
+Evidence: `src/exomem/replace.py` old-status check (~119-127) has no CAS around the read; `_mark_superseded` and the new/old/log writes are sequential (~131, ~181-187); `vault.batch_atomic_write` documents partial commits (~173-175).
+
+## What Changes
+
+- Guard the old-page status read + flip with a compare-and-swap (e.g. the old page's `expected_hash` held across the whole supersession transaction) so a concurrent replace that changed the old page is refused.
+- Stage all pages of a supersession (new page, old page's pointer/status flip, log) in ONE atomic write batch so a partial commit cannot leave a dangling new page or a half-updated chain.
+
+## Capabilities
+
+### New Capabilities
+
+- `supersession-atomicity`: Guarantees that a supersession either fully commits its bidirectional chain or makes no change, and that concurrent supersessions of the same page cannot both win.
+
+## Impact
+
+Affects `src/exomem/replace.py` and its use of `src/exomem/vault.py` atomic write. No change to the read path or MCP tool schema. Existing `tests/test_replace.py` / `tests/test_supersession_surface.py` must stay green; new tests cover the concurrent-replace and mid-transaction-failure cases.

--- a/openspec/changes/harden-supersession-atomicity/specs/supersession-atomicity/spec.md
+++ b/openspec/changes/harden-supersession-atomicity/specs/supersession-atomicity/spec.md
@@ -2,12 +2,14 @@
 
 ### Requirement: Atomic Supersession
 
-A supersession SHALL either fully commit its bidirectional chain — the new page, the old page's `status: superseded` + `superseded_by` flip, and the log entry — or make no change at all. A failure partway through MUST NOT leave a standalone new page with a dangling `supersedes` pointer or a half-updated chain.
+A supersession SHALL either fully commit its complete planned write set — the new page, source backreferences, navigation indexes, the old page's `status: superseded` + `superseded_by` flip, and the combined note/replace log update — or make no change at all. A failure partway through MUST NOT leave a standalone new page with a dangling `supersedes` pointer, a half-updated chain, or note side effects from a supersession that did not commit.
 
-#### Scenario: A failure mid-supersession leaves no dangling page
+#### Scenario: A failure during destination replacement rolls back the full write set
 
-- **WHEN** a supersession fails after the new-page content is prepared but before the old-page chain flip commits
-- **THEN** no standalone new page remains and the old page is unchanged (the operation is all-or-nothing)
+- **WHEN** an injected failure occurs after at least one destination in the supersession batch is replaced but before the complete batch commits
+- **THEN** no standalone new page remains
+- **AND** the old page retains its pre-supersession content and active status
+- **AND** source backreferences, navigation indexes, and the log retain their pre-supersession content
 
 ### Requirement: Single-Winner Concurrent Supersession
 
@@ -15,11 +17,19 @@ Concurrent supersessions of the same active page SHALL NOT both succeed. The sys
 
 #### Scenario: Two concurrent replaces produce exactly one successor
 
-- **WHEN** two `replace` calls target the same active old page concurrently and both pass the initial "not already superseded" check
+- **WHEN** two `replace` calls target the same active old page concurrently and both perform their eligibility read against the same content version
 - **THEN** exactly one commits a successor chain
-- **AND** the other is refused with a stale/changed error and writes nothing
+- **AND** the committed old page points to that winner without dropping its pointer
+- **AND** the other is refused with `STALE_SUPERSEDE` and writes no new page, backreference, index, or log side effect
 
 #### Scenario: Re-superseding an already-superseded page is still refused
 
 - **WHEN** a `replace` targets a page that is already `status: superseded`
-- **THEN** it is refused and no second successor is created
+- **THEN** it is refused with `ALREADY_SUPERSEDED`
+- **AND** no second successor or note side effect is created
+
+#### Scenario: The old page changes after the eligibility read
+
+- **WHEN** the old page's content hash changes after `replace` reads it as eligible but before the supersession batch commits
+- **THEN** the supersession is refused with `STALE_SUPERSEDE`
+- **AND** none of its planned writes are committed

--- a/openspec/changes/harden-supersession-atomicity/specs/supersession-atomicity/spec.md
+++ b/openspec/changes/harden-supersession-atomicity/specs/supersession-atomicity/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Atomic Supersession
+
+A supersession SHALL either fully commit its bidirectional chain — the new page, the old page's `status: superseded` + `superseded_by` flip, and the log entry — or make no change at all. A failure partway through MUST NOT leave a standalone new page with a dangling `supersedes` pointer or a half-updated chain.
+
+#### Scenario: A failure mid-supersession leaves no dangling page
+
+- **WHEN** a supersession fails after the new-page content is prepared but before the old-page chain flip commits
+- **THEN** no standalone new page remains and the old page is unchanged (the operation is all-or-nothing)
+
+### Requirement: Single-Winner Concurrent Supersession
+
+Concurrent supersessions of the same active page SHALL NOT both succeed. The system MUST detect that the old page changed between the eligibility read and the write (a compare-and-swap on its content version) and refuse the losing call with a stale error, so exactly one successor chain results.
+
+#### Scenario: Two concurrent replaces produce exactly one successor
+
+- **WHEN** two `replace` calls target the same active old page concurrently and both pass the initial "not already superseded" check
+- **THEN** exactly one commits a successor chain
+- **AND** the other is refused with a stale/changed error and writes nothing
+
+#### Scenario: Re-superseding an already-superseded page is still refused
+
+- **WHEN** a `replace` targets a page that is already `status: superseded`
+- **THEN** it is refused and no second successor is created

--- a/openspec/changes/harden-supersession-atomicity/tasks.md
+++ b/openspec/changes/harden-supersession-atomicity/tasks.md
@@ -1,0 +1,17 @@
+## 1. Design + spec
+
+- [ ] 1.1 Map `replace.py`'s current commit sequence and `note()`'s staging; decide whether the new page can join the old-page flip + log in one `batch_atomic_write`.
+- [ ] 1.2 Finalize `specs/supersession-atomicity/spec.md` (expand scenarios: concurrent-replace loser refused, crash-mid-transaction leaves no dangling new page, sequential re-supersede of an already-superseded page still refused). `openspec validate harden-supersession-atomicity --strict`.
+
+## 2. Implement
+
+- [ ] 2.1 Add a compare-and-swap on the old page's `content_hash` across the supersession transaction.
+- [ ] 2.2 Stage new page + old-page chain flip + log in ONE atomic batch (all-or-nothing).
+- [ ] 2.3 On CAS failure, refuse with a clear stale error and write nothing.
+
+## 3. Verify
+
+- [ ] 3.1 New test: two concurrent `replace` calls on the same active page → exactly one successor chain, the other refused; no dropped pointer.
+- [ ] 3.2 New test: an injected failure mid-transaction leaves NO standalone new page and no half-flipped old page.
+- [ ] 3.3 `tests/test_replace.py`, `tests/test_supersession_surface.py` stay green.
+- [ ] 3.4 `uvx ruff check` scoped to changed files only.

--- a/openspec/changes/harden-supersession-atomicity/tasks.md
+++ b/openspec/changes/harden-supersession-atomicity/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Design + spec
 
-- [ ] 1.1 Map `replace.py`'s current commit sequence and `note()`'s staging; decide whether the new page can join the old-page flip + log in one `batch_atomic_write`.
-- [ ] 1.2 Finalize `specs/supersession-atomicity/spec.md` (expand scenarios: concurrent-replace loser refused, crash-mid-transaction leaves no dangling new page, sequential re-supersede of an already-superseded page still refused). `openspec validate harden-supersession-atomicity --strict`.
+- [x] 1.1 Map `replace.py`'s current commit sequence and `note()`'s staging; decide whether the new page can join the old-page flip + log in one `batch_atomic_write`.
+- [x] 1.2 Finalize `specs/supersession-atomicity/spec.md` (expand scenarios: concurrent-replace loser refused, crash-mid-transaction leaves no dangling new page, sequential re-supersede of an already-superseded page still refused). `openspec validate harden-supersession-atomicity --strict`.
 
 ## 2. Implement
 
-- [ ] 2.1 Add a compare-and-swap on the old page's `content_hash` across the supersession transaction.
-- [ ] 2.2 Stage new page + old-page chain flip + log in ONE atomic batch (all-or-nothing).
-- [ ] 2.3 On CAS failure, refuse with a clear stale error and write nothing.
+- [x] 2.1 Add a compare-and-swap on the old page's `content_hash` across the supersession transaction.
+- [x] 2.2 Stage new page + old-page chain flip + log in ONE atomic batch (all-or-nothing).
+- [x] 2.3 On CAS failure, refuse with a clear stale error and write nothing.
 
 ## 3. Verify
 
-- [ ] 3.1 New test: two concurrent `replace` calls on the same active page → exactly one successor chain, the other refused; no dropped pointer.
-- [ ] 3.2 New test: an injected failure mid-transaction leaves NO standalone new page and no half-flipped old page.
-- [ ] 3.3 `tests/test_replace.py`, `tests/test_supersession_surface.py` stay green.
-- [ ] 3.4 `uvx ruff check` scoped to changed files only.
+- [x] 3.1 New test: two concurrent `replace` calls on the same active page → exactly one successor chain, the other refused; no dropped pointer.
+- [x] 3.2 New test: an injected failure mid-transaction leaves NO standalone new page and no half-flipped old page.
+- [x] 3.3 `tests/test_replace.py`, `tests/test_supersession_surface.py` stay green.
+- [x] 3.4 `uvx ruff check` scoped to changed files only.

--- a/openspec/changes/harden-writer-lease-fencing/.openspec.yaml
+++ b/openspec/changes/harden-writer-lease-fencing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/harden-writer-lease-fencing/design.md
+++ b/openspec/changes/harden-writer-lease-fencing/design.md
@@ -1,0 +1,24 @@
+## Context
+
+The lease flow today: `writer_lease.invoke(command)` → if the command is read-only or the lease is disabled, run directly; otherwise `ensure_writer()` (acquire/verify holder) once, then run the mutation. The fencing token returned by acquire/renew is stored in local lease state but never reaches the write. So the window between "lease verified" and "bytes hit disk" is unguarded: TTL can expire and replica B can take the next token while replica A's command is still executing.
+
+## Goals / Non-Goals
+
+- Goal: a mutation lands only if the issuing replica's fencing token is still current at the moment of commit.
+- Goal: fail closed — a stale token aborts with a clear fenced error; no partial write.
+- Non-goal: distributed transactions or cross-replica locking beyond the existing coordinator's fencing-token semantics.
+- Non-goal: changing lease-disabled or read-only behavior, or the MCP tool surface.
+
+## Approach (to be finalized by the implementer)
+
+1. Capture the fencing token from `ensure_writer()` and pass it through `invoke` into the command's write path (an explicit parameter or a contextvar scoped to the command).
+2. At the `batch_atomic_write` commit boundary — after staging, before/around `os.replace` — re-validate the token: cheap local check against the last-known-good token, and/or a coordinator check-and-fence call if the coordinator contract supports it. Prefer the strongest check the coordinator already offers to avoid a new round-trip per write where possible.
+3. If the token is stale (renewal was rejected, or the coordinator reports a newer holder), raise a `WRITER_FENCED` error and DO NOT replace staged temps (clean them up).
+4. Ensure the renewer path marks the token stale synchronously enough that an in-flight command sees it.
+
+Open questions for the implementer: exact coordinator contract for a check-and-fence vs. relying on the renewer's local staleness flag; whether to re-validate once per batch or per file (batch is likely sufficient given atomic staging).
+
+## Risks
+
+- A per-write coordinator round-trip could add latency; prefer a local staleness flag updated by the renewer, with a coordinator confirmation only on suspicion. Measure against the latency gate.
+- Must not introduce a deadlock/livelock between the renewer thread and the write path.

--- a/openspec/changes/harden-writer-lease-fencing/proposal.md
+++ b/openspec/changes/harden-writer-lease-fencing/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The failover-safe connector promises single-writer safety via an opt-in writer lease, but the lease is validated only ONCE at the start of a mutating command and is never re-checked or passed down into the write itself. A replica that loses or outlives its lease — it expires, and another replica acquires a newer fencing token — can still complete an in-flight vault mutation, because the vault writers never consult the fencing token. This defeats the single-writer guarantee under exactly the failover it was built for. (Audit finding CDX-06, HIGH-plausible; needs concurrency/multi-replica to trigger.)
+
+Evidence: `src/exomem/writer_lease.py` `invoke` (~289-300) validates the lease then calls the mutation without threading or re-validating the fencing token; vault writers (`vault.batch_atomic_write`) never check it; the renewer only clears local state on a rejected renewal (~345-354) and cannot cancel an already-running command.
+
+## What Changes
+
+- Thread the acquired fencing token into the mutating write path.
+- Re-validate the fencing token (compare-and-swap against the coordinator's current token) at the atomic-write boundary, so a stale token aborts the write with a fenced error instead of committing.
+- Make lease loss during an in-flight command fail closed: the write does not land if the holder was superseded.
+- Preserve current behavior when the lease is disabled (no `EXOMEM_WRITER_LEASE_URL`) and for read-only commands.
+
+## Capabilities
+
+### New Capabilities
+
+- `writer-lease-fencing`: Guarantees that a vault mutation completes only while its issuing replica still holds the lease it was authorized under, so a superseded replica cannot land a stale write during failover.
+
+## Impact
+
+Affects `src/exomem/writer_lease.py` and the atomic write boundary in `src/exomem/vault.py`; no change to the read path, to lease-disabled operation, or to the MCP tool schema. Existing writer-lease tests must stay green; a new concurrency test covers the fenced-write case.

--- a/openspec/changes/harden-writer-lease-fencing/specs/writer-lease-fencing/spec.md
+++ b/openspec/changes/harden-writer-lease-fencing/specs/writer-lease-fencing/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Fenced Vault Mutations
+
+A vault mutation issued under a writer lease SHALL complete only while the issuing replica still holds the fencing token it was authorized under. If the lease was lost or superseded (its renewal was rejected, or the coordinator reports a newer holder) before the write commits, the system MUST abort the write with a fenced error and leave the vault unchanged. This applies only when the lease is enabled; lease-disabled operation and read-only commands are unaffected.
+
+#### Scenario: A superseded replica cannot land a stale write
+
+- **WHEN** replica A begins a mutating command under a valid lease, its lease then expires, and replica B acquires the next fencing token before A's write commits
+- **THEN** A's write is refused with a `WRITER_FENCED` error
+- **AND** no staged bytes are replaced into the vault (the target files are unchanged)
+
+#### Scenario: The holder writes normally while its token is current
+
+- **WHEN** a replica holds a current, un-superseded fencing token throughout a mutating command
+- **THEN** the write commits normally with no additional refusal
+
+#### Scenario: Lease disabled and read-only commands are unaffected
+
+- **WHEN** no writer lease is configured, or the command is read-only
+- **THEN** the command runs exactly as before with no fencing check

--- a/openspec/changes/harden-writer-lease-fencing/specs/writer-lease-fencing/spec.md
+++ b/openspec/changes/harden-writer-lease-fencing/specs/writer-lease-fencing/spec.md
@@ -10,12 +10,31 @@ A vault mutation issued under a writer lease SHALL complete only while the issui
 - **THEN** A's write is refused with a `WRITER_FENCED` error
 - **AND** no staged bytes are replaced into the vault (the target files are unchanged)
 
+#### Scenario: A rejected renewal fences an in-flight write
+
+- **WHEN** a replica begins a mutating command under a valid fencing token
+- **AND** its lease renewal is rejected before the staged write commits
+- **THEN** the commit boundary refuses the write with a `WRITER_FENCED` error
+- **AND** cleans up the staged temporary files without changing the target files
+
+#### Scenario: The coordinator reports a newer holder at commit
+
+- **WHEN** a replica begins a mutating command under fencing token N
+- **AND** the coordinator reports another holder with a fencing token greater than N before commit
+- **THEN** the commit boundary refuses the stale write with a `WRITER_FENCED` error
+- **AND** no staged bytes are replaced into the vault
+
 #### Scenario: The holder writes normally while its token is current
 
 - **WHEN** a replica holds a current, un-superseded fencing token throughout a mutating command
 - **THEN** the write commits normally with no additional refusal
 
-#### Scenario: Lease disabled and read-only commands are unaffected
+#### Scenario: Lease-disabled mutation is unchanged
 
-- **WHEN** no writer lease is configured, or the command is read-only
-- **THEN** the command runs exactly as before with no fencing check
+- **WHEN** no writer lease is configured and a mutating command writes to the vault
+- **THEN** the command commits exactly as before with no fencing check
+
+#### Scenario: Read-only commands bypass fencing
+
+- **WHEN** a command is read-only
+- **THEN** it runs exactly as before without acquiring, threading, or validating a fencing token

--- a/openspec/changes/harden-writer-lease-fencing/tasks.md
+++ b/openspec/changes/harden-writer-lease-fencing/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Design + spec
 
-- [ ] 1.1 Confirm the coordinator's fencing-token contract (`src/exomem/lease_coordinator.py`) and whether a check-and-fence call exists or the local staleness flag is authoritative.
-- [ ] 1.2 Finalize `specs/writer-lease-fencing/spec.md` (expand scenarios: renewal-rejected mid-write, coordinator-reports-newer-holder, lease-disabled no-op, read-only bypass). `openspec validate harden-writer-lease-fencing --strict`.
+- [x] 1.1 Confirm the coordinator's fencing-token contract (`src/exomem/lease_coordinator.py`) and whether a check-and-fence call exists or the local staleness flag is authoritative.
+- [x] 1.2 Finalize `specs/writer-lease-fencing/spec.md` (expand scenarios: renewal-rejected mid-write, coordinator-reports-newer-holder, lease-disabled no-op, read-only bypass). `openspec validate harden-writer-lease-fencing --strict`.
 
 ## 2. Implement
 
-- [ ] 2.1 Thread the fencing token from `ensure_writer()` through `writer_lease.invoke` into the write path.
-- [ ] 2.2 Re-validate the token at the `vault.batch_atomic_write` commit boundary; raise `WRITER_FENCED` + clean up staged temps on a stale token.
-- [ ] 2.3 Ensure the renewer marks the token stale synchronously enough for an in-flight command to observe.
+- [x] 2.1 Thread the fencing token from `ensure_writer()` through `writer_lease.invoke` into the write path.
+- [x] 2.2 Re-validate the token at the `vault.batch_atomic_write` commit boundary; raise `WRITER_FENCED` + clean up staged temps on a stale token.
+- [x] 2.3 Ensure the renewer marks the token stale synchronously enough for an in-flight command to observe.
 
 ## 3. Verify
 
-- [ ] 3.1 New test: simulate lease loss mid-write (short TTL, replica A paused past expiry, replica B acquires the next token, resume A) → A's write is refused `WRITER_FENCED`, no bytes land.
-- [ ] 3.2 Existing `tests/test_writer_lease.py` + coordinator tests stay green.
-- [ ] 3.3 Latency gate green (`tests/test_latency_gate.py`) — the fencing check adds no per-write blow-up.
-- [ ] 3.4 `uvx ruff check` scoped to changed files only.
+- [x] 3.1 New test: simulate lease loss mid-write (short TTL, replica A paused past expiry, replica B acquires the next token, resume A) → A's write is refused `WRITER_FENCED`, no bytes land.
+- [x] 3.2 Existing `tests/test_writer_lease.py` + coordinator tests stay green.
+- [x] 3.3 Latency gate green (`tests/test_latency_gate.py`) — the fencing check adds no per-write blow-up.
+- [x] 3.4 `uvx ruff check` scoped to changed files only.

--- a/openspec/changes/harden-writer-lease-fencing/tasks.md
+++ b/openspec/changes/harden-writer-lease-fencing/tasks.md
@@ -1,0 +1,17 @@
+## 1. Design + spec
+
+- [ ] 1.1 Confirm the coordinator's fencing-token contract (`src/exomem/lease_coordinator.py`) and whether a check-and-fence call exists or the local staleness flag is authoritative.
+- [ ] 1.2 Finalize `specs/writer-lease-fencing/spec.md` (expand scenarios: renewal-rejected mid-write, coordinator-reports-newer-holder, lease-disabled no-op, read-only bypass). `openspec validate harden-writer-lease-fencing --strict`.
+
+## 2. Implement
+
+- [ ] 2.1 Thread the fencing token from `ensure_writer()` through `writer_lease.invoke` into the write path.
+- [ ] 2.2 Re-validate the token at the `vault.batch_atomic_write` commit boundary; raise `WRITER_FENCED` + clean up staged temps on a stale token.
+- [ ] 2.3 Ensure the renewer marks the token stale synchronously enough for an in-flight command to observe.
+
+## 3. Verify
+
+- [ ] 3.1 New test: simulate lease loss mid-write (short TTL, replica A paused past expiry, replica B acquires the next token, resume A) → A's write is refused `WRITER_FENCED`, no bytes land.
+- [ ] 3.2 Existing `tests/test_writer_lease.py` + coordinator tests stay green.
+- [ ] 3.3 Latency gate green (`tests/test_latency_gate.py`) — the fencing check adds no per-write blow-up.
+- [ ] 3.4 `uvx ruff check` scoped to changed files only.

--- a/openspec/changes/scope-lease-to-write-operations/.openspec.yaml
+++ b/openspec/changes/scope-lease-to-write-operations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/scope-lease-to-write-operations/design.md
+++ b/openspec/changes/scope-lease-to-write-operations/design.md
@@ -1,0 +1,23 @@
+## Context
+
+The lease decision is currently binary per command: `writer_lease.invoke` runs a command directly if `command.read_only` is True, else it requires the lease. `command.read_only` is derived from `cli_writes`, which is set True for `connect_memory`/`adopt_vault` because SOME of their operations write. So the read-only operations inherit the write gating and fail closed when the coordinator is down — the opposite of the "reads stay available during a coordinator outage" promise.
+
+## Goals / Non-Goals
+
+- Goal: a read-only operation of a write-capable tool bypasses the lease and works during a coordinator outage.
+- Goal: write operations stay lease-gated exactly as today.
+- Non-goal: changing which operations are reads vs writes (that mapping already exists in the operation dispatch).
+- Non-goal: expanding the public MCP tool surface unless unavoidable; if it changes, the schema-fidelity baseline is regenerated and reviewed deliberately.
+
+## Approach (to be finalized by the implementer)
+
+Two viable shapes:
+
+- **A — per-operation read-only predicate (preferred, no schema change):** give the lease gate visibility into the resolved operation so it can ask "does THIS invocation write?" instead of "is this command write-capable?". The operation-to-read/write mapping already exists in `connect_memory`/`adopt_vault` dispatch (proposal/scan branches are reads; `create-entity`/`accept-relation`/adopt-write are writes). Route that per-operation read-only signal into `writer_lease.invoke`'s bypass check.
+- **B — split surfaces:** move the read-only operations onto a read-only command surface. Cleaner conceptually but changes the tool surface and the schema baseline — only if A proves infeasible.
+
+Prefer A. Verify no write operation slips into the read bypass (fail safe: default to lease-required if the operation's read-only-ness is unknown).
+
+## Risks
+
+- Getting the per-operation read/write classification wrong would either block reads (no worse than today) or, dangerously, let a write bypass the lease — so the classification must fail SAFE (unknown → treat as write, require lease).

--- a/openspec/changes/scope-lease-to-write-operations/proposal.md
+++ b/openspec/changes/scope-lease-to-write-operations/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+`connect_memory` and `adopt_vault` are write-CAPABLE tools, but their DEFAULT operations are read-only (`suggest-links`, `suggest-relations`, `graph-context`, `inbound-links`; scan-only adopt). Because they carry `cli_writes=True` at the command level, `command_surface.read_only` is False and the writer lease gates EVERY invocation — so a proposal-only or scan-only call fails `WRITER_COORDINATOR_UNAVAILABLE` when the coordinator is down, even though it performs no write. Read-only-ness is per-OPERATION, not per-command, and reads should stay available during a coordinator outage (a core failover promise). (Audit finding CDX-08, MED.)
+
+Evidence: `src/exomem/commands.py` connect (~3554) / adopt (~3730); `cli_writes=True` (~4518-4533); the lease gate in `writer_lease.invoke` keys off `command.read_only`.
+
+## What Changes
+
+- Make the writer-lease gate consider the ACTUAL operation's read-only-ness rather than the command-level flag, so a read-only invocation of a write-capable tool bypasses the lease and succeeds during a coordinator outage.
+- Keep write operations (`create-entity`, `accept-relation`, adopt write modes) gated by the lease as today.
+- Preserve the MCP tool schema (do not split tools unless strictly necessary; if the surface must change, regenerate + review the schema-fidelity baseline deliberately).
+
+## Capabilities
+
+### New Capabilities
+
+- `lease-operation-scope`: The writer lease gates a command only when the specific invoked operation writes to the vault; read-only operations of write-capable tools remain available when the lease coordinator is unreachable.
+
+## Impact
+
+Affects the lease gating in `src/exomem/writer_lease.py` / the command dispatch in `src/exomem/commands.py`; must keep `tests/test_mcp_schema_fidelity.py` green. New tests cover a read-only connect/adopt call succeeding with an unreachable lease URL while a write op still refuses.

--- a/openspec/changes/scope-lease-to-write-operations/specs/lease-operation-scope/spec.md
+++ b/openspec/changes/scope-lease-to-write-operations/specs/lease-operation-scope/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Lease Gates Only Writing Operations
+
+The writer lease SHALL gate a command invocation only when the specific operation being invoked writes to the vault. A read-only operation of a write-capable tool (for example `connect_memory` in a suggest/graph-context mode, or `adopt_vault` in scan-only mode) MUST NOT require the lease and MUST remain available when the lease coordinator is unreachable. Classification MUST fail safe: an operation whose read/write nature is unknown is treated as a write and requires the lease.
+
+#### Scenario: A read-only operation works during a coordinator outage
+
+- **WHEN** `EXOMEM_WRITER_LEASE_URL` points at an unreachable coordinator and a `connect_memory` suggest-links (or `adopt_vault` scan-only) call is made
+- **THEN** the call succeeds and performs no vault write
+- **AND** it does not raise `WRITER_COORDINATOR_UNAVAILABLE`
+
+#### Scenario: A write operation still requires the lease
+
+- **WHEN** the coordinator is unreachable and a `connect_memory` `create-entity`/`accept-relation` (or an `adopt_vault` write mode) call is made
+- **THEN** the call is refused with `WRITER_COORDINATOR_UNAVAILABLE` and writes nothing
+
+#### Scenario: Unknown operations fail safe
+
+- **WHEN** an operation's read/write classification cannot be determined
+- **THEN** it is treated as a write and requires the lease

--- a/openspec/changes/scope-lease-to-write-operations/specs/lease-operation-scope/spec.md
+++ b/openspec/changes/scope-lease-to-write-operations/specs/lease-operation-scope/spec.md
@@ -4,18 +4,36 @@
 
 The writer lease SHALL gate a command invocation only when the specific operation being invoked writes to the vault. A read-only operation of a write-capable tool (for example `connect_memory` in a suggest/graph-context mode, or `adopt_vault` in scan-only mode) MUST NOT require the lease and MUST remain available when the lease coordinator is unreachable. Classification MUST fail safe: an operation whose read/write nature is unknown is treated as a write and requires the lease.
 
-#### Scenario: A read-only operation works during a coordinator outage
+#### Scenario: Every read-only connect operation works during a coordinator outage
 
-- **WHEN** `EXOMEM_WRITER_LEASE_URL` points at an unreachable coordinator and a `connect_memory` suggest-links (or `adopt_vault` scan-only) call is made
+- **WHEN** `EXOMEM_WRITER_LEASE_URL` points at an unreachable coordinator
+- **AND** `connect_memory` is invoked with omitted/default `suggest-links`, explicit `suggest-links`, `suggest-relations`, `context`, `graph-context`, or `inbound-links`
 - **THEN** the call succeeds and performs no vault write
 - **AND** it does not raise `WRITER_COORDINATOR_UNAVAILABLE`
 
-#### Scenario: A write operation still requires the lease
+#### Scenario: Every read-only adopt operation works during a coordinator outage
 
-- **WHEN** the coordinator is unreachable and a `connect_memory` `create-entity`/`accept-relation` (or an `adopt_vault` write mode) call is made
+- **WHEN** `EXOMEM_WRITER_LEASE_URL` points at an unreachable coordinator
+- **AND** `adopt_vault` is invoked with its mode omitted/defaulted or explicitly set to `scan-only`
+- **THEN** the call succeeds and performs no vault write
+- **AND** it does not raise `WRITER_COORDINATOR_UNAVAILABLE`
+
+#### Scenario: Connect write operations still require the lease
+
+- **WHEN** the coordinator is unreachable and `connect_memory` is invoked with `create-entity` or `accept-relation`
 - **THEN** the call is refused with `WRITER_COORDINATOR_UNAVAILABLE` and writes nothing
 
-#### Scenario: Unknown operations fail safe
+#### Scenario: Adopt write operations still require the lease
 
-- **WHEN** an operation's read/write classification cannot be determined
+- **WHEN** the coordinator is unreachable and `adopt_vault` is invoked with `save-manifest`, `copy-as-sources`, or `compile-selected`
+- **THEN** the call is refused with `WRITER_COORDINATOR_UNAVAILABLE` and writes nothing
+
+#### Scenario: Unknown or malformed operation values fail safe
+
+- **WHEN** a write-capable command's operation or mode is empty, explicitly null, unknown, or introduced by a future version without a read-only classification
 - **THEN** it is treated as a write and requires the lease
+
+#### Scenario: Other write-capable commands remain gated
+
+- **WHEN** a write-capable command without a per-operation read-only classification is invoked
+- **THEN** it requires the lease regardless of its arguments

--- a/openspec/changes/scope-lease-to-write-operations/tasks.md
+++ b/openspec/changes/scope-lease-to-write-operations/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Design + spec
 
-- [ ] 1.1 Enumerate every `connect_memory` and `adopt_vault` operation and classify read vs write from the existing dispatch; confirm the classification source of truth.
-- [ ] 1.2 Choose approach A (per-operation predicate, no schema change) vs B (split surface); finalize `specs/lease-operation-scope/spec.md`. `openspec validate scope-lease-to-write-operations --strict`.
+- [x] 1.1 Enumerate every `connect_memory` and `adopt_vault` operation and classify read vs write from the existing dispatch; confirm the classification source of truth.
+- [x] 1.2 Choose approach A (per-operation predicate, no schema change) vs B (split surface); finalize `specs/lease-operation-scope/spec.md`. `openspec validate scope-lease-to-write-operations --strict`.
 
 ## 2. Implement
 
-- [ ] 2.1 Thread the resolved operation's read-only-ness into `writer_lease.invoke`'s bypass decision (fail SAFE: unknown → require lease).
-- [ ] 2.2 Keep write operations lease-gated; do not change the read/write classification of any operation.
-- [ ] 2.3 If (and only if) the tool surface must change, regenerate + review `tests/fixtures/mcp_tool_schemas.json`.
+- [x] 2.1 Thread the resolved operation's read-only-ness into `writer_lease.invoke`'s bypass decision (fail SAFE: unknown → require lease).
+- [x] 2.2 Keep write operations lease-gated; do not change the read/write classification of any operation.
+- [x] 2.3 If (and only if) the tool surface must change, regenerate + review `tests/fixtures/mcp_tool_schemas.json`.
 
 ## 3. Verify
 
-- [ ] 3.1 New test: with an unreachable `EXOMEM_WRITER_LEASE_URL`, a default `connect_memory` (suggest-links) and `adopt_vault` (scan) succeed; `create-entity` / `accept-relation` / an adopt write mode still refuse `WRITER_COORDINATOR_UNAVAILABLE`.
-- [ ] 3.2 `tests/test_mcp_schema_fidelity.py` green (surface unchanged, or baseline deliberately updated).
-- [ ] 3.3 `tests/test_writer_lease.py` and connect/adopt tests stay green.
-- [ ] 3.4 `uvx ruff check` scoped to changed files only.
+- [x] 3.1 New test: with an unreachable `EXOMEM_WRITER_LEASE_URL`, a default `connect_memory` (suggest-links) and `adopt_vault` (scan) succeed; `create-entity` / `accept-relation` / an adopt write mode still refuse `WRITER_COORDINATOR_UNAVAILABLE`.
+- [x] 3.2 `tests/test_mcp_schema_fidelity.py` green (surface unchanged, or baseline deliberately updated).
+- [x] 3.3 `tests/test_writer_lease.py` and connect/adopt tests stay green.
+- [x] 3.4 `uvx ruff check` scoped to changed files only.

--- a/openspec/changes/scope-lease-to-write-operations/tasks.md
+++ b/openspec/changes/scope-lease-to-write-operations/tasks.md
@@ -1,0 +1,17 @@
+## 1. Design + spec
+
+- [ ] 1.1 Enumerate every `connect_memory` and `adopt_vault` operation and classify read vs write from the existing dispatch; confirm the classification source of truth.
+- [ ] 1.2 Choose approach A (per-operation predicate, no schema change) vs B (split surface); finalize `specs/lease-operation-scope/spec.md`. `openspec validate scope-lease-to-write-operations --strict`.
+
+## 2. Implement
+
+- [ ] 2.1 Thread the resolved operation's read-only-ness into `writer_lease.invoke`'s bypass decision (fail SAFE: unknown → require lease).
+- [ ] 2.2 Keep write operations lease-gated; do not change the read/write classification of any operation.
+- [ ] 2.3 If (and only if) the tool surface must change, regenerate + review `tests/fixtures/mcp_tool_schemas.json`.
+
+## 3. Verify
+
+- [ ] 3.1 New test: with an unreachable `EXOMEM_WRITER_LEASE_URL`, a default `connect_memory` (suggest-links) and `adopt_vault` (scan) succeed; `create-entity` / `accept-relation` / an adopt write mode still refuse `WRITER_COORDINATOR_UNAVAILABLE`.
+- [ ] 3.2 `tests/test_mcp_schema_fidelity.py` green (surface unchanged, or baseline deliberately updated).
+- [ ] 3.3 `tests/test_writer_lease.py` and connect/adopt tests stay green.
+- [ ] 3.4 `uvx ruff check` scoped to changed files only.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -19,6 +19,7 @@ named in `HAND_REGISTERED_EXCEPTIONS`.
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 from importlib.metadata import PackageNotFoundError, version
@@ -101,6 +102,8 @@ from .vault import (
 )
 
 _link_summary = link_summary_module.link_summary
+_CONNECT_MEMORY_DEFAULT_OPERATION = "suggest-links"
+_ADOPT_VAULT_DEFAULT_MODE = "scan-only"
 
 # Keep commands.py as the public command-surface facade for server, CLI, docs,
 # and tests while the implementation lives in command_surface.py.
@@ -3570,7 +3573,7 @@ def op_triage_memory(
 
 def op_connect_memory(
     vault_root: Path,
-    operation: str = "suggest-links",
+    operation: str = _CONNECT_MEMORY_DEFAULT_OPERATION,
     path: str | None = None,
     target: str | None = None,
     query: str | None = None,
@@ -3770,7 +3773,7 @@ def op_connect_memory(
 def op_adopt_vault(
     vault_root: Path,
     path: str = "",
-    mode: str = "scan-only",
+    mode: str = _ADOPT_VAULT_DEFAULT_MODE,
     max_depth: int = overview_module.DEFAULT_MAX_DEPTH,
     include_hidden: bool = False,
     samples: int = 5,
@@ -4218,6 +4221,21 @@ _CONNECT_MEMORY_READ_ONLY_OPERATIONS = frozenset(
     {"suggest-links", "suggest-relations", "context", "graph-context", "inbound-links"}
 )
 _ADOPT_VAULT_READ_ONLY_MODES = frozenset({"scan-only"})
+_MISSING_SELECTOR_DEFAULT = object()
+
+
+def _resolved_invocation_selector(
+    command: Command, kwargs: dict[str, Any], selector: str
+) -> Any:
+    if selector in kwargs:
+        return kwargs[selector]
+    try:
+        parameter = inspect.signature(command.leaf).parameters.get(selector)
+    except (TypeError, ValueError):
+        return _MISSING_SELECTOR_DEFAULT
+    if parameter is None or parameter.default is inspect.Parameter.empty:
+        return _MISSING_SELECTOR_DEFAULT
+    return parameter.default
 
 
 def invocation_is_read_only(command: Command, kwargs: dict[str, Any]) -> bool:
@@ -4230,13 +4248,13 @@ def invocation_is_read_only(command: Command, kwargs: dict[str, Any]) -> bool:
     if command.read_only:
         return True
     if command.name == "connect_memory":
-        operation = "suggest-links" if "operation" not in kwargs else kwargs["operation"]
+        operation = _resolved_invocation_selector(command, kwargs, "operation")
         return (
             isinstance(operation, str)
             and operation in _CONNECT_MEMORY_READ_ONLY_OPERATIONS
         )
     if command.name == "adopt_vault":
-        mode = "scan-only" if "mode" not in kwargs else kwargs["mode"]
+        mode = _resolved_invocation_selector(command, kwargs, "mode")
         return isinstance(mode, str) and mode in _ADOPT_VAULT_READ_ONLY_MODES
     return False
 

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -4214,6 +4214,33 @@ def note_description(project_keys_hint: str) -> str:
 # The registry
 # --------------------------------------------------------------------------- #
 # (name, leaf, tier, cli_writes, needs_schema, cli_positional, surfaces)
+_CONNECT_MEMORY_READ_ONLY_OPERATIONS = frozenset(
+    {"suggest-links", "suggest-relations", "context", "graph-context", "inbound-links"}
+)
+_ADOPT_VAULT_READ_ONLY_MODES = frozenset({"scan-only"})
+
+
+def invocation_is_read_only(command: Command, kwargs: dict[str, Any]) -> bool:
+    """Classify one resolved product-command invocation for lease gating.
+
+    Write-capable product commands default to requiring the lease. The two
+    mixed read/write commands opt into a finite read-only allowlist, with their
+    Python signature defaults applied only when the selector was truly omitted.
+    """
+    if command.read_only:
+        return True
+    if command.name == "connect_memory":
+        operation = "suggest-links" if "operation" not in kwargs else kwargs["operation"]
+        return (
+            isinstance(operation, str)
+            and operation in _CONNECT_MEMORY_READ_ONLY_OPERATIONS
+        )
+    if command.name == "adopt_vault":
+        mode = "scan-only" if "mode" not in kwargs else kwargs["mode"]
+        return isinstance(mode, str) and mode in _ADOPT_VAULT_READ_ONLY_MODES
+    return False
+
+
 _PRODUCT_ACTIONS: tuple[str, ...] = ("save", "adopt", "ask", "prove", "review", "update", "connect")
 _SIMPLE_ACTIONS: tuple[str, ...] = (
     "ask",

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -246,6 +246,7 @@ def note(
     suggestions: bool = True,
     today: dt.date | None = None,
     project_category: str | None = None,
+    _planned_writes: list[PlannedWrite] | None = None,
 ) -> NoteResult:
     """Create a compiled note + update indexes/log + back-ref cited sources atomically.
 
@@ -558,25 +559,30 @@ def note(
     else:
         warnings.append(f"{kb_prefix()}log.md missing; skipped log entry")
 
-    try:
-        batch_atomic_write(writes, vault_root=vault_root)
-    except Exception as e:
-        log.exception("partial write during note(); some files may be updated")
-        warnings.append(f"partial write — reconcile on desktop: {e}")
-        # Purge this write's add_pending registration from the SHARED resolver
-        # — the note never landed, and a phantom entry would resolve wikilinks
-        # to a nonexistent page until the next full rebuild.
+    if _planned_writes is None:
         try:
-            find_module.on_resolver_files_changed(
-                vault_root, [rel_note_no_ext + ".md"], []
-            )
-        except Exception:  # noqa: BLE001 — purge is best-effort cleanup
-            log.debug("resolver pending-purge failed", exc_info=True)
-        raise
+            batch_atomic_write(writes, vault_root=vault_root)
+        except Exception as e:
+            log.exception("partial write during note(); some files may be updated")
+            warnings.append(f"partial write — reconcile on desktop: {e}")
+            # Purge this write's add_pending registration from the SHARED resolver
+            # — the note never landed, and a phantom entry would resolve wikilinks
+            # to a nonexistent page until the next full rebuild.
+            try:
+                find_module.on_resolver_files_changed(
+                    vault_root, [rel_note_no_ext + ".md"], []
+                )
+            except Exception:  # noqa: BLE001 — purge is best-effort cleanup
+                log.debug("resolver pending-purge failed", exc_info=True)
+            raise
 
-    rotate_note = rotate_log_if_needed(vault_root)
-    if rotate_note:
-        warnings.append(rotate_note)
+        rotate_note = rotate_log_if_needed(vault_root)
+        if rotate_note:
+            warnings.append(rotate_note)
+    else:
+        # Internal composition seam for replace(): preserve note()'s exact
+        # write plan while letting the supersession pointers join the same batch.
+        _planned_writes.extend(writes)
 
     write_feedback["sources"]["backrefs_planned"] = backrefs_planned
 

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -108,6 +108,7 @@ def _plan_project_registrations(
         expected_hash = MISSING_CONTENT_HASH
 
     warnings: list[str] = []
+    required_project_dirs: list[Path] = []
     changed = False
     for candidate in candidates:
         if candidate in folders:
@@ -132,6 +133,9 @@ def _plan_project_registrations(
         )
         folders[candidate] = folder
         categories[candidate] = category
+        required_project_dirs.append(
+            kb_root(vault_root) / "Notes" / "Research" / folder
+        )
         changed = True
         warnings.append(
             f"Auto-registered project key {candidate!r} (folder: {folder!r}"
@@ -144,6 +148,7 @@ def _plan_project_registrations(
             path=registry_path,
             content=text,
             expected_hash=expected_hash,
+            ensure_directories=tuple(required_project_dirs),
         )
         if changed
         else None

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -39,10 +39,12 @@ from . import corpus_aware, indexes, markdown_relations, memory_refs, semantic_b
 from . import project_keys as project_keys_module
 from .kbdir import kb_prefix
 from .vault import (
+    MISSING_CONTENT_HASH,
     InvalidSlugError,
     PlannedWrite,
     WikilinkResolver,
     batch_atomic_write,
+    content_hash,
     ensure_canonical_h1,
     escape_wikilinks_for_log,
     find_body_wikilinks,
@@ -68,6 +70,89 @@ NOTE_TYPES = (
 def _load_keys(vault_root: Path) -> project_keys_module.ProjectRegistry:
     """Load the live project registry (from `_Schema/project-keys.yaml`)."""
     return project_keys_module.load_project_registry(vault_root)
+
+
+def _plan_project_registrations(
+    vault_root: Path,
+    candidates: list[str],
+    *,
+    category: str,
+) -> tuple[
+    project_keys_module.ProjectRegistry,
+    PlannedWrite | None,
+    list[str],
+]:
+    """Build registry updates for a composed write without mutating the vault."""
+    registry = _load_keys(vault_root)
+    folders = dict(registry.project_to_folder)
+    categories = dict(registry.project_to_category)
+    registry_path = kb_root(vault_root) / "_Schema" / "project-keys.yaml"
+    if registry_path.exists():
+        original = registry_path.read_text(encoding="utf-8")
+        text = original
+        expected_hash = content_hash(original)
+    else:
+        bootstrap_lines = [
+            "# Project keys for research-notes and cross-cutting projects: list.",
+            "# exomem loads this at startup and auto-appends new keys on use.",
+            "",
+            "projects:",
+        ]
+        for key, folder in folders.items():
+            bootstrap_lines.append(f"  {key}:")
+            bootstrap_lines.append(f"    folder: {folder}")
+            bootstrap_lines.append(
+                f"    category: {categories.get(key, 'uncategorized')}"
+            )
+        text = "\n".join(bootstrap_lines) + "\n"
+        expected_hash = MISSING_CONTENT_HASH
+
+    warnings: list[str] = []
+    changed = False
+    for candidate in candidates:
+        if candidate in folders:
+            continue
+        if not project_keys_module._SLUG_RE.match(candidate):
+            continue
+        close = project_keys_module._closest_existing_key(
+            candidate, list(folders)
+        )
+        if close is not None:
+            raise project_keys_module.ProjectKeyTypoError(
+                candidate, close[0], close[1]
+            )
+        folder = project_keys_module._title_case_slug(candidate)
+        if not text.endswith("\n"):
+            text += "\n"
+        text += (
+            "\n  # auto-registered by exomem\n"
+            f"  {candidate}:\n"
+            f"    folder: {folder}\n"
+            f"    category: {category}\n"
+        )
+        folders[candidate] = folder
+        categories[candidate] = category
+        changed = True
+        warnings.append(
+            f"Auto-registered project key {candidate!r} (folder: {folder!r}"
+            + (f", category: {category!r}" if category != "uncategorized" else "")
+            + ")."
+        )
+
+    planned_write = (
+        PlannedWrite(
+            path=registry_path,
+            content=text,
+            expected_hash=expected_hash,
+        )
+        if changed
+        else None
+    )
+    planned_registry = project_keys_module.ProjectRegistry(
+        project_to_folder=folders,
+        project_to_category=categories,
+    )
+    return planned_registry, planned_write, warnings
 
 SEVERITY_VALUES = ("minor", "moderate", "serious", "critical")
 
@@ -272,41 +357,62 @@ def note(
     # registration is visible. Invalid slugs fall through to validation
     # which rejects them with a typed error.
     autoregister_warnings: list[str] = []
+    planned_registry: project_keys_module.ProjectRegistry | None = None
+    project_registration_write: PlannedWrite | None = None
     candidates: list[str] = []
     if project:
         candidates.append(project)
     if projects:
         candidates.extend(p for p in projects if p)
     if candidates:
-        registry = _load_keys(vault_root)
-        for cand in candidates:
-            if cand in registry.project_to_folder:
-                continue
+        if _planned_writes is not None:
             try:
-                _, new_folder, was_new = project_keys_module.register_project_key(
-                    vault_root, cand,
+                (
+                    planned_registry,
+                    project_registration_write,
+                    autoregister_warnings,
+                ) = _plan_project_registrations(
+                    vault_root,
+                    candidates,
                     category=project_category or "uncategorized",
                 )
-                if was_new:
-                    cat_note = (
-                        f", category: {project_category!r}"
-                        if project_category else ""
-                    )
-                    autoregister_warnings.append(
-                        f"Auto-registered project key {cand!r} (folder: "
-                        f"{new_folder!r}{cat_note})."
-                    )
             except project_keys_module.ProjectKeyTypoError as e:
-                # Surface as a typed validation error — the agent's natural
-                # recovery is to re-call with the suggested key.
                 raise NoteError(
                     code="PROJECT_KEY_TYPO",
-                    missing=["project" if cand == project else "projects"],
+                    missing=["project" if e.key == project else "projects"],
                     reason=str(e),
                 ) from e
-            except ValueError:
-                # Invalid slug — fall through to validation which will reject.
-                pass
+        else:
+            registry = _load_keys(vault_root)
+            for cand in candidates:
+                if cand in registry.project_to_folder:
+                    continue
+                try:
+                    _, new_folder, was_new = project_keys_module.register_project_key(
+                        vault_root,
+                        cand,
+                        category=project_category or "uncategorized",
+                    )
+                    if was_new:
+                        cat_note = (
+                            f", category: {project_category!r}"
+                            if project_category else ""
+                        )
+                        autoregister_warnings.append(
+                            f"Auto-registered project key {cand!r} (folder: "
+                            f"{new_folder!r}{cat_note})."
+                        )
+                except project_keys_module.ProjectKeyTypoError as e:
+                    # Surface as a typed validation error — the agent's natural
+                    # recovery is to re-call with the suggested key.
+                    raise NoteError(
+                        code="PROJECT_KEY_TYPO",
+                        missing=["project" if cand == project else "projects"],
+                        reason=str(e),
+                    ) from e
+                except ValueError:
+                    # Invalid slug — fall through to validation which will reject.
+                    pass
 
     err = _validate(
         note_type=note_type,
@@ -322,6 +428,7 @@ def note(
         duration=duration,
         medium=medium,
         vault_root=vault_root,
+        project_registry=planned_registry,
     )
     if err is not None:
         raise NoteError(code=err.code, missing=err.missing, reason=err.reason)
@@ -340,6 +447,8 @@ def note(
         medium=medium,
         started=started,
         date_iso=date_iso,
+        project_registry=planned_registry,
+        create_parents=_planned_writes is None,
     )
     rel_note_no_ext = note_path.relative_to(vault_root).with_suffix("").as_posix()
     new_note_wikilink = f"[[{render_wikilink_target(rel_note_no_ext, vault_root)}]]"
@@ -462,7 +571,10 @@ def note(
         backrefs_planned=0,
         suggestions_count=len(corpus_suggestions),
     )
-    writes: list[PlannedWrite] = [PlannedWrite(path=note_path, content=note_md)]
+    writes: list[PlannedWrite] = []
+    if project_registration_write is not None:
+        writes.append(project_registration_write)
+    writes.append(PlannedWrite(path=note_path, content=note_md))
     warnings: list[str] = (
         list(autoregister_warnings)
         + list(slug_warnings)
@@ -623,6 +735,7 @@ def _validate(
     duration: str | None,
     medium: str | None,
     vault_root: Path,
+    project_registry: project_keys_module.ProjectRegistry | None = None,
 ) -> _Err | None:
     missing: list[str] = []
     reasons: list[str] = []
@@ -669,7 +782,7 @@ def _validate(
             missing.append("status")
             reasons.append(f"status must be 'active' or 'draft', got {status!r}")
 
-    registry = _load_keys(vault_root)
+    registry = project_registry or _load_keys(vault_root)
     valid_keys = registry.project_to_folder
     if note_type == "research-note":
         if not project:
@@ -771,12 +884,14 @@ def _resolve_path(
     medium: str | None,
     started: str | None,
     date_iso: str,
+    project_registry: project_keys_module.ProjectRegistry | None = None,
+    create_parents: bool = True,
 ) -> Path:
     kb = kb_root(vault_root)
     if note_type == "research-note":
         assert project is not None  # validated above
         # Use live registry so auto-registered keys resolve to their folder.
-        registry = _load_keys(vault_root)
+        registry = project_registry or _load_keys(vault_root)
         folder_name = registry.folder_for(project) or project.capitalize()
         folder = kb / "Notes" / "Research" / folder_name
         stem = slug
@@ -799,7 +914,8 @@ def _resolve_path(
         stem = f"{date_iso[:7]}-{slug}"  # YYYY-MM-<slug>
     else:  # pragma: no cover — validation guards this
         raise ValueError(f"unhandled note_type: {note_type}")
-    folder.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        folder.mkdir(parents=True, exist_ok=True)
     return unique_path(folder, stem)
 
 

--- a/src/exomem/replace.py
+++ b/src/exomem/replace.py
@@ -25,12 +25,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import find as find_module
-from . import indexes
+from . import indexes, memory_refs
 from . import note as note_module
-from . import memory_refs
 from .kbdir import kb_prefix
-from .vault import PlannedWrite, batch_atomic_write, kb_root, render_wikilink_target
-
+from .vault import (
+    ContentHashMismatchError,
+    PlannedWrite,
+    batch_atomic_write,
+    content_hash,
+    kb_root,
+    parse_frontmatter,
+    render_wikilink_target,
+    rotate_log_if_needed,
+)
 
 log = logging.getLogger(__name__)
 
@@ -99,24 +106,25 @@ def replace(
             ),
         )
 
-    # Load old page, validate it's actually supersedable.
+    # Load one content version of the old page for both eligibility and CAS.
     try:
-        mtime = old_resolved.stat().st_mtime
-    except OSError as e:
+        old_text = old_resolved.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
         raise ReplaceError(
             code="OLD_NOT_FOUND",
             missing=["old_path"],
             reason=str(e),
         ) from e
-    old_parsed = find_module._parse_page(old_resolved, mtime, vault_root)
-    if old_parsed is None:
+    except (OSError, UnicodeDecodeError) as e:
         raise ReplaceError(
             code="UNREADABLE",
             missing=["old_path"],
-            reason=f"could not parse {rel_old_with_ext} as markdown",
-        )
+            reason=str(e),
+        ) from e
+    old_frontmatter, _old_body, _old_frontmatter_text = parse_frontmatter(old_text)
+    old_expected_hash = content_hash(old_text)
 
-    if old_parsed.frontmatter.get("status") == "superseded":
+    if old_frontmatter.get("status") == "superseded":
         raise ReplaceError(
             code="ALREADY_SUPERSEDED",
             missing=["old_path"],
@@ -126,9 +134,15 @@ def replace(
             ),
         )
 
-    # Construct the new page via note.note() — full reuse, including
-    # index/log/back-ref writes.
-    new_result = note_module.note(vault_root, today=today, **note_kwargs)
+    # Construct note()'s complete write plan without committing it yet. The
+    # public note() path still commits normally when this private list is absent.
+    note_writes: list[PlannedWrite] = []
+    new_result = note_module.note(
+        vault_root,
+        today=today,
+        _planned_writes=note_writes,
+        **note_kwargs,
+    )
     new_path_str = new_result.path  # vault-relative, with .md
     rel_new_no_ext = new_path_str.removesuffix(".md")
     if not rel_new_no_ext.startswith(kb_prefix()):
@@ -137,8 +151,9 @@ def replace(
 
     warnings: list[str] = list(new_result.warnings)
 
-    # Inject `supersedes:` into the freshly-written new page's frontmatter.
-    new_text = new_resolved.read_text(encoding="utf-8")
+    # Inject `supersedes:` into the planned new page's frontmatter.
+    new_page_write = next(write for write in note_writes if write.path == new_resolved)
+    new_text = new_page_write.content
     old_link_target = render_wikilink_target(rel_old_no_ext, vault_root)
     new_text_updated = _inject_supersedes(new_text, old_link_target)
     if new_text_updated == new_text:
@@ -146,9 +161,9 @@ def replace(
             "could not inject supersedes: into new page frontmatter — "
             "frontmatter shape unexpected"
         )
+    new_page_write.content = new_text_updated
 
     # Patch old page: status -> superseded, add superseded_by, refresh updated.
-    old_text = old_resolved.read_text(encoding="utf-8")
     new_link_target = render_wikilink_target(rel_new_no_ext, vault_root)
     old_text_updated = _mark_superseded(old_text, new_link_target, date_iso)
     if old_text_updated == old_text:
@@ -160,8 +175,11 @@ def replace(
     # Append a log entry naming the supersession explicitly.
     kb = kb_root(vault_root)
     log_file = kb / "log.md"
-    log_writes: list[PlannedWrite] = []
-    if log_file.exists():
+    log_write = next(
+        (write for write in reversed(note_writes) if write.path == log_file),
+        None,
+    )
+    if log_write is not None:
         log_body_parts = [
             f"Supersedes `{rel_old_no_ext}` via exomem."
         ]
@@ -169,26 +187,46 @@ def replace(
             log_body_parts.append(reason.strip())
         log_body = " ".join(log_body_parts)
         new_log = _prepend_replace_log_entry(
-            log_file.read_text(encoding="utf-8"),
+            log_write.content,
             date_iso=date_iso,
             rel_new_no_ext=rel_new_no_ext,
             body=log_body,
         )
-        log_writes.append(PlannedWrite(path=log_file, content=new_log))
+        log_write.content = new_log
+    elif log_file.exists():
+        warnings.append("note write plan omitted log.md; skipped replace log entry")
     else:
         warnings.append(f"{kb_prefix()}log.md missing; skipped replace log entry")
 
-    writes = [
-        PlannedWrite(path=new_resolved, content=new_text_updated),
-        PlannedWrite(path=old_resolved, content=old_text_updated),
-    ] + log_writes
+    writes = note_writes + [
+        PlannedWrite(
+            path=old_resolved,
+            content=old_text_updated,
+            expected_hash=old_expected_hash,
+        )
+    ]
 
     try:
         batch_atomic_write(writes, vault_root=vault_root)
+    except ContentHashMismatchError as e:
+        _purge_planned_note(vault_root, rel_new_no_ext)
+        raise ReplaceError(
+            code="STALE_SUPERSEDE",
+            missing=["old_path"],
+            reason=(
+                f"{rel_old_with_ext} changed after supersession eligibility was read; "
+                "retry against the current active page"
+            ),
+        ) from e
     except Exception as e:
-        log.exception("partial write during replace(); some files may be updated")
-        warnings.append(f"partial write — reconcile on desktop: {e}")
+        _purge_planned_note(vault_root, rel_new_no_ext)
+        log.exception("supersession batch failed and was rolled back")
+        warnings.append(f"supersession batch rolled back: {e}")
         raise
+
+    rotate_note = rotate_log_if_needed(vault_root)
+    if rotate_note:
+        warnings.append(rotate_note)
 
     return ReplaceResult(
         old_path=rel_old_with_ext,
@@ -197,6 +235,16 @@ def replace(
         old_ref=memory_refs.ReferenceIndex(vault_root).ref_for_path(rel_old_with_ext),
         new_ref=new_result.ref,
     )
+
+
+def _purge_planned_note(vault_root: Path, rel_new_no_ext: str) -> None:
+    """Remove note()'s pending resolver entry when its composed batch fails."""
+    try:
+        find_module.on_resolver_files_changed(
+            vault_root, [rel_new_no_ext + ".md"], []
+        )
+    except Exception:  # noqa: BLE001 — purge is best-effort cleanup
+        log.debug("resolver pending-purge failed", exc_info=True)
 
 
 # ---------------- path resolution ----------------

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -248,6 +248,7 @@ class PlannedWrite:
     path: Path
     content: str
     expected_hash: str | None = None
+    ensure_directories: tuple[Path, ...] = ()
 
 
 class ContentHashMismatchError(RuntimeError):
@@ -370,6 +371,8 @@ def _batch_atomic_write_locked(
     created_dirs: list[Path] = []
     try:
         for w in writes:
+            for directory in w.ensure_directories:
+                _create_parent_dirs(directory, created_dirs)
             _create_parent_dirs(w.path.parent, created_dirs)
             # NamedTemporaryFile would need delete=False + cross-platform care;
             # explicit tmp sibling is simpler and survives os.replace.
@@ -378,8 +381,8 @@ def _batch_atomic_write_locked(
             )
             os.close(fd)
             tmp = Path(tmp_str)
-            tmp.write_text(w.content, encoding="utf-8", newline="\n")
             staged.append((w.path, tmp))
+            tmp.write_text(w.content, encoding="utf-8", newline="\n")
     except Exception:
         for _, tmp in staged:
             tmp.unlink(missing_ok=True)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -334,6 +334,9 @@ def batch_atomic_write(
 
     replaced: list[Path] = []
     try:
+        from .writer_lease import validate_active_write_fence
+
+        validate_active_write_fence()
         for final, tmp in staged:
             os.replace(tmp, final)
             replaced.append(final)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -16,6 +16,7 @@ import os
 import re
 import shutil
 import tempfile
+import threading
 from collections.abc import Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -242,13 +243,44 @@ def unique_path(directory: Path, stem: str, suffix: str = ".md") -> Path:
 
 @dataclass
 class PlannedWrite:
-    """One target file in a batch write: destination path + final content."""
+    """One target file in a batch write, with an optional commit-time CAS guard."""
 
     path: Path
     content: str
+    expected_hash: str | None = None
+
+
+class ContentHashMismatchError(RuntimeError):
+    """A planned destination changed before its guarded batch could commit."""
+
+    def __init__(self, path: Path, expected_hash: str, actual_hash: str | None):
+        self.path = path
+        self.expected_hash = expected_hash
+        self.actual_hash = actual_hash
+        actual = actual_hash or "<missing>"
+        super().__init__(
+            f"content changed before commit: {path} "
+            f"(expected {expected_hash}, found {actual})"
+        )
+
+
+_BATCH_COMMIT_LOCK = threading.RLock()
 
 
 def batch_atomic_write(
+    writes: Iterable[PlannedWrite], *, vault_root: Path | None = None
+) -> list[Path]:
+    """Commit one batch while serializing all in-process vault writers.
+
+    A process-shared lock closes the gap between validating any ``expected_hash``
+    guards and replacing destinations. The locked implementation retains the
+    existing staging, rollback, and index-refresh behavior.
+    """
+    with _BATCH_COMMIT_LOCK:
+        return _batch_atomic_write_locked(writes, vault_root=vault_root)
+
+
+def _batch_atomic_write_locked(
     writes: Iterable[PlannedWrite], *, vault_root: Path | None = None
 ) -> list[Path]:
     """Stage each write as a sibling .tmp file, then os.replace() them into place.
@@ -271,6 +303,19 @@ def batch_atomic_write(
     for write in writes:
         deduped[write.path] = write
     writes = list(deduped.values())
+    for write in writes:
+        if write.expected_hash is None:
+            continue
+        try:
+            current = write.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            actual_hash = None
+        else:
+            actual_hash = content_hash(current)
+        if actual_hash != write.expected_hash:
+            raise ContentHashMismatchError(
+                write.path, write.expected_hash, actual_hash
+            )
     # Access-tier backstop: when the caller knows the vault root, refuse any
     # write that lands in a `readonly`/`excluded` tree (_access.yaml). Central
     # here so every content writer inherits it without per-tool wiring. No

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -265,6 +265,33 @@ class ContentHashMismatchError(RuntimeError):
 
 
 _BATCH_COMMIT_LOCK = threading.RLock()
+MISSING_CONTENT_HASH = "<missing>"
+
+
+def _create_parent_dirs(parent: Path, created_dirs: list[Path]) -> None:
+    """Create missing parents and record only directories created by this call."""
+    missing: list[Path] = []
+    cursor = parent
+    while not cursor.exists():
+        missing.append(cursor)
+        if cursor.parent == cursor:
+            break
+        cursor = cursor.parent
+    for directory in reversed(missing):
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            continue
+        created_dirs.append(directory)
+
+
+def _remove_empty_created_dirs(created_dirs: list[Path]) -> None:
+    """Best-effort rollback for empty parent directories created during staging."""
+    for directory in reversed(created_dirs):
+        try:
+            directory.rmdir()
+        except OSError:
+            pass
 
 
 def batch_atomic_write(
@@ -312,7 +339,8 @@ def _batch_atomic_write_locked(
             actual_hash = None
         else:
             actual_hash = content_hash(current)
-        if actual_hash != write.expected_hash:
+        expected_missing = write.expected_hash == MISSING_CONTENT_HASH
+        if not (expected_missing and actual_hash is None) and actual_hash != write.expected_hash:
             raise ContentHashMismatchError(
                 write.path, write.expected_hash, actual_hash
             )
@@ -339,9 +367,10 @@ def _batch_atomic_write_locked(
             if reason is not None:
                 raise ValueError(f"WRITE_REFUSED: {rel}: {reason}")
     staged: list[tuple[Path, Path]] = []  # (final, tmp)
+    created_dirs: list[Path] = []
     try:
         for w in writes:
-            w.path.parent.mkdir(parents=True, exist_ok=True)
+            _create_parent_dirs(w.path.parent, created_dirs)
             # NamedTemporaryFile would need delete=False + cross-platform care;
             # explicit tmp sibling is simpler and survives os.replace.
             fd, tmp_str = tempfile.mkstemp(
@@ -354,6 +383,7 @@ def _batch_atomic_write_locked(
     except Exception:
         for _, tmp in staged:
             tmp.unlink(missing_ok=True)
+        _remove_empty_created_dirs(created_dirs)
         raise
 
     backups: dict[Path, Path | None] = {}
@@ -375,6 +405,7 @@ def _batch_atomic_write_locked(
         for backup in backups.values():
             if backup is not None:
                 backup.unlink(missing_ok=True)
+        _remove_empty_created_dirs(created_dirs)
         raise
 
     replaced: list[Path] = []
@@ -403,6 +434,7 @@ def _batch_atomic_write_locked(
                 tmp.unlink(missing_ok=True)
         if rollback_errors:
             retained = [str(path) for path in backups.values() if path is not None]
+            _remove_empty_created_dirs(created_dirs)
             raise RuntimeError(
                 f"batch commit failed ({commit_error}); rollback also failed: "
                 + "; ".join(rollback_errors)
@@ -411,6 +443,7 @@ def _batch_atomic_write_locked(
         for backup in backups.values():
             if backup is not None:
                 backup.unlink(missing_ok=True)
+        _remove_empty_created_dirs(created_dirs)
         raise
     else:
         for backup in backups.values():

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -20,6 +20,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,9 @@ _COORDINATOR_USER_AGENT = (
 )
 _IMPLICIT_RETRY_TTL_SECONDS = 60.0
 logger = logging.getLogger(__name__)
+_ACTIVE_WRITE_FENCE: ContextVar[tuple[Any, int] | None] = ContextVar(
+    "exomem_active_write_fence", default=None
+)
 
 
 @dataclass(frozen=True)
@@ -315,8 +319,7 @@ class LeaseManager:
     ) -> Any:
         if command.read_only:
             return command.leaf(*injected, **kwargs)
-        if self.config.enabled:
-            self.ensure_writer()
+        lease = self.ensure_writer() if self.config.enabled else None
         digest = hashlib.sha256(
             json.dumps(
                 {"command": command.name, "kwargs": kwargs},
@@ -339,12 +342,47 @@ class LeaseManager:
                 logger.info("Replayed retry-safe MCP mutation command=%s", command.name)
 
             on_replay = log_replay
-        return self.idempotency.run(
-            key,
-            digest,
-            lambda: command.leaf(*injected, **kwargs),
-            expires_after=expires_after,
-            on_replay=on_replay,
+        fence_context: Token[tuple[Any, int] | None] | None = None
+        if lease is not None:
+            fence_context = _ACTIVE_WRITE_FENCE.set((self, lease.fencing_token))
+        try:
+            return self.idempotency.run(
+                key,
+                digest,
+                lambda: command.leaf(*injected, **kwargs),
+                expires_after=expires_after,
+                on_replay=on_replay,
+            )
+        finally:
+            if fence_context is not None:
+                _ACTIVE_WRITE_FENCE.reset(fence_context)
+
+    def validate_fencing_token(self, fencing_token: int) -> None:
+        """Fail closed unless the command's token is still locally and remotely current."""
+        with self._lock:
+            if self._fencing_token != fencing_token:
+                self._raise_fenced(fencing_token)
+        assert self.client is not None
+        record = self.client.status()
+        with self._lock:
+            still_current = self._fencing_token == fencing_token
+            coordinator_current = (
+                record.holder == self.config.replica_id
+                and record.fencing_token == fencing_token
+            )
+            if still_current and coordinator_current:
+                return
+            if self._fencing_token == fencing_token:
+                self._fencing_token = None
+                self._expires_at = None
+        self._raise_fenced(fencing_token)
+
+    @staticmethod
+    def _raise_fenced(fencing_token: int) -> None:
+        raise OpError(
+            "WRITER_FENCED",
+            f"writer lease fencing token {fencing_token} is no longer current",
+            "Retry the mutation on the current writer.",
         )
 
     def status(self) -> dict[str, Any]:
@@ -392,6 +430,8 @@ class LeaseManager:
             try:
                 record = self.client.renew(token)
                 with self._lock:
+                    if self._fencing_token != token:
+                        continue
                     if record.granted and record.holder == self.config.replica_id:
                         self._expires_at = record.expires_at
                     else:
@@ -411,6 +451,15 @@ class LeaseManager:
                 self.client.release(token)
             except OpError:
                 pass
+
+
+def validate_active_write_fence() -> None:
+    """Revalidate the active command's lease token at a vault commit boundary."""
+    active = _ACTIVE_WRITE_FENCE.get()
+    if active is None:
+        return
+    manager, fencing_token = active
+    manager.validate_fencing_token(fencing_token)
 
 
 _MANAGERS: dict[LeaseConfig, LeaseManager] = {}

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -314,10 +314,12 @@ class LeaseManager:
         injected: tuple[Any, ...],
         kwargs: dict[str, Any],
         *,
+        read_only: bool | None = None,
         idempotency_key: str | None = None,
         implicit_idempotency_scope: str | None = None,
     ) -> Any:
-        if command.read_only:
+        invocation_read_only = command.read_only if read_only is None else read_only
+        if invocation_read_only:
             return command.leaf(*injected, **kwargs)
         lease = self.ensure_writer() if self.config.enabled else None
         digest = hashlib.sha256(
@@ -483,10 +485,13 @@ def invoke_command(
     implicit_idempotency_scope: str | None = None,
     **kwargs: Any,
 ) -> Any:
+    from .commands import invocation_is_read_only
+
     return get_manager().invoke(
         command,
         injected,
         kwargs,
+        read_only=invocation_is_read_only(command, kwargs),
         idempotency_key=idempotency_key,
         implicit_idempotency_scope=implicit_idempotency_scope,
     )

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import datetime as dt
+import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -10,7 +13,7 @@ import yaml
 
 from exomem import note as note_module
 from exomem import replace as replace_module
-
+from exomem import vault as vault_module
 
 TODAY = dt.date(2026, 5, 25)
 
@@ -34,6 +37,13 @@ def _make_insight(vault: Path, title: str) -> str:
         today=TODAY,
     )
     return result.path
+
+
+def _markdown_snapshot(vault: Path) -> dict[str, str]:
+    return {
+        path.relative_to(vault).as_posix(): _read(path)
+        for path in sorted((vault / "Knowledge Base").rglob("*.md"))
+    }
 
 
 def test_replace_writes_new_and_flips_old(vault: Path) -> None:
@@ -240,3 +250,111 @@ def test_replace_propagates_new_note_validation_errors(vault: Path) -> None:
     # Old should be untouched (no half-state)
     old_fm = _fm(vault / old_rel)
     assert old_fm.get("status") != "superseded"
+
+
+def test_concurrent_replace_has_exactly_one_winner(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_rel = _make_insight(vault, "Concurrent Supersession Source")
+    real_note = note_module.note
+    both_eligible = threading.Barrier(2)
+
+    def note_after_both_eligibility_reads(*args, **kwargs):
+        both_eligible.wait(timeout=5)
+        return real_note(*args, **kwargs)
+
+    monkeypatch.setattr(replace_module.note_module, "note", note_after_both_eligibility_reads)
+
+    def supersede(label: str):
+        title = f"Concurrent Successor {label}"
+        try:
+            return label, replace_module.replace(
+                vault,
+                old_path=old_rel,
+                content=f"# {title}\n\nrevised by {label}.\n",
+                note_type="insight",
+                title=title,
+                today=TODAY,
+            )
+        except replace_module.ReplaceError as error:
+            return label, error
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(supersede, ("A", "B")))
+
+    winners = [
+        (label, result)
+        for label, result in outcomes
+        if isinstance(result, replace_module.ReplaceResult)
+    ]
+    losers = [
+        (label, result)
+        for label, result in outcomes
+        if isinstance(result, replace_module.ReplaceError)
+    ]
+    assert len(winners) == 1
+    assert len(losers) == 1
+    assert losers[0][1].code == "STALE_SUPERSEDE"
+
+    winner_label, winner = winners[0]
+    loser_label = losers[0][0]
+    old_fm = _fm(vault / old_rel)
+    assert old_fm["status"] == "superseded"
+    assert old_fm["superseded_by"] == [
+        f"[[{winner.new_path.removesuffix('.md')}]]"
+    ]
+    assert (vault / winner.new_path).exists()
+    loser_path = (
+        vault
+        / "Knowledge Base"
+        / "Notes"
+        / "Insights"
+        / f"concurrent-successor-{loser_label.lower()}.md"
+    )
+    assert not loser_path.exists()
+    log_text = _read(vault / "Knowledge Base" / "log.md")
+    assert f"Concurrent Successor {winner_label}" in log_text
+    assert f"Concurrent Successor {loser_label}" not in log_text
+
+
+def test_replace_rolls_back_entire_note_plan_on_mid_commit_failure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_rel = _make_insight(vault, "Atomic Supersession Source")
+    before = _markdown_snapshot(vault)
+    real_batch = replace_module.batch_atomic_write
+    real_os_replace = os.replace
+
+    def fail_second_destination(writes, *, vault_root):
+        replacements = 0
+
+        def injected_replace(src, dst):
+            nonlocal replacements
+            if str(src).endswith(".tmp"):
+                replacements += 1
+                if replacements == 2:
+                    raise OSError("injected supersession commit failure")
+            return real_os_replace(src, dst)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(vault_module.os, "replace", injected_replace)
+            return real_batch(writes, vault_root=vault_root)
+
+    monkeypatch.setattr(replace_module, "batch_atomic_write", fail_second_destination)
+
+    with pytest.raises(OSError, match="injected supersession commit failure"):
+        replace_module.replace(
+            vault,
+            old_path=old_rel,
+            content="# Atomic Successor\n\nreplacement body.\n",
+            note_type="insight",
+            title="Atomic Successor",
+            sources=[
+                "Knowledge Base/Sources/Articles/2026-05-04-best-egcg-supplements"
+            ],
+            today=TODAY,
+        )
+
+    assert _markdown_snapshot(vault) == before
+    resolver = replace_module.find_module._get_query_resolver(vault)
+    assert "Knowledge Base/Notes/Insights/atomic-successor" not in resolver.full_paths

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -421,3 +421,108 @@ def test_replace_failure_does_not_leave_project_registration_or_folder(
     if registry_existed:
         assert _read(registry) == registry_before
     assert project_folder.exists() is folder_existed
+
+
+def test_replace_staging_failure_cleans_temp_registry_and_project_folder(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_rel = _make_insight(vault, "Staging Failure Supersession Source")
+    registry = vault / "Knowledge Base" / "_Schema" / "project-keys.yaml"
+    project_folder = (
+        vault
+        / "Knowledge Base"
+        / "Notes"
+        / "Research"
+        / "Staging Failure Project"
+    )
+    real_write_text = Path.write_text
+    temp_writes = 0
+
+    def fail_second_temp_write(path: Path, *args, **kwargs):
+        nonlocal temp_writes
+        if path.name.endswith(".tmp"):
+            temp_writes += 1
+            if temp_writes == 2:
+                raise OSError("injected supersession staging failure")
+        return real_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_second_temp_write)
+
+    with pytest.raises(OSError, match="injected supersession staging failure"):
+        replace_module.replace(
+            vault,
+            old_path=old_rel,
+            content="# Staging Failure Successor\n\nreplacement body.\n",
+            note_type="research-note",
+            title="Staging Failure Successor",
+            project="staging-failure-project",
+            today=TODAY,
+    )
+
+    assert not registry.exists()
+    assert list(vault.rglob("*.tmp")) == []
+    assert not project_folder.exists()
+
+
+def test_plural_project_registration_creates_folder_only_on_success(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_rel = _make_insight(vault, "Plural Project Supersession Source")
+    registry = vault / "Knowledge Base" / "_Schema" / "project-keys.yaml"
+    failed_folder = (
+        vault / "Knowledge Base" / "Notes" / "Research" / "Failed Plural Project"
+    )
+    successful_folder = (
+        vault
+        / "Knowledge Base"
+        / "Notes"
+        / "Research"
+        / "Successful Plural Project"
+    )
+    real_batch = replace_module.batch_atomic_write
+    real_os_replace = os.replace
+
+    def fail_second_destination(writes, *, vault_root):
+        replacements = 0
+
+        def injected_replace(src, dst):
+            nonlocal replacements
+            if str(src).endswith(".tmp"):
+                replacements += 1
+                if replacements == 2:
+                    raise OSError("injected plural project failure")
+            return real_os_replace(src, dst)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(vault_module.os, "replace", injected_replace)
+            return real_batch(writes, vault_root=vault_root)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(replace_module, "batch_atomic_write", fail_second_destination)
+        with pytest.raises(OSError, match="injected plural project failure"):
+            replace_module.replace(
+                vault,
+                old_path=old_rel,
+                content="# Failed Plural Successor\n\nreplacement body.\n",
+                note_type="insight",
+                title="Failed Plural Successor",
+                projects=["failed-plural-project"],
+                today=TODAY,
+            )
+
+    assert not registry.exists()
+    assert not failed_folder.exists()
+
+    replace_module.replace(
+        vault,
+        old_path=old_rel,
+        content="# Successful Plural Successor\n\nreplacement body.\n",
+        note_type="insight",
+        title="Successful Plural Successor",
+        projects=["successful-plural-project"],
+        today=TODAY,
+    )
+
+    assert "successful-plural-project:" in _read(registry)
+    assert "failed-plural-project:" not in _read(registry)
+    assert successful_folder.is_dir()

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -358,3 +358,66 @@ def test_replace_rolls_back_entire_note_plan_on_mid_commit_failure(
     assert _markdown_snapshot(vault) == before
     resolver = replace_module.find_module._get_query_resolver(vault)
     assert "Knowledge Base/Notes/Insights/atomic-successor" not in resolver.full_paths
+
+
+@pytest.mark.parametrize("registry_existed", [False, True])
+def test_replace_failure_does_not_leave_project_registration_or_folder(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    registry_existed: bool,
+) -> None:
+    old_rel = _make_insight(vault, "Project Registration Supersession Source")
+    registry = vault / "Knowledge Base" / "_Schema" / "project-keys.yaml"
+    if registry_existed:
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.write_text(
+            "projects:\n"
+            "  personal:\n"
+            "    folder: Personal\n"
+            "    category: cross-cutting\n",
+            encoding="utf-8",
+        )
+    project_folder = (
+        vault
+        / "Knowledge Base"
+        / "Notes"
+        / "Research"
+        / "Atomic Deferred Project"
+    )
+    registry_before = _read(registry) if registry_existed else None
+    folder_existed = project_folder.exists()
+    real_batch = replace_module.batch_atomic_write
+    real_os_replace = os.replace
+
+    def fail_second_destination(writes, *, vault_root):
+        replacements = 0
+
+        def injected_replace(src, dst):
+            nonlocal replacements
+            if str(src).endswith(".tmp"):
+                replacements += 1
+                if replacements == 2:
+                    raise OSError("injected project supersession failure")
+            return real_os_replace(src, dst)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(vault_module.os, "replace", injected_replace)
+            return real_batch(writes, vault_root=vault_root)
+
+    monkeypatch.setattr(replace_module, "batch_atomic_write", fail_second_destination)
+
+    with pytest.raises(OSError, match="injected project supersession failure"):
+        replace_module.replace(
+            vault,
+            old_path=old_rel,
+            content="# Atomic Project Successor\n\nreplacement body.\n",
+            note_type="research-note",
+            title="Atomic Project Successor",
+            project="atomic-deferred-project",
+            today=TODAY,
+        )
+
+    assert registry.exists() is registry_existed
+    if registry_existed:
+        assert _read(registry) == registry_before
+    assert project_folder.exists() is folder_existed

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import threading
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -170,6 +171,30 @@ def _unreachable_coordinator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "lease-state"))
 
 
+def _recording_product_command(command, calls: list[dict], result: str):  # noqa: ANN001, ANN201
+    selector = {"connect_memory": "operation", "adopt_vault": "mode"}.get(command.name)
+    if selector is None:
+        return replace(
+            command,
+            leaf=lambda _vault_root, **leaf_kwargs: calls.append(leaf_kwargs) or result,
+        )
+
+    default = inspect.signature(command.leaf).parameters[selector].default
+    if selector == "operation":
+
+        def leaf(_vault_root, operation=default, **leaf_kwargs):  # noqa: ANN001, ANN202
+            calls.append({"operation": operation, **leaf_kwargs})
+            return result
+
+    else:
+
+        def leaf(_vault_root, mode=default, **leaf_kwargs):  # noqa: ANN001, ANN202
+            calls.append({"mode": mode, **leaf_kwargs})
+            return result
+
+    return replace(command, leaf=leaf)
+
+
 @pytest.mark.parametrize(
     ("command_name", "kwargs"),
     [
@@ -204,13 +229,14 @@ def test_read_only_product_operations_bypass_unreachable_coordinator(
     _unreachable_coordinator(monkeypatch, tmp_path)
     calls: list[dict] = []
     command = next(c for c in product_commands_for("mcp") if c.name == command_name)
-    command = replace(
-        command,
-        leaf=lambda _vault_root, **leaf_kwargs: calls.append(leaf_kwargs) or "read-ok",
-    )
+    command = _recording_product_command(command, calls, "read-ok")
     try:
         assert invoke_command(command, tmp_path, **kwargs) == "read-ok"
-        assert calls == [kwargs]
+        assert len(calls) == 1
+        selector = "operation" if command_name == "connect_memory" else "mode"
+        expected = dict(kwargs)
+        expected.setdefault(selector, inspect.signature(command.leaf).parameters[selector].default)
+        assert calls == [expected]
     finally:
         reset_managers_for_tests()
 
@@ -235,6 +261,55 @@ def test_default_connect_and_adopt_calls_run_during_coordinator_outage(
 
     assert isinstance(suggestions, list)
     assert report["mode"] == "scan-only"
+
+
+@pytest.mark.parametrize(
+    ("command_name", "selector_default"),
+    [
+        pytest.param("connect_memory", inspect.Parameter.empty, id="connect-default-absent"),
+        pytest.param("connect_memory", "future-mode", id="connect-default-unknown"),
+        pytest.param("connect_memory", "create-entity", id="connect-default-write"),
+        pytest.param("adopt_vault", inspect.Parameter.empty, id="adopt-default-absent"),
+        pytest.param("adopt_vault", "future-mode", id="adopt-default-unknown"),
+        pytest.param("adopt_vault", "save-manifest", id="adopt-default-write"),
+    ],
+)
+def test_omitted_selector_fails_closed_when_leaf_default_is_not_known_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command_name: str,
+    selector_default: object,
+) -> None:
+    from exomem.commands import product_commands_for
+
+    _unreachable_coordinator(monkeypatch, tmp_path)
+    calls: list[dict] = []
+    command = next(c for c in product_commands_for("mcp") if c.name == command_name)
+    if selector_default is inspect.Parameter.empty:
+
+        def leaf(_vault_root, **leaf_kwargs):  # noqa: ANN001, ANN202
+            calls.append(leaf_kwargs)
+            return "write-ran"
+
+    elif command_name == "connect_memory":
+
+        def leaf(_vault_root, operation=selector_default, **leaf_kwargs):  # noqa: ANN001, ANN202
+            calls.append({"operation": operation, **leaf_kwargs})
+            return "write-ran"
+
+    else:
+
+        def leaf(_vault_root, mode=selector_default, **leaf_kwargs):  # noqa: ANN001, ANN202
+            calls.append({"mode": mode, **leaf_kwargs})
+            return "write-ran"
+
+    command = replace(command, leaf=leaf)
+    try:
+        with pytest.raises(OpError, match="WRITER_COORDINATOR_UNAVAILABLE"):
+            invoke_command(command, tmp_path)
+        assert calls == []
+    finally:
+        reset_managers_for_tests()
 
 
 @pytest.mark.parametrize(
@@ -276,10 +351,7 @@ def test_write_and_unknown_product_operations_fail_closed_without_calling_leaf(
     _unreachable_coordinator(monkeypatch, tmp_path)
     calls: list[dict] = []
     command = next(c for c in product_commands_for("mcp") if c.name == command_name)
-    command = replace(
-        command,
-        leaf=lambda _vault_root, **leaf_kwargs: calls.append(leaf_kwargs) or "write-ran",
-    )
+    command = _recording_product_command(command, calls, "write-ran")
     try:
         with pytest.raises(OpError, match="WRITER_COORDINATOR_UNAVAILABLE"):
             invoke_command(command, tmp_path, **kwargs)

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,7 +10,13 @@ import pytest
 from exomem.cli_ops import OpError, http_status_for
 from exomem.lease_coordinator import SQLiteLeaseStore
 from exomem.vault import PlannedWrite, batch_atomic_write
-from exomem.writer_lease import LeaseConfig, LeaseManager, LeaseRecord
+from exomem.writer_lease import (
+    LeaseConfig,
+    LeaseManager,
+    LeaseRecord,
+    invoke_command,
+    reset_managers_for_tests,
+)
 
 
 def test_config_is_default_off_and_requires_identities() -> None:
@@ -154,6 +160,132 @@ def test_reads_bypass_unavailable_coordinator(tmp_path: Path) -> None:
     assert (
         manager.invoke(_command(writes=False, leaf=lambda value: value + 1), (), {"value": 2}) == 3
     )
+
+
+def _unreachable_coordinator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TIMEOUT", "0.05")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "lease-state"))
+
+
+@pytest.mark.parametrize(
+    ("command_name", "kwargs"),
+    [
+        pytest.param("connect_memory", {}, id="connect-default-suggest-links"),
+        pytest.param(
+            "connect_memory", {"operation": "suggest-links"}, id="connect-suggest-links"
+        ),
+        pytest.param(
+            "connect_memory",
+            {"operation": "suggest-relations"},
+            id="connect-suggest-relations",
+        ),
+        pytest.param("connect_memory", {"operation": "context"}, id="connect-context"),
+        pytest.param(
+            "connect_memory", {"operation": "graph-context"}, id="connect-graph-context"
+        ),
+        pytest.param(
+            "connect_memory", {"operation": "inbound-links"}, id="connect-inbound-links"
+        ),
+        pytest.param("adopt_vault", {}, id="adopt-default-scan-only"),
+        pytest.param("adopt_vault", {"mode": "scan-only"}, id="adopt-scan-only"),
+    ],
+)
+def test_read_only_product_operations_bypass_unreachable_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command_name: str,
+    kwargs: dict,
+) -> None:
+    from exomem.commands import product_commands_for
+
+    _unreachable_coordinator(monkeypatch, tmp_path)
+    calls: list[dict] = []
+    command = next(c for c in product_commands_for("mcp") if c.name == command_name)
+    command = replace(
+        command,
+        leaf=lambda _vault_root, **leaf_kwargs: calls.append(leaf_kwargs) or "read-ok",
+    )
+    try:
+        assert invoke_command(command, tmp_path, **kwargs) == "read-ok"
+        assert calls == [kwargs]
+    finally:
+        reset_managers_for_tests()
+
+
+def test_default_connect_and_adopt_calls_run_during_coordinator_outage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, vault: Path
+) -> None:
+    from exomem.commands import product_commands_for
+
+    _unreachable_coordinator(monkeypatch, tmp_path)
+    commands = {c.name: c for c in product_commands_for("mcp")}
+    try:
+        suggestions = invoke_command(
+            commands["connect_memory"],
+            vault,
+            draft_title="Lease-safe read",
+            draft_body="A draft that must remain readable during coordinator downtime.",
+        )
+        report = invoke_command(commands["adopt_vault"], vault)
+    finally:
+        reset_managers_for_tests()
+
+    assert isinstance(suggestions, list)
+    assert report["mode"] == "scan-only"
+
+
+@pytest.mark.parametrize(
+    ("command_name", "kwargs"),
+    [
+        pytest.param(
+            "connect_memory", {"operation": "create-entity"}, id="connect-create-entity"
+        ),
+        pytest.param(
+            "connect_memory", {"operation": "accept-relation"}, id="connect-accept-relation"
+        ),
+        pytest.param("connect_memory", {"operation": ""}, id="connect-empty"),
+        pytest.param("connect_memory", {"operation": None}, id="connect-explicit-none"),
+        pytest.param("connect_memory", {"operation": "entity"}, id="connect-nonexistent-entity"),
+        pytest.param(
+            "connect_memory", {"operation": "future-read-mode"}, id="connect-future-mode"
+        ),
+        pytest.param("adopt_vault", {"mode": "save-manifest"}, id="adopt-save-manifest"),
+        pytest.param(
+            "adopt_vault", {"mode": "copy-as-sources"}, id="adopt-copy-as-sources"
+        ),
+        pytest.param(
+            "adopt_vault", {"mode": "compile-selected"}, id="adopt-compile-selected"
+        ),
+        pytest.param("adopt_vault", {"mode": ""}, id="adopt-empty"),
+        pytest.param("adopt_vault", {"mode": None}, id="adopt-explicit-none"),
+        pytest.param("adopt_vault", {"mode": "future-mode"}, id="adopt-future-mode"),
+        pytest.param("remember", {}, id="generic-write-capable-command"),
+    ],
+)
+def test_write_and_unknown_product_operations_fail_closed_without_calling_leaf(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command_name: str,
+    kwargs: dict,
+) -> None:
+    from exomem.commands import product_commands_for
+
+    _unreachable_coordinator(monkeypatch, tmp_path)
+    calls: list[dict] = []
+    command = next(c for c in product_commands_for("mcp") if c.name == command_name)
+    command = replace(
+        command,
+        leaf=lambda _vault_root, **leaf_kwargs: calls.append(leaf_kwargs) or "write-ran",
+    )
+    try:
+        with pytest.raises(OpError, match="WRITER_COORDINATOR_UNAVAILABLE"):
+            invoke_command(command, tmp_path, **kwargs)
+        assert calls == []
+    finally:
+        reset_managers_for_tests()
 
 
 def test_writer_executes_but_follower_and_outage_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ import pytest
 
 from exomem.cli_ops import OpError, http_status_for
 from exomem.lease_coordinator import SQLiteLeaseStore
+from exomem.vault import PlannedWrite, batch_atomic_write
 from exomem.writer_lease import LeaseConfig, LeaseManager, LeaseRecord
 
 
@@ -89,6 +91,48 @@ class FakeClient:
         return LeaseRecord(None, None, fencing_token, True)
 
 
+class StoreClient:
+    def __init__(self, store: SQLiteLeaseStore, replica_id: str):
+        self.store = store
+        self.replica_id = replica_id
+
+    def acquire(self) -> LeaseRecord:
+        return LeaseRecord.from_json(self.store.acquire("main", self.replica_id, 10))
+
+    def status(self) -> LeaseRecord:
+        return LeaseRecord.from_json(self.store.status("main"))
+
+    def renew(self, fencing_token: int) -> LeaseRecord:
+        return LeaseRecord.from_json(
+            self.store.renew("main", self.replica_id, fencing_token, 10)
+        )
+
+    def release(self, fencing_token: int) -> LeaseRecord:
+        return LeaseRecord.from_json(self.store.release("main", self.replica_id, fencing_token))
+
+
+class BlockingRejectedRenewalClient(FakeClient):
+    def __init__(self):
+        super().__init__(LeaseRecord("desktop", 200, 3))
+        self.renew_started = threading.Event()
+        self.resume_renewal = threading.Event()
+
+    def renew(self, fencing_token: int) -> LeaseRecord:
+        assert fencing_token == 1
+        self.renew_started.set()
+        assert self.resume_renewal.wait(timeout=5)
+        return LeaseRecord("laptop", 200, 2, False)
+
+
+class TwoStepStop:
+    def __init__(self):
+        self.calls = 0
+
+    def wait(self, timeout: float) -> bool:  # noqa: ARG002
+        self.calls += 1
+        return self.calls > 1
+
+
 def _command(*, writes: bool, leaf):  # noqa: ANN001
     return SimpleNamespace(name="mutate" if writes else "read", read_only=not writes, leaf=leaf)
 
@@ -125,6 +169,97 @@ def test_writer_executes_but_follower_and_outage_fail_closed(tmp_path: Path) -> 
     assert calls == ["write"]
     assert http_status_for("WRITER_LEASE_REQUIRED") == 409
     assert http_status_for("WRITER_COORDINATOR_UNAVAILABLE") == 503
+
+
+def test_superseded_replica_cannot_land_staged_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    replica_a = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path / "desktop-state",
+        ),
+        client=StoreClient(store, "desktop"),
+    )
+    replica_b = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+        ),
+        client=StoreClient(store, "laptop"),
+    )
+    target = tmp_path / "vault" / "note.md"
+    target.parent.mkdir()
+    target.write_text("old bytes", encoding="utf-8")
+    staged = threading.Event()
+    resume = threading.Event()
+    original_write_text = Path.write_text
+
+    def pause_after_staging(path: Path, content: str, *args, **kwargs):  # noqa: ANN002, ANN003
+        result = original_write_text(path, content, *args, **kwargs)
+        if path.suffix == ".tmp":
+            staged.set()
+            assert resume.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(Path, "write_text", pause_after_staging)
+    command = _command(
+        writes=True,
+        leaf=lambda: batch_atomic_write([PlannedWrite(target, "stale bytes")]),
+    )
+    outcome: list[BaseException | object] = []
+
+    def run_replica_a() -> None:
+        try:
+            outcome.append(replica_a.invoke(command, (), {}))
+        except BaseException as exc:  # noqa: BLE001 - assertion inspects worker failure
+            outcome.append(exc)
+
+    worker = threading.Thread(target=run_replica_a)
+    worker.start()
+    assert staged.wait(timeout=5)
+    clock.value = 111
+    assert replica_b.ensure_writer().fencing_token == 2
+    resume.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], OpError)
+    assert outcome[0].code == "WRITER_FENCED"
+    assert target.read_text(encoding="utf-8") == "old bytes"
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_delayed_rejected_renewal_does_not_clear_newer_local_token(tmp_path: Path) -> None:
+    client = BlockingRejectedRenewalClient()
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=client,
+    )
+    manager._fencing_token = 1
+    manager._stop = TwoStepStop()
+    renewer = threading.Thread(target=manager._renew_loop)
+    renewer.start()
+    assert client.renew_started.wait(timeout=5)
+
+    assert manager.ensure_writer().fencing_token == 3
+    client.resume_renewal.set()
+    renewer.join(timeout=5)
+
+    assert not renewer.is_alive()
+    assert manager._fencing_token == 3
 
 
 def test_idempotency_returns_saved_result_and_rejects_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- fence batch-backed vault writes against a superseded writer lease immediately before commit
- make supersession single-winner and rollback-safe across the complete note plan, registry/folder intents, chain flip, indexes, backlinks, and logs
- scope writer-lease gating to the actual connect/adopt operation while failing closed for unknown or malformed selectors
- add strict OpenSpec deltas and concurrency/failure regressions for all three changes

## Verification

- OpenSpec strict validation: 3/3 valid, task lists 9/9 each
- combined regression suite: 135 passed
- explicit MCP schema fidelity: 2 passed
- monitored quiescent latency gate: 2 passed, no external pytest overlap
- scoped Ruff: clean
- independent integrated review: approved, no Critical or Important findings
- guarded files, MCP schema fixtures, gate thresholds, CI, and `uv.lock`: untouched

## Known bounded residuals

- the existing coordinator contract cannot make its status read atomic with the following filesystem replacement
- multi-file rollback handles raised failures but is not power-loss atomic across replacements
- a project-registry CAS conflict is safely refused as `STALE_SUPERSEDE`, though its message is diagnostically imprecise
