### PR TITLE
fix: keep frontmatter cache content-fresh

### DIFF
--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -1381,7 +1381,7 @@ def on_resolver_files_changed(
 def unload_ram_caches() -> dict[str, int]:
     """Evict rebuildable find RAM caches without clearing freshness/inbound metadata."""
     page_entries = len(_CACHE.entries)
-    _CACHE.entries.clear()
+    _CACHE.clear()
     with _RESOLVER_LOCK:
         resolver_entries = len(_RESOLVER_CACHE)
         _RESOLVER_CACHE.clear()

--- a/src/exomem/find_corpus.py
+++ b/src/exomem/find_corpus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
@@ -36,26 +37,59 @@ def _page_cache_size() -> int:
 
 @dataclass
 class FrontmatterCache:
-    """Per-process cache of parsed pages, invalidated by mtime."""
+    """Per-process cache invalidated by file identity or content changes."""
 
     entries: OrderedDict[Path, ParsedPage] = field(default_factory=OrderedDict)
+    _signatures: dict[Path, tuple[int, int, int, int, int, bytes]] = field(
+        default_factory=dict, repr=False
+    )
+
+    def clear(self) -> None:
+        self.entries.clear()
+        self._signatures.clear()
 
     def get(self, path: Path, vault_root: Path) -> ParsedPage | None:
         try:
-            mtime = path.stat().st_mtime
+            stat = path.stat()
         except FileNotFoundError:
             self.entries.pop(path, None)
+            self._signatures.pop(path, None)
             return None
+        if len(self._signatures) != len(self.entries):
+            self._signatures = {
+                cached_path: self._signatures[cached_path]
+                for cached_path in self.entries
+                if cached_path in self._signatures
+            }
+        content = _read_page_bytes(path)
+        if content is None:
+            self.entries.pop(path, None)
+            self._signatures.pop(path, None)
+            return None
+        # Stat metadata is not content identity: on native Windows ctime is
+        # creation time, so a same-size rewrite can preserve this whole tuple.
+        # Hash the bytes already needed on a miss and reuse those exact bytes
+        # for parsing, keeping the fingerprint and ParsedPage consistent.
+        signature = (
+            stat.st_mtime_ns,
+            stat.st_ctime_ns,
+            stat.st_size,
+            stat.st_dev,
+            stat.st_ino,
+            hashlib.blake2b(content, digest_size=16).digest(),
+        )
         cached = self.entries.get(path)
-        if cached and cached.mtime == mtime:
+        if cached and self._signatures.get(path) == signature:
             self.entries.move_to_end(path)
             return cached
-        parsed = parse_page(path, mtime, vault_root)
+        parsed = parse_page(path, stat.st_mtime, vault_root, content=content)
         if parsed is not None:
             self.entries[path] = parsed
+            self._signatures[path] = signature
             self.entries.move_to_end(path)
             while len(self.entries) > _page_cache_size():
-                self.entries.popitem(last=False)
+                evicted_path, _ = self.entries.popitem(last=False)
+                self._signatures.pop(evicted_path, None)
         return parsed
 
 
@@ -99,10 +133,28 @@ def walk_md(root: Path):
             yield child
 
 
-def parse_page(path: Path, mtime: float, vault_root: Path) -> ParsedPage | None:
+def _read_page_bytes(path: Path) -> bytes | None:
     try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as e:
+        return path.read_bytes()
+    except OSError as e:
+        log.warning("could not read %s: %s", path, e)
+        return None
+
+
+def parse_page(
+    path: Path,
+    mtime: float,
+    vault_root: Path,
+    *,
+    content: bytes | None = None,
+) -> ParsedPage | None:
+    if content is None:
+        content = _read_page_bytes(path)
+        if content is None:
+            return None
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as e:
         log.warning("could not read %s: %s", path, e)
         return None
 

--- a/tests/test_find_hot_cache.py
+++ b/tests/test_find_hot_cache.py
@@ -136,12 +136,14 @@ def test_unload_ram_caches_preserves_freshness(vault: Path) -> None:
     status = find_module.cache_status()
     assert status["pages"]["entries"] > 0
     assert status["hot_find"]["entries"] > 0
+    assert find_module._CACHE._signatures
 
     unloaded = find_module.unload_ram_caches()
     assert unloaded["pages"] > 0
     assert unloaded["hot_find"] > 0
     assert find_module.cache_status()["pages"]["entries"] == 0
     assert find_module.cache_status()["hot_find"]["entries"] == 0
+    assert not find_module._CACHE._signatures
     assert freshness.triple(vault, "kb") == before_freshness
 
     assert find_module.find(vault, query="metabolism")

--- a/tests/test_frontmatter_cache_bound.py
+++ b/tests/test_frontmatter_cache_bound.py
@@ -40,10 +40,10 @@ def test_cache_hit_within_bound_does_not_parse_again(tmp_path: Path, monkeypatch
     parse_calls = 0
     original_parse_page = find_corpus.parse_page
 
-    def count_parses(path: Path, mtime: float, vault_root: Path):
+    def count_parses(path: Path, mtime: float, vault_root: Path, **kwargs):
         nonlocal parse_calls
         parse_calls += 1
-        return original_parse_page(path, mtime, vault_root)
+        return original_parse_page(path, mtime, vault_root, **kwargs)
 
     monkeypatch.setattr(find_corpus, "parse_page", count_parses)
 
@@ -62,10 +62,10 @@ def test_mtime_change_invalidates_entry_within_bound(tmp_path: Path, monkeypatch
     parse_calls = 0
     original_parse_page = find_corpus.parse_page
 
-    def count_parses(path: Path, mtime: float, vault_root: Path):
+    def count_parses(path: Path, mtime: float, vault_root: Path, **kwargs):
         nonlocal parse_calls
         parse_calls += 1
-        return original_parse_page(path, mtime, vault_root)
+        return original_parse_page(path, mtime, vault_root, **kwargs)
 
     monkeypatch.setattr(find_corpus, "parse_page", count_parses)
 
@@ -79,3 +79,50 @@ def test_mtime_change_invalidates_entry_within_bound(tmp_path: Path, monkeypatch
     assert updated is not None
     assert updated.title == "Updated title"
     assert parse_calls == 2
+
+
+def test_size_change_with_preserved_mtime_invalidates_entry(tmp_path: Path) -> None:
+    page = tmp_path / "page.md"
+    _page(page, "Original title")
+    cache = find_corpus.FrontmatterCache()
+
+    first = cache.get(page, tmp_path)
+    old_stat = page.stat()
+    _page(page, "A much longer updated title")
+    os.utime(page, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns))
+    assert page.stat().st_mtime_ns == old_stat.st_mtime_ns
+
+    updated = cache.get(page, tmp_path)
+
+    assert first is not updated
+    assert updated is not None
+    assert updated.title == "A much longer updated title"
+
+
+def test_same_size_content_change_with_unchanged_stat_invalidates_entry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    page = tmp_path / "page.md"
+    _page(page, "Original title")
+    cache = find_corpus.FrontmatterCache()
+
+    first = cache.get(page, tmp_path)
+    old_stat = page.stat()
+    old_size = len(page.read_bytes())
+    _page(page, "Modified title")
+    assert len(page.read_bytes()) == old_size
+
+    original_stat = Path.stat
+
+    def frozen_stat(path: Path, *args, **kwargs):
+        if path == page:
+            return old_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", frozen_stat)
+
+    updated = cache.get(page, tmp_path)
+
+    assert first is not updated
+    assert updated is not None
+    assert updated.title == "Modified title"


### PR DESCRIPTION
## Why

The parsed frontmatter cache could return stale pages when rapid rewrites preserved filesystem metadata. That made the full suite order-dependent and could surface stale schema/frontmatter in a live process.

## What changed

- Fingerprint the exact page bytes used for parsing alongside the bounded stat signature.
- Reuse those bytes on cache misses so the cached signature and parsed page cannot diverge.
- Evict and clear fingerprints with their parsed entries.
- Cover preserved-mtime, same-size/frozen-stat rewrites, unload behavior, and the existing 2,000-note latency gate.

## Evidence

- Full lean suite: 2,233 passed, 19 skipped.
- Focused correctness/performance suite: 95 passed.
- Original order-dependent regression: 30 consecutive runs passed.
- Ruff and diff checks pass.
- Independent review: approved; measured cold 2,000-note direct keyword scans remain below 100 ms.

## Scope

This is an independent prerequisite for refreshing hosted PR #227; it does not include hosted-service or infrastructure changes.