### PR TITLE
fix(ci): disable unconfigured hosted black-box schedule

### DIFF
--- a/.github/workflows/hosted-infrastructure.yml
+++ b/.github/workflows/hosted-infrastructure.yml
@@ -16,8 +16,9 @@ on:
       - "tests/test_hosted_*.py"
       - "openspec/changes/add-hosted-private-alpha-infrastructure/**"
       - ".github/workflows/hosted-infrastructure.yml"
-  schedule:
-    - cron: "*/5 * * * *"
+  # Re-enable the five-minute schedule only after the hosted deployment exists
+  # and all three EXOMEM_BLACKBOX_* repository secrets are configured. The
+  # cadence must match observability-v1.json poll_interval_seconds (300).
   workflow_dispatch:
     inputs:
       release_proof:

--- a/docs/runbooks/hosted/backup-restore.md
+++ b/docs/runbooks/hosted/backup-restore.md
@@ -23,6 +23,14 @@ individual Secret refs and never appear in that ConfigMap.
 python3 infra/scripts/external_blackbox.py --contract infra/contracts/observability-v1.json
 ```
 
+The GitHub Actions black-box schedule stays disabled until the hosted deployment
+exists. Before the first production invite, configure the repository secrets
+`EXOMEM_BLACKBOX_CONTROL_URL`, `EXOMEM_BLACKBOX_BACKUP_FRESHNESS_URL`, and
+`EXOMEM_BLACKBOX_SCHEDULER_URL`; run the workflow manually and require three
+healthy observations; then restore the `*/5 * * * *` schedule in
+`.github/workflows/hosted-infrastructure.yml`. The five-minute cadence must stay
+aligned with `poll_interval_seconds: 300` in the observability contract.
+
 Start backup or restore through the product lifecycle endpoint with the original
 idempotency key. Never archive a live filesystem or copy a source binding marker.
 The restore request is the control plane's complete mode-`0600` `RestoreRequest`;

--- a/docs/superpowers/specs/2026-07-19-disable-premature-hosted-blackbox-schedule-design.md
+++ b/docs/superpowers/specs/2026-07-19-disable-premature-hosted-blackbox-schedule-design.md
@@ -1,0 +1,28 @@
+# Disable the premature hosted black-box schedule
+
+## Context
+
+The hosted private beta is merged and statically verified but not deployed. The
+Hosted infrastructure workflow nevertheless starts an external black-box run
+every five minutes. Its three target URL secrets do not exist, so each scheduled
+run correctly fails closed with `black-box target is not configured` before any
+network request.
+
+## Design
+
+Remove only the `schedule` trigger. Preserve pull-request and push validation,
+manual dispatch, the external black-box job, and its fail-closed treatment of
+missing targets. Document the deployment gate: configure all three repository
+secrets, prove one manual run returns three healthy observations, and only then
+restore the five-minute schedule. The cadence remains coupled to the
+observability contract's 300-second poll interval.
+
+## Verification
+
+- Parse the edited workflow and confirm it retains pull request, push, and manual
+  dispatch triggers but has no schedule trigger.
+- Confirm the external black-box job and all three secret bindings are unchanged.
+- Run the hosted workflow's normal static validation in CI.
+- After merge, confirm no new scheduled run appears beyond the previous
+  five-minute cadence.
+


### PR DESCRIPTION
## Summary

- stop the undeployed hosted black-box monitor from running every five minutes
- retain manual dispatch and fail-closed behavior when targets are missing
- document the exact production activation gate and its 300-second cadence coupling

## Root cause

The hosted private beta is merged and verified but not deployed. The scheduled job nevertheless ran every five minutes while all three `EXOMEM_BLACKBOX_*` target secrets were absent, so every run correctly exited with `black-box target is not configured` before making a network request.

## Verification

- confirmed 12/12 recent scheduled runs failed through the same missing-target path
- confirmed PR/push hosted static validation remains green
- workflow-shape check: pull request, push, and manual dispatch retained; schedule removed; external job and all three secret bindings retained
- `git diff --check`: pass
- independent Claude Opus 4.8 review: endorsed the minimal fix and fail-closed preservation
- hosted static CI is authoritative for the edited workflow
