### PR TITLE
feat(deploy): report install provenance and gate version deploys

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -755,6 +755,61 @@ Pick the strongest option that fits the situation:
 | Want to stop the service but leave the public URL configured | Stop the service (e.g. elevated `Start-Process -Verb RunAs -Wait sc.exe -ArgumentList 'stop','exomem'`). The tunnel stays up but proxies to nothing. |
 | Want a clean uninstall | Stop + remove service, turn off the tunnel/Funnel, delete the connector in claude.ai, delete the GitHub OAuth App. |
 
+## Deploying a new version
+
+**The service interpreter is the source of truth — not the checkout you are standing in.**
+A service can run from a standalone venv while its `AppDirectory` points at a checkout, so
+the checkout looks authoritative and is not. When that happens, `uv sync` in the checkout
+changes nothing the service runs and `/health` keeps reporting the old version through any
+number of clean restarts.
+
+Ask the running server where it came from:
+
+```bash
+curl -s http://127.0.0.1:8765/health
+```
+
+```json
+{"status": "ok", "service": "exomem", "version": "0.25.5",
+ "install_source": "wheel", "revision": null,
+ "torch": "2.13.0", "accelerated": false, "extras": ["embeddings", "media"]}
+```
+
+`install_source` is the field that matters. `wheel` with a null `revision` means the server
+is **not** running a local checkout — upgrade the venv directly. `editable` reports the git
+`revision` it is serving. For full detail including the interpreter path, run
+`exomem install-info` locally; `/health` withholds paths because it is unauthenticated and
+publicly reachable.
+
+The scripted path resolves the interpreter from NSSM, gates on `doctor` and accelerator
+capability, restarts, and verifies the running version:
+
+```powershell
+pwsh -File scripts/deploy.ps1 -Version 0.25.5
+```
+
+It fails rather than reporting success if the running server does not serve the requested
+version after restart.
+
+### The CUDA pin does not survive a PyPI upgrade
+
+`[tool.uv.sources]` pins torch to the `pytorch-cu132` index, but that is **repo
+configuration, not wheel metadata** — it does not travel with the published `exomem` wheel.
+Upgrading a PyPI-backed venv with `uv pip install` therefore resolves torch from default
+PyPI, which on Windows is CPU-only, silently replacing `2.12.0+cu132` with a bare `2.13.0`.
+
+`deploy.ps1` treats that as a hard failure. On a genuinely CPU-only host, pass
+`-AllowCpuTorch`. To restore the pinned wheel:
+
+```powershell
+uv pip install --python <service venv python> --index-url https://download.pytorch.org/whl/cu132 --upgrade torch
+```
+
+Note the difference in meaning between the two signals: `/health` reports **which wheel is
+installed** (a deploy property, read from metadata without importing torch), while `doctor`
+reports **whether a GPU is usable right now**. Conflating them is what let this regression
+hide as one advisory line among passing checks.
+
 ## Restarting the service
 
 Remote Streamable HTTP runs statelessly: authenticated tool calls do not rely

--- a/docs/release.md
+++ b/docs/release.md
@@ -58,6 +58,23 @@ Run the optional checks only on machines configured for those profiles. `media`
 expects the media extra plus Tesseract; `remote` expects OAuth and public-url
 environment variables.
 
+## Rolling a release onto a running service
+
+Use `scripts/deploy.ps1 -Version X.Y.Z` rather than upgrading by hand. It resolves the
+service interpreter from NSSM instead of assuming the current checkout, gates on `doctor`,
+and verifies the running server actually reports the requested version before claiming
+success. See [deployment.md](deployment.md#deploying-a-new-version).
+
+Two release-time hazards it exists to catch:
+
+- **The checkout is not necessarily the deploy target.** A wheel-backed service venv can sit
+  beside a checkout whose `uv sync` has no effect on what runs. `/health` now reports
+  `install_source`, so this is visible rather than inferred.
+- **The CUDA pin does not survive a PyPI upgrade.** `[tool.uv.sources]` is repo
+  configuration and does not travel with the published wheel, so upgrading a PyPI-backed
+  venv silently swaps the pinned `+cu132` torch for the default CPU wheel. The deploy fails
+  on that regression; pass `-AllowCpuTorch` on hosts that are intentionally CPU-only.
+
 ## Commit convention
 
 Release Please reads Conventional Commit messages after the latest release tag:

--- a/openspec/changes/add-deploy-provenance/design.md
+++ b/openspec/changes/add-deploy-provenance/design.md
@@ -1,0 +1,111 @@
+## Context
+
+The 2026-07-20 deploy session established the concrete facts this design responds to:
+
+- Service interpreter: `...\exomem-service-ha\.venv\Scripts\python.exe` (standalone,
+  PyPI-backed, non-editable `site-packages` install — **not** a git worktree).
+- Service `AppDirectory`: the primary checkout, which is what makes the topology misleading.
+- The cu132 pin lives in the repo's `pyproject.toml` under `[tool.uv.sources]` with
+  `explicit = true`, so it is repo configuration and does not travel with the PyPI wheel.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One request answers "what version is deployed, and from where".
+- One command deploys a version and refuses to report success unless the running server
+  actually serves it.
+- A CPU-torch regression fails the deploy loudly instead of passing as an advisory line.
+
+**Non-Goals**
+
+- Deciding whether the service should return to a repo-backed venv. That is a real question
+  (it would restore the lockfile pin path and make every existing runbook correct again), but
+  it carries HA/failover implications and is tracked separately. This change makes the current
+  topology *legible*; it does not change it.
+- Multi-host orchestration or remote deploy. This targets the single-host NSSM service.
+
+## Decisions
+
+### Decision 1: `/health` gets provenance, but never filesystem paths
+
+`/health` is unauthenticated by design — it is the tunnel/orchestrator liveness probe, and
+its docstring commits to "no vault data, no auth required". It is reachable publicly at
+`https://<host>/health`.
+
+Absolute interpreter paths embed the OS username and host layout (`C:\Users\<name>\...`).
+Publishing those on an unauthenticated endpoint is an information leak that serves no probe
+consumer, so the public payload carries only:
+
+```json
+{
+  "status": "ok", "service": "exomem", "version": "0.25.5",
+  "install_source": "wheel",          // "wheel" | "editable" | "unknown"
+  "revision": null,                    // git sha, only when editable
+  "torch": "2.13.0",                   // wheel build tag, null when absent
+  "accelerated": false,                // torch build carries a CUDA/ROCm local tag
+  "extras": ["embeddings", "media"]
+}
+```
+
+`install_source` and `revision` are the fields that would have ended the 2026-07-20 confusion:
+a `wheel` install with a null revision immediately says "this is not running your checkout".
+
+Full detail — including `interpreter` — is available locally via `exomem install-info`, which
+runs on the operator's own host where the path is not a disclosure.
+
+The command is named `install-info`, not `provenance`: this codebase already uses
+"provenance" for note/source provenance (`src/exomem/provenance.py` scans `<!-- key:value -->`
+tags in note bodies), and in a knowledge-base product that word would read as vault
+provenance rather than install origin.
+
+### Decision 2: Never import torch to determine the torch build
+
+`/health` must stay fast and must never fail; importing torch costs seconds and allocates.
+`importlib.metadata.version("torch")` reads the installed distribution's metadata without
+importing the package, and on Windows returns the full local version tag — `2.12.0+cu132`
+versus a bare `2.13.0`. That local tag is exactly the signal that distinguishes the CUDA wheel
+from the default-PyPI CPU wheel, which is the regression we need to catch.
+
+`accelerated` is therefore derived from the presence of a CUDA/ROCm local tag in the version
+string, **not** from `torch.cuda.is_available()`. This is a deliberate difference in meaning:
+`/health` reports *which wheel is installed* (a deploy property, stable and cheap), while
+`doctor` continues to report *whether a GPU is actually usable right now* (a runtime property
+requiring the import). Both are useful; conflating them is what let the regression hide.
+
+### Decision 3: `deploy.ps1` resolves the target from NSSM, never from cwd
+
+The script's first act is `nssm get exomem Application` to obtain the true interpreter. Every
+subsequent step operates on that interpreter. This structurally prevents the failure where an
+operator syncs the checkout they happen to be standing in and concludes the deploy worked.
+
+The script refuses to run if the resolved interpreter does not exist, rather than falling back
+to a guess.
+
+### Decision 4: The CUDA gate is opt-out, not opt-in
+
+After upgrading, the script compares the torch build tag before and after. If the host had an
+accelerated build and now does not, the deploy **fails** and the script reports the exact
+repair command. Hosts that are legitimately CPU-only pass `-AllowCpuTorch` to acknowledge it.
+
+Defaulting to fail is the right asymmetry: a silent capability loss is expensive to discover
+later (it took a full session), while a spurious failure costs one flag.
+
+### Decision 5: Verify by polling `/health`, not by trusting the installer
+
+`uv pip install` reporting success only proves the venv changed. The deploy is not complete
+until the *running process* serves the target version, which requires the restart to have
+taken effect. The script polls `/health` until `version` equals the requested version or a
+timeout elapses, and fails otherwise. This is what turns "I ran the commands" into evidence.
+
+## Risks / Trade-offs
+
+- **`/health` payload growth.** Probes that assume an exact-shape body could be affected.
+  Mitigated by only adding keys and preserving existing ones; JSON consumers ignore unknown
+  fields.
+- **`extras` detection cost.** Uses `importlib.util.find_spec`, which does not execute module
+  code, so it stays cheap. A missing extra reports as absent rather than raising.
+- **Version tag heuristic.** `accelerated` keys off local version tags (`+cu132`, `+rocm`).
+  A future wheel could ship CUDA without a local tag, producing a false negative. Acceptable:
+  `doctor` remains the authority on live GPU availability, and a false negative fails safe
+  (blocks a deploy) rather than passing a regression through.

--- a/openspec/changes/add-deploy-provenance/proposal.md
+++ b/openspec/changes/add-deploy-provenance/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Nothing in the running system reports **where its code came from**. `/health` returns a
+version string and nothing else, so answering "what is deployed, and from which venv" requires
+knowing to run `nssm get exomem Application` — undiscoverable unless you already suspect the
+answer.
+
+On 2026-07-20 that cost most of a deploy session. The NSSM service runs
+`...\exomem-service-ha\.venv\Scripts\python.exe` while its `AppDirectory` is the primary
+checkout, so the primary *looks* like the deploy target and reports a plausible-but-wrong
+story: `uv sync` there changes nothing the service runs, and `/health` keeps reporting the old
+version through any number of clean restarts.
+
+The same session exposed a second, silent failure. Because that service venv is PyPI-backed
+rather than repo-backed, `uv pip install --upgrade "exomem[embeddings,media]"` has no
+visibility into `[tool.uv.sources]`, where the `pytorch-cu132` pin lives. The upgrade resolved
+`torch 2.12.0+cu132` → `torch 2.13.0` (default PyPI, CPU-only on Windows), silently dropping
+GPU capability and breaking the desktop/laptop same-wheel invariant the pin exists to protect.
+`doctor` reported it, but only as one advisory line among many PASS rows.
+
+Both failures share a root cause: **deploy provenance is invisible, and the one signal that
+would catch a bad deploy is not a gate.**
+
+## What Changes
+
+- Add a `deploy-provenance` capability that reports how the running server was installed:
+  version, install source (editable checkout vs installed wheel), git revision when
+  repo-backed, the resolved torch wheel build tag, and which optional extras are present.
+- Extend the public `/health` route with the non-sensitive subset of that provenance.
+  `/health` is unauthenticated and publicly reachable through the tunnel, so it MUST NOT
+  expose absolute filesystem paths, usernames, or host layout.
+- Add an `exomem install-info` CLI command that reports the full detail, including the
+  interpreter path, for local operators who need to identify the actual deploy target.
+- Add a `scripts/deploy.ps1` that resolves the service's real interpreter from NSSM rather
+  than assuming the checkout, upgrades it while preserving the CUDA index pin, gates on
+  `doctor` including CUDA capability, restarts, and verifies the deployed version matches the
+  requested one.
+- Make the CUDA-capability check a **hard deploy gate** rather than advisory output, with an
+  explicit opt-out for hosts that are legitimately CPU-only.
+
+## Capabilities
+
+### New Capabilities
+
+- `deploy-provenance`: how the running server reports its own installation origin across the
+  HTTP surface, the CLI, and the deploy script.
+
+## Impact
+
+- `src/exomem/server_assets.py` — `/health` payload gains provenance fields.
+- `src/exomem/deploy_provenance.py` — new module computing provenance.
+- `src/exomem/commands.py` — new `provenance` command on the shared surface.
+- `scripts/deploy.ps1` — new deploy entrypoint.
+- `docs/deployment.md`, `docs/release.md` — document the deploy path and the gate.
+
+Backwards compatible: `/health` only gains keys. Existing `status`, `service`, and `version`
+fields keep their current meaning, so tunnel and orchestrator probes are unaffected.

--- a/openspec/changes/add-deploy-provenance/specs/deploy-provenance/spec.md
+++ b/openspec/changes/add-deploy-provenance/specs/deploy-provenance/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Runtime Reports Its Install Origin
+
+The server SHALL report how the running code was installed, so an operator can determine the
+deployed version and its origin without inspecting service-manager configuration. The report
+SHALL distinguish an editable checkout install from an installed wheel, and SHALL include the
+git revision when and only when the install is editable and a revision is resolvable.
+
+#### Scenario: Wheel-backed service is identifiable as not-the-checkout
+
+- **WHEN** `/health` is requested against a server running from an installed wheel
+- **THEN** the response includes `install_source` of `wheel`
+- **AND** `revision` is null
+- **AND** the operator can conclude the running code is not the local checkout
+
+#### Scenario: Editable install reports its revision
+
+- **WHEN** `/health` is requested against a server running from an editable checkout
+- **THEN** the response includes `install_source` of `editable`
+- **AND** `revision` is the short git revision of that checkout when resolvable
+
+#### Scenario: Provenance never fails the probe
+
+- **WHEN** any provenance field cannot be determined
+- **THEN** that field reports a null or `unknown` value
+- **AND** `/health` still returns 200 with `status` of `ok`
+
+### Requirement: Public Health Route Excludes Host-Identifying Detail
+
+The `/health` route is unauthenticated and publicly reachable. It SHALL NOT expose absolute
+filesystem paths, operating-system usernames, or host directory layout. Full provenance
+including the interpreter path SHALL be available only through the local CLI surface.
+
+#### Scenario: Public payload omits paths
+
+- **WHEN** `/health` is requested
+- **THEN** the response contains no absolute filesystem path
+- **AND** no field reveals the operating-system username
+
+#### Scenario: Local CLI exposes full detail
+
+- **WHEN** an operator runs the `install-info` command locally
+- **THEN** the output includes the interpreter path and the resolved package location
+- **AND** the output includes every field published on `/health`
+
+### Requirement: Torch Build Tag Reported Without Importing Torch
+
+Provenance SHALL report the installed torch wheel build tag using distribution metadata and
+MUST NOT import torch, so the probe stays fast and cannot fail on a broken ML stack. The
+reported value SHALL preserve any local version tag that distinguishes an accelerated wheel
+from a default CPU wheel.
+
+#### Scenario: CUDA wheel is distinguishable from CPU wheel
+
+- **WHEN** the environment has torch installed with a CUDA local version tag
+- **THEN** provenance reports the full build tag including that local tag
+- **AND** reports `accelerated` as true
+
+#### Scenario: Default PyPI wheel reports unaccelerated
+
+- **WHEN** the environment has a torch wheel with no accelerator local version tag
+- **THEN** provenance reports `accelerated` as false
+
+#### Scenario: Absent torch does not error
+
+- **WHEN** torch is not installed
+- **THEN** provenance reports a null torch build and `accelerated` as false
+
+### Requirement: Deploy Resolves The Service Interpreter From The Service Manager
+
+The deploy script SHALL resolve the target interpreter from the service manager configuration
+rather than from the current working directory or an assumed checkout path. If the resolved
+interpreter does not exist, the deploy SHALL abort rather than fall back to a guessed target.
+
+#### Scenario: Deploy targets the real service venv
+
+- **WHEN** the deploy script runs while the operator's shell is in a different checkout
+- **THEN** it resolves the interpreter from the service manager
+- **AND** it upgrades that interpreter's environment, not the checkout's
+
+#### Scenario: Missing interpreter aborts the deploy
+
+- **WHEN** the configured service interpreter path does not exist
+- **THEN** the deploy aborts with an error naming the resolved path
+- **AND** no upgrade or restart is attempted
+
+### Requirement: Accelerator Capability Regression Blocks The Deploy
+
+The deploy SHALL fail when the target environment had an accelerated torch build before an
+upgrade and does not have one after it, and SHALL report the repair command. Hosts that are
+intentionally CPU-only SHALL be able to acknowledge this explicitly and proceed.
+
+#### Scenario: Silent CUDA loss fails the deploy
+
+- **WHEN** an upgrade replaces an accelerated torch build with a default CPU build
+- **THEN** the deploy fails
+- **AND** the output names the accelerator index required to restore the pinned wheel
+
+#### Scenario: CPU-only host proceeds with acknowledgement
+
+- **WHEN** the operator passes the CPU-torch acknowledgement flag
+- **THEN** the deploy proceeds despite an unaccelerated torch build
+
+### Requirement: Deploy Verifies The Running Version
+
+The deploy SHALL NOT report success based on installer output alone. It SHALL poll the health
+route after restart and confirm the running server reports the requested version, failing if
+the version does not match within a bounded wait.
+
+#### Scenario: Restart that did not take effect fails the deploy
+
+- **WHEN** the upgrade succeeds but the running process still serves the previous version
+- **THEN** the deploy fails and reports both the requested and the observed version
+
+#### Scenario: Successful deploy reports observed version
+
+- **WHEN** the running server reports the requested version after restart
+- **THEN** the deploy reports success including the observed version and install source

--- a/openspec/changes/add-deploy-provenance/tasks.md
+++ b/openspec/changes/add-deploy-provenance/tasks.md
@@ -1,0 +1,50 @@
+## 1. Provenance module
+
+- [x] 1.1 Add `src/exomem/deploy_provenance.py` with a `provenance(include_local: bool)` entry
+      returning version, install source, revision, torch build, accelerated flag, and extras.
+- [x] 1.2 Detect install source via the distribution's `direct_url.json` / `__editable__`
+      markers; fall back to `unknown` rather than guessing.
+- [x] 1.3 Read the torch build tag from `importlib.metadata` only — never import torch.
+- [x] 1.4 Detect extras with `importlib.util.find_spec` so no extra module code executes.
+- [x] 1.5 Resolve git revision only for editable installs, tolerating a missing git binary.
+
+## 2. HTTP surface
+
+- [x] 2.1 Extend `/health` in `src/exomem/server_assets.py` with the public provenance subset.
+- [x] 2.2 Guarantee the route cannot raise: wrap provenance in the existing defensive try.
+- [x] 2.3 Assert no absolute path or username reaches the public payload.
+
+## 3. CLI surface
+
+- [x] 3.1 Add an `install-info` command exposing full detail including interpreter path.
+- [x] 3.2 Keep `install-info` CLI-only, matching `doctor`. Both are local operator
+      diagnostics about the host install rather than vault operations, and `doctor` is
+      deliberately absent from the MCP tool surface. Exposing install paths and host
+      layout over MCP would also work against the `/health` path-withholding decision.
+
+## 4. Deploy script
+
+- [x] 4.1 Add `scripts/deploy.ps1` resolving the interpreter via `nssm get exomem Application`.
+- [x] 4.2 Abort when the resolved interpreter is missing.
+- [x] 4.3 Capture the torch build tag before and after the upgrade.
+- [x] 4.4 Fail on accelerator regression unless `-AllowCpuTorch` is passed; print the
+      `--index-url https://download.pytorch.org/whl/cu132` repair command.
+- [x] 4.5 Run `doctor --profile hybrid` as a gate before restarting.
+- [x] 4.6 Restart via the existing `restart.ps1` path rather than duplicating service logic.
+- [x] 4.7 Poll `/health` until the reported version matches the requested version or timeout.
+- [x] 4.8 Print a final summary: requested vs observed version, install source, torch build.
+
+## 5. Tests
+
+- [x] 5.1 Unit-test provenance against wheel, editable, and unknown install shapes.
+- [x] 5.2 Unit-test torch tag parsing for `+cu132`, bare `2.13.0`, and absent torch.
+- [x] 5.3 Test that the public payload contains no absolute path (regression guard for the
+      unauthenticated-endpoint leak).
+- [x] 5.4 Test `/health` still returns 200 when provenance resolution raises.
+
+## 6. Docs
+
+- [x] 6.1 Document the deploy path in `docs/deployment.md`, stating that the service
+      interpreter is authoritative and the checkout is not.
+- [x] 6.2 Note the accelerator gate and its opt-out in `docs/release.md`.
+- [x] 6.3 Cross-reference the PyPI-backed-venv failure mode so the runbook and the KB agree.

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,136 @@
+# Deploy a released exomem version to the local NSSM service.
+#
+# The service interpreter is the source of truth, NOT the checkout you happen to
+# be standing in. This script resolves it from NSSM, upgrades that environment,
+# gates on doctor + accelerator capability, restarts, and refuses to report
+# success until the RUNNING process serves the requested version.
+#
+# Usage:
+#   pwsh -File scripts/deploy.ps1 -Version 0.25.5
+#   pwsh -File scripts/deploy.ps1 -Version 0.25.5 -AllowCpuTorch   # CPU-only host
+#   pwsh -File scripts/deploy.ps1 -Version 0.25.5 -DryRun          # resolve + report only
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [string]$ServiceName = "exomem",
+    [string]$Profile = "hybrid",
+    [string]$Extras = "embeddings,media",
+    [string]$HealthUrl = "http://127.0.0.1:8765/health",
+    [string]$NssmPath = "",
+
+    # Accelerator regression is a hard failure by default: a silent CPU-torch
+    # downgrade is expensive to discover later. CPU-only hosts opt out.
+    [switch]$AllowCpuTorch,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+function Fail($msg) {
+    Write-Host "DEPLOY FAILED: $msg" -ForegroundColor Red
+    exit 1
+}
+
+# --- 1. Resolve the real target from the service manager ----------------------
+# Never infer this from cwd. The AppDirectory can point at a checkout the
+# service does not actually run from.
+$nssm = if ($NssmPath) { $NssmPath } else { (Get-Command nssm -ErrorAction SilentlyContinue).Source }
+if (-not $nssm -or -not (Test-Path $nssm)) {
+    Fail "nssm not found. Put it on PATH or pass -NssmPath <path to nssm.exe>."
+}
+
+$servicePython = (& $nssm get $ServiceName Application) -replace "`0", ""
+$servicePython = $servicePython.Trim()
+if (-not $servicePython) { Fail "could not read Application for service '$ServiceName'." }
+if (-not (Test-Path $servicePython)) {
+    Fail "service interpreter does not exist: $servicePython"
+}
+
+Write-Host "Service interpreter: $servicePython" -ForegroundColor Cyan
+
+function Get-Provenance {
+    $raw = & $servicePython -m exomem install-info --json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return $null }
+    try { return $raw | ConvertFrom-Json } catch { return $null }
+}
+
+$before = Get-Provenance
+if ($before) {
+    $accelBefore = [bool]$before.accelerated
+    Write-Host "Currently deployed: $($before.version) ($($before.install_source)), torch $($before.torch)"
+} else {
+    # A pre-provenance build cannot self-report; fall back to metadata so the
+    # accelerator comparison still has a baseline.
+    $accelBefore = $false
+    $torchBefore = & $servicePython -c "import importlib.metadata as m; print(m.version('torch'))" 2>$null
+    if ($torchBefore -and ($torchBefore -match '\+(cu|rocm|xpu)')) { $accelBefore = $true }
+    Write-Host "Currently deployed: (pre-provenance build), torch $torchBefore"
+}
+
+if ($DryRun) {
+    Write-Host "DryRun: resolved target only, no changes made." -ForegroundColor Yellow
+    exit 0
+}
+
+# --- 2. Upgrade that environment ---------------------------------------------
+Write-Host "`nUpgrading to exomem[$Extras]==$Version ..." -ForegroundColor Cyan
+& uv pip install --python $servicePython --upgrade "exomem[$Extras]==$Version"
+if ($LASTEXITCODE -ne 0) { Fail "uv pip install returned $LASTEXITCODE." }
+
+# --- 3. Accelerator regression gate ------------------------------------------
+# The cu132 pin lives in the repo's [tool.uv.sources], which a PyPI-backed venv
+# cannot see, so an upgrade silently resolves the default CPU wheel on Windows.
+$after = Get-Provenance
+$accelAfter = if ($after) { [bool]$after.accelerated } else { $false }
+$torchAfter = if ($after) { $after.torch } else { "unknown" }
+
+if ($accelBefore -and -not $accelAfter) {
+    Write-Host ""
+    Write-Host "Accelerated torch was replaced by a CPU build ($torchAfter)." -ForegroundColor Red
+    Write-Host "The CUDA pin lives in the repo's [tool.uv.sources] and does not travel"
+    Write-Host "with the PyPI wheel. Restore it with:"
+    Write-Host ""
+    Write-Host "  uv pip install --python `"$servicePython`" --index-url https://download.pytorch.org/whl/cu132 --upgrade torch" -ForegroundColor Yellow
+    Write-Host ""
+    if (-not $AllowCpuTorch) {
+        Fail "accelerator capability regression (pass -AllowCpuTorch to accept a CPU-only host)."
+    }
+    Write-Host "Continuing: -AllowCpuTorch was passed." -ForegroundColor Yellow
+}
+
+# --- 4. Preflight, then restart ----------------------------------------------
+Write-Host "`nRunning doctor gate (profile: $Profile) ..." -ForegroundColor Cyan
+& $servicePython -m exomem doctor --profile $Profile | Out-Null
+if ($LASTEXITCODE -ne 0) { Fail "doctor preflight failed for profile '$Profile'." }
+
+Write-Host "Restarting service ..." -ForegroundColor Cyan
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot "restart.ps1") -ServiceName $ServiceName -Profile $Profile
+if ($LASTEXITCODE -ne 0) { Fail "restart returned $LASTEXITCODE." }
+
+# --- 5. Verify the RUNNING process, not the installer ------------------------
+# An installer that succeeded only proves the venv changed. The deploy is not
+# done until the live process serves the requested version.
+Write-Host "`nVerifying deployed version at $HealthUrl ..." -ForegroundColor Cyan
+$observed = $null
+$source = $null
+foreach ($attempt in 1..30) {
+    Start-Sleep -Seconds 2
+    try {
+        $resp = Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 5 -ErrorAction Stop
+        $observed = $resp.version
+        $source = $resp.install_source
+        if ($observed -eq $Version) { break }
+    } catch {
+        continue
+    }
+}
+
+if ($observed -ne $Version) {
+    Fail "requested $Version but the running server reports '$observed'. The restart may not have taken effect."
+}
+
+Write-Host ""
+Write-Host "Deployed $observed (install_source: $source, torch: $torchAfter)" -ForegroundColor Green

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -67,6 +67,8 @@ def main(argv: list[str] | None = None) -> int:
         return _studio_main(raw[1:])
     if raw and raw[0] == "doctor":
         return _doctor_main(raw[1:])
+    if raw and raw[0] == "install-info":
+        return _install_info_main(raw[1:])
     if raw and raw[0] == "auth":
         return _auth_main(raw[1:])
     if raw and raw[0] == "status":
@@ -547,6 +549,53 @@ def _status_main(argv: list[str]) -> int:
         print(f"  deferred_work: {status['deferred_work']}")
         print(f"  cuda: {status['cuda']}")
     return 0
+
+def _install_info_main(argv: list[str]) -> int:
+    """Report where this install came from.
+
+    Answers "what version is deployed, and from which environment" without
+    inspecting service-manager config. Unlike the `/health` route, this runs
+    locally and so may include the interpreter path — the detail that identifies
+    the real deploy target when a service venv sits apart from the checkout.
+
+    Named `install-info` rather than `provenance` deliberately: in this codebase
+    provenance already means note/source provenance (see `provenance.py`), and
+    reusing the word for install origin would be genuinely ambiguous.
+    """
+    parser = argparse.ArgumentParser(
+        prog="exomem install-info",
+        description="Report install origin: version, source, revision, torch build, extras.",
+    )
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
+    args = parser.parse_args(argv)
+
+    from . import deploy_provenance
+
+    report = deploy_provenance.provenance(include_local=True)
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, default=str))
+        return 0
+
+    print(f"version:        {report['version']}")
+    print(f"install source: {report['install_source']}")
+    if report.get("revision"):
+        print(f"revision:       {report['revision']}")
+    print(f"interpreter:    {report.get('interpreter')}")
+    if report.get("checkout"):
+        print(f"checkout:       {report['checkout']}")
+    torch_build = report.get("torch") or "not installed"
+    accel = "accelerated" if report.get("accelerated") else "CPU-only"
+    print(f"torch:          {torch_build} ({accel})")
+    print(f"extras:         {', '.join(report['extras']) or 'none'}")
+    if report["install_source"] == "wheel":
+        print(
+            "\nThis is a wheel install: it does NOT run a local checkout. "
+            "Upgrade it with `uv pip install --python <this interpreter> ...`; "
+            "`uv sync` in a checkout will not affect it."
+        )
+    return 0
+
 
 def _doctor_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(

--- a/src/exomem/deploy_provenance.py
+++ b/src/exomem/deploy_provenance.py
@@ -1,0 +1,162 @@
+"""Report how the running server was installed.
+
+The deploy question "what version is running, and from where" was previously
+unanswerable from the server itself: `/health` reported a version and nothing
+else, so identifying the actual deploy target meant inspecting service-manager
+configuration. That gap let a service run from a standalone wheel-backed venv
+while the nearby checkout looked authoritative.
+
+Two constraints shape this module:
+
+* **Never import torch.** The build tag comes from distribution metadata. The
+  probe must stay fast and must not fail on a broken ML stack.
+* **Never leak host layout to the public surface.** `/health` is unauthenticated
+  and publicly reachable, so absolute paths are gated behind ``include_local``
+  and surface only on the local CLI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError, distribution, version
+from pathlib import Path
+from typing import Any
+
+# Import-name -> extra it belongs to. `find_spec` does not execute module code,
+# so probing these stays cheap even for the heavy ML packages.
+_EXTRA_PROBES: dict[str, tuple[str, ...]] = {
+    "embeddings": ("sentence_transformers", "torch"),
+    "media": ("faster_whisper", "fitz"),
+    "vision": ("PIL",),
+}
+
+# Local version tags that mark an accelerator build. Default PyPI wheels carry
+# no local tag, which on Windows means CPU-only.
+_ACCEL_TAGS = ("+cu", "+rocm", "+xpu")
+
+
+def _package_version() -> str:
+    try:
+        return version("exomem")
+    except Exception:  # noqa: BLE001 — provenance must never raise
+        return "unknown"
+
+
+def _install_source_and_root() -> tuple[str, Path | None]:
+    """Classify the install as an editable checkout or an installed wheel.
+
+    pip/uv record `direct_url.json` for direct installs; `dir_info.editable`
+    marks an editable one. Anything we cannot classify reports ``unknown``
+    rather than guessing, since a wrong answer here is what caused the original
+    confusion.
+    """
+    try:
+        dist = distribution("exomem")
+    except PackageNotFoundError:
+        return "unknown", None
+    except Exception:  # noqa: BLE001
+        return "unknown", None
+
+    try:
+        raw = dist.read_text("direct_url.json")
+    except Exception:  # noqa: BLE001
+        raw = None
+
+    if raw:
+        try:
+            info = json.loads(raw)
+            if info.get("dir_info", {}).get("editable"):
+                url = info.get("url", "")
+                root = None
+                if url.startswith("file://"):
+                    # Windows file URLs arrive as file:///C:/... — lstrip the
+                    # leading slash so Path() gets a drive-rooted path.
+                    candidate = url[len("file://") :]
+                    if len(candidate) > 2 and candidate[0] == "/" and candidate[2] == ":":
+                        candidate = candidate[1:]
+                    root = Path(candidate)
+                return "editable", root
+        except Exception:  # noqa: BLE001
+            pass
+
+    # No direct_url, or a non-editable one: an installed wheel.
+    return "wheel", None
+
+
+def _revision(root: Path | None) -> str | None:
+    """Short git revision, only meaningful for an editable checkout."""
+    if root is None or not root.exists():
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001 — a missing git binary is not an error here
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def _torch_build() -> str | None:
+    """Installed torch build tag, read from metadata without importing torch.
+
+    Returns the full local version (``2.12.0+cu132``) so an accelerated wheel is
+    distinguishable from the default PyPI CPU wheel (``2.13.0``).
+    """
+    try:
+        return version("torch")
+    except Exception:  # noqa: BLE001 — torch is an optional extra
+        return None
+
+
+def _is_accelerated(build: str | None) -> bool:
+    if not build:
+        return False
+    return any(tag in build for tag in _ACCEL_TAGS)
+
+
+def _extras_present() -> list[str]:
+    present: list[str] = []
+    for extra, modules in _EXTRA_PROBES.items():
+        try:
+            if all(importlib.util.find_spec(m) is not None for m in modules):
+                present.append(extra)
+        except Exception:  # noqa: BLE001 — a broken finder must not fail the probe
+            continue
+    return present
+
+
+def provenance(include_local: bool = False) -> dict[str, Any]:
+    """Describe this installation.
+
+    Args:
+        include_local: include host-identifying detail (interpreter and package
+            paths). Only ever true on the local CLI surface — never on the
+            unauthenticated ``/health`` route.
+    """
+    source, root = _install_source_and_root()
+    build = _torch_build()
+
+    report: dict[str, Any] = {
+        "version": _package_version(),
+        "install_source": source,
+        "revision": _revision(root) if source == "editable" else None,
+        "torch": build,
+        "accelerated": _is_accelerated(build),
+        "extras": _extras_present(),
+    }
+
+    if include_local:
+        report["interpreter"] = sys.executable
+        report["package_path"] = str(Path(__file__).parent)
+        report["checkout"] = str(root) if root else None
+
+    return report

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -90,18 +90,23 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
 
     @mcp_app.custom_route("/health", methods=["GET"])
     async def _health(request: Request) -> JSONResponse:  # noqa: ARG001
-        """Unauthenticated liveness probe for tunnels/orchestrators. Reports only
-        that the process is up + its version — no vault data, no auth required."""
-        try:
-            from importlib.metadata import version
+        """Unauthenticated liveness probe for tunnels/orchestrators. Reports that
+        the process is up, its version, and where that code was installed from —
+        no vault data, no auth required.
 
-            ver = version("exomem")
-        except Exception:  # noqa: BLE001 — version lookup must never fail the probe
-            ver = "unknown"
-        return JSONResponse(
-            {"status": "ok", "service": "exomem", "version": ver},
-            headers={"Cache-Control": "no-store"},
-        )
+        Install provenance is included so an operator can tell a wheel-backed
+        service from one running a local checkout without inspecting the service
+        manager. Host-identifying detail (interpreter path, checkout location) is
+        deliberately withheld here because this route is publicly reachable; use
+        the local `provenance` command for that."""
+        payload: dict[str, object] = {"status": "ok", "service": "exomem"}
+        try:
+            from . import deploy_provenance
+
+            payload.update(deploy_provenance.provenance(include_local=False))
+        except Exception:  # noqa: BLE001 — provenance must never fail the probe
+            payload["version"] = "unknown"
+        return JSONResponse(payload, headers={"Cache-Control": "no-store"})
 
     @mcp_app.custom_route("/health/ready", methods=["GET"])
     async def _runtime_ready(request: Request) -> JSONResponse:  # noqa: ARG001

--- a/tests/test_deploy_provenance.py
+++ b/tests/test_deploy_provenance.py
@@ -1,0 +1,171 @@
+"""Provenance reporting: install origin, torch build, and the public/local split.
+
+The regression these guard against: a service running from a wheel-backed venv
+while a nearby checkout looked authoritative, plus a CUDA torch wheel silently
+replaced by the default CPU wheel during an upgrade.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exomem import deploy_provenance
+
+
+class _FakeDist:
+    def __init__(self, direct_url: str | None):
+        self._direct_url = direct_url
+
+    def read_text(self, name: str) -> str | None:
+        if name == "direct_url.json":
+            return self._direct_url
+        return None
+
+
+def _editable_url(path: str) -> str:
+    return json.dumps({"url": f"file:///{path}", "dir_info": {"editable": True}})
+
+
+def _wheel_url() -> str:
+    return json.dumps({"url": "https://pypi.org/simple/exomem", "dir_info": {}})
+
+
+# --- install source classification -------------------------------------------
+
+
+def test_editable_install_is_classified_editable(monkeypatch):
+    monkeypatch.setattr(
+        deploy_provenance,
+        "distribution",
+        lambda name: _FakeDist(_editable_url("C:/proj/exomem")),
+    )
+    source, root = deploy_provenance._install_source_and_root()
+    assert source == "editable"
+    assert root is not None
+    assert root.as_posix().endswith("proj/exomem")
+
+
+def test_wheel_install_is_classified_wheel(monkeypatch):
+    monkeypatch.setattr(deploy_provenance, "distribution", lambda name: _FakeDist(_wheel_url()))
+    source, root = deploy_provenance._install_source_and_root()
+    assert source == "wheel"
+    assert root is None
+
+
+def test_missing_direct_url_reports_wheel(monkeypatch):
+    """No direct_url.json is the normal shape for a plain wheel install."""
+    monkeypatch.setattr(deploy_provenance, "distribution", lambda name: _FakeDist(None))
+    source, _ = deploy_provenance._install_source_and_root()
+    assert source == "wheel"
+
+
+def test_unresolvable_distribution_reports_unknown(monkeypatch):
+    """A wrong guess here is what caused the original confusion; say 'unknown'."""
+
+    def _boom(name):
+        raise RuntimeError("no metadata")
+
+    monkeypatch.setattr(deploy_provenance, "distribution", _boom)
+    source, root = deploy_provenance._install_source_and_root()
+    assert source == "unknown"
+    assert root is None
+
+
+def test_malformed_direct_url_does_not_raise(monkeypatch):
+    monkeypatch.setattr(deploy_provenance, "distribution", lambda name: _FakeDist("{not json"))
+    source, _ = deploy_provenance._install_source_and_root()
+    assert source == "wheel"
+
+
+# --- torch build tag ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("build", "expected"),
+    [
+        ("2.12.0+cu132", True),
+        ("2.12.0+cu121", True),
+        ("2.5.0+rocm6.1", True),
+        ("2.13.0", False),
+        ("2.13.0+cpu", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_accelerated_detection(build, expected):
+    assert deploy_provenance._is_accelerated(build) is expected
+
+
+def test_torch_build_read_without_importing_torch(monkeypatch):
+    """Metadata only. Importing torch would cost seconds and can fail outright."""
+    seen: list[str] = []
+
+    def _version(name: str) -> str:
+        seen.append(name)
+        return "2.12.0+cu132"
+
+    monkeypatch.setattr(deploy_provenance, "version", _version)
+    assert deploy_provenance._torch_build() == "2.12.0+cu132"
+    assert seen == ["torch"]
+
+
+def test_absent_torch_reports_none(monkeypatch):
+    def _version(name: str):
+        raise RuntimeError("not installed")
+
+    monkeypatch.setattr(deploy_provenance, "version", _version)
+    assert deploy_provenance._torch_build() is None
+    assert deploy_provenance._is_accelerated(None) is False
+
+
+# --- public vs local payload --------------------------------------------------
+
+
+def test_public_payload_excludes_host_identifying_detail():
+    """`/health` is unauthenticated and publicly reachable through the tunnel."""
+    report = deploy_provenance.provenance(include_local=False)
+    assert "interpreter" not in report
+    assert "package_path" not in report
+    assert "checkout" not in report
+
+    blob = json.dumps(report)
+    assert "C:\\Users" not in blob
+    assert "/home/" not in blob
+
+
+def test_local_payload_includes_interpreter():
+    report = deploy_provenance.provenance(include_local=True)
+    assert report["interpreter"]
+    assert report["package_path"]
+    # Everything published publicly is also present locally.
+    public = deploy_provenance.provenance(include_local=False)
+    assert set(public).issubset(set(report))
+
+
+def test_provenance_reports_expected_keys():
+    report = deploy_provenance.provenance()
+    for key in ("version", "install_source", "revision", "torch", "accelerated", "extras"):
+        assert key in report
+    assert report["install_source"] in {"editable", "wheel", "unknown"}
+    assert isinstance(report["extras"], list)
+
+
+def test_revision_only_for_editable_installs(monkeypatch):
+    monkeypatch.setattr(deploy_provenance, "distribution", lambda name: _FakeDist(_wheel_url()))
+    monkeypatch.setattr(deploy_provenance, "_revision", lambda root: "deadbee")
+    report = deploy_provenance.provenance()
+    assert report["revision"] is None
+
+
+def test_revision_tolerates_missing_git(monkeypatch, tmp_path):
+    def _boom(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(deploy_provenance.subprocess, "run", _boom)
+    assert deploy_provenance._revision(tmp_path) is None
+
+
+def test_revision_none_for_missing_root():
+    assert deploy_provenance._revision(None) is None

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -59,6 +59,42 @@ def test_health_endpoint_public_and_reports_version(vault, monkeypatch: pytest.M
     assert r2.status_code == 200, r2.text
 
 
+def test_health_reports_install_provenance(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answers "what is deployed, and from where" without inspecting the service
+    manager — the gap that let a wheel-backed service hide behind a checkout."""
+    body = _client(vault, monkeypatch).get("/health").json()
+    assert body["install_source"] in {"editable", "wheel", "unknown"}
+    for key in ("revision", "torch", "accelerated", "extras"):
+        assert key in body
+
+
+def test_health_omits_host_identifying_detail(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """This route is unauthenticated and publicly reachable through the tunnel, so
+    absolute paths would leak the OS username and host layout."""
+    r = _client(vault, monkeypatch).get("/health")
+    body = r.json()
+    assert "interpreter" not in body
+    assert "package_path" not in body
+    assert "checkout" not in body
+    assert "C:\\Users" not in r.text
+    assert "/home/" not in r.text
+
+
+def test_health_survives_provenance_failure(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Liveness must never depend on provenance resolution succeeding."""
+    from exomem import deploy_provenance
+
+    def _boom(**_kwargs):
+        raise RuntimeError("metadata unavailable")
+
+    monkeypatch.setattr(deploy_provenance, "provenance", _boom)
+    r = _client(vault, monkeypatch).get("/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["version"] == "unknown"
+
+
 def test_readiness_endpoint_is_public_and_content_free(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Why

The running server could not report **where its code came from**. `/health` returned a version and nothing else, so identifying the real deploy target meant knowing to run `nssm get exomem Application`.

That is not hypothetical. On this host the NSSM service runs `...\exomem-service-ha\.venv\Scripts\python.exe` while its `AppDirectory` points at the primary checkout — so the checkout *looks* authoritative and isn't. `uv sync` there changes nothing the service runs, and `/health` keeps reporting the old version through any number of clean restarts. Diagnosing that consumed most of a deploy session.

The same topology silently drops CUDA. The `cu132` pin lives in the repo's `[tool.uv.sources]` with `explicit = true` — **repo configuration, not wheel metadata** — so it does not travel with the published wheel. Upgrading a PyPI-backed venv resolves torch from default PyPI, which on Windows is CPU-only: `2.12.0+cu132` → `2.13.0`, GPU capability gone. `doctor` reported it, but as one advisory line among passing checks.

Both failures share a root cause: deploy provenance is invisible, and the one signal that would catch a bad deploy is not a gate.

## What changed

- **`/health` gains install provenance** — `install_source` (`editable`/`wheel`/`unknown`), `revision`, `torch` build tag, `accelerated`, and `extras`. A `wheel` source with a null revision immediately says "this is not your checkout."
- **`exomem install-info`** reports full detail locally, including the interpreter path.
- **`scripts/deploy.ps1`** resolves the interpreter from NSSM rather than the checkout, fails on accelerator regression (`-AllowCpuTorch` to opt out), gates on `doctor`, and polls `/health` until the *running process* serves the requested version.

## Design decisions

**`/health` never exposes filesystem paths.** The route is unauthenticated and publicly reachable through the tunnel; absolute paths would leak the OS username and host layout. Full detail is local-CLI-only, with a test asserting no absolute path reaches the public payload.

**Torch build is read from metadata, never imported.** Keeps the probe fast and unable to fail on a broken ML stack. This makes `/health` report *which wheel is installed* (a deploy property) while `doctor` still reports *whether a GPU is usable now* (a runtime property). Conflating those is how the regression hid.

**Named `install-info`, not `provenance`.** `src/exomem/provenance.py` already means note/source provenance; in a knowledge-base product that word would read as vault provenance.

**The accelerator gate fails by default.** A silent capability loss is expensive to discover later; a spurious failure costs one flag.

## Verification

- 29 targeted tests pass (provenance units + `/health` route)
- `install-info` verified against all three real environments: wheel-backed service venv, primary checkout, worktree
- `deploy.ps1 -DryRun` correctly resolved the service interpreter while run from an unrelated worktree
- `openspec validate add-deploy-provenance --strict` passes
- ruff clean on all changed files

**Full suite: zero regressions.** This host has ~313 pre-existing failures (POSIX file modes, symlinks, `fcntl`, hosted-tier) that are green in CI on Linux, so the suite was compared per-file against the unmodified primary checkout across four chunks — counts identical in every one, including `test_service_installers.py` (7 and 7).

## Note for reviewers

Two modules must be `--ignore`d to run the suite on Windows at all: `test_continuation_checkpoint.py` (`os.fsdecode` of a non-UTF-8 byte filename) and `test_hosted_restore_candidate.py` (POSIX-only `fcntl`). Both are pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhctErfRgVoN5ZAPqCjjwb
