### PR TITLE
fix: preserve exact bytes and review access on Windows

### DIFF
--- a/src/exomem/relation_review.py
+++ b/src/exomem/relation_review.py
@@ -2427,9 +2427,8 @@ def _open_review_directory(
     if chain is None:
         yield None
         return
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
-        descriptor = os.open(directory, flags)
+        descriptor = vault._open_directory_path(directory)
     except OSError as error:
         raise RelationReviewError(
             "RELATION_REVIEW_DIRECTORY_UNSAFE", "review directory cannot be opened"
@@ -2514,7 +2513,11 @@ def _read_artifact_bytes(
         or not stat.S_ISREG(before.st_mode)
     ):
         raise RelationReviewError("RELATION_REVIEW_UNSAFE_FILE", "review artifact is unsafe")
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
     try:
         descriptor = (
             os.open(name, flags, dir_fd=opened.descriptor)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -559,7 +559,11 @@ def _safe_guard_target(target: str) -> tuple[str, ...]:
 
 
 def _leaf_hash(path: Path, expected: PathIdentity) -> str:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
     try:
         descriptor = os.open(path, flags)
     except OSError as error:
@@ -1218,6 +1222,7 @@ class _BatchWorkspace:
             os.O_RDWR
             | os.O_CREAT
             | os.O_EXCL
+            | getattr(os, "O_BINARY", 0)
             | getattr(os, "O_NOFOLLOW", 0)
         )
         if os.open in getattr(os, "supports_dir_fd", set()):
@@ -1275,7 +1280,9 @@ class _BatchWorkspace:
                 if os.path.lexists(artifact.path):
                     descriptor = os.open(
                         artifact.path,
-                        os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+                        os.O_RDWR
+                        | getattr(os, "O_BINARY", 0)
+                        | getattr(os, "O_NOFOLLOW", 0),
                     )
                     try:
                         descriptor_info = os.fstat(descriptor)
@@ -1384,7 +1391,11 @@ class _BatchWorkspace:
 
 
 def _open_bound_artifact(artifact: _BatchArtifactGuard) -> int:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
     try:
         descriptor = os.open(artifact.path, flags)
     except OSError as error:

--- a/tests/test_relation_review.py
+++ b/tests/test_relation_review.py
@@ -1044,6 +1044,14 @@ def test_review_directory_parent_symlink_fails_closed(tmp_path: Path) -> None:
     assert exc.value.code == "RELATION_REVIEW_DIRECTORY_UNSAFE"
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows directory descriptor regression")
+def test_existing_review_directory_opens_on_windows(tmp_path: Path) -> None:
+    directory = tmp_path / "Knowledge Base/_Schema/relation-reviews"
+    directory.mkdir(parents=True)
+
+    assert relation_review.load_relation_reviews(tmp_path) == ()
+
+
 def test_auxiliary_traversal_and_final_symlink_fail_before_activation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_transactional_writes.py
+++ b/tests/test_transactional_writes.py
@@ -222,6 +222,62 @@ def test_batch_atomic_write_uses_private_workspaces_and_fans_out_once(
     assert not [path for path in tmp_path.iterdir() if path.name.endswith(".bak")]
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows binary-read regression")
+def test_batch_rollback_preserves_crlf_bytes_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    original = b"first\r\nold\r\n"
+    first.write_bytes(original)
+    second.write_bytes(b"second-old")
+    real_replace = os.replace
+    flips = 0
+
+    def fail_second_flip(src, dst, *args, **kwargs):
+        nonlocal flips
+        if _leaf(src).startswith("stage-"):
+            flips += 1
+            if flips == 2:
+                raise OSError("injected second flip failure")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(vault_module.os, "replace", fail_second_flip)
+
+    with pytest.raises(OSError, match="injected second flip failure"):
+        vault_module.batch_atomic_write(
+            [
+                vault_module.PlannedWrite(first, "first-new"),
+                vault_module.PlannedWrite(second, "second-new"),
+            ]
+        )
+
+    assert first.read_bytes() == original
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows binary-descriptor regression")
+def test_batch_pre_flip_failure_cleans_crlf_stage_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "target.md"
+    real_replace = os.replace
+
+    def fail_before_flip(src, dst, *args, **kwargs):
+        if _leaf(src).startswith("stage-"):
+            raise OSError("injected pre-flip failure")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(vault_module.os, "replace", fail_before_flip)
+
+    with pytest.raises(OSError, match="injected pre-flip failure"):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(target, "first\r\nsecond\r\n")]
+        )
+
+    assert not target.exists()
+    assert _workspaces(tmp_path) == []
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows directory-handle regression")
 def test_batch_atomic_write_replaces_and_creates_on_windows(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -137,6 +137,17 @@ def test_path_guards_share_new_parent_chain_safely(tmp_path: Path) -> None:
     assert [path.read_text(encoding="utf-8") for path in paths] == ["one", "two"]
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows binary-read regression")
+def test_read_guarded_text_preserves_crlf_bytes_on_windows(tmp_path: Path) -> None:
+    target = tmp_path / "guarded.md"
+    target.write_bytes(b"first\r\nsecond\r\n")
+
+    text, guard = vault.read_guarded_text(tmp_path, target)
+
+    assert text == "first\r\nsecond\r\n"
+    guard.recheck(tmp_path)
+
+
 def test_missing_parent_swap_cannot_redirect_nested_directory_creation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed

- open exact-byte vault descriptors with Windows binary mode so CRLF bytes are never normalized during hashing, staging, rollback, or cleanup
- open relation-review directories through the guarded Win32 directory-handle path
- read relation-review artifacts in binary mode
- add Windows CRLF and existing-review-directory regressions

## Root cause

Windows CRT text mode normalized CRLF bytes read through `os.open`, producing false content-guard mismatches. Separately, raw CRT directory opens fail on Windows once the relation-review directory exists.

## Production impact

The hotfix is already running on the production Windows service. It restored governed writes, cleared the media queue after repairing five legacy ACL-contaminated sidecars, and preserved the CUDA-enabled runtime.

## Validation

- `43 passed` across the complete relation-review suite and focused Windows descriptor regressions
- Ruff clean on all five changed files
- independent production verification: local/public readiness green, media pending/running/blocked/failed all zero, governed preview/commit/read-back successful
