### PR TITLE
fix: accept CRLF frontmatter field edits

### DIFF
--- a/src/exomem/set_frontmatter_field.py
+++ b/src/exomem/set_frontmatter_field.py
@@ -155,6 +155,10 @@ def set_frontmatter_field(
         raise SetFrontmatterError(
             code="UNREADABLE", reason=f"could not safely read {rel_path}"
         ) from error
+    # Match the public read/edit contract: parse and render logical Markdown
+    # with LF newlines while semantic_writes retains the raw-byte PathGuard for
+    # the commit. Windows-authored CRLF must not make valid frontmatter unreadable.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     m = _FM_PATTERN.match(text)
     if not m:
         raise SetFrontmatterError(

--- a/tests/test_tier2.py
+++ b/tests/test_tier2.py
@@ -613,6 +613,25 @@ def test_set_frontmatter_field_changes_value_and_bumps_updated(vault: Path) -> N
     assert result.field == "status"
 
 
+def test_set_frontmatter_field_accepts_crlf_frontmatter(vault: Path) -> None:
+    path = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
+    absolute = vault / path
+    absolute.write_bytes(absolute.read_bytes().replace(b"\n", b"\r\n"))
+
+    result = set_fm_module.set_frontmatter_field(
+        vault,
+        path=path,
+        field="status",
+        value="active",
+        why="reaffirm active on a Windows-authored page",
+        today=TODAY,
+    )
+
+    assert result.field == "status"
+    assert "status: active" in absolute.read_text(encoding="utf-8")
+    assert "updated: 2026-05-24" in absolute.read_text(encoding="utf-8")
+
+
 def test_set_frontmatter_field_requires_why(vault: Path) -> None:
     path = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation.md"
     with pytest.raises(set_fm_module.SetFrontmatterError) as exc:


### PR DESCRIPTION
## Summary
- normalize Windows CRLF before parsing frontmatter in the field editor
- retain semantic_writes' raw-byte PathGuard for the actual commit
- add a live CRLF regression through set_frontmatter_field

## Verification
- 5 focused field/lifecycle tests passed
- Ruff passed
- diff check passed

Found during the guarded migration of a real legacy Windows note after the 0.25.1 rollout.