### PR TITLE
Add least-privilege Hosted agent surface

### DIFF
--- a/openspec/changes/add-hosted-agent-surface-profile/.openspec.yaml
+++ b/openspec/changes/add-hosted-agent-surface-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/add-hosted-agent-surface-profile/design.md
+++ b/openspec/changes/add-hosted-agent-surface-profile/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Hosted cells already expose a deterministic, authenticated private REST command contract generated from `PRODUCT_COMMANDS`. That contract intentionally includes control-plane and broad product operations needed by Home, transfers, adoption, and maintenance. The planned shared Substrate MCP facade needs a smaller public-agent view, but placing a second allowlist in Substrate would violate the registry-as-source-of-truth rule and allow MCP discovery, bootstrap guidance, and the cell contract to drift.
+
+The existing `ActiveSurfaceDescriptor` and bootstrap filtering solve part of the problem: when an adapter binds an exact command set, `bootstrap` removes unavailable recommendations. A contract-only profile is not sufficient, however, because the current private command route always binds the full `private-command-router` descriptor. This change therefore adds a separate authenticated agent contract/dispatch path while leaving the current private contract and command route unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one stable `hosted-alpha-agent-v1` profile inside the product registry.
+- Expose only the governed text-memory operations needed for private-alpha capture, recall, review, and linking.
+- Produce a deterministic profile contract containing canonical schemas plus an active-capability fingerprint.
+- Enforce the profile at an authenticated cell route, including for `bootstrap`.
+- Prove bootstrap guidance cannot advertise a command outside the profile.
+- Preserve the existing private Hosted contract, digest, command routing, and release fixture by default.
+
+**Non-Goals:**
+
+- Public MCP transport, OAuth, token scopes, tenant routing, revocation, or Substrate UI.
+- Client skill/plugin packaging or the existing ChatGPT connector promotion contract.
+- Provider infrastructure, cell deployment, release manifests, or live rollout.
+- Transfers, uploads, adoption, media, maintenance/schema administration, Tier-2 tools, or general command-surface redesign.
+
+## Decisions
+
+### 1. Profile membership is one set-level registry policy, not transport policy
+
+An immutable `ProductSurfaceProfile` registry lives beside `PRODUCT_COMMANDS`. Each profile owns one ordered command-name tuple and resolves those names to canonical `Command` objects while rejecting missing, duplicate, non-REST, or non-Tier-1 entries. `product_commands_for_profile(profile, surface)` rejects an unknown profile and returns canonical commands in the profile's pinned order. Command schema, description, read/write classification, annotations, and execution still come exclusively from `PRODUCT_COMMANDS`; only set-level exposure policy lives in the profile registry.
+
+An allowlist in `hosted_gateway.py` was rejected because transport code must not own product exposure policy. Scattering versioned membership across each `Command` was rejected because exact profile membership is a set-level decision. Inferring membership from tier or `product_surface` was rejected because those fields are broader product taxonomy, not a security/exposure decision.
+
+### 2. The v1 profile is deliberately narrow
+
+The exact ordered profile is:
+
+1. `bootstrap`
+2. `ask_memory`
+3. `read_memory`
+4. `browse_memory`
+5. `remember`
+6. `observe_memory`
+7. `capture_source`
+8. `compile_source`
+9. `preserve_evidence`
+10. `review_memory`
+11. `review_item_context`
+12. `triage_memory`
+13. `connect_memory`
+
+This includes the governed text-memory loop while excluding coordination internals, transfer, media processing, both adoption commands, maintenance/schema administration, and all Tier-2 commands. It also excludes `edit_memory` and `replace_memory`: both are intentionally broad page-level primitives that can target instruction/schema material, so they are not appropriate for a first Hosted agent boundary. Governed semantic-unit updates remain available through `observe_memory`. `v1` is immutable: any membership change creates a new profile identifier and contract.
+
+### 3. The agent contract is an additive derived variant
+
+`build_gateway_contract()` remains the full private control-plane contract with its existing signature and output. A separate `build_agent_gateway_contract(profile=...)` selects the profile registry, reuses the existing envelope/compatibility fields except the unrelated transfer-grant capability, and adds profile metadata from an `ActiveSurfaceDescriptor`. Each agent command also carries the canonical MCP discovery description, input JSON Schema, and annotations generated from the same bound `Command` definition used by FastMCP. This prevents the current `/private/exomem/v1/contract` response and digest from changing while giving Substrate sufficient data for `tools/list`.
+
+The separate builder avoids changing the legacy contract. The cell additionally exposes authenticated profile-specific private endpoints; the public MCP transport and OAuth boundary still belong to Substrate.
+
+### 4. Profile enforcement happens at a distinct authenticated cell path
+
+The cell adds private agent-contract and agent-command routes scoped to the immutable profile. They use the same service authentication and trusted cell/principal context as existing private routes, but resolve commands only from the profile and bind the profile descriptor during invocation. Excluded commands fail with `COMMAND_NOT_FOUND` before a leaf or lifecycle admission runs. The existing full private contract/command routes remain unchanged for Home and control-plane workflows.
+
+The public caller never selects a profile through body, query, cookie, or untrusted header. The shared Substrate gateway pins the private route for its token policy and constructs the private request after resolving the authenticated account. A distinct public token audience/scope is part of the paired Substrate OAuth design; the cell continues to trust only its private service credential plus trusted routing context.
+
+### 5. One descriptor links contract discovery to bootstrap behavior
+
+`hosted_agent_surface_descriptor(profile)` is the sole constructor for the active Hosted agent descriptor. The derived contract embeds its metadata and fingerprint, and the agent-command route binds it around every invocation. A forwarded `bootstrap` therefore executes inside the cell with the exact descriptor, causing the existing recursive bootstrap filter to remove all unavailable tools, routes, and workflow guidance.
+
+Tests compare the contract command names, descriptor command names, fingerprint, and every callable reference extracted from all bootstrap profiles. This is the drift gate needed by both Claude and ChatGPT.
+
+### 6. Verification separates pure contracts from route integration
+
+Pure tests exercise registry, contract, descriptor, MCP schema, and bootstrap behavior without constructing POSIX-oriented runtime/temp directories. One focused ASGI integration test injects the existing test seams for runtime-temp authority, exercises the new authenticated routes, proves excluded commands never invoke a leaf, proves `bootstrap` reports the exact profile, and confirms the legacy route remains full. The untouched broad hosted-route baseline still runs in Linux/CI; it currently fails before route registration on Windows due to `os.geteuid` and Unix mode-bit assumptions.
+
+## Risks / Trade-offs
+
+- [Profile becomes stale as the product registry evolves] → Exact ordered membership and explicit forbidden-command tests fail on intentional or accidental change.
+- [Derived contract diverges from the full command schema] → Both builders share the same command serializer; tests compare every shared command entry for equality.
+- [Public MCP discovery loses validation or safety metadata] → Generate canonical FastMCP input schema and annotations from the same bound command functions and fingerprint the full agent contract.
+- [An agent rewrites governance or instruction files] → Keep arbitrary-page `edit_memory` and `replace_memory` outside v1; expose only constrained semantic-unit mutation through `observe_memory`.
+- [Bootstrap advertises a filtered-out route through nested guidance] → Reuse the active-surface filter and extract callable references from compact, full, and diagnostics payloads.
+- [A future gateway accidentally consumes the full contract] → Give the agent variant a stable profile identifier and fingerprint; the Substrate change must pin both.
+- [The alpha needs media or adoption sooner] → Add a new versioned profile; never revise `hosted-alpha-agent-v1` membership.
+
+## Migration Plan
+
+1. Land the additive profile metadata, builders, and tests with no runtime consumer.
+2. In the separate Substrate connector change, pin `hosted-alpha-agent-v1`, its membership fingerprint, and its full schema-contract digest while generating MCP discovery and forwarding policy.
+3. Forward agent calls only to the profile-specific private cell path; the cell binds the matching descriptor for `bootstrap` and every other command.
+4. Roll back by removing the consumer; the existing full private contract remains available and unchanged throughout.
+
+## Open Questions
+
+None for this Exomem-side slice. OAuth scopes and client-specific installation mechanics remain in the Substrate connector design.

--- a/openspec/changes/add-hosted-agent-surface-profile/proposal.md
+++ b/openspec/changes/add-hosted-agent-surface-profile/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The shared Hosted MCP facade needs one stable, least-privilege Exomem tool contract for Claude and ChatGPT. The cell currently publishes its complete private control-plane command registry, so consuming that contract directly would expose alpha-inappropriate operations and let the public gateway, bootstrap guidance, and future client packages drift apart.
+
+## What Changes
+
+- Add an immutable `hosted-alpha-agent-v1` profile beside the canonical product command registry.
+- Limit that profile to governed text-memory capture, recall, review, and connection operations; exclude transfers, adoption, media processing, maintenance/schema administration, coordination internals, and every Tier-2 operation.
+- Add a deterministic MCP-ready registry contract and capability fingerprint for the profile without changing the existing private cell contract or its digest.
+- Add authenticated private agent-contract and agent-command routes that enforce the profile and bind its active descriptor inside the cell.
+- Make `bootstrap` advertise only commands in the active Hosted agent profile when invoked through that surface.
+- Add drift and compatibility tests proving the profile is registry-derived, deterministic, internally coherent, and additive to existing Hosted behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-agent-surface`: Defines the versioned private-alpha agent tool profile, its deterministic contract, its bootstrap parity, and its compatibility boundary with the full private cell contract.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: the Exomem product profile registry, Hosted gateway contract generation, authenticated private Hosted routing, active capability metadata, and focused contract/bootstrap tests.
+- Consumers: the future Substrate shared MCP facade can consume the named profile instead of maintaining its own allowlist.
+- Compatibility: existing private routes, release manifests, control-plane fixtures, full MCP/REST/CLI surfaces, and their digests remain unchanged by default.
+- Explicitly out of scope: OAuth, public MCP transport, Substrate UI, provider infrastructure, deployment, client skill/plugin packaging, file transfer, media, adoption, and performance work.

--- a/openspec/changes/add-hosted-agent-surface-profile/specs/hosted-agent-surface/spec.md
+++ b/openspec/changes/add-hosted-agent-surface-profile/specs/hosted-agent-surface/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Hosted Alpha Agent Profile Is Explicit And Least Privilege
+
+The system SHALL define the immutable profile `hosted-alpha-agent-v1` in a canonical surface-profile registry beside the product command registry. The profile MUST contain exactly `bootstrap`, `ask_memory`, `read_memory`, `browse_memory`, `remember`, `observe_memory`, `capture_source`, `compile_source`, `preserve_evidence`, `review_memory`, `review_item_context`, `triage_memory`, and `connect_memory`, in its pinned order. Changing membership MUST require a new profile identifier.
+
+#### Scenario: Alpha profile is selected
+
+- **WHEN** a caller resolves `hosted-alpha-agent-v1` for the REST-backed Hosted agent surface
+- **THEN** the resolver returns exactly the thirteen named Tier-1 product commands in canonical registry order
+- **AND** every returned schema, description, route, and read/write classification comes from the corresponding canonical command entry
+
+#### Scenario: Broad operations are not exposed
+
+- **WHEN** the alpha profile is inspected
+- **THEN** it excludes broad page-level editing and replacement, coordination internals, transfer, media processing, adoption, maintenance, schema administration, and every Tier-2 command
+- **AND** those exclusions cannot be bypassed by selecting another surface or enabling Tier-2
+
+#### Scenario: Governance files cannot be rewritten through broad page mutation
+
+- **WHEN** an agent requests `edit_memory` or `replace_memory`, including with a path under `_Schema`
+- **THEN** the command is absent from the profile and rejected before invocation or lifecycle admission
+- **AND** governed semantic-unit mutation remains available through `observe_memory`
+
+### Requirement: Profile Membership Has One Declarative Source
+
+Profile membership SHALL be one immutable, ordered set-level policy in the canonical surface-profile registry. Gateway/transport code MUST NOT maintain another command-name allowlist or copied command schema for the Hosted agent surface, and an unknown profile identifier MUST fail closed.
+
+#### Scenario: Canonical command metadata changes
+
+- **WHEN** an included command's canonical parameter schema, description, route metadata, or read/write classification changes
+- **THEN** the next derived agent contract reflects that canonical change without a parallel schema edit
+
+#### Scenario: Unknown profile is requested
+
+- **WHEN** a caller requests an unregistered Hosted agent profile
+- **THEN** profile resolution fails with a stable error before returning any command contract
+
+### Requirement: Agent Gateway Contract Is Deterministic And Additive
+
+The system SHALL generate a deterministic Hosted agent gateway contract from the selected profile using the existing envelope contract, protocol compatibility policy, and canonical JSON digest. The contract SHALL include the profile identifier, exact active capability metadata, active capability fingerprint, full schema-contract digest, and canonical MCP discovery description, input JSON Schema, and annotations for every command. It MUST omit the unrelated private transfer-grant capability. The existing full private gateway contract MUST retain its current default shape, command set, and digest behavior.
+
+#### Scenario: Agent contract is generated twice
+
+- **WHEN** `hosted-alpha-agent-v1` is generated twice for the same release and protocol
+- **THEN** both canonical JSON payloads and digests are identical
+- **AND** the command list equals the resolved profile in the same order
+
+#### Scenario: Shared command is compared with the private contract
+
+- **WHEN** an agent-profile command is looked up in the full private contract
+- **THEN** its serialized command entry is identical in both contracts
+- **AND** the profile contract contains no command absent from the full private contract
+
+#### Scenario: Existing private contract is generated
+
+- **WHEN** the existing private gateway contract builder is called without an agent profile
+- **THEN** it returns the complete registry-derived private contract without agent-profile metadata
+- **AND** existing control-plane consumers do not need to opt into or understand the new profile
+
+### Requirement: Cell Enforces The Agent Profile On Authenticated Private Routes
+
+The cell SHALL expose authenticated profile-specific private contract and command routes without changing the existing full private routes. The agent command route MUST resolve commands only from the pinned profile, bind that profile's active surface descriptor during invocation, and reject an excluded or unknown command before leaf invocation or lifecycle admission. Profile selection MUST NOT be accepted from a public caller-controlled body, query, cookie, or untrusted header.
+
+#### Scenario: Trusted gateway invokes an allowed agent command
+
+- **WHEN** the authenticated control plane forwards a command to the private `hosted-alpha-agent-v1` agent route with valid trusted cell and principal context
+- **THEN** the cell resolves the command from that profile, binds the matching active descriptor, and invokes the canonical command through normal admission and idempotency handling
+
+#### Scenario: Trusted gateway invokes an excluded command
+
+- **WHEN** the authenticated control plane names transfer, adoption, media, maintenance, schema, coordination, Tier-2, or another command absent from `hosted-alpha-agent-v1`
+- **THEN** the cell returns `COMMAND_NOT_FOUND` before invoking a leaf or entering lifecycle admission
+- **AND** it does not fall back to the full private command router
+
+#### Scenario: Existing private command route is used
+
+- **WHEN** an existing Home or control-plane caller uses the legacy private command or contract route
+- **THEN** the complete existing private command surface and `private-command-router` descriptor remain available
+- **AND** its default contract shape and digest behavior are unchanged
+
+### Requirement: Bootstrap Matches The Active Hosted Agent Surface
+
+The system SHALL construct one active surface descriptor from `hosted-alpha-agent-v1` and SHALL use the same descriptor metadata and fingerprint in the derived contract and bootstrap context. For `compact`, `full`, and `diagnostics`, bootstrap MUST NOT advertise a product tool, callable route, example, or workflow step unavailable on the active profile.
+
+#### Scenario: Generic client bootstraps through the Hosted agent surface
+
+- **WHEN** `bootstrap` runs with the `hosted-alpha-agent-v1` active descriptor
+- **THEN** `active_capabilities` identifies that profile, disables Tier-2, lists exactly the profile commands, and carries the same fingerprint as the derived agent contract
+- **AND** every callable reference in the bootstrap payload belongs to the active descriptor
+
+#### Scenario: Excluded workflow guidance is filtered
+
+- **WHEN** bootstrap guidance would normally mention transfer, adoption, media, maintenance, schema, or Tier-2 operations
+- **THEN** the unavailable tool reference, route, example, or workflow entry is removed or marked unavailable
+- **AND** capture, recall, review, and connection guidance that remains executable is preserved

--- a/openspec/changes/add-hosted-agent-surface-profile/tasks.md
+++ b/openspec/changes/add-hosted-agent-surface-profile/tasks.md
@@ -13,4 +13,9 @@
 - [x] 3.1 Add failing tests that extract callable references from compact, full, and diagnostics bootstrap payloads and require every reference to belong to the active profile.
 - [x] 3.2 Add failing authenticated ASGI tests for the profile contract/command routes, allowed dispatch, excluded-command rejection before invocation, exact bootstrap descriptor binding, and unchanged legacy routes.
 - [x] 3.3 Implement the additive private agent routes by sharing existing auth, coercion, admission, idempotency, and error-envelope behavior; preserve useful filtered bootstrap guidance.
-- [ ] 3.4 Run focused tests, the platform-neutral lean suite, Ruff, strict OpenSpec validation, and an independent review; document the pre-existing Windows-only hosted-route baseline separately.
+- [x] 3.4 Run focused tests, the platform-neutral lean suite, Ruff, strict OpenSpec validation, and an independent review; document the pre-existing Windows-only hosted-route baseline separately.
+  - Focused Hosted/registry/bootstrap/MCP suite: 71 passed on the rebased branch; frozen route/security regression: 10 passed.
+  - Linux-native frozen lean run: 4,721 passed and 62 skipped. Its three unrelated failures were qualified against untouched `origin/main`: two transfer tests pass in isolation on both revisions and expire only after the suite exceeds their module-level five-minute grant fixture; one macOS installer test fails identically under WSL's injected Windows `PATH` and passes with a native Linux `PATH`.
+  - Changed-file Ruff, compileall, diff check, lock check, and strict OpenSpec validation passed.
+  - Independent verifier reported no remaining code findings after the broad-mutation denial regression covered both `edit_memory` and `replace_memory` while active and quiesced.
+  - The broader Windows baseline remains unsuitable as a green gate because pre-existing POSIX ownership/mode assumptions, invalid-byte filename collection, and missing `fcntl` fail outside this diff.

--- a/openspec/changes/add-hosted-agent-surface-profile/tasks.md
+++ b/openspec/changes/add-hosted-agent-surface-profile/tasks.md
@@ -1,0 +1,16 @@
+## 1. Pin The Canonical Profile
+
+- [x] 1.1 Add failing pure tests for the exact ordered `hosted-alpha-agent-v1` membership, forbidden broad operations, Tier-2 exclusion, and unknown-profile rejection.
+- [x] 1.2 Add the immutable set-level profile registry beside canonical product commands and implement the fail-closed profile resolver.
+
+## 2. Derive The Agent Contract
+
+- [x] 2.1 Add failing tests for deterministic agent-contract generation, canonical MCP input-schema/annotation fidelity, descriptor metadata/fingerprint parity, full contract digest, and unchanged default private-contract shape.
+- [x] 2.2 Implement the Hosted agent descriptor and additive MCP-ready derived gateway-contract builder from canonical bound commands.
+
+## 3. Prove Bootstrap And Compatibility
+
+- [x] 3.1 Add failing tests that extract callable references from compact, full, and diagnostics bootstrap payloads and require every reference to belong to the active profile.
+- [x] 3.2 Add failing authenticated ASGI tests for the profile contract/command routes, allowed dispatch, excluded-command rejection before invocation, exact bootstrap descriptor binding, and unchanged legacy routes.
+- [x] 3.3 Implement the additive private agent routes by sharing existing auth, coercion, admission, idempotency, and error-envelope behavior; preserve useful filtered bootstrap guidance.
+- [ ] 3.4 Run focused tests, the platform-neutral lean suite, Ruff, strict OpenSpec validation, and an independent review; document the pre-existing Windows-only hosted-route baseline separately.

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -23,8 +23,10 @@ import inspect
 import json
 import os
 import re
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from types import MappingProxyType
 from typing import Annotated, Any, Literal, NotRequired
 
 from fastmcp.tools import ToolResult
@@ -5911,6 +5913,50 @@ PRODUCT_PUBLIC_NAMES: tuple[str, ...] = tuple(c.name for c in PRODUCT_COMMANDS)
 PRODUCT_ROUTE_HELPERS: frozenset[str] = frozenset({"transfer_token"})
 HAND_REGISTERED_EXCEPTIONS: frozenset[str] = frozenset()
 
+HOSTED_ALPHA_AGENT_PROFILE = "hosted-alpha-agent-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ProductSurfaceProfile:
+    """One immutable, ordered exposure policy over canonical product commands."""
+
+    name: str
+    command_names: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        names = tuple(self.command_names)
+        if not self.name:
+            raise ValueError("product surface profile name must be non-empty")
+        if not names or any(not isinstance(name, str) or not name for name in names):
+            raise ValueError("product surface profile commands must be non-empty strings")
+        if len(names) != len(set(names)):
+            raise ValueError("product surface profile contains duplicate commands")
+        object.__setattr__(self, "command_names", names)
+
+
+PRODUCT_SURFACE_PROFILES = MappingProxyType(
+    {
+        HOSTED_ALPHA_AGENT_PROFILE: ProductSurfaceProfile(
+            name=HOSTED_ALPHA_AGENT_PROFILE,
+            command_names=(
+                "bootstrap",
+                "ask_memory",
+                "read_memory",
+                "browse_memory",
+                "remember",
+                "observe_memory",
+                "capture_source",
+                "compile_source",
+                "preserve_evidence",
+                "review_memory",
+                "review_item_context",
+                "triage_memory",
+                "connect_memory",
+            ),
+        )
+    }
+)
+
 
 def commands_for(surface: str, *, expose_tier2: bool = True) -> tuple[Command, ...]:
     """Canonical implementation commands exposed by the old primitive registry."""
@@ -5926,6 +5972,32 @@ def product_commands_for(surface: str, *, expose_tier2: bool = True) -> tuple[Co
         for c in PRODUCT_COMMANDS
         if surface in c.surfaces and (expose_tier2 or c.tier == 1)
     )
+
+
+def product_commands_for_profile(
+    profile: str,
+    surface: str,
+) -> tuple[Command, ...]:
+    """Resolve a pinned surface profile to its canonical command objects."""
+
+    definition = PRODUCT_SURFACE_PROFILES.get(profile)
+    if definition is None:
+        raise ValueError(f"unsupported product surface profile: {profile!r}")
+
+    canonical = {command.name: command for command in PRODUCT_COMMANDS}
+    selected: list[Command] = []
+    for name in definition.command_names:
+        command = canonical.get(name)
+        if command is None:
+            raise RuntimeError(
+                f"product surface profile {profile!r} references missing command {name!r}"
+            )
+        if command.tier != 1 or surface not in command.surfaces:
+            raise RuntimeError(
+                f"product surface profile {profile!r} cannot expose {name!r} on {surface!r}"
+            )
+        selected.append(command)
+    return tuple(selected)
 
 
 def validate_product_registry() -> dict:

--- a/src/exomem/hosted_gateway.py
+++ b/src/exomem/hosted_gateway.py
@@ -10,9 +10,12 @@ import re
 import time
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-from . import __version__
+from fastmcp.tools import FunctionTool
+
+from . import __version__, capabilities
 from . import commands as commands_module
 from .hosted_runtime import (
     HOSTED_PROTOCOL_VERSION,
@@ -113,6 +116,55 @@ def _command_contract(command: commands_module.Command) -> dict[str, Any]:
     }
 
 
+def _mcp_tool_contract(
+    command: commands_module.Command,
+    *,
+    descriptor: capabilities.ActiveSurfaceDescriptor,
+) -> dict[str, Any]:
+    injected: tuple[object, ...] = (
+        (Path("."), object()) if command.needs_schema else (Path("."),)
+    )
+    bound = commands_module.bind_vault(
+        command.leaf,
+        *injected,
+        name=command.name,
+        description=command.doc,
+        command=command,
+        surface_descriptor=descriptor,
+    )
+    tool = FunctionTool.from_function(
+        bound,
+        name=command.name,
+        annotations=command.mcp_annotations,
+    )
+    return tool.to_mcp_tool().model_dump(mode="json", by_alias=True)
+
+
+def hosted_agent_surface_descriptor(
+    profile: str = commands_module.HOSTED_ALPHA_AGENT_PROFILE,
+) -> capabilities.ActiveSurfaceDescriptor:
+    """Return the immutable descriptor for one supported Hosted agent profile."""
+
+    if profile != commands_module.HOSTED_ALPHA_AGENT_PROFILE:
+        raise HostedGatewayError(
+            "HOSTED_SURFACE_PROFILE_UNSUPPORTED",
+            "hosted agent surface profile is not supported",
+        )
+    try:
+        registry = commands_module.product_commands_for_profile(profile, "rest")
+    except ValueError as exc:
+        raise HostedGatewayError(
+            "HOSTED_SURFACE_PROFILE_UNSUPPORTED",
+            "hosted agent surface profile is not supported",
+        ) from exc
+    return capabilities.ActiveSurfaceDescriptor(
+        surface="hosted-agent",
+        profile=profile,
+        tier2_enabled=False,
+        product_commands=tuple(command.name for command in registry),
+    )
+
+
 def build_gateway_contract(
     *,
     protocol_version: str = HOSTED_PROTOCOL_VERSION,
@@ -175,6 +227,44 @@ def build_gateway_contract(
         },
         "commands": [_command_contract(command) for command in registry],
     }
+    return {
+        **base,
+        "digest": {
+            "algorithm": "sha256",
+            "value": hashlib.sha256(canonical_json(base)).hexdigest(),
+        },
+    }
+
+
+def build_agent_gateway_contract(
+    *,
+    profile: str = commands_module.HOSTED_ALPHA_AGENT_PROFILE,
+    protocol_version: str = HOSTED_PROTOCOL_VERSION,
+) -> dict[str, Any]:
+    """Build an MCP-ready, least-privilege contract for a Hosted agent surface."""
+
+    descriptor = hosted_agent_surface_descriptor(profile)
+    registry = commands_module.product_commands_for_profile(profile, "rest")
+    legacy = build_gateway_contract(
+        protocol_version=protocol_version,
+        expose_tier2=False,
+    )
+    base = {
+        key: value
+        for key, value in legacy.items()
+        if key not in {"commands", "digest", "transfer_grant"}
+    }
+    base["agent_profile"] = {
+        **descriptor.as_metadata(),
+        "immutable": True,
+    }
+    base["commands"] = [
+        {
+            **_command_contract(command),
+            "mcp_tool": _mcp_tool_contract(command, descriptor=descriptor),
+        }
+        for command in registry
+    ]
     return {
         **base,
         "digest": {
@@ -507,10 +597,12 @@ __all__ = [
     "HostedGatewayError",
     "TransferGrant",
     "TrustedGatewayContext",
+    "build_agent_gateway_contract",
     "build_gateway_contract",
     "canonical_contract_json",
     "canonical_json",
     "implicit_retry_scope",
+    "hosted_agent_surface_descriptor",
     "mint_transfer_grant",
     "scoped_idempotency_key",
     "validate_opaque_scope",

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -719,6 +719,14 @@ def register_hosted_routes(
         protocol_version=config.protocol_version,
         expose_tier2=expose_tier2,
     )
+    agent_profile = commands_module.HOSTED_ALPHA_AGENT_PROFILE
+    agent_commands = commands_module.product_commands_for_profile(agent_profile, "rest")
+    agent_commands_by_name = {command.name: command for command in agent_commands}
+    agent_surface_descriptor = gateway.hosted_agent_surface_descriptor(agent_profile)
+    agent_contract = gateway.build_agent_gateway_contract(
+        profile=agent_profile,
+        protocol_version=config.protocol_version,
+    )
     invoke = invoke_command_func
     if invoke is None:
         from .writer_lease import invoke_command
@@ -771,6 +779,43 @@ def register_hosted_routes(
         )
         return Response(
             gateway.canonical_contract_json(contract),
+            media_type="application/json",
+        )
+
+    @mcp_app.custom_route(
+        "/private/exomem/v1/agent/{surface_profile}/contract",
+        methods=["GET"],
+    )
+    async def _agent_contract(request: Request) -> Response:
+        started = time.perf_counter()
+        context: gateway.TrustedGatewayContext | None = None
+        try:
+            context = _trusted_context(request, config, private_authenticator)
+            surface_profile = str(request.path_params.get("surface_profile", ""))
+            if surface_profile != agent_profile:
+                raise gateway.HostedGatewayError(
+                    "HOSTED_SURFACE_PROFILE_UNSUPPORTED",
+                    "hosted agent surface profile is not supported",
+                )
+        except gateway.HostedGatewayError as exc:
+            return _error_response(
+                exc.code,
+                config=config,
+                operation="agent-contract",
+                request_id=context.request_id if context else None,
+                started=started,
+            )
+        assert context is not None
+        _trace(
+            config=config,
+            operation="agent-contract",
+            request_id=context.request_id,
+            outcome="success",
+            code="OK",
+            started=started,
+        )
+        return Response(
+            gateway.canonical_contract_json(agent_contract),
             media_type="application/json",
         )
 
@@ -830,8 +875,12 @@ def register_hosted_routes(
             started=started,
         )
 
-    @mcp_app.custom_route("/private/exomem/v1/command/{command_name}", methods=["POST"])
-    async def _command(request: Request) -> HostedJSONResponse:
+    async def _execute_command(
+        request: Request,
+        *,
+        command_map: Mapping[str, commands_module.Command],
+        descriptor: capabilities.ActiveSurfaceDescriptor,
+    ) -> HostedJSONResponse:
         started = time.perf_counter()
         operation = "command"
         context: gateway.TrustedGatewayContext | None = None
@@ -839,7 +888,7 @@ def register_hosted_routes(
             context = _trusted_context(request, config, private_authenticator)
             body = await _json_body(request)
             command_name = str(request.path_params.get("command_name", ""))
-            command = by_name.get(command_name)
+            command = command_map.get(command_name)
             if command is None:
                 raise cli_ops.OpError("COMMAND_NOT_FOUND", "command is not exposed")
             if command.leaf is commands_module.op_transfer_artifact:
@@ -866,7 +915,7 @@ def register_hosted_routes(
             )
 
             def invoke_admitted() -> Any:
-                with capabilities.active_surface(surface_descriptor):
+                with capabilities.active_surface(descriptor):
                     if commands_module.invocation_is_read_only(command, kwargs):
                         with lifecycle.admit_read():
                             return invoke(
@@ -931,6 +980,45 @@ def register_hosted_routes(
             operation=operation,
             request_id=context.request_id,
             started=started,
+        )
+
+    @mcp_app.custom_route("/private/exomem/v1/command/{command_name}", methods=["POST"])
+    async def _command(request: Request) -> HostedJSONResponse:
+        return await _execute_command(
+            request,
+            command_map=by_name,
+            descriptor=surface_descriptor,
+        )
+
+    @mcp_app.custom_route(
+        "/private/exomem/v1/agent/{surface_profile}/command/{command_name}",
+        methods=["POST"],
+    )
+    async def _agent_command(request: Request) -> HostedJSONResponse:
+        surface_profile = str(request.path_params.get("surface_profile", ""))
+        if surface_profile != agent_profile:
+            started = time.perf_counter()
+            context: gateway.TrustedGatewayContext | None = None
+            try:
+                context = _trusted_context(request, config, private_authenticator)
+            except gateway.HostedGatewayError as exc:
+                return _error_response(
+                    exc.code,
+                    config=config,
+                    operation="agent-command",
+                    started=started,
+                )
+            return _error_response(
+                "HOSTED_SURFACE_PROFILE_UNSUPPORTED",
+                config=config,
+                operation="agent-command",
+                request_id=context.request_id,
+                started=started,
+            )
+        return await _execute_command(
+            request,
+            command_map=agent_commands_by_name,
+            descriptor=agent_surface_descriptor,
         )
 
     async def lifecycle_context(

--- a/tests/test_hosted_agent_surface.py
+++ b/tests/test_hosted_agent_surface.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import commands
+from exomem import hosted_gateway as gateway
+from exomem.capabilities import active_surface
+
+ALPHA_PROFILE = "hosted-alpha-agent-v1"
+ALPHA_COMMANDS = (
+    "bootstrap",
+    "ask_memory",
+    "read_memory",
+    "browse_memory",
+    "remember",
+    "observe_memory",
+    "capture_source",
+    "compile_source",
+    "preserve_evidence",
+    "review_memory",
+    "review_item_context",
+    "triage_memory",
+    "connect_memory",
+)
+FORBIDDEN_COMMANDS = {
+    "coordination_status",
+    "edit_memory",
+    "replace_memory",
+    "transfer_artifact",
+    "process_media",
+    "adopt_vault",
+    "adoption_studio",
+    "maintain_memory",
+    "schema_memory",
+    "manage_memory_file",
+    "query_dataset",
+    "read_media",
+}
+MCP_SCHEMA_FIXTURE = Path(__file__).parent / "fixtures" / "mcp_tool_schemas.json"
+
+
+def test_hosted_alpha_agent_profile_is_exact_and_fail_closed() -> None:
+    resolver = getattr(commands, "product_commands_for_profile", None)
+    assert resolver is not None, "missing canonical product surface-profile resolver"
+
+    selected = resolver(ALPHA_PROFILE, "rest")
+
+    assert tuple(command.name for command in selected) == ALPHA_COMMANDS
+    assert all(command.tier == 1 for command in selected)
+    assert all("rest" in command.surfaces for command in selected)
+    assert FORBIDDEN_COMMANDS.isdisjoint(command.name for command in selected)
+    canonical = {command.name: command for command in commands.PRODUCT_COMMANDS}
+    assert all(command is canonical[command.name] for command in selected)
+
+    with pytest.raises(ValueError, match="unsupported product surface profile"):
+        resolver("hosted-alpha-agent-v999", "rest")
+
+
+@pytest.mark.parametrize("surface", ["mcp", "rest", "cli"])
+def test_hosted_alpha_membership_cannot_expand_on_another_surface(surface: str) -> None:
+    resolver = getattr(commands, "product_commands_for_profile", None)
+    assert resolver is not None, "missing canonical product surface-profile resolver"
+
+    selected = resolver(ALPHA_PROFILE, surface)
+
+    assert tuple(command.name for command in selected) == ALPHA_COMMANDS
+    assert FORBIDDEN_COMMANDS.isdisjoint(command.name for command in selected)
+
+
+def test_agent_contract_is_mcp_ready_deterministic_and_additive() -> None:
+    descriptor_builder = getattr(gateway, "hosted_agent_surface_descriptor", None)
+    contract_builder = getattr(gateway, "build_agent_gateway_contract", None)
+    assert descriptor_builder is not None, "missing Hosted agent surface descriptor"
+    assert contract_builder is not None, "missing Hosted agent gateway contract"
+
+    descriptor = descriptor_builder(ALPHA_PROFILE)
+    contract = contract_builder(profile=ALPHA_PROFILE)
+    repeated = contract_builder(profile=ALPHA_PROFILE)
+    legacy = gateway.build_gateway_contract()
+
+    assert gateway.canonical_contract_json(contract) == gateway.canonical_contract_json(
+        repeated
+    )
+    assert tuple(entry["name"] for entry in contract["commands"]) == ALPHA_COMMANDS
+    assert contract["agent_profile"] == {
+        **descriptor.as_metadata(),
+        "immutable": True,
+    }
+    assert descriptor.product_commands == ALPHA_COMMANDS
+    assert descriptor.tier2_enabled is False
+    assert descriptor.fingerprint == contract["agent_profile"][
+        "active_capability_sha256"
+    ]
+
+    unsigned = dict(contract)
+    digest = unsigned.pop("digest")
+    assert digest == {
+        "algorithm": "sha256",
+        "value": hashlib.sha256(gateway.canonical_json(unsigned)).hexdigest(),
+    }
+    assert set(legacy) == {
+        "schema_version",
+        "protocol_version",
+        "exomem_release",
+        "compatibility",
+        "trusted_headers",
+        "envelopes",
+        "transfer_grant",
+        "commands",
+        "digest",
+    }
+    assert "agent_profile" not in legacy
+    assert "transfer_grant" not in contract
+
+    fixture = json.loads(MCP_SCHEMA_FIXTURE.read_text(encoding="utf-8"))
+    canonical_commands = {command.name: command for command in commands.PRODUCT_COMMANDS}
+    legacy_entries = {entry["name"]: entry for entry in legacy["commands"]}
+    for entry in contract["commands"]:
+        name = entry["name"]
+        mcp_tool = entry["mcp_tool"]
+        base_entry = {key: value for key, value in entry.items() if key != "mcp_tool"}
+        assert base_entry == legacy_entries[name]
+        assert mcp_tool["name"] == name
+        assert mcp_tool["description"] == fixture[name]["description"]
+        assert mcp_tool["inputSchema"] == fixture[name]["inputSchema"]
+        assert mcp_tool["annotations"] == canonical_commands[
+            name
+        ].mcp_annotations.model_dump(mode="json", by_alias=True)
+
+
+def test_agent_contract_rejects_unknown_profile_with_stable_error() -> None:
+    contract_builder = getattr(gateway, "build_agent_gateway_contract", None)
+    assert contract_builder is not None, "missing Hosted agent gateway contract"
+
+    with pytest.raises(gateway.HostedGatewayError) as error:
+        contract_builder(profile="hosted-alpha-agent-v999")
+
+    assert error.value.code == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"
+
+
+@pytest.mark.parametrize("bootstrap_profile", ["compact", "full", "diagnostics"])
+def test_agent_bootstrap_advertises_only_the_active_profile(
+    tmp_path: Path,
+    bootstrap_profile: str,
+) -> None:
+    descriptor = gateway.hosted_agent_surface_descriptor(ALPHA_PROFILE)
+
+    with active_surface(descriptor):
+        payload = commands.op_bootstrap(tmp_path, profile=bootstrap_profile)
+
+    assert payload["active_capabilities"] == descriptor.as_metadata()
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert all(name not in serialized for name in FORBIDDEN_COMMANDS)
+    for action in ("ask", "remember", "capture", "review", "connect"):
+        route = payload["simple_actions"][action]["route"]
+        assert route["tool"] in descriptor.callable_commands
+    for action in ("adopt", "maintain"):
+        assert payload["simple_actions"][action]["available"] is False
+        assert "route" not in payload["simple_actions"][action]

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -678,11 +678,8 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
         for call in mutation_calls
     )
 
-    calls_before_exclusion = len(invoker.calls)
-    excluded = client.post(
-        f"{command_path}/edit_memory",
-        headers=headers,
-        json={
+    broad_mutation_bodies = {
+        "edit_memory": {
             "path": "_Schema/SKILL.md",
             "why": "must never reach the hosted agent invoker",
             "operation": {
@@ -691,12 +688,37 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
                 "new": "rewritten",
             },
         },
-    )
-    assert excluded.status_code == 404
-    assert excluded.json()["error"]["code"] == "COMMAND_NOT_FOUND"
-    assert len(invoker.calls) == calls_before_exclusion
+        "replace_memory": {
+            "old_path": "Knowledge Base/_Schema/SKILL.md",
+            "title": "Rewritten governance",
+            "content": "# Rewritten governance\n",
+        },
+    }
+    calls_before_exclusion = len(invoker.calls)
+    for command_name, body in broad_mutation_bodies.items():
+        excluded = client.post(
+            f"{command_path}/{command_name}",
+            headers=headers,
+            json=body,
+        )
+        assert excluded.status_code == 404
+        assert excluded.json()["error"]["code"] == "COMMAND_NOT_FOUND"
+        assert len(invoker.calls) == calls_before_exclusion
 
     lifecycle.quiesce(timeout=0.1)
+    for command_name, body in broad_mutation_bodies.items():
+        excluded_while_quiesced = client.post(
+            f"{command_path}/{command_name}",
+            headers=headers,
+            json=body,
+        )
+        assert excluded_while_quiesced.status_code == 404
+        assert (
+            excluded_while_quiesced.json()["error"]["code"]
+            == "COMMAND_NOT_FOUND"
+        )
+        assert len(invoker.calls) == calls_before_exclusion
+
     rejected_while_quiesced = client.post(
         f"{command_path}/remember",
         headers=_headers(

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -23,6 +23,7 @@ from exomem import (
     find_corpus,
     hosted_portability,
     hosted_runtime,
+    hosted_runtime_temp,
     preserve,
     privacy_log,
     schema,
@@ -586,6 +587,150 @@ def test_hosted_bootstrap_profiles_match_private_command_contract(
             assert {"manage_memory_file", "query_dataset"}.isdisjoint(
                 _hosted_bootstrap_tool_refs(payload)
             )
+
+
+def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hosted_runtime_temp,
+        "ensure_hosted_runtime_temp",
+        lambda *_args, **_kwargs: tmp_path / "runtime-temp",
+    )
+    monkeypatch.setattr(
+        hosted_runtime_temp,
+        "HostedRuntimeTempAuthority",
+        lambda *_args, **_kwargs: object(),
+    )
+    client, config, lifecycle, invoker = _cell(
+        tmp_path,
+        cell_id="cell-agent-alpha",
+        credential="agent-alpha-private-service-credential-0001",
+    )
+    headers = _headers(config)
+    profile = commands_module.HOSTED_ALPHA_AGENT_PROFILE
+    contract_path = f"/private/exomem/v1/agent/{profile}/contract"
+    command_path = f"/private/exomem/v1/agent/{profile}/command"
+
+    assert client.get(contract_path).status_code == 401
+    assert client.post(f"{command_path}/remember", json=_remember_body("no auth")).status_code == 401
+    contract_response = client.get(contract_path, headers=headers)
+    assert contract_response.status_code == 200, contract_response.text
+    contract = contract_response.json()
+    command_names = tuple(command["name"] for command in contract["commands"])
+    expected = tuple(
+        command.name
+        for command in commands_module.product_commands_for_profile(profile, "rest")
+    )
+    assert command_names == expected
+    assert contract["agent_profile"]["profile"] == profile
+    assert "transfer_grant" not in contract
+
+    legacy = client.get("/private/exomem/v1/contract", headers=headers).json()
+    legacy_names = {command["name"] for command in legacy["commands"]}
+    assert set(expected) < legacy_names
+    assert {"maintain_memory", "adoption_studio", "transfer_artifact"} <= legacy_names
+    assert "agent_profile" not in legacy
+
+    for bootstrap_profile in ("compact", "full", "diagnostics"):
+        response = client.post(
+            f"{command_path}/bootstrap",
+            headers=headers,
+            json={"profile": bootstrap_profile},
+        )
+        assert response.status_code == 200, response.text
+        payload = response.json()["data"]
+        active = payload["active_capabilities"]
+        assert active["profile"] == profile
+        assert active["surface"] == "hosted-agent"
+        assert active["tier2_policy"] == "disabled"
+        assert active["available_product_tools"] == sorted(expected)
+        assert active["active_capability_sha256"] == contract["agent_profile"][
+            "active_capability_sha256"
+        ]
+        assert _hosted_bootstrap_tool_refs(payload) <= set(expected)
+
+    mutation_headers = _headers(
+        config,
+        request_id="de305d54-75b4-431b-adb2-eb6b9e546051",
+        idempotency_key="agent-profile-remember-0001",
+    )
+    remembered = client.post(
+        f"{command_path}/remember",
+        headers=mutation_headers,
+        json=_remember_body("agent profile mutation sentinel"),
+    )
+    replayed = client.post(
+        f"{command_path}/remember",
+        headers=mutation_headers,
+        json=_remember_body("agent profile mutation sentinel"),
+    )
+    assert remembered.status_code == 200, remembered.text
+    assert replayed.status_code == 200, replayed.text
+    assert replayed.json()["data"] == remembered.json()["data"]
+    mutation_calls = [call for call in invoker.calls if call["command"] == "remember"]
+    assert len(mutation_calls) == 2
+    assert all(
+        call["public_idempotency_key"] == "agent-profile-remember-0001"
+        and call["idempotency_key"]
+        and call["request_id"] == "de305d54-75b4-431b-adb2-eb6b9e546051"
+        for call in mutation_calls
+    )
+
+    calls_before_exclusion = len(invoker.calls)
+    excluded = client.post(
+        f"{command_path}/edit_memory",
+        headers=headers,
+        json={
+            "path": "_Schema/SKILL.md",
+            "why": "must never reach the hosted agent invoker",
+            "operation": {
+                "kind": "replace_text",
+                "old": "governed",
+                "new": "rewritten",
+            },
+        },
+    )
+    assert excluded.status_code == 404
+    assert excluded.json()["error"]["code"] == "COMMAND_NOT_FOUND"
+    assert len(invoker.calls) == calls_before_exclusion
+
+    lifecycle.quiesce(timeout=0.1)
+    rejected_while_quiesced = client.post(
+        f"{command_path}/remember",
+        headers=_headers(
+            config,
+            request_id="de305d54-75b4-431b-adb2-eb6b9e546052",
+            idempotency_key="agent-profile-quiesced-0001",
+        ),
+        json=_remember_body("must not pass mutation admission"),
+    )
+    assert rejected_while_quiesced.status_code == 503
+    assert (
+        rejected_while_quiesced.json()["error"]["code"]
+        == "HOSTED_MUTATION_NOT_ADMITTED"
+    )
+    assert len(invoker.calls) == calls_before_exclusion
+
+    unknown = client.get(
+        "/private/exomem/v1/agent/hosted-alpha-agent-v999/contract",
+        headers=headers,
+    )
+    assert unknown.status_code == 400
+    assert unknown.json()["error"]["code"] == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"
+
+    unknown_command = client.post(
+        "/private/exomem/v1/agent/hosted-alpha-agent-v999/command/remember",
+        headers=headers,
+        json=_remember_body("unknown profile"),
+    )
+    assert unknown_command.status_code == 400
+    assert (
+        unknown_command.json()["error"]["code"]
+        == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"
+    )
+    assert len(invoker.calls) == calls_before_exclusion
 
 
 def _remember_body(sentinel: str) -> dict[str, str]:


### PR DESCRIPTION
## What changed

- add the immutable `hosted-alpha-agent-v1` product-surface profile with 13 governed memory commands
- derive an MCP-ready Hosted agent contract from canonical command schemas and annotations
- add authenticated profile-specific private contract and command routes
- bind bootstrap and execution to the exact active-surface descriptor
- keep the existing full private Hosted contract and routes unchanged

## Why

The shared Hosted gateway needs a small, enforceable agent surface for Claude and ChatGPT. Discovery filtering alone was insufficient because the existing private cell dispatcher still exposed the broader control-plane surface.

The v1 profile deliberately excludes arbitrary page mutation (`edit_memory`, `replace_memory`), transfer metadata, admin/schema operations, media, adoption, coordination internals, and Tier-2 commands. Governed semantic-unit mutation remains available through `observe_memory`.

## Impact

Substrate can pin one deterministic profile fingerprint and schema-contract digest, generate MCP discovery from the cell contract, and forward calls to a cell route that enforces the same command set. Existing Home/control-plane consumers retain their current contract and behavior.

## Validation

- 71 focused Hosted/registry/bootstrap/MCP tests passed
- frozen route/security regression: 10 passed
- changed-file Ruff, compileall, lock check, diff check, and strict OpenSpec validation passed
- independent verifier: ready, no remaining blocker
- Linux lean run: 4,721 passed, 62 skipped; three unrelated environment/baseline failures were qualified against `origin/main` and documented in the OpenSpec checklist
