### PR TITLE
feat: make edge ingress deterministic and self-verifying

### DIFF
--- a/deploy/cloudflare-ha/README.md
+++ b/deploy/cloudflare-ha/README.md
@@ -16,8 +16,20 @@ and the stable route, then deploy:
 ```powershell
 npx wrangler login
 npx wrangler secret put STATE_TOKEN
-npx wrangler deploy
+.\deploy.ps1
 ```
+
+```bash
+npx wrangler login
+npx wrangler secret put STATE_TOKEN
+./deploy.sh
+```
+
+`deploy.ps1` / `deploy.sh` wrap `wrangler deploy` with
+`--var WORKER_GIT_SHA:<short git SHA>`, so the authenticated `GET /__version`
+endpoint (gated by the same bearer as the coordinator endpoints) reports which
+commit is live instead of `"git_sha": "unlabeled"`. A bare `wrangler deploy`
+still works; it just leaves the deploy unlabeled.
 
 Configure both replicas with the same stable `EXOMEM_BASE_URL`, GitHub OAuth app,
 `EXOMEM_JWT_SIGNING_KEY`, state URL/token, vault ID, and lease token. Give each a

--- a/deploy/cloudflare-ha/deploy.ps1
+++ b/deploy/cloudflare-ha/deploy.ps1
@@ -1,0 +1,34 @@
+# Deploy the HA edge worker labeled with the current git SHA.
+#
+# A bare `wrangler deploy` still works, but /__version then reports
+# "git_sha": "unlabeled" and doctor's ingress check surfaces that as a
+# warning. This script exists so the deploy identity is not silently lost.
+#
+# Usage:
+#   pwsh -File deploy/cloudflare-ha/deploy.ps1
+
+$ErrorActionPreference = "Stop"
+Set-Location -Path $PSScriptRoot
+
+function Fail($msg) {
+    Write-Host "DEPLOY FAILED: $msg" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Fail "git not found; install git to resolve the deploy SHA."
+}
+if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
+    Fail "npx not found; install Node.js to run wrangler."
+}
+
+$gitSha = (git rev-parse --short HEAD 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $gitSha) {
+    Fail "git rev-parse --short HEAD failed; is this a git checkout?"
+}
+
+Write-Host "Deploying exomem-ha-edge at $gitSha ..." -ForegroundColor Cyan
+& npx wrangler deploy --var "WORKER_GIT_SHA:$gitSha"
+if ($LASTEXITCODE -ne 0) {
+    Fail "wrangler deploy returned $LASTEXITCODE."
+}

--- a/deploy/cloudflare-ha/deploy.sh
+++ b/deploy/cloudflare-ha/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deploy the HA edge worker labeled with the current git SHA.
+#
+# A bare `wrangler deploy` still works, but /__version then reports
+# "git_sha": "unlabeled" and doctor's ingress check surfaces that as a
+# warning. This script exists so the deploy identity is not silently lost.
+#
+# Usage:
+#   bash deploy/cloudflare-ha/deploy.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+die() { echo "deploy: $*" >&2; exit 1; }
+
+command -v git >/dev/null 2>&1 || die "git not found; install git to resolve the deploy SHA."
+command -v npx >/dev/null 2>&1 || die "npx not found; install Node.js to run wrangler."
+
+git_sha="$(git rev-parse --short HEAD)" || die "git rev-parse --short HEAD failed; is this a git checkout?"
+
+echo "Deploying exomem-ha-edge at ${git_sha} ..."
+npx wrangler deploy --var "WORKER_GIT_SHA:${git_sha}"

--- a/deploy/cloudflare-ha/src/worker.js
+++ b/deploy/cloudflare-ha/src/worker.js
@@ -240,6 +240,10 @@ export class ExomemState {
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+    if (url.pathname === "/__version") {
+      if (!authorized(request, env.STATE_TOKEN)) return json({ error: "unauthorized" }, 401);
+      return json(versionPayload(env));
+    }
     const leaseMatch = url.pathname.match(/^\/v1\/vaults\/([^/]+)\/lease(?:\/([^/]+))?$/);
     const stateMatch = url.pathname.match(/^\/v1\/state\/([^/]+)\/([^/]+)$/);
     if (leaseMatch || stateMatch) {
@@ -263,6 +267,7 @@ export default {
       return proxyMutationRequest(request, env, lease);
     }
 
+    const stamped = await stampEdgeTransit(request, env);
     const replicas = holder === env.LAPTOP_REPLICA_ID
       ? [env.LAPTOP_ORIGIN, env.DESKTOP_ORIGIN]
       : [env.DESKTOP_ORIGIN, env.LAPTOP_ORIGIN];
@@ -271,7 +276,7 @@ export default {
       if (!origin) continue;
       try {
         const target = new URL(url.pathname + url.search, origin);
-        const response = await fetch(new Request(target, request.clone()), {
+        const response = await fetch(new Request(target, stamped.clone()), {
           signal: AbortSignal.timeout(Number(env.ORIGIN_TIMEOUT_MS || 2500)),
           redirect: "manual",
         });
@@ -311,7 +316,7 @@ export async function isMutationCapableRequest(request) {
 }
 
 async function proxyMutationRequest(request, env, lease) {
-  request = withMutationRequestId(request);
+  request = await stampEdgeTransit(request, env);
   const requestId = request.headers.get("x-exomem-request-id");
   const shortTimeout = Number(env.ORIGIN_TIMEOUT_MS || 2500);
   // 60s, not 15s: a governed write validates the draft against the full corpus
@@ -363,14 +368,55 @@ async function proxyMutationRequest(request, env, lease) {
   }
 }
 
-function withMutationRequestId(request) {
+// Stamps every request the worker proxies to an origin (read fan-out and
+// mutation path alike) with a request-id and an HMAC transit proof over that
+// id, keyed by STATE_TOKEN. An origin with the writer lease enabled refuses
+// Cloudflare-transited POSTs lacking a valid proof; the raw token never
+// travels on proxied requests, only the per-request HMAC does.
+async function stampEdgeTransit(request, env) {
   const headers = new Headers(request.headers);
   const presented = String(headers.get("x-exomem-request-id") || "").trim();
   const requestId = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(presented)
     ? presented
     : crypto.randomUUID();
   headers.set("x-exomem-request-id", requestId);
+  const auth = await edgeAuthHmac(env.STATE_TOKEN, requestId);
+  if (auth) headers.set("x-exomem-edge-auth", auth);
+  else headers.delete("x-exomem-edge-auth");
   return new Request(request, { headers });
+}
+
+// Unset STATE_TOKEN omits the header rather than throwing: standalone
+// deployments with no coordinator secret are unaffected by the stamp.
+async function edgeAuthHmac(token, requestId) {
+  const secret = String(token || "").trim();
+  if (!secret) return null;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(requestId));
+  return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function versionPayload(env) {
+  return {
+    service: "exomem-ha-edge",
+    git_sha: env.WORKER_GIT_SHA || "unlabeled",
+    deployed_vars: {
+      MCP_TOOL_TIMEOUT_MS: Number(env.MCP_TOOL_TIMEOUT_MS || 60000),
+      ORIGIN_TIMEOUT_MS: Number(env.ORIGIN_TIMEOUT_MS || 2500),
+      REQUIRE_COORDINATION: requireCoordination(env),
+      SUPPORTED_RUNTIME_CONTRACTS: env.SUPPORTED_RUNTIME_CONTRACTS,
+      DESKTOP_REPLICA_ID: env.DESKTOP_REPLICA_ID,
+      LAPTOP_REPLICA_ID: env.LAPTOP_REPLICA_ID,
+      DESKTOP_ORIGIN: env.DESKTOP_ORIGIN,
+      LAPTOP_ORIGIN: env.LAPTOP_ORIGIN,
+    },
+  };
 }
 
 function candidateForHolder(env, holder) {

--- a/deploy/cloudflare-ha/test/worker.test.mjs
+++ b/deploy/cloudflare-ha/test/worker.test.mjs
@@ -596,6 +596,144 @@ test("cached active-holder admission preserves the steady-state single-fetch pat
   }
 });
 
+async function expectedEdgeAuth(token, requestId) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(token),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(requestId));
+  return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+// Golden cross-implementation vector: tests/test_edge_ingress.py asserts the
+// identical constant for compute_edge_auth, so a unilateral change to
+// key/message encoding or hex casing in either implementation fails one of
+// the two suites instead of 403ing every proxied request in production.
+test("edge-auth HMAC matches the origin implementation's golden vector", async () => {
+  assert.equal(
+    await expectedEdgeAuth("secret-token", "11111111-1111-4111-8111-111111111111"),
+    "1d489d84d7a8dcec3ddef522064e6ee09269bb80fd3dc91cd62c4ebf1ab220b4",
+  );
+});
+
+test("read fan-out stamps a request-id and a valid HMAC edge-auth header on every attempt", async () => {
+  const forwarded = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    forwarded.push({
+      origin: new URL(request.url).origin,
+      requestId: request.headers.get("x-exomem-request-id"),
+      edgeAuth: request.headers.get("x-exomem-edge-auth"),
+    });
+    return new Response("down", { status: 503 });
+  };
+  try {
+    const env = edgeEnv(null);
+    env.STATE_TOKEN = "coordinator-secret";
+    const request = new Request("https://exomem.example.com/health/ready");
+    await worker.fetch(request, env);
+
+    assert.equal(forwarded.length, 2);
+    const requestId = forwarded[0].requestId;
+    assert.match(requestId, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    const expected = await expectedEdgeAuth("coordinator-secret", requestId);
+    for (const attempt of forwarded) {
+      assert.equal(attempt.requestId, requestId);
+      assert.equal(attempt.edgeAuth, expected);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("mutation proxy stamps a valid HMAC edge-auth header alongside the request-id", async () => {
+  const forwarded = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    forwarded.push({
+      requestId: request.headers.get("x-exomem-request-id"),
+      edgeAuth: request.headers.get("x-exomem-edge-auth"),
+    });
+    return new Response("ok", { status: 200 });
+  };
+  try {
+    const env = edgeEnv("desktop");
+    env.STATE_TOKEN = "coordinator-secret";
+    const response = await worker.fetch(toolCall(), env);
+    assert.equal(response.status, 200);
+    assert.equal(forwarded.length, 1);
+    const expected = await expectedEdgeAuth("coordinator-secret", forwarded[0].requestId);
+    assert.equal(forwarded[0].edgeAuth, expected);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("edge-auth header is omitted (not thrown) when STATE_TOKEN is unset", async () => {
+  const forwarded = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (request) => {
+    forwarded.push(request.headers.get("x-exomem-edge-auth"));
+    return new Response("ok", { status: 200 });
+  };
+  try {
+    const env = edgeEnv("desktop");
+    delete env.STATE_TOKEN;
+    const response = await worker.fetch(toolCall(), env);
+    assert.equal(response.status, 200);
+    assert.deepEqual(forwarded, [null]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GET /__version rejects requests without the coordinator bearer token", async () => {
+  const env = edgeEnv("desktop");
+  env.STATE_TOKEN = "secret";
+  const response = await worker.fetch(new Request("https://exomem.example.com/__version"), env);
+  assert.equal(response.status, 401);
+  assert.deepEqual(await body(response), { error: "unauthorized" });
+});
+
+test("GET /__version returns deploy identity and effective vars without leaking the secret", async () => {
+  const env = edgeEnv("desktop");
+  env.STATE_TOKEN = "secret";
+  env.WORKER_GIT_SHA = "abc1234";
+  const request = new Request("https://exomem.example.com/__version");
+  request.headers.set("authorization", "Bearer secret");
+  const response = await worker.fetch(request, env);
+  assert.equal(response.status, 200);
+  const payload = await body(response);
+  assert.deepEqual(payload, {
+    service: "exomem-ha-edge",
+    git_sha: "abc1234",
+    deployed_vars: {
+      MCP_TOOL_TIMEOUT_MS: 15000,
+      ORIGIN_TIMEOUT_MS: 2500,
+      REQUIRE_COORDINATION: true,
+      SUPPORTED_RUNTIME_CONTRACTS: "1",
+      DESKTOP_REPLICA_ID: "desktop",
+      LAPTOP_REPLICA_ID: "laptop",
+      DESKTOP_ORIGIN: "https://desktop.example.com",
+      LAPTOP_ORIGIN: "https://laptop.example.com",
+    },
+  });
+  assert.equal(JSON.stringify(payload).includes("secret"), false);
+});
+
+test("GET /__version reports an unlabeled deploy when WORKER_GIT_SHA is not set", async () => {
+  const env = edgeEnv("desktop");
+  env.STATE_TOKEN = "secret";
+  const request = new Request("https://exomem.example.com/__version");
+  request.headers.set("authorization", "Bearer secret");
+  const response = await worker.fetch(request, env);
+  assert.equal(response.status, 200);
+  assert.equal((await body(response)).git_sha, "unlabeled");
+});
+
 test("safe MCP initialization retains short-timeout fallback", async () => {
   const calls = [];
   const timeouts = [];

--- a/deploy/cloudflare-ha/wrangler.toml.example
+++ b/deploy/cloudflare-ha/wrangler.toml.example
@@ -35,3 +35,7 @@ new_sqlite_classes = ["ExomemState"]
 
 # Add the coordinator bearer token separately; never commit it:
 #   npx wrangler secret put STATE_TOKEN
+
+# WORKER_GIT_SHA is not set here. deploy.ps1 / deploy.sh pass it at deploy time
+# (--var WORKER_GIT_SHA:<short sha>) so GET /__version reports deploy identity.
+# A bare `wrangler deploy` leaves it at the "unlabeled" fallback.

--- a/openspec/changes/deterministic-edge-ingress/design.md
+++ b/openspec/changes/deterministic-edge-ingress/design.md
@@ -1,0 +1,142 @@
+# Design — deterministic edge ingress
+
+## Context
+
+Topology: two Windows machines each run the exomem service on `127.0.0.1:8765`
+behind their own named cloudflared tunnel and per-machine hostname. The public
+apex hostname is (must be) served exclusively by the HA worker
+(`deploy/cloudflare-ha/src/worker.js`), which also hosts the lease coordinator
+Durable Object. The worker proxies reads holder-first with fallback and routes
+mutation-capable requests to the lease holder only.
+
+The failure this change defends against: apex traffic reaching an origin
+without passing through the worker (stale DNS binding to a tunnel, path-scoped
+worker route, a second connector on a shared tunnel, or any future ingress
+drift).
+
+## Decision 1 — Edge-transit stamp
+
+**Mechanism.** The worker computes `hex(HMAC_SHA256(STATE_TOKEN, request_id))`
+(WebCrypto) and sets two headers on every proxied origin fetch — both the
+read fan-out loop and `proxyMutationRequest`:
+
+- `x-exomem-request-id`: already present on the mutation path; the read path
+  now gets it too (fresh UUIDv4 when the client did not present a valid one).
+- `x-exomem-edge-auth`: the HMAC over the request-id value.
+
+**Key.** `STATE_TOKEN` on the worker is the same secret as
+`EXOMEM_WRITER_LEASE_TOKEN` on the origins, so no new secret distribution is
+needed. The raw token never travels on proxied requests; only the per-request
+HMAC does.
+
+**Enforcement point (origin).** ASGI middleware installed on the FastMCP app
+and the REST facade. A request is refused when ALL hold:
+
+1. lease coordination is enabled (`EXOMEM_WRITER_LEASE_URL` set) and a token
+   is configured;
+2. the request transited Cloudflare — detected by the presence of a `cf-ray`
+   header. Local CLI/REST/localhost traffic never carries `cf-ray` and is
+   exempt; anything arriving through a tunnel always does, so external
+   clients cannot dodge the check;
+3. the method is unsafe — anything other than `GET`/`HEAD`/`OPTIONS` (SSE and
+   health GETs stay open so reads keep working during break-glass; the unsafe
+   set covers every mutation including the capability-bound transfer `PUT`,
+   which the worker also classifies as mutation-capable and stamps);
+4. `x-exomem-edge-auth` is absent or does not verify against
+   `x-exomem-request-id` (comparison via `hmac.compare_digest`).
+
+Refusal: HTTP 403 with the standard OpError envelope, code `INGRESS_BYPASSED`,
+message "request reached the origin without transiting the HA edge",
+remediation "Public traffic must enter via the HA edge hostname; check DNS,
+tunnel ingress, and worker route coverage, or set
+EXOMEM_EDGE_STAMP_ENFORCE=0 to break glass." Refusals are logged content-free
+with the request path and a counter; the readiness payload is unchanged.
+
+**Why method-scope instead of parsing mutation-capability at the origin:** the
+worker already stamps everything it proxies, so scoping enforcement by method
+avoids re-implementing `isMutationCapableRequest` body-sniffing in ASGI while
+covering every mutation (all unsafe methods, including the transfer `PUT`)
+plus non-tool MCP POSTs — making bypass loud even for traffic that would not
+have corrupted state.
+
+**Kill switch.** `EXOMEM_EDGE_STAMP_ENFORCE=0` disables refusal (checks still
+log). Default is enforce-when-lease-enabled. Standalone deployments (no lease
+URL) are entirely unaffected.
+
+**Replay considerations.** The stamp proves edge transit, not freshness; an
+HMAC pair could be replayed by an actor who can already read proxied traffic
+inside the trust boundary (cloudflared <-> localhost). That actor can reach
+`127.0.0.1:8765` directly anyway, so no nonce/timestamp is added.
+
+## Decision 2 — Edge provenance
+
+`GET /__version` on the worker, gated by the same bearer check as the
+coordinator endpoints (`authorized(request, env.STATE_TOKEN)`), returns:
+
+```json
+{
+  "service": "exomem-ha-edge",
+  "git_sha": "<env.WORKER_GIT_SHA or 'unlabeled'>",
+  "deployed_vars": {
+    "MCP_TOOL_TIMEOUT_MS": 60000,
+    "ORIGIN_TIMEOUT_MS": 2500,
+    "REQUIRE_COORDINATION": true,
+    "SUPPORTED_RUNTIME_CONTRACTS": "1",
+    "DESKTOP_REPLICA_ID": "desktop",
+    "LAPTOP_REPLICA_ID": "laptop",
+    "DESKTOP_ORIGIN": "https://...",
+    "LAPTOP_ORIGIN": "https://..."
+  }
+}
+```
+
+No secrets are included (`STATE_TOKEN` never appears). Unauthenticated
+requests get the existing `{"error":"unauthorized"}` 401 — which itself serves
+as the "worker is in front" fingerprint for doctor.
+
+Deploy labeling: `deploy/cloudflare-ha/deploy.ps1` (and a POSIX `deploy.sh`)
+run `npx wrangler deploy --var WORKER_GIT_SHA:$(git rev-parse --short HEAD)`.
+A bare `wrangler deploy` still works and reports `"git_sha": "unlabeled"`.
+
+## Decision 3 — Doctor ingress conformance
+
+New doctor section `edge-ingress` (skipped entirely when the lease is
+disabled), using `EXOMEM_BASE_URL` as the public URL and the lease token for
+auth:
+
+1. `GET <base>/v1/vaults/<vault>/lease` **without** auth must return 401 with
+   the worker's JSON shape — proves the worker fronts the apex for coordinator
+   paths.
+2. `GET <base>/__version` **with** auth must succeed — proves worker route
+   coverage beyond `/v1/*` (a tunnel-direct apex would 404 here) — and its
+   `deployed_vars` must satisfy: `MCP_TOOL_TIMEOUT_MS >= 60000`,
+   `REQUIRE_COORDINATION` truthy, and this origin's own
+   `EXOMEM_WRITER_LEASE_REPLICA_ID` present among the replica-id vars with an
+   origin URL configured. Mismatch or `git_sha: "unlabeled"` -> warning;
+   missing endpoint -> failure.
+3. `GET <base>/health/ready` must report a `replica_id` equal to the
+   coordinator's current lease holder (fetched via the lease status API) —
+   proves holder-first read routing is intact.
+4. Config lint: warn when `EXOMEM_WRITER_LEASE_TTL` is set below 30.
+
+Failures render in the existing doctor report format with remediation lines
+pointing at DNS binding / tunnel ingress / worker route as the three usual
+suspects.
+
+## Rollback
+
+- Origin: `EXOMEM_EDGE_STAMP_ENFORCE=0` (env, no redeploy).
+- Worker: previous deploy via `wrangler rollback`; `/__version` and the stamp
+  headers are additive and ignored by pre-change origins.
+- Doctor checks are read-only.
+
+## Test strategy
+
+- Worker (`deploy/cloudflare-ha/test/worker.test.mjs`): stamp present+valid on
+  read-path and mutation-path proxied fetches; `/__version` auth gate, payload
+  shape, secret exclusion; unlabeled fallback.
+- Python: middleware unit tests — enforced refusal (cf-ray + POST + bad/absent
+  stamp), pass-through (valid stamp; no cf-ray; GET; kill switch; lease
+  disabled); `INGRESS_BYPASSED` terminal classification; doctor checks against
+  a stubbed public endpoint (worker-shaped vs tunnel-shaped responses).
+- Existing lease/worker suites stay green.

--- a/openspec/changes/deterministic-edge-ingress/proposal.md
+++ b/openspec/changes/deterministic-edge-ingress/proposal.md
@@ -1,0 +1,65 @@
+# Deterministic edge ingress
+
+## Why
+
+The 2026-07-20/21 incident had one meta-cause: **the public hostname is served by
+two competing routing layers**. The HA edge worker routes mutation-capable
+requests to the current lease holder, but the same hostname can also be served
+tunnel-direct by a machine's cloudflared connector (a legacy binding from the
+pre-HA, single-host ingress). Which layer answers a given request is an
+accident of DNS bindings, worker route path coverage, and connector restarts.
+
+When traffic goes tunnel-direct it lands on an arbitrary machine:
+
+- If that machine is a follower, every write is refused with
+  `WRITER_LEASE_REQUIRED` while reads keep working — observed for 1h+ on
+  2026-07-21 (receipt `7bfa92a4049bdcd1` absent from the lease holder's logs;
+  the coordinator lease was held stably by `laptop` at fencing token 98 the
+  whole time, so the refusals can only have been served by an origin the edge
+  worker would never have chosen).
+- If that machine's service is restarting, the caller sees cloudflared's
+  `502 origin_bad_gateway` — with no worker timeout/replay semantics at all.
+
+A second gap made this worse: **the worker is hand-deployed and unverifiable**.
+The service gained install provenance and version-gated deploys (#279), but the
+edge has neither a version surface nor a vars surface. The #285 deploy
+checklist ("redeploy the worker AND set the live `MCP_TOOL_TIMEOUT_MS` var to
+60000") could silently not happen, leaving a live 15s mutation budget that the
+repo said was 60s — and nothing that could detect the drift.
+
+Operational cleanup (single-hostname-per-tunnel, worker-only apex route) fixes
+today's routing. This change makes the invariant **self-enforcing and
+observable**, so a regression is a loud, named error instead of a
+lease-shaped mystery.
+
+## What Changes
+
+- **Edge-transit stamp, enforced at the origin.** The worker stamps every
+  request it proxies (read fan-out and mutation path alike) with an HMAC
+  header derived from the shared coordinator token. Origins with the writer
+  lease enabled refuse Cloudflare-transited MCP/REST POSTs that lack a valid
+  stamp with a new terminal error `INGRESS_BYPASSED` ("public traffic must
+  enter via the HA edge"). Local traffic (CLI, localhost REST, health probes)
+  is unaffected; a kill switch restores the old accept-anything behavior.
+- **Edge provenance surface.** The worker answers an authenticated
+  `GET /__version` with its deploy identity (git SHA supplied at deploy time)
+  and its effective non-secret routing vars (`MCP_TOOL_TIMEOUT_MS`,
+  `REQUIRE_COORDINATION`, origins, replica ids, runtime-contract set). A
+  deploy helper script passes the SHA so a bare `wrangler deploy` remains
+  possible but visibly unlabeled.
+- **Ingress conformance in doctor.** `exomem doctor` gains checks that (a) the
+  public base URL is served by the worker (`/__version` answers and `/v1`
+  returns the worker's 401 shape), (b) the worker's effective vars match the
+  repo expectation (mutation budget >= 60s, replica-id/origin mapping matches
+  this origin's configuration), (c) the public `/health/ready` replica agrees
+  with the coordinator's lease holder, and (d) the configured lease TTL is not
+  below the supported floor (warn under 30s).
+
+## Non-Goals
+
+- No follower-side proxying of mutations to the writer. With bypass traffic
+  refused loudly and the edge verified, a forwarding path would be dead code
+  that doubles the mutation surface.
+- No change to lease semantics, preemption, or the idempotency store.
+- No automation of the Cloudflare-side cleanup (DNS bindings, tunnel ingress
+  files); that is operator work, verified after the fact by doctor.

--- a/openspec/changes/deterministic-edge-ingress/specs/hosted-gateway-contract/spec.md
+++ b/openspec/changes/deterministic-edge-ingress/specs/hosted-gateway-contract/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Edge-Transit Stamp
+
+The HA edge worker SHALL attach a per-request transit proof to every request it
+proxies to an origin — on both the read fan-out path and the mutation path —
+consisting of a request identifier header and an HMAC header computed over that
+identifier with the shared coordinator secret. An origin with writer-lease
+coordination enabled SHALL refuse Cloudflare-transited unsafe-method requests
+(any method other than GET/HEAD/OPTIONS) that lack a valid transit proof with
+the terminal error `INGRESS_BYPASSED`, and SHALL
+leave non-Cloudflare (local) traffic unaffected. Enforcement SHALL be
+disableable via `EXOMEM_EDGE_STAMP_ENFORCE=0` without redeploying.
+
+#### Scenario: Tunnel-direct mutation is refused loudly
+
+- **WHEN** a mutation-capable POST reaches an origin through a Cloudflare
+  tunnel without transiting the HA edge worker
+- **THEN** the origin refuses it with `INGRESS_BYPASSED` before lease
+  evaluation
+- **AND** the refusal names ingress (DNS binding, tunnel ingress, worker route
+  coverage) rather than surfacing a writer-lease error
+
+#### Scenario: Edge-proxied traffic passes
+
+- **WHEN** the worker proxies any request to an origin
+- **THEN** the request carries a request-id and a valid HMAC transit proof
+- **AND** the origin serves it exactly as before this change
+
+#### Scenario: Local traffic is exempt
+
+- **WHEN** a request without a `cf-ray` header reaches the origin (CLI, REST on
+  localhost, health probes)
+- **THEN** no transit proof is required
+
+#### Scenario: Break-glass
+
+- **WHEN** `EXOMEM_EDGE_STAMP_ENFORCE=0` is set on an origin
+- **THEN** requests lacking a transit proof are served
+- **AND** each such request is still logged content-free as a bypass
+
+### Requirement: Edge Deploy Provenance
+
+The HA edge worker SHALL expose an authenticated `GET /__version` endpoint
+returning its deploy identity (git SHA when supplied at deploy time,
+`"unlabeled"` otherwise) and its effective non-secret routing variables,
+including the mutation timeout, coordination requirement, replica ids, and
+origins. The coordinator secret SHALL never appear in the response.
+Unauthenticated requests SHALL receive the standard 401 envelope.
+
+#### Scenario: Doctor detects a stale or misconfigured edge
+
+- **WHEN** `exomem doctor` fetches `/__version` from the public base URL
+- **THEN** it fails the ingress check if the endpoint is absent (apex not
+  served by the worker)
+- **AND** it reports drift when the effective mutation timeout is below 60
+  seconds or the replica-id/origin mapping does not include this origin
+
+#### Scenario: Unlabeled deploy is visible
+
+- **WHEN** the worker was deployed without the deploy helper supplying a git
+  SHA
+- **THEN** `/__version` reports `"git_sha": "unlabeled"`
+- **AND** doctor surfaces this as a warning, not a failure
+
+### Requirement: Ingress Conformance Check
+
+`exomem doctor` SHALL verify, on lease-enabled deployments, that the public
+base URL is served by the HA edge worker (worker-shaped 401 on unauthenticated
+coordinator paths and a responsive `/__version`), that the public
+`/health/ready` replica matches the coordinator's current lease holder, and
+SHALL warn when the configured lease TTL is below 30 seconds. The checks SHALL
+be read-only and skipped entirely when coordination is disabled.
+
+#### Scenario: Apex served tunnel-direct
+
+- **WHEN** the public base URL responds to `/__version` with anything other
+  than the worker's authenticated payload
+- **THEN** doctor fails the ingress check and names the three usual suspects
+  (DNS binding, tunnel ingress hostname, worker route coverage)
+
+#### Scenario: Read routing disagrees with the lease
+
+- **WHEN** the public `/health/ready` reports a replica other than the
+  coordinator's current holder
+- **THEN** doctor reports the divergence with both identities

--- a/openspec/changes/deterministic-edge-ingress/tasks.md
+++ b/openspec/changes/deterministic-edge-ingress/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — deterministic edge ingress
+
+## Lane W — worker (deploy/cloudflare-ha)
+
+- [ ] W1. Stamp all proxied requests: extract the request-id/HMAC helper, apply
+      it in the read fan-out loop and `proxyMutationRequest` (WebCrypto
+      HMAC-SHA256 keyed by `STATE_TOKEN` over the request-id value; headers
+      `x-exomem-request-id`, `x-exomem-edge-auth`).
+- [ ] W2. `GET /__version` gated by `authorized(request, env.STATE_TOKEN)`;
+      payload per design.md Decision 2; `WORKER_GIT_SHA` var with
+      `"unlabeled"` fallback; no secrets in payload.
+- [ ] W3. Deploy helpers `deploy.ps1` / `deploy.sh` passing
+      `--var WORKER_GIT_SHA:<short sha>`; README + wrangler.toml.example
+      updated.
+- [ ] W4. Tests in `test/worker.test.mjs`: stamp on both paths, HMAC
+      correctness, /__version auth gate + shape + secret exclusion +
+      unlabeled fallback.
+
+## Lane P — origin (src/exomem) and doctor
+
+- [ ] P1. Edge-stamp verification middleware (new module, e.g.
+      `edge_ingress.py`): enforcement predicate per design.md Decision 1;
+      installed on the FastMCP streamable-http app and the REST facade;
+      `INGRESS_BYPASSED` OpError (403) registered as terminal; content-free
+      bypass logging; `EXOMEM_EDGE_STAMP_ENFORCE` kill switch.
+- [ ] P2. Doctor `edge-ingress` section per design.md Decision 3 (four
+      checks), skipped when coordination disabled.
+- [ ] P3. Tests: middleware matrix (enforce/exempt/kill-switch/lease-off),
+      terminal classification, doctor checks against stubbed worker-shaped
+      and tunnel-shaped endpoints.
+
+## Verification
+
+- [ ] V1. `node --test deploy/cloudflare-ha/test/` green.
+- [ ] V2. Lean pytest (lease + new suites) green on Windows.
+- [ ] V3. `openspec validate deterministic-edge-ingress` passes.

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -67,6 +67,10 @@ _REMEDIATION: dict[str, str] = {
         "available."
     ),
     "WRITER_FENCED": "Retry the mutation on the current writer.",
+    "INGRESS_BYPASSED": (
+        "Public traffic must enter via the HA edge hostname; check DNS, tunnel ingress, "
+        "and worker route coverage, or set EXOMEM_EDGE_STAMP_ENFORCE=0 to break glass."
+    ),
     "MUTATION_BUSY": "Retry after the active vault mutation finishes.",
     "MUTATION_ACKNOWLEDGEMENT_PENDING": (
         "Retry with the same mutation identity; do not submit a revised payload."
@@ -208,6 +212,8 @@ def http_status_for(code: str) -> int:
         return 409
     if code in {"WRITER_COORDINATOR_UNAVAILABLE", "MUTATION_LOCK_UNAVAILABLE"}:
         return 503
+    if code == "INGRESS_BYPASSED":
+        return 403
     return 400
 
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -30,9 +30,13 @@ import sys
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
+from .cli_ops import OpError
 from .kbdir import kb_dirname, kb_prefix
+
+if TYPE_CHECKING:
+    from .writer_lease import LeaseConfig
 
 Status = Literal["pass", "warn", "fail"]
 Profile = Literal["lean", "hybrid", "standard", "media", "remote", "ha"]
@@ -1199,6 +1203,22 @@ def _probe_get(url: str) -> tuple[int, object]:
     return resp.status_code, body
 
 
+def _probe_get_authorized(url: str, token: str) -> tuple[int, object]:
+    """Authenticated GET with a short timeout; returns (status, parsed-JSON-or-text).
+
+    Module-level seam so tests fake the transport, mirroring `_probe_get`.
+    """
+    import httpx
+
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+    resp = httpx.get(url, headers=headers, timeout=5.0, follow_redirects=False)
+    try:
+        body: object = resp.json()
+    except Exception:  # noqa: BLE001 — non-JSON bodies are fine for probes
+        body = resp.text
+    return resp.status_code, body
+
+
 def _probe_state(url: str, namespace: str, token: str | None) -> tuple[int, object]:
     """Read a deliberately absent coordinator key, optionally authenticated."""
     import httpx
@@ -1425,6 +1445,206 @@ def _check_remote_probes() -> list[DoctorCheck]:
     return checks
 
 
+_REPLICA_ORIGIN_VARS = {
+    "DESKTOP_REPLICA_ID": "DESKTOP_ORIGIN",
+    "LAPTOP_REPLICA_ID": "LAPTOP_ORIGIN",
+}
+
+
+def _check_edge_ingress_worker_fronting(base_url: str, vault_id: str) -> DoctorCheck:
+    """Unauthenticated GET on a coordinator path must return the worker's 401
+    shape — proves the worker (not a tunnel-direct origin) fronts the apex for
+    coordinator paths (design.md Decision 3, check 1)."""
+    url = f"{base_url}/v1/vaults/{urllib.parse.quote(vault_id, safe='')}/lease"
+    try:
+        status, body = _probe_get(url)
+    except Exception as e:  # noqa: BLE001 - network diagnostic boundary
+        return _check(
+            "edge_ingress.worker_fronting",
+            "fail",
+            f"Could not reach {url}: {e}",
+            "Check DNS binding, tunnel ingress hostname, and worker route coverage for "
+            "the public apex.",
+        )
+    if status == 401 and isinstance(body, dict) and body.get("error") == "unauthorized":
+        return _check(
+            "edge_ingress.worker_fronting",
+            "pass",
+            "Public apex answers the worker's unauthenticated 401 shape on the "
+            "coordinator path.",
+        )
+    return _check(
+        "edge_ingress.worker_fronting",
+        "fail",
+        f"{url} answered status={status} body={body!r}, expected the worker's "
+        "401 {'error': 'unauthorized'} shape.",
+        "The public apex may be served tunnel-direct instead of by the HA worker. Check "
+        "DNS binding, tunnel ingress hostname, and worker route coverage.",
+    )
+
+
+def _check_edge_ingress_provenance(base_url: str, config: LeaseConfig) -> DoctorCheck:
+    """Authenticated GET /__version must succeed and its `deployed_vars` must not
+    have drifted from this origin's expectations (design.md Decision 3, check 2)."""
+    url = f"{base_url}/__version"
+    try:
+        status, body = _probe_get_authorized(url, config.token or "")
+    except Exception as e:  # noqa: BLE001 - network diagnostic boundary
+        return _check(
+            "edge_ingress.provenance",
+            "fail",
+            f"Could not reach {url}: {e}",
+            "Check DNS binding, tunnel ingress hostname, and worker route coverage for "
+            "the public apex.",
+        )
+    if status != 200 or not isinstance(body, dict) or not isinstance(body.get("deployed_vars"), dict):
+        return _check(
+            "edge_ingress.provenance",
+            "fail",
+            f"{url} answered status={status}, expected an authenticated 200 with a "
+            "deployed_vars payload.",
+            "The public apex may not be served by the HA worker beyond /v1/*. Check "
+            "DNS binding, tunnel ingress hostname, and worker route coverage.",
+        )
+    deployed_vars = body["deployed_vars"]
+    drift: list[str] = []
+    timeout_ms = deployed_vars.get("MCP_TOOL_TIMEOUT_MS")
+    if not isinstance(timeout_ms, (int, float)) or isinstance(timeout_ms, bool) or timeout_ms < 60000:
+        drift.append(f"MCP_TOOL_TIMEOUT_MS={timeout_ms!r} is below the 60000ms floor")
+    if not deployed_vars.get("REQUIRE_COORDINATION"):
+        drift.append("REQUIRE_COORDINATION is not truthy")
+    replica_id = config.replica_id or ""
+    replica_configured = any(
+        deployed_vars.get(replica_var) == replica_id and deployed_vars.get(origin_var)
+        for replica_var, origin_var in _REPLICA_ORIGIN_VARS.items()
+    )
+    if not replica_configured:
+        drift.append(
+            f"this origin's replica id {replica_id!r} is not present among the worker's "
+            "replica-id vars with an origin configured"
+        )
+    git_sha = body.get("git_sha")
+    if git_sha == "unlabeled":
+        drift.append("worker was deployed without a labeled git_sha")
+    if drift:
+        return _check(
+            "edge_ingress.provenance",
+            "warn",
+            f"Worker deploy provenance drift: {'; '.join(drift)}.",
+            "Redeploy the worker with the deploy helper and verify MCP_TOOL_TIMEOUT_MS, "
+            "REQUIRE_COORDINATION, and the replica-id/origin vars.",
+            details={"git_sha": git_sha, "deployed_vars": deployed_vars},
+        )
+    return _check(
+        "edge_ingress.provenance",
+        "pass",
+        f"Worker deploy provenance is current (git_sha={git_sha!r}).",
+        details={"git_sha": git_sha},
+    )
+
+
+def _check_edge_ingress_read_routing(base_url: str, config: LeaseConfig) -> DoctorCheck:
+    """Public /health/ready must agree with the coordinator's current lease holder —
+    proves holder-first read routing is intact (design.md Decision 3, check 3)."""
+    from .writer_lease import LeaseCoordinatorClient
+
+    url = f"{base_url}/health/ready"
+    try:
+        status, body = _probe_get(url)
+    except Exception as e:  # noqa: BLE001 - network diagnostic boundary
+        return _check(
+            "edge_ingress.read_routing",
+            "fail",
+            f"Could not reach {url}: {e}",
+            "Check DNS binding, tunnel ingress hostname, and worker route coverage for "
+            "the public apex.",
+        )
+    if not isinstance(body, dict):
+        return _check(
+            "edge_ingress.read_routing",
+            "fail",
+            f"{url} answered status={status} with a non-JSON body.",
+        )
+    reported_replica = body.get("replica_id")
+    try:
+        record = LeaseCoordinatorClient(config).status()
+    except OpError as e:
+        return _check(
+            "edge_ingress.read_routing",
+            "fail",
+            f"Could not confirm the coordinator's current lease holder: {e}",
+            "Check the writer-lease coordinator URL, credentials, and health.",
+        )
+    if reported_replica == record.holder:
+        return _check(
+            "edge_ingress.read_routing",
+            "pass",
+            f"Public /health/ready replica ({reported_replica!r}) matches the "
+            "coordinator's current lease holder.",
+        )
+    return _check(
+        "edge_ingress.read_routing",
+        "fail",
+        f"Public /health/ready reports replica {reported_replica!r}, but the "
+        f"coordinator's current lease holder is {record.holder!r}.",
+        "Investigate holder-first read routing at the HA edge worker.",
+        details={"reported_replica": reported_replica, "lease_holder": record.holder},
+    )
+
+
+def _check_edge_ingress(*, probe: bool) -> list[DoctorCheck]:
+    """Doctor's `edge-ingress` section (design.md Decision 3): verifies the public
+    apex is fronted by the HA edge worker rather than tunnel-direct. Skipped
+    entirely when writer-lease coordination is disabled."""
+    if not os.environ.get("EXOMEM_WRITER_LEASE_URL", "").strip():
+        return []
+    from .writer_lease import LeaseConfig
+
+    try:
+        config = LeaseConfig.from_env()
+    except ValueError as e:
+        return [_check(
+            "edge_ingress.config",
+            "fail",
+            str(e),
+            "Fix the writer-lease environment configuration.",
+        )]
+
+    checks: list[DoctorCheck] = []
+    if config.ttl_seconds < 30:
+        checks.append(_check(
+            "edge_ingress.lease_ttl",
+            "warn",
+            f"EXOMEM_WRITER_LEASE_TTL is {config.ttl_seconds:g}s, below the supported "
+            "floor of 30s.",
+            "Raise EXOMEM_WRITER_LEASE_TTL to at least 30 seconds.",
+        ))
+    else:
+        checks.append(_check(
+            "edge_ingress.lease_ttl",
+            "pass",
+            f"EXOMEM_WRITER_LEASE_TTL is {config.ttl_seconds:g}s (>= 30s floor).",
+        ))
+
+    if not probe:
+        return checks
+
+    base_url = os.environ.get("EXOMEM_BASE_URL", "").strip().rstrip("/")
+    if not base_url:
+        checks.append(_check(
+            "edge_ingress.base_url",
+            "fail",
+            "EXOMEM_BASE_URL is not set; cannot probe the public ingress.",
+            "Set EXOMEM_BASE_URL to the public HTTPS origin.",
+        ))
+        return checks
+
+    checks.append(_check_edge_ingress_worker_fronting(base_url, config.vault_id or ""))
+    checks.append(_check_edge_ingress_provenance(base_url, config))
+    checks.append(_check_edge_ingress_read_routing(base_url, config))
+    return checks
+
+
 def doctor(
     *,
     vault: str | None = None,
@@ -1512,6 +1732,10 @@ def doctor(
                 ))
             else:
                 checks.extend(_check_ha_probes(urls))
+
+    # Not profile-gated: any profile can run with writer-lease coordination
+    # enabled, and the section self-skips when it is not (design.md Decision 3).
+    checks.extend(_check_edge_ingress(probe=probe))
 
     return DoctorReport(profile=profile, checks=checks)
 

--- a/src/exomem/edge_ingress.py
+++ b/src/exomem/edge_ingress.py
@@ -1,0 +1,192 @@
+"""Origin-side enforcement of the HA edge's per-request transit stamp.
+
+design.md ("Decision 1 — Edge-transit stamp") describes the failure this
+guards against: apex traffic reaching an origin without passing through the
+HA edge worker (a stale DNS binding, a path-scoped worker route, a second
+tunnel connector, or any future ingress drift). The worker stamps every
+request it proxies — reads and mutations alike — with a request id and an
+HMAC computed over that id, keyed by the same secret as
+``EXOMEM_WRITER_LEASE_TOKEN``. This module is the origin-side half: pure ASGI
+middleware that refuses a Cloudflare-transited unsafe-method request lacking a
+valid stamp.
+
+It is installed via the ``middleware=`` list passed to ``FastMCP.run()`` (see
+``server.run``), which wraps the single Starlette app FastMCP builds for both
+the streamable-http MCP endpoint and the REST facade (``server_rest`` and
+``server_assets`` register their routes onto the same FastMCP instance via
+``custom_route``) — one middleware insertion covers both surfaces.
+
+Enforcement fires only when ALL of the following hold: writer-lease
+coordination is enabled and a token is configured, the kill switch
+(``EXOMEM_EDGE_STAMP_ENFORCE=0``) is not set, the request carries a
+``cf-ray`` header (i.e. it transited Cloudflare — local CLI/REST/health
+traffic never does), the method is unsafe (anything other than
+GET/HEAD/OPTIONS — the worker classifies and stamps exactly that set,
+including the capability-bound transfer PUT), and the ``x-exomem-edge-auth``
+header is absent or does not match ``hex(HMAC_SHA256(token, request_id))``
+for the presented ``x-exomem-request-id``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from . import cli_ops
+from .cli_ops import OpError
+from .writer_lease import LeaseConfig
+
+ASGIMessage = dict[str, Any]
+Receive = Callable[[], Awaitable[ASGIMessage]]
+Send = Callable[[ASGIMessage], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
+
+INGRESS_BYPASSED_MESSAGE = "request reached the origin without transiting the HA edge"
+
+
+def compute_edge_auth(token: str, request_id: str) -> str:
+    """The worker's HMAC transit proof: hex(HMAC-SHA256(token, request_id))."""
+    return hmac.new(
+        token.encode("utf-8"), request_id.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def is_valid_stamp(token: str, request_id: str | None, presented_auth: str | None) -> bool:
+    """Whether the presented transit proof verifies for the given request id.
+
+    A missing request id or a missing auth header is invalid regardless of the
+    other — an auth header without its paired request id can't be checked, so
+    it is treated as invalid rather than silently ignored.
+    """
+    if not request_id or not presented_auth:
+        return False
+    # A malformed proof (wrong length, non-hex, non-ASCII bytes decoded via
+    # latin-1) is invalid, not an error: compare_digest raises TypeError on
+    # non-ASCII str input, which would turn a bad header into a 500 instead of
+    # the INGRESS_BYPASSED refusal.
+    if re.fullmatch(r"[0-9a-f]{64}", presented_auth) is None:
+        return False
+    return hmac.compare_digest(presented_auth, compute_edge_auth(token, request_id))
+
+
+def is_ingress_violation(
+    *,
+    lease_enabled: bool,
+    token: str | None,
+    method: str,
+    has_cf_ray: bool,
+    request_id: str | None,
+    presented_auth: str | None,
+) -> bool:
+    """Pure enforcement predicate (design.md Decision 1), independent of the kill switch.
+
+    True when this request should have carried a valid edge-transit stamp but
+    didn't. The kill switch decides what to DO about a violation (refuse vs.
+    serve-and-log); it plays no part in whether one occurred.
+    """
+    if not lease_enabled or not token:
+        return False
+    if not has_cf_ray:
+        return False
+    # Exempt only truly-safe methods. The worker stamps every unsafe-method
+    # request it proxies (its isMutationCapableRequest includes the transfer
+    # PUT), so allow-listing POST here would leave that PUT unenforced.
+    if method in {"GET", "HEAD", "OPTIONS"}:
+        return False
+    return not is_valid_stamp(token, request_id, presented_auth)
+
+
+def enforcement_disabled(env: Mapping[str, str] | None = None) -> bool:
+    """``EXOMEM_EDGE_STAMP_ENFORCE=0`` (or ``false``) breaks glass without a redeploy."""
+    values = os.environ if env is None else env
+    return values.get("EXOMEM_EDGE_STAMP_ENFORCE", "").strip().lower() in {"0", "false"}
+
+
+def _header_value(headers: list[tuple[bytes, bytes]], name: bytes) -> str | None:
+    for key, value in headers:
+        if key.lower() == name:
+            return value.decode("latin-1")
+    return None
+
+
+def _refusal_exception() -> OpError:
+    return OpError("INGRESS_BYPASSED", INGRESS_BYPASSED_MESSAGE)
+
+
+async def _send_refusal(send: Send) -> None:
+    err = cli_ops.error_dict(_refusal_exception())
+    body = json.dumps(
+        cli_ops.envelope(False, error=err), ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": cli_ops.http_status_for(err["code"]),
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+class EdgeIngressMiddleware:
+    """Pure ASGI middleware refusing Cloudflare-transited POSTs without a valid
+    edge-transit stamp. See the module docstring for where this is installed.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self._refused_count = 0
+        self._bypassed_count = 0
+        self._config: LeaseConfig | None = None
+
+    async def __call__(self, scope: ASGIMessage, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Lease env is process-lifetime constant; read it once per instance
+        # instead of re-parsing ~8 env vars on every request.
+        config = self._config
+        if config is None:
+            config = self._config = LeaseConfig.from_env()
+        headers = scope.get("headers") or []
+        violation = is_ingress_violation(
+            lease_enabled=config.enabled,
+            token=config.token,
+            method=str(scope.get("method") or ""),
+            has_cf_ray=_header_value(headers, b"cf-ray") is not None,
+            request_id=_header_value(headers, b"x-exomem-request-id"),
+            presented_auth=_header_value(headers, b"x-exomem-edge-auth"),
+        )
+        if violation:
+            # Content-free: only the path and a running counter are logged, never
+            # headers or bodies.
+            path = str(scope.get("path") or "")
+            if enforcement_disabled():
+                self._bypassed_count += 1
+                logger.warning(
+                    "event=edge_ingress_bypassed path=%s count=%s",
+                    path,
+                    self._bypassed_count,
+                )
+            else:
+                self._refused_count += 1
+                logger.warning(
+                    "event=edge_ingress_refused path=%s count=%s",
+                    path,
+                    self._refused_count,
+                )
+                await _send_refusal(send)
+                return
+
+        await self.app(scope, receive, send)

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -21,6 +21,7 @@ from starlette.middleware import Middleware as ASGIMiddleware
 
 from . import capabilities, edit_operations, guards, multi_edit
 from . import commands as commands_module
+from .edge_ingress import EdgeIngressMiddleware
 from .server_assets import (
     register_asset_routes,
     register_oauth_metadata_route,
@@ -501,7 +502,13 @@ def run(
             transport=transport,
             host=host,
             port=port,
-            middleware=[ASGIMiddleware(PrimeMcpSSEMiddleware)],
+            # Edge-ingress enforcement runs first so a Cloudflare-transited
+            # bypass is refused before SSE priming or MCP/REST routing ever
+            # see the request (design.md Decision 1).
+            middleware=[
+                ASGIMiddleware(EdgeIngressMiddleware),
+                ASGIMiddleware(PrimeMcpSSEMiddleware),
+            ],
             # Remote clients may be routed to another replica or outlive this
             # process.  A process-local Mcp-Session-Id turns either event into
             # a 404/reconnect cascade; each Exomem operation is already an

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -47,7 +47,21 @@ def test_http_status_mapping() -> None:
     assert cli_ops.http_status_for("WRITER_FENCED") == 409
     assert cli_ops.http_status_for("MUTATION_BUSY") == 409
     assert cli_ops.http_status_for("MUTATION_LOCK_UNAVAILABLE") == 503
+    assert cli_ops.http_status_for("INGRESS_BYPASSED") == 403
     assert cli_ops.http_status_for("INVALID_NOTE") == 400
+
+
+def test_ingress_bypassed_is_a_terminal_refusal_with_actionable_remediation() -> None:
+    # Registered alongside WRITER_LEASE_REQUIRED (design.md Decision 1): a
+    # deliberate refusal — not a retryable/transient status — surfaced as 403
+    # with its own canned remediation.
+    op_error = cli_ops.OpError(
+        "INGRESS_BYPASSED", "request reached the origin without transiting the HA edge"
+    )
+    error = cli_ops.error_dict(op_error)
+    assert error["code"] == "INGRESS_BYPASSED"
+    assert cli_ops.http_status_for(error["code"]) == 403
+    assert "EXOMEM_EDGE_STAMP_ENFORCE=0" in error["remediation"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_doctor_edge_ingress.py
+++ b/tests/test_doctor_edge_ingress.py
@@ -1,0 +1,354 @@
+"""`exomem doctor`'s `edge-ingress` section (design.md Decision 3): verifies the
+public apex is fronted by the HA edge worker rather than tunnel-direct.
+Network probes are stubbed at the same module-level seams as the `ha` profile
+tests (`_probe_get`, `_probe_get_authorized`, `urllib.request.urlopen`)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import doctor as doctor_module
+
+_COORDINATOR_URL = "https://coordinator.example.com"
+_VAULT_ID = "main"
+_REPLICA_ID = "desktop"
+_TOKEN = "secret"
+_BASE_URL = "https://kb.example.com"
+_LEASE_URL = f"{_BASE_URL}/v1/vaults/{_VAULT_ID}/lease"
+_READY_URL = f"{_BASE_URL}/health/ready"
+
+
+def _set_edge_ingress_env(monkeypatch: pytest.MonkeyPatch, *, ttl: str | None = None) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", _COORDINATOR_URL)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", _VAULT_ID)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", _REPLICA_ID)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", _TOKEN)
+    monkeypatch.setenv("EXOMEM_BASE_URL", _BASE_URL)
+    if ttl is not None:
+        monkeypatch.setenv("EXOMEM_WRITER_LEASE_TTL", ttl)
+    else:
+        monkeypatch.delenv("EXOMEM_WRITER_LEASE_TTL", raising=False)
+
+
+def _valid_version_payload(**overrides: object) -> dict:
+    payload: dict = {
+        "service": "exomem-ha-edge",
+        "git_sha": "abc1234",
+        "deployed_vars": {
+            "MCP_TOOL_TIMEOUT_MS": 60000,
+            "ORIGIN_TIMEOUT_MS": 2500,
+            "REQUIRE_COORDINATION": True,
+            "SUPPORTED_RUNTIME_CONTRACTS": "1",
+            "DESKTOP_REPLICA_ID": "desktop",
+            "LAPTOP_REPLICA_ID": "laptop",
+            "DESKTOP_ORIGIN": "https://desktop.example.com",
+            "LAPTOP_ORIGIN": "https://laptop.example.com",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _stub_lease_status(monkeypatch: pytest.MonkeyPatch, *, holder: str) -> None:
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):  # noqa: ANN002
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {"holder": holder, "expires_at": 4102444800.0, "fencing_token": 7}
+            ).encode("utf-8")
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda request, timeout: _Response(), raising=True
+    )
+
+
+def _apply_probe_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    lease_response: tuple[int, object] = (401, {"error": "unauthorized"}),
+    version_response: tuple[int, object] | None = None,
+    ready_response: tuple[int, object] = (200, {"replica_id": _REPLICA_ID}),
+    lease_holder: str = _REPLICA_ID,
+) -> None:
+    """Stub the three network seams the probe checks use: unauthenticated GET,
+    authenticated GET, and the coordinator status client."""
+    if version_response is None:
+        version_response = (200, _valid_version_payload())
+
+    def fake_probe_get(url: str) -> tuple[int, object]:
+        if url == _LEASE_URL:
+            return lease_response
+        if url == _READY_URL:
+            return ready_response
+        raise AssertionError(f"unexpected _probe_get url: {url}")
+
+    monkeypatch.setattr(doctor_module, "_probe_get", fake_probe_get)
+    monkeypatch.setattr(
+        doctor_module,
+        "_probe_get_authorized",
+        lambda url, token: version_response,  # noqa: ARG005
+    )
+    _stub_lease_status(monkeypatch, holder=lease_holder)
+
+
+def _checks_by_id(report: doctor_module.DoctorReport) -> dict[str, doctor_module.DoctorCheck]:
+    return {c.id: c for c in report.checks}
+
+
+# --------------------------------------------------------------------------- #
+# Gating: skipped when disabled, offline unless --probe
+# --------------------------------------------------------------------------- #
+def test_edge_ingress_section_skipped_when_lease_disabled(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_URL", raising=False)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+
+    assert not any(c.id.startswith("edge_ingress.") for c in report.checks)
+
+
+def test_edge_ingress_is_offline_by_default(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+
+    def fail_network(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("edge-ingress doctor made an unexpected network call")
+
+    monkeypatch.setattr(doctor_module, "_probe_get", fail_network)
+    monkeypatch.setattr(doctor_module, "_probe_get_authorized", fail_network)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean")
+    checks = _checks_by_id(report)
+
+    assert checks["edge_ingress.lease_ttl"].status == "pass"
+    assert "edge_ingress.worker_fronting" not in checks
+    assert "edge_ingress.provenance" not in checks
+    assert "edge_ingress.read_routing" not in checks
+
+
+# --------------------------------------------------------------------------- #
+# Config lint: lease TTL floor
+# --------------------------------------------------------------------------- #
+def test_edge_ingress_lease_ttl_warns_below_floor(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch, ttl="10")
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean")
+    check = _checks_by_id(report)["edge_ingress.lease_ttl"]
+
+    assert check.status == "warn"
+    assert "30" in check.message
+
+
+def test_edge_ingress_lease_ttl_passes_at_floor(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch, ttl="30")
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean")
+    check = _checks_by_id(report)["edge_ingress.lease_ttl"]
+
+    assert check.status == "pass"
+
+
+def test_edge_ingress_config_error_reports_a_single_failure(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", _COORDINATOR_URL)
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_VAULT_ID", raising=False)
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_REPLICA_ID", raising=False)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    edge_checks = [c for c in report.checks if c.id.startswith("edge_ingress.")]
+
+    assert [c.id for c in edge_checks] == ["edge_ingress.config"]
+    assert edge_checks[0].status == "fail"
+
+
+def test_edge_ingress_base_url_missing_fails_before_probing(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    checks = _checks_by_id(report)
+
+    assert checks["edge_ingress.base_url"].status == "fail"
+    assert "edge_ingress.worker_fronting" not in checks
+
+
+# --------------------------------------------------------------------------- #
+# Check 1: worker-shaped 401 on the unauthenticated coordinator path
+# --------------------------------------------------------------------------- #
+def test_edge_ingress_probes_all_pass_on_a_healthy_worker_fronted_apex(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    _apply_probe_stubs(monkeypatch)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    checks = _checks_by_id(report)
+
+    assert checks["edge_ingress.worker_fronting"].status == "pass"
+    assert checks["edge_ingress.provenance"].status == "pass"
+    assert checks["edge_ingress.read_routing"].status == "pass"
+    assert report.success is True
+
+
+def test_edge_ingress_worker_fronting_fails_when_apex_is_tunnel_direct(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    # A tunnel-direct origin 404s the worker-only coordinator path instead of
+    # answering the worker's `{"error": "unauthorized"}` 401 shape.
+    _apply_probe_stubs(monkeypatch, lease_response=(404, {"error": "not found"}))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.worker_fronting"]
+
+    assert check.status == "fail"
+    assert check.remediation is not None
+    assert "tunnel" in check.remediation.lower()
+
+
+def test_edge_ingress_worker_fronting_fails_on_unexpected_401_body(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    _apply_probe_stubs(monkeypatch, lease_response=(401, {"detail": "unauthorized"}))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+
+    assert _checks_by_id(report)["edge_ingress.worker_fronting"].status == "fail"
+
+
+def test_edge_ingress_worker_fronting_fails_on_network_error(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+
+    def raise_probe(_url: str):
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr(doctor_module, "_probe_get", raise_probe)
+    monkeypatch.setattr(
+        doctor_module, "_probe_get_authorized", lambda url, token: (200, _valid_version_payload())  # noqa: ARG005
+    )
+    _stub_lease_status(monkeypatch, holder=_REPLICA_ID)
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.worker_fronting"]
+
+    assert check.status == "fail"
+    assert "reach" in check.message.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Check 2: authenticated /__version + deploy provenance drift
+# --------------------------------------------------------------------------- #
+def test_edge_ingress_provenance_fails_on_missing_endpoint(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    _apply_probe_stubs(monkeypatch, version_response=(404, {"error": "not found"}))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+
+    assert _checks_by_id(report)["edge_ingress.provenance"].status == "fail"
+
+
+def test_edge_ingress_provenance_warns_on_unlabeled_git_sha(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    _apply_probe_stubs(
+        monkeypatch, version_response=(200, _valid_version_payload(git_sha="unlabeled"))
+    )
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.provenance"]
+
+    assert check.status == "warn"
+    assert "git_sha" in check.message.lower()
+    assert check.details is not None
+    assert check.details["git_sha"] == "unlabeled"
+    assert report.success is True  # warnings never fail the report
+
+
+def test_edge_ingress_provenance_warns_on_timeout_below_floor(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    payload = _valid_version_payload()
+    payload["deployed_vars"]["MCP_TOOL_TIMEOUT_MS"] = 15000
+    _apply_probe_stubs(monkeypatch, version_response=(200, payload))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.provenance"]
+
+    assert check.status == "warn"
+    assert "MCP_TOOL_TIMEOUT_MS" in check.message
+
+
+def test_edge_ingress_provenance_warns_when_coordination_not_required(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    payload = _valid_version_payload()
+    payload["deployed_vars"]["REQUIRE_COORDINATION"] = False
+    _apply_probe_stubs(monkeypatch, version_response=(200, payload))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.provenance"]
+
+    assert check.status == "warn"
+    assert "REQUIRE_COORDINATION" in check.message
+
+
+def test_edge_ingress_provenance_warns_on_missing_replica_origin_mapping(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    payload = _valid_version_payload()
+    payload["deployed_vars"]["DESKTOP_ORIGIN"] = ""
+    _apply_probe_stubs(monkeypatch, version_response=(200, payload))
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.provenance"]
+
+    assert check.status == "warn"
+    assert "desktop" in check.message.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Check 3: public /health/ready agrees with the coordinator's lease holder
+# --------------------------------------------------------------------------- #
+def test_edge_ingress_read_routing_fails_on_replica_mismatch(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_edge_ingress_env(monkeypatch)
+    _apply_probe_stubs(
+        monkeypatch,
+        ready_response=(200, {"replica_id": "laptop"}),
+        lease_holder="desktop",
+    )
+
+    report = doctor_module.doctor(vault=str(vault), profile="lean", probe=True)
+    check = _checks_by_id(report)["edge_ingress.read_routing"]
+
+    assert check.status == "fail"
+    assert "laptop" in check.message
+    assert "desktop" in check.message
+    assert report.success is False

--- a/tests/test_doctor_ha.py
+++ b/tests/test_doctor_ha.py
@@ -255,6 +255,10 @@ def test_ha_probe_accepts_compatible_release_drift(
         "https://laptop.example.com/health/ready": (200, _ready("laptop", "0.20.2")),
     }
     monkeypatch.setattr(doctor_module, "_probe_get", lambda url: responses[url])
+    # This test is about ha.replica.*/ha.compatibility/ha.release_drift, not the
+    # separate edge-ingress section (also lease-gated); silence it like the
+    # sibling probe tests above silence `_check_ha_probes`.
+    monkeypatch.setattr(doctor_module, "_check_edge_ingress", lambda **_kwargs: [])
 
     report = doctor_module.doctor(
         vault=str(vault),

--- a/tests/test_edge_ingress.py
+++ b/tests/test_edge_ingress.py
@@ -1,0 +1,376 @@
+"""Unit tests for the origin-side edge-transit stamp enforcement (design.md
+Decision 1): the pure predicate, the HMAC helper, and the ASGI middleware
+matrix (enforce / exempt / kill-switch / lease-disabled)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+import pytest
+
+from exomem import edge_ingress
+
+# --------------------------------------------------------------------------- #
+# Pure HMAC + predicate helpers
+# --------------------------------------------------------------------------- #
+# Golden cross-implementation vector: the worker suite asserts the identical
+# constant for edgeAuthHmac (deploy/cloudflare-ha/test/worker.test.mjs), so a
+# unilateral change to key/message encoding or hex casing in either
+# implementation fails one of the two suites instead of 403ing production.
+_GOLDEN_EDGE_AUTH = "1d489d84d7a8dcec3ddef522064e6ee09269bb80fd3dc91cd62c4ebf1ab220b4"
+
+
+def test_compute_edge_auth_matches_worker_hmac() -> None:
+    digest = edge_ingress.compute_edge_auth("secret-token", "11111111-1111-4111-8111-111111111111")
+    assert digest == _GOLDEN_EDGE_AUTH
+
+
+def test_is_valid_stamp_accepts_matching_hmac() -> None:
+    token = "secret-token"
+    request_id = "11111111-1111-4111-8111-111111111111"
+    auth = edge_ingress.compute_edge_auth(token, request_id)
+    assert edge_ingress.is_valid_stamp(token, request_id, auth) is True
+
+
+def test_is_valid_stamp_rejects_wrong_hmac() -> None:
+    token = "secret-token"
+    request_id = "11111111-1111-4111-8111-111111111111"
+    assert edge_ingress.is_valid_stamp(token, request_id, "0" * 64) is False
+
+
+def test_is_valid_stamp_rejects_malformed_auth_without_raising() -> None:
+    # Non-ASCII header bytes decode via latin-1 into a non-ASCII str, which
+    # hmac.compare_digest refuses with TypeError; malformed proofs must be
+    # invalid, not a 500.
+    token = "secret-token"
+    request_id = "11111111-1111-4111-8111-111111111111"
+    assert edge_ingress.is_valid_stamp(token, request_id, "\xff" * 64) is False
+    assert edge_ingress.is_valid_stamp(token, request_id, "not-hex") is False
+    assert edge_ingress.is_valid_stamp(token, request_id, "A" * 64) is False
+
+
+@pytest.mark.parametrize(
+    ("request_id", "presented_auth"),
+    [
+        (None, "a" * 64),
+        ("11111111-1111-4111-8111-111111111111", None),
+        (None, None),
+        ("", ""),
+    ],
+)
+def test_is_valid_stamp_requires_both_pieces(
+    request_id: str | None, presented_auth: str | None
+) -> None:
+    assert edge_ingress.is_valid_stamp("secret-token", request_id, presented_auth) is False
+
+
+class TestIsIngressViolation:
+    _TOKEN = "secret-token"
+    _REQUEST_ID = "11111111-1111-4111-8111-111111111111"
+
+    def _valid_auth(self) -> str:
+        return edge_ingress.compute_edge_auth(self._TOKEN, self._REQUEST_ID)
+
+    def test_lease_disabled_is_never_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=False,
+                token=None,
+                method="POST",
+                has_cf_ray=True,
+                request_id=None,
+                presented_auth=None,
+            )
+            is False
+        )
+
+    def test_no_token_configured_is_never_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=None,
+                method="POST",
+                has_cf_ray=True,
+                request_id=None,
+                presented_auth=None,
+            )
+            is False
+        )
+
+    def test_no_cf_ray_is_exempt_local_traffic(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="POST",
+                has_cf_ray=False,
+                request_id=None,
+                presented_auth=None,
+            )
+            is False
+        )
+
+    def test_get_is_exempt_even_without_a_stamp(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="GET",
+                has_cf_ray=True,
+                request_id=None,
+                presented_auth=None,
+            )
+            is False
+        )
+
+    def test_valid_stamp_on_post_is_not_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="POST",
+                has_cf_ray=True,
+                request_id=self._REQUEST_ID,
+                presented_auth=self._valid_auth(),
+            )
+            is False
+        )
+
+    def test_missing_stamp_on_post_is_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="POST",
+                has_cf_ray=True,
+                request_id=None,
+                presented_auth=None,
+            )
+            is True
+        )
+
+    def test_wrong_stamp_on_post_is_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="POST",
+                has_cf_ray=True,
+                request_id=self._REQUEST_ID,
+                presented_auth="0" * 64,
+            )
+            is True
+        )
+
+    def test_auth_present_without_its_request_id_is_a_violation(self) -> None:
+        assert (
+            edge_ingress.is_ingress_violation(
+                lease_enabled=True,
+                token=self._TOKEN,
+                method="POST",
+                has_cf_ray=True,
+                request_id=None,
+                presented_auth=self._valid_auth(),
+            )
+            is True
+        )
+
+
+# --------------------------------------------------------------------------- #
+# enforcement_disabled kill switch
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("raw", ["0", "false", "False", "0 "])
+def test_enforcement_disabled_recognizes_kill_switch_values(raw: str) -> None:
+    assert edge_ingress.enforcement_disabled({"EXOMEM_EDGE_STAMP_ENFORCE": raw}) is True
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "", "no", "off"])
+def test_enforcement_disabled_defaults_to_enforcing(raw: str) -> None:
+    assert edge_ingress.enforcement_disabled({"EXOMEM_EDGE_STAMP_ENFORCE": raw}) is False
+
+
+def test_enforcement_disabled_defaults_to_enforcing_when_unset() -> None:
+    assert edge_ingress.enforcement_disabled({}) is False
+
+
+# --------------------------------------------------------------------------- #
+# ASGI middleware matrix
+# --------------------------------------------------------------------------- #
+_TOKEN = "secret-token"
+_VAULT_ID = "main"
+_REPLICA_ID = "desktop"
+_REQUEST_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def _set_lease_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://coordinator.example.com")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", _VAULT_ID)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", _REPLICA_ID)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_TOKEN", _TOKEN)
+    monkeypatch.delenv("EXOMEM_EDGE_STAMP_ENFORCE", raising=False)
+
+
+async def _receive() -> dict:
+    return {"type": "http.disconnect"}
+
+
+def _scope(*, method: str = "POST", path: str = "/mcp", headers: dict[str, str] | None = None) -> dict:
+    encoded = [
+        (name.encode("ascii"), value.encode("ascii")) for name, value in (headers or {}).items()
+    ]
+    return {"type": "http", "method": method, "path": path, "headers": encoded}
+
+
+def _run_middleware(scope: dict) -> tuple[list[dict], bool]:
+    app_called = False
+
+    async def inner_app(inner_scope, receive, send) -> None:  # noqa: ANN001
+        nonlocal app_called
+        app_called = True
+
+    sent: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        sent.append(message)
+
+    middleware = edge_ingress.EdgeIngressMiddleware(inner_app)
+
+    async def scenario() -> None:
+        await middleware(scope, _receive, capture)
+
+    asyncio.run(scenario())
+    return sent, app_called
+
+
+def test_enforced_refusal_returns_403_envelope_and_does_not_call_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_lease_env(monkeypatch)
+    scope = _scope(headers={"cf-ray": "abc123"})
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is False
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 403
+    body = json.loads(sent[1]["body"])
+    assert body["success"] is False
+    assert body["error"]["code"] == "INGRESS_BYPASSED"
+    assert body["error"]["message"] == edge_ingress.INGRESS_BYPASSED_MESSAGE
+    assert "EXOMEM_EDGE_STAMP_ENFORCE=0" in body["error"]["remediation"]
+
+
+def test_valid_stamp_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_lease_env(monkeypatch)
+    auth = edge_ingress.compute_edge_auth(_TOKEN, _REQUEST_ID)
+    scope = _scope(
+        headers={
+            "cf-ray": "abc123",
+            "x-exomem-request-id": _REQUEST_ID,
+            "x-exomem-edge-auth": auth,
+        }
+    )
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+
+
+def test_no_cf_ray_is_exempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_lease_env(monkeypatch)
+    scope = _scope(headers={})
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+
+
+def test_unstamped_put_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The transfer upload is the one non-POST mutating route; the worker stamps
+    # it, so a bare PUT through Cloudflare is ingress drift like any other.
+    _set_lease_env(monkeypatch)
+    scope = _scope(method="PUT", path="/api/transfer/upload", headers={"cf-ray": "abc123"})
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is False
+    assert sent[0]["status"] == 403
+    assert json.loads(sent[1]["body"])["error"]["code"] == "INGRESS_BYPASSED"
+
+
+def test_stamped_put_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_lease_env(monkeypatch)
+    auth = edge_ingress.compute_edge_auth(_TOKEN, _REQUEST_ID)
+    scope = _scope(
+        method="PUT",
+        path="/api/transfer/upload",
+        headers={
+            "cf-ray": "abc123",
+            "x-exomem-request-id": _REQUEST_ID,
+            "x-exomem-edge-auth": auth,
+        },
+    )
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+
+
+def test_get_is_exempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_lease_env(monkeypatch)
+    scope = _scope(method="GET", headers={"cf-ray": "abc123"})
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+
+
+def test_lease_disabled_serves_unconditionally(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "EXOMEM_WRITER_LEASE_URL",
+        "EXOMEM_WRITER_LEASE_VAULT_ID",
+        "EXOMEM_WRITER_LEASE_REPLICA_ID",
+        "EXOMEM_WRITER_LEASE_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    scope = _scope(headers={"cf-ray": "abc123"})
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+
+
+def test_kill_switch_serves_the_request_but_logs_the_bypass_content_free(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _set_lease_env(monkeypatch)
+    monkeypatch.setenv("EXOMEM_EDGE_STAMP_ENFORCE", "0")
+    scope = _scope(path="/api/edit_memory", headers={"cf-ray": "abc123"})
+
+    with caplog.at_level(logging.WARNING, logger="exomem.edge_ingress"):
+        sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1
+    assert "edge_ingress_bypassed" in messages[0]
+    assert "/api/edit_memory" in messages[0]
+    assert "count=1" in messages[0]
+
+
+def test_non_http_scope_passes_through_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_lease_env(monkeypatch)
+    scope = {"type": "lifespan"}
+
+    sent, app_called = _run_middleware(scope)
+
+    assert app_called is True
+    assert sent == []

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -133,8 +133,9 @@ def test_remote_http_runs_stateless(
         "port": 9876,
         "stateless_http": True,
     }
-    assert len(middleware) == 1
-    assert middleware[0].cls is server.PrimeMcpSSEMiddleware
+    assert len(middleware) == 2
+    assert middleware[0].cls is server.EdgeIngressMiddleware
+    assert middleware[1].cls is server.PrimeMcpSSEMiddleware
 
 
 def test_stdio_does_not_apply_http_stateless_configuration(fake_mcp: _FakeMcp) -> None:


### PR DESCRIPTION
## Why

Root cause of the 2026-07-20/21 incident's writer-lease phase (`WRITER_LEASE_REQUIRED: replica is read-only; current writer is laptop` for 1h+ while reads worked): the public hostname was answerable both by the lease-aware HA worker **and** tunnel-direct by a machine's cloudflared binding. Connector writes landing on the follower origin were refused for as long as the accidental binding held — the coordinator lease sat stably (and correctly) on the other replica the whole time (fencing token 98; the incident receipt appears nowhere in the holder's logs). Full diagnosis: `openspec/changes/deterministic-edge-ingress/proposal.md`.

A second gap compounded it: the worker is hand-deployed with no version/vars surface, so a live `MCP_TOOL_TIMEOUT_MS=15000` pin silently overrode the repo's 60s default (the #285 deploy-checklist step nothing could verify).

## What

- **Edge-transit stamp** — worker stamps every proxied request (read fan-out + mutation path) with `x-exomem-request-id` + `x-exomem-edge-auth` (hex HMAC-SHA256 keyed by `STATE_TOKEN`); origins with the lease enabled refuse Cloudflare-transited unsafe-method requests (non-GET/HEAD/OPTIONS, incl. the transfer PUT) lacking a valid stamp with 403 `INGRESS_BYPASSED`. Local traffic (no `cf-ray`) exempt; `EXOMEM_EDGE_STAMP_ENFORCE=0` breaks glass; golden cross-implementation HMAC vector pinned in both suites.
- **Edge provenance** — authenticated `GET /__version` returns deploy git SHA + effective non-secret routing vars; `deploy.ps1`/`deploy.sh` label deploys.
- **Doctor `edge-ingress` section** (probe-gated) — worker-fronting check, `/__version` var-drift check (budget ≥ 60s, coordination, replica mapping), public `/health/ready` vs coordinator holder agreement, TTL floor warning (<30s).

## Verification

- `node --test deploy/cloudflare-ha/test/worker.test.mjs` → 29/29.
- `pytest` lease/doctor/transport/cli-ops/edge-ingress suites → 264+ passed on Windows (1 pre-existing unrelated skip).
- `openspec validate deterministic-edge-ingress` → valid.
- Independent code review: no critical/high findings; both MEDIUMs (transfer-PUT enforcement scope, golden-vector parity pin) and both LOWs (malformed-auth 500, per-request config parse) fixed in this diff.

## Deploy notes (not done by this PR)

1. Merge, upgrade both replicas, restart (writer last).
2. `deploy/cloudflare-ha/deploy.ps1` (labels the worker with the git SHA) **and** confirm live var `MCP_TOOL_TIMEOUT_MS=60000`.
3. Cloudflare dashboard: apex hostname must be worker-route-only (`/*`); each machine's tunnel serves only its own per-machine hostname.
4. `exomem doctor --probe` on both machines → `edge-ingress` section green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tyv6Wu9DNvpFSTwD7gSH9
