### PR TITLE
fix(plugin): drop the manifest hooks key and state the vault prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,20 @@ itself (no separate `claude mcp add`):
 /plugin install exomem@exomem
 ```
 
-Set `EXOMEM_VAULT_PATH` to your vault first, or run `exomem setup` afterwards to
-create and configure one.
+**Set `EXOMEM_VAULT_PATH` before installing** — a plugin cannot ask where your
+notes live, so without it the MCP server refuses to start:
+
+```powershell
+setx EXOMEM_VAULT_PATH "C:\path\to\your\Obsidian"   # Windows, then reopen the terminal
+```
+```bash
+export EXOMEM_VAULT_PATH="/path/to/your/Obsidian"   # macOS/Linux, add to your shell profile
+```
+
+Don't have a vault yet, or want the path baked into the registration instead of
+read from the environment? Use the one-line installer above — `exomem setup`
+passes the vault explicitly via `claude mcp add --env`, so it works regardless of
+your environment.
 
 ### claude.ai and ChatGPT
 

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,9 +1,8 @@
 {
   "name": "exomem",
-  "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded.",
+  "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
   "version": "0.25.5",
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "exomem": {
       "command": "uvx",

--- a/src/exomem/package_skills.py
+++ b/src/exomem/package_skills.py
@@ -110,11 +110,16 @@ def _plugin_manifest() -> dict:
         "description": (
             "Governed long-term memory over a markdown vault: raw sources stay "
             "immutable, conclusions are compiled with provenance, and nothing is "
-            "deleted - it is superseded."
+            "deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at "
+            "your vault; run `exomem setup` if you do not have one yet."
         ),
         "version": _package_version(),
+        # No "hooks" key: hooks/hooks.json is loaded automatically by convention,
+        # and declaring it as well fails the install with "Duplicate hooks file
+        # detected". The manifest key is only for ADDITIONAL hook files.
+        # skills/ is likewise auto-discovered; declared here because it is the
+        # documented form and does not collide.
         "skills": "./skills/",
-        "hooks": "./hooks/hooks.json",
         "mcpServers": {
             "exomem": {
                 # `uvx` fetches and runs the published package, so the plugin works


### PR DESCRIPTION
Follow-up from actually installing the published plugin.

After the hooks-schema fix (#274), the install still failed:

```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file ...
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should
only reference additional hook files.
```

`hooks/hooks.json` is auto-discovered by convention, so declaring it in `plugin.json` as well is a duplicate. Removed.

**Verified working after the fix:** status `enabled`, all ten skills present, all hooks present, and the MCP server auto-registered as `plugin:exomem:exomem` with no separate `claude mcp add` — the core claim of the plugin route.

The server then refuses to start when `EXOMEM_VAULT_PATH` is unset. A plugin cannot ask where the user's notes live; it can only read the environment. That limit is irreducible, so it is now stated plainly in the plugin description and README instead of surfacing as a confusing first run. The CLI installer stays the prerequisite-free path — it passes the vault explicitly via `claude mcp add --env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FjWCFgYuEY9GxQzVBvvfV