### PR TITLE
test(hosted): add real browser transfer drill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scripts/generic/substitutions.txt
 # session transcripts, and project memory). Untracked but present in working
 # checkouts; ignored so a stray `git add` can't leak them into the public repo.
 .omc/
+*.storage-state.json
 # Ignore everything under .claude/ EXCEPT shared tooling that should travel with
 # the repo (OpenSpec's /opsx: commands). settings.local.json, skills/, and
 # worktrees/ (machine paths) stay ignored.

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -1,4 +1,4 @@
-# Review Studio browser acceptance
+# Browser acceptance
 
 This is an opt-in development lane, not a Python or runtime dependency. Start an
 Exomem service from the checkout, then run:
@@ -13,3 +13,42 @@ STUDIO_BASE_URL=http://127.0.0.1:8765 npm test
 The browser loads the real packaged shell and intercepts only `/api/*` with
 deterministic fixtures. Python route/integration tests separately exercise the
 real authenticated REST leaves and governed writes.
+
+## Hosted live-transfer drill
+
+`live-transfer.spec.mjs` is a separate, mutating canary gate for OpenSpec task
+12.3. It never intercepts routes or substitutes fixtures. It obtains fresh
+tickets from the real Substrate owner session, then sends browser bodies through
+the reviewed Cloudflare transfer hostname. Regular `npm test` excludes it.
+
+Run it only against the disposable owner canary. A successful run preserves its
+uploaded Evidence artifacts so the later product-scoped deletion drill can prove
+their removal. The storage-state file is a private operator artifact and must not
+be committed. The gate requires it to be a regular non-symlink file outside the
+repository and, on POSIX systems, rejects group/other access. Create it
+interactively after the owner invite/session flow, for example:
+
+```sh
+npx playwright codegen \
+  --save-storage=/secure/exomem-owner.storage-state.json \
+  https://substratesystems.io/exomem
+chmod 600 /secure/exomem-owner.storage-state.json
+```
+
+Close the codegen browser only after the Exomem owner page is authenticated.
+Then run the live gate:
+
+```sh
+EXOMEM_LIVE_ENABLED=1 \
+EXOMEM_LIVE_BASE_URL=https://substratesystems.io \
+EXOMEM_LIVE_TRANSFER_HOST=transfer.substratesystems.io \
+EXOMEM_LIVE_STORAGE_STATE=/secure/exomem-owner.storage-state.json \
+npm run test:hosted-live
+```
+
+The 90 MiB upload becomes the default large-download fixture in the same serial
+run. `EXOMEM_LIVE_DOWNLOAD_PATH` may instead name a reviewed pre-existing canary
+artifact; set `EXOMEM_LIVE_DOWNLOAD_MIN_BYTES` when its minimum expected size is
+not 5 MiB (lower values are rejected). The gate fails—rather than skips—when
+enabled without its required origin, transfer host, or private storage state.
+Grant-bearing traces are disabled for the live project.

--- a/tests/browser/live-transfer.spec.mjs
+++ b/tests/browser/live-transfer.spec.mjs
@@ -1,0 +1,682 @@
+import {createHash, randomUUID} from "node:crypto";
+import {lstatSync, realpathSync} from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+
+import {expect, test} from "@playwright/test";
+
+const LIVE_ENABLED = process.env.EXOMEM_LIVE_ENABLED === "1";
+const LIVE_BASE_URL = process.env.EXOMEM_LIVE_BASE_URL?.trim() || "";
+const LIVE_STORAGE_STATE = process.env.EXOMEM_LIVE_STORAGE_STATE?.trim() || "";
+const LIVE_TRANSFER_HOST = process.env.EXOMEM_LIVE_TRANSFER_HOST?.trim() || "";
+const LIVE_DOWNLOAD_PATH = process.env.EXOMEM_LIVE_DOWNLOAD_PATH?.trim() || "";
+const LIVE_DOWNLOAD_MIN_BYTES = Number(
+  process.env.EXOMEM_LIVE_DOWNLOAD_MIN_BYTES || "5242880"
+);
+const TRANSFER_GRANT_HEADER = "X-Exomem-Transfer-Grant";
+const TRANSFER_GRANT_MAX_BYTES = 8192;
+const TRANSFER_PATHS = {
+  upload: "/public/exomem/v2/transfers/upload",
+  download: "/public/exomem/v2/transfers/download",
+};
+const BROWSER_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = realpathSync(path.resolve(BROWSER_ROOT, "../.."));
+const MIN_LARGE_DOWNLOAD_BYTES = 5 * 1024 * 1024;
+const LARGE_TRANSFER_RESPONSE_TIMEOUT_MS = 4 * 60_000;
+const UPLOAD_BYTES = 90 * 1024 * 1024;
+const ABORT_BYTES = 64 * 1024 * 1024;
+const SMALL_BYTES = 1024 * 1024;
+const ZERO_CHUNK = Buffer.alloc(1024 * 1024);
+
+let canonicalOrigin = "";
+let uploadedPath = "";
+
+test.describe.configure({mode: "serial"});
+
+function isInside(parent, candidate) {
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+test.beforeAll(() => {
+  if (!LIVE_ENABLED) {
+    throw new Error("set EXOMEM_LIVE_ENABLED=1 to run the mutating hosted canary drill");
+  }
+  if (!LIVE_BASE_URL || new URL(LIVE_BASE_URL).origin !== LIVE_BASE_URL) {
+    throw new Error("EXOMEM_LIVE_BASE_URL must be one canonical HTTPS origin");
+  }
+  if (new URL(LIVE_BASE_URL).protocol !== "https:") {
+    throw new Error("EXOMEM_LIVE_BASE_URL must use HTTPS");
+  }
+  let storageState;
+  let storageStatePath;
+  try {
+    storageState = lstatSync(LIVE_STORAGE_STATE);
+    storageStatePath = realpathSync(LIVE_STORAGE_STATE);
+  } catch {
+    throw new Error("EXOMEM_LIVE_STORAGE_STATE must name the private owner storage-state file");
+  }
+  if (!storageState.isFile() || storageState.isSymbolicLink()) {
+    throw new Error("EXOMEM_LIVE_STORAGE_STATE must be a regular, non-symlink file");
+  }
+  if (isInside(REPO_ROOT, storageStatePath)) {
+    throw new Error("owner storage state must be outside the repository");
+  }
+  if (process.platform !== "win32" && (storageState.mode & 0o077) !== 0) {
+    throw new Error("owner storage state must not be readable by group or other users");
+  }
+  if (!LIVE_TRANSFER_HOST || LIVE_TRANSFER_HOST.includes("/") || LIVE_TRANSFER_HOST.includes("@")) {
+    throw new Error("EXOMEM_LIVE_TRANSFER_HOST must name the reviewed transfer host");
+  }
+  if (
+    !Number.isSafeInteger(LIVE_DOWNLOAD_MIN_BYTES) ||
+    LIVE_DOWNLOAD_MIN_BYTES < MIN_LARGE_DOWNLOAD_BYTES
+  ) {
+    throw new Error("EXOMEM_LIVE_DOWNLOAD_MIN_BYTES must be at least 5 MiB");
+  }
+  canonicalOrigin = LIVE_BASE_URL;
+});
+
+function zeroSha256(size) {
+  const digest = createHash("sha256");
+  let remaining = size;
+  while (remaining > 0) {
+    const length = Math.min(remaining, ZERO_CHUNK.length);
+    digest.update(ZERO_CHUNK.subarray(0, length));
+    remaining -= length;
+  }
+  return digest.digest("hex");
+}
+
+function mutateDownloadPathClaim(grant) {
+  const parts = grant.split(".");
+  if (parts.length !== 2) {
+    throw new Error("download grant does not use the reviewed two-part encoding");
+  }
+  const [payload, signature] = parts;
+  const originalJson = Buffer.from(payload, "base64url").toString("utf8");
+  let claims;
+  try {
+    claims = JSON.parse(originalJson);
+  } catch {
+    throw new Error("download grant claims are not canonical transfer-v2 claims");
+  }
+  if (
+    JSON.stringify(claims) !== originalJson ||
+    claims?.op !== "download" ||
+    claims?.target?.kind !== "download-v1" ||
+    typeof claims.target.path !== "string"
+  ) {
+    throw new Error("download grant claims are not canonical transfer-v2 claims");
+  }
+  claims.target.path = `${claims.target.path}.altered`;
+  const alteredPayload = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  return `${alteredPayload}.${signature}`;
+}
+
+function liveFilename(label) {
+  return `${label}-${Date.now()}-${randomUUID()}.bin`;
+}
+
+function hasExactKeys(value, expected) {
+  return (
+    Boolean(value && typeof value === "object" && !Array.isArray(value)) &&
+    JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...expected].sort())
+  );
+}
+
+function isExactUploadProof(result, size) {
+  const body = result?.body;
+  const data = body?.data;
+  return (
+    result?.status === 201 &&
+    hasExactKeys(body, ["success", "data"]) &&
+    body.success === true &&
+    hasExactKeys(data, ["operation", "bytes", "sha256", "committed"]) &&
+    data.operation === "upload" &&
+    data.bytes === size &&
+    data.sha256 === zeroSha256(size) &&
+    data.committed === true
+  );
+}
+
+function isExactGrantRejection(result) {
+  const body = result?.body;
+  const error = body?.error;
+  return (
+    result?.status === 401 &&
+    hasExactKeys(body, ["success", "error"]) &&
+    body.success === false &&
+    hasExactKeys(error, ["code", "message", "retryable", "requires_new_grant"]) &&
+    error.code === "TRANSFER_GRANT_REJECTED" &&
+    error.message === "transfer authorization failed" &&
+    error.retryable === false &&
+    error.requires_new_grant === true
+  );
+}
+
+async function openOwnerCell(page) {
+  await page.goto("/exomem", {waitUntil: "domcontentloaded"});
+  const probe = await page.evaluate(async () => {
+    const response = await fetch("/api/exomem/status", {
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+    return {status: response.status};
+  });
+  expect(probe.status, "owner/cell status probe failed").toBe(200);
+}
+
+async function issueTicket(
+  page,
+  endpoint,
+  body,
+  {expectedOperation, expectedContentType = null}
+) {
+  const result = await page.evaluate(
+    async ({endpoint: ticketEndpoint, body: ticketBody}) => {
+      const csrf = document.cookie
+        .split(";")
+        .map((part) => part.trim().split("="))
+        .find(([name]) => name === "exomem_csrf")
+        ?.slice(1)
+        .join("=");
+      const response = await fetch(ticketEndpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-exomem-csrf": decodeURIComponent(csrf || ""),
+        },
+        body: JSON.stringify(ticketBody),
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      let responseBody;
+      try {
+        responseBody = await response.json();
+      } catch {
+        responseBody = null;
+      }
+      return {status: response.status, body: responseBody};
+    },
+    {endpoint, body}
+  );
+  expect(result.status, `ticket endpoint ${endpoint} rejected the owner session`).toBe(200);
+  expect(result.body?.success === true, "ticket endpoint returned an invalid envelope").toBe(true);
+  const ticket = result.body?.data;
+  expect(
+    Boolean(ticket && typeof ticket === "object" && !Array.isArray(ticket)),
+    "ticket endpoint returned an invalid data object"
+  ).toBe(true);
+  const expectedMethod = expectedOperation === "upload" ? "PUT" : "GET";
+  const expectedTransferPath = TRANSFER_PATHS[expectedOperation];
+  expect(expectedTransferPath, "test requested an unsupported transfer operation").toBeTruthy();
+  expect(ticket.method).toBe(expectedMethod);
+  let transferUrl;
+  try {
+    if (typeof ticket.url !== "string") throw new Error("invalid URL type");
+    transferUrl = new URL(ticket.url);
+  } catch {
+    throw new Error("ticket endpoint returned an invalid transfer URL");
+  }
+  const cellPath = transferUrl.pathname.slice(0, -expectedTransferPath.length);
+  const urlHasNoForbiddenComponents =
+    transferUrl.protocol === "https:" &&
+    transferUrl.host === LIVE_TRANSFER_HOST &&
+    transferUrl.origin !== canonicalOrigin &&
+    transferUrl.username === "" &&
+    transferUrl.password === "" &&
+    transferUrl.search === "" &&
+    transferUrl.hash === "" &&
+    /^\/cells\/[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(cellPath) &&
+    transferUrl.pathname === `${cellPath}${expectedTransferPath}`;
+  expect(
+    urlHasNoForbiddenComponents,
+    "ticket transfer URL must be the exact reviewed credential-free cell route"
+  ).toBe(true);
+
+  const rawHeaders = ticket.headers;
+  expect(
+    Boolean(rawHeaders && typeof rawHeaders === "object" && !Array.isArray(rawHeaders)),
+    "ticket endpoint returned invalid transfer headers"
+  ).toBe(true);
+  const expectedHeaderNames =
+    expectedOperation === "upload"
+      ? ["Content-Type", TRANSFER_GRANT_HEADER]
+      : [TRANSFER_GRANT_HEADER];
+  expect(Object.keys(rawHeaders).sort()).toEqual(expectedHeaderNames.sort());
+  expect(Object.values(rawHeaders).every((value) => typeof value === "string")).toBe(true);
+  const grant = rawHeaders[TRANSFER_GRANT_HEADER];
+  const grantIsBoundedAscii =
+    typeof grant === "string" &&
+    grant.length > 0 &&
+    Buffer.byteLength(grant, "ascii") === grant.length &&
+    grant.length <= TRANSFER_GRANT_MAX_BYTES &&
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(grant);
+  expect(grantIsBoundedAscii, "ticket returned a malformed transfer grant").toBe(true);
+  if (expectedOperation === "upload") {
+    expect(rawHeaders["Content-Type"]).toBe(expectedContentType);
+  }
+  expect(Number.isSafeInteger(ticket.maxBytes) && ticket.maxBytes > 0).toBe(true);
+
+  const safeHeaders = {
+    ...(expectedOperation === "upload" ? {"Content-Type": expectedContentType} : {}),
+    [TRANSFER_GRANT_HEADER]: grant,
+  };
+  return {
+    url: transferUrl.toString(),
+    method: expectedMethod,
+    headers: safeHeaders,
+    maxBytes: ticket.maxBytes,
+  };
+}
+
+async function issueUploadTicket(page, {filename, size}) {
+  return issueTicket(
+    page,
+    "/api/exomem/upload",
+    {
+      metadata: {
+        category: "live-transfer",
+        content_type: "application/octet-stream",
+        description: null,
+        filename,
+        scope: "hosted-alpha",
+        sha256: zeroSha256(size),
+        size,
+      },
+    },
+    {expectedOperation: "upload", expectedContentType: "application/octet-stream"}
+  );
+}
+
+async function issueDownloadTicket(page, path) {
+  return issueTicket(
+    page,
+    "/api/exomem/download",
+    {path},
+    {expectedOperation: "download"}
+  );
+}
+
+async function putZeroBytes(page, ticket, size) {
+  return page.evaluate(
+    async ({ticket: directTicket, size: payloadSize}) => {
+      const response = await fetch(directTicket.url, {
+        method: directTicket.method,
+        headers: directTicket.headers,
+        body: new Uint8Array(payloadSize),
+        credentials: "omit",
+        cache: "no-store",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+      let body;
+      try {
+        body = await response.json();
+      } catch {
+        body = null;
+      }
+      return {
+        status: response.status,
+        body,
+      };
+    },
+    {ticket, size}
+  );
+}
+
+async function fetchDirectTicket(page, ticket, bodySize = null) {
+  return page.evaluate(
+    async ({ticket: directTicket, bodySize: directBodySize}) => {
+      const response = await fetch(directTicket.url, {
+        method: directTicket.method,
+        headers: directTicket.headers,
+        ...(directBodySize === null ? {} : {body: new Uint8Array(directBodySize)}),
+        credentials: "omit",
+        cache: "no-store",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.startsWith("application/json")) {
+        return {status: response.status, body: await response.json(), bytes: null};
+      }
+      return {
+        status: response.status,
+        body: null,
+        bytes: (await response.arrayBuffer()).byteLength,
+      };
+    },
+    {ticket, bodySize}
+  );
+}
+
+async function abortUploadAfterProgress(page, ticket, size) {
+  return page.evaluate(
+    ({ticket: directTicket, size: payloadSize}) =>
+      new Promise((resolve) => {
+        const request = new XMLHttpRequest();
+        let settled = false;
+        let reachedUploadProgress = false;
+        const finish = (value) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(deadline);
+          resolve(value);
+        };
+        request.open(directTicket.method, directTicket.url);
+        request.withCredentials = false;
+        for (const [name, value] of Object.entries(directTicket.headers)) {
+          request.setRequestHeader(name, value);
+        }
+        request.upload.onprogress = (event) => {
+          if (event.loaded <= 0 || (event.lengthComputable && event.loaded >= event.total)) {
+            return;
+          }
+          reachedUploadProgress = true;
+          request.abort();
+          finish({aborted: true, reachedUploadProgress: true});
+        };
+        request.onload = () => finish({aborted: false, status: request.status});
+        request.onerror = () => finish({aborted: false, networkError: true});
+        request.onabort = () => finish({aborted: true, reachedUploadProgress});
+        const deadline = setTimeout(() => {
+          request.abort();
+          finish({aborted: true, reachedUploadProgress: false});
+        }, 15_000);
+        request.send(
+          new Blob([new Uint8Array(payloadSize)], {type: "application/octet-stream"})
+        );
+      }),
+    {ticket, size}
+  );
+}
+
+async function observeConsumedGrant(page, ticket, size) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const replay = await putZeroBytes(page, ticket, size);
+    if (isExactGrantRejection(replay)) {
+      return replay;
+    }
+    const retryableBeforeConsumption =
+      [409, 503].includes(replay.status) &&
+      replay.body?.error?.requires_new_grant === false;
+    if (!retryableBeforeConsumption) {
+      throw new Error(
+        `aborted transfer grant was not consumed; replay returned status ${replay.status}`
+      );
+    }
+    await page.waitForTimeout(250);
+  }
+  throw new Error("aborted transfer grant consumption was not observable within 30 seconds");
+}
+
+test("canonical CORS preflight", async ({page}) => {
+  await openOwnerCell(page);
+  const ticket = await issueUploadTicket(page, {filename: liveFilename("preflight"), size: 1});
+  const preflightResponse = page.waitForResponse(
+    (response) =>
+      response.url() === ticket.url && response.request().method() === "OPTIONS"
+  );
+  const [response, transfer] = await Promise.all([
+    preflightResponse,
+    putZeroBytes(page, ticket, 1),
+  ]);
+
+  expect(response.status()).toBe(204);
+  const headers = await response.allHeaders();
+  expect(headers["access-control-allow-origin"]).toBe(canonicalOrigin);
+  expect(headers["access-control-allow-methods"]).toBe("PUT");
+  expect(headers["access-control-allow-headers"]).toBe(
+    "Content-Type, X-Exomem-Transfer-Grant"
+  );
+  expect(headers["access-control-max-age"]).toBe("300");
+  expect(headers["access-control-allow-credentials"]).toBeUndefined();
+  expect(headers["vary"]).toBe("Origin");
+  expect(
+    isExactUploadProof(transfer, 1),
+    "the browser preflight must not consume the grant"
+  ).toBe(true);
+});
+
+test("exact transfer headers and methods", async ({page, request}) => {
+  await openOwnerCell(page);
+  const ticket = await issueUploadTicket(page, {filename: liveFilename("exact"), size: 1});
+  const cases = [
+    {method: "POST", headers: "content-type, x-exomem-transfer-grant"},
+    {method: "PUT", headers: "content-type"},
+    {method: "PUT", headers: "content-type, x-exomem-transfer-grant, authorization"},
+  ];
+  for (const item of cases) {
+    const response = await request.fetch(ticket.url, {
+      method: "OPTIONS",
+      headers: {
+        Origin: canonicalOrigin,
+        "Access-Control-Request-Method": item.method,
+        "Access-Control-Request-Headers": item.headers,
+      },
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(400);
+    expect(response.headers()["access-control-allow-origin"]).toBeUndefined();
+  }
+  const correct = await putZeroBytes(page, ticket, 1);
+  expect(
+    isExactUploadProof(correct, 1),
+    "rejected preflights must not consume the grant"
+  ).toBe(true);
+});
+
+test("90 MiB upload streams through the real edge", async ({page}) => {
+  test.setTimeout(5 * 60_000);
+  await openOwnerCell(page);
+  const filename = liveFilename("edge-90mib");
+  const ticket = await issueUploadTicket(page, {filename, size: UPLOAD_BYTES});
+  expect(ticket.method).toBe("PUT");
+  expect(ticket.maxBytes).toBe(UPLOAD_BYTES);
+
+  const actualResponse = page.waitForResponse(
+    (response) => response.url() === ticket.url && response.request().method() === "PUT",
+    {timeout: LARGE_TRANSFER_RESPONSE_TIMEOUT_MS}
+  );
+  const [response, result] = await Promise.all([
+    actualResponse,
+    putZeroBytes(page, ticket, UPLOAD_BYTES),
+  ]);
+  const responseHeaders = await response.allHeaders();
+  expect(isExactUploadProof(result, UPLOAD_BYTES), "upload commit proof is invalid").toBe(true);
+  expect(responseHeaders["access-control-allow-origin"]).toBe(canonicalOrigin);
+  expect(responseHeaders["access-control-allow-credentials"]).toBeUndefined();
+  expect(responseHeaders["vary"]).toBe("Origin");
+  expect(responseHeaders["cache-control"]).toBe("private, no-store");
+  uploadedPath = `Knowledge Base/Evidence/hosted-alpha/live-transfer/${filename}`;
+});
+
+test("large download streams through the real edge", async ({page}) => {
+  test.setTimeout(5 * 60_000);
+  await openOwnerCell(page);
+  const path = LIVE_DOWNLOAD_PATH || uploadedPath;
+  expect(path, "the 90 MiB upload must run first or EXOMEM_LIVE_DOWNLOAD_PATH must be set").not.toBe("");
+  const ticket = await issueDownloadTicket(page, path);
+  expect(ticket.method).toBe("GET");
+  const minimumBytes = LIVE_DOWNLOAD_PATH ? LIVE_DOWNLOAD_MIN_BYTES : UPLOAD_BYTES;
+  const actualResponse = page.waitForResponse(
+    (response) => response.url() === ticket.url && response.request().method() === "GET",
+    {timeout: LARGE_TRANSFER_RESPONSE_TIMEOUT_MS}
+  );
+  const [response, result] = await Promise.all([
+    actualResponse,
+    page.evaluate(async (directTicket) => {
+      const transferResponse = await fetch(directTicket.url, {
+        method: directTicket.method,
+        headers: directTicket.headers,
+        credentials: "omit",
+        cache: "no-store",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+      let bytes = 0;
+      let chunks = 0;
+      const reader = transferResponse.body?.getReader();
+      if (reader) {
+        while (true) {
+          const {done, value} = await reader.read();
+          if (done) break;
+          bytes += value.byteLength;
+          chunks += 1;
+        }
+      }
+      return {
+        status: transferResponse.status,
+        bytes,
+        chunks,
+        contentLength: transferResponse.headers.get("content-length"),
+        contentType: transferResponse.headers.get("content-type"),
+        contentDisposition: transferResponse.headers.get("content-disposition"),
+      };
+    }, ticket),
+  ]);
+  const responseHeaders = await response.allHeaders();
+
+  expect(result.status).toBe(200);
+  expect(result.bytes).toBeGreaterThanOrEqual(minimumBytes);
+  expect(result.chunks).toBeGreaterThan(1);
+  expect(Number(result.contentLength)).toBe(result.bytes);
+  expect(result.contentType).toBe("application/octet-stream");
+  expect(result.contentDisposition).toMatch(/^attachment;/);
+  expect(responseHeaders["access-control-allow-origin"]).toBe(canonicalOrigin);
+  expect(responseHeaders["access-control-allow-credentials"]).toBeUndefined();
+  expect(responseHeaders["access-control-expose-headers"]).toBe(
+    "Content-Disposition, Content-Length, Content-Type"
+  );
+  expect(responseHeaders["vary"]).toBe("Origin");
+  expect(responseHeaders["cache-control"]).toBe("private, no-store");
+});
+
+test("aborted upload requires a fresh ticket", async ({page}) => {
+  test.setTimeout(5 * 60_000);
+  await openOwnerCell(page);
+  const abortedTicket = await issueUploadTicket(page, {
+    filename: liveFilename("aborted"),
+    size: ABORT_BYTES,
+  });
+  const aborted = await abortUploadAfterProgress(page, abortedTicket, ABORT_BYTES);
+  expect(aborted.aborted).toBe(true);
+  expect(aborted.reachedUploadProgress).toBe(true);
+
+  const replay = await observeConsumedGrant(page, abortedTicket, ABORT_BYTES);
+  expect(isExactGrantRejection(replay), "aborted grant replay was not rejected exactly").toBe(
+    true
+  );
+
+  const freshTicket = await issueUploadTicket(page, {
+    filename: liveFilename("after-abort"),
+    size: SMALL_BYTES,
+  });
+  const fresh = await putZeroBytes(page, freshTicket, SMALL_BYTES);
+  expect(isExactUploadProof(fresh, SMALL_BYTES), "fresh ticket upload failed").toBe(true);
+});
+
+test("successful ticket replay is rejected", async ({page}) => {
+  await openOwnerCell(page);
+  const ticket = await issueUploadTicket(page, {
+    filename: liveFilename("replay"),
+    size: SMALL_BYTES,
+  });
+  const first = await putZeroBytes(page, ticket, SMALL_BYTES);
+  expect(isExactUploadProof(first, SMALL_BYTES), "initial ticket upload failed").toBe(true);
+
+  const replay = await putZeroBytes(page, ticket, SMALL_BYTES);
+  expect(isExactGrantRejection(replay), "successful ticket replay was not rejected exactly").toBe(
+    true
+  );
+});
+
+test("grant path and operation alteration is rejected", async ({page}) => {
+  await openOwnerCell(page);
+  const filename = liveFilename("alteration");
+  const uploadTicket = await issueUploadTicket(page, {
+    filename,
+    size: 1,
+  });
+  const uploadGrant = uploadTicket.headers[TRANSFER_GRANT_HEADER];
+  const wrongOperationUrl = uploadTicket.url.replace(
+    TRANSFER_PATHS.upload,
+    TRANSFER_PATHS.download
+  );
+  expect(wrongOperationUrl).not.toBe(uploadTicket.url);
+  const operationResponse = await fetchDirectTicket(page, {
+    url: wrongOperationUrl,
+    method: "GET",
+    headers: {[TRANSFER_GRANT_HEADER]: uploadGrant},
+  });
+  expect(
+    isExactGrantRejection(operationResponse),
+    "operation-altered grant was not rejected exactly"
+  ).toBe(true);
+
+  const correctUpload = await putZeroBytes(page, uploadTicket, 1);
+  expect(isExactUploadProof(correctUpload, 1), "unaltered upload grant failed").toBe(true);
+
+  const committedPath = `Knowledge Base/Evidence/hosted-alpha/live-transfer/${filename}`;
+  const downloadTicket = await issueDownloadTicket(page, committedPath);
+  const originalDownloadGrant = downloadTicket.headers[TRANSFER_GRANT_HEADER];
+  const pathResponse = await fetchDirectTicket(page, {
+    ...downloadTicket,
+    headers: {
+      [TRANSFER_GRANT_HEADER]: mutateDownloadPathClaim(originalDownloadGrant),
+    },
+  });
+  expect(
+    isExactGrantRejection(pathResponse),
+    "path-altered grant was not rejected exactly"
+  ).toBe(true);
+
+  const correctDownload = await fetchDirectTicket(page, downloadTicket);
+  expect(correctDownload.status).toBe(200);
+  expect(correctDownload.bytes).toBe(1);
+});
+
+test("hostile origin is denied", async ({page, request}) => {
+  await openOwnerCell(page);
+  const ticket = await issueUploadTicket(page, {
+    filename: liveFilename("hostile-origin"),
+    size: SMALL_BYTES,
+  });
+  const preflight = await request.fetch(ticket.url, {
+    method: "OPTIONS",
+    headers: {
+      Origin: "https://attacker.invalid",
+      "Access-Control-Request-Method": "PUT",
+      "Access-Control-Request-Headers": "content-type, x-exomem-transfer-grant",
+    },
+    maxRedirects: 0,
+  });
+  expect(preflight.status()).toBe(403);
+  expect(preflight.headers()["access-control-allow-origin"]).toBeUndefined();
+
+  const hostilePage = await page.context().newPage();
+  await hostilePage.goto("data:text/html,<title>hostile origin</title>");
+  const hostile = await hostilePage.evaluate(async (directTicket) => {
+    try {
+      await fetch(directTicket.url, {
+        method: directTicket.method,
+        headers: directTicket.headers,
+        body: new Uint8Array(1024 * 1024),
+        credentials: "omit",
+      });
+      return {blocked: false};
+    } catch (error) {
+      return {blocked: true, name: error instanceof Error ? error.name : "unknown"};
+    }
+  }, ticket);
+  await hostilePage.close();
+  expect(hostile).toEqual({blocked: true, name: "TypeError"});
+
+  const canonical = await putZeroBytes(page, ticket, SMALL_BYTES);
+  expect(isExactUploadProof(canonical, SMALL_BYTES), "canonical origin upload failed").toBe(
+    true
+  );
+});

--- a/tests/browser/package.json
+++ b/tests/browser/package.json
@@ -2,6 +2,9 @@
   "name": "exomem-studio-browser-tests",
   "private": true,
   "type": "module",
-  "scripts": {"test": "playwright test"},
+  "scripts": {
+    "test": "playwright test --project=chromium",
+    "test:hosted-live": "playwright test live-transfer.spec.mjs --project=hosted-live-chromium"
+  },
   "devDependencies": {"@playwright/test": "^1.53.0"}
 }

--- a/tests/browser/playwright.config.mjs
+++ b/tests/browser/playwright.config.mjs
@@ -1,5 +1,7 @@
 import {defineConfig} from "@playwright/test";
 
+const liveStorageState = process.env.EXOMEM_LIVE_STORAGE_STATE?.trim();
+
 export default defineConfig({
   testDir: ".",
   testMatch: "*.spec.mjs",
@@ -8,5 +10,22 @@ export default defineConfig({
     baseURL: process.env.STUDIO_BASE_URL || "http://127.0.0.1:8765",
     trace: "retain-on-failure",
   },
-  projects: [{name: "chromium", use: {browserName: "chromium"}}],
+  projects: [
+    {
+      name: "chromium",
+      testIgnore: "live-transfer.spec.mjs",
+      use: {browserName: "chromium"},
+    },
+    {
+      name: "hosted-live-chromium",
+      testMatch: "live-transfer.spec.mjs",
+      use: {
+        browserName: "chromium",
+        baseURL: process.env.EXOMEM_LIVE_BASE_URL || "https://substratesystems.io",
+        ...(liveStorageState ? {storageState: liveStorageState} : {}),
+        // Transfer grants are short-lived credentials. Never retain them in a trace.
+        trace: "off",
+      },
+    },
+  ],
 });

--- a/tests/test_hosted_browser_live_gate_contract.py
+++ b/tests/test_hosted_browser_live_gate_contract.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[1]
 BROWSER_ROOT = ROOT / "tests" / "browser"
 LIVE_SPEC = BROWSER_ROOT / "live-transfer.spec.mjs"

--- a/tests/test_hosted_browser_live_gate_contract.py
+++ b/tests/test_hosted_browser_live_gate_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+BROWSER_ROOT = ROOT / "tests" / "browser"
+LIVE_SPEC = BROWSER_ROOT / "live-transfer.spec.mjs"
+
+
+def test_live_transfer_browser_gate_has_an_explicit_opt_in_entrypoint() -> None:
+    package = json.loads((BROWSER_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert package["scripts"]["test:hosted-live"] == (
+        "playwright test live-transfer.spec.mjs --project=hosted-live-chromium"
+    )
+    assert LIVE_SPEC.is_file()
+
+
+def test_live_transfer_browser_gate_cannot_substitute_mocked_routes() -> None:
+    spec = LIVE_SPEC.read_text(encoding="utf-8")
+
+    assert "EXOMEM_LIVE_ENABLED" in spec
+    assert "EXOMEM_LIVE_STORAGE_STATE" in spec
+    assert "EXOMEM_LIVE_DOWNLOAD_PATH" in spec
+    assert "page.route(" not in spec
+    assert "route.fulfill(" not in spec
+    assert ".example.test" not in spec
+
+
+def test_live_transfer_browser_gate_names_every_openspec_scenario() -> None:
+    spec = LIVE_SPEC.read_text(encoding="utf-8")
+    required_markers = {
+        "canonical CORS preflight",
+        "exact transfer headers and methods",
+        "90 MiB upload streams through the real edge",
+        "large download streams through the real edge",
+        "aborted upload requires a fresh ticket",
+        "successful ticket replay is rejected",
+        "grant path and operation alteration is rejected",
+        "hostile origin is denied",
+    }
+
+    assert all(marker in spec for marker in required_markers)
+    assert "90 * 1024 * 1024" in spec
+
+
+def test_live_transfer_owner_storage_state_stays_outside_the_repository() -> None:
+    spec = LIVE_SPEC.read_text(encoding="utf-8")
+    ignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
+
+    assert "*.storage-state.json" in ignore
+    assert "lstatSync" in spec
+    assert "realpathSync" in spec
+    assert "REPO_ROOT" in spec
+    assert "storage state must be outside the repository" in spec
+    assert "0o077" in spec
+
+
+def test_live_transfer_ticket_and_browser_probe_are_strict() -> None:
+    spec = LIVE_SPEC.read_text(encoding="utf-8")
+
+    assert "expectedOperation" in spec
+    assert "transferUrl.username" in spec
+    assert "transferUrl.search" in spec
+    assert "transferUrl.hash" in spec
+    assert "expectedTransferPath" in spec
+    assert "safeHeaders" in spec
+    assert spec.count("page.waitForResponse") >= 3
+    assert "urlHasNoForbiddenComponents" in spec
+    assert "expect(transferUrl.username)" not in spec
+    assert 'response.headers.get("access-control-allow-origin")' not in spec
+    assert 'response.headers.get("access-control-expose-headers")' not in spec
+    assert "mutateDownloadPathClaim" in spec
+    assert "isExactUploadProof" in spec
+    assert "isExactGrantRejection" in spec
+    assert "expect(result.body).toEqual" not in spec
+    assert "LARGE_TRANSFER_RESPONSE_TIMEOUT_MS" in spec
+    assert "MIN_LARGE_DOWNLOAD_BYTES" in spec
+    assert "access-control-expose-headers" in spec


### PR DESCRIPTION
## Outcome

Adds the missing credential-free implementation for OpenSpec task 12.3: an opt-in Playwright drill that exercises the real Substrate owner session, Cloudflare transfer hostname, and hosted cell without route interception or fixtures.

The OpenSpec checkbox intentionally remains open. It closes only after this drill passes against the deployed disposable owner canary.

## Coverage

- Chromium-issued canonical preflight and same-grant non-consumption proof
- exact ticket URL, method, header, and CORS policy allowlists
- 90 MiB upload and large streaming download
- abort/new-ticket and successful replay rejection
- signed path and operation mutation rejection on valid routes
- hostile-origin denial followed by canonical-origin success
- private outside-repository storage state and grant-safe failure output

## Verification

- 60 focused Python tests passed
- 11 normal Chromium acceptance tests passed; live drill excluded
- all 8 hosted-live scenarios discovered
- hosted-live invocation fails closed unless explicitly enabled
- Node syntax and git diff checks passed
- independent adversarial review approved
