### PR TITLE
fix: keep doctor SQLite checks filesystem read-only

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -342,28 +342,28 @@ def _sqlite_companion_exists(companions: tuple[Path, Path]) -> bool:
 
 def _lexical_page_count(path: Path) -> int:
     companions = _sqlite_companions(path)
-    immutable = not _sqlite_companion_exists(companions)
-    identity: tuple[int, int, int, int] | None = None
-    if immutable:
-        identity = _sqlite_snapshot_identity(path)
-        with path.open("rb") as stream:
-            if not stream.read(1):
-                raise OSError("lexical sidecar is empty")
-        if (
-            _sqlite_snapshot_identity(path) != identity
-            or _sqlite_companion_exists(companions)
-        ):
-            raise OSError("lexical sidecar is not a stable standalone snapshot")
+    if _sqlite_companion_exists(companions):
+        raise OSError("lexical sidecar has live SQLite companions")
+    identity = _sqlite_snapshot_identity(path)
+    with path.open("rb") as stream:
+        if not stream.read(1):
+            raise OSError("lexical sidecar is empty")
+    if (
+        _sqlite_snapshot_identity(path) != identity
+        or _sqlite_companion_exists(companions)
+    ):
+        raise OSError("lexical sidecar is not a stable standalone snapshot")
 
-    query = "mode=ro&immutable=1" if immutable else "mode=ro"
-    conn = sqlite3.connect(f"{path.resolve().as_uri()}?{query}", uri=True)
+    conn = sqlite3.connect(
+        f"{path.resolve().as_uri()}?mode=ro&immutable=1", uri=True
+    )
     try:
         conn.execute("PRAGMA query_only = ON")
         count = int(conn.execute("SELECT count(*) FROM pages").fetchone()[0])
     finally:
         conn.close()
 
-    if immutable and (
+    if (
         _sqlite_snapshot_identity(path) != identity
         or _sqlite_companion_exists(companions)
     ):

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -326,6 +326,51 @@ def _check_resource_posture(profile: Profile) -> DoctorCheck:
         details=posture,
     )
 
+
+def _sqlite_snapshot_identity(path: Path) -> tuple[int, int, int, int]:
+    info = path.stat()
+    return info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns
+
+
+def _sqlite_companions(path: Path) -> tuple[Path, Path]:
+    return path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm")
+
+
+def _sqlite_companion_exists(companions: tuple[Path, Path]) -> bool:
+    return any(os.path.lexists(item) for item in companions)
+
+
+def _lexical_page_count(path: Path) -> int:
+    companions = _sqlite_companions(path)
+    immutable = not _sqlite_companion_exists(companions)
+    identity: tuple[int, int, int, int] | None = None
+    if immutable:
+        identity = _sqlite_snapshot_identity(path)
+        with path.open("rb") as stream:
+            if not stream.read(1):
+                raise OSError("lexical sidecar is empty")
+        if (
+            _sqlite_snapshot_identity(path) != identity
+            or _sqlite_companion_exists(companions)
+        ):
+            raise OSError("lexical sidecar is not a stable standalone snapshot")
+
+    query = "mode=ro&immutable=1" if immutable else "mode=ro"
+    conn = sqlite3.connect(f"{path.resolve().as_uri()}?{query}", uri=True)
+    try:
+        conn.execute("PRAGMA query_only = ON")
+        count = int(conn.execute("SELECT count(*) FROM pages").fetchone()[0])
+    finally:
+        conn.close()
+
+    if immutable and (
+        _sqlite_snapshot_identity(path) != identity
+        or _sqlite_companion_exists(companions)
+    ):
+        raise OSError("lexical sidecar changed during diagnostic snapshot")
+    return count
+
+
 def _check_lexical(vault_root: Path | None) -> DoctorCheck:
     """Lexical FTS5 backend availability + sidecar health.
 
@@ -362,13 +407,8 @@ def _check_lexical(vault_root: Path | None) -> DoctorCheck:
             "on first search (or by warm-up).",
         )
     try:
-        conn = sqlite3.connect(f"{side.resolve().as_uri()}?mode=ro", uri=True)
-        try:
-            conn.execute("PRAGMA query_only = ON")
-            n = conn.execute("SELECT count(*) FROM pages").fetchone()[0]
-        finally:
-            conn.close()
-    except sqlite3.Error as e:
+        n = _lexical_page_count(side)
+    except (OSError, sqlite3.Error) as e:
         return _check(
             "dep.fts5-lexical",
             "warn",

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -362,8 +362,9 @@ def _check_lexical(vault_root: Path | None) -> DoctorCheck:
             "on first search (or by warm-up).",
         )
     try:
-        conn = sqlite3.connect(side)
+        conn = sqlite3.connect(f"{side.resolve().as_uri()}?mode=ro", uri=True)
         try:
+            conn.execute("PRAGMA query_only = ON")
             n = conn.execute("SELECT count(*) FROM pages").fetchone()[0]
         finally:
             conn.close()
@@ -561,7 +562,7 @@ def _check_media_runtime(vault_root: Path | None) -> DoctorCheck | None:
         return None
     from . import media_jobs
 
-    status = media_jobs.status(vault_root)
+    status = media_jobs.status(vault_root, diagnostic_snapshot=True)
     if not status["healthy"]:
         return _check(
             "media.runtime",

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -517,7 +517,72 @@ class MediaJobStore:
         )
 
 
-def status(vault_root: Path | None) -> dict[str, Any]:
+def _read_status_rows(
+    conn: sqlite3.Connection,
+) -> tuple[list[Any], Any, list[Any], list[Any]]:
+    rows = conn.execute("SELECT state, count(*) AS n FROM jobs GROUP BY state").fetchall()
+    runtime = conn.execute(
+        "SELECT worker_pid, idle_seconds FROM runtime WHERE singleton = 1"
+    ).fetchone()
+    errors = conn.execute(
+        "SELECT state, last_error FROM jobs "
+        "WHERE state IN ('blocked', 'failed') ORDER BY updated_at DESC LIMIT 5"
+    ).fetchall()
+    jobs = conn.execute(
+        "SELECT id, binary_rel, sidecar_rel, media_type, state, attempts, last_error "
+        "FROM jobs ORDER BY updated_at DESC, id DESC LIMIT ?",
+        (STATUS_JOB_LIMIT,),
+    ).fetchall()
+    return rows, runtime, errors, jobs
+
+
+def _sqlite_file_identity(path: Path) -> tuple[int, int, int, int]:
+    info = path.stat()
+    return info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns
+
+
+def _sqlite_sidecars(path: Path) -> tuple[Path, Path]:
+    return path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm")
+
+
+def _sqlite_sidecar_exists(sidecars: tuple[Path, Path]) -> bool:
+    return any(os.path.lexists(item) for item in sidecars)
+
+
+def _diagnostic_snapshot_rows(
+    path: Path,
+) -> tuple[list[Any], Any, list[Any], list[Any]]:
+    identity = _sqlite_file_identity(path)
+    with path.open("rb") as stream:
+        if not stream.read(1):
+            raise OSError("media job database is empty")
+    sidecars = _sqlite_sidecars(path)
+    if _sqlite_file_identity(path) != identity or _sqlite_sidecar_exists(sidecars):
+        raise OSError("media job database is not a stable standalone snapshot")
+
+    uri = f"{path.resolve().as_uri()}?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True, timeout=5.0)
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only = ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        result = _read_status_rows(conn)
+    finally:
+        conn.close()
+
+    if _sqlite_file_identity(path) != identity or _sqlite_sidecar_exists(sidecars):
+        raise OSError("media job database changed during diagnostic snapshot")
+    return result
+
+
+def _is_sqlite_cantopen(error: sqlite3.Error) -> bool:
+    code = getattr(error, "sqlite_errorcode", None)
+    return isinstance(code, int) and code & 0xFF == sqlite3.SQLITE_CANTOPEN
+
+
+def status(
+    vault_root: Path | None, *, diagnostic_snapshot: bool = False
+) -> dict[str, Any]:
     """Read ledger state without creating a DB or importing model modules."""
     empty = {
         "store": "missing",
@@ -536,23 +601,16 @@ def status(vault_root: Path | None) -> dict[str, Any]:
         return empty
     try:
         store = MediaJobStore(vault_root, create=False)
-        conn = store._connect(readonly=True)
         try:
-            rows = conn.execute("SELECT state, count(*) AS n FROM jobs GROUP BY state").fetchall()
-            runtime = conn.execute(
-                "SELECT worker_pid, idle_seconds FROM runtime WHERE singleton = 1"
-            ).fetchone()
-            errors = conn.execute(
-                "SELECT state, last_error FROM jobs "
-                "WHERE state IN ('blocked', 'failed') ORDER BY updated_at DESC LIMIT 5"
-            ).fetchall()
-            jobs = conn.execute(
-                "SELECT id, binary_rel, sidecar_rel, media_type, state, attempts, last_error "
-                "FROM jobs ORDER BY updated_at DESC, id DESC LIMIT ?",
-                (STATUS_JOB_LIMIT,),
-            ).fetchall()
-        finally:
-            conn.close()
+            conn = store._connect(readonly=True)
+            try:
+                rows, runtime, errors, jobs = _read_status_rows(conn)
+            finally:
+                conn.close()
+        except sqlite3.Error as error:
+            if not diagnostic_snapshot or not _is_sqlite_cantopen(error):
+                raise
+            rows, runtime, errors, jobs = _diagnostic_snapshot_rows(path)
         counts = {state: 0 for state in STATES}
         counts.update({str(row["state"]): int(row["n"]) for row in rows})
         pid = int(runtime["worker_pid"]) if runtime and runtime["worker_pid"] else None

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -102,7 +102,9 @@ class MediaJobStore:
 
     def _connect(self, *, readonly: bool = False) -> sqlite3.Connection:
         if readonly:
-            conn = sqlite3.connect(f"file:{self.path}?mode=ro", uri=True, timeout=5.0)
+            conn = sqlite3.connect(
+                f"{self.path.resolve().as_uri()}?mode=ro", uri=True, timeout=5.0
+            )
         else:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             conn = sqlite3.connect(self.path, timeout=5.0)

--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -554,11 +554,13 @@ def _sqlite_sidecar_exists(sidecars: tuple[Path, Path]) -> bool:
 def _diagnostic_snapshot_rows(
     path: Path,
 ) -> tuple[list[Any], Any, list[Any], list[Any]]:
+    sidecars = _sqlite_sidecars(path)
+    if _sqlite_sidecar_exists(sidecars):
+        raise OSError("media job database has live SQLite companions")
     identity = _sqlite_file_identity(path)
     with path.open("rb") as stream:
         if not stream.read(1):
             raise OSError("media job database is empty")
-    sidecars = _sqlite_sidecars(path)
     if _sqlite_file_identity(path) != identity or _sqlite_sidecar_exists(sidecars):
         raise OSError("media job database is not a stable standalone snapshot")
 
@@ -575,11 +577,6 @@ def _diagnostic_snapshot_rows(
     if _sqlite_file_identity(path) != identity or _sqlite_sidecar_exists(sidecars):
         raise OSError("media job database changed during diagnostic snapshot")
     return result
-
-
-def _is_sqlite_cantopen(error: sqlite3.Error) -> bool:
-    code = getattr(error, "sqlite_errorcode", None)
-    return isinstance(code, int) and code & 0xFF == sqlite3.SQLITE_CANTOPEN
 
 
 def status(
@@ -602,17 +599,15 @@ def status(
     if not path.exists():
         return empty
     try:
-        store = MediaJobStore(vault_root, create=False)
-        try:
+        if diagnostic_snapshot:
+            rows, runtime, errors, jobs = _diagnostic_snapshot_rows(path)
+        else:
+            store = MediaJobStore(vault_root, create=False)
             conn = store._connect(readonly=True)
             try:
                 rows, runtime, errors, jobs = _read_status_rows(conn)
             finally:
                 conn.close()
-        except sqlite3.Error as error:
-            if not diagnostic_snapshot or not _is_sqlite_cantopen(error):
-                raise
-            rows, runtime, errors, jobs = _diagnostic_snapshot_rows(path)
         counts = {state: 0 for state in STATES}
         counts.update({str(row["state"]): int(row["n"]) for row in rows})
         pid = int(runtime["worker_pid"]) if runtime and runtime["worker_pid"] else None

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -114,40 +114,51 @@ def test_lexical_check_reads_clean_wal_database_without_creating_sidecars(
     assert not shm.exists()
 
 
-def test_lexical_check_uses_live_readonly_connection_when_wal_sidecars_exist(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "live_suffixes",
+    [("-wal",), ("-shm",), ("-wal", "-shm")],
+)
+def test_lexical_check_refuses_live_sqlite_companions_without_connecting(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    live_suffixes: tuple[str, ...],
 ) -> None:
     from exomem import lexstore
 
     sidecar = lexstore.lexical_path(vault)
-    writer = sqlite3.connect(sidecar)
-    real_connect = sqlite3.connect
+    conn = sqlite3.connect(sidecar)
     try:
-        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
-        writer.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
-        writer.execute("INSERT INTO pages DEFAULT VALUES")
-        writer.commit()
-        wal = sidecar.with_name(f"{sidecar.name}-wal")
-        shm = sidecar.with_name(f"{sidecar.name}-shm")
-        assert wal.exists()
-        assert shm.exists()
-        connections: list[str] = []
-
-        def record_connect(database, *args, **kwargs):
-            connections.append(str(database))
-            return real_connect(database, *args, **kwargs)
-
-        monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
-        monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
-        monkeypatch.setattr(doctor_module.sqlite3, "connect", record_connect)
-
-        check = doctor_module._check_lexical(vault)
-
-        assert check.status == "pass"
-        assert "1 pages indexed" in check.message
-        assert connections == [f"{sidecar.resolve().as_uri()}?mode=ro"]
+        conn.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        conn.commit()
     finally:
-        writer.close()
+        conn.close()
+    companions = [sidecar.with_name(f"{sidecar.name}{suffix}") for suffix in live_suffixes]
+    for index, companion in enumerate(companions):
+        companion.write_bytes(f"live-{index}".encode())
+    before = {
+        companion: (companion.read_bytes(), companion.stat()) for companion in companions
+    }
+
+    def reject_connect(*_args, **_kwargs):
+        pytest.fail("doctor must not sqlite-connect while WAL/SHM exists")
+
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+    monkeypatch.setattr(doctor_module.sqlite3, "connect", reject_connect)
+
+    check = doctor_module._check_lexical(vault)
+
+    assert check.status == "warn"
+    assert "unreadable" in check.message
+    for companion, (content, info) in before.items():
+        after = companion.stat()
+        assert companion.read_bytes() == content
+        assert (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) == (
+            info.st_dev,
+            info.st_ino,
+            info.st_size,
+            info.st_mtime_ns,
+        )
 
 
 @pytest.mark.parametrize("change", ["wal", "identity"])

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -45,7 +45,7 @@ def test_doctor_lean_passes_with_fixture_vault(vault: Path) -> None:
     assert checks["command.registry"].status == "pass"
 
 
-def test_lexical_check_uses_escaped_readonly_query_only_connection(
+def test_lexical_check_uses_escaped_immutable_query_only_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from exomem import lexstore
@@ -78,9 +78,125 @@ def test_lexical_check_uses_escaped_readonly_query_only_connection(
 
     assert check.status == "pass"
     [(database, kwargs)] = connections
-    assert database == f"{sidecar.resolve().as_uri()}?mode=ro"
+    assert database == f"{sidecar.resolve().as_uri()}?mode=ro&immutable=1"
     assert kwargs["uri"] is True
     assert any(statement.upper().startswith("PRAGMA QUERY_ONLY") for statement in statements)
+
+
+def test_lexical_check_reads_clean_wal_database_without_creating_sidecars(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import lexstore
+
+    sidecar = lexstore.lexical_path(vault)
+    conn = sqlite3.connect(sidecar)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        conn.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO pages DEFAULT VALUES")
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        conn.close()
+    wal = sidecar.with_name(f"{sidecar.name}-wal")
+    shm = sidecar.with_name(f"{sidecar.name}-shm")
+    assert not wal.exists()
+    assert not shm.exists()
+
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+
+    check = doctor_module._check_lexical(vault)
+
+    assert check.status == "pass"
+    assert "1 pages indexed" in check.message
+    assert not wal.exists()
+    assert not shm.exists()
+
+
+def test_lexical_check_uses_live_readonly_connection_when_wal_sidecars_exist(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import lexstore
+
+    sidecar = lexstore.lexical_path(vault)
+    writer = sqlite3.connect(sidecar)
+    real_connect = sqlite3.connect
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        writer.execute("INSERT INTO pages DEFAULT VALUES")
+        writer.commit()
+        wal = sidecar.with_name(f"{sidecar.name}-wal")
+        shm = sidecar.with_name(f"{sidecar.name}-shm")
+        assert wal.exists()
+        assert shm.exists()
+        connections: list[str] = []
+
+        def record_connect(database, *args, **kwargs):
+            connections.append(str(database))
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+        monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+        monkeypatch.setattr(doctor_module.sqlite3, "connect", record_connect)
+
+        check = doctor_module._check_lexical(vault)
+
+        assert check.status == "pass"
+        assert "1 pages indexed" in check.message
+        assert connections == [f"{sidecar.resolve().as_uri()}?mode=ro"]
+    finally:
+        writer.close()
+
+
+@pytest.mark.parametrize("change", ["wal", "identity"])
+def test_lexical_immutable_snapshot_refuses_state_change_during_query(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, change: str
+) -> None:
+    from exomem import lexstore
+
+    sidecar = lexstore.lexical_path(vault)
+    conn = sqlite3.connect(sidecar)
+    try:
+        conn.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+    wal = sidecar.with_name(f"{sidecar.name}-wal")
+    real_connect = sqlite3.connect
+
+    class ChangingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+        def execute(self, statement: str, *args, **kwargs):
+            result = self.connection.execute(statement, *args, **kwargs)
+            if statement.startswith("SELECT count"):
+                if change == "wal":
+                    wal.write_bytes(b"appeared during snapshot")
+                else:
+                    info = sidecar.stat()
+                    os.utime(
+                        sidecar,
+                        ns=(info.st_atime_ns, info.st_mtime_ns + 1_000_000_000),
+                    )
+            return result
+
+    def changing_connect(database, *args, **kwargs):
+        return ChangingConnection(real_connect(database, *args, **kwargs))
+
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+    monkeypatch.setattr(doctor_module.sqlite3, "connect", changing_connect)
+
+    check = doctor_module._check_lexical(vault)
+
+    assert check.status == "warn"
+    assert "unreadable" in check.message
 
 
 def test_media_runtime_requests_diagnostic_snapshot(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sqlite3
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,6 +43,66 @@ def test_doctor_lean_passes_with_fixture_vault(vault: Path) -> None:
     assert checks["python.version"].status == "pass"
     assert checks["vault.path"].status == "pass"
     assert checks["command.registry"].status == "pass"
+
+
+def test_lexical_check_uses_escaped_readonly_query_only_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import lexstore
+
+    vault = tmp_path / "vault #% name"
+    sidecar = lexstore.lexical_path(vault)
+    sidecar.parent.mkdir(parents=True)
+    conn = sqlite3.connect(sidecar)
+    try:
+        conn.execute("CREATE TABLE pages (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    real_connect = sqlite3.connect
+    connections: list[tuple[object, dict[str, object]]] = []
+    statements: list[str] = []
+
+    def traced_connect(database, *args, **kwargs):
+        connections.append((database, kwargs.copy()))
+        opened = real_connect(database, *args, **kwargs)
+        opened.set_trace_callback(statements.append)
+        return opened
+
+    monkeypatch.setattr(lexstore, "backend", lambda: "fts5")
+    monkeypatch.setattr(lexstore, "fts5_available", lambda: True)
+    monkeypatch.setattr(doctor_module.sqlite3, "connect", traced_connect)
+
+    check = doctor_module._check_lexical(vault)
+
+    assert check.status == "pass"
+    [(database, kwargs)] = connections
+    assert database == f"{sidecar.resolve().as_uri()}?mode=ro"
+    assert kwargs["uri"] is True
+    assert any(statement.upper().startswith("PRAGMA QUERY_ONLY") for statement in statements)
+
+
+def test_media_runtime_requests_diagnostic_snapshot(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import media_jobs
+
+    calls: list[bool] = []
+
+    def fake_status(_vault: Path, *, diagnostic_snapshot: bool = False):
+        calls.append(diagnostic_snapshot)
+        return {
+            "healthy": True,
+            "counts": {state: 0 for state in media_jobs.STATES},
+        }
+
+    monkeypatch.setattr(media_jobs, "status", fake_status)
+
+    check = doctor_module._check_media_runtime(vault)
+
+    assert check is not None and check.status == "pass"
+    assert calls == [True]
 
 
 def test_doctor_json_cli(vault: Path, capsys) -> None:

--- a/tests/test_media_jobs.py
+++ b/tests/test_media_jobs.py
@@ -46,6 +46,29 @@ def test_status_does_not_create_store(vault: Path) -> None:
     assert not path.exists()
 
 
+def test_readonly_connection_uses_percent_safe_sqlite_uri(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault #% üll"
+    store = media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    real_connect = sqlite3.connect
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def capture_connect(database, *args, **kwargs):
+        calls.append((database, kwargs.copy()))
+        return real_connect(path)
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", capture_connect)
+
+    conn = store._connect(readonly=True)
+    conn.close()
+
+    [(database, kwargs)] = calls
+    assert database == f"{path.resolve().as_uri()}?mode=ro"
+    assert kwargs["uri"] is True
+
+
 def test_status_diagnostic_snapshot_falls_back_to_stable_immutable_database(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -173,6 +196,41 @@ def test_diagnostic_snapshot_refuses_identity_drift_after_immutable_queries(
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is False
+
+
+def test_diagnostic_snapshot_refuses_sidecar_created_during_immutable_query(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    wal = path.with_name(f"{path.name}-wal")
+    real_connect = sqlite3.connect
+
+    class SidecarCreatingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+        def execute(self, statement: str, *args, **kwargs):
+            result = self.connection.execute(statement, *args, **kwargs)
+            if statement.startswith("SELECT state, count"):
+                wal.write_bytes(b"appeared during snapshot")
+            return result
+
+    def cantopen_then_create_sidecar(database, *args, **kwargs):
+        uri = str(database)
+        if "mode=ro" in uri and "immutable=1" not in uri:
+            raise _cantopen()
+        return SidecarCreatingConnection(real_connect(database, *args, **kwargs))
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_then_create_sidecar)
+
+    snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
+
+    assert snapshot["healthy"] is False
+    assert wal.exists()
 
 
 def test_pid_alive_handles_current_and_missing_processes() -> None:

--- a/tests/test_media_jobs.py
+++ b/tests/test_media_jobs.py
@@ -69,7 +69,7 @@ def test_readonly_connection_uses_percent_safe_sqlite_uri(
     assert kwargs["uri"] is True
 
 
-def test_status_diagnostic_snapshot_falls_back_to_stable_immutable_database(
+def test_status_diagnostic_snapshot_uses_only_stable_immutable_database(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     media_jobs.MediaJobStore(vault)
@@ -77,21 +77,18 @@ def test_status_diagnostic_snapshot_falls_back_to_stable_immutable_database(
     real_connect = sqlite3.connect
     calls: list[str] = []
 
-    def cantopen_readonly(database, *args, **kwargs):
+    def record_connect(database, *args, **kwargs):
         uri = str(database)
         calls.append(uri)
-        if "mode=ro" in uri and "immutable=1" not in uri:
-            raise _cantopen()
         return real_connect(database, *args, **kwargs)
 
-    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_readonly)
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", record_connect)
 
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is True
-    assert len(calls) == 2
-    assert "mode=ro" in calls[0] and "immutable=1" not in calls[0]
-    assert "mode=ro" in calls[1] and "immutable=1" in calls[1]
+    assert len(calls) == 1
+    assert "mode=ro" in calls[0] and "immutable=1" in calls[0]
     assert not path.with_name(f"{path.name}-wal").exists()
     assert not path.with_name(f"{path.name}-shm").exists()
 
@@ -125,7 +122,9 @@ def test_diagnostic_snapshot_refuses_immutable_with_live_sqlite_sidecar(
 ) -> None:
     media_jobs.MediaJobStore(vault)
     path = media_jobs.job_store_path(vault)
-    path.with_name(f"{path.name}{live_suffix}").write_bytes(b"live")
+    companion = path.with_name(f"{path.name}{live_suffix}")
+    companion.write_bytes(b"live")
+    before = companion.read_bytes(), companion.stat()
     calls: list[str] = []
 
     def cantopen_readonly(database, *args, **kwargs):
@@ -137,7 +136,16 @@ def test_diagnostic_snapshot_refuses_immutable_with_live_sqlite_sidecar(
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is False
-    assert len(calls) == 1
+    assert calls == []
+    content, info = before
+    after = companion.stat()
+    assert companion.read_bytes() == content
+    assert (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) == (
+        info.st_dev,
+        info.st_ino,
+        info.st_size,
+        info.st_mtime_ns,
+    )
 
 
 def test_diagnostic_snapshot_refuses_immutable_when_main_database_is_not_readable(
@@ -163,7 +171,7 @@ def test_diagnostic_snapshot_refuses_immutable_when_main_database_is_not_readabl
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is False
-    assert len(calls) == 1
+    assert calls == []
 
 
 def test_diagnostic_snapshot_refuses_identity_drift_after_immutable_queries(
@@ -185,17 +193,18 @@ def test_diagnostic_snapshot_refuses_identity_drift_after_immutable_queries(
             with path.open("ab") as stream:
                 stream.write(b"drift")
 
-    def cantopen_then_drift(database, *args, **kwargs):
-        uri = str(database)
-        if "mode=ro" in uri and "immutable=1" not in uri:
-            raise _cantopen()
+    calls: list[str] = []
+
+    def immutable_then_drift(database, *args, **kwargs):
+        calls.append(str(database))
         return DriftingConnection(real_connect(database, *args, **kwargs))
 
-    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_then_drift)
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", immutable_then_drift)
 
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is False
+    assert len(calls) == 1 and "immutable=1" in calls[0]
 
 
 def test_diagnostic_snapshot_refuses_sidecar_created_during_immutable_query(
@@ -219,18 +228,19 @@ def test_diagnostic_snapshot_refuses_sidecar_created_during_immutable_query(
                 wal.write_bytes(b"appeared during snapshot")
             return result
 
-    def cantopen_then_create_sidecar(database, *args, **kwargs):
-        uri = str(database)
-        if "mode=ro" in uri and "immutable=1" not in uri:
-            raise _cantopen()
+    calls: list[str] = []
+
+    def immutable_then_create_sidecar(database, *args, **kwargs):
+        calls.append(str(database))
         return SidecarCreatingConnection(real_connect(database, *args, **kwargs))
 
-    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_then_create_sidecar)
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", immutable_then_create_sidecar)
 
     snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
 
     assert snapshot["healthy"] is False
     assert wal.exists()
+    assert len(calls) == 1 and "immutable=1" in calls[0]
 
 
 def test_pid_alive_handles_current_and_missing_processes() -> None:

--- a/tests/test_media_jobs.py
+++ b/tests/test_media_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -8,6 +9,12 @@ import pytest
 
 from exomem import media_jobs
 from exomem.media_worker_child import _VaultLock
+
+
+def _cantopen() -> sqlite3.OperationalError:
+    error = sqlite3.OperationalError("unable to open database file")
+    error.sqlite_errorcode = sqlite3.SQLITE_CANTOPEN
+    return error
 
 
 def _job(
@@ -37,6 +44,135 @@ def test_status_does_not_create_store(vault: Path) -> None:
     status = media_jobs.status(vault)
     assert status["counts"]["pending"] == 0
     assert not path.exists()
+
+
+def test_status_diagnostic_snapshot_falls_back_to_stable_immutable_database(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    real_connect = sqlite3.connect
+    calls: list[str] = []
+
+    def cantopen_readonly(database, *args, **kwargs):
+        uri = str(database)
+        calls.append(uri)
+        if "mode=ro" in uri and "immutable=1" not in uri:
+            raise _cantopen()
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_readonly)
+
+    snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
+
+    assert snapshot["healthy"] is True
+    assert len(calls) == 2
+    assert "mode=ro" in calls[0] and "immutable=1" not in calls[0]
+    assert "mode=ro" in calls[1] and "immutable=1" in calls[1]
+    assert not path.with_name(f"{path.name}-wal").exists()
+    assert not path.with_name(f"{path.name}-shm").exists()
+
+
+def test_normal_status_does_not_use_immutable_fallback(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    real_connect = sqlite3.connect
+    calls: list[str] = []
+
+    def cantopen_readonly(database, *args, **kwargs):
+        uri = str(database)
+        calls.append(uri)
+        if "mode=ro" in uri:
+            raise _cantopen()
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_readonly)
+
+    snapshot = media_jobs.status(vault)
+
+    assert snapshot["healthy"] is False
+    assert len(calls) == 1
+    assert "immutable=1" not in calls[0]
+
+
+@pytest.mark.parametrize("live_suffix", ["-wal", "-shm"])
+def test_diagnostic_snapshot_refuses_immutable_with_live_sqlite_sidecar(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, live_suffix: str
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    path.with_name(f"{path.name}{live_suffix}").write_bytes(b"live")
+    calls: list[str] = []
+
+    def cantopen_readonly(database, *args, **kwargs):
+        calls.append(str(database))
+        raise _cantopen()
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_readonly)
+
+    snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
+
+    assert snapshot["healthy"] is False
+    assert len(calls) == 1
+
+
+def test_diagnostic_snapshot_refuses_immutable_when_main_database_is_not_readable(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    real_open = Path.open
+    calls: list[str] = []
+
+    def cantopen_readonly(database, *args, **kwargs):
+        calls.append(str(database))
+        raise _cantopen()
+
+    def deny_main_database(self: Path, *args, **kwargs):
+        if self == path and args and args[0] == "rb":
+            raise PermissionError("database bytes denied")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_readonly)
+    monkeypatch.setattr(Path, "open", deny_main_database)
+
+    snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
+
+    assert snapshot["healthy"] is False
+    assert len(calls) == 1
+
+
+def test_diagnostic_snapshot_refuses_identity_drift_after_immutable_queries(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_jobs.MediaJobStore(vault)
+    path = media_jobs.job_store_path(vault)
+    real_connect = sqlite3.connect
+
+    class DriftingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+        def close(self) -> None:
+            self.connection.close()
+            with path.open("ab") as stream:
+                stream.write(b"drift")
+
+    def cantopen_then_drift(database, *args, **kwargs):
+        uri = str(database)
+        if "mode=ro" in uri and "immutable=1" not in uri:
+            raise _cantopen()
+        return DriftingConnection(real_connect(database, *args, **kwargs))
+
+    monkeypatch.setattr(media_jobs.sqlite3, "connect", cantopen_then_drift)
+
+    snapshot = media_jobs.status(vault, diagnostic_snapshot=True)
+
+    assert snapshot["healthy"] is False
 
 
 def test_pid_alive_handles_current_and_missing_processes() -> None:


### PR DESCRIPTION
## What changed

- make lexical doctor checks use guarded, filesystem-read-only SQLite snapshots
- make media doctor diagnostics bypass WAL-aware connections and use guarded immutable snapshots only when the database is standalone
- percent-encode Windows SQLite read-only URIs
- preserve normal live `media_jobs.status()` behavior

## Root cause

Doctor was documented read-only but its lexical probe opened SQLite read-write, while WAL-mode read-only connections can still create or update `-wal`/`-shm` files. RX-only diagnostic tokens therefore saw false `unable to open database file` warnings even when the databases were byte-readable and the live service was healthy.

## Safety

Doctor refuses live WAL/SHM state without opening SQLite. Standalone snapshots require stable file identity and no companions both before and after the query. Mid-query drift is rejected.

## Verification

- `uv run pytest tests/test_doctor.py tests/test_media_jobs.py -q` — 56 passed, 1 skipped
- `uvx ruff check src/exomem/doctor.py src/exomem/media_jobs.py tests/test_doctor.py tests/test_media_jobs.py` — clean
- independent review — no Critical or Important findings