### PR TITLE
fix(release): enforce parseable squash titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,25 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    steps:
+      # Use the base revision so a pull request cannot weaken its own title gate.
+      - name: Check out trusted base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Validate pull-request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python scripts/check_pr_title.py "$PR_TITLE"

--- a/docs/release.md
+++ b/docs/release.md
@@ -106,6 +106,28 @@ Use scopes when helpful, for example `feat(doctor): ...` or
 changelog by default and do not drive releases unless they include a breaking
 marker.
 
+GitHub squash merges use the pull-request title as the resulting commit header,
+so the `Conventional Commit title` PR check validates this exact shape:
+
+```text
+<lowercase-type>[optional scope][!]: <non-empty description>
+```
+
+For example, `fix(release): preserve parsed squash commits` and
+`feat(api)!: replace the response contract` pass; `Fix the release pipeline`
+does not. Any lowercase Conventional Commit type is parseable, but only the
+non-breaking types configured in `release-please-config.json` drive a normal
+version bump or receive a named changelog section. A breaking `!` on any
+parseable type can drive the configured breaking-release bump.
+
+The `main` branch ruleset must require the `Conventional Commit title` status
+check. Without that repository setting, the workflow reports an invalid title
+but GitHub does not block the merge. To check a title locally, run:
+
+```bash
+python scripts/check_pr_title.py "fix(release): preserve parsed squash commits"
+```
+
 ## Release flow
 
 1. Merge feature/fix PRs to `main` using Conventional Commit titles.

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,46 @@
+"""Validate that a PR title is a Release Please-compatible commit header."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+
+_CONVENTIONAL_HEADER = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^()\r\n]+)\))?(?P<breaking>!)?: "
+    r"(?P<description>\S(?:.*\S)?)$"
+)
+_EXPECTED = "<type>[optional scope][!]: <description>"
+
+
+def validate_pr_title(title: str) -> str | None:
+    """Return an explanation when *title* is not a conventional commit header."""
+
+    if _CONVENTIONAL_HEADER.fullmatch(title) is None:
+        return (
+            f"expected {_EXPECTED} with a lowercase type, optional non-empty scope, "
+            "and non-empty description without surrounding whitespace"
+        )
+    return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("title", help="pull-request title to validate")
+    args = parser.parse_args(argv)
+
+    error = validate_pr_title(args.title)
+    if error is not None:
+        print(f"Invalid PR title: {error}.", file=sys.stderr)
+        print("Examples:", file=sys.stderr)
+        print("  fix: describe the change", file=sys.stderr)
+        print("  feat(parser)!: describe the breaking change", file=sys.stderr)
+        return 1
+
+    print(f"Valid PR title: {args.title}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_pr_title.py
+++ b/tests/test_check_pr_title.py
@@ -1,0 +1,92 @@
+"""Contract tests for the pull-request title release guard."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "check_pr_title.py"
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "pr-title.yml"
+
+
+def _load_script_module():
+    assert SCRIPT.is_file(), "the reusable PR-title checker must exist"
+    spec = importlib.util.spec_from_file_location("check_pr_title_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "fix: preserve release commits",
+        "feat(parser): accept scoped titles",
+        "feat!: change the public contract",
+        "feat(api)!: change the public contract",
+        "chore(deps-dev): refresh the lockfile",
+        "revert: restore the previous behavior",
+        "refactor!: remove the legacy contract",
+        "docs(release): explain the title contract",
+    ],
+)
+def test_validate_pr_title_accepts_conventional_commit_headers(title: str) -> None:
+    checker = _load_script_module()
+
+    assert checker.validate_pr_title(title) is None
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Fix release title parsing",
+        "fix release title parsing",
+        "Fix: reject uppercase types",
+        "fix:",
+        "fix: ",
+        "fix(): reject an empty scope",
+        "fix(scope: reject an unclosed scope",
+        " fix: reject leading whitespace",
+        "fix: reject trailing whitespace ",
+        "fix(scope)! : reject spacing before the colon",
+    ],
+)
+def test_validate_pr_title_rejects_unparseable_squash_headers(title: str) -> None:
+    checker = _load_script_module()
+
+    assert checker.validate_pr_title(title) is not None
+
+
+def test_main_reports_a_useful_error_for_an_invalid_title(capsys) -> None:
+    checker = _load_script_module()
+
+    assert checker.main(["Fix the release pipeline"]) == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert "Invalid PR title" in output.err
+    assert "fix: describe the change" in output.err
+    assert "feat(parser)!: describe the breaking change" in output.err
+
+
+def test_main_accepts_a_valid_title(capsys) -> None:
+    checker = _load_script_module()
+
+    assert checker.main(["fix(release): preserve parsed squash commits"]) == 0
+    output = capsys.readouterr()
+    assert output.err == ""
+    assert "Valid PR title" in output.out
+
+
+def test_workflow_checks_edited_titles_with_the_trusted_base_script() -> None:
+    assert WORKFLOW.is_file(), "the PR-title workflow must exist"
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request_target:" in text
+    assert "types: [opened, edited, reopened, synchronize]" in text
+    assert "permissions:\n  contents: read" in text
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in text
+    assert 'python scripts/check_pr_title.py "$PR_TITLE"' in text


### PR DESCRIPTION
## Why

Release Please reads the squash-merge commit header, which GitHub derives from the PR title. PR #299 and several preceding merges used prose titles, so the release workflow succeeded while logging unparseable commits and opening no release PR.

## What changed

- validate PR titles with a reusable Conventional Commit header checker
- run the checker from a trusted-base pull_request_target workflow so a PR cannot weaken its own gate
- cover accepted, rejected, breaking, CLI, and workflow wiring behavior
- document the exact squash-title and Release Please semantics

## Verification

- 21 focused tests passed
- Ruff passed
- git diff check passed
- independent review completed; findings resolved

## After merge

Configure the main branch ruleset to require the `Conventional Commit title` status check. This merge is intentionally titled as a `fix(release): ...` commit so Release Please can create the patch release that carries PR #299.