### PR TITLE
fix: exclude nested dot-trash from corpus scans

### DIFF
--- a/src/exomem/find_corpus.py
+++ b/src/exomem/find_corpus.py
@@ -18,7 +18,7 @@ from .find_types import ParsedPage
 log = logging.getLogger(__name__)
 
 EXCLUDED_DIR_NAMES = frozenset(
-    {".graph-coordination", "_Schema", "_attachments", "_archive", "_trash"}
+    {".graph-coordination", ".trash", "_Schema", "_attachments", "_archive", "_trash"}
 )
 EXCLUDED_DIR_PREFIXES = (".exomem-batch-",)
 NAVIGATION_BASENAMES = frozenset({"index.md", "log.md"})

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -58,6 +58,22 @@ def test_graph_coordination_directory_is_excluded_from_both_full_walkers(
     assert coordination_note not in set(walk_vault_md(vault))
 
 
+def test_nested_dot_trash_directory_is_excluded_from_both_full_walkers(
+    vault: Path,
+) -> None:
+    kb = vault / "Knowledge Base"
+    trashed_note = kb / "Imported" / "Legacy" / ".trash" / "gone.md"
+    normal_note = kb / "Imported" / "Legacy" / "kept.md"
+    trashed_note.parent.mkdir(parents=True, exist_ok=True)
+    normal_note.write_text("# Kept\n", encoding="utf-8")
+    trashed_note.write_text("# Gone\n", encoding="utf-8")
+
+    assert normal_note in set(find_corpus.walk_md(kb))
+    assert normal_note in set(walk_vault_md(vault))
+    assert trashed_note not in set(find_corpus.walk_md(kb))
+    assert trashed_note not in set(walk_vault_md(vault))
+
+
 def test_index_sync_upsert_drops_excluded_paths(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Align the corpus walker with the vault/index exclusion contract so nested .trash directories cannot produce permanent derived-index drift. Includes a regression proving both full walkers retain the normal sibling and skip the trashed note.\n\nVerification: 24 focused tests passed; Ruff and diff checks passed; independent review found no blocker.