### PR TITLE
feat: survive session-store outages with stale-while-revalidate validation

### DIFF
--- a/openspec/changes/survive-session-store-outages/.openspec.yaml
+++ b/openspec/changes/survive-session-store-outages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/survive-session-store-outages/design.md
+++ b/openspec/changes/survive-session-store-outages/design.md
@@ -1,0 +1,112 @@
+# Design — survive session-store outages
+
+## Context
+
+Hosted connector access tokens are resolved through `SessionAuthority.remote`
+against the worker auth-state store. The existing 300-second in-memory cache
+cannot bridge a material store outage, and because both replicas share that
+remote dependency a single Cloudflare failure can disable every otherwise
+healthy connector path.
+
+This change applies only to validation/loading of an already-issued session.
+All token issuance, exchange, refresh, dynamic client registration, and
+revocation paths continue to require the live store.
+
+## Decision 1 — Durable local validation cache
+
+Each replica has a sqlite cache outside the synced vault, in the same local
+state-directory family and with the same default (`~/.cache/exomem`) used by the
+idempotency store. The cache key is `sha256(token)`; raw bearer tokens never
+touch disk.
+
+Each value contains the validated principal/claims payload and `validated_at`.
+The value is encrypted at rest with the derived storage-encryption key already
+used for the local OAuth `FileTreeStore`. Server wiring derives that key once
+from the signing root and passes it to the cache. The cache module owns sqlite
+schema initialization, encrypted serialization, upsert, lookup, and deletion.
+
+Successful remote validation upserts the entry and otherwise behaves exactly as
+before. An authoritative negative response — invalid, revoked, or expired —
+deletes the entry and is refused. Negative results are never cached.
+
+## Decision 2 — Serve stale only on unavailability
+
+The session load path distinguishes remote unavailability (timeout, connection
+error, or HTTP 5xx) from an authoritative negative response. On unavailability,
+it loads the digest-keyed local entry and serves its claims only when:
+
+```
+now - validated_at <= EXOMEM_SESSION_STALE_GRACE_SECONDS
+```
+
+The grace defaults to 86400 seconds. A missing, unreadable, or expired cache
+entry fails closed with `temporarily_unavailable`, matching the existing outage
+behavior. Setting `EXOMEM_SESSION_STALE_GRACE_SECONDS=0` bypasses stale lookup
+and restores exact pre-change fail-closed behavior.
+
+Every stale serve emits a content-free `event=session_stale_served` log with a
+monotonic process-local counter. Claims, principals, token digests, and tokens
+are not logged.
+
+## Decision 3 — Readiness state
+
+The process tracks whether the last remote session-store contact failed while
+stale serving is enabled, plus the running stale-served count. `/health/ready`
+adds:
+
+```json
+{
+  "session_store": {
+    "state": "ok",
+    "stale_served_count": 0
+  }
+}
+```
+
+`state` is `degraded` while the last remote contact failed and stale serving is
+active; a later successful or authoritatively negative remote contact restores
+`ok`. With the grace set to zero, stale serving is inactive and readiness
+retains `ok` while validation continues to fail closed as before.
+
+## Accepted tradeoff
+
+A revocation performed while the store is down propagates to an affected
+replica only when the store recovers, bounded by the configured grace window.
+For a single-operator personal deployment this is strictly better than a total
+connector outage. An authoritative revocation observed from the store deletes
+the cached entry immediately, so it can never be served stale afterward.
+
+## Fail-safe mechanisms around cache invalidation
+
+Two deliberate safety devices back the revocation-always-wins invariant:
+
+- **In-memory block list.** `delete()` records the token digest in an
+  in-memory set before touching sqlite, so a revocation survives even when the
+  row DELETE fails. When the DELETE succeeds and removed no row, the digest is
+  discarded again — every failed validation (including forged bearers from
+  unauthenticated callers) passes through `delete()`, and only digests that
+  actually guarded a cached row may stay resident. The set is also cleared on
+  generation rotation and process restart.
+- **Stale-serving disable latch.** If a bulk invalidation (`delete_session`,
+  `delete_family`, `clear`) hits a sqlite error mid-operation, stale serving is
+  latched off for the remainder of the process lifetime: the cache can no
+  longer prove a revoked entry was removed, so availability yields to
+  correctness until a restart re-establishes a clean baseline. The latch is
+  logged content-free when it engages.
+
+## Rollback
+
+Set `EXOMEM_SESSION_STALE_GRACE_SECONDS=0` to restore fail-closed validation
+without redeploying. The additive readiness field and unused local sqlite file
+are inert under the kill switch.
+
+## Test strategy
+
+- Cache tests cover digest-only keys, encrypted values, round-trip claims,
+  deletion, expiry inputs, and corrupt/unreadable entries failing closed.
+- Session-authority tests cover remote success/upsert, outage with an eligible
+  entry, outage without an entry, authoritative revocation clearing the entry,
+  expiry, the zero-grace kill switch, logging/counters, and readiness state
+  recovery.
+- Existing server transport tests prove unchanged hosted transport behavior and
+  the additive readiness payload.

--- a/openspec/changes/survive-session-store-outages/proposal.md
+++ b/openspec/changes/survive-session-store-outages/proposal.md
@@ -1,0 +1,50 @@
+# Survive session-store outages
+
+## Why
+
+On 2026-07-21 the worker auth-state Durable Object (`state:personal-main`) hung
+for roughly two hours during a Cloudflare partial outage. Origin session
+validation hard-depends on that remote store and has only a 300-second
+in-memory cache, so every claude.ai and ChatGPT connector session failed on
+both replicas while both origins were otherwise healthy.
+
+One remote KV instance must not be able to take down the entire connector
+surface. A bounded, encrypted local validation record lets already-proven
+sessions survive a store outage without permitting stale issuance or caching
+negative validation results.
+
+## What Changes
+
+- Add a per-replica sqlite cache of successful session validations outside the
+  synced vault, keyed by `sha256(token)` with encrypted claims and validation
+  timestamps.
+- On remote session-store unavailability, serve a previously validated session
+  within `EXOMEM_SESSION_STALE_GRACE_SECONDS` (default 86400); continue to fail
+  closed when no eligible entry exists.
+- Clear the local entry on an authoritative invalid, revoked, or expired result,
+  and never cache or serve negative validation results.
+- Keep token issuance, exchange, refresh, dynamic client registration, and
+  revocation dependent on the live store.
+- Add a kill switch: `EXOMEM_SESSION_STALE_GRACE_SECONDS=0` restores the prior
+  fail-closed behavior.
+- Add content-free stale-serving logs and an additive `session_store` object to
+  `/health/ready` with store state and a running stale-served count.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `hosted-gateway-contract`: Adds bounded outage tolerance for validation of
+  sessions that were previously validated successfully on the same replica.
+
+## Impact
+
+The session validation/load path gains an encrypted local sqlite cache and
+store-health telemetry. Server authentication wiring supplies the existing
+derived storage-encryption key and a cache path in the local state-directory
+family. The readiness response gains one additive object. Issuance, exchange,
+refresh, DCR, and revocation behavior do not change.

--- a/openspec/changes/survive-session-store-outages/specs/hosted-gateway-contract/spec.md
+++ b/openspec/changes/survive-session-store-outages/specs/hosted-gateway-contract/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Session Validation Outage Tolerance
+
+The hosted gateway SHALL maintain a per-replica durable cache of successful
+session validations and MAY use a cached validation only when the remote session
+store is unavailable and the entry is within the configured stale grace window.
+The cache SHALL identify entries by a digest of the token, SHALL encrypt the
+validated claims at rest, and SHALL never persist raw tokens or negative
+validation results. Token issuance, exchange, refresh, dynamic client
+registration, and revocation SHALL continue to require the live store.
+
+#### Scenario: Store outage with a recently validated session
+
+- **WHEN** the remote session store is unavailable
+- **AND** the same replica previously validated the session successfully
+- **AND** the cached validation is within `EXOMEM_SESSION_STALE_GRACE_SECONDS`
+- **THEN** the cached claims are served
+- **AND** `stale_served_count` is incremented
+- **AND** `/health/ready` reports `session_store.state` as `degraded`
+
+#### Scenario: Store outage without a prior validation
+
+- **WHEN** the remote session store is unavailable
+- **AND** no eligible successful validation exists in the local cache
+- **THEN** the session is refused with `temporarily_unavailable`
+
+#### Scenario: Authoritative revocation clears stale eligibility
+
+- **WHEN** the remote session store authoritatively reports a session invalid,
+  revoked, or expired
+- **THEN** the local cache entry is deleted
+- **AND** the session is refused
+- **AND** that entry is never served stale on a later store outage
+
+#### Scenario: Stale grace kill switch
+
+- **WHEN** `EXOMEM_SESSION_STALE_GRACE_SECONDS=0`
+- **AND** the remote session store is unavailable
+- **THEN** validation fails closed exactly as it did before this change
+- **AND** no cached validation is served
+
+#### Scenario: Session token confidentiality on disk
+
+- **WHEN** a successful validation is persisted locally
+- **THEN** its sqlite key is `sha256(token)` rather than the raw token
+- **AND** its claims value is encrypted at rest
+- **AND** the raw token does not appear in the cache file

--- a/openspec/changes/survive-session-store-outages/tasks.md
+++ b/openspec/changes/survive-session-store-outages/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — survive session-store outages
+
+## Session validation cache
+
+- [x] C1. Add the per-replica sqlite validation cache outside the synced vault,
+      keyed by `sha256(token)` with encrypted successful claims and
+      `validated_at`; include safe upsert, lookup, and deletion operations.
+- [x] C2. Wire the cache path and the existing derived local OAuth storage key
+      from server authentication setup without changing other auth flows.
+
+## Validation behavior and telemetry
+
+- [x] V1. Update the remote session validation/load path to upsert on success,
+      delete on authoritative negative, and serve an eligible cached success
+      only for remote timeout, connection, or 5xx unavailability.
+- [x] V2. Implement `EXOMEM_SESSION_STALE_GRACE_SECONDS` with default 86400 and
+      zero as exact fail-closed parity; keep issuance, exchange, refresh, DCR,
+      and revocation live-store-only.
+- [x] V3. Emit content-free `event=session_stale_served` logging with a running
+      counter and expose additive `session_store` state/count readiness data.
+
+## Tests and verification
+
+- [x] T1. Add focused cache tests proving digest-only keys, encrypted values,
+      round-trip/deletion behavior, and raw-token absence.
+- [x] T2. Add focused validation tests for remote success, eligible and
+      ineligible outage fallback, authoritative revocation, grace expiry, zero
+      grace, counters, degraded readiness, and recovery.
+- [x] T3. Run the task acceptance pytest, ruff, and OpenSpec validation commands.

--- a/src/exomem/auth_sessions.py
+++ b/src/exomem/auth_sessions.py
@@ -12,10 +12,12 @@ import errno
 import hashlib
 import hmac
 import json
+import logging
 import math
 import os
 import re
 import secrets
+import sqlite3
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field, replace
@@ -34,6 +36,15 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from key_value.aio.stores.filetree import FileTreeStore
 
 from .remote_oauth_storage import RemoteOAuthStorage
+from .session_validation_cache import (
+    SessionStoreTelemetry,
+    SessionValidationCache,
+)
+from .session_validation_cache import (
+    session_store_telemetry as _default_session_store_telemetry,
+)
+
+logger = logging.getLogger(__name__)
 
 _TOKEN_VERSION = "exo_s1"
 _ACCESS_TOKEN_VERSION = "exo_a2"
@@ -687,9 +698,14 @@ class SessionAuthority:
         issuer: str,
         audience: str,
         clock: Callable[[], float] = time.time,
+        validation_cache: SessionValidationCache | None = None,
+        stale_grace_seconds: float = 0.0,
+        session_store_telemetry: SessionStoreTelemetry | None = None,
     ):
         if not issuer or not audience:
             raise ValueError("session issuer and audience are required")
+        if not math.isfinite(stale_grace_seconds) or stale_grace_seconds < 0:
+            raise ValueError("session stale grace must be a non-negative finite number")
         keys = derive_session_keys(signing_root)
         self.fingerprint = keys.fingerprint
         self.issuer = issuer
@@ -710,6 +726,11 @@ class SessionAuthority:
             f"exomem-auth-refresh-grace-v2-{keys.fingerprint}"
         )
         self._storage = _EncryptedStorage(storage, keys.storage_key)
+        self._validation_cache = validation_cache
+        self._stale_grace_seconds = float(stale_grace_seconds)
+        self._session_store_telemetry = (
+            session_store_telemetry or _default_session_store_telemetry
+        )
 
     @classmethod
     def local(
@@ -742,6 +763,9 @@ class SessionAuthority:
         timeout: float = 5.0,
         transport: httpx.AsyncBaseTransport | None = None,
         clock: Callable[[], float] = time.time,
+        validation_cache: SessionValidationCache | None = None,
+        stale_grace_seconds: float = 0.0,
+        session_store_telemetry: SessionStoreTelemetry | None = None,
     ) -> SessionAuthority:
         if not storage_token or not storage_token.strip():
             raise ValueError("a non-empty OAuth storage token is required for HA sessions")
@@ -759,6 +783,9 @@ class SessionAuthority:
             issuer=issuer,
             audience=audience,
             clock=clock,
+            validation_cache=validation_cache,
+            stale_grace_seconds=stale_grace_seconds,
+            session_store_telemetry=session_store_telemetry,
         )
 
     def _new_generation(self) -> GenerationRecord:
@@ -803,6 +830,8 @@ class SessionAuthority:
             replacement.to_dict(),
             collection=self.generations_collection,
         )
+        if self._validation_cache is not None:
+            self._validation_cache.clear()
         return replacement.generation
 
     @staticmethod
@@ -1133,7 +1162,7 @@ class SessionAuthority:
             return None
         return record
 
-    async def validate(self, bearer: str) -> SessionRecord | None:
+    async def _validate_authoritatively(self, bearer: str) -> SessionRecord | None:
         record = await self._load_session_for_bearer(bearer)
         if record is None:
             return None
@@ -1155,6 +1184,89 @@ class SessionAuthority:
                 return None
         return record
 
+    @staticmethod
+    def _remote_failure_allows_stale(error: SessionStoreUnavailable) -> bool:
+        cause: BaseException | None = error
+        while cause is not None:
+            if isinstance(cause, httpx.HTTPStatusError):
+                return cause.response.status_code >= 500
+            if isinstance(
+                cause,
+                (
+                    httpx.TimeoutException,
+                    httpx.NetworkError,
+                    ConnectionError,
+                    TimeoutError,
+                ),
+            ):
+                return True
+            cause = cause.__cause__
+        return False
+
+    def _cached_record_is_eligible(self, bearer: str, record: SessionRecord) -> bool:
+        if (
+            record.status != "active"
+            or record.issuer != self.issuer
+            or record.audience != self.audience
+        ):
+            return False
+        codec: SessionTokenCodec = self.codec
+        if record.schema_version == _ACCESS_SCHEMA_VERSION:
+            codec = self.access_codec
+            if record.expires_at is None or float(self.clock()) >= record.expires_at:
+                return False
+            if record.family_id is None:
+                return False
+        return codec.verify(bearer, record.token_digest)
+
+    async def validate(self, bearer: str) -> SessionRecord | None:
+        if self._validation_cache is None:
+            return await self._validate_authoritatively(bearer)
+        bearer_is_parseable = (
+            self.codec.parse(bearer) is not None
+            or self.access_codec.parse(bearer) is not None
+        )
+        try:
+            record = await self._validate_authoritatively(bearer)
+        except SessionStoreUnavailable as error:
+            if not self._remote_failure_allows_stale(error):
+                raise
+            stale_active = self._stale_grace_seconds > 0
+            self._session_store_telemetry.remote_unavailable(stale_active=stale_active)
+            if not stale_active:
+                raise
+            cached = self._validation_cache.get(bearer)
+            if cached is None:
+                raise
+            age = float(self.clock()) - cached.validated_at
+            if age < 0 or age > self._stale_grace_seconds:
+                raise
+            try:
+                record = SessionRecord.from_dict(cached.claims)
+            except ValueError:
+                raise error from None
+            if not self._cached_record_is_eligible(bearer, record):
+                self._validation_cache.delete(bearer)
+                raise error
+            count = self._session_store_telemetry.stale_served()
+            logger.warning("event=session_stale_served count=%d", count)
+            return record
+
+        if bearer_is_parseable:
+            self._session_store_telemetry.remote_ok()
+        if record is None:
+            self._validation_cache.delete(bearer)
+        else:
+            try:
+                self._validation_cache.upsert(
+                    bearer,
+                    record.to_dict(),
+                    validated_at=float(self.clock()),
+                )
+            except (OSError, sqlite3.Error, ValueError):
+                logger.warning("event=session_validation_cache_write_failed")
+        return record
+
     async def _write_tombstone(self, record: SessionRecord, *, reason: str) -> SessionRecord:
         tombstone = replace(
             record,
@@ -1167,6 +1279,8 @@ class SessionAuthority:
             tombstone.to_dict(),
             collection=self.sessions_collection,
         )
+        if self._validation_cache is not None:
+            self._validation_cache.delete_session(record.session_id)
         return tombstone
 
     async def _revoke_family(self, family_id: str, *, reason: str) -> bool:
@@ -1176,6 +1290,8 @@ class SessionAuthority:
         if family is None:
             return False
         if family.status == "revoked":
+            if self._validation_cache is not None:
+                self._validation_cache.delete_family(family_id)
             return True
         tombstone = replace(
             family,
@@ -1188,6 +1304,8 @@ class SessionAuthority:
             tombstone.to_dict(),
             collection=self.refresh_families_collection,
         )
+        if self._validation_cache is not None:
+            self._validation_cache.delete_family(family_id)
         return True
 
     async def revoke_bearer(self, bearer: str, *, reason: str) -> bool:
@@ -1196,14 +1314,21 @@ class SessionAuthority:
             raise ValueError("revocation reason is required")
         parsed_refresh = self.refresh_codec.parse(bearer)
         if parsed_refresh is not None:
-            return await self._revoke_family(parsed_refresh.family_id, reason=reason)
+            revoked = await self._revoke_family(parsed_refresh.family_id, reason=reason)
+            if self._validation_cache is not None:
+                self._validation_cache.delete_family(parsed_refresh.family_id)
+            return revoked
         record = await self._load_session_for_bearer(bearer)
         if record is None:
+            if self._validation_cache is not None:
+                self._validation_cache.delete(bearer)
             return False
         if record.family_id is not None:
             await self._revoke_family(record.family_id, reason=reason)
         if record.status != "revoked":
             await self._write_tombstone(record, reason=reason)
+        if self._validation_cache is not None:
+            self._validation_cache.delete(bearer)
         return True
 
     async def tombstone(self, session_id: str, *, reason: str) -> bool:
@@ -1221,6 +1346,8 @@ class SessionAuthority:
                 "session record does not match its authoritative storage key"
             )
         if record.status == "revoked":
+            if self._validation_cache is not None:
+                self._validation_cache.delete_session(session_id)
             return True
         if record.family_id is not None:
             await self._revoke_family(record.family_id, reason=reason)

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -39,6 +39,7 @@ def build_runtime_readiness(
     coordination: Mapping[str, Any],
     release: str,
     mcp_tool_surface_sha256: str | None,
+    session_store: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -59,6 +60,17 @@ def build_runtime_readiness(
             reasons.append("replica_identity_missing")
 
     takeover_eligible = not reasons
+    session_store_state = (
+        "degraded"
+        if session_store and session_store.get("state") == "degraded"
+        else "ok"
+    )
+    raw_stale_count = session_store.get("stale_served_count", 0) if session_store else 0
+    stale_served_count = (
+        raw_stale_count
+        if isinstance(raw_stale_count, int) and raw_stale_count >= 0
+        else 0
+    )
     return {
         "status": "ready" if takeover_eligible else "not_ready",
         "service": "exomem",
@@ -75,6 +87,10 @@ def build_runtime_readiness(
                 coordination.get("mutation_boundary")
             ),
         },
+        "session_store": {
+            "state": session_store_state,
+            "stale_served_count": stale_served_count,
+        },
         "takeover_eligible": takeover_eligible,
         "reasons": reasons,
     }
@@ -82,6 +98,7 @@ def build_runtime_readiness(
 
 def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
     """Measure this process's eligibility without exposing vault or credential state."""
+    from .session_validation_cache import session_store_readiness
     from .writer_lease import coordination_status
 
     try:
@@ -97,4 +114,5 @@ def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
         coordination=coordination,
         release=package_release(),
         mcp_tool_surface_sha256=mcp_tool_surface_sha256,
+        session_store=session_store_readiness(),
     )

--- a/src/exomem/server_auth.py
+++ b/src/exomem/server_auth.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
 import os
 from contextlib import nullcontext
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -25,6 +27,7 @@ from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from .auth_sessions import SessionAuthority
 from .remote_oauth_storage import ReadThroughMirrorStorage, RemoteOAuthStorage
 from .session_oauth import OAUTH_AUTHORIZATION_SCOPES, ExomemSessionOAuthProxy
+from .session_validation_cache import SessionValidationCache
 
 if TYPE_CHECKING:
     from .hosted_runtime import HostedCellConfig
@@ -200,6 +203,24 @@ def build_session_authority(*, base_url: str) -> SessionAuthority:
     shared = _shared_storage_settings()
     if shared is not None:
         storage_url, namespace, storage_token, timeout = shared
+        stale_grace_seconds = _session_stale_grace_seconds()
+        state_raw = os.environ.get("EXOMEM_WRITER_LEASE_STATE_DIR", "").strip()
+        state_dir = (
+            Path(state_raw).expanduser()
+            if state_raw
+            else Path.home() / ".cache" / "exomem"
+        )
+        replica = os.environ.get("EXOMEM_WRITER_LEASE_REPLICA_ID", "").strip() or "standalone"
+        vault = os.environ.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip() or namespace
+        safe_name = hashlib.sha256(f"{vault}\0{replica}".encode()).hexdigest()[:20]
+        cache = (
+            None
+            if stale_grace_seconds == 0
+            else SessionValidationCache(
+                state_dir / f"session-validations-{safe_name}.sqlite",
+                encryption_key=_oauth_storage_encryption_key(signing_root),
+            )
+        )
         return SessionAuthority.remote(
             url=storage_url,
             namespace=namespace,
@@ -208,6 +229,8 @@ def build_session_authority(*, base_url: str) -> SessionAuthority:
             issuer=issuer,
             audience=audience,
             timeout=timeout,
+            validation_cache=cache,
+            stale_grace_seconds=stale_grace_seconds,
         )
 
     from fastmcp import settings
@@ -220,20 +243,37 @@ def build_session_authority(*, base_url: str) -> SessionAuthority:
     )
 
 
+def _oauth_storage_encryption_key(signing_root: str) -> bytes:
+    signing_key = derive_jwt_key(
+        low_entropy_material=signing_root,
+        salt="fastmcp-jwt-signing-key",
+    )
+    return derive_jwt_key(
+        high_entropy_material=signing_key.decode(),
+        salt="fastmcp-storage-encryption-key",
+    )
+
+
+def _session_stale_grace_seconds() -> float:
+    raw = os.environ.get("EXOMEM_SESSION_STALE_GRACE_SECONDS", "86400").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        raise RuntimeError("EXOMEM_SESSION_STALE_GRACE_SECONDS must be a number") from None
+    if not math.isfinite(value) or value < 0:
+        raise RuntimeError(
+            "EXOMEM_SESSION_STALE_GRACE_SECONDS must be a non-negative finite number"
+        )
+    return value
+
+
 def _build_oauth_client_storage(*, signing_root: str) -> Any | None:
     """Preserve FastMCP's DCR/transaction/code storage behavior in HA mode."""
     shared = _shared_storage_settings()
     if shared is None:
         return None
     storage_url, namespace, storage_token, timeout = shared
-    signing_key = derive_jwt_key(
-        low_entropy_material=signing_root,
-        salt="fastmcp-jwt-signing-key",
-    )
-    storage_key = derive_jwt_key(
-        high_entropy_material=signing_key.decode(),
-        salt="fastmcp-storage-encryption-key",
-    )
+    storage_key = _oauth_storage_encryption_key(signing_root)
     remote = RemoteOAuthStorage(
         url=storage_url,
         namespace=namespace,

--- a/src/exomem/session_validation_cache.py
+++ b/src/exomem/session_validation_cache.py
@@ -1,0 +1,225 @@
+"""Encrypted, replica-local cache for successful session validations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import sqlite3
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CachedSessionValidation:
+    claims: dict[str, Any]
+    validated_at: float
+
+
+class SessionValidationCache:
+    """Persist successful validations without ever storing the raw bearer."""
+
+    def __init__(self, path: Path, *, encryption_key: bytes) -> None:
+        self.path = Path(path).expanduser().resolve()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fernet = Fernet(encryption_key)
+        self._lock = threading.RLock()
+        self._blocked_digests: set[str] = set()
+        self._stale_disabled = False
+        self._initialize()
+
+    @staticmethod
+    def token_digest(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=5.0)
+        connection.execute("PRAGMA busy_timeout = 5000")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS session_validations (
+                    token_digest TEXT PRIMARY KEY,
+                    encrypted_value BLOB NOT NULL
+                )
+                """
+            )
+
+    def upsert(
+        self,
+        token: str,
+        claims: Mapping[str, Any],
+        *,
+        validated_at: float,
+    ) -> None:
+        timestamp = float(validated_at)
+        if not math.isfinite(timestamp) or timestamp <= 0:
+            raise ValueError("validated_at must be a positive finite timestamp")
+        plaintext = json.dumps(
+            {"claims": dict(claims), "validated_at": timestamp},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        encrypted = self._fernet.encrypt(plaintext)
+        digest = self.token_digest(token)
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO session_validations(token_digest, encrypted_value)
+                VALUES (?, ?)
+                ON CONFLICT(token_digest) DO UPDATE SET
+                    encrypted_value = excluded.encrypted_value
+                """,
+                (digest, encrypted),
+            )
+            self._blocked_digests.discard(digest)
+
+    def get(self, token: str) -> CachedSessionValidation | None:
+        digest = self.token_digest(token)
+        try:
+            with self._lock:
+                if self._stale_disabled or digest in self._blocked_digests:
+                    return None
+                with self._connect() as connection:
+                    row = connection.execute(
+                        "SELECT encrypted_value FROM session_validations WHERE token_digest = ?",
+                        (digest,),
+                    ).fetchone()
+                if row is None:
+                    return None
+                return self._decode(bytes(row[0]))
+        except (InvalidToken, KeyError, TypeError, ValueError, json.JSONDecodeError, sqlite3.Error):
+            logger.warning("event=session_validation_cache_read_failed")
+            return None
+
+    def _decode(self, encrypted: bytes) -> CachedSessionValidation:
+        plaintext = self._fernet.decrypt(encrypted)
+        payload = json.loads(plaintext)
+        claims = payload["claims"]
+        validated_at = float(payload["validated_at"])
+        if (
+            not isinstance(claims, dict)
+            or not math.isfinite(validated_at)
+            or validated_at <= 0
+        ):
+            raise ValueError("invalid cached validation")
+        return CachedSessionValidation(claims=dict(claims), validated_at=validated_at)
+
+    def delete(self, token: str) -> None:
+        digest = self.token_digest(token)
+        with self._lock:
+            self._blocked_digests.add(digest)
+        try:
+            with self._lock, self._connect() as connection:
+                removed = connection.execute(
+                    "DELETE FROM session_validations WHERE token_digest = ?",
+                    (digest,),
+                ).rowcount
+                if removed == 0:
+                    # No row existed, so there is nothing for a block to guard.
+                    # Dropping the digest keeps unauthenticated garbage bearers
+                    # (every failed validation lands here) from growing this
+                    # set without bound; the exception path below keeps the
+                    # block so a failed DELETE still cannot lose a revocation.
+                    self._blocked_digests.discard(digest)
+        except sqlite3.Error:
+            logger.warning("event=session_validation_cache_delete_failed")
+
+    def _delete_matching(self, field: str, value: str) -> None:
+        with self._lock:
+            was_disabled = self._stale_disabled
+            self._stale_disabled = True
+            try:
+                with self._connect() as connection:
+                    rows = connection.execute(
+                        "SELECT token_digest, encrypted_value FROM session_validations"
+                    ).fetchall()
+                    digests: list[str] = []
+                    for digest, encrypted in rows:
+                        try:
+                            cached = self._decode(bytes(encrypted))
+                        except (
+                            InvalidToken,
+                            KeyError,
+                            TypeError,
+                            ValueError,
+                            json.JSONDecodeError,
+                        ):
+                            continue
+                        if cached.claims.get(field) == value:
+                            digests.append(str(digest))
+                    connection.executemany(
+                        "DELETE FROM session_validations WHERE token_digest = ?",
+                        ((digest,) for digest in digests),
+                    )
+                    self._blocked_digests.update(digests)
+            except sqlite3.Error:
+                logger.warning("event=session_validation_cache_delete_failed")
+                return
+            self._stale_disabled = was_disabled
+
+    def delete_session(self, session_id: str) -> None:
+        self._delete_matching("session_id", session_id)
+
+    def delete_family(self, family_id: str) -> None:
+        """Invalidate cached access sessions belonging to a revoked refresh family."""
+        self._delete_matching("family_id", family_id)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._stale_disabled = True
+            try:
+                with self._connect() as connection:
+                    connection.execute("DELETE FROM session_validations")
+            except sqlite3.Error:
+                logger.warning("event=session_validation_cache_delete_failed")
+                return
+            self._blocked_digests.clear()
+            self._stale_disabled = False
+
+
+class SessionStoreTelemetry:
+    """Process-local, content-free session-store readiness counters."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._degraded = False
+        self._stale_served_count = 0
+
+    def remote_ok(self) -> None:
+        with self._lock:
+            self._degraded = False
+
+    def remote_unavailable(self, *, stale_active: bool) -> None:
+        with self._lock:
+            self._degraded = stale_active
+
+    def stale_served(self) -> int:
+        with self._lock:
+            self._stale_served_count += 1
+            return self._stale_served_count
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "state": "degraded" if self._degraded else "ok",
+                "stale_served_count": self._stale_served_count,
+            }
+
+
+session_store_telemetry = SessionStoreTelemetry()
+
+
+def session_store_readiness() -> dict[str, Any]:
+    return session_store_telemetry.snapshot()

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -36,6 +36,7 @@ def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
             "coordinator_healthy": True,
             "mutation_boundary": {"state": "free"},
         },
+        "session_store": {"state": "ok", "stale_served_count": 0},
         "takeover_eligible": True,
         "reasons": [],
     }

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -93,12 +93,15 @@ def test_build_session_authority_uses_encrypted_local_store(
 
 def test_build_session_authority_uses_authenticated_uncached_remote_store(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    monkeypatch.delenv("EXOMEM_SESSION_STALE_GRACE_SECONDS", raising=False)
     _set_oauth_env(
         monkeypatch,
         EXOMEM_OAUTH_STORAGE_URL="https://coordinator.example",
         EXOMEM_OAUTH_STORAGE_NAMESPACE="vault",
         EXOMEM_OAUTH_STORAGE_TOKEN="coordinator-secret",
+        EXOMEM_WRITER_LEASE_STATE_DIR=str(tmp_path),
     )
 
     authority = server_auth.build_session_authority(base_url="https://memory.example")
@@ -107,6 +110,7 @@ def test_build_session_authority_uses_authenticated_uncached_remote_store(
     assert isinstance(raw_store, RemoteOAuthStorage)
     assert raw_store.token == "coordinator-secret"
     assert raw_store.cache_ttl == 0
+    assert authority._stale_grace_seconds == 86_400.0
 
 
 def test_shared_session_authority_refuses_missing_storage_bearer(

--- a/tests/test_session_stale_validation.py
+++ b/tests/test_session_stale_validation.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from cryptography.fernet import Fernet
+
+from exomem import server_auth
+from exomem.auth_sessions import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    SessionAuthority,
+    SessionIdentity,
+    SessionStoreUnavailable,
+)
+from exomem.runtime_readiness import build_runtime_readiness
+
+
+class AtomicStore:
+    def __init__(self) -> None:
+        self.data: dict[tuple[str | None, str], dict[str, Any]] = {}
+        self.fail_get = False
+        self.get_error: Exception | None = None
+        self._lock = asyncio.Lock()
+
+    async def get(
+        self, key: str, *, collection: str | None = None
+    ) -> dict[str, Any] | None:
+        if self.fail_get:
+            raise TimeoutError("remote store timed out")
+        if self.get_error is not None:
+            raise self.get_error
+        value = self.data.get((collection, key))
+        return None if value is None else dict(value)
+
+    async def put(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        del ttl
+        self.data[(collection, key)] = dict(value)
+
+    async def put_if_absent(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> bool:
+        del ttl
+        async with self._lock:
+            storage_key = (collection, key)
+            if storage_key in self.data:
+                return False
+            self.data[storage_key] = dict(value)
+            return True
+
+    async def list_keys(self, *, collection: str | None = None) -> list[str]:
+        return sorted(key for stored_collection, key in self.data if stored_collection == collection)
+
+
+def _stale_authority(
+    tmp_path: Path,
+    *,
+    now: list[float],
+    grace: float = 86_400.0,
+) -> tuple[SessionAuthority, AtomicStore, Any, Any]:
+    from exomem.session_validation_cache import (
+        SessionStoreTelemetry,
+        SessionValidationCache,
+    )
+
+    store = AtomicStore()
+    cache = SessionValidationCache(
+        tmp_path / "session-validations.sqlite",
+        encryption_key=Fernet.generate_key(),
+    )
+    telemetry = SessionStoreTelemetry()
+    authority = SessionAuthority(
+        storage=store,
+        signing_root="stable-signing-root",
+        issuer="https://memory.example",
+        audience="https://memory.example/mcp",
+        clock=lambda: now[0],
+        validation_cache=cache,
+        stale_grace_seconds=grace,
+        session_store_telemetry=telemetry,
+    )
+    return authority, store, cache, telemetry
+
+
+async def _issue(authority: SessionAuthority) -> tuple[str, Any]:
+    return await authority.issue(
+        client_id="codex-client",
+        scopes=("exomem:read",),
+        identity=SessionIdentity(github_user_id=123456, github_login="Person"),
+    )
+
+
+async def _issue_offline(authority: SessionAuthority) -> tuple[str, Any, str]:
+    return await authority.issue_offline(
+        client_id="codex-client",
+        scopes=("offline_access", "exomem:read"),
+        identity=SessionIdentity(github_user_id=123456, github_login="Person"),
+    )
+
+
+@pytest.mark.anyio
+async def test_store_outage_serves_recent_validation_and_marks_degraded(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+
+    store.fail_get = True
+    with caplog.at_level(logging.WARNING, logger="exomem.auth_sessions"):
+        assert await authority.validate(bearer) == issued
+
+    assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 1}
+    assert "event=session_stale_served count=1" in caplog.text
+    assert bearer not in caplog.text
+    assert issued.github_login not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_store_outage_without_prior_validation_fails_closed(tmp_path: Path) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, _ = await _issue(authority)
+    store.fail_get = True
+
+    with pytest.raises(SessionStoreUnavailable, match="unavailable"):
+        await authority.validate(bearer)
+
+    assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 0}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(("status_code", "serves_stale"), [(503, True), (401, False)])
+async def test_only_remote_5xx_status_allows_stale_fallback(
+    tmp_path: Path,
+    status_code: int,
+    serves_stale: bool,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+    request = httpx.Request("POST", "https://coordinator.example/v1/state/get")
+    response = httpx.Response(status_code, request=request)
+    store.get_error = httpx.HTTPStatusError(
+        "remote status",
+        request=request,
+        response=response,
+    )
+
+    if serves_stale:
+        assert await authority.validate(bearer) == issued
+        assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 1}
+    else:
+        with pytest.raises(SessionStoreUnavailable):
+            await authority.validate(bearer)
+        assert telemetry.snapshot() == {"state": "ok", "stale_served_count": 0}
+
+
+@pytest.mark.anyio
+async def test_connection_error_allows_stale_but_unrelated_os_error_does_not(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+    request = httpx.Request("POST", "https://coordinator.example/v1/state/get")
+    store.get_error = httpx.ConnectError("connection refused", request=request)
+    assert await authority.validate(bearer) == issued
+    assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 1}
+
+    store.get_error = OSError("unrelated local failure")
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.validate(bearer)
+    assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 1}
+
+
+@pytest.mark.anyio
+async def test_authoritative_revocation_clears_entry_and_prevents_later_stale_use(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, cache, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+    assert cache.get(bearer) is not None
+
+    assert await authority.revoke_bearer(bearer, reason="operator-revocation")
+    assert cache.get(bearer) is None
+
+    store.fail_get = True
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.validate(bearer)
+    assert telemetry.snapshot()["stale_served_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_generation_replacement_and_session_tombstone_clear_stale_eligibility(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, cache, _ = _stale_authority(tmp_path, now=now)
+    first_bearer, first = await _issue(authority)
+    second_bearer, second = await _issue(authority)
+    assert await authority.validate(first_bearer) == first
+    assert await authority.validate(second_bearer) == second
+
+    await authority.replace_generation()
+    assert cache.get(first_bearer) is None
+    assert cache.get(second_bearer) is None
+
+    third_bearer, third = await _issue(authority)
+    assert await authority.validate(third_bearer) == third
+    assert await authority.tombstone(third.session_id, reason="operator-revocation")
+    assert cache.get(third_bearer) is None
+
+    store.fail_get = True
+    for bearer in (first_bearer, second_bearer, third_bearer):
+        with pytest.raises(SessionStoreUnavailable):
+            await authority.validate(bearer)
+
+
+@pytest.mark.anyio
+async def test_access_or_refresh_revocation_clears_every_cached_family_session(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, cache, _ = _stale_authority(tmp_path, now=now)
+    first_access, first_record, refresh = await _issue_offline(authority)
+    assert await authority.validate(first_access) == first_record
+    second_access, second_record, next_refresh = await authority.rotate_refresh(
+        refresh,
+        client_id="codex-client",
+        scopes=("offline_access", "exomem:read"),
+    )
+    assert await authority.validate(second_access) == second_record
+
+    assert await authority.revoke_bearer(first_access, reason="access-revocation")
+    assert cache.get(first_access) is None
+    assert cache.get(second_access) is None
+
+    third_access, third_record, third_refresh = await _issue_offline(authority)
+    assert await authority.validate(third_access) == third_record
+    assert await authority.revoke_bearer(third_refresh, reason="refresh-revocation")
+    assert cache.get(third_access) is None
+
+    store.fail_get = True
+    for bearer in (first_access, second_access, third_access):
+        with pytest.raises(SessionStoreUnavailable):
+            await authority.validate(bearer)
+    assert next_refresh
+
+
+@pytest.mark.anyio
+async def test_authoritative_expiry_clears_cached_access_session(tmp_path: Path) -> None:
+    now = [1_800_000_000.0]
+    authority, store, cache, _ = _stale_authority(tmp_path, now=now)
+    access, record, _ = await _issue_offline(authority)
+    assert await authority.validate(access) == record
+
+    now[0] += ACCESS_TOKEN_TTL_SECONDS
+    assert await authority.validate(access) is None
+    assert cache.get(access) is None
+
+    store.fail_get = True
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.validate(access)
+
+
+@pytest.mark.anyio
+async def test_failed_cache_invalidation_disables_stale_serving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, cache, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, record = await _issue(authority)
+    assert await authority.validate(bearer) == record
+    connect = cache._connect
+
+    def fail_connect() -> Any:
+        raise sqlite3.OperationalError("database unavailable")
+
+    monkeypatch.setattr(cache, "_connect", fail_connect)
+    assert await authority.tombstone(record.session_id, reason="operator-revocation")
+    monkeypatch.setattr(cache, "_connect", connect)
+
+    store.fail_get = True
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.validate(bearer)
+    assert telemetry.snapshot()["stale_served_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_stale_cache_never_enables_issuance_refresh_or_revocation(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, _ = _stale_authority(tmp_path, now=now)
+    access, record, refresh = await _issue_offline(authority)
+    assert await authority.validate(access) == record
+    store.fail_get = True
+
+    with pytest.raises(SessionStoreUnavailable):
+        await _issue(authority)
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.rotate_refresh(
+            refresh,
+            client_id="codex-client",
+            scopes=("offline_access", "exomem:read"),
+        )
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.revoke_bearer(access, reason="offline-revocation")
+
+
+@pytest.mark.anyio
+async def test_expired_grace_and_zero_grace_preserve_fail_closed_behavior(
+    tmp_path: Path,
+) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path / "expired", now=now, grace=60)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+    now[0] += 61
+    store.fail_get = True
+    with pytest.raises(SessionStoreUnavailable):
+        await authority.validate(bearer)
+    assert telemetry.snapshot() == {"state": "degraded", "stale_served_count": 0}
+
+    now = [1_800_000_000.0]
+    disabled, disabled_store, _, disabled_telemetry = _stale_authority(
+        tmp_path / "disabled", now=now, grace=0
+    )
+    disabled_bearer, disabled_record = await _issue(disabled)
+    assert await disabled.validate(disabled_bearer) == disabled_record
+    disabled_store.fail_get = True
+    with pytest.raises(SessionStoreUnavailable):
+        await disabled.validate(disabled_bearer)
+    assert disabled_telemetry.snapshot() == {"state": "ok", "stale_served_count": 0}
+
+
+@pytest.mark.anyio
+async def test_successful_remote_recovery_restores_ok_state(tmp_path: Path) -> None:
+    now = [1_800_000_000.0]
+    authority, store, _, telemetry = _stale_authority(tmp_path, now=now)
+    bearer, issued = await _issue(authority)
+    assert await authority.validate(bearer) == issued
+    store.fail_get = True
+    assert await authority.validate(bearer) == issued
+    assert telemetry.snapshot()["state"] == "degraded"
+
+    store.fail_get = False
+    assert await authority.validate(bearer) == issued
+    assert telemetry.snapshot() == {"state": "ok", "stale_served_count": 1}
+
+
+def test_readiness_includes_session_store_telemetry() -> None:
+    snapshot = build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="a" * 64,
+        session_store={"state": "degraded", "stale_served_count": 7},
+    )
+
+    assert snapshot["session_store"] == {"state": "degraded", "stale_served_count": 7}
+
+
+def test_server_auth_wires_replica_local_cache_and_grace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / "state"
+    values = {
+        "EXOMEM_JWT_SIGNING_KEY": "stable-signing-root",
+        "EXOMEM_OAUTH_STORAGE_URL": "https://coordinator.example",
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE": "personal-main",
+        "EXOMEM_OAUTH_STORAGE_TOKEN": "coordinator-secret",
+        "EXOMEM_WRITER_LEASE_STATE_DIR": str(state_dir),
+        "EXOMEM_WRITER_LEASE_REPLICA_ID": "laptop",
+        "EXOMEM_SESSION_STALE_GRACE_SECONDS": "123",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+    authority = server_auth.build_session_authority(base_url="https://memory.example")
+
+    expected_suffix = hashlib.sha256(b"personal-main\0laptop").hexdigest()[:20]
+    assert authority._validation_cache.path == (
+        state_dir / f"session-validations-{expected_suffix}.sqlite"
+    ).resolve()
+    assert authority._stale_grace_seconds == 123.0
+
+
+def test_server_auth_uses_exact_fastmcp_storage_key_and_zero_grace_omits_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class RecordingCache:
+        def __init__(self, path: Path, *, encryption_key: bytes) -> None:
+            captured.update(path=path, encryption_key=encryption_key)
+
+    values = {
+        "EXOMEM_JWT_SIGNING_KEY": "stable-signing-root",
+        "EXOMEM_OAUTH_STORAGE_URL": "https://coordinator.example",
+        "EXOMEM_OAUTH_STORAGE_NAMESPACE": "personal-main",
+        "EXOMEM_OAUTH_STORAGE_TOKEN": "coordinator-secret",
+        "EXOMEM_WRITER_LEASE_STATE_DIR": str(tmp_path),
+        "EXOMEM_WRITER_LEASE_REPLICA_ID": "laptop",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(server_auth, "SessionValidationCache", RecordingCache)
+
+    enabled = server_auth.build_session_authority(base_url="https://memory.example")
+    assert captured["encryption_key"] == server_auth._oauth_storage_encryption_key(
+        "stable-signing-root"
+    )
+    assert enabled._validation_cache is not None
+
+    captured.clear()
+    monkeypatch.setenv("EXOMEM_SESSION_STALE_GRACE_SECONDS", "0")
+    disabled = server_auth.build_session_authority(base_url="https://memory.example")
+    assert disabled._validation_cache is None
+    assert disabled._stale_grace_seconds == 0
+    assert captured == {}

--- a/tests/test_session_validation_cache.py
+++ b/tests/test_session_validation_cache.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+
+def test_cache_persists_only_digest_key_and_encrypted_payload(tmp_path: Path) -> None:
+    from exomem.session_validation_cache import SessionValidationCache
+
+    path = tmp_path / "session-validations.sqlite"
+    cache = SessionValidationCache(path, encryption_key=Fernet.generate_key())
+    token = "exo_s1.secret-session.raw-bearer-material"
+    claims = {
+        "client_id": "codex-client",
+        "scopes": ["exomem:read"],
+        "github_login": "person",
+    }
+
+    cache.upsert(token, claims, validated_at=1_800_000_000.0)
+
+    entry = cache.get(token)
+    assert entry is not None
+    assert entry.claims == claims
+    assert entry.validated_at == 1_800_000_000.0
+
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    with sqlite3.connect(path) as connection:
+        row = connection.execute(
+            "SELECT token_digest, encrypted_value FROM session_validations"
+        ).fetchone()
+    assert row is not None
+    assert row[0] == digest
+    assert token.encode("utf-8") not in path.read_bytes()
+    assert b"codex-client" not in path.read_bytes()
+    assert b"github_login" not in row[1]
+
+
+def test_cache_delete_and_wrong_key_fail_closed(tmp_path: Path) -> None:
+    from exomem.session_validation_cache import SessionValidationCache
+
+    path = tmp_path / "session-validations.sqlite"
+    token = "session-token"
+    cache = SessionValidationCache(path, encryption_key=Fernet.generate_key())
+    cache.upsert(token, {"client_id": "codex"}, validated_at=1_800_000_000.0)
+
+    wrong_key_cache = SessionValidationCache(path, encryption_key=Fernet.generate_key())
+    assert wrong_key_cache.get(token) is None
+
+    cache.delete(token)
+    assert cache.get(token) is None
+
+
+def test_cache_delete_family_clears_only_matching_access_sessions(tmp_path: Path) -> None:
+    from exomem.session_validation_cache import SessionValidationCache
+
+    cache = SessionValidationCache(
+        tmp_path / "session-validations.sqlite",
+        encryption_key=Fernet.generate_key(),
+    )
+    cache.upsert("family-a-token", {"family_id": "family-a"}, validated_at=1_800_000_000)
+    cache.upsert("family-b-token", {"family_id": "family-b"}, validated_at=1_800_000_000)
+
+    cache.delete_family("family-a")
+
+    assert cache.get("family-a-token") is None
+    assert cache.get("family-b-token") is not None
+
+
+def test_cache_rejects_invalid_validation_timestamp(tmp_path: Path) -> None:
+    from exomem.session_validation_cache import SessionValidationCache
+
+    cache = SessionValidationCache(
+        tmp_path / "session-validations.sqlite",
+        encryption_key=Fernet.generate_key(),
+    )
+
+    for invalid in (0.0, -1.0, float("inf"), float("nan")):
+        try:
+            cache.upsert("session-token", {"client_id": "codex"}, validated_at=invalid)
+        except ValueError:
+            pass
+        else:  # pragma: no cover - assertion branch
+            raise AssertionError(f"accepted invalid validation timestamp {invalid!r}")
+
+
+def test_delete_of_unknown_bearer_does_not_grow_block_list(tmp_path: Path) -> None:
+    # Every failed validation calls delete(), including forged bearers from
+    # unauthenticated callers; a digest may only stay blocked when a cached row
+    # actually existed, or the in-memory set grows without bound.
+    from exomem.session_validation_cache import SessionValidationCache
+
+    cache = SessionValidationCache(
+        tmp_path / "session-validations.sqlite", encryption_key=Fernet.generate_key()
+    )
+    for index in range(50):
+        cache.delete(f"garbage-bearer-{index}")
+    assert cache._blocked_digests == set()
+
+    cache.upsert("real-token", {"client_id": "codex"}, validated_at=1_800_000_000.0)
+    cache.delete("real-token")
+    digest = hashlib.sha256(b"real-token").hexdigest()
+    assert digest in cache._blocked_digests
+    assert cache.get("real-token") is None


### PR DESCRIPTION
## Why

On 2026-07-21 the HA edge's auth-state Durable Object hung for ~2h during a Cloudflare partial outage. Origin session validation hard-depends on that store with a 300s in-memory cache and fails closed — so one stuck remote KV instance killed every connector session (claude.ai and ChatGPT, reads **and** writes) on both replicas simultaneously, while both origins were healthy. Diagnosis: KB `incident-2026-07-21-diagnosis-...` + `openspec/changes/survive-session-store-outages/proposal.md`.

## What

Stale-while-revalidate session validation (OpenSpec change `survive-session-store-outages`):

- Durable per-replica sqlite cache of **successful** validations, outside the synced vault; keys are `sha256(token)` (raw bearers never on disk), values encrypted with the existing derived local-OAuth storage key.
- Serve-stale **only** on store unavailability (timeout / network / 5xx — never an authoritative 4xx), bounded by `EXOMEM_SESSION_STALE_GRACE_SECONDS` (default 86400; `0` = exact pre-change fail-closed path).
- Revocation always wins: every negative path (token, session, refresh family, generation rotation) clears matching entries; an in-memory block list preserves a revocation across a failed row delete; a sqlite error during bulk invalidation latches stale serving off for the process lifetime.
- Issuance / exchange / refresh / DCR / revocation still require the live store — no stale issuance.
- Additive `/health/ready` `session_store {state, stale_served_count}`; content-free logging.

## Verification

- 46 focused tests green on Windows (cache, validation matrix incl. 401-not-stale vs 5xx-stale, revocation clearing, kill-switch parity, raw-token-absence on disk and in logs, readiness recovery); ruff clean on changed files; `openspec validate` passes.
- Independent security-focused review: encryption at rest, digest-only keys, unavailability-only predicate, revocation clearing, and kill-switch parity all confirmed correct; its one MEDIUM finding (unbounded block-list growth on garbage bearers) fixed with a regression test.
- Local `codex_task.sh verify` fails only on the two documented Unix-only modules (`test_hosted_restore_candidate.py` fcntl import, `test_continuation_checkpoint.py` fsdecode-at-import) breaking Windows collection plus the latency benchmark on a non-quiesced machine — identical environmental set noted in #290; Linux CI is authoritative.

## Deploy notes

After merge + release: upgrade both replicas and restart (writer last). No worker change; no new secrets — the cache key derives from the existing `EXOMEM_JWT_SIGNING_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tyv6Wu9DNvpFSTwD7gSH9
