### PR TITLE
Make memory citations human-readable

### DIFF
--- a/openspec/changes/human-readable-memory-citations/.openspec.yaml
+++ b/openspec/changes/human-readable-memory-citations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/human-readable-memory-citations/design.md
+++ b/openspec/changes/human-readable-memory-citations/design.md
@@ -1,0 +1,108 @@
+## Context
+
+Governed pages carry an immutable `exomem_id`, and Exomem resolves the corresponding
+`exomem://memory/<uuid>` reference through a rebuildable index. That identity is the
+right machine contract because it survives note moves and renames. Search and read
+results already keep identity and presentation separate by returning a human-readable
+`title`, a current `path`, and a canonical `ref`.
+
+The gap is in agent guidance. The bootstrap contract and installed skill explain when
+canonical refs are useful, but they do not clearly prohibit showing the opaque ref in
+normal conversation. Some clients therefore render a UUID where the user needs the note
+name. This is a presentation leak, not an identity or resolver defect.
+
+The relevant guidance surfaces are the generic MCP bootstrap in
+`src/exomem/commands.py` and the installed scaffold in
+`src/exomem/_scaffold/_Schema/`. The change must keep those surfaces semantically
+aligned without introducing blocking hooks, server-side prose rendering, or reasoning
+models.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve immutable note identity and move-safe canonical references.
+- Make note titles the default citation shown in user-facing agent prose.
+- Give agents a deterministic fallback and disambiguation rule based on the existing
+  path field.
+- Keep generic bootstrap clients and installed-skill clients on the same contract.
+- Cover the contract with lightweight, model-free regression tests.
+
+**Non-Goals:**
+
+- Removing, replacing, or making users edit `exomem_id` frontmatter.
+- Changing the canonical reference grammar or reference index.
+- Adding slugs to canonical references.
+- Adding a citation formatter or a new citation field to search/read responses.
+- Blocking tool execution when an agent violates presentation guidance.
+- Hiding refs from machine-readable tool results or explicit diagnostic requests.
+
+## Decisions
+
+### Keep identity opaque and presentation human-readable
+
+`exomem_id` and `exomem://memory/<uuid>` remain the canonical machine identity. In
+normal user-facing prose, agents cite the hit's title and omit the raw canonical ref.
+When a title is ambiguous, the agent adds the current vault-relative path or another
+short human-readable disambiguator. When no usable title is available, the path or file
+name is the fallback; the UUID is not.
+
+This preserves the property the UUID was introduced for while making the default output
+legible. Removing UUIDs or using mutable title slugs would weaken rename safety. A
+hybrid slug-plus-UUID URI would still expose an implementation-shaped identifier and
+would add grammar and migration complexity without improving normal prose.
+
+### Make this an agent contract, not a response-shaping API
+
+The server continues returning `title`, `path`, and `ref` as separate fields. Guidance
+will tell agents to use `ref` for tool arguments, durable machine state, and explicit
+debugging, while using `title`/`path` for conversation. Agents must not create Markdown
+links whose visible source includes the raw custom-scheme target; plain title-first
+citations are the portable default across clients.
+
+Adding a `citation_label` or rendered Markdown field was rejected because it duplicates
+data already present on every relevant hit, spends response tokens, and still cannot
+control how a client displays prose. No server-side model or formatter is involved, so
+the pure-substrate boundary is unchanged and there is no optional/heavy capability to
+gate or soft-fail.
+
+### Keep both guidance surfaces equivalent
+
+The bootstrap workflow guidance, scaffold `SKILL.md`, and detailed operations reference
+will express the same rules:
+
+- show the title by default;
+- add the path only for clarity or disambiguation;
+- keep the canonical ref for machine use;
+- reveal the raw ref when the user explicitly asks for it or when presenting diagnostic
+  or automation output where the identifier itself is the subject.
+
+The bootstrap contract version will be bumped because its guidance changes, without
+adding a new response field. Tests will assert the semantic rules in the bootstrap and
+the shipped scaffold so future edits cannot silently restore title/UUID ambiguity.
+
+## Risks / Trade-offs
+
+- **Prompt guidance cannot force every third-party client to comply** -> put the rule in
+  both authoritative agent surfaces, make it direct rather than advisory, and pin it
+  with contract tests. A blocking hook is intentionally out of scope.
+- **Duplicate titles can make title-only citations ambiguous** -> permit a short
+  vault-relative path as a disambiguator instead of exposing the UUID.
+- **A malformed legacy hit may lack a useful title** -> fall back to its path or file
+  name and retain the raw ref only in machine state.
+- **Hiding refs by default can slow debugging** -> explicitly allow the ref when the
+  user asks for the canonical identifier or when the identifier itself is under
+  inspection.
+- **Bootstrap and scaffold wording can drift** -> add focused tests for both surfaces,
+  checking behavior rather than requiring byte-identical prose.
+
+## Migration Plan
+
+Ship the bootstrap and scaffold guidance together. Generic clients receive the updated
+rule on their next bootstrap call; installed skills receive it through the normal
+Exomem skill install/update path. Existing notes, IDs, refs, and indexes require no
+migration. Rollback is a documentation/contract revert and does not touch vault data.
+
+## Open Questions
+
+None. The existing `title`, `path`, and `ref` fields provide all required information.

--- a/openspec/changes/human-readable-memory-citations/proposal.md
+++ b/openspec/changes/human-readable-memory-citations/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Exomem's canonical `exomem://memory/<uuid>` references correctly survive note moves and
+renames, but generic agents can leak those opaque identifiers into conversation even
+when the search result already includes a human-readable title and path. Stable machine
+identity should remain durable without making users decode UUIDs in normal prose.
+
+## What Changes
+
+- Define a single presentation contract for memory references: agents show a note title
+  in user-facing prose, add a path or other short disambiguator only when useful, and do
+  not expose the raw canonical UUID reference by default.
+- Keep `exomem_id` frontmatter and `exomem://memory/<uuid>` unchanged as internal,
+  move-safe identity for tool calls, durable stored state, and explicit debugging.
+- Apply the same contract to the generic MCP bootstrap and the installed skill scaffold,
+  with regression tests that prevent the two guidance surfaces from drifting.
+- Leave search/read response schemas unchanged because hits already provide `title`,
+  `path`, and `ref` separately.
+
+## Capabilities
+
+### New Capabilities
+
+- `memory-reference-presentation`: define how agents separate stable machine identity
+  from human-readable note citations across bootstrap and skill guidance.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Agent contract:** bootstrap operating guidance and the generic installed skill gain
+  explicit human-facing citation rules.
+- **Documentation:** durable-reference guidance consistently distinguishes presentation
+  from resolution.
+- **Tests:** contract tests assert that both agent surfaces teach title-first citations
+  while preserving canonical refs for machine use.
+- **Compatibility:** no command input, search/read response schema, reference grammar,
+  frontmatter, index, migration, dependency, model, or runtime behavior changes. The
+  bootstrap contract version changes because its guidance changes.

--- a/openspec/changes/human-readable-memory-citations/specs/memory-reference-presentation/spec.md
+++ b/openspec/changes/human-readable-memory-citations/specs/memory-reference-presentation/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Agent guidance keeps stable memory identity machine-facing
+
+Agent guidance SHALL identify immutable `exomem_id` frontmatter and canonical
+`exomem://memory/<uuid>` references as move-safe machine identity, consistent with the
+stable-memory-references contract. It SHALL reserve canonical refs for tool arguments,
+durable machine state, machine-readable automation, and cases where the identifier
+itself is explicitly requested or inspected.
+
+#### Scenario: A workflow continues after a note move
+
+- **WHEN** an agent needs to retain a note identity across later tool calls or a note
+  move
+- **THEN** the guidance directs it to retain and use the canonical ref internally
+- **AND** it does not substitute a mutable title or path for that machine identity
+
+#### Scenario: A user explicitly asks for the canonical identifier
+
+- **WHEN** a user asks to see a note's canonical reference or is debugging reference
+  resolution
+- **THEN** the agent may show the raw canonical ref because the identifier itself is the
+  requested information
+
+### Requirement: User-facing citations are title-first
+
+Agent guidance SHALL direct agents to cite a memory note by its human-readable title in
+normal user-facing prose and SHALL direct them not to expose the raw
+`exomem://memory/<uuid>` reference by default. The guidance SHALL allow a current
+vault-relative path or another short human-readable qualifier when needed for clarity.
+
+#### Scenario: A search hit has a title, path, and canonical ref
+
+- **WHEN** an agent cites the hit in a normal answer
+- **THEN** the visible citation names the note title
+- **AND** the answer omits the raw canonical ref
+
+#### Scenario: Two relevant notes have the same title
+
+- **WHEN** title-only citations would be ambiguous
+- **THEN** the agent adds a human-readable path or short qualifier to distinguish them
+- **AND** it does not use the UUID as the default disambiguator
+
+#### Scenario: A legacy result has no usable title
+
+- **WHEN** an agent must cite a result whose title is missing or unusable
+- **THEN** the agent uses the current path or file name as the visible fallback
+- **AND** it keeps the raw canonical ref out of normal prose
+
+#### Scenario: A client renders Markdown source visibly
+
+- **WHEN** a custom-scheme Markdown link would expose its raw UUID target in the client
+- **THEN** the agent uses a plain title-first citation instead of embedding the canonical
+  ref as the link target
+
+### Requirement: Bootstrap and installed skill teach the same presentation rule
+
+The generic MCP bootstrap and the installed skill scaffold SHALL both teach the
+title-first citation rule, the optional path disambiguator, the machine-use role of the
+canonical ref, and the explicit-request diagnostic exception. The bootstrap contract
+version SHALL change when this guidance ships.
+
+#### Scenario: A generic client initializes from bootstrap
+
+- **WHEN** a client without the installed Exomem skill reads the bootstrap contract
+- **THEN** it receives the title-first human-presentation rule and the machine-use ref
+  rule
+
+#### Scenario: An installed-skill client handles a memory result
+
+- **WHEN** an agent follows the shipped scaffold guidance
+- **THEN** it applies the same presentation and exception rules as a bootstrap client
+
+#### Scenario: Contract guidance is regression-tested
+
+- **WHEN** the bootstrap or scaffold guidance is changed
+- **THEN** model-free tests detect removal of the title-first rule, path fallback,
+  machine-use ref rule, or explicit-request exception

--- a/openspec/changes/human-readable-memory-citations/tasks.md
+++ b/openspec/changes/human-readable-memory-citations/tasks.md
@@ -29,4 +29,4 @@
   human-readable-memory-citations`.
 - [x] 3.3 Review the final diff against every OpenSpec scenario, mark completed tasks,
   and commit the implementation on the isolated feature branch.
-- [ ] 3.4 Obtain an independent code/spec review and resolve all substantive findings.
+- [x] 3.4 Obtain an independent code/spec review and resolve all substantive findings.

--- a/openspec/changes/human-readable-memory-citations/tasks.md
+++ b/openspec/changes/human-readable-memory-citations/tasks.md
@@ -1,0 +1,32 @@
+## 1. Contract Tests
+
+- [ ] 1.1 Extend `tests/test_bootstrap.py` to require the bumped bootstrap contract
+  version and title-first citation guidance covering path disambiguation, machine-only
+  canonical refs, and the explicit-request/debugging exception.
+- [ ] 1.2 Add `tests/test_memory_reference_presentation.py` to require equivalent
+  title/path/ref guidance in the shipped `SKILL.md` and `references/operations.md`.
+- [ ] 1.3 Run the focused tests and confirm they fail because the approved presentation
+  guidance is absent, not because of test setup errors.
+
+## 2. Guidance Implementation
+
+- [ ] 2.1 Update `src/exomem/commands.py` to bump the bootstrap contract version and add
+  the presentation rule to the existing workflow guidance without adding a response
+  field or changing search/read schemas.
+- [ ] 2.2 Rewrite the durable-reference section in
+  `src/exomem/_scaffold/_Schema/SKILL.md` so titles are visible by default, paths are
+  human-readable fallback/disambiguation, and raw refs remain machine-facing unless
+  explicitly requested or inspected.
+- [ ] 2.3 Apply the equivalent contract to the stable-identity section in
+  `src/exomem/_scaffold/_Schema/references/operations.md`, including the
+  custom-scheme Markdown-link warning.
+- [ ] 2.4 Re-run the focused tests and confirm they pass.
+
+## 3. Verification and Delivery
+
+- [ ] 3.1 Run the scaffold leak guard and Ruff over the changed Python/test files.
+- [ ] 3.2 Run the full model-disabled test suite and `openspec validate
+  human-readable-memory-citations`.
+- [ ] 3.3 Review the final diff against every OpenSpec scenario, mark completed tasks,
+  and commit the implementation on the isolated feature branch.
+- [ ] 3.4 Obtain an independent code/spec review and resolve all substantive findings.

--- a/openspec/changes/human-readable-memory-citations/tasks.md
+++ b/openspec/changes/human-readable-memory-citations/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Contract Tests
 
-- [ ] 1.1 Extend `tests/test_bootstrap.py` to require the bumped bootstrap contract
+- [x] 1.1 Extend `tests/test_bootstrap.py` to require the bumped bootstrap contract
   version and title-first citation guidance covering path disambiguation, machine-only
   canonical refs, and the explicit-request/debugging exception.
-- [ ] 1.2 Add `tests/test_memory_reference_presentation.py` to require equivalent
+- [x] 1.2 Add `tests/test_memory_reference_presentation.py` to require equivalent
   title/path/ref guidance in the shipped `SKILL.md` and `references/operations.md`.
-- [ ] 1.3 Run the focused tests and confirm they fail because the approved presentation
+- [x] 1.3 Run the focused tests and confirm they fail because the approved presentation
   guidance is absent, not because of test setup errors.
 
 ## 2. Guidance Implementation
 
-- [ ] 2.1 Update `src/exomem/commands.py` to bump the bootstrap contract version and add
+- [x] 2.1 Update `src/exomem/commands.py` to bump the bootstrap contract version and add
   the presentation rule to the existing workflow guidance without adding a response
   field or changing search/read schemas.
-- [ ] 2.2 Rewrite the durable-reference section in
+- [x] 2.2 Rewrite the durable-reference section in
   `src/exomem/_scaffold/_Schema/SKILL.md` so titles are visible by default, paths are
   human-readable fallback/disambiguation, and raw refs remain machine-facing unless
   explicitly requested or inspected.
-- [ ] 2.3 Apply the equivalent contract to the stable-identity section in
+- [x] 2.3 Apply the equivalent contract to the stable-identity section in
   `src/exomem/_scaffold/_Schema/references/operations.md`, including the
   custom-scheme Markdown-link warning.
-- [ ] 2.4 Re-run the focused tests and confirm they pass.
+- [x] 2.4 Re-run the focused tests and confirm they pass.
 
 ## 3. Verification and Delivery
 
-- [ ] 3.1 Run the scaffold leak guard and Ruff over the changed Python/test files.
-- [ ] 3.2 Run the full model-disabled test suite and `openspec validate
+- [x] 3.1 Run the scaffold leak guard and Ruff over the changed Python/test files.
+- [x] 3.2 Run the full model-disabled test suite and `openspec validate
   human-readable-memory-citations`.
-- [ ] 3.3 Review the final diff against every OpenSpec scenario, mark completed tasks,
+- [x] 3.3 Review the final diff against every OpenSpec scenario, mark completed tasks,
   and commit the implementation on the isolated feature branch.
 - [ ] 3.4 Obtain an independent code/spec review and resolve all substantive findings.

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -239,9 +239,15 @@ Examples:
 
 New governed pages and evidence sidecars carry an immutable `exomem_id`, and
 write responses return both a current `path` and a canonical
-`exomem://memory/<uuid>` reference. Use the reference when a later workflow must
-survive moves or renames; paths remain valid and are usually easier to show to a
-person. Never invent, copy, or edit an `exomem_id` by hand.
+`exomem://memory/<uuid>` reference. In normal user-facing prose, show the note
+title by default and do not expose the raw canonical ref by default. Add the
+current vault-relative path for clarity or disambiguation; if the title is
+missing or unusable, use the path or file name as the visible fallback.
+
+Keep the canonical ref for tool arguments, durable machine state, and
+machine-readable automation so identity survives moves and renames. Show the
+raw ref only when the user explicitly asks for it or the identifier itself is
+being inspected or debugged. Never invent, copy, or edit an `exomem_id` by hand.
 
 Legacy pages are not rewritten automatically. To add IDs, first run
 `maintain_memory(mode="backfill-ids")` in its default dry-run mode, inspect the

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -247,7 +247,9 @@ missing or unusable, use the path or file name as the visible fallback.
 Keep the canonical ref for tool arguments, durable machine state, and
 machine-readable automation so identity survives moves and renames. Show the
 raw ref only when the user explicitly asks for it or the identifier itself is
-being inspected or debugged. Never invent, copy, or edit an `exomem_id` by hand.
+being inspected or debugged. Do not embed the canonical ref as a Markdown link
+target; use a plain title-first citation. Never invent, copy, or edit an
+`exomem_id` by hand.
 
 Legacy pages are not rewritten automatically. To add IDs, first run
 `maintain_memory(mode="backfill-ids")` in its default dry-run mode, inspect the

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -51,9 +51,16 @@ index + log update is implicit.
 Every new governed page and evidence Markdown sidecar receives an immutable
 `exomem_id` UUID. Writers return both its current vault-relative `path` and a
 canonical `exomem://memory/<uuid>` reference. Commands that accept a governed
-page identifier accept either form. Prefer the reference for durable automation
-or citations that must survive moves; keep showing paths when they are clearer
-to a person.
+page identifier accept either form. In normal user-facing prose, show the note
+title by default and do not expose the raw canonical ref by default. Add the
+current vault-relative path for clarity or disambiguation; if the title is
+missing or unusable, use the path or file name as the visible fallback.
+
+Keep the canonical ref for tool arguments, durable machine state, and
+machine-readable automation so identity survives moves and renames. Show the
+raw ref only when the user explicitly asks for it or the identifier itself is
+being inspected or debugged. Do not embed the canonical ref as a Markdown link
+target when a client could expose its UUID; use a plain title-first citation.
 
 Do not manually create, copy, or modify IDs. Legacy pages remain untouched until
 `maintain_memory(mode="backfill-ids")` is requested. That mode is a dry run by

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -237,7 +237,7 @@ def op_bootstrap(
     requested_workflow = workflow.strip() if workflow and workflow.strip() else "general"
     selected_packs = knowledge_packs_module.selected_pack_state(vault_root)
     payload: dict = {
-        "contract_version": "2026-07-10.1",
+        "contract_version": "2026-07-15.1",
         "profile": profile,
         "server": {
             "name": "exomem",
@@ -273,6 +273,15 @@ def op_bootstrap(
                 "adopt_vault or browse_memory when first seeing an existing vault",
                 "ask_memory for cheap product recall",
                 "read_memory or ask_memory(deep=true) when more context is needed",
+                (
+                    "show the note title by default in normal user-facing prose and do not "
+                    "expose the raw canonical ref by default; add the current vault-relative "
+                    "path for clarity or disambiguation, or use the path or file name as the "
+                    "visible fallback when the title is unusable; keep the canonical "
+                    "exomem://memory/<uuid> ref for tool arguments, durable machine state, "
+                    "and machine-readable automation; show it only when the user explicitly "
+                    "asks for it or the identifier itself is being inspected or debugged"
+                ),
                 "reason in the agent",
                 "use connect_memory(operation='suggest-links' or 'suggest-relations') before important compiled writes",
                 "remember, edit_memory, or replace_memory when there is a durable conclusion",

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -280,7 +280,9 @@ def op_bootstrap(
                     "visible fallback when the title is unusable; keep the canonical "
                     "exomem://memory/<uuid> ref for tool arguments, durable machine state, "
                     "and machine-readable automation; show it only when the user explicitly "
-                    "asks for it or the identifier itself is being inspected or debugged"
+                    "asks for it or the identifier itself is being inspected or debugged; "
+                    "do not embed the canonical ref as a Markdown link target; use a plain "
+                    "title-first citation"
                 ),
                 "reason in the agent",
                 "use connect_memory(operation='suggest-links' or 'suggest-relations') before important compiled writes",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -106,6 +106,8 @@ def test_bootstrap_teaches_human_readable_memory_citations(vault: Path) -> None:
         "machine-readable automation",
         "user explicitly asks",
         "identifier itself is being inspected or debugged",
+        "do not embed the canonical ref as a markdown link target",
+        "plain title-first citation",
     ):
         assert required in guidance
     assert "exomem://memory/<uuid>" in guidance

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -89,6 +89,28 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
     assert "Progressive disclosure" not in serialized
 
 
+def test_bootstrap_teaches_human_readable_memory_citations(vault: Path) -> None:
+    out = commands.op_bootstrap(vault)
+    guidance = json.dumps(out["workflow"]).lower()
+
+    assert out["contract_version"] == "2026-07-15.1"
+    for required in (
+        "show the note title by default",
+        "normal user-facing prose",
+        "do not expose the raw canonical ref by default",
+        "current vault-relative path",
+        "clarity or disambiguation",
+        "path or file name as the visible fallback",
+        "tool arguments",
+        "durable machine state",
+        "machine-readable automation",
+        "user explicitly asks",
+        "identifier itself is being inspected or debugged",
+    ):
+        assert required in guidance
+    assert "exomem://memory/<uuid>" in guidance
+
+
 def test_bootstrap_profiles_and_validation(vault: Path) -> None:
     full = commands.op_bootstrap(vault, profile="full", workflow="research")
     assert full["workflow"]["requested"] == "research"

--- a/tests/test_memory_reference_presentation.py
+++ b/tests/test_memory_reference_presentation.py
@@ -31,6 +31,8 @@ def test_shipped_scaffold_teaches_human_readable_memory_citations() -> None:
             "machine-readable automation",
             "user explicitly asks",
             "identifier itself is being inspected or debugged",
+            "do not embed the canonical ref as a markdown link target",
+            "plain title-first citation",
         ):
             assert required in guidance
         assert "exomem://memory/<uuid>" in guidance

--- a/tests/test_memory_reference_presentation.py
+++ b/tests/test_memory_reference_presentation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAFFOLD_ROOT = REPO_ROOT / "src/exomem/_scaffold/_Schema"
+
+
+def _section(relative: str, heading: str) -> str:
+    text = (SCAFFOLD_ROOT / relative).read_text(encoding="utf-8")
+    section = text.split(heading, 1)[1].split("\n## ", 1)[0]
+    return " ".join(section.lower().split())
+
+
+def test_shipped_scaffold_teaches_human_readable_memory_citations() -> None:
+    sections = (
+        _section("SKILL.md", "## Durable references"),
+        _section("references/operations.md", "## Stable identity and references"),
+    )
+
+    for guidance in sections:
+        for required in (
+            "show the note title by default",
+            "normal user-facing prose",
+            "do not expose the raw canonical ref by default",
+            "current vault-relative path",
+            "clarity or disambiguation",
+            "path or file name as the visible fallback",
+            "tool arguments",
+            "durable machine state",
+            "machine-readable automation",
+            "user explicitly asks",
+            "identifier itself is being inspected or debugged",
+        ):
+            assert required in guidance
+        assert "exomem://memory/<uuid>" in guidance
+
+
+def test_operations_warns_against_visible_custom_scheme_link_targets() -> None:
+    guidance = _section(
+        "references/operations.md", "## Stable identity and references"
+    )
+
+    assert "do not embed the canonical ref as a markdown link target" in guidance
+    assert "plain title-first citation" in guidance


### PR DESCRIPTION
## Summary

- keep `exomem_id` UUIDs and canonical refs as move-safe machine identity
- make agent-facing citations show note titles, with paths only for fallback or disambiguation
- align bootstrap, the main installed skill, and detailed operations guidance
- prevent raw canonical refs from leaking through Markdown link targets
- add model-free regression coverage for the complete presentation contract

## Verification

- `uv run pytest -q tests/test_bootstrap.py tests/test_memory_reference_presentation.py tests/test_scaffold_no_leak.py` (`12 passed`)
- `uvx ruff check src/exomem/commands.py tests/test_bootstrap.py tests/test_memory_reference_presentation.py`
- `openspec validate human-readable-memory-citations`
- full model-disabled suite: `2884 passed, 49 skipped`

Independent code/spec review approved after fixing cross-surface Markdown-link parity.
