### PR TITLE
fix: keep a preferred replica reclaiming writer authority

### DIFF
--- a/openspec/changes/fix-preferred-writer-reclaim/.openspec.yaml
+++ b/openspec/changes/fix-preferred-writer-reclaim/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/fix-preferred-writer-reclaim/design.md
+++ b/openspec/changes/fix-preferred-writer-reclaim/design.md
@@ -1,0 +1,77 @@
+# Design — preferred-writer reclaim
+
+## The deadlock, precisely
+
+Three components each behave reasonably alone and deadlock together.
+
+1. `start_server_lifecycle()` (`writer_lease.py`) calls `ensure_writer()` once
+   when `preferred_writer` is set, and swallows `OpError`.
+2. `_renew_loop()` reads `self._fencing_token`; when it is `None` it `continue`s.
+   The loop **renews an existing lease and never acquires one**.
+3. The HA edge worker routes mutation-capable requests to the lease holder.
+
+A preferred replica that loses the startup race therefore has no remaining path
+to writer authority. There is no retry, and the event that the code expects to
+trigger a retry — an incoming mutation — is precisely what the edge withholds
+from followers.
+
+## Why a plain retry is safe
+
+The reflex worry is that retrying takeover lets a stale replica seize authority
+and write from a vault copy that is behind the current writer's. Under
+Syncthing-style replication that would be a real hazard.
+
+It does not apply here, because the coordinator does not preempt:
+
+```python
+# lease_coordinator.py
+active = holder is not None and old_expiry is not None and old_expiry > now
+if active and holder != replica_id:
+    # not granted
+```
+
+An acquisition is granted only when the lease is **free or expired**. A retrying
+preferred replica cannot displace a live holder no matter how often it asks; it
+can only claim authority once the other replica has actually stopped renewing
+(one TTL, default 12s).
+
+That leaves exactly one residual: when a holder stops and another replica takes
+over, the new writer's copy may lag the old writer's final writes. This is
+**pre-existing and symmetric** — it is how the laptop takes over from the desktop
+today, by the same code path — and the deployment documentation already places
+replication convergence with the operator. This change restores the missing
+direction of an existing behaviour; it does not introduce a new class of risk.
+
+Consequently no freshness/lag protocol is needed, and none is added. Inventing
+one here would be speculative: there is currently no cross-replica currency
+marker to compare against, and adding one would mean a coordinator schema change
+for a hazard the coordinator already prevents.
+
+## Rejected alternatives
+
+**Retry inside `start_server_lifecycle()` with a bounded loop.** Only moves the
+race a few seconds later. If the other replica is up and renewing — the actual
+observed situation, sustained for 15 hours — any bounded startup loop still ends
+in permanent follower state.
+
+**Have the edge probe followers and redirect.** The edge deliberately pins
+mutation-capable traffic to a single origin and never replays it, because the
+origin may commit after the edge stops waiting. Routing mutations to a
+non-holder to provoke acquisition would attack that guarantee directly.
+
+**Operator-triggered takeover only.** Makes every restart of the preferred
+replica a manual operation, and offers no signal that intervention is needed —
+the replica reports healthy with `takeover_eligible: true` throughout, which is
+what made this cost a full session to find.
+
+## Cadence
+
+Reclaim is attempted on the existing renew cadence, `max(1.0, ttl/3)` — 4s at the
+default 12s TTL. This bounds reclaim latency at roughly one TTL after the other
+holder stops, matches the responsiveness the renewer already assumes, and adds
+one coordinator call per interval only while this replica is a follower.
+
+No additional backoff is introduced. The call is a single indexed SQLite
+statement against a coordinator the replica already contacts on this same
+interval when it *is* the writer, so the steady-state cost is unchanged rather
+than added.

--- a/openspec/changes/fix-preferred-writer-reclaim/proposal.md
+++ b/openspec/changes/fix-preferred-writer-reclaim/proposal.md
@@ -1,0 +1,57 @@
+# Fix preferred-writer reclaim
+
+## Why
+
+A replica configured with `EXOMEM_WRITER_LEASE_PREFERRED=1` attempts to become
+writer exactly once, at server startup. If that attempt fails because another
+replica holds a live lease, the `OpError` is swallowed and the replica stays a
+follower **permanently** — for the entire lifetime of the process.
+
+`start_server_lifecycle()` justifies swallowing the failure with "Mutations will
+retry authoritatively." That assumption is false under the HA edge. The edge
+worker routes mutation-capable requests to the **current lease holder**
+(`deploy/cloudflare-ha/src/worker.js`), so a follower never receives a mutation.
+The result is a circular deadlock:
+
+- the preferred replica reclaims the lease only when a mutation arrives;
+- a mutation arrives only once it holds the lease.
+
+Observed on 2026-07-20. The desktop replica restarted at 21:01 the previous
+evening, lost a startup race to the laptop, and remained a follower for over 15
+hours while reporting `role: "follower"`, `coordinator_healthy: true`,
+`takeover_eligible: true`, `reasons: []`. Nothing was unhealthy; it had simply
+stopped trying. Its own access log recorded 118 external requests before the
+restart and zero after.
+
+The practical damage is that the preferred replica is also the machine the
+operator deploys to. A release installed and restarted there changes nothing
+observable, because the edge is still routing every request to the other
+replica. A 0.25.4 deploy on 2026-07-20 was diagnosed as ineffective for exactly
+this reason.
+
+## What Changes
+
+- The lease renewer periodically retries acquisition when this replica is
+  configured as the preferred writer and currently holds no fencing token,
+  instead of relying on a single startup attempt.
+- Retry failures stay non-fatal and unlogged-at-error, matching the existing
+  "startup remains readable" posture. A follower that cannot acquire is a normal
+  steady state, not a fault.
+- No change to preemption semantics. See design.md: the coordinator already
+  refuses to displace a live holder, so this cannot steal a lease from a running
+  replica — it only claims one that has genuinely expired.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-mutation-safety`: a preferred replica must keep attempting to reclaim
+  writer authority for as long as it is a follower, so that edge routing can
+  return to it without operator intervention.
+
+## Impact
+
+- `writer_lease.py` renew loop only. No coordinator protocol change, no schema
+  change, no edge worker change.
+- Deterministic tests for reclaim-after-expiry, no-preemption-of-a-live-holder,
+  and non-preferred replicas never self-promoting.

--- a/openspec/changes/fix-preferred-writer-reclaim/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/fix-preferred-writer-reclaim/specs/hosted-mutation-safety/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Preferred Writer Reclaim
+
+A replica configured as the preferred writer SHALL continue attempting to acquire writer authority for as long as it holds no lease, rather than attempting once at startup. Reclaim MUST NOT displace a live holder: authority is granted only when the existing lease is absent or expired. A replica not configured as preferred MUST NOT promote itself; it acquires authority only when a mutation reaches it.
+
+#### Scenario: Preferred replica loses the startup race
+
+- **WHEN** a preferred replica starts while another replica holds a live lease
+- **THEN** its startup acquisition fails without terminating startup
+- **AND** it continues attempting acquisition on the renew cadence rather than remaining a follower for the process lifetime
+
+#### Scenario: Previous holder stops renewing
+
+- **WHEN** the replica holding the lease stops renewing and the lease expires
+- **THEN** the preferred replica acquires writer authority on a subsequent attempt
+- **AND** edge routing follows the new holder without operator intervention
+
+#### Scenario: Reclaim never preempts a live holder
+
+- **WHEN** a preferred replica repeatedly attempts acquisition while another replica holds an unexpired lease
+- **THEN** every attempt is refused
+- **AND** the existing holder retains authority and its fencing token is unchanged
+
+#### Scenario: Non-preferred follower does not self-promote
+
+- **WHEN** a replica without the preferred-writer setting holds no lease
+- **THEN** it makes no periodic acquisition attempt
+- **AND** it becomes writer only when a mutation reaching it acquires authority

--- a/openspec/changes/fix-preferred-writer-reclaim/tasks.md
+++ b/openspec/changes/fix-preferred-writer-reclaim/tasks.md
@@ -1,0 +1,28 @@
+## 1. Regression Tests
+
+- [x] 1.1 Add a test proving a preferred follower reclaims once the previous holder's lease expires.
+- [x] 1.2 Add a test proving repeated reclaim attempts never displace a live holder, and leave its fencing token unchanged.
+- [x] 1.3 Add a test proving a non-preferred replica never self-promotes from the renew loop.
+- [x] 1.4 Add a test proving the renew loop *invokes* reclaim, not merely that a reclaim helper exists. Verified to fail against the unfixed loop with "renew loop never attempted reclaim while preferred and unleased"; the other three tests pass with the bug restored, so this is the one that actually guards it.
+
+## 2. Implementation
+
+- [x] 2.1 Attempt acquisition from the renew loop when this replica is preferred and holds no fencing token.
+- [x] 2.2 Keep reclaim failure non-fatal; a follower unable to acquire is normal steady state, not a fault.
+
+## 3. Verification
+
+- [x] 3.1 Run the writer-lease, mutation-lock, and lease-coordinator suites. 129 passed.
+- [x] 3.2 Run changed-file Ruff. Clean.
+- [ ] 3.3 Confirm the deployed preferred replica returns to `role: "writer"` after the other holder stops.
+
+## Status of 3.3
+
+**3.3 is deliberately open and is not a code gap.** It can only be exercised
+against the running deployment: stop the current holder, then confirm the
+preferred replica reports `role: "writer"` on `/health/ready` within roughly one
+TTL. The code path it verifies is covered by tests 1.1 and 1.4.
+
+This note exists because an unticked box on a nearly-complete change is exactly
+what caused a full misdiagnosis on 2026-07-20 — a reader concluded shipped work
+was unshipped. Do not read 3.3 as "the fix was never landed".

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -1085,12 +1085,38 @@ class LeaseManager:
         )
         self._renewer.start()
 
+    def _attempt_preferred_reclaim(self) -> None:
+        """Retry writer acquisition while this preferred replica is a follower.
+
+        `start_server_lifecycle()` attempts acquisition once at startup and
+        swallows the failure, reasoning that "mutations will retry
+        authoritatively". Under the HA edge that is false: the edge routes
+        mutation-capable requests to the current lease holder, so a follower is
+        never sent the mutation that would trigger a retry. Without this the
+        preferred replica loses one startup race and stays a follower for the
+        entire process lifetime — observed as a 15-hour outage on 2026-07-20
+        while reporting healthy and `takeover_eligible: true`.
+
+        This cannot displace a live holder. The coordinator grants acquisition
+        only when the existing lease is absent or expired, so a refused attempt
+        is the normal steady state for a follower, not a fault worth logging.
+        """
+        if not self.config.preferred_writer:
+            return
+        try:
+            self.ensure_writer()
+        except OpError:
+            return
+
     def _renew_loop(self) -> None:
         interval = max(1.0, self.config.ttl_seconds / 3)
         while not self._stop.wait(interval):
             with self._lock:
                 token = self._fencing_token
-            if token is None or self.client is None:
+            if self.client is None:
+                continue
+            if token is None:
+                self._attempt_preferred_reclaim()
                 continue
             try:
                 record = self.client.renew(token)

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import sqlite3
 import threading
+import time
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, replace
@@ -1770,6 +1771,122 @@ class Clock:
 
     def __call__(self) -> float:
         return self.value
+
+
+def _reclaim_replica(
+    store: SQLiteLeaseStore,
+    tmp_path: Path,
+    replica_id: str,
+    *,
+    preferred: bool,
+    ttl_seconds: float = 30.0,
+) -> LeaseManager:
+    return LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id=replica_id,
+            state_dir=tmp_path / f"{replica_id}-state",
+            preferred_writer=preferred,
+            ttl_seconds=ttl_seconds,
+        ),
+        client=StoreClient(store, replica_id),
+    )
+
+
+def test_preferred_follower_reclaims_once_the_previous_lease_expires(tmp_path: Path) -> None:
+    """A preferred replica must keep trying, not give up after one startup race.
+
+    Regression: `start_server_lifecycle()` attempted acquisition once and
+    swallowed the failure, reasoning that mutations would retry. The HA edge
+    routes mutations to the lease holder, so a follower never receives one. The
+    preferred replica lost a startup race on 2026-07-19 and stayed a follower
+    for 15 hours while reporting healthy.
+    """
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    laptop = _reclaim_replica(store, tmp_path, "laptop", preferred=False)
+    desktop = _reclaim_replica(store, tmp_path, "desktop", preferred=True)
+
+    assert laptop.ensure_writer().holder == "laptop"
+    # Desktop starts while the laptop holds a live lease: startup acquisition fails.
+    with pytest.raises(OpError, match="WRITER_LEASE_REQUIRED"):
+        desktop.ensure_writer()
+    assert desktop.status()["role"] == "follower"
+
+    # Retrying changes nothing while the holder is live.
+    desktop._attempt_preferred_reclaim()
+    assert desktop.status()["role"] == "follower"
+
+    # The laptop stops renewing and its lease lapses.
+    clock.value += 60
+    desktop._attempt_preferred_reclaim()
+    assert desktop.status()["role"] == "writer"
+
+
+def test_reclaim_never_preempts_a_live_holder(tmp_path: Path) -> None:
+    """Repeated reclaim must not displace a running writer or disturb its fencing token."""
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    laptop = _reclaim_replica(store, tmp_path, "laptop", preferred=False)
+    desktop = _reclaim_replica(store, tmp_path, "desktop", preferred=True)
+
+    granted = laptop.ensure_writer()
+    for _ in range(5):
+        desktop._attempt_preferred_reclaim()
+
+    held = store.status("main")
+    assert held["holder"] == "laptop"
+    # The holder's fencing token is untouched: no takeover was even half-applied.
+    assert held["fencing_token"] == granted.fencing_token
+    assert desktop.status()["role"] == "follower"
+
+
+def test_renew_loop_actually_drives_reclaim(tmp_path: Path) -> None:
+    """The renewer must invoke reclaim, not merely have a reclaim method available.
+
+    The defect was in the loop itself: it read `_fencing_token`, found None, and
+    `continue`d — renewing an existing lease but never acquiring one. Tests that
+    call the reclaim helper directly would all still pass with that `continue`
+    restored, so this asserts the wiring end to end.
+    """
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    laptop = _reclaim_replica(store, tmp_path, "laptop", preferred=False)
+    # ttl/3 floors at a 1s renew interval, keeping the test bounded.
+    desktop = _reclaim_replica(store, tmp_path, "desktop", preferred=True, ttl_seconds=1.0)
+
+    assert laptop.ensure_writer().holder == "laptop"
+    with pytest.raises(OpError, match="WRITER_LEASE_REQUIRED"):
+        desktop.ensure_writer()
+
+    clock.value += 60  # the laptop's lease lapses
+    desktop.start_renewer()
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if store.status("main")["holder"] == "desktop":
+                break
+            time.sleep(0.05)
+        assert store.status("main")["holder"] == "desktop", (
+            "renew loop never attempted reclaim while preferred and unleased"
+        )
+    finally:
+        desktop.close()
+
+
+def test_non_preferred_follower_does_not_self_promote(tmp_path: Path) -> None:
+    """Only a preferred replica reclaims in the background; others wait for a mutation."""
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    follower = _reclaim_replica(store, tmp_path, "laptop", preferred=False)
+
+    # Lease is entirely free — the only thing stopping acquisition is the policy.
+    assert store.status("main")["holder"] is None
+    follower._attempt_preferred_reclaim()
+
+    assert store.status("main")["holder"] is None
+    assert follower.status()["role"] == "follower"
 
 
 def test_sqlite_coordinator_exclusivity_expiry_takeover_and_fencing(tmp_path: Path) -> None:


### PR DESCRIPTION
## The deadlock

A replica with `EXOMEM_WRITER_LEASE_PREFERRED=1` attempted acquisition **exactly once**, at startup. If another replica held a live lease, the `OpError` was swallowed and it stayed a follower for the entire process lifetime.

`start_server_lifecycle()` justified swallowing it:

```python
except OpError:
    # Startup remains readable. Mutations will retry authoritatively.
    pass
```

That assumption is false under the HA edge, which routes mutation-capable requests to the **current lease holder** — so a follower is never sent the mutation that would trigger the retry. The renew loop didn't help either:

```python
token = self._fencing_token
if token is None or self.client is None:
    continue          # renews an existing lease; never acquires one
```

Circular deadlock: **reclaim requires a mutation, and a mutation requires the lease.**

## Observed impact

On 2026-07-20 the desktop replica had restarted the previous evening at 21:01, lost the startup race, and remained a follower for **15+ hours** while reporting:

```json
{"role":"follower","coordinator_healthy":true,"takeover_eligible":true,"reasons":[]}
```

Nothing was unhealthy — it had simply stopped trying. Its access log shows 118 external requests before the restart and zero after.

The compounding problem: the preferred replica is also the machine the operator deploys to. A 0.25.4 release installed and restarted there produced no observable change, because the edge was still routing every request to the other replica. That is what kept the deadlock hidden, and it cost a full debugging session.

## Why a plain retry is safe — no freshness protocol needed

The reflex concern is a stale replica seizing authority and writing from a lagging vault copy. That does not apply, because the coordinator never preempts:

```python
# lease_coordinator.py
active = holder is not None and old_expiry is not None and old_expiry > now
if active and holder != replica_id:
    # not granted
```

Acquisition is granted only when the lease is **free or expired**. A retrying replica cannot displace a live holder however often it asks; it can only claim authority the previous holder has genuinely let lapse (one TTL, default 12s).

The residual — a new writer's copy possibly lagging the old writer's final writes — is **pre-existing and symmetric**: it is exactly how the laptop takes over from the desktop today, via this same path. This change restores the missing direction of an existing behaviour. Adding a freshness protocol would mean a coordinator schema change to guard a hazard the coordinator already prevents, so none is added. Reasoning recorded in `design.md`.

## Tests

Three tests cover the semantics (reclaim after expiry, no preemption of a live holder, non-preferred never self-promotes). A fourth covers the **wiring**, and it is the one that matters: the other three pass with the bug restored, because they call the reclaim helper directly. `test_renew_loop_actually_drives_reclaim` was confirmed to fail against the unfixed loop with *"renew loop never attempted reclaim while preferred and unleased"*.

## Verification

- 129 passed across `test_writer_lease.py`, `test_mutation_lock.py`
- `ruff check` clean
- Task 3.3 (deployment confirmation) is intentionally left open — it can only be exercised against the running deployment by stopping the holder. `tasks.md` says so explicitly, because an unticked box on a nearly-complete change is what caused the misdiagnosis this change came out of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z8W4eQFrREL758npaVPH6
