### PR TITLE
fix(plugin): drop the manifest hooks key and state the vault prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,20 @@ itself (no separate `claude mcp add`):
 /plugin install exomem@exomem
 ```
 
-Set `EXOMEM_VAULT_PATH` to your vault first, or run `exomem setup` afterwards to
-create and configure one.
+**Set `EXOMEM_VAULT_PATH` before installing** — a plugin cannot ask where your
+notes live, so without it the MCP server refuses to start:
+
+```powershell
+setx EXOMEM_VAULT_PATH "C:\path\to\your\Obsidian"   # Windows, then reopen the terminal
+```
+```bash
+export EXOMEM_VAULT_PATH="/path/to/your/Obsidian"   # macOS/Linux, add to your shell profile
+```
+
+Don't have a vault yet, or want the path baked into the registration instead of
+read from the environment? Use the one-line installer above — `exomem setup`
+passes the vault explicitly via `claude mcp add --env`, so it works regardless of
+your environment.
 
 ### claude.ai and ChatGPT
 

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,9 +1,8 @@
 {
   "name": "exomem",
-  "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded.",
+  "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
   "version": "0.25.5",
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "exomem": {
       "command": "uvx",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exomem",
   "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded.",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json",
   "mcpServers": {

--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -1,54 +1,57 @@
 {
-  "Stop": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/exomem-capture-nudge.sh"
-        }
-      ]
-    }
-  ],
-  "UserPromptSubmit": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/exomem-retrieve-nudge.sh"
-        }
-      ]
-    }
-  ],
-  "PreCompact": [
-    {
-      "matcher": "manual|auto",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh"
-        }
-      ]
-    }
-  ],
-  "SessionEnd": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh"
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "matcher": "compact|resume",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh"
-        }
-      ]
-    }
-  ]
+  "description": "Exomem capture, retrieval, and continuation hooks.",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/exomem-capture-nudge.sh\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/exomem-retrieve-nudge.sh\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/exomem-continuation-checkpoint.sh\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/exomem/package_skills.py
+++ b/src/exomem/package_skills.py
@@ -110,11 +110,16 @@ def _plugin_manifest() -> dict:
         "description": (
             "Governed long-term memory over a markdown vault: raw sources stay "
             "immutable, conclusions are compiled with provenance, and nothing is "
-            "deleted - it is superseded."
+            "deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at "
+            "your vault; run `exomem setup` if you do not have one yet."
         ),
         "version": _package_version(),
+        # No "hooks" key: hooks/hooks.json is loaded automatically by convention,
+        # and declaring it as well fails the install with "Duplicate hooks file
+        # detected". The manifest key is only for ADDITIONAL hook files.
+        # skills/ is likewise auto-discovered; declared here because it is the
+        # documented form and does not collide.
         "skills": "./skills/",
-        "hooks": "./hooks/hooks.json",
         "mcpServers": {
             "exomem": {
                 # `uvx` fetches and runs the published package, so the plugin works

--- a/src/exomem/package_skills.py
+++ b/src/exomem/package_skills.py
@@ -130,7 +130,17 @@ def _plugin_manifest() -> dict:
 
 
 def _plugin_hooks() -> dict:
-    hooks: dict[str, list] = {}
+    """Render hooks.json.
+
+    The event map MUST sit under a top-level "hooks" key. Emitting the events at
+    the document root parses as valid JSON but the plugin then fails to load with
+    `expected record, received undefined` at path ["hooks"] -- caught only by
+    actually installing the plugin, not by any schema we control.
+
+    The script path is quoted because ${CLAUDE_PLUGIN_ROOT} expands to a real
+    install path, which on Windows and macOS routinely contains spaces.
+    """
+    events: dict[str, list] = {}
     for event, matcher in _PLUGIN_HOOK_EVENTS:
         entry: dict = {}
         if matcher is not None:
@@ -139,12 +149,15 @@ def _plugin_hooks() -> dict:
             {
                 "type": "command",
                 "command": (
-                    f"bash ${{CLAUDE_PLUGIN_ROOT}}/hooks/{_PLUGIN_HOOK_SCRIPTS[event]}"
+                    f'bash "${{CLAUDE_PLUGIN_ROOT}}/hooks/{_PLUGIN_HOOK_SCRIPTS[event]}"'
                 ),
             }
         ]
-        hooks.setdefault(event, []).append(entry)
-    return hooks
+        events.setdefault(event, []).append(entry)
+    return {
+        "description": "Exomem capture, retrieval, and continuation hooks.",
+        "hooks": events,
+    }
 
 
 def sync_plugin(plugin_root: Path) -> dict:

--- a/tests/test_plugin_sync.py
+++ b/tests/test_plugin_sync.py
@@ -93,14 +93,30 @@ def test_core_skill_does_not_nest_the_workflow_skills() -> None:
     assert not (PLUGIN_ROOT / "skills" / "exomem" / "workflow-skills").exists()
 
 
-def test_hook_commands_resolve_through_the_plugin_root_placeholder() -> None:
-    hooks = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+def test_hooks_file_nests_events_under_a_top_level_hooks_key() -> None:
+    """Events at the document root parse as JSON but the plugin refuses to load:
+    `expected record, received undefined` at path ["hooks"]. Only installing the
+    plugin surfaces that, so pin the shape here."""
+    document = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
 
-    for event, groups in hooks.items():
+    assert set(document) <= {"description", "hooks"}
+    assert isinstance(document.get("hooks"), dict) and document["hooks"]
+    # A known event must live under "hooks", not at the root.
+    assert "Stop" in document["hooks"]
+    assert "Stop" not in document
+
+
+def test_hook_commands_resolve_through_the_plugin_root_placeholder() -> None:
+    document = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+
+    for event, groups in document["hooks"].items():
         for group in groups:
             for hook in group["hooks"]:
-                assert "${CLAUDE_PLUGIN_ROOT}" in hook["command"], event
-                script = hook["command"].rsplit("/", 1)[-1]
+                command = hook["command"]
+                assert "${CLAUDE_PLUGIN_ROOT}" in command, event
+                # Quoted: the expanded install path routinely contains spaces.
+                assert '"${CLAUDE_PLUGIN_ROOT}' in command, event
+                script = command.rstrip('"').rsplit("/", 1)[-1]
                 assert (PLUGIN_ROOT / "hooks" / script).is_file(), script
 
 


### PR DESCRIPTION
Follow-up from actually installing the published plugin.

After the hooks-schema fix, the install still failed:

```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file ...
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should
only reference additional hook files.
```

`hooks/hooks.json` is auto-discovered by convention, so declaring it in `plugin.json` too is a duplicate. Removed.

**Verified working after the fix:** status `enabled`, all ten skills present, all hooks present, and the MCP server auto-registered as `plugin:exomem:exomem` with no separate `claude mcp add` — the core claim of the plugin route.

The server then refuses to start when `EXOMEM_VAULT_PATH` is unset. A plugin cannot ask where the user's notes live; it can only read the environment. That limit is irreducible, so it is now stated plainly in the plugin description and README instead of surfacing as a confusing first run. The CLI installer stays the prerequisite-free path — it passes the vault explicitly via `claude mcp add --env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FjWCFgYuEY9GxQzVBvvfV