### PR TITLE
fix: repair Windows hook atomic replacement

### DIFF
--- a/src/exomem/_hooks/exomem_continuation_checkpoint.py
+++ b/src/exomem/_hooks/exomem_continuation_checkpoint.py
@@ -1497,7 +1497,14 @@ def _windows_rename_at(
         share=0x7,
     )
     try:
-        encoded = destination.encode("utf-16-le")
+        # SetFileInformationByHandle's Win32 FILE_RENAME_INFO contract requires
+        # RootDirectory to be NULL.  Keep the already-validated directory tree
+        # pinned by its retained handles, but pass the destination as the absolute
+        # final path of that retained directory rather than as a handle-relative
+        # basename (which fails with ERROR_INVALID_PARAMETER on Windows 11).
+        directory_path = _windows_final_path(directory.windows_handle).rstrip("\\/")
+        destination_path = f"{directory_path}\\{destination}"
+        encoded = destination_path.encode("utf-16-le")
 
         class _RenameHeader(ctypes.Structure):
             _fields_ = [
@@ -1507,10 +1514,16 @@ def _windows_rename_at(
             ]
 
         offset = _RenameHeader.length.offset + ctypes.sizeof(wintypes.DWORD)
-        buffer = ctypes.create_string_buffer(offset + len(encoded))
+        # FILE_RENAME_INFO's FileNameLength excludes the terminator, but the
+        # FileName member itself must still be NUL-terminated.  Without these
+        # two zero bytes Windows can consume adjacent memory as a filename
+        # suffix and report success after renaming to the wrong path.
+        buffer = ctypes.create_string_buffer(
+            offset + len(encoded) + ctypes.sizeof(wintypes.WCHAR)
+        )
         header = _RenameHeader.from_buffer(buffer)
         header.replace = bool(replace)
-        header.root = wintypes.HANDLE(directory.windows_handle)
+        header.root = wintypes.HANDLE()
         header.length = len(encoded)
         ctypes.memmove(ctypes.addressof(buffer) + offset, encoded, len(encoded))
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -1521,7 +1534,7 @@ def _windows_rename_at(
             error = ctypes.get_last_error()
             if error in {5, 32}:
                 raise PermissionError(error, "Windows entry is held open")
-            raise OSError(error, "handle-relative Windows rename failed")
+            raise OSError(error, "secure Windows rename failed")
     finally:
         _windows_close_handle(source_handle)
 

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -739,6 +739,24 @@ def test_real_config_change_creates_unique_mode_preserving_backup(tmp_path: Path
     assert first["config_changed"] is True
 
 
+@pytest.mark.skipif(os.name != "nt", reason="requires live Windows rename semantics")
+def test_windows_safe_replace_atomically_replaces_existing_file(tmp_path: Path) -> None:
+    expected: set[str] = set()
+    for index in range(32):
+        source = tmp_path / f"replacement-{index}.tmp"
+        destination = tmp_path / f"current-{index}.json"
+        source.write_text("new", encoding="utf-8")
+        destination.write_text("old", encoding="utf-8")
+
+        checkpoint._safe_replace(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "new"
+        assert not source.exists()
+        expected.add(destination.name)
+
+    assert {path.name for path in tmp_path.iterdir()} == expected
+
+
 def test_postcommit_replace_error_retains_backup_and_committed_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- use the absolute final path required by Win32 FILE_RENAME_INFO while retaining validated directory handles
- NUL-terminate the UTF-16 destination buffer so Windows cannot consume adjacent memory as a filename suffix
- add a live Windows regression that performs 32 replacements and rejects stray filenames

## Verification
- live Windows regression: 1 passed
- Windows hook suite excluding three pre-existing platform-specific failures: 71 passed, 9 skipped
- real Claude + Codex install and health check: PASS
- Ruff and diff check: PASS

This fixes the install-hook Errno 87 failure found during the 0.25.0 rollout.