### PR TITLE
fix: name the blocking findings in SEMANTIC_CONTRACT_BLOCKED

### DIFF
--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import re
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -175,6 +175,71 @@ def _fit_feedback_byte_budget(value: dict[str, Any]) -> dict[str, Any]:
             sorted(relation["omitted_counts"].items())
         )
     return value
+
+
+_ERROR_FINDING_LIMIT = 3
+
+
+def _blocking_finding_text(finding: semantic_contract.ContractFinding) -> str:
+    text = finding.code
+    if finding.path:
+        text += f" at {finding.path}"
+    if finding.detail:
+        text += f": {finding.detail}"
+    if finding.remediation:
+        text += f" (fix: {finding.remediation})"
+    return text
+
+
+def _blocking_reason(
+    result: semantic_contract.SemanticContractResult,
+    prefix: str = "semantic contract has blocking findings",
+) -> str:
+    """Name the blocking findings in the error the caller actually receives.
+
+    Only `code` and `reason` survive out to the MCP caller, so a bare prefix
+    tells a writer that something is wrong while withholding what — forcing a
+    second `validate_only` round-trip purely to learn it. That round-trip is the
+    dominant source of write friction: 69 blocked writes in one day on
+    2026-07-20, none of them self-describing.
+
+    Bounded like `_bounded_semantic_feedback`, and the omitted count is stated
+    rather than silently dropped, so a truncated list never reads as complete.
+    """
+    findings = result.blocking_findings
+    if not findings:
+        return prefix
+    shown = findings[:_ERROR_FINDING_LIMIT]
+    rendered = "; ".join(_blocking_finding_text(item) for item in shown)
+    omitted = len(findings) - len(shown)
+    if omitted:
+        rendered += f"; +{omitted} more (validate_only returns the full set)"
+    return f"{prefix}: {rendered}"
+
+
+def _blocking_reason_for_evaluations(
+    evaluations: Sequence[Any],
+    prefix: str = "semantic contract has blocking findings",
+) -> str:
+    """Same as `_blocking_reason` for multi-page operations (move, recovery).
+
+    `should_block` on these preflights is an `any()` across evaluations, so the
+    blocking findings are spread over several pages. Naming the page each
+    finding came from is what makes a multi-page rejection actionable.
+    """
+    findings = tuple(
+        finding
+        for item in evaluations
+        for finding in item.contract_result.blocking_findings
+    )
+    if not findings:
+        return prefix
+    shown = findings[:_ERROR_FINDING_LIMIT]
+    rendered = "; ".join(_blocking_finding_text(item) for item in shown)
+    omitted = len(findings) - len(shown)
+    if omitted:
+        rendered += f"; +{omitted} more (validate_only returns the full set)"
+    return f"{prefix}: {rendered}"
 
 
 def _bounded_semantic_feedback(
@@ -1523,7 +1588,8 @@ def commit_existing(
     root = Path(vault_root)
     if preflight.contract_result.should_block:
         raise SemanticWriteError(
-            "SEMANTIC_CONTRACT_BLOCKED", "semantic contract has blocking findings"
+            "SEMANTIC_CONTRACT_BLOCKED",
+            _blocking_reason(preflight.contract_result),
         )
 
     result = preflight.contract_result
@@ -1536,7 +1602,10 @@ def commit_existing(
         if result.should_block:
             raise SemanticWriteError(
                 "SEMANTIC_CONTRACT_BLOCKED",
-                "semantic contract blocked against the activation boundary winner",
+                _blocking_reason(
+                    result,
+                    "semantic contract blocked against the activation boundary winner",
+                ),
             )
 
     try:
@@ -2073,7 +2142,8 @@ def commit_move(
     root = Path(vault_root)
     if preflight.should_block:
         raise SemanticWriteError(
-            "SEMANTIC_CONTRACT_BLOCKED", "semantic contract has blocking findings"
+            "SEMANTIC_CONTRACT_BLOCKED",
+            _blocking_reason_for_evaluations(preflight.evaluations),
         )
     if preflight.manifest_install_required:
         winner = activation_manifest.ensure_manifest(
@@ -2507,7 +2577,7 @@ def commit_recovery(
             if preflight.should_block:
                 raise SemanticWriteError(
                     "SEMANTIC_CONTRACT_BLOCKED",
-                    "semantic contract has blocking findings",
+                    _blocking_reason_for_evaluations(preflight.evaluations),
                 )
             destination_root_guard = (
                 preflight.destination_root_guard.prepare_and_bind_parents(root)
@@ -2641,7 +2711,7 @@ def preflight_creation(
         )
     ):
         raise SemanticWriteError(
-            "SEMANTIC_CONTRACT_BLOCKED", "semantic contract has blocking findings"
+            "SEMANTIC_CONTRACT_BLOCKED", _blocking_reason(result)
         )
     if page_type in _COMPILED_TYPES and state.eligible_compiled:
         if draft_id is None:

--- a/tests/test_semantic_lifecycle_writers.py
+++ b/tests/test_semantic_lifecycle_writers.py
@@ -2914,6 +2914,62 @@ def test_existing_feedback_byte_bounds_one_oversized_diagnostic(tmp_path: Path) 
     assert result.findings[0].governed_element_identity == (oversized,)
 
 
+def _blocking_finding(code: str, index: int = 0) -> semantic_contract.ContractFinding:
+    return semantic_contract.ContractFinding(
+        code=code,
+        severity="error",
+        path=_PAGE,
+        span=None,
+        detail=f"relation target {index} does not resolve",
+        remediation="link by the slug the write returned",
+        governed_element_identity=(f"rel-{index}",),
+        resolved_rule=("relations", "*", "target"),
+    )
+
+
+def test_blocked_write_names_what_blocked_it(tmp_path: Path) -> None:
+    """A blocked write must say what blocked it, not merely that something did.
+
+    Regression: SEMANTIC_CONTRACT_BLOCKED carried a generic sentence and threw
+    the findings away, so a writer had to issue a second `validate_only` call
+    purely to learn the reason. That round-trip was the single largest source of
+    write friction — 69 blocked writes in one day on 2026-07-20, none of them
+    self-describing.
+    """
+    preflight = _feedback_preflight(tmp_path)
+    finding = _blocking_finding("RELATION_TARGET_UNRESOLVED")
+    result = replace(preflight.contract_result, blocking_findings=(finding,))
+
+    reason = semantic_writes._blocking_reason(result)
+
+    assert "RELATION_TARGET_UNRESOLVED" in reason
+    assert "does not resolve" in reason
+    assert "link by the slug the write returned" in reason
+    assert _PAGE in reason
+
+
+def test_blocked_write_states_what_it_omitted(tmp_path: Path) -> None:
+    """A truncated finding list must never read as the complete set."""
+    preflight = _feedback_preflight(tmp_path)
+    findings = tuple(_blocking_finding(f"RULE_{i}", i) for i in range(7))
+    result = replace(preflight.contract_result, blocking_findings=findings)
+
+    reason = semantic_writes._blocking_reason(result)
+
+    assert "+4 more" in reason
+    assert "validate_only" in reason
+
+
+def test_blocked_write_with_no_findings_keeps_the_bare_prefix(tmp_path: Path) -> None:
+    """should_block without findings must not render an empty, dangling list."""
+    preflight = _feedback_preflight(tmp_path)
+    result = replace(preflight.contract_result, blocking_findings=())
+
+    assert semantic_writes._blocking_reason(result) == (
+        "semantic contract has blocking findings"
+    )
+
+
 def test_existing_feedback_byte_bounds_one_oversized_relation_fact(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## The friction

A blocked write reported this and nothing else:

> `SEMANTIC_CONTRACT_BLOCKED: semantic contract has blocking findings; validate first and supply the returned transition review fields when remediation requires them`

Only `code` and `reason` reach the MCP caller, so a writer learns that *something* is wrong but not *what*. The only way to find out is a second `validate_only` call, then a third call to actually write.

## Why it matters

Measured from the running service on 2026-07-20:

| Count | Error |
|---|---|
| **69** | `SEMANTIC_CONTRACT_BLOCKED` |
| 6 | `RELATION_REVIEW_STABLE_ID_REQUIRED` |
| 6 | `DRAFT_HASH_MISMATCH` |

By tool: `remember` 16, `edit_memory` 13, `observe_memory` 7. **Not one of the 69 named its cause.**

By contrast `INVALID_NOTE` is already self-describing — `f"severity {severity!r} not valid. Valid: {list(SEVERITY_VALUES)}"` — which is the standard this brings the contract errors up to.

The findings were in scope at every raise site (`preflight.contract_result.blocking_findings`) and simply weren't read.

## The change

The reason string now names each blocking finding's code, page, detail, and remediation:

```
SEMANTIC_CONTRACT_BLOCKED: semantic contract has blocking findings:
RELATION_TARGET_UNRESOLVED at Knowledge Base/Notes/Insights/x.md:
relation target does not resolve (fix: link by the slug the write returned)
```

Bounded at 3 findings, matching the existing `_bounded_semantic_feedback` idiom, with the omitted count stated (`+4 more (validate_only returns the full set)`) so a truncated list never reads as complete.

Covers the create and existing-page commit paths, including the multi-page move and recovery preflights whose `should_block` is an `any()` across evaluations — there each finding is attributed to its page, which is what makes a multi-page rejection actionable.

## Not covered

The two `relation_review.py` raise sites. `relation_review` cannot import `semantic_writes` (the dependency runs the other way), so sharing the helper needs a small extraction into a common module. Left as a follow-up rather than bundled here.

## Verification

- 3 new tests: findings are named; the omitted count is stated; the no-findings case keeps the bare prefix rather than rendering a dangling empty list
- `ruff check` clean

`test_semantic_lifecycle_writers.py` has **14 pre-existing failures on a clean `origin/main` checkout** — verified by stashing this change and re-running. Unchanged by this commit. They are part of the same Windows-only cluster noted in #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z8W4eQFrREL758npaVPH6
