### PR TITLE
fix: skip readonly subtrees in audit_fix instead of aborting the pass

### DIFF
--- a/src/exomem/audit_fix.py
+++ b/src/exomem/audit_fix.py
@@ -50,9 +50,9 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from . import access, indexes
 from . import audit as audit_module
 from . import find as find_module
-from . import indexes
 from .vault import (
     PlannedWrite,
     WikilinkResolver,
@@ -63,7 +63,6 @@ from .vault import (
     parse_frontmatter,
     render_wikilink_target,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -91,6 +90,10 @@ class AuditFixReport:
     files_rewritten: int = 0
     summary: dict[str, int] = field(default_factory=dict)
     dry_run: bool = False
+    # Pages passed over because they sit in a `readonly` subtree. Reported
+    # rather than silently dropped: a caller comparing a dry run against the
+    # audit's finding count must be able to account for the difference.
+    skipped_readonly: int = 0
 
     def as_dict(self) -> dict:
         return {
@@ -107,6 +110,7 @@ class AuditFixReport:
             "files_rewritten": self.files_rewritten,
             "summary": self.summary,
             "dry_run": self.dry_run,
+            "skipped_readonly": self.skipped_readonly,
         }
 
 
@@ -304,6 +308,19 @@ def audit_fix(
     pending_paths: list[str] = []
 
     for md in _walk_compiled_pages(kb):
+        # A `readonly` subtree refuses every write with no override, so a
+        # canonicalisation planned for one can never be applied. Planning it
+        # anyway broke this pass twice: the dry run reported the page as
+        # fixed (disagreeing with what a real run could do), and the real run
+        # hit WRITE_REFUSED at the write layer and aborted the entire batch —
+        # so a handful of readonly pages blocked every writeable page beside
+        # them, leaving the fixer permanently unusable on any vault that
+        # marks a subtree readonly.
+        if access.access_tier(vault_root, md.relative_to(vault_root).as_posix()) != (
+            access.TIER_READ_WRITE
+        ):
+            report.skipped_readonly += 1
+            continue
         try:
             original = md.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/tests/test_audit_fix.py
+++ b/tests/test_audit_fix.py
@@ -11,13 +11,67 @@ from pathlib import Path
 
 from exomem import audit_fix as audit_fix_module
 
-
 TODAY = dt.date(2026, 5, 28)
 
 
 def _seed(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def test_readonly_subtree_does_not_block_fixing_writeable_pages(vault: Path) -> None:
+    """One readonly page must not abort the whole pass.
+
+    Regression: `audit_fix` walked every compiled page without consulting
+    `_access.yaml`. A `readonly` subtree refuses every write with no override,
+    so the planned canonicalisation reached the write layer and raised
+    WRITE_REFUSED, aborting the entire batch. On a real vault three readonly
+    pages blocked seventeen perfectly writeable ones, leaving the fixer
+    permanently unusable for anyone who marks a subtree readonly.
+    """
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly:\n  - Products\n", encoding="utf-8"
+    )
+    link = "See [[Notes/Insights/progressive-disclosure-without-mode-fragmentation]].\n"
+    header = (
+        "---\ntype: insight\nstatus: active\ncreated: 2026-05-28\n"
+        "updated: 2026-05-28\ntags: []\n---\n# Page\n\n"
+    )
+    writeable = vault / "Knowledge Base" / "Notes" / "Insights" / "writeable.md"
+    locked = vault / "Knowledge Base" / "Products" / "locked.md"
+    _seed(writeable, header + link)
+    _seed(locked, header + link)
+
+    report = audit_fix_module.audit_fix(vault, today=TODAY)
+
+    # The writeable page is canonicalised despite the readonly page beside it.
+    assert (
+        "[[Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fragmentation]]"
+        in writeable.read_text(encoding="utf-8")
+    )
+    # The readonly page is left exactly as authored.
+    assert locked.read_text(encoding="utf-8") == header + link
+    # And the skip is reported, not silently swallowed.
+    assert report.skipped_readonly >= 1
+    assert not any(f.path.startswith("Knowledge Base/Products/") for f in report.fixed)
+
+
+def test_dry_run_does_not_promise_fixes_it_cannot_apply(vault: Path) -> None:
+    """A dry run must match what a real run can do, or it is not a preview."""
+    (vault / "Knowledge Base" / "_access.yaml").write_text(
+        "readonly:\n  - Products\n", encoding="utf-8"
+    )
+    _seed(
+        vault / "Knowledge Base" / "Products" / "locked.md",
+        "---\ntype: insight\nstatus: active\ncreated: 2026-05-28\n"
+        "updated: 2026-05-28\ntags: []\n---\n# Page\n\n"
+        "See [[Notes/Insights/progressive-disclosure-without-mode-fragmentation]].\n",
+    )
+
+    preview = audit_fix_module.audit_fix(vault, dry_run=True, today=TODAY)
+
+    assert not any(f.path.startswith("Knowledge Base/Products/") for f in preview.fixed)
+    assert preview.skipped_readonly >= 1
 
 
 def test_audit_fix_canonicalizes_wikilinks_in_body(vault: Path) -> None:


### PR DESCRIPTION
## The defect

`audit_fix` walks every compiled page without consulting `_access.yaml`. A `readonly` subtree refuses every write with **no override**, so a planned wikilink canonicalisation for one reaches the write layer, raises `WRITE_REFUSED`, and aborts the entire batch.

Found on a real vault today:

```
WRITE_REFUSED: Knowledge Base/Products/Call Center AI/Strategy.md:
path is in a `readonly` tree (_access.yaml): findable but write-protected
```

Three pages under a readonly `Products/` tree blocked **seventeen** perfectly writeable pages. `maintain_memory(mode="fix")` could repair nothing at all. Since `readonly` is the documented, supported configuration, any vault using it has a permanently unusable link fixer.

## Two defects, one cause

1. **The dry run promises work it cannot do.** Readonly pages were reported under `fixed`, so `maintain_memory(mode="fix", dry_run=true)` returned `fixed: 20` when a real run could apply none of them. A preview that disagrees with the real run isn't a preview.
2. **The real run fails closed on the first refusal**, taking every unrelated writeable page down with it.

## The change

The pass now consults `access.access_tier` per page — the same guard `audit.py` already applies at three other sites (lines 1447, 1699, 1863) — and skips anything not `TIER_READ_WRITE`.

The count surfaces as `skipped_readonly` rather than being dropped silently: a caller reconciling a dry run against the audit's finding count needs to account for the gap, and a silent skip would just relocate the confusion.

## Tests

Both confirmed to **fail against the unfixed pass** (verified by stashing `src/` and re-running), then pass with it:

- `test_readonly_subtree_does_not_block_fixing_writeable_pages` — a writeable page beside a readonly one is still canonicalised; the readonly page is left byte-identical; the skip is reported.
- `test_dry_run_does_not_promise_fixes_it_cannot_apply` — the preview never lists a readonly page under `fixed`.

## Verification

- 22 passed across `test_audit_fix.py` and `test_access.py`
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z8W4eQFrREL758npaVPH6
