### PR TITLE
fix: make deferred embedding replay durable

### DIFF
--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -84,7 +84,13 @@ def add_receipts(vault_root: Path, rel_paths: list[str]) -> list[DeferredReceipt
 def _add_receipts(
     vault_root: Path, rel_paths: list[str]
 ) -> tuple[list[DeferredReceipt], int]:
-    rels = sorted({rel.replace("\\", "/") for rel in rel_paths if rel.endswith(".md")})
+    rels = sorted(
+        {
+            rel.replace("\\", "/")
+            for rel in rel_paths
+            if rel.lower().endswith(".md")
+        }
+    )
     if not rels:
         return [], 0
     now = time.time()
@@ -173,7 +179,12 @@ def snapshot(
         return []
     conn = _connect(vault_root, create=False)
     try:
-        sql = "SELECT rel_path, revision FROM semantic_upserts ORDER BY rel_path"
+        columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(semantic_upserts)")
+        }
+        revision = "revision" if "revision" in columns else "1 AS revision"
+        sql = f"SELECT rel_path, {revision} FROM semantic_upserts ORDER BY rel_path"
         params: tuple[Any, ...] = ()
         if limit is not None:
             sql += " LIMIT ?"

--- a/src/exomem/deferred_index.py
+++ b/src/exomem/deferred_index.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import sqlite3
+import tempfile
 import time
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +22,9 @@ def store_path(vault_root: Path) -> Path:
 def _connect(vault_root: Path, *, create: bool) -> sqlite3.Connection:
     path = store_path(vault_root)
     if not create:
-        return sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5.0)
+        return sqlite3.connect(
+            f"{path.resolve().as_uri()}?mode=ro", uri=True, timeout=5.0
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=5.0)
     conn.execute("PRAGMA journal_mode=WAL")
@@ -27,7 +34,8 @@ def _connect(vault_root: Path, *, create: bool) -> sqlite3.Connection:
         CREATE TABLE IF NOT EXISTS semantic_upserts (
             rel_path TEXT PRIMARY KEY,
             created_at REAL NOT NULL,
-            updated_at REAL NOT NULL
+            updated_at REAL NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 1
         )
         """
     )
@@ -40,11 +48,80 @@ def _connect(vault_root: Path, *, create: bool) -> sqlite3.Connection:
         )
         """
     )
+    columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(semantic_upserts)")
+    }
+    if "revision" not in columns:
+        conn.execute(
+            "ALTER TABLE semantic_upserts "
+            "ADD COLUMN revision INTEGER NOT NULL DEFAULT 1"
+        )
     return conn
 
 
+@dataclass(frozen=True, slots=True)
+class DeferredReceipt:
+    rel_path: str
+    revision: int
+
+
+class EmbeddingFreshness(StrEnum):
+    CURRENT = "current"
+    STALE = "stale"
+    UNVERIFIABLE = "unverifiable"
+
+
 def add(vault_root: Path, rel_paths: list[str]) -> int:
-    return _add(vault_root, rel_paths, table="semantic_upserts")
+    _receipts, added = _add_receipts(vault_root, rel_paths)
+    return added
+
+
+def add_receipts(vault_root: Path, rel_paths: list[str]) -> list[DeferredReceipt]:
+    receipts, _added = _add_receipts(vault_root, rel_paths)
+    return receipts
+
+
+def _add_receipts(
+    vault_root: Path, rel_paths: list[str]
+) -> tuple[list[DeferredReceipt], int]:
+    rels = sorted({rel.replace("\\", "/") for rel in rel_paths if rel.endswith(".md")})
+    if not rels:
+        return [], 0
+    now = time.time()
+    receipts: list[DeferredReceipt] = []
+    added = 0
+    conn = _connect(vault_root, create=True)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            for rel in rels:
+                row = conn.execute(
+                    "SELECT revision FROM semantic_upserts WHERE rel_path = ?",
+                    (rel,),
+                ).fetchone()
+                if row is None:
+                    revision = 1
+                    added += 1
+                    conn.execute(
+                        "INSERT INTO semantic_upserts"
+                        "(rel_path, created_at, updated_at, revision) VALUES (?, ?, ?, ?)",
+                        (rel, now, now, revision),
+                    )
+                else:
+                    revision = int(row[0]) + 1
+                    conn.execute(
+                        "UPDATE semantic_upserts SET updated_at = ?, revision = ? "
+                        "WHERE rel_path = ?",
+                        (now, revision, rel),
+                    )
+                receipts.append(DeferredReceipt(rel, revision))
+        except Exception:
+            conn.rollback()
+            raise
+        conn.commit()
+        return receipts, added
+    finally:
+        conn.close()
 
 
 def add_full(vault_root: Path, rel_paths: list[str]) -> int:
@@ -86,6 +163,45 @@ def list_paths(vault_root: Path, *, limit: int | None = None) -> list[str]:
 
 def list_full_paths(vault_root: Path, *, limit: int | None = None) -> list[str]:
     return _list_paths(vault_root, table="full_upserts", limit=limit)
+
+
+def snapshot(
+    vault_root: Path, *, limit: int | None = None
+) -> list[DeferredReceipt]:
+    path = store_path(vault_root)
+    if not path.exists():
+        return []
+    conn = _connect(vault_root, create=False)
+    try:
+        sql = "SELECT rel_path, revision FROM semantic_upserts ORDER BY rel_path"
+        params: tuple[Any, ...] = ()
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (max(0, limit),)
+        return [
+            DeferredReceipt(str(row[0]), int(row[1]))
+            for row in conn.execute(sql, params).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def clear_receipts(vault_root: Path, receipts: list[DeferredReceipt]) -> int:
+    if not receipts or not store_path(vault_root).exists():
+        return 0
+    conn = _connect(vault_root, create=True)
+    try:
+        with conn:
+            changed = sum(
+                conn.execute(
+                    "DELETE FROM semantic_upserts WHERE rel_path = ? AND revision = ?",
+                    (receipt.rel_path, receipt.revision),
+                ).rowcount
+                for receipt in receipts
+            )
+        return int(changed)
+    finally:
+        conn.close()
 
 
 def _list_paths(
@@ -176,3 +292,117 @@ def _status(vault_root: Path | None, *, table: str) -> dict[str, Any]:
         }
     except (OSError, sqlite3.Error):
         return empty
+
+
+def _embedding_sidecar(vault_root: Path) -> Path:
+    return vault_root / kb_dirname() / ".embeddings.sqlite"
+
+
+def _file_identity(path: Path) -> tuple[int, int, int, int]:
+    info = path.stat()
+    return info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns
+
+
+def _sidecar_state(sidecar: Path) -> tuple[tuple[bool, tuple[int, int, int, int] | None], ...]:
+    paths = (
+        sidecar,
+        Path(f"{sidecar}-wal"),
+        Path(f"{sidecar}-shm"),
+        Path(f"{sidecar}-journal"),
+    )
+    state: list[tuple[bool, tuple[int, int, int, int] | None]] = []
+    for path in paths:
+        if os.path.lexists(path):
+            state.append((True, _file_identity(path)))
+        else:
+            state.append((False, None))
+    return tuple(state)
+
+
+def inspect_embedding_freshness(
+    vault_root: Path, rel_paths: list[str]
+) -> dict[str, EmbeddingFreshness]:
+    """Classify paths without importing or initializing the embedding stack."""
+    rels = sorted({rel.replace("\\", "/") for rel in rel_paths})
+    result = {rel: EmbeddingFreshness.UNVERIFIABLE for rel in rels}
+    if not rels:
+        return result
+    sidecar = _embedding_sidecar(vault_root)
+    if not sidecar.is_file():
+        return result
+    try:
+        before_sidecar = _sidecar_state(sidecar)
+        wal_exists = before_sidecar[1][0]
+        shm_exists = before_sidecar[2][0]
+        rollback_journal_exists = before_sidecar[3][0]
+        if wal_exists != shm_exists or rollback_journal_exists:
+            return result
+        disk_mtimes: dict[str, float] = {}
+        disk_identities: dict[str, tuple[int, int, int, int]] = {}
+        for rel in rels:
+            path = vault_root / rel
+            try:
+                disk_identities[rel] = _file_identity(path)
+                disk_mtimes[rel] = path.stat().st_mtime
+            except OSError:
+                continue
+        query_sidecar = sidecar
+        snapshot_dir = None
+        query = "mode=ro&immutable=1"
+        if wal_exists:
+            # SQLite's WAL reader mutates lock bytes in the source -shm even for a
+            # mode=ro connection. Query a private byte-for-byte snapshot instead.
+            snapshot_dir = tempfile.TemporaryDirectory(
+                prefix="exomem-embedding-read-"
+            )
+            query_sidecar = Path(snapshot_dir.name) / sidecar.name
+            for source in (
+                sidecar,
+                Path(f"{sidecar}-wal"),
+                Path(f"{sidecar}-shm"),
+            ):
+                shutil.copyfile(
+                    source,
+                    Path(snapshot_dir.name) / source.name,
+                )
+            query = "mode=ro"
+        conn = sqlite3.connect(
+            f"{query_sidecar.resolve().as_uri()}?{query}",
+            uri=True,
+            timeout=0.0,
+        )
+        try:
+            conn.execute("PRAGMA query_only = ON")
+            conn.execute("PRAGMA busy_timeout=0")
+            stored: dict[str, float] = {}
+            for offset in range(0, len(rels), 400):
+                batch = rels[offset : offset + 400]
+                rows = conn.execute(
+                    "SELECT file_path, MAX(file_mtime) FROM chunks "
+                    f"WHERE file_path IN ({','.join('?' for _ in batch)}) "
+                    "GROUP BY file_path",
+                    batch,
+                ).fetchall()
+                stored.update({str(row[0]): float(row[1]) for row in rows})
+        finally:
+            conn.close()
+            if snapshot_dir is not None:
+                snapshot_dir.cleanup()
+        if _sidecar_state(sidecar) != before_sidecar:
+            return result
+        for rel, disk_mtime in disk_mtimes.items():
+            path = vault_root / rel
+            try:
+                if _file_identity(path) != disk_identities[rel]:
+                    continue
+            except OSError:
+                continue
+            row_mtime = stored.get(rel)
+            result[rel] = (
+                EmbeddingFreshness.CURRENT
+                if row_mtime is not None and row_mtime == disk_mtime
+                else EmbeddingFreshness.STALE
+            )
+        return result
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        return result

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -1079,9 +1079,9 @@ def upsert_after_write_status(
             try:
                 race_receipts = deferred_index.add_receipts(vault_root, rels)
             except (OSError, sqlite3.Error):
-                log.warning("durable warm defer failed; embedding inline")
+                log.warning("durable warm defer failed; deferring in memory only")
                 race_receipts = []
-            if race_receipts and readiness.defer(
+            if readiness.defer(
                 "embeddings", (vault_root, tuple(md_paths), tuple(race_receipts))
             ):
                 log.info(

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -20,6 +20,7 @@ import gc
 import logging
 import math
 import os
+import sqlite3
 import threading
 import time
 from dataclasses import dataclass
@@ -1037,7 +1038,10 @@ class EmbeddingSyncStatus:
 
 
 def upsert_after_write_status(
-    vault_root: Path, written_paths: list[Path]
+    vault_root: Path,
+    written_paths: list[Path],
+    *,
+    defer_during_warm: bool = True,
 ) -> EmbeddingSyncStatus:
     """Re-embed eligible files and return an observable bounded outcome."""
     global _IMPORT_FAILED
@@ -1060,13 +1064,40 @@ def upsert_after_write_status(
     # write on the singleton lock — park the batch; the warm thread drains it
     # right after the model lands (readiness.mark_ready("embeddings")). If the
     # process dies before draining, audit/reconcile recover the stale sidecar.
-    from . import readiness
-    if readiness.defer("embeddings", (vault_root, tuple(md_paths))):
-        log.info(
-            "write-embed deferred until the embedding model is warm (%d file(s))",
-            len(md_paths),
-        )
-        return EmbeddingSyncStatus("deferred", "deferred_warmup", eligible_count)
+    race_receipts = []
+    if defer_during_warm:
+        from . import deferred_index, readiness
+
+        if readiness.should_defer("embeddings"):
+            rels: list[str] = []
+            root = vault_root.resolve()
+            for path in md_paths:
+                try:
+                    rels.append(path.resolve().relative_to(root).as_posix())
+                except (OSError, ValueError):
+                    continue
+            try:
+                race_receipts = deferred_index.add_receipts(vault_root, rels)
+            except (OSError, sqlite3.Error):
+                log.warning("durable warm defer failed; embedding inline")
+                race_receipts = []
+            if race_receipts and readiness.defer(
+                "embeddings", (vault_root, tuple(md_paths), tuple(race_receipts))
+            ):
+                log.info(
+                    "write-embed deferred until the embedding model is warm (%d file(s))",
+                    len(md_paths),
+                )
+                return EmbeddingSyncStatus(
+                    "deferred", "deferred_warmup", eligible_count
+                )
+
+    def finish(status: EmbeddingSyncStatus) -> EmbeddingSyncStatus:
+        if race_receipts and status.status == "completed":
+            from . import deferred_index
+
+            deferred_index.clear_receipts(vault_root, race_receipts)
+        return status
 
     try:
         get_model()  # triggers the heavy import; cheap thereafter.
@@ -1078,13 +1109,17 @@ def upsert_after_write_status(
                 e,
             )
             _IMPORT_FAILED = True
-        return EmbeddingSyncStatus(
-            "disabled", "embeddings_import_unavailable", eligible_count
+        return finish(
+            EmbeddingSyncStatus(
+                "disabled", "embeddings_import_unavailable", eligible_count
+            )
         )
     except Exception as e:  # noqa: BLE001 - model backends soft-fail by contract
         log.warning("embedding model load failed: %s; skipping upsert", e)
-        return EmbeddingSyncStatus(
-            "degraded", "embedding_model_load_failed", eligible_count
+        return finish(
+            EmbeddingSyncStatus(
+                "degraded", "embedding_model_load_failed", eligible_count
+            )
         )
 
     from . import find as find_module
@@ -1093,8 +1128,10 @@ def upsert_after_write_status(
         index = get_embedding_index(vault_root)
     except Exception as e:  # noqa: BLE001 - derived index open is best-effort
         log.warning("could not open embedding sidecar for upsert: %s", e)
-        return EmbeddingSyncStatus(
-            "degraded", "embedding_index_open_failed", eligible_count
+        return finish(
+            EmbeddingSyncStatus(
+                "degraded", "embedding_index_open_failed", eligible_count
+            )
         )
     per_file: list[tuple[Path, Any, list[str], float]] = []
     failure_code: str | None = None
@@ -1134,10 +1171,12 @@ def upsert_after_write_status(
         per_file.append((md, page, chunks, mtime))
 
     if not per_file:
-        return EmbeddingSyncStatus(
-            "completed" if failure_code is None else "degraded",
-            failure_code or "embedding_upsert_completed",
-            eligible_count,
+        return finish(
+            EmbeddingSyncStatus(
+                "completed" if failure_code is None else "degraded",
+                failure_code or "embedding_upsert_completed",
+                eligible_count,
+            )
         )
 
     from . import semantic_index
@@ -1192,10 +1231,12 @@ def upsert_after_write_status(
     except Exception as e:  # noqa: BLE001
         log.debug("claim sidecar upsert skipped (%s)", e)
         failure_code = failure_code or "embedding_auxiliary_failed"
-    return EmbeddingSyncStatus(
-        "completed" if failure_code is None else "degraded",
-        failure_code or "embedding_upsert_completed",
-        eligible_count,
+    return finish(
+        EmbeddingSyncStatus(
+            "completed" if failure_code is None else "degraded",
+            failure_code or "embedding_upsert_completed",
+            eligible_count,
+        )
     )
 
 

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -519,7 +519,7 @@ def _dispatch_upsert_components(
             )
         else:
             components.append(component)
-            if status.status != "completed":
+            if status.status != "completed" and status.code != "deferred_warmup":
                 try:
                     _record_deferred_semantic_upserts(vault_root, eligible)
                 except Exception:  # noqa: BLE001 - report remains the primary outcome

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -301,7 +301,7 @@ def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
 
 
 def _record_deferred_semantic_upserts(
-    vault_root: Path, paths: list[Path]
+    vault_root: Path, paths: list[Path], *, omit_proven_current: bool = False
 ) -> tuple[int, int]:
     from . import index_paths
 
@@ -310,7 +310,37 @@ def _record_deferred_semantic_upserts(
         for rel in _rel_md_paths(vault_root, paths)
         if index_paths.is_embeddable_path(vault_root / rel)
     ]
+    if omit_proven_current and rels:
+        freshness = deferred_index.inspect_embedding_freshness(vault_root, rels)
+        rels = [
+            rel
+            for rel in rels
+            if freshness.get(rel) is not deferred_index.EmbeddingFreshness.CURRENT
+        ]
     return len(rels), deferred_index.add(vault_root, rels)
+
+
+def replay_deferred_embedding(
+    vault_root: Path,
+    paths: list[Path],
+    receipts: list[deferred_index.DeferredReceipt] | tuple[deferred_index.DeferredReceipt, ...] | None = None,
+):
+    """Replay one durable embedding batch and clear only its completed revisions."""
+    from . import embeddings
+
+    if receipts is None:
+        rels = set(_rel_md_paths(vault_root, paths))
+        receipts = [
+            receipt
+            for receipt in deferred_index.snapshot(vault_root)
+            if receipt.rel_path in rels
+        ]
+    status = embeddings.upsert_after_write_status(
+        vault_root, paths, defer_during_warm=False
+    )
+    if status.status == "completed":
+        deferred_index.clear_receipts(vault_root, list(receipts))
+    return status
 
 
 def deferred_work_status(vault_root: Path | None = None) -> dict:
@@ -401,21 +431,19 @@ def drain_deferred_work(
         return processed
 
     remaining_limit = None if limit is None else max(0, limit - processed)
-    pending = deferred_index.list_paths(vault_root, limit=remaining_limit)
-    if not pending:
+    receipts = deferred_index.snapshot(vault_root, limit=remaining_limit)
+    if not receipts:
         return processed
-    from . import embeddings
-
-    paths = [vault_root / rel for rel in pending]
+    paths = [vault_root / receipt.rel_path for receipt in receipts]
     try:
-        dispatched = embeddings.upsert_after_write(vault_root, paths)
+        status = replay_deferred_embedding(vault_root, paths, receipts)
     except Exception:  # noqa: BLE001 - durable work must survive a failed dispatch
         log.warning("deferred semantic dispatch failed; work remains queued", exc_info=True)
         return processed
-    if dispatched is False:
+    if status.status != "completed":
         log.warning("deferred semantic dispatch incomplete; work remains queued")
         return processed
-    return processed + clear_deferred_work(vault_root, paths=paths)
+    return processed + len(receipts)
 
 
 def _dispatch_upsert_components(
@@ -452,7 +480,9 @@ def _dispatch_upsert_components(
     if defer_semantic or mode.defer_expensive_indexes():
         try:
             semantic_count, added = _record_deferred_semantic_upserts(
-                vault_root, eligible
+                vault_root,
+                eligible,
+                omit_proven_current=defer_semantic,
             )
         except Exception:  # noqa: BLE001 - degradation is reported, other lanes landed
             log.warning("durable semantic defer failed", exc_info=True)

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -190,6 +190,19 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             log.debug("%s warm-encode skipped", step, exc_info=True)
         return True
 
+    def _replay_deferred_embeddings(items: list) -> None:
+        from . import index_sync
+
+        for item in items:
+            item_vault, paths, *receipt_payload = item
+            receipts = receipt_payload[0] if receipt_payload else None
+            try:
+                index_sync.replay_deferred_embedding(
+                    item_vault, list(paths), receipts
+                )
+            except Exception:  # noqa: BLE001 — durable receipt survives retry
+                log.warning("deferred embed drain failed", exc_info=True)
+
     disabled = bool(os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"))
     if disabled or not preload:
         # Skip model preloads: either a lexical-only install (DISABLE_EMBEDDINGS,
@@ -205,15 +218,9 @@ def warm_all(vault_root: Path) -> dict[str, float]:
         # Quiet mode: embeddings ARE available (just lazy), so replay any write
         # parked during the brief lexical warm — mirror the real-preload branch so
         # those edits aren't stranded. Under DISABLE_EMBEDDINGS there's nothing to
-        # embed (upsert_after_write no-ops), so the drain is discarded.
+        # embed, so the in-memory drain is discarded and its durable receipt remains.
         if not disabled and drained:
-            from . import embeddings
-
-            for item_vault, paths in drained:
-                try:
-                    embeddings.upsert_after_write(item_vault, list(paths))
-                except Exception:  # noqa: BLE001 — drain is best-effort
-                    log.warning("deferred embed drain failed", exc_info=True)
+            _replay_deferred_embeddings(drained)
             log.info("drained %d deferred write-embed batch(es)", len(drained))
     else:
         from . import embeddings
@@ -233,11 +240,7 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             drained = readiness.mark_ready("embeddings")
         else:
             drained = readiness.drain_deferred("embeddings")
-        for item_vault, paths in drained:
-            try:
-                embeddings.upsert_after_write(item_vault, list(paths))
-            except Exception:  # noqa: BLE001 — drain is best-effort
-                log.warning("deferred embed drain failed", exc_info=True)
+        _replay_deferred_embeddings(drained)
         if drained:
             log.info("drained %d deferred write-embed batch(es)", len(drained))
 

--- a/tests/test_deferred_index.py
+++ b/tests/test_deferred_index.py
@@ -1,8 +1,36 @@
 from __future__ import annotations
 
+import os
+import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 from exomem import deferred_index
+
+
+def _embedding_sidecar(vault: Path) -> Path:
+    return vault / "Knowledge Base" / ".embeddings.sqlite"
+
+
+def _seed_embedding_rows(vault: Path, rows: list[tuple[str, float]]) -> None:
+    sidecar = _embedding_sidecar(vault)
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(sidecar)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS chunks ("
+            "file_path TEXT NOT NULL, chunk_idx INTEGER NOT NULL, "
+            "file_mtime REAL NOT NULL, PRIMARY KEY(file_path, chunk_idx))"
+        )
+        conn.executemany(
+            "INSERT OR REPLACE INTO chunks(file_path, chunk_idx, file_mtime) "
+            "VALUES (?, 0, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def test_deferred_paths_are_durable_deduplicated_and_clearable(vault: Path) -> None:
@@ -20,5 +48,211 @@ def test_deferred_paths_are_durable_deduplicated_and_clearable(vault: Path) -> N
 def test_deferred_status_does_not_create_sidecar(vault: Path) -> None:
     path = deferred_index.store_path(vault)
     assert not path.exists()
-    assert deferred_index.status(vault)["count"] == 0
-    assert not path.exists()
+
+
+def test_embedding_freshness_is_exact_and_tri_state(vault: Path) -> None:
+    root = vault / "Knowledge Base" / "Notes"
+    root.mkdir(parents=True, exist_ok=True)
+    paths = [root / name for name in ("current.md", "ahead.md", "behind.md", "missing.md")]
+    for index, path in enumerate(paths):
+        path.write_text(f"# {index}\n", encoding="utf-8")
+        info = path.stat()
+        os.utime(path, ns=(info.st_atime_ns, 1_800_000_000_000_000_000 + index * 1_000_000))
+    rels = [path.relative_to(vault).as_posix() for path in paths]
+    mtimes = [path.stat().st_mtime for path in paths]
+    _seed_embedding_rows(
+        vault,
+        [
+            (rels[0], mtimes[0]),
+            (rels[1], mtimes[1] + 0.1),
+            (rels[2], mtimes[2] - 0.1),
+        ],
+    )
+
+    result = deferred_index.inspect_embedding_freshness(vault, rels)
+
+    assert result == {
+        rels[0]: deferred_index.EmbeddingFreshness.CURRENT,
+        rels[1]: deferred_index.EmbeddingFreshness.STALE,
+        rels[2]: deferred_index.EmbeddingFreshness.STALE,
+        rels[3]: deferred_index.EmbeddingFreshness.STALE,
+    }
+    sidecar = _embedding_sidecar(vault)
+    assert not Path(f"{sidecar}-wal").exists()
+    assert not Path(f"{sidecar}-shm").exists()
+
+
+def test_freshness_inspection_imports_no_embedding_or_model_stack() -> None:
+    code = (
+        "import sys; import exomem.deferred_index; "
+        "print(any(name == 'exomem.embeddings' or name == 'torch' "
+        "or name.startswith('sentence_transformers') for name in sys.modules))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_embedding_freshness_uses_percent_safe_uri_and_live_wal_without_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault #% üll"
+    note = vault / "Knowledge Base" / "Notes" / "current.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# current\n", encoding="utf-8")
+    rel = note.relative_to(vault).as_posix()
+    sidecar = _embedding_sidecar(vault)
+    writer = sqlite3.connect(sidecar)
+    real_connect = sqlite3.connect
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute(
+            "CREATE TABLE chunks (file_path TEXT, chunk_idx INTEGER, file_mtime REAL)"
+        )
+        writer.execute(
+            "INSERT INTO chunks(file_path, chunk_idx, file_mtime) VALUES (?, 0, ?)",
+            (rel, note.stat().st_mtime),
+        )
+        writer.commit()
+        companions = [sidecar, Path(f"{sidecar}-wal"), Path(f"{sidecar}-shm")]
+        assert all(path.exists() for path in companions)
+        before = {
+            path: (path.read_bytes(), path.stat())
+            for path in companions
+        }
+        calls: list[str] = []
+
+        def record_connect(database, *args, **kwargs):
+            calls.append(str(database))
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(deferred_index.sqlite3, "connect", record_connect)
+
+        result = deferred_index.inspect_embedding_freshness(vault, [rel])
+
+        assert result[rel] is deferred_index.EmbeddingFreshness.CURRENT
+        assert len(calls) == 1
+        assert calls[0].startswith("file:///")
+        assert calls[0].endswith("/.embeddings.sqlite?mode=ro")
+        for path, (content, info) in before.items():
+            after = path.stat()
+            assert path.read_bytes() == content
+            assert (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) == (
+                info.st_dev,
+                info.st_ino,
+                info.st_size,
+                info.st_mtime_ns,
+            )
+    finally:
+        writer.close()
+
+
+def test_embedding_freshness_batches_beyond_sqlite_variable_limit(vault: Path) -> None:
+    root = vault / "Knowledge Base" / "Notes"
+    root.mkdir(parents=True, exist_ok=True)
+    rels: list[str] = []
+    rows: list[tuple[str, float]] = []
+    for index in range(1_050):
+        path = root / f"note-{index:04d}.md"
+        path.write_text("# note\n", encoding="utf-8")
+        rel = path.relative_to(vault).as_posix()
+        rels.append(rel)
+        rows.append((rel, path.stat().st_mtime))
+    _seed_embedding_rows(vault, rows)
+
+    result = deferred_index.inspect_embedding_freshness(vault, rels)
+
+    assert len(result) == len(rels)
+    assert set(result.values()) == {deferred_index.EmbeddingFreshness.CURRENT}
+
+
+def test_embedding_freshness_conservatively_unverifiable_sidecars(vault: Path) -> None:
+    note = vault / "Knowledge Base" / "Notes" / "note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# note\n", encoding="utf-8")
+    rel = note.relative_to(vault).as_posix()
+    sidecar = _embedding_sidecar(vault)
+
+    missing = deferred_index.inspect_embedding_freshness(vault, [rel])
+    assert missing[rel] is deferred_index.EmbeddingFreshness.UNVERIFIABLE
+
+    sidecar.write_bytes(b"not sqlite")
+    corrupt = deferred_index.inspect_embedding_freshness(vault, [rel])
+    assert corrupt[rel] is deferred_index.EmbeddingFreshness.UNVERIFIABLE
+
+
+def test_embedding_freshness_busy_rollback_journal_is_unverifiable(
+    vault: Path,
+) -> None:
+    note = vault / "Knowledge Base" / "Notes" / "busy.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# busy\n", encoding="utf-8")
+    rel = note.relative_to(vault).as_posix()
+    _seed_embedding_rows(vault, [(rel, note.stat().st_mtime)])
+    sidecar = _embedding_sidecar(vault)
+    writer = sqlite3.connect(sidecar)
+    try:
+        writer.execute("BEGIN EXCLUSIVE")
+        writer.execute(
+            "UPDATE chunks SET file_mtime = file_mtime + 1 WHERE file_path = ?",
+            (rel,),
+        )
+        assert Path(f"{sidecar}-journal").exists()
+
+        result = deferred_index.inspect_embedding_freshness(vault, [rel])
+
+        assert result[rel] is deferred_index.EmbeddingFreshness.UNVERIFIABLE
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+def test_revisioned_receipt_conditional_clear_preserves_newer_work(vault: Path) -> None:
+    rel = "Knowledge Base/Notes/revisioned.md"
+    [first] = deferred_index.add_receipts(vault, [rel])
+    [second] = deferred_index.add_receipts(vault, [rel])
+
+    assert first.revision == 1
+    assert second.revision == 2
+    assert deferred_index.clear_receipts(vault, [first]) == 0
+    assert deferred_index.snapshot(vault) == [second]
+    assert deferred_index.clear_receipts(vault, [second]) == 1
+    assert deferred_index.snapshot(vault) == []
+
+
+def test_receipt_schema_migrates_and_vaults_are_isolated(tmp_path: Path) -> None:
+    first_vault = tmp_path / "first"
+    second_vault = tmp_path / "second"
+    legacy = deferred_index.store_path(first_vault)
+    legacy.parent.mkdir(parents=True)
+    conn = sqlite3.connect(legacy)
+    try:
+        conn.execute(
+            "CREATE TABLE semantic_upserts ("
+            "rel_path TEXT PRIMARY KEY, created_at REAL NOT NULL, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO semantic_upserts VALUES ('Knowledge Base/Notes/legacy.md', 1, 1)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    [migrated] = deferred_index.add_receipts(
+        first_vault, ["Knowledge Base/Notes/legacy.md"]
+    )
+    [other] = deferred_index.add_receipts(
+        second_vault, ["Knowledge Base/Notes/legacy.md"]
+    )
+
+    assert migrated.revision == 2
+    assert other.revision == 1
+    assert deferred_index.clear_receipts(first_vault, [migrated]) == 1
+    assert deferred_index.snapshot(first_vault) == []
+    assert deferred_index.snapshot(second_vault) == [other]

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -254,6 +254,43 @@ def test_durable_defer_report_does_not_enter_embedding_warmup_queue(
         deferred_index.clear(tmp_path)
 
 
+def test_public_warm_defer_replay_does_not_strand_newer_duplicate_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph, find, lexstore, memory_refs, warmup
+
+    target = tmp_path / "Knowledge Base" / "Notes" / "warm-race.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Warm race\n", encoding="utf-8")
+    for module in (lexstore, memory_refs, epistemic_graph):
+        monkeypatch.setattr(module, "upsert_after_write", lambda *_args: None)
+    monkeypatch.setattr(find, "on_resolver_files_changed", lambda *_args: None)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    monkeypatch.setattr(embeddings, "_IMPORT_FAILED", False)
+    monkeypatch.setattr(warmup, "warm_caches", lambda *_args, **_kwargs: {})
+    readiness.reset()
+    readiness.begin_warm()
+    deferred_index.clear(tmp_path)
+    try:
+        report = index_sync.upsert_after_write(tmp_path, [target])
+        assert _outcome(report, "embeddings").code == "deferred_warmup"
+
+        monkeypatch.setattr(
+            embeddings,
+            "upsert_after_write_status",
+            lambda *_args, **_kwargs: embeddings.EmbeddingSyncStatus(
+                "completed", "embedding_upsert_completed", 1
+            ),
+        )
+        warmup.warm_all(tmp_path)
+
+        assert deferred_index.snapshot(tmp_path) == []
+    finally:
+        readiness.reset()
+        deferred_index.clear(tmp_path)
+
+
 def test_durable_defer_with_no_semantic_paths_reports_accepted_noop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -37,7 +37,7 @@ def test_embedding_upsert_status_distinguishes_disabled_and_warmup(
         assert warmup.status == "deferred"
         assert warmup.code == "deferred_warmup"
         assert readiness.snapshot()["deferred_counts"]["embeddings"] == 1
-        assert deferred_index.status(tmp_path)["count"] == 0
+        assert deferred_index.status(tmp_path)["count"] == 1
     finally:
         readiness.reset()
         deferred_index.clear(tmp_path)

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -16,6 +16,7 @@ Deletes stay UNfiltered so legacy pollution can still be purged.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -198,6 +199,139 @@ def test_index_sync_explicit_defer_semantic_upserts(
         index_sync.clear_deferred_work(vault)
 
 
+def test_bulk_defer_skips_only_proven_current_without_clearing_existing_receipt(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "normal")
+    from exomem import epistemic_graph, find, lexstore, memory_refs
+
+    for module in (lexstore, memory_refs, epistemic_graph):
+        monkeypatch.setattr(module, "upsert_after_write", lambda *_a, **_kw: None)
+    monkeypatch.setattr(find, "on_resolver_files_changed", lambda *_a, **_kw: None)
+    root = vault / "Knowledge Base" / "Notes" / "Insights"
+    root.mkdir(parents=True, exist_ok=True)
+    current = root / "current.md"
+    current_with_receipt = root / "current-receipt.md"
+    stale = root / "stale.md"
+    for path in (current, current_with_receipt, stale):
+        path.write_text("# note\n", encoding="utf-8")
+    sidecar = vault / "Knowledge Base" / ".embeddings.sqlite"
+    conn = sqlite3.connect(sidecar)
+    try:
+        conn.execute(
+            "CREATE TABLE chunks (file_path TEXT, chunk_idx INTEGER, file_mtime REAL)"
+        )
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, 0, ?)",
+            [
+                (path.relative_to(vault).as_posix(), path.stat().st_mtime)
+                for path in (current, current_with_receipt)
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    receipt_rel = current_with_receipt.relative_to(vault).as_posix()
+    [existing] = deferred_index.add_receipts(vault, [receipt_rel])
+
+    index_sync.upsert_after_write(
+        vault, [current, current_with_receipt, stale], defer_semantic=True
+    )
+
+    receipts = {item.rel_path: item for item in deferred_index.snapshot(vault)}
+    assert current.relative_to(vault).as_posix() not in receipts
+    assert receipts[receipt_rel] == existing
+    assert stale.relative_to(vault).as_posix() in receipts
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "cleared"),
+    [
+        ("completed", "embedding_upsert_completed", True),
+        ("disabled", "embeddings_disabled", False),
+        ("deferred", "deferred_warmup", False),
+        ("degraded", "embedding_upsert_failed", False),
+        ("degraded", "embedding_auxiliary_failed", False),
+    ],
+)
+def test_replay_clears_only_completed_receipt(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    code: str,
+    cleared: bool,
+) -> None:
+    from exomem import embeddings
+
+    path = vault / "Knowledge Base" / "Notes" / "replay.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# replay\n", encoding="utf-8")
+    [receipt] = deferred_index.add_receipts(
+        vault, [path.relative_to(vault).as_posix()]
+    )
+    calls: list[bool] = []
+
+    def replay_status(_vault, _paths, *, defer_during_warm=True):
+        calls.append(defer_during_warm)
+        return embeddings.EmbeddingSyncStatus(status, code, 1)
+
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", replay_status)
+
+    result = index_sync.replay_deferred_embedding(vault, [path], [receipt])
+
+    assert result.status == status
+    assert calls == [False]
+    assert (deferred_index.snapshot(vault) == []) is cleared
+
+
+def test_old_replay_cannot_clear_newer_same_path_receipt(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import embeddings
+
+    path = vault / "Knowledge Base" / "Notes" / "race.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# race\n", encoding="utf-8")
+    rel = path.relative_to(vault).as_posix()
+    [old] = deferred_index.add_receipts(vault, [rel])
+    newer: list[deferred_index.DeferredReceipt] = []
+
+    def replay_status(*_args, **_kwargs):
+        newer.extend(deferred_index.add_receipts(vault, [rel]))
+        return embeddings.EmbeddingSyncStatus(
+            "completed", "embedding_upsert_completed", 1
+        )
+
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", replay_status)
+
+    index_sync.replay_deferred_embedding(vault, [path], [old])
+
+    assert deferred_index.snapshot(vault) == newer
+
+
+
+def test_replay_exception_preserves_receipt(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import embeddings
+
+    path = vault / "Knowledge Base" / "Notes" / "exception.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# exception\n", encoding="utf-8")
+    [receipt] = deferred_index.add_receipts(
+        vault, [path.relative_to(vault).as_posix()]
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write_status",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        index_sync.replay_deferred_embedding(vault, [path], [receipt])
+
+    assert deferred_index.snapshot(vault) == [receipt]
+
 
 def test_index_sync_nonquiet_keeps_immediate_embedding_upsert(
     vault: Path, monkeypatch: pytest.MonkeyPatch
@@ -254,10 +388,16 @@ def test_drain_deferred_work_processes_and_clears_semantic_upserts(
         lambda root, changed, deleted: None,
     )
     calls: list[list[Path]] = []
+
+    def completed(root, paths, *, defer_during_warm=True):
+        assert defer_during_warm is False
+        calls.append(list(paths))
+        return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
+
     monkeypatch.setattr(
         embeddings,
-        "upsert_after_write",
-        lambda root, paths: calls.append(list(paths)),
+        "upsert_after_write_status",
+        completed,
     )
     good = vault / "Knowledge Base" / "Notes" / "Insights" / "drain-me.md"
     good.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -413,6 +413,48 @@ def test_drain_deferred_work_processes_and_clears_semantic_upserts(
     assert index_sync.deferred_work_status(vault)["semantic_upserts"]["count"] == 0
 
 
+def test_drain_legacy_receipt_registry_before_any_writable_migration(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import embeddings
+
+    rel = "Knowledge Base/Notes/Insights/legacy-drain.md"
+    target = vault / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# legacy drain\n", encoding="utf-8")
+    registry = deferred_index.store_path(vault)
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(registry)
+    try:
+        conn.execute(
+            "CREATE TABLE semantic_upserts ("
+            "rel_path TEXT PRIMARY KEY, created_at REAL NOT NULL, "
+            "updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE full_upserts ("
+            "rel_path TEXT PRIMARY KEY, created_at REAL NOT NULL, "
+            "updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO semantic_upserts VALUES (?, 1, 1)",
+            (rel,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write_status",
+        lambda *_args, **_kwargs: embeddings.EmbeddingSyncStatus(
+            "completed", "embedding_upsert_completed", 1
+        ),
+    )
+
+    assert index_sync.drain_deferred_work(vault) == 1
+    assert deferred_index.snapshot(vault) == []
+
+
 def test_drain_deferred_work_preserves_failed_semantic_upserts(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -905,6 +905,60 @@ def test_warm_defer_is_durable_before_in_memory_item_is_visible(
     assert deferred_index.status(tmp_path)["count"] == 1
 
 
+def test_warm_defer_stays_in_memory_when_durable_receipt_creation_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    readiness.begin_warm()
+    path = tmp_path / "Knowledge Base" / "Notes" / "store-failed.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# failed store\n", encoding="utf-8")
+
+    def fail_receipt(*_args, **_kwargs):
+        raise OSError("registry unavailable")
+
+    monkeypatch.setattr(deferred_index, "add_receipts", fail_receipt)
+    monkeypatch.setattr(
+        embeddings,
+        "get_model",
+        lambda: pytest.fail("warm-deferred write loaded the model"),
+    )
+
+    status = embeddings.upsert_after_write_status(tmp_path, [path])
+
+    assert status.code == "deferred_warmup"
+    [(item_vault, item_paths, receipts)] = readiness.mark_ready("embeddings")
+    assert item_vault == tmp_path
+    assert list(item_paths) == [path]
+    assert list(receipts) == []
+
+
+def test_uppercase_markdown_warm_defer_has_durable_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    readiness.begin_warm()
+    path = tmp_path / "Knowledge Base" / "Notes" / "uppercase.MD"
+    path.parent.mkdir(parents=True)
+    path.write_text("# uppercase\n", encoding="utf-8")
+    monkeypatch.setattr(
+        embeddings,
+        "get_model",
+        lambda: pytest.fail("warm-deferred write loaded the model"),
+    )
+
+    status = embeddings.upsert_after_write_status(tmp_path, [path])
+
+    assert status.code == "deferred_warmup"
+    [(item_vault, item_paths, receipts)] = readiness.mark_ready("embeddings")
+    assert item_vault == tmp_path
+    assert list(item_paths) == [path]
+    assert list(receipts) == deferred_index.snapshot(tmp_path)
+    assert [receipt.rel_path for receipt in receipts] == [
+        "Knowledge Base/Notes/uppercase.MD"
+    ]
+
+
 @pytest.mark.parametrize(
     ("mode_name", "preload_succeeds", "status_name", "receipt_cleared"),
     [

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -32,7 +32,15 @@ from pathlib import Path
 
 import pytest
 
-from exomem import bm25, commands, embeddings, readiness, server, warmup
+from exomem import (
+    bm25,
+    commands,
+    deferred_index,
+    embeddings,
+    readiness,
+    server,
+    warmup,
+)
 from exomem import doctor as doctor_module
 from exomem import find as find_module
 from exomem.__main__ import main
@@ -322,9 +330,14 @@ def test_warm_all_quiet_mode_replays_deferred_write_embeds(
     monkeypatch.setenv("EXOMEM_MODE", "quiet")
     monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
     drained_calls: list[tuple] = []
+
+    def completed(vr, paths, *, defer_during_warm=True):
+        assert defer_during_warm is False
+        drained_calls.append((vr, list(paths)))
+        return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
+
     monkeypatch.setattr(
-        embeddings, "upsert_after_write",
-        lambda vr, paths: drained_calls.append((vr, list(paths))),
+        embeddings, "upsert_after_write_status", completed
     )
 
     readiness.begin_warm()
@@ -437,9 +450,14 @@ def test_warm_all_drains_deferred_write_embeds_after_embeddings_ready(
     monkeypatch.setattr(embeddings, "get_reranker", lambda: object())
     monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
     drained_calls: list[tuple] = []
+
+    def completed(vr, paths, *, defer_during_warm=True):
+        assert defer_during_warm is False
+        drained_calls.append((vr, list(paths)))
+        return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
+
     monkeypatch.setattr(
-        embeddings, "upsert_after_write",
-        lambda vr, paths: drained_calls.append((vr, list(paths))),
+        embeddings, "upsert_after_write_status", completed
     )
 
     readiness.begin_warm()  # so the manual defer() below actually records
@@ -471,9 +489,14 @@ def test_warm_all_drains_deferred_write_embeds_even_when_bge_preload_fails(
     monkeypatch.setattr(embeddings, "get_reranker", lambda: object())
     monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
     drained_calls: list[tuple] = []
+
+    def completed(vr, paths, *, defer_during_warm=True):
+        assert defer_during_warm is False
+        drained_calls.append((vr, list(paths)))
+        return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
+
     monkeypatch.setattr(
-        embeddings, "upsert_after_write",
-        lambda vr, paths: drained_calls.append((vr, list(paths))),
+        embeddings, "upsert_after_write_status", completed
     )
 
     readiness.begin_warm()  # so the manual defer() below actually records
@@ -843,10 +866,130 @@ def test_upsert_after_write_defers_during_warm_without_loading_model(
 
     drained = readiness.mark_ready("embeddings")
     assert len(drained) == 1
-    drained_vault, drained_paths = drained[0]
+    drained_vault, drained_paths, receipts = drained[0]
     assert drained_vault == tmp_path
     assert list(drained_paths) == [md_path]
+    assert [receipt.rel_path for receipt in receipts] == [
+        "Knowledge Base/Notes/probe.md"
+    ]
     assert readiness.mark_ready("embeddings") == []  # drained exactly once
+
+
+def test_warm_defer_is_durable_before_in_memory_item_is_visible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    readiness.begin_warm()
+    path = tmp_path / "Knowledge Base" / "Notes" / "durable-first.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# durable\n", encoding="utf-8")
+    real_defer = readiness.defer
+
+    def assert_durable(component, item):
+        item_vault, item_paths, receipts = item
+        assert item_vault == tmp_path
+        assert list(item_paths) == [path]
+        assert deferred_index.snapshot(tmp_path) == list(receipts)
+        return real_defer(component, item)
+
+    monkeypatch.setattr(readiness, "defer", assert_durable)
+    monkeypatch.setattr(
+        embeddings,
+        "get_model",
+        lambda: pytest.fail("warm-deferred write loaded the model"),
+    )
+
+    status = embeddings.upsert_after_write_status(tmp_path, [path])
+
+    assert status.status == "deferred"
+    assert deferred_index.status(tmp_path)["count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("mode_name", "preload_succeeds", "status_name", "receipt_cleared"),
+    [
+        ("quiet", True, "completed", True),
+        ("normal", True, "completed", True),
+        ("normal", False, "degraded", False),
+    ],
+)
+def test_warm_replay_receipt_outcomes_and_no_second_defer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode_name: str,
+    preload_succeeds: bool,
+    status_name: str,
+    receipt_cleared: bool,
+) -> None:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_MODE", mode_name)
+    monkeypatch.setattr(warmup, "warm_caches", lambda *_a, **_kw: {})
+    path = tmp_path / "Knowledge Base" / "Notes" / "warm-replay.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# warm\n", encoding="utf-8")
+    rel = path.relative_to(tmp_path).as_posix()
+    [receipt] = deferred_index.add_receipts(tmp_path, [rel])
+    readiness.begin_warm()
+    assert readiness.defer(
+        "embeddings", (tmp_path, (path,), (receipt,))
+    ) is True
+
+    if preload_succeeds:
+        monkeypatch.setattr(embeddings, "get_model", lambda: object())
+    else:
+        monkeypatch.setattr(
+            embeddings,
+            "get_model",
+            lambda: (_ for _ in ()).throw(RuntimeError("preload failed")),
+        )
+    monkeypatch.setattr(embeddings, "get_reranker", lambda: object())
+    monkeypatch.setattr(embeddings, "ranking_enabled", lambda: False)
+    monkeypatch.setattr(embeddings, "clip_enabled", lambda: False)
+    defer_flags: list[bool] = []
+
+    def replay_status(_vault, _paths, *, defer_during_warm=True):
+        defer_flags.append(defer_during_warm)
+        code = (
+            "embedding_upsert_completed"
+            if status_name == "completed"
+            else "embedding_model_load_failed"
+        )
+        return embeddings.EmbeddingSyncStatus(status_name, code, 1)
+
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", replay_status)
+
+    warmup.warm_all(tmp_path)
+
+    assert defer_flags == [False]
+    assert (deferred_index.snapshot(tmp_path) == []) is receipt_cleared
+    assert readiness.snapshot()["deferred_counts"]["embeddings"] == 0
+
+
+def test_disabled_warm_drains_memory_but_preserves_durable_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    monkeypatch.setattr(warmup, "warm_caches", lambda *_a, **_kw: {})
+    path = tmp_path / "Knowledge Base" / "Notes" / "disabled.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# disabled\n", encoding="utf-8")
+    [receipt] = deferred_index.add_receipts(
+        tmp_path, [path.relative_to(tmp_path).as_posix()]
+    )
+    readiness.begin_warm()
+    assert readiness.defer(
+        "embeddings", (tmp_path, (path,), (receipt,))
+    ) is True
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write_status",
+        lambda *_a, **_kw: pytest.fail("disabled warm must not replay"),
+    )
+
+    warmup.warm_all(tmp_path)
+
+    assert deferred_index.snapshot(tmp_path) == [receipt]
+    assert readiness.snapshot()["deferred_counts"]["embeddings"] == 0
 
 
 def test_upsert_after_write_defer_after_embeddable_filter_logmd_defers_nothing(

--- a/tests/test_semantic_unit_embeddings.py
+++ b/tests/test_semantic_unit_embeddings.py
@@ -200,9 +200,17 @@ def test_disabled_or_warming_embedding_path_never_loads_unit_work(
     )
 
     monkeypatch.setattr(embeddings, "_IMPORT_FAILED", False)
-    monkeypatch.setattr(readiness, "defer", lambda *_args: True)
-    deferred = embeddings.upsert_after_write_status(tmp_path, [page])
-    assert (deferred.status, deferred.code) == ("deferred", "deferred_warmup")
+    readiness.reset()
+    readiness.begin_warm()
+    try:
+        deferred = embeddings.upsert_after_write_status(tmp_path, [page])
+        assert (deferred.status, deferred.code) == (
+            "deferred",
+            "deferred_warmup",
+        )
+    finally:
+        readiness.finish_warm()
+        readiness.reset()
 
 
 def test_post_start_unit_encode_failure_degrades_without_raising(


### PR DESCRIPTION
## What changed

- filter metadata-only watcher bursts against exact current embedding mtimes without importing or mutating the embedding stack
- make deferred semantic receipts revisioned and conditionally cleared after completed replay
- persist warmup deferrals before they become drainable and preserve receipts on disabled, degraded, failed, or concurrent paths
- support legacy receipt registries and preserve nonblocking startup when durable receipt creation fails

## Why

The Windows ACL repair touched file metadata across the vault. The watcher treated those paths as semantic work even when embeddings were already current, creating a false backlog. Startup replay could then complete the embedding work while leaving durable receipts behind, including races where newer work could be erased or old work stranded.

## Impact

Metadata-only bursts no longer manufacture semantic backlog. Real edits and unverifiable paths still queue conservatively. Deferred work survives failures and concurrent edits, and legacy registries migrate safely.

## Validation

- 96 focused watcher/deferred-index/warmup/index-sync tests passed
- 235-test related suite passed apart from one unrelated Windows timestamp flake that passed on exact rerun
- Ruff passed on every touched file
- `git diff --check` passed
- independent review approved with no remaining Critical or Important findings
