### PR TITLE
fix: prevent stale connector rollouts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,8 +75,34 @@ jobs:
               raise SystemExit(f"pyproject version {actual} does not match release tag {expected}")
           PY
 
+      - name: Validate external connector rollout state
+        run: >-
+          uv run --frozen pytest
+          tests/test_connector_guardrails.py
+          tests/test_mcp_schema_fidelity.py
+          tests/test_runtime_readiness.py
+          tests/test_bootstrap.py
+          tests/test_server_transport.py
+          -q
+
       - name: Build package artifacts
         run: uv build
+
+      - name: Smoke packaged connector fingerprint
+        run: |
+          python - <<'PY'
+          import glob
+          import sys
+
+          [wheel] = glob.glob("dist/*.whl")
+          sys.path.insert(0, wheel)
+          from exomem.tool_surface import contract, sha256
+
+          payload = contract()
+          assert payload["tool_count"] > 0
+          assert payload["sha256"] == sha256()
+          print(payload["tool_count"], payload["sha256"])
+          PY
 
       - name: Upload artifacts to GitHub release
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ decisions, and reusable conclusions.
 ## Connector triage ("MCP not working" / slow first call / forced reconnect)
 
 claude.ai connector problems are almost always **connection-side, not the service**.
-The public ingress is a **Cloudflare Tunnel** (`kb.substratesystems.io`, cloudflared
+The public ingress is a **Cloudflare Tunnel** (`exomem.substratesystems.io`, cloudflared
 Windows service; migrated FROM Tailscale Funnel 2026-06-21 — the funnel throttled
 connector bursts, KB note `kb-mcp-ingress-migrated-to-cloudflare-tunnel-…`). Known
 connection-side patterns: (1) a long-lived claude.ai session's **first MCP call

--- a/deploy/chatgpt/personal-plugin-contract.json
+++ b/deploy/chatgpt/personal-plugin-contract.json
@@ -1,0 +1,16 @@
+{
+  "contract_version": 1,
+  "mcp_url": "https://exomem.substratesystems.io/mcp",
+  "authentication": "oauth",
+  "client_registration": "cimd",
+  "oidc_enabled": false,
+  "default_scopes": [],
+  "base_scopes": [],
+  "registered_tool_surface_sha256": null,
+  "pending_tool_surface_sha256": "91927b86184f40dd9e99f98bec4c0d31373a807a2333a4eca947771096b9a5bf",
+  "refresh_required": true,
+  "rollout_state": "awaiting-post-deploy-refresh",
+  "last_verified_release": "0.24.0",
+  "last_verified_at": "2026-07-18",
+  "verification": "Current 0.24.0 Personal Plugin works, but its pre-fingerprint dynamic schema is not claimed as the pending invariant surface. After deployment, recreate or rescan, invoke bootstrap and ask_memory from a fresh conversation, then promote pending to registered and clear refresh_required."
+}

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -337,6 +337,9 @@ Claude Code skill. Connect Exomem through whatever remote MCP/connector support
 the client offers, then add the instruction block above as account-level or
 project-level custom instructions.
 
+For ChatGPT Personal Plugins, follow the exact OAuth-only settings and
+tool-surface refresh gate in [remote-quickstart.md](remote-quickstart.md#chatgpt-personal-plugin-oauth-only).
+
 If the hosted client cannot reliably call `bootstrap()` on its own, start a new
 chat with:
 

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -214,6 +214,38 @@ Then add Exomem behavior to the hosted client. Paste the instruction block from
 [ai-assistant-guide.md](ai-assistant-guide.md), or at minimum start new chats by
 asking it to call `bootstrap(profile="compact")` once before using the KB.
 
+### ChatGPT Personal Plugin (OAuth only)
+
+Create the Personal Plugin with MCP Server URL `https://<host>/mcp` and
+Authentication set to **OAuth**. Keep the discovered authorization, token,
+registration, authorization-server, resource, CIMD metadata, and callback
+values. Leave **Default scopes** and **Base scopes** blank, and turn **OIDC
+enabled** off. Exomem deliberately provides OAuth authorization-code flow, not
+OpenID identity claims; the compatibility discovery alias is not permission to
+invent a `userinfo` endpoint. In particular, never accept a placeholder such as
+`https://example.com` for that field.
+
+Tool-surface changes use a truthful two-phase rollout. Before release, record
+the new packaged digest as `pending_tool_surface_sha256` with
+`refresh_required: true`; do not claim it is already registered. After the new
+service is deployed, confirm `/health/ready.mcp_tool_surface_sha256` matches the
+pending digest, refresh or recreate the Personal Plugin, and verify from a fresh
+conversation that `bootstrap` and `ask_memory` both invoke. Only then promote
+the pending digest to `registered_tool_surface_sha256`, clear the pending value,
+and set `refresh_required: false`. The release gate accepts an explicit pending
+rollout but blocks an unacknowledged schema change. The post-deploy promotion is
+a manual attestation because ChatGPT exposes no API for reading its registered
+plugin snapshot.
+
+`bootstrap.server.published_mcp_tool_surface_sha256` identifies the packaged
+canonical surface; `/health/ready` fingerprints the tools actually registered
+by that process, including configuration differences. Tool discovery alone is
+not proof that calls are routable. If an existing conversation says it is
+restricted to developer MCPs, advertises a missing resource, or keeps the
+previous schema after refresh, that conversation's host policy is poisoned: use
+a fresh conversation. Server or plugin changes cannot repair policy state
+already frozen into that thread.
+
 ## ngrok free-tier limits
 
 - **120 requests/minute**, **~20,000 requests/month** per endpoint.
@@ -234,6 +266,8 @@ asking it to call `bootstrap(profile="compact")` once before using the KB.
 | "Couldn't reach the MCP server" during connector add | OAuth discovery failed | See [deployment.md's troubleshooting table](deployment.md#troubleshooting) — the rest of the fixes there apply regardless of ingress profile. |
 | An existing connector gets one `401 invalid_token` immediately after the durable-session cutover | Its legacy FastMCP reference token is intentionally no longer accepted | Complete one final browser login. Do not delete or recreate the connector. |
 | Tools return `503` without an OAuth challenge | The authoritative session store is unavailable, not the login | Repair coordinator/network/storage health and retry. Re-authorizing cannot fix a 503. |
+| ChatGPT enables OIDC or proposes `https://example.com` as `userinfo` | The Personal Plugin UI inferred OpenID from Exomem's OAuth compatibility alias | Turn OIDC off, leave scopes blank, and keep the discovered OAuth/CIMD endpoints. |
+| ChatGPT discovers tools but invocation says `Resource not found` | Its registered tool snapshot is older than the deployed MCP surface | Refresh or recreate the Personal Plugin, verify the tool-surface fingerprint, then test from a fresh conversation. |
 
 For everything else — service management, GPU/CUDA, revoking access,
 restarting, logs, multi-host setups — see [deployment.md](deployment.md).

--- a/scripts/dump-tool-schemas.py
+++ b/scripts/dump-tool-schemas.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Regenerate the MCP schema-fidelity baseline (`tests/fixtures/mcp_tool_schemas.json`).
+"""Regenerate the MCP schema baseline and packaged discovery fingerprint.
 
 `tests/test_mcp_schema_fidelity.py` pins every MCP tool's `description` + `inputSchema`
 byte-for-byte — that JSON IS what Claude sees. Adding, removing, or renaming a command,
@@ -13,6 +13,10 @@ It builds the server under the SAME env the test captures the fixture with
 (embeddings/media/CLIP off, tier-2 on, dotenv neutralized, vault = tests/fixtures) so the
 live schemas are deterministic, and writes them in the shape the test reads. It mirrors
 `tests/test_mcp_schema_fidelity.py::_build_server` / `_live_schemas` — keep them in sync.
+
+The ChatGPT Personal Plugin attestation is intentionally separate and is never updated
+here. A changed fingerprint must remain release-blocking until that external consumer is
+refreshed and verified explicitly.
 """
 
 from __future__ import annotations
@@ -27,10 +31,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "mcp_tool_schemas.json"
+TOOL_SURFACE_CONTRACT_PATH = REPO_ROOT / "src" / "exomem" / "tool_surface_contract.json"
 FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
 SRC_PATH = REPO_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
+
+from exomem import tool_surface  # noqa: E402 - src path is inserted above
 
 
 def _build_server(vault_root: Path, state_root: Path):
@@ -58,12 +65,21 @@ def _live_schemas(mcp) -> dict[str, dict]:
     return out
 
 
+def _discovery_contract(mcp) -> dict[str, object]:
+    """Hash every client-visible field that can affect connector routing/policy."""
+    tools = asyncio.run(mcp.list_tools())
+    wires = [tool.to_mcp_tool().model_dump(mode="json") for tool in tools]
+    return tool_surface.discovery_contract(wires)
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="exomem-schema-") as temp_dir:
         temp_root = Path(temp_dir)
         vault_root = temp_root / "schema_vault"
         shutil.copytree(FIXTURE_VAULT, vault_root)
-        schemas = _live_schemas(_build_server(vault_root, temp_root / "writer-lease"))
+        mcp = _build_server(vault_root, temp_root / "writer-lease")
+        schemas = _live_schemas(mcp)
+        discovery_contract = _discovery_contract(mcp)
     # Preserve the established coordination-first baseline, then store product tool
     # keys alphabetically. Nested inputSchema property order is signature-order and
     # load-bearing, so only the outer mapping is normalized.
@@ -76,7 +92,21 @@ def main() -> None:
         encoding="utf-8",
         newline="\n",  # keep the committed fixture LF even when run on Windows
     )
+    TOOL_SURFACE_CONTRACT_PATH.write_text(
+        json.dumps(discovery_contract, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
     print(f"wrote {len(schemas)} tool schemas to {FIXTURE_PATH.relative_to(REPO_ROOT)}")
+    print(
+        "wrote MCP discovery fingerprint "
+        f"{discovery_contract['sha256']} to "
+        f"{TOOL_SURFACE_CONTRACT_PATH.relative_to(REPO_ROOT)}"
+    )
+    print(
+        "connector attestation is intentionally NOT updated: refresh/recreate and "
+        "verify external connectors before updating deploy/chatgpt/personal-plugin-contract.json"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/install-service.ps1
+++ b/scripts/install-service.ps1
@@ -296,5 +296,24 @@ try {
     Write-Warning "Service is still installed and running; you can grant manually later."
 }
 
-Write-Host "Installed and started service '$ServiceName' bound to ${BindHost}:${Port}."
+$connectorPending = $false
+$connectorContractPath = Join-Path $repoRoot "deploy\chatgpt\personal-plugin-contract.json"
+if (Test-Path $connectorContractPath) {
+    try {
+        $connectorContract = Get-Content -Raw $connectorContractPath | ConvertFrom-Json
+        $connectorPending = $connectorContract.refresh_required -eq $true
+    } catch {
+        Write-Warning "Could not read ChatGPT connector rollout contract: $_"
+    }
+}
+
+if ($connectorPending) {
+    Write-Warning "CHATGPT_PLUGIN_REFRESH_REQUIRED: service is running, but connector rollout is incomplete."
+    Write-Host "  Confirm /health/ready.mcp_tool_surface_sha256 matches pending_tool_surface_sha256."
+    Write-Host "  Refresh or recreate the ChatGPT Personal Plugin, then invoke bootstrap and ask_memory from a fresh conversation."
+    Write-Host "  Promote the pending digest to registered_tool_surface_sha256 only after that smoke test passes."
+    Write-Host "Installed and started service '$ServiceName' bound to ${BindHost}:${Port}; connector promotion remains pending."
+} else {
+    Write-Host "Installed, started, and connector-cleared service '$ServiceName' bound to ${BindHost}:${Port}."
+}
 Write-Host "Logs: $logDir\service.out.log (stdout), service.err.log (stderr), exomem.log (app)"

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -216,12 +216,13 @@ def op_bootstrap(
         package_version = "0+unknown"
 
     from . import mode as mode_module
+    from . import tool_surface as tool_surface_module
 
     compute_policy = mode_module.resolved()
     requested_workflow = workflow.strip() if workflow and workflow.strip() else "general"
     selected_packs = knowledge_packs_module.selected_pack_state(vault_root)
     payload: dict = {
-        "contract_version": "2026-07-16.2",
+        "contract_version": "2026-07-18.1",
         "profile": profile,
         "server": {
             "name": "exomem",
@@ -229,6 +230,7 @@ def op_bootstrap(
             "kb_dir": kb_dirname(),
             "pure_substrate": True,
             "content_included": False,
+            "published_mcp_tool_surface_sha256": tool_surface_module.sha256(),
             "compute_policy": compute_policy,
         },
         "memory_model": {

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -22,7 +22,10 @@ def package_release() -> str:
 
 
 def build_runtime_readiness(
-    *, coordination: Mapping[str, Any], release: str
+    *,
+    coordination: Mapping[str, Any],
+    release: str,
+    mcp_tool_surface_sha256: str | None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -32,6 +35,8 @@ def build_runtime_readiness(
     replica_id = replica_raw if isinstance(replica_raw, str) and replica_raw else None
 
     reasons: list[str] = []
+    if mcp_tool_surface_sha256 is None:
+        reasons.append("mcp_tool_surface_unavailable")
     if enabled:
         if not healthy:
             reasons.append("coordinator_unavailable")
@@ -45,6 +50,7 @@ def build_runtime_readiness(
         "status": "ready" if takeover_eligible else "not_ready",
         "service": "exomem",
         "release": release,
+        "mcp_tool_surface_sha256": mcp_tool_surface_sha256,
         "runtime_contract": RUNTIME_CONTRACT,
         "transport": HTTP_TRANSPORT,
         "replica_id": replica_id,
@@ -58,7 +64,7 @@ def build_runtime_readiness(
     }
 
 
-def runtime_readiness() -> dict[str, Any]:
+def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
     """Measure this process's eligibility without exposing vault or credential state."""
     from .writer_lease import coordination_status
 
@@ -71,4 +77,8 @@ def runtime_readiness() -> dict[str, Any]:
             "replica_id": os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID") or None,
             "coordinator_healthy": False,
         }
-    return build_runtime_readiness(coordination=coordination, release=package_release())
+    return build_runtime_readiness(
+        coordination=coordination,
+        release=package_release(),
+        mcp_tool_surface_sha256=mcp_tool_surface_sha256,
+    )

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -216,8 +216,6 @@ def build_server(*, require_auth: bool) -> FastMCP:
                 else (runtime.vault_root,)
             )
             description = cmd.doc
-            if cmd.name == "remember":
-                description = commands_module.remember_description(runtime.project_keys_hint)
             mcp.tool(
                 commands_module.bind_vault(
                     cmd.leaf,
@@ -371,8 +369,6 @@ def _register_legacy_mcp_tools(
             continue
         injected = (vault_root, source_schema) if cmd.needs_schema else (vault_root,)
         description = cmd.doc
-        if cmd.name == "note":
-            description = commands_module.remember_description(project_keys_hint)
         mcp.tool(
             commands_module.bind_vault(
                 cmd.leaf,

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 
 from . import runtime_readiness as runtime_readiness_module
+from . import tool_surface as tool_surface_module
 
 _STUDIO_SECURITY_HEADERS = {
     "Content-Security-Policy": (
@@ -104,7 +105,17 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
     @mcp_app.custom_route("/health/ready", methods=["GET"])
     async def _runtime_ready(request: Request) -> JSONResponse:  # noqa: ARG001
         """Content-free admission probe; liveness remains the separate /health route."""
-        snapshot = runtime_readiness_module.runtime_readiness()
+        digest = getattr(mcp_app, "_exomem_tool_surface_sha256", None)
+        if digest is None:
+            try:
+                live = await tool_surface_module.live_contract(mcp_app)
+                digest = live["sha256"]
+                mcp_app._exomem_tool_surface_sha256 = digest
+            except Exception:  # noqa: BLE001 - readiness must stay structured
+                digest = None
+        snapshot = runtime_readiness_module.runtime_readiness(
+            mcp_tool_surface_sha256=digest
+        )
         status_code = 200 if snapshot["status"] == "ready" else 503
         return JSONResponse(
             snapshot,

--- a/src/exomem/tool_surface.py
+++ b/src/exomem/tool_surface.py
@@ -1,0 +1,70 @@
+"""Packaged fingerprint for the client-visible MCP discovery surface."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from importlib.resources import files
+from typing import Any
+
+DISCOVERY_FIELDS = (
+    "name",
+    "title",
+    "description",
+    "inputSchema",
+    "outputSchema",
+    "icons",
+    "annotations",
+    "meta",
+    "execution",
+)
+
+
+def contract() -> dict[str, Any]:
+    """Load the generated, content-free MCP discovery contract."""
+    resource = files("exomem").joinpath("tool_surface_contract.json")
+    payload = json.loads(resource.read_text(encoding="utf-8"))
+    digest = payload.get("sha256")
+    if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise RuntimeError("packaged MCP tool-surface contract has an invalid digest")
+    if payload.get("fields") != list(DISCOVERY_FIELDS):
+        raise RuntimeError("packaged MCP tool-surface contract has unsupported fields")
+    return payload
+
+
+def sha256() -> str:
+    """Return the published canonical-surface fingerprint."""
+    return str(contract()["sha256"])
+
+
+def discovery_contract(wire_tools: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Fingerprint complete MCP Tool objects in deterministic name order."""
+    surface: list[dict[str, Any]] = []
+    for wire in sorted(wire_tools, key=lambda item: str(item["name"])):
+        if tuple(wire) != DISCOVERY_FIELDS:
+            raise RuntimeError(
+                "FastMCP discovery fields changed; review the new wire surface before "
+                "updating exomem.tool_surface.DISCOVERY_FIELDS"
+            )
+        surface.append({field: wire[field] for field in DISCOVERY_FIELDS})
+    canonical = json.dumps(
+        surface,
+        ensure_ascii=False,
+        sort_keys=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return {
+        "contract_version": 1,
+        "fields": list(DISCOVERY_FIELDS),
+        "tool_count": len(surface),
+        "sha256": hashlib.sha256(canonical).hexdigest(),
+    }
+
+
+async def live_contract(mcp: Any) -> dict[str, Any]:
+    """Fingerprint the tools actually registered on one running FastMCP app."""
+    tools = await mcp.list_tools()
+    wires = [tool.to_mcp_tool().model_dump(mode="json") for tool in tools]
+    return discovery_contract(wires)

--- a/src/exomem/tool_surface_contract.json
+++ b/src/exomem/tool_surface_contract.json
@@ -1,0 +1,16 @@
+{
+  "contract_version": 1,
+  "fields": [
+    "name",
+    "title",
+    "description",
+    "inputSchema",
+    "outputSchema",
+    "icons",
+    "annotations",
+    "meta",
+    "execution"
+  ],
+  "tool_count": 25,
+  "sha256": "91927b86184f40dd9e99f98bec4c0d31373a807a2333a4eca947771096b9a5bf"
+}

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -2187,7 +2187,7 @@
             }
           ],
           "default": null,
-          "description": "Required for research-note. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
+          "description": "Required for research-note. (any slug; unknown keys auto-register on first use)"
         },
         "projects": {
           "anyOf": [
@@ -2202,7 +2202,7 @@
             }
           ],
           "default": null,
-          "description": "Optional project keys for cross-project notes. Any slug-shaped key is accepted; unknown keys auto-register on first use (a typo guard rejects near-misses within edit distance 2 of an existing key) and create the matching Notes/Research/<Folder>/. Pass project_category to bucket a new key. Current keys (not exhaustive): personal, project-alpha, project-beta, work."
+          "description": "Optional project keys for cross-project notes. (any slug; unknown keys auto-register on first use)"
         },
         "sources": {
           "anyOf": [

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,9 @@ def test_bootstrap_compact_contract_is_public_safe(vault: Path) -> None:
     assert out["server"]["name"] == "exomem"
     assert out["server"]["content_included"] is False
     assert out["server"]["pure_substrate"] is True
+    assert re.fullmatch(
+        r"[0-9a-f]{64}", out["server"]["published_mcp_tool_surface_sha256"]
+    )
     assert "compute_policy" in out["server"]
     assert {
         "workflow",
@@ -119,7 +123,7 @@ def test_bootstrap_teaches_human_readable_memory_citations(vault: Path) -> None:
     out = commands.op_bootstrap(vault)
     guidance = json.dumps(out["workflow"]).lower()
 
-    assert out["contract_version"] == "2026-07-16.2"
+    assert out["contract_version"] == "2026-07-18.1"
     for required in (
         "show the note title by default",
         "normal user-facing prose",

--- a/tests/test_connector_guardrails.py
+++ b/tests/test_connector_guardrails.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_SURFACE_CONTRACT = REPO_ROOT / "src" / "exomem" / "tool_surface_contract.json"
+CHATGPT_PLUGIN_CONTRACT = (
+    REPO_ROOT / "deploy" / "chatgpt" / "personal-plugin-contract.json"
+)
+
+
+def test_chatgpt_personal_plugin_tracks_current_tool_surface_rollout() -> None:
+    assert TOOL_SURFACE_CONTRACT.is_file(), "missing packaged MCP tool-surface contract"
+    assert CHATGPT_PLUGIN_CONTRACT.is_file(), (
+        "missing ChatGPT Personal Plugin attestation; refresh/recreate the plugin "
+        "before shipping a changed MCP surface"
+    )
+
+    surface = json.loads(TOOL_SURFACE_CONTRACT.read_text(encoding="utf-8"))
+    plugin = json.loads(CHATGPT_PLUGIN_CONTRACT.read_text(encoding="utf-8"))
+
+    assert plugin["mcp_url"] == "https://exomem.substratesystems.io/mcp"
+    assert plugin["authentication"] == "oauth"
+    assert plugin["client_registration"] == "cimd"
+    assert plugin["oidc_enabled"] is False
+    assert plugin["default_scopes"] == []
+    assert plugin["base_scopes"] == []
+    registered = plugin["registered_tool_surface_sha256"]
+    pending = plugin["pending_tool_surface_sha256"]
+    if registered == surface["sha256"]:
+        assert plugin["refresh_required"] is False
+        assert pending is None
+        assert plugin["rollout_state"] == "registered"
+        assert plugin["last_verified_tool_surface_sha256"] == registered
+    else:
+        assert plugin["refresh_required"] is True, (
+            "MCP tool surface changed without a rollout acknowledgement. Record the "
+            "new digest as pending before release; do not claim it is registered yet."
+        )
+        assert pending == surface["sha256"]
+        assert plugin["rollout_state"] == "awaiting-post-deploy-refresh"
+    if registered is not None:
+        assert re.fullmatch(r"[0-9a-f]{64}", registered)
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", plugin["last_verified_at"])
+    assert "bootstrap" in plugin["verification"]
+    assert "ask_memory" in plugin["verification"]
+
+
+def test_operator_connector_host_is_canonical() -> None:
+    instructions = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    connector_section = instructions.split('## Connector triage', 1)[1].split('\n## ', 1)[0]
+
+    assert "exomem.substratesystems.io" in connector_section
+    assert "kb.substratesystems.io" not in connector_section
+
+
+def test_remote_quickstart_documents_chatgpt_oauth_only_setup() -> None:
+    guide = (REPO_ROOT / "docs" / "remote-quickstart.md").read_text(
+        encoding="utf-8"
+    ).lower()
+
+    assert "chatgpt personal plugin" in guide
+    assert "https://<host>/mcp" in guide
+    assert "oidc" in guide and "off" in guide
+    assert "default scopes" in guide and "blank" in guide
+    assert "fresh conversation" in guide

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -219,15 +219,17 @@ def test_delete_detects_directory(vault: Path, monkeypatch) -> None:
     assert not d.exists()
 
 
-# ---------------- note: project key description is dynamic + open ----------------
+# ---------------- note: project key description is stable + open ----------------
 
-def test_remember_project_description_is_dynamic_and_open(vault: Path, monkeypatch) -> None:
-    """The `remember` tool schema must advertise the live project-key set + the
-    auto-register contract, not a frozen closed list.
+def test_remember_project_description_is_stable_and_open(vault: Path, monkeypatch) -> None:
+    """The `remember` schema must expose a stable open-set project contract.
 
     Regression: claude.ai burned reasoning cycles (and nearly misfiled a note)
     treating an unlisted scope like `home` as illegal, because the docstring
     listed a fixed `Valid: ...` enum with no hint that keys auto-register.
+
+    Hosted connector clients cache discovered schemas, so live project names
+    must not leak into the tool description and cause per-vault schema drift.
     """
     mcp = _build(monkeypatch)
     tool = asyncio.run(mcp.get_tool("remember"))
@@ -239,12 +241,11 @@ def test_remember_project_description_is_dynamic_and_open(vault: Path, monkeypat
     assert "__PROJECT_KEYS_HINT__" not in projects_desc
     # Open-set framing: the model must know unlisted keys are legal.
     assert "auto-register" in project_desc.lower()
-    assert "not exhaustive" in project_desc.lower()
+    assert "any slug" in project_desc.lower()
     assert "auto-register" in projects_desc.lower()
-    # The list is sourced from the live registry (fixture falls back to the
-    # built-in set, which includes these), not a hand-maintained string.
-    assert "project-alpha" in project_desc
-    assert "personal" in project_desc
+    # Live registry values must not alter the discovery surface.
+    assert "project-alpha" not in project_desc
+    assert "personal" not in project_desc
 
 
 def test_review_memory_attention_mode_composes_review_surface(vault: Path, monkeypatch) -> None:

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -67,7 +67,7 @@ def test_readiness_endpoint_is_public_and_content_free(
     monkeypatch.setattr(
         runtime_readiness,
         "runtime_readiness",
-        lambda: {
+        lambda **_kwargs: {
             "status": "ready",
             "service": "exomem",
             "release": "1.2.3",
@@ -101,7 +101,7 @@ def test_readiness_endpoint_returns_503_without_changing_liveness(
     monkeypatch.setattr(
         runtime_readiness,
         "runtime_readiness",
-        lambda: {
+        lambda **_kwargs: {
             "status": "not_ready",
             "service": "exomem",
             "release": "1.2.3",

--- a/tests/test_mcp_schema_fidelity.py
+++ b/tests/test_mcp_schema_fidelity.py
@@ -23,17 +23,32 @@ no overlap and no silent gap).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import shutil
 from pathlib import Path
 
 import pytest
+from starlette.testclient import TestClient
 
+from exomem import project_keys as project_keys_module
 from exomem import server as server_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "mcp_tool_schemas.json"
+TOOL_SURFACE_CONTRACT_PATH = REPO_ROOT / "src" / "exomem" / "tool_surface_contract.json"
 FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
+DISCOVERY_FIELDS = (
+    "name",
+    "title",
+    "description",
+    "inputSchema",
+    "outputSchema",
+    "icons",
+    "annotations",
+    "meta",
+    "execution",
+)
 
 
 def _build_server(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -69,6 +84,25 @@ def _canonical(entry: dict) -> str:
     return json.dumps(entry, ensure_ascii=False, sort_keys=False, indent=2)
 
 
+def _tool_surface_sha256(mcp) -> tuple[str, int]:
+    tools = asyncio.run(mcp.list_tools())
+    surface = []
+    for tool in sorted(tools, key=lambda item: item.name):
+        wire = tool.to_mcp_tool().model_dump(mode="json")
+        assert tuple(wire) == DISCOVERY_FIELDS, (
+            "FastMCP discovery fields changed; deliberately review and fingerprint "
+            f"the new wire surface: {tuple(wire)}"
+        )
+        surface.append({field: wire[field] for field in DISCOVERY_FIELDS})
+    canonical = json.dumps(
+        surface,
+        ensure_ascii=False,
+        sort_keys=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest(), len(surface)
+
+
 def test_live_tools_match_committed_baseline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -97,6 +131,59 @@ def test_live_tools_match_committed_baseline(
             "",
         )
     )
+
+
+def test_full_mcp_discovery_surface_matches_packaged_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert TOOL_SURFACE_CONTRACT_PATH.is_file(), (
+        "missing packaged tool-surface contract; run scripts/dump-tool-schemas.py"
+    )
+    contract = json.loads(TOOL_SURFACE_CONTRACT_PATH.read_text(encoding="utf-8"))
+    digest, tool_count = _tool_surface_sha256(_build_server(monkeypatch, tmp_path))
+
+    assert contract["fields"] == list(DISCOVERY_FIELDS)
+    assert contract["tool_count"] == tool_count
+    assert contract["sha256"] == digest, (
+        "full MCP discovery surface drifted; run scripts/dump-tool-schemas.py, "
+        "then refresh and verify every registered external connector"
+    )
+
+
+def test_remember_discovery_schema_is_vault_invariant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mcp_before = _build_server(monkeypatch, tmp_path)
+    before = {
+        tool.name: tool.to_mcp_tool().model_dump(mode="json")
+        for tool in asyncio.run(mcp_before.list_tools())
+    }["remember"]
+
+    vault_root = tmp_path / "schema_vault"
+    project_keys_module.register_project_key(vault_root, "new-project-key")
+    mcp_after = server_module.build_server(require_auth=False)
+    after = {
+        tool.name: tool.to_mcp_tool().model_dump(mode="json")
+        for tool in asyncio.run(mcp_after.list_tools())
+    }["remember"]
+
+    assert after == before, (
+        "remember discovery changed when the vault gained a project key; dynamic "
+        "tool schemas silently invalidate hosted connector registrations"
+    )
+
+
+def test_readiness_fingerprint_matches_actual_registered_surface(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MCP_LEGACY_COMPAT", "1")
+    mcp = _build_server(monkeypatch, tmp_path)
+    actual_digest, _ = _tool_surface_sha256(mcp)
+
+    response = TestClient(mcp.http_app()).get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json()["mcp_tool_surface_sha256"] == actual_digest
 
 
 def test_hand_registered_exceptions_are_explicit(

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -16,7 +16,12 @@ def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
             "coordinator_healthy": True,
         },
         release="1.2.3",
+        mcp_tool_surface_sha256="a" * 64,
     )
+
+    fingerprint = snapshot.pop("mcp_tool_surface_sha256", None)
+    assert isinstance(fingerprint, str)
+    assert fingerprint == "a" * 64
 
     assert snapshot == {
         "status": "ready",
@@ -47,6 +52,7 @@ def test_healthy_coordinated_follower_is_takeover_eligible() -> None:
             "coordinator_healthy": True,
         },
         release="1.2.4",
+        mcp_tool_surface_sha256="b" * 64,
     )
 
     assert snapshot["status"] == "ready"
@@ -72,6 +78,7 @@ def test_coordinator_outage_is_not_ready_and_uses_stable_reason() -> None:
             "coordinator_healthy": False,
         },
         release="1.2.3",
+        mcp_tool_surface_sha256="c" * 64,
     )
 
     assert snapshot["status"] == "not_ready"
@@ -88,6 +95,7 @@ def test_missing_replica_identity_is_not_ready_when_coordination_enabled() -> No
             "coordinator_healthy": True,
         },
         release="1.2.3",
+        mcp_tool_surface_sha256="d" * 64,
     )
 
     assert snapshot["status"] == "not_ready"

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -174,3 +174,11 @@ def test_openid_discovery_alias_returns_oauth_metadata() -> None:
     assert metadata["token_endpoint"] == "https://memory.example/token"
     assert metadata["registration_endpoint"] == "https://memory.example/register"
     assert metadata["code_challenge_methods_supported"] == ["S256"]
+    assert "openid" not in metadata["scopes_supported"]
+    for oidc_only_field in (
+        "userinfo_endpoint",
+        "jwks_uri",
+        "subject_types_supported",
+        "id_token_signing_alg_values_supported",
+    ):
+        assert oidc_only_field not in metadata

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -382,5 +382,8 @@ def test_windows_installer_gates_remote_and_verifies_before_success() -> None:
     assert "function Test-McpEndpoint" in text
     assert "-SkipHttpErrorCheck" in text
     assert "OAuth is not enforced" in text
+    assert "CHATGPT_PLUGIN_REFRESH_REQUIRED" in text
+    assert "connector rollout is incomplete" in text
     assert text.index("Preflight: exomem doctor --profile remote") < text.index("& $NssmPath install")
     assert text.index("Test-McpEndpoint -HostName") < text.index("Granted no-UAC")
+    assert text.index("Test-McpEndpoint -HostName") < text.index("CHATGPT_PLUGIN_REFRESH_REQUIRED")


### PR DESCRIPTION
## What changed

- replace the stale `kb.substratesystems.io` operator reference with the canonical Exomem hostname
- make product MCP discovery vault-invariant instead of embedding live project keys
- fingerprint the complete MCP `Tool` wire surface
- expose the actual running fingerprint from `/health/ready` and the packaged canonical fingerprint from `bootstrap`
- add a truthful two-phase ChatGPT Personal Plugin contract: pending before deployment, registered only after a fresh-chat smoke test
- pin OAuth + CIMD, blank scopes, and OIDC off in the documented setup
- make the Windows service installer emit `CHATGPT_PLUGIN_REFRESH_REQUIRED` while connector promotion is pending
- gate release publication on connector rollout state and smoke the fingerprint resource from the built wheel

## Why

The 2026-07-18 incident combined a retired hostname, ChatGPT OIDC misclassification, a stale Personal Plugin tool snapshot, and poisoned per-thread policy state. Existing schema fidelity tests only protected the committed fixture; they did not force downstream connector rollout acknowledgement, and the live `remember` description could drift whenever project keys changed.

## Impact

Future MCP discovery changes cannot silently pass as a completed connector rollout. Operators can compare the deployed process fingerprint to the pending/registered contract, and service installation no longer claims the ChatGPT integration is complete before post-deploy verification.

ChatGPT-owned thread policy remains an external limit: an already-poisoned conversation still requires a fresh conversation.

## Verification

- `33 passed` across connector guardrails, MCP schema fidelity, readiness, bootstrap, OAuth metadata, public readiness, and the Windows installer contract
- Ruff: all changed Python files pass
- Wheel build succeeds and zip-imports `exomem.tool_surface`; packaged contract reports 25 tools with digest `91927b86184f40dd9e99f98bec4c0d31373a807a2333a4eca947771096b9a5bf`
- Independent review found no remaining high-severity flaw
