### PR TITLE
fix: prevent uv lockfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,17 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+      - name: Verify lockfile is current
+        run: uv lock --check
       - name: Run tests (lean — BM25/keyword, server media extraction off)
         env:
           # The suite runs without the embeddings/media extras; these mirror the
           # conftest autouse defaults so a forgotten extra can't change behaviour.
           KB_MCP_DISABLE_EMBEDDINGS: "1"
           KB_MCP_DISABLE_MEDIA_EXTRACTION: "1"
-        run: uv run --python ${{ matrix.python-version }} python -m pytest -q
+        run: uv run --frozen --python ${{ matrix.python-version }} python -m pytest -q
       - name: Sample vault smoke (the exact command users run)
-        run: uv run --python ${{ matrix.python-version }} exomem demo --json
+        run: uv run --frozen --python ${{ matrix.python-version }} exomem demo --json
 
   product-e2e:
     name: product E2E (installed wheel, stdio + HTTP)
@@ -43,7 +45,7 @@ jobs:
         with:
           enable-cache: true
       - name: Governed lifecycle, restart persistence, and transport shutdown
-        run: uv run python scripts/e2e_product_loop.py --budget-seconds 240 --request-timeout 20
+        run: uv run --frozen python scripts/e2e_product_loop.py --budget-seconds 240 --request-timeout 20
 
   retrieval-eval:
     name: retrieval eval (golden gate, embeddings)
@@ -69,14 +71,14 @@ jobs:
         # / recall@10 clear their floors. Kept OFF the fast 3-version matrix so
         # lean CI never pays the torch download. EXOMEM_DISABLE_EMBEDDINGS is
         # deliberately unset here — the test lifts it and loads the real model.
-        run: uv run --extra embeddings python -m pytest -m embeddings -v
+        run: uv run --frozen --extra embeddings python -m pytest -m embeddings -v
       - name: Per-lane latency ceiling gate (2000-note synthetic vault, model-free)
         # The anti-"hidden 14s" gate (tests/test_latency_gate.py): generates a
         # realistic densely-wikilinked 2000-note vault and asserts NO retrieval
         # lane exceeds its ceiling (graph rebuild → ~1.9s trips it). Model-free,
         # so it ALSO runs in the lean matrix; pinned here as the benchmark gate's
         # home next to the golden quality gate.
-        run: uv run python -m pytest tests/test_latency_gate.py -q
+        run: uv run --frozen python -m pytest tests/test_latency_gate.py -q
 
   onboarding:
     name: onboarding (wheel path)
@@ -91,7 +93,7 @@ jobs:
         # Proves the onboarding path works from the built wheel alone — the
         # packaged sample vault ships, `exomem demo` has no repo dependency,
         # and `exomem setup --yes` completes — with a hard wall-time budget.
-        run: uv run python scripts/time-to-value.py --budget-seconds 120
+        run: uv run --frozen python scripts/time-to-value.py --budget-seconds 120
 
   docker:
     name: docker (lean build + smoke)
@@ -167,7 +169,7 @@ jobs:
         with:
           enable-cache: true
       - name: Check generated capabilities doc
-        run: uv run python scripts/generate-capabilities.py --check
+        run: uv run --frozen python scripts/generate-capabilities.py --check
 
   lint:
     name: lint + targeted types

--- a/.github/workflows/heavy-media.yml
+++ b/.github/workflows/heavy-media.yml
@@ -27,5 +27,5 @@ jobs:
           key: heavy-media-tiny-whisper-clip-v1
       - name: Run real media product smoke
         run: >-
-          uv run --extra embeddings --extra media
+          uv run --frozen --extra embeddings --extra media
           python scripts/smoke-media-pipeline.py --require-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Every stage builds from the checked-out source tree (COPY src/ pyproject.toml
 # uv.lock), never a published PyPI wheel — see design.md D1.
 
-ARG UV_VERSION=0.9.7
+ARG UV_VERSION=0.11.28
 
 # COPY --from does not support ARG expansion; a global-scope FROM alias does
 # (buildx's documented workaround), so the pin lives in one place above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,11 @@ markers = [
 # break lockfile reproducibility across the desktop + laptop hosts — the explicit
 # pinned index keeps both boxes on the same wheel. `explicit = true` keeps this
 # index out of general resolution. Multi-host GPU bring-up is documented in README.
+[tool.uv]
+# A single writer version prevents harmless-but-noisy marker normalization
+# differences between Windows, WSL, Docker, and CI.
+required-version = "==0.11.28"
+
 [tool.uv.sources]
 torch = [
   { index = "pytorch-cu132", marker = "sys_platform == 'win32' or sys_platform == 'linux'" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -41,6 +41,10 @@
         {
           "type": "generic",
           "path": "src/exomem/__init__.py"
+        },
+        {
+          "type": "generic",
+          "path": "uv.lock"
         }
       ]
     }

--- a/tests/test_uv_lock_policy.py
+++ b/tests/test_uv_lock_policy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UV_VERSION = "0.11.28"
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_release_please_keeps_root_package_version_locked() -> None:
+    project = tomllib.loads(_read("pyproject.toml"))
+    project_version = project["project"]["version"]
+    release_config = json.loads(_read("release-please-config.json"))
+    extra_files = release_config["packages"]["."]["extra-files"]
+
+    assert {"type": "generic", "path": "uv.lock"} in extra_files
+
+    match = re.search(
+        r'\[\[package\]\]\nname = "exomem"\n'
+        r'version = "(?P<version>[^"]+)"(?P<suffix>[^\n]*)',
+        _read("uv.lock"),
+    )
+    assert match is not None
+    assert match.group("version") == project_version
+    assert "x-release-please-version" in match.group("suffix")
+
+
+def test_uv_writer_version_is_pinned_across_repository_surfaces() -> None:
+    project = tomllib.loads(_read("pyproject.toml"))
+
+    assert project["tool"]["uv"]["required-version"] == f"=={UV_VERSION}"
+    assert f"ARG UV_VERSION={UV_VERSION}" in _read("Dockerfile")
+    assert f"UV_VERSION={UV_VERSION}" in _read("infra/tool-versions.env")
+    assert f'UV_VERSION: "{UV_VERSION}"' in _read(
+        ".github/workflows/hosted-infrastructure.yml"
+    )
+
+
+def test_ci_checks_and_never_rewrites_the_root_lockfile() -> None:
+    ci = _read(".github/workflows/ci.yml")
+    assert "run: uv lock --check" in ci
+
+    for workflow in sorted((ROOT / ".github/workflows").glob("*.yml")):
+        for line_number, line in enumerate(
+            workflow.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if re.search(r"\buv run\b", line):
+                assert "uv run --frozen" in line, (
+                    f"{workflow.relative_to(ROOT)}:{line_number} may rewrite uv.lock"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.22.0"
+version = "0.22.0" # x-release-please-version
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- keep the root `exomem` package version in `uv.lock` synchronized by Release Please
- pin uv 0.11.28 across repository writers and freeze CI project commands
- add executable policy coverage for lock freshness and writer consistency

## Verification

- `uv 0.11.28 lock --check`
- `pytest -q tests/test_uv_lock_policy.py tests/test_container_distribution.py tests/test_hosted_platform_operations.py` (40 passed)
- independent review: no Critical or Important findings

Hosted product behavior is unchanged.