### PR TITLE
fix: bound reconcile maintenance work

### DIFF
--- a/openspec/changes/bound-reconcile-maintenance/.openspec.yaml
+++ b/openspec/changes/bound-reconcile-maintenance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -25,11 +25,27 @@ The repair must preserve graph edge semantics, conservative embedding durability
 
 ## Decisions
 
-### Use one detached resolver per graph maintenance operation
+### Use one detached resolver per graph maintenance pass
 
 `rebuild_all()` and `refresh_paths()` will acquire one detached resolver snapshot before opening or mutating the graph sidecar, then pass it explicitly through `_index_path(..., resolver=...)` to `_edges_for_page(..., resolver=...)`. `_edges_for_page` keeps an optional fallback for its existing direct callers, while graph maintenance always supplies the snapshot.
 
 This makes resolver/freshness acquisition O(1) per operation and page parsing O(n). A detached resolver cannot be changed midway by a concurrent watcher patch. Resolver acquisition occurs before graph deletion so acquisition failure preserves the existing sidecar. Separate `refresh_paths()` calls reacquire freshness, while one multi-path call shares one snapshot.
+
+### Stabilize full rebuilds against concurrent target changes
+
+A full rebuild brackets each resolver-plus-graph pass with direct disk-truth
+vault freshness walks. The disk key is supplied to detached resolver acquisition,
+so a stale event-maintained registry cannot cause a stale shared resolver fork.
+If the key moves during the first pass, the rebuild retries once with a newly
+acquired snapshot. A stable vault therefore retains one resolver acquisition and
+one O(n) graph pass; a moving vault is capped at two acquisitions and two O(n)
+passes, never per-page O(n) freshness work.
+
+If the disk key moves during the second pass, the rebuild deletes its graph
+schema-version marker and raises. The resulting sidecar is explicitly
+unavailable/non-current, so readers cannot trust the unstable graph and a later
+refresh or reconcile rebuilds it. The first attempt still acquires its resolver
+before any graph mutation.
 
 Alternatives rejected:
 
@@ -49,13 +65,20 @@ Successful write-mode reconcile will seed exact `kb` and `vault` freshness maps 
 
 If a final baseline scan cannot complete, reconcile will log the failure and leave that scope non-live; the next periodic watcher pass installs a baseline without fanout. Event-index kill-switch behavior remains unchanged.
 
+`freshness.seed()` intentionally consumes the final stat-entry iterable while
+holding the registry lock. Scanning outside the lock and then overwriting the map
+would allow an event patch published after the scan to be lost by the later
+install. The bounded explicit-reconcile scan may briefly delay registry readers,
+but preserves exact race ordering; this change does not trade correctness for a
+shorter lock hold.
+
 ### Test structural work, parity, and fanout—not a fragile stopwatch
 
-Scaling tests count detached resolver acquisition and freshness/vault-walk boundaries across many pages. Parity tests compare graph results for representative and ambiguous links. Freshness/watcher tests cover missing versus empty baselines, independent scopes, no phantom index dispatch or receipts, and the next real source edit. A quiescent real-vault benchmark is retained as deployment evidence, not as a timing assertion in lean CI.
+Scaling tests count detached resolver acquisition and freshness/vault-walk boundaries across many pages. Parity tests compare graph results for representative and ambiguous links. Stabilization tests deterministically change a target after snapshot acquisition and force repeated churn to prove the retry cap and unavailable failure state. Freshness/watcher tests cover missing versus empty baselines, independent scopes, no phantom index dispatch or receipts, and exact-once modification and deletion recovery. A quiescent real-vault benchmark is retained as deployment evidence, not as a timing assertion in lean CI.
 
 ## Risks / Trade-offs
 
-- [Risk] Files change during a detached graph rebuild. → The rebuild is an internally consistent best-effort snapshot; normal watcher/reconcile paths heal later changes, matching the existing non-transactional filesystem contract.
+- [Risk] Files change during a detached graph rebuild. → Disk-truth bracketing retries once with a fresh snapshot. Repeated churn marks the graph unavailable and raises, leaving later watcher/reconcile maintenance to rebuild instead of trusting stale edges.
 - [Risk] Rebaseline scan races a filesystem event. → Event publishers continue patching live maps and periodic reconciliation remains the bounded safety net; missing state is never converted into fabricated drift.
 - [Risk] A broad test run is not green on current Windows `main`. → Pin new acceptance to targeted regressions, record inherited failures, and require CI/independent review to show the PR adds no new failures.
 - [Risk] A cold detached resolver still performs a full vault read. → One O(n) read is required for correct resolution; the contract removes the repeated per-page O(n) read/check.

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`EpistemicGraphIndex.rebuild_all()` walks every KB Markdown file and delegates each page to `_index_path()`. `_edges_for_page()` currently reacquires `find.shared_resolver()` per page. In a server with a live freshness registry that check is cheap, but a CLI or otherwise non-live process computes the vault freshness triple by walking the full vault each time. A graph rebuild over `n` pages therefore performs `n` vault walks before link resolution and becomes effectively O(n²).
+
+Explicit reconcile ends by invalidating the live freshness maps. The watcher later calls `freshness.reconcile()` in non-seed mode; because that function currently treats an absent old map as an empty map, it reports every current Markdown file as newly changed. The watcher fans that false delta through `index_sync`, and a temporarily unverifiable embedding sidecar correctly-but-expensively records durable work for every path.
+
+The repair must preserve graph edge semantics, conservative embedding durability, watcher recovery for real missed events, and the public reconcile contract. It must not introduce a process-global snapshot that can remain stale across operations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make full graph rebuild and one batched graph refresh perform a bounded, operation-constant number of resolver/freshness acquisitions.
+- Keep link resolution consistent within one graph maintenance operation and fresh between separate operations.
+- Make missing freshness state baseline initialization rather than evidence of source changes.
+- Leave an explicit reconcile with live, exact freshness baselines when event indexes are enabled.
+- Prove real post-baseline changes still dispatch while phantom corpus-wide receipts do not.
+
+**Non-Goals:**
+
+- Make a graph rebuild transactionally snapshot concurrent filesystem changes.
+- Change wikilink resolution, graph schemas, edge types, embedding freshness classification, or durable receipt semantics.
+- Repair the separate vault audit findings or inherited graph-semantic/Windows-newline baseline failures.
+- Add an event journal or new persistence layer.
+
+## Decisions
+
+### Use one detached resolver per graph maintenance operation
+
+`rebuild_all()` and `refresh_paths()` will acquire one detached resolver snapshot before opening or mutating the graph sidecar, then pass it explicitly through `_index_path(..., resolver=...)` to `_edges_for_page(..., resolver=...)`. `_edges_for_page` keeps an optional fallback for its existing direct callers, while graph maintenance always supplies the snapshot.
+
+This makes resolver/freshness acquisition O(1) per operation and page parsing O(n). A detached resolver cannot be changed midway by a concurrent watcher patch. Resolver acquisition occurs before graph deletion so acquisition failure preserves the existing sidecar. Separate `refresh_paths()` calls reacquire freshness, while one multi-path call shares one snapshot.
+
+Alternatives rejected:
+
+- Reusing only the global shared resolver would still require freshness validation at the wrong per-page boundary and would allow concurrent mutation during a rebuild.
+- Passing one freshness tuple through repeated shared-cache lookups removes the walk but retains unnecessary global coupling and repeated acquisition calls.
+- Bulk-compiling a separate link table could reduce constants further but is a larger redesign with no evidence it is needed after restoring linear scaling.
+
+### Distinguish an absent baseline from a seeded empty baseline
+
+`freshness.reconcile()` will atomically install the fresh map in both cases, but when no prior map exists it will return an empty, non-drift delta. A prior map of `{}` remains a real baseline: files that appear afterward are reported as changes. Each scope is handled independently.
+
+This is the semantic boundary that prevents initialization from masquerading as missed filesystem events. It does not weaken recovery: once a baseline exists, create/modify/delete deltas continue to dispatch exactly as before.
+
+### Rebaseline explicit reconcile immediately
+
+Successful write-mode reconcile will seed exact `kb` and `vault` freshness maps from final on-disk state before returning, rather than invalidate them and wait up to one watcher interval. The inbound-link cache is still cleared so its next read rebuilds from final disk state. Existing resolver cache entries remain safe because their stored triple is compared with the new baseline and rebuilt once if it changed.
+
+If a final baseline scan cannot complete, reconcile will log the failure and leave that scope non-live; the next periodic watcher pass installs a baseline without fanout. Event-index kill-switch behavior remains unchanged.
+
+### Test structural work, parity, and fanout—not a fragile stopwatch
+
+Scaling tests count detached resolver acquisition and freshness/vault-walk boundaries across many pages. Parity tests compare graph results for representative and ambiguous links. Freshness/watcher tests cover missing versus empty baselines, independent scopes, no phantom index dispatch or receipts, and the next real source edit. A quiescent real-vault benchmark is retained as deployment evidence, not as a timing assertion in lean CI.
+
+## Risks / Trade-offs
+
+- [Risk] Files change during a detached graph rebuild. → The rebuild is an internally consistent best-effort snapshot; normal watcher/reconcile paths heal later changes, matching the existing non-transactional filesystem contract.
+- [Risk] Rebaseline scan races a filesystem event. → Event publishers continue patching live maps and periodic reconciliation remains the bounded safety net; missing state is never converted into fabricated drift.
+- [Risk] A broad test run is not green on current Windows `main`. → Pin new acceptance to targeted regressions, record inherited failures, and require CI/independent review to show the PR adds no new failures.
+- [Risk] A cold detached resolver still performs a full vault read. → One O(n) read is required for correct resolution; the contract removes the repeated per-page O(n) read/check.
+
+## Migration Plan
+
+No data migration is required. Deploy the code, run targeted and lean verification, then run explicit reconcile once on a quiescent production vault while measuring wall time, queue counts, graph drift, and health. Rollback is a normal code rollback; graph and freshness state are derived and rebuildable.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -55,6 +55,31 @@ so an incremental refresh already admitted against the old current graph cannot
 resurrect a failed overlapping rebuild. Refresh against a missing or unavailable
 sidecar routes through a full rebuild rather than publishing a partial graph.
 
+All public graph mutators (`rebuild_all`, `refresh_paths`, and `delete_paths`)
+share one `VaultMutationCoordinator` boundary. Its state root is
+`<Knowledge Base>/.graph-coordination`, keyed by the canonical vault identity,
+with a 30-second bounded acquisition timeout. Keeping the OS-backed lock inside
+the vault is intentional: the LocalSystem service and an interactive user have
+different per-account runtime/cache roots, but both see the same vault path and
+therefore the same lock file. The coordinator's process-local `RLock` preserves
+same-thread re-entrancy; refresh routes to a locked rebuild internal while still
+holding the outer boundary.
+
+The lock covers availability decisions, resolver acquisition, graph row and
+metadata changes, disk-truth stabilization checks, and final marker publication.
+An older operation therefore cannot publish or remove availability after a
+newer mutation has begun, and a refresh admitted before a rebuild cannot mutate
+the sidecar during that rebuild.
+
+`.graph-coordination` is excluded by both the KB corpus walker and the full
+vault walker. Lock state is not corpus content, and excluding the subtree before
+recursion prevents lock-file ACL/read behavior from entering freshness or
+resolver scans. Structured lock failures (`MUTATION_BUSY` and
+`MUTATION_LOCK_UNAVAILABLE`) propagate through the graph leaf wrapper to
+`index_sync`, which records that component as degraded while allowing the
+canonical Markdown write and other index lanes to complete. Unstructured graph
+leaf failures retain the existing soft-failure behavior.
+
 Failure ordering follows the same mutation boundary. An initial disk-freshness
 or resolver acquisition failure occurs before the first pass and preserves the
 previously current graph. Once a pass starts, any exceptional exit—including

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -47,6 +47,13 @@ unavailable/non-current, so readers cannot trust the unstable graph and a later
 refresh or reconcile rebuilds it. The first attempt still acquires its resolver
 before any graph mutation.
 
+Failure ordering follows the same mutation boundary. An initial disk-freshness
+or resolver acquisition failure occurs before the first pass and preserves the
+previously current graph. Once a pass starts, any exceptional exit—including
+partial indexing, the post-pass freshness check, or acquisition for a required
+retry—removes the schema-version marker before propagating. A partial or
+known-moved pass can therefore never remain advertised as current.
+
 Alternatives rejected:
 
 - Reusing only the global shared resolver would still require freshness validation at the wrong per-page boundary and would allow concurrent mutation during a rebuild.

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -80,6 +80,22 @@ resolver scans. Structured lock failures (`MUTATION_BUSY` and
 canonical Markdown write and other index lanes to complete. Unstructured graph
 leaf failures retain the existing soft-failure behavior.
 
+Trusted graph readers do not take the mutation lock. Instead, each public read
+opens the graph sidecar read-only, begins one explicit SQLite read transaction,
+and validates `schema_version`, `core_registry_version`, and
+`extension_registry_hash` as the first read in that transaction. Every graph
+row and metadata query for that operation then uses the same connection and
+snapshot. `_connect()` is deliberately excluded from this path because it may
+create or migrate schema.
+
+This gives readers SQLite's complete-old-or-unavailable contract without
+serializing them behind writers. A reader whose marker validation precedes a
+rebuild sees the complete previously committed graph for its whole operation;
+a reader whose first snapshot read follows marker removal returns
+unavailable/empty and never observes partially rebuilt rows. The boundary is
+shared by nodes, edges, neighbors, indexed paths and unit-parent resolution,
+graph context, cache tokens, graph drift, and graph-backed relation suggestions.
+
 Failure ordering follows the same mutation boundary. An initial disk-freshness
 or resolver acquisition failure occurs before the first pass and preserves the
 previously current graph. Once a pass starts, any exceptional exit—including

--- a/openspec/changes/bound-reconcile-maintenance/design.md
+++ b/openspec/changes/bound-reconcile-maintenance/design.md
@@ -47,11 +47,19 @@ unavailable/non-current, so readers cannot trust the unstable graph and a later
 refresh or reconcile rebuilds it. The first attempt still acquires its resolver
 before any graph mutation.
 
+The schema-version marker has one publisher: stable full-rebuild completion.
+Pass setup removes it in the same transaction that clears prior rows, and it
+stays absent throughout page indexing and any bounded retry. `_index_path()`
+updates graph rows and registry/profile metadata but never graph availability,
+so an incremental refresh already admitted against the old current graph cannot
+resurrect a failed overlapping rebuild. Refresh against a missing or unavailable
+sidecar routes through a full rebuild rather than publishing a partial graph.
+
 Failure ordering follows the same mutation boundary. An initial disk-freshness
 or resolver acquisition failure occurs before the first pass and preserves the
 previously current graph. Once a pass starts, any exceptional exit—including
 partial indexing, the post-pass freshness check, or acquisition for a required
-retry—removes the schema-version marker before propagating. A partial or
+retry—leaves the schema-version marker absent before propagating. A partial or
 known-moved pass can therefore never remain advertised as current.
 
 Alternatives rejected:

--- a/openspec/changes/bound-reconcile-maintenance/proposal.md
+++ b/openspec/changes/bound-reconcile-maintenance/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Explicit reconcile can become effectively quadratic on a large vault because each graph page reacquires a freshness-checked wikilink resolver, and invalidating the live freshness registry can make the watcher misclassify a later baseline install as a corpus-wide source edit. On the production vault this turned one repair into roughly twenty minutes of single-core graph work followed by 1,621 already-current deferred embedding receipts.
+
+## What Changes
+
+- Bound a full or batched epistemic-graph maintenance operation to one detached wikilink-resolver acquisition, while preserving freshness checks between separate operations.
+- Treat installation of a missing freshness baseline as initialization, not filesystem drift.
+- End explicit reconcile with an immediate on-disk freshness baseline instead of leaving the registry non-live until the next periodic watcher pass.
+- Preserve conservative deferred-work behavior for genuinely stale or unverifiable embedding rows and preserve exact watcher fan-out for real source changes.
+- Add scaling, parity, failure-ordering, and no-phantom-fanout regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-index-maintenance`: Bounded resolver work and snapshot consistency for full and batched epistemic-graph maintenance.
+
+### Modified Capabilities
+
+- `live-index-freshness`: Missing-baseline and explicit-reconcile behavior no longer reports or dispatches corpus-wide phantom drift.
+
+## Impact
+
+Affected areas are the epistemic graph rebuild/refresh path, detached resolver acquisition, freshness registry reconciliation, explicit reconcile cleanup, the file-watcher reconciliation seam, and their tests. No public MCP, REST, CLI, Markdown, sidecar-schema, dependency, or model behavior changes.

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -67,18 +67,63 @@ schema-version marker. `refresh_paths` on a missing or unavailable sidecar MUST
 route to a full rebuild so a partial path set is never advertised as a complete
 current graph.
 
-#### Scenario: Admitted refresh overlaps a failing rebuild
+#### Scenario: Refresh contends with a full rebuild
 
-- **WHEN** a refresh passes its initial availability decision
-- **AND** an overlapping full rebuild removes the marker and fails partially
-- **THEN** the admitted refresh may update its owned rows
-- **BUT** it does not restore current graph availability
+- **WHEN** refresh and full rebuild are requested concurrently for one vault
+- **THEN** one operation holds the shared mutation boundary
+- **AND** the other waits or reports bounded `MUTATION_BUSY` without mutating graph rows or availability
 
 #### Scenario: Refresh starts without a current sidecar
 
 - **WHEN** `refresh_paths` starts with a missing or unavailable graph sidecar
 - **THEN** it routes to a full rebuild
 - **AND** availability is published only after the complete rebuild stabilizes
+
+### Requirement: Graph mutations serialize across processes and accounts
+
+The system SHALL serialize `rebuild_all`, `refresh_paths`, and `delete_paths`
+through one re-entrant OS-backed mutation boundary keyed to the canonical vault
+identity. The lock state MUST be rooted at
+`<Knowledge Base>/.graph-coordination` rather than a per-account runtime root,
+so service and interactive processes coordinate through the same lock file.
+Acquisition SHALL use a bounded timeout of approximately 30 seconds. The held
+boundary MUST include the initial availability decision, all row and metadata
+mutation, stabilization checks, and final availability-marker publication.
+
+#### Scenario: Cross-process mutation waits for an active rebuild
+
+- **WHEN** one process is inside a full graph rebuild mutation boundary
+- **AND** another process calls refresh or delete for the same canonical vault
+- **THEN** the later mutator does not enter graph mutation until the rebuild releases the boundary
+
+#### Scenario: Service and interactive accounts share authority
+
+- **WHEN** two processes use different per-account runtime state directories but the same vault
+- **THEN** all graph mutators resolve the lock beneath that vault's Knowledge Base
+- **AND** they contend on the same canonical lock path
+
+#### Scenario: Refresh routes to rebuild while holding the boundary
+
+- **WHEN** refresh observes a missing or unavailable graph while holding mutation authority
+- **THEN** it performs the required full rebuild without deadlocking or releasing authority between the decision and rebuild
+
+#### Scenario: Older operation cannot reorder availability
+
+- **WHEN** an older graph operation would otherwise publish or remove the schema marker after a newer overlapping mutation
+- **THEN** serialization prevents the operations from overlapping
+- **AND** marker state reflects completed mutation order
+
+#### Scenario: Coordination state is outside the indexed corpus
+
+- **WHEN** KB-only or full-vault Markdown traversal reaches the Knowledge Base
+- **THEN** it excludes the `.graph-coordination` subtree before recursion
+- **AND** lock state or its host ACLs do not participate in graph freshness or resolver input
+
+#### Scenario: Lock acquisition cannot establish mutation authority
+
+- **WHEN** a graph writer cannot acquire or open the shared mutation lock
+- **THEN** it does not mutate graph rows or availability
+- **AND** its structured lock error reaches index-sync reporting as a degraded graph component rather than accepted success
 
 ### Requirement: Bounded graph maintenance preserves correctness and failure ordering
 

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -29,7 +29,9 @@ key rather than potentially stale event-registry state. If freshness changes
 during the first pass, it SHALL retry once with a new disk key and detached
 resolver. It MUST perform at most two passes. If freshness changes during the
 second pass, it SHALL mark the graph unavailable/non-current and raise instead
-of exposing the unstable result as trusted.
+of exposing the unstable result as trusted. The schema-version marker MUST
+remain absent throughout every pass and retry and MUST be published only after
+the final direct disk-truth post-check succeeds.
 
 #### Scenario: Target appears after snapshot acquisition
 
@@ -50,6 +52,33 @@ of exposing the unstable result as trusted.
 - **WHEN** disk freshness is unchanged around the first graph pass
 - **THEN** the rebuild performs one resolver acquisition and one graph pass
 - **AND** resolver or freshness work does not scale per indexed page
+
+#### Scenario: Stable completion is the only availability publisher
+
+- **WHEN** a full rebuild is indexing pages or preparing a bounded retry
+- **THEN** the graph schema-version marker remains absent
+- **AND** only a successful final disk-freshness post-check publishes it
+
+### Requirement: Incremental refresh does not own graph availability
+
+The system SHALL allow incremental refresh to update graph rows and
+registry/profile metadata but `_index_path` MUST NOT insert or restore the
+schema-version marker. `refresh_paths` on a missing or unavailable sidecar MUST
+route to a full rebuild so a partial path set is never advertised as a complete
+current graph.
+
+#### Scenario: Admitted refresh overlaps a failing rebuild
+
+- **WHEN** a refresh passes its initial availability decision
+- **AND** an overlapping full rebuild removes the marker and fails partially
+- **THEN** the admitted refresh may update its owned rows
+- **BUT** it does not restore current graph availability
+
+#### Scenario: Refresh starts without a current sidecar
+
+- **WHEN** `refresh_paths` starts with a missing or unavailable graph sidecar
+- **THEN** it routes to a full rebuild
+- **AND** availability is published only after the complete rebuild stabilizes
 
 ### Requirement: Bounded graph maintenance preserves correctness and failure ordering
 

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Graph maintenance uses one operation-scoped resolver snapshot
+
+The system SHALL acquire one detached wikilink-resolver snapshot before mutating the epistemic graph for a full rebuild or one batched refresh, and SHALL reuse that snapshot for every page in the operation. Resolver acquisition and vault-wide freshness work MUST NOT scale with the number of pages in that operation. The snapshot MUST NOT warm or mutate the process-shared resolver cache.
+
+#### Scenario: Full rebuild has bounded resolver work
+
+- **WHEN** a full graph rebuild indexes multiple Markdown pages in a process without a live freshness registry
+- **THEN** it acquires one detached resolver snapshot for the operation
+- **AND** it does not perform a vault-wide resolver freshness check for each page
+
+#### Scenario: Batched refresh has bounded resolver work
+
+- **WHEN** one `refresh_paths` operation indexes multiple changed Markdown pages
+- **THEN** it acquires one detached resolver snapshot and reuses it for the batch
+- **AND** a later separate `refresh_paths` operation acquires a new snapshot
+
+#### Scenario: Shared resolver changes do not mutate an active graph snapshot
+
+- **WHEN** the process-shared resolver is patched after graph maintenance has acquired its detached snapshot
+- **THEN** the active operation continues resolving every page against its original snapshot
+
+### Requirement: Bounded graph maintenance preserves correctness and failure ordering
+
+The system SHALL preserve the same graph nodes and edges produced from an equivalent stable vault, including ambiguous-link behavior. It MUST acquire the resolver before deleting or replacing existing graph rows so a resolver acquisition failure leaves the prior graph intact.
+
+#### Scenario: Resolver acquisition fails before graph mutation
+
+- **WHEN** resolver snapshot acquisition fails at the start of a full graph rebuild
+- **THEN** the rebuild reports the failure
+- **AND** the previously committed graph rows remain unchanged
+
+#### Scenario: Resolver reuse preserves graph output
+
+- **WHEN** a stable fixture vault is rebuilt with an operation-scoped resolver snapshot
+- **THEN** its graph node and edge payloads match the fresh-resolution reference for that vault
+
+#### Scenario: Concurrent source changes remain eventually repairable
+
+- **WHEN** a Markdown file changes after graph maintenance acquired its snapshot
+- **THEN** the current operation remains internally consistent with that snapshot
+- **AND** a later watcher event or reconcile operation can refresh the affected derived graph state

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -125,6 +125,39 @@ mutation, stabilization checks, and final availability-marker publication.
 - **THEN** it does not mutate graph rows or availability
 - **AND** its structured lock error reaches index-sync reporting as a degraded graph component rather than accepted success
 
+### Requirement: Trusted graph reads use one validated SQLite snapshot
+
+The system SHALL perform each trusted graph read operation through one explicit
+SQLite read transaction without acquiring the OS mutation lock. It MUST open a
+read-only connection, `BEGIN` the transaction, and validate schema-version,
+core-registry-version, and extension-registry-hash markers as the first read in
+that transaction. Every row and metadata query for the operation MUST use that
+same connection and snapshot. Read operations MUST NOT use the schema-creating
+or schema-migrating writer connection helper.
+
+This boundary applies to public node, edge, neighbor, indexed-path, graph
+context, cache-token, graph-drift, and indexed unit-parent reads, plus
+graph-backed relation-suggestion reads.
+
+#### Scenario: Reader snapshot precedes rebuild mutation
+
+- **WHEN** a trusted reader validates current markers before a rebuild removes them
+- **AND** the rebuild mutates graph rows while the read operation remains active
+- **THEN** every query in that read operation observes the complete previously committed graph snapshot
+- **AND** the reader never mixes old and rebuilt rows
+
+#### Scenario: Reader snapshot follows marker removal
+
+- **WHEN** a trusted reader begins after a rebuild has removed the schema-version marker
+- **THEN** marker validation rejects the snapshot as unavailable
+- **AND** the operation returns its unavailable or empty result without querying partial graph rows
+
+#### Scenario: Readers remain lock-free
+
+- **WHEN** a trusted graph read overlaps a serialized writer
+- **THEN** the reader does not acquire the OS mutation coordinator
+- **AND** SQLite snapshot isolation supplies complete-old-or-unavailable behavior
+
 ### Requirement: Bounded graph maintenance preserves correctness and failure ordering
 
 The system SHALL preserve the same graph nodes and edges produced from an equivalent stable vault, including ambiguous-link behavior. It MUST acquire initial disk freshness and the resolver before deleting or replacing existing graph rows so an initial acquisition failure leaves the prior graph intact. Once a rebuild pass begins, every exceptional exit MUST mark the graph unavailable/non-current before propagating, including pass failures, post-pass freshness failures, and freshness or resolver failures while acquiring a required retry.

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -53,13 +53,26 @@ of exposing the unstable result as trusted.
 
 ### Requirement: Bounded graph maintenance preserves correctness and failure ordering
 
-The system SHALL preserve the same graph nodes and edges produced from an equivalent stable vault, including ambiguous-link behavior. It MUST acquire the resolver before deleting or replacing existing graph rows so a resolver acquisition failure leaves the prior graph intact.
+The system SHALL preserve the same graph nodes and edges produced from an equivalent stable vault, including ambiguous-link behavior. It MUST acquire initial disk freshness and the resolver before deleting or replacing existing graph rows so an initial acquisition failure leaves the prior graph intact. Once a rebuild pass begins, every exceptional exit MUST mark the graph unavailable/non-current before propagating, including pass failures, post-pass freshness failures, and freshness or resolver failures while acquiring a required retry.
 
 #### Scenario: Resolver acquisition fails before graph mutation
 
 - **WHEN** resolver snapshot acquisition fails at the start of a full graph rebuild
 - **THEN** the rebuild reports the failure
 - **AND** the previously committed graph rows remain unchanged
+
+#### Scenario: Retry acquisition fails after a moved pass
+
+- **WHEN** a completed graph pass observes changed disk freshness
+- **AND** disk-freshness or resolver acquisition for the required retry fails
+- **THEN** the rebuild marks the graph unavailable/non-current
+- **AND** it propagates the acquisition failure
+
+#### Scenario: Graph pass fails after mutation begins
+
+- **WHEN** a full rebuild pass fails during indexing or its post-pass freshness check
+- **THEN** the rebuild marks the partial graph unavailable/non-current
+- **AND** it propagates the original failure
 
 #### Scenario: Resolver reuse preserves graph output
 

--- a/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/bounded-index-maintenance/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Graph maintenance uses one operation-scoped resolver snapshot
 
-The system SHALL acquire one detached wikilink-resolver snapshot before mutating the epistemic graph for a full rebuild or one batched refresh, and SHALL reuse that snapshot for every page in the operation. Resolver acquisition and vault-wide freshness work MUST NOT scale with the number of pages in that operation. The snapshot MUST NOT warm or mutate the process-shared resolver cache.
+The system SHALL acquire one detached wikilink-resolver snapshot before mutating the epistemic graph for one stable full-rebuild pass or one batched refresh, and SHALL reuse that snapshot for every page in the pass. Resolver acquisition and vault-wide freshness work MUST NOT scale with the number of pages in that pass. The snapshot MUST NOT warm or mutate the process-shared resolver cache.
 
 #### Scenario: Full rebuild has bounded resolver work
 
@@ -20,6 +20,36 @@ The system SHALL acquire one detached wikilink-resolver snapshot before mutating
 
 - **WHEN** the process-shared resolver is patched after graph maintenance has acquired its detached snapshot
 - **THEN** the active operation continues resolving every page against its original snapshot
+
+### Requirement: Full rebuild stabilization is disk-truth and constant-bounded
+
+The system SHALL bracket a full graph rebuild pass with direct on-disk vault
+freshness keys and SHALL acquire its detached resolver against the pre-pass disk
+key rather than potentially stale event-registry state. If freshness changes
+during the first pass, it SHALL retry once with a new disk key and detached
+resolver. It MUST perform at most two passes. If freshness changes during the
+second pass, it SHALL mark the graph unavailable/non-current and raise instead
+of exposing the unstable result as trusted.
+
+#### Scenario: Target appears after snapshot acquisition
+
+- **WHEN** a target file appears or is renamed after the first detached resolver is acquired
+- **AND** the first graph pass observes changed disk freshness
+- **THEN** the rebuild acquires a new detached resolver and retries
+- **AND** the stable retry resolves source edges against the target's final path
+
+#### Scenario: Vault moves during both bounded passes
+
+- **WHEN** direct disk freshness changes during both the first and second graph passes
+- **THEN** the rebuild performs exactly two resolver acquisitions and two passes
+- **AND** it marks the graph unavailable/non-current
+- **AND** it raises so later reconcile or refresh can rebuild the graph
+
+#### Scenario: Stable rebuild retains linear work
+
+- **WHEN** disk freshness is unchanged around the first graph pass
+- **THEN** the rebuild performs one resolver acquisition and one graph pass
+- **AND** resolver or freshness work does not scale per indexed page
 
 ### Requirement: Bounded graph maintenance preserves correctness and failure ordering
 

--- a/openspec/changes/bound-reconcile-maintenance/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/live-index-freshness/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Freshness Reconciliation Bounds Missed Events
+
+The system SHALL bound how stale the event-maintained freshness registry can become from a missed filesystem event by periodically re-walking each live scope's tree and reconciling the registry against the fresh walk's result, on an interval independent of file-change events. A mismatch between an existing registry baseline and the fresh walk MUST be logged, MUST be corrected in the registry, and MUST return only the exact changed/deleted delta for derived-index fanout. When no prior baseline exists for a scope, the fresh walk SHALL install the initial baseline without reporting drift or dispatching the current corpus as changed; a previously seeded empty map remains an existing baseline. A successful user-invoked write-mode reconcile SHALL install final on-disk freshness baselines before returning, while event-maintained indexes are enabled, instead of leaving the registry non-live until the periodic timer.
+
+#### Scenario: Periodic reconciliation heals a missed event
+
+- **WHEN** a filesystem change event for a live-registry scope is missed and the periodic reconciliation interval elapses
+- **THEN** the registry is re-walked and corrected to match the on-disk tree
+- **AND** the mismatch is logged
+- **AND** only the exact changed or deleted paths are returned for fanout
+
+#### Scenario: Missing baseline initializes without phantom drift
+
+- **WHEN** periodic reconciliation runs for a scope whose registry has no prior baseline
+- **THEN** the fresh walk is installed as that scope's live baseline
+- **AND** no current path is reported or dispatched as changed
+
+#### Scenario: Seeded empty baseline still detects a new file
+
+- **WHEN** a scope was explicitly seeded with an empty baseline
+- **AND** a Markdown file appears before periodic reconciliation
+- **THEN** that file is reported exactly once as changed
+
+#### Scenario: Explicit reconcile leaves exact live baselines
+
+- **WHEN** a user-invoked write-mode reconcile completes successfully with event-maintained indexes enabled
+- **THEN** the `kb` and `vault` freshness scopes are live and match final on-disk state before the command returns
+- **AND** the next unchanged watcher reconciliation produces no index fanout or deferred semantic receipts
+
+#### Scenario: Real change after rebaseline still dispatches
+
+- **WHEN** explicit reconcile installs final freshness baselines
+- **AND** a Markdown source is subsequently modified or deleted
+- **THEN** watcher reconciliation reports and dispatches that exact path once
+
+#### Scenario: Scope baselines are independent
+
+- **WHEN** one freshness scope has a prior baseline and another scope does not
+- **THEN** the missing scope initializes without drift
+- **AND** real drift in the existing scope is still reported and dispatched

--- a/openspec/changes/bound-reconcile-maintenance/specs/live-index-freshness/spec.md
+++ b/openspec/changes/bound-reconcile-maintenance/specs/live-index-freshness/spec.md
@@ -35,6 +35,13 @@ The system SHALL bound how stale the event-maintained freshness registry can bec
 - **AND** a Markdown source is subsequently modified or deleted
 - **THEN** watcher reconciliation reports and dispatches that exact path once
 
+#### Scenario: Real deletion after rebaseline still dispatches
+
+- **WHEN** explicit reconcile installs final freshness baselines
+- **AND** a Markdown source is subsequently deleted
+- **THEN** watcher reconciliation dispatches one delete for that exact path
+- **AND** it does not dispatch a matching upsert or any unrelated corpus path
+
 #### Scenario: Scope baselines are independent
 
 - **WHEN** one freshness scope has a prior baseline and another scope does not

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -6,6 +6,7 @@
 - [x] 1.4 Add deterministic stabilization regressions for target creation after snapshot acquisition and repeated two-pass churn.
 - [x] 1.5 Mutate the shared cached resolver after detached acquisition and prove the active graph pass remains isolated.
 - [x] 1.6 Add failure-ordering regressions for retry freshness/resolver acquisition and partial-pass failures while preserving initial acquisition behavior.
+- [x] 1.7 Add marker-publication regressions for stable passes, post-check failure, an already-admitted refresh overlapping a failed rebuild, and missing-sidecar refresh.
 
 ## 2. Bounded Graph Implementation
 
@@ -13,6 +14,7 @@
 - [x] 2.2 Keep direct edge-extraction compatibility while preventing graph maintenance from performing per-page resolver freshness work.
 - [x] 2.3 Bracket full rebuild passes with disk-truth freshness, retry once on movement, and mark repeated churn unavailable before raising.
 - [x] 2.4 Invalidate every exceptional exit after a rebuild pass starts without invalidating failures before the first mutation boundary.
+- [x] 2.5 Make stable full-rebuild completion the only schema-version publisher and route non-current incremental refresh through a full rebuild.
 
 ## 3. Freshness and Fanout Regressions
 

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -1,0 +1,28 @@
+## 1. Graph Maintenance Regressions
+
+- [x] 1.1 Add a failing full-rebuild test proving one detached resolver acquisition is reused across multiple pages without mutating the shared cache.
+- [x] 1.2 Add failing batched-refresh tests proving one acquisition per batch and reacquisition across separate operations.
+- [x] 1.3 Add failing failure-ordering and snapshot-parity tests covering existing-row preservation, ambiguous links, and isolation from shared-resolver patches.
+
+## 2. Bounded Graph Implementation
+
+- [x] 2.1 Acquire the detached resolver before graph mutation and thread it explicitly through full rebuild and batched refresh indexing.
+- [x] 2.2 Keep direct edge-extraction compatibility while preventing graph maintenance from performing per-page resolver freshness work.
+
+## 3. Freshness and Fanout Regressions
+
+- [x] 3.1 Add failing freshness tests distinguishing missing baselines from seeded empty baselines and preserving independent scope drift.
+- [x] 3.2 Add failing explicit-reconcile tests proving final exact live baselines are installed when event indexes are enabled.
+- [x] 3.3 Add failing watcher integration tests proving an unchanged post-reconcile pass creates no fanout/receipts and the next real source change dispatches exactly once.
+
+## 4. Freshness and Reconcile Implementation
+
+- [x] 4.1 Make missing-baseline reconciliation initialize live state with an empty non-drift delta while preserving real deltas from existing baselines.
+- [x] 4.2 Add final on-disk freshness rebaselining and use it from successful write-mode reconcile with safe fallback behavior.
+- [x] 4.3 Preserve inbound/resolver cache correctness and event-index kill-switch behavior after rebaseline.
+
+## 5. Verification and Delivery
+
+- [ ] 5.1 Run focused graph/freshness/watcher/reconcile tests, Ruff, OpenSpec validation, and the lean suite while recording inherited baseline failures separately.
+- [ ] 5.2 Run an independent review for spec conformance, race safety, and regression scope; address all actionable findings.
+- [ ] 5.3 Benchmark a quiescent production reconcile, verify queue counts and derived-index drift remain zero, and confirm local/public health after deployment.

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -38,6 +38,6 @@
 
 ## 5. Verification and Delivery
 
-- [ ] 5.1 Run focused graph/freshness/watcher/reconcile tests, Ruff, OpenSpec validation, and the lean suite while recording inherited baseline failures separately.
-- [ ] 5.2 Run an independent review for spec conformance, race safety, and regression scope; address all actionable findings.
+- [x] 5.1 Run focused graph/freshness/watcher/reconcile tests, Ruff, OpenSpec validation, and the lean suite while recording inherited baseline failures separately.
+- [x] 5.2 Run an independent review for spec conformance, race safety, and regression scope; address all actionable findings.
 - [ ] 5.3 Benchmark a quiescent production reconcile, verify queue counts and derived-index drift remain zero, and confirm local/public health after deployment.

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -3,23 +3,28 @@
 - [x] 1.1 Add a failing full-rebuild test proving one detached resolver acquisition is reused across multiple pages without mutating the shared cache.
 - [x] 1.2 Add failing batched-refresh tests proving one acquisition per batch and reacquisition across separate operations.
 - [x] 1.3 Add failing failure-ordering and snapshot-parity tests covering existing-row preservation, ambiguous links, and isolation from shared-resolver patches.
+- [x] 1.4 Add deterministic stabilization regressions for target creation after snapshot acquisition and repeated two-pass churn.
+- [x] 1.5 Mutate the shared cached resolver after detached acquisition and prove the active graph pass remains isolated.
 
 ## 2. Bounded Graph Implementation
 
 - [x] 2.1 Acquire the detached resolver before graph mutation and thread it explicitly through full rebuild and batched refresh indexing.
 - [x] 2.2 Keep direct edge-extraction compatibility while preventing graph maintenance from performing per-page resolver freshness work.
+- [x] 2.3 Bracket full rebuild passes with disk-truth freshness, retry once on movement, and mark repeated churn unavailable before raising.
 
 ## 3. Freshness and Fanout Regressions
 
 - [x] 3.1 Add failing freshness tests distinguishing missing baselines from seeded empty baselines and preserving independent scope drift.
 - [x] 3.2 Add failing explicit-reconcile tests proving final exact live baselines are installed when event indexes are enabled.
 - [x] 3.3 Add failing watcher integration tests proving an unchanged post-reconcile pass creates no fanout/receipts and the next real source change dispatches exactly once.
+- [x] 3.4 Add symmetric exact-once deletion recovery coverage after explicit rebaseline.
 
 ## 4. Freshness and Reconcile Implementation
 
 - [x] 4.1 Make missing-baseline reconciliation initialize live state with an empty non-drift delta while preserving real deltas from existing baselines.
 - [x] 4.2 Add final on-disk freshness rebaselining and use it from successful write-mode reconcile with safe fallback behavior.
 - [x] 4.3 Preserve inbound/resolver cache correctness and event-index kill-switch behavior after rebaseline.
+- [x] 4.4 Document and retain lock-held final baseline installation so a post-scan event patch cannot be overwritten.
 
 ## 5. Verification and Delivery
 

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -5,12 +5,14 @@
 - [x] 1.3 Add failing failure-ordering and snapshot-parity tests covering existing-row preservation, ambiguous links, and isolation from shared-resolver patches.
 - [x] 1.4 Add deterministic stabilization regressions for target creation after snapshot acquisition and repeated two-pass churn.
 - [x] 1.5 Mutate the shared cached resolver after detached acquisition and prove the active graph pass remains isolated.
+- [x] 1.6 Add failure-ordering regressions for retry freshness/resolver acquisition and partial-pass failures while preserving initial acquisition behavior.
 
 ## 2. Bounded Graph Implementation
 
 - [x] 2.1 Acquire the detached resolver before graph mutation and thread it explicitly through full rebuild and batched refresh indexing.
 - [x] 2.2 Keep direct edge-extraction compatibility while preventing graph maintenance from performing per-page resolver freshness work.
 - [x] 2.3 Bracket full rebuild passes with disk-truth freshness, retry once on movement, and mark repeated churn unavailable before raising.
+- [x] 2.4 Invalidate every exceptional exit after a rebuild pass starts without invalidating failures before the first mutation boundary.
 
 ## 3. Freshness and Fanout Regressions
 

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -7,6 +7,8 @@
 - [x] 1.5 Mutate the shared cached resolver after detached acquisition and prove the active graph pass remains isolated.
 - [x] 1.6 Add failure-ordering regressions for retry freshness/resolver acquisition and partial-pass failures while preserving initial acquisition behavior.
 - [x] 1.7 Add marker-publication regressions for stable passes, post-check failure, an already-admitted refresh overlapping a failed rebuild, and missing-sidecar refresh.
+- [x] 1.8 Add a spawned-process serialization regression and assert graph coordination state is vault-rooted and shared.
+- [x] 1.9 Add regressions for walker exclusion, pre-mutation lock failure, and degraded index-sync reporting of structured lock errors.
 
 ## 2. Bounded Graph Implementation
 
@@ -15,6 +17,8 @@
 - [x] 2.3 Bracket full rebuild passes with disk-truth freshness, retry once on movement, and mark repeated churn unavailable before raising.
 - [x] 2.4 Invalidate every exceptional exit after a rebuild pass starts without invalidating failures before the first mutation boundary.
 - [x] 2.5 Make stable full-rebuild completion the only schema-version publisher and route non-current incremental refresh through a full rebuild.
+- [x] 2.6 Serialize all public graph mutators with one vault-rooted re-entrant OS-backed mutation coordinator.
+- [x] 2.7 Exclude coordination state from both walkers and propagate structured lock failures to the index-sync degradation boundary.
 
 ## 3. Freshness and Fanout Regressions
 

--- a/openspec/changes/bound-reconcile-maintenance/tasks.md
+++ b/openspec/changes/bound-reconcile-maintenance/tasks.md
@@ -9,6 +9,7 @@
 - [x] 1.7 Add marker-publication regressions for stable passes, post-check failure, an already-admitted refresh overlapping a failed rebuild, and missing-sidecar refresh.
 - [x] 1.8 Add a spawned-process serialization regression and assert graph coordination state is vault-rooted and shared.
 - [x] 1.9 Add regressions for walker exclusion, pre-mutation lock failure, and degraded index-sync reporting of structured lock errors.
+- [x] 1.10 Add deterministic reader races proving complete-old snapshots before rebuild and unavailable/empty results after marker removal.
 
 ## 2. Bounded Graph Implementation
 
@@ -19,6 +20,7 @@
 - [x] 2.5 Make stable full-rebuild completion the only schema-version publisher and route non-current incremental refresh through a full rebuild.
 - [x] 2.6 Serialize all public graph mutators with one vault-rooted re-entrant OS-backed mutation coordinator.
 - [x] 2.7 Exclude coordination state from both walkers and propagate structured lock failures to the index-sync degradation boundary.
+- [x] 2.8 Route every trusted graph read through one read-only validated SQLite transaction without taking the mutation lock.
 
 ## 3. Freshness and Fanout Regressions
 

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -443,8 +443,17 @@ async def _stdio_session(
                     relation_ref=state["relation_ref"],
                     timeout=timeout,
                 )
-                if reconcile.get("graph_status") != "refreshed":
-                    raise RuntimeError("deleted graph sidecar was not rebuilt after restart")
+                from exomem import epistemic_graph
+
+                graph_status = reconcile.get("graph_status")
+                graph_available = epistemic_graph.EpistemicGraphIndex(
+                    Path(env["EXOMEM_VAULT_PATH"])
+                ).available()
+                if graph_status not in {"current", "refreshed"} or not graph_available:
+                    raise RuntimeError(
+                        "deleted graph sidecar was not rebuilt after restart: "
+                        f"status={graph_status!r}, available={graph_available!r}"
+                    )
     return state
 
 

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -230,6 +230,7 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
+        resolver = find_module.writer_resolver_snapshot(self.vault_root)
         conn = self._connect()
         try:
             with conn:
@@ -266,7 +267,7 @@ class EpistemicGraphIndex:
             kb = self.vault_root / kb_dirname()
             if kb.is_dir():
                 for md in find_module._walk_md(kb):
-                    if self._index_path(conn, md):
+                    if self._index_path(conn, md, resolver=resolver):
                         indexed += 1
             with conn:
                 n_nodes = conn.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0]
@@ -280,11 +281,12 @@ class EpistemicGraphIndex:
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
         if self.path.exists() and not self.available():
             return self.rebuild_all()
+        resolver = find_module.writer_resolver_snapshot(self.vault_root)
         conn = self._connect()
         indexed = 0
         try:
             for path in paths:
-                if self._index_path(conn, path):
+                if self._index_path(conn, path, resolver=resolver):
                     indexed += 1
             with conn:
                 n_nodes = conn.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0]
@@ -345,7 +347,13 @@ class EpistemicGraphIndex:
             conn.close()
         return [_edge_row_to_dict(r) for r in rows]
 
-    def _index_path(self, conn: sqlite3.Connection, path: Path) -> bool:
+    def _index_path(
+        self,
+        conn: sqlite3.Connection,
+        path: Path,
+        *,
+        resolver: vault_module.WikilinkResolver,
+    ) -> bool:
         try:
             rel = path.resolve().relative_to(self.vault_root.resolve()).as_posix()
         except (ValueError, OSError):
@@ -381,6 +389,7 @@ class EpistemicGraphIndex:
             registry=self.registry,
             source_hash=file_node.source_hash,
             parent_state=state,
+            resolver=resolver,
         )
         with conn:
             conn.execute("DELETE FROM graph_edges WHERE source_path = ?", (rel,))
@@ -1157,6 +1166,7 @@ def _edges_for_page(
     registry: relation_registry.RelationRegistry | None = None,
     source_hash: str | None = None,
     parent_state: semantic_index.SemanticParentIndexState | None = None,
+    resolver: vault_module.WikilinkResolver | None = None,
 ) -> list[GraphEdge]:
     registry = registry or relation_registry.load_registry(vault_root)
     source_hash = source_hash or vault_module.content_hash(page.body)
@@ -1174,7 +1184,8 @@ def _edges_for_page(
 
     rel = page.rel_path
     file_key = _file_key(rel)
-    resolver = find_module.shared_resolver(vault_root)
+    if resolver is None:
+        resolver = find_module.shared_resolver(vault_root)
     edges: list[GraphEdge] = []
     for unit in document.units:
         if unit.unit_ref is None or unit.form == "rich":

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -34,6 +34,7 @@ SCHEMA_VERSION = 4
 UNIT_SEED_MAX_BATCHES = 4
 UNIT_PARENT_REF_MAX_CANDIDATES = 16
 EDGE_INSPECTION_MULTIPLIER = 4
+REBUILD_STABILIZATION_ATTEMPTS = 2
 
 RELATION_TYPES: frozenset[str] = relation_registry.core_registry().keys
 
@@ -126,6 +127,13 @@ def graph_enabled() -> bool:
 
 def sidecar_path(vault_root: Path) -> Path:
     return vault_root / kb_dirname() / ".graph.sqlite"
+
+
+def _disk_vault_freshness(vault_root: Path) -> tuple[int, int, str]:
+    """Vault freshness from a direct walk, bypassing event-registry state."""
+    return find_module._walk_freshness_key(
+        vault_module.walk_vault_md(vault_root)
+    )
 
 
 class EpistemicGraphIndex:
@@ -230,7 +238,24 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        resolver = find_module.writer_resolver_snapshot(self.vault_root)
+        for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
+            before = _disk_vault_freshness(self.vault_root)
+            resolver = find_module.writer_resolver_snapshot(
+                self.vault_root,
+                freshness_key=before,
+            )
+            report = self._rebuild_all_pass(resolver)
+            if _disk_vault_freshness(self.vault_root) == before:
+                return report
+        self._mark_unavailable()
+        raise RuntimeError(
+            "epistemic graph rebuild did not stabilize after 2 attempts"
+        )
+
+    def _rebuild_all_pass(
+        self,
+        resolver: vault_module.WikilinkResolver,
+    ) -> dict[str, int]:
         conn = self._connect()
         try:
             with conn:
@@ -273,6 +298,18 @@ class EpistemicGraphIndex:
                 n_nodes = conn.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0]
                 n_edges = conn.execute("SELECT COUNT(*) FROM graph_edges").fetchone()[0]
             return {"indexed_files": indexed, "nodes": int(n_nodes), "edges": int(n_edges)}
+        finally:
+            conn.close()
+
+    def _mark_unavailable(self) -> None:
+        if not self.path.exists():
+            return
+        conn = sqlite3.connect(self.path)
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM graph_meta WHERE key = 'schema_version'"
+                )
         finally:
             conn.close()
 

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -223,26 +223,41 @@ class EpistemicGraphIndex:
         return conn
 
     def available(self) -> bool:
+        conn = self._open_read_snapshot()
+        if conn is None:
+            return False
+        conn.close()
+        return True
+
+    def _open_read_snapshot(self) -> sqlite3.Connection | None:
+        """Open one validated read transaction without creating or migrating schema."""
         if not graph_enabled() or not self.path.exists():
-            return False
+            return None
+        conn: sqlite3.Connection | None = None
         try:
-            conn = sqlite3.connect(self.path)
-            try:
-                values = dict(
-                    conn.execute(
-                        "SELECT key, value FROM graph_meta WHERE key IN "
-                        "('schema_version', 'core_registry_version', 'extension_registry_hash')"
-                    ).fetchall()
-                )
-            finally:
-                conn.close()
+            uri = f"{self.path.resolve().as_uri()}?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+            conn.execute("BEGIN")
+            # This marker validation MUST remain the first read in the transaction.
+            values = dict(
+                conn.execute(
+                    "SELECT key, value FROM graph_meta WHERE key IN "
+                    "('schema_version', 'core_registry_version', 'extension_registry_hash')"
+                ).fetchall()
+            )
         except sqlite3.Error:
-            return False
-        return (
+            if conn is not None:
+                conn.close()
+            return None
+        current = (
             values.get("schema_version") == str(SCHEMA_VERSION)
             and values.get("core_registry_version") == str(self.registry.core_version)
             and values.get("extension_registry_hash") == self.registry.extension_hash
         )
+        if not current:
+            conn.close()
+            return None
+        return conn
 
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
@@ -385,42 +400,59 @@ class EpistemicGraphIndex:
             conn.close()
 
     def nodes(self, *, path: str | None = None) -> list[dict[str, Any]]:
-        if not self.path.exists():
+        conn = self._open_read_snapshot()
+        if conn is None:
             return []
-        conn = self._connect()
         try:
-            select = (
-                "SELECT node_key, kind, path, anchor, title, text, source_hash, "
-                "line_start, line_end, metadata FROM graph_nodes"
-            )
-            if path is None:
-                rows = conn.execute(select + " ORDER BY node_key").fetchall()
-            else:
-                rows = conn.execute(
-                    select + " WHERE path = ? ORDER BY node_key", (_with_md(path),)
-                ).fetchall()
+            return self._nodes_from_snapshot(conn, path=path)
         finally:
             conn.close()
+
+    def _nodes_from_snapshot(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        path: str | None = None,
+    ) -> list[dict[str, Any]]:
+        select = (
+            "SELECT node_key, kind, path, anchor, title, text, source_hash, "
+            "line_start, line_end, metadata FROM graph_nodes"
+        )
+        if path is None:
+            rows = conn.execute(select + " ORDER BY node_key").fetchall()
+        else:
+            rows = conn.execute(
+                select + " WHERE path = ? ORDER BY node_key", (_with_md(path),)
+            ).fetchall()
         return [_node_row_to_dict(r) for r in rows]
 
     def edges(self, *, source_path: str | None = None) -> list[dict[str, Any]]:
-        if not self.path.exists():
+        conn = self._open_read_snapshot()
+        if conn is None:
             return []
-        conn = self._connect()
         try:
-            select = (
-                "SELECT edge_key, src_key, dst_key, relation_type, raw_relation, "
-                "parent_relation, registry_status, registry_version, registry_hash, "
-                "origin, source_path, source_anchor, metadata FROM graph_edges"
-            )
-            if source_path is None:
-                rows = conn.execute(select + " ORDER BY edge_key").fetchall()
-            else:
-                rows = conn.execute(
-                    select + " WHERE source_path = ? ORDER BY edge_key", (_with_md(source_path),)
-                ).fetchall()
+            return self._edges_from_snapshot(conn, source_path=source_path)
         finally:
             conn.close()
+
+    def _edges_from_snapshot(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        source_path: str | None = None,
+    ) -> list[dict[str, Any]]:
+        select = (
+            "SELECT edge_key, src_key, dst_key, relation_type, raw_relation, "
+            "parent_relation, registry_status, registry_version, registry_hash, "
+            "origin, source_path, source_anchor, metadata FROM graph_edges"
+        )
+        if source_path is None:
+            rows = conn.execute(select + " ORDER BY edge_key").fetchall()
+        else:
+            rows = conn.execute(
+                select + " WHERE source_path = ? ORDER BY edge_key",
+                (_with_md(source_path),),
+            ).fetchall()
         return [_edge_row_to_dict(r) for r in rows]
 
     def _index_path(
@@ -529,7 +561,7 @@ class EpistemicGraphIndex:
         Self-edges (a block's own `derived_from` edge to its owning file) drop
         out via the same-path check below.
         """
-        if not seeds or not self.available():
+        if not seeds:
             return []
         seed_order: dict[str, int] = {}
         for i, seed in enumerate(seeds):
@@ -537,7 +569,9 @@ class EpistemicGraphIndex:
             if rel not in seed_order:
                 seed_order[rel] = i
         seed_paths = list(seed_order)
-        conn = self._connect()
+        conn = self._open_read_snapshot()
+        if conn is None:
+            return []
         try:
             path_placeholders = ",".join("?" for _ in seed_paths)
             node_rows = conn.execute(
@@ -594,10 +628,12 @@ class EpistemicGraphIndex:
         it (reachable under `scope="vault"`) is never in this set — the
         find-lane hybrid branch uses that to run legacy wikilink expansion for
         seeds the sidecar never covered, instead of silently dropping them."""
-        if not paths or not self.available():
+        if not paths:
             return set()
         rels = [_with_md(p) for p in paths]
-        conn = self._connect()
+        conn = self._open_read_snapshot()
+        if conn is None:
+            return set()
         try:
             placeholders = ",".join("?" for _ in rels)
             rows = conn.execute(
@@ -627,15 +663,6 @@ def graph_context(
 ) -> dict[str, Any]:
     """Return a bounded, read-only graph neighborhood for a path or query."""
     idx = EpistemicGraphIndex(vault_root)
-    if not idx.available():
-        return {
-            "available": False,
-            "reason": "graph sidecar unavailable",
-            "seeds": [],
-            "nodes": [],
-            "edges": [],
-            "truncation": [],
-        }
     profile_registry = traversal_profiles.load_profiles(vault_root, registry=idx.registry)
     profile = profile_registry.resolve(traversal_profile)
     depth = min(max(0, int(depth)), profile.max_depth, traversal_profiles.MAX_DEPTH)
@@ -649,7 +676,16 @@ def graph_context(
     narrowed = traversal_profiles.narrow_relations(profile, relation_types, idx.registry)
     if narrowed is not None:
         allowed &= set(narrowed)
-    conn = idx._connect()
+    conn = idx._open_read_snapshot()
+    if conn is None:
+        return {
+            "available": False,
+            "reason": "graph sidecar unavailable",
+            "seeds": [],
+            "nodes": [],
+            "edges": [],
+            "truncation": [],
+        }
     try:
         drift_counts: dict[str, int] = {}
         freshness_cache: dict[tuple[str, str, str, int], bool] = {}
@@ -1017,10 +1053,8 @@ def _bump_generation(conn: sqlite3.Connection) -> None:
     Self-initializing upsert (no separate "seed the row" step): a fresh sidecar
     has no `generation` row yet, so the first bump inserts '1'; every
     subsequent bump increments in place. This keeps row initialization scoped
-    to genuine write paths — `_connect()` (shared by read-only callers like
-    `neighbors_for`/`nodes`/`edges`) must never open a write transaction just
-    to guarantee this row exists (a read connection holding the writer lock
-    would contend with a real concurrent writer).
+    to genuine write paths. Trusted readers use `_open_read_snapshot()` instead
+    of the schema-creating `_connect()` writer helper.
     """
     conn.execute(
         "INSERT INTO graph_meta(key, value) VALUES ('generation', '1') "
@@ -1036,21 +1070,20 @@ def cache_token(vault_root: Path) -> tuple | None:
     absent-sentinel so typed-mode and fallback-mode entries never collide.
     """
     idx = EpistemicGraphIndex(vault_root)
-    if not idx.available():
+    conn = idx._open_read_snapshot()
+    if conn is None:
         return None
     try:
-        conn = sqlite3.connect(idx.path)
-        try:
-            values = dict(
-                conn.execute(
-                    "SELECT key, value FROM graph_meta WHERE key IN "
-                    "('schema_version', 'extension_registry_hash', 'generation')"
-                ).fetchall()
-            )
-        finally:
-            conn.close()
+        values = dict(
+            conn.execute(
+                "SELECT key, value FROM graph_meta WHERE key IN "
+                "('schema_version', 'extension_registry_hash', 'generation')"
+            ).fetchall()
+        )
     except sqlite3.Error:
         return None
+    finally:
+        conn.close()
     return (
         values.get("schema_version"),
         values.get("extension_registry_hash"),
@@ -1084,7 +1117,8 @@ def graph_drift(vault_root: Path) -> list[dict[str, Any]]:
     if not graph_enabled():
         return []
     idx = EpistemicGraphIndex(vault_root)
-    if not idx.path.exists() or not idx.available():
+    conn = idx._open_read_snapshot()
+    if conn is None:
         return [
             {
                 "path": kb_prefix(),
@@ -1094,7 +1128,14 @@ def graph_drift(vault_root: Path) -> list[dict[str, Any]]:
                 ),
             }
         ]
-    by_path = {n["path"]: n for n in idx.nodes() if n["kind"] == "file"}
+    try:
+        by_path = {
+            node["path"]: node
+            for node in idx._nodes_from_snapshot(conn)
+            if node["kind"] == "file"
+        }
+    finally:
+        conn.close()
     drift: list[dict[str, Any]] = []
     kb = vault_root / kb_dirname()
     if not kb.is_dir():
@@ -2033,9 +2074,9 @@ def indexed_unit_parent_path_resolution(
     vault_root: Path, unit_ref: str
 ) -> tuple[list[str], bool]:
     idx = EpistemicGraphIndex(vault_root)
-    if not idx.available():
+    conn = idx._open_read_snapshot()
+    if conn is None:
         return [], False
-    conn = idx._connect()
     try:
         _status, paths, _seeds, _drift_counts, work_exhausted = _current_unit_status(
             conn, vault_root, unit_ref
@@ -2177,9 +2218,9 @@ def _frontmatter_source_candidates(page) -> list[dict[str, Any]]:
 
 def _shared_source_candidates(vault_root: Path, rel_path: str) -> list[dict[str, Any]]:
     idx = EpistemicGraphIndex(vault_root)
-    if not idx.available():
+    conn = idx._open_read_snapshot()
+    if conn is None:
         return []
-    conn = idx._connect()
     try:
         src_key = _file_key(rel_path)
         rows = conn.execute(

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -238,19 +238,26 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
-            before = _disk_vault_freshness(self.vault_root)
-            resolver = find_module.writer_resolver_snapshot(
-                self.vault_root,
-                freshness_key=before,
+        pass_started = False
+        stable = False
+        try:
+            for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
+                before = _disk_vault_freshness(self.vault_root)
+                resolver = find_module.writer_resolver_snapshot(
+                    self.vault_root,
+                    freshness_key=before,
+                )
+                pass_started = True
+                report = self._rebuild_all_pass(resolver)
+                if _disk_vault_freshness(self.vault_root) == before:
+                    stable = True
+                    return report
+            raise RuntimeError(
+                "epistemic graph rebuild did not stabilize after 2 attempts"
             )
-            report = self._rebuild_all_pass(resolver)
-            if _disk_vault_freshness(self.vault_root) == before:
-                return report
-        self._mark_unavailable()
-        raise RuntimeError(
-            "epistemic graph rebuild did not stabilize after 2 attempts"
-        )
+        finally:
+            if pass_started and not stable:
+                self._mark_unavailable()
 
     def _rebuild_all_pass(
         self,

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -19,6 +19,7 @@ from typing import Any
 from . import find as find_module
 from . import (
     memory_refs,
+    mutation_lock,
     relation_registry,
     semantic_blocks,
     semantic_index,
@@ -27,6 +28,7 @@ from . import (
     traversal_profiles,
 )
 from . import vault as vault_module
+from .cli_ops import OpError
 from .kbdir import kb_dirname, kb_prefix
 from .markdown_relations import MarkdownRelation
 
@@ -35,6 +37,8 @@ UNIT_SEED_MAX_BATCHES = 4
 UNIT_PARENT_REF_MAX_CANDIDATES = 16
 EDGE_INSPECTION_MULTIPLIER = 4
 REBUILD_STABILIZATION_ATTEMPTS = 2
+GRAPH_MUTATION_TIMEOUT_SECONDS = 30.0
+GRAPH_COORDINATION_DIRNAME = ".graph-coordination"
 
 RELATION_TYPES: frozenset[str] = relation_registry.core_registry().keys
 
@@ -142,6 +146,11 @@ class EpistemicGraphIndex:
         self.path = sidecar_path(self.vault_root)
         self.registry = relation_registry.load_registry(self.vault_root)
         self.language_registry = semantic_language_registry.load_registry(self.vault_root)
+        self._mutation_coordinator = mutation_lock.VaultMutationCoordinator(
+            self.vault_root / kb_dirname() / GRAPH_COORDINATION_DIRNAME,
+            self.vault_root,
+            timeout_seconds=GRAPH_MUTATION_TIMEOUT_SECONDS,
+        )
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -238,6 +247,10 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
+        with self._mutation_coordinator.hold():
+            return self._rebuild_all_locked()
+
+    def _rebuild_all_locked(self) -> dict[str, int]:
         pass_started = False
         stable = False
         try:
@@ -334,8 +347,12 @@ class EpistemicGraphIndex:
     def refresh_paths(self, paths: list[Path]) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
+        with self._mutation_coordinator.hold():
+            return self._refresh_paths_locked(paths)
+
+    def _refresh_paths_locked(self, paths: list[Path]) -> dict[str, int]:
         if not self.available():
-            return self.rebuild_all()
+            return self._rebuild_all_locked()
         resolver = find_module.writer_resolver_snapshot(self.vault_root)
         conn = self._connect()
         indexed = 0
@@ -351,6 +368,10 @@ class EpistemicGraphIndex:
             conn.close()
 
     def delete_paths(self, rel_paths: list[str]) -> int:
+        with self._mutation_coordinator.hold():
+            return self._delete_paths_locked(rel_paths)
+
+    def _delete_paths_locked(self, rel_paths: list[str]) -> int:
         if not self.path.exists():
             return 0
         conn = self._connect()
@@ -1042,6 +1063,8 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
         return
     try:
         EpistemicGraphIndex(vault_root).refresh_paths(written_paths)
+    except OpError:
+        raise
     except Exception:  # noqa: BLE001 - writer hooks must not break Markdown writes
         return
 
@@ -1051,6 +1074,8 @@ def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
         return
     try:
         EpistemicGraphIndex(vault_root).delete_paths(removed_rel_paths)
+    except OpError:
+        raise
     except Exception:  # noqa: BLE001 - writer hooks must not break Markdown writes
         return
 

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -250,6 +250,7 @@ class EpistemicGraphIndex:
                 pass_started = True
                 report = self._rebuild_all_pass(resolver)
                 if _disk_vault_freshness(self.vault_root) == before:
+                    self._mark_available()
                     stable = True
                     return report
             raise RuntimeError(
@@ -270,8 +271,7 @@ class EpistemicGraphIndex:
                 conn.execute("DELETE FROM graph_nodes")
                 conn.execute("DELETE FROM graph_parent_refs")
                 conn.execute(
-                    "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
-                    ("schema_version", str(SCHEMA_VERSION)),
+                    "DELETE FROM graph_meta WHERE key = 'schema_version'"
                 )
                 conn.execute(
                     "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
@@ -320,10 +320,21 @@ class EpistemicGraphIndex:
         finally:
             conn.close()
 
+    def _mark_available(self) -> None:
+        conn = sqlite3.connect(self.path)
+        try:
+            with conn:
+                conn.execute(
+                    "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+                    ("schema_version", str(SCHEMA_VERSION)),
+                )
+        finally:
+            conn.close()
+
     def refresh_paths(self, paths: list[Path]) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        if self.path.exists() and not self.available():
+        if not self.available():
             return self.rebuild_all()
         resolver = find_module.writer_resolver_snapshot(self.vault_root)
         conn = self._connect()
@@ -439,10 +450,6 @@ class EpistemicGraphIndex:
             conn.execute("DELETE FROM graph_edges WHERE source_path = ?", (rel,))
             conn.execute("DELETE FROM graph_nodes WHERE path = ?", (rel,))
             conn.execute("DELETE FROM graph_parent_refs WHERE path = ?", (rel,))
-            conn.execute(
-                "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
-                ("schema_version", str(SCHEMA_VERSION)),
-            )
             conn.execute(
                 "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
                 ("core_registry_version", str(self.registry.core_version)),

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -2352,16 +2352,26 @@ def shared_resolver(vault_root: Path):
     return _get_query_resolver(vault_root)
 
 
-def writer_resolver_snapshot(vault_root: Path):
+def writer_resolver_snapshot(
+    vault_root: Path,
+    *,
+    freshness_key: tuple[int, int, str] | None = None,
+):
     """Return a detached resolver snapshot without warming the shared cache.
 
     A fresh matching cached resolver is forked.  A cold/stale cache remains
-    untouched and preparation gets a one-off resolver built from disk.
+    untouched and preparation gets a one-off resolver built from disk. Callers
+    that already measured direct disk freshness may supply that key to bypass
+    potentially stale event-registry state.
     """
     from .vault import WikilinkResolver
 
     root = Path(vault_root)
-    current_freshness = FreshnessSnapshot(root).vault()
+    current_freshness = (
+        freshness_key
+        if freshness_key is not None
+        else FreshnessSnapshot(root).vault()
+    )
     with _RESOLVER_LOCK:
         cached = _RESOLVER_CACHE.get(root)
         if cached and cached[0] == current_freshness:

--- a/src/exomem/find_corpus.py
+++ b/src/exomem/find_corpus.py
@@ -17,7 +17,9 @@ from .find_types import ParsedPage
 
 log = logging.getLogger(__name__)
 
-EXCLUDED_DIR_NAMES = frozenset({"_Schema", "_attachments", "_archive", "_trash"})
+EXCLUDED_DIR_NAMES = frozenset(
+    {".graph-coordination", "_Schema", "_attachments", "_archive", "_trash"}
+)
 EXCLUDED_DIR_PREFIXES = (".exomem-batch-",)
 NAVIGATION_BASENAMES = frozenset({"index.md", "log.md"})
 FRONTMATTER_PATTERN = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -232,7 +232,8 @@ def reconcile(
         _maps[key] = fresh
         _triples[key] = None
         _live.add(key)
-    old = old or {}
+    if old is None:
+        return ReconcileDelta(drifted=False, changed=[], deleted=[])
     changed = [sp for sp, signature in fresh.items() if old.get(sp) != signature]
     deleted = [sp for sp in old if sp not in fresh]
     drifted = bool(changed or deleted)
@@ -400,6 +401,42 @@ def invalidate(vault_root: Path | None = None) -> None:
             _maps.pop(key, None)
             _triples.pop(key, None)
             _live.discard(key)
+
+
+def rebaseline(vault_root: Path) -> dict[str, bool]:
+    """Install exact final on-disk baselines for each event-maintained scope.
+
+    Each scope is independent: a failed walk leaves only that scope non-live so
+    the watcher's next periodic reconcile can initialize it without fanout.
+    """
+    invalidate(vault_root)
+    result = {scope: False for scope in SCOPES}
+    if not event_indexes_enabled():
+        return result
+
+    from . import find as find_module
+    from .vault import walk_vault_md
+
+    for scope in SCOPES:
+        try:
+            if scope == "kb":
+                root = vault_root / kb_dirname()
+                paths = find_module._walk_md(root) if root.is_dir() else ()
+            else:
+                paths = walk_vault_md(vault_root)
+            seed(
+                vault_root,
+                scope,
+                ((str(path), stat_signature(path)) for path in paths),
+            )
+            result[scope] = True
+        except Exception:  # noqa: BLE001 - periodic reconcile safely retries
+            log.exception(
+                "freshness rebaseline failed; scope remains non-live: %s scope=%s",
+                vault_root,
+                scope,
+            )
+    return result
 
 
 def snapshot() -> dict:

--- a/src/exomem/reconcile.py
+++ b/src/exomem/reconcile.py
@@ -350,17 +350,17 @@ def reconcile(vault_root: Path, *, dry_run: bool = False) -> ReconcileReport:
     )
     report.remaining_drift = [f.as_dict() for f in post.findings]
 
-    # ---- 5. Invalidate the event-maintained registries ----
+    # ---- 5. Rebaseline the event-maintained registries ----
     # reconcile is the "I edited around the system, heal it" command — after it
     # runs, no in-memory freshness/inbound registry should keep trusting
-    # pre-reconcile state. Freshness re-seeds on the watcher's next reconcile
-    # tick; inbound rebuilds on next read. (The embedding matrix cache is
+    # pre-reconcile state. Freshness is immediately re-derived from final disk
+    # state; inbound rebuilds on next read. (The embedding matrix cache is
     # maintained separately by the shared-index memo and its own mtime check.)
     if not dry_run:
         from . import freshness
         from . import vault as vault_module
 
-        freshness.invalidate(vault_root)
+        freshness.rebaseline(vault_root)
         vault_module.clear_inbound_index()
 
     return report

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -93,6 +93,7 @@ VAULT_SCAN_SKIP_DIRS = frozenset(
     {
         ".obsidian",
         ".git",
+        ".graph-coordination",
         ".trash",
         "_attachments",
         "_archive",

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -152,6 +152,86 @@ def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
     assert index.available() is False
 
 
+def test_full_rebuild_retry_acquisition_failure_marks_graph_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_snapshot = find_module.writer_resolver_snapshot
+    acquisitions = 0
+
+    def acquire(root: Path, **kwargs):
+        nonlocal acquisitions
+        acquisitions += 1
+        if acquisitions == 2:
+            raise RuntimeError("retry resolver failed")
+        snapshot = real_snapshot(root, **kwargs)
+        _write(vault, "Knowledge Base/Notes/Insights/moved.md", "# Moved\n")
+        return snapshot
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+
+    with pytest.raises(RuntimeError, match="retry resolver failed"):
+        index.rebuild_all()
+
+    assert acquisitions == 2
+    assert index.available() is False
+
+
+def test_full_rebuild_retry_freshness_failure_marks_graph_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_freshness = epistemic_graph._disk_vault_freshness
+    real_snapshot = find_module.writer_resolver_snapshot
+    freshness_checks = 0
+
+    def freshness(root: Path):
+        nonlocal freshness_checks
+        freshness_checks += 1
+        if freshness_checks == 3:
+            raise RuntimeError("retry freshness failed")
+        return real_freshness(root)
+
+    def acquire(root: Path, **kwargs):
+        snapshot = real_snapshot(root, **kwargs)
+        _write(vault, "Knowledge Base/Notes/Insights/moved.md", "# Moved\n")
+        return snapshot
+
+    monkeypatch.setattr(epistemic_graph, "_disk_vault_freshness", freshness)
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+
+    with pytest.raises(RuntimeError, match="retry freshness failed"):
+        index.rebuild_all()
+
+    assert freshness_checks == 3
+    assert index.available() is False
+
+
+def test_full_rebuild_pass_failure_marks_partial_graph_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+
+    def fail_index(*_args, **_kwargs):
+        raise RuntimeError("index pass failed")
+
+    monkeypatch.setattr(index, "_index_path", fail_index)
+
+    with pytest.raises(RuntimeError, match="index pass failed"):
+        index.rebuild_all()
+
+    assert index.available() is False
+
+
 def test_full_rebuild_snapshot_isolated_from_shared_cache_patch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -229,6 +309,30 @@ def test_rebuild_resolver_failure_preserves_committed_graph_rows(
     with pytest.raises(RuntimeError, match="resolver failed"):
         index.rebuild_all()
 
+    assert index.available() is True
+    assert index.nodes() == before_nodes
+    assert index.edges() == before_edges
+
+
+def test_rebuild_initial_freshness_failure_preserves_committed_graph_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    before_nodes = index.nodes()
+    before_edges = index.edges()
+    monkeypatch.setattr(
+        epistemic_graph,
+        "_disk_vault_freshness",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("freshness failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="freshness failed"):
+        index.rebuild_all()
+
+    assert index.available() is True
     assert index.nodes() == before_nodes
     assert index.edges() == before_edges
 

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -197,6 +198,123 @@ def test_spawned_mutator_waits_for_full_rebuild_mutation_boundary(
     assert rebuild_errors == []
     assert completed.is_set()
     assert child.exitcode == 0
+
+
+def test_neighbor_reader_admitted_before_rebuild_sees_complete_old_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    expected = index.neighbors_for([A])
+    assert expected
+    snapshot_admitted = threading.Event()
+    writer_entered = threading.Event()
+    reader_results: list[list[epistemic_graph.GraphNeighbor]] = []
+    reader_errors: list[Exception] = []
+    writer_errors: list[Exception] = []
+    real_rebuild_pass = index._rebuild_all_pass
+
+    def open_snapshot():
+        conn = sqlite3.connect(index.path)
+        conn.execute("BEGIN")
+        markers = dict(
+            conn.execute(
+                "SELECT key, value FROM graph_meta WHERE key IN "
+                "('schema_version', 'core_registry_version', 'extension_registry_hash')"
+            ).fetchall()
+        )
+        assert markers["schema_version"] == str(epistemic_graph.SCHEMA_VERSION)
+        snapshot_admitted.set()
+        if not writer_entered.wait(5.0):
+            conn.close()
+            raise RuntimeError("writer did not enter rebuild")
+        return conn
+
+    def rebuild_pass(resolver):
+        writer_entered.set()
+        return real_rebuild_pass(resolver)
+
+    def read_neighbors() -> None:
+        try:
+            reader_results.append(index.neighbors_for([A]))
+        except Exception as exc:  # noqa: BLE001 - asserted in parent thread
+            reader_errors.append(exc)
+
+    def rebuild() -> None:
+        try:
+            index.rebuild_all()
+        except Exception as exc:  # noqa: BLE001 - asserted in parent thread
+            writer_errors.append(exc)
+
+    monkeypatch.setattr(index, "_open_read_snapshot", open_snapshot, raising=False)
+    monkeypatch.setattr(index, "_rebuild_all_pass", rebuild_pass)
+    reader = threading.Thread(target=read_neighbors)
+    writer = threading.Thread(target=rebuild)
+    reader.start()
+    try:
+        assert snapshot_admitted.wait(3.0)
+        writer.start()
+        reader.join(timeout=8.0)
+        writer.join(timeout=8.0)
+    finally:
+        if writer.is_alive():
+            writer.join(timeout=3.0)
+        if reader.is_alive():
+            reader.join(timeout=3.0)
+
+    assert not reader.is_alive()
+    assert not writer.is_alive()
+    assert reader_errors == []
+    assert writer_errors == []
+    assert reader_results == [expected]
+
+
+def test_trusted_reads_after_marker_removal_never_expose_partial_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_index_path = index._index_path
+    partial_written = threading.Event()
+    release_rebuild = threading.Event()
+    writer_errors: list[Exception] = []
+    indexed = 0
+
+    def pause_after_first_path(*args, **kwargs):
+        nonlocal indexed
+        result = real_index_path(*args, **kwargs)
+        indexed += 1
+        if indexed == 1:
+            partial_written.set()
+            if not release_rebuild.wait(5.0):
+                raise RuntimeError("test rebuild release signal was not received")
+        return result
+
+    def rebuild() -> None:
+        try:
+            index.rebuild_all()
+        except Exception as exc:  # noqa: BLE001 - asserted in parent thread
+            writer_errors.append(exc)
+
+    monkeypatch.setattr(index, "_index_path", pause_after_first_path)
+    writer = threading.Thread(target=rebuild)
+    writer.start()
+    try:
+        assert partial_written.wait(3.0)
+        assert index.nodes() == []
+        assert index.edges() == []
+        assert index.neighbors_for([A]) == []
+        assert epistemic_graph.graph_context(vault, path=A)["available"] is False
+    finally:
+        release_rebuild.set()
+        writer.join(timeout=8.0)
+
+    assert not writer.is_alive()
+    assert writer_errors == []
 
 
 def test_full_rebuild_reuses_one_detached_resolver_without_shared_cache(

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from exomem import audit, epistemic_graph, reconcile
+import pytest
+
+from exomem import audit, epistemic_graph, reconcile, semantic_index
+from exomem import find as find_module
 
 A = "Knowledge Base/Notes/Insights/a.md"
 B = "Knowledge Base/Notes/Insights/b.md"
@@ -49,6 +52,122 @@ B claim.
 """,
     )
     return a, b
+
+
+def test_full_rebuild_reuses_one_detached_resolver_without_shared_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    find_module._RESOLVER_CACHE.clear()
+    real_snapshot = find_module.writer_resolver_snapshot
+    acquisitions: list[Path] = []
+
+    def acquire(root: Path):
+        acquisitions.append(root)
+        return real_snapshot(root)
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+    monkeypatch.setattr(
+        find_module,
+        "shared_resolver",
+        lambda *_args: pytest.fail("graph maintenance used the shared resolver"),
+    )
+
+    report = epistemic_graph.EpistemicGraphIndex(vault).rebuild_all()
+
+    assert report["indexed_files"] == 2
+    assert acquisitions == [vault]
+    assert vault not in find_module._RESOLVER_CACHE
+
+
+def test_refresh_batch_reuses_one_snapshot_and_separate_calls_reacquire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    a, b = _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_snapshot = find_module.writer_resolver_snapshot
+    acquisitions: list[Path] = []
+
+    def acquire(root: Path):
+        acquisitions.append(root)
+        return real_snapshot(root)
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+    monkeypatch.setattr(
+        find_module,
+        "shared_resolver",
+        lambda *_args: pytest.fail("graph maintenance used the shared resolver"),
+    )
+
+    index.refresh_paths([a, b])
+    assert acquisitions == [vault]
+
+    index.refresh_paths([a])
+    assert acquisitions == [vault, vault]
+
+
+def test_rebuild_resolver_failure_preserves_committed_graph_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    before_nodes = index.nodes()
+    before_edges = index.edges()
+    monkeypatch.setattr(
+        find_module,
+        "writer_resolver_snapshot",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("resolver failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="resolver failed"):
+        index.rebuild_all()
+
+    assert index.nodes() == before_nodes
+    assert index.edges() == before_edges
+
+
+def test_explicit_detached_resolver_matches_direct_fallback_for_ambiguous_links(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    source, _target = _seed(vault)
+    _write(vault, "Knowledge Base/Notes/one/collision.md", "# First collision\n")
+    _write(vault, "Knowledge Base/Notes/two/collision.md", "# Second collision\n")
+    source.write_text(
+        source.read_text(encoding="utf-8") + "\n- supports: [[collision]]\n",
+        encoding="utf-8",
+    )
+    page = find_module._parse_page(source, source.stat().st_mtime, vault)
+    assert page is not None
+    state = semantic_index.build_parent_index_state(vault, source)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    kwargs = {
+        "registry": index.registry,
+        "source_hash": epistemic_graph.vault_module.content_hash(
+            source.read_text(encoding="utf-8")
+        ),
+        "parent_state": state,
+    }
+
+    fallback = epistemic_graph._edges_for_page(
+        vault, page, state.document, **kwargs
+    )
+    explicit = epistemic_graph._edges_for_page(
+        vault,
+        page,
+        state.document,
+        resolver=find_module.writer_resolver_snapshot(vault),
+        **kwargs,
+    )
+
+    assert [edge.as_dict() for edge in explicit] == [
+        edge.as_dict() for edge in fallback
+    ]
 
 
 def test_single_file_edit_refreshes_affected_graph_rows(tmp_path: Path) -> None:

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -63,9 +63,9 @@ def test_full_rebuild_reuses_one_detached_resolver_without_shared_cache(
     real_snapshot = find_module.writer_resolver_snapshot
     acquisitions: list[Path] = []
 
-    def acquire(root: Path):
+    def acquire(root: Path, **kwargs):
         acquisitions.append(root)
-        return real_snapshot(root)
+        return real_snapshot(root, **kwargs)
 
     monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
     monkeypatch.setattr(
@@ -81,6 +81,106 @@ def test_full_rebuild_reuses_one_detached_resolver_without_shared_cache(
     assert vault not in find_module._RESOLVER_CACHE
 
 
+def test_full_rebuild_retries_when_target_is_renamed_after_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    source = _write(
+        vault,
+        A,
+        "# Source\n\nLinks to [[Knowledge Base/Notes/Insights/late-target]].\n",
+    )
+    target_rel = "Knowledge Base/Notes/Insights/late-target.md"
+    target = vault / target_rel
+    staged_target = _write(
+        vault,
+        "Knowledge Base/Notes/Insights/staged-target.md",
+        "# Late target\n",
+    )
+    real_snapshot = find_module.writer_resolver_snapshot
+    acquisitions = 0
+
+    def acquire(root: Path, **kwargs):
+        nonlocal acquisitions
+        snapshot = real_snapshot(root, **kwargs)
+        acquisitions += 1
+        if acquisitions == 1:
+            staged_target.rename(target)
+        return snapshot
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    report = index.rebuild_all()
+
+    assert source.exists()
+    assert acquisitions == 2
+    assert report["indexed_files"] == 2
+    assert any(
+        edge["relation_type"] == "links_to"
+        and edge["dst_key"] == epistemic_graph._file_key(target_rel)
+        for edge in index.edges(source_path=A)
+    )
+
+
+def test_full_rebuild_twice_moving_vault_is_marked_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    real_snapshot = find_module.writer_resolver_snapshot
+    acquisitions = 0
+
+    def acquire(root: Path, **kwargs):
+        nonlocal acquisitions
+        snapshot = real_snapshot(root, **kwargs)
+        acquisitions += 1
+        _write(
+            vault,
+            f"Knowledge Base/Notes/Insights/churn-{acquisitions}.md",
+            f"# Churn {acquisitions}\n",
+        )
+        return snapshot
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+
+    with pytest.raises(RuntimeError, match="did not stabilize"):
+        index.rebuild_all()
+
+    assert acquisitions == 2
+    assert index.available() is False
+
+
+def test_full_rebuild_snapshot_isolated_from_shared_cache_patch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    find_module._RESOLVER_CACHE.clear()
+    shared = find_module.shared_resolver(vault)
+    real_snapshot = find_module.writer_resolver_snapshot
+
+    def acquire(root: Path, **kwargs):
+        snapshot = real_snapshot(root, **kwargs)
+        assert snapshot is not shared
+        shared._remove_entry(B.removesuffix(".md"))
+        return snapshot
+
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+    try:
+        index = epistemic_graph.EpistemicGraphIndex(vault)
+        index.rebuild_all()
+
+        assert any(
+            edge["relation_type"] == "links_to"
+            and edge["dst_key"] == epistemic_graph._file_key(B)
+            for edge in index.edges(source_path=A)
+        )
+    finally:
+        find_module._RESOLVER_CACHE.clear()
+
+
 def test_refresh_batch_reuses_one_snapshot_and_separate_calls_reacquire(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -91,9 +191,9 @@ def test_refresh_batch_reuses_one_snapshot_and_separate_calls_reacquire(
     real_snapshot = find_module.writer_resolver_snapshot
     acquisitions: list[Path] = []
 
-    def acquire(root: Path):
+    def acquire(root: Path, **kwargs):
         acquisitions.append(root)
-        return real_snapshot(root)
+        return real_snapshot(root, **kwargs)
 
     monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
     monkeypatch.setattr(
@@ -121,7 +221,9 @@ def test_rebuild_resolver_failure_preserves_committed_graph_rows(
     monkeypatch.setattr(
         find_module,
         "writer_resolver_snapshot",
-        lambda *_args: (_ for _ in ()).throw(RuntimeError("resolver failed")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("resolver failed")
+        ),
     )
 
     with pytest.raises(RuntimeError, match="resolver failed"):

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import multiprocessing
+import os
+import threading
 from pathlib import Path
 
 import pytest
 
 from exomem import audit, epistemic_graph, reconcile, semantic_index
 from exomem import find as find_module
+from exomem.cli_ops import OpError
+from exomem.mutation_lock import VaultMutationCoordinator
 
 A = "Knowledge Base/Notes/Insights/a.md"
 B = "Knowledge Base/Notes/Insights/b.md"
@@ -52,6 +57,146 @@ B claim.
 """,
     )
     return a, b
+
+
+def _spawn_graph_mutation(
+    vault_root: str,
+    operation: str,
+    rel_path: str,
+    attempting,
+    completed,
+) -> None:
+    os.environ["EXOMEM_DISABLE_EMBEDDINGS"] = "1"
+    attempting.set()
+    index = epistemic_graph.EpistemicGraphIndex(Path(vault_root))
+    if operation == "refresh":
+        index.refresh_paths([Path(vault_root) / rel_path])
+    else:
+        index.delete_paths([rel_path])
+    completed.set()
+
+
+def test_graph_mutation_lock_is_shared_and_rooted_inside_vault_kb(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+
+    first = epistemic_graph.EpistemicGraphIndex(vault)
+    second = epistemic_graph.EpistemicGraphIndex(vault / ".")
+
+    expected_root = (vault / "Knowledge Base" / ".graph-coordination").resolve()
+    assert first._mutation_coordinator.state_root == expected_root
+    assert first._mutation_coordinator.lock_path == second._mutation_coordinator.lock_path
+    assert first._mutation_coordinator.timeout_seconds == 30.0
+
+
+def test_graph_mutation_lock_unavailable_preserves_current_graph(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    before_nodes = index.nodes()
+    before_edges = index.edges()
+    unusable_state_root = tmp_path / "not-a-directory"
+    unusable_state_root.write_text("occupied", encoding="utf-8")
+    index._mutation_coordinator = VaultMutationCoordinator(
+        unusable_state_root,
+        vault,
+        timeout_seconds=0.05,
+    )
+
+    with pytest.raises(OpError) as raised:
+        index.rebuild_all()
+
+    assert raised.value.code == "MUTATION_LOCK_UNAVAILABLE"
+    assert index.available() is True
+    assert index.nodes() == before_nodes
+    assert index.edges() == before_edges
+
+
+def test_graph_dispatch_wrappers_propagate_structured_lock_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / A
+    lock_error = OpError("MUTATION_BUSY", "graph mutation is busy")
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "refresh_paths",
+        lambda *_args: (_ for _ in ()).throw(lock_error),
+    )
+
+    with pytest.raises(OpError, match="MUTATION_BUSY"):
+        epistemic_graph.upsert_after_write(tmp_path, [target])
+
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "delete_paths",
+        lambda *_args: (_ for _ in ()).throw(lock_error),
+    )
+    with pytest.raises(OpError, match="MUTATION_BUSY"):
+        epistemic_graph.delete_after_remove(tmp_path, [A])
+
+
+@pytest.mark.parametrize("operation", ["refresh", "delete"])
+def test_spawned_mutator_waits_for_full_rebuild_mutation_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    context = multiprocessing.get_context("spawn")
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_index_path = index._index_path
+    rebuild_entered = threading.Event()
+    release_rebuild = threading.Event()
+    rebuild_errors: list[Exception] = []
+    blocked_once = False
+
+    def blocking_index_path(*args, **kwargs):
+        nonlocal blocked_once
+        if not blocked_once:
+            blocked_once = True
+            rebuild_entered.set()
+            if not release_rebuild.wait(8.0):
+                raise RuntimeError("test rebuild release signal was not received")
+        return real_index_path(*args, **kwargs)
+
+    def rebuild() -> None:
+        try:
+            index.rebuild_all()
+        except Exception as exc:  # noqa: BLE001 - asserted in parent thread
+            rebuild_errors.append(exc)
+
+    monkeypatch.setattr(index, "_index_path", blocking_index_path)
+    rebuild_thread = threading.Thread(target=rebuild)
+    attempting = context.Event()
+    completed = context.Event()
+    child = context.Process(
+        target=_spawn_graph_mutation,
+        args=(str(vault), operation, A, attempting, completed),
+    )
+
+    rebuild_thread.start()
+    assert rebuild_entered.wait(3.0)
+    child.start()
+    try:
+        assert attempting.wait(5.0)
+        assert not completed.wait(0.5)
+    finally:
+        release_rebuild.set()
+        rebuild_thread.join(timeout=8.0)
+        child.join(timeout=8.0)
+        if child.is_alive():
+            child.terminate()
+            child.join(timeout=3.0)
+
+    assert not rebuild_thread.is_alive()
+    assert rebuild_errors == []
+    assert completed.is_set()
+    assert child.exitcode == 0
 
 
 def test_full_rebuild_reuses_one_detached_resolver_without_shared_cache(

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -803,6 +803,18 @@ def test_graph_drift_is_audited_and_reconciled_without_markdown_mutation(tmp_pat
     assert all(f["category"] != "graph_drift" for f in reconciled.remaining_drift)
 
 
+def test_reconcile_rebuilds_a_deleted_graph_sidecar(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    epistemic_graph.EpistemicGraphIndex(vault).rebuild_all()
+    epistemic_graph.sidecar_path(vault).unlink()
+
+    reconciled = reconcile.reconcile(vault)
+
+    assert reconciled.graph_status == "refreshed"
+    assert epistemic_graph.EpistemicGraphIndex(vault).available()
+
+
 def test_disabled_graph_indexing_makes_drift_check_noop(tmp_path: Path, monkeypatch) -> None:
     vault = tmp_path / "vault"
     _seed(vault)

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -232,6 +232,109 @@ def test_full_rebuild_pass_failure_marks_partial_graph_unavailable(
     assert index.available() is False
 
 
+def test_full_rebuild_keeps_schema_marker_absent_until_stable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_index_path = index._index_path
+    indexed = 0
+
+    def index_path(*args, **kwargs):
+        nonlocal indexed
+        assert index.available() is False
+        indexed += 1
+        return real_index_path(*args, **kwargs)
+
+    monkeypatch.setattr(index, "_index_path", index_path)
+
+    index.rebuild_all()
+
+    assert indexed == 2
+    assert index.available() is True
+
+
+def test_refresh_admitted_before_failed_rebuild_cannot_restore_availability(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    source, _target = _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_snapshot = find_module.writer_resolver_snapshot
+    real_index_path = index._index_path
+    rebuild_active = False
+    overlap_triggered = False
+
+    def index_path(*args, **kwargs):
+        if rebuild_active:
+            raise RuntimeError("overlapping rebuild failed")
+        return real_index_path(*args, **kwargs)
+
+    def acquire(root: Path, **kwargs):
+        nonlocal rebuild_active, overlap_triggered
+        snapshot = real_snapshot(root, **kwargs)
+        if "freshness_key" not in kwargs and not overlap_triggered:
+            overlap_triggered = True
+            rebuild_active = True
+            try:
+                with pytest.raises(RuntimeError, match="overlapping rebuild failed"):
+                    index.rebuild_all()
+            finally:
+                rebuild_active = False
+            assert index.available() is False
+        return snapshot
+
+    monkeypatch.setattr(index, "_index_path", index_path)
+    monkeypatch.setattr(find_module, "writer_resolver_snapshot", acquire)
+
+    report = index.refresh_paths([source])
+
+    assert overlap_triggered is True
+    assert report["indexed_files"] == 1
+    assert index.available() is False
+
+
+def test_refresh_missing_sidecar_routes_to_full_rebuild(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    source, _target = _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+
+    report = index.refresh_paths([source])
+
+    assert report["indexed_files"] == 2
+    assert {node["path"] for node in index.nodes()} == {A, B}
+    assert index.available() is True
+
+
+def test_full_rebuild_first_post_pass_freshness_failure_marks_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    _seed(vault)
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    real_freshness = epistemic_graph._disk_vault_freshness
+    freshness_checks = 0
+
+    def freshness(root: Path):
+        nonlocal freshness_checks
+        freshness_checks += 1
+        if freshness_checks == 2:
+            raise RuntimeError("post-pass freshness failed")
+        return real_freshness(root)
+
+    monkeypatch.setattr(epistemic_graph, "_disk_vault_freshness", freshness)
+
+    with pytest.raises(RuntimeError, match="post-pass freshness failed"):
+        index.rebuild_all()
+
+    assert freshness_checks == 2
+    assert index.available() is False
+
+
 def test_full_rebuild_snapshot_isolated_from_shared_cache_patch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -16,8 +16,9 @@ from pathlib import Path
 
 import pytest
 
-from exomem import embeddings, file_watcher, media_processing
+from exomem import deferred_index, embeddings, file_watcher, freshness, media_processing
 from exomem import find as find_module
+from exomem import reconcile as reconcile_module
 
 
 def _stub_embeddings(monkeypatch: pytest.MonkeyPatch):
@@ -644,6 +645,50 @@ def test_reconcile_no_drift_dispatches_nothing(vault, monkeypatch: pytest.Monkey
     w._reconcile_once(seed=False)  # nothing changed on disk since the seed
 
     assert calls == {"inbound": [], "resolver": [], "upsert": [], "delete": [], "warm": []}
+
+
+def test_missing_baseline_and_post_reconcile_watcher_do_not_phantom_fanout(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_watcher.clear_self_write_registry()
+    freshness.clear()
+    index_sync = file_watcher.index_sync
+    index_sync.clear_deferred_work(vault)
+    calls = _spy_reconcile_fanout(monkeypatch)
+    watcher = file_watcher.FileWatcher(vault)
+
+    watcher._reconcile_once(seed=False)
+
+    assert calls == {
+        "inbound": [],
+        "resolver": [],
+        "upsert": [],
+        "delete": [],
+        "warm": [],
+    }
+    reconcile_module.reconcile(vault)
+    for recorded in calls.values():
+        recorded.clear()
+    watcher._reconcile_once(seed=False)
+    assert calls == {
+        "inbound": [],
+        "resolver": [],
+        "upsert": [],
+        "delete": [],
+        "warm": [],
+    }
+    assert deferred_index.status(vault)["count"] == 0
+
+    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    target.write_text(
+        target.read_text(encoding="utf-8") + "\nreal watcher change\n",
+        encoding="utf-8",
+    )
+    watcher._reconcile_once(seed=False)
+
+    assert len(calls["upsert"]) == 1
+    assert [path.resolve() for path in calls["upsert"][0]] == [target.resolve()]
+    assert calls["delete"] == []
 
 
 def test_periodic_reconcile_discovers_missed_media_without_text_reembed(

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -690,6 +690,17 @@ def test_missing_baseline_and_post_reconcile_watcher_do_not_phantom_fanout(
     assert [path.resolve() for path in calls["upsert"][0]] == [target.resolve()]
     assert calls["delete"] == []
 
+    for recorded in calls.values():
+        recorded.clear()
+    rel = _vault_rel(vault, target)
+    target.unlink()
+    watcher._reconcile_once(seed=False)
+
+    assert calls["upsert"] == []
+    assert calls["delete"] == [[rel]]
+    assert calls["inbound"] == [([], [rel])]
+    assert calls["resolver"] == [([], [rel])]
+
 
 def test_periodic_reconcile_discovers_missed_media_without_text_reembed(
     vault: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_freshness_registry.py
+++ b/tests/test_freshness_registry.py
@@ -275,6 +275,96 @@ def test_reconcile_with_no_drift_returns_false(vault: Path) -> None:
     assert freshness.triple(vault, "kb") == _fresh_walk_triple(vault, "kb")
 
 
+def test_reconcile_missing_baseline_initializes_without_reporting_corpus(
+    vault: Path,
+) -> None:
+    kb_dir = vault / "Knowledge Base"
+    entries = [
+        (str(path), freshness.stat_signature(path))
+        for path in find_module._walk_md(kb_dir)
+    ]
+
+    delta = freshness.reconcile(vault, "kb", entries)
+
+    assert delta == freshness.ReconcileDelta(False, [], [])
+    assert freshness.live_entries(vault, "kb") == dict(entries)
+    assert freshness.triple(vault, "kb") == _fresh_walk_triple(vault, "kb")
+
+
+def test_reconcile_seeded_empty_baseline_reports_new_file(vault: Path) -> None:
+    freshness.seed(vault, "kb", [])
+    path = vault / "Knowledge Base" / "Notes" / "Insights" / "after-empty.md"
+    path.write_text("# After empty\n", encoding="utf-8")
+
+    delta = freshness.reconcile(
+        vault,
+        "kb",
+        [(str(path), freshness.stat_signature(path))],
+    )
+
+    assert delta == freshness.ReconcileDelta(True, [str(path)], [])
+
+
+def test_reconcile_missing_and_existing_scope_baselines_are_independent(
+    vault: Path,
+) -> None:
+    kb_dir = vault / "Knowledge Base"
+    kb_entries = [
+        (str(path), freshness.stat_signature(path))
+        for path in find_module._walk_md(kb_dir)
+    ]
+    freshness.seed(vault, "kb", kb_entries)
+    target = Path(kb_entries[0][0])
+    future = time.time() + 10_000
+    os.utime(target, (future, future))
+    vault_entries = [
+        (str(path), freshness.stat_signature(path))
+        for path in vault_module.walk_vault_md(vault)
+    ]
+
+    vault_delta = freshness.reconcile(vault, "vault", vault_entries)
+    kb_delta = freshness.reconcile(
+        vault,
+        "kb",
+        [
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(kb_dir)
+        ],
+    )
+
+    assert vault_delta == freshness.ReconcileDelta(False, [], [])
+    assert kb_delta.changed == [str(target)]
+    assert kb_delta.deleted == []
+
+
+def test_rebaseline_scope_failure_leaves_only_failed_scope_non_live(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_kb_walk(*_args, **_kwargs):
+        raise OSError("kb scan failed")
+
+    monkeypatch.setattr(find_module, "_walk_md", fail_kb_walk)
+
+    result = freshness.rebaseline(vault)
+
+    assert result == {"kb": False, "vault": True}
+    assert freshness.live_entries(vault, "kb") is None
+    assert freshness.live_entries(vault, "vault") is not None
+
+
+def test_rebaseline_respects_event_index_kill_switch(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_both_scopes(vault)
+    monkeypatch.setenv("EXOMEM_DISABLE_EVENT_INDEXES", "1")
+
+    result = freshness.rebaseline(vault)
+
+    assert result == {"kb": False, "vault": False}
+    root = str(vault.resolve())
+    assert all(item[0] != root for item in freshness.snapshot()["live"])
+
+
 def test_reconcile_delta_reports_changed_and_deleted_paths(vault: Path) -> None:
     _seed_both_scopes(vault)
 

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -353,6 +353,41 @@ def test_batch_atomic_write_collector_observes_existing_fanout_once(
     assert collected == [report]
 
 
+def test_graph_lock_error_reaches_index_sync_as_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph, find, lexstore, memory_refs
+    from exomem.cli_ops import OpError
+
+    target = tmp_path / "Knowledge Base" / "Notes" / "item.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Item\n", encoding="utf-8")
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda *_args: None)
+    monkeypatch.setattr(memory_refs, "upsert_after_write", lambda *_args: None)
+    monkeypatch.setattr(find, "on_resolver_files_changed", lambda *_args: None)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex,
+        "refresh_paths",
+        lambda *_args: (_ for _ in ()).throw(
+            OpError("MUTATION_BUSY", "graph mutation is busy")
+        ),
+    )
+    monkeypatch.setattr(
+        embeddings,
+        "upsert_after_write_status",
+        lambda *_args: embeddings.EmbeddingSyncStatus(
+            "completed", "embedding_upsert_completed", 1
+        ),
+    )
+
+    report = index_sync.upsert_after_write(tmp_path, [target])
+
+    graph = _outcome(report, "epistemic_graph")
+    assert graph.outcome == "degraded"
+    assert graph.code == "dispatch_failed"
+    assert report.reconcile_required is True
+
+
 def test_delete_report_continues_after_observable_component_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -21,8 +21,8 @@ from pathlib import Path
 
 import pytest
 
-from exomem import deferred_index, index_sync
-from exomem.vault import in_excluded_scan_dir
+from exomem import deferred_index, find_corpus, index_sync
+from exomem.vault import in_excluded_scan_dir, walk_vault_md
 
 
 def test_excluded_scan_dir_predicate() -> None:
@@ -30,6 +30,7 @@ def test_excluded_scan_dir_predicate() -> None:
     assert in_excluded_scan_dir(f"{kb}/_trash/2026-07-04/foo.md")
     assert in_excluded_scan_dir(f"{kb}/_archive/old.md")
     assert in_excluded_scan_dir(f"{kb}/_Schema/SKILL.md")
+    assert in_excluded_scan_dir(f"{kb}/.graph-coordination/mutation-locks/lock.md")
     assert in_excluded_scan_dir(".obsidian/workspace.json")
     # Backslash tolerance (Windows callers).
     assert in_excluded_scan_dir(f"{kb}\\_trash\\2026-07-04\\foo.md")
@@ -38,6 +39,23 @@ def test_excluded_scan_dir_predicate() -> None:
     assert not in_excluded_scan_dir(f"{kb}/Sources/Articles/bar.md")
     # Only whole segments match — a note ABOUT trash isn't excluded.
     assert not in_excluded_scan_dir(f"{kb}/Notes/Insights/_trash-handling.md")
+
+
+def test_graph_coordination_directory_is_excluded_from_both_full_walkers(
+    vault: Path,
+) -> None:
+    kb = vault / "Knowledge Base"
+    coordination_note = kb / ".graph-coordination" / "unreadable-lock-state.md"
+    normal_note = kb / "Notes" / "normal.md"
+    coordination_note.parent.mkdir(parents=True, exist_ok=True)
+    normal_note.parent.mkdir(parents=True, exist_ok=True)
+    coordination_note.write_text("# coordination state\n", encoding="utf-8")
+    normal_note.write_text("# normal\n", encoding="utf-8")
+
+    assert normal_note in set(find_corpus.walk_md(kb))
+    assert normal_note in set(walk_vault_md(vault))
+    assert coordination_note not in set(find_corpus.walk_md(kb))
+    assert coordination_note not in set(walk_vault_md(vault))
 
 
 def test_index_sync_upsert_drops_excluded_paths(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -19,12 +19,14 @@ import pytest
 from exomem import (
     activation_manifest,
     commands,
+    freshness,
     index_sync,
     relation_review,
     semantic_contract,
     semantic_writes,
 )
 from exomem import audit as audit_module
+from exomem import find as find_module
 from exomem import reconcile as reconcile_module
 from exomem import (
     vault as vault_module,
@@ -899,6 +901,27 @@ def test_reconcile_reports_embeddings_disabled_in_test_env(vault: Path) -> None:
     assert rep.embeddings_status == "disabled"
     assert rep.embeddings_refreshed == 0
     assert rep.dry_run is False
+
+
+def test_successful_write_reconcile_installs_exact_live_freshness_baselines(
+    vault: Path,
+) -> None:
+    freshness.clear()
+    try:
+        reconcile_module.reconcile(vault)
+
+        expected_kb = {
+            str(path): freshness.stat_signature(path)
+            for path in find_module._walk_md(vault / "Knowledge Base")
+        }
+        expected_vault = {
+            str(path): freshness.stat_signature(path)
+            for path in vault_module.walk_vault_md(vault)
+        }
+        assert freshness.live_entries(vault, "kb") == expected_kb
+        assert freshness.live_entries(vault, "vault") == expected_vault
+    finally:
+        freshness.clear()
 
 
 def test_reconcile_heals_index_count_drift(vault: Path) -> None:


### PR DESCRIPTION
## Summary

- make graph rebuild and batched refresh reuse one detached resolver snapshot, eliminating effective O(n²) vault rescans
- stabilize full rebuilds against concurrent filesystem movement and publish availability only after a stable pass
- serialize graph writers across CLI/service processes with a vault-local OS-backed lock, while serving trusted reads from explicit SQLite snapshots
- install exact freshness baselines after explicit reconcile so the watcher does not replay the whole corpus or enqueue already-current embeddings
- add OpenSpec coverage and regression tests for rebuild races, lock failures, reader snapshots, and watcher fanout

## Verification

- `123 passed` in the focused graph/freshness/watcher/reconcile/index-sync suite
- Ruff passed for all changed Python files (two pre-existing BLE001 findings in `find.py` excluded)
- `openspec validate bound-reconcile-maintenance --strict`
- `git diff --check origin/main..HEAD`
- `python -m compileall -q src/exomem`
- independent review: ready to merge, no findings

The broader Windows lean baseline still has the separately reproduced pre-existing semantic-order expectations, CRLF lifecycle fixtures, surrogate-filename collection issue, and Unix-only `fcntl` collection issue. This change does not modify those baselines.
