### PR TITLE
Separate hosted release and black-box proofs

### DIFF
--- a/.github/workflows/hosted-infrastructure.yml
+++ b/.github/workflows/hosted-infrastructure.yml
@@ -30,6 +30,11 @@ on:
         description: Exact published ghcr.io/artexis10/exomem-provisioner@sha256 digest
         required: false
         type: string
+      external_blackbox:
+        description: Run the deployed availability, backup-freshness, and scheduler probes
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -132,7 +137,7 @@ jobs:
             --require-published
 
   external-blackbox:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.external_blackbox)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -118,10 +118,19 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
         "bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea"
     ) in tool_versions
     parsed = yaml.safe_load(workflow)
+    triggers = parsed.get("on", parsed.get(True))
+    blackbox_input = triggers["workflow_dispatch"]["inputs"]["external_blackbox"]
+    assert blackbox_input["default"] is False
+    assert blackbox_input["type"] == "boolean"
     assert parsed["jobs"]["static"]["name"] == "Offline static validation (not release proof)"
     release_job = parsed["jobs"]["release-proof"]
     assert release_job["needs"] == "static"
     assert "inputs.release_proof" in release_job["if"]
+    blackbox_job = parsed["jobs"]["external-blackbox"]
+    assert blackbox_job["if"] == (
+        "github.event_name == 'schedule' || "
+        "(github.event_name == 'workflow_dispatch' && inputs.external_blackbox)"
+    )
     assert "--fetch-substrate-fixture" in workflow
     assert "--probe-image" in workflow
     assert "--require-published" in workflow


### PR DESCRIPTION
## Summary

- add an explicit false-by-default external_blackbox workflow-dispatch input
- keep scheduled black-box probes unchanged
- let release_proof run independently before a deployment exists
- lock the exact trigger semantics in the hosted workflow contract test

## Root cause

A manual release-proof dispatch also unconditionally started external-blackbox. Before the live deployment and its three URLs exist, that independent probe correctly fails and makes the otherwise valid artifact-proof workflow red.

## Verification

- red first: hosted workflow contract test failed on the missing input
- tests/test_hosted_platform_operations.py: 51 passed
- pinned Ruff: passed
- git diff --check: passed
- independent re-review: clean