### PR TITLE
feat: add semantic unit context packs

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,12 +6,12 @@ Run `uv run python scripts/generate-capabilities.py --check` to verify it is cur
 
 ## Summary
 
-- Product commands: 23
-- Tier 1 commands: 20
+- Product commands: 24
+- Tier 1 commands: 21
 - Tier 2 commands: 3
-- Registry-generated MCP commands: 23
-- REST commands: 22
-- CLI commands: 22
+- Registry-generated MCP commands: 24
+- REST commands: 23
+- CLI commands: 23
 - Hand-registered MCP tools: none
 
 ## Hosted Cell Capability Boundary

--- a/openspec/changes/add-first-class-semantic-language/tasks.md
+++ b/openspec/changes/add-first-class-semantic-language/tasks.md
@@ -61,7 +61,7 @@
 - [ ] 6.9 Add isolated-lane fidelity tests proving public hybrid explanations reproduce candidate membership, ranks, fusion contributions, degradation, and final ordering within documented rounding.
 - [x] 6.10 Extend `read_memory` to resolve exact anchored/fingerprint-bound unit references and return bounded parent context or explicit stale/ambiguous status.
 - [ ] 6.11 Extend graph context to seed/filter compact and rich unit nodes by category/kind without inferring semantics.
-- [ ] 6.12 Extend context packs with bounded cited semantic units, unit-seeded authored relations, provenance/lifecycle context, explicit truncation, and a nonduplicating legacy `semantic_blocks` projection.
+- [x] 6.12 Extend context packs with bounded cited semantic units, unit-seeded authored relations, provenance/lifecycle context, explicit truncation, and a nonduplicating legacy `semantic_blocks` projection.
 - [ ] 6.13 Add embeddings-disabled and degraded-path tests proving lexical/category/filter recall, explanations, and context remain useful without loading a model.
 
 ## 7. Structured Unit Mutation And Lifecycle

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -609,13 +609,16 @@ def op_find(
             usual hit list, unchanged). The pack is PURE MEASUREMENT over the
             notes you already wrote — no server-side reasoning: each top note's
             structurally-extracted key claims (lede + headline-section lines +
-            heading outline), the 1-hop wikilink neighbourhood of those notes
-            ranked by co-citation, and the contradictions among them (recorded
-            supersession edges + proximity "tension" pairs in the embedding
-            band, surfaced for you to judge — proximity, not polarity). Lets you
-            reason over the matches in one shot instead of fanning out `get`
-            calls. Bounded with explicit `truncation`; the tension part needs
-            the embedding sidecar and reports `embeddings_available`.
+            heading outline), bounded cited compact/rich semantic units with
+            parent provenance/lifecycle and authored relations, the 1-hop
+            wikilink neighbourhood of those notes ranked by co-citation, and
+            the contradictions among them (recorded supersession edges +
+            proximity "tension" pairs in the embedding band, surfaced for you
+            to judge — proximity, not polarity). Page, unit, and mixed results
+            all group by parent before packing. Lets you reason over the matches
+            in one shot instead of fanning out `get` calls. Bounded with explicit
+            `truncation`; the tension part needs the embedding sidecar and reports
+            `embeddings_available`.
         graph_enrich: When true with `pack=true`, add typed graph neighborhood
             data from the derived epistemic graph sidecar to the pack. Default
             false; missing/disabled/stale graph state soft-fails inside
@@ -654,8 +657,10 @@ def op_find(
         independent of graph_hop, which only fires for graph-only
         results.
         With pack on: {"hits": [...the same list...], "pack": {packed_paths,
-        claims, neighborhood, contradictions: {superseded, tension},
-        embeddings_available, truncation}}.
+        claims, semantic_units, semantic_blocks, neighborhood, contradictions:
+        {superseded, tension}, embeddings_available, truncation}}. `semantic_units`
+        groups bounded citable units under one parent context; `semantic_blocks`
+        is a bounded compatibility projection from those same rich units.
         With detail="compact": each hit is the routing stub described under
         `detail` (no excerpt/signals) — same paths, same order.
         With include_timings on: {"hits": [...], ["pack": {...},]
@@ -725,11 +730,6 @@ def op_find(
     )
     pack_obj: dict | None = None
     if pack:
-        if any(isinstance(hit, find_module.SemanticUnitHit) for hit in hits):
-            raise ValueError(
-                "PACK_REQUIRES_PAGE_RESULTS: deep context currently requires "
-                "result_level='page'; use shallow semantic-unit recall first"
-            )
         with find_module._span(timings, "pack"):
             pack_obj = context_pack_module.assemble_pack(
                 vault_root, hits, graph_enrich=graph_enrich

--- a/src/exomem/context_pack.py
+++ b/src/exomem/context_pack.py
@@ -3,12 +3,14 @@
 `find` normally returns ranked hit *excerpts*; to reason over them a caller then fans out
 `get` calls, chases wikilinks by hand, and has no view of contradictions among the hits.
 This module assembles, in one pass over the top hits, a **context pack**: each note's key
-claims, the 1-hop wikilink neighbourhood of those notes, and the contradictions /
-supersessions among them.
+claims, bounded citable semantic units, the 1-hop wikilink neighbourhood of those notes,
+and the contradictions / supersessions among them.
 
 It is PURE ASSEMBLY (measurement), mirroring `attention.py`:
 - "Key claims" are extracted STRUCTURALLY from the note's own markdown (lede, recognized
   headline-section lines, the `##` outline) — never generated or summarized by a model.
+- Compact and rich semantic units come from the same parent snapshot and canonical parser,
+  grouped under bounded provenance/lifecycle context. Selected unit hits are packed first.
 - The neighbourhood reuses `find`'s outbound-link resolution + `vault`'s inbound search.
 - Contradictions are recorded supersession edges (frontmatter) plus proximity "tension"
   pairs whose cosine sits in the existing `[floor, dup)` band (reusing
@@ -22,26 +24,45 @@ that drops content is reported in `truncation` — never a silent truncation.
 
 from __future__ import annotations
 
+import json
 import os
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from . import (
     corpus_aware,
     epistemic_graph,
-    relation_registry,
-    semantic_language_registry,
+    find_corpus,
+    semantic_index,
     semantic_units,
 )
 from . import find as find_module
 from . import vault as vault_module
-from .find import Hit, ParsedPage
+from .find_types import Hit, ParsedPage, SemanticUnitHit
 
 # --- bounds (env-overridable at call time so tests can monkeypatch) ---
 _DEFAULT_MAX_HITS = 5
 _DEFAULT_MAX_NEIGHBORS = 10
 _DEFAULT_MAX_TENSION = 10
 _DEFAULT_CLAIM_CHARS = 280
+_DEFAULT_MAX_UNITS_PER_PAGE = 8
+_DEFAULT_MAX_UNITS = 24
+_DEFAULT_UNIT_CHARS = 360
+_DEFAULT_MAX_UNIT_TOTAL_CHARS = 12_000
+
+_MAX_UNIT_TAGS = 16
+_MAX_UNIT_TAG_CHARS = 64
+_MAX_UNIT_CONTEXT_CHARS = 240
+_MAX_UNIT_RELATIONS = 8
+_MAX_UNIT_RELATION_TARGET_CHARS = 240
+_MAX_UNIT_RELATION_RAW_CHARS = 320
+_MAX_PARENT_PROVENANCE = 8
+_MAX_PARENT_PROVENANCE_CHARS = 240
+_MAX_LEGACY_METADATA = 8
+_MAX_LEGACY_METADATA_KEY_CHARS = 64
+_MAX_LEGACY_METADATA_VALUE_CHARS = 160
 
 # Per-note claim shaping — small, fixed (claims are inherently bounded by note structure).
 _SECTION_MAX_LINES = 3
@@ -103,6 +124,8 @@ def _collapse(text: str) -> str:
 
 def _cap(text: str, n: int) -> str:
     text = text.strip()
+    if n <= 0:
+        return ""
     if len(text) <= n:
         return text
     return text[:n].rstrip() + "…"
@@ -206,12 +229,230 @@ def _extract_claims(page: ParsedPage, *, claim_chars: int = _DEFAULT_CLAIM_CHARS
     }
 
 
-def _extract_semantic_blocks(
-    page: ParsedPage,
-    document: semantic_units.SemanticUnitDocument,
-) -> list[dict]:
-    del page
-    return document.semantic_blocks
+def _hit_parent_path(hit: Hit | SemanticUnitHit) -> str:
+    return hit.parent_path if isinstance(hit, SemanticUnitHit) else hit.path
+
+
+def _selected_unit_refs(hit: Hit | SemanticUnitHit) -> list[str]:
+    if isinstance(hit, SemanticUnitHit):
+        return [hit.unit_ref]
+    return [
+        str(item["unit_ref"])
+        for item in (hit.matched_units or [])
+        if item.get("unit_ref")
+    ]
+
+
+def _load_parent_snapshot(
+    vault_root: Path,
+    rel_path: str,
+) -> tuple[ParsedPage, semantic_index.SemanticParentIndexState] | None:
+    """Read one parent once, then derive page and semantic state from those bytes."""
+    try:
+        root = vault_root.resolve()
+        path = (root / rel_path).resolve()
+        path.relative_to(root)
+        content = path.read_bytes()
+        mtime = path.stat().st_mtime
+        source = content.decode("utf-8")
+    except (FileNotFoundError, OSError, UnicodeError, ValueError):
+        return None
+    page = find_corpus.parse_page(path, mtime, root, content=content)
+    if page is None:
+        return None
+    try:
+        state = semantic_index.build_parent_index_state(root, path, source=source)
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return page, state
+
+
+def _bounded_values(value: Any, *, limit: int, chars: int) -> tuple[list[str], int]:
+    if value is None:
+        values: list[Any] = []
+    elif isinstance(value, list):
+        values = value
+    else:
+        values = [value]
+    cap = max(0, limit)
+    shown = [_cap(str(item), chars) for item in values[:cap]]
+    clipped = sum(len(str(item).strip()) > chars for item in values[:cap])
+    return shown, max(0, len(values) - len(shown)) + clipped
+
+
+def _parent_context(page: ParsedPage, parent_ref: str | None) -> tuple[dict, int]:
+    sources, dropped_sources = _bounded_values(
+        page.frontmatter.get("sources"),
+        limit=_MAX_PARENT_PROVENANCE,
+        chars=_MAX_PARENT_PROVENANCE_CHARS,
+    )
+    evidence_values: list[Any] = []
+    for key in ("evidence", "evidence_file"):
+        value = page.frontmatter.get(key)
+        if isinstance(value, list):
+            evidence_values.extend(value)
+        elif value is not None:
+            evidence_values.append(value)
+    evidence, dropped_evidence = _bounded_values(
+        evidence_values,
+        limit=_MAX_PARENT_PROVENANCE,
+        chars=_MAX_PARENT_PROVENANCE_CHARS,
+    )
+    return (
+        {
+            "path": page.rel_path,
+            "ref": parent_ref,
+            "title": _cap(page.title, _MAX_PARENT_PROVENANCE_CHARS),
+            "type": _cap(page.page_type, 64) if page.page_type else None,
+            "status": _cap(page.status or "active", 64),
+            "updated": _cap(page.updated, 64),
+            "supersedes": [
+                _cap(value, _MAX_PARENT_PROVENANCE_CHARS)
+                for value in page.supersedes[:_MAX_PARENT_PROVENANCE]
+            ],
+            "superseded_by": [
+                _cap(value, _MAX_PARENT_PROVENANCE_CHARS)
+                for value in page.superseded_by[:_MAX_PARENT_PROVENANCE]
+            ],
+            "sources": sources,
+            "evidence": evidence,
+        },
+        dropped_sources
+        + dropped_evidence
+        + max(0, len(page.supersedes) - _MAX_PARENT_PROVENANCE)
+        + max(0, len(page.superseded_by) - _MAX_PARENT_PROVENANCE),
+    )
+
+
+def _pack_unit(
+    unit: semantic_units.SemanticUnit,
+    *,
+    unit_chars: int,
+) -> tuple[dict, int]:
+    relations: list[dict] = []
+    for relation in unit.relations[:_MAX_UNIT_RELATIONS]:
+        relations.append(
+            {
+                "kind": relation.kind,
+                "target": _cap(relation.target, _MAX_UNIT_RELATION_TARGET_CHARS),
+                "line": relation.line,
+                "origin": "authored_rich_unit",
+                "direction": "outbound",
+                "source_anchor": unit.anchor,
+            }
+        )
+    tags = [_cap(tag, _MAX_UNIT_TAG_CHARS) for tag in unit.tags[:_MAX_UNIT_TAGS]]
+    clipped_fields = int(len(unit.content.strip()) > max(0, unit_chars))
+    if unit.context:
+        clipped_fields += int(
+            len(unit.context.strip()) > _MAX_UNIT_CONTEXT_CHARS
+        )
+    clipped_fields += sum(
+        len(str(tag).strip()) > _MAX_UNIT_TAG_CHARS for tag in unit.tags[:_MAX_UNIT_TAGS]
+    )
+    clipped_fields += sum(
+        len(relation.target.strip()) > _MAX_UNIT_RELATION_TARGET_CHARS
+        for relation in unit.relations[:_MAX_UNIT_RELATIONS]
+    )
+    return (
+        {
+            "unit_ref": unit.unit_ref,
+            "fingerprint": unit.fingerprint,
+            "form": unit.form,
+            "category_raw": unit.category_raw,
+            "category_key": unit.category_key,
+            "category": unit.category,
+            "kind": unit.kind,
+            "excerpt": _cap(unit.content, max(0, unit_chars)),
+            "tags": tags,
+            "context": _cap(unit.context, _MAX_UNIT_CONTEXT_CHARS)
+            if unit.context
+            else None,
+            "source_anchor": unit.anchor,
+            "source_span": {
+                "start_line": unit.span.start_line,
+                "start_column": unit.span.start_column,
+                "end_line": unit.span.end_line,
+                "end_column": unit.span.end_column,
+                "start_offset": unit.span.start_offset,
+                "end_offset": unit.span.end_offset,
+            },
+            "source_hash": unit.source_hash,
+            "relations": relations,
+        },
+        max(0, len(unit.tags) - len(tags))
+        + max(0, len(unit.relations) - len(relations))
+        + clipped_fields,
+    )
+
+
+def _bounded_legacy_metadata(unit: semantic_units.SemanticUnit) -> tuple[dict[str, str], int]:
+    items = list(unit.metadata.items())
+    shown = {
+        _cap(str(key), _MAX_LEGACY_METADATA_KEY_CHARS): _cap(
+            str(value), _MAX_LEGACY_METADATA_VALUE_CHARS
+        )
+        for key, value in items[:_MAX_LEGACY_METADATA]
+    }
+    clipped = sum(
+        len(str(key).strip()) > _MAX_LEGACY_METADATA_KEY_CHARS
+        or len(str(value).strip()) > _MAX_LEGACY_METADATA_VALUE_CHARS
+        for key, value in items[:_MAX_LEGACY_METADATA]
+    )
+    return shown, max(0, len(items) - len(shown)) + clipped
+
+
+def _legacy_block_from_packed_unit(
+    unit: semantic_units.SemanticUnit,
+    packed: dict,
+) -> tuple[dict | None, int]:
+    if unit.form != "rich":
+        return None, 0
+    metadata, dropped = _bounded_legacy_metadata(unit)
+    relations: list[dict[str, Any]] = []
+    for authored, relation in zip(
+        unit.relations,
+        packed["relations"],
+        strict=False,
+    ):
+        relations.append(
+            {
+                "kind": relation["kind"],
+                "target": relation["target"],
+                "raw": _cap(authored.raw, _MAX_UNIT_RELATION_RAW_CHARS),
+                "line": relation["line"],
+            }
+        )
+        dropped += int(len(authored.raw.strip()) > _MAX_UNIT_RELATION_RAW_CHARS)
+    out: dict[str, Any] = {
+        "type": unit.kind,
+        "title": _cap(unit.title, 160) if unit.title else None,
+        "level": unit.level,
+        "line": packed["source_span"]["start_line"],
+        "end_line": packed["source_span"]["end_line"],
+        "body": packed["excerpt"],
+        "metadata": metadata,
+        "relations": relations,
+    }
+    if unit.anchor:
+        out["id"] = unit.anchor
+    return out, dropped
+
+
+@dataclass
+class _UnitPackPlan:
+    page: ParsedPage
+    parent: dict[str, Any]
+    selected: list[tuple[int, int, semantic_units.SemanticUnit]]
+    fillers: list[semantic_units.SemanticUnit]
+    dropped_provenance: int = 0
+    packed_units: list[dict[str, Any]] = field(default_factory=list)
+    legacy_blocks: list[dict[str, Any]] = field(default_factory=list)
+    chosen_units: list[tuple[semantic_units.SemanticUnit, dict[str, Any]]] = field(
+        default_factory=list
+    )
+    omitted_reasons: set[str] = field(default_factory=set)
+    dropped_fields: int = 0
 
 
 # ----------------------------- neighbourhood -----------------------------
@@ -349,75 +590,230 @@ def _tension_pairs(
 
 def assemble_pack(
     vault_root: Path,
-    hits: list[Hit],
+    hits: list[Hit | SemanticUnitHit],
     *,
     max_hits: int | None = None,
     max_neighbors: int | None = None,
     max_tension: int | None = None,
+    max_units_per_page: int | None = None,
+    max_units: int | None = None,
+    unit_chars: int | None = None,
+    max_unit_total_chars: int | None = None,
     graph_enrich: bool = False,
 ) -> dict:
     """Assemble a reasoning-ready context pack over the top `hits`. Pure measurement.
 
-    Returns ``{packed_paths, claims, neighborhood, contradictions, embeddings_available,
-    truncation}``. Reads note content, frontmatter, wikilinks, and precomputed sidecar
-    embeddings only — no mutation, no generative model, `find` ordering untouched.
+    Returns ``{packed_paths, claims, semantic_units, semantic_blocks, neighborhood,
+    contradictions, embeddings_available, truncation}``. Reads note content,
+    frontmatter, wikilinks, and precomputed sidecar embeddings only — no mutation,
+    no generative model, `find` ordering untouched.
     """
     max_hits = _resolve_cap(max_hits, "EXOMEM_PACK_MAX_HITS", _DEFAULT_MAX_HITS)
     max_neighbors = _resolve_cap(max_neighbors, "EXOMEM_PACK_MAX_NEIGHBORS", _DEFAULT_MAX_NEIGHBORS)
     max_tension = _resolve_cap(max_tension, "EXOMEM_PACK_MAX_TENSION", _DEFAULT_MAX_TENSION)
     claim_chars = _resolve_cap(None, "EXOMEM_PACK_CLAIM_CHARS", _DEFAULT_CLAIM_CHARS)
+    max_units_per_page = max(
+        0,
+        _resolve_cap(
+            max_units_per_page,
+            "EXOMEM_PACK_MAX_UNITS_PER_PAGE",
+            _DEFAULT_MAX_UNITS_PER_PAGE,
+        ),
+    )
+    max_units = max(
+        0,
+        _resolve_cap(max_units, "EXOMEM_PACK_MAX_UNITS", _DEFAULT_MAX_UNITS),
+    )
+    unit_chars = max(
+        0,
+        _resolve_cap(unit_chars, "EXOMEM_PACK_UNIT_CHARS", _DEFAULT_UNIT_CHARS),
+    )
+    max_unit_total_chars = max(
+        0,
+        _resolve_cap(
+            max_unit_total_chars,
+            "EXOMEM_PACK_MAX_UNIT_TOTAL_CHARS",
+            _DEFAULT_MAX_UNIT_TOTAL_CHARS,
+        ),
+    )
 
     truncation: list[str] = []
-    # De-dupe by canonical path up front: `find` rarely emits the same path twice, but a
-    # duplicate would otherwise double-count in `packed_paths` and the supersession edges.
-    seen: set[str] = set()
-    unique_hits: list[Hit] = []
-    for hit in hits:
-        canon = corpus_aware._canon(hit.path)
-        if canon in seen:
-            continue
-        seen.add(canon)
-        unique_hits.append(hit)
+    # Group page/unit/mixed results by parent before applying max_hits. Repeated unit
+    # hits from one parent therefore cannot starve lower-ranked parents.
+    groups: list[dict[str, Any]] = []
+    by_parent: dict[str, dict[str, Any]] = {}
+    for hit_rank, hit in enumerate(hits):
+        parent_path = _hit_parent_path(hit)
+        canon = corpus_aware._canon(parent_path)
+        group = by_parent.get(canon)
+        if group is None:
+            group = {"path": parent_path, "selected_refs": []}
+            by_parent[canon] = group
+            groups.append(group)
+        selected_refs = group["selected_refs"]
+        known_refs = {item[2] for item in selected_refs}
+        for unit_order, unit_ref in enumerate(_selected_unit_refs(hit)):
+            if unit_ref not in known_refs:
+                selected_refs.append((hit_rank, unit_order, unit_ref))
+                known_refs.add(unit_ref)
 
-    total = len(unique_hits)
-    packed_hits = unique_hits[:max_hits] if max_hits > 0 else unique_hits
-    if total > len(packed_hits):
+    total = len(groups)
+    packed_groups = groups[:max_hits] if max_hits > 0 else groups
+    if total > len(packed_groups):
         truncation.append(
-            f"packed {len(packed_hits)} of {total} hits "
-            f"({total - len(packed_hits)} more not packed; raise EXOMEM_PACK_MAX_HITS)"
+            f"packed {len(packed_groups)} of {total} parent hits "
+            f"({total - len(packed_groups)} more not packed; raise EXOMEM_PACK_MAX_HITS)"
         )
 
     packed_pages: list[ParsedPage] = []
+    semantic_states: dict[str, semantic_index.SemanticParentIndexState] = {}
+    selected_by_path: dict[str, list[tuple[int, int, str]]] = {}
     missing = 0
-    for hit in packed_hits:
-        page = find_module._CACHE.get(vault_root / hit.path, vault_root)
-        if page is None:
+    for group in packed_groups:
+        snapshot = _load_parent_snapshot(vault_root, str(group["path"]))
+        if snapshot is None:
             missing += 1  # a packed hit whose file is gone/unreadable — surface it.
             continue
+        page, state = snapshot
         packed_pages.append(page)
+        semantic_states[page.rel_path] = state
+        selected_by_path[page.rel_path] = list(group["selected_refs"])
     if missing:
         truncation.append(f"{missing} packed hit(s) unreadable or missing, not packed")
 
     claims = {p.rel_path: _extract_claims(p, claim_chars=claim_chars) for p in packed_pages}
-    relations = relation_registry.load_registry(vault_root)
-    language = semantic_language_registry.load_registry(vault_root)
-    semantic_documents = {
-        page.rel_path: semantic_units.parse_semantic_units(
-            page.body,
-            path=page.rel_path,
-            validate=False,
-            language_registry=language,
-            relation_registry=relations,
-            project=(str(page.frontmatter.get("project")) if page.frontmatter.get("project") else None),
-            page_type=page.page_type,
-        )
-        for page in packed_pages
-    }
+    semantic_unit_map: dict[str, dict[str, Any]] = {}
     semantic_block_map: dict[str, list[dict]] = {}
+    plans: list[_UnitPackPlan] = []
     for page in packed_pages:
-        blocks = _extract_semantic_blocks(page, semantic_documents[page.rel_path])
-        if blocks:
-            semantic_block_map[page.rel_path] = blocks
+        document = semantic_states[page.rel_path].document
+        by_ref = {
+            unit.unit_ref: unit for unit in document.units if unit.unit_ref is not None
+        }
+        selected: list[tuple[int, int, semantic_units.SemanticUnit]] = []
+        unresolved = 0
+        for hit_rank, unit_order, unit_ref in selected_by_path.get(page.rel_path, []):
+            unit = by_ref.get(unit_ref)
+            if unit is None:
+                unresolved += 1
+            elif all(existing[2] is not unit for existing in selected):
+                selected.append((hit_rank, unit_order, unit))
+        if unresolved:
+            truncation.append(
+                f"{page.rel_path}: {unresolved} selected semantic unit(s) stale or missing"
+            )
+
+        selected_ids = {id(item[2]) for item in selected}
+        parent, dropped_provenance = _parent_context(
+            page, semantic_states[page.rel_path].parent_ref
+        )
+        plans.append(
+            _UnitPackPlan(
+                page=page,
+                parent=parent,
+                selected=selected,
+                fillers=[
+                    unit for unit in document.units if id(unit) not in selected_ids
+                ],
+                dropped_provenance=dropped_provenance,
+            )
+        )
+
+    packed_unit_count = 0
+
+    def _try_pack(
+        plan: _UnitPackPlan,
+        unit: semantic_units.SemanticUnit,
+    ) -> None:
+        nonlocal packed_unit_count
+        if len(plan.packed_units) >= max_units_per_page:
+            plan.omitted_reasons.add("per-page cap")
+            return
+        if packed_unit_count >= max_units:
+            plan.omitted_reasons.add("pack-wide cap")
+            return
+
+        packed, dropped = _pack_unit(unit, unit_chars=unit_chars)
+        block, dropped_metadata = _legacy_block_from_packed_unit(unit, packed)
+        candidate_unit_map = {
+            **semantic_unit_map,
+            plan.page.rel_path: {
+                "parent": plan.parent,
+                "units": plan.packed_units + [packed],
+            },
+        }
+        candidate_block_map = dict(semantic_block_map)
+        if block is not None:
+            candidate_block_map[plan.page.rel_path] = plan.legacy_blocks + [block]
+        encoded = json.dumps(
+            {
+                "semantic_units": candidate_unit_map,
+                "semantic_blocks": candidate_block_map,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        if len(encoded) > max_unit_total_chars:
+            plan.omitted_reasons.add("character cap")
+            return
+
+        plan.packed_units.append(packed)
+        plan.chosen_units.append((unit, packed))
+        if block is not None:
+            plan.legacy_blocks.append(block)
+        plan.dropped_fields += dropped + dropped_metadata
+        packed_unit_count += 1
+        semantic_unit_map[plan.page.rel_path] = {
+            "parent": plan.parent,
+            "units": plan.packed_units,
+        }
+        if plan.legacy_blocks:
+            semantic_block_map[plan.page.rel_path] = plan.legacy_blocks
+
+    selected_candidates = sorted(
+        (
+            (hit_rank, unit_order, plan_index, plan, unit)
+            for plan_index, plan in enumerate(plans)
+            for hit_rank, unit_order, unit in plan.selected
+        ),
+        key=lambda item: (item[0], item[1], item[2]),
+    )
+    for _hit_rank, _unit_order, _plan_index, plan, unit in selected_candidates:
+        _try_pack(plan, unit)
+    for plan in plans:
+        for unit in plan.fillers:
+            _try_pack(plan, unit)
+
+    for plan in plans:
+        total_units = len(plan.selected) + len(plan.fillers)
+        omitted = total_units - len(plan.packed_units)
+        if omitted:
+            reason = ", ".join(sorted(plan.omitted_reasons)) or "configured bounds"
+            truncation.append(
+                f"{plan.page.rel_path}: {omitted} semantic units omitted by {reason}"
+            )
+        selected_included = {
+            packed["unit_ref"]
+            for _unit, packed in plan.chosen_units
+            if packed["unit_ref"]
+        }
+        selected_omitted = sum(
+            1
+            for _hit_rank, _unit_order, unit in plan.selected
+            if unit.unit_ref not in selected_included
+        )
+        if selected_omitted:
+            truncation.append(
+                f"{plan.page.rel_path}: {selected_omitted} selected semantic unit(s) omitted by bounds"
+            )
+        if plan.dropped_provenance:
+            truncation.append(
+                f"{plan.page.rel_path}: {plan.dropped_provenance} provenance/lifecycle value(s) omitted"
+            )
+        if plan.dropped_fields:
+            truncation.append(
+                f"{plan.page.rel_path}: {plan.dropped_fields} semantic-unit field value(s) omitted by bounds"
+            )
 
     neighborhood, n_dropped = _neighborhood(vault_root, packed_pages, max_neighbors)
     if n_dropped > 0:
@@ -437,6 +833,7 @@ def assemble_pack(
     result = {
         "packed_paths": [p.rel_path for p in packed_pages],
         "claims": claims,
+        "semantic_units": semantic_unit_map,
         "semantic_blocks": semantic_block_map,
         "neighborhood": neighborhood,
         "contradictions": {"superseded": superseded, "tension": tension},

--- a/src/exomem/find_candidates.py
+++ b/src/exomem/find_candidates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -140,7 +141,10 @@ def collect_candidates(
     vector_ranking: list[str] = []
     chunk_text_by_path: dict[str, str] = {}
     vector_score_by_path: dict[str, float] = {}
-    if readiness.should_defer("embeddings"):
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        if timings is not None:
+            timings.skipped("vector")
+    elif readiness.should_defer("embeddings"):
         if timings is not None:
             timings.skipped("vector")
         if degraded_out is not None:

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -13,9 +13,16 @@ from pathlib import Path
 
 import pytest
 
-from exomem import context_pack, corpus_aware, epistemic_graph, semantic_blocks
+from exomem import (
+    context_pack,
+    corpus_aware,
+    epistemic_graph,
+    semantic_blocks,
+    semantic_index,
+)
 from exomem import find as find_module
 from exomem.find import Hit
+from exomem.find_types import SemanticUnitHit
 
 # --- a small cluster: Alpha + Beta packed; Hub (co-cited), Charlie, Delta neighbours ---
 
@@ -104,6 +111,31 @@ type: insight
 The current lede that supersedes the old one.
 """
 
+UNIT_CONTEXT = """\
+---
+type: insight
+exomem_id: 11111111-1111-4111-8111-111111111111
+status: superseded
+updated: 2026-07-16
+superseded_by: "[[Knowledge Base/Notes/NewView]]"
+sources:
+  - "[[Knowledge Base/Sources/Cache benchmark]]"
+---
+# Cache Policy
+
+## Observations
+
+- [config] Cache TTL is thirty seconds #runtime (edge cache) ^cache-ttl
+- [rule] Evict least-recently-used entries first #runtime ^evict-lru
+
+## Decision
+- id: choose-lru
+- category: architecture
+- relations: evidenced_by: [[Knowledge Base/Sources/Cache benchmark]]
+
+Use LRU eviction for the bounded edge cache.
+"""
+
 
 def _write(vault: Path, rel: str, body: str) -> None:
     p = vault / rel
@@ -115,6 +147,30 @@ def _hit(rel: str) -> Hit:
     return Hit(path=rel, type=None, scope=None, title="", updated="", excerpt="")
 
 
+def _unit_hit(rel: str, unit_ref: str) -> SemanticUnitHit:
+    return SemanticUnitHit(
+        unit_ref=unit_ref,
+        form="compact",
+        category_raw="config",
+        category_key="config",
+        category="config",
+        kind="observation",
+        content="selected",
+        excerpt="selected",
+        tags=[],
+        context=None,
+        source_anchor=None,
+        source_span={},
+        source_hash="hash",
+        parent_path=rel,
+        parent_ref=None,
+        parent_title="",
+        parent_type="insight",
+        parent_status="active",
+        parent_updated="",
+    )
+
+
 ALPHA_P = "Knowledge Base/Notes/Alpha.md"
 BETA_P = "Knowledge Base/Notes/Beta.md"
 CHARLIE_P = "Knowledge Base/Notes/Charlie.md"
@@ -122,6 +178,7 @@ HUB_P = "Knowledge Base/Notes/Hub.md"
 DELTA_P = "Knowledge Base/Notes/Delta.md"
 OLD_P = "Knowledge Base/Notes/Old.md"
 NEW_P = "Knowledge Base/Notes/NewView.md"
+UNIT_CONTEXT_P = "Knowledge Base/Notes/CachePolicy.md"
 
 
 @pytest.fixture
@@ -134,6 +191,7 @@ def cluster(tmp_path: Path) -> Path:
     _write(vault, DELTA_P, DELTA)
     _write(vault, OLD_P, OLD)
     _write(vault, NEW_P, NEW)
+    _write(vault, UNIT_CONTEXT_P, UNIT_CONTEXT)
     find_module.clear_cache()
     return vault
 
@@ -327,6 +385,7 @@ def test_pack_without_graph_enrichment_preserves_shape(cluster: Path) -> None:
     assert set(pack) == {
         "packed_paths",
         "claims",
+        "semantic_units",
         "semantic_blocks",
         "neighborhood",
         "contradictions",
@@ -361,7 +420,7 @@ def test_pack_parses_each_readable_page_once_and_preserves_exact_json(
         ).blocks
         if blocks:
             legacy_block_map[rel_path] = [block.to_dict() for block in blocks]
-    expected = {
+    expected_legacy = {
         "packed_paths": actual["packed_paths"],
         "claims": actual["claims"],
         "semantic_blocks": legacy_block_map,
@@ -372,9 +431,220 @@ def test_pack_parses_each_readable_page_once_and_preserves_exact_json(
     }
 
     assert parse_calls == 2
-    assert json.dumps(actual, ensure_ascii=False, sort_keys=False) == json.dumps(
-        expected, ensure_ascii=False, sort_keys=False
+    legacy_actual = {key: value for key, value in actual.items() if key != "semantic_units"}
+    assert json.dumps(legacy_actual, ensure_ascii=False, sort_keys=False) == json.dumps(
+        expected_legacy, ensure_ascii=False, sort_keys=False
     )
+    assert set(actual["semantic_units"]) == {BETA_P}
+    assert actual["semantic_units"][BETA_P]["units"][0]["kind"] == "pattern"
+
+
+def test_pack_includes_bounded_citable_compact_and_rich_semantic_units(
+    cluster: Path,
+) -> None:
+    pack = context_pack.assemble_pack(cluster, [_hit(UNIT_CONTEXT_P)])
+
+    entry = pack["semantic_units"][UNIT_CONTEXT_P]
+    units = entry["units"]
+    assert [unit["form"] for unit in units] == ["compact", "compact", "rich"]
+
+    compact = units[0]
+    assert compact["category"] == "config"
+    assert compact["kind"] == "observation"
+    assert compact["excerpt"] == "Cache TTL is thirty seconds"
+    assert compact["source_anchor"] == "cache-ttl"
+    assert compact["unit_ref"].endswith("#cache-ttl")
+    assert "text" not in compact["source_span"]
+    assert entry["parent"] == {
+        "path": UNIT_CONTEXT_P,
+        "ref": "exomem://memory/11111111-1111-4111-8111-111111111111",
+        "title": "Cache Policy",
+        "type": "insight",
+        "status": "superseded",
+        "updated": "2026-07-16",
+        "supersedes": [],
+        "superseded_by": ["[[Knowledge Base/Notes/NewView]]"],
+        "sources": ["[[Knowledge Base/Sources/Cache benchmark]]"],
+        "evidence": [],
+    }
+
+    rich = units[-1]
+    assert rich["kind"] == "decision"
+    assert rich["category"] == "architecture"
+    assert rich["source_anchor"] == "choose-lru"
+    assert rich["relations"] == [
+        {
+            "kind": "evidenced_by",
+            "target": "[[Knowledge Base/Sources/Cache benchmark]]",
+            "line": rich["source_span"]["start_line"] + 3,
+            "origin": "authored_rich_unit",
+            "direction": "outbound",
+            "source_anchor": "choose-lru",
+        }
+    ]
+
+    expected_legacy = [
+        block.to_dict()
+        for block in semantic_blocks.parse_semantic_blocks(
+            find_module._CACHE.get(cluster / UNIT_CONTEXT_P, cluster).body,
+            validate=False,
+        ).blocks
+    ]
+    assert pack["semantic_blocks"][UNIT_CONTEXT_P] == expected_legacy
+
+
+def test_semantic_unit_caps_are_explicit_and_bound_legacy_projection(
+    cluster: Path,
+) -> None:
+    pack = context_pack.assemble_pack(
+        cluster,
+        [_hit(UNIT_CONTEXT_P)],
+        max_units_per_page=1,
+        max_units=1,
+    )
+
+    assert len(pack["semantic_units"][UNIT_CONTEXT_P]["units"]) == 1
+    assert pack["semantic_blocks"] == {}
+    assert any(
+        "2 semantic units omitted" in item
+        for item in pack["truncation"]
+    )
+
+
+def test_semantic_unit_character_cap_is_hard_and_legacy_body_uses_same_excerpt(
+    cluster: Path,
+) -> None:
+    bounded = context_pack.assemble_pack(
+        cluster,
+        [_hit(UNIT_CONTEXT_P)],
+        unit_chars=12,
+    )
+    rich = bounded["semantic_units"][UNIT_CONTEXT_P]["units"][-1]
+    assert rich["excerpt"].endswith("…")
+    assert bounded["semantic_blocks"][UNIT_CONTEXT_P][0]["body"] == rich["excerpt"]
+
+    total_cap = 2_500
+    total_bounded = context_pack.assemble_pack(
+        cluster,
+        [_hit(UNIT_CONTEXT_P)],
+        max_unit_total_chars=total_cap,
+    )
+    semantic_payload = json.dumps(
+        {
+            "semantic_units": total_bounded["semantic_units"],
+            "semantic_blocks": total_bounded["semantic_blocks"],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    assert total_bounded["semantic_units"]
+    assert len(semantic_payload) <= total_cap
+
+    exhausted = context_pack.assemble_pack(
+        cluster,
+        [_hit(UNIT_CONTEXT_P)],
+        max_unit_total_chars=0,
+    )
+    assert exhausted["semantic_units"] == {}
+    assert exhausted["semantic_blocks"] == {}
+    assert any("character cap" in item for item in exhausted["truncation"])
+
+
+def test_parent_grouping_precedes_hit_cap_and_stale_selection_is_explicit(
+    cluster: Path,
+) -> None:
+    stale = "exomem://memory/11111111-1111-4111-8111-111111111111#gone"
+    pack = context_pack.assemble_pack(
+        cluster,
+        [_unit_hit(UNIT_CONTEXT_P, stale), _hit(UNIT_CONTEXT_P), _hit(BETA_P)],
+        max_hits=2,
+    )
+
+    assert pack["packed_paths"] == [UNIT_CONTEXT_P, BETA_P]
+    assert any("selected semantic unit(s) stale or missing" in item for item in pack["truncation"])
+
+
+def test_pack_wide_selected_units_precede_fillers_from_earlier_parents(
+    cluster: Path,
+) -> None:
+    beta_ref = semantic_index.build_parent_index_state(
+        cluster, cluster / BETA_P
+    ).document.units[0].unit_ref
+    assert beta_ref is not None
+
+    pack = context_pack.assemble_pack(
+        cluster,
+        [_hit(UNIT_CONTEXT_P), _unit_hit(BETA_P, beta_ref)],
+        max_units=1,
+    )
+
+    assert set(pack["semantic_units"]) == {BETA_P}
+    assert pack["semantic_units"][BETA_P]["units"][0]["unit_ref"] == beta_ref
+    assert not any(
+        "selected semantic unit(s) omitted" in item
+        for item in pack["truncation"]
+    )
+
+
+def test_deleted_selected_unit_is_reported_when_parent_has_no_units(
+    cluster: Path,
+) -> None:
+    pack = context_pack.assemble_pack(
+        cluster,
+        [_unit_hit(ALPHA_P, "path:Knowledge Base/Notes/Alpha.md#gone")],
+    )
+
+    assert pack["semantic_units"] == {}
+    assert any(
+        "1 selected semantic unit(s) stale or missing" in item
+        for item in pack["truncation"]
+    )
+
+
+def test_unit_level_find_can_return_deep_context_seeded_by_selected_unit(
+    cluster: Path,
+) -> None:
+    from exomem import commands
+
+    result = commands.op_find(
+        cluster,
+        query="bounded edge cache",
+        kinds=["decision"],
+        result_level="unit",
+        pack=True,
+        mode="keyword",
+        graph=False,
+        scope="kb-only",
+        prefer_active=False,
+    )
+
+    selected = result["hits"][0]
+    packed = result["pack"]["semantic_units"][UNIT_CONTEXT_P]["units"]
+    assert selected["result_type"] == "semantic_unit"
+    assert packed[0]["unit_ref"] == selected["unit_ref"]
+    assert packed[0]["kind"] == "decision"
+    assert packed[0]["relations"][0]["kind"] == "evidenced_by"
+
+
+def test_deep_ask_memory_supports_unit_level_context(cluster: Path) -> None:
+    from exomem import commands
+
+    result = commands.op_ask_memory(
+        cluster,
+        query="bounded edge cache",
+        kinds=["decision"],
+        result_level="unit",
+        deep=True,
+        mode="keyword",
+        graph=False,
+        scope="kb-only",
+        prefer_active=False,
+    )
+
+    assert result["hits"][0]["result_type"] == "semantic_unit"
+    assert result["pack"]["semantic_units"][UNIT_CONTEXT_P]["units"][0][
+        "kind"
+    ] == "decision"
 
 
 def test_graph_enriched_pack_includes_typed_neighborhood(cluster: Path) -> None:

--- a/tests/test_degradation_alarm.py
+++ b/tests/test_degradation_alarm.py
@@ -36,6 +36,7 @@ def test_vector_lane_failure_bumps_counter_and_sets_degraded_marker(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A post-warm vector-lane exception → counter += 1 and envelope `degraded`."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
 
     def _boom(*_a, **_k):
         raise RuntimeError("sidecar corrupt")

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -667,6 +667,7 @@ def test_find_defers_vector_lane_mid_warm_without_calling_embed_texts(
     degraded_out, and rank identically to the natural post-warm fallback —
     proven below: torch is absent in this sandbox, so the post-warm call
     ImportErrors its way to the exact same BM25/keyword-lane ranking."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")
     real_embed_texts = embeddings.embed_texts
     guard = {"forbidden": True}
@@ -752,6 +753,7 @@ def test_op_find_warming_envelope_mid_warm_then_bare_list_after_finish(
 ) -> None:
     """op_find returns {"hits": [...], "warming": {...}} while a lane was
     deferred mid-warm, and reverts to a bare list once finish_warm() runs."""
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setenv("EXOMEM_FIND_CACHE_SIZE", "0")
     readiness.begin_warm()
     out = commands.op_find(vault, query="metabolism", mode="hybrid")

--- a/tests/test_semantic_product_surface.py
+++ b/tests/test_semantic_product_surface.py
@@ -63,19 +63,24 @@ def test_ask_memory_returns_filtered_semantic_units(tmp_path: Path) -> None:
     assert hits[0]["parent_path"].endswith("semantic-surface.md")
 
 
-def test_deep_semantic_unit_recall_fails_with_a_stable_error(tmp_path: Path) -> None:
+def test_deep_semantic_unit_recall_returns_a_citable_context_pack(tmp_path: Path) -> None:
     _write_semantic_page(tmp_path)
 
-    with pytest.raises(ValueError, match="PACK_REQUIRES_PAGE_RESULTS"):
-        commands.op_ask_memory(
-            tmp_path,
-            query="SQLite",
-            mode="keyword",
-            scope="kb-only",
-            categories=["config"],
-            result_level="unit",
-            deep=True,
-        )
+    result = commands.op_ask_memory(
+        tmp_path,
+        query="SQLite",
+        mode="keyword",
+        scope="kb-only",
+        categories=["config"],
+        result_level="unit",
+        deep=True,
+    )
+
+    hit = result["hits"][0]
+    entry = result["pack"]["semantic_units"][hit["parent_path"]]
+    assert entry["units"][0]["unit_ref"] == hit["unit_ref"]
+    assert entry["units"][0]["kind"] == "decision"
+    assert entry["parent"]["ref"] == hit["parent_ref"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- pack page, unit, and mixed recall by canonical parent
- return bounded citable semantic units with provenance, lifecycle, and authored relations
- preserve the legacy semantic_blocks projection without duplication
- keep lexical deep context useful when embeddings are disabled

## Verification

- 169 public/surface tests passed
- 173 semantic/index tests passed
- independent final review: Ready; 88 focused tests passed
- repo-wide Ruff F checks passed
- capability docs are current
- strict OpenSpec validation passed