### PR TITLE
Fix replay-safe MCP mutation acknowledgements

### DIFF
--- a/deploy/cloudflare-ha/README.md
+++ b/deploy/cloudflare-ha/README.md
@@ -25,27 +25,32 @@ different replica ID; set `EXOMEM_WRITER_LEASE_PREFERRED=1` only on the preferre
 desktop. See `docs/deployment.md` for the complete environment block and takeover
 test.
 
-## Tool-call routing safety
+## Mutation-capable routing safety
 
 Use two edge timeouts:
 
 - `ORIGIN_TIMEOUT_MS` (default `2500`) is the short connectivity/fallback window
   for OAuth, discovery, initialization, tool listing, and GET/SSE traffic.
 - `MCP_TOOL_TIMEOUT_MS` (default `15000`) is the execution window for
-  `tools/call`; correctness comes from single-origin routing, not from ordering
-  this timeout against the writer-lease TTL.
+  `tools/call` and other unsafe non-`/mcp` methods, including personal REST and
+  lifecycle POSTs plus public transfer PUT uploads. Correctness comes from
+  single-origin routing, not from ordering this timeout against the writer-lease
+  TTL.
 
-While a writer lease is active, a tool call goes only to that replica. The edge
-never replays an ambiguous timeout or 5xx response to the passive replica: the
-first origin may already have completed a mutation. Before routing, it admits the
-runtime through `/health/ready`: supported runtime contract, stateless transport,
+While a writer lease is active, a tool call or other mutation-capable request
+goes only to that replica. The edge never replays an ambiguous timeout or 5xx
+response to the passive replica: the first origin may already have completed a
+mutation. Safe GET/HEAD/OPTIONS traffic and non-tool MCP initialization retain
+the short fallback path. Before single-origin routing, the edge admits the runtime
+through `/health/ready`: supported runtime contract, stateless transport,
 expected replica identity, healthy coordination, and takeover eligibility. The
 admission is bound to the lease fencing token in the Durable Object, so steady
 state does not add a readiness round trip to every MCP call.
 
-With no holder, both origins are probed concurrently and the call is forwarded
-exactly once to the first eligible replica. A live but stale service that lacks
-the readiness contract is skipped instead of becoming the failover writer.
+With no holder, both origins are probed concurrently and the mutation-capable
+request is forwarded exactly once to the first eligible replica. A live but stale
+service that lacks the readiness contract is skipped instead of becoming the
+failover writer.
 
 Configure `SUPPORTED_RUNTIME_CONTRACTS` with behavioral contract versions, not
 package versions. Compatible releases can differ during a rolling deployment.

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -259,8 +259,8 @@ export default {
 
     const lease = await currentLease(env);
     const holder = lease.holder;
-    if (await isMcpToolCall(request)) {
-      return proxyToolCall(request, env, lease);
+    if (await isMutationCapableRequest(request)) {
+      return proxyMutationRequest(request, env, lease);
     }
 
     const replicas = holder === env.LAPTOP_REPLICA_ID
@@ -300,7 +300,19 @@ export async function isMcpToolCall(request) {
   return messages.some((message) => message && message.method === "tools/call");
 }
 
-async function proxyToolCall(request, env, lease) {
+export async function isMutationCapableRequest(request) {
+  if (await isMcpToolCall(request)) return true;
+  if (["GET", "HEAD", "OPTIONS"].includes(request.method)) return false;
+  const pathname = new URL(request.url).pathname;
+  // Non-tool MCP messages retain their compatibility fallback. Every other
+  // unsafe method is single-origin by default, including REST/lifecycle POSTs
+  // and the capability-bound public transfer PUT.
+  return pathname !== "/mcp";
+}
+
+async function proxyMutationRequest(request, env, lease) {
+  request = withMutationRequestId(request);
+  const requestId = request.headers.get("x-exomem-request-id");
   const shortTimeout = Number(env.ORIGIN_TIMEOUT_MS || 2500);
   const toolTimeout = Number(env.MCP_TOOL_TIMEOUT_MS || 15000);
   const holder = lease.holder;
@@ -324,13 +336,36 @@ async function proxyToolCall(request, env, lease) {
   }
 
   try {
+    console.log(JSON.stringify({
+      event: "mutation_proxy",
+      request_id: requestId,
+      origin: candidate.origin,
+    }));
     return await proxyOnce(request, candidate.origin, toolTimeout);
   } catch {
-    // Never replay an ambiguous tools/call request. The origin may have
+    // Never replay an ambiguous mutation-capable request. The origin may have
     // committed after the edge stopped waiting; cross-replica replay turns a
     // transport timeout into duplicate governed state.
-    return json({ error: "active Exomem tool call did not complete at the edge" }, 504);
+    console.warn(JSON.stringify({
+      event: "mutation_timeout",
+      request_id: requestId,
+      origin: candidate.origin,
+    }));
+    return json({
+      error: "active Exomem mutation-capable request did not complete at the edge",
+      request_id: requestId,
+    }, 504);
   }
+}
+
+function withMutationRequestId(request) {
+  const headers = new Headers(request.headers);
+  const presented = String(headers.get("x-exomem-request-id") || "").trim();
+  const requestId = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(presented)
+    ? presented
+    : crypto.randomUUID();
+  headers.set("x-exomem-request-id", requestId);
+  return new Request(request, { headers });
 }
 
 function candidateForHolder(env, holder) {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -287,6 +287,20 @@ const toolCall = (name = "remember") => mcp({
   params: { name, arguments: {} },
 });
 
+const restMutation = (name = "remember") =>
+  new Request(`https://exomem.example.com/api/${name}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ content: "one canonical payload" }),
+  });
+
+const transferUpload = () =>
+  new Request("https://exomem.example.com/public/exomem/v2/transfers/upload", {
+    method: "PUT",
+    headers: { "content-type": "application/octet-stream" },
+    body: "artifact bytes",
+  });
+
 test("classifies single and batched tool calls conservatively", async () => {
   assert.equal(await isMcpToolCall(toolCall()), true);
   assert.equal(await isMcpToolCall(mcp([
@@ -362,11 +376,13 @@ test("lease admission is bound to holder and fencing token and cleared on takeov
 
 test("active-holder tool call uses the long timeout and is never replayed", async () => {
   const calls = [];
+  const requestIds = [];
   const timeouts = [];
   const originalFetch = globalThis.fetch;
   const originalTimeout = AbortSignal.timeout;
   globalThis.fetch = async (request) => {
     calls.push(new URL(request.url).origin);
+    requestIds.push(request.headers.get("x-exomem-request-id"));
     return new Response("tool failed after execution", { status: 500 });
   };
   AbortSignal.timeout = (ms) => {
@@ -377,10 +393,34 @@ test("active-holder tool call uses the long timeout and is never replayed", asyn
     const response = await worker.fetch(toolCall(), edgeEnv("desktop"));
     assert.equal(response.status, 500);
     assert.deepEqual(calls, ["https://desktop.example.com"]);
+    assert.match(requestIds[0], /^[0-9a-f-]{36}$/);
     assert.deepEqual(timeouts, [15_000]);
   } finally {
     globalThis.fetch = originalFetch;
     AbortSignal.timeout = originalTimeout;
+  }
+});
+
+test("edge replaces non-UUID mutation correlation text before forwarding and logging", async () => {
+  const forwarded = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    forwarded.push(request.headers.get("x-exomem-request-id"));
+    return new Response("ok", { status: 200 });
+  };
+  try {
+    const request = toolCall();
+    request.headers.set("x-exomem-request-id", "attacker-controlled-log-text");
+    const response = await worker.fetch(request, edgeEnv("desktop"));
+    assert.equal(response.status, 200);
+    assert.equal(forwarded.length, 1);
+    assert.match(
+      forwarded[0],
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    assert.notEqual(forwarded[0], "attacker-controlled-log-text");
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 });
 
@@ -394,6 +434,41 @@ test("active-holder tool timeout fails closed without passive replay", async () 
   try {
     const response = await worker.fetch(toolCall(), edgeEnv("desktop"));
     assert.equal(response.status, 504);
+    assert.deepEqual(calls, ["https://desktop.example.com"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("personal REST mutation failure and timeout never replay to passive origin", async () => {
+  for (const outcome of ["response", "timeout"]) {
+    const calls = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (request) => {
+      calls.push(new URL(request.url).origin);
+      if (outcome === "timeout") throw new DOMException("timed out", "TimeoutError");
+      return new Response("write failed after possible commit", { status: 500 });
+    };
+    try {
+      const response = await worker.fetch(restMutation(), edgeEnv("desktop"));
+      assert.equal(response.status, outcome === "timeout" ? 504 : 500);
+      assert.deepEqual(calls, ["https://desktop.example.com"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("public transfer PUT failure never replays to passive origin", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    calls.push(new URL(request.url).origin);
+    return new Response("upload failed after possible commit", { status: 500 });
+  };
+  try {
+    const response = await worker.fetch(transferUpload(), edgeEnv("desktop"));
+    assert.equal(response.status, 500);
     assert.deepEqual(calls, ["https://desktop.example.com"]);
   } finally {
     globalThis.fetch = originalFetch;

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/.openspec.yaml
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/deferred-ergonomics.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/deferred-ergonomics.md
@@ -1,0 +1,34 @@
+## Follow-up change boundaries
+
+This change closes mutation acknowledgement and replay correctness. The remaining ChatGPT ergonomics work is intentionally split so response-shape and tool-schema churn cannot obscure the incident fix.
+
+### B. Compact mutation terminal envelope
+
+Proposed change: `compact-mutation-terminal-envelope`.
+
+- Lead every mutation response with `ok`, `status`, `mutated`, primary `path`, `request_id`, replay disposition, and warning count.
+- Keep semantic/index detail under `diagnostics` or `detail="full"`; do not discard it.
+- Preserve exact replay semantics by storing and replaying the compact terminal envelope plus its diagnostics reference.
+- Add conformance tests for committed, replayed, pre-commit busy, pending acknowledgement, committed-uncertain, and full-detail responses.
+
+This correctness change implements the structured error half (`status`, `committed`, `request_id`, `receipt_id`, reusable explicit key when present) but does not change successful leaf return shapes.
+
+### C. Discriminated edit schema and capability conformance
+
+Proposed change: `discriminate-edit-memory-and-filter-bootstrap`.
+
+- Replace the optional-field matrix with a discriminated operation union for `replace_body`, `replace_string`, `edit_section`, `patch_frontmatter`, and `fill_row`, or expose those as focused tools.
+- Generate each schema so unrelated fields are absent, and return mode-specific local validation guidance.
+- Derive bootstrap recommendations from the actual exported `tools/list` for each profile/surface, or export every advertised command.
+- Add schema-negative tests and bootstrap-versus-tool-surface conformance tests for ChatGPT, compact MCP, full MCP, REST, and hosted profiles.
+
+### D. Action-first audit and bounded reranking
+
+Proposed change: `triage-audit-output-and-bound-reranking`.
+
+- Sort current non-grandfathered blockers first, malformed/unregistered relations next, and legacy/grandfathered disposition debt into grouped backlog counts.
+- Return representative samples by default and require an explicit full-enumeration option.
+- Prove a small current blocker set remains visible beside hundreds of legacy findings.
+- Keep reranking opt-in; add a candidate cap and caller latency budget with timing tests around the rerank stage.
+
+The present change only prevents `maintain_memory(mode="audit")` from retaining the hosted mutation boundary. It does not alter audit finding severity or retrieval ranking.

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/design.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The active mutation stack is FastMCP/REST/CLI → authenticated caller scope → `LeaseManager.invoke` → vault mutation boundary → writer lease/fence → command leaf → canonical transaction and index/log fanout → idempotency result persistence → transport response. The implementation currently enters the vault boundary before it consults idempotency. An overlapping identical retry therefore competes with its original request and can return pre-leaf `MUTATION_BUSY` while the original worker keeps running and commits.
+
+The three preserved incident notes prove three separate canonical creates on the desktop writer at 2026-07-17 14:58:17.824Z, 14:59:03.203Z, and 15:00:43.127Z. Their IDs, content hashes, and payloads differ, so title similarity must not collapse them. The likely identical retries were transport-level contenders within each visible attempt. Current logs have no stable cross-layer request/idempotency correlation, so the exact A/B response pairing is not recoverable.
+
+The Cloudflare HA worker already sends `tools/call` to one eligible origin once and fails closed on timeout/5xx, but personal REST and other mutation-capable POSTs still use generic cross-origin fallback. FastMCP runs synchronous command leaves in worker threads, so cancellation of HTTP response delivery does not necessarily stop the underlying mutation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make an identical in-flight retry observe the original idempotency record before it can contend for the mutation boundary.
+- Persist a completed terminal result before releasing the mutation boundary and before response construction/delivery.
+- Return the exact stored terminal result for a completed replay without rerunning writer authority or the leaf.
+- Distinguish live acknowledgement uncertainty from pre-commit mutation contention.
+- Scope mutation identity to vault/tenant, stable authenticated principal, command, and canonical payload.
+- Add deterministic fault injection and privacy-safe phase correlation around terminal persistence and acknowledgement loss.
+- Stop personal/local read-only maintenance audit from being misclassified as a mutation.
+
+**Non-Goals:**
+
+- Deduplicate revised payloads or similar titles.
+- Promise cross-replica exactly-once recovery after process death between filesystem commit and local receipt persistence. The edge remains single-origin and the per-replica receipt limitation remains explicit.
+- Shorten the transaction boundary around required index, log, rollback, and notification work in this correctness change.
+- Implement the separate compact envelope, `edit_memory` schema redesign, bootstrap capability filtering, audit output triage, or reranker budget changes.
+
+## Decisions
+
+### Claim idempotency before mutation authority
+
+`IdempotencyStore.run` will reserve or inspect the request identity before entering an injected operation guard. Only the owner of a new pending record may acquire the vault mutation boundary and writer lease. A completed replay returns directly; a mismatched digest fails directly; an identical pending retry waits outside the mutation boundary.
+
+This preserves the existing single-writer/fencing gate for new mutations while preventing a replay from competing with its own original. Merely increasing the lock timeout was rejected because it leaves the ordering bug and ambiguous result intact.
+
+### Bounded-wait for an identical pending request
+
+An identical pending retry will poll the durable SQLite record for a bounded interval, using process-local notifications to avoid unnecessary latency. Completion returns the exact stored result. A pre-commit failure removes the pending row and lets the waiter claim and execute. Expiry of the wait returns `MUTATION_ACKNOWLEDGEMENT_PENDING`, which explicitly says the original outcome is not yet known; it never returns `MUTATION_BUSY` for that identity.
+
+`MUTATION_BUSY` remains reserved for a different/new mutation which could not acquire the boundary and whose leaf never ran.
+
+### Persist the terminal receipt while the mutation boundary is still held
+
+For a claimed request, result serialization and the SQLite transition from `pending` to `completed` occur inside the same operation guard as the command leaf. A post-persistence acknowledgement hook sits after that transition, providing a deterministic test seam for timeout/cancellation without deleting the committed receipt. Recognized committed-cleanup failures keep their sanitized durable terminal marker. The canonical writer also marks its exact non-empty file-commit boundary; any unexpected later exception is converted into a durable `committed_uncertain` receipt instead of escaping as a pre-commit retryable error or deleting the receipt. If exact-result persistence itself fails, the first caller receives committed-uncertain only when that marker was crossed; validation/no-op results report acknowledgement-pending with `committed=null`. Both paths retain a fail-closed pending or uncertain receipt.
+
+This closes the ordinary response-loss window. It cannot make a Markdown filesystem commit and a separate SQLite update atomic across process death; a stranded pending marker remains fail-closed and requires reconciliation.
+
+### Use stable verified principal identity
+
+Personal MCP retry scope will hash verified issuer plus stable subject claims when available, falling back to the current credential/session scope only when no verified principal exists. Hosted implicit scope will use trusted cell plus principal scope rather than request ID. Explicit keys are additionally namespaced by a caller principal scope supplied by authenticated surfaces.
+
+Raw credentials, payloads, and public keys are never logged in identity fields. Public explicit keys are persisted only through their namespaced digest and are echoed only to their caller; the privacy-safe internal fingerprint is separately named `receipt_id`. Exact explicit terminal receipts have a 24-hour retention window, while implicit receipts retain the existing 60-second window. Pending and committed-uncertain receipts remain fail-closed for reconciliation rather than expiring into a possible duplicate.
+
+### Correlate phases without exposing content
+
+Each invocation will log one request-scoped canonical UUIDv4 plus a stable fingerprint of the internal idempotency identity at reservation, pending wait, replay, lock-busy, terminal persistence, and acknowledgement interruption. Middleware binds the UUID through the tool wrapper so direct-origin calls retain one cross-layer identity. Caller-supplied non-UUID log text is rejected and regenerated. Hosted redaction rules remain authoritative. Edge tests prove every mutation-capable POST and public transfer PUT reaches at most one origin.
+
+### Keep required semantic/index work inside the boundary for now
+
+Canonical note creation currently commits before optional corpus diagnostics finish, while transactional index/log fanout is part of the observable mutation. The lock therefore covers more than raw Markdown replacement. This change fixes retry ambiguity without weakening transaction consistency. Moving optional diagnostics out is a separate latency/design change because it changes result consistency and requires its own contract.
+
+### Classify maintenance audit as read-only
+
+`maintain_memory(mode="audit")` will use the common read-only classifier and bypass the hosted consistency guard. Audit is a diagnostic snapshot and may observe a changing corpus, but it cannot retain or contend for the mutation boundary. Other hosted reads keep the consistency guard so they observe pre- or post-transaction state.
+
+## Risks / Trade-offs
+
+- [The original request outlives the pending wait bound] → Return acknowledgement-pending with the same identity; a later same-key retry retrieves the terminal result once persisted.
+- [A process dies after canonical commit but before local receipt persistence] → Leave the pending marker fail-closed and require reconciliation; do not automatically rerun or claim success.
+- [A retry lands on another replica after failover] → The edge never fans out a mutation, but a later takeover cannot read the former replica's local receipt. Keep this limitation explicit and consider a shared/co-located receipt in a separate HA design.
+- [Stable principal claims are absent] → Fall back narrowly to credential or session scope and log the scope kind, never the credential.
+- [An intentional identical mutation occurs within a retention window] → Preserve the bounded 60-second implicit behavior and document the 24-hour explicit-key guarantee; a new identity is required for an intentional repeat.
+
+## Migration Plan
+
+No vault migration is required. The local SQLite schema remains compatible. Existing implicit receipts created from bearer scope remain reachable only through their original scope for at most 60 seconds across rollout; new receipts use stable issuer/subject scope. Pre-change CF Access REST receipts are in an unattributed shared namespace and cannot be safely assigned to post-change principals, so quiesce in-flight CF REST mutations for the deployment window; direct personal API-key receipts retain their legacy single-owner namespace. Deploy the code to both replicas, restart the services, verify the deployed Cloudflare worker retains single-origin behavior for MCP, REST, hosted mutation-capable POSTs, and public transfer PUTs, and keep existing pending records fail-closed. Rollback restores prior ordering without modifying vault content or deleting receipt state.
+
+## Open Questions
+
+- A cross-replica crash receipt requires a shared or transactionally co-located design and is deliberately deferred; it is not needed to close the observed live-worker acknowledgement-loss path.

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/proposal.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+An MCP retry can currently time out on the vault mutation boundary and report `MUTATION_BUSY` while the original identical request continues and commits. On 2026-07-17 that ambiguity caused an agent to retry three changed `remember` payloads, creating three distinct notes while every visible attempt appeared to fail.
+
+## What Changes
+
+- Claim and resolve mutation idempotency before mutation-boundary contention, then persist the terminal committed result before response delivery.
+- Give identical in-flight retries a bounded path to the original terminal result; if it is still pending, report acknowledgement uncertainty rather than a false pre-commit busy result.
+- Bind explicit and implicit mutation identity to tenant/vault, authenticated principal, operation, and canonical payload; reject key reuse with a different payload.
+- Expose stable request correlation in mutation logs and preserve deterministic fault-injection seams around terminal-result persistence and response delivery.
+- Classify read-only maintenance audit invocations as reads so diagnostics cannot retain the mutation boundary.
+- Preserve the HA edge rule that an ambiguous MCP `tools/call` is never replayed to another origin.
+
+## Capabilities
+
+### New Capabilities
+
+- `acknowledgement-safe-mutations`: Terminal-state, replay, cancellation, and acknowledgement-loss guarantees for mutations across MCP, REST, and CLI.
+
+### Modified Capabilities
+
+- `hosted-mutation-safety`: Idempotency must be consulted before lock contention, principal isolation must apply to caller-supplied keys, and read-only maintenance audit must not acquire the mutation boundary.
+
+## Impact
+
+- `writer_lease.py`, mutation error/result handling, MCP command binding, hosted/personal request context, and structured logging.
+- Deterministic unit and black-box tests for in-flight replay, response interruption, cancellation, contention, key mismatch, principal isolation, audit classification, and Cloudflare single-origin fail-closed behavior.
+- Local idempotency runtime state only; no vault migration and no new network dependency.

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/specs/acknowledgement-safe-mutations/spec.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/specs/acknowledgement-safe-mutations/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Mutation Identity Precedes Mutation Authority
+
+The system SHALL reserve or inspect mutation idempotency before acquiring the vault mutation boundary or writer lease. Mutation identity MUST bind the resolved vault or tenant, authenticated principal scope, operation, and canonical payload digest.
+
+#### Scenario: Identical retry overlaps its original
+
+- **WHEN** a retry with the same mutation identity arrives while the original request owns the mutation boundary
+- **THEN** the retry observes the original pending receipt without competing for the mutation boundary
+- **AND** it never returns `MUTATION_BUSY` for that identity
+
+#### Scenario: Same key carries a different payload
+
+- **WHEN** a caller reuses an idempotency key for a different operation or canonical payload
+- **THEN** the request fails with `IDEMPOTENCY_KEY_REUSED` before the mutation leaf runs
+
+### Requirement: Terminal Receipts Survive Acknowledgement Loss
+
+The system SHALL persist the exact terminal committed result before releasing mutation authority and before constructing or delivering the transport acknowledgement. Repeating the same identity SHALL return that result without rerunning the mutation.
+
+#### Scenario: Response delivery is interrupted after commit
+
+- **WHEN** a mutation commits and its terminal receipt is persisted but response delivery is cancelled or interrupted
+- **THEN** a retry with the same identity returns the original committed result
+- **AND** the mutation leaf has executed exactly once
+
+#### Scenario: Cancellation arrives while synchronous work continues
+
+- **WHEN** transport cancellation stops waiting for a synchronous mutation worker after canonical commit
+- **THEN** the worker can finish terminal-result persistence
+- **AND** a later retry retrieves that committed result without creating a duplicate
+
+#### Scenario: Exact terminal receipt persistence fails after canonical commit
+
+- **WHEN** a mutation crosses the canonical non-empty commit marker but its exact result cannot be serialized or stored
+- **THEN** the first caller receives `MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN`
+- **AND** the receipt remains fail-closed so the same identity cannot execute again
+
+#### Scenario: Validation result persistence fails without a commit
+
+- **WHEN** a write-capable command returns a validation or no-op result without crossing the canonical commit marker and its receipt cannot be stored
+- **THEN** the first caller receives `MUTATION_ACKNOWLEDGEMENT_PENDING` with `committed=null`
+- **AND** it never claims a commit that did not occur
+
+### Requirement: Pending And Busy States Are Unambiguous
+
+The system SHALL use `MUTATION_BUSY` only for a request rejected before its mutation leaf runs. An identical request whose original execution is still pending SHALL bounded-wait outside the mutation boundary and, if the bound expires, SHALL report `MUTATION_ACKNOWLEDGEMENT_PENDING` rather than a pre-commit busy result.
+
+#### Scenario: Different mutation cannot acquire the boundary
+
+- **WHEN** a new mutation identity cannot acquire the vault mutation boundary within the configured bound
+- **THEN** it returns structured `MUTATION_BUSY`
+- **AND** its leaf has not run and no part of that request committed
+
+#### Scenario: Identical request remains pending beyond the wait bound
+
+- **WHEN** the original matching request has not persisted a terminal result before the pending wait expires
+- **THEN** the retry reports `MUTATION_ACKNOWLEDGEMENT_PENDING`
+- **AND** it does not claim that the mutation was rejected or safe to rerun with a new identity
+
+### Requirement: Replay Is Isolated By Authenticated Principal
+
+The system SHALL derive retry scope from stable verified principal claims when available. Identical public idempotency keys or payloads from different authenticated principals MUST resolve independent receipt records.
+
+#### Scenario: Bearer rotates for the same verified principal
+
+- **WHEN** the same verified principal retries an identical mutation using a newly issued bearer
+- **THEN** the request resolves the same mutation identity and replays the original result
+
+#### Scenario: Different principals reuse the same key
+
+- **WHEN** two authenticated principals submit the same operation, payload, and public idempotency key
+- **THEN** each principal resolves an independent mutation receipt
+- **AND** neither receives the other's result
+
+### Requirement: Terminal Receipt Retention Is Bounded
+
+The system SHALL retain exact explicit-key terminal results for 24 hours and implicit terminal results for 60 seconds. Cleanup MUST NOT expire pending or committed-uncertain records into automatic re-execution.
+
+#### Scenario: Exact explicit terminal result exceeds retention
+
+- **WHEN** an explicit completed receipt is older than 24 hours
+- **THEN** bounded cleanup may remove it
+- **AND** later reuse is a new mutation identity outside the guarantee window
+
+### Requirement: Acknowledgement Boundaries Are Deterministically Testable
+
+The system SHALL provide a deterministic test seam after terminal receipt persistence and before acknowledgement return, and SHALL emit privacy-safe phase correlation for request receipt, idempotency disposition, mutation-boundary acquisition, terminal persistence, replay, and interruption.
+
+#### Scenario: Fault injected after terminal persistence
+
+- **WHEN** a deterministic fault interrupts the first caller immediately after its terminal receipt is durable
+- **THEN** the fault does not delete or downgrade that receipt
+- **AND** the next identical call returns the stored terminal result
+
+### Requirement: Mutation-Capable POSTs Remain Single-Origin
+
+The HA edge SHALL send MCP `tools/call`, personal REST, hosted command, lifecycle, and other mutation-capable POST requests, plus public transfer PUT uploads, to at most one origin. Timeout, cancellation, or an origin 5xx MUST NOT cause the edge to replay such a request to another replica.
+
+#### Scenario: Active origin times out after accepting a tool call
+
+- **WHEN** the active origin does not return before the edge bound
+- **THEN** the edge returns an acknowledgement-delivery failure
+- **AND** it sends no copy of that tool call to the passive origin
+
+#### Scenario: Personal REST mutation returns 5xx or times out
+
+- **WHEN** the selected origin accepts `/api/remember` but returns 5xx or exceeds the edge bound
+- **THEN** the edge returns that failure or an acknowledgement-delivery failure
+- **AND** it sends no copy of the REST POST to the passive origin
+
+### Requirement: Correlation Identity Is Stable And Log-Safe
+
+The system SHALL use one canonical UUIDv4 request identity from edge admission through MCP middleware, mutation reservation, canonical commit, and terminal response logging. Non-canonical caller-controlled request identifiers MUST be replaced rather than logged.
+
+#### Scenario: Direct-origin call has no correlation header
+
+- **WHEN** a tool call reaches the origin without `x-exomem-request-id`
+- **THEN** middleware generates one canonical UUIDv4
+- **AND** the bound mutation and canonical writer phases use that same UUID

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/specs/hosted-mutation-safety/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Tenant-Scoped Retry And Idempotency Semantics
+
+Hosted mutations SHALL preserve caller-supplied idempotency keys and bounded implicit MCP retry replay through the existing common invocation boundary. Retry identity MUST include the resolved tenant, stable authenticated principal scope, command, and canonical arguments, and MUST be inspected before writer authority or the mutation boundary is acquired. A key or implicit retry from one tenant or principal MUST NOT replay or suppress a mutation for another tenant or principal. Failed pre-commit mutations MUST remain retryable.
+
+#### Scenario: Gateway retries a completed hosted mutation
+
+- **WHEN** the gateway repeats an identical successful mutation for the same tenant and authenticated principal with the same idempotency identity
+- **THEN** the original result is replayed without acquiring writer authority or executing the mutation leaf again
+- **AND** only one durable vault change exists
+
+#### Scenario: Same key is presented for another tenant or principal
+
+- **WHEN** two tenant or principal contexts present the same explicit idempotency key for otherwise identical input
+- **THEN** each context resolves an independent idempotency record
+- **AND** neither context receives the other's result or suppresses the other's mutation
+
+#### Scenario: First attempt fails before commit
+
+- **WHEN** a mutation raises before successful completion and the caller retries it
+- **THEN** the failure is not replayed as a completed result
+- **AND** the retry can acquire the boundary and execute normally
+
+#### Scenario: Identical retry arrives while original is pending
+
+- **WHEN** the same tenant and principal repeat identical canonical arguments while the original request is still executing
+- **THEN** the retry waits on the original receipt outside the mutation boundary
+- **AND** it cannot return `MUTATION_BUSY` for that identity
+
+## ADDED Requirements
+
+### Requirement: Read-Only Maintenance Does Not Own Mutation Authority
+
+The common invocation classifier SHALL treat `maintain_memory(mode="audit")` as read-only. It MUST NOT acquire writer authority or be assigned a mutation idempotency record.
+
+#### Scenario: Routine audit overlaps a mutation
+
+- **WHEN** `maintain_memory(mode="audit")` is invoked while another request holds writer authority
+- **THEN** the audit is not rejected as a competing mutation
+- **AND** it cannot be reported as the holder operation for `MUTATION_BUSY`
+- **AND** it does not acquire the hosted consistency guard that shares the mutation boundary

--- a/openspec/changes/make-mcp-acknowledgement-replay-safe/tasks.md
+++ b/openspec/changes/make-mcp-acknowledgement-replay-safe/tasks.md
@@ -1,0 +1,32 @@
+## 1. Deterministic Regression Tests
+
+- [x] 1.1 Add an in-flight same-identity replay test that pauses the original, proves the retry waits outside the mutation boundary, and asserts one leaf execution.
+- [x] 1.2 Add terminal-persistence fault tests for lost acknowledgement and cancellation after commit.
+- [x] 1.3 Add tests for pending-wait expiry, different-key pre-commit `MUTATION_BUSY`, key/payload mismatch, and explicit-key principal isolation.
+- [x] 1.4 Add stable-principal tests for personal MCP bearer rotation and hosted retries with new request IDs.
+- [x] 1.5 Add read-only `maintain_memory(mode="audit")` classification tests and retain the edge single-origin timeout/5xx regression tests.
+- [x] 1.6 Add regressions for receipt-persistence failure, single pending cleanup, hosted audit overlap, request-scoped correlation, explicit receipt expiry, REST mutation fail-closed routing, and structured REST errors.
+
+## 2. Receipt And Mutation Ordering
+
+- [x] 2.1 Refactor idempotency reservation/replay ahead of the operation guard while keeping new mutations behind the writer lease and vault mutation boundary.
+- [x] 2.2 Add bounded pending-result waiting and the distinct `MUTATION_ACKNOWLEDGEMENT_PENDING` error.
+- [x] 2.3 Persist completed results, recognized committed failures, and generic post-commit uncertainty before releasing mutation authority, preserving receipts across post-persistence interruption.
+- [x] 2.4 Bind explicit receipt namespaces to authenticated principal scope and change hosted implicit identity from request-scoped to principal-scoped.
+- [x] 2.5 Bound exact explicit terminal receipt retention at 24 hours while keeping uncertain states fail-closed for reconciliation.
+
+## 3. Surface Classification And Correlation
+
+- [x] 3.1 Derive personal MCP retry scope from verified issuer/subject claims with narrow credential/session fallback.
+- [x] 3.2 Classify maintenance audit as read-only in the common command classifier.
+- [x] 3.3 Emit privacy-safe request, receipt, lock, replay, terminal-persistence, and interruption phase correlation.
+- [x] 3.4 Bind one canonical UUIDv4 across MCP middleware, command invocation, canonical writer logs, and edge forwarding.
+- [x] 3.5 Route REST, upload, hosted command, and other mutation-capable POSTs to one origin without fallback replay.
+- [x] 3.6 Exempt hosted maintenance audit from the consistency/mutation boundary and publish structured mutation error fields in REST OpenAPI.
+
+## 4. Verification And Delivery
+
+- [x] 4.1 Run focused writer-lease, mutation-lock, command-surface, hosted-gateway, REST principal-isolation, and Cloudflare worker tests.
+- [x] 4.2 Run changed-file Ruff, scaffold leak checks, semantic/writer/watcher/reconcile/HA suites, and the full non-embedding suite; rerun the one path-length-sensitive Unix-socket case under a shorter secure temp root.
+- [x] 4.3 Perform independent adversarial review and verification of cancellation, crash, failover, and compatibility boundaries.
+- [ ] 4.4 Commit and publish the isolated branch, then record the diagnosed mechanism, fix, verification, and remaining cross-replica risk in Exomem without altering the forensic notes.

--- a/src/exomem/cf_access.py
+++ b/src/exomem/cf_access.py
@@ -26,8 +26,10 @@ def make_jwks_client(team_domain: str):
     return jwt.PyJWKClient(f"https://{team_domain}/cdn-cgi/access/certs")
 
 
-def verify(token: str | None, *, jwks_client, team_domain: str, audience: str) -> bool:
-    """True iff `token` is a valid Cloudflare Access JWT for this application.
+def verified_claims(
+    token: str | None, *, jwks_client, team_domain: str, audience: str
+) -> dict | None:
+    """Return verified Access claims, or ``None`` when validation fails.
 
     Checks: RS256 signature against the team JWKS, `aud` == the configured AUD
     tag, `iss` == https://<team_domain>, and a live `exp`. Any failure → False
@@ -35,12 +37,12 @@ def verify(token: str | None, *, jwks_client, team_domain: str, audience: str) -
     minted for any other Access app in the same team would otherwise pass.
     """
     if not token:
-        return False
+        return None
     import jwt
 
     try:
         signing_key = jwks_client.get_signing_key_from_jwt(token).key
-        jwt.decode(
+        claims = jwt.decode(
             token,
             signing_key,
             algorithms=["RS256"],
@@ -48,7 +50,20 @@ def verify(token: str | None, *, jwks_client, team_domain: str, audience: str) -
             issuer=f"https://{team_domain}",
             options={"require": ["exp", "iss", "aud"]},
         )
-        return True
+        return claims if isinstance(claims, dict) else None
     except Exception as e:  # noqa: BLE001 — any verification failure must deny
         log.info("CF Access JWT rejected: %s", type(e).__name__)
-        return False
+        return None
+
+
+def verify(token: str | None, *, jwks_client, team_domain: str, audience: str) -> bool:
+    """True iff `token` is a valid Cloudflare Access JWT for this application."""
+    return (
+        verified_claims(
+            token,
+            jwks_client=jwks_client,
+            team_domain=team_domain,
+            audience=audience,
+        )
+        is not None
+    )

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -65,6 +65,13 @@ _REMEDIATION: dict[str, str] = {
     ),
     "WRITER_FENCED": "Retry the mutation on the current writer.",
     "MUTATION_BUSY": "Retry after the active vault mutation finishes.",
+    "MUTATION_ACKNOWLEDGEMENT_PENDING": (
+        "Retry with the same mutation identity; do not submit a revised payload."
+    ),
+    "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN": (
+        "Do not rerun with a new identity; reconcile the committed mutation and retry "
+        "only with the same identity."
+    ),
     "MUTATION_LOCK_UNAVAILABLE": (
         "Check that the runtime state root is writable and supports host file locking."
     ),
@@ -100,6 +107,8 @@ _CONFLICT_CODES = frozenset(
         "BATCH_ROLLBACK_INCOMPLETE",
         "BATCH_CLEANUP_INCOMPLETE",
         "MUTATION_BUSY",
+        "MUTATION_ACKNOWLEDGEMENT_PENDING",
+        "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN",
         # Adoption Studio drift codes (add-adoption-studio): a stale plan/apply or a
         # proposal whose bound content changed since review is a conflict, not a
         # plain bad-request — the client's honest recourse is to re-scan/re-read,
@@ -118,11 +127,40 @@ class OpError(Exception):
     `ValueError`s when surfaced as plain text.
     """
 
-    def __init__(self, code: str, message: str, remediation: str | None = None):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        remediation: str | None = None,
+        *,
+        details: dict[str, Any] | None = None,
+    ):
         self.code = code
         self.message = message
         self.remediation = remediation or _REMEDIATION.get(code)
+        self.details = dict(details or {})
         super().__init__(f"{code}: {message}")
+
+    def as_public_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "remediation": self.remediation,
+        }
+        if self.details:
+            payload.update(ok=False, error_code=self.code)
+        payload.update(self.details)
+        return payload
+
+    def __str__(self) -> str:
+        if self.details:
+            return json.dumps(
+                self.as_public_dict(),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        return f"{self.code}: {self.message}"
 
 
 def envelope(success: bool, data: Any = None, error: dict | None = None) -> dict:

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -6,7 +6,10 @@ import hashlib
 import inspect
 import types
 import typing
+import uuid
 from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from mcp.types import ToolAnnotations
@@ -32,6 +35,11 @@ GUARDED_WRITE_FIELDS: dict[str, tuple[str, ...]] = {
     "replace_memory": ("content",),
     "manage_memory_file": ("content",),
 }
+
+
+_MCP_REQUEST_ID: ContextVar[str | None] = ContextVar(
+    "exomem_mcp_request_id", default=None
+)
 
 
 # Write ops whose mutation OVERWRITES or REMOVES existing vault content, as opposed
@@ -152,6 +160,7 @@ def bind_vault(
         return invoke_command(
             command,
             *injected,
+            mutation_request_id=mcp_request_id(),
             implicit_idempotency_scope=(
                 None if invocation_read_only else mcp_retry_scope()
             ),
@@ -174,9 +183,21 @@ def bind_vault(
 
 
 def mcp_retry_scope() -> str | None:
-    """Return a credential-safe caller scope for bounded MCP retry replay."""
+    """Return a stable, privacy-safe principal scope for bounded MCP replay."""
     try:
-        from fastmcp.server.dependencies import get_context, get_http_headers
+        from fastmcp.server.dependencies import (
+            get_access_token,
+            get_context,
+            get_http_headers,
+        )
+
+        access_token = get_access_token()
+        claims = getattr(access_token, "claims", None) or {}
+        subject = str(claims.get("sub") or "").strip()
+        if subject:
+            issuer = str(claims.get("iss") or "verified-principal").strip()
+            digest = hashlib.sha256(f"{issuer}\0{subject}".encode()).hexdigest()
+            return f"principal:{digest}"
 
         headers = get_http_headers(include={"authorization"})
         authorization = headers.get("authorization", "").strip()
@@ -187,6 +208,47 @@ def mcp_retry_scope() -> str | None:
         return f"session:{get_context().session_id}"
     except (LookupError, RuntimeError):
         return None
+
+
+def mcp_request_id() -> str:
+    """Return one canonical correlation ID for the active MCP tool call."""
+    active = _MCP_REQUEST_ID.get()
+    if active is not None:
+        return active
+    try:
+        from fastmcp.server.dependencies import get_http_headers
+
+        value = get_http_headers(include={"x-exomem-request-id"}).get(
+            "x-exomem-request-id", ""
+        )
+        canonical = canonical_request_id(value)
+        if canonical is not None:
+            return canonical
+    except (LookupError, RuntimeError):
+        pass
+    return str(uuid.uuid4())
+
+
+def canonical_request_id(value: object) -> str | None:
+    """Return a canonical UUIDv4 request ID or reject caller-controlled log text."""
+    clean = str(value or "").strip()
+    try:
+        parsed = uuid.UUID(clean)
+    except (AttributeError, ValueError):
+        return None
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122 or str(parsed) != clean:
+        return None
+    return clean
+
+
+@contextmanager
+def mcp_request_context(request_id: str):
+    """Bind the middleware correlation ID through the synchronous tool wrapper."""
+    token = _MCP_REQUEST_ID.set(request_id)
+    try:
+        yield
+    finally:
+        _MCP_REQUEST_ID.reset(token)
 
 
 def _annotate_description(annotation: object, description: str) -> object:

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -5131,6 +5131,9 @@ def invocation_is_read_only(command: Command, kwargs: dict[str, Any]) -> bool:
             isinstance(operation, str)
             and operation in _OBSERVE_MEMORY_READ_ONLY_OPERATIONS
         )
+    if command.name == "maintain_memory":
+        mode = _resolved_invocation_selector(command, kwargs, "mode")
+        return mode == "audit"
     return False
 
 

--- a/src/exomem/hosted_gateway.py
+++ b/src/exomem/hosted_gateway.py
@@ -256,10 +256,9 @@ def implicit_retry_scope(context: TrustedGatewayContext) -> str:
         (
             context.cell_id,
             context.principal_scope,
-            context.request_id,
         )
     )
-    return f"hosted-request:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+    return f"hosted-principal:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
 
 
 def _b64encode(value: bytes) -> str:

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -219,4 +219,9 @@ def _mutation_busy() -> OpError:
         "MUTATION_BUSY",
         "vault mutation boundary is busy",
         "Retry after the current mutation completes; inspect cell health if it remains busy.",
+        details={
+            "status": "retryable",
+            "committed": False,
+            "retry_after_ms": 750,
+        },
     )

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -79,40 +79,52 @@ class CallTraceMiddleware(Middleware):
         self.hosted = hosted
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
-        tool_name = _extract_tool_name(context.message)
-        guarded_fields = _GUARDED_WRITE_FIELDS.get(tool_name)
-        if guarded_fields:
-            args = _extract_tool_args(context.message)
-            for field in guarded_fields:
-                guards.guard_text_content(args.get(field), tool=tool_name, field=field)
-            if tool_name in ("edit", "edit_memory"):
-                for item in args.get("edits") or []:
-                    if isinstance(item, dict):
-                        guards.guard_text_content(
-                            item.get("new_string"),
-                            tool=tool_name,
-                            field="edits[].new_string",
-                        )
+        from .command_surface import mcp_request_context, mcp_request_id
 
-        extras = (
-            _find_call_summary(context.message)
-            if tool_name == "ask_memory" and not self.hosted
-            else ""
-        )
-        _call_log.info(f"event=tool_start tool={tool_name}{extras}")
-        t0 = time.perf_counter()
-        try:
-            result = await call_next(context)
-            dur = round((time.perf_counter() - t0) * 1000, 2)
-            _call_log.info(f"event=tool_success tool={tool_name} duration_ms={dur}{extras}")
-            return result
-        except Exception as exc:
-            dur = round((time.perf_counter() - t0) * 1000, 2)
-            _call_log.error(
-                f"event=tool_error tool={tool_name} duration_ms={dur} "
-                f"err={type(exc).__name__}{extras}"
+        tool_name = _extract_tool_name(context.message)
+        request_id = mcp_request_id()
+        with mcp_request_context(request_id):
+            guarded_fields = _GUARDED_WRITE_FIELDS.get(tool_name)
+            if guarded_fields:
+                args = _extract_tool_args(context.message)
+                for field in guarded_fields:
+                    guards.guard_text_content(args.get(field), tool=tool_name, field=field)
+                if tool_name in ("edit", "edit_memory"):
+                    for item in args.get("edits") or []:
+                        if isinstance(item, dict):
+                            guards.guard_text_content(
+                                item.get("new_string"),
+                                tool=tool_name,
+                                field="edits[].new_string",
+                            )
+
+            extras = (
+                _find_call_summary(context.message)
+                if tool_name == "ask_memory" and not self.hosted
+                else ""
             )
-            raise
+            event_prefix = "hosted_call kind=" if self.hosted else ""
+            _call_log.info(
+                f"event={event_prefix}tool_start tool={tool_name} "
+                f"request_id={request_id}{extras}"
+            )
+            t0 = time.perf_counter()
+            try:
+                result = await call_next(context)
+                dur = round((time.perf_counter() - t0) * 1000, 2)
+                _call_log.info(
+                    f"event={event_prefix}tool_success tool={tool_name} "
+                    f"request_id={request_id} duration_ms={dur}{extras}"
+                )
+                return result
+            except Exception as exc:
+                dur = round((time.perf_counter() - t0) * 1000, 2)
+                _call_log.error(
+                    f"event={event_prefix}tool_error tool={tool_name} "
+                    f"request_id={request_id} duration_ms={dur} "
+                    f"err={type(exc).__name__}{extras}"
+                )
+                raise
 
 
 def _extract_tool_name(message) -> str:

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -806,6 +806,7 @@ def register_hosted_routes(
                             *injected,
                             idempotency_key=gateway.scoped_idempotency_key(context),
                             implicit_idempotency_scope=gateway.implicit_retry_scope(context),
+                            mutation_request_id=context.request_id,
                             **kwargs,
                         )
                 with lifecycle.admit_mutation():
@@ -814,6 +815,7 @@ def register_hosted_routes(
                         *injected,
                         idempotency_key=gateway.scoped_idempotency_key(context),
                         implicit_idempotency_scope=gateway.implicit_retry_scope(context),
+                        mutation_request_id=context.request_id,
                         **kwargs,
                     )
 

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -17,6 +18,7 @@ from starlette.responses import JSONResponse
 
 from . import cf_access, cli_ops, upload_tokens
 from . import commands as commands_module
+from .command_surface import canonical_request_id
 from .server_transfer import TransferConfig
 
 
@@ -69,6 +71,16 @@ _OPENAPI_ERROR_SCHEMA = {
         "message": {"type": "string"},
         "remediation": {"type": ["string", "null"]},
         "outcome": _OPENAPI_OUTCOME_SCHEMA,
+        "ok": {"type": "boolean"},
+        "error_code": {"type": "string"},
+        "status": {"type": "string"},
+        "committed": {"type": ["boolean", "null"]},
+        "retry_after_ms": {"type": "integer", "minimum": 0},
+        "holder_operation": {"type": ["string", "null"]},
+        "holder_age_ms": {"type": ["integer", "null"], "minimum": 0},
+        "request_id": {"type": "string", "format": "uuid"},
+        "receipt_id": {"type": ["string", "null"]},
+        "idempotency_key": {"type": "string"},
     },
     "required": ["code", "message", "remediation"],
     "additionalProperties": False,
@@ -83,7 +95,9 @@ _OPENAPI_ERROR_ENVELOPE_SCHEMA = {
     "additionalProperties": False,
 }
 _OPENAPI_ERROR_RESPONSE = {
-    "description": "{success: false, error: {code, message, remediation, outcome?}}",
+    "description": (
+        "{success: false, error: {code, message, remediation, terminal-state fields?}}"
+    ),
     "content": {
         "application/json": {"schema": {"$ref": "#/components/schemas/ErrorEnvelope"}}
     },
@@ -134,24 +148,29 @@ def register_rest_facade(
     expose_tier2 = not os.environ.get("EXOMEM_DISABLE_TIER2")
     rest_commands = commands_module.product_commands_for("rest", expose_tier2=expose_tier2)
 
-    def _rest_authorized(request: Request) -> bool:
+    def _rest_principal(request: Request) -> tuple[bool, str | None]:
         if rest_api_key is not None:
             header = request.headers.get("authorization", "")
             if header.startswith("Bearer "):
                 presented = header[len("Bearer ") :].strip()
                 if secrets.compare_digest(presented, rest_api_key):
-                    return True
+                    return True, None
                 if upload_tokens.verify(presented, rest_api_key, scope="rest"):
-                    return True
+                    return True, None
         if transfer_config.cf_jwks is not None:
-            if cf_access.verify(
+            claims = cf_access.verified_claims(
                 request.headers.get("cf-access-jwt-assertion"),
                 jwks_client=transfer_config.cf_jwks,
                 team_domain=transfer_config.cf_team,
                 audience=transfer_config.cf_aud,
-            ):
-                return True
-        return False
+            )
+            if claims is not None:
+                subject = str(claims.get("sub") or claims.get("email") or "").strip()
+                issuer = str(claims.get("iss") or "").strip()
+                if subject and issuer:
+                    digest = hashlib.sha256(f"{issuer}\0{subject}".encode()).hexdigest()
+                    return True, f"cf-access:{digest}"
+        return False, None
 
     def _rest_err(
         code: str, message: str, status: int, remediation: str | None = None
@@ -163,16 +182,23 @@ def register_rest_facade(
             status_code=status,
         )
 
-    def _rest_gate(request: Request) -> JSONResponse | None:
+    def _rest_gate(request: Request) -> tuple[JSONResponse | None, str | None]:
         if not rest_enabled:
-            return _rest_err(
-                "REST_DISABLED",
-                "REST API is off: set EXOMEM_REST_API_KEY to enable the /api/* facade",
-                503,
+            return (
+                _rest_err(
+                    "REST_DISABLED",
+                    "REST API is off: set EXOMEM_REST_API_KEY to enable the /api/* facade",
+                    503,
+                ),
+                None,
             )
-        if not _rest_authorized(request):
-            return _rest_err("UNAUTHORIZED", "missing or invalid REST API key", 401)
-        return None
+        authorized, principal_scope = _rest_principal(request)
+        if not authorized:
+            return (
+                _rest_err("UNAUTHORIZED", "missing or invalid REST API key", 401),
+                None,
+            )
+        return None, principal_scope
 
     async def _rest_body(request: Request) -> dict | None:
         try:
@@ -192,7 +218,7 @@ def register_rest_facade(
         async def _handler(
             request: Request, _cmd: commands_module.Command = cmd
         ) -> JSONResponse:
-            gate = _rest_gate(request)
+            gate, principal_scope = _rest_gate(request)
             if gate is not None:
                 return gate
             body = await _rest_body(request)
@@ -210,6 +236,10 @@ def register_rest_facade(
                     _cmd,
                     *injected,
                     idempotency_key=request.headers.get("idempotency-key"),
+                    idempotency_principal_scope=principal_scope,
+                    mutation_request_id=canonical_request_id(
+                        request.headers.get("x-exomem-request-id")
+                    ),
                     **kwargs,
                 )
             except (cli_ops.OpError, ValueError, TypeError) as exc:

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -2838,9 +2838,14 @@ def _batch_atomic_write_locked(
     replaced: list[Path] = []
     final_guards: dict[Path, _BatchArtifactGuard] = {}
     try:
-        from .writer_lease import validate_active_write_fence
+        from .writer_lease import (
+            log_active_mutation_phase,
+            mark_active_mutation_committed,
+            validate_active_write_fence,
+        )
 
         validate_active_write_fence()
+        log_active_mutation_phase("canonical_commit_started", affected_count=len(staged))
         for index, (final, workspace, artifact) in enumerate(staged):
             for candidate_workspace in workspace_by_parent.values():
                 candidate_workspace.recheck()
@@ -2908,6 +2913,9 @@ def _batch_atomic_write_locked(
                 guard.recheck(root, allowed_changes=allowed_census_changes)
         for guard in final_guards.values():
             guard.recheck()
+        log_active_mutation_phase("canonical_files_committed", affected_count=len(replaced))
+        if replaced:
+            mark_active_mutation_committed()
     except Exception as commit_error:
         rollback_errors: list[BaseException] = []
         implicated_workspaces: list[_BatchWorkspace] = []

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -21,21 +21,25 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from .cli_ops import OpError
-from .mutation_lock import VaultMutationCoordinator
+from .mutation_lock import VaultMutationCoordinator, canonical_mutation_identity
 from .privacy_log import content_private_logging_enabled
 
 _COORDINATOR_USER_AGENT = (
     "Mozilla/5.0 (compatible; Exomem-Coordinator/1.0; +https://github.com/Artexis10/exomem)"
 )
 _IMPLICIT_RETRY_TTL_SECONDS = 60.0
+_EXPLICIT_RETRY_TTL_SECONDS = 24 * 60 * 60.0
+_IDEMPOTENCY_WAIT_SECONDS = 5.0
+_IDEMPOTENCY_POLL_INTERVAL_SECONDS = 0.025
 _COMMITTED_FAILURE_CODE = "BATCH_CLEANUP_INCOMPLETE"
 _COMMITTED_FAILURE_MESSAGE = "The batch workspace cleanup is incomplete."
 _COMMITTED_FAILURE_REMEDIATION = (
@@ -53,11 +57,64 @@ _COMMITTED_FAILURE_OUTCOME_KEYS = frozenset(
         "omitted_target_count",
     }
 )
+_RETRY_IDEMPOTENCY_CLAIM = object()
 _WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
 logger = logging.getLogger(__name__)
+_mutation_logger = logging.getLogger("exomem.calls")
 _ACTIVE_WRITE_FENCE: ContextVar[tuple[Any, int] | None] = ContextVar(
     "exomem_active_write_fence", default=None
 )
+_ACTIVE_MUTATION_TRACE: ContextVar[tuple[str, str, str] | None] = ContextVar(
+    "exomem_active_mutation_trace", default=None
+)
+_ACTIVE_MUTATION_COMMITTED: ContextVar[bool] = ContextVar(
+    "exomem_active_mutation_committed", default=False
+)
+
+
+def _log_mutation_event(phase: str, *, level: int = logging.INFO, **fields: Any) -> None:
+    prefix = (
+        "event=hosted_call kind=mutation"
+        if content_private_logging_enabled()
+        else "event=mutation"
+    )
+    suffix = " ".join(f"{name}={value}" for name, value in fields.items())
+    _mutation_logger.log(level, f"{prefix} phase={phase} {suffix}".rstrip())
+
+
+def log_active_mutation_phase(phase: str, **fields: Any) -> None:
+    """Log a canonical-writer phase against the active privacy-safe trace."""
+    active = _ACTIVE_MUTATION_TRACE.get()
+    if active is None:
+        return
+    request_id, command, receipt = active
+    _log_mutation_event(
+        phase,
+        request_id=request_id,
+        command=command,
+        receipt=receipt,
+        **fields,
+    )
+
+
+def mark_active_mutation_committed() -> None:
+    """Mark that the current canonical writer crossed its durable commit boundary."""
+    if _ACTIVE_MUTATION_TRACE.get() is not None:
+        _ACTIVE_MUTATION_COMMITTED.set(True)
+
+
+class _PostCommitOutcomeUncertain(OpError):
+    """Sanitized terminal state for an unexpected exception after canonical commit."""
+
+    committed = True
+
+    def __init__(self) -> None:
+        super().__init__(
+            "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN",
+            "the mutation completed but its exact terminal result could not be persisted",
+            "Do not rerun with a new identity; reconcile and retry only with the same identity.",
+            details={"status": "committed", "committed": True},
+        )
 
 
 def _invalid_committed_failure_payload() -> ValueError:
@@ -342,9 +399,27 @@ class LeaseCoordinatorClient:
 class IdempotencyStore:
     """Durable per-replica retry cache, deliberately outside the synced vault."""
 
-    def __init__(self, path: Path, *, clock=time.time):  # noqa: ANN001
+    def __init__(
+        self,
+        path: Path,
+        *,
+        clock=time.time,  # noqa: ANN001
+        monotonic=time.monotonic,  # noqa: ANN001
+        wait_seconds: float = _IDEMPOTENCY_WAIT_SECONDS,
+        poll_interval_seconds: float = _IDEMPOTENCY_POLL_INTERVAL_SECONDS,
+        after_terminal_persisted=None,  # noqa: ANN001
+    ):
+        if wait_seconds < 0:
+            raise ValueError("idempotency wait must be non-negative")
+        if poll_interval_seconds <= 0:
+            raise ValueError("idempotency poll interval must be positive")
         self.path = path
         self.clock = clock
+        self.monotonic = monotonic
+        self.wait_seconds = wait_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self.after_terminal_persisted = after_terminal_persisted
+        self._condition = threading.Condition()
         path.parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as conn:
             conn.execute(
@@ -366,134 +441,229 @@ class IdempotencyStore:
         *,
         expires_after: float | None = None,
         on_replay=None,  # noqa: ANN001
+        operation_guard=None,  # noqa: ANN001
+        commit_observed=None,  # noqa: ANN001
     ) -> Any:
         if not key:
-            return operation()
+            with operation_guard() if operation_guard is not None else nullcontext():
+                return operation()
+
+        while True:
+            disposition, stored = self._claim_or_inspect(key, digest, expires_after)
+            if disposition == "owner":
+                break
+            if disposition == "pending":
+                waited = self._wait_for_terminal(key, digest, on_replay=on_replay)
+                if waited is _RETRY_IDEMPOTENCY_CLAIM:
+                    continue
+                return waited
+            return self._replay(disposition, stored, on_replay)
+
+        guard = operation_guard() if operation_guard is not None else nullcontext()
+        leaf_returned = False
+        terminal_persisted = False
+        try:
+            with guard:
+                try:
+                    result = operation()
+                except Exception as operation_error:
+                    if isinstance(operation_error, _PostCommitOutcomeUncertain):
+                        leaf_returned = True
+                        try:
+                            self._persist_committed_uncertain(key, digest)
+                        except Exception as storage_error:
+                            raise operation_error from storage_error
+                        terminal_persisted = True
+                        self._notify_waiters()
+                        self._after_terminal_persisted()
+                        raise
+                    committed_failure = _committed_failure_payload(operation_error)
+                    if committed_failure is None:
+                        raise
+                    leaf_returned = True
+                    try:
+                        self._persist_committed_failure(key, digest, committed_failure)
+                    except Exception as storage_error:
+                        raise operation_error from storage_error
+                    terminal_persisted = True
+                    self._notify_waiters()
+                    self._after_terminal_persisted()
+                    raise
+                leaf_returned = True
+                try:
+                    self._persist_completed(key, digest, result)
+                except Exception as storage_error:
+                    if commit_observed is not None and commit_observed():
+                        uncertain = _PostCommitOutcomeUncertain()
+                        try:
+                            self._persist_committed_uncertain(key, digest)
+                        except Exception:  # noqa: BLE001 - leave pending fail-closed
+                            pass
+                        else:
+                            terminal_persisted = True
+                    else:
+                        uncertain = OpError(
+                            "MUTATION_ACKNOWLEDGEMENT_PENDING",
+                            "the mutation result could not be persisted; its commit outcome "
+                            "is not known",
+                            "Retry with the same mutation identity; do not submit a revised "
+                            "payload.",
+                        )
+                    self._notify_waiters()
+                    raise uncertain from storage_error
+                terminal_persisted = True
+                self._notify_waiters()
+                self._after_terminal_persisted()
+                return result
+        except Exception:
+            # Guard acquisition is pre-leaf and safe to retry. Once a leaf has
+            # returned (or reported a recognized committed outcome), storage or
+            # acknowledgement failures must leave the pending/terminal receipt
+            # fail-closed rather than allow a duplicate execution.
+            if not leaf_returned and not terminal_persisted:
+                self._delete_pending(key, digest)
+            raise
+
+    def _claim_or_inspect(
+        self, key: str, digest: str, expires_after: float | None
+    ) -> tuple[str, Any]:
         now = self.clock()
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
-            if expires_after is not None:
-                cutoff = now - expires_after
-                conn.execute(
-                    "DELETE FROM mutations WHERE key LIKE 'implicit:%' "
-                    "AND state = 'completed' "
-                    "AND typeof(updated_at) IN ('integer', 'real') "
-                    "AND updated_at >= 0 AND updated_at <= ?",
-                    (cutoff,),
-                )
-                expired_failures = conn.execute(
-                    "SELECT key, result FROM mutations WHERE key LIKE 'implicit:%' "
-                    "AND state = 'committed_failure' "
-                    "AND typeof(updated_at) IN ('integer', 'real') "
-                    "AND updated_at >= 0 AND updated_at <= ?",
-                    (cutoff,),
-                ).fetchall()
-                for expired_key, expired_payload in expired_failures:
-                    try:
-                        _deserialize_committed_failure_payload(expired_payload)
-                    except Exception:  # noqa: BLE001 - corrupt markers remain fail-closed
-                        continue
-                    conn.execute(
-                        "DELETE FROM mutations WHERE key = ? AND state = 'committed_failure'",
-                        (expired_key,),
-                    )
+            self._prune_expired(conn, now, expires_after, key)
             row = conn.execute(
                 "SELECT digest, state, result, updated_at FROM mutations WHERE key = ?", (key,)
             ).fetchone()
-            if (
-                row
-                and expires_after is not None
-                and row[1] in {"completed", "committed_failure"}
-            ):
-                updated_at = row[3]
-                if row[1] == "committed_failure":
-                    try:
-                        _deserialize_committed_failure_payload(row[2])
-                    except Exception:  # noqa: BLE001 - corrupt state blocks mutation
-                        raise OpError(
-                            "IDEMPOTENCY_IN_PROGRESS",
-                            "cached committed mutation state requires reconciliation",
-                            "Reconcile the local idempotency store before retrying this mutation.",
-                        ) from None
-                if (
-                    type(updated_at) not in {int, float}
-                    or not math.isfinite(updated_at)
-                    or updated_at < 0
-                ):
-                    raise OpError(
-                        "IDEMPOTENCY_IN_PROGRESS",
-                        "cached mutation state requires reconciliation",
-                        "Reconcile the local idempotency store before retrying this mutation.",
-                    )
-                if updated_at <= now - expires_after:
-                    conn.execute("DELETE FROM mutations WHERE key = ?", (key,))
-                    row = None
-            if row:
-                if row[0] != digest:
-                    raise OpError(
-                        "IDEMPOTENCY_KEY_REUSED",
-                        "idempotency key was already used for different input",
-                    )
-                if row[1] == "completed":
-                    if on_replay is not None:
-                        on_replay()
-                    return pickle.loads(row[2])  # noqa: S301 - local trusted runtime state
-                if row[1] == "committed_failure":
-                    try:
-                        failure = _CachedCommittedFailure(
-                            _deserialize_committed_failure_payload(row[2])
-                        )
-                    except Exception:  # noqa: BLE001 - corrupt state blocks mutation
-                        raise OpError(
-                            "IDEMPOTENCY_IN_PROGRESS",
-                            "cached committed mutation state requires reconciliation",
-                            "Reconcile the local idempotency store before retrying this mutation.",
-                        ) from None
-                    if on_replay is not None:
-                        on_replay()
-                    raise failure
-                if row[1] != "pending":
-                    raise OpError(
-                        "IDEMPOTENCY_IN_PROGRESS",
-                        "cached mutation state requires reconciliation",
-                        "Reconcile the local idempotency store before retrying this mutation.",
-                    )
-                raise OpError(
-                    "IDEMPOTENCY_IN_PROGRESS",
-                    "an identical mutation with this key is already in progress",
-                )
-            else:
-                conn.execute(
-                    "INSERT INTO mutations(key, digest, state, updated_at) "
-                    "VALUES (?, ?, 'pending', ?)",
-                    (key, digest, now),
-                )
-        try:
-            result = operation()
-        except Exception as operation_error:
-            committed_failure = _committed_failure_payload(operation_error)
-            if committed_failure is None:
-                with self._connect() as conn:
-                    conn.execute(
-                        "DELETE FROM mutations WHERE key = ? AND digest = ? AND state = 'pending'",
-                        (key, digest),
-                    )
-                raise
+            if row and self._expired_row(row, now, expires_after):
+                conn.execute("DELETE FROM mutations WHERE key = ?", (key,))
+                row = None
+            if row is not None:
+                return self._decode_disposition(row, digest)
+            conn.execute(
+                "INSERT INTO mutations(key, digest, state, updated_at) "
+                "VALUES (?, ?, 'pending', ?)",
+                (key, digest, now),
+            )
+        _log_mutation_event("reserved", receipt=_receipt_tag(key))
+        return "owner", None
+
+    def _prune_expired(
+        self,
+        conn: sqlite3.Connection,
+        now: float,
+        expires_after: float | None,
+        key: str,
+    ) -> None:
+        if expires_after is None:
+            return
+        cutoff = now - expires_after
+        key_pattern = f"{key.partition(':')[0]}:%"
+        conn.execute(
+            "DELETE FROM mutations WHERE key LIKE ? "
+            "AND state = 'completed' "
+            "AND typeof(updated_at) IN ('integer', 'real') "
+            "AND updated_at >= 0 AND updated_at <= ?",
+            (key_pattern, cutoff),
+        )
+        expired_failures = conn.execute(
+            "SELECT key, result FROM mutations WHERE key LIKE ? "
+            "AND state = 'committed_failure' "
+            "AND typeof(updated_at) IN ('integer', 'real') "
+            "AND updated_at >= 0 AND updated_at <= ?",
+            (key_pattern, cutoff),
+        ).fetchall()
+        for expired_key, expired_payload in expired_failures:
             try:
-                payload = _serialize_committed_failure_payload(committed_failure)
-                with self._connect() as conn:
-                    cursor = conn.execute(
-                        "UPDATE mutations SET state = 'committed_failure', result = ?, "
-                        "updated_at = ? WHERE key = ? AND digest = ? AND state = 'pending'",
-                        (payload, self.clock(), key, digest),
-                    )
-                    if cursor.rowcount != 1:
-                        raise sqlite3.OperationalError(
-                            "pending idempotency marker changed before committed failure update"
-                        )
-            except Exception as storage_error:
-                raise operation_error from storage_error
-            raise
+                _deserialize_committed_failure_payload(expired_payload)
+            except Exception:  # noqa: BLE001 - corrupt markers remain fail-closed
+                continue
+            conn.execute(
+                "DELETE FROM mutations WHERE key = ? AND state = 'committed_failure'",
+                (expired_key,),
+            )
+
+    def _expired_row(
+        self, row: tuple[Any, ...], now: float, expires_after: float | None
+    ) -> bool:
+        if expires_after is None or row[1] not in {"completed", "committed_failure"}:
+            return False
+        updated_at = row[3]
+        if row[1] == "committed_failure":
+            try:
+                _deserialize_committed_failure_payload(row[2])
+            except Exception:  # noqa: BLE001 - corrupt state blocks mutation
+                raise self._reconciliation_error("cached committed mutation state") from None
+        if (
+            type(updated_at) not in {int, float}
+            or not math.isfinite(updated_at)
+            or updated_at < 0
+        ):
+            raise self._reconciliation_error("cached mutation state")
+        return updated_at <= now - expires_after
+
+    def _decode_disposition(self, row: tuple[Any, ...], digest: str) -> tuple[str, Any]:
+        if row[0] != digest:
+            raise OpError(
+                "IDEMPOTENCY_KEY_REUSED",
+                "idempotency key was already used for different input",
+            )
+        state = row[1]
+        if state == "completed":
+            return "completed", pickle.loads(row[2])  # noqa: S301 - trusted runtime state
+        if state == "committed_failure":
+            try:
+                failure = _CachedCommittedFailure(
+                    _deserialize_committed_failure_payload(row[2])
+                )
+            except Exception:  # noqa: BLE001 - corrupt state blocks mutation
+                raise self._reconciliation_error("cached committed mutation state") from None
+            return "committed_failure", failure
+        if state == "committed_uncertain":
+            if row[2] is not None:
+                raise self._reconciliation_error("cached committed mutation state")
+            return "committed_uncertain", _PostCommitOutcomeUncertain()
+        if state == "pending":
+            return "pending", None
+        raise self._reconciliation_error("cached mutation state")
+
+    def _wait_for_terminal(
+        self, key: str, digest: str, *, on_replay=None  # noqa: ANN001
+    ) -> Any:
+        _log_mutation_event("pending", receipt=_receipt_tag(key))
+        deadline = self.monotonic() + self.wait_seconds
+        while True:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT digest, state, result, updated_at FROM mutations WHERE key = ?",
+                    (key,),
+                ).fetchone()
+            if row is None:
+                return _RETRY_IDEMPOTENCY_CLAIM
+            disposition, stored = self._decode_disposition(row, digest)
+            if disposition != "pending":
+                return self._replay(disposition, stored, on_replay)
+            remaining = deadline - self.monotonic()
+            if remaining <= 0:
+                raise OpError(
+                    "MUTATION_ACKNOWLEDGEMENT_PENDING",
+                    "an identical mutation is still executing; its commit outcome is not yet known",
+                    "Retry with the same mutation identity; do not submit a revised payload.",
+                )
+            with self._condition:
+                self._condition.wait(timeout=min(self.poll_interval_seconds, remaining))
+
+    def _replay(self, disposition: str, stored: Any, on_replay) -> Any:  # noqa: ANN001
+        if on_replay is not None:
+            on_replay()
+        if disposition == "completed":
+            return stored
+        if disposition == "committed_failure":
+            raise stored
+        if disposition == "committed_uncertain":
+            raise stored
+        raise self._reconciliation_error("cached mutation state")
+
+    def _persist_completed(self, key: str, digest: str, result: Any) -> None:
         payload = pickle.dumps(result)
         with self._connect() as conn:
             cursor = conn.execute(
@@ -502,21 +672,119 @@ class IdempotencyStore:
                 (payload, self.clock(), key, digest),
             )
             if cursor.rowcount != 1:
-                raise OpError(
-                    "IDEMPOTENCY_IN_PROGRESS",
-                    "completed mutation state requires reconciliation",
-                    "Reconcile the local idempotency store before retrying this mutation.",
-                )
+                raise self._reconciliation_error("completed mutation state")
+        _log_mutation_event("terminal", receipt=_receipt_tag(key))
+
+    def _persist_committed_failure(
+        self, key: str, digest: str, committed_failure: dict[str, Any]
+    ) -> None:
+        payload = _serialize_committed_failure_payload(committed_failure)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'committed_failure', result = ?, "
+                "updated_at = ? WHERE key = ? AND digest = ? AND state = 'pending'",
+                (payload, self.clock(), key, digest),
+            )
             if cursor.rowcount != 1:
                 raise sqlite3.OperationalError(
-                    "pending idempotency marker changed before completion update"
+                    "pending idempotency marker changed before committed failure update"
                 )
-        return result
+        _log_mutation_event("terminal", receipt=_receipt_tag(key))
+
+    def _persist_committed_uncertain(self, key: str, digest: str) -> None:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'committed_uncertain', result = NULL, "
+                "updated_at = ? WHERE key = ? AND digest = ? AND state = 'pending'",
+                (self.clock(), key, digest),
+            )
+            if cursor.rowcount != 1:
+                raise self._reconciliation_error("committed mutation state")
+        _log_mutation_event("terminal_uncertain", receipt=_receipt_tag(key))
+
+    def _delete_pending(self, key: str, digest: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM mutations WHERE key = ? AND digest = ? AND state = 'pending'",
+                (key, digest),
+            )
+        self._notify_waiters()
+
+    def _notify_waiters(self) -> None:
+        with self._condition:
+            self._condition.notify_all()
+
+    def _after_terminal_persisted(self) -> None:
+        if self.after_terminal_persisted is not None:
+            self.after_terminal_persisted()
+
+    @staticmethod
+    def _reconciliation_error(subject: str) -> OpError:
+        return OpError(
+            "IDEMPOTENCY_IN_PROGRESS",
+            f"{subject} requires reconciliation",
+            "Reconcile the local idempotency store before retrying this mutation.",
+        )
 
 
 def _namespaced_idempotency_key(kind: str, identity: str, public_key: str) -> str:
     digest = hashlib.sha256(f"{identity}\0{public_key}".encode()).hexdigest()
     return f"{kind}:{digest}"
+
+
+def _receipt_tag(key: str) -> str:
+    """Return a short privacy-safe correlation tag for an internal receipt key."""
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _command_digest(command: Any, kwargs: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            {"command": command.name, "kwargs": kwargs},
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _effective_idempotency_key(
+    manager: LeaseManager,
+    *,
+    command: Any,
+    mutation_subject: os.PathLike[str] | str,
+    digest: str,
+    idempotency_key: str | None,
+    principal_scope: str | None,
+    implicit_idempotency_scope: str | None = None,
+) -> tuple[str | None, float | None, Any]:
+    identity = canonical_mutation_identity(mutation_subject)
+    namespace = f"cell:{manager.config.vault_id}" if manager.config.vault_id else identity
+    if idempotency_key:
+        explicit_namespace = (
+            f"{namespace}\0principal:{principal_scope}" if principal_scope else namespace
+        )
+        return (
+            _namespaced_idempotency_key("explicit", explicit_namespace, idempotency_key),
+            _EXPLICIT_RETRY_TTL_SECONDS,
+            None,
+        )
+    if implicit_idempotency_scope:
+        key = _namespaced_idempotency_key(
+            "implicit",
+            namespace,
+            f"{implicit_idempotency_scope}\0{digest}",
+        )
+
+        def log_replay() -> None:
+            _log_mutation_event(
+                "replayed",
+                command=command.name,
+                receipt=_receipt_tag(key),
+            )
+
+        return key, _IMPLICIT_RETRY_TTL_SECONDS, log_replay
+    return None, None, None
 
 
 class LeaseManager:
@@ -528,6 +796,8 @@ class LeaseManager:
         clock=time.time,  # noqa: ANN001
         mutation_timeout_seconds: float = 5.0,
         mutation_poll_interval_seconds: float = 0.025,
+        idempotency_wait_seconds: float = _IDEMPOTENCY_WAIT_SECONDS,
+        after_terminal_persisted=None,  # noqa: ANN001
     ):
         self.config = config
         self.client = (
@@ -539,7 +809,10 @@ class LeaseManager:
         vault = config.vault_id or "standalone"
         safe_name = hashlib.sha256(f"{vault}\0{replica}".encode()).hexdigest()[:20]
         self.idempotency = IdempotencyStore(
-            config.state_dir / f"idempotency-{safe_name}.sqlite", clock=clock
+            config.state_dir / f"idempotency-{safe_name}.sqlite",
+            clock=clock,
+            wait_seconds=idempotency_wait_seconds,
+            after_terminal_persisted=after_terminal_persisted,
         )
         self._fencing_token: int | None = None
         self._expires_at: float | None = None
@@ -603,53 +876,95 @@ class LeaseManager:
         *,
         read_only: bool | None = None,
         idempotency_key: str | None = None,
+        idempotency_principal_scope: str | None = None,
         implicit_idempotency_scope: str | None = None,
+        mutation_request_id: str | None = None,
     ) -> Any:
         invocation_read_only = command.read_only if read_only is None else read_only
         if invocation_read_only:
-            if content_private_logging_enabled():
+            audit_without_consistency_lock = (
+                command.name == "maintain_memory"
+                and kwargs.get("mode", "audit") == "audit"
+            )
+            if content_private_logging_enabled() and not audit_without_consistency_lock:
                 with self.consistency_guard(self._mutation_subject(injected)):
                     return command.leaf(*injected, **kwargs)
             return command.leaf(*injected, **kwargs)
         mutation_subject = self._mutation_subject(injected)
-        with self.mutation_guard(mutation_subject) as mutation:
-            digest = hashlib.sha256(
-                json.dumps(
-                    {"command": command.name, "kwargs": kwargs},
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    default=str,
-                ).encode("utf-8")
-            ).hexdigest()
-            key = None
-            expires_after = None
-            on_replay = None
-            idempotency_namespace = (
-                f"cell:{self.config.vault_id}" if self.config.vault_id else mutation.identity
+        digest = _command_digest(command, kwargs)
+        key, expires_after, on_replay = _effective_idempotency_key(
+            self,
+            command=command,
+            mutation_subject=mutation_subject,
+            digest=digest,
+            idempotency_key=idempotency_key,
+            principal_scope=idempotency_principal_scope,
+            implicit_idempotency_scope=implicit_idempotency_scope,
+        )
+        request_id = mutation_request_id or str(uuid.uuid4())
+        receipt = _receipt_tag(key) if key else None
+        commit_state = {"observed": False}
+        _log_mutation_event(
+            "received",
+            request_id=request_id,
+            command=command.name,
+            receipt=receipt or "none",
+        )
+
+        def invoke_leaf() -> Any:
+            trace_token = _ACTIVE_MUTATION_TRACE.set(
+                (request_id, command.name, receipt or "none")
             )
-            if idempotency_key:
-                key = _namespaced_idempotency_key(
-                    "explicit", idempotency_namespace, idempotency_key
-                )
-            elif implicit_idempotency_scope:
-                key = _namespaced_idempotency_key(
-                    "implicit",
-                    idempotency_namespace,
-                    f"{implicit_idempotency_scope}\0{digest}",
-                )
-                expires_after = _IMPLICIT_RETRY_TTL_SECONDS
+            commit_token = _ACTIVE_MUTATION_COMMITTED.set(False)
+            try:
+                return command.leaf(*injected, **kwargs)
+            except Exception as error:
+                if (
+                    _ACTIVE_MUTATION_COMMITTED.get()
+                    and getattr(error, "committed", None) is not True
+                ):
+                    raise _PostCommitOutcomeUncertain() from error
+                raise
+            finally:
+                commit_state["observed"] = _ACTIVE_MUTATION_COMMITTED.get()
+                _ACTIVE_MUTATION_COMMITTED.reset(commit_token)
+                _ACTIVE_MUTATION_TRACE.reset(trace_token)
 
-                def log_replay() -> None:
-                    logger.info("Replayed retry-safe MCP mutation command=%s", command.name)
-
-                on_replay = log_replay
-            return self.idempotency.run(
+        try:
+            result = self.idempotency.run(
                 key,
                 digest,
-                lambda: command.leaf(*injected, **kwargs),
+                invoke_leaf,
                 expires_after=expires_after,
                 on_replay=on_replay,
+                operation_guard=lambda: self.mutation_guard(mutation_subject),
+                commit_observed=lambda: commit_state["observed"],
             )
+        except BaseException as error:
+            if isinstance(error, OpError):
+                if error.code == "MUTATION_BUSY":
+                    error.details.update(status="retryable", committed=False, retry_after_ms=750)
+                elif error.code == "MUTATION_ACKNOWLEDGEMENT_PENDING":
+                    error.details.update(status="uncertain", committed=None)
+                error.details.update(request_id=request_id, receipt_id=receipt)
+                if idempotency_key is not None:
+                    error.details["idempotency_key"] = idempotency_key
+            _log_mutation_event(
+                "interrupted",
+                level=logging.WARNING,
+                request_id=request_id,
+                command=command.name,
+                receipt=receipt or "none",
+                error=type(error).__name__,
+            )
+            raise
+        _log_mutation_event(
+            "returned",
+            request_id=request_id,
+            command=command.name,
+            receipt=receipt or "none",
+        )
+        return result
 
     def _mutation_subject(self, injected: tuple[Any, ...]) -> os.PathLike[str] | str:
         if injected and isinstance(injected[0], os.PathLike):
@@ -781,7 +1096,9 @@ def invoke_command(
     command: Any,
     *injected: Any,
     idempotency_key: str | None = None,
+    idempotency_principal_scope: str | None = None,
     implicit_idempotency_scope: str | None = None,
+    mutation_request_id: str | None = None,
     **kwargs: Any,
 ) -> Any:
     from .commands import invocation_is_read_only
@@ -792,7 +1109,9 @@ def invoke_command(
         kwargs,
         read_only=invocation_is_read_only(command, kwargs),
         idempotency_key=idempotency_key,
+        idempotency_principal_scope=idempotency_principal_scope,
         implicit_idempotency_scope=implicit_idempotency_scope,
+        mutation_request_id=mutation_request_id,
     )
 
 

--- a/tests/test_cf_access.py
+++ b/tests/test_cf_access.py
@@ -28,7 +28,7 @@ class _FakeJWKS:
 
 
 def _make(priv, *, aud=AUD, iss=f"https://{TEAM}", exp_delta=3600, drop=None) -> str:
-    now = dt.datetime.now(dt.timezone.utc)
+    now = dt.datetime.now(dt.UTC)
     payload = {
         "aud": aud,
         "iss": iss,
@@ -49,6 +49,21 @@ def _verify(token, priv_for_jwks) -> bool:
 def test_valid_token_passes() -> None:
     priv = _key()
     assert _verify(_make(priv), priv) is True
+
+
+def test_verified_claims_returns_signed_identity() -> None:
+    priv = _key()
+    token = _make(priv)
+    claims = cf_access.verified_claims(
+        token,
+        jwks_client=_FakeJWKS(priv.public_key()),
+        team_domain=TEAM,
+        audience=AUD,
+    )
+
+    assert claims is not None
+    assert claims["sub"] == "user@example.com"
+    assert claims["iss"] == f"https://{TEAM}"
 
 
 def test_none_token_fails() -> None:

--- a/tests/test_command_surface_retry.py
+++ b/tests/test_command_surface_retry.py
@@ -1,15 +1,23 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from exomem import command_surface, writer_lease
+from exomem import server as server_module
 from exomem import vault as vault_module
 
 
 def test_mcp_retry_scope_hashes_bearer_and_falls_back_to_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_access_token",
+        lambda: None,
+    )
     monkeypatch.setattr(
         "fastmcp.server.dependencies.get_http_headers",
         lambda **kwargs: {"authorization": "Bearer super-secret-token"},
@@ -26,6 +34,48 @@ def test_mcp_retry_scope_hashes_bearer_and_falls_back_to_session(monkeypatch) ->
     assert command_surface.mcp_retry_scope() == "session:session-1"
 
 
+def test_mcp_retry_scope_uses_stable_verified_principal_across_bearer_rotation(
+    monkeypatch,
+) -> None:
+    token = SimpleNamespace(
+        token="first-bearer",
+        client_id="chat-client",
+        claims={"iss": "https://memory.example", "sub": "user-42"},
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_access_token",
+        lambda: token,
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers",
+        lambda **kwargs: {"authorization": f"Bearer {token.token}"},
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_context",
+        lambda: SimpleNamespace(session_id="session-1"),
+    )
+
+    first = command_surface.mcp_retry_scope()
+    token.token = "rotated-bearer"
+    second = command_surface.mcp_retry_scope()
+
+    assert first == second
+    assert first.startswith("principal:")
+    assert "user-42" not in first
+
+
+def test_maintain_audit_is_read_only_for_common_invocation_boundary() -> None:
+    from exomem.commands import invocation_is_read_only, product_commands_for
+
+    command = next(
+        item for item in product_commands_for("mcp") if item.name == "maintain_memory"
+    )
+    assert invocation_is_read_only(command, {}) is True
+    assert invocation_is_read_only(command, {"mode": "audit"}) is True
+    assert invocation_is_read_only(command, {"mode": "fix"}) is False
+    assert invocation_is_read_only(command, {"mode": "reconcile"}) is False
+
+
 def test_bound_mcp_tool_passes_retry_scope(monkeypatch) -> None:
     seen = {}
 
@@ -35,6 +85,11 @@ def test_bound_mcp_tool_passes_retry_scope(monkeypatch) -> None:
     command = SimpleNamespace(name="mutate", leaf=leaf, read_only=False)
     bound = command_surface.bind_vault(leaf, object(), command=command)
     monkeypatch.setattr(command_surface, "mcp_retry_scope", lambda: "bearer:abc")
+    monkeypatch.setattr(
+        command_surface,
+        "mcp_request_id",
+        lambda: "11111111-1111-4111-8111-111111111111",
+    )
 
     def fake_invoke(cmd, *injected, **kwargs):  # noqa: ANN001
         seen.update(command=cmd, injected=injected, kwargs=kwargs)
@@ -42,7 +97,60 @@ def test_bound_mcp_tool_passes_retry_scope(monkeypatch) -> None:
 
     monkeypatch.setattr("exomem.writer_lease.invoke_command", fake_invoke)
     assert bound(value=1) == "ok"
-    assert seen["kwargs"] == {"value": 1, "implicit_idempotency_scope": "bearer:abc"}
+    assert seen["kwargs"] == {
+        "value": 1,
+        "implicit_idempotency_scope": "bearer:abc",
+        "mutation_request_id": "11111111-1111-4111-8111-111111111111",
+    }
+
+
+def test_mcp_request_id_prefers_edge_correlation_header(monkeypatch) -> None:
+    expected = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers",
+        lambda **kwargs: {"x-exomem-request-id": expected},
+    )
+    assert command_surface.mcp_request_id() == expected
+
+
+def test_mcp_request_id_rejects_non_uuid_header(monkeypatch) -> None:
+    generated = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers",
+        lambda **kwargs: {"x-exomem-request-id": "attacker supplied log content"},
+    )
+    monkeypatch.setattr(command_surface.uuid, "uuid4", lambda: generated)
+
+    assert command_surface.mcp_request_id() == str(generated)
+
+
+def test_call_trace_and_bound_tool_share_generated_request_id(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    generated = iter(
+        [
+            uuid.UUID("11111111-1111-4111-8111-111111111111"),
+            uuid.UUID("22222222-2222-4222-8222-222222222222"),
+        ]
+    )
+    seen: list[str] = []
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers", lambda **kwargs: {}
+    )
+    monkeypatch.setattr(command_surface.uuid, "uuid4", lambda: next(generated))
+    middleware = server_module.CallTraceMiddleware()
+    context = SimpleNamespace(message={"params": {"name": "remember", "arguments": {}}})
+
+    async def call_next(_context):  # noqa: ANN001
+        seen.append(command_surface.mcp_request_id())
+        return {"ok": True}
+
+    with caplog.at_level(logging.INFO, logger="exomem.calls"):
+        asyncio.run(middleware.on_call_tool(context, call_next))
+
+    expected = "11111111-1111-4111-8111-111111111111"
+    assert seen == [expected]
+    assert f"request_id={expected}" in caplog.text
 
 
 def test_bound_process_media_status_skips_mutation_retry_scope(
@@ -114,3 +222,54 @@ def test_bound_mcp_committed_failure_replays_sanitized_without_second_leaf_call(
         assert secret not in str(first.value)
         assert secret not in str(replay.value)
     assert calls == 1
+
+
+def test_bound_remember_replays_after_terminal_acknowledgement_loss(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem.commands import op_remember, product_commands_for
+
+    kwargs = {
+        "content": "# Acknowledgement-safe save\n\nOne deterministic conclusion.\n",
+        "title": "Acknowledgement-safe save",
+        "slug": "acknowledgement-safe-save",
+        "suggestions": False,
+    }
+    validation = op_remember(vault, validate_only=True, **kwargs)
+    kwargs.update(
+        draft_id=validation["draft_id"],
+        draft_hash=validation["draft_hash"],
+        draft_token=validation["draft_token"],
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation["draft_hash"],
+        relation_review_reason="No honest relation exists in the isolated fixture.",
+    )
+    interrupt = True
+
+    def after_terminal_persisted() -> None:
+        nonlocal interrupt
+        if interrupt:
+            interrupt = False
+            raise asyncio.CancelledError
+
+    manager = writer_lease.LeaseManager(
+        writer_lease.LeaseConfig(state_dir=vault.parent / "state"),
+        after_terminal_persisted=after_terminal_persisted,
+    )
+    command = next(
+        item for item in product_commands_for("mcp") if item.name == "remember"
+    )
+    bound = command_surface.bind_vault(command.leaf, vault, command=command)
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
+    monkeypatch.setattr(command_surface, "mcp_retry_scope", lambda: "principal:test")
+
+    with pytest.raises(asyncio.CancelledError):
+        bound(**kwargs)
+    replay = bound(**kwargs)
+
+    assert replay["path"] == validation["destination"]
+    assert (vault / replay["path"]).is_file()
+    assert list((vault / replay["path"]).parent.glob("acknowledgement-safe-save*.md")) == [
+        vault / replay["path"]
+    ]

--- a/tests/test_hosted_gateway.py
+++ b/tests/test_hosted_gateway.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -246,6 +247,21 @@ def test_hosted_idempotency_scope_changes_by_cell_and_principal(tmp_path: Path) 
     assert len(keys) == 3
     assert all(key and key.startswith("hosted:") for key in keys)
     assert not any("principal" in key or "tenant" in key for key in keys)
+
+
+def test_implicit_retry_scope_is_stable_across_gateway_request_ids() -> None:
+    first = gateway.TrustedGatewayContext(
+        cell_id="cell-alpha",
+        protocol_version="1",
+        request_id="11111111-1111-4111-8111-111111111111",
+        principal_scope=PRINCIPAL_ALPHA,
+    )
+    second = replace(
+        first,
+        request_id="22222222-2222-4222-8222-222222222222",
+    )
+
+    assert gateway.implicit_retry_scope(first) == gateway.implicit_retry_scope(second)
 
 
 def test_gateway_context_identity_formats_are_exact() -> None:

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -115,6 +115,7 @@ class IsolatedInvoker:
         *injected,
         idempotency_key: str | None = None,
         implicit_idempotency_scope: str | None = None,
+        mutation_request_id: str | None = None,
         **kwargs,
     ) -> Any:
         self.calls.append(
@@ -123,6 +124,7 @@ class IsolatedInvoker:
                 "vault": injected[0],
                 "idempotency_key": idempotency_key,
                 "implicit_scope": implicit_idempotency_scope,
+                "request_id": mutation_request_id,
             }
         )
         digest = hashlib.sha256(repr((command.name, sorted(kwargs.items()))).encode()).hexdigest()

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -16,6 +16,7 @@ from exomem import access, commands, server, writer_lease
 from exomem import commands as commands_module
 from exomem import find as find_module
 from exomem import vault as vault_module
+from exomem.cli_ops import OpError
 
 PRODUCT_ROUTES = [
     "bootstrap",
@@ -257,6 +258,106 @@ def test_committed_batch_failure_rest_replay_is_exact_409_and_invokes_once(
     assert calls == 1
 
 
+def test_structured_busy_error_matches_openapi_and_preserves_public_identity(
+    vault, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def busy_before_commit(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        raise OpError(
+            "MUTATION_BUSY",
+            "vault mutation boundary is busy",
+            details={"status": "retryable", "committed": False, "retry_after_ms": 750},
+        )
+
+    writer_lease.reset_managers_for_tests()
+    monkeypatch.setattr(commands, "op_create_file", busy_before_commit)
+    client = _client(
+        vault,
+        monkeypatch,
+        EXOMEM_REST_API_KEY="sekret",
+        EXOMEM_WRITER_LEASE_STATE_DIR=str(tmp_path / "lease-state"),
+    )
+    request_id = "11111111-1111-4111-8111-111111111111"
+    response = client.post(
+        "/api/manage_memory_file",
+        json={
+            "operation": "create",
+            "path": "Knowledge Base/Notes/Insights/not-written.md",
+            "content": "not written",
+        },
+        headers={
+            **_auth(),
+            "Idempotency-Key": "rest-busy",
+            "X-Exomem-Request-Id": request_id,
+        },
+    )
+
+    assert response.status_code == 409
+    error = response.json()["error"]
+    assert error["status"] == "retryable"
+    assert error["committed"] is False
+    assert error["request_id"] == request_id
+    assert error["idempotency_key"] == "rest-busy"
+    assert error["receipt_id"] != "rest-busy"
+    schema_properties = client.get("/api/openapi.json").json()["components"]["schemas"][
+        "Error"
+    ]["properties"]
+    assert set(error) <= set(schema_properties)
+
+
+def test_cf_access_principals_isolate_explicit_rest_idempotency(
+    vault, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def committed_create(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        calls.append("write")
+        return {"sequence": len(calls)}
+
+    def verified_claims(token, **kwargs):  # noqa: ANN001, ARG001
+        return {
+            "iss": "https://team.cloudflareaccess.com",
+            "sub": token,
+        }
+
+    writer_lease.reset_managers_for_tests()
+    monkeypatch.setattr(commands, "op_create_file", committed_create)
+    monkeypatch.setattr("exomem.cf_access.make_jwks_client", lambda _team: object())
+    monkeypatch.setattr("exomem.cf_access.verified_claims", verified_claims)
+    client = _client(
+        vault,
+        monkeypatch,
+        EXOMEM_REST_API_KEY="sekret",
+        EXOMEM_CF_ACCESS_TEAM_DOMAIN="team.cloudflareaccess.com",
+        EXOMEM_CF_ACCESS_AUD="rest-audience",
+        EXOMEM_WRITER_LEASE_STATE_DIR=str(tmp_path / "lease-state"),
+    )
+    request = {
+        "operation": "create",
+        "path": "Knowledge Base/Notes/Insights/principal-isolation.md",
+        "content": "same canonical payload",
+    }
+
+    def invoke(principal: str):
+        return client.post(
+            "/api/manage_memory_file",
+            json=request,
+            headers={
+                "Cf-Access-Jwt-Assertion": principal,
+                "Idempotency-Key": "shared-public-key",
+            },
+        )
+
+    alice = invoke("alice")
+    bob = invoke("bob")
+    alice_replay = invoke("alice")
+
+    assert alice.status_code == bob.status_code == alice_replay.status_code == 200
+    assert alice.json()["data"] == {"sequence": 1}
+    assert bob.json()["data"] == {"sequence": 2}
+    assert alice_replay.json()["data"] == {"sequence": 1}
+    assert calls == ["write", "write"]
+
+
 def test_remember_route_preserves_unicode_title_and_explicit_slug(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -436,6 +537,16 @@ def test_openapi_lists_real_product_params(vault, monkeypatch: pytest.MonkeyPatc
 
     error_schema = doc["components"]["schemas"]["Error"]
     assert "outcome" in error_schema["properties"]
+    assert {
+        "ok",
+        "error_code",
+        "status",
+        "committed",
+        "retry_after_ms",
+        "request_id",
+        "receipt_id",
+        "idempotency_key",
+    } <= set(error_schema["properties"])
     assert "outcome" not in error_schema.get("required", [])
     outcome_schema = error_schema["properties"]["outcome"]
     assert set(outcome_schema["required"]) == {

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import sqlite3
@@ -14,7 +15,7 @@ import pytest
 
 from exomem import vault as vault_module
 from exomem import writer_lease as writer_lease_module
-from exomem.cli_ops import OpError, http_status_for
+from exomem.cli_ops import OpError, error_dict, http_status_for
 from exomem.lease_coordinator import SQLiteLeaseStore
 from exomem.mutation_lock import VaultMutationCoordinator
 from exomem.vault import PlannedWrite, batch_atomic_write
@@ -778,6 +779,431 @@ def test_idempotency_returns_saved_result_and_rejects_mismatch(tmp_path: Path) -
     assert calls == [1]
 
 
+def test_identical_inflight_retry_waits_for_original_terminal_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    leaf_started = threading.Event()
+    release_leaf = threading.Event()
+    pending_seen = threading.Event()
+    calls: list[int] = []
+    outcomes: dict[str, object] = {}
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        mutation_timeout_seconds=0,
+        idempotency_wait_seconds=2,
+    )
+
+    def leaf(value: int) -> dict[str, object]:
+        calls.append(value)
+        leaf_started.set()
+        assert release_leaf.wait(timeout=2)
+        return {"committed": True, "value": value}
+
+    command = _command(writes=True, leaf=leaf)
+    original_wait = manager.idempotency._wait_for_terminal
+
+    def observed_wait(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        pending_seen.set()
+        return original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(manager.idempotency, "_wait_for_terminal", observed_wait)
+
+    def invoke(name: str) -> None:
+        try:
+            outcomes[name] = manager.invoke(
+                command,
+                (),
+                {"value": 1},
+                implicit_idempotency_scope="principal:alice",
+            )
+        except BaseException as error:  # noqa: BLE001 - assert thread outcome below
+            outcomes[name] = error
+
+    original = threading.Thread(target=invoke, args=("original",), daemon=True)
+    retry = threading.Thread(target=invoke, args=("retry",), daemon=True)
+    original.start()
+    assert leaf_started.wait(timeout=2)
+    retry.start()
+    assert pending_seen.wait(timeout=2)
+    release_leaf.set()
+    original.join(timeout=2)
+    retry.join(timeout=2)
+
+    assert not original.is_alive()
+    assert not retry.is_alive()
+    expected = {"committed": True, "value": 1}
+    assert outcomes == {"original": expected, "retry": expected}
+    assert calls == [1]
+
+
+def test_terminal_receipt_survives_acknowledgement_cancellation(tmp_path: Path) -> None:
+    calls: list[int] = []
+    interrupt = True
+
+    def after_terminal_persisted() -> None:
+        nonlocal interrupt
+        if interrupt:
+            interrupt = False
+            raise asyncio.CancelledError
+
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        after_terminal_persisted=after_terminal_persisted,
+    )
+    command = _command(
+        writes=True,
+        leaf=lambda value: calls.append(value) or {"committed": True, "value": value},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        manager.invoke(
+            command,
+            (),
+            {"value": 1},
+            idempotency_key="ack-lost",
+            idempotency_principal_scope="principal:alice",
+        )
+
+    assert manager.invoke(
+        command,
+        (),
+        {"value": 1},
+        idempotency_key="ack-lost",
+        idempotency_principal_scope="principal:alice",
+    ) == {"committed": True, "value": 1}
+    assert calls == [1]
+
+
+def test_identical_orphaned_pending_reports_acknowledgement_uncertain(
+    tmp_path: Path,
+) -> None:
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        idempotency_wait_seconds=0,
+    )
+    command = _command(writes=True, leaf=lambda: pytest.fail("pending retry ran leaf"))
+    digest = writer_lease_module._command_digest(command, {})
+    key = writer_lease_module._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject="standalone",
+        digest=digest,
+        idempotency_key="pending",
+        principal_scope="principal:alice",
+    )[0]
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at) "
+            "VALUES (?, ?, 'pending', ?)",
+            (key, digest, 100.0),
+        )
+
+    with pytest.raises(OpError) as pending:
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="pending",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert pending.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+    pending_payload = error_dict(pending.value)
+    assert pending_payload["status"] == "uncertain"
+    assert pending_payload["committed"] is None
+    assert pending_payload["request_id"]
+    assert pending_payload["idempotency_key"] == "pending"
+    assert pending_payload["receipt_id"]
+
+
+def test_different_identity_busy_is_precommit(tmp_path: Path) -> None:
+    leaf_started = threading.Event()
+    release_leaf = threading.Event()
+    first_calls: list[str] = []
+    second_calls: list[str] = []
+    outcome: list[object] = []
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        mutation_timeout_seconds=0,
+    )
+
+    def first_leaf() -> str:
+        first_calls.append("first")
+        leaf_started.set()
+        assert release_leaf.wait(timeout=2)
+        return "committed"
+
+    first = _command(writes=True, leaf=first_leaf)
+    second = SimpleNamespace(
+        name="other-mutation",
+        read_only=False,
+        leaf=lambda: second_calls.append("second") or "unexpected",
+    )
+
+    def invoke_first() -> None:
+        try:
+            outcome.append(
+                manager.invoke(
+                    first,
+                    (),
+                    {},
+                    idempotency_key="first",
+                    idempotency_principal_scope="alice",
+                )
+            )
+        except BaseException as error:  # noqa: BLE001
+            outcome.append(error)
+
+    worker = threading.Thread(target=invoke_first, daemon=True)
+    worker.start()
+    assert leaf_started.wait(timeout=2)
+    with pytest.raises(OpError) as busy:
+        manager.invoke(
+            second,
+            (),
+            {},
+            idempotency_key="second",
+            idempotency_principal_scope="alice",
+        )
+    assert busy.value.code == "MUTATION_BUSY"
+    busy_payload = error_dict(busy.value)
+    assert busy_payload["status"] == "retryable"
+    assert busy_payload["committed"] is False
+    assert busy_payload["retry_after_ms"] == 750
+    assert busy_payload["request_id"]
+    assert busy_payload["idempotency_key"] == "second"
+    assert busy_payload["receipt_id"]
+    busy_wire = json.loads(str(busy.value))
+    assert busy_wire["ok"] is False
+    assert busy_wire["error_code"] == "MUTATION_BUSY"
+    assert busy_wire["request_id"] == busy_payload["request_id"]
+    assert second_calls == []
+    release_leaf.set()
+    worker.join(timeout=2)
+    assert outcome == ["committed"]
+    assert first_calls == ["first"]
+
+
+def test_postcommit_error_cannot_escape_as_precommit_retryable(tmp_path: Path) -> None:
+    target = tmp_path / "note.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+
+    def commits_then_misreports(vault: Path) -> None:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write(
+            [PlannedWrite(target, "committed\n")],
+            vault_root=vault,
+        )
+        raise OpError("MUTATION_BUSY", "misleading post-commit error")
+
+    command = _command(writes=True, leaf=commits_then_misreports)
+    for _ in range(2):
+        with pytest.raises(OpError) as uncertain:
+            manager.invoke(
+                command,
+                (tmp_path,),
+                {},
+                idempotency_key="postcommit-error",
+                idempotency_principal_scope="principal:alice",
+            )
+        assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+        payload = error_dict(uncertain.value)
+        assert payload["status"] == "committed"
+        assert payload["committed"] is True
+
+    assert target.read_text(encoding="utf-8") == "committed\n"
+    assert calls == 1
+
+
+def test_empty_batch_does_not_mark_a_commit(tmp_path: Path) -> None:
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    calls = 0
+
+    def no_commit(vault: Path) -> None:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([], vault_root=vault)
+        raise OpError("MUTATION_BUSY", "pre-commit rejection")
+
+    command = _command(writes=True, leaf=no_commit)
+    for _ in range(2):
+        with pytest.raises(OpError) as busy:
+            manager.invoke(command, (tmp_path,), {}, idempotency_key="empty-batch")
+        assert busy.value.code == "MUTATION_BUSY"
+        assert error_dict(busy.value)["committed"] is False
+
+    assert calls == 2
+
+
+def test_completed_result_receipt_failure_is_committed_uncertain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "note.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+
+    def commit(vault: Path) -> dict[str, bool]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(target, "committed\n")], vault_root=vault)
+        return {"committed": True}
+
+    def fail_terminal_receipt(*_args, **_kwargs) -> None:
+        raise sqlite3.OperationalError("deterministic receipt write failure")
+
+    monkeypatch.setattr(manager.idempotency, "_persist_completed", fail_terminal_receipt)
+    command = _command(writes=True, leaf=commit)
+
+    for _ in range(2):
+        with pytest.raises(OpError) as uncertain:
+            manager.invoke(
+                command,
+                (tmp_path,),
+                {},
+                idempotency_key="receipt-failure",
+                idempotency_principal_scope="principal:alice",
+            )
+        assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+        assert error_dict(uncertain.value)["committed"] is True
+
+    assert target.read_text(encoding="utf-8") == "committed\n"
+    assert calls == 1
+
+
+def test_uncommitted_result_receipt_failure_does_not_claim_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = 0
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path / "state"), idempotency_wait_seconds=0
+    )
+
+    def validate_only() -> dict[str, bool]:
+        nonlocal calls
+        calls += 1
+        return {"validate_only": True, "committed": False}
+
+    def fail_terminal_receipt(*_args, **_kwargs) -> None:
+        raise sqlite3.OperationalError("deterministic receipt write failure")
+
+    monkeypatch.setattr(manager.idempotency, "_persist_completed", fail_terminal_receipt)
+    command = _command(writes=True, leaf=validate_only)
+
+    for _ in range(2):
+        with pytest.raises(OpError) as pending:
+            manager.invoke(
+                command,
+                (),
+                {},
+                idempotency_key="validate-receipt-failure",
+            )
+        assert pending.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+        assert error_dict(pending.value)["committed"] is None
+
+    assert calls == 1
+
+
+def test_precommit_failure_releases_pending_receipt_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path))
+    command = _command(writes=True, leaf=lambda: (_ for _ in ()).throw(ValueError("no commit")))
+    deletes = 0
+    original_delete = manager.idempotency._delete_pending
+
+    def counted_delete(key: str, digest: str) -> None:
+        nonlocal deletes
+        deletes += 1
+        original_delete(key, digest)
+
+    monkeypatch.setattr(manager.idempotency, "_delete_pending", counted_delete)
+
+    with pytest.raises(ValueError, match="no commit"):
+        manager.invoke(command, (), {}, idempotency_key="precommit-failure")
+
+    assert deletes == 1
+
+
+def test_hosted_audit_does_not_hold_mutation_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audit_started = threading.Event()
+    release_audit = threading.Event()
+    audit_outcome: list[object] = []
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"), mutation_timeout_seconds=0)
+
+    def audit_leaf(_vault: Path, *, mode: str = "audit") -> str:  # noqa: ARG001
+        audit_started.set()
+        assert release_audit.wait(timeout=2)
+        return "audited"
+
+    audit = SimpleNamespace(name="maintain_memory", read_only=False, leaf=audit_leaf)
+    mutation = SimpleNamespace(
+        name="remember", read_only=False, leaf=lambda _vault: "committed"
+    )
+    monkeypatch.setattr(writer_lease_module, "content_private_logging_enabled", lambda: True)
+
+    def run_audit() -> None:
+        try:
+            audit_outcome.append(
+                manager.invoke(audit, (tmp_path,), {"mode": "audit"}, read_only=True)
+            )
+        except BaseException as error:  # noqa: BLE001
+            audit_outcome.append(error)
+
+    worker = threading.Thread(target=run_audit, daemon=True)
+    worker.start()
+    assert audit_started.wait(timeout=2)
+    assert manager.invoke(mutation, (tmp_path,), {}) == "committed"
+    release_audit.set()
+    worker.join(timeout=2)
+
+    assert audit_outcome == ["audited"]
+
+
+def test_explicit_idempotency_receipts_have_bounded_retention(tmp_path: Path) -> None:
+    clock = Clock()
+    calls: list[int] = []
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path), clock=clock)
+    command = _command(writes=True, leaf=lambda: calls.append(1) or len(calls))
+
+    assert manager.invoke(command, (), {}, idempotency_key="bounded-explicit") == 1
+    assert manager.invoke(command, (), {}, idempotency_key="bounded-explicit") == 1
+    clock.value += writer_lease_module._EXPLICIT_RETRY_TTL_SECONDS + 1
+    assert manager.invoke(command, (), {}, idempotency_key="bounded-explicit") == 2
+    assert calls == [1, 1]
+
+
+def test_explicit_idempotency_is_isolated_by_principal(tmp_path: Path) -> None:
+    calls: list[str] = []
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path))
+    command = _command(writes=True, leaf=lambda: calls.append("write") or len(calls))
+
+    assert manager.invoke(
+        command,
+        (),
+        {},
+        idempotency_key="same-public-key",
+        idempotency_principal_scope="principal:alice",
+    ) == 1
+    assert manager.invoke(
+        command,
+        (),
+        {},
+        idempotency_key="same-public-key",
+        idempotency_principal_scope="principal:bob",
+    ) == 2
+    assert manager.invoke(
+        command,
+        (),
+        {},
+        idempotency_key="same-public-key",
+        idempotency_principal_scope="principal:alice",
+    ) == 1
+    assert calls == ["write", "write"]
+
+
 @pytest.mark.parametrize("implicit", [False, True], ids=["explicit", "implicit"])
 def test_committed_cleanup_failure_replays_exact_public_payload_without_reinvoking(
     tmp_path: Path,
@@ -811,7 +1237,7 @@ def test_committed_cleanup_failure_replays_exact_public_payload_without_reinvoki
     assert calls == 1
 
 
-def test_lost_writer_authority_rejects_before_committed_failure_replay(
+def test_committed_failure_replays_without_reacquiring_writer_authority(
     tmp_path: Path,
 ) -> None:
     calls = 0
@@ -837,10 +1263,11 @@ def test_lost_writer_authority_rejects_before_committed_failure_replay(
         manager.invoke(command, (), {}, idempotency_key="authority-bound")
 
     client.record = LeaseRecord("laptop", 99, 5)
-    with pytest.raises(OpError) as rejected:
+    with pytest.raises(ValueError) as replay:
         manager.invoke(command, (), {}, idempotency_key="authority-bound")
-    assert rejected.value.code == "WRITER_LEASE_REQUIRED"
+    assert replay.value.as_public_dict() == original.as_public_dict()
     assert calls == 1
+    assert client.acquisitions == 1
 
 
 def test_committed_failure_persists_only_sanitized_public_json(tmp_path: Path) -> None:
@@ -1196,7 +1623,7 @@ def test_committed_marker_storage_failure_keeps_pending_and_blocks_retry(
 
     with pytest.raises(OpError) as blocked:
         manager.invoke(command, (), {}, idempotency_key="storage-failure")
-    assert blocked.value.code == "IDEMPOTENCY_IN_PROGRESS"
+    assert blocked.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
     assert calls == 1
 
 
@@ -1224,7 +1651,7 @@ def test_explicit_idempotency_blocks_orphaned_pending_after_process_abort(
     )
     with pytest.raises(OpError) as blocked:
         manager.invoke(recovered, (), {}, idempotency_key="request-after-crash")
-    assert blocked.value.code == "IDEMPOTENCY_IN_PROGRESS"
+    assert blocked.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
     assert calls == ["aborted"]
 
 


### PR DESCRIPTION
## What changed

- reserve and inspect mutation receipts before acquiring writer authority or the vault mutation boundary;
- bounded-wait identical in-flight retries outside the lock and replay the exact stored terminal result;
- distinguish pre-commit `MUTATION_BUSY`, acknowledgement-pending, committed-uncertain, and completed replay states;
- bind replay identity to stable authenticated principals and canonical payloads, with 60-second implicit and 24-hour explicit retention;
- propagate one canonical request UUID through the edge, MCP middleware, mutation layer, and canonical writer;
- fail closed at one HA origin for tool calls, REST/lifecycle mutations, and public transfer uploads;
- exempt hosted maintenance audit from the mutation boundary;
- expose structured mutation errors in REST/OpenAPI and document the remaining ergonomics changes separately.

## Root cause

The old path acquired the vault mutation boundary before consulting idempotency. An original synchronous worker could continue and commit after acknowledgement delivery was cancelled, while an overlapping identical retry waited five seconds on that same boundary and returned pre-leaf `MUTATION_BUSY`. The client could therefore surface the retry's error while the original committed. Because the receipt lookup was behind the lock, existing replay protection never got a chance to collapse the overlap.

## Verification

- full non-embedding suite: `4110 passed, 61 skipped`;
- expanded writer/mutation/transactional/semantic/HA gate: `516 passed, 4 skipped`;
- final REST/auth/correlation retest: `57 passed`;
- Cloudflare worker: `22 passed`;
- scaffold leak checks: `5 passed`;
- changed-file Ruff, OpenSpec strict validation, and `git diff --check`: clean;
- independent adversarial reviewer and verifier: GO.

## Compatibility and residual risk

No vault or SQLite schema migration is required. Quiesce in-flight CF Access REST mutations during rollout because pre-change shared receipts cannot be safely attributed to post-change principal scopes. Receipts remain replica-local: process death after filesystem commit but before receipt persistence, or a later takeover by another replica, remains fail-closed rather than cross-replica exactly-once.

The compact success envelope, discriminated `edit_memory` schema, bootstrap capability conformance, action-first audit output, and reranker budget are precisely scoped as follow-up changes in the OpenSpec artifact.
