### PR TITLE
fix: cache the corpus context on a stat census and size the edge budget to measured write cost

### DIFF
--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -314,7 +314,12 @@ async function proxyMutationRequest(request, env, lease) {
   request = withMutationRequestId(request);
   const requestId = request.headers.get("x-exomem-request-id");
   const shortTimeout = Number(env.ORIGIN_TIMEOUT_MS || 2500);
-  const toolTimeout = Number(env.MCP_TOOL_TIMEOUT_MS || 15000);
+  // 60s, not 15s: a governed write validates the draft against the full corpus
+  // and re-validates under the creation lock, measured at 12-45s warm on the
+  // 2026-07 production corpus (2.4k pages). Abandoning at 15s guaranteed the
+  // origin kept committing after the edge stopped waiting — acknowledgement
+  // loss on nearly every write. 60s stays under Cloudflare's ~100s proxy cap.
+  const toolTimeout = Number(env.MCP_TOOL_TIMEOUT_MS || 60000);
   const holder = lease.holder;
   let candidate = candidateForHolder(env, holder);
 

--- a/deploy/cloudflare-ha/wrangler.toml.example
+++ b/deploy/cloudflare-ha/wrangler.toml.example
@@ -11,8 +11,11 @@ LAPTOP_ORIGIN = "https://exomem-laptop.example.com"
 ORIGIN_TIMEOUT_MS = "2500"
 # MCP tools can legitimately take longer than a connectivity probe. Keep this
 # independent from the short connectivity probe; ambiguous tool calls are
-# never cross-replica replayed regardless of timeout.
-MCP_TOOL_TIMEOUT_MS = "15000"
+# never cross-replica replayed regardless of timeout. Governed writes validate
+# against the full corpus (measured 12-45s warm at 2.4k pages), so this must
+# comfortably exceed a warm write and stay under Cloudflare's ~100s proxy cap.
+# An abandoned mutation is acknowledgement loss: the origin commits anyway.
+MCP_TOOL_TIMEOUT_MS = "60000"
 # Behavioral compatibility, not exact package versions. During an incompatible
 # rolling deployment, expand to "1,2", roll every replica, then contract to "2".
 SUPPORTED_RUNTIME_CONTRACTS = "1"

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -5205,6 +5205,13 @@ def invocation_is_read_only(command: Command, kwargs: dict[str, Any]) -> bool:
         return mode == "audit"
     if command.name == "edit_memory":
         return kwargs.get("validate_only") is True
+    if command.name == "remember":
+        # A validate-only remember builds and returns an immutable draft and
+        # writes nothing (note() returns its preflight before any commit), so
+        # it needs neither writer authority nor the mutation boundary. Any
+        # inconsistency from reading beside a concurrent write is caught by
+        # the fresh under-lock re-validation at commit time.
+        return kwargs.get("validate_only") is True
     return False
 
 

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -32,6 +32,7 @@ import datetime as dt
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1342,6 +1343,9 @@ def note(
     _predecessor_content_hash: str | None = None,
 ) -> NoteResult | semantic_writes.CreationPreflight | _PreparedNote:
     """Create or validate one compiled-note draft through the semantic boundary."""
+    # Coarse per-stage wall-clock timings, logged (never returned) so a slow
+    # write is attributable from service logs alone. Content-free by design.
+    write_started = time.perf_counter()
     root = Path(vault_root)
     try:
         filename_slug, slug_warnings = resolve_filename_slug(title, slug)
@@ -1491,6 +1495,7 @@ def note(
         )
     except (semantic_writes.SemanticWriteError, relation_review.RelationReviewError) as error:
         raise NoteError(error.code, [], error.reason) from error
+    preflight_ms = (time.perf_counter() - write_started) * 1000.0
     if draft_hash is not None and preflight.draft_hash != draft_hash:
         raise NoteError("DRAFT_HASH_MISMATCH", ["draft_hash"], "draft requires fresh validation")
     warnings = list(slug_warnings) + list(source_warnings) + list(body_warnings)
@@ -1583,6 +1588,11 @@ def note(
     if log_plan.rotation_note is not None:
         warnings.append(log_plan.rotation_note)
     if validate_only:
+        log.info(
+            "note write timings mode=validate note_type=%s preflight_ms=%.1f",
+            note_type,
+            preflight_ms,
+        )
         return preflight
     if _return_prepared:
         return _PreparedNote(
@@ -1593,6 +1603,7 @@ def note(
             destination,
             encoded_token,
         )
+    commit_started = time.perf_counter()
     try:
         committed = semantic_writes.commit_creation(
             root,
@@ -1605,10 +1616,17 @@ def note(
         )
     except (semantic_writes.SemanticWriteError, relation_review.RelationReviewError) as error:
         raise NoteError(error.code, [], error.reason) from error
+    commit_ms = (time.perf_counter() - commit_started) * 1000.0
 
+    advisory_started = time.perf_counter()
     corpus_suggestions: list[dict] = []
     duplicate_warnings: list[str] = []
     contradiction_warnings: list[str] = []
+    # suggestions=False gates ONLY the related-links query below; the near-dup
+    # /contradiction sweep is a dedupe guardrail and stays on in every mode
+    # (locked by tests/test_note_suggestions_knob.py). Its latency lives inside
+    # the widened edge budget; `note write timings ... advisory_ms` makes it
+    # attributable when it grows.
     if not os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
         try:
             if suggestions:
@@ -1650,6 +1668,16 @@ def note(
             log.debug("corpus-aware nudges failed (non-fatal)", exc_info=True)
     warnings.extend(duplicate_warnings)
     warnings.extend(contradiction_warnings)
+    log.info(
+        "note write timings mode=commit note_type=%s preflight_ms=%.1f "
+        "commit_ms=%.1f advisory_ms=%.1f total_ms=%.1f suggestions=%s",
+        note_type,
+        preflight_ms,
+        commit_ms,
+        (time.perf_counter() - advisory_started) * 1000.0,
+        (time.perf_counter() - write_started) * 1000.0,
+        suggestions,
+    )
     feedback = _build_write_feedback(
         note_type=note_type,
         sources_norm=sources_norm,

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import stat
+import threading
+import time
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
@@ -43,6 +46,8 @@ _GRANDFATHERED_OPERATIONS = frozenset(
     {"edit", "move", "observe", "recover", "tier2_overwrite", "tier2_append"}
 )
 _WIKILINK_RE = re.compile(r"\[\[([^\]\n]+)\]\]")
+
+log = logging.getLogger(__name__)
 _REVIEW_FINGERPRINT_UNSET = object()
 
 
@@ -756,6 +761,158 @@ def build_page_state(
     )
 
 
+class _CensusUnsafe(Exception):
+    """The corpus tree cannot be fingerprinted safely; do not use the cache."""
+
+
+# Process cache for the fully-materialized corpus context: one bounded entry
+# per vault root, keyed on a stat-level census of every filesystem input the
+# build reads. Serving rule: the current census must equal the stored census,
+# and the stored census was confirmed identical before AND after the build it
+# captions, so a tree that changed mid-build is never stored. Invalidation
+# needs no TTL and no cooperation from writers: any input change that alters a
+# path, size, or mtime_ns is caught by the census taken on the next call.
+#
+# Why (path, size, mtime_ns) per file and not a max-mtime scan: Syncthing (and
+# any mtime-preserving sync) materializes remote edits with the SOURCE's
+# modification time, which can be older than every local timestamp — max-mtime
+# would silently serve a stale corpus. The full census still catches such an
+# edit because the synced file's mtime_ns (and normally size) differs from the
+# entry recorded for the previous content at that path. The residual
+# undetectable case — new content with byte-identical size and identical
+# 100ns-resolution mtime at the same path — is not producible by the engine's
+# own temp+rename writes nor by observed sync behavior.
+_CORPUS_CONTEXT_CACHE: dict[
+    tuple[str, str], tuple[tuple, "SemanticCorpusContext"]
+] = {}
+_CORPUS_CONTEXT_CACHE_LOCK = threading.Lock()
+_CORPUS_CONTEXT_CACHE_MAX_VAULTS = 2
+
+
+def corpus_context_cache_enabled() -> bool:
+    """Whether the corpus-context cache is active (EXOMEM_DISABLE_CORPUS_CACHE)."""
+    return not os.environ.get("EXOMEM_DISABLE_CORPUS_CACHE")
+
+
+def reset_corpus_context_cache() -> None:
+    """Drop every cached corpus context; intentionally public for tests."""
+    with _CORPUS_CONTEXT_CACHE_LOCK:
+        _CORPUS_CONTEXT_CACHE.clear()
+
+
+def _corpus_cache_key(root: Path) -> tuple[str, str]:
+    return (
+        os.path.normcase(str(root.resolve(strict=False))),
+        os.path.normcase(str(vault.kb_root(root).resolve(strict=False))),
+    )
+
+
+def _corpus_census(root: Path) -> tuple | None:
+    """Stat census of every filesystem input ``build_corpus_context`` reads.
+
+    Mirrors both production walks — ``_build_identity_census`` (every ``.md``
+    under the KB, refusing filesystem aliases) and ``vault.walk_vault_md``
+    (the full vault minus skip dirs and sync-conflict copies) — and appends
+    the non-Markdown inputs: ``_access.yaml`` (page eligibility via
+    ``access.access_tier``) and the two ``_Schema`` registry files. Returns
+    ``None`` when the tree cannot be fingerprinted safely; callers must then
+    build uncached so the build path surfaces its own safety errors.
+    """
+    entries: set[tuple[str, str, int, int]] = set()
+    kb = vault.kb_root(root)
+
+    def strict_walk(directory: Path) -> None:
+        # Mirror of _build_identity_census: every entry under KB, alias-free.
+        for child in os.scandir(directory):
+            path = Path(child.path)
+            info = child.stat(follow_symlinks=False)
+            if child.is_symlink() or vault._is_reparse(info):
+                raise _CensusUnsafe
+            if stat.S_ISDIR(info.st_mode):
+                strict_walk(path)
+                continue
+            if path.suffix.casefold() != ".md":
+                continue
+            if not stat.S_ISREG(info.st_mode):
+                raise _CensusUnsafe
+            entries.add(
+                (path.relative_to(root).as_posix(), "f", info.st_size, info.st_mtime_ns)
+            )
+
+    def loose_walk(directory: Path) -> None:
+        # Mirror of vault.walk_vault_md: skip dirs and sync-conflict copies,
+        # with the same is_dir()/is_file() semantics (which traverse links).
+        for child in os.scandir(directory):
+            path = Path(child.path)
+            if child.is_dir():
+                if child.name in vault.VAULT_SCAN_SKIP_DIRS:
+                    continue
+                loose_walk(path)
+            elif (
+                child.is_file()
+                and path.suffix.lower() == ".md"
+                and ".sync-conflict-" not in child.name
+            ):
+                info = child.stat()
+                entries.add(
+                    (path.relative_to(root).as_posix(), "f", info.st_size, info.st_mtime_ns)
+                )
+
+    try:
+        try:
+            kb_info = kb.lstat()
+        except FileNotFoundError:
+            kb_info = None
+        if kb_info is not None:
+            # A KB root that is an alias makes the identity census raise; the
+            # census must refuse to vouch for that tree rather than mask it.
+            if not stat.S_ISDIR(kb_info.st_mode) or vault._is_reparse(kb_info):
+                raise _CensusUnsafe
+            strict_walk(kb)
+        loose_walk(root)
+        for extra in (
+            access.access_config_path(root),
+            relation_registry.extension_registry_path(root),
+            semantic_language_registry.registry_path(root),
+        ):
+            marker = str(extra.relative_to(root).as_posix())
+            try:
+                info = extra.stat()
+            except FileNotFoundError:
+                entries.add((marker, "absent", -1, -1))
+            else:
+                entries.add((marker, "cfg", info.st_size, info.st_mtime_ns))
+    except (_CensusUnsafe, OSError, ValueError):
+        return None
+    return tuple(sorted(entries))
+
+
+def _registries_match_disk(
+    root: Path,
+    relation_definitions: relation_registry.RelationRegistry,
+    language: semantic_language_registry.SemanticLanguageRegistry,
+) -> bool:
+    """Whether the supplied registries are content-identical to the on-disk ones.
+
+    The cache stores contexts derived from on-disk registry state (the
+    registry files are census entries). A caller-supplied registry object is
+    only compatible with that stored state when its content fingerprint equals
+    a fresh disk load — synthetic/proposal registries fail this and bypass the
+    cache entirely.
+    """
+    try:
+        disk_registry = relation_registry.load_registry(root)
+        disk_language = semantic_language_registry.load_registry(root)
+    except Exception:  # noqa: BLE001 — unreadable registry state: never cache
+        return False
+    return (
+        (disk_registry.core_version, disk_registry.extension_hash)
+        == (relation_definitions.core_version, relation_definitions.extension_hash)
+        and (disk_language.schema_version, disk_language.content_hash)
+        == (language.schema_version, language.content_hash)
+    )
+
+
 def build_corpus_context(
     vault_root: Path,
     *,
@@ -763,10 +920,79 @@ def build_corpus_context(
     registry: relation_registry.RelationRegistry | None = None,
     language_registry: semantic_language_registry.SemanticLanguageRegistry | None = None,
 ) -> SemanticCorpusContext:
-    """Read and parse the corpus once, then resolve every fact in memory."""
+    """Read and parse the corpus once, then resolve every fact in memory.
+
+    Warm calls are served from a bounded process cache keyed on a stat census
+    of every filesystem input (see ``_corpus_census``). A cached context is
+    returned only when the census matches exactly and any caller-supplied
+    registries are content-identical to disk; candidate-bearing builds always
+    take the uncached path. ``EXOMEM_DISABLE_CORPUS_CACHE=1`` restores the
+    always-rebuild behavior.
+    """
     root = Path(vault_root)
     relation_definitions = registry or relation_registry.load_registry(root)
     language = language_registry or semantic_language_registry.load_registry(root)
+
+    census: tuple | None = None
+    cache_key: tuple[str, str] | None = None
+    if candidate is None and corpus_context_cache_enabled():
+        started = time.perf_counter()
+        census = _corpus_census(root)
+        census_ms = (time.perf_counter() - started) * 1000.0
+        if census is not None and _registries_match_disk(
+            root, relation_definitions, language
+        ):
+            cache_key = _corpus_cache_key(root)
+            with _CORPUS_CONTEXT_CACHE_LOCK:
+                entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
+            if entry is not None and entry[0] == census:
+                log.info(
+                    "semantic corpus context reused pages=%d census_ms=%.1f",
+                    len(entry[1].pages),
+                    census_ms,
+                )
+                return entry[1]
+        else:
+            census = None
+
+    started = time.perf_counter()
+    context = _build_corpus_context_uncached(
+        root,
+        candidate=candidate,
+        relation_definitions=relation_definitions,
+        language=language,
+    )
+    build_ms = (time.perf_counter() - started) * 1000.0
+    stored = False
+    if census is not None and cache_key is not None:
+        confirmed = _corpus_census(root)
+        if confirmed == census:
+            with _CORPUS_CONTEXT_CACHE_LOCK:
+                _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
+                while len(_CORPUS_CONTEXT_CACHE) > _CORPUS_CONTEXT_CACHE_MAX_VAULTS:
+                    for stale_key in list(_CORPUS_CONTEXT_CACHE):
+                        if stale_key != cache_key:
+                            del _CORPUS_CONTEXT_CACHE[stale_key]
+                            break
+                    else:
+                        break
+            stored = True
+    log.info(
+        "semantic corpus context built pages=%d build_ms=%.1f cached=%s",
+        len(context.pages),
+        build_ms,
+        stored,
+    )
+    return context
+
+
+def _build_corpus_context_uncached(
+    root: Path,
+    *,
+    candidate: SemanticPageState | None,
+    relation_definitions: relation_registry.RelationRegistry,
+    language: semantic_language_registry.SemanticLanguageRegistry,
+) -> SemanticCorpusContext:
     identity_census, census_sources = _build_identity_census(root)
     states: dict[str, SemanticPageState] = {}
     candidate_path = candidate.path if candidate is not None else None

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -40,7 +40,13 @@ from .privacy_log import content_private_logging_enabled
 _COORDINATOR_USER_AGENT = (
     "Mozilla/5.0 (compatible; Exomem-Coordinator/1.0; +https://github.com/Artexis10/exomem)"
 )
-_IMPLICIT_RETRY_TTL_SECONDS = 60.0
+# The implicit replay window is the acknowledgement-loss recovery budget: when
+# the edge abandons a slow write that the origin then commits, retrying the
+# byte-identical call within this window replays the stored result (with the
+# written slug) instead of double-writing or failing on the existing page.
+# 60s was shorter than one abandoned-write investigation; 10 minutes covers a
+# human noticing the timeout, checking state, and retrying.
+_IMPLICIT_RETRY_TTL_SECONDS = 600.0
 _EXPLICIT_RETRY_TTL_SECONDS = 24 * 60 * 60.0
 _IDEMPOTENCY_WAIT_SECONDS = 5.0
 _IDEMPOTENCY_POLL_INTERVAL_SECONDS = 0.025
@@ -266,17 +272,20 @@ class LeaseConfig:
     #
     # This is a *share of the edge budget*, not a free parameter. The HA edge
     # worker abandons a mutation-capable request at MCP_TOOL_TIMEOUT_MS
-    # (default 15s, deploy/cloudflare-ha/src/worker.js) and deliberately does
+    # (default 60s, deploy/cloudflare-ha/src/worker.js) and deliberately does
     # not replay it, because the origin may commit after the edge stops
     # waiting. Queueing here spends that same budget: time spent waiting is
     # unavailable to the write itself. A value at or near the edge timeout
     # guarantees the caller sees a 504 while the write commits anyway — the
     # exact acknowledgement loss this system works hardest to avoid.
     #
-    # 5s leaves the majority of the 15s budget for the write. Raise this only
-    # in tandem with MCP_TOOL_TIMEOUT_MS, and never to meet or exceed it. The
-    # real headroom win is shortening the critical section — the corpus-aware
-    # embedding pass currently runs inside the boundary — not widening the wait.
+    # 5s leaves the large majority of the 60s budget for the write, whose own
+    # cost is dominated by full-corpus contract validation (measured 12-45s
+    # warm at 2.4k pages, 2026-07). Raise this only in tandem with
+    # MCP_TOOL_TIMEOUT_MS, and never to meet or exceed it. The real headroom
+    # win is shortening the critical section — the per-write corpus parse is
+    # uncached and the corpus-aware embedding pass runs inside the boundary —
+    # not widening the wait.
     mutation_timeout_seconds: float = 5.0
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,26 @@ import pytest
 from exomem import embeddings as embeddings_module
 from exomem import find as find_module
 from exomem import schema as schema_module
+from exomem import semantic_contract as semantic_contract_module
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_VAULT = REPO_ROOT / "tests" / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _reset_corpus_context_cache():
+    """Every test starts with a cold corpus-context cache.
+
+    The cache invalidates on filesystem changes, which production writes
+    always make; tests additionally monkeypatch corpus-affecting internals
+    (access tiers, registries, walks), which no filesystem census can see.
+    A per-test reset keeps such patches from serving a context built under a
+    different test's (or an unpatched) environment.
+    """
+    semantic_contract_module.reset_corpus_context_cache()
+    yield
+    semantic_contract_module.reset_corpus_context_cache()
 
 
 @pytest.fixture(autouse=True)
@@ -55,6 +71,12 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     # Don't spawn the mode-config watch daemon from build_server in the suite; mode-watch
     # tests drive it directly.
     monkeypatch.setenv("EXOMEM_DISABLE_MODE_WATCH", "1")
+    # The corpus-context cache invalidates on filesystem changes, which is
+    # complete for production inputs — but tests also monkeypatch
+    # corpus-affecting internals (access tiers, registries, walks), which no
+    # filesystem census can observe. Default it off in the suite;
+    # test_corpus_context_cache.py deletes this var to exercise it.
+    monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
 
 
 @pytest.fixture

--- a/tests/test_command_surface_retry.py
+++ b/tests/test_command_surface_retry.py
@@ -45,6 +45,26 @@ def test_edit_memory_validate_only_is_read_only() -> None:
     assert invocation_is_read_only(command, {}) is False
 
 
+def test_remember_validate_only_is_read_only() -> None:
+    from exomem.commands import invocation_is_read_only, product_commands_for
+
+    command = next(
+        item for item in product_commands_for("mcp") if item.name == "remember"
+    )
+
+    assert invocation_is_read_only(command, {"validate_only": True}) is True
+    assert invocation_is_read_only(command, {"validate_only": False}) is False
+    assert invocation_is_read_only(command, {}) is False
+    # A draft commit is a write even though it carries draft identity fields.
+    assert (
+        invocation_is_read_only(
+            command,
+            {"validate_only": False, "draft_id": "d", "draft_hash": "h"},
+        )
+        is False
+    )
+
+
 def test_validate_only_row_edit_refuses_instead_of_mutating(vault: Path) -> None:
     from exomem.commands import op_edit_memory
 

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -1,0 +1,173 @@
+"""Correctness of the corpus-context cache (semantic_contract).
+
+The cache may only ever serve a context that is indistinguishable from a
+fresh build. Object identity is the detector below: a cache hit returns the
+same object, a rebuild returns a new one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+
+import pytest
+
+from exomem import relation_registry, semantic_contract, semantic_language_registry
+
+_PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
+
+
+def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "type: insight\n"
+        "status: active\n"
+        "project: atlas\n"
+        "---\n\n"
+        f"{body}"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch: pytest.MonkeyPatch):
+    # The suite-wide conftest defaults the cache OFF; this suite exists to
+    # exercise it, so opt back in and start cold.
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    semantic_contract.reset_corpus_context_cache()
+    yield
+    semantic_contract.reset_corpus_context_cache()
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    notes = tmp_path / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True)
+    (notes / "one.md").write_text(_page(title="One"), encoding="utf-8")
+    (notes / "two.md").write_text(_page(title="Two"), encoding="utf-8")
+    return tmp_path
+
+
+def test_unchanged_corpus_is_reused(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is first
+    assert set(second.pages) == {
+        "Knowledge Base/Notes/Insights/one.md",
+        "Knowledge Base/Notes/Insights/two.md",
+    }
+
+
+def test_content_change_rebuilds(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    (vault / _PAGE_REL).write_text(
+        _page(title="One", body="Entirely new body text.\n"), encoding="utf-8"
+    )
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first
+    assert second.pages[_PAGE_REL].source_hash != first.pages[_PAGE_REL].source_hash
+
+
+def test_mtime_preserving_sync_edit_rebuilds(vault: Path) -> None:
+    """The Syncthing trap: new content materialized with an OLDER mtime.
+
+    A max-mtime freshness key would serve the stale corpus here. The census
+    compares (path, size, mtime_ns) per file, so the synced file's changed
+    mtime — even though it is older than every other timestamp in the vault —
+    invalidates the entry.
+    """
+    page = vault / _PAGE_REL
+    first = semantic_contract.build_corpus_context(vault)
+    original = page.stat()
+    original_bytes = page.read_bytes()
+    replacement = original_bytes.replace(b"One", b"Uno")
+    assert replacement != original_bytes
+    assert len(replacement) == original.st_size
+    page.write_bytes(replacement)
+    hour_ns = 3_600_000_000_000
+    os.utime(page, ns=(original.st_mtime_ns - hour_ns, original.st_mtime_ns - hour_ns))
+    assert page.stat().st_size == original.st_size
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first
+    assert second.pages[_PAGE_REL].title == "Uno"
+
+
+def test_added_page_rebuilds(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    (vault / "Knowledge Base" / "Notes" / "Insights" / "three.md").write_text(
+        _page(title="Three"), encoding="utf-8"
+    )
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first
+    assert "Knowledge Base/Notes/Insights/three.md" in second.pages
+
+
+def test_removed_page_rebuilds(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    (vault / "Knowledge Base" / "Notes" / "Insights" / "two.md").unlink()
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first
+    assert "Knowledge Base/Notes/Insights/two.md" not in second.pages
+
+
+def test_access_config_change_rebuilds(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly:\n- Notes\n", encoding="utf-8"
+    )
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first
+
+
+def test_census_covers_non_markdown_inputs(vault: Path) -> None:
+    census = semantic_contract._corpus_census(vault)
+    assert census is not None
+    markers = {entry[0] for entry in census if entry[1] in {"cfg", "absent"}}
+    assert "Knowledge Base/_access.yaml" in markers
+    assert "Knowledge Base/_Schema/relation-registry.yaml" in markers
+    assert "Knowledge Base/_Schema/semantic-language-registry.yaml" in markers
+
+
+def test_candidate_build_bypasses_and_does_not_pollute_cache(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    candidate = semantic_contract.build_page_state(
+        vault,
+        "Knowledge Base/Notes/Insights/draft.md",
+        _page(title="Draft"),
+        relation_registry=relation_registry.core_registry(),
+        language_registry=semantic_language_registry.core_registry(),
+    )
+    with_candidate = semantic_contract.build_corpus_context(vault, candidate=candidate)
+    assert with_candidate is not first
+    assert "Knowledge Base/Notes/Insights/draft.md" in with_candidate.pages
+    again = semantic_contract.build_corpus_context(vault)
+    assert again is first
+    assert "Knowledge Base/Notes/Insights/draft.md" not in again.pages
+
+
+def test_disk_equal_registries_share_the_cache(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    registry = relation_registry.load_registry(vault)
+    language = semantic_language_registry.load_registry(vault)
+    second = semantic_contract.build_corpus_context(
+        vault, registry=registry, language_registry=language
+    )
+    assert second is first
+
+
+def test_synthetic_registry_bypasses_cache(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    core = relation_registry.load_registry(vault)
+    synthetic = dataclasses.replace(core, extension_hash="0" * 64)
+    second = semantic_contract.build_corpus_context(vault, registry=synthetic)
+    assert second is not first
+
+
+def test_kill_switch_disables_cache(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
+    first = semantic_contract.build_corpus_context(vault)
+    second = semantic_contract.build_corpus_context(vault)
+    assert second is not first

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -1370,7 +1370,7 @@ def test_implicit_committed_failure_expires_under_retry_ttl(tmp_path: Path) -> N
         assert failure.value.as_public_dict()["outcome"]["committed"] is True
     assert calls == 1
 
-    clock.value += 61
+    clock.value += writer_lease_module._IMPLICIT_RETRY_TTL_SECONDS + 1
     with pytest.raises(vault_module.BatchWriteError):
         manager.invoke(command, (), {}, implicit_idempotency_scope="alice")
     assert calls == 2
@@ -1604,7 +1604,7 @@ def test_expired_corrupt_implicit_committed_failure_payload_fails_closed_without
             (b"not-json",),
         )
 
-    clock.value += 61
+    clock.value += writer_lease_module._IMPLICIT_RETRY_TTL_SECONDS + 1
     with pytest.raises(OpError) as blocked:
         manager.invoke(command, (), {}, **marker)
     assert blocked.value.code == "IDEMPOTENCY_IN_PROGRESS"
@@ -1711,7 +1711,7 @@ def test_implicit_idempotency_is_bounded_and_principal_scoped(tmp_path: Path) ->
     }
     assert calls == [1, 1]
 
-    clock.value += 61
+    clock.value += writer_lease_module._IMPLICIT_RETRY_TTL_SECONDS + 1
     assert manager.invoke(command, (), {"value": 1}, implicit_idempotency_scope="alice") == {
         "value": 1
     }


### PR DESCRIPTION
## What was measured (production corpus: 2,444 KB pages, laptop replica)

Before this branch, on the real vault:

| Stage | Cold | Warm |
|---|---|---|
| `note()` validate-only end-to-end | 40.2 s | 12.5-14.6 s |
| `build_corpus_context` (per call; up to 3x per one-shot write) | dominates cold | ~7.0 s |
| BGE model load (lazy, idle-evicted ~15 min in every mode) | 34.0 s | 0 |
| BM25 corpus build (lazy, suggest lane) | 40.0 s | 0 |

The HA edge abandoned every mutation-capable request at 15 s and deliberately
never replays, so nearly every write 502'd at the caller while the origin kept
committing: acknowledgement loss, while reads stayed fast.

After this branch, same vault, same machine:

| Stage | Result |
|---|---|
| `build_corpus_context` warm | **219.8 ms** (cache hit; census scan is 217.5 ms of it) |
| `note()` validate-only end-to-end warm | **2,005-2,067 ms** (3 consecutive runs) |

## What changed

1. **Permanent fix - corpus-context cache** (`semantic_contract.py`): the
   fully-built context is cached per vault root and served only when a
   stat-level census of every filesystem input matches exactly.
   `EXOMEM_DISABLE_CORPUS_CACHE=1` is the kill switch.
2. **Edge budget** (`deploy/cloudflare-ha`): default `MCP_TOOL_TIMEOUT_MS`
   15 s -> 60 s (under Cloudflare's ~100 s cap). **Live deploys that pin the
   old var must update it and redeploy the worker.**
3. **Acknowledgement-loss recovery** (`writer_lease.py`): implicit idempotency
   replay TTL 60 s -> 600 s; retrying a byte-identical write after an
   abandoned request replays the committed result (with the written slug)
   instead of failing against the existing page.
4. **Commit-stage semantics preserved** (`note.py`): an earlier iteration of
   this branch gated the whole post-commit corpus-aware pass behind
   `suggestions`; that was reverted on discovering
   `test_note_suggestions_knob.py` locks the dedupe sweep as a deliberate
   guardrail ("suggestions=False must skip the related-links pass and keep
   the sweep"). The sweep stays on in every mode; its cost is inside the
   widened budget and now visible per-write in the timing log.
5. **Write-path observability** (`note.py`, `semantic_contract.py`):
   content-free per-stage timings (preflight/commit/advisory/total and corpus
   census/build ms) logged on every write, so the next slow write is
   attributable from service logs in minutes, not hours.
6. **Classification** (`commands.py`): `remember` with `validate_only=true`
   is read-only (mirrors the existing `edit_memory` carve-out). Verified
   write-free by inspection: `note()` returns its preflight before any commit,
   path resolution uses `create_parents=False`, and all auxiliary work is
   planning-only. Draft commits remain writes.

## Why the invalidation is correct

The census records `(path, size, mtime_ns)` for **every filesystem input the
build reads** - the input set was enumerated by reading the full call tree:

- every `.md` under the KB, walked exactly like `_build_identity_census`
  (recursing everything, refusing symlinks/reparse points/non-regular files -
  the census returns "uncacheable" where the build would raise);
- every `.md` vault-wide, walked exactly like `vault.walk_vault_md` (same
  skip-dirs, same sync-conflict exclusion, same link-following semantics);
- `Knowledge Base/_access.yaml` (page eligibility via `access.access_tier`);
- `Knowledge Base/_Schema/relation-registry.yaml` and
  `semantic-language-registry.yaml` (presence AND absence are recorded);
- core registries ship in the package and are process-invariant.

Serving rule: current census == stored census. Storing rule: the census must
be **identical before and after** the build, so a context built from a tree
that changed mid-build is never stored. Caller-supplied registry objects must
be content-fingerprint-identical (`core_version`/`extension_hash`,
`schema_version`/`content_hash`) to a fresh disk load, or the cache is
bypassed - synthetic/proposal registries can never be served a disk-derived
context or poison it. Candidate-bearing builds always take the uncached path
(their inline candidate handling has subtly different unreadable-file
semantics than `with_candidate`, so it is not cached rather than approximated).

**Why not max-mtime:** Syncthing materializes remote edits with the source's
timestamp, which can be older than every local mtime - a max-mtime key would
silently serve a stale corpus. The per-path census catches this because the
synced file's `mtime_ns` (and normally size) differs from the entry recorded
for the previous content. Locked by a regression test that rewrites a page
with byte-identical length and an mtime one hour older, and asserts a rebuild.

`SemanticCorpusContext` is deep-frozen (`MappingProxyType`, frozensets,
tuples; the registry is defensively copied at construction), so a shared
cached instance cannot be mutated by consumers; `with_candidate` returns a
new context.

## Fixed permanently vs mitigated

- **Fixed permanently:** the O(corpus) re-parse on warm writes. Warm validates
  and both commit-time re-validations now cost a ~0.2 s census instead of
  ~7 s each; each committed write invalidates once and pays one rebuild
  afterwards. One-shot remember: 3 corpus parses -> 1.
- **Mitigated:** the rebuild itself is still O(corpus) (~7.8 s today) and
  runs once after every committed write and on every cold start; the census
  scan is O(corpus stats) (~0.2 s at 2.4 k pages). At sharply larger corpora
  the rebuild-after-write and the census will grow linearly - the next step,
  if ever needed, is incremental context updates keyed on the same census.
- **Mitigated:** cold model/BM25 loads (34 s / 40 s) are untouched product
  behavior (idle reaper runs in every mode); under the 60 s edge budget they
  no longer break writes. `EXOMEM_RELEASE_GPU_WHEN_IDLE=0` or
  `EXOMEM_MODE=performance` remove them at RAM cost.

## Remaining risk (explicit)

- The undetectable census case: new content at the same path with
  byte-identical size and identical 100 ns mtime. Not producible by the
  engine's own temp+rename writes nor by observed sync behavior; would
  require deliberate forgery or a filesystem without ns timestamps on the
  vault volume.
- One cached context per vault stays resident (bounded to 2 vault roots),
  raising steady-state RSS by roughly one corpus parse's worth of objects.
  Unmeasured; the kill switch restores the old memory profile.
- Read-only `remember validate_only` now runs without the mutation boundary,
  so it can observe a torn multi-file batch mid-commit exactly like every
  other read; any resulting inconsistency is caught by the fresh under-lock
  re-validation at commit. This matches the existing `edit_memory` posture.
- Full test suite on Windows excludes two pre-existing Unix-only modules
  (`test_hosted_restore_candidate.py` imports `fcntl`;
  `test_continuation_checkpoint.py` does `os.fsdecode(b"\xff")` at import) -
  both untouched by this branch and covered by Linux CI.
- 11 pre-existing Windows failures in `test_adopt.py` (semantic census
  scan-only, `markdown_files_scanned == 0`) and
  `test_adoption_proposals.py::test_apply_proposal_supersession_uses_replace_cas`
  were verified byte-identical on a pristine pre-branch checkout on this
  machine (via `git stash` round-trip): not introduced by this branch.
- Suite posture: the wider suite runs with the cache disabled via the same
  conftest convention used for embeddings/CLIP/watcher/warmup, because many
  tests monkeypatch corpus-affecting internals (access tiers, registries,
  walks) that no filesystem census can observe; the dedicated
  `test_corpus_context_cache.py` suite opts back in. Production inputs are
  filesystem-only, which is exactly what the census covers; cache behavior in
  production is additionally observable per call via the census/build log
  line.

## Deploy checklist (not done by this PR)

1. Merge, pull on the desktop (writer), restart the exomem service there
   (laptop follower next).
2. `npx wrangler deploy` the edge worker AND set the live
   `MCP_TOOL_TIMEOUT_MS` var to `60000` (the pinned old value overrides the
   new code default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhLLSASsBqv7DNn7vRp1eJ

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhLLSASsBqv7DNn7vRp1eJ
