### PR TITLE
Add durable OAuth refresh tokens

### DIFF
--- a/deploy/chatgpt/personal-plugin-contract.json
+++ b/deploy/chatgpt/personal-plugin-contract.json
@@ -5,7 +5,7 @@
   "client_registration": "cimd",
   "oidc_enabled": false,
   "default_scopes": [],
-  "base_scopes": [],
+  "base_scopes": ["offline_access"],
   "registered_tool_surface_sha256": null,
   "pending_tool_surface_sha256": "91927b86184f40dd9e99f98bec4c0d31373a807a2333a4eca947771096b9a5bf",
   "refresh_required": true,

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -219,8 +219,10 @@ asking it to call `bootstrap(profile="compact")` once before using the KB.
 Create the Personal Plugin with MCP Server URL `https://<host>/mcp` and
 Authentication set to **OAuth**. Keep the discovered authorization, token,
 registration, authorization-server, resource, CIMD metadata, and callback
-values. Leave **Default scopes** and **Base scopes** blank, and turn **OIDC
-enabled** off. Exomem deliberately provides OAuth authorization-code flow, not
+values. Leave **Default scopes** blank, set **Base scopes** to
+`offline_access`, and turn **OIDC enabled** off. That base scope lets Exomem's
+one-hour access tokens renew through durable rotating refresh tokens without
+another GitHub login. Exomem deliberately provides OAuth authorization-code flow, not
 OpenID identity claims; the compatibility discovery alias is not permission to
 invent a `userinfo` endpoint. In particular, never accept a placeholder such as
 `https://example.com` for that field.

--- a/openspec/changes/add-durable-oauth-refresh-tokens/.openspec.yaml
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-durable-oauth-refresh-tokens/design.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/design.md
@@ -45,7 +45,7 @@ Alternative considered: rotate a mutable `current_sequence` field with ordinary 
 
 ### 4. Family revocation is authoritative and generation rotation remains the global kill switch
 
-Revoking an `exo_r2` token revokes its complete family. Revoking an `exo_a2` token tombstones that access token only. Reuse detection revokes the family and therefore invalidates every access token bound to it. Replacing the existing signing generation invalidates legacy sessions, v2 access tokens, and refresh families without enumerating records. Unknown tokens still receive RFC 7009's non-disclosing success response.
+Revoking an `exo_r2` or `exo_a2` token revokes its complete family; otherwise an operator or client could "disconnect" an access token and have it silently resurrected through refresh. Reuse detection likewise revokes the family and therefore invalidates every access token bound to it. Replacing the existing signing generation invalidates legacy sessions, v2 access tokens, and refresh families without enumerating records. Unknown tokens still receive RFC 7009's non-disclosing success response.
 
 ### 5. Honest discovery and bounded scope behavior
 

--- a/openspec/changes/add-durable-oauth-refresh-tokens/design.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/design.md
@@ -37,9 +37,9 @@ Alternative considered: store each next refresh bearer encrypted in a redemption
 
 ### 3. Atomic redemption receipts implement rotation and retry idempotency
 
-Redeeming refresh sequence `n` atomically creates one encrypted receipt keyed by `(family_id, n)` via the existing shared `put_if_absent`. The winner returns the deterministic `n+1` refresh token and a new one-hour access token. A concurrent or repeated redemption that observes the same receipt within 30 seconds returns the same `n+1` refresh token and may issue a fresh access token. A use after that window tombstones the family as refresh-token reuse and returns `invalid_grant`.
+Redeeming refresh sequence `n` creates one permanent encrypted receipt keyed by `(family_id, n)` via the existing shared `put_if_absent`. A matching encrypted grace marker carries the same random claim ID and a 30-second TTL enforced by the authoritative storage coordinator, not a replica clock. Creating the grace marker before the permanent receipt makes crash recovery safe; claim-ID matching prevents a late observer from recreating an expired marker around an older receipt. The winner returns the deterministic `n+1` refresh token and a new one-hour access token. A concurrent or repeated redemption with the matching live marker returns the same `n+1` refresh token and may issue a fresh access token. A use after the marker expires tombstones the family as refresh-token reuse and returns `invalid_grant`.
 
-No compare-and-swap or replica-local lock is required: the receipt is the single global claim. Family state is re-read after claiming and access-token validation checks the family, so a concurrent family revocation fails closed or invalidates any just-issued access token.
+No compare-and-swap, replica-local clock, or replica-local lock is required: the permanent receipt plus coordinator-TTL marker is the single global claim. Family state is re-read after claiming and access-token validation checks the family, so a concurrent family revocation fails closed or invalidates any just-issued access token.
 
 Alternative considered: rotate a mutable `current_sequence` field with ordinary writes. Rejected because the current store has no compare-and-swap and two replicas could both accept different rotations or overwrite revocation state.
 

--- a/openspec/changes/add-durable-oauth-refresh-tokens/design.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Exomem uses GitHub only to prove the configured user's identity, then replaces the upstream credential with an Exomem-owned opaque `exo_s1` session stored through the encrypted local/shared session authority. Those sessions intentionally have no expiry or refresh path. The proxy nevertheless inherits FastMCP metadata that advertises the refresh grant, while `load_refresh_token` returns `None` and `exchange_refresh_token` returns `invalid_grant`. ChatGPT now depends on a real offline refresh contract and freezes discovered OAuth/tool metadata into an app version, so the mismatch produces manual reconnects and misleading connector setup.
+
+The current authority already provides purpose-separated HMAC/encryption keys, encrypted durable collections, an atomic `put_if_absent`, generation-based global invalidation, and uncached remote-canonical reads. Those primitives must remain the source of truth across the laptop writer, passive replicas, and process restarts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give clients requesting `offline_access` a one-hour opaque access token and a durable rotating refresh token.
+- Make a refresh retry safe across concurrent ChatGPT workers, processes, restarts, and replicas without persisting raw bearer tokens.
+- Detect refresh-token reuse outside a short retry window and revoke the complete token family.
+- Keep every existing `exo_s1` session valid and keep the old non-expiring issuance behavior for clients that do not request `offline_access`.
+- Make canonical and compatibility discovery documents accurately advertise the supported scopes and grant.
+
+**Non-Goals:**
+
+- Retaining or refreshing GitHub credentials after identity bootstrap.
+- Replacing OAuth with OIDC or issuing ID tokens.
+- Forcing existing Codex, Claude, or other clients to reconnect during deployment.
+- Solving ChatGPT's frozen tool snapshot in place; the post-deploy connector must be refreshed or recreated once.
+
+## Decisions
+
+### 1. Opt-in v2 token family alongside legacy sessions
+
+An authorization code whose granted scopes include `offline_access` produces an `exo_a2` access token, an `exo_r2` refresh token, `expires_in=3600`, and the granted scope string. Authorization without `offline_access` continues to produce the current non-expiring `exo_s1` bearer with no refresh token. Validation accepts both formats, so rollout is additive and existing records require no rewrite.
+
+Alternative considered: convert every authorization to expiring access tokens. Rejected because clients that do not request or implement refresh would be disconnected after one hour and existing connector behavior would regress.
+
+### 2. Opaque deterministic refresh descendants with encrypted family metadata
+
+Each refresh family has a random family identifier and immutable encrypted metadata: client, scopes, identity, issuer, audience, signing generation, creation time, and active/revoked state. Refresh tokens contain only a version, family identifier, monotonically increasing sequence, and a purpose-separated HMAC proof. The next token is deterministically derived for `sequence + 1`; raw refresh bearers are never stored. Access records retain only their existing keyed digest plus expiry and family identifier.
+
+Alternative considered: store each next refresh bearer encrypted in a redemption record. Rejected because deterministic descendants give idempotent responses without keeping reusable bearer material at rest.
+
+### 3. Atomic redemption receipts implement rotation and retry idempotency
+
+Redeeming refresh sequence `n` atomically creates one encrypted receipt keyed by `(family_id, n)` via the existing shared `put_if_absent`. The winner returns the deterministic `n+1` refresh token and a new one-hour access token. A concurrent or repeated redemption that observes the same receipt within 30 seconds returns the same `n+1` refresh token and may issue a fresh access token. A use after that window tombstones the family as refresh-token reuse and returns `invalid_grant`.
+
+No compare-and-swap or replica-local lock is required: the receipt is the single global claim. Family state is re-read after claiming and access-token validation checks the family, so a concurrent family revocation fails closed or invalidates any just-issued access token.
+
+Alternative considered: rotate a mutable `current_sequence` field with ordinary writes. Rejected because the current store has no compare-and-swap and two replicas could both accept different rotations or overwrite revocation state.
+
+### 4. Family revocation is authoritative and generation rotation remains the global kill switch
+
+Revoking an `exo_r2` token revokes its complete family. Revoking an `exo_a2` token tombstones that access token only. Reuse detection revokes the family and therefore invalidates every access token bound to it. Replacing the existing signing generation invalidates legacy sessions, v2 access tokens, and refresh families without enumerating records. Unknown tokens still receive RFC 7009's non-disclosing success response.
+
+### 5. Honest discovery and bounded scope behavior
+
+The authorization server advertises `offline_access`, `exomem:read`, and `exomem:write` as valid scopes and continues advertising both `authorization_code` and `refresh_token` grants. The protected-resource documents advertise the resource scopes. Refresh requests may retain or narrow the originally granted scopes but cannot expand them. `offline_access` is a protocol scope, not an additional MCP authorization requirement.
+
+## Risks / Trade-offs
+
+- [A client retries a consumed refresh token after 30 seconds because its first response was lost] → Treat it as possible credential theft and revoke the family; the client must reauthorize. The 30-second window covers normal concurrent/retry races without leaving replay acceptance open indefinitely.
+- [The shared authority becomes unavailable during refresh] → Return retryable `temporarily_unavailable`/HTTP 503 and do not fall back to replica-local state or mint an untracked token.
+- [A failure occurs after the redemption receipt is committed but before the response is delivered] → Retries within the window reconstruct the same next refresh token and can issue another access token.
+- [A replay races a legitimate current-token redemption] → Re-read family state after the atomic claim and check it on every v2 access validation; revocation wins from the caller's perspective.
+- [Discovery metadata is cached by ChatGPT] → Release and deploy first, then refresh actions or recreate the app once; no server-side change can mutate an already-frozen connector snapshot.
+
+## Migration Plan
+
+1. Add v2 codecs and backward-compatible records to the session authority, with tests proving old v1 records still parse and validate.
+2. Add refresh-family issuance, load, rotation, idempotency, replay detection, and revocation using encrypted shared collections.
+3. Wire the OAuth proxy and discovery metadata, then run focused auth tests, the full suite, lint, and an independent security review.
+4. Release 0.24.2 and restart the Exomem service. Existing `exo_s1` sessions continue without intervention.
+5. Recreate or refresh the ChatGPT Exomem app with `offline_access` as its base scope, authorize once, and verify a refresh grant succeeds without GitHub interaction.
+6. Roll back the service package if necessary. V2 tokens then fail closed on the old version while legacy sessions remain usable; restoring 0.24.2 restores the durable v2 records because storage is versioned and retained.
+
+## Open Questions
+
+None. The lifetime, retry window, rotation, replay, revocation, compatibility, and rollout behavior are fixed by this change.

--- a/openspec/changes/add-durable-oauth-refresh-tokens/proposal.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Exomem currently advertises OAuth refresh-token support while issuing only non-expiring session bearers and rejecting the refresh grant. ChatGPT therefore cannot renew credentials reliably after connector expiry, reconnect, service restart, or replica failover, producing avoidable manual reauthentication and a misleading discovery contract.
+
+## What Changes
+
+- Issue one-hour access tokens plus durable, rotating refresh tokens to OAuth clients that request `offline_access`.
+- Make refresh-token redemption restart-safe and replica-safe, with a short idempotency window for concurrent retries and whole-family revocation when an already-rotated token is replayed after that window.
+- Advertise the actual `offline_access` scope and refresh grant in OAuth discovery metadata.
+- Preserve existing `exo_s1` session validation so installed Codex and Claude connections are not forced to log in again.
+- Extend revocation and operational tests to cover refresh families, concurrency, replay, restart/failover, and legacy-session compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+- `durable-oauth-refresh`: Defines Exomem-owned access/refresh token issuance, rotation, concurrency handling, revocation, discovery, and legacy-session compatibility.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: OAuth proxy, session authority/storage records, authorization-server metadata, revocation handling, and auth boundary tests under `src/exomem/` and `tests/`.
+- Affected APIs: `/authorize`, `/token`, `/revoke`, and OAuth/OIDC discovery documents at `exomem.substratesystems.io`.
+- Persistence: refresh-family state and redemption receipts use the existing shared encrypted OAuth storage/coordinator so behavior survives process and replica changes; raw bearer tokens are never persisted.
+- Rollout: release 0.24.2, deploy the service, then recreate or refresh the ChatGPT connector once so its frozen OAuth/tool snapshot includes the corrected metadata.

--- a/openspec/changes/add-durable-oauth-refresh-tokens/specs/durable-oauth-refresh/spec.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/specs/durable-oauth-refresh/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Offline authorization issues bounded access and durable refresh credentials
+When the granted OAuth scopes include `offline_access`, Exomem SHALL issue an opaque access token valid for 3600 seconds and an opaque refresh token valid until its family is explicitly revoked or its signing generation is replaced. The credentials MUST be bound to the authenticated identity, OAuth client, issuer, audience, generation, and granted scopes, and Exomem MUST NOT retain the upstream GitHub access or refresh credential after identity bootstrap.
+
+#### Scenario: Client completes offline authorization
+- **WHEN** an authorized client exchanges a valid authorization code whose granted scopes include `offline_access`
+- **THEN** the token response contains `token_type=Bearer`, `expires_in=3600`, the granted scopes, an opaque access token, and an opaque refresh token
+- **AND** subsequent access validation uses only the Exomem authority and does not contact GitHub
+
+#### Scenario: Client authorizes without offline access
+- **WHEN** an authorized client exchanges a valid authorization code without the `offline_access` scope
+- **THEN** Exomem issues the existing non-expiring `exo_s1` session without a refresh token
+- **AND** the client is not silently migrated to an expiring credential it cannot refresh
+
+### Requirement: Refresh rotation is durable and cannot expand authority
+Exomem SHALL accept an active refresh token only for its bound client and SHALL rotate it to a deterministic next refresh token while issuing a new 3600-second access token. A refresh request MAY retain or narrow the original scopes and MUST NOT add a scope outside the refresh family's grant. Family and redemption state MUST use the authoritative encrypted session store so rotation survives service restart and replica failover, and raw bearer tokens MUST NOT be persisted.
+
+#### Scenario: Active token rotates successfully
+- **WHEN** the bound client redeems an active refresh token with its original scopes or a subset
+- **THEN** Exomem returns a new one-hour access token and the next refresh token in the family
+- **AND** the consumed refresh sequence cannot begin another independent rotation
+
+#### Scenario: Refresh attempts to expand scopes
+- **WHEN** a client requests a scope that was not granted to the refresh family
+- **THEN** Exomem rejects the request with `invalid_scope`
+- **AND** the refresh token remains usable with its original scopes
+
+#### Scenario: Service or replica changes between rotations
+- **WHEN** one process issues a refresh token and another process handles its redemption after restart or failover
+- **THEN** the second process observes the same family and redemption state and completes exactly the same rotation contract
+
+### Requirement: Concurrent refresh retries are briefly idempotent
+The first redemption of a refresh sequence SHALL create one atomic shared redemption receipt. Every redemption of that same token within 30 seconds of the first SHALL return the same next refresh token and MUST NOT be classified as theft; each response MAY contain a distinct valid access token.
+
+#### Scenario: Two ChatGPT workers refresh concurrently
+- **WHEN** two valid requests for the same refresh token race across one or more Exomem processes
+- **THEN** exactly one atomic redemption receipt is created
+- **AND** both successful responses contain the same next refresh token
+
+#### Scenario: First refresh response is lost
+- **WHEN** the bound client retries the consumed refresh token within 30 seconds because it did not receive the first response
+- **THEN** Exomem reconstructs the same next refresh token from durable state and succeeds without GitHub reauthorization
+
+### Requirement: Late refresh-token reuse revokes the family
+A consumed refresh token presented more than 30 seconds after its first redemption SHALL be treated as refresh-token reuse. Exomem MUST revoke the complete family, return `invalid_grant`, and reject every refresh token and access token bound to that family thereafter.
+
+#### Scenario: Rotated token is replayed after the retry window
+- **WHEN** a previously consumed refresh token is presented more than 30 seconds after its redemption
+- **THEN** Exomem returns `invalid_grant` and durably revokes the refresh family
+- **AND** the current refresh token and all family-bound access tokens no longer validate
+
+#### Scenario: Replay races the current token
+- **WHEN** late reuse of an old token races a legitimate redemption of the current family token
+- **THEN** family state is rechecked at the security boundary and the family ends revoked
+- **AND** no access token remains usable after revocation is authoritative
+
+### Requirement: Revocation and signing rotation fail closed
+Revoking a refresh token SHALL revoke its complete family, while revoking a v2 access token SHALL revoke that access token. Replacing the signing generation SHALL invalidate every legacy session, v2 access token, and refresh family issued under the old generation. Revocation endpoints MUST NOT disclose whether an unknown token existed.
+
+#### Scenario: Client disconnects an offline grant
+- **WHEN** the client revokes any refresh token from an active family
+- **THEN** every refresh token in that family and every family-bound access token is rejected thereafter
+
+#### Scenario: Operator rotates the signing generation
+- **WHEN** the operator replaces the active signing generation
+- **THEN** all credentials bound to the prior generation fail validation without a per-record migration
+
+#### Scenario: Unknown token is revoked
+- **WHEN** a caller submits an unknown or malformed token to the revocation endpoint
+- **THEN** Exomem returns the standard non-disclosing revocation success response
+
+### Requirement: Legacy sessions remain compatible
+Deployment of durable refresh support MUST preserve the parsing, validation, listing, and explicit revocation behavior of existing `exo_s1` records. No deployment or connector recreation for the new flow SHALL automatically revoke those sessions.
+
+#### Scenario: Existing Codex or Claude session crosses the deployment
+- **WHEN** an active `exo_s1` session issued by version 0.24.1 is presented after version 0.24.2 starts
+- **THEN** Exomem validates it under the existing issuer, audience, digest, status, and generation rules
+- **AND** the user is not forced to reconnect
+
+### Requirement: Discovery advertises the implemented offline contract
+The canonical authorization-server metadata and compatibility OIDC alias SHALL advertise `authorization_code` and `refresh_token` grants plus the supported `offline_access`, `exomem:read`, and `exomem:write` scopes. Protected-resource metadata SHALL advertise the resource scopes, and Exomem MUST NOT advertise OIDC userinfo or ID-token support it does not implement.
+
+#### Scenario: ChatGPT discovers OAuth settings
+- **WHEN** ChatGPT reads Exomem's authorization-server, protected-resource, or compatibility discovery document
+- **THEN** the document identifies the Exomem authorization, token, registration, resource, and supported-scope contract consistently
+- **AND** ChatGPT can select `offline_access` as a base scope before creating the connector
+
+#### Scenario: Connector refreshes without GitHub
+- **WHEN** an installed connector uses the advertised refresh grant after its one-hour access token expires
+- **THEN** Exomem rotates the refresh token and issues a new access token without redirecting the user to GitHub

--- a/openspec/changes/add-durable-oauth-refresh-tokens/specs/durable-oauth-refresh/spec.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/specs/durable-oauth-refresh/spec.md
@@ -56,10 +56,10 @@ A consumed refresh token presented more than 30 seconds after its first redempti
 - **AND** no access token remains usable after revocation is authoritative
 
 ### Requirement: Revocation and signing rotation fail closed
-Revoking a refresh token SHALL revoke its complete family, while revoking a v2 access token SHALL revoke that access token. Replacing the signing generation SHALL invalidate every legacy session, v2 access token, and refresh family issued under the old generation. Revocation endpoints MUST NOT disclose whether an unknown token existed.
+Revoking a refresh token or v2 access token SHALL revoke its complete family so the credential cannot silently resurrect through refresh. Replacing the signing generation SHALL invalidate every legacy session, v2 access token, and refresh family issued under the old generation. Revocation endpoints MUST NOT disclose whether an unknown token existed.
 
 #### Scenario: Client disconnects an offline grant
-- **WHEN** the client revokes any refresh token from an active family
+- **WHEN** the client revokes any refresh token or access token from an active family
 - **THEN** every refresh token in that family and every family-bound access token is rejected thereafter
 
 #### Scenario: Operator rotates the signing generation

--- a/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
@@ -18,7 +18,7 @@
 
 ## 4. Verification and Rollout
 
-- [ ] 4.1 Run focused auth/session tests, the full test suite with embeddings disabled, and `ruff check`.
+- [x] 4.1 Run focused auth/session tests, the full test suite with embeddings disabled, and `ruff check`.
 - [x] 4.2 Run an independent security review covering concurrent refresh races, replay, revocation, secret persistence, failover, and legacy compatibility; address every actionable finding.
 - [ ] 4.3 Open the implementation PR, pass CI, release version 0.24.2, deploy/restart Exomem, and verify health plus public OAuth discovery.
 - [ ] 4.4 Refresh or recreate the ChatGPT Exomem app with base scope `offline_access`, authorize once, and verify an actual refresh grant succeeds without GitHub reauthentication.

--- a/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
@@ -19,6 +19,6 @@
 ## 4. Verification and Rollout
 
 - [ ] 4.1 Run focused auth/session tests, the full test suite with embeddings disabled, and `ruff check`.
-- [ ] 4.2 Run an independent security review covering concurrent refresh races, replay, revocation, secret persistence, failover, and legacy compatibility; address every actionable finding.
+- [x] 4.2 Run an independent security review covering concurrent refresh races, replay, revocation, secret persistence, failover, and legacy compatibility; address every actionable finding.
 - [ ] 4.3 Open the implementation PR, pass CI, release version 0.24.2, deploy/restart Exomem, and verify health plus public OAuth discovery.
 - [ ] 4.4 Refresh or recreate the ChatGPT Exomem app with base scope `offline_access`, authorize once, and verify an actual refresh grant succeeds without GitHub reauthentication.

--- a/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Token Authority Tests
 
-- [ ] 1.1 Add failing codec and record tests for `exo_a2` access tokens, deterministic `exo_r2` refresh descendants, expiry, encrypted family metadata, and v1 record compatibility.
-- [ ] 1.2 Add failing authority tests for offline issuance, successful rotation, scope narrowing, 30-second retry idempotency, late-replay family revocation, and access invalidation.
-- [ ] 1.3 Add failing shared-storage tests proving concurrent claims, restart/failover behavior, and fail-closed store outages.
+- [x] 1.1 Add failing codec and record tests for `exo_a2` access tokens, deterministic `exo_r2` refresh descendants, expiry, encrypted family metadata, and v1 record compatibility.
+- [x] 1.2 Add failing authority tests for offline issuance, successful rotation, scope narrowing, 30-second retry idempotency, late-replay family revocation, and access invalidation.
+- [x] 1.3 Add failing shared-storage tests proving concurrent claims, restart/failover behavior, and fail-closed store outages.
 
 ## 2. Token Authority Implementation
 
-- [ ] 2.1 Add purpose-separated v2 access/refresh codecs and backward-compatible session record fields without changing `exo_s1` validation.
-- [ ] 2.2 Add encrypted refresh-family and redemption-receipt records plus offline family issuance to `SessionAuthority`.
-- [ ] 2.3 Implement atomic refresh rotation, deterministic retry responses, late-replay family revocation, v2 access expiry/family checks, and refresh/access revocation.
+- [x] 2.1 Add purpose-separated v2 access/refresh codecs and backward-compatible session record fields without changing `exo_s1` validation.
+- [x] 2.2 Add encrypted refresh-family and redemption-receipt records plus offline family issuance to `SessionAuthority`.
+- [x] 2.3 Implement atomic refresh rotation, deterministic retry responses, late-replay family revocation, v2 access expiry/family checks, and refresh/access revocation.
 
 ## 3. OAuth Boundary
 
-- [ ] 3.1 Add failing proxy and HTTP boundary tests for offline authorization-code exchange, refresh loading/exchange, invalid client/scope/grant behavior, RFC 7009 revocation, and absence of GitHub/legacy FastMCP token-store access.
-- [ ] 3.2 Wire the v2 authority into `ExomemSessionOAuthProxy` while retaining legacy issuance for authorization without `offline_access`.
-- [ ] 3.3 Add failing discovery tests, then advertise `offline_access`, `exomem:read`, and `exomem:write` consistently in canonical and compatibility OAuth metadata.
+- [x] 3.1 Add failing proxy and HTTP boundary tests for offline authorization-code exchange, refresh loading/exchange, invalid client/scope/grant behavior, RFC 7009 revocation, and absence of GitHub/legacy FastMCP token-store access.
+- [x] 3.2 Wire the v2 authority into `ExomemSessionOAuthProxy` while retaining legacy issuance for authorization without `offline_access`.
+- [x] 3.3 Add failing discovery tests, then advertise `offline_access`, `exomem:read`, and `exomem:write` consistently in canonical and compatibility OAuth metadata.
 
 ## 4. Verification and Rollout
 

--- a/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
+++ b/openspec/changes/add-durable-oauth-refresh-tokens/tasks.md
@@ -1,0 +1,24 @@
+## 1. Token Authority Tests
+
+- [ ] 1.1 Add failing codec and record tests for `exo_a2` access tokens, deterministic `exo_r2` refresh descendants, expiry, encrypted family metadata, and v1 record compatibility.
+- [ ] 1.2 Add failing authority tests for offline issuance, successful rotation, scope narrowing, 30-second retry idempotency, late-replay family revocation, and access invalidation.
+- [ ] 1.3 Add failing shared-storage tests proving concurrent claims, restart/failover behavior, and fail-closed store outages.
+
+## 2. Token Authority Implementation
+
+- [ ] 2.1 Add purpose-separated v2 access/refresh codecs and backward-compatible session record fields without changing `exo_s1` validation.
+- [ ] 2.2 Add encrypted refresh-family and redemption-receipt records plus offline family issuance to `SessionAuthority`.
+- [ ] 2.3 Implement atomic refresh rotation, deterministic retry responses, late-replay family revocation, v2 access expiry/family checks, and refresh/access revocation.
+
+## 3. OAuth Boundary
+
+- [ ] 3.1 Add failing proxy and HTTP boundary tests for offline authorization-code exchange, refresh loading/exchange, invalid client/scope/grant behavior, RFC 7009 revocation, and absence of GitHub/legacy FastMCP token-store access.
+- [ ] 3.2 Wire the v2 authority into `ExomemSessionOAuthProxy` while retaining legacy issuance for authorization without `offline_access`.
+- [ ] 3.3 Add failing discovery tests, then advertise `offline_access`, `exomem:read`, and `exomem:write` consistently in canonical and compatibility OAuth metadata.
+
+## 4. Verification and Rollout
+
+- [ ] 4.1 Run focused auth/session tests, the full test suite with embeddings disabled, and `ruff check`.
+- [ ] 4.2 Run an independent security review covering concurrent refresh races, replay, revocation, secret persistence, failover, and legacy compatibility; address every actionable finding.
+- [ ] 4.3 Open the implementation PR, pass CI, release version 0.24.2, deploy/restart Exomem, and verify health plus public OAuth discovery.
+- [ ] 4.4 Refresh or recreate the ChatGPT Exomem app with base scope `offline_access`, authorize once, and verify an actual refresh grant succeeds without GitHub reauthentication.

--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -422,7 +422,7 @@ class RefreshRedemptionRecord:
     schema_version: int
     family_id: str
     sequence: int
-    redeemed_at: float
+    claim_id: str
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -434,7 +434,7 @@ class RefreshRedemptionRecord:
                 schema_version=int(value["schema_version"]),
                 family_id=str(value["family_id"]),
                 sequence=int(value["sequence"]),
-                redeemed_at=float(value["redeemed_at"]),
+                claim_id=str(value["claim_id"]),
             )
         except (KeyError, TypeError, ValueError) as error:
             raise ValueError("invalid refresh redemption record") from error
@@ -442,8 +442,7 @@ class RefreshRedemptionRecord:
             record.schema_version != _ACCESS_SCHEMA_VERSION
             or not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", record.family_id)
             or record.sequence < 0
-            or not math.isfinite(record.redeemed_at)
-            or record.redeemed_at <= 0
+            or not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", record.claim_id)
         ):
             raise ValueError("invalid refresh redemption record")
         return record
@@ -533,7 +532,12 @@ class _EncryptedStorage:
             raise self._unavailable("write", error) from error
 
     async def put_if_absent(
-        self, key: str, value: Mapping[str, Any], *, collection: str
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str,
+        ttl: float | None = None,
     ) -> bool:
         encrypted = self._encrypt(value)
         try:
@@ -542,7 +546,14 @@ class _EncryptedStorage:
                 raise SessionStoreUnavailable(
                     "session store lacks atomic put-if-absent support"
                 )
-            return bool(await operation(key, encrypted, collection=collection))
+            return bool(
+                await operation(
+                    key,
+                    encrypted,
+                    collection=collection,
+                    ttl=ttl,
+                )
+            )
         except Exception as error:
             if isinstance(error, SessionStoreUnavailable):
                 raise
@@ -695,6 +706,9 @@ class SessionAuthority:
         self.refresh_redemptions_collection = (
             f"exomem-auth-refresh-redemptions-v2-{keys.fingerprint}"
         )
+        self.refresh_grace_collection = (
+            f"exomem-auth-refresh-grace-v2-{keys.fingerprint}"
+        )
         self._storage = _EncryptedStorage(storage, keys.storage_key)
 
     @classmethod
@@ -793,9 +807,9 @@ class SessionAuthority:
 
     @staticmethod
     def _normalize_scopes(scopes: Sequence[str]) -> tuple[str, ...]:
-        normalized = tuple(str(scope) for scope in scopes)
-        if any(not scope for scope in normalized) or len(set(normalized)) != len(normalized):
-            raise ValueError("session scopes must be non-empty and unique")
+        normalized = tuple(dict.fromkeys(str(scope) for scope in scopes))
+        if any(not scope for scope in normalized):
+            raise ValueError("session scopes must be non-empty")
         return normalized
 
     async def issue(
@@ -997,42 +1011,87 @@ class SessionAuthority:
         if any(scope not in grant.scopes for scope in normalized_scopes):
             raise InvalidRefreshToken("refresh scopes exceed the family grant")
 
-        now = float(self.clock())
-        receipt = RefreshRedemptionRecord(
-            schema_version=_ACCESS_SCHEMA_VERSION,
-            family_id=grant.family_id,
-            sequence=grant.sequence,
-            redeemed_at=now,
-        )
         receipt_key = f"{grant.family_id}.{grant.sequence}"
-        created = await self._storage.put_if_absent(
+
+        def parse_redemption(
+            raw: Mapping[str, Any],
+            *,
+            label: str,
+        ) -> RefreshRedemptionRecord:
+            try:
+                record = RefreshRedemptionRecord.from_dict(raw)
+            except ValueError as error:
+                raise SessionStoreUnavailable(f"refresh {label} record is corrupt") from error
+            if record.family_id != grant.family_id or record.sequence != grant.sequence:
+                raise SessionStoreUnavailable(
+                    f"refresh {label} does not match its authoritative storage key"
+                )
+            return record
+
+        raw_receipt = await self._storage.get(
             receipt_key,
-            receipt.to_dict(),
             collection=self.refresh_redemptions_collection,
         )
-        if not created:
-            raw = await self._storage.get(
+        if raw_receipt is None:
+            proposed = RefreshRedemptionRecord(
+                schema_version=_ACCESS_SCHEMA_VERSION,
+                family_id=grant.family_id,
+                sequence=grant.sequence,
+                claim_id=secrets.token_urlsafe(18),
+            )
+            grace_created = await self._storage.put_if_absent(
                 receipt_key,
+                proposed.to_dict(),
+                collection=self.refresh_grace_collection,
+                ttl=REFRESH_RETRY_GRACE_SECONDS,
+            )
+            if grace_created:
+                grace = proposed
+            else:
+                raw_grace = await self._storage.get(
+                    receipt_key,
+                    collection=self.refresh_grace_collection,
+                )
+                if raw_grace is None:
+                    raise SessionStoreUnavailable(
+                        "refresh grace disappeared during an atomic claim"
+                    )
+                grace = parse_redemption(raw_grace, label="grace")
+            receipt_created = await self._storage.put_if_absent(
+                receipt_key,
+                grace.to_dict(),
                 collection=self.refresh_redemptions_collection,
             )
-            if raw is None:
-                raise SessionStoreUnavailable(
-                    "refresh redemption disappeared after an atomic claim"
+            if receipt_created:
+                receipt = grace
+            else:
+                raw_receipt = await self._storage.get(
+                    receipt_key,
+                    collection=self.refresh_redemptions_collection,
                 )
-            try:
-                receipt = RefreshRedemptionRecord.from_dict(raw)
-            except ValueError as error:
-                raise SessionStoreUnavailable("refresh redemption record is corrupt") from error
-            if receipt.family_id != grant.family_id or receipt.sequence != grant.sequence:
-                raise SessionStoreUnavailable(
-                    "refresh redemption does not match its authoritative storage key"
-                )
-            if now - receipt.redeemed_at > REFRESH_RETRY_GRACE_SECONDS:
-                await self._revoke_family(
-                    grant.family_id,
-                    reason="refresh-token-reuse",
-                )
-                raise InvalidRefreshToken("refresh token reuse detected")
+                if raw_receipt is None:
+                    raise SessionStoreUnavailable(
+                        "refresh redemption disappeared after an atomic claim"
+                    )
+                receipt = parse_redemption(raw_receipt, label="redemption")
+        else:
+            receipt = parse_redemption(raw_receipt, label="redemption")
+
+        raw_grace = await self._storage.get(
+            receipt_key,
+            collection=self.refresh_grace_collection,
+        )
+        grace = (
+            None
+            if raw_grace is None
+            else parse_redemption(raw_grace, label="grace")
+        )
+        if grace is None or grace.claim_id != receipt.claim_id:
+            await self._revoke_family(
+                grant.family_id,
+                reason="refresh-token-reuse",
+            )
+            raise InvalidRefreshToken("refresh token reuse detected")
 
         family = await self._load_family(grant.family_id)
         if family is None or not await self._family_is_active(family):

--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -36,10 +36,23 @@ from key_value.aio.stores.filetree import FileTreeStore
 from .remote_oauth_storage import RemoteOAuthStorage
 
 _TOKEN_VERSION = "exo_s1"
+_ACCESS_TOKEN_VERSION = "exo_a2"
+_REFRESH_TOKEN_VERSION = "exo_r2"
 _SCHEMA_VERSION = 1
+_ACCESS_SCHEMA_VERSION = 2
+ACCESS_TOKEN_TTL_SECONDS = 3600
+REFRESH_RETRY_GRACE_SECONDS = 30
 _TOKEN_PATTERN = re.compile(
     rf"^{_TOKEN_VERSION}\.(?P<session_id>[A-Za-z0-9_-]{{16,64}})\."
     r"(?P<secret>[A-Za-z0-9_-]{43,128})$"
+)
+_ACCESS_TOKEN_PATTERN = re.compile(
+    rf"^{_ACCESS_TOKEN_VERSION}\.(?P<session_id>[A-Za-z0-9_-]{{16,64}})\."
+    r"(?P<secret>[A-Za-z0-9_-]{43,128})$"
+)
+_REFRESH_TOKEN_PATTERN = re.compile(
+    rf"^{_REFRESH_TOKEN_VERSION}\.(?P<family_id>[A-Za-z0-9_-]{{16,64}})\."
+    r"(?P<sequence>0|[1-9][0-9]{0,19})\.(?P<proof>[A-Za-z0-9_-]{43})$"
 )
 _GENERATION_KEY = "current"
 _MAX_ISSUANCE_ATTEMPTS = 8
@@ -49,9 +62,15 @@ class SessionStoreUnavailable(RuntimeError):
     """The authoritative session store or its cipher could not be used."""
 
 
+class InvalidRefreshToken(ValueError):
+    """A refresh token is malformed, inactive, mismatched, or replayed."""
+
+
 @dataclass(frozen=True)
 class SessionKeys:
     hmac_key: bytes = field(repr=False)
+    access_hmac_key: bytes = field(repr=False)
+    refresh_hmac_key: bytes = field(repr=False)
     storage_key: bytes = field(repr=False)
     fingerprint: str
 
@@ -70,6 +89,16 @@ def derive_session_keys(signing_root: str) -> SessionKeys:
         salt=b"exomem-session-proof-v1",
         info=b"opaque MCP bearer HMAC",
     )
+    access_hmac_key = _derive(
+        material,
+        salt=b"exomem-access-proof-v2",
+        info=b"opaque OAuth access bearer HMAC",
+    )
+    refresh_hmac_key = _derive(
+        material,
+        salt=b"exomem-refresh-proof-v2",
+        info=b"deterministic OAuth refresh rotation HMAC",
+    )
     storage_key = _derive(
         material,
         salt=b"exomem-session-storage-v1",
@@ -82,6 +111,8 @@ def derive_session_keys(signing_root: str) -> SessionKeys:
     )
     return SessionKeys(
         hmac_key=hmac_key,
+        access_hmac_key=access_hmac_key,
+        refresh_hmac_key=refresh_hmac_key,
         storage_key=storage_key,
         fingerprint=hashlib.sha256(fingerprint_key).hexdigest()[:16],
     )
@@ -127,6 +158,75 @@ class SessionTokenCodec:
         return hmac.compare_digest(calculated, expected_digest)
 
 
+class AccessTokenCodec(SessionTokenCodec):
+    """Issue and verify expiring v2 OAuth access tokens."""
+
+    def issue(self) -> tuple[str, str, str]:
+        session_id = secrets.token_urlsafe(18)
+        secret = secrets.token_urlsafe(32)
+        bearer = f"{_ACCESS_TOKEN_VERSION}.{session_id}.{secret}"
+        return bearer, session_id, self.digest(bearer)
+
+    @staticmethod
+    def parse(bearer: str) -> ParsedSessionToken | None:
+        if not isinstance(bearer, str):
+            return None
+        match = _ACCESS_TOKEN_PATTERN.fullmatch(bearer)
+        if match is None:
+            return None
+        return ParsedSessionToken(
+            session_id=match.group("session_id"),
+            secret=match.group("secret"),
+        )
+
+
+@dataclass(frozen=True)
+class ParsedRefreshToken:
+    family_id: str
+    sequence: int
+    proof: str = field(repr=False)
+
+
+class RefreshTokenCodec:
+    """Create deterministic, self-authenticating refresh descendants."""
+
+    def __init__(self, hmac_key: bytes):
+        if len(hmac_key) < 32:
+            raise ValueError("refresh HMAC key must contain at least 256 bits")
+        self._hmac_key = hmac_key
+
+    def issue(self) -> tuple[str, str]:
+        family_id = secrets.token_urlsafe(18)
+        return self.token_for(family_id, 0), family_id
+
+    def token_for(self, family_id: str, sequence: int) -> str:
+        if not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", family_id) or sequence < 0:
+            raise ValueError("invalid refresh family or sequence")
+        prefix = f"{_REFRESH_TOKEN_VERSION}.{family_id}.{sequence}"
+        proof = base64.urlsafe_b64encode(
+            hmac.new(self._hmac_key, prefix.encode("ascii"), hashlib.sha256).digest()
+        ).decode("ascii").rstrip("=")
+        return f"{prefix}.{proof}"
+
+    def parse(self, bearer: str) -> ParsedRefreshToken | None:
+        if not isinstance(bearer, str):
+            return None
+        match = _REFRESH_TOKEN_PATTERN.fullmatch(bearer)
+        if match is None:
+            return None
+        family_id = match.group("family_id")
+        sequence = int(match.group("sequence"))
+        expected = self.token_for(family_id, sequence).rsplit(".", 1)[1]
+        proof = match.group("proof")
+        if not hmac.compare_digest(proof, expected):
+            return None
+        return ParsedRefreshToken(
+            family_id=family_id,
+            sequence=sequence,
+            proof=proof,
+        )
+
+
 @dataclass(frozen=True)
 class SessionIdentity:
     github_user_id: int
@@ -158,6 +258,8 @@ class SessionRecord:
     issued_at: float
     generation: str
     status: SessionStatus
+    expires_at: float | None = None
+    family_id: str | None = None
     revoked_at: float | None = None
     revocation_reason: str | None = None
 
@@ -182,6 +284,12 @@ class SessionRecord:
                 issued_at=float(value["issued_at"]),
                 generation=str(value["generation"]),
                 status=str(value["status"]),  # type: ignore[arg-type]
+                expires_at=(
+                    None if value.get("expires_at") is None else float(value["expires_at"])
+                ),
+                family_id=(
+                    None if value.get("family_id") is None else str(value["family_id"])
+                ),
                 revoked_at=(
                     None if value.get("revoked_at") is None else float(value["revoked_at"])
                 ),
@@ -198,7 +306,7 @@ class SessionRecord:
         return record
 
     def structurally_valid(self) -> bool:
-        if self.schema_version != _SCHEMA_VERSION:
+        if self.schema_version not in {_SCHEMA_VERSION, _ACCESS_SCHEMA_VERSION}:
             return False
         if SessionTokenCodec.parse(f"{_TOKEN_VERSION}.{self.session_id}.{'a' * 43}") is None:
             return False
@@ -212,6 +320,17 @@ class SessionRecord:
             return False
         if not self.github_login or not math.isfinite(self.issued_at) or self.issued_at <= 0:
             return False
+        if self.schema_version == _SCHEMA_VERSION:
+            if self.expires_at is not None or self.family_id is not None:
+                return False
+        elif (
+            self.expires_at is None
+            or not math.isfinite(self.expires_at)
+            or self.expires_at <= self.issued_at
+            or self.family_id is None
+            or not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", self.family_id)
+        ):
+            return False
         if self.status == "active":
             return self.revoked_at is None and self.revocation_reason is None
         if self.status == "revoked":
@@ -221,6 +340,121 @@ class SessionRecord:
                 and bool(self.revocation_reason)
             )
         return False
+
+
+@dataclass(frozen=True)
+class RefreshFamilyRecord:
+    schema_version: int
+    family_id: str
+    client_id: str
+    scopes: tuple[str, ...]
+    issuer: str
+    audience: str
+    github_user_id: int
+    github_login: str
+    created_at: float
+    generation: str
+    status: SessionStatus
+    revoked_at: float | None = None
+    revocation_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["scopes"] = list(self.scopes)
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RefreshFamilyRecord:
+        try:
+            record = cls(
+                schema_version=int(value["schema_version"]),
+                family_id=str(value["family_id"]),
+                client_id=str(value["client_id"]),
+                scopes=tuple(str(scope) for scope in value["scopes"]),
+                issuer=str(value["issuer"]),
+                audience=str(value["audience"]),
+                github_user_id=int(value["github_user_id"]),
+                github_login=str(value["github_login"]),
+                created_at=float(value["created_at"]),
+                generation=str(value["generation"]),
+                status=str(value["status"]),  # type: ignore[arg-type]
+                revoked_at=(
+                    None if value.get("revoked_at") is None else float(value["revoked_at"])
+                ),
+                revocation_reason=(
+                    None
+                    if value.get("revocation_reason") is None
+                    else str(value["revocation_reason"])
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid refresh family record") from error
+        if not record.structurally_valid():
+            raise ValueError("invalid refresh family record")
+        return record
+
+    def structurally_valid(self) -> bool:
+        if self.schema_version != _ACCESS_SCHEMA_VERSION:
+            return False
+        if not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", self.family_id):
+            return False
+        if not self.client_id or not self.issuer or not self.audience or not self.generation:
+            return False
+        if any(not scope for scope in self.scopes) or len(set(self.scopes)) != len(self.scopes):
+            return False
+        if self.github_user_id <= 0 or self.github_login != self.github_login.strip().casefold():
+            return False
+        if not self.github_login or not math.isfinite(self.created_at) or self.created_at <= 0:
+            return False
+        if self.status == "active":
+            return self.revoked_at is None and self.revocation_reason is None
+        if self.status == "revoked":
+            return (
+                self.revoked_at is not None
+                and math.isfinite(self.revoked_at)
+                and bool(self.revocation_reason)
+            )
+        return False
+
+
+@dataclass(frozen=True)
+class RefreshRedemptionRecord:
+    schema_version: int
+    family_id: str
+    sequence: int
+    redeemed_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RefreshRedemptionRecord:
+        try:
+            record = cls(
+                schema_version=int(value["schema_version"]),
+                family_id=str(value["family_id"]),
+                sequence=int(value["sequence"]),
+                redeemed_at=float(value["redeemed_at"]),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid refresh redemption record") from error
+        if (
+            record.schema_version != _ACCESS_SCHEMA_VERSION
+            or not re.fullmatch(r"[A-Za-z0-9_-]{16,64}", record.family_id)
+            or record.sequence < 0
+            or not math.isfinite(record.redeemed_at)
+            or record.redeemed_at <= 0
+        ):
+            raise ValueError("invalid refresh redemption record")
+        return record
+
+
+@dataclass(frozen=True)
+class RefreshGrant:
+    family_id: str
+    sequence: int
+    client_id: str
+    scopes: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -451,8 +685,16 @@ class SessionAuthority:
         self.audience = audience
         self.clock = clock
         self.codec = SessionTokenCodec(keys.hmac_key)
+        self.access_codec = AccessTokenCodec(keys.access_hmac_key)
+        self.refresh_codec = RefreshTokenCodec(keys.refresh_hmac_key)
         self.sessions_collection = f"exomem-auth-sessions-v1-{keys.fingerprint}"
         self.generations_collection = f"exomem-auth-generations-v1-{keys.fingerprint}"
+        self.refresh_families_collection = (
+            f"exomem-auth-refresh-families-v2-{keys.fingerprint}"
+        )
+        self.refresh_redemptions_collection = (
+            f"exomem-auth-refresh-redemptions-v2-{keys.fingerprint}"
+        )
         self._storage = _EncryptedStorage(storage, keys.storage_key)
 
     @classmethod
@@ -599,8 +841,220 @@ class SessionAuthority:
             await self._write_tombstone(record, reason="generation-changed-during-issuance")
         raise SessionStoreUnavailable("could not issue a generation-stable session")
 
-    async def validate(self, bearer: str) -> SessionRecord | None:
+    async def _load_family(self, family_id: str) -> RefreshFamilyRecord | None:
+        raw = await self._storage.get(
+            family_id,
+            collection=self.refresh_families_collection,
+        )
+        if raw is None:
+            return None
+        try:
+            family = RefreshFamilyRecord.from_dict(raw)
+        except ValueError as error:
+            raise SessionStoreUnavailable("refresh family record is corrupt") from error
+        if family.family_id != family_id:
+            raise SessionStoreUnavailable(
+                "refresh family record does not match its authoritative storage key"
+            )
+        return family
+
+    async def _family_is_active(self, family: RefreshFamilyRecord) -> bool:
+        return (
+            family.status == "active"
+            and family.issuer == self.issuer
+            and family.audience == self.audience
+            and family.generation == await self.current_generation()
+        )
+
+    async def _issue_access_for_family(
+        self,
+        family: RefreshFamilyRecord,
+        *,
+        scopes: Sequence[str],
+    ) -> tuple[str, SessionRecord]:
+        normalized_scopes = self._normalize_scopes(scopes)
+        if any(scope not in family.scopes for scope in normalized_scopes):
+            raise InvalidRefreshToken("refresh scopes exceed the family grant")
+        for _ in range(_MAX_ISSUANCE_ATTEMPTS):
+            issued_at = float(self.clock())
+            bearer, session_id, digest = self.access_codec.issue()
+            record = SessionRecord(
+                schema_version=_ACCESS_SCHEMA_VERSION,
+                session_id=session_id,
+                token_digest=digest,
+                client_id=family.client_id,
+                scopes=normalized_scopes,
+                issuer=family.issuer,
+                audience=family.audience,
+                github_user_id=family.github_user_id,
+                github_login=family.github_login,
+                issued_at=issued_at,
+                generation=family.generation,
+                status="active",
+                expires_at=issued_at + ACCESS_TOKEN_TTL_SECONDS,
+                family_id=family.family_id,
+            )
+            created = await self._storage.put_if_absent(
+                session_id,
+                record.to_dict(),
+                collection=self.sessions_collection,
+            )
+            if not created:
+                continue
+            current_family = await self._load_family(family.family_id)
+            if current_family is not None and await self._family_is_active(current_family):
+                return bearer, record
+            await self._write_tombstone(record, reason="refresh-family-inactive")
+            raise InvalidRefreshToken("refresh family is inactive")
+        raise SessionStoreUnavailable("could not issue an OAuth access token")
+
+    async def issue_offline(
+        self,
+        *,
+        client_id: str,
+        scopes: Sequence[str],
+        identity: SessionIdentity,
+    ) -> tuple[str, SessionRecord, str]:
+        """Issue a one-hour access token and durable refresh family."""
+        if not client_id:
+            raise ValueError("session client ID is required")
+        normalized_scopes = self._normalize_scopes(scopes)
+        if "offline_access" not in normalized_scopes:
+            raise ValueError("offline issuance requires the offline_access scope")
+        if not isinstance(identity, SessionIdentity):
+            raise TypeError("session identity is required")
+
+        for _ in range(_MAX_ISSUANCE_ATTEMPTS):
+            generation = await self.current_generation()
+            refresh_token, family_id = self.refresh_codec.issue()
+            family = RefreshFamilyRecord(
+                schema_version=_ACCESS_SCHEMA_VERSION,
+                family_id=family_id,
+                client_id=client_id,
+                scopes=normalized_scopes,
+                issuer=self.issuer,
+                audience=self.audience,
+                github_user_id=identity.github_user_id,
+                github_login=identity.github_login,
+                created_at=float(self.clock()),
+                generation=generation,
+                status="active",
+            )
+            created = await self._storage.put_if_absent(
+                family_id,
+                family.to_dict(),
+                collection=self.refresh_families_collection,
+            )
+            if not created:
+                continue
+            if generation != await self.current_generation():
+                await self._revoke_family(family_id, reason="generation-changed-during-issuance")
+                continue
+            try:
+                access_token, access_record = await self._issue_access_for_family(
+                    family,
+                    scopes=normalized_scopes,
+                )
+            except InvalidRefreshToken:
+                continue
+            return access_token, access_record, refresh_token
+        raise SessionStoreUnavailable("could not issue a generation-stable refresh family")
+
+    async def validate_refresh(
+        self,
+        bearer: str,
+        *,
+        client_id: str,
+    ) -> RefreshGrant | None:
+        parsed = self.refresh_codec.parse(bearer)
+        if parsed is None:
+            return None
+        family = await self._load_family(parsed.family_id)
+        if (
+            family is None
+            or family.client_id != client_id
+            or not await self._family_is_active(family)
+        ):
+            return None
+        return RefreshGrant(
+            family_id=family.family_id,
+            sequence=parsed.sequence,
+            client_id=family.client_id,
+            scopes=family.scopes,
+        )
+
+    async def rotate_refresh(
+        self,
+        bearer: str,
+        *,
+        client_id: str,
+        scopes: Sequence[str],
+    ) -> tuple[str, SessionRecord, str]:
+        grant = await self.validate_refresh(bearer, client_id=client_id)
+        if grant is None:
+            raise InvalidRefreshToken("refresh token is invalid or inactive")
+        normalized_scopes = self._normalize_scopes(scopes)
+        if any(scope not in grant.scopes for scope in normalized_scopes):
+            raise InvalidRefreshToken("refresh scopes exceed the family grant")
+
+        now = float(self.clock())
+        receipt = RefreshRedemptionRecord(
+            schema_version=_ACCESS_SCHEMA_VERSION,
+            family_id=grant.family_id,
+            sequence=grant.sequence,
+            redeemed_at=now,
+        )
+        receipt_key = f"{grant.family_id}.{grant.sequence}"
+        created = await self._storage.put_if_absent(
+            receipt_key,
+            receipt.to_dict(),
+            collection=self.refresh_redemptions_collection,
+        )
+        if not created:
+            raw = await self._storage.get(
+                receipt_key,
+                collection=self.refresh_redemptions_collection,
+            )
+            if raw is None:
+                raise SessionStoreUnavailable(
+                    "refresh redemption disappeared after an atomic claim"
+                )
+            try:
+                receipt = RefreshRedemptionRecord.from_dict(raw)
+            except ValueError as error:
+                raise SessionStoreUnavailable("refresh redemption record is corrupt") from error
+            if receipt.family_id != grant.family_id or receipt.sequence != grant.sequence:
+                raise SessionStoreUnavailable(
+                    "refresh redemption does not match its authoritative storage key"
+                )
+            if now - receipt.redeemed_at > REFRESH_RETRY_GRACE_SECONDS:
+                await self._revoke_family(
+                    grant.family_id,
+                    reason="refresh-token-reuse",
+                )
+                raise InvalidRefreshToken("refresh token reuse detected")
+
+        family = await self._load_family(grant.family_id)
+        if family is None or not await self._family_is_active(family):
+            raise InvalidRefreshToken("refresh family is inactive")
+        access_token, access_record = await self._issue_access_for_family(
+            family,
+            scopes=normalized_scopes,
+        )
+        next_refresh = self.refresh_codec.token_for(
+            grant.family_id,
+            grant.sequence + 1,
+        )
+        return access_token, access_record, next_refresh
+
+    async def _load_session_for_bearer(self, bearer: str) -> SessionRecord | None:
         parsed = self.codec.parse(bearer)
+        codec: SessionTokenCodec = self.codec
+        expected_schema = _SCHEMA_VERSION
+        if parsed is None:
+            parsed = self.access_codec.parse(bearer)
+            codec = self.access_codec
+            expected_schema = _ACCESS_SCHEMA_VERSION
         if parsed is None:
             return None
         raw = await self._storage.get(parsed.session_id, collection=self.sessions_collection)
@@ -614,7 +1068,15 @@ class SessionAuthority:
             raise SessionStoreUnavailable(
                 "session record does not match its authoritative storage key"
             )
-        if not self.codec.verify(bearer, record.token_digest):
+        if record.schema_version != expected_schema or not codec.verify(
+            bearer, record.token_digest
+        ):
+            return None
+        return record
+
+    async def validate(self, bearer: str) -> SessionRecord | None:
+        record = await self._load_session_for_bearer(bearer)
+        if record is None:
             return None
         if (
             record.status != "active"
@@ -624,6 +1086,14 @@ class SessionAuthority:
             return None
         if record.generation != await self.current_generation():
             return None
+        if record.schema_version == _ACCESS_SCHEMA_VERSION:
+            if record.expires_at is None or float(self.clock()) >= record.expires_at:
+                return None
+            if record.family_id is None:
+                return None
+            family = await self._load_family(record.family_id)
+            if family is None or not await self._family_is_active(family):
+                return None
         return record
 
     async def _write_tombstone(self, record: SessionRecord, *, reason: str) -> SessionRecord:
@@ -639,6 +1109,43 @@ class SessionAuthority:
             collection=self.sessions_collection,
         )
         return tombstone
+
+    async def _revoke_family(self, family_id: str, *, reason: str) -> bool:
+        if not family_id or not reason:
+            raise ValueError("refresh family ID and revocation reason are required")
+        family = await self._load_family(family_id)
+        if family is None:
+            return False
+        if family.status == "revoked":
+            return True
+        tombstone = replace(
+            family,
+            status="revoked",
+            revoked_at=float(self.clock()),
+            revocation_reason=reason,
+        )
+        await self._storage.put(
+            family.family_id,
+            tombstone.to_dict(),
+            collection=self.refresh_families_collection,
+        )
+        return True
+
+    async def revoke_bearer(self, bearer: str, *, reason: str) -> bool:
+        """Revoke a legacy session or an entire v2 access/refresh family."""
+        if not reason:
+            raise ValueError("revocation reason is required")
+        parsed_refresh = self.refresh_codec.parse(bearer)
+        if parsed_refresh is not None:
+            return await self._revoke_family(parsed_refresh.family_id, reason=reason)
+        record = await self._load_session_for_bearer(bearer)
+        if record is None:
+            return False
+        if record.family_id is not None:
+            await self._revoke_family(record.family_id, reason=reason)
+        if record.status != "revoked":
+            await self._write_tombstone(record, reason=reason)
+        return True
 
     async def tombstone(self, session_id: str, *, reason: str) -> bool:
         if not session_id or not reason:
@@ -656,6 +1163,8 @@ class SessionAuthority:
             )
         if record.status == "revoked":
             return True
+        if record.family_id is not None:
+            await self._revoke_family(record.family_id, reason=reason)
         await self._write_tombstone(record, reason=reason)
         return True
 

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -13,6 +13,7 @@ from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 
 from . import runtime_readiness as runtime_readiness_module
 from . import tool_surface as tool_surface_module
+from .session_oauth import OAUTH_SUPPORTED_SCOPES
 
 _STUDIO_SECURITY_HEADERS = {
     "Content-Security-Policy": (
@@ -202,7 +203,7 @@ def register_oauth_metadata_route(
                 "authorization_endpoint": f"{base_url}/authorize",
                 "token_endpoint": f"{base_url}/token",
                 "registration_endpoint": f"{base_url}/register",
-                "scopes_supported": [],
+                "scopes_supported": list(OAUTH_SUPPORTED_SCOPES),
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code", "refresh_token"],
                 "token_endpoint_auth_methods_supported": [
@@ -223,7 +224,7 @@ def register_oauth_metadata_route(
             {
                 "resource": resource_url,
                 "authorization_servers": [issuer_url],
-                "scopes_supported": [],
+                "scopes_supported": list(OAUTH_SUPPORTED_SCOPES),
                 "bearer_methods_supported": ["header"],
             },
             headers={"Cache-Control": "public, max-age=3600"},

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -13,7 +13,7 @@ from starlette.responses import FileResponse, JSONResponse, RedirectResponse
 
 from . import runtime_readiness as runtime_readiness_module
 from . import tool_surface as tool_surface_module
-from .session_oauth import OAUTH_SUPPORTED_SCOPES
+from .session_oauth import OAUTH_AUTHORIZATION_SCOPES, OAUTH_RESOURCE_SCOPES
 
 _STUDIO_SECURITY_HEADERS = {
     "Content-Security-Policy": (
@@ -203,7 +203,7 @@ def register_oauth_metadata_route(
                 "authorization_endpoint": f"{base_url}/authorize",
                 "token_endpoint": f"{base_url}/token",
                 "registration_endpoint": f"{base_url}/register",
-                "scopes_supported": list(OAUTH_SUPPORTED_SCOPES),
+                "scopes_supported": list(OAUTH_AUTHORIZATION_SCOPES),
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code", "refresh_token"],
                 "token_endpoint_auth_methods_supported": [
@@ -224,7 +224,7 @@ def register_oauth_metadata_route(
             {
                 "resource": resource_url,
                 "authorization_servers": [issuer_url],
-                "scopes_supported": list(OAUTH_SUPPORTED_SCOPES),
+                "scopes_supported": list(OAUTH_RESOURCE_SCOPES),
                 "bearer_methods_supported": ["header"],
             },
             headers={"Cache-Control": "public, max-age=3600"},

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -24,7 +24,7 @@ from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
 from .auth_sessions import SessionAuthority
 from .remote_oauth_storage import ReadThroughMirrorStorage, RemoteOAuthStorage
-from .session_oauth import ExomemSessionOAuthProxy
+from .session_oauth import OAUTH_SUPPORTED_SCOPES, ExomemSessionOAuthProxy
 
 if TYPE_CHECKING:
     from .hosted_runtime import HostedCellConfig
@@ -323,4 +323,5 @@ def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
         base_url=base_url,
         jwt_signing_key=signing_root,
         client_storage=client_storage,
+        valid_scopes=list(OAUTH_SUPPORTED_SCOPES),
     )

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -24,7 +24,7 @@ from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
 from .auth_sessions import SessionAuthority
 from .remote_oauth_storage import ReadThroughMirrorStorage, RemoteOAuthStorage
-from .session_oauth import OAUTH_SUPPORTED_SCOPES, ExomemSessionOAuthProxy
+from .session_oauth import OAUTH_AUTHORIZATION_SCOPES, ExomemSessionOAuthProxy
 
 if TYPE_CHECKING:
     from .hosted_runtime import HostedCellConfig
@@ -323,5 +323,5 @@ def build_oauth(*, require_auth: bool, base_url: str) -> OAuthProxy | None:
         base_url=base_url,
         jwt_signing_key=signing_root,
         client_storage=client_storage,
-        valid_scopes=list(OAUTH_SUPPORTED_SCOPES),
+        valid_scopes=list(OAUTH_AUTHORIZATION_SCOPES),
     )

--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -6,7 +6,7 @@ import logging
 import secrets
 import time
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastmcp.server.auth.auth import AccessToken
@@ -25,9 +25,17 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 from typing_extensions import override
 
-from .auth_sessions import SessionAuthority, SessionIdentity, SessionStoreUnavailable
+from .auth_sessions import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    InvalidRefreshToken,
+    SessionAuthority,
+    SessionIdentity,
+    SessionStoreUnavailable,
+)
 
 logger = logging.getLogger(__name__)
+
+OAUTH_SUPPORTED_SCOPES = ("offline_access", "exomem:read", "exomem:write")
 
 
 class SessionStoreUnavailableMiddleware:
@@ -111,17 +119,27 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         if client.client_id is None:
             raise TokenError("invalid_client", "Client ID is required")
         scopes = list(code_model.scopes)
-        bearer, _ = await self._session_authority.issue(
-            client_id=client.client_id,
-            scopes=scopes,
-            identity=identity,
-        )
+        refresh_token: str | None = None
+        if "offline_access" in scopes:
+            bearer, _, refresh_token = await self._session_authority.issue_offline(
+                client_id=client.client_id,
+                scopes=scopes,
+                identity=identity,
+            )
+            expires_in: int | None = ACCESS_TOKEN_TTL_SECONDS
+        else:
+            bearer, _ = await self._session_authority.issue(
+                client_id=client.client_id,
+                scopes=scopes,
+                identity=identity,
+            )
+            expires_in = None
         return OAuthToken(
             access_token=bearer,
             token_type="Bearer",
-            expires_in=None,
+            expires_in=expires_in,
             scope=" ".join(scopes) or None,
-            refresh_token=None,
+            refresh_token=refresh_token,
         )
 
     @override
@@ -133,7 +151,9 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             token=token,
             client_id=record.client_id,
             scopes=list(record.scopes),
-            expires_at=None,
+            expires_at=(
+                None if record.expires_at is None else int(record.expires_at)
+            ),
             resource=record.audience,
             claims={
                 "sub": str(record.github_user_id),
@@ -150,9 +170,21 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         client: OAuthClientInformationFull,
         refresh_token: str,
     ) -> RefreshToken | None:
-        """Refuse refresh without consulting preserved FastMCP legacy state."""
-        del client, refresh_token
-        return None
+        """Load only an Exomem-owned refresh grant, never FastMCP legacy state."""
+        if client.client_id is None:
+            return None
+        grant = await self._session_authority.validate_refresh(
+            refresh_token,
+            client_id=client.client_id,
+        )
+        if grant is None:
+            return None
+        return RefreshToken(
+            token=refresh_token,
+            client_id=grant.client_id,
+            scopes=list(grant.scopes),
+            expires_at=None,
+        )
 
     @override
     async def exchange_refresh_token(
@@ -161,17 +193,29 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        """Defensively prevent callers from re-entering FastMCP's legacy flow."""
-        del client, refresh_token, scopes
-        raise TokenError("invalid_grant", "Refresh tokens are not supported")
+        """Rotate an Exomem refresh token through the shared session authority."""
+        if client.client_id is None:
+            raise TokenError("invalid_client", "Client ID is required")
+        try:
+            access, _, next_refresh = await self._session_authority.rotate_refresh(
+                refresh_token.token,
+                client_id=client.client_id,
+                scopes=scopes,
+            )
+        except InvalidRefreshToken as error:
+            raise TokenError("invalid_grant", str(error)) from error
+        return OAuthToken(
+            access_token=access,
+            token_type="Bearer",
+            expires_in=ACCESS_TOKEN_TTL_SECONDS,
+            scope=" ".join(scopes) or None,
+            refresh_token=next_refresh,
+        )
 
     @override
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
-        record = await self._session_authority.validate(token.token)
-        if record is None:
-            return
-        await self._session_authority.tombstone(
-            record.session_id,
+        await self._session_authority.revoke_bearer(
+            token.token,
             reason="oauth-client-revocation",
         )
 
@@ -181,6 +225,29 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             Middleware(SessionStoreUnavailableMiddleware),
             *super().get_middleware(),
         ]
+
+    @override
+    def _build_upstream_authorize_url(
+        self,
+        txn_id: str,
+        transaction: dict[str, Any],
+    ) -> str:
+        """Keep Exomem protocol scopes out of the GitHub identity request."""
+        upstream = super()._build_upstream_authorize_url(
+            txn_id,
+            {**transaction, "scopes": []},
+        )
+        parts = urlsplit(upstream)
+        query = urlencode(
+            [(key, value) for key, value in parse_qsl(parts.query) if key != "scope"]
+        )
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+    @override
+    def _prepare_scopes_for_token_exchange(self, scopes: list[str]) -> list[str]:
+        """GitHub proves identity only; downstream Exomem scopes stay local."""
+        del scopes
+        return []
 
     async def _cleanup_github_token(self, access_token: str) -> None:
         if self._upstream_client_secret is None:

--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -18,11 +18,13 @@ from fastmcp.server.auth.oauth_proxy.models import (
 )
 from fastmcp.server.auth.oauth_proxy.ui import create_error_html
 from mcp.server.auth.provider import AuthorizationCode, RefreshToken, TokenError
+from mcp.server.auth.routes import create_protected_resource_routes
 from mcp.server.auth.settings import RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
+from starlette.routing import Route
 from typing_extensions import override
 
 from .auth_sessions import (
@@ -35,7 +37,8 @@ from .auth_sessions import (
 
 logger = logging.getLogger(__name__)
 
-OAUTH_SUPPORTED_SCOPES = ("offline_access", "exomem:read", "exomem:write")
+OAUTH_AUTHORIZATION_SCOPES = ("offline_access", "exomem:read", "exomem:write")
+OAUTH_RESOURCE_SCOPES = ("exomem:read", "exomem:write")
 
 
 class SessionStoreUnavailableMiddleware:
@@ -196,11 +199,12 @@ class ExomemSessionOAuthProxy(OAuthProxy):
         """Rotate an Exomem refresh token through the shared session authority."""
         if client.client_id is None:
             raise TokenError("invalid_client", "Client ID is required")
+        normalized_scopes = list(dict.fromkeys(scopes))
         try:
-            access, _, next_refresh = await self._session_authority.rotate_refresh(
+            access, record, next_refresh = await self._session_authority.rotate_refresh(
                 refresh_token.token,
                 client_id=client.client_id,
-                scopes=scopes,
+                scopes=normalized_scopes,
             )
         except InvalidRefreshToken as error:
             raise TokenError("invalid_grant", str(error)) from error
@@ -208,7 +212,7 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             access_token=access,
             token_type="Bearer",
             expires_in=ACCESS_TOKEN_TTL_SECONDS,
-            scope=" ".join(scopes) or None,
+            scope=" ".join(record.scopes) or None,
             refresh_token=next_refresh,
         )
 
@@ -225,6 +229,20 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             Middleware(SessionStoreUnavailableMiddleware),
             *super().get_middleware(),
         ]
+
+    @override
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        """Keep protocol-only scopes out of protected-resource metadata."""
+        routes = super().get_routes(mcp_path)
+        if self._resource_url is None or self.issuer_url is None:
+            return routes
+        resource_routes = create_protected_resource_routes(
+            resource_url=self._resource_url,
+            authorization_servers=[self.issuer_url],
+            scopes_supported=list(OAUTH_RESOURCE_SCOPES),
+        )
+        replacements = {route.path: route for route in resource_routes}
+        return [replacements.get(route.path, route) for route in routes]
 
     @override
     def _build_upstream_authorize_url(

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -249,6 +249,29 @@ async def test_discovery_and_real_http_dcr_match_legacy_fastmcp() -> None:
 
 
 @pytest.mark.anyio
+async def test_canonical_discovery_separates_offline_and_resource_scopes() -> None:
+    proxy = ExomemSessionOAuthProxy(
+        session_authority=Authority(),
+        valid_scopes=["offline_access", "exomem:read", "exomem:write"],
+        **_kwargs(MemoryStore()),
+    )
+    app = Starlette(routes=proxy.get_routes("/mcp"))
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="https://memory.example",
+    ) as client:
+        authorization = await client.get("/.well-known/oauth-authorization-server")
+        resource = await client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert authorization.json()["scopes_supported"] == [
+        "offline_access",
+        "exomem:read",
+        "exomem:write",
+    ]
+    assert resource.json()["scopes_supported"] == ["exomem:read", "exomem:write"]
+
+
+@pytest.mark.anyio
 async def test_authorize_preserves_downstream_state_pkce_resource_and_redirect() -> None:
     proxy = ExomemSessionOAuthProxy(
         session_authority=Authority(),

--- a/tests/test_auth_migration.py
+++ b/tests/test_auth_migration.py
@@ -27,6 +27,7 @@ from pydantic import AnyUrl
 from starlette.applications import Starlette
 from starlette.requests import Request
 
+from exomem.auth_sessions import InvalidRefreshToken
 from exomem.session_oauth import ExomemSessionOAuthProxy
 
 
@@ -44,11 +45,27 @@ class Verifier:
 class Authority:
     def __init__(self) -> None:
         self.validations: list[str] = []
+        self.refresh_validations: list[str] = []
+        self.revocations: list[str] = []
         self.sessions = {"new-session": object()}
 
     async def validate(self, token: str) -> Any:
         self.validations.append(token)
         return None
+
+    async def validate_refresh(self, token: str, *, client_id: str) -> Any:
+        del client_id
+        self.refresh_validations.append(token)
+        return None
+
+    async def rotate_refresh(self, token: str, **kwargs: Any) -> Any:
+        del kwargs
+        raise InvalidRefreshToken(f"invalid Exomem refresh token: {token[:8]}")
+
+    async def revoke_bearer(self, token: str, *, reason: str) -> bool:
+        del reason
+        self.revocations.append(token)
+        return False
 
 
 def _kwargs(storage: MemoryStore) -> dict[str, Any]:
@@ -240,7 +257,7 @@ async def test_authorize_preserves_downstream_state_pkce_resource_and_redirect()
     proxy.get_routes("/mcp")
     params = AuthorizationParams(
         state="downstream-state",
-        scopes=["exomem:read"],
+        scopes=["offline_access", "exomem:read"],
         code_challenge="downstream-code-challenge",
         redirect_uri=AnyUrl("http://127.0.0.1:8765/callback"),
         redirect_uri_provided_explicitly=True,
@@ -256,9 +273,11 @@ async def test_authorize_preserves_downstream_state_pkce_resource_and_redirect()
     assert transaction.client_state == "downstream-state"
     assert transaction.client_redirect_uri == "http://127.0.0.1:8765/callback"
     assert transaction.code_challenge == "downstream-code-challenge"
+    assert transaction.scopes == ["offline_access", "exomem:read"]
     assert transaction.resource == "https://memory.example/mcp"
     assert transaction.proxy_code_verifier
     assert upstream_query["code_challenge"][0] != "downstream-code-challenge"
+    assert "scope" not in upstream_query
 
 
 @pytest.mark.anyio
@@ -368,7 +387,7 @@ async def test_refresh_and_revocation_paths_never_read_or_mutate_legacy_state(
         monkeypatch.setattr(adapter, "delete", forbidden_legacy_access)
 
     assert await proxy.load_refresh_token(_client(), refresh_token) is None
-    with pytest.raises(TokenError, match="Refresh tokens are not supported"):
+    with pytest.raises(TokenError, match="invalid Exomem refresh token"):
         await proxy.exchange_refresh_token(
             _client(),
             RefreshToken(
@@ -407,6 +426,8 @@ async def test_refresh_and_revocation_paths_never_read_or_mutate_legacy_state(
     )
     assert revoke_response.status_code == 200
     assert authority.validations == [refresh_token]
+    assert authority.refresh_validations
+    assert authority.revocations == []
     assert proxy._token_validator.calls == []
 
     after = {

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -10,6 +10,9 @@ from typing import Any
 import pytest
 
 from exomem.auth_sessions import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    REFRESH_RETRY_GRACE_SECONDS,
+    InvalidRefreshToken,
     SessionAuthority,
     SessionIdentity,
     SessionStoreUnavailable,
@@ -152,13 +155,14 @@ def _authority(
     signing_root: str = "test-signing-root",
     issuer: str = "https://memory.example",
     audience: str = "https://memory.example/mcp",
+    clock: Any = None,
 ) -> SessionAuthority:
     return SessionAuthority(
         storage=store,
         signing_root=signing_root,
         issuer=issuer,
         audience=audience,
-        clock=lambda: 1_800_000_000.0,
+        clock=clock or (lambda: 1_800_000_000.0),
     )
 
 
@@ -263,6 +267,109 @@ async def test_issue_validate_list_and_tombstone_without_storing_bearer() -> Non
     assert revoked.status == "revoked"
     assert revoked.revoked_at == 1_800_000_000.0
     assert revoked.revocation_reason == "operator"
+
+
+@pytest.mark.anyio
+async def test_offline_issue_creates_one_hour_access_and_unstored_refresh_token() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+
+    access, record, refresh = await authority.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access", "exomem:read"),
+        identity=_identity(),
+    )
+
+    assert access.startswith("exo_a2.")
+    assert refresh.startswith("exo_r2.")
+    assert record.schema_version == 2
+    assert record.expires_at == record.issued_at + ACCESS_TOKEN_TTL_SECONDS
+    assert record.family_id
+    assert await authority.validate(access) == record
+    grant = await authority.validate_refresh(refresh, client_id="chatgpt")
+    assert grant is not None
+    assert grant.scopes == ("offline_access", "exomem:read")
+    assert access not in repr(raw.data)
+    assert refresh not in repr(raw.data)
+    assert all("__encrypted_data__" in value for value in raw.data.values())
+
+
+@pytest.mark.anyio
+async def test_refresh_rotation_is_cross_authority_idempotent_then_revokes_on_replay() -> None:
+    raw = AtomicMemoryStore()
+    now = [1_800_000_000.0]
+    first = _authority(raw, clock=lambda: now[0])
+    second = _authority(raw, clock=lambda: now[0])
+    access, _, refresh = await first.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access", "exomem:read"),
+        identity=_identity(),
+    )
+
+    rotated_a, rotated_record_a, next_refresh_a = await first.rotate_refresh(
+        refresh,
+        client_id="chatgpt",
+        scopes=("offline_access", "exomem:read"),
+    )
+    now[0] += REFRESH_RETRY_GRACE_SECONDS - 1
+    rotated_b, rotated_record_b, next_refresh_b = await second.rotate_refresh(
+        refresh,
+        client_id="chatgpt",
+        scopes=("offline_access", "exomem:read"),
+    )
+
+    assert next_refresh_a == next_refresh_b
+    assert rotated_a != rotated_b
+    assert await first.validate(rotated_a) == rotated_record_a
+    assert await second.validate(rotated_b) == rotated_record_b
+
+    now[0] += 2
+    with pytest.raises(InvalidRefreshToken, match="reuse"):
+        await second.rotate_refresh(
+            refresh,
+            client_id="chatgpt",
+            scopes=("offline_access", "exomem:read"),
+        )
+
+    assert await first.validate(access) is None
+    assert await first.validate(rotated_a) is None
+    assert await first.validate_refresh(next_refresh_a, client_id="chatgpt") is None
+
+
+@pytest.mark.anyio
+async def test_offline_access_expiry_revocation_and_generation_fail_closed() -> None:
+    raw = AtomicMemoryStore()
+    now = [1_800_000_000.0]
+    authority = _authority(raw, clock=lambda: now[0])
+    access, record, refresh = await authority.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access",),
+        identity=_identity(),
+    )
+
+    now[0] = record.expires_at
+    assert await authority.validate(access) is None
+    assert await authority.validate_refresh(refresh, client_id="other") is None
+    assert await authority.validate_refresh(refresh, client_id="chatgpt") is not None
+
+    assert await authority.revoke_bearer(access, reason="oauth-client-revocation")
+    assert await authority.validate_refresh(refresh, client_id="chatgpt") is None
+
+    _, tombstone_record, tombstone_refresh = await authority.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access",),
+        identity=_identity(),
+    )
+    assert await authority.tombstone(tombstone_record.session_id, reason="operator")
+    assert await authority.validate_refresh(tombstone_refresh, client_id="chatgpt") is None
+
+    _, _, another_refresh = await authority.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access",),
+        identity=_identity(),
+    )
+    await authority.replace_generation()
+    assert await authority.validate_refresh(another_refresh, client_id="chatgpt") is None
 
 
 @pytest.mark.anyio

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import multiprocessing
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,9 @@ from exomem.auth_sessions import (
 class AtomicMemoryStore:
     def __init__(self) -> None:
         self.data: dict[tuple[str | None, str], dict[str, Any]] = {}
+        self.expiries: dict[tuple[str | None, str], float] = {}
         self.calls: list[tuple[str, str | None, str]] = []
+        self.clock = time.time
         self.pause_after_session_put = False
         self.session_written = asyncio.Event()
         self.resume_session_put = asyncio.Event()
@@ -36,6 +39,11 @@ class AtomicMemoryStore:
         self.calls.append(("get", collection, key))
         if self.fail_get:
             raise OSError("store unavailable")
+        storage_key = (collection, key)
+        expires_at = self.expiries.get(storage_key)
+        if expires_at is not None and self.clock() >= expires_at:
+            self.data.pop(storage_key, None)
+            self.expiries.pop(storage_key, None)
         value = self.data.get((collection, key))
         return dict(value) if value is not None else None
 
@@ -47,9 +55,12 @@ class AtomicMemoryStore:
         collection: str | None = None,
         ttl: float | None = None,
     ) -> None:
-        del ttl
         self.calls.append(("put", collection, key))
         self.data[(collection, key)] = dict(value)
+        if ttl is None:
+            self.expiries.pop((collection, key), None)
+        else:
+            self.expiries[(collection, key)] = self.clock() + ttl
         if self.pause_after_session_put and collection and "sessions" in collection:
             self.pause_after_session_put = False
             self.session_written.set()
@@ -63,11 +74,17 @@ class AtomicMemoryStore:
         collection: str | None = None,
         ttl: float | None = None,
     ) -> bool:
-        del ttl
         async with self._lock:
+            storage_key = (collection, key)
+            expires_at = self.expiries.get(storage_key)
+            if expires_at is not None and self.clock() >= expires_at:
+                self.data.pop(storage_key, None)
+                self.expiries.pop(storage_key, None)
             if (collection, key) in self.data:
                 return False
             self.data[(collection, key)] = dict(value)
+            if ttl is not None:
+                self.expiries[(collection, key)] = self.clock() + ttl
         if self.pause_after_session_put and collection and "sessions" in collection:
             self.pause_after_session_put = False
             self.session_written.set()
@@ -270,6 +287,43 @@ async def test_issue_validate_list_and_tombstone_without_storing_bearer() -> Non
 
 
 @pytest.mark.anyio
+async def test_literal_pre_0242_session_mapping_still_validates_lists_and_revokes() -> None:
+    raw = AtomicMemoryStore()
+    authority = _authority(raw)
+    generation = await authority.current_generation()
+    bearer, session_id, digest = authority.codec.issue()
+    legacy_mapping = {
+        "schema_version": 1,
+        "session_id": session_id,
+        "token_digest": digest,
+        "client_id": "codex",
+        "scopes": ["exomem:read"],
+        "issuer": "https://memory.example",
+        "audience": "https://memory.example/mcp",
+        "github_user_id": 123456,
+        "github_login": "person",
+        "issued_at": 1_800_000_000.0,
+        "generation": generation,
+        "status": "active",
+        "revoked_at": None,
+        "revocation_reason": None,
+    }
+    assert "expires_at" not in legacy_mapping and "family_id" not in legacy_mapping
+    await authority._storage.put(
+        session_id,
+        legacy_mapping,
+        collection=authority.sessions_collection,
+    )
+
+    validated = await authority.validate(bearer)
+    assert validated is not None and validated.schema_version == 1
+    assert validated.expires_at is None and validated.family_id is None
+    assert await authority.list_sessions() == [validated]
+    assert await authority.tombstone(session_id, reason="operator")
+    assert await authority.validate(bearer) is None
+
+
+@pytest.mark.anyio
 async def test_offline_issue_creates_one_hour_access_and_unstored_refresh_token() -> None:
     raw = AtomicMemoryStore()
     authority = _authority(raw)
@@ -298,6 +352,7 @@ async def test_offline_issue_creates_one_hour_access_and_unstored_refresh_token(
 async def test_refresh_rotation_is_cross_authority_idempotent_then_revokes_on_replay() -> None:
     raw = AtomicMemoryStore()
     now = [1_800_000_000.0]
+    raw.clock = lambda: now[0]
     first = _authority(raw, clock=lambda: now[0])
     second = _authority(raw, clock=lambda: now[0])
     access, _, refresh = await first.issue_offline(
@@ -334,6 +389,87 @@ async def test_refresh_rotation_is_cross_authority_idempotent_then_revokes_on_re
     assert await first.validate(access) is None
     assert await first.validate(rotated_a) is None
     assert await first.validate_refresh(next_refresh_a, client_id="chatgpt") is None
+
+
+@pytest.mark.anyio
+async def test_refresh_grace_uses_store_time_not_replica_clocks() -> None:
+    raw = AtomicMemoryStore()
+    store_now = [1_800_000_000.0]
+    raw.clock = lambda: store_now[0]
+    ahead = _authority(raw, clock=lambda: store_now[0] + 3600)
+    behind = _authority(raw, clock=lambda: store_now[0] - 3600)
+    _, _, refresh = await ahead.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access",),
+        identity=_identity(),
+    )
+
+    first = await ahead.rotate_refresh(
+        refresh,
+        client_id="chatgpt",
+        scopes=("offline_access",),
+    )
+    concurrent = await behind.rotate_refresh(
+        refresh,
+        client_id="chatgpt",
+        scopes=("offline_access",),
+    )
+    assert first[2] == concurrent[2]
+
+    store_now[0] += REFRESH_RETRY_GRACE_SECONDS + 1
+    with pytest.raises(InvalidRefreshToken, match="reuse"):
+        await behind.rotate_refresh(
+            refresh,
+            client_id="chatgpt",
+            scopes=("offline_access",),
+        )
+    assert await ahead.validate(first[0]) is None
+
+
+@pytest.mark.anyio
+async def test_late_replay_wins_race_with_current_refresh_issuance() -> None:
+    raw = AtomicMemoryStore()
+    now = [1_800_000_000.0]
+    raw.clock = lambda: now[0]
+    first = _authority(raw, clock=lambda: now[0])
+    second = _authority(raw, clock=lambda: now[0])
+    _, _, old_refresh = await first.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access",),
+        identity=_identity(),
+    )
+    prior_access, _, current_refresh = await first.rotate_refresh(
+        old_refresh,
+        client_id="chatgpt",
+        scopes=("offline_access",),
+    )
+    now[0] += REFRESH_RETRY_GRACE_SECONDS + 1
+    raw.pause_after_session_put = True
+
+    current_task = asyncio.create_task(
+        second.rotate_refresh(
+            current_refresh,
+            client_id="chatgpt",
+            scopes=("offline_access",),
+        )
+    )
+    await raw.session_written.wait()
+    with pytest.raises(InvalidRefreshToken, match="reuse"):
+        await first.rotate_refresh(
+            old_refresh,
+            client_id="chatgpt",
+            scopes=("offline_access",),
+        )
+    raw.resume_session_put.set()
+
+    with pytest.raises(InvalidRefreshToken, match="inactive"):
+        await current_task
+    assert await first.validate(prior_access) is None
+    assert await first.validate_refresh(current_refresh, client_id="chatgpt") is None
+    family_records = [
+        record for record in await first.list_sessions() if record.family_id is not None
+    ]
+    assert any(record.status == "revoked" for record in family_records)
 
 
 @pytest.mark.anyio

--- a/tests/test_connector_guardrails.py
+++ b/tests/test_connector_guardrails.py
@@ -26,7 +26,7 @@ def test_chatgpt_personal_plugin_tracks_current_tool_surface_rollout() -> None:
     assert plugin["client_registration"] == "cimd"
     assert plugin["oidc_enabled"] is False
     assert plugin["default_scopes"] == []
-    assert plugin["base_scopes"] == []
+    assert plugin["base_scopes"] == ["offline_access"]
     registered = plugin["registered_tool_surface_sha256"]
     pending = plugin["pending_tool_surface_sha256"]
     if registered == surface["sha256"]:
@@ -65,4 +65,5 @@ def test_remote_quickstart_documents_chatgpt_oauth_only_setup() -> None:
     assert "https://<host>/mcp" in guide
     assert "oidc" in guide and "off" in guide
     assert "default scopes" in guide and "blank" in guide
+    assert "base scopes" in guide and "offline_access" in guide
     assert "fresh conversation" in guide

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -159,6 +159,11 @@ def test_build_oauth_constructs_durable_proxy_and_cache_disabled_verifier(
     assert isinstance(captured["session_authority"], SessionAuthority)
     assert captured["jwt_signing_key"] == "stable-signing-root"
     assert captured["upstream_revocation_endpoint"] is None
+    assert captured["valid_scopes"] == [
+        "offline_access",
+        "exomem:read",
+        "exomem:write",
+    ]
     verifier = captured["token_verifier"]
     assert isinstance(verifier, server_auth.SingleUserGitHubVerifier)
     assert verifier._allowed_login == "person"

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -187,3 +187,24 @@ def test_openid_discovery_alias_returns_oauth_metadata() -> None:
         "id_token_signing_alg_values_supported",
     ):
         assert oidc_only_field not in metadata
+
+
+def test_bare_protected_resource_alias_omits_protocol_scope() -> None:
+    mcp = server.ExomemFastMCP("discovery-test")
+    register_oauth_metadata_route(
+        mcp,
+        base_url="https://memory.example",
+        auth_enabled=True,
+    )
+    app = mcp.http_app(transport="streamable-http", stateless_http=True)
+    route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/.well-known/oauth-protected-resource"
+    )
+
+    response = asyncio.run(route.endpoint(None))
+    metadata = json.loads(response.body)
+
+    assert metadata["scopes_supported"] == ["exomem:read", "exomem:write"]
+    assert "offline_access" not in metadata["scopes_supported"]

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -174,6 +174,11 @@ def test_openid_discovery_alias_returns_oauth_metadata() -> None:
     assert metadata["token_endpoint"] == "https://memory.example/token"
     assert metadata["registration_endpoint"] == "https://memory.example/register"
     assert metadata["code_challenge_methods_supported"] == ["S256"]
+    assert metadata["scopes_supported"] == [
+        "offline_access",
+        "exomem:read",
+        "exomem:write",
+    ]
     assert "openid" not in metadata["scopes_supported"]
     for oidc_only_field in (
         "userinfo_endpoint",

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -26,7 +26,12 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import AnyUrl
 from starlette.requests import Request
 
-from exomem.auth_sessions import SessionIdentity, SessionStoreUnavailable
+from exomem.auth_sessions import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    RefreshGrant,
+    SessionIdentity,
+    SessionStoreUnavailable,
+)
 from exomem.session_oauth import ExomemSessionOAuthProxy
 
 
@@ -132,13 +137,18 @@ class FakeRecord:
     audience: str = "https://memory.example/mcp"
     github_user_id: int = 123456
     github_login: str = "person"
+    expires_at: float | None = None
 
 
 class FakeAuthority:
     def __init__(self) -> None:
         self.sessions: dict[str, FakeRecord] = {}
         self.issue_calls: list[dict[str, Any]] = []
+        self.offline_issue_calls: list[dict[str, Any]] = []
+        self.rotate_calls: list[dict[str, Any]] = []
         self.tombstones: list[tuple[str, str]] = []
+        self.revoked_bearers: list[tuple[str, str]] = []
+        self.refreshes: dict[str, RefreshGrant] = {}
         self.validation_error: Exception | None = None
 
     async def issue(
@@ -162,6 +172,72 @@ class FakeAuthority:
         self.sessions[token] = record
         return token, record
 
+    async def issue_offline(
+        self,
+        *,
+        client_id: str,
+        scopes: list[str],
+        identity: SessionIdentity,
+    ) -> tuple[str, FakeRecord, str]:
+        index = len(self.offline_issue_calls)
+        access = f"local-access-{index}"
+        refresh = f"local-refresh-{index}"
+        record = FakeRecord(
+            session_id=f"access-session-{index}",
+            client_id=client_id,
+            scopes=tuple(scopes),
+            github_user_id=identity.github_user_id,
+            github_login=identity.github_login,
+            expires_at=time.time() + ACCESS_TOKEN_TTL_SECONDS,
+        )
+        call = {"client_id": client_id, "scopes": list(scopes), "identity": identity}
+        self.offline_issue_calls.append(call)
+        self.sessions[access] = record
+        self.refreshes[refresh] = RefreshGrant(
+            family_id=f"family-{index:016d}",
+            sequence=0,
+            client_id=client_id,
+            scopes=tuple(scopes),
+        )
+        return access, record, refresh
+
+    async def validate_refresh(
+        self, token: str, *, client_id: str
+    ) -> RefreshGrant | None:
+        grant = self.refreshes.get(token)
+        return grant if grant is not None and grant.client_id == client_id else None
+
+    async def rotate_refresh(
+        self,
+        token: str,
+        *,
+        client_id: str,
+        scopes: list[str],
+    ) -> tuple[str, FakeRecord, str]:
+        grant = await self.validate_refresh(token, client_id=client_id)
+        if grant is None:
+            raise AssertionError("proxy attempted to rotate an invalid fake refresh")
+        index = len(self.rotate_calls)
+        access = f"rotated-access-{index}"
+        refresh = f"rotated-refresh-{index}"
+        record = FakeRecord(
+            session_id=f"rotated-session-{index}",
+            client_id=client_id,
+            scopes=tuple(scopes),
+            expires_at=time.time() + ACCESS_TOKEN_TTL_SECONDS,
+        )
+        self.rotate_calls.append(
+            {"token": token, "client_id": client_id, "scopes": list(scopes)}
+        )
+        self.sessions[access] = record
+        self.refreshes[refresh] = RefreshGrant(
+            family_id=grant.family_id,
+            sequence=grant.sequence + 1,
+            client_id=client_id,
+            scopes=grant.scopes,
+        )
+        return access, record, refresh
+
     async def validate(self, token: str) -> FakeRecord | None:
         if self.validation_error is not None:
             raise self.validation_error
@@ -174,6 +250,12 @@ class FakeAuthority:
                 del self.sessions[token]
                 return True
         return False
+
+    async def revoke_bearer(self, token: str, *, reason: str) -> bool:
+        self.revoked_bearers.append((token, reason))
+        self.sessions.pop(token, None)
+        self.refreshes.pop(token, None)
+        return True
 
 
 class StubVerifier:
@@ -279,9 +361,9 @@ def _install_token_exchange(
     proxy._upstream_oauth_client = client_factory
 
 
-def _client() -> OAuthClientInformationFull:
+def _client(client_id: str = "codex-client") -> OAuthClientInformationFull:
     return OAuthClientInformationFull(
-        client_id="codex-client",
+        client_id=client_id,
         client_secret="client-secret",
         redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
         token_endpoint_auth_method="client_secret_post",
@@ -317,6 +399,45 @@ def _token_request(*, code: str, code_verifier: str) -> Request:
             "code_verifier": code_verifier,
         }
     ).encode()
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/token",
+            "raw_path": b"/token",
+            "query_string": b"",
+            "headers": [
+                (b"content-type", b"application/x-www-form-urlencoded"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("memory.example", 443),
+        },
+        receive,
+    )
+
+
+def _refresh_request(refresh_token: str, *, scope: str | None = None) -> Request:
+    values = {
+            "grant_type": "refresh_token",
+            "client_id": "codex-client",
+            "client_secret": "client-secret",
+            "refresh_token": refresh_token,
+    }
+    if scope is not None:
+        values["scope"] = scope
+    body = urlencode(values).encode()
     sent = False
 
     async def receive() -> dict[str, Any]:
@@ -661,6 +782,91 @@ async def test_token_endpoint_omits_expiry_and_refresh_fields() -> None:
 
 
 @pytest.mark.anyio
+async def test_offline_code_exchange_issues_expiring_access_and_refresh_token() -> None:
+    authority = FakeAuthority()
+    proxy = _proxy(authority=authority)
+    code = "offline-downstream-code"
+    await proxy._code_store.put(
+        key=code,
+        value=ClientCode(
+            code=code,
+            client_id="codex-client",
+            redirect_uri="http://127.0.0.1:8765/callback",
+            code_challenge="downstream-pkce-challenge",
+            code_challenge_method="S256",
+            scopes=["offline_access", "exomem:read"],
+            idp_tokens={
+                "exomem_identity": {
+                    "github_user_id": 123456,
+                    "github_login": "person",
+                }
+            },
+            expires_at=int(time.time() + 300),
+            created_at=time.time(),
+        ),
+        ttl=300,
+    )
+
+    token = await proxy.exchange_authorization_code(
+        _client(), _authorization_code(code)
+    )
+
+    assert token.access_token == "local-access-0"
+    assert token.refresh_token == "local-refresh-0"
+    assert token.expires_in == ACCESS_TOKEN_TTL_SECONDS
+    assert token.scope == "offline_access exomem:read"
+    assert authority.issue_calls == []
+    assert len(authority.offline_issue_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_proxy_loads_rotates_and_revokes_exomem_refresh_without_legacy_store() -> None:
+    authority = FakeAuthority()
+    proxy = _proxy(authority=authority)
+    _, _, refresh = await authority.issue_offline(
+        client_id="codex-client",
+        scopes=["offline_access", "exomem:read"],
+        identity=SessionIdentity(github_user_id=123456, github_login="person"),
+    )
+
+    loaded = await proxy.load_refresh_token(_client(), refresh)
+    assert loaded is not None
+    assert loaded.client_id == "codex-client"
+    assert loaded.scopes == ["offline_access", "exomem:read"]
+    assert loaded.expires_at is None
+    assert await proxy.load_refresh_token(_client("other-client"), refresh) is None
+
+    expanded = await TokenHandler(proxy, _ClientAuthenticator()).handle(
+        _refresh_request(refresh, scope="offline_access exomem:admin")
+    )
+    assert expanded.status_code == 400
+    assert json.loads(expanded.body)["error"] == "invalid_scope"
+    assert authority.rotate_calls == []
+
+    response = await TokenHandler(proxy, _ClientAuthenticator()).handle(
+        _refresh_request(refresh)
+    )
+    assert response.status_code == 200
+    rotated = json.loads(response.body)
+    assert rotated["access_token"] == "rotated-access-0"
+    assert rotated["refresh_token"] == "rotated-refresh-0"
+    assert rotated["expires_in"] == ACCESS_TOKEN_TTL_SECONDS
+    assert rotated["scope"] == "offline_access exomem:read"
+    assert authority.rotate_calls == [
+        {
+            "token": refresh,
+            "client_id": "codex-client",
+            "scopes": ["offline_access", "exomem:read"],
+        }
+    ]
+
+    await proxy.revoke_token(loaded)
+    assert authority.revoked_bearers == [
+        (refresh, "oauth-client-revocation")
+    ]
+
+
+@pytest.mark.anyio
 async def test_exchange_rejects_corrupt_boolean_identity_proof() -> None:
     authority = FakeAuthority()
     proxy = _proxy(authority=authority)
@@ -763,9 +969,14 @@ async def test_rfc7009_revocation_tombstones_shared_session_and_unknown_is_succe
         AccessToken(token="session-token", client_id="codex-client", scopes=["exomem:read"])
     )
 
-    assert authority.tombstones == [("session-id", "oauth-client-revocation")]
+    assert authority.revoked_bearers == [
+        ("session-token", "oauth-client-revocation")
+    ]
     assert await proxy.load_access_token("session-token") is None
     await proxy.revoke_token(
         AccessToken(token="unknown", client_id="codex-client", scopes=["exomem:read"])
     )
-    assert authority.tombstones == [("session-id", "oauth-client-revocation")]
+    assert authority.revoked_bearers == [
+        ("session-token", "oauth-client-revocation"),
+        ("unknown", "oauth-client-revocation"),
+    ]

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -68,8 +68,12 @@ def test_fastmcp_private_adapter_contract_is_pinned() -> None:
         assert list(
             inspect.signature(getattr(ExomemSessionOAuthProxy, seam)).parameters
         ) == list(inspect.signature(getattr(OAuthProxy, seam)).parameters)
-    for inherited_compatibility_seam in ("register_client", "get_client", "get_routes"):
+    for inherited_compatibility_seam in ("register_client", "get_client"):
         assert inherited_compatibility_seam not in ExomemSessionOAuthProxy.__dict__
+    assert list(inspect.signature(ExomemSessionOAuthProxy.get_routes).parameters) == [
+        "self",
+        "mcp_path",
+    ]
     assert list(
         inspect.signature(OAuthProxy._validate_client_redirect_uri).parameters
     ) == ["self", "redirect_uri"]
@@ -844,7 +848,10 @@ async def test_proxy_loads_rotates_and_revokes_exomem_refresh_without_legacy_sto
     assert authority.rotate_calls == []
 
     response = await TokenHandler(proxy, _ClientAuthenticator()).handle(
-        _refresh_request(refresh)
+        _refresh_request(
+            refresh,
+            scope="offline_access exomem:read exomem:read",
+        )
     )
     assert response.status_code == 200
     rotated = json.loads(response.body)

--- a/tests/test_shared_oauth_storage.py
+++ b/tests/test_shared_oauth_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import httpx
@@ -153,6 +154,49 @@ async def test_remote_session_authority_is_cross_replica_and_revocation_safe(tmp
     assert await first.validate(bearer) is None
     [listed] = await first.list_sessions()
     assert listed.status == "revoked"
+
+
+@pytest.mark.anyio
+async def test_remote_refresh_rotation_converges_across_replicas(tmp_path: Path) -> None:
+    now = [1_800_000_000.0]
+    database = tmp_path / "refresh-coordinator.sqlite"
+    app = create_app(database=database, bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+    kwargs = {
+        "url": "https://coordinator.example",
+        "namespace": "main",
+        "storage_token": "secret",
+        "signing_root": "stable-root",
+        "issuer": "https://memory.example",
+        "audience": "https://memory.example/mcp",
+        "transport": transport,
+        "clock": lambda: now[0],
+    }
+    first = SessionAuthority.remote(**kwargs)
+    second = SessionAuthority.remote(**kwargs)
+    _, _, refresh = await first.issue_offline(
+        client_id="chatgpt",
+        scopes=("offline_access", "exomem:read"),
+        identity=SessionIdentity(github_user_id=123, github_login="person"),
+    )
+
+    first_result, second_result = await asyncio.gather(
+        first.rotate_refresh(
+            refresh,
+            client_id="chatgpt",
+            scopes=("offline_access", "exomem:read"),
+        ),
+        second.rotate_refresh(
+            refresh,
+            client_id="chatgpt",
+            scopes=("offline_access", "exomem:read"),
+        ),
+    )
+
+    assert first_result[2] == second_result[2]
+    assert await first.validate(first_result[0]) == first_result[1]
+    assert await second.validate(second_result[0]) == second_result[1]
+    assert refresh.encode() not in database.read_bytes()
 
 
 def test_remote_session_authority_requires_storage_bearer() -> None:


### PR DESCRIPTION
## What changed

- add opt-in `exo_a2` one-hour access tokens and durable rotating `exo_r2` refresh families for clients requesting `offline_access`
- use encrypted permanent redemption receipts plus coordinator-TTL grace markers, so concurrent/retried refreshes converge across replicas without trusting replica clocks
- revoke the complete family on late token reuse or explicit access/refresh revocation
- preserve existing non-expiring `exo_s1` sessions for Codex/Claude clients that do not request offline access
- advertise honest authorization and resource scopes, keep Exomem scopes out of the GitHub identity request, and document ChatGPT's `offline_access` base scope

## Why

Exomem inherited discovery metadata that advertised the refresh grant while its durable OAuth adapter rejected every refresh request. ChatGPT could therefore discover the connector successfully but later lose authorization and require a manual reconnect. The old contract also could not safely coordinate rotating refreshes across multiple ChatGPT workers or Exomem replicas.

## Impact

ChatGPT authorizes once, receives a one-hour access token, and renews silently through Exomem-owned refresh tokens. Service restarts, replica failover, and normal concurrent refresh retries no longer require GitHub reauthentication. Existing `exo_s1` sessions remain valid through the rollout.

## Validation

- 85 focused auth/session/discovery tests passed
- changed-file Ruff checks passed
- `git diff --check` passed
- strict OpenSpec validation passed
- independent security review and re-review found no remaining blocker, high, or medium issue

The managed Windows runner cannot execute four pre-existing local-filesystem/process tests because it blocks pytest temp enumeration, named pipes, and async file I/O. The full suite also has two unrelated Windows collection failures (`fcntl` and a non-UTF8 filename fixture); GitHub CI is the authoritative full-suite run.
