### PR TITLE
Fix lexical orphan-row healing

### DIFF
--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -501,6 +501,10 @@ class LexicalStore:
             for row in conn.execute("SELECT path, rowid, mtime_ns, in_kb, in_vault FROM pages")
         }
         with conn:
+            # External page-row corruption can leave index rowids that SQLite
+            # will reuse for missing pages; clear those orphans before inserts.
+            conn.execute("DELETE FROM fts WHERE rowid NOT IN (SELECT rowid FROM pages)")
+            conn.execute("DELETE FROM tri WHERE rowid NOT IN (SELECT rowid FROM pages)")
             for rel, (rowid, mtime_ns, in_kb, in_vault) in stored.items():
                 w = walk.get(rel)
                 if w is None or (w[1][0], w[2], w[3]) != (mtime_ns, in_kb, in_vault):

--- a/tests/test_lexstore.py
+++ b/tests/test_lexstore.py
@@ -228,24 +228,42 @@ def test_restart_with_no_changes_skips_the_walk_verify(tmp_path):
     assert calls["n"] == 0
 
 
-def test_manual_row_drift_self_heals(tmp_path):
-    """Rows deleted out from under the sidecar (count mismatch, markdown
-    untouched) are rebuilt from the markdown walk by the next fresh store."""
+def test_manual_row_drift_self_heals(tmp_path, monkeypatch):
+    """Highest page rowids deleted while their index rows remain are restored
+    incrementally by the next fresh store."""
     for i in range(4):
         _write_page(tmp_path, f"Knowledge Base/n{i}.md", f"payload token{i}")
     assert lexstore.search_bm25(tmp_path, "payload", k=10, scope="kb")
     side = lexstore.lexical_path(tmp_path)
     conn = sqlite3.connect(side)
     try:
-        conn.execute("DELETE FROM pages WHERE rowid IN (SELECT rowid FROM pages LIMIT 2)")
+        conn.execute(
+            "DELETE FROM pages WHERE rowid IN "
+            "(SELECT rowid FROM pages ORDER BY rowid DESC LIMIT 2)"
+        )
         conn.commit()
     finally:
         conn.close()
     assert _count(side, "pages") == 2
+    assert _count(side, "fts") == 4
+    assert _count(side, "tri") == 4
     lexstore.clear_stores()
+
+    rebuilds = 0
+    real_rebuild = lexstore.LexicalStore._rebuild
+
+    def _counting_rebuild(self, conn):
+        nonlocal rebuilds
+        rebuilds += 1
+        return real_rebuild(self, conn)
+
+    monkeypatch.setattr(lexstore.LexicalStore, "_rebuild", _counting_rebuild)
     hits = lexstore.search_bm25(tmp_path, "payload", k=10, scope="kb")
     assert hits is not None and len(hits) == 4
     assert _count(side, "pages") == 4
+    assert _count(side, "fts") == 4
+    assert _count(side, "tri") == 4
+    assert rebuilds == 0
 
 
 def test_out_of_band_single_edit_heals_incrementally_not_full_rebuild(tmp_path):


### PR DESCRIPTION
## Summary

- make the lexical-sidecar drift regression deterministic by deleting the highest page row IDs
- clean orphan FTS and trigram rows before delta healing reuses those IDs
- preserve incremental healing and prove the path does not fall back to a full rebuild

## Root cause

Out-of-band deletion from `pages` can leave matching FTS/trigram rows behind. When SQLite reuses those page row IDs during delta healing, inserting replacement index rows fails with `constraint failed`. The previous unordered test exposed this only under some SQLite query plans.

## Verification

- deterministic regression passed on Python 3.11.15 and 3.13.14
- `tests/test_lexstore.py`: `31 passed`
- scoped Ruff clean
- full model-disabled suite: `2881 passed, 49 skipped`

Independent review approved; no correctness or scope blockers found.
