### PR TITLE
fix: defer media work on follower replicas

### DIFF
--- a/src/exomem/media_jobs.py
+++ b/src/exomem/media_jobs.py
@@ -25,6 +25,23 @@ COMPLETED = "completed"
 STATES = (PENDING, RUNNING, BLOCKED, FAILED)
 STATUS_JOB_LIMIT = 100
 DISCOVERY_CURSOR_KEY = "discovery_cursor"
+_TRANSIENT_OPERATION_CODES = frozenset(
+    {
+        "MUTATION_BUSY",
+        "MUTATION_LOCK_UNAVAILABLE",
+        "WRITER_COORDINATOR_UNAVAILABLE",
+        "WRITER_FENCED",
+        "WRITER_LEASE_REQUIRED",
+    }
+)
+
+
+def _is_transient_operation_error(error: str | None) -> bool:
+    if not error or not error.startswith("OpError:"):
+        return False
+    return any(
+        f"{code}:" in error or f'"code":"{code}"' in error for code in _TRANSIENT_OPERATION_CODES
+    )
 
 
 def job_store_path(vault_root: Path) -> Path:
@@ -309,6 +326,24 @@ class MediaJobStore:
         finally:
             conn.close()
 
+    def defer(self, job_id: int) -> bool:
+        """Return a claimed job to pending after transient coordination refusal."""
+        conn = self._connect()
+        try:
+            with conn:
+                changed = conn.execute(
+                    """
+                    UPDATE jobs
+                    SET state = 'pending', attempts = MAX(0, attempts - 1),
+                        last_error = NULL, updated_at = ?
+                    WHERE id = ? AND state = 'running'
+                    """,
+                    (time.time(), job_id),
+                ).rowcount
+                return changed == 1
+        finally:
+            conn.close()
+
     def get(self, job_id: int) -> MediaJob | None:
         conn = self._connect()
         try:
@@ -369,6 +404,28 @@ class MediaJobStore:
                     f"UPDATE jobs SET state = 'pending', updated_at = ? "
                     f"WHERE state IN ({placeholders})",
                     (time.time(), *states),
+                ).rowcount
+                return int(changed)
+        finally:
+            conn.close()
+
+    def recover_transient_failures(self) -> int:
+        """Repair jobs poisoned by older workers treating coordination as media failure."""
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT id, last_error FROM jobs WHERE state = 'failed'").fetchall()
+            job_ids = [
+                int(row["id"]) for row in rows if _is_transient_operation_error(row["last_error"])
+            ]
+            if not job_ids:
+                return 0
+            placeholders = ",".join("?" for _ in job_ids)
+            with conn:
+                changed = conn.execute(
+                    f"UPDATE jobs SET state = 'pending', "
+                    "attempts = MAX(0, attempts - 1), last_error = NULL, updated_at = ? "
+                    f"WHERE state = 'failed' AND id IN ({placeholders})",
+                    (time.time(), *job_ids),
                 ).rowcount
                 return int(changed)
         finally:

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -66,6 +66,10 @@ _TRANSIENT_OPERATION_CODES = frozenset(
     }
 )
 _FOLLOWER_RECHECK_SECONDS = 5.0
+_TRANSIENT_EXIT_CODE = 75
+_LOCK_UNAVAILABLE_EXIT_CODE = 76
+_TRANSIENT_RECHECK_SECONDS = 5.0
+_LOCK_UNAVAILABLE_RECHECK_SECONDS = 30.0
 
 
 def _writer_authority_available() -> bool:
@@ -590,13 +594,26 @@ class MediaWorker:
                     recovered = self._store.recover_interrupted() if owns_runtime else 0
                     if owns_runtime:
                         self._store.clear_worker(child_pid)
-                    if returncode:
+                    if returncode in {_TRANSIENT_EXIT_CODE, _LOCK_UNAVAILABLE_EXIT_CODE}:
+                        delay = (
+                            _LOCK_UNAVAILABLE_RECHECK_SECONDS
+                            if returncode == _LOCK_UNAVAILABLE_EXIT_CODE
+                            else _TRANSIENT_RECHECK_SECONDS
+                        )
+                        log.info(
+                            "media child deferred work; retrying after %.1fs",
+                            delay,
+                        )
+                    elif returncode:
+                        delay = 2.0
                         log.warning(
                             "media child exited %s; recovered %d job(s)",
                             returncode,
                             recovered,
                         )
-                    relaunch_after = time.monotonic() + (2.0 if returncode else 0.5)
+                    else:
+                        delay = 0.5
+                    relaunch_after = time.monotonic() + delay
                 if (
                     self._child is None
                     and time.monotonic() >= relaunch_after
@@ -745,7 +762,7 @@ def run_child(vault_root: Path, *, parent_pid: int, idle_seconds: float) -> int:
     store.recover_interrupted()
     if not _writer_authority_available():
         log.info("media worker: writer authority unavailable; leaving work queued")
-        return 0
+        return _TRANSIENT_EXIT_CODE
     store.set_worker(os.getpid(), idle_seconds)
     # Process mode makes scene-frame follow-up enqueue durable in this same ledger;
     # the nested supervisor is never started because the child calls _process directly.
@@ -775,7 +792,9 @@ def run_child(vault_root: Path, *, parent_pid: int, idle_seconds: float) -> int:
                         job.binary_path,
                         exc.code,
                     )
-                    return 0
+                    if exc.code == "MUTATION_LOCK_UNAVAILABLE":
+                        return _LOCK_UNAVAILABLE_EXIT_CODE
+                    return _TRANSIENT_EXIT_CODE
                 log.exception("media child job crashed: %s", job.binary_path)
                 store.mark(job.id, FAILED, f"{type(exc).__name__}: {exc}")
             except Exception as exc:  # noqa: BLE001 - preserve worker availability

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from . import embeddings, extract, index_sync, preserve, scene_frames, semantic_segments
 from .backfill import iter_kb_files
+from .cli_ops import OpError
 from .kbdir import kb_dirname
 from .media_jobs import (
     BLOCKED,
@@ -55,6 +56,26 @@ _STALE = "stale"
 _BLOCKED_ACTION = "install the required media dependency, then retry"
 _RENDERER_ACTION = "check the timestamp renderer, then retry"
 _FAILED_ACTION = "repair or replace the media artifact, then retry"
+_TRANSIENT_OPERATION_CODES = frozenset(
+    {
+        "MUTATION_BUSY",
+        "MUTATION_LOCK_UNAVAILABLE",
+        "WRITER_COORDINATOR_UNAVAILABLE",
+        "WRITER_FENCED",
+        "WRITER_LEASE_REQUIRED",
+    }
+)
+_FOLLOWER_RECHECK_SECONDS = 5.0
+
+
+def _writer_authority_available() -> bool:
+    try:
+        get_manager().ensure_writer()
+    except OpError as exc:
+        if exc.code in _TRANSIENT_OPERATION_CODES:
+            return False
+        raise
+    return True
 
 
 @dataclass(frozen=True)
@@ -127,6 +148,12 @@ class MediaWorker:
             self._stop_event.clear()
             if self._execution_mode == "process":
                 assert self._store is not None
+                recovered = self._store.recover_transient_failures()
+                if recovered:
+                    log.info(
+                        "media worker: recovered %d transient coordination failure(s)",
+                        recovered,
+                    )
                 target = self._supervise
                 name = "exomem-media-supervisor"
             else:
@@ -234,6 +261,10 @@ class MediaWorker:
             with get_manager().mutation_guard(self._vault_root):
                 index_sync.upsert_after_write(self._vault_root, [job.sidecar_path])
             log.info("re-embedded %s (post-frame-OCR segmentation)", job.sidecar_path.name)
+        except OpError as exc:
+            if exc.code in _TRANSIENT_OPERATION_CODES:
+                raise
+            log.exception("re-embed failed for %s", job.sidecar_path.name)
         except Exception:  # noqa: BLE001 — enrichment, never fatal
             log.exception("re-embed failed for %s", job.sidecar_path.name)
 
@@ -571,11 +602,14 @@ class MediaWorker:
                     and time.monotonic() >= relaunch_after
                     and self._store.needs_worker()
                 ):
-                    try:
-                        self._child = self._launch_child()
-                    except OSError:
-                        log.exception("media worker: could not start child")
-                        relaunch_after = time.monotonic() + 5.0
+                    if not _writer_authority_available():
+                        relaunch_after = time.monotonic() + _FOLLOWER_RECHECK_SECONDS
+                    else:
+                        try:
+                            self._child = self._launch_child()
+                        except OSError:
+                            log.exception("media worker: could not start child")
+                            relaunch_after = time.monotonic() + 5.0
                 self._wake.wait(0.5)
                 self._wake.clear()
         finally:
@@ -709,6 +743,9 @@ def run_child(vault_root: Path, *, parent_pid: int, idle_seconds: float) -> int:
     """Claim and process durable jobs until idle or the parent disappears."""
     store = MediaJobStore(vault_root)
     store.recover_interrupted()
+    if not _writer_authority_available():
+        log.info("media worker: writer authority unavailable; leaving work queued")
+        return 0
     store.set_worker(os.getpid(), idle_seconds)
     # Process mode makes scene-frame follow-up enqueue durable in this same ledger;
     # the nested supervisor is never started because the child calls _process directly.
@@ -729,6 +766,18 @@ def run_child(vault_root: Path, *, parent_pid: int, idle_seconds: float) -> int:
             last_work = time.monotonic()
             try:
                 outcome = worker._process(job)
+            except OpError as exc:
+                assert job.id is not None
+                if exc.code in _TRANSIENT_OPERATION_CODES:
+                    store.defer(job.id)
+                    log.info(
+                        "media worker: deferred %s after transient %s",
+                        job.binary_path,
+                        exc.code,
+                    )
+                    return 0
+                log.exception("media child job crashed: %s", job.binary_path)
+                store.mark(job.id, FAILED, f"{type(exc).__name__}: {exc}")
             except Exception as exc:  # noqa: BLE001 - preserve worker availability
                 log.exception("media child job crashed: %s", job.binary_path)
                 assert job.id is not None

--- a/tests/test_media_jobs.py
+++ b/tests/test_media_jobs.py
@@ -400,6 +400,40 @@ def test_duplicate_enqueue_does_not_implicitly_retry_terminal_job(vault: Path) -
     assert store.claim_next() is None
 
 
+def test_transient_coordination_failures_recover_without_consuming_attempts(
+    vault: Path,
+) -> None:
+    store = media_jobs.MediaJobStore(vault)
+    transient_errors = (
+        "OpError: WRITER_LEASE_REQUIRED: replica is read-only; current writer is desktop",
+        "OpError: MUTATION_BUSY: vault mutation boundary is busy",
+        'OpError: {"code":"WRITER_COORDINATOR_UNAVAILABLE","message":"offline"}',
+    )
+    transient_ids: list[int] = []
+    for index, error in enumerate(transient_errors):
+        job_id = store.enqueue(_job(vault, name=f"transient-{index}.mp3"))
+        claimed = store.claim_next()
+        assert claimed is not None and claimed.id == job_id
+        store.mark(job_id, media_jobs.FAILED, error)
+        transient_ids.append(job_id)
+
+    permanent_id = store.enqueue(_job(vault, name="corrupt.mp3"))
+    permanent = store.claim_next()
+    assert permanent is not None and permanent.id == permanent_id
+    store.mark(permanent_id, media_jobs.FAILED, "ValueError: corrupt container")
+
+    assert store.recover_transient_failures() == len(transient_ids)
+
+    jobs = {job["id"]: job for job in media_jobs.status(vault)["jobs"]}
+    for job_id in transient_ids:
+        assert jobs[job_id]["state"] == media_jobs.PENDING
+        assert jobs[job_id]["attempts"] == 0
+        assert jobs[job_id]["error"] is None
+    assert jobs[permanent_id]["state"] == media_jobs.FAILED
+    assert jobs[permanent_id]["attempts"] == 1
+    assert jobs[permanent_id]["error"] == "ValueError: corrupt container"
+
+
 def test_live_worker_prevents_duplicate_recovery(vault: Path) -> None:
     store = media_jobs.MediaJobStore(vault)
     store.enqueue(_job(vault))

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -1012,7 +1012,10 @@ def test_child_defers_transient_writer_failure_without_poisoning_job(
         ),
     )
 
-    assert media_worker.run_child(vault, parent_pid=os.getpid(), idle_seconds=0.1) == 0
+    assert (
+        media_worker.run_child(vault, parent_pid=os.getpid(), idle_seconds=0.1)
+        == media_worker._TRANSIENT_EXIT_CODE
+    )
 
     [status] = media_jobs.status(vault)["jobs"]
     assert status["state"] == media_jobs.PENDING
@@ -1048,6 +1051,47 @@ def test_follower_supervisor_does_not_launch_media_child(
         assert worker._child is None
         assert worker._store is not None
         assert worker._store.counts()[media_jobs.PENDING] == 1
+    finally:
+        worker._stop_event.set()
+        worker._wake.set()
+        thread.join(timeout=2)
+    assert not thread.is_alive()
+
+
+@pytest.mark.parametrize(
+    "returncode",
+    [media_worker._TRANSIENT_EXIT_CODE, media_worker._LOCK_UNAVAILABLE_EXIT_CODE],
+)
+def test_supervisor_backs_off_after_transient_child_exit(
+    vault, monkeypatch: pytest.MonkeyPatch, returncode: int
+) -> None:
+    result = _preserve_media_stub(vault, filename=f"transient-exit-{returncode}.mp3")
+    worker = media_worker.MediaWorker(vault, execution_mode="process")
+    worker.enqueue(
+        binary_path=vault / result.path,
+        sidecar_path=vault / result.sidecar_path,
+        media_type="audio",
+    )
+
+    class _TransientChild:
+        pid = 2_147_483_645
+
+        @staticmethod
+        def poll():
+            return returncode
+
+    worker._child = _TransientChild()
+    monkeypatch.setattr(
+        worker,
+        "_launch_child",
+        lambda: pytest.fail("transient child was relaunched before backoff"),
+    )
+
+    thread = threading.Thread(target=worker._supervise)
+    thread.start()
+    try:
+        time.sleep(0.1)
+        assert worker._child is None
     finally:
         worker._stop_event.set()
         worker._wake.set()

--- a/tests/test_media_worker.py
+++ b/tests/test_media_worker.py
@@ -553,6 +553,34 @@ def test_scene_artifacts_and_reembed_index_commit_use_guard(
     assert manager.depth == 0
 
 
+def test_reembed_propagates_transient_writer_refusal(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _preserve_media_stub(vault, filename="reembed-lease-race.mp3")
+
+    class _DeniedManager:
+        @contextmanager
+        def mutation_guard(self, _vault):
+            raise media_worker.OpError(
+                "WRITER_LEASE_REQUIRED",
+                "replica is read-only; current writer is desktop",
+            )
+            yield
+
+    monkeypatch.setattr(media_worker, "get_manager", lambda: _DeniedManager())
+    worker = media_worker.MediaWorker(vault, execution_mode="inline")
+    job = media_worker._Job(
+        binary_path=vault / result.path,
+        sidecar_path=vault / result.sidecar_path,
+        media_type="audio",
+        do_ocr=False,
+        do_reembed=True,
+    )
+
+    with pytest.raises(media_worker.OpError, match="WRITER_LEASE_REQUIRED"):
+        worker._process(job)
+
+
 def test_parent_media_change_during_clip_compute_skips_stale_index_and_scenes(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -956,6 +984,75 @@ def test_process_worker_drains_and_exits_after_idle(vault, monkeypatch: pytest.M
         assert media_jobs.status(vault)["worker_active"] is False
     finally:
         w.stop()
+
+
+def test_child_defers_transient_writer_failure_without_poisoning_job(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(extract, "asr_prewarm_enabled", lambda: False)
+    monkeypatch.setattr(extract, "log_diarization_readiness", lambda _vault: None)
+    result = _preserve_media_stub(vault, filename="lease-race.mp3")
+    store = media_jobs.MediaJobStore(vault)
+    store.enqueue(
+        media_jobs.MediaJob(
+            binary_path=vault / result.path,
+            sidecar_path=vault / result.sidecar_path,
+            media_type="audio",
+        )
+    )
+
+    monkeypatch.setattr(
+        media_worker.MediaWorker,
+        "_process",
+        lambda _self, _job: (_ for _ in ()).throw(
+            media_worker.OpError(
+                "WRITER_LEASE_REQUIRED",
+                "replica is read-only; current writer is desktop",
+            )
+        ),
+    )
+
+    assert media_worker.run_child(vault, parent_pid=os.getpid(), idle_seconds=0.1) == 0
+
+    [status] = media_jobs.status(vault)["jobs"]
+    assert status["state"] == media_jobs.PENDING
+    assert status["attempts"] == 0
+    assert status["error"] is None
+
+
+def test_follower_supervisor_does_not_launch_media_child(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _preserve_media_stub(vault, filename="follower-pending.mp3")
+    worker = media_worker.MediaWorker(vault, execution_mode="process")
+    worker.enqueue(
+        binary_path=vault / result.path,
+        sidecar_path=vault / result.sidecar_path,
+        media_type="audio",
+    )
+    monkeypatch.setattr(
+        media_worker,
+        "_writer_authority_available",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_launch_child",
+        lambda: pytest.fail("follower must not launch a media child"),
+    )
+
+    thread = threading.Thread(target=worker._supervise)
+    thread.start()
+    try:
+        time.sleep(0.1)
+        assert worker._child is None
+        assert worker._store is not None
+        assert worker._store.counts()[media_jobs.PENDING] == 1
+    finally:
+        worker._stop_event.set()
+        worker._wake.set()
+        thread.join(timeout=2)
+    assert not thread.is_alive()
 
 
 def test_child_marks_unavailable_engine_blocked(vault, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed

- gate durable media children on current writer authority
- defer transient lease/coordinator/mutation failures without consuming attempts
- recover legacy jobs poisoned by those transient failures while preserving real media failures
- propagate re-embed authority loss instead of silently completing the job

## Why

The v0.25.0 laptop follower marked 131 media jobs failed immediately after restart because its background worker claimed jobs before the desktop writer rejected the commit. This makes follower startup non-destructive and repairs existing coordination-only failures.

## Verification

- isolated production-style follower harness passes
- re-embed authority propagation harness passes
- targeted Ruff checks pass
- full CI required before merge