### PR TITLE
fix: restore fast reliable recall and writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
         # so it ALSO runs in the lean matrix; pinned here as the benchmark gate's
         # home next to the golden quality gate.
         run: uv run --frozen python -m pytest tests/test_latency_gate.py -q
+      - name: Semantic validate and commit latency scaling gate (2k and 8k)
+        # Aggregate timings only: the foreground semantic path must stay bounded
+        # after startup warm-up and must not regress to corpus-wide parse/resolver
+        # work when the corpus grows 4x.
+        run: uv run --frozen python scripts/semantic_write_latency.py --check
 
   onboarding:
     name: onboarding (wheel path)

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ pytest-cache-files-*/
 .pytest-tmp/
 .review-basetemp-*/
 .tmp-product-benchmark/
+.bench-*/
+.benchmark-*/
+.semantic-latency-*/
 .codex-manual-cache/
 .python-write-probe/
 .surface-probe/
@@ -71,3 +74,4 @@ infra/provisioner/.ruff_cache/
 infra/provisioner/.pytest_cache/
 infra/provisioner/*.sqlite*
 .refs.sqlite
+.lexical.sqlite*

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ uv tool install exomem   # or: pip install exomem
 exomem setup --vault "/path/to/your/Obsidian"
 ```
 
+Re-running the one-line installer upgrades an existing uv-tool install instead
+of leaving an older `exomem` command on PATH. `exomem --version --json` is a
+model-free provenance check, so it also works in the intentional lean CLI paired
+with a fuller managed service.
+
 One command does the whole local setup: the wizard scans your vault and shows
 what's already there, initializes `Knowledge Base/`, runs the `doctor`
 preflight, registers the server with every client it detects (Claude Code and

--- a/deploy/chatgpt/personal-plugin-contract.json
+++ b/deploy/chatgpt/personal-plugin-contract.json
@@ -9,7 +9,7 @@
     "offline_access"
   ],
   "registered_tool_surface_sha256": "3fb189ee7d9e48183c404d5b5d36df3c36d5e8df995b7e4cd78ad8c763672ae6",
-  "pending_tool_surface_sha256": "a82e7dd233501b0fe5383ac1ed8dab81d4fe31580214ecc1e1fba1f5f8c0ff03",
+  "pending_tool_surface_sha256": "fbb09bb51901121075805a331a62f3ff963caac566d718c6695fccda872a11d4",
   "refresh_required": true,
   "rollout_state": "awaiting-post-deploy-refresh",
   "last_verified_release": "0.25.5",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -318,12 +318,33 @@ pwsh -File scripts/install-service.ps1 -Release
 
 ```powershell
 pwsh -File scripts/upgrade.ps1
+# Explicit policy: -CliSync auto|always|never (default: auto)
 ```
 
 The service runs a PyPI-backed venv that is **not** the repo checkout, so `git pull`
 never touches it. `upgrade.ps1` locates that venv from the NSSM registry, upgrades
 it, repairs the CUDA torch build, gates on `doctor`, restarts, and then asserts the
-**live** `/health` version matches what it just installed. No elevation needed.
+**live** `/health` version matches what it just installed. It then records a
+non-secret managed-install manifest and, in the default `auto` mode, aligns an
+existing uv-managed `exomem`/`kb` command to that exact verified release. `auto`
+never installs a command that was absent; `always` may install it; `never` leaves
+CLI management alone. `-SkipRestart` stages only the service venv and deliberately
+defers CLI alignment until a later run verifies the live release. No elevation is
+needed.
+
+The CLI and service need release parity, not dependency parity. The uv-tool CLI
+stays lean while a `standard` or `media` service keeps its embedding/media extras;
+duplicating Torch and model dependencies into the command environment is wasteful.
+Check the resolved command and its paired service identity without loading those
+optional stacks:
+
+```powershell
+exomem --version --json
+kb --version
+```
+
+On macOS/Linux, `bash scripts/upgrade.sh` provides the same behavior with
+`--cli-sync auto|always|never`.
 
 Releases carrying semantic parser changes bump the parser generation used by the
 lexical, vector, graph, pack, and count sidecars. Canonical Markdown is not
@@ -509,7 +530,7 @@ change the payload or create a fresh explicit identity to recover a pending or
 committed-uncertain acknowledgement: retry only with the same identity as
 directed, or reconcile.
 
-Expected MCP operation refusals such as `MUTATION_BUSY` are normal tool content:
+Expected MCP operation refusals such as `MUTATION_WARMING` and `MUTATION_BUSY` are normal tool content:
 inspect top-level `success: false` and the structured `error` object, then follow
 its retry fields. They are not transport failures. A `receipt_id` is diagnostic,
 not a caller-supplied cross-session replay key; effective retry identity remains
@@ -824,9 +845,11 @@ curl -s http://127.0.0.1:8765/health
 
 `install_source` is the field that matters. `wheel` with a null `revision` means the server
 is **not** running a local checkout — upgrade the venv directly. `editable` reports the git
-`revision` it is serving. For full detail including the interpreter path, run
-`exomem install-info` locally; `/health` withholds paths because it is unauthenticated and
-publicly reachable.
+`revision` it is serving. For local CLI/service release, profile, route, and
+interpreter identity, run `exomem --version --json` (or `exomem install-info`);
+`/health` withholds local paths because it is unauthenticated and publicly
+reachable. A false `version_match` means the shell command and managed service
+are split and should be reconciled before treating the upgrade as complete.
 
 The scripted path resolves the interpreter from NSSM, gates on `doctor` and accelerator
 capability, restarts, and verifies the running version:

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,9 +67,10 @@ Release Please handles the version bump and PyPI publish. Around it:
    images.
 2. `exomem package-skills --plugin-root plugins/claude-code` if the scaffold
    changed, and commit the result. CI catches you if you forget.
-3. On each self-hosted box: `pwsh -File scripts/upgrade.ps1` (Windows) or re-run
-   `scripts/install-service.sh --release`. It asserts the live `/health` version
-   matches what it installed.
+3. On each self-hosted box: `pwsh -File scripts/upgrade.ps1` (Windows) or
+   `bash scripts/upgrade.sh` (macOS/Linux). It asserts the live `/health` version,
+   records the managed profile, and reconciles any existing uv-tool CLI to that
+   exact release without copying the service's heavy extras.
 4. Re-upload the web-client archives only when `SKILL.md` itself changed — the MCP
    surface upgrades with the server, so most releases need no re-upload.
 

--- a/openspec/changes/restore-fast-runtime-and-install-parity/.openspec.yaml
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/restore-fast-runtime-and-install-parity/design.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The source of truth remains Markdown, but several foreground paths reconstruct derived corpus state from that source on every request or after any corpus change:
+
+- `semantic_writes.preflight_existing()` calls `semantic_contract.build_corpus_context()` for every validation. Its cache key is a full `(path, size, mtime_ns)` census, so Syncthing, media sidecars, or any unrelated Markdown write causes another whole-vault rebuild.
+- mixed/unit recall walks every eligible Markdown file and calls `semantic_index.current_parent_index_state()` before querying the semantic-unit sidecars.
+- `scope="kb"` auto-widen calls vault-scope BM25 and can rebuild the entire outside-KB corpus under ordinary churn.
+- validate and commit are separate stateless calls, so they both repeat preflight work.
+- the managed service installer upgrades its private venv, while a separately installed `uv tool` command can remain years behind with a lean capability set.
+
+Live 0.29.1 evidence isolates these costs without model or reranker work: keyword `ask_memory` took 55.1 seconds, including 12.2 seconds in semantic units and 41.3 seconds outside KB; `kb-only` still took 13.1 seconds, including 11.6 seconds in semantic units. A guarded `observe_memory` validation took about 29 seconds and its commit about 16 seconds. Prior measured warm production edits were 32-48 ms and note creation was about 212 ms.
+
+The system already has the needed primitives: atomic canonical writes, process-shared writer fencing, watcher-driven freshness state, a WAL lexical sidecar containing page and semantic-unit generations, and per-parent semantic parses emitted by the write coordinator. The repair makes those event-maintained artifacts the foreground substrate instead of treating them as optional caches behind a new corpus walk.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep warm persistent-server keyword reads and governed semantic-unit validate/commit operations sub-second at realistic vault sizes.
+- Eliminate corpus-wide Markdown I/O from optimized foreground lanes and keep cached-metadata reconciliation inside explicit sub-second ceilings.
+- Preserve exact freshness, relation governance, stable identities, writer fencing, read-your-write behavior, and crash recovery.
+- Keep cold parsing off normal foreground requests by starting semantic-corpus warm-up with the service and retaining its result in the persistent process.
+- Make CLI and service release/profile identity explicit and reconcile managed installations automatically.
+- Add structural gates against corpus-wide Markdown parsing plus wall-clock and scaling ceilings for both validation and commit.
+
+**Non-Goals:**
+
+- Changing the authored semantic language, Markdown source-of-truth rule, ranking model, or MCP mutation schema.
+- Adding a server-side reasoning model or changing any epistemic judgment.
+- Replacing SQLite, BM25, embedding, CLIP, or graph ranking architecture.
+- Requiring optional ML/media dependencies in lean installations.
+- Making arbitrary one-shot Python startup the performance baseline; managed CLI calls should use the warm service runtime.
+
+## Decisions
+
+### 1. Maintain one warm semantic corpus context per vault
+
+Keep the existing bounded process cache as the rebuildable semantic snapshot. Its hot key is the freshness event token plus the small registry/config census, so a normal request does not stat every Markdown page. Canonical writes and watcher batches patch exact changed/deleted Markdown paths in that cached context. A full census remains the correctness fallback when no event token exists or continuity is uncertain, but a Markdown-only mismatch reparses only the changed paths.
+
+Cold startup primes the context in the existing background warm-up. If Markdown changes during that build, the builder absorbs a bounded number of exact census deltas rather than throwing away the completed parse. Registry/schema changes still invalidate the context and use a cold rebuild because their meaning is corpus-wide.
+
+Alternative considered: add a durable semantic snapshot and delta journal in this repair. Deferred because it expands the storage/recovery protocol substantially; the observed regression was in a persistent service whose in-process cache was invalidated and rebuilt on foreground requests. The current change fixes that measured path while keeping Markdown canonical.
+
+### 2. Incrementally evaluate common same-page transitions
+
+`SemanticCorpusContext.with_candidate()` gains a stable-topology replacement path. When path, title, stable identity, eligibility, and resolver keys are unchanged (the normal `observe_memory` update), it reparses only the candidate page and reuses the cached corpus pages/resolver inputs. It may rederive relation and activation maps from cached facts, but it does not reopen or reparse unchanged Markdown. Structural changes that affect resolver keys retain the full correctness oracle.
+
+If the event token cannot prove currency, Exomem checks the existing exact census. It applies Markdown-only differences incrementally and uses the full build oracle only for a cold cache or corpus-wide configuration change.
+
+### 3. Query semantic-unit and outside-KB rows before hydrating Markdown
+
+Semantic-unit recall asks the lexical/vector sidecars for matching current-generation rows first. Category and kind constraints are pushed into the sidecars before ranking; remaining structured predicates are evaluated while hydrating a bounded candidate window. If that window cannot satisfy the requested result count, the response reports `semantic_units_candidate_window` instead of silently claiming complete recall. The optimized unit lane no longer builds an all-unit in-memory dictionary as a prerequisite to searching; filtered page-level/mixed eligibility outside this lane is not covered by that claim.
+
+Outside-KB widening uses the WAL lexical sidecar’s vault-scope FTS rows directly rather than reconstructing an in-memory vault BM25 corpus after every freshness change. The existing relaxed any-stem gate and reserved result slots remain unchanged.
+
+Fallbacks remain correctness-first but bounded: a missing/stale sidecar starts or joins background repair and reports the affected lane as warming/unavailable. A foreground request never silently falls back to an unbounded whole-vault scan.
+
+### 4. Reuse already-parsed state on the guarded commit path
+
+Validation already constructs the current corpus and resolver inputs. Before the guarded commit, seed the shared wikilink resolver from those exact entries so graph/index fanout does not immediately reopen and parse the entire vault. Canonical transaction, writer fencing, read-your-write behavior, and existing optional-worker boundaries remain unchanged by this repair.
+
+### 5. Gate both latency and scaling
+
+Add a persistent-process, model-free benchmark over deterministic 2,000- and 8,000-page generated vaults. It measures cold semantic warm-up plus repeated `observe_memory(validate)` and guarded commit. Structural retrieval/cache tests separately prove that an unrelated change or keyword recall does not reopen every parent.
+
+Acceptance on the reference lane is: local validate median below 500 ms and p95 below 1 second, commit median below 750 ms and p95 below 1.5 seconds at each size, and both 8k medians must remain below `2 * their 2k median + 200 ms`. Structural tests—not the noisy wall-clock ratio—assert that no full Markdown parse occurs on warm/event-maintained paths. Thresholds exclude cold semantic warm-up, optional model download, and one-shot interpreter startup.
+
+### 6. Treat managed CLI/service identity as one install contract
+
+Add a cheap `exomem --version` / `exomem install-info --json` path that imports no optional ML stack and reports distribution version, interpreter, install source, selected profile, and managed-service target without secrets or vault paths.
+
+Windows and Unix upgrade scripts write a non-secret managed-install manifest after verifying the live service release, then resolve every `exomem`/`kb` command visible on PATH. In `auto` mode an existing uv-tool install is upgraded to that exact release; `always` may install it and `never` opts out. Verification fails with a concrete repair command if any visible executable remains stale. The command environment stays lean; parity means the same Exomem release, not duplicate media/ML dependencies.
+
+The historical `find` command becomes a compatibility alias for current `ask` semantics. Before loading command leaves, a lean direct CLI detects an absent local model stack and disables embedding, reranking, and CLIP lanes for that invocation. Once release-aligned it therefore uses the bounded lexical sidecars without the obsolete CLI's raw missing-ML warnings; structured diagnostics still describe explicitly requested unavailable capabilities.
+
+## Risks / Trade-offs
+
+- **Watcher loss could leave the cache stale** -> compare the exact existing corpus census whenever the freshness event token cannot prove currency; apply Markdown-only differences as bounded deltas and retain the full-build oracle for cold/config-wide changes.
+- **Incremental resolver updates are subtle** -> store raw-target dependencies, test rename/title/alias ambiguity transitions, and retain a full-rebuild oracle for equivalence tests.
+- **Process restart loses the warm corpus** -> start a background semantic warm-up immediately; never treat the cache as canonical.
+- **Wall-clock tests can be noisy** -> pair generous sub-second ceilings with deterministic no-walk/no-full-parse assertions and scaling ratios; run connector p95 on the dedicated performance lane.
+- **Automatic CLI reconciliation may touch an independently managed tool** -> limit it to commands that resolve to the Exomem distribution, show planned/current/target provenance, and support an explicit opt-out while doctor remains actionable.
+
+## Migration Plan
+
+1. Ship the in-process cache/event maintenance and bounded sidecar recall changes without a storage migration.
+2. Keep the full semantic build as a cold/config-change correctness oracle and prove incremental equivalence in tests.
+3. Update upgrade scripts to record verified service provenance and reconcile existing uv-tool CLIs.
+4. Deploy to the follower first, verify readiness and aggregate latency, then upgrade the writer and allow normal lease election. Roll back by installing the previous wheel; Markdown remains canonical and every cache/sidecar is rebuildable.
+
+## Open Questions
+
+- A durable semantic snapshot and authenticated warm loopback CLI remain possible follow-up changes, but neither is required to fix the measured persistent-service regression or the stale executable split.

--- a/openspec/changes/restore-fast-runtime-and-install-parity/proposal.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Exomem 0.29.1 has regressed from millisecond-scale warm operations to corpus-scale foreground work: a live keyword-only query took 55.1 seconds (12.2 seconds in semantic-unit projection and 41.3 seconds in outside-KB widening), while a guarded `observe_memory` validate/commit pair took 29/16 seconds. The same deployment also left the user-facing `exomem` command on a separate lean 0.4.1 environment while the service ran 0.29.1 with media/vision extras, causing misleading BM25-only fallback warnings and proving that install provenance is not one coherent runtime contract.
+
+## What Changes
+
+- Replace foreground full-vault semantic parsing and stat-census validation with an event-maintained, incrementally patched process cache. Startup warms it off the request path; canonical writes, watcher events, and a bounded census fallback keep it current.
+- Make semantic-unit recall and outside-KB widening query their maintained derived indexes directly and hydrate only bounded selected/current pages; these optimized warm lanes MUST NOT scan or parse the whole vault.
+- Add explicit warm/cold and post-unrelated-change latency gates over realistic 2k/8k corpora, with per-stage diagnostics and scaling bounds that reject O(corpus) foreground behavior.
+- Reconcile an existing uv-managed user-facing CLI with the verified managed-service release during upgrade. Add a cheap version/provenance surface and fail upgrade verification when any visible `exomem`/`kb` executable remains stale.
+- Preserve the historical `exomem find` command as a compatibility alias for the current bounded `ask` surface.
+- Preserve optional embedding/CLIP/media capabilities as default-off/soft-fail for lean installations; when absent, diagnostics identify the intentional install profile without claiming the managed service has the same capability state.
+
+## Capabilities
+
+### New Capabilities
+
+- `foreground-latency-slo`: Defines bounded foreground read/validate/commit latency, realistic scaling gates, and stage-level evidence for regressions.
+
+### Modified Capabilities
+
+- `live-index-freshness`: Extends event-maintained freshness to semantic corpus/unit state and outside-KB lexical state, including restart and external-sync reconciliation.
+- `find-recall-efficiency`: Removes corpus walks/parses from the normal semantic-unit and outside-KB query paths while preserving recall and freshness behavior.
+- `install-readiness`: Records managed service provenance, reconciles stale uv-tool CLIs during upgrade, and verifies every PATH-visible Exomem command before success.
+- `command-surface`: Adds a cheap, stable version/provenance CLI surface that does not import optional ML stacks and remains consistent with install diagnostics.
+
+## Impact
+
+This affects semantic corpus/index state, `find`/`ask_memory`, governed write preflight, watcher behavior, Windows and Unix upgrade scripts, CLI provenance reporting, and CI/benchmark gates. It changes no Markdown source-of-truth rule, MCP mutation schema, semantic language, or pure-substrate boundary. Embedding, CLIP, OCR, ASR, and other models remain optional extras; the change does not duplicate them into the lean CLI environment.

--- a/openspec/changes/restore-fast-runtime-and-install-parity/specs/command-surface/spec.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/specs/command-surface/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Cheap Version And Install Provenance Surface
+
+The `exomem` and `kb` console scripts SHALL accept `--version` and `--version --json` before loading command leaves or optional ML/media dependencies. The JSON result SHALL report distribution version, Python executable, install source, selected local profile, managed-service release/profile when configured, and effective CLI route. It MUST NOT include credentials, vault paths, user-authored content, or model initialization.
+
+#### Scenario: Lean environment reports version without ML imports
+
+- **WHEN** `exomem --version --json` runs in a lean environment without torch or sentence-transformers
+- **THEN** it exits successfully with provenance JSON
+- **AND** it does not import, initialize, or warn about optional ML capabilities
+
+#### Scenario: Managed service differs from CLI
+
+- **WHEN** the managed-install manifest names a service release different from the current CLI distribution
+- **THEN** version JSON reports the mismatch explicitly and identifies the effective execution route

--- a/openspec/changes/restore-fast-runtime-and-install-parity/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Semantic-Unit Recall Queries Derived Rows First
+
+Semantic-unit recall SHALL query current-generation lexical/vector unit rows before hydrating Markdown. The optimized unit lane MUST NOT build an all-parent or all-unit in-memory projection as a prerequisite to searching. Page-level eligibility work performed by mixed recall is outside this requirement.
+
+#### Scenario: Keyword mixed recall touches only selected parents
+
+- **WHEN** a warm keyword mixed-level query matches a bounded set of semantic units
+- **THEN** ranking is computed from current derived rows
+- **AND** only selected parents needed for returned context are opened
+
+#### Scenario: Indexed category and kind filters remain exact
+
+- **WHEN** category or kind filters are supplied
+- **THEN** the returned units are identical to the full Markdown oracle
+- **AND** the implementation does not parse every eligible parent to evaluate the filters
+
+#### Scenario: A post-hydration filter exhausts the bounded window
+
+- **WHEN** a tags, context, lifecycle, project, or other structured predicate rejects every indexed candidate in the bounded window
+- **THEN** the response reports `semantic_units_candidate_window` when it cannot fill the requested result count
+- **AND** it does not silently run an unbounded whole-vault parse
+
+### Requirement: Outside-KB Widening Uses The Maintained Lexical Store
+
+`scope="kb"` auto-widen SHALL use current vault-scope lexical sidecar rows for outside-KB candidates. It MUST preserve the relaxed any-stem gate, reserved result slots, exclusions, and `outside_kb` markers without rebuilding an in-memory vault BM25 corpus in the request.
+
+#### Scenario: Empty KB result widens without a vault rebuild
+
+- **WHEN** a warm keyword query has no KB hit and auto-widens outside Knowledge Base
+- **THEN** outside candidates come from the maintained vault lexical store
+- **AND** the request performs no vault-wide Markdown walk, parse, or BM25 reconstruction
+
+### Requirement: Missing Derived State Never Triggers An Unbounded Foreground Fallback
+
+When semantic-unit or outside-KB derived state is missing, schema-stale, or reconciling, `find`/`ask_memory` SHALL report the affected lane as warming or unavailable and trigger/join repair. It MUST NOT silently fall back to a whole-vault foreground parse or tokenization pass.
+
+#### Scenario: Lexical sidecar is rebuilding
+
+- **WHEN** outside-KB lexical state is not current during an auto-widen request
+- **THEN** the response identifies outside-KB recall as warming or unavailable
+- **AND** other current lanes still return bounded results
+- **AND** no unbounded filesystem fallback runs

--- a/openspec/changes/restore-fast-runtime-and-install-parity/specs/foreground-latency-slo/spec.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/specs/foreground-latency-slo/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Foreground Operations Have Explicit Latency Ceilings
+
+The system SHALL keep warm persistent-runtime semantic-unit validation and guarded semantic-unit commit below explicit latency ceilings on deterministic 2,000- and 8,000-page reference corpora. Local validation SHALL have median below 500 ms and p95 below 1,000 ms; local commit SHALL have median below 750 ms and p95 below 1,500 ms. Cold semantic warm-up, model download, first interpreter startup, and explicitly requested heavy reranking are excluded; ordinary graph, relation-governance, logging, and coordination work are included.
+
+#### Scenario: Warm semantic-unit write meets the ceiling
+
+- **WHEN** the benchmark runs repeated guarded `observe_memory` validate and commit operations against a warmed 2,000-page vault
+- **THEN** validation and commit each meet the local median and p95 ceilings
+
+#### Scenario: Optional models do not redefine the write ceiling
+
+- **WHEN** embedding, CLIP, OCR, ASR, or other optional measurement models are absent or warming
+- **THEN** required canonical and semantic write acknowledgement still meets the foreground ceiling
+- **AND** optional lanes report disabled, warming, or unavailable without blocking the write
+
+### Requirement: Foreground Work Avoids Corpus-Wide Markdown Parsing
+
+Optimized warm unit recall, validate, and commit paths MUST NOT open or parse every Markdown page. They MAY rederive bounded in-memory structures from cached metadata. On equivalent 2,000- and 8,000-page reference corpora, both the 8,000-page validation and commit medians SHALL remain below `2 * the corresponding 2,000-page median + 200 ms`; each size SHALL also satisfy the tighter absolute ceilings.
+
+#### Scenario: Larger unchanged corpus remains bounded
+
+- **WHEN** the benchmark repeats the same selected-page query and semantic-unit update on 2,000- and 8,000-page vaults
+- **THEN** each operation satisfies the scaling formula
+- **AND** instrumentation shows Markdown I/O bounded to indexed candidates and changed paths rather than every Markdown page
+
+### Requirement: Unrelated Changes Do Not Reintroduce A Cold Corpus Rebuild
+
+One unrelated Markdown create, edit, delete, move, or synchronized replacement SHALL be incorporated as a bounded delta before the next foreground request. It MUST NOT force that request to rebuild the complete semantic, lexical, resolver, or identity corpus.
+
+#### Scenario: Unrelated synced edit precedes validation
+
+- **WHEN** one unrelated page changes after the semantic snapshot is warm and the watcher reports that exact path
+- **THEN** the next guarded validation applies or awaits only the bounded delta
+- **AND** it still meets the foreground p95 ceiling
+
+#### Scenario: Incremental state cannot be trusted
+
+- **WHEN** the freshness token cannot prove current semantic state
+- **THEN** the existing exact census identifies the changed inputs
+- **AND** Markdown-only changes are reconciled by path while registry/config changes retain the cold full-build fallback
+
+### Requirement: Latency Gates Combine Timing With Structural Evidence
+
+CI SHALL run model-free regression tests that assert the absence of full-corpus foreground parses and a reproducible benchmark SHALL report cold warm-up, median, p95, and scaling-bound timings. Reports MUST contain aggregate counts/timings only and MUST NOT contain private paths, queries, or note content.
+
+#### Scenario: O-corpus implementation fails even on a fast machine
+
+- **WHEN** a candidate implementation meets the wall-clock threshold only by running on faster hardware but opens or parses the full reference corpus
+- **THEN** the structural latency gate fails
+
+#### Scenario: Benchmark output is safe to publish
+
+- **WHEN** the foreground latency report is generated
+- **THEN** it contains only aggregate timing and operation-count evidence
+- **AND** it contains no authored query, Markdown body, title, or vault-relative path

--- a/openspec/changes/restore-fast-runtime-and-install-parity/specs/install-readiness/spec.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/specs/install-readiness/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Managed CLI And Service Provenance Stay Coherent
+
+Managed service upgrade SHALL record a non-secret manifest after verifying the live release and reconcile an existing uv-managed `exomem`/`kb` command with that exact release. Version reporting SHALL compare CLI distribution/interpreter provenance, service release, selected profiles, and the declared execution route without importing optional model stacks.
+
+#### Scenario: Upgrade finds a stale uv-tool command
+
+- **WHEN** the managed service is upgraded and an `exomem` command on PATH resolves to an older uv-tool distribution
+- **THEN** upgrade reconciles that command to the requested release or fails before reporting success with an exact remediation command
+- **AND** post-upgrade verification reports matching release provenance
+
+#### Scenario: Intentional lean CLI accompanies a full service
+
+- **WHEN** the uv-tool CLI is lean and the managed service uses a standard or media profile
+- **THEN** release reconciliation upgrades only the Exomem distribution in the CLI
+- **AND** it does not install Torch, sentence-transformers, or media extras into that CLI environment
+
+#### Scenario: Historical find command survives alignment
+
+- **WHEN** a release-aligned user runs `exomem find <query>`
+- **THEN** it uses the current compact `ask` behavior
+- **AND** it does not fall through to the server argument parser or the obsolete 0.4.1 fallback path
+
+#### Scenario: Lean find skips capabilities it does not own
+
+- **WHEN** a release-aligned lean CLI runs `exomem find <query>` without Torch or sentence-transformers
+- **THEN** it uses the maintained lexical lanes directly
+- **AND** it does not emit raw missing-module or missing-model warnings
+
+### Requirement: Upgrade Verifies The User-Facing Command
+
+The managed upgrade SHALL run the resolved post-upgrade `exomem --version --json` and a model-free command-surface smoke from the same shell resolution a user receives. Service health alone MUST NOT be sufficient to declare the installation upgraded.
+
+#### Scenario: Service updated but PATH command remained stale
+
+- **WHEN** the service reports the target release but the shell resolves an older executable
+- **THEN** upgrade fails its verification phase and identifies both executable paths and releases without exposing secrets

--- a/openspec/changes/restore-fast-runtime-and-install-parity/specs/live-index-freshness/spec.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/specs/live-index-freshness/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Warm Semantic Corpus State Is Event-Maintained
+
+The persistent server SHALL maintain a bounded rebuildable semantic corpus context containing current parent generations, stable identities, typed relation facts, resolver entries, and governed eligibility. Canonical writers and watcher events SHALL patch the warm context by exact changed path. Startup SHALL begin warming the context in the background so model loading and normal request handling do not wait for it synchronously.
+
+#### Scenario: Canonical write patches one parent
+
+- **WHEN** a governed write changes one Markdown parent without changing its path or stable identity
+- **THEN** the snapshot replaces that parent generation and its affected relations incrementally
+- **AND** unchanged parents are neither reopened nor reparsed
+
+#### Scenario: Restart starts a cold warm-up
+
+- **WHEN** a server process starts with no warm semantic context
+- **THEN** semantic warm-up begins outside the foreground startup path
+- **AND** later foreground requests reuse the warmed context
+
+#### Scenario: Mutation arrives during restart warm-up
+
+- **WHEN** a mutation arrives before the semantic corpus is ready
+- **THEN** it returns the retryable `MUTATION_WARMING` outcome with `committed: false`
+- **AND** it does not acquire or hold the vault mutation boundary while waiting for the cold build
+- **AND** the unchanged mutation may be retried after the supplied `retry_after_ms`
+
+### Requirement: External Changes Patch The Warm Context By Path
+
+The watcher/freshness subsystem SHALL publish exact Markdown create, modify, delete, and move paths to the semantic corpus cache. A matching freshness event token SHALL prove that the cached context includes the observed batch without a full corpus stat walk.
+
+#### Scenario: Synced backdated replacement is applied
+
+- **WHEN** sync replaces one Markdown file and the watcher reports the path
+- **THEN** that parent is reopened and reparsed into the current context
+- **AND** unchanged parents are not reopened or reparsed
+
+#### Scenario: Event continuity cannot prove currency
+
+- **WHEN** no matching freshness event token can prove the warm context current
+- **THEN** the exact existing census detects changes
+- **AND** Markdown-only changes are applied as bounded path deltas
+- **AND** corpus-wide registry/config changes retain the full-build correctness fallback
+
+#### Scenario: Unsafe delta breaks event continuity
+
+- **WHEN** a watcher delta encounters a symlink, reparse point, nonregular Markdown entry, unreadable page, or invalid semantic state after freshness advances
+- **THEN** the warm corpus captions are evicted before the failure is surfaced
+- **AND** a later valid event cannot stamp the older context as current
+- **AND** the next rebuild applies the full identity and filesystem safety oracle
+
+### Requirement: Incremental State Matches The Full-Rebuild Oracle
+
+For stable-topology edits and exact-path create/edit/delete events, the incrementally maintained context SHALL produce the same page states, stable-identity census, resolved relation facts, inbound/outbound maps, and eligibility sets as a fresh full rebuild over the same Markdown bytes. Resolver-topology or registry changes MAY use the full-build oracle.
+
+#### Scenario: Incremental and rebuilt contexts are equivalent
+
+- **WHEN** a deterministic transition sequence is applied once through incremental updates and once through the full-rebuild oracle
+- **THEN** their serialized semantic corpus contexts are identical

--- a/openspec/changes/restore-fast-runtime-and-install-parity/tasks.md
+++ b/openspec/changes/restore-fast-runtime-and-install-parity/tasks.md
@@ -1,0 +1,41 @@
+## 1. Regression Gates
+
+- [x] 1.1 Add failing structural tests proving warm semantic-unit recall does not walk/parse every parent and outside-KB widening does not rebuild vault BM25 state.
+- [x] 1.2 Add failing structural tests proving repeated and post-unrelated-change `observe_memory` validation/commit do not parse the full corpus.
+- [x] 1.3 Add the aggregate-only 2k/8k foreground benchmark and enforce median, p95, and scaling thresholds in CI.
+
+## 2. Event-Maintained Semantic Corpus State
+
+- [x] 2.1 Add an event-token hot path to the bounded process cache while retaining exact config and census fallbacks.
+- [x] 2.2 Implement exact-path Markdown create/edit/delete reconciliation and stable-topology candidate replacement with full-build equivalence tests.
+- [x] 2.3 Wire canonical writers and watcher batches to patch the warm context, and start cold semantic warm-up in the background.
+- [x] 2.4 Absorb bounded Markdown churn during cold build instead of discarding the completed context.
+- [x] 2.5 Expose semantic-corpus readiness and reject restart-window mutations as retryable before acquiring the mutation boundary.
+
+## 3. Bounded Recall Paths
+
+- [x] 3.1 Query/filter current semantic-unit sidecar rows first and hydrate only selected parents, preserving rich category/kind/tags/context and typed relations.
+- [x] 3.2 Route outside-KB widening through maintained vault lexical rows while preserving the relaxed any-stem gate, reserved slots, and exclusions.
+- [x] 3.3 Remove automatic unbounded filesystem fallbacks; retain the Python corpus only as an explicit operator rollback.
+
+## 4. Fast Guarded Commit
+
+- [x] 4.1 Seed the shared wikilink resolver from the exact corpus entries already parsed during preflight.
+- [x] 4.2 Preserve existing canonical transaction, read-your-write, writer-fencing, and optional-worker behavior.
+- [x] 4.3 Normalize explicit CRLF source snapshots so Windows deep-context memory references match disk-read indexing.
+
+## 5. CLI And Service Install Parity
+
+- [x] 5.1 Add cheap `--version`/JSON install provenance without optional dependency imports or private fields.
+- [x] 5.2 Add the non-secret managed-install manifest and expose CLI/service version, profile, interpreter, and declared execution route.
+- [x] 5.3 Update Windows and Unix upgrades to reconcile existing stale uv-tool commands to the verified live release without duplicating ML installs.
+- [x] 5.4 Verify every PATH-visible `exomem`/`kb` executable and fail with an actionable exact-version repair command on drift.
+- [x] 5.5 Preserve `exomem find` as a compatibility alias for current bounded `ask` behavior.
+
+## 6. Verification And Delivery
+
+- [x] 6.1 Run focused semantic, retrieval, writer, watcher, install, privacy, and OpenSpec tests plus the Windows-feasible lean matrix and ruff.
+- [x] 6.2 Run the local 2k/8k gate and synthetic guarded commit/read-back; record only aggregate timing evidence.
+- [x] 6.3 Update generic operator/release documentation for latency gates, install provenance, and CLI reconciliation recovery.
+- [x] 6.4 Complete an independent code/security/performance review, address findings, and verify the final diff contains no private vault data.
+- [ ] 6.5 After the merged release is deployed, run live connector validation/commit/read-back on the managed installation without recording private content.

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exomem",
   "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "skills": "./skills/",
   "mcpServers": {
     "exomem": {

--- a/plugins/claude-code/skills/exomem/SKILL.md
+++ b/plugins/claude-code/skills/exomem/SKILL.md
@@ -287,10 +287,10 @@ with the former raw result. Response detail is presentation-only: changing it
 does not change mutation identity, execute the leaf again, or alter a replayed
 terminal.
 
-`MUTATION_BUSY`, `MUTATION_ACKNOWLEDGEMENT_PENDING`, and
+`MUTATION_WARMING`, `MUTATION_BUSY`, `MUTATION_ACKNOWLEDGEMENT_PENDING`, and
 `MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN` remain errors, not successful
 terminals. Preserve the same mutation identity and unchanged payload when
-following their remediation: wait before retrying a busy call; retry a pending
+following their remediation: wait before retrying a warming or busy call; retry a pending
 call only with the same identity; do not submit a new identity after a
 committed-uncertain result—reconcile and retry only as instructed.
 

--- a/plugins/claude-code/skills/exomem/references/operations.md
+++ b/plugins/claude-code/skills/exomem/references/operations.md
@@ -79,11 +79,15 @@ is retained for at least one compatibility release. The response-detail choice
 is removed before mutation identity is calculated, so it cannot create a second
 write or change which stored terminal a replay receives.
 
-Busy, acknowledgement-pending, and committed-acknowledgement-uncertain outcomes
+Warming, busy, acknowledgement-pending, and committed-acknowledgement-uncertain outcomes
 remain structured errors. Retrying must retain the same identity and payload:
-wait before retrying `MUTATION_BUSY`; never revise a pending payload; and after
+wait before retrying `MUTATION_WARMING` or `MUTATION_BUSY`; never revise a pending payload; and after
 `MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN`, reconcile and retry only with the
 same identity rather than creating a new write.
+
+`MUTATION_WARMING` means the restart-time semantic corpus is still being built.
+It never holds the mutation boundary and never means the Exomem tool is disabled;
+retry the unchanged call after `retry_after_ms`.
 
 `edit_memory` is one tool. New calls supply `path`, `why`, and one nested
 `operation` selected by `kind`:

--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -284,3 +284,104 @@ function Get-ExomemRepoVersion {
     }
     return $null
 }
+
+function Test-ExomemUvToolInstall {
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) { return $false }
+    $listing = & uv tool list 2>$null
+    if ($LASTEXITCODE -ne 0) { return $false }
+    return [bool]($listing | Where-Object { $_ -match '^exomem(?:\s|$)' } | Select-Object -First 1)
+}
+
+function Sync-ExomemUvCli {
+    <# Align only the lean uv-tool command; the service keeps its selected extras. #>
+    param(
+        [ValidateSet("auto", "always", "never")]
+        [string]$Mode,
+        [string]$ServiceVersion
+    )
+
+    if ($Mode -eq "never") {
+        Write-Host "CLI sync disabled (-CliSync never)."
+        return $false
+    }
+    if ($Mode -eq "auto" -and -not (Test-ExomemUvToolInstall)) {
+        Write-Host "No existing uv-managed Exomem CLI; auto mode will not install one."
+        return $false
+    }
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+        throw "uv is required for CLI sync. Install uv or pass -CliSync never."
+    }
+    if (-not $ServiceVersion) {
+        throw "Cannot sync the CLI without a verified live service version."
+    }
+    Write-Host "Aligning lean uv-tool CLI to exomem==$ServiceVersion..."
+    $code = Invoke-LoggedNative @("uv", "tool", "install", "--force", "exomem==$ServiceVersion")
+    if ($code -ne 0) { throw "uv tool CLI sync failed for exomem==$ServiceVersion" }
+    return $true
+}
+
+function Get-ExomemManagedManifestPath {
+    if ($env:EXOMEM_MANAGED_INSTALL_MANIFEST) {
+        return $env:EXOMEM_MANAGED_INSTALL_MANIFEST
+    }
+    $root = if ($env:LOCALAPPDATA) {
+        Join-Path $env:LOCALAPPDATA "Exomem"
+    } else {
+        Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "Exomem"
+    }
+    return Join-Path $root "managed-install.json"
+}
+
+function Write-ExomemManagedManifest {
+    param(
+        [string]$ServiceVersion,
+        [string]$ServiceProfile,
+        [string]$ServiceTarget
+    )
+
+    $path = Get-ExomemManagedManifestPath
+    $parent = Split-Path -Parent $path
+    if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+    $payload = [ordered]@{
+        schema_version = 1
+        service_version = $ServiceVersion
+        service_profile = $ServiceProfile
+        service_target = $ServiceTarget
+        cli_profile = "lean"
+        cli_route = "direct"
+    }
+    $temporary = "$path.$PID.tmp"
+    $payload | ConvertTo-Json | Set-Content -Path $temporary -Encoding utf8
+    Move-Item -LiteralPath $temporary -Destination $path -Force
+    Write-Host "Managed install manifest: $path"
+}
+
+function Assert-ExomemVisibleCliVersions {
+    param(
+        [string]$ExpectedVersion,
+        [bool]$RequireOne = $false
+    )
+
+    $commands = @(
+        Get-Command exomem, kb -All -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Source -Unique
+    )
+    if ($RequireOne -and $commands.Count -eq 0) {
+        throw "CLI sync completed but neither exomem nor kb is visible on PATH. Run 'uv tool update-shell', open a new shell, and retry."
+    }
+    foreach ($executable in $commands) {
+        $raw = & $executable --version --json 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) {
+            throw "CLI verification failed: '$executable' does not support --version --json. Repair with: uv tool install --force exomem==$ExpectedVersion"
+        }
+        try {
+            $identity = ($raw -join "`n") | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            throw "CLI verification failed: '$executable' returned invalid version JSON. Repair with: uv tool install --force exomem==$ExpectedVersion"
+        }
+        if ($identity.version -ne $ExpectedVersion) {
+            throw "CLI/service split: '$executable' reports '$($identity.version)' while the live service reports '$ExpectedVersion'. Repair with: uv tool install --force exomem==$ExpectedVersion"
+        }
+        Write-Host "Verified $executable -> exomem $($identity.version)"
+    }
+}

--- a/scripts/_service-common.sh
+++ b/scripts/_service-common.sh
@@ -69,3 +69,113 @@ exomem_dotenv_value() {
     sed -n "s|^[[:space:]]*${name}[[:space:]]*=[[:space:]]*||p" "$repo_root/.env" \
         | head -n1 | sed 's|^"\(.*\)"$|\1|; s|^'"'"'\(.*\)'"'"'$|\1|'
 }
+
+# True when the per-user uv tool registry already owns Exomem.  Looking at the
+# registry, rather than merely `command -v exomem`, avoids taking over an
+# independently managed pip/pipx command in auto mode.
+exomem_uv_tool_has_exomem() {
+    command -v uv >/dev/null 2>&1 || return 1
+    uv tool list 2>/dev/null | grep -Eq '^exomem([[:space:]]|$)'
+}
+
+# Align the lean user-facing command with the exact release verified from the
+# live service.  The service keeps its selected extras; duplicating its media/ML
+# stack into the uv-tool environment would waste gigabytes and is not parity.
+exomem_sync_uv_cli() {
+    local mode="$1" service_version="$2"
+    case "$mode" in
+        never)
+            echo "CLI sync disabled (--cli-sync never)."
+            return 0
+            ;;
+        auto)
+            if ! exomem_uv_tool_has_exomem; then
+                echo "No existing uv-managed Exomem CLI; auto mode will not install one."
+                return 0
+            fi
+            ;;
+        always) ;;
+        *)
+            echo "invalid CLI sync mode: $mode" >&2
+            return 2
+            ;;
+    esac
+    command -v uv >/dev/null 2>&1 || {
+        echo "uv is required for CLI sync; install uv or use --cli-sync never." >&2
+        return 1
+    }
+    [[ -n "$service_version" ]] || {
+        echo "cannot sync the CLI without a verified live service version." >&2
+        return 1
+    }
+    echo "Aligning lean uv-tool CLI to exomem==$service_version..."
+    uv tool install --force "exomem==$service_version"
+}
+
+exomem_managed_manifest_path() {
+    if [[ -n "${EXOMEM_MANAGED_INSTALL_MANIFEST:-}" ]]; then
+        printf '%s\n' "$EXOMEM_MANAGED_INSTALL_MANIFEST"
+    elif [[ "$(uname -s)" == "Darwin" ]]; then
+        printf '%s\n' "$HOME/Library/Application Support/Exomem/managed-install.json"
+    else
+        printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/exomem/managed-install.json"
+    fi
+}
+
+exomem_write_managed_manifest() {
+    local python="$1" service_version="$2" service_profile="$3" service_target="$4"
+    local path
+    path="$(exomem_managed_manifest_path)"
+    "$python" - "$path" "$service_version" "$service_profile" "$service_target" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+payload = {
+    "schema_version": 1,
+    "service_version": sys.argv[2],
+    "service_profile": sys.argv[3],
+    "service_target": sys.argv[4],
+    "cli_profile": "lean",
+    "cli_route": "direct",
+}
+temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+os.chmod(temporary, 0o600)
+os.replace(temporary, path)
+PY
+    echo "Managed install manifest: $path"
+}
+
+# Verify each PATH-visible console script, not just the first shim.  A stale
+# shadowed command is a split install waiting to reappear after PATH changes.
+exomem_verify_visible_clis() {
+    local expected="$1" python="$2" require_one="${3:-0}"
+    local found=0 command_name executable output actual
+    for command_name in exomem kb; do
+        while IFS= read -r executable; do
+            [[ -n "$executable" ]] || continue
+            found=1
+            if ! output="$("$executable" --version --json 2>&1)"; then
+                echo "CLI verification failed: $executable does not support --version --json. Repair with: uv tool install --force exomem==$expected" >&2
+                return 1
+            fi
+            if ! actual="$(printf '%s' "$output" | "$python" -c 'import json,sys; print(json.load(sys.stdin).get("version", ""))')"; then
+                echo "CLI verification failed: $executable returned invalid version JSON. Repair with: uv tool install --force exomem==$expected" >&2
+                return 1
+            fi
+            if [[ "$actual" != "$expected" ]]; then
+                echo "CLI/service split: $executable reports '$actual' while the live service reports '$expected'. Repair with: uv tool install --force exomem==$expected" >&2
+                return 1
+            fi
+            echo "Verified $executable -> exomem $actual"
+        done < <(type -a -p "$command_name" 2>/dev/null | awk '!seen[$0]++')
+    done
+    if [[ "$require_one" == 1 && "$found" == 0 ]]; then
+        echo "CLI sync completed but neither exomem nor kb is visible on PATH. Run 'uv tool update-shell', open a new shell, and retry." >&2
+        return 1
+    fi
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,9 +109,16 @@ fi
 # 2. exomem
 # ---------------------------------------------------------------------------
 info "Installing exomem (first time may take a minute)..."
-if ! uv tool install exomem; then
-    die "'uv tool install exomem' failed." \
-        "Check your internet connection, then try running that command by hand to see the full error."
+if uv tool list 2>/dev/null | grep -Eq '^exomem([[:space:]]|$)'; then
+    if ! uv tool upgrade exomem; then
+        die "'uv tool upgrade exomem' failed." \
+            "Check your internet connection, then try running that command by hand to see the full error."
+    fi
+else
+    if ! uv tool install exomem; then
+        die "'uv tool install exomem' failed." \
+            "Check your internet connection, then try running that command by hand to see the full error."
+    fi
 fi
 ok "exomem is installed."
 

--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -1,0 +1,197 @@
+"""Aggregate-only semantic validate/commit latency gate at realistic scale."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from synth_vault import gen_dense_vault  # noqa: E402
+
+from exomem import find, freshness, semantic_contract, semantic_writes  # noqa: E402
+from exomem.vault import walk_vault_md  # noqa: E402
+
+DEFAULT_SIZES = (2_000, 8_000)
+VALIDATE_MEDIAN_MS = 500.0
+VALIDATE_P95_MS = 1_000.0
+COMMIT_MEDIAN_MS = 750.0
+COMMIT_P95_MS = 1_500.0
+SCALING_RATIO = 2.0
+SCALING_SLACK_MS = 200.0
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * fraction + 0.999) - 1))
+    return ordered[index]
+
+
+def _seed_freshness(vault_root: Path) -> None:
+    freshness.seed(
+        vault_root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in walk_vault_md(vault_root)),
+    )
+    kb = vault_root / "Knowledge Base"
+    freshness.seed(
+        vault_root,
+        "kb",
+        ((str(path), freshness.stat_signature(path)) for path in find._walk_md(kb)),
+    )
+
+
+def _next_source(source: str, version: int) -> str:
+    marker = "Synthetic write latency version "
+    start = source.index(marker) + len(marker)
+    end = source.index(" ", start)
+    return source[:start] + str(version) + source[end:]
+
+
+def _transition(vault_root: Path, rel_path: str, version: int) -> tuple[float, float]:
+    path = vault_root / rel_path
+    before = path.read_text(encoding="utf-8")
+    after = _next_source(before, version)
+    started = time.perf_counter()
+    preflight = semantic_writes.preflight_existing(
+        vault_root,
+        path=rel_path,
+        after_source=after,
+        operation="observe",
+    )
+    validate_ms = (time.perf_counter() - started) * 1_000.0
+    if preflight.contract_result.should_block:
+        codes = [item.code for item in preflight.contract_result.blocking_findings]
+        raise RuntimeError(f"synthetic transition was blocked: {codes}")
+    started = time.perf_counter()
+    semantic_writes.commit_existing(vault_root, preflight=preflight)
+    commit_ms = (time.perf_counter() - started) * 1_000.0
+    return validate_ms, commit_ms
+
+
+def measure(vault_root: Path, size: int, samples: int) -> dict[str, float | int]:
+    semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
+    gen_dense_vault(vault_root, size, links_per_note=3)
+    target_rel = "Knowledge Base/Entities/Concepts/write-latency-target.md"
+    target = vault_root / target_rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\n"
+        "title: Write latency target\n"
+        "type: entity\n"
+        "status: active\n"
+        "updated: 2026-07-22\n"
+        "---\n\n"
+        "# Write latency target\n\n"
+        "## Observations\n\n"
+        "- [config] Synthetic write latency version 0 #latency (benchmark) ^latency-gate\n",
+        encoding="utf-8",
+    )
+
+    cold_started = time.perf_counter()
+    semantic_contract.build_corpus_context(vault_root)
+    cold_ms = (time.perf_counter() - cold_started) * 1_000.0
+    _seed_freshness(vault_root)
+    semantic_contract.build_corpus_context(vault_root)
+
+    # Install the activation boundary and warm derived sidecars outside samples.
+    _transition(vault_root, target_rel, 1)
+    validates: list[float] = []
+    commits: list[float] = []
+    for version in range(2, samples + 2):
+        validate_ms, commit_ms = _transition(vault_root, target_rel, version)
+        validates.append(validate_ms)
+        commits.append(commit_ms)
+    return {
+        "pages": size,
+        "samples": samples,
+        "cold_ms": round(cold_ms, 1),
+        "validate_median_ms": round(statistics.median(validates), 1),
+        "validate_p95_ms": round(_percentile(validates, 0.95), 1),
+        "commit_median_ms": round(statistics.median(commits), 1),
+        "commit_p95_ms": round(_percentile(commits, 0.95), 1),
+    }
+
+
+def check(results: list[dict[str, float | int]]) -> None:
+    failures: list[str] = []
+    for result in results:
+        pages = int(result["pages"])
+        for key, ceiling in (
+            ("validate_median_ms", VALIDATE_MEDIAN_MS),
+            ("validate_p95_ms", VALIDATE_P95_MS),
+            ("commit_median_ms", COMMIT_MEDIAN_MS),
+            ("commit_p95_ms", COMMIT_P95_MS),
+        ):
+            value = float(result[key])
+            if value >= ceiling:
+                failures.append(f"{pages} pages: {key}={value:.1f}ms >= {ceiling:.1f}ms")
+    if len(results) >= 2:
+        ordered = sorted(results, key=lambda item: int(item["pages"]))
+        small, large = ordered[0], ordered[-1]
+        for operation in ("validate", "commit"):
+            key = f"{operation}_median_ms"
+            bound = float(small[key]) * SCALING_RATIO + SCALING_SLACK_MS
+            if float(large[key]) >= bound:
+                failures.append(
+                    f"{operation} scaling: {large[key]}ms >= {bound:.1f}ms "
+                    f"({small['pages']} -> {large['pages']} pages)"
+                )
+    if failures:
+        raise SystemExit("semantic write latency gate failed: " + "; ".join(failures))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sizes", nargs="+", type=int, default=list(DEFAULT_SIZES))
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_CLIP",
+        "EXOMEM_DISABLE_MEDIA_EXTRACTION",
+        "EXOMEM_DISABLE_RANKING",
+    ):
+        os.environ[name] = "1"
+
+    if args.root is not None:
+        args.root.mkdir(parents=True, exist_ok=False)
+        runtime_temp = args.root / "runtime-temp"
+        runtime_temp.mkdir()
+        tempfile.tempdir = str(runtime_temp)
+        roots = [args.root / f"vault-{size}" for size in args.sizes]
+        for root in roots:
+            root.mkdir(parents=True)
+        results = [
+            measure(root, size, args.samples) for root, size in zip(roots, args.sizes, strict=True)
+        ]
+    else:
+        with tempfile.TemporaryDirectory(prefix="exomem-write-latency-") as temp:
+            base = Path(temp)
+            results = []
+            for size in args.sizes:
+                root = base / f"vault-{size}"
+                root.mkdir()
+                results.append(measure(root, size, args.samples))
+    print(json.dumps({"results": results}, sort_keys=True))
+    if args.check:
+        check(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -23,6 +23,8 @@ param(
     [string]$PackageVersion = "",
     [ValidateSet("auto", "always", "never")]
     [string]$CudaTorch = "auto",
+    [ValidateSet("auto", "always", "never")]
+    [string]$CliSync = "auto",
     [string]$Vault = "",
     [switch]$SkipRestart
 )
@@ -89,7 +91,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 if ($SkipRestart) {
-    Write-Host "-SkipRestart given: the new version is installed but the service is still running the old one."
+    Write-Host "-SkipRestart given: the new version is staged, but the running service and user-facing CLI are unchanged. CLI sync is deferred until the live release is verified."
     exit 0
 }
 
@@ -132,6 +134,16 @@ if ($after -and $served -ne $after) {
 }
 if ($repoVersion -and $served -ne $repoVersion) {
     Write-Warning "Live service is on $served but this checkout is $repoVersion. Expected when the checkout is mid-release (repo ahead of PyPI) or on an older branch (repo behind); investigate if neither applies."
+}
+
+# The live process is the release authority.  Only now may a separately managed
+# lean uv-tool command be aligned; -SkipRestart deliberately exits before this
+# point so it can never move the CLI ahead of the running service.
+$serviceTarget = "http://$($endpoint.Host):$($endpoint.Port)"
+Write-ExomemManagedManifest -ServiceVersion $served -ServiceProfile $Profile -ServiceTarget $serviceTarget
+$cliSynced = Sync-ExomemUvCli -Mode $CliSync -ServiceVersion $served
+if ($CliSync -ne "never") {
+    Assert-ExomemVisibleCliVersions -ExpectedVersion $served -RequireOne ([bool]$cliSynced -or $CliSync -eq "always")
 }
 
 $readyUrl = "http://$($endpoint.Host):$($endpoint.Port)/health/ready"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -11,6 +11,7 @@
 #   bash scripts/upgrade.sh
 #   bash scripts/upgrade.sh --profile media
 #   bash scripts/upgrade.sh --package-version 0.25.4   # pin instead of latest
+#   bash scripts/upgrade.sh --cli-sync always          # install CLI if absent
 #   bash scripts/upgrade.sh --skip-restart             # stage it, restart later
 
 set -euo pipefail
@@ -26,6 +27,7 @@ PROFILE="standard"
 PACKAGE_VERSION=""
 VAULT=""
 SKIP_RESTART=0
+CLI_SYNC="auto"
 
 die() { echo "upgrade: $*" >&2; exit 1; }
 
@@ -34,6 +36,7 @@ while [[ $# -gt 0 ]]; do
         --profile)         PROFILE="${2:?}"; shift 2 ;;
         --package-version) PACKAGE_VERSION="${2:?}"; shift 2 ;;
         --vault)           VAULT="${2:?}"; shift 2 ;;
+        --cli-sync)        CLI_SYNC="${2:?}"; shift 2 ;;
         --skip-restart)    SKIP_RESTART=1; shift ;;
         -h|--help)         sed -n '2,14p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
@@ -43,6 +46,10 @@ done
 case "$PROFILE" in
     lean|hybrid|standard|media) ;;
     *) die "profile must be lean, hybrid, standard, or media (got: $PROFILE)" ;;
+esac
+case "$CLI_SYNC" in
+    auto|always|never) ;;
+    *) die "cli sync must be auto, always, or never (got: $CLI_SYNC)" ;;
 esac
 
 OS="$(uname -s)"
@@ -109,7 +116,7 @@ if ! "$VENV_PYTHON" "${DOCTOR_ARGS[@]}"; then
 fi
 
 if [[ "$SKIP_RESTART" -eq 1 ]]; then
-    echo "--skip-restart given: the new version is installed but the service is still running the old one."
+    echo "--skip-restart given: the new version is staged, but the running service and user-facing CLI are unchanged. CLI sync is deferred until the live release is verified."
     exit 0
 fi
 
@@ -141,6 +148,18 @@ done
 echo "Serving version: $SERVED (from $HEALTH)"
 if [[ -n "$AFTER" && "$SERVED" != "$AFTER" ]]; then
     die "version mismatch: installed '$AFTER' but the live service reports '$SERVED'. Something else is bound to $PORT, or the restart did not take."
+fi
+
+# The verified live process is the release authority.  Keep the daily CLI lean:
+# align its Exomem release, not the service's optional ML/media dependency set.
+CLI_REQUIRED=0
+if [[ "$CLI_SYNC" == "always" ]] || { [[ "$CLI_SYNC" == "auto" ]] && exomem_uv_tool_has_exomem; }; then
+    CLI_REQUIRED=1
+fi
+exomem_write_managed_manifest "$VENV_PYTHON" "$SERVED" "$PROFILE" "http://127.0.0.1:$PORT"
+exomem_sync_uv_cli "$CLI_SYNC" "$SERVED"
+if [[ "$CLI_SYNC" != "never" ]]; then
+    exomem_verify_visible_clis "$SERVED" "$VENV_PYTHON" "$CLI_REQUIRED"
 fi
 
 READY="$(curl -fsS --max-time 10 "http://127.0.0.1:$PORT/health/ready" 2>/dev/null || true)"

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import importlib.util
 import json
 import os
 import sys
@@ -37,8 +38,46 @@ from pathlib import Path
 from .kbdir import kb_dirname, kb_prefix
 
 
+def _module_available(name: str) -> bool:
+    """Cheaply detect an optional local capability without importing it."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _configure_local_search_capabilities(action: str | None) -> None:
+    """Keep lean direct CLI retrieval on its intentionally installed lanes.
+
+    The managed service can carry model/media extras while PATH-visible uv-tool
+    commands stay lean. A local ``ask``/legacy ``find`` must not import missing
+    model stacks merely to discover that BM25 is its available backend.
+    """
+    if action not in {"ask", "ask_memory"}:
+        return
+    model_stack_available = _module_available("torch") and _module_available(
+        "sentence_transformers"
+    )
+    if not model_stack_available:
+        os.environ.setdefault("EXOMEM_DISABLE_EMBEDDINGS", "1")
+        os.environ.setdefault("EXOMEM_DISABLE_RANKING", "1")
+        os.environ.setdefault("EXOMEM_DISABLE_CLIP", "1")
+
+
 def main(argv: list[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
+    if raw in (["--version"], ["--version", "--json"]):
+        # Keep this before command-registry and optional capability imports.  A
+        # lean uv-tool command must always be able to identify itself and the
+        # separately managed service it is paired with.
+        from .install_info import print_version
+
+        return print_version(as_json="--json" in raw)
+    if raw and raw[0] == "find":
+        # `find` was the original friendly retrieval command.  Keep existing
+        # scripts useful while the current product language calls it `ask`.
+        raw[0] = "ask"
+    _configure_local_search_capabilities(raw[0] if raw else None)
     if raw and raw[0] == "hosted":
         from .hosted_operator import main as hosted_operator_main
 
@@ -193,8 +232,7 @@ def _auth_main(argv: list[str]) -> int:
                 ]
             }
         reason = (
-            args.reason
-            or ("operator-revoke-all" if args.revoke_all else "operator-revocation")
+            args.reason or ("operator-revoke-all" if args.revoke_all else "operator-revocation")
         ).strip()
         if args.revoke_all:
             await authority.replace_generation()
@@ -314,7 +352,8 @@ def _backfill_media_main(argv: list[str]) -> int:
         "missing, extract text (OCR/ASR/PDF), and CLIP-embed images. Idempotent; CPU or GPU.",
     )
     parser.add_argument(
-        "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
         help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     parser.add_argument(
@@ -329,13 +368,15 @@ def _backfill_media_main(argv: list[str]) -> int:
     )
     parser.add_argument("--no-clip", action="store_true", help="skip CLIP image embedding")
     parser.add_argument(
-        "--rediarize", action="store_true",
+        "--rediarize",
+        action="store_true",
         help="re-extract audio/video transcribed before diarization (extracted_by without "
         "'+diarized') so they gain speaker turns + a speakers: frontmatter list. Requires "
         "EXOMEM_DIARIZE set in this shell (the CLI does not read .env).",
     )
     parser.add_argument(
-        "--retime", action="store_true",
+        "--retime",
+        action="store_true",
         help="re-extract audio/video transcribed before timed transcripts (extracted_by "
         "without '+timed') so they gain per-segment [m:ss] lines — the substrate for "
         "semantic segments. Requires EXOMEM_SEMANTIC_SEGMENTS set in this shell (the CLI "
@@ -376,27 +417,35 @@ def _index_main(argv: list[str]) -> int:
         "become semantically searchable).",
     )
     parser.add_argument(
-        "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
         help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     parser.add_argument(
-        "--scope", choices=("kb", "vault"), default=None,
+        "--scope",
+        choices=("kb", "vault"),
+        default=None,
         help="index scope override; default reads EXOMEM_INDEX_SCOPE (else 'kb'). "
         f"'vault' indexes the whole vault, not just {kb_prefix()}.",
     )
     parser.add_argument(
-        "--batch-size", type=int, default=256,
+        "--batch-size",
+        type=int,
+        default=256,
         help="chunks per embedding batch (default: 256)",
     )
     parser.add_argument(
-        "--device", choices=("auto", "cpu", "gpu"), default=None,
+        "--device",
+        choices=("auto", "cpu", "gpu"),
+        default=None,
         help="embedding device for this run. Default: GPU when a capable one is present "
         "and the mode isn't 'quiet' (this is a short-lived process, so it frees the CUDA "
         "context on exit — safe even on a CPU-default server). 'cpu' forces CPU; 'gpu'/"
         "'auto' opt in with the marginal-VRAM guard.",
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="report what would be (re)embedded and pruned; write nothing",
     )
     args = parser.parse_args(argv)
@@ -473,10 +522,16 @@ def _mode_main(argv: list[str]) -> int:
         "~/.exomem/config.json, read by BOTH the server and CLI ops.",
     )
     parser.add_argument(
-        "mode", nargs="?",
+        "mode",
+        nargs="?",
         choices=(
-            "quiet", "normal", "performance", "gpu", "turbo",
-            "resource-saver", "low-resource",
+            "quiet",
+            "normal",
+            "performance",
+            "gpu",
+            "turbo",
+            "resource-saver",
+            "low-resource",
         ),
         help="mode to set; omit to show the current one",
     )
@@ -485,9 +540,12 @@ def _mode_main(argv: list[str]) -> int:
 
     if args.mode is None:
         source = (
-            "env" if os.environ.get("EXOMEM_MODE")
-            else "config" if mode_mod.read_config().get("mode")
-            else "quiet-alias" if os.environ.get("EXOMEM_QUIET_MODE")
+            "env"
+            if os.environ.get("EXOMEM_MODE")
+            else "config"
+            if mode_mod.read_config().get("mode")
+            else "quiet-alias"
+            if os.environ.get("EXOMEM_QUIET_MODE")
             else "default"
         )
         policy = mode_mod.resolved()
@@ -550,6 +608,7 @@ def _status_main(argv: list[str]) -> int:
         print(f"  cuda: {status['cuda']}")
     return 0
 
+
 def _install_info_main(argv: list[str]) -> int:
     """Report where this install came from.
 
@@ -569,31 +628,25 @@ def _install_info_main(argv: list[str]) -> int:
     parser.add_argument("--json", action="store_true", help="emit stable JSON")
     args = parser.parse_args(argv)
 
-    from . import deploy_provenance
+    from . import install_info
 
-    report = deploy_provenance.provenance(include_local=True)
+    report = install_info.report()
 
     if args.json:
         print(json.dumps(report, ensure_ascii=False, default=str))
         return 0
 
-    print(f"version:        {report['version']}")
-    print(f"install source: {report['install_source']}")
-    if report.get("revision"):
-        print(f"revision:       {report['revision']}")
-    print(f"interpreter:    {report.get('interpreter')}")
-    if report.get("checkout"):
-        print(f"checkout:       {report['checkout']}")
-    torch_build = report.get("torch") or "not installed"
-    accel = "accelerated" if report.get("accelerated") else "CPU-only"
-    print(f"torch:          {torch_build} ({accel})")
-    print(f"extras:         {', '.join(report['extras']) or 'none'}")
-    if report["install_source"] == "wheel":
-        print(
-            "\nThis is a wheel install: it does NOT run a local checkout. "
-            "Upgrade it with `uv pip install --python <this interpreter> ...`; "
-            "`uv sync` in a checkout will not affect it."
-        )
+    print(f"version:          {report['version']}")
+    print(f"install source:   {report['install_source']}")
+    print(f"interpreter:      {report['python_executable']}")
+    print(f"local profile:    {report['local_profile']}")
+    print(f"effective route:  {report['effective_route']}")
+    if report["managed_service_version"]:
+        print(f"service version:  {report['managed_service_version']}")
+        print(f"service profile:  {report['managed_service_profile']}")
+        print(f"version match:    {str(report['version_match']).lower()}")
+    else:
+        print(f"managed manifest: {report['manifest_status']}")
     return 0
 
 
@@ -767,21 +820,26 @@ def _enroll_speaker_main(argv: list[str]) -> int:
             "diarization. The sample is embedded into a 192-dim ECAPA voiceprint and stored in "
             "the per-machine profile store beside the embedding sidecar — desk-side admin, never "
             "an MCP tool. Re-enrolling the same name running-averages the centroid over samples. "
-            'Example: exomem enroll-speaker --name Alice --self alice-sample.wav'
+            "Example: exomem enroll-speaker --name Alice --self alice-sample.wav"
         ),
     )
     parser.add_argument("audio", help="path to an audio sample of the speaker's voice")
     parser.add_argument("--name", required=True, help="speaker name to attach to matched clusters")
     parser.add_argument(
-        "--self", dest="is_self", action="store_true",
+        "--self",
+        dest="is_self",
+        action="store_true",
         help="mark this profile as the vault owner's own voice (is_self).",
     )
     parser.add_argument(
-        "--threshold", type=float, default=None,
+        "--threshold",
+        type=float,
+        default=None,
         help="per-profile cosine match threshold (default 0.40). Raise for confusable voices.",
     )
     parser.add_argument(
-        "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
         help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
@@ -791,7 +849,9 @@ def _enroll_speaker_main(argv: list[str]) -> int:
 
     try:
         rec = enroll_module.enroll_speaker(
-            args.audio, args.name, is_self=args.is_self,
+            args.audio,
+            args.name,
+            is_self=args.is_self,
             threshold=args.threshold if args.threshold is not None else DEFAULT_THRESHOLD,
             vault_root=_speaker_vault(args),
         )
@@ -811,7 +871,8 @@ def _list_speakers_main(argv: list[str]) -> int:
         description="List the enrolled voice profiles used for named diarization.",
     )
     parser.add_argument(
-        "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
         help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
@@ -839,7 +900,8 @@ def _remove_speaker_main(argv: list[str]) -> int:
     )
     parser.add_argument("--name", required=True, help="profile name to remove")
     parser.add_argument(
-        "--vault", default=os.environ.get("EXOMEM_VAULT_PATH"),
+        "--vault",
+        default=os.environ.get("EXOMEM_VAULT_PATH"),
         help=f"vault root containing '{kb_prefix()}' (default: $EXOMEM_VAULT_PATH)",
     )
     args = parser.parse_args(argv)
@@ -933,7 +995,9 @@ def _install_skill_main(argv: list[str]) -> int:
     target = Path(args.target) if args.target else None
     try:
         if target is not None:
-            reports = {"claude": install_module.install_skill(target, force=args.force, link=args.link)}
+            reports = {
+                "claude": install_module.install_skill(target, force=args.force, link=args.link)
+            }
         else:
             reports = install_module.install_skills(
                 client=args.client, force=args.force, link=args.link
@@ -944,8 +1008,7 @@ def _install_skill_main(argv: list[str]) -> int:
 
     for client, report in reports.items():
         print(
-            f"Installed the Exomem skills for {client} "
-            f"({report['mode']}, {report['files']} files):"
+            f"Installed the Exomem skills for {client} ({report['mode']}, {report['files']} files):"
         )
         print(f"  {report['target']}")
         if report.get("workflow_skills"):
@@ -1188,8 +1251,7 @@ def _simple_ask_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem ask",
         description=(
-            "Ask Exomem what it knows. Thin alias over ask_memory with compact "
-            "recall defaults."
+            "Ask Exomem what it knows. Thin alias over ask_memory with compact recall defaults."
         ),
     )
     parser.add_argument("query", help="question or search phrase")
@@ -1396,9 +1458,7 @@ def _simple_review_main(argv: list[str]) -> int:
         )
         parser.add_argument("ref", help="stable exomem://review/<id> reference")
         if action == "snooze":
-            parser.add_argument(
-                "--until", required=True, help="snooze through YYYY-MM-DD"
-            )
+            parser.add_argument("--until", required=True, help="snooze through YYYY-MM-DD")
         parser.add_argument("--why", help="optional review rationale")
         parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
         args = parser.parse_args(argv[1:])
@@ -1435,15 +1495,19 @@ def _simple_review_main(argv: list[str]) -> int:
     parser.add_argument("--json", action="store_true", help="emit the shared JSON envelope")
     args = parser.parse_args(argv)
 
-    core = ["review_memory", "--mode", "audit"] if args.audit else [
-        "review_memory",
-        "--mode",
-        "attention",
-        "--limit",
-        str(args.limit),
-        "--state",
-        args.state,
-    ]
+    core = (
+        ["review_memory", "--mode", "audit"]
+        if args.audit
+        else [
+            "review_memory",
+            "--mode",
+            "attention",
+            "--limit",
+            str(args.limit),
+            "--state",
+            args.state,
+        ]
+    )
     _append_repeated(core, "--categories", args.categories)
     return _core_op_main(_with_json(core, args.json))
 
@@ -1531,6 +1595,7 @@ def _simple_adopt_main(argv: list[str]) -> int:
     _append_repeated(core, "--selected-paths", args.selected_paths)
     return _core_op_main(_with_json(core, args.json))
 
+
 def _simple_maintain_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="exomem maintain",
@@ -1583,6 +1648,7 @@ def _simple_maintain_main(argv: list[str]) -> int:
         _append_repeated(core, "--categories", args.categories)
     return _core_op_main(_with_json(core, args.json))
 
+
 # --------------------------------------------------------------------------- #
 # Registry-driven core operations (reads + writes)
 # --------------------------------------------------------------------------- #
@@ -1591,9 +1657,7 @@ def _simple_maintain_main(argv: list[str]) -> int:
 # repeatable `--field key=value`, so the CLI stays clean.
 _FIELD_ESCAPE = frozenset({"remember", "replace_memory"})
 _FIELD_ESCAPE_VISIBLE_PARAMS = frozenset({"slug", "response_detail"})
-_LEGACY_EDIT_BOOL_FIELDS = frozenset(
-    {"replace_all", "overwrite", "allow_curated", "validate_only"}
-)
+_LEGACY_EDIT_BOOL_FIELDS = frozenset({"replace_all", "overwrite", "allow_curated", "validate_only"})
 
 
 def _expose_tier2() -> bool:
@@ -1624,11 +1688,7 @@ def _flag(name: str) -> str:
 def _add_command_args(sp: argparse.ArgumentParser, cmd) -> None:
     field_escape = cmd.name in _FIELD_ESCAPE
     for p in cmd.params:
-        if (
-            field_escape
-            and not p.required
-            and p.name not in _FIELD_ESCAPE_VISIBLE_PARAMS
-        ):
+        if field_escape and not p.required and p.name not in _FIELD_ESCAPE_VISIBLE_PARAMS:
             continue  # reachable via --field
         if p.cli_positional:
             sp.add_argument(
@@ -1705,17 +1765,11 @@ def _add_command_args(sp: argparse.ArgumentParser, cmd) -> None:
                 )
 
 
-def _collect_raw_args(
-    cmd, args: argparse.Namespace, parser: argparse.ArgumentParser
-) -> dict:
+def _collect_raw_args(cmd, args: argparse.Namespace, parser: argparse.ArgumentParser) -> dict:
     field_escape = cmd.name in _FIELD_ESCAPE
     raw: dict = {}
     for p in cmd.params:
-        if (
-            field_escape
-            and not p.required
-            and p.name not in _FIELD_ESCAPE_VISIBLE_PARAMS
-        ):
+        if field_escape and not p.required and p.name not in _FIELD_ESCAPE_VISIBLE_PARAMS:
             continue
         val = getattr(args, p.name, None)
         if val is not None:
@@ -1755,9 +1809,7 @@ def _normalize_cli_edit(cmd, raw: dict, cli_ops) -> dict:  # noqa: ANN001
         try:
             legacy["edits"] = json.loads(legacy["edits"])
         except json.JSONDecodeError as error:
-            raise cli_ops.OpError(
-                "BAD_JSON", f"`edits` must be valid JSON: {error}"
-            ) from None
+            raise cli_ops.OpError("BAD_JSON", f"`edits` must be valid JSON: {error}") from None
     if isinstance(legacy.get("value"), str):
         try:
             legacy["value"] = json.loads(legacy["value"])
@@ -1807,10 +1859,7 @@ def _print_adopt_human(result: dict) -> None:
     actions = result.get("next_actions") or []
     print("\nSafe next actions")
     for action in actions:
-        print(
-            f"  - {action.get('action')} [{action.get('status')}]: "
-            f"{action.get('description')}"
-        )
+        print(f"  - {action.get('action')} [{action.get('status')}]: {action.get('description')}")
 
     if manifest := result.get("manifest"):
         print(f"\nSaved manifest: {manifest.get('path')}")
@@ -1825,10 +1874,7 @@ def _print_adopt_human(result: dict) -> None:
         sources = plan.get("sources") or []
         skipped = plan.get("skipped") or []
         status = plan.get("status", "unknown")
-        print(
-            f"\nCompile plan: {status} "
-            f"({len(sources)} source(s), {len(skipped)} skipped)"
-        )
+        print(f"\nCompile plan: {status} ({len(sources)} source(s), {len(skipped)} skipped)")
         proposal = plan.get("proposal") or {}
         if proposal.get("suggested_title"):
             print(f"  Suggested title: {proposal.get('suggested_title')}")
@@ -1928,9 +1974,7 @@ def _core_op_main(argv: list[str]) -> int:
     from .vault import resolve_vault
 
     expose_tier2 = _expose_tier2()
-    registered_commands = commands_module.product_commands_for(
-        "cli", expose_tier2=expose_tier2
-    )
+    registered_commands = commands_module.product_commands_for("cli", expose_tier2=expose_tier2)
     cmds = {command.name: command for command in registered_commands}
     surface_descriptor = capabilities.ActiveSurfaceDescriptor(
         surface="cli",

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -46,22 +46,32 @@ def _module_available(name: str) -> bool:
         return False
 
 
-def _configure_local_search_capabilities(action: str | None) -> None:
+def _configure_local_search_capabilities(action: str | None) -> tuple[str, ...]:
     """Keep lean direct CLI retrieval on its intentionally installed lanes.
 
     The managed service can carry model/media extras while PATH-visible uv-tool
     commands stay lean. A local ``ask``/legacy ``find`` must not import missing
-    model stacks merely to discover that BM25 is its available backend.
+    model stacks merely to discover that BM25 is its available backend. Return
+    only the fallback variables introduced for this invocation so callers can
+    restore the surrounding process environment without touching explicit user
+    configuration.
     """
     if action not in {"ask", "ask_memory"}:
-        return
+        return ()
     model_stack_available = _module_available("torch") and _module_available(
         "sentence_transformers"
     )
+    introduced: list[str] = []
     if not model_stack_available:
-        os.environ.setdefault("EXOMEM_DISABLE_EMBEDDINGS", "1")
-        os.environ.setdefault("EXOMEM_DISABLE_RANKING", "1")
-        os.environ.setdefault("EXOMEM_DISABLE_CLIP", "1")
+        for name in (
+            "EXOMEM_DISABLE_EMBEDDINGS",
+            "EXOMEM_DISABLE_RANKING",
+            "EXOMEM_DISABLE_CLIP",
+        ):
+            if name not in os.environ:
+                os.environ[name] = "1"
+                introduced.append(name)
+    return tuple(introduced)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -77,7 +87,15 @@ def main(argv: list[str] | None = None) -> int:
         # `find` was the original friendly retrieval command.  Keep existing
         # scripts useful while the current product language calls it `ask`.
         raw[0] = "ask"
-    _configure_local_search_capabilities(raw[0] if raw else None)
+    introduced = _configure_local_search_capabilities(raw[0] if raw else None)
+    try:
+        return _dispatch_main(raw)
+    finally:
+        for name in introduced:
+            os.environ.pop(name, None)
+
+
+def _dispatch_main(raw: list[str]) -> int:
     if raw and raw[0] == "hosted":
         from .hosted_operator import main as hosted_operator_main
 

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -287,10 +287,10 @@ with the former raw result. Response detail is presentation-only: changing it
 does not change mutation identity, execute the leaf again, or alter a replayed
 terminal.
 
-`MUTATION_BUSY`, `MUTATION_ACKNOWLEDGEMENT_PENDING`, and
+`MUTATION_WARMING`, `MUTATION_BUSY`, `MUTATION_ACKNOWLEDGEMENT_PENDING`, and
 `MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN` remain errors, not successful
 terminals. Preserve the same mutation identity and unchanged payload when
-following their remediation: wait before retrying a busy call; retry a pending
+following their remediation: wait before retrying a warming or busy call; retry a pending
 call only with the same identity; do not submit a new identity after a
 committed-uncertain result—reconcile and retry only as instructed.
 

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -79,11 +79,15 @@ is retained for at least one compatibility release. The response-detail choice
 is removed before mutation identity is calculated, so it cannot create a second
 write or change which stored terminal a replay receives.
 
-Busy, acknowledgement-pending, and committed-acknowledgement-uncertain outcomes
+Warming, busy, acknowledgement-pending, and committed-acknowledgement-uncertain outcomes
 remain structured errors. Retrying must retain the same identity and payload:
-wait before retrying `MUTATION_BUSY`; never revise a pending payload; and after
+wait before retrying `MUTATION_WARMING` or `MUTATION_BUSY`; never revise a pending payload; and after
 `MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN`, reconcile and retry only with the
 same identity rather than creating a new write.
+
+`MUTATION_WARMING` means the restart-time semantic corpus is still being built.
+It never holds the mutation boundary and never means the Exomem tool is disabled;
+retry the unchanged call after `retry_after_ms`.
 
 `edit_memory` is one tool. New calls supply `path`, `why`, and one nested
 `operation` selected by `kind`:

--- a/src/exomem/activation_manifest.py
+++ b/src/exomem/activation_manifest.py
@@ -7,7 +7,10 @@ independent from rebuildable indexes and review decisions.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import threading
 from collections import Counter
 from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
@@ -35,12 +38,13 @@ from .vault import (
 SCHEMA_VERSION = 1
 CONTRACT_VERSION = 1
 _MANIFEST_NAME = "semantic-activation.yaml"
-_PAGE_KEYS = frozenset(
-    {"identity_kind", "identity", "path_at_activation", "source_hash"}
-)
+_PAGE_KEYS = frozenset({"identity_kind", "identity", "path_at_activation", "source_hash"})
 _ROOT_KEYS = frozenset({"schema_version", "contract_version", "pages"})
 _HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 _UNSET = object()
+_MANIFEST_CACHE: dict[str, tuple[str | None, ActivationManifest | None]] = {}
+_MANIFEST_CACHE_LOCK = threading.Lock()
+_MANIFEST_CACHE_MAX = 8
 
 
 @dataclass
@@ -105,23 +109,17 @@ class ActivationCensus:
                 )
             by_path[candidate.rel_path] = candidate
             if candidate.normalized_id is not None:
-                id_paths.setdefault(candidate.normalized_id, []).append(
-                    candidate.rel_path
-                )
+                id_paths.setdefault(candidate.normalized_id, []).append(candidate.rel_path)
         object.__setattr__(self, "candidates", ordered)
         object.__setattr__(self, "by_path", MappingProxyType(by_path))
         object.__setattr__(
             self,
             "paths_by_id",
-            MappingProxyType(
-                {key: tuple(paths) for key, paths in sorted(id_paths.items())}
-            ),
+            MappingProxyType({key: tuple(paths) for key, paths in sorted(id_paths.items())}),
         )
 
     @classmethod
-    def from_candidates(
-        cls, candidates: Iterable[ActivationCandidate]
-    ) -> ActivationCensus:
+    def from_candidates(cls, candidates: Iterable[ActivationCandidate]) -> ActivationCensus:
         return cls(tuple(candidates))
 
     def unique_path_for_id(self, normalized_id: str) -> str | None:
@@ -146,9 +144,7 @@ def _validate_candidate(candidate: ActivationCandidate, *, index: int) -> None:
             "ACTIVATION_CENSUS_INVALID",
             f"invalid activation census candidate {index}: {error.reason}",
         ) from error
-    if not isinstance(candidate.source_hash, str) or not _HASH_RE.fullmatch(
-        candidate.source_hash
-    ):
+    if not isinstance(candidate.source_hash, str) or not _HASH_RE.fullmatch(candidate.source_hash):
         raise ActivationManifestError(
             "ACTIVATION_CENSUS_INVALID",
             f"activation census candidate {index} source_hash must be a lowercase full SHA-256",
@@ -168,26 +164,94 @@ def manifest_path(vault_root: Path) -> Path:
     return Path(vault_root) / kb_dirname() / "_Schema" / _MANIFEST_NAME
 
 
+def reset_manifest_cache() -> None:
+    """Drop immutable-manifest parse memoization; public for tests/repair."""
+    with _MANIFEST_CACHE_LOCK:
+        _MANIFEST_CACHE.clear()
+
+
+def _manifest_cache_key(path: Path) -> str:
+    return os.path.normcase(str(path.resolve(strict=False)))
+
+
+def _manifest_signature(path: Path) -> tuple[int, int, int] | None:
+    try:
+        info = path.stat()
+    except FileNotFoundError:
+        return None
+    return (info.st_mtime_ns, info.st_ctime_ns, info.st_size)
+
+
+def _cache_manifest(
+    key: str,
+    digest: str | None,
+    manifest: ActivationManifest | None,
+) -> None:
+    with _MANIFEST_CACHE_LOCK:
+        _MANIFEST_CACHE[key] = (digest, manifest)
+        while len(_MANIFEST_CACHE) > _MANIFEST_CACHE_MAX:
+            del _MANIFEST_CACHE[next(iter(_MANIFEST_CACHE))]
+
+
 def load_manifest(vault_root: Path) -> ActivationManifest | None:
     """Load and validate an existing manifest without changing its bytes."""
     path = manifest_path(vault_root)
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return None
-    except (OSError, UnicodeDecodeError) as error:
-        raise ActivationManifestError(
-            "ACTIVATION_MANIFEST_UNREADABLE",
-            f"could not read {path}: {error}",
-        ) from error
-    try:
-        value = yaml.safe_load(raw)
-    except yaml.YAMLError as error:
-        raise ActivationManifestError(
-            "ACTIVATION_MANIFEST_INVALID_YAML",
-            f"{path} is not valid YAML: {error}",
-        ) from error
-    return _validate_manifest(value, path=path)
+    key = _manifest_cache_key(path)
+    for _ in range(2):
+        try:
+            signature = _manifest_signature(path)
+        except OSError as error:
+            raise ActivationManifestError(
+                "ACTIVATION_MANIFEST_UNREADABLE",
+                f"could not inspect {path}: {error}",
+            ) from error
+        if signature is None:
+            _cache_manifest(key, None, None)
+            return None
+        try:
+            raw_bytes = path.read_bytes()
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            raise ActivationManifestError(
+                "ACTIVATION_MANIFEST_UNREADABLE",
+                f"could not read {path}: {error}",
+            ) from error
+        try:
+            confirmed = _manifest_signature(path)
+        except OSError as error:
+            raise ActivationManifestError(
+                "ACTIVATION_MANIFEST_UNREADABLE",
+                f"could not re-inspect {path}: {error}",
+            ) from error
+        if confirmed != signature:
+            continue
+        digest = hashlib.sha256(raw_bytes).hexdigest()
+        with _MANIFEST_CACHE_LOCK:
+            cached = _MANIFEST_CACHE.get(key)
+        if cached is not None and cached[0] == digest:
+            return cached[1]
+        try:
+            raw = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ActivationManifestError(
+                "ACTIVATION_MANIFEST_UNREADABLE",
+                f"could not read {path}: {error}",
+            ) from error
+        try:
+            value = yaml.safe_load(raw)
+        except yaml.YAMLError as error:
+            raise ActivationManifestError(
+                "ACTIVATION_MANIFEST_INVALID_YAML",
+                f"{path} is not valid YAML: {error}",
+            ) from error
+        manifest = _validate_manifest(value, path=path)
+        _cache_manifest(key, digest, manifest)
+        return manifest
+    raise ActivationManifestError(
+        "ACTIVATION_MANIFEST_UNSTABLE",
+        f"{path} changed repeatedly while it was being read",
+    )
 
 
 def ensure_manifest(
@@ -199,11 +263,7 @@ def ensure_manifest(
     if existing is not None:
         return existing
 
-    candidate = (
-        _snapshot(vault_root)
-        if census is None
-        else _snapshot(vault_root, census=census)
-    )
+    candidate = _snapshot(vault_root) if census is None else _snapshot(vault_root, census=census)
     path = manifest_path(vault_root)
     with _creation_lock(path):
         winner = load_manifest(vault_root)
@@ -295,22 +355,15 @@ def snapshot_from_census(census: ActivationCensus) -> ActivationManifest:
         )
     candidates = census.candidates
     counts = Counter(
-        candidate.normalized_id
-        for candidate in candidates
-        if candidate.normalized_id is not None
+        candidate.normalized_id for candidate in candidates if candidate.normalized_id is not None
     )
     pages = []
     for candidate in candidates:
-        stable = (
-            candidate.normalized_id is not None
-            and counts[candidate.normalized_id] == 1
-        )
+        stable = candidate.normalized_id is not None and counts[candidate.normalized_id] == 1
         pages.append(
             ActivationPage(
                 identity_kind="exomem_id" if stable else "path_source_hash",
-                identity=(
-                    candidate.normalized_id if stable else candidate.rel_path
-                ),
+                identity=(candidate.normalized_id if stable else candidate.rel_path),
                 path_at_activation=candidate.rel_path,
                 source_hash=candidate.source_hash,
             )
@@ -333,9 +386,7 @@ def plan_activation_boundary(
     return ActivationBoundaryPlan(snapshot_from_census(census), True)
 
 
-def _snapshot(
-    vault_root: Path, *, census: ActivationCensus | None = None
-) -> ActivationManifest:
+def _snapshot(vault_root: Path, *, census: ActivationCensus | None = None) -> ActivationManifest:
     observed = census if census is not None else build_census(vault_root)
     return snapshot_from_census(observed)
 

--- a/src/exomem/bm25.py
+++ b/src/exomem/bm25.py
@@ -113,6 +113,7 @@ class BM25Index:
 
         if scope == "vault":
             from .vault import walk_vault_md
+
             walk = walk_vault_md(vault_root)
         else:
             kb = vault_root / kb_dirname()
@@ -174,6 +175,7 @@ class BM25Index:
         scope: str = "kb",
         freshness: tuple | None = None,
         allowed_paths: set[str] | None = None,
+        repair: bool = True,
     ) -> list[tuple[str, float]]:
         """Return top-k `(rel_path, bm25_score)` for `query`. Empty query → [].
 
@@ -195,6 +197,7 @@ class BM25Index:
             scope=scope,
             freshness=freshness,
             allowed_paths=allowed_paths,
+            repair=repair,
         )
         if indexed is not None:
             return indexed
@@ -262,6 +265,7 @@ def corpus_key(vault_root: Path, scope: str) -> tuple:
     """Digest-strength corpus freshness key for a scope (one stat walk)."""
     if scope == "vault":
         from .vault import walk_vault_md
+
         walk = walk_vault_md(vault_root)
     else:
         kb = vault_root / kb_dirname()
@@ -282,6 +286,7 @@ def search(
     scope: str = "kb",
     freshness: tuple | None = None,
     allowed_paths: set[str] | None = None,
+    repair: bool = True,
 ) -> list[tuple[str, float]]:
     """Module-level convenience using the per-process singleton."""
     return _INDEX.search(
@@ -291,6 +296,7 @@ def search(
         scope=scope,
         freshness=freshness,
         allowed_paths=allowed_paths,
+        repair=repair,
     )
 
 

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -49,22 +49,18 @@ _REMEDIATION: dict[str, str] = {
     "STALE_UNIT_REFERENCE": (
         "Re-read the exact unit and retry with its current reference/fingerprint."
     ),
-    "AMBIGUOUS_UNIT_REFERENCE": (
-        "Re-read the parent and select one exact current unit reference."
-    ),
+    "AMBIGUOUS_UNIT_REFERENCE": ("Re-read the parent and select one exact current unit reference."),
     "COMPACT_RELATIONS_REQUIRE_RICH_KIND": (
         "Select an explicit governed rich kind or author a canonical note-level relation."
     ),
     "DRIFT_GUARDS_REQUIRED": (
-        "Re-read the parent and exact unit, then pass both expected_hash and "
-        "expected_fingerprint."
+        "Re-read the parent and exact unit, then pass both expected_hash and expected_fingerprint."
     ),
     "WRITER_LEASE_REQUIRED": (
         "Send the mutation to the current writer or retry after its lease expires."
     ),
     "WRITER_COORDINATOR_UNAVAILABLE": (
-        "Check the coordinator URL, credentials, and service health; reads remain "
-        "available."
+        "Check the coordinator URL, credentials, and service health; reads remain available."
     ),
     "WRITER_FENCED": "Retry the mutation on the current writer.",
     "INGRESS_BYPASSED": (
@@ -72,6 +68,7 @@ _REMEDIATION: dict[str, str] = {
         "and worker route coverage, or set EXOMEM_EDGE_STAMP_ENFORCE=0 to break glass."
     ),
     "MUTATION_BUSY": "Retry after the active vault mutation finishes.",
+    "MUTATION_WARMING": "Retry after semantic corpus warm-up completes.",
     "MUTATION_ACKNOWLEDGEMENT_PENDING": (
         "Retry with the same mutation identity; do not submit a revised payload."
     ),
@@ -86,13 +83,13 @@ _REMEDIATION: dict[str, str] = {
     "UNSUPPORTED_MEDIA": "Use a supported audio, video, image, document, or text-media extension.",
     "MEDIA_NOT_FOUND": "Check the governed Knowledge Base path and original filename.",
     "MEDIA_PATH_OUTSIDE_KB": "Choose a media artifact inside the governed Knowledge Base.",
-    "MEDIA_PATH_ACCESS_DENIED": "Move the artifact to a writable governed subtree or update _access.yaml policy.",
+    "MEDIA_PATH_ACCESS_DENIED": (
+        "Move the artifact to a writable governed subtree or update _access.yaml policy."
+    ),
 }
 
 # Error codes whose HTTP status is NOT the default 400.
-_NOT_FOUND_CODES = frozenset(
-    {"NOT_FOUND", "OLD_NOT_FOUND", "SOURCES_NOT_FOUND", "NOT_IN_TRASH"}
-)
+_NOT_FOUND_CODES = frozenset({"NOT_FOUND", "OLD_NOT_FOUND", "SOURCES_NOT_FOUND", "NOT_IN_TRASH"})
 _CONFLICT_CODES = frozenset(
     {
         "ARTIFACT_EXISTS",
@@ -115,6 +112,7 @@ _CONFLICT_CODES = frozenset(
         "BATCH_ROLLBACK_INCOMPLETE",
         "BATCH_CLEANUP_INCOMPLETE",
         "MUTATION_BUSY",
+        "MUTATION_WARMING",
         "MUTATION_ACKNOWLEDGEMENT_PENDING",
         "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN",
         # Adoption Studio drift codes (add-adoption-studio): a stale plan/apply or a
@@ -344,9 +342,7 @@ def coerce(
     if tool == "edit_memory" and isinstance(raw.get("operation"), dict):
         operation = raw["operation"]
         for field in ("new_body", "new_string"):
-            guards.guard_text_content(
-                operation.get(field), tool=tool, field=f"operation.{field}"
-            )
+            guards.guard_text_content(operation.get(field), tool=tool, field=f"operation.{field}")
         for item in operation.get("edits") or []:
             if isinstance(item, dict):
                 guards.guard_text_content(

--- a/src/exomem/embedding_index.py
+++ b/src/exomem/embedding_index.py
@@ -45,7 +45,6 @@ SEMANTIC_UNIT_SCHEMA_VERSION = 3
 # single-machine-per-sidecar deployment; would need re-litigating for multi-writer.
 
 
-
 class _EmbCache(NamedTuple):
     """EmbeddingIndex's in-memory matrix cache. `(epoch, generation, instance)` is
     the write token (F1-F3); `mtime` is retained only for the gen==0 legacy
@@ -170,8 +169,7 @@ class EmbeddingIndex:
         """Replace all rows for `rel_path` in a single transaction."""
         if len(chunks) != len(vectors):
             raise ValueError(
-                f"chunks/vectors length mismatch for {rel_path}: "
-                f"{len(chunks)} vs {len(vectors)}"
+                f"chunks/vectors length mismatch for {rel_path}: {len(chunks)} vs {len(vectors)}"
             )
         conn = self._connect()
         try:
@@ -400,7 +398,9 @@ class EmbeddingIndex:
             log.info(
                 "embedding matrix full load: reason=%s rows=%d gen=%d epoch=%d",
                 sidecar_store.reload_reason(c, loaded.epoch, loaded.generation),
-                len(loaded.metadata), loaded.generation, loaded.epoch,
+                len(loaded.metadata),
+                loaded.generation,
+                loaded.epoch,
             )
             self._cache = loaded
             return loaded.metadata, loaded.matrix
@@ -443,8 +443,7 @@ class EmbeddingIndex:
             try:
                 epoch, gen, instance = sidecar_store.read_meta_token(conn)
                 rows = conn.execute(
-                    "SELECT file_path, chunk_idx, vector FROM chunks "
-                    "ORDER BY file_path, chunk_idx"
+                    "SELECT file_path, chunk_idx, vector FROM chunks ORDER BY file_path, chunk_idx"
                 ).fetchall()
             finally:
                 conn.rollback()  # read-only txn — release the snapshot
@@ -515,14 +514,15 @@ class EmbeddingIndex:
         k: int,
         *,
         allowed_unit_refs: set[str] | None = None,
+        validate: bool = True,
     ) -> list[SemanticUnitVectorHit]:
-        """Return current unit rows ranked by cosine after exact eligibility.
+        """Score unit rows first, then validate only a bounded winner window.
 
-        Semantic-unit rows deliberately use the exact numpy rung even when the
-        optional vec0 page backend is enabled. The allowlist and parent
-        generation/source/parser validation are applied before scoring and
-        top-k, so stale or ineligible high-cosine rows cannot consume the
-        bounded candidate window.
+        Vector scoring is an in-memory/numpy scan of rebuildable blobs. Markdown
+        freshness validation is the expensive part, so an unfiltered query
+        overfetches a bounded ranked window instead of reopening every parent.
+        An explicit allowlist retains its exact validation contract for audit
+        and repair callers.
         """
         if k <= 0 or not self.path.exists():
             return []
@@ -548,66 +548,79 @@ class EmbeddingIndex:
         finally:
             conn.close()
 
-        current_rows: list[tuple[str, str, str, str, int, np.ndarray]] = []
-        freshness_by_stamp: dict[tuple[str, str, str, int], bool] = {}
+        candidates: list[tuple[str, str, str, str, int, np.ndarray]] = []
         for unit_ref, parent_path, generation, source_hash, parser_version, blob in rows:
-            stamp = (
-                str(parent_path),
-                str(generation),
-                str(source_hash),
-                int(parser_version),
+            vector = np.frombuffer(blob, dtype=np.float32)
+            if vector.shape != (VECTOR_DIM,):
+                continue
+            candidates.append(
+                (
+                    str(unit_ref),
+                    str(parent_path),
+                    str(generation),
+                    str(source_hash),
+                    int(parser_version),
+                    vector,
+                )
             )
+        if not candidates:
+            return []
+
+        query = query_vec.astype(np.float32, copy=False)
+        matrix = np.stack([candidate[5] for candidate in candidates])
+        scores = matrix @ query
+        order = sorted(
+            range(len(candidates)),
+            key=lambda index: (-float(scores[index]), candidates[index][0]),
+        )
+        validation_limit = (
+            len(order) if allowed_unit_refs is not None else min(len(order), max(k * 4, k + 32))
+        )
+        if not validate:
+            return [
+                SemanticUnitVectorHit(
+                    candidates[index][0],
+                    candidates[index][1],
+                    candidates[index][2],
+                    candidates[index][3],
+                    candidates[index][4],
+                    float(scores[index]),
+                )
+                for index in order[:k]
+            ]
+
+        freshness_by_stamp: dict[tuple[str, str, str, int], bool] = {}
+        ranked: list[SemanticUnitVectorHit] = []
+        for index in order[:validation_limit]:
+            unit_ref, parent_path, generation, source_hash, parser_version, _vector = candidates[
+                index
+            ]
+            stamp = (parent_path, generation, source_hash, parser_version)
             accepted = freshness_by_stamp.get(stamp)
             if accepted is None:
                 accepted = semantic_index.validate_parent_record(
                     self.vault_root,
-                    parent_path=stamp[0],
-                    parent_generation_value=stamp[1],
-                    parent_source_hash=stamp[2],
-                    parser_version=stamp[3],
+                    parent_path=parent_path,
+                    parent_generation_value=generation,
+                    parent_source_hash=source_hash,
+                    parser_version=parser_version,
                 ).current
                 freshness_by_stamp[stamp] = accepted
             if not accepted:
                 continue
-            vector = np.frombuffer(blob, dtype=np.float32)
-            if vector.shape != (VECTOR_DIM,):
-                continue
-            current_rows.append(
-                (
-                    str(unit_ref),
-                    stamp[0],
-                    stamp[1],
-                    stamp[2],
-                    stamp[3],
-                    vector,
-                )
-            )
-        if not current_rows:
-            return []
-
-        query = query_vec.astype(np.float32, copy=False)
-        ranked = sorted(
-            (
+            ranked.append(
                 SemanticUnitVectorHit(
                     unit_ref,
                     parent_path,
                     generation,
                     source_hash,
                     parser_version,
-                    float(vector @ query),
+                    float(scores[index]),
                 )
-                for (
-                    unit_ref,
-                    parent_path,
-                    generation,
-                    source_hash,
-                    parser_version,
-                    vector,
-                ) in current_rows
-            ),
-            key=lambda hit: (-hit.cosine, hit.unit_ref),
-        )
-        return ranked[:k]
+            )
+            if len(ranked) == k:
+                break
+        return ranked
 
     def _texts_for(self, pairs: list[tuple[str, int]]) -> dict[tuple[str, int], str]:
         """chunk_text for `(file_path, chunk_idx)` pairs — search's top-k only.
@@ -624,10 +637,8 @@ class EmbeddingIndex:
         try:
             batch_size = 150  # 2 bound params per pair
             for s in range(0, len(pairs), batch_size):
-                batch = pairs[s:s + batch_size]
-                where = " OR ".join(
-                    "(file_path = ? AND chunk_idx = ?)" for _ in batch
-                )
+                batch = pairs[s : s + batch_size]
+                where = " OR ".join("(file_path = ? AND chunk_idx = ?)" for _ in batch)
                 params: list = []
                 for fp, ci in batch:
                     params.extend((fp, ci))
@@ -681,7 +692,8 @@ class EmbeddingIndex:
         except Exception as e:  # noqa: BLE001 — vec failure must never break search
             log.warning(
                 "vec search failed for %s (%s); falling back to the in-memory scan",
-                self.path, e,
+                self.path,
+                e,
             )
             self._vec_failed = True
             return None
@@ -713,16 +725,13 @@ class EmbeddingIndex:
         conn = self._connect()
         try:
             rows = conn.execute(
-                "SELECT parent_path, parent_generation, unit_ref "
-                "FROM semantic_unit_vectors"
+                "SELECT parent_path, parent_generation, unit_ref FROM semantic_unit_vectors"
             ).fetchall()
         finally:
             conn.close()
         grouped: dict[str, tuple[set[str], set[str]]] = {}
         for parent_path, generation, unit_ref in rows:
-            generations, unit_refs = grouped.setdefault(
-                str(parent_path), (set(), set())
-            )
+            generations, unit_refs = grouped.setdefault(str(parent_path), (set(), set()))
             generations.add(str(generation))
             unit_refs.add(str(unit_ref))
         return {

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -66,6 +66,7 @@ def _reconcile_background_media(vault_root: Path, binary: Path) -> object:
         commit_guard=lambda: _media_mutation_guard(vault_root),
     )
 
+
 DEBOUNCE_SECONDS = 0.5
 # How often the watcher re-walks and reconciles the freshness registry against
 # disk truth, bounding how long a dropped watchdog event can leave it stale.
@@ -139,10 +140,15 @@ def _publish_registry_change(
         # Kill switch on: don't even pay the resolve() syscalls in _rel_posix.
         return
     try:
-        deleted_paths = [vault_root / r for r in deleted_rels]
-        freshness.on_files_changed(vault_root, changed=changed, deleted=deleted_paths)
-    except Exception:  # noqa: BLE001 — bookkeeping must never break a write
-        log.debug("self-write freshness publish failed", exc_info=True)
+        from . import semantic_contract
+
+        semantic_contract.publish_corpus_files_changed(
+            vault_root,
+            changed=changed,
+            deleted=deleted_rels,
+        )
+    except Exception:  # noqa: BLE001 — rebuildable state never breaks a write
+        log.debug("self-write freshness/semantic publish failed", exc_info=True)
     changed_rels = [r for r in (_rel_posix(vault_root, p) for p in changed) if r]
     try:
         from . import vault as vault_module
@@ -374,11 +380,16 @@ class FileWatcher:
             return
 
         # Freshness: the whole vault, since both index sibling folders too.
-        deleted_paths = [self._vault_root / r for r in del_rels]
         try:
-            freshness.on_files_changed(self._vault_root, changed=ups, deleted=deleted_paths)
-        except Exception:  # noqa: BLE001 — a bad batch must never kill the watcher
-            log.exception("file watcher: freshness publish failed")
+            from . import semantic_contract
+
+            semantic_contract.publish_corpus_files_changed(
+                self._vault_root,
+                changed=ups,
+                deleted=del_rels,
+            )
+        except Exception:  # noqa: BLE001 — sidecar repair retries from its census
+            log.exception("file watcher: freshness/semantic publish failed")
         up_rels = [r for r in (self._rel(p) for p in ups) if r]
         self._dispatch_batch(ups, up_rels, del_rels, cap=False)
 
@@ -583,11 +594,7 @@ class FileWatcher:
                     operation="watcher",
                 )
                 summary = posthoc.as_dict()
-                logger = (
-                    log.warning
-                    if summary["semantic_contract_findings"]
-                    else log.info
-                )
+                logger = log.warning if summary["semantic_contract_findings"] else log.info
                 logger(
                     "file watcher: semantic posthoc batch %s",
                     json.dumps(summary, ensure_ascii=True, sort_keys=True),

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -16,6 +16,7 @@ import os
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Iterable
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -151,9 +152,7 @@ def auto_rerank_allowed_by_policy() -> bool:
     try:
         from . import accel
 
-        return _accelerated_device(
-            accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
-        )
+        return _accelerated_device(accel.select_device(override_env="EXOMEM_EMBED_DEVICE"))
     except Exception:  # noqa: BLE001 - auto-rerank must fail closed to cheap find.
         return False
 
@@ -172,6 +171,16 @@ _FIND_CACHE: OrderedDict[tuple, list[Hit]] = OrderedDict()
 _FIND_CACHE_LOCK = threading.Lock()
 _DEFAULT_FIND_CACHE_SIZE = 32
 MAX_RERANK_CANDIDATES = 300
+_FOREGROUND_LEXICAL_REPAIR_PAGE_CAP = 64
+
+
+def _bounded_lexical_repair_allowed(freshness_key: tuple | None) -> bool:
+    """Permit a cold inline sidecar build only for a provably small corpus."""
+    return bool(
+        freshness_key
+        and isinstance(freshness_key[0], int)
+        and freshness_key[0] <= _FOREGROUND_LEXICAL_REPAIR_PAGE_CAP
+    )
 
 
 def _set_rerank_timing_profile(
@@ -202,11 +211,7 @@ def _order_reranked_prefix(hits: list[Any], *, prefix_count: int) -> list[Any]:
     """Sort only the scored prefix, preserving the fused tail byte-for-byte."""
     prefix = hits[:prefix_count]
     prefix.sort(
-        key=lambda hit: -(
-            hit.rerank_score
-            if hit.rerank_score is not None
-            else float("-inf")
-        )
+        key=lambda hit: -(hit.rerank_score if hit.rerank_score is not None else float("-inf"))
     )
     return prefix + hits[prefix_count:]
 
@@ -220,7 +225,6 @@ def _find_cache_size() -> int:
     except ValueError:
         log.warning("EXOMEM_FIND_CACHE_SIZE=%r is not an int; using default", raw)
         return _DEFAULT_FIND_CACHE_SIZE
-
 
 
 class FreshnessSnapshot:
@@ -478,19 +482,14 @@ def find(
     `EXOMEM_DISABLE_USAGE_BOOST`. Bypasses the hot find cache.
     """
     if scope not in ("kb", "vault", "kb-only"):
-        raise ValueError(
-            f"find: scope must be 'kb', 'vault', or 'kb-only', got {scope!r}"
-        )
+        raise ValueError(f"find: scope must be 'kb', 'vault', or 'kb-only', got {scope!r}")
     if mode not in ("hybrid", "keyword", "vector"):
-        raise ValueError(
-            f"find: mode must be 'hybrid', 'keyword', or 'vector', got {mode!r}"
-        )
+        raise ValueError(f"find: mode must be 'hybrid', 'keyword', or 'vector', got {mode!r}")
     if limit < 1:
         limit = 1
     limit = min(limit, 100)
     if rerank_max_candidates is not None and (
-        isinstance(rerank_max_candidates, bool)
-        or not isinstance(rerank_max_candidates, int)
+        isinstance(rerank_max_candidates, bool) or not isinstance(rerank_max_candidates, int)
     ):
         raise ValueError(
             "find: rerank_max_candidates must be an integer "
@@ -564,9 +563,7 @@ def find(
             updated_before=updated_before,
             recency_days=recency_days,
         ),
-        resolve_category=lambda value: _resolve_language_value(
-            value, namespace="category"
-        ),
+        resolve_category=lambda value: _resolve_language_value(value, namespace="category"),
         resolve_kind=lambda value: _resolve_language_value(value, namespace="kind"),
     )
     filter_key = json.dumps(
@@ -644,20 +641,45 @@ def find(
     if timings is not None:
         timings.cache["enabled"] = cache_size > 0
     if cache_size > 0:
+
         def _t(v: list | None) -> tuple | None:
             return tuple(v) if v is not None else None
 
         request_key = (
-            str(vault_root.resolve()), query, _t(types), _t(projects), _t(tags),
-            _t(speakers), _t(file_types), _t(exclude_file_types), limit, scope,
-            mode, graph, rerank, rerank_max_candidates, auto_rerank, temporal, intent,
-            updated_after, updated_before, recency_days, filter_key,
-            effective_result_level, prefer_compiled, prefer_active, resolved_config,
+            str(vault_root.resolve()),
+            query,
+            _t(types),
+            _t(projects),
+            _t(tags),
+            _t(speakers),
+            _t(file_types),
+            _t(exclude_file_types),
+            limit,
+            scope,
+            mode,
+            graph,
+            rerank,
+            rerank_max_candidates,
+            auto_rerank,
+            temporal,
+            intent,
+            updated_after,
+            updated_before,
+            recency_days,
+            filter_key,
+            effective_result_level,
+            prefer_compiled,
+            prefer_active,
+            resolved_config,
         )
         with _span(timings, "freshness"):
             fresh = _freshness_key(
-                vault_root, scope=scope, query_norm=query_norm, mode=mode,
-                graph=graph, snapshot=snapshot,
+                vault_root,
+                scope=scope,
+                query_norm=query_norm,
+                mode=mode,
+                graph=graph,
+                snapshot=snapshot,
                 unit_filters=filter_plan.has_unit_predicate,
             )
         cache_key = (request_key, fresh)
@@ -726,19 +748,38 @@ def find(
             hits = _find_keyword(
                 vault_root,
                 query_norm=query_norm,
-                types=types, projects=projects, tags=tags, speakers=speakers,
-                file_types=file_types, exclude_file_types=exclude_file_types,
-                limit=limit, scope=walk_scope, eligible_paths=eligible_paths,
+                types=types,
+                projects=projects,
+                tags=tags,
+                speakers=speakers,
+                file_types=file_types,
+                exclude_file_types=exclude_file_types,
+                limit=limit,
+                scope=walk_scope,
+                eligible_paths=eligible_paths,
+                freshness_key=snapshot.for_scope(walk_scope),
+                failed_out=failed,
             )
     else:
         hits = _find_semantic(
             vault_root,
-            query=query, query_norm=query_norm,
-            types=types, projects=projects, tags=tags, speakers=speakers,
-            file_types=file_types, exclude_file_types=exclude_file_types,
-            limit=limit, scope=walk_scope, mode=mode, graph=graph, rerank=rerank,
+            query=query,
+            query_norm=query_norm,
+            types=types,
+            projects=projects,
+            tags=tags,
+            speakers=speakers,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
+            limit=limit,
+            scope=walk_scope,
+            mode=mode,
+            graph=graph,
+            rerank=rerank,
             rerank_max_candidates=rerank_max_candidates,
-            auto_rerank=auto_rerank, temporal=temporal, intent=intent,
+            auto_rerank=auto_rerank,
+            temporal=temporal,
+            intent=intent,
             prefer_compiled=prefer_compiled,
             prefer_active=prefer_active,
             prefer_used=prefer_used,
@@ -783,15 +824,22 @@ def find(
         with _span(timings, "outside_kb"):
             seen = {h.path for h in hits}
             outside = [
-                h for h in _find_outside_kb(
+                h
+                for h in _find_outside_kb(
                     vault_root,
                     query=query,
                     query_norm=query_norm,
-                    types=types, projects=projects, tags=tags, speakers=speakers,
-                    file_types=file_types, exclude_file_types=exclude_file_types,
-                    limit=limit, snapshot=snapshot,
+                    types=types,
+                    projects=projects,
+                    tags=tags,
+                    speakers=speakers,
+                    file_types=file_types,
+                    exclude_file_types=exclude_file_types,
+                    limit=limit,
+                    snapshot=snapshot,
                     filter_plan=filter_plan if filter_plan.root is not None else None,
                     exclude_paths=seen,
+                    failed_out=failed,
                     retrieval_trace=retrieval_trace,
                 )
                 if h.path not in seen
@@ -815,10 +863,7 @@ def find(
                     retrieval_trace.record_auto_widen(
                         hits,
                         strong_paths=[hit.path for hit in strong[:kb_keep]],
-                        weak_paths=[
-                            hit.path
-                            for hit in weak[: max(0, kb_keep - len(strong))]
-                        ],
+                        weak_paths=[hit.path for hit in weak[: max(0, kb_keep - len(strong))]],
                         outside_paths=[hit.path for hit in outside],
                         reserve=reserve,
                         kb_keep=kb_keep,
@@ -869,7 +914,6 @@ def find(
             while len(_FIND_CACHE) > cache_size:
                 _FIND_CACHE.popitem(last=False)
     return hits
-
 
 
 def _collapse_frame_children(
@@ -969,6 +1013,118 @@ def _eligible_unit_records(
     return eligible
 
 
+def _indexed_unit_constraints(
+    plan: structured_filters.FilterPlan,
+) -> tuple[list[str] | None, list[str] | None]:
+    """Extract safe conjunctive category/kind constraints for SQL pushdown."""
+    values: dict[str, set[str] | None] = {"unit.category": None, "unit.kind": None}
+
+    def visit(node: structured_filters.FilterNode | None) -> None:
+        if node is None:
+            return
+        if isinstance(node, structured_filters.AllOf):
+            for child in node.children:
+                visit(child)
+            return
+        if not isinstance(node, structured_filters.Predicate):
+            return
+        field = node.field.name
+        if field not in values:
+            return
+        for operator, operand in node.operators:
+            if operator == "$eq":
+                candidates = {str(operand.value)}
+            elif operator == "$in":
+                candidates = {str(item.value) for item in operand}
+            else:
+                continue
+            current = values[field]
+            values[field] = candidates if current is None else current & candidates
+
+    visit(plan.root)
+    categories = values["unit.category"]
+    kinds = values["unit.kind"]
+    return (
+        sorted(categories) if categories else None,
+        sorted(kinds) if kinds else None,
+    )
+
+
+def _hydrate_indexed_unit_records(
+    vault_root: Path,
+    indexed: list[Any],
+    *,
+    plan: structured_filters.FilterPlan,
+    stale_out: list[str] | None = None,
+) -> dict[str, tuple[ParsedPage, Any, int]]:
+    """Hydrate only sidecar-selected parents, rejecting any generation race."""
+    from . import semantic_index
+
+    parents: dict[str, tuple[ParsedPage, Any] | None] = {}
+    records: dict[str, tuple[ParsedPage, Any, int]] = {}
+    for hit in indexed:
+        parent = parents.get(hit.parent_path)
+        if hit.parent_path not in parents:
+            page = _CACHE.get(vault_root / hit.parent_path, vault_root)
+            if page is None or not _passes_filters(
+                page,
+                vault_root=vault_root,
+                types=None,
+                projects=None,
+                tags=None,
+                speakers=None,
+                file_types=None,
+                exclude_file_types=None,
+            ):
+                if page is None and stale_out is not None:
+                    stale_out.append(hit.unit_ref)
+                parents[hit.parent_path] = None
+                continue
+            try:
+                state = semantic_index.current_parent_index_state(vault_root, hit.parent_path)
+            except (OSError, UnicodeError, ValueError) as error:
+                log.warning(
+                    "semantic-unit candidate hydration failed for %s: %s",
+                    hit.parent_path,
+                    error,
+                )
+                if stale_out is not None:
+                    stale_out.append(hit.unit_ref)
+                parents[hit.parent_path] = None
+                continue
+            if state.parent_generation != hit.parent_generation:
+                if stale_out is not None:
+                    stale_out.append(hit.unit_ref)
+                parents[hit.parent_path] = None
+                continue
+            parent = (page, state)
+            parents[hit.parent_path] = parent
+        if parent is None:
+            continue
+        page, state = parent
+        located = next(
+            (
+                (source_order, candidate)
+                for source_order, candidate in enumerate(state.document.units)
+                if candidate.unit_ref == hit.unit_ref
+            ),
+            None,
+        )
+        if located is None:
+            if stale_out is not None:
+                stale_out.append(hit.unit_ref)
+            continue
+        source_order, unit = located
+        if not structured_filters.evaluate_filter(
+            plan,
+            page=structured_filters.page_view(page),
+            unit=structured_filters.unit_view(unit),
+        ):
+            continue
+        records[hit.unit_ref] = (page, unit, getattr(hit, "source_order", source_order))
+    return records
+
+
 def _python_unit_scores(
     records: dict[str, tuple[ParsedPage, Any, int]],
     query: str,
@@ -1044,6 +1200,7 @@ def _semantic_unit_hit(
         excerpt=_unit_excerpt(unit.content),
         tags=list(unit.tags),
         context=unit.context,
+        relations=[relation.to_dict() for relation in unit.relations],
         source_anchor=unit.anchor,
         source_span=_unit_span(unit),
         source_hash=unit.source_hash,
@@ -1059,6 +1216,68 @@ def _semantic_unit_hit(
         vector_rank=vector_rank,
         vector_score=vector_score,
     )
+
+
+def _vector_unit_candidates(
+    vault_root: Path,
+    *,
+    query: str,
+    candidate_limit: int,
+    allowed_unit_refs: set[str] | None,
+    degraded_out: list[str] | None,
+    failed_out: list[str] | None,
+) -> tuple[list[Any], dict[str, Any], str]:
+    """Return bounded vector candidates without opening every Markdown parent."""
+    model_name = "BAAI/bge-base-en-v1.5"
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        return (
+            [],
+            {"status": "disabled", "reason": "embeddings_disabled", "model": model_name},
+            "kb",
+        )
+
+    from . import readiness
+
+    if readiness.should_defer("embeddings"):
+        if degraded_out is not None:
+            degraded_out.append("embeddings")
+        return [], {"status": "warming", "reason": "model_warming", "model": model_name}, "kb"
+    try:
+        from . import embeddings
+
+        index = embeddings.get_embedding_index(vault_root)
+        query_vector = embeddings.embed_texts([query], is_query=True)[0]
+        hits = index.search_semantic_units(
+            query_vector,
+            k=candidate_limit,
+            allowed_unit_refs=allowed_unit_refs,
+            validate=False,
+        )
+        profile = {
+            "status": "participated" if hits else "available_nonmatching",
+            "backend": type(index).__name__,
+            "model": embeddings.MODEL_NAME,
+            "metric": {
+                "name": "cosine_similarity",
+                "direction": "higher",
+                "range": [-1.0, 1.0],
+                "rounding": 6,
+            },
+        }
+        return hits, profile, embeddings.index_scope()
+    except ImportError as error:
+        log.info("semantic-unit vector search unavailable (%s); using lexical ranking", error)
+        return (
+            [],
+            {"status": "unavailable", "reason": "dependency_unavailable", "model": model_name},
+            "kb",
+        )
+    except Exception as error:  # noqa: BLE001 - vector lane soft-falls back
+        log.warning("semantic-unit vector search failed: %s; using lexical ranking", error)
+        _record_degradation("vector")
+        if failed_out is not None:
+            failed_out.append("vector")
+        return [], {"status": "failed", "reason": "search_failed", "model": model_name}, "kb"
 
 
 def _find_semantic_units(
@@ -1077,11 +1296,49 @@ def _find_semantic_units(
     retrieval_trace: Any | None = None,
 ) -> list[SemanticUnitHit]:
     """Rank current, exactly eligible units through lexical and vector lanes."""
-    records = _eligible_unit_records(vault_root, scope=scope, plan=plan)
-    if not records:
-        return []
+    from . import lexstore
+
+    indexed: list[Any] | None = None
+    candidate_window_exhausted = False
+    categories, kinds = _indexed_unit_constraints(plan)
+    requested_limit = 20 if limit is None else max(1, limit)
+    candidate_limit = max(20, min(200, requested_limit * 8))
+    if mode in {"keyword", "hybrid", "vector"}:
+        indexed = lexstore.search_semantic_units(
+            vault_root,
+            query,
+            k=candidate_limit + 1,
+            categories=categories,
+            kinds=kinds,
+            scope=scope,
+            freshness=snapshot.for_scope(scope),
+            literal_all=mode == "keyword" and bool(query.strip()),
+            _repair_stale=True,
+            repair=_bounded_lexical_repair_allowed(snapshot.for_scope(scope)),
+        )
+        if indexed is None:
+            if lexstore.backend() != "python":
+                if failed_out is not None:
+                    failed_out.append("semantic_units_lexical")
+                _record_degradation("semantic_units_lexical")
+                records = {}
+            else:
+                records = _eligible_unit_records(vault_root, scope=scope, plan=plan)
+        else:
+            if len(indexed) > candidate_limit:
+                candidate_window_exhausted = True
+                indexed = indexed[:candidate_limit]
+            records = (
+                {}
+                if mode == "vector"
+                else _hydrate_indexed_unit_records(vault_root, indexed, plan=plan)
+            )
+    else:
+        records = _eligible_unit_records(vault_root, scope=scope, plan=plan)
 
     if not query.strip():
+        if not records:
+            return []
         ordered = sorted(
             records.values(),
             key=lambda record: (
@@ -1101,6 +1358,8 @@ def _find_semantic_units(
         return ordered_hits
 
     if mode == "keyword":
+        if not records:
+            return []
         tokens = query.lower().split()
         ordered = sorted(
             (
@@ -1126,16 +1385,87 @@ def _find_semantic_units(
             retrieval_trace.record_unit_keyword(selected)
         return hits
 
-    from . import lexstore
+    vector_hits: list[Any] = []
+    vector_profile: dict[str, Any] = {
+        "status": "non_applicable",
+        "reason": "requested_mode_keyword",
+    }
+    if mode in {"hybrid", "vector"}:
+        vector_allowed_refs: set[str] | None = None
+        if categories or kinds:
+            filter_rows = lexstore.search_semantic_units(
+                vault_root,
+                "",
+                k=2_147_483_647,
+                categories=categories,
+                kinds=kinds,
+                scope=scope,
+                freshness=snapshot.for_scope(scope),
+                _validate_current=False,
+                repair=_bounded_lexical_repair_allowed(snapshot.for_scope(scope)),
+            )
+            if filter_rows is None:
+                vector_allowed_refs = set()
+                if failed_out is not None:
+                    failed_out.append("semantic_unit_filter_index")
+                _record_degradation("semantic_unit_filter_index")
+            else:
+                vector_allowed_refs = {row.unit_ref for row in filter_rows}
+        vector_hits, vector_profile, _indexed_scope = _vector_unit_candidates(
+            vault_root,
+            query=query,
+            candidate_limit=candidate_limit + 1,
+            allowed_unit_refs=vector_allowed_refs,
+            degraded_out=degraded_out,
+            failed_out=failed_out,
+        )
+        if len(vector_hits) > candidate_limit:
+            candidate_window_exhausted = True
+            vector_hits = vector_hits[:candidate_limit]
+    if vector_hits:
+        stale_vector_refs: list[str] = []
+        records.update(
+            _hydrate_indexed_unit_records(
+                vault_root,
+                vector_hits,
+                plan=plan,
+                stale_out=stale_vector_refs,
+            )
+        )
+        if stale_vector_refs:
+            vector_hits = []
+            vector_profile = {
+                "status": "failed",
+                "reason": "stale_candidates",
+                "model": vector_profile.get("model", "BAAI/bge-base-en-v1.5"),
+            }
+            _record_degradation("vector")
+            if failed_out is not None and "vector" not in failed_out:
+                failed_out.append("vector")
 
-    indexed = lexstore.search_semantic_units(
-        vault_root,
-        query,
-        k=len(records),
-        scope=scope,
-        freshness=snapshot.for_scope(scope),
-        allowed_unit_refs=set(records),
-    )
+    # Pure vector mode keeps lexical rows cold unless the vector lane could not
+    # produce a trustworthy ranking. This avoids reparsing the same candidate
+    # parents twice while preserving the deterministic lexical fallback.
+    if mode == "vector" and not vector_hits and indexed:
+        records.update(_hydrate_indexed_unit_records(vault_root, indexed, plan=plan))
+
+    if not records:
+        if candidate_window_exhausted and failed_out is not None:
+            failed_out.append("semantic_units_candidate_window")
+            _record_degradation("semantic_units_candidate_window")
+        return []
+
+    if indexed is None:
+        indexed = lexstore.search_semantic_units(
+            vault_root,
+            query,
+            k=len(records),
+            scope=scope,
+            freshness=snapshot.for_scope(scope),
+            allowed_unit_refs=set(records),
+            _repair_stale=True,
+            repair=_bounded_lexical_repair_allowed(snapshot.for_scope(scope)),
+        )
     if indexed is None:
         scores = _python_unit_scores(records, query)
     else:
@@ -1186,118 +1516,7 @@ def _find_semantic_units(
     lexical_ranking = _raw_ranking(scores)
     lexical_rank = {unit_ref: rank for rank, unit_ref in enumerate(lexical_ranking, 1)}
 
-    vector_scores: dict[str, float] = {}
-    vector_profile: dict[str, Any]
-    if mode not in ("hybrid", "vector"):
-        vector_profile = {
-            "status": "non_applicable",
-            "reason": "requested_mode_keyword",
-        }
-    elif os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
-        vector_profile = {
-            "status": "disabled",
-            "reason": "embeddings_disabled",
-            "model": "BAAI/bge-base-en-v1.5",
-        }
-    else:
-        vector_profile = {
-            "status": "unavailable",
-            "reason": "not_attempted",
-            "model": "BAAI/bge-base-en-v1.5",
-        }
-    if mode in ("hybrid", "vector") and not os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
-        from . import readiness
-
-        if readiness.should_defer("embeddings"):
-            vector_profile = {
-                "status": "warming",
-                "reason": "model_warming",
-                "model": "BAAI/bge-base-en-v1.5",
-            }
-            if degraded_out is not None:
-                degraded_out.append("embeddings")
-        else:
-            try:
-                from . import embeddings
-
-                index = embeddings.get_embedding_index(vault_root)
-                query_vector = embeddings.embed_texts([query], is_query=True)[0]
-                vector_eligible_refs = set(records)
-                if embeddings.index_scope() == "kb":
-                    vector_eligible_refs = {
-                        unit_ref
-                        for unit_ref, (page, _unit, _source_order) in records.items()
-                        if page.rel_path.startswith(kb_prefix())
-                    }
-                vector_hits = (
-                    index.search_semantic_units(
-                        query_vector,
-                        k=len(vector_eligible_refs),
-                        allowed_unit_refs=vector_eligible_refs,
-                    )
-                    if vector_eligible_refs
-                    else []
-                )
-                vector_scores = {
-                    hit.unit_ref: hit.cosine for hit in vector_hits if hit.unit_ref in records
-                }
-                vector_profile = {
-                    "status": (
-                        "participated" if vector_scores else "available_nonmatching"
-                    ),
-                    "backend": type(index).__name__,
-                    "model": embeddings.MODEL_NAME,
-                    "metric": {
-                        "name": "cosine_similarity",
-                        "direction": "higher",
-                        "range": [-1.0, 1.0],
-                        "rounding": 6,
-                    },
-                }
-                index_path = getattr(index, "path", None)
-                if (
-                    index_path is not None
-                    and index_path.exists()
-                    and set(vector_scores) != vector_eligible_refs
-                ):
-                    log.warning(
-                        "semantic-unit vector coverage is stale/incomplete "
-                        "(%d/%d current rows); using lexical ranking",
-                        len(vector_scores),
-                        len(vector_eligible_refs),
-                    )
-                    _record_degradation("vector")
-                    if failed_out is not None:
-                        failed_out.append("vector")
-                    vector_scores = {}
-                    vector_profile = {
-                        "status": "failed",
-                        "reason": "stale_or_incomplete_index",
-                        "model": embeddings.MODEL_NAME,
-                    }
-            except ImportError as error:
-                vector_profile = {
-                    "status": "unavailable",
-                    "reason": "dependency_unavailable",
-                    "model": "BAAI/bge-base-en-v1.5",
-                }
-                log.info(
-                    "semantic-unit vector search unavailable (%s); using lexical ranking",
-                    error,
-                )
-            except Exception as error:  # noqa: BLE001 - vector lane soft-falls back
-                vector_profile = {
-                    "status": "failed",
-                    "reason": "search_failed",
-                    "model": "BAAI/bge-base-en-v1.5",
-                }
-                log.warning(
-                    "semantic-unit vector search failed: %s; using lexical ranking",
-                    error,
-                )
-                _record_degradation("vector")
-                if failed_out is not None:
-                    failed_out.append("vector")
+    vector_scores = {hit.unit_ref: hit.cosine for hit in vector_hits if hit.unit_ref in records}
 
     vector_ranking = _raw_ranking(vector_scores)
     vector_rank = {unit_ref: rank for rank, unit_ref in enumerate(vector_ranking, 1)}
@@ -1338,6 +1557,10 @@ def _find_semantic_units(
 
     if limit is not None:
         final_ranking = final_ranking[:limit]
+    if candidate_window_exhausted and (limit is None or len(final_ranking) < limit):
+        if failed_out is not None:
+            failed_out.append("semantic_units_candidate_window")
+        _record_degradation("semantic_units_candidate_window")
     vector_succeeded = bool(vector_ranking)
     if retrieval_trace is not None:
         intent_weights = config.intent_weights(find_policy.classify_intent(query))
@@ -1529,11 +1752,7 @@ def _eligible_filter_paths(
         # scene-frame child whose match is emitted as its parent video.
         if not _indexable(page):
             continue
-        emitted = (
-            pages.get(page.parent_media + ".md", page)
-            if page.parent_media
-            else page
-        )
+        emitted = pages.get(page.parent_media + ".md", page) if page.parent_media else page
         if not _indexable(emitted):
             continue
         matches = eligibility_by_emitted_path.get(emitted.rel_path)
@@ -1543,12 +1762,9 @@ def _eligible_filter_paths(
                 try:
                     from . import semantic_index
 
-                    state = semantic_index.current_parent_index_state(
-                        vault_root, emitted.path
-                    )
+                    state = semantic_index.current_parent_index_state(vault_root, emitted.path)
                     units = tuple(
-                        structured_filters.unit_view(unit)
-                        for unit in state.document.units
+                        structured_filters.unit_view(unit) for unit in state.document.units
                     )
                 except (OSError, UnicodeError, ValueError) as error:
                     log.warning(
@@ -1584,9 +1800,21 @@ def _find_keyword(
     limit: int,
     scope: str,
     eligible_paths: set[str] | None = None,
+    freshness_key: tuple[int, int, str] | None = None,
+    failed_out: list[str] | None = None,
 ) -> list[Hit]:
-    """Original keyword-mode find. Preserved for backward compat."""
-    if scope == "kb":
+    """Keyword-mode recall, hydrating only maintained-index matches."""
+    if query_norm:
+        candidate_paths = _keyword_match_paths(
+            vault_root,
+            query_norm,
+            scope,
+            freshness=freshness_key,
+            failed_out=failed_out,
+            repair=_bounded_lexical_repair_allowed(freshness_key),
+        )
+        walk: Iterable[Path] = (vault_root / rel_path for rel_path in candidate_paths)
+    elif scope == "kb":
         kb = vault_root / kb_dirname()
         if not kb.is_dir():
             log.error("KB directory missing: %s", kb)
@@ -1594,6 +1822,7 @@ def _find_keyword(
         walk = _walk_md(kb)
     else:
         from .vault import walk_vault_md
+
         walk = walk_vault_md(vault_root)
 
     hits: list[tuple[str, Hit]] = []
@@ -1627,8 +1856,16 @@ def _find_keyword(
                 page = parent_page
         if page.rel_path in by_path:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
-                               file_types=file_types, exclude_file_types=exclude_file_types):
+        if not _passes_filters(
+            page,
+            vault_root=vault_root,
+            types=types,
+            projects=projects,
+            tags=tags,
+            speakers=speakers,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
+        ):
             continue
         hit = Hit(
             path=page.rel_path,
@@ -1645,8 +1882,14 @@ def _find_keyword(
             scene_frame_ts=scene_frame_ts,
         )
         hit.transcript_ts = _transcript_ts_for_hit(page, None, query_norm)
-        if hit.scene_frame is None and page.media_type == "video" and page.media_file and hit.transcript_ts is not None:
+        if (
+            hit.scene_frame is None
+            and page.media_type == "video"
+            and page.media_file
+            and hit.transcript_ts is not None
+        ):
             from . import scene_frames  # lazy: keyword mode stays import-light
+
             nf = scene_frames.nearest_frame(vault_root, page.media_file, hit.transcript_ts)
             if nf is not None:
                 hit.scene_frame, hit.scene_frame_ts = nf
@@ -1746,9 +1989,17 @@ def _find_semantic(
         fallback_hits = _find_keyword(
             vault_root,
             query_norm=query_norm,
-            types=types, projects=projects, tags=tags, speakers=speakers,
-            file_types=file_types, exclude_file_types=exclude_file_types,
-            limit=limit, scope=scope, eligible_paths=eligible_paths,
+            types=types,
+            projects=projects,
+            tags=tags,
+            speakers=speakers,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
+            limit=limit,
+            scope=scope,
+            eligible_paths=eligible_paths,
+            freshness_key=snapshot.for_scope(scope),
+            failed_out=failed_out,
         )
         if retrieval_trace is not None:
             retrieval_trace.record_keyword_fallback(
@@ -1824,8 +2075,16 @@ def _find_semantic(
             continue
         if eligible_paths is not None and rel_path not in eligible_paths:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
-                               file_types=file_types, exclude_file_types=exclude_file_types):
+        if not _passes_filters(
+            page,
+            vault_root=vault_root,
+            types=types,
+            projects=projects,
+            tags=tags,
+            speakers=speakers,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
+        ):
             continue
         keyword_excerpt = _make_excerpt(page, query_norm)
         if (
@@ -1843,9 +2102,7 @@ def _find_semantic(
                 continue
             keyword_excerpt = _stem_anchored_excerpt(page, query_norm)
         elif (
-            rel_path in graph_set
-            or rel_path in clip_set
-            or rel_path in frame_attribution
+            rel_path in graph_set or rel_path in clip_set or rel_path in frame_attribution
         ) and keyword_excerpt is None:
             # Graph-hop neighbour, CLIP visual match, or frame-collapsed parent:
             # no all-tokens-present requirement (the reason for surfacing is
@@ -1871,11 +2128,10 @@ def _find_semantic(
         hit_usage_mult: float | None = None
         if usage_map:
             from . import usage as usage_module
+
             hit_activation = usage_map.get(usage_module.canon(rel_path))
             if hit_activation is not None:
-                hit_usage_mult = usage_module.usage_multiplier(
-                    hit_activation, config
-                )
+                hit_usage_mult = usage_module.usage_multiplier(hit_activation, config)
         attr = frame_attribution.get(rel_path)
         hit = Hit(
             path=page.rel_path,
@@ -1971,6 +2227,7 @@ def _find_semantic(
         scorer_input_count = len(rerank_prefix)
         try:
             from . import embeddings as emb
+
             # Best passage for each hit: the matched chunk when we have one,
             # else the leading body slice.
             passages: list[str] = []
@@ -1984,9 +2241,7 @@ def _find_semantic(
                     passages.append(body[:1500])  # CrossEncoder caps at 512 tokens
             scores = emb.rerank_pairs(query, passages)
             if len(scores) != len(rerank_prefix):
-                raise ValueError(
-                    "reranker returned a score count that does not match its inputs"
-                )
+                raise ValueError("reranker returned a score count that does not match its inputs")
             score_updates: list[
                 tuple[
                     Hit,
@@ -1996,9 +2251,7 @@ def _find_semantic(
                     list[dict[str, float | str]] | None,
                 ]
             ] = []
-            for input_rank, (h, s) in enumerate(
-                zip(rerank_prefix, scores, strict=True), start=1
-            ):
+            for input_rank, (h, s) in enumerate(zip(rerank_prefix, scores, strict=True), start=1):
                 raw_score = float(s)
                 adjusted = raw_score
                 chain: list[dict[str, float | str]] | None = (
@@ -2043,9 +2296,7 @@ def _find_semantic(
                                 "after": adjusted,
                             }
                         )
-                score_updates.append(
-                    (h, input_rank, raw_score, adjusted, chain)
-                )
+                score_updates.append((h, input_rank, raw_score, adjusted, chain))
             # Commit annotations only after every returned score and multiplier
             # has been validated. A late conversion/application failure must
             # leave the fused fallback free of partial reranker evidence.
@@ -2117,6 +2368,7 @@ def _find_outside_kb(
     snapshot: FreshnessSnapshot | None = None,
     filter_plan: structured_filters.FilterPlan | None = None,
     exclude_paths: set[str] | None = None,
+    failed_out: list[str] | None = None,
     retrieval_trace: Any | None = None,
 ) -> list[Hit]:
     """BM25/keyword recall over the vault, RESTRICTED to paths outside
@@ -2133,7 +2385,7 @@ def _find_outside_kb(
     """
     if not query_norm or limit < 1:
         return []
-    from . import bm25
+    from . import bm25, lexstore
 
     eligible_paths = (
         _eligible_filter_paths(vault_root, scope="vault", plan=filter_plan)
@@ -2142,11 +2394,7 @@ def _find_outside_kb(
     )
 
     allowed_outside = (
-        {
-            path
-            for path in eligible_paths or ()
-            if not path.startswith(kb_prefix())
-        }
+        {path for path in eligible_paths or () if not path.startswith(kb_prefix())}
         if eligible_paths is not None
         else None
     )
@@ -2154,44 +2402,45 @@ def _find_outside_kb(
     # vault corpus. A structured filter instead ranks the exact outside-KB
     # eligible set, so no eligible page can be buried below that over-fetch cap.
     bm25_k = (
-        max(limit, len(allowed_outside))
-        if allowed_outside is not None
-        else max(limit * 5, 100)
+        max(limit, len(allowed_outside)) if allowed_outside is not None else max(limit * 5, 100)
     )
     candidates: list[str] = []
     score_by_path: dict[str, float] = {}
-    lexical_backend = "keyword_fallback"
+    lexical_backend = lexstore.cache_token(vault_root)
     try:
-        bm25_hits = (
-            bm25.search(
-                vault_root,
-                query,
-                k=bm25_k,
-                scope="vault",
-                freshness=snapshot.vault() if snapshot is not None else None,
-            )
-            if allowed_outside is None
-            else bm25.search(
-                vault_root,
-                query,
-                k=bm25_k,
-                scope="vault",
-                freshness=snapshot.vault() if snapshot is not None else None,
-                allowed_paths=allowed_outside,
-            )
+        search_kwargs = {
+            "scope": "vault",
+            "freshness": snapshot.vault() if snapshot is not None else None,
+            "allowed_paths": allowed_outside,
+        }
+        search_kwargs["repair"] = _bounded_lexical_repair_allowed(search_kwargs["freshness"])
+        bm25_hits = lexstore.search_bm25(
+            vault_root,
+            query,
+            bm25_k,
+            **search_kwargs,
         )
+        if bm25_hits is None:
+            if lexstore.backend() == "python":
+                # An explicit operator rollback is allowed to use the old
+                # in-process corpus. Automatic sidecar failure is not.
+                bm25_hits = bm25.search(vault_root, query, k=bm25_k, **search_kwargs)
+                lexical_backend = "keyword_fallback"
+            else:
+                if failed_out is not None:
+                    failed_out.append("outside_kb_lexical")
+                _record_degradation("outside_kb_lexical")
+                return []
         for path, _score in bm25_hits:
             if not path.startswith(kb_prefix()):
                 candidates.append(path)
                 score_by_path[path] = float(_score)
-        from . import lexstore
-
-        lexical_backend = lexstore.cache_token(vault_root)
-    except ImportError:
-        candidates = _outside_kb_keyword_paths(vault_root, query_norm)
     except Exception as e:  # noqa: BLE001 — widening must never break find
-        log.warning("auto-widen BM25 failed: %s; falling back to keyword", e)
-        candidates = _outside_kb_keyword_paths(vault_root, query_norm)
+        log.warning("auto-widen lexical sidecar failed: %s", e)
+        if failed_out is not None:
+            failed_out.append("outside_kb_lexical")
+        _record_degradation("outside_kb_lexical")
+        return []
 
     hits: list[Hit] = []
     seen: set[str] = set()
@@ -2206,27 +2455,37 @@ def _find_outside_kb(
             continue
         if eligible_paths is not None and rel_path not in eligible_paths:
             continue
-        if not _passes_filters(page, vault_root=vault_root, types=types, projects=projects, tags=tags, speakers=speakers,
-                               file_types=file_types, exclude_file_types=exclude_file_types):
+        if not _passes_filters(
+            page,
+            vault_root=vault_root,
+            types=types,
+            projects=projects,
+            tags=tags,
+            speakers=speakers,
+            file_types=file_types,
+            exclude_file_types=exclude_file_types,
+        ):
             continue
         # Relaxed gate: BM25 score>0 already implies a token match, but the
         # keyword fallback path needs this explicit check.
         if not _any_stem_present(page, query_norm):
             continue
         excerpt = _stem_anchored_excerpt(page, query_norm)
-        hits.append(Hit(
-            path=page.rel_path,
-            type=page.page_type,
-            scope=page.scope,
-            title=page.title,
-            updated=page.updated,
-            excerpt=excerpt or "",
-            media_type=page.media_type,
-            media_file=page.media_file,
-            status=page.status,
-            superseded_by=page.superseded_by,
-            outside_kb=True,
-        ))
+        hits.append(
+            Hit(
+                path=page.rel_path,
+                type=page.page_type,
+                scope=page.scope,
+                title=page.title,
+                updated=page.updated,
+                excerpt=excerpt or "",
+                media_type=page.media_type,
+                media_file=page.media_file,
+                status=page.status,
+                superseded_by=page.superseded_by,
+                outside_kb=True,
+            )
+        )
         if len(hits) >= limit:
             break
     if retrieval_trace is not None:
@@ -2249,6 +2508,7 @@ def _any_stem_present(page: ParsedPage, query_norm: str) -> bool:
     if not query_norm:
         return False
     from . import bm25 as bm25_module
+
     return any(qs in page.stem_set for qs in bm25_module.tokenize(query_norm))
 
 
@@ -2256,6 +2516,7 @@ def _outside_kb_keyword_paths(vault_root: Path, query_norm: str) -> list[str]:
     """BM25-unavailable fallback: walk vault .md outside Knowledge Base/, keep
     files where >=1 query stem is present, ordered most-recent first."""
     from .vault import walk_vault_md
+
     vault_resolved = vault_root.resolve()
     matches: list[tuple[str, str]] = []
     for path in walk_vault_md(vault_root):
@@ -2342,21 +2603,20 @@ def _apply_temporal_boost(
     query: str,
     config: RankingConfig = DEFAULT_RANKING,
 ) -> list[tuple[str, float]]:
-    return find_policy.apply_temporal_boost(
-        fused, query, _page_of(vault_root), config
-    )
+    return find_policy.apply_temporal_boost(fused, query, _page_of(vault_root), config)
 
 
-def _recency_ranking(
-    candidate_paths: list[str], vault_root: Path, cap: int
-) -> list[str]:
-    return find_policy.recency_ranking(
-        candidate_paths, _page_of(vault_root), cap
-    )
+def _recency_ranking(candidate_paths: list[str], vault_root: Path, cap: int) -> list[str]:
+    return find_policy.recency_ranking(candidate_paths, _page_of(vault_root), cap)
 
 
 def _keyword_match_paths(
-    vault_root: Path, query_norm: str, scope: str, freshness: tuple | None = None
+    vault_root: Path,
+    query_norm: str,
+    scope: str,
+    freshness: tuple | None = None,
+    failed_out: list[str] | None = None,
+    repair: bool = True,
 ) -> list[str]:
     """Return paths that satisfy keyword mode's all-tokens-present gate.
 
@@ -2376,10 +2636,19 @@ def _keyword_match_paths(
     from . import lexstore
 
     indexed = lexstore.search_substring(
-        vault_root, query_norm, scope=scope, freshness=freshness
+        vault_root,
+        query_norm,
+        scope=scope,
+        freshness=freshness,
+        repair=repair,
     )
     if indexed is not None:
         return indexed
+    if lexstore.backend() != "python":
+        if failed_out is not None:
+            failed_out.append("keyword_lexical")
+        _record_degradation("keyword_lexical")
+        return []
     if scope == "kb":
         kb = vault_root / kb_dirname()
         if not kb.is_dir():
@@ -2387,6 +2656,7 @@ def _keyword_match_paths(
         walk = _walk_md(kb)
     else:
         from .vault import walk_vault_md
+
         walk = walk_vault_md(vault_root)
     matches: list[tuple[str, str]] = []  # (updated, rel_path)
     for path in walk:
@@ -2402,9 +2672,7 @@ def _keyword_match_paths(
     return [p for _, p in matches]
 
 
-def _outbound_wikilink_paths(
-    page: ParsedPage, vault_root: Path, resolver=None
-) -> list[str]:
+def _outbound_wikilink_paths(page: ParsedPage, vault_root: Path, resolver=None) -> list[str]:
     """Vault-relative POSIX paths (no .md) that this page's body links to.
 
     Skips matches inside fenced code blocks and inline code (delegates to
@@ -2419,6 +2687,7 @@ def _outbound_wikilink_paths(
         find_body_wikilinks,
         normalize_wikilink,
     )
+
     if resolver is None:
         resolver = _get_query_resolver(vault_root)
     out: list[str] = []
@@ -2473,6 +2742,7 @@ def _get_query_resolver(vault_root: Path, freshness: tuple | None = None):
     vault (every edit moved the freshness digest and invalidated this cache).
     """
     from .vault import WikilinkResolver
+
     if freshness is None:
         freshness = FreshnessSnapshot(vault_root).vault()
     cached = _RESOLVER_CACHE.get(vault_root)
@@ -2508,6 +2778,36 @@ def shared_resolver(vault_root: Path):
     return _get_query_resolver(vault_root)
 
 
+def prime_resolver_from_entries(
+    vault_root: Path,
+    entries,
+    *,
+    freshness_key: tuple[int, int, str] | None = None,
+    expected_freshness: tuple[int, int, str] | None = None,
+):
+    """Install a current shared resolver from already-parsed corpus entries.
+
+    Semantic preflight already owns exact path/title state. Reusing it avoids a
+    full vault read/YAML parse when post-commit graph fanout is the first caller
+    to need the resolver.
+    """
+    from .vault import WikilinkResolver
+
+    root = Path(vault_root)
+    current_freshness = (
+        freshness_key if freshness_key is not None else FreshnessSnapshot(root).vault()
+    )
+    if expected_freshness is not None and current_freshness != expected_freshness:
+        return None
+    with _RESOLVER_LOCK:
+        cached = _RESOLVER_CACHE.get(root)
+        if cached and cached[0] == current_freshness:
+            return cached[1]
+        resolver = WikilinkResolver.from_entries(root, entries)
+        _RESOLVER_CACHE[root] = (current_freshness, resolver)
+        return resolver
+
+
 def writer_resolver_snapshot(
     vault_root: Path,
     *,
@@ -2524,9 +2824,7 @@ def writer_resolver_snapshot(
 
     root = Path(vault_root)
     current_freshness = (
-        freshness_key
-        if freshness_key is not None
-        else FreshnessSnapshot(root).vault()
+        freshness_key if freshness_key is not None else FreshnessSnapshot(root).vault()
     )
     with _RESOLVER_LOCK:
         cached = _RESOLVER_CACHE.get(root)
@@ -2577,7 +2875,6 @@ def on_resolver_files_changed(
         _RESOLVER_CACHE[vault_root] = (FreshnessSnapshot(vault_root).vault(), resolver)
 
 
-
 def unload_ram_caches() -> dict[str, int]:
     """Evict rebuildable find RAM caches without clearing freshness/inbound metadata."""
     page_entries = len(_CACHE.entries)
@@ -2616,4 +2913,5 @@ def clear_cache() -> None:
     unload_ram_caches()
     freshness.clear()
     from . import vault as vault_module
+
     vault_module.clear_inbound_index()

--- a/src/exomem/find_types.py
+++ b/src/exomem/find_types.py
@@ -341,6 +341,7 @@ class SemanticUnitHit:
     parent_status: str | None
     parent_updated: str
     parent_superseded_by: list[str] = field(default_factory=list)
+    relations: list[dict[str, Any]] = field(default_factory=list)
     bm25_rank: int | None = None
     bm25_score: float | None = None
     vector_rank: int | None = None
@@ -360,6 +361,7 @@ class SemanticUnitHit:
             "excerpt": self.excerpt,
             "tags": self.tags,
             "context": self.context,
+            "relations": self.relations,
             "source_anchor": self.source_anchor,
             "source_span": self.source_span,
             "source_hash": self.source_hash,

--- a/src/exomem/install_info.py
+++ b/src/exomem/install_info.py
@@ -1,0 +1,145 @@
+"""Cheap, non-secret CLI and managed-service install identity.
+
+This module is intentionally dependency-light.  ``exomem --version`` must work
+in a lean uv-tool environment without importing optional model/media packages,
+and it must be useful when that lean command fronts a separately managed full
+service installation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from importlib.metadata import distribution, version
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+_MANIFEST_ENV = "EXOMEM_MANAGED_INSTALL_MANIFEST"
+_VALID_PROFILES = frozenset({"lean", "hybrid", "standard", "media"})
+_VALID_ROUTES = frozenset({"direct", "service"})
+
+
+def _package_version() -> str:
+    try:
+        return version("exomem")
+    except Exception:  # noqa: BLE001 - version reporting must not crash
+        return "unknown"
+
+
+def _install_source() -> str:
+    """Classify the distribution without resolving git or importing extras."""
+    try:
+        dist = distribution("exomem")
+    except Exception:  # noqa: BLE001 - metadata may be partially installed
+        return "unknown"
+    try:
+        raw = dist.read_text("direct_url.json")
+        if raw and json.loads(raw).get("dir_info", {}).get("editable"):
+            return "editable"
+    except Exception:  # noqa: BLE001 - malformed metadata is non-fatal
+        return "unknown"
+    return "wheel"
+
+
+def managed_manifest_path() -> Path:
+    override = os.environ.get(_MANIFEST_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    if sys.platform == "win32":
+        root = os.environ.get("LOCALAPPDATA", "").strip()
+        if root:
+            return Path(root) / "Exomem" / "managed-install.json"
+        return Path.home() / "AppData" / "Local" / "Exomem" / "managed-install.json"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Exomem" / "managed-install.json"
+    root = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    return (Path(root) if root else Path.home() / ".config") / "exomem" / "managed-install.json"
+
+
+def _manifest() -> tuple[dict[str, Any], str]:
+    path = managed_manifest_path()
+    if not path.is_file():
+        return {}, "absent"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}, "invalid"
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        return {}, "unsupported"
+    return value, "ready"
+
+
+def _safe_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _safe_service_target(value: Any) -> str | None:
+    target = _safe_string(value)
+    if target is None:
+        return None
+    try:
+        parsed = urlsplit(target)
+        hostname = parsed.hostname
+        _ = parsed.port  # Validate a present port before exposing the original value.
+    except ValueError:
+        return None
+    if (
+        parsed.geturl() != target
+        or parsed.scheme not in {"http", "https"}
+        or hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    return target
+
+
+def report() -> dict[str, Any]:
+    """Return the stable local report, whitelisting every manifest field.
+
+    Unknown manifest fields are ignored so a future installer can never make
+    this surface echo credentials, vault locations, or user-authored content.
+    """
+    package_version = _package_version()
+    manifest, status = _manifest()
+    service_version = _safe_string(manifest.get("service_version"))
+    service_profile = _safe_string(manifest.get("service_profile"))
+    if service_profile not in _VALID_PROFILES:
+        service_profile = None
+    target = _safe_service_target(manifest.get("service_target"))
+    local_profile = os.environ.get("EXOMEM_PROFILE", "").strip()
+    if local_profile not in _VALID_PROFILES:
+        local_profile = _safe_string(manifest.get("cli_profile")) or "lean"
+    if local_profile not in _VALID_PROFILES:
+        local_profile = "lean"
+    route = _safe_string(manifest.get("cli_route")) or "direct"
+    if route not in _VALID_ROUTES:
+        route = "direct"
+    return {
+        "version": package_version,
+        "python_executable": sys.executable,
+        "install_source": _install_source(),
+        "local_profile": local_profile,
+        "managed_service_version": service_version,
+        "managed_service_profile": service_profile,
+        "managed_service_target": target,
+        "effective_route": route,
+        "version_match": (
+            package_version == service_version if service_version is not None else None
+        ),
+        "manifest_status": status,
+    }
+
+
+def print_version(*, as_json: bool) -> int:
+    identity = report()
+    if as_json:
+        print(json.dumps(identity, ensure_ascii=False))
+    else:
+        print(f"exomem {identity['version']}")
+    return 0

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -74,6 +74,8 @@ _PROBE_LOCK = threading.Lock()
 
 _STORES: dict[Path, LexicalStore] = {}
 _STORES_LOCK = threading.Lock()
+_REPAIRS_IN_FLIGHT: set[Path] = set()
+_REPAIRS_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -172,6 +174,41 @@ def clear_stores() -> None:
         _STORES.clear()
 
 
+def _schedule_repair(vault_root: Path) -> None:
+    """Start at most one best-effort lexical repair per vault.
+
+    Foreground retrieval uses this seam after declining stale or missing
+    sidecar work. The worker owns all corpus reconciliation; callers return
+    immediately and may retry on a later request.
+    """
+    key = vault_root.resolve()
+    with _REPAIRS_LOCK:
+        if key in _REPAIRS_IN_FLIGHT:
+            return
+        _REPAIRS_IN_FLIGHT.add(key)
+
+    def _run() -> None:
+        try:
+            get_store(vault_root).ensure_fresh()
+        except Exception as e:  # noqa: BLE001 - daemon must not escape into stderr
+            log.warning("lexical background repair skipped (%s)", e)
+        finally:
+            with _REPAIRS_LOCK:
+                _REPAIRS_IN_FLIGHT.discard(key)
+
+    thread = threading.Thread(
+        target=_run,
+        name=f"exomem-lexical-repair-{key.name}",
+        daemon=True,
+    )
+    try:
+        thread.start()
+    except RuntimeError:
+        with _REPAIRS_LOCK:
+            _REPAIRS_IN_FLIGHT.discard(key)
+        log.warning("lexical background repair could not start for %s", key)
+
+
 # ------------------------------------------------------------------ policy
 
 
@@ -187,6 +224,7 @@ def search_bm25(
     scope: str = "kb",
     freshness: tuple | None = None,
     allowed_paths: set[str] | None = None,
+    repair: bool = True,
 ) -> list[tuple[str, float]] | None:
     """Top-k `(rel_path, score)` from the FTS5 index, or None → use the
     in-process rung. Matches the python rung's shape: OR membership,
@@ -202,7 +240,7 @@ def search_bm25(
     if not tokens:
         return []
     store = get_store(vault_root)
-    return store.search_bm25(tokens, k, scope, freshness, allowed_paths)
+    return store.search_bm25(tokens, k, scope, freshness, allowed_paths, repair)
 
 
 def search_substring(
@@ -211,6 +249,7 @@ def search_substring(
     *,
     scope: str = "kb",
     freshness: tuple | None = None,
+    repair: bool = True,
 ) -> list[str] | None:
     """The keyword lane's match set (every whitespace token a substring of
     title or body), ordered `updated` desc then path desc, navigation files
@@ -224,7 +263,7 @@ def search_substring(
     if not tokens:
         return []
     store = get_store(vault_root)
-    return store.search_substring(tokens, scope, freshness)
+    return store.search_substring(tokens, scope, freshness, repair)
 
 
 def search_semantic_units(
@@ -237,6 +276,10 @@ def search_semantic_units(
     scope: str = "kb",
     freshness: tuple | None = None,
     allowed_unit_refs: set[str] | None = None,
+    literal_all: bool = False,
+    _repair_stale: bool = False,
+    _validate_current: bool = True,
+    repair: bool = True,
 ) -> list[SemanticUnitLexicalHit] | None:
     """Return exact-metadata semantic-unit candidates from the lexical sidecar."""
     if not _usable():
@@ -245,7 +288,8 @@ def search_semantic_units(
     from .semantic_units import canonicalize_category
 
     tokens = bm25_module.tokenize(query) if query.strip() else []
-    if query.strip() and not tokens:
+    literal_tokens = tuple(query.lower().split()) if literal_all else ()
+    if query.strip() and not tokens and not literal_tokens:
         return []
     category_keys = tuple(sorted({canonicalize_category(value) for value in categories or ()}))
     kind_keys = tuple(sorted({canonicalize_category(value) for value in kinds or ()}))
@@ -257,12 +301,17 @@ def search_semantic_units(
         scope,
         freshness,
         allowed_unit_refs,
+        literal_tokens,
+        repair,
     )
     if hits is None:
         return None
+    if not _validate_current:
+        return hits
     from .semantic_index import validate_parent_record
 
     current: list[SemanticUnitLexicalHit] = []
+    stale_paths: set[str] = set()
     freshness_by_stamp: dict[tuple[str, str, str, int], bool] = {}
     for hit in hits:
         stamp = (
@@ -283,6 +332,29 @@ def search_semantic_units(
             freshness_by_stamp[stamp] = accepted
         if accepted:
             current.append(hit)
+        else:
+            stale_paths.add(hit.parent_path)
+    if stale_paths and _repair_stale and repair:
+        # Registry edits and missed watcher events can invalidate a parent
+        # generation without changing the FTS match itself. Repair only the
+        # indexed candidate parents and retry once; never parse the corpus.
+        store = get_store(vault_root)
+        store.upsert_paths([vault_root / path for path in sorted(stale_paths)])
+        return search_semantic_units(
+            vault_root,
+            query,
+            k,
+            categories=categories,
+            kinds=kinds,
+            scope=scope,
+            freshness=freshness,
+            allowed_unit_refs=allowed_unit_refs,
+            literal_all=literal_all,
+            _repair_stale=False,
+            repair=repair,
+        )
+    if stale_paths and _repair_stale:
+        _schedule_repair(vault_root)
     return current
 
 
@@ -479,7 +551,14 @@ class LexicalStore:
         conn.commit()
         self._synced[scope] = triple
 
-    def _ensure_synced(self, conn: sqlite3.Connection, scope: str, freshness: tuple | None) -> None:
+    def _ensure_synced(
+        self,
+        conn: sqlite3.Connection,
+        scope: str,
+        freshness: tuple | None,
+        *,
+        repair: bool = True,
+    ) -> bool:
         """Reconcile against the walk ONCE per observed corpus change.
 
         `freshness` is the scope's `(count, max_mtime_ns, digest)` walk triple
@@ -488,26 +567,38 @@ class LexicalStore:
         this implements.
         """
         if freshness is None:
+            if not repair:
+                return False
             freshness = self._scope_triple(scope)
         if self._synced.get(scope) == freshness:
-            return
+            return True
         with self._lock:
             if self._synced.get(scope) == freshness:
-                return
+                return True
             if not self._ensure_schema(conn):
+                if not repair:
+                    return False
                 self._rebuild(conn)
-                return
+                return True
             if self._stored_count_max(conn, scope) != (freshness[0], freshness[1]):
+                if not repair:
+                    return False
                 self._heal_delta(conn)  # incremental: patch only the drifted rows
-                return
+                return True
             witnessed = self._witnessed.pop(scope, None)
             if witnessed == freshness:
                 # The hook updated the sidecar for exactly this registry state.
                 self._bless(conn, scope, freshness)
-                return
+                return True
             if self._meta_triple(conn, scope) == freshness:
                 self._synced[scope] = freshness  # verified before; unchanged
-                return
+                return True
+            if not repair:
+                # Establishing whether an unknown digest is a cheap path-only
+                # drift or a preserved-mtime content replacement requires an
+                # exact corpus comparison. Leave that work to the repair
+                # worker rather than putting it on this request.
+                return False
             # Unwitnessed change with matching count/mtime. A path/mtime drift
             # can be healed incrementally. If those legacy row fields still
             # match while the full corpus signature changed, bytes were
@@ -517,6 +608,7 @@ class LexicalStore:
                 self._rebuild(conn)
             else:
                 self._heal_delta(conn)
+            return True
 
     def _walk_entries(self):
         """One pass over both walks: membership flags + file signatures."""
@@ -787,10 +879,7 @@ class LexicalStore:
         ).fetchall()
         for (parent_path,) in orphan_parents:
             self._delete_semantic_units(conn, str(parent_path))
-        conn.execute(
-            "DELETE FROM unit_fts WHERE rowid NOT IN "
-            "(SELECT rowid FROM semantic_units)"
-        )
+        conn.execute("DELETE FROM unit_fts WHERE rowid NOT IN (SELECT rowid FROM semantic_units)")
         conn.execute("DELETE FROM fts WHERE rowid NOT IN (SELECT rowid FROM pages)")
         conn.execute("DELETE FROM tri WHERE rowid NOT IN (SELECT rowid FROM pages)")
 
@@ -924,16 +1013,20 @@ class LexicalStore:
         scope: str,
         freshness: tuple | None,
         allowed_paths: set[str] | None = None,
+        repair: bool = True,
     ) -> list[tuple[str, float]] | None:
         if self._failed:
+            return None
+        if not repair and not self.path.exists():
+            _schedule_repair(self.vault_root)
             return None
         try:
             conn = self._connect()
             try:
-                self._ensure_synced(conn, scope, freshness)
-                return self._bm25_query(
-                    conn, stemmed_tokens, k, scope, allowed_paths
-                )
+                if not self._ensure_synced(conn, scope, freshness, repair=repair):
+                    _schedule_repair(self.vault_root)
+                    return None
+                return self._bm25_query(conn, stemmed_tokens, k, scope, allowed_paths)
             finally:
                 conn.close()
         except sqlite3.Error as e:
@@ -965,9 +1058,7 @@ class LexicalStore:
         rows = conn.execute(
             "SELECT p.path, -bm25(fts) AS score "
             "FROM fts JOIN pages p ON p.rowid = fts.rowid "
-            f"WHERE fts MATCH ? AND p.{col} = 1"
-            + allowed_clause
-            + " "
+            f"WHERE fts MATCH ? AND p.{col} = 1" + allowed_clause + " "
             "ORDER BY bm25(fts), p.path LIMIT ?",
             params,
         ).fetchall()
@@ -982,13 +1073,20 @@ class LexicalStore:
         scope: str,
         freshness: tuple | None,
         allowed_unit_refs: set[str] | None = None,
+        literal_tokens: tuple[str, ...] = (),
+        repair: bool = True,
     ) -> list[SemanticUnitLexicalHit] | None:
         if self._failed:
+            return None
+        if not repair and not self.path.exists():
+            _schedule_repair(self.vault_root)
             return None
         try:
             conn = self._connect()
             try:
-                self._ensure_synced(conn, scope, freshness)
+                if not self._ensure_synced(conn, scope, freshness, repair=repair):
+                    _schedule_repair(self.vault_root)
+                    return None
                 return self._semantic_unit_query(
                     conn,
                     stemmed_tokens,
@@ -997,6 +1095,7 @@ class LexicalStore:
                     kinds,
                     scope,
                     allowed_unit_refs,
+                    literal_tokens,
                 )
             finally:
                 conn.close()
@@ -1017,6 +1116,7 @@ class LexicalStore:
         kinds: tuple[str, ...],
         scope: str,
         allowed_unit_refs: set[str] | None = None,
+        literal_tokens: tuple[str, ...] = (),
     ) -> list[SemanticUnitLexicalHit]:
         col = "in_vault" if scope == "vault" else "in_kb"
         clauses = [f"u.{col} = 1"]
@@ -1031,9 +1131,7 @@ class LexicalStore:
             params.extend(kinds)
         if allowed_unit_refs is not None:
             clauses.append("u.unit_ref IN (SELECT value FROM json_each(?))")
-            params.append(
-                json.dumps(sorted(allowed_unit_refs), ensure_ascii=False)
-            )
+            params.append(json.dumps(sorted(allowed_unit_refs), ensure_ascii=False))
         columns = (
             "u.record_type, u.unit_ref, u.parent_path, u.parent_ref, "
             "u.parent_generation, u.parent_source_hash, u.parser_version, u.form, "
@@ -1041,7 +1139,15 @@ class LexicalStore:
             "u.tags_json, u.context, u.unit_source_hash, u.anchor, u.line, "
             "u.end_line, u.fingerprint, u.source_order"
         )
-        if tokens:
+        if literal_tokens:
+            literal_clauses = ["instr(lower(u.content), ?) > 0" for _ in literal_tokens]
+            rows = conn.execute(
+                f"SELECT {columns}, NULL AS lexical_score FROM semantic_units u WHERE "
+                + " AND ".join([*clauses, *literal_clauses])
+                + " ORDER BY u.updated DESC, u.parent_path DESC, u.source_order LIMIT ?",
+                [*params, *literal_tokens, k],
+            ).fetchall()
+        elif tokens:
             match = " OR ".join(f'"{token}"' for token in tokens)
             rows = conn.execute(
                 f"SELECT {columns}, -bm25(unit_fts) AS lexical_score "
@@ -1089,14 +1195,23 @@ class LexicalStore:
         )
 
     def search_substring(
-        self, tokens: list[str], scope: str, freshness: tuple | None
+        self,
+        tokens: list[str],
+        scope: str,
+        freshness: tuple | None,
+        repair: bool = True,
     ) -> list[str] | None:
         if self._failed:
+            return None
+        if not repair and not self.path.exists():
+            _schedule_repair(self.vault_root)
             return None
         try:
             conn = self._connect()
             try:
-                self._ensure_synced(conn, scope, freshness)
+                if not self._ensure_synced(conn, scope, freshness, repair=repair):
+                    _schedule_repair(self.vault_root)
+                    return None
                 return self._substring_query(conn, tokens, scope)
             finally:
                 conn.close()

--- a/src/exomem/readiness.py
+++ b/src/exomem/readiness.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import threading
 import time
 
-COMPONENTS = ("lexical", "embeddings", "reranker", "clip")
+COMPONENTS = ("lexical", "semantic_corpus", "embeddings", "reranker", "clip")
 
 _lock = threading.Lock()
 _events: dict[str, threading.Event] = {c: threading.Event() for c in COMPONENTS}

--- a/src/exomem/retrieval_models.py
+++ b/src/exomem/retrieval_models.py
@@ -144,6 +144,7 @@ class SemanticUnitHit(TypedDict):
     content: NotRequired[str]
     tags: NotRequired[list[str]]
     context: NotRequired[str | None]
+    relations: NotRequired[list[dict[str, Any]]]
     source_span: NotRequired[dict[str, int]]
     source_hash: NotRequired[str]
     parent_superseded_by: NotRequired[list[str]]

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1395,10 +1395,24 @@ def _patch_corpus_files_changed_locked(
             return None
 
     changed_paths = tuple(
-        sorted({rel for value in changed if (rel := relative(value)) is not None})
+        sorted(
+            {
+                rel
+                for value in changed
+                if (rel := relative(value)) is not None
+                and PurePosixPath(rel).suffix.casefold() == ".md"
+            }
+        )
     )
     deleted_paths = tuple(
-        sorted({rel for value in deleted if (rel := relative(value)) is not None})
+        sorted(
+            {
+                rel
+                for value in deleted
+                if (rel := relative(value)) is not None
+                and PurePosixPath(rel).suffix.casefold() == ".md"
+            }
+        )
     )
     reconcile_paths = tuple(sorted(set(changed_paths) | set(deleted_paths)))
     if not reconcile_paths:

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -21,6 +21,7 @@ from . import (
     access,
     activation,
     activation_manifest,
+    freshness,
     memory_refs,
     memory_schema,
     relation_registry,
@@ -58,12 +59,12 @@ COMPILED_DESTINATIONS = MappingProxyType(
 )
 COMPILED_TYPES = frozenset(COMPILED_DESTINATIONS)
 _COMPILED_ROOT_TYPES = MappingProxyType(
-    {destination.rsplit("/", 1)[-1].casefold(): page_type
-     for page_type, destination in COMPILED_DESTINATIONS.items()}
+    {
+        destination.rsplit("/", 1)[-1].casefold(): page_type
+        for page_type, destination in COMPILED_DESTINATIONS.items()
+    }
 )
-_INACTIVE_STATUSES = frozenset(
-    {"archived", "draft", "dropped", "planned", "superseded"}
-)
+_INACTIVE_STATUSES = frozenset({"archived", "draft", "dropped", "planned", "superseded"})
 _SEMANTIC_UNIT_EXEMPT_PARTS = frozenset(
     {"sources", "evidence", "_trash", "trash", "_schema", "templates", "data"}
 )
@@ -98,9 +99,7 @@ def review_content_fingerprint(page_identity: str, source: str) -> str:
         {
             "schema_version": 1,
             "page_identity": page_identity,
-            "normalized_source_hash": hashlib.sha256(
-                normalized.encode("utf-8")
-            ).hexdigest(),
+            "normalized_source_hash": hashlib.sha256(normalized.encode("utf-8")).hexdigest(),
         }
     )
 
@@ -115,9 +114,7 @@ def _freeze(value: Any) -> Any:
         return MappingProxyType(
             {
                 key: _freeze(child)
-                for key, child in sorted(
-                    value.items(), key=lambda item: _stable_value_key(item[0])
-                )
+                for key, child in sorted(value.items(), key=lambda item: _stable_value_key(item[0]))
             }
         )
     if isinstance(value, (list, tuple)):
@@ -133,19 +130,14 @@ def _thaw(value: Any) -> Any:
     if isinstance(value, (tuple, list)):
         return [_thaw(child) for child in value]
     if isinstance(value, frozenset):
-        return [
-            _thaw(child)
-            for child in sorted(value, key=_stable_value_key)
-        ]
+        return [_thaw(child) for child in sorted(value, key=_stable_value_key)]
     return value
 
 
 def _mapping_of_tuples(
     values: Mapping[str, Iterable[Any]],
 ) -> Mapping[str, tuple[Any, ...]]:
-    return MappingProxyType(
-        {key: tuple(values[key]) for key in sorted(values)}
-    )
+    return MappingProxyType({key: tuple(values[key]) for key in sorted(values)})
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,9 +254,7 @@ class StableIdentityCensus:
             identity: str | None = None
             if raw_identity is not None:
                 if not isinstance(raw_identity, str) or normalize_id(raw_identity) is None:
-                    raise ValueError(
-                        f"stable identity is invalid at {state.path}"
-                    )
+                    raise ValueError(f"stable identity is invalid at {state.path}")
                 identity = normalize_id(raw_identity)
             entries.append(StableIdentityEntry(state.path, identity))
         return cls(tuple(entries))
@@ -274,12 +264,10 @@ class StableIdentityCensus:
             "entry_count": len(self.entries),
             "identity_count": len(self.paths_by_identity),
             "entries": [
-                {"path": entry.path, "page_identity": entry.page_identity}
-                for entry in self.entries
+                {"path": entry.path, "page_identity": entry.page_identity} for entry in self.entries
             ],
             "paths_by_identity": {
-                identity: list(paths)
-                for identity, paths in self.paths_by_identity.items()
+                identity: list(paths) for identity, paths in self.paths_by_identity.items()
             },
         }
 
@@ -649,9 +637,7 @@ def _missing_semantic_unit_finding(page: SemanticPageState) -> ContractFinding |
         path=page.path,
         span=None,
         detail=str(finding["when"]),
-        remediation=(
-            f"{finding['compact_remediation']} {finding['rich_remediation']}"
-        ),
+        remediation=(f"{finding['compact_remediation']} {finding['rich_remediation']}"),
         governed_element_identity=("semantic_units", "minimum"),
         resolved_rule=("semantic_authoring", "semantic_unit", "minimum"),
     )
@@ -685,14 +671,9 @@ def _copy_registry(
     return relation_registry.RelationRegistry(
         registry.core_version,
         registry.extension_hash,
+        MappingProxyType({key: _copy_definition(value) for key, value in registry.core.items()}),
         MappingProxyType(
-            {key: _copy_definition(value) for key, value in registry.core.items()}
-        ),
-        MappingProxyType(
-            {
-                key: _copy_definition(value)
-                for key, value in registry.extensions.items()
-            }
+            {key: _copy_definition(value) for key, value in registry.extensions.items()}
         ),
         MappingProxyType(dict(registry.aliases)),
         tuple(MappingProxyType(dict(finding)) for finding in registry.findings),
@@ -726,9 +707,7 @@ class SemanticCorpusContext:
         )
         object.__setattr__(self, "resolver_entries", tuple(self.resolver_entries))
         object.__setattr__(self, "resolver_full_paths", frozenset(self.resolver_full_paths))
-        object.__setattr__(
-            self, "resolver_kb_stripped", frozenset(self.resolver_kb_stripped)
-        )
+        object.__setattr__(self, "resolver_kb_stripped", frozenset(self.resolver_kb_stripped))
         object.__setattr__(
             self,
             "resolver_stems",
@@ -781,6 +760,25 @@ class SemanticCorpusContext:
         )
 
     def with_candidate(self, state: SemanticPageState) -> SemanticCorpusContext:
+        current = self.pages.get(state.path)
+        if current is not None and (
+            current.title,
+            current.identity_kind,
+            current.identity,
+            current.page_type,
+            current.projects,
+            current.language_registry_hash,
+            current.relation_registry_hash,
+        ) == (
+            state.title,
+            state.identity_kind,
+            state.identity,
+            state.page_type,
+            state.projects,
+            state.language_registry_hash,
+            state.relation_registry_hash,
+        ):
+            return _context_with_stable_topology_candidate(self, state)
         pages = dict(self.pages)
         pages[state.path] = state
         return _context_from_state_map(
@@ -864,15 +862,9 @@ def build_page_state(
     document = semantic_units.parse_semantic_units(
         body,
         path=rel_path,
-        parent_ref=(
-            memory_refs.memory_ref(normalized_id)
-            if normalized_id is not None
-            else None
-        ),
+        parent_ref=(memory_refs.memory_ref(normalized_id) if normalized_id is not None else None),
         validate=True,
-        language_registry=semantic_language_registry.for_attached_projects(
-            language, projects
-        ),
+        language_registry=semantic_language_registry.for_attached_projects(language, projects),
         relation_registry=registry,
         include_legacy_relations=True,
         retain_unknown_relations=True,
@@ -904,16 +896,10 @@ def build_page_state(
         identity_kind=identity_kind,
         identity=identity,
         source_hash=vault.content_hash(raw_source),
-        language_registry_hash=(
-            f"{language.schema_version}:{language.content_hash}"
-        ),
-        relation_registry_hash=(
-            f"{registry.core_version}:{registry.extension_hash}"
-        ),
+        language_registry_hash=(f"{language.schema_version}:{language.content_hash}"),
+        relation_registry_hash=(f"{registry.core_version}:{registry.extension_hash}"),
         review_fingerprint=(
-            str(resolved_review_fingerprint)
-            if resolved_review_fingerprint is not None
-            else None
+            str(resolved_review_fingerprint) if resolved_review_fingerprint is not None else None
         ),
         frontmatter=frontmatter,
         page_type=page_type,
@@ -931,12 +917,11 @@ class _CensusUnsafe(Exception):
 
 
 # Process cache for the fully-materialized corpus context: one bounded entry
-# per vault root, keyed on a stat-level census of every filesystem input the
-# build reads. Serving rule: the current census must equal the stored census,
-# and the stored census was confirmed identical before AND after the build it
-# captions, so a tree that changed mid-build is never stored. Invalidation
-# needs no TTL and no cooperation from writers: any input change that alters a
-# path, size, or mtime_ns is caught by the census taken on the next call.
+# per vault root, captioned by a stat-level census of every filesystem input the
+# build reads. Exact census matches are returned directly. Markdown-only census
+# deltas are reconciled by reparsing just the changed parents and rebuilding the
+# cheap derived maps from the retained page states. Configuration/registry
+# changes still take the full-build oracle path.
 #
 # Why (path, size, mtime_ns) per file and not a max-mtime scan: Syncthing (and
 # any mtime-preserving sync) materializes remote edits with the SOURCE's
@@ -947,11 +932,25 @@ class _CensusUnsafe(Exception):
 # undetectable case — new content with byte-identical size and identical
 # 100ns-resolution mtime at the same path — is not producible by the engine's
 # own temp+rename writes nor by observed sync behavior.
-_CORPUS_CONTEXT_CACHE: dict[
-    tuple[str, str], tuple[tuple, SemanticCorpusContext]
-] = {}
+_CORPUS_CONTEXT_CACHE: dict[tuple[str, str], tuple[tuple, SemanticCorpusContext]] = {}
+_CORPUS_CONTEXT_EVENT_TOKENS: dict[tuple[str, str], tuple[int, int, str]] = {}
+_CORPUS_CONTEXT_LANGUAGE_HASHES: dict[tuple[str, str], str] = {}
 _CORPUS_CONTEXT_CACHE_LOCK = threading.Lock()
+_CORPUS_CONTEXT_UPDATE_LOCK = threading.RLock()
 _CORPUS_CONTEXT_CACHE_MAX_VAULTS = 2
+
+
+@dataclass(slots=True)
+class _CorpusContextFlight:
+    census: tuple
+    registry_identity: tuple[Any, ...]
+    language_identity: tuple[Any, ...]
+    done: threading.Event = field(default_factory=threading.Event)
+    result: SemanticCorpusContext | None = None
+    error: BaseException | None = None
+
+
+_CORPUS_CONTEXT_FLIGHTS: dict[tuple[str, str], _CorpusContextFlight] = {}
 
 
 def corpus_context_cache_enabled() -> bool:
@@ -963,6 +962,8 @@ def reset_corpus_context_cache() -> None:
     """Drop every cached corpus context; intentionally public for tests."""
     with _CORPUS_CONTEXT_CACHE_LOCK:
         _CORPUS_CONTEXT_CACHE.clear()
+        _CORPUS_CONTEXT_EVENT_TOKENS.clear()
+        _CORPUS_CONTEXT_LANGUAGE_HASHES.clear()
 
 
 def _corpus_cache_key(root: Path) -> tuple[str, str]:
@@ -1000,9 +1001,7 @@ def _corpus_census(root: Path) -> tuple | None:
                 continue
             if not stat.S_ISREG(info.st_mode):
                 raise _CensusUnsafe
-            entries.add(
-                (path.relative_to(root).as_posix(), "f", info.st_size, info.st_mtime_ns)
-            )
+            entries.add((path.relative_to(root).as_posix(), "f", info.st_size, info.st_mtime_ns))
 
     def loose_walk(directory: Path) -> None:
         # Mirror of vault.walk_vault_md: skip dirs and sync-conflict copies,
@@ -1052,6 +1051,52 @@ def _corpus_census(root: Path) -> tuple | None:
     return tuple(sorted(entries))
 
 
+def _config_census(root: Path) -> tuple[tuple[str, str, int, int], ...] | None:
+    """O(1) freshness stamp for non-Markdown semantic inputs."""
+    entries: list[tuple[str, str, int, int]] = []
+    try:
+        for extra in (
+            access.access_config_path(root),
+            relation_registry.extension_registry_path(root),
+            semantic_language_registry.registry_path(root),
+        ):
+            marker = extra.relative_to(root).as_posix()
+            try:
+                info = extra.stat()
+            except FileNotFoundError:
+                entries.append((marker, "absent", -1, -1))
+            else:
+                entries.append((marker, "cfg", info.st_size, info.st_mtime_ns))
+    except (OSError, ValueError):
+        return None
+    return tuple(sorted(entries))
+
+
+def _stored_config_census(census: tuple) -> tuple:
+    return tuple(entry for entry in census if entry[1] != "f")
+
+
+def _patch_markdown_census(
+    root: Path,
+    census: tuple,
+    *,
+    changed_paths: tuple[str, ...],
+    deleted_paths: tuple[str, ...],
+) -> tuple:
+    entries = {str(entry[0]): entry for entry in census}
+    for rel_path in deleted_paths:
+        entries.pop(rel_path, None)
+    for rel_path in changed_paths:
+        path = root / rel_path
+        try:
+            info = path.stat()
+        except FileNotFoundError:
+            entries.pop(rel_path, None)
+        else:
+            entries[rel_path] = (rel_path, "f", info.st_size, info.st_mtime_ns)
+    return tuple(sorted(entries.values()))
+
+
 def _registries_match_disk(
     root: Path,
     relation_definitions: relation_registry.RelationRegistry,
@@ -1070,12 +1115,319 @@ def _registries_match_disk(
         disk_language = semantic_language_registry.load_registry(root)
     except Exception:  # noqa: BLE001 — unreadable registry state: never cache
         return False
-    return (
-        (disk_registry.core_version, disk_registry.extension_hash)
-        == (relation_definitions.core_version, relation_definitions.extension_hash)
-        and (disk_language.schema_version, disk_language.content_hash)
-        == (language.schema_version, language.content_hash)
+    return (disk_registry.core_version, disk_registry.extension_hash) == (
+        relation_definitions.core_version,
+        relation_definitions.extension_hash,
+    ) and (disk_language.schema_version, disk_language.content_hash) == (
+        language.schema_version,
+        language.content_hash,
     )
+
+
+def _markdown_census_delta(before: tuple, after: tuple) -> tuple[str, ...] | None:
+    """Return changed Markdown paths, or ``None`` for a non-page delta.
+
+    Census entries are ``(path, kind, size, mtime_ns)``. A removed path only
+    exists in ``before`` and an added path only in ``after``; both remain safe
+    incremental page changes when their surviving entry kind is ``f``.
+    """
+    before_by_path = {str(entry[0]): entry for entry in before}
+    after_by_path = {str(entry[0]): entry for entry in after}
+    changed = tuple(
+        sorted(
+            path
+            for path in before_by_path.keys() | after_by_path.keys()
+            if before_by_path.get(path) != after_by_path.get(path)
+        )
+    )
+    for path in changed:
+        old = before_by_path.get(path)
+        new = after_by_path.get(path)
+        if (old is not None and old[1] != "f") or (new is not None and new[1] != "f"):
+            return None
+    return changed
+
+
+def _identity_guarded_delta_source(root: Path, rel_path: str) -> str | None:
+    """Read one KB Markdown delta under the full census' alias policy."""
+    kb = vault.kb_root(root)
+    try:
+        kb_info = kb.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise activation_manifest.ActivationManifestError(
+            "IDENTITY_CENSUS_ROOT_UNREADABLE",
+            "Knowledge Base root is unavailable for identity census",
+        ) from error
+    if (
+        not stat.S_ISDIR(kb_info.st_mode)
+        or stat.S_ISLNK(kb_info.st_mode)
+        or vault._is_reparse(kb_info)
+    ):
+        raise activation_manifest.ActivationManifestError(
+            "IDENTITY_CENSUS_UNSAFE_ROOT",
+            "Knowledge Base root is unsafe for identity census",
+        )
+
+    source_path = root / rel_path
+    try:
+        leaf_info = source_path.lstat()
+    except FileNotFoundError:
+        try:
+            vault.PathGuard.capture(root, rel_path, leaf_policy="absent")
+        except vault.PathGuardError as error:
+            code = (
+                "IDENTITY_CENSUS_UNSAFE_ENTRY"
+                if error.code in {"PATH_GUARD_ROOT", "PATH_GUARD_UNSAFE"}
+                else "IDENTITY_CENSUS_ENTRY_UNREADABLE"
+            )
+            raise activation_manifest.ActivationManifestError(
+                code,
+                f"could not safely inspect stable identity at {rel_path}",
+            ) from error
+        return None
+    except OSError as error:
+        raise activation_manifest.ActivationManifestError(
+            "IDENTITY_CENSUS_ENTRY_UNREADABLE",
+            "could not inspect a stable-identity census entry",
+        ) from error
+    if stat.S_ISLNK(leaf_info.st_mode) or vault._is_reparse(leaf_info):
+        raise activation_manifest.ActivationManifestError(
+            "IDENTITY_CENSUS_UNSAFE_ENTRY",
+            "stable-identity census contains a filesystem alias",
+        )
+    if not stat.S_ISREG(leaf_info.st_mode):
+        raise activation_manifest.ActivationManifestError(
+            "IDENTITY_CENSUS_NONREGULAR_MARKDOWN",
+            "stable-identity census contains nonregular Markdown",
+        )
+    try:
+        guard = vault.PathGuard.capture(root, rel_path, leaf_policy="stable")
+    except vault.PathGuardError as error:
+        code = (
+            "IDENTITY_CENSUS_UNSAFE_ENTRY"
+            if error.code in {"PATH_GUARD_ROOT", "PATH_GUARD_UNSAFE"}
+            else "IDENTITY_CENSUS_ENTRY_UNREADABLE"
+        )
+        raise activation_manifest.ActivationManifestError(
+            code,
+            f"could not safely inspect stable identity at {rel_path}",
+        ) from error
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        guard.recheck(root)
+    except (OSError, UnicodeDecodeError, vault.PathGuardError) as error:
+        governed_writable = (
+            activation.is_managed_governed_path(root, source_path)
+            and access.access_tier(root, rel_path) == access.TIER_READ_WRITE
+        )
+        code = (
+            "ACTIVATION_MANIFEST_PAGE_UNREADABLE"
+            if governed_writable
+            else "IDENTITY_CENSUS_PAGE_UNREADABLE"
+        )
+        raise activation_manifest.ActivationManifestError(
+            code,
+            f"could not safely inspect stable identity at {rel_path}",
+        ) from error
+    return source
+
+
+def _reconcile_markdown_delta(
+    root: Path,
+    context: SemanticCorpusContext,
+    changed_paths: tuple[str, ...],
+    *,
+    relation_definitions: relation_registry.RelationRegistry,
+    language: semantic_language_registry.SemanticLanguageRegistry,
+) -> SemanticCorpusContext:
+    """Apply current Markdown bytes to an already-materialized context.
+
+    The stable-identity census intentionally covers every Markdown file under
+    the KB, including scan-excluded paths. The semantic page map mirrors
+    ``vault.walk_vault_md`` and therefore excludes trash/schema/sync-conflict
+    paths. Any read or identity ambiguity raises through the same full-build
+    validation types instead of blessing partial state.
+    """
+    states = dict(context.pages)
+    identities = {entry.path: entry for entry in context.identity_census.entries}
+    kb_rel = vault.kb_root(root).relative_to(root).as_posix().rstrip("/")
+    for rel_path in changed_paths:
+        source_path = root / rel_path
+        in_kb = rel_path == kb_rel or rel_path.startswith(kb_rel + "/")
+        included = not vault.in_excluded_scan_dir(rel_path) and (
+            ".sync-conflict-" not in PurePosixPath(rel_path).name
+        )
+        if in_kb:
+            source = _identity_guarded_delta_source(root, rel_path)
+        else:
+            try:
+                source = source_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                source = None
+        if source is None:
+            states.pop(rel_path, None)
+            identities.pop(rel_path, None)
+            continue
+
+        state = build_page_state(
+            root,
+            rel_path,
+            source,
+            relation_registry=relation_definitions,
+            language_registry=language,
+        )
+        if included:
+            states[rel_path] = state
+        else:
+            states.pop(rel_path, None)
+        if in_kb:
+            # ``from_states`` preserves the strict invalid-ID failure that the
+            # full stable-identity census would raise for governed Markdown.
+            identities[rel_path] = StableIdentityCensus.from_states((state,)).entries[0]
+        else:
+            identities.pop(rel_path, None)
+
+    return _context_from_state_map(
+        root,
+        states,
+        _copy_registry(relation_definitions),
+        StableIdentityCensus(tuple(identities.values())),
+    )
+
+
+def on_corpus_files_changed(
+    vault_root: Path,
+    *,
+    changed: Iterable[Path] = (),
+    deleted: Iterable[Path | str] = (),
+) -> None:
+    """Patch a warm semantic corpus after a watcher or canonical write event.
+
+    Callers that also publish freshness MUST use
+    :func:`publish_corpus_files_changed` so both derived states advance under
+    one boundary. This lower-level hook remains useful for tests and repair.
+    """
+    with _CORPUS_CONTEXT_UPDATE_LOCK:
+        _patch_corpus_files_changed_locked(
+            vault_root,
+            changed=changed,
+            deleted=deleted,
+            event_token=freshness.triple(Path(vault_root), "vault"),
+        )
+
+
+def publish_corpus_files_changed(
+    vault_root: Path,
+    *,
+    changed: Iterable[Path] = (),
+    deleted: Iterable[Path | str] = (),
+) -> None:
+    """Atomically advance freshness and the warm semantic corpus context.
+
+    Serializing these two derived-state publications prevents concurrent file
+    events from stamping a context that contains only one event with a
+    freshness token that already represents both.
+    """
+    root = Path(vault_root)
+    changed_values = tuple(Path(value) for value in changed)
+    deleted_values = tuple(Path(value) for value in deleted)
+    changed_paths = tuple(
+        value if value.is_absolute() else root / value for value in changed_values
+    )
+    deleted_paths = tuple(
+        value if value.is_absolute() else root / value for value in deleted_values
+    )
+    with _CORPUS_CONTEXT_UPDATE_LOCK:
+        freshness.on_files_changed(root, changed=changed_paths, deleted=deleted_paths)
+        try:
+            _patch_corpus_files_changed_locked(
+                root,
+                changed=changed_values,
+                deleted=deleted_values,
+                event_token=freshness.triple(root, "vault"),
+            )
+        except BaseException:
+            # Freshness already advanced, so the previous context can no
+            # longer prove continuity. Evict every caption before propagating
+            # the safety/parse failure; a later good event must not leapfrog
+            # this missed delta and stamp stale state as current.
+            cache_key = _corpus_cache_key(root)
+            with _CORPUS_CONTEXT_CACHE_LOCK:
+                _CORPUS_CONTEXT_CACHE.pop(cache_key, None)
+                _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
+                _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(cache_key, None)
+            raise
+
+
+def _patch_corpus_files_changed_locked(
+    vault_root: Path,
+    *,
+    changed: Iterable[Path],
+    deleted: Iterable[Path | str],
+    event_token: tuple[int, int, str] | None,
+) -> None:
+    """Patch one cache entry while ``_CORPUS_CONTEXT_UPDATE_LOCK`` is held."""
+    root = Path(vault_root)
+    cache_key = _corpus_cache_key(root)
+    with _CORPUS_CONTEXT_CACHE_LOCK:
+        entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
+    if entry is None:
+        return
+    if _config_census(root) != _stored_config_census(entry[0]):
+        with _CORPUS_CONTEXT_CACHE_LOCK:
+            if _CORPUS_CONTEXT_CACHE.get(cache_key) is entry:
+                _CORPUS_CONTEXT_CACHE.pop(cache_key, None)
+                _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
+                _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(cache_key, None)
+        return
+
+    def relative(value: Path | str) -> str | None:
+        path = Path(value)
+        try:
+            return (
+                path.resolve().relative_to(root.resolve()).as_posix()
+                if path.is_absolute()
+                else _normalize_path(root, path)
+            )
+        except (OSError, ValueError):
+            return None
+
+    changed_paths = tuple(
+        sorted({rel for value in changed if (rel := relative(value)) is not None})
+    )
+    deleted_paths = tuple(
+        sorted({rel for value in deleted if (rel := relative(value)) is not None})
+    )
+    reconcile_paths = tuple(sorted(set(changed_paths) | set(deleted_paths)))
+    if not reconcile_paths:
+        return
+    relation_definitions = relation_registry.load_registry(root)
+    language = semantic_language_registry.load_registry(root)
+    context = _reconcile_markdown_delta(
+        root,
+        entry[1],
+        reconcile_paths,
+        relation_definitions=relation_definitions,
+        language=language,
+    )
+    census = _patch_markdown_census(
+        root,
+        entry[0],
+        changed_paths=changed_paths,
+        deleted_paths=deleted_paths,
+    )
+    with _CORPUS_CONTEXT_CACHE_LOCK:
+        if _CORPUS_CONTEXT_CACHE.get(cache_key) is entry:
+            _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
+            _CORPUS_CONTEXT_LANGUAGE_HASHES[cache_key] = (
+                f"{language.schema_version}:{language.content_hash}"
+            )
+            if event_token is None:
+                _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
+            else:
+                _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = event_token
 
 
 def build_corpus_context(
@@ -1087,12 +1439,11 @@ def build_corpus_context(
 ) -> SemanticCorpusContext:
     """Read and parse the corpus once, then resolve every fact in memory.
 
-    Warm calls are served from a bounded process cache keyed on a stat census
-    of every filesystem input (see ``_corpus_census``). A cached context is
-    returned only when the census matches exactly and any caller-supplied
-    registries are content-identical to disk; candidate-bearing builds always
-    take the uncached path. ``EXOMEM_DISABLE_CORPUS_CACHE=1`` restores the
-    always-rebuild behavior.
+    Warm calls are served from a bounded process cache captioned by a stat
+    census of every filesystem input (see ``_corpus_census``). Exact matches
+    return directly; Markdown-only changes reparse only the changed parents.
+    Candidate-bearing builds always take the uncached path.
+    ``EXOMEM_DISABLE_CORPUS_CACHE=1`` restores the always-rebuild behavior.
     """
     root = Path(vault_root)
     relation_definitions = registry or relation_registry.load_registry(root)
@@ -1101,53 +1452,212 @@ def build_corpus_context(
     census: tuple | None = None
     cache_key: tuple[str, str] | None = None
     if candidate is None and corpus_context_cache_enabled():
+        cache_key = _corpus_cache_key(root)
+        event_token = freshness.triple(root, "vault")
+        if event_token is not None:
+            with _CORPUS_CONTEXT_CACHE_LOCK:
+                event_entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
+                cached_token = _CORPUS_CONTEXT_EVENT_TOKENS.get(cache_key)
+                cached_language_hash = _CORPUS_CONTEXT_LANGUAGE_HASHES.get(cache_key)
+            if (
+                event_entry is not None
+                and cached_token == event_token
+                and cached_language_hash == f"{language.schema_version}:{language.content_hash}"
+                and _config_census(root) == _stored_config_census(event_entry[0])
+                and (
+                    event_entry[1].registry.core_version,
+                    event_entry[1].registry.extension_hash,
+                )
+                == (
+                    relation_definitions.core_version,
+                    relation_definitions.extension_hash,
+                )
+            ):
+                log.info(
+                    "semantic corpus context event-hit pages=%d",
+                    len(event_entry[1].pages),
+                )
+                return event_entry[1]
         started = time.perf_counter()
         census = _corpus_census(root)
         census_ms = (time.perf_counter() - started) * 1000.0
-        if census is not None and _registries_match_disk(
-            root, relation_definitions, language
-        ):
-            cache_key = _corpus_cache_key(root)
+        if census is not None and _registries_match_disk(root, relation_definitions, language):
             with _CORPUS_CONTEXT_CACHE_LOCK:
                 entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
             if entry is not None and entry[0] == census:
-                log.info(
-                    "semantic corpus context reused pages=%d census_ms=%.1f",
-                    len(entry[1].pages),
-                    census_ms,
-                )
-                return entry[1]
+                with _CORPUS_CONTEXT_UPDATE_LOCK, _CORPUS_CONTEXT_CACHE_LOCK:
+                    current = _CORPUS_CONTEXT_CACHE.get(cache_key)
+                    if current is not entry:
+                        entry = current
+                    elif entry[0] == census:
+                        current_token = freshness.triple(root, "vault")
+                        if current_token is not None:
+                            _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = current_token
+                        log.info(
+                            "semantic corpus context reused pages=%d census_ms=%.1f",
+                            len(entry[1].pages),
+                            census_ms,
+                        )
+                        return entry[1]
+                if entry is not None and entry[0] == census:
+                    with _CORPUS_CONTEXT_CACHE_LOCK:
+                        if _CORPUS_CONTEXT_CACHE.get(cache_key) is entry:
+                            return entry[1]
+            if entry is not None:
+                changed_paths = _markdown_census_delta(entry[0], census)
+                if changed_paths is not None:
+                    started = time.perf_counter()
+                    context = _reconcile_markdown_delta(
+                        root,
+                        entry[1],
+                        changed_paths,
+                        relation_definitions=relation_definitions,
+                        language=language,
+                    )
+                    with _CORPUS_CONTEXT_UPDATE_LOCK:
+                        confirmed = _corpus_census(root)
+                        with _CORPUS_CONTEXT_CACHE_LOCK:
+                            current = _CORPUS_CONTEXT_CACHE.get(cache_key)
+                            if confirmed == census and current is entry:
+                                _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
+                                _CORPUS_CONTEXT_LANGUAGE_HASHES[cache_key] = (
+                                    f"{language.schema_version}:{language.content_hash}"
+                                )
+                                current_token = freshness.triple(root, "vault")
+                                if current_token is not None:
+                                    _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = current_token
+                                log.info(
+                                    "semantic corpus context reconciled pages=%d "
+                                    "changed=%d reconcile_ms=%.1f census_ms=%.1f",
+                                    len(context.pages),
+                                    len(changed_paths),
+                                    (time.perf_counter() - started) * 1000.0,
+                                    census_ms,
+                                )
+                                return context
+                            if current is not None and current is not entry:
+                                return current[1]
         else:
             census = None
 
-    started = time.perf_counter()
-    context = _build_corpus_context_uncached(
-        root,
-        candidate=candidate,
-        relation_definitions=relation_definitions,
-        language=language,
-    )
-    build_ms = (time.perf_counter() - started) * 1000.0
-    stored = False
+    flight: _CorpusContextFlight | None = None
     if census is not None and cache_key is not None:
-        confirmed = _corpus_census(root)
-        if confirmed == census:
-            with _CORPUS_CONTEXT_CACHE_LOCK:
-                _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
-                while len(_CORPUS_CONTEXT_CACHE) > _CORPUS_CONTEXT_CACHE_MAX_VAULTS:
-                    for stale_key in list(_CORPUS_CONTEXT_CACHE):
-                        if stale_key != cache_key:
-                            del _CORPUS_CONTEXT_CACHE[stale_key]
-                            break
-                    else:
+        registry_identity = (
+            relation_definitions.core_version,
+            relation_definitions.extension_hash,
+        )
+        language_identity = (language.schema_version, language.content_hash)
+        with _CORPUS_CONTEXT_CACHE_LOCK:
+            flight = _CORPUS_CONTEXT_FLIGHTS.get(cache_key)
+            if flight is None:
+                flight = _CorpusContextFlight(
+                    census,
+                    registry_identity,
+                    language_identity,
+                )
+                _CORPUS_CONTEXT_FLIGHTS[cache_key] = flight
+                owns_flight = True
+            else:
+                owns_flight = False
+        if not owns_flight:
+            same_inputs = (
+                flight.census == census
+                and flight.registry_identity == registry_identity
+                and flight.language_identity == language_identity
+            )
+            flight.done.wait()
+            if not same_inputs:
+                return build_corpus_context(
+                    root,
+                    candidate=candidate,
+                    registry=registry,
+                    language_registry=language_registry,
+                )
+            if flight.error is not None:
+                raise flight.error
+            assert flight.result is not None
+            return flight.result
+
+    try:
+        started = time.perf_counter()
+        context = _build_corpus_context_uncached(
+            root,
+            candidate=candidate,
+            relation_definitions=relation_definitions,
+            language=language,
+        )
+        build_ms = (time.perf_counter() - started) * 1000.0
+        stored = False
+        if census is not None and cache_key is not None:
+            with _CORPUS_CONTEXT_UPDATE_LOCK:
+                stable_census = census
+                # A busy watcher/media worker can change Markdown while the cold
+                # build runs. Once publication begins, serialize with event
+                # freshness+cache updates, absorb exact deltas, then stamp the same
+                # state atomically so a newer event context cannot be overwritten.
+                for _ in range(3):
+                    confirmed = _corpus_census(root)
+                    if confirmed == stable_census:
                         break
-            stored = True
-    log.info(
-        "semantic corpus context built pages=%d build_ms=%.1f cached=%s",
-        len(context.pages),
-        build_ms,
-        stored,
-    )
+                    if confirmed is None:
+                        stable_census = None
+                        break
+                    changed_paths = _markdown_census_delta(stable_census, confirmed)
+                    if changed_paths is None:
+                        stable_census = None
+                        break
+                    context = _reconcile_markdown_delta(
+                        root,
+                        context,
+                        changed_paths,
+                        relation_definitions=relation_definitions,
+                        language=language,
+                    )
+                    stable_census = confirmed
+                else:
+                    confirmed = None
+                if confirmed == stable_census and stable_census is not None:
+                    census = stable_census
+                    with _CORPUS_CONTEXT_CACHE_LOCK:
+                        _CORPUS_CONTEXT_CACHE[cache_key] = (census, context)
+                        _CORPUS_CONTEXT_LANGUAGE_HASHES[cache_key] = (
+                            f"{language.schema_version}:{language.content_hash}"
+                        )
+                        current_token = freshness.triple(root, "vault")
+                        if current_token is None:
+                            _CORPUS_CONTEXT_EVENT_TOKENS.pop(cache_key, None)
+                        else:
+                            _CORPUS_CONTEXT_EVENT_TOKENS[cache_key] = current_token
+                        while len(_CORPUS_CONTEXT_CACHE) > _CORPUS_CONTEXT_CACHE_MAX_VAULTS:
+                            for stale_key in list(_CORPUS_CONTEXT_CACHE):
+                                if stale_key != cache_key:
+                                    del _CORPUS_CONTEXT_CACHE[stale_key]
+                                    _CORPUS_CONTEXT_EVENT_TOKENS.pop(stale_key, None)
+                                    _CORPUS_CONTEXT_LANGUAGE_HASHES.pop(stale_key, None)
+                                    break
+                            else:
+                                break
+                    stored = True
+        log.info(
+            "semantic corpus context built pages=%d build_ms=%.1f cached=%s",
+            len(context.pages),
+            build_ms,
+            stored,
+        )
+    except BaseException as error:
+        if flight is not None:
+            flight.error = error
+            with _CORPUS_CONTEXT_CACHE_LOCK:
+                if _CORPUS_CONTEXT_FLIGHTS.get(cache_key) is flight:
+                    del _CORPUS_CONTEXT_FLIGHTS[cache_key]
+            flight.done.set()
+        raise
+    if flight is not None:
+        flight.result = context
+        with _CORPUS_CONTEXT_CACHE_LOCK:
+            if _CORPUS_CONTEXT_FLIGHTS.get(cache_key) is flight:
+                del _CORPUS_CONTEXT_FLIGHTS[cache_key]
+        flight.done.set()
     return context
 
 
@@ -1327,6 +1837,55 @@ def _context_from_state_map(
     entries = tuple((path, ordered_pages[path].title) for path in ordered_pages)
     resolver = vault.WikilinkResolver.from_entries(root, entries)
     facts = _derive_relation_facts(root, ordered_pages, resolver, registry)
+    return _context_from_resolved_state(
+        root,
+        ordered_pages,
+        registry,
+        identity_census,
+        entries=entries,
+        resolver=resolver,
+        facts=facts,
+    )
+
+
+def _context_with_stable_topology_candidate(
+    context: SemanticCorpusContext,
+    state: SemanticPageState,
+) -> SemanticCorpusContext:
+    """Replace one page without re-resolving every authored corpus fact."""
+    pages = dict(context.pages)
+    pages[state.path] = state
+    resolver = vault.WikilinkResolver.from_entries(context.vault_root, context.resolver_entries)
+    candidate_facts = _derive_relation_facts(
+        context.vault_root,
+        {state.path: state},
+        resolver,
+        context.registry,
+        target_states=pages,
+    )
+    retained_facts = (fact for fact in context.relation_facts if fact.authored_path != state.path)
+    facts = tuple(sorted((*retained_facts, *candidate_facts), key=lambda item: item.identity))
+    return _context_from_resolved_state(
+        context.vault_root,
+        pages,
+        context.registry,
+        context.identity_census,
+        entries=context.resolver_entries,
+        resolver=resolver,
+        facts=facts,
+    )
+
+
+def _context_from_resolved_state(
+    root: Path,
+    ordered_pages: Mapping[str, SemanticPageState],
+    registry: relation_registry.RelationRegistry,
+    identity_census: StableIdentityCensus,
+    *,
+    entries: tuple[tuple[str, str], ...],
+    resolver: vault.WikilinkResolver,
+    facts: tuple[RelationFact, ...],
+) -> SemanticCorpusContext:
     inbound: dict[str, list[RelationFact]] = {}
     outbound: dict[str, list[RelationFact]] = {}
     dependencies: dict[str, list[str]] = {}
@@ -1431,9 +1990,7 @@ def _resolve_target(
 ) -> tuple[str, str | None, str | None, str | None]:
     _, authored_anchor, alias = _target_parts(raw_target)
     try:
-        normalized, _ = vault.normalize_wikilink(
-            raw_target, root, resolver=resolver, strict=True
-        )
+        normalized, _ = vault.normalize_wikilink(raw_target, root, resolver=resolver, strict=True)
     except vault.AmbiguousWikilinkError:
         return "ambiguous", None, authored_anchor, alias
     except vault.UnresolvedWikilinkError:
@@ -1477,11 +2034,7 @@ def _registry_resolution(
         ),
         resolutions[0],
     )
-    if (
-        selected.definition is not None
-        and selected.definition.projects
-        and not projects
-    ):
+    if selected.definition is not None and selected.definition.projects and not projects:
         return replace(
             selected,
             status="scope_violation",
@@ -1507,16 +2060,17 @@ def _derive_relation_facts(
     states: Mapping[str, SemanticPageState],
     resolver: vault.WikilinkResolver,
     registry: relation_registry.RelationRegistry,
+    *,
+    target_states: Mapping[str, SemanticPageState] | None = None,
 ) -> tuple[RelationFact, ...]:
+    resolved_states = target_states if target_states is not None else states
     raw_facts: list[dict[str, Any]] = []
     for state in states.values():
         for relation in state.document.note_relations:
             raw_facts.append(
                 {
                     "authored": state,
-                    "raw_relation": _raw_note_relation(
-                        relation.raw, relation.kind
-                    ),
+                    "raw_relation": _raw_note_relation(relation.raw, relation.kind),
                     "raw_target": _raw_note_target(relation.raw, relation.target),
                     "line": relation.line,
                     "anchor": None,
@@ -1531,9 +2085,7 @@ def _derive_relation_facts(
                 raw_facts.append(
                     {
                         "authored": state,
-                        "raw_relation": _raw_rich_relation(
-                            relation.raw, relation.kind
-                        ),
+                        "raw_relation": _raw_rich_relation(relation.raw, relation.kind),
                         "raw_target": relation.target,
                         "line": relation.line,
                         "anchor": unit.anchor,
@@ -1576,7 +2128,7 @@ def _derive_relation_facts(
             root, raw["raw_target"], resolver
         )
         resolved_base = resolved_target.split("#", 1)[0] if resolved_target else None
-        target_state = states.get(resolved_base or "")
+        target_state = resolved_states.get(resolved_base or "")
         target_kind = "file" if target_state is not None else "unresolved"
         resolution = _registry_resolution(
             registry,
@@ -1703,8 +2255,7 @@ def qualify_relation(
             source_kind=fact.source_kind,
             target_kind=(
                 "file"
-                if fact.target_status == "resolved"
-                and resolved_base in corpus.pages
+                if fact.target_status == "resolved" and resolved_base in corpus.pages
                 else "unresolved"
             ),
             origin=fact.origin,
@@ -1758,9 +2309,7 @@ def _relation_disposition(
             qualifying.append((direction, fact))
         else:
             rejected.append(RejectedRelationFact(fact, result.reasons))
-    review_is_current = review is not None and is_relation_review_current(
-        review, page, corpus
-    )
+    review_is_current = review is not None and is_relation_review_current(review, page, corpus)
     stale_review = review is not None and not review_is_current
     other_governed = corpus.eligible_governed_paths - {page.path}
     if qualifying:
@@ -1780,9 +2329,7 @@ def _relation_disposition(
             actions=actions,
         )
     if review_is_current and review is not None and review.kind == "reviewed_none":
-        return RelationDisposition(
-            "reviewed_none", True, True, rejected_facts=tuple(rejected)
-        )
+        return RelationDisposition("reviewed_none", True, True, rejected_facts=tuple(rejected))
     if (
         review_is_current
         and review is not None
@@ -1827,16 +2374,12 @@ def _diagnostic_findings(page: SemanticPageState) -> list[ContractFinding]:
     occurrences: Counter[tuple[str, str]] = Counter()
     diagnostics = tuple(page.document.errors) + tuple(page.document.warnings)
     for diagnostic in diagnostics:
-        if (
-            diagnostic.code == "unsupported_relation"
-            and diagnostic.registry_namespace is None
-        ):
+        if diagnostic.code == "unsupported_relation" and diagnostic.registry_namespace is None:
             continue
         raw_key = " ".join(diagnostic.raw.casefold().split())
         occurrences[(diagnostic.code, raw_key)] += 1
         registry_diagnostic = (
-            diagnostic.registry_namespace is not None
-            and diagnostic.registry_key is not None
+            diagnostic.registry_namespace is not None and diagnostic.registry_key is not None
         )
         findings.append(
             ContractFinding(
@@ -2109,9 +2652,7 @@ def _page_rule_findings(
                 )
         elif rule == "allowed" and constraint.value is not None:
             values = observed.get(namespace, set())
-            for unknown in sorted(
-                values - set(constraint.value), key=_stable_value_key
-            ):
+            for unknown in sorted(values - set(constraint.value), key=_stable_value_key):
                 findings.append(
                     _rule_finding(
                         page,
@@ -2141,23 +2682,17 @@ def _disposition_finding(
         span=None,
         detail=_disposition_detail(page, disposition),
         remediation=(
-            "Add a qualifying typed relation or record a current reviewed-none "
-            "disposition."
+            "Add a qualifying typed relation or record a current reviewed-none disposition."
         ),
         governed_element_identity=("relations", "disposition"),
         resolved_rule=("relations", "*", "disposition"),
     )
 
 
-def _disposition_detail(
-    page: SemanticPageState, disposition: RelationDisposition
-) -> str:
+def _disposition_detail(page: SemanticPageState, disposition: RelationDisposition) -> str:
     if disposition.kind == "stale":
         return "the saved non-edge relation disposition is no longer current"
-    if (
-        page.document.canonical_section_present
-        and page.document.canonical_bullet_count == 0
-    ):
+    if page.document.canonical_section_present and page.document.canonical_bullet_count == 0:
         return (
             "the empty canonical Relations section requires a current "
             "reviewed-none or bootstrap disposition"
@@ -2206,11 +2741,9 @@ def _raw_findings(
     minimum_finding = _missing_semantic_unit_finding(page)
     if minimum_finding is not None:
         findings.append(minimum_finding)
-    if (
-        page.identity_kind == "exomem_id"
-        and corpus.identity_census.paths_by_identity.get(page.identity)
-        != (page.path,)
-    ):
+    if page.identity_kind == "exomem_id" and corpus.identity_census.paths_by_identity.get(
+        page.identity
+    ) != (page.path,):
         findings.append(
             ContractFinding(
                 code="SEMANTIC_IDENTITY_DUPLICATE",
@@ -2243,10 +2776,7 @@ def _corpus_mismatch_finding(
         severity="error",
         path=page.path,
         span=None,
-        detail=(
-            f"the supplied {phase}-corpus snapshot does not contain the evaluated "
-            "page state"
-        ),
+        detail=(f"the supplied {phase}-corpus snapshot does not contain the evaluated page state"),
         remediation="Rebuild the immutable corpus context with the exact pending candidate.",
         governed_element_identity=(
             "corpus",
@@ -2284,9 +2814,7 @@ def evaluate(
     """Evaluate supplied immutable state without crossing any adapter boundary."""
     if mode not in {"precommit", "posthoc"}:
         raise ValueError("mode must be precommit or posthoc")
-    before_context_matches = (
-        before is None or before_corpus.pages.get(before.path) == before
-    )
+    before_context_matches = before is None or before_corpus.pages.get(before.path) == before
     effective_before_corpus = (
         before_corpus
         if before_context_matches or before is None
@@ -2333,9 +2861,7 @@ def evaluate(
         finding.key for finding in after_findings if finding.severity == "error"
     }
     use_subset_exception = (
-        grandfathered
-        and operation in _GRANDFATHERED_OPERATIONS
-        and before is not None
+        grandfathered and operation in _GRANDFATHERED_OPERATIONS and before is not None
     )
     normalized: list[ContractFinding] = []
     for finding in after_findings:
@@ -2374,9 +2900,7 @@ def evaluate(
         blocking = tuple(item for item in errors if item.key in new_error_keys)
     if invalidated_disposition:
         disposition_errors = tuple(
-            item
-            for item in errors
-            if item.resolved_rule == ("relations", "*", "disposition")
+            item for item in errors if item.resolved_rule == ("relations", "*", "disposition")
         )
         blocking = tuple(sorted({*blocking, *disposition_errors}, key=_finding_sort_key))
     if mode == "posthoc":

--- a/src/exomem/semantic_index.py
+++ b/src/exomem/semantic_index.py
@@ -15,8 +15,8 @@ from . import memory_refs, relation_registry, semantic_language_registry, semant
 
 PARSER_VERSION = 4
 _GENERATION_SCHEMA = "exomem.semantic-unit.parent-generation.v4"
-_ACTIVE_PARENT_STATES: ContextVar[Mapping[str, SemanticParentIndexState] | None] = (
-    ContextVar("exomem_semantic_parent_states", default=None)
+_ACTIVE_PARENT_STATES: ContextVar[Mapping[str, SemanticParentIndexState] | None] = ContextVar(
+    "exomem_semantic_parent_states", default=None
 )
 
 
@@ -84,9 +84,7 @@ def reset_parent_states(
     _ACTIVE_PARENT_STATES.reset(token)
 
 
-def parent_state_for_path(
-    vault_root: Path, path: Path | str
-) -> SemanticParentIndexState | None:
+def parent_state_for_path(vault_root: Path, path: Path | str) -> SemanticParentIndexState | None:
     states = _ACTIVE_PARENT_STATES.get()
     if not states:
         return None
@@ -198,6 +196,12 @@ def build_parent_index_state(
         source_path = root / rel_path
     if source is None:
         source = source_path.read_text(encoding="utf-8")
+    else:
+        # ``Path.read_text`` uses universal-newline translation, while callers
+        # that share an exact byte snapshot may pass decoded CRLF content.
+        # Normalize both routes before frontmatter/ref parsing so Windows deep
+        # packs retain the same stable memory identity as indexed retrieval.
+        source = source.replace("\r\n", "\n").replace("\r", "\n")
     frontmatter, body, _ = vault.parse_frontmatter(source)
     parent_ref = memory_refs.ref_from_markdown(source)
     page_type = str(frontmatter["type"]) if frontmatter.get("type") else None
@@ -210,9 +214,7 @@ def build_parent_index_state(
         path=rel_path,
         parent_ref=parent_ref,
         validate=True,
-        language_registry=semantic_language_registry.for_attached_projects(
-            language, projects
-        ),
+        language_registry=semantic_language_registry.for_attached_projects(language, projects),
         relation_registry=relations,
         include_legacy_relations=True,
         retain_unknown_relations=True,
@@ -270,9 +272,7 @@ def from_semantic_page_state(state: Any) -> SemanticParentIndexState:
     path = str(state.path)
     source_hash = str(state.source_hash)
     parent_ref = (
-        memory_refs.memory_ref(str(state.identity))
-        if state.identity_kind == "exomem_id"
-        else None
+        memory_refs.memory_ref(str(state.identity)) if state.identity_kind == "exomem_id" else None
     )
     return SemanticParentIndexState(
         path=path,
@@ -327,9 +327,7 @@ def _rows_by_parent(
         values["unit_refs"].add(str(unit_ref))
         if parent_ref:
             values["parent_refs"].add(str(parent_ref))
-        values["stamps"].add(
-            (str(generation), str(source_hash), int(parser_version))
-        )
+        values["stamps"].add((str(generation), str(source_hash), int(parser_version)))
     return {
         path: _SidecarParentRows(
             frozenset(values["unit_refs"]),
@@ -363,12 +361,9 @@ def _graph_unit_rows(path: Path) -> dict[str, _SidecarParentRows]:
     try:
         conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
         try:
-            node_rows = conn.execute(
-                "SELECT path, metadata FROM graph_nodes"
-            ).fetchall()
+            node_rows = conn.execute("SELECT path, metadata FROM graph_nodes").fetchall()
             edge_rows = conn.execute(
-                "SELECT source_path, metadata FROM graph_edges "
-                "WHERE relation_type = 'derived_from'"
+                "SELECT source_path, metadata FROM graph_edges WHERE relation_type = 'derived_from'"
             ).fetchall()
         finally:
             conn.close()
@@ -380,9 +375,7 @@ def _graph_unit_rows(path: Path) -> dict[str, _SidecarParentRows]:
             metadata = json.loads(raw_metadata)
         except (TypeError, ValueError):
             continue
-        if metadata.get("record_type") != "semantic_unit" or not metadata.get(
-            "unit_ref"
-        ):
+        if metadata.get("record_type") != "semantic_unit" or not metadata.get("unit_ref"):
             continue
         values = grouped.setdefault(
             str(parent_path),
@@ -406,9 +399,7 @@ def _graph_unit_rows(path: Path) -> dict[str, _SidecarParentRows]:
             metadata = json.loads(raw_metadata)
         except (TypeError, ValueError):
             continue
-        if metadata.get("record_type") != "semantic_unit" or not metadata.get(
-            "unit_ref"
-        ):
+        if metadata.get("record_type") != "semantic_unit" or not metadata.get("unit_ref"):
             continue
         values = grouped.setdefault(
             str(parent_path),
@@ -460,33 +451,25 @@ def audit_semantic_unit_sidecars(
 
     expected = dict(expected_states)
     expected_by_ref = {
-        state.parent_ref: path
-        for path, state in expected.items()
-        if state.parent_ref is not None
+        state.parent_ref: path for path, state in expected.items() if state.parent_ref is not None
     }
     sidecars: list[tuple[str, dict[str, _SidecarParentRows]]] = []
     if include_lexical:
         sidecars.append(
             (
                 "lexical",
-                _sqlite_unit_rows(
-                    lexstore.lexical_path(vault_root), "semantic_units"
-                ),
+                _sqlite_unit_rows(lexstore.lexical_path(vault_root), "semantic_units"),
             )
         )
     if include_vectors:
         sidecars.append(
             (
                 "vector",
-                _sqlite_unit_rows(
-                    index_paths.sidecar_path(vault_root), "semantic_unit_vectors"
-                ),
+                _sqlite_unit_rows(index_paths.sidecar_path(vault_root), "semantic_unit_vectors"),
             )
         )
     if include_graph:
-        sidecars.append(
-            ("graph", _graph_unit_rows(epistemic_graph.sidecar_path(vault_root)))
-        )
+        sidecars.append(("graph", _graph_unit_rows(epistemic_graph.sidecar_path(vault_root))))
     trashed = _trash_original_paths(vault_root)
     drift: list[SemanticUnitSidecarDrift] = []
     generations_by_parent: dict[str, dict[str, frozenset[str]]] = {}
@@ -516,16 +499,12 @@ def audit_semantic_unit_sidecars(
                         sidecar,
                         parent_path,
                         tuple(sorted(orphan_reasons)),
-                        actual_generations=tuple(
-                            sorted(stamp[0] for stamp in actual.stamps)
-                        ),
+                        actual_generations=tuple(sorted(stamp[0] for stamp in actual.stamps)),
                     )
                 )
                 continue
             expected_refs = frozenset(
-                unit.unit_ref
-                for unit in state.document.units
-                if unit.unit_ref is not None
+                unit.unit_ref for unit in state.document.units if unit.unit_ref is not None
             )
             if actual is None:
                 if expected_refs:
@@ -539,9 +518,7 @@ def audit_semantic_unit_sidecars(
                     )
                 continue
             actual_generations = frozenset(stamp[0] for stamp in actual.stamps)
-            generations_by_parent.setdefault(parent_path, {})[sidecar] = (
-                actual_generations
-            )
+            generations_by_parent.setdefault(parent_path, {})[sidecar] = actual_generations
             reasons: set[str] = set()
             if actual.unit_refs != expected_refs:
                 reasons.add("unit_set_mismatch")

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 from . import (
     activation_manifest,
+    freshness,
     memory_schema,
     relation_registry,
     relation_review,
@@ -24,6 +25,9 @@ from . import (
     semantic_index,
     semantic_language_registry,
     vault,
+)
+from . import (
+    find as find_module,
 )
 from .kbdir import kb_prefix
 
@@ -39,9 +43,7 @@ _COMPILED_TYPES = frozenset(
         "production-log",
     }
 )
-_EXISTING_OPERATIONS = frozenset(
-    {"edit", "observe", "tier2_overwrite", "tier2_append"}
-)
+_EXISTING_OPERATIONS = frozenset({"edit", "observe", "tier2_overwrite", "tier2_append"})
 _FEEDBACK_FINDING_LIMIT = 32
 _FEEDBACK_RELATION_FACT_LIMIT = 16
 _FEEDBACK_ITEM_LIMIT = 32
@@ -58,9 +60,7 @@ _POSTHOC_BYTE_BUDGET = 120 * 1024
 _MOVE_WIKILINK_PATTERN = re.compile(r"\[\[([^\]\|\n]+?)(\|[^\]\n]*)?\]\]")
 
 
-def rewrite_wikilinks_for_move(
-    text: str, old_rel: str, new_rel: str
-) -> tuple[str, int]:
+def rewrite_wikilinks_for_move(text: str, old_rel: str, new_rel: str) -> tuple[str, int]:
     """Pure canonical path-only rewrite shared by move staging and review carry."""
     old_no_ext = old_rel.removesuffix(".md")
     new_no_ext = new_rel.removesuffix(".md")
@@ -129,9 +129,7 @@ def _bounded_feedback_value(value: Any, truncation: dict[str, int]) -> Any:
 
 
 def _feedback_serialized_size(value: dict[str, Any]) -> int:
-    return len(
-        json.dumps(value, ensure_ascii=True, sort_keys=True).encode("utf-8")
-    )
+    return len(json.dumps(value, ensure_ascii=True, sort_keys=True).encode("utf-8"))
 
 
 def _fit_feedback_byte_budget(value: dict[str, Any]) -> dict[str, Any]:
@@ -172,9 +170,7 @@ def _fit_feedback_byte_budget(value: dict[str, Any]) -> dict[str, Any]:
         value["truncation"]["budget_items_omitted"] += removed_total
     value["omitted_counts"] = dict(sorted(top_omitted.items()))
     if isinstance(relation, dict):
-        relation["omitted_counts"] = dict(
-            sorted(relation["omitted_counts"].items())
-        )
+        relation["omitted_counts"] = dict(sorted(relation["omitted_counts"].items()))
     return value
 
 
@@ -229,9 +225,7 @@ def _blocking_reason_for_evaluations(
     finding came from is what makes a multi-page rejection actionable.
     """
     findings = tuple(
-        finding
-        for item in evaluations
-        for finding in item.contract_result.blocking_findings
+        finding for item in evaluations for finding in item.contract_result.blocking_findings
     )
     if not findings:
         return prefix
@@ -267,19 +261,14 @@ def _bounded_semantic_feedback(
     def items(name: str, values: tuple[str, ...]) -> list[str]:
         if len(values) > _FEEDBACK_ITEM_LIMIT:
             omitted[name] = len(values) - _FEEDBACK_ITEM_LIMIT
-        return [
-            _bounded_feedback_text(item, truncation)
-            for item in values[:_FEEDBACK_ITEM_LIMIT]
-        ]
+        return [_bounded_feedback_text(item, truncation) for item in values[:_FEEDBACK_ITEM_LIMIT]]
 
     kind_counts = result.kind_counts[:_FEEDBACK_COUNT_LIMIT]
     category_counts = result.category_counts[:_FEEDBACK_COUNT_LIMIT]
     if len(result.kind_counts) > _FEEDBACK_COUNT_LIMIT:
         omitted["kind_counts"] = len(result.kind_counts) - _FEEDBACK_COUNT_LIMIT
     if len(result.category_counts) > _FEEDBACK_COUNT_LIMIT:
-        omitted["category_counts"] = (
-            len(result.category_counts) - _FEEDBACK_COUNT_LIMIT
-        )
+        omitted["category_counts"] = len(result.category_counts) - _FEEDBACK_COUNT_LIMIT
 
     relation_value: dict[str, Any] | None = None
     disposition = result.relation_disposition
@@ -290,8 +279,7 @@ def _bounded_semantic_feedback(
             if len(values) > _FEEDBACK_ITEM_LIMIT:
                 relation_omitted[name] = len(values) - _FEEDBACK_ITEM_LIMIT
             return [
-                _bounded_feedback_text(item, truncation)
-                for item in values[:_FEEDBACK_ITEM_LIMIT]
+                _bounded_feedback_text(item, truncation) for item in values[:_FEEDBACK_ITEM_LIMIT]
             ]
 
         if len(disposition.qualifying_facts) > _FEEDBACK_RELATION_FACT_LIMIT:
@@ -311,9 +299,7 @@ def _bounded_semantic_feedback(
             ),
             "qualifying_facts": [
                 _bounded_feedback_value(fact.as_dict(), truncation)
-                for fact in disposition.qualifying_facts[
-                    :_FEEDBACK_RELATION_FACT_LIMIT
-                ]
+                for fact in disposition.qualifying_facts[:_FEEDBACK_RELATION_FACT_LIMIT]
             ],
             "rejected_facts": [
                 _bounded_feedback_value(item.as_dict(), truncation)
@@ -329,17 +315,13 @@ def _bounded_semantic_feedback(
         "findings": findings("findings", result.findings),
         "errors": findings("errors", result.errors),
         "warnings": findings("warnings", result.warnings),
-        "blocking_findings": findings(
-            "blocking_findings", result.blocking_findings
-        ),
+        "blocking_findings": findings("blocking_findings", result.blocking_findings),
         "should_block": result.should_block,
         "semantic_unit_count": result.semantic_unit_count,
         "compact_unit_count": result.compact_unit_count,
         "rich_unit_count": result.rich_unit_count,
         "kind_counts": _bounded_feedback_value(dict(kind_counts), truncation),
-        "category_counts": _bounded_feedback_value(
-            dict(category_counts), truncation
-        ),
+        "category_counts": _bounded_feedback_value(dict(category_counts), truncation),
         "relation_disposition": relation_value,
         "actions": items("actions", result.actions),
         "omitted_counts": dict(sorted(omitted.items())),
@@ -374,9 +356,7 @@ class SemanticWriteError(ValueError):
         """Project only canonical semantic-authoring refusals for public facades."""
         canonical = semantic_authoring.AUTHORING_CONTRACT.findings
         authored = tuple(
-            finding
-            for finding in self.validation_findings
-            if finding.code in canonical
+            finding for finding in self.validation_findings if finding.code in canonical
         )
         if not authored:
             return None
@@ -425,13 +405,15 @@ def _posthoc_finding_sort_key(item: dict[str, Any]) -> tuple[Any, ...]:
         code == "RELATION_DISPOSITION_MISSING" and item.get("grandfathered") is True
     )
     current = item.get("activation") == "current"
-    if not legacy_backlog and current and item.get("grandfathered") is not True and item.get(
-        "severity"
-    ) == "error":
+    if (
+        not legacy_backlog
+        and current
+        and item.get("grandfathered") is not True
+        and item.get("severity") == "error"
+    ):
         priority = 0
     elif rule == "syntax" or (
-        namespace in {"categories", "kinds"}
-        and (rule == "registry" or "REGISTRY" in code.upper())
+        namespace in {"categories", "kinds"} and (rule == "registry" or "REGISTRY" in code.upper())
     ):
         priority = 1
     elif legacy_backlog:
@@ -455,9 +437,7 @@ class PosthocBatch:
     evaluations: tuple[PosthocPageEvaluation, ...]
     corpus: semantic_contract.SemanticCorpusContext | None = None
 
-    def as_dict(
-        self, detail: Literal["actionable", "full"] = "actionable"
-    ) -> dict[str, Any]:
+    def as_dict(self, detail: Literal["actionable", "full"] = "actionable") -> dict[str, Any]:
         if detail not in {"actionable", "full"}:
             raise SemanticWriteError(
                 "SEMANTIC_POSTHOC_INVALID_DETAIL",
@@ -489,18 +469,14 @@ class PosthocBatch:
                     "path": evaluation.path,
                     "code": finding.code,
                     "severity": finding.severity,
-                    "governed_element_identity": list(
-                        finding.governed_element_identity
-                    ),
+                    "governed_element_identity": list(finding.governed_element_identity),
                     "resolved_rule": list(finding.resolved_rule),
                     "relation_disposition": disposition_value,
                     "actions": list(evaluation.contract_result.actions),
                     "activation": evaluation.activation,
                     "grandfathered": evaluation.grandfathered,
                 }
-                findings.append(
-                    item if full else _bounded_feedback_value(item, bounded)
-                )
+                findings.append(item if full else _bounded_feedback_value(item, bounded))
         total = len(findings)
         ordered_for_bounds = False
         if not full and audit_projection and total > _POSTHOC_FINDING_LIMIT:
@@ -518,9 +494,7 @@ class PosthocBatch:
             ]
         summary_items = sorted(summary.items())
         retained_summary = dict(
-            summary_items
-            if full or audit_projection
-            else summary_items[:_POSTHOC_SUMMARY_LIMIT]
+            summary_items if full or audit_projection else summary_items[:_POSTHOC_SUMMARY_LIMIT]
         )
         value: dict[str, Any] = {
             "operation": self.operation,
@@ -531,16 +505,13 @@ class PosthocBatch:
             "omitted_counts": {
                 "evaluated_paths": len(self.evaluations) - len(evaluated_paths),
                 "semantic_contract_findings": omitted,
-                "semantic_contract_summary": len(summary_items)
-                - len(retained_summary),
+                "semantic_contract_summary": len(summary_items) - len(retained_summary),
             },
             "truncation": {
                 "byte_budget": None if full else _POSTHOC_BYTE_BUDGET,
                 "finding_limit": None if full else _POSTHOC_FINDING_LIMIT,
                 "path_limit": None if full else _POSTHOC_PATH_LIMIT,
-                "summary_limit": (
-                    None if full or audit_projection else _POSTHOC_SUMMARY_LIMIT
-                ),
+                "summary_limit": (None if full or audit_projection else _POSTHOC_SUMMARY_LIMIT),
                 **bounded,
                 "budget_items_omitted": 0,
             },
@@ -565,9 +536,7 @@ class PosthocBatch:
             ("evaluated_paths", evaluated_paths),
         ]
         if not audit_projection:
-            variable_collections.append(
-                ("semantic_contract_summary", retained_summary)
-            )
+            variable_collections.append(("semantic_contract_summary", retained_summary))
         while _feedback_serialized_size(value) >= _POSTHOC_BYTE_BUDGET:
             removed_total = 0
             for name, collection in variable_collections:
@@ -646,11 +615,7 @@ def evaluate_posthoc_batch(
         selected = sorted(corpus.pages)
     else:
         selected = sorted(
-            {
-                rel
-                for path in paths
-                if (rel := _posthoc_relative_path(root, path)) is not None
-            }
+            {rel for path in paths if (rel := _posthoc_relative_path(root, path)) is not None}
         )
 
     contracts_by_scope: dict[
@@ -682,9 +647,7 @@ def evaluate_posthoc_batch(
                 root,
                 state.path,
                 source_hash=state.source_hash,
-                exomem_id=(
-                    state.identity if state.identity_kind == "exomem_id" else None
-                ),
+                exomem_id=(state.identity if state.identity_kind == "exomem_id" else None),
                 manifest=manifest,
                 census=corpus.activation_census,
             )
@@ -741,9 +704,9 @@ class DraftToken:
             "render_date": self.render_date,
             "registrations": [item.as_dict() for item in self.registrations],
         }
-        raw = json.dumps(
-            value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
+        raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
         if len(raw) > _MAX_TOKEN_BYTES:
             raise SemanticWriteError("DRAFT_TOKEN_TOO_LARGE", "draft token exceeds its bound")
         encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
@@ -756,8 +719,7 @@ class DraftToken:
         if (
             type(token) is not str
             or not token
-            or len(token.encode("utf-8"))
-            > relation_review.MAX_DRAFT_TOKEN_ENCODED_BYTES
+            or len(token.encode("utf-8")) > relation_review.MAX_DRAFT_TOKEN_ENCODED_BYTES
         ):
             raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token is invalid")
         try:
@@ -765,9 +727,7 @@ class DraftToken:
             raw = base64.b64decode(padded, altchars=b"-_", validate=True)
             if len(raw) > _MAX_TOKEN_BYTES:
                 raise ValueError
-            value = json.loads(
-                raw.decode("utf-8"), object_pairs_hook=_unique_json_object
-            )
+            value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_json_object)
         except (
             binascii.Error,
             ValueError,
@@ -807,8 +767,10 @@ class DraftToken:
             raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token has invalid registrations")
         registrations: list[DraftRegistration] = []
         for item in registrations_raw:
-            if type(item) is not dict or set(item) != {"key", "category", "folder"} or any(
-                type(item[key]) is not str for key in ("key", "category", "folder")
+            if (
+                type(item) is not dict
+                or set(item) != {"key", "category", "folder"}
+                or any(type(item[key]) is not str for key in ("key", "category", "folder"))
             ):
                 raise SemanticWriteError(
                     "INVALID_DRAFT_TOKEN", "draft token has invalid registrations"
@@ -840,11 +802,7 @@ class CreationPreflight:
 
     @property
     def draft_hash(self) -> str | None:
-        return (
-            self.creation_validation.draft_hash
-            if self.creation_validation is not None
-            else None
-        )
+        return self.creation_validation.draft_hash if self.creation_validation is not None else None
 
     @property
     def relation_candidates(self) -> tuple[relation_review.RelationCandidate, ...]:
@@ -921,6 +879,7 @@ class ExistingPreflight:
     activation_census: activation_manifest.ActivationCensus
     prospective_manifest: activation_manifest.ActivationManifest
     manifest_install_required: bool
+    resolver_freshness: tuple[int, int, str] | None
     primary_guard: vault.PathGuard
     committed_replay: bool
 
@@ -1116,9 +1075,7 @@ def _recovery_feedback(
         {
             "page_identity": item.after.identity,
             "transition_token": item.transition_token,
-            "transition_hash": hashlib.sha256(
-                item.transition_token.encode("utf-8")
-            ).hexdigest(),
+            "transition_hash": hashlib.sha256(item.transition_token.encode("utf-8")).hexdigest(),
         }
         for item in preflight.evaluations
         if item.after.eligible_compiled
@@ -1126,9 +1083,7 @@ def _recovery_feedback(
         and item.after_review is None
         and item.requested_decision is None
         and _recovery_result_reviewable(item.contract_result)
-        and preflight.after_corpus.identity_census.paths_by_identity.get(
-            item.after.identity
-        )
+        and preflight.after_corpus.identity_census.paths_by_identity.get(item.after.identity)
         == (item.after.path,)
     ]
     retained_entries = preflight.entries[:_RECOVERY_FEEDBACK_ENTRY_LIMIT]
@@ -1205,9 +1160,9 @@ def _existing_transition_token(
         "before_hash": before_hash,
         "after_hash": after_hash,
     }
-    raw = json.dumps(
-        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-    ).encode("utf-8")
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
     return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
 
@@ -1223,8 +1178,7 @@ def _decode_existing_transition_token(token: str) -> dict[str, Any]:
     if (
         type(token) is not str
         or not token
-        or len(token.encode("utf-8"))
-        > relation_review.MAX_DRAFT_TOKEN_ENCODED_BYTES
+        or len(token.encode("utf-8")) > relation_review.MAX_DRAFT_TOKEN_ENCODED_BYTES
     ):
         raise SemanticWriteError(
             "LIFECYCLE_TRANSITION_INVALID_TOKEN", "transition token is invalid"
@@ -1310,9 +1264,7 @@ def preflight_existing(
             "existing semantic write operation is unsupported",
         )
     if relation_disposition not in {None, "reviewed_none"}:
-        raise SemanticWriteError(
-            "INVALID_RELATION_REVIEW", "relation disposition is invalid"
-        )
+        raise SemanticWriteError("INVALID_RELATION_REVIEW", "relation disposition is invalid")
     root = Path(vault_root)
     before_source, primary_guard = vault.read_guarded_text(root, root / path)
     raw_before_hash = vault.content_hash(before_source)
@@ -1325,15 +1277,18 @@ def preflight_existing(
         raw_before_hash,
         before_hash,
     }:
-        raise SemanticWriteError(
-            "STALE_SEMANTIC_WRITE", "page changed before semantic preflight"
-        )
+        raise SemanticWriteError("STALE_SEMANTIC_WRITE", "page changed before semantic preflight")
 
     registry = relation_registry.load_registry(root)
     language = semantic_language_registry.load_registry(root)
     loaded_contracts = memory_schema.load_saved_contracts(root)
+    resolver_freshness_before = freshness.triple(root, "vault")
     before_corpus = semantic_contract.build_corpus_context(
         root, registry=registry, language_registry=language
+    )
+    resolver_freshness_after = freshness.triple(root, "vault")
+    resolver_freshness = (
+        resolver_freshness_before if resolver_freshness_before == resolver_freshness_after else None
     )
     before = semantic_contract.build_page_state(
         root,
@@ -1342,6 +1297,12 @@ def preflight_existing(
         relation_registry=registry,
         language_registry=language,
     )
+    if before_corpus.pages.get(path) != before:
+        # The guarded read can observe a canonical or external replacement in
+        # the short window before its freshness event is published. Repair the
+        # exact evaluated page from those authoritative bytes so a lagging
+        # process cache never turns a valid write into a corpus-state refusal.
+        before_corpus = before_corpus.with_candidate(before)
     after = semantic_contract.build_page_state(
         root,
         path,
@@ -1366,12 +1327,8 @@ def preflight_existing(
     before_review: semantic_contract.RelationReviewState | None = None
     after_review: semantic_contract.RelationReviewState | None = None
     if applicability == "full":
-        before_review = relation_review.load_relation_review(
-            root, before, corpus=before_corpus
-        )
-        after_review = relation_review.load_relation_review(
-            root, after, corpus=after_corpus
-        )
+        before_review = relation_review.load_relation_review(root, before, corpus=before_corpus)
+        after_review = relation_review.load_relation_review(root, after, corpus=after_corpus)
 
     token = transition_token or _existing_transition_token(
         operation=operation,
@@ -1391,10 +1348,7 @@ def preflight_existing(
         token_value["operation"] != operation
         or token_value["path"] != path
         or token_value["after_hash"] != after.source_hash
-        or (
-            token_value["before_hash"] != before.source_hash
-            and not committed_replay
-        )
+        or (token_value["before_hash"] != before.source_hash and not committed_replay)
     ):
         raise SemanticWriteError(
             "LIFECYCLE_TRANSITION_MISMATCH",
@@ -1416,8 +1370,7 @@ def preflight_existing(
         if (
             after.identity_kind != "exomem_id"
             or after.review_fingerprint is None
-            or after_corpus.identity_census.paths_by_identity.get(after.identity)
-            != (after.path,)
+            or after_corpus.identity_census.paths_by_identity.get(after.identity) != (after.path,)
         ):
             raise SemanticWriteError(
                 "RELATION_REVIEW_STABLE_ID_REQUIRED",
@@ -1488,6 +1441,7 @@ def preflight_existing(
         before_corpus.activation_census,
         boundary.manifest,
         boundary.install_required,
+        resolver_freshness,
         primary_guard,
         committed_replay,
     )
@@ -1503,9 +1457,7 @@ def _reevaluate_existing(
         preflight.path,
         source_hash=preflight.before.source_hash,
         exomem_id=(
-            preflight.before.identity
-            if preflight.before.identity_kind == "exomem_id"
-            else None
+            preflight.before.identity if preflight.before.identity_kind == "exomem_id" else None
         ),
         manifest=manifest,
         census=preflight.activation_census,
@@ -1557,9 +1509,7 @@ def _commit_existing_locked(
                 "committed replay requires the exact stable resulting identity",
             )
         try:
-            prepared = relation_review.load_lifecycle_prepared(
-                root, preflight.after.identity
-            )
+            prepared = relation_review.load_lifecycle_prepared(root, preflight.after.identity)
         except relation_review.RelationReviewError as error:
             raise SemanticWriteError(error.code, error.reason) from error
         token_value = _decode_existing_transition_token(preflight.transition_token)
@@ -1608,9 +1558,7 @@ def _commit_existing_locked(
         preflight.applicability == "full"
         and preflight.after.identity_kind == "exomem_id"
         and preflight.after.review_fingerprint is not None
-        and preflight.after_corpus.identity_census.paths_by_identity.get(
-            preflight.after.identity
-        )
+        and preflight.after_corpus.identity_census.paths_by_identity.get(preflight.after.identity)
         == (preflight.path,)
     )
     if stable_active:
@@ -1626,9 +1574,7 @@ def _commit_existing_locked(
                 after_fingerprint=preflight.after.review_fingerprint,
                 decision=preflight.requested_decision,
                 transition_token=preflight.transition_token,
-                auxiliary_hash=relation_review.lifecycle_auxiliary_hash(
-                    auxiliaries, root
-                ),
+                auxiliary_hash=relation_review.lifecycle_auxiliary_hash(auxiliaries, root),
             )
             current = relation_review.LifecyclePrimaryBinding(
                 preflight.before.path,
@@ -1673,9 +1619,7 @@ def _commit_existing_locked(
         vault_root=root,
         required_guards=required_guards,
         index_reports=reports,
-        semantic_states={
-            preflight.path: semantic_index.from_semantic_page_state(preflight.after)
-        },
+        semantic_states={preflight.path: semantic_index.from_semantic_page_state(preflight.after)},
     )
     report = reports[0] if reports else None
     return ExistingCommit(
@@ -1709,9 +1653,7 @@ def commit_existing(
     result = preflight.contract_result
     auxiliaries = tuple(auxiliary_writes)
     if preflight.manifest_install_required:
-        winner = activation_manifest.ensure_manifest(
-            root, census=preflight.activation_census
-        )
+        winner = activation_manifest.ensure_manifest(root, census=preflight.activation_census)
         result, _ = _reevaluate_existing(preflight, manifest=winner)
         if result.should_block:
             raise SemanticWriteError(
@@ -1722,6 +1664,16 @@ def commit_existing(
                 ),
                 result.blocking_findings,
             )
+
+    if preflight.resolver_freshness is not None:
+        try:
+            find_module.prime_resolver_from_entries(
+                root,
+                preflight.before_corpus.resolver_entries,
+                expected_freshness=preflight.resolver_freshness,
+            )
+        except Exception:  # noqa: BLE001 — rebuildable graph cache never blocks commit
+            pass
 
     try:
         with vault.vault_creation_lock(root, "semantic-creation"):
@@ -1917,9 +1869,9 @@ def _move_evaluation_pairs(
         for path in sorted(after_corpus.eligible_compiled_paths):
             if path in pairs or path not in before_corpus.pages:
                 continue
-            if _move_dependency_signature(
-                before_corpus, path
-            ) != _move_dependency_signature(after_corpus, path):
+            if _move_dependency_signature(before_corpus, path) != _move_dependency_signature(
+                after_corpus, path
+            ):
                 pairs[path] = path
                 added = True
         if not added:
@@ -1952,9 +1904,7 @@ def preflight_move(
             "LIFECYCLE_TRANSITION_MISMATCH",
             "move guards do not bind the exact source and destination",
         )
-    expected_moved_source, _ = rewrite_wikilinks_for_move(
-        source, old_path, new_path
-    )
+    expected_moved_source, _ = rewrite_wikilinks_for_move(source, old_path, new_path)
     if moved_source not in {source, expected_moved_source}:
         raise SemanticWriteError(
             "LIFECYCLE_TRANSITION_MISMATCH",
@@ -1975,14 +1925,10 @@ def preflight_move(
     )
     before_moved = before_corpus.pages.get(old_path)
     normalized_source = source.replace("\r\n", "\n").replace("\r", "\n")
-    if (
-        before_moved is None
-        or before_moved.source_hash
-        not in {
-            vault.content_hash(source),
-            vault.content_hash(normalized_source),
-        }
-    ):
+    if before_moved is None or before_moved.source_hash not in {
+        vault.content_hash(source),
+        vault.content_hash(normalized_source),
+    }:
         raise SemanticWriteError(
             "STALE_SEMANTIC_WRITE", "move source changed during semantic preflight"
         )
@@ -1997,9 +1943,7 @@ def preflight_move(
                 "STALE_SEMANTIC_WRITE",
                 "inbound page changed during semantic move preflight",
             ) from error
-        normalized_before_source = before_source.replace("\r\n", "\n").replace(
-            "\r", "\n"
-        )
+        normalized_before_source = before_source.replace("\r\n", "\n").replace("\r", "\n")
         if (
             before_rewrite is None
             or before_rewrite.source_hash
@@ -2095,10 +2039,7 @@ def preflight_move(
                     carried_from = relation_review.load_lifecycle_decision(
                         root, before.identity, before.review_fingerprint
                     )
-                    if (
-                        carried_from is None
-                        or carried_from.reference != before_review.reference
-                    ):
+                    if carried_from is None or carried_from.reference != before_review.reference:
                         carried_from = None
                     else:
                         requested_decision = relation_review.build_lifecycle_decision(
@@ -2192,9 +2133,7 @@ def _plan_move_lifecycle(
     states: list[tuple[str, str]] = []
     auxiliaries = list(preflight.rewrites)
     if preflight.moved_source != preflight.source:
-        auxiliaries.append(
-            vault.PlannedWrite(root / preflight.new_path, preflight.moved_source)
-        )
+        auxiliaries.append(vault.PlannedWrite(root / preflight.new_path, preflight.moved_source))
     auxiliary_hash = relation_review.lifecycle_auxiliary_hash(auxiliaries, root)
     for item in preflight.evaluations:
         if (
@@ -2207,9 +2146,7 @@ def _plan_move_lifecycle(
             item.after.eligible_compiled
             and item.after.identity_kind == "exomem_id"
             and item.after.review_fingerprint is not None
-            and preflight.after_corpus.identity_census.paths_by_identity.get(
-                item.after.identity
-            )
+            and preflight.after_corpus.identity_census.paths_by_identity.get(item.after.identity)
             == (item.after.path,)
         )
         if not stable_active:
@@ -2266,9 +2203,7 @@ def commit_move(
             ),
         )
     if preflight.manifest_install_required:
-        winner = activation_manifest.ensure_manifest(
-            root, census=preflight.activation_census
-        )
+        winner = activation_manifest.ensure_manifest(root, census=preflight.activation_census)
         if winner != preflight.prospective_manifest:
             raise SemanticWriteError(
                 "SEMANTIC_CONTRACT_BLOCKED",
@@ -2277,12 +2212,10 @@ def commit_move(
     try:
         with vault.vault_creation_lock(root, "semantic-creation"):
             preflight.source_guard.recheck(root)
-            destination_guard = preflight.destination_guard.prepare_and_bind_parents(
-                root
-            )
+            destination_guard = preflight.destination_guard.prepare_and_bind_parents(root)
             preflight.source_guard.recheck(root)
-            lifecycle_writes, required_guards, lifecycle_states = (
-                _plan_move_lifecycle(root, preflight)
+            lifecycle_writes, required_guards, lifecycle_states = _plan_move_lifecycle(
+                root, preflight
             )
             mutate(lifecycle_writes, required_guards, destination_guard)
     except vault.VaultLockTimeout as error:
@@ -2305,11 +2238,7 @@ def _corpus_with_recovery_states(
 ) -> semantic_contract.SemanticCorpusContext:
     pages = dict(base.pages)
     identity_census = semantic_contract.StableIdentityCensus(
-        tuple(
-            entry
-            for entry in base.identity_census.entries
-            if entry.path not in removed_paths
-        )
+        tuple(entry for entry in base.identity_census.entries if entry.path not in removed_paths)
     )
     for state in states:
         pages[state.path] = state
@@ -2334,10 +2263,7 @@ def preflight_recovery(
     """Evaluate exact trashed Markdown bytes at all final restore paths."""
     root = Path(vault_root)
     review_mapping = relation_reviews or {}
-    if (
-        not isinstance(review_mapping, Mapping)
-        or len(review_mapping) > _RECOVERY_REVIEW_LIMIT
-    ):
+    if not isinstance(review_mapping, Mapping) or len(review_mapping) > _RECOVERY_REVIEW_LIMIT:
         raise SemanticWriteError(
             "INVALID_RELATION_REVIEW",
             "recovery relation reviews must be a bounded identity mapping",
@@ -2365,14 +2291,10 @@ def preflight_recovery(
         if (
             item.source_guard.target != item.trash_path
             or item.source_guard.leaf_policy != "content"
-            or item.source_guard.expected_content_hash
-            != vault.content_hash(item.source)
+            or item.source_guard.expected_content_hash != vault.content_hash(item.source)
             or item.destination_guard.target != item.restore_path
             or item.destination_guard.leaf_policy != "absent"
-            or (
-                item.sidecar_guard is not None
-                and item.sidecar_guard.leaf_policy != "content"
-            )
+            or (item.sidecar_guard is not None and item.sidecar_guard.leaf_policy != "content")
             or (item.sidecar_guard is None) != (item.sidecar_source is None)
             or (
                 item.restore_path != root_destination.target
@@ -2427,9 +2349,7 @@ def preflight_recovery(
     )
     manifest = activation_manifest.load_manifest(root)
     evaluations: list[RecoveryPageEvaluation] = []
-    for entry, before, after in zip(
-        bound_entries, prior_states, after_states, strict=True
-    ):
+    for entry, before, after in zip(bound_entries, prior_states, after_states, strict=True):
         before_contracts = memory_schema.resolve_contracts(
             loaded_contracts,
             projects=before.projects,
@@ -2506,11 +2426,9 @@ def preflight_recovery(
                 or after_corpus.identity_census.paths_by_identity.get(after.identity)
                 != (after.path,)
                 or not isinstance(requested_review, Mapping)
-                or set(requested_review)
-                != {"transition_token", "transition_hash", "reason"}
+                or set(requested_review) != {"transition_token", "transition_hash", "reason"}
                 or token_value["operation"] != "recover"
-                or token_value["path"]
-                != _recovery_token_path(entry.trash_path, entry.restore_path)
+                or token_value["path"] != _recovery_token_path(entry.trash_path, entry.restore_path)
                 or token_value["before_hash"] != before.source_hash
                 or token_value["after_hash"] != after.source_hash
                 or requested_review.get("transition_hash") != expected_hash
@@ -2572,8 +2490,7 @@ def preflight_recovery(
             "recovery review mapping contains an unvalidated page identity",
         )
     reviewable_count = sum(
-        item.requested_decision is None
-        and _recovery_result_reviewable(item.contract_result)
+        item.requested_decision is None and _recovery_result_reviewable(item.contract_result)
         for item in evaluations
     )
     if reviewable_count > _RECOVERY_REVIEW_LIMIT:
@@ -2611,9 +2528,7 @@ def _plan_recovery_lifecycle(
             item.after.eligible_compiled
             and item.after.identity_kind == "exomem_id"
             and item.after.review_fingerprint is not None
-            and preflight.after_corpus.identity_census.paths_by_identity.get(
-                item.after.identity
-            )
+            and preflight.after_corpus.identity_census.paths_by_identity.get(item.after.identity)
             == (item.after.path,)
         )
         if not stable_active:
@@ -2691,8 +2606,8 @@ def commit_recovery(
                 if item.sidecar_guard is not None:
                     item.sidecar_guard.recheck(root)
                 item.destination_guard.recheck(root)
-            lifecycle_writes, required_guards, lifecycle_states = (
-                _plan_recovery_lifecycle(root, preflight)
+            lifecycle_writes, required_guards, lifecycle_states = _plan_recovery_lifecycle(
+                root, preflight
             )
             if preflight.should_block:
                 raise SemanticWriteError(
@@ -2704,20 +2619,14 @@ def commit_recovery(
                         for finding in item.contract_result.blocking_findings
                     ),
                 )
-            destination_root_guard = (
-                preflight.destination_root_guard.prepare_and_bind_parents(root)
-            )
+            destination_root_guard = preflight.destination_root_guard.prepare_and_bind_parents(root)
             destination_root_guard.recheck(root)
             destination_guards = tuple(
-                vault.PathGuard.capture(
-                    root, item.restore_path, leaf_policy="absent"
-                )
+                vault.PathGuard.capture(root, item.restore_path, leaf_policy="absent")
                 for item in preflight.entries
             )
             destination_root_guard.recheck(root)
-            for item, destination_guard in zip(
-                preflight.entries, destination_guards, strict=True
-            ):
+            for item, destination_guard in zip(preflight.entries, destination_guards, strict=True):
                 item.source_guard.recheck(root)
                 destination_guard.recheck(root)
                 if item.sidecar_guard is not None:
@@ -2785,9 +2694,7 @@ def _evaluate_structural(
             after_contracts=resolved,
             before_corpus=before,
             after_corpus=before.with_candidate(candidate),
-            include_relation_disposition=semantic_contract.requires_semantic_unit(
-                candidate
-            ),
+            include_relation_disposition=semantic_contract.requires_semantic_unit(candidate),
         ),
         candidate,
     )
@@ -2809,9 +2716,7 @@ def preflight_creation(
 ) -> CreationPreflight:
     root = Path(vault_root)
     if relation_disposition not in {None, "reviewed_none"}:
-        raise SemanticWriteError(
-            "INVALID_RELATION_REVIEW", "relation disposition is invalid"
-        )
+        raise SemanticWriteError("INVALID_RELATION_REVIEW", "relation disposition is invalid")
     token = DraftToken.decode(draft_token)
     if (
         token.writer != writer
@@ -2819,16 +2724,12 @@ def preflight_creation(
         or token.destination != path
         or token.registrations != registrations
     ):
-        raise SemanticWriteError(
-            "INVALID_DRAFT_TOKEN", "draft token does not match this creation"
-        )
+        raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token does not match this creation")
     try:
         vault.parse_frontmatter(source, strict=True)
     except vault.FrontmatterError as error:
         raise SemanticWriteError(error.code, "draft frontmatter is invalid") from error
-    result, state = _evaluate_structural(
-        root, destination=path, source=source, operation=operation
-    )
+    result, state = _evaluate_structural(root, destination=path, source=source, operation=operation)
     if semantic_contract.requires_semantic_unit(state):
         if draft_id is None:
             raise SemanticWriteError("DRAFT_IDENTITY_MISMATCH", "active draft requires identity")
@@ -2844,8 +2745,15 @@ def preflight_creation(
             predecessor_content_hash=predecessor_content_hash,
         )
         return CreationPreflight(
-            "full", path, source, draft_id, draft_token, False,
-            validation.contract_result, validation, state,
+            "full",
+            path,
+            source,
+            draft_id,
+            draft_token,
+            False,
+            validation.contract_result,
+            validation,
+            state,
         )
     applicability: Literal["structural", "not_semantic"] = (
         "structural"
@@ -2876,8 +2784,7 @@ def commit_creation(
         if finding.resolved_rule != ("relations", "*", "disposition")
     )
     if non_review_blockers or (
-        preflight.applicability != "full"
-        and preflight.contract_result.should_block
+        preflight.applicability != "full" and preflight.contract_result.should_block
     ):
         raise SemanticWriteError(
             "SEMANTIC_CONTRACT_BLOCKED",
@@ -2899,9 +2806,7 @@ def commit_creation(
             draft_token=preflight.draft_token,
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
-            semantic_state=semantic_index.from_semantic_page_state(
-                preflight.semantic_state
-            ),
+            semantic_state=semantic_index.from_semantic_page_state(preflight.semantic_state),
         )
         return CreationCommit(
             "full", True, committed.written_paths, committed.contract_result, committed
@@ -2912,17 +2817,11 @@ def commit_creation(
             root / preflight.destination,
             preflight.source,
             create_only=True,
-            guard=vault.PathGuard.capture(
-                root, preflight.destination, leaf_policy="absent"
-            ),
+            guard=vault.PathGuard.capture(root, preflight.destination, leaf_policy="absent"),
         )
     )
     token = semantic_index.set_parent_states(
-        {
-            preflight.destination: semantic_index.from_semantic_page_state(
-                preflight.semantic_state
-            )
-        }
+        {preflight.destination: semantic_index.from_semantic_page_state(preflight.semantic_state)}
     )
     try:
         written = vault.batch_atomic_write(writes, vault_root=root)

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -64,6 +64,7 @@ _HOSTED_MUTATION_DETAIL_FIELDS = (
 )
 _HOSTED_MUTATION_ERROR_SHAPES = {
     "MUTATION_BUSY": ("retryable", False),
+    "MUTATION_WARMING": ("retryable", False),
     "MUTATION_ACKNOWLEDGEMENT_PENDING": ("uncertain", None),
     "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN": ("committed", True),
 }
@@ -263,11 +264,7 @@ def _error_response(
     }
     if details is not None:
         error.update(
-            {
-                field: details[field]
-                for field in _HOSTED_MUTATION_DETAIL_FIELDS
-                if field in details
-            }
+            {field: details[field] for field in _HOSTED_MUTATION_DETAIL_FIELDS if field in details}
         )
     return HostedJSONResponse(
         cli_ops.envelope(False, error=error),
@@ -291,7 +288,7 @@ def _hosted_mutation_error_details(
         details["committed"] = expected_committed
     retry_after_ms = error.get("retry_after_ms")
     if (
-        error.get("code") == "MUTATION_BUSY"
+        error.get("code") in {"MUTATION_BUSY", "MUTATION_WARMING"}
         and type(retry_after_ms) is int
         and retry_after_ms >= 0
     ):
@@ -402,9 +399,7 @@ def _trusted_context(
             authentication = None
         authenticated = authentication is not None
         if authentication is not None:
-            authenticated_credential_version = getattr(
-                authentication, "credential_version", None
-            )
+            authenticated_credential_version = getattr(authentication, "credential_version", None)
             security_revision = getattr(authentication, "security_revision", None)
             if (
                 not isinstance(authenticated_credential_version, str)
@@ -852,14 +847,10 @@ def register_hosted_routes(
                 "vault_id": config.vault_id,
                 "exomem_release": __version__,
                 "hosted_protocol": config.protocol_version,
-                "authenticated_credential_version": (
-                    context.authenticated_credential_version
-                ),
+                "authenticated_credential_version": (context.authenticated_credential_version),
                 "security_revision": context.security_revision,
                 "service_authenticated": True,
-                "mutation_authority": lifecycle.control_plane_readiness()[
-                    "mutationAuthority"
-                ],
+                "mutation_authority": lifecycle.control_plane_readiness()["mutationAuthority"],
                 "admission_phase": readiness.phase,
                 "read_admission": readiness.read_admitted,
                 "write_admission": readiness.write_admitted,
@@ -923,9 +914,7 @@ def register_hosted_routes(
                                 *injected,
                                 idempotency_key=gateway.scoped_idempotency_key(context),
                                 public_idempotency_key=context.idempotency_key,
-                                implicit_idempotency_scope=gateway.implicit_retry_scope(
-                                    context
-                                ),
+                                implicit_idempotency_scope=gateway.implicit_retry_scope(context),
                                 mutation_request_id=context.request_id,
                                 **kwargs,
                             )
@@ -935,9 +924,7 @@ def register_hosted_routes(
                             *injected,
                             idempotency_key=gateway.scoped_idempotency_key(context),
                             public_idempotency_key=context.idempotency_key,
-                            implicit_idempotency_scope=gateway.implicit_retry_scope(
-                                context
-                            ),
+                            implicit_idempotency_scope=gateway.implicit_retry_scope(context),
                             mutation_request_id=context.request_id,
                             **kwargs,
                         )

--- a/src/exomem/tool_surface_contract.json
+++ b/src/exomem/tool_surface_contract.json
@@ -12,5 +12,5 @@
     "execution"
   ],
   "tool_count": 25,
-  "sha256": "a82e7dd233501b0fe5383ac1ed8dab81d4fe31580214ecc1e1fba1f5f8c0ff03"
+  "sha256": "fbb09bb51901121075805a331a62f3ff963caac566d718c6695fccda872a11d4"
 }

--- a/src/exomem/warmup.py
+++ b/src/exomem/warmup.py
@@ -2,7 +2,7 @@
 
 `warm_all` runs everything the first user-facing calls would otherwise pay
 inline: the parsed-page cache, the BM25 corpora for BOTH scopes (auto-widen
-runs a vault-scope BM25 on every kb query), the wikilink resolver, the
+runs a vault-scope BM25 on every kb query), the wikilink resolver, the semantic corpus, the
 embedding/CLIP matrices, and then the model preloads (bge, reranker, CLIP)
 that used to block `build_server` for ~30s (minutes on a first-ever
 download).
@@ -117,7 +117,7 @@ def warm_caches(
 
             q = np.full(
                 embeddings.VECTOR_DIM,
-                1.0 / (embeddings.VECTOR_DIM ** 0.5),
+                1.0 / (embeddings.VECTOR_DIM**0.5),
                 dtype=np.float32,
             )
             embeddings.get_embedding_index(vault_root).search(q, k=1)
@@ -130,7 +130,7 @@ def warm_caches(
             if embeddings.clip_enabled():
                 q = np.full(
                     embeddings.CLIP_DIM,
-                    1.0 / (embeddings.CLIP_DIM ** 0.5),
+                    1.0 / (embeddings.CLIP_DIM**0.5),
                     dtype=np.float32,
                 )
                 embeddings.get_clip_index(vault_root).search(q, k=1)
@@ -154,12 +154,28 @@ def warm_all(vault_root: Path) -> dict[str, float]:
 
     mode_name = mode.resolve_mode()
     preload = model_preload_allowed(mode_name)
-    durations = warm_caches(
-        vault_root,
-        preload_models=preload,
-        preload_cpu_caches=mode.preload_cpu_caches(),
+    durations: dict[str, float] = {}
+    durations.update(
+        warm_caches(
+            vault_root,
+            preload_models=preload,
+            preload_cpu_caches=mode.preload_cpu_caches(),
+        )
     )
     readiness.mark_ready("lexical")
+    semantic_started = time.perf_counter()
+    try:
+        from . import semantic_contract
+
+        semantic_contract.build_corpus_context(vault_root)
+        readiness.mark_ready("semantic_corpus")
+    except Exception:  # noqa: BLE001 — semantic warm-up remains rebuildable
+        log.warning("semantic corpus warm-up failed", exc_info=True)
+    finally:
+        durations["semantic_corpus"] = round(
+            (time.perf_counter() - semantic_started) * 1000.0,
+            1,
+        )
 
     def _model_step(name: str, fn) -> bool:
         t0 = time.perf_counter()
@@ -197,9 +213,7 @@ def warm_all(vault_root: Path) -> dict[str, float]:
             item_vault, paths, *receipt_payload = item
             receipts = receipt_payload[0] if receipt_payload else None
             try:
-                index_sync.replay_deferred_embedding(
-                    item_vault, list(paths), receipts
-                )
+                index_sync.replay_deferred_embedding(item_vault, list(paths), receipts)
             except Exception:  # noqa: BLE001 — durable receipt survives retry
                 log.warning("deferred embed drain failed", exc_info=True)
 
@@ -246,7 +260,9 @@ def warm_all(vault_root: Path) -> dict[str, float]:
 
         if embeddings.ranking_enabled():
             log.info("preloading reranker %s", embeddings.RERANKER_NAME)
-            if _preload("model_reranker", embeddings.get_reranker, lambda m: m.predict([("warm", "warm")])):
+            if _preload(
+                "model_reranker", embeddings.get_reranker, lambda m: m.predict([("warm", "warm")])
+            ):
                 log.info("reranker model ready")
                 readiness.mark_ready("reranker")
         else:

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -92,9 +92,7 @@ _ACTIVE_LEASE_MANAGER: ContextVar[Any | None] = ContextVar(
 
 def _log_mutation_event(phase: str, *, level: int = logging.INFO, **fields: Any) -> None:
     prefix = (
-        "event=hosted_call kind=mutation"
-        if content_private_logging_enabled()
-        else "event=mutation"
+        "event=hosted_call kind=mutation" if content_private_logging_enabled() else "event=mutation"
     )
     suffix = " ".join(f"{name}={value}" for name, value in fields.items())
     _mutation_logger.log(level, f"{prefix} phase={phase} {suffix}".rstrip())
@@ -314,9 +312,7 @@ class LeaseConfig:
             timeout_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TIMEOUT", 3.0),
             preferred_writer=_truthy(values.get("EXOMEM_WRITER_LEASE_PREFERRED", "")),
             state_dir=Path(state_raw).expanduser() if state_raw else cls.state_dir,
-            mutation_timeout_seconds=_positive_float(
-                values, "EXOMEM_MUTATION_TIMEOUT", 5.0
-            ),
+            mutation_timeout_seconds=_positive_float(values, "EXOMEM_MUTATION_TIMEOUT", 5.0),
         )
         if config.enabled and (not config.vault_id or not config.replica_id):
             raise ValueError(
@@ -581,8 +577,7 @@ class IdempotencyStore:
             if row is not None:
                 return self._decode_disposition(row, digest)
             conn.execute(
-                "INSERT INTO mutations(key, digest, state, updated_at) "
-                "VALUES (?, ?, 'pending', ?)",
+                "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
                 (key, digest, now),
             )
         _log_mutation_event("reserved", receipt=_receipt_tag(key))
@@ -623,9 +618,7 @@ class IdempotencyStore:
                 (expired_key,),
             )
 
-    def _expired_row(
-        self, row: tuple[Any, ...], now: float, expires_after: float | None
-    ) -> bool:
+    def _expired_row(self, row: tuple[Any, ...], now: float, expires_after: float | None) -> bool:
         if expires_after is None or row[1] not in {"completed", "committed_failure"}:
             return False
         updated_at = row[3]
@@ -634,11 +627,7 @@ class IdempotencyStore:
                 _deserialize_committed_failure_payload(row[2])
             except Exception:  # noqa: BLE001 - corrupt state blocks mutation
                 raise self._reconciliation_error("cached committed mutation state") from None
-        if (
-            type(updated_at) not in {int, float}
-            or not math.isfinite(updated_at)
-            or updated_at < 0
-        ):
+        if type(updated_at) not in {int, float} or not math.isfinite(updated_at) or updated_at < 0:
             raise self._reconciliation_error("cached mutation state")
         return updated_at <= now - expires_after
 
@@ -653,9 +642,7 @@ class IdempotencyStore:
             return "completed", pickle.loads(row[2])  # noqa: S301 - trusted runtime state
         if state == "committed_failure":
             try:
-                failure = _CachedCommittedFailure(
-                    _deserialize_committed_failure_payload(row[2])
-                )
+                failure = _CachedCommittedFailure(_deserialize_committed_failure_payload(row[2]))
             except Exception:  # noqa: BLE001 - corrupt state blocks mutation
                 raise self._reconciliation_error("cached committed mutation state") from None
             return "committed_failure", failure
@@ -668,7 +655,11 @@ class IdempotencyStore:
         raise self._reconciliation_error("cached mutation state")
 
     def _wait_for_terminal(
-        self, key: str, digest: str, *, on_replay=None  # noqa: ANN001
+        self,
+        key: str,
+        digest: str,
+        *,
+        on_replay=None,  # noqa: ANN001
     ) -> Any:
         _log_mutation_event("pending", receipt=_receipt_tag(key))
         deadline = self.monotonic() + self.wait_seconds
@@ -808,8 +799,7 @@ def _read_bypasses_consistency_guard(command: Any, kwargs: Mapping[str, Any]) ->
         operation = kwargs.get("operation")
         return (
             isinstance(operation, Mapping)
-            and operation.get("kind")
-            in {"replace_string", "batch_replace", "patch_frontmatter"}
+            and operation.get("kind") in {"replace_string", "batch_replace", "patch_frontmatter"}
             and operation.get("validate_only") is True
         )
     return False
@@ -981,15 +971,11 @@ class LeaseManager:
         if public_idempotency_key is _PUBLIC_IDEMPOTENCY_KEY_UNSET:
             effective_public_idempotency_key = idempotency_key
         else:
-            assert public_idempotency_key is None or isinstance(
-                public_idempotency_key, str
-            )
+            assert public_idempotency_key is None or isinstance(public_idempotency_key, str)
             effective_public_idempotency_key = public_idempotency_key
         invocation_read_only = command.read_only if read_only is None else read_only
         if invocation_read_only:
-            audit_without_consistency_lock = _read_bypasses_consistency_guard(
-                command, kwargs
-            )
+            audit_without_consistency_lock = _read_bypasses_consistency_guard(command, kwargs)
             if content_private_logging_enabled() and not audit_without_consistency_lock:
                 with self.consistency_guard(self._mutation_subject(injected)):
                     return command.leaf(*injected, **kwargs)
@@ -1014,11 +1000,35 @@ class LeaseManager:
             command=command.name,
             receipt=receipt or "none",
         )
+        from . import readiness
+
+        if readiness.should_defer("semantic_corpus"):
+            details: dict[str, Any] = {
+                "status": "retryable",
+                "committed": False,
+                "retry_after_ms": 750,
+                "request_id": request_id,
+                "receipt_id": receipt,
+            }
+            if effective_public_idempotency_key is not None:
+                details["idempotency_key"] = effective_public_idempotency_key
+            _log_mutation_event(
+                "interrupted",
+                level=logging.INFO,
+                request_id=request_id,
+                command=command.name,
+                receipt=receipt or "none",
+                error="MUTATION_WARMING",
+            )
+            raise OpError(
+                "MUTATION_WARMING",
+                "semantic corpus warm-up is still in progress",
+                "Retry the same mutation after warm-up completes.",
+                details=details,
+            )
 
         def invoke_leaf() -> Any:
-            trace_token = _ACTIVE_MUTATION_TRACE.set(
-                (request_id, command.name, receipt or "none")
-            )
+            trace_token = _ACTIVE_MUTATION_TRACE.set((request_id, command.name, receipt or "none"))
             commit_token = _ACTIVE_MUTATION_COMMITTED.set(False)
             manager_token = _ACTIVE_LEASE_MANAGER.set(self)
             try:
@@ -1044,10 +1054,9 @@ class LeaseManager:
                 _ACTIVE_MUTATION_COMMITTED.reset(commit_token)
                 _ACTIVE_MUTATION_TRACE.reset(trace_token)
 
-        narrow_media_commit = (
-            command.name == "process_media"
-            and kwargs.get("operation", "process") in {"process", "retry"}
-        )
+        narrow_media_commit = command.name == "process_media" and kwargs.get(
+            "operation", "process"
+        ) in {"process", "retry"}
         try:
             result = self.idempotency.run(
                 key,
@@ -1111,8 +1120,7 @@ class LeaseManager:
         with self._lock:
             still_current = self._fencing_token == fencing_token
             coordinator_current = (
-                record.holder == self.config.replica_id
-                and record.fencing_token == fencing_token
+                record.holder == self.config.replica_id and record.fencing_token == fencing_token
             )
             if still_current and coordinator_current:
                 return
@@ -1129,9 +1137,7 @@ class LeaseManager:
             "Retry the mutation on the current writer.",
         )
 
-    def status(
-        self, vault_or_cell: os.PathLike[str] | str | None = None
-    ) -> dict[str, Any]:
+    def status(self, vault_or_cell: os.PathLike[str] | str | None = None) -> dict[str, Any]:
         mutation_boundary = (
             VaultMutationCoordinator(
                 self.config.state_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from exomem import activation_manifest as activation_manifest_module
 from exomem import embeddings as embeddings_module
 from exomem import find as find_module
 from exomem import schema as schema_module
@@ -27,8 +28,10 @@ def _reset_corpus_context_cache():
     different test's (or an unpatched) environment.
     """
     semantic_contract_module.reset_corpus_context_cache()
+    activation_manifest_module.reset_manifest_cache()
     yield
     semantic_contract_module.reset_corpus_context_cache()
+    activation_manifest_module.reset_manifest_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/install_fixtures/managed-install.json
+++ b/tests/install_fixtures/managed-install.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "service_version": "99.1.0",
+  "service_profile": "media",
+  "service_target": "http://127.0.0.1:8765",
+  "cli_profile": "lean",
+  "cli_route": "direct",
+  "vault_path": "TOP SECRET",
+  "credential": "also secret"
+}

--- a/tests/test_activation_manifest.py
+++ b/tests/test_activation_manifest.py
@@ -47,16 +47,59 @@ def _write_page(
 
 
 def _markdown_snapshot(root: Path) -> dict[str, bytes]:
-    return {
-        path.relative_to(root).as_posix(): path.read_bytes()
-        for path in root.rglob("*.md")
-    }
+    return {path.relative_to(root).as_posix(): path.read_bytes() for path in root.rglob("*.md")}
 
 
 def _ensure_worker(root: str, gate, output) -> None:  # noqa: ANN001
     gate.wait()
     manifest = activation_manifest.ensure_manifest(Path(root))
     output.put(manifest)
+
+
+def test_unchanged_manifest_is_parsed_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_page(tmp_path, "Knowledge Base/Notes/Insights/one.md")
+    expected = activation_manifest.snapshot_from_census(activation_manifest.build_census(tmp_path))
+    path = activation_manifest.manifest_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(activation_manifest._serialize(expected), encoding="utf-8")
+    activation_manifest.reset_manifest_cache()
+    first = activation_manifest.load_manifest(tmp_path)
+
+    def fail_reparse(*args, **kwargs):
+        raise AssertionError("unchanged immutable activation manifest was reparsed")
+
+    monkeypatch.setattr(activation_manifest.yaml, "safe_load", fail_reparse)
+    second = activation_manifest.load_manifest(tmp_path)
+
+    assert first == expected
+    assert second is first
+
+
+def test_manifest_cache_detects_same_stat_signature_content_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page = _write_page(tmp_path, "Knowledge Base/Notes/Insights/one.md")
+    manifest = activation_manifest.snapshot_from_census(activation_manifest.build_census(tmp_path))
+    path = activation_manifest.manifest_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original = activation_manifest._serialize(manifest)
+    changed = original.replace("one.md", "two.md")
+    assert len(changed.encode("utf-8")) == len(original.encode("utf-8"))
+    path.write_text(original, encoding="utf-8")
+    activation_manifest.reset_manifest_cache()
+    monkeypatch.setattr(
+        activation_manifest,
+        "_manifest_signature",
+        lambda _path: (1, 1, len(original.encode("utf-8"))),
+    )
+
+    first = activation_manifest.load_manifest(tmp_path)
+    path.write_text(changed, encoding="utf-8")
+    second = activation_manifest.load_manifest(tmp_path)
+
+    assert first is not None and second is not None
+    assert first.pages[0].path_at_activation == page.relative_to(tmp_path).as_posix()
+    assert second.pages[0].path_at_activation == "Knowledge Base/Notes/Insights/two.md"
 
 
 def test_nonempty_baseline_captures_only_active_writable_compiled_pages(
@@ -118,9 +161,10 @@ def test_nonempty_baseline_captures_only_active_writable_compiled_pages(
     assert by_path[stable.relative_to(tmp_path).as_posix()].identity_kind == "exomem_id"
     assert by_path[stable.relative_to(tmp_path).as_posix()].identity == _ID_A
     assert by_path[legacy.relative_to(tmp_path).as_posix()].identity_kind == "path_source_hash"
-    assert by_path[legacy.relative_to(tmp_path).as_posix()].identity == legacy.relative_to(
-        tmp_path
-    ).as_posix()
+    assert (
+        by_path[legacy.relative_to(tmp_path).as_posix()].identity
+        == legacy.relative_to(tmp_path).as_posix()
+    )
     assert by_path[stable.relative_to(tmp_path).as_posix()].source_hash == vault.content_hash(
         stable.read_text(encoding="utf-8")
     )
@@ -130,9 +174,7 @@ def test_nonempty_baseline_captures_only_active_writable_compiled_pages(
     )
     assert _markdown_snapshot(tmp_path) == before_md
     after_files = {p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*") if p.is_file()}
-    assert after_files - before_files == {
-        "Knowledge Base/_Schema/semantic-activation.yaml"
-    }
+    assert after_files - before_files == {"Knowledge Base/_Schema/semantic-activation.yaml"}
 
 
 def test_manifest_is_deterministic_create_once_and_does_not_append_later_pages(
@@ -228,12 +270,8 @@ def test_stable_id_survives_move_but_legacy_membership_requires_original_path_an
         encoding="utf-8",
     )
 
-    assert activation_manifest.is_grandfathered(
-        tmp_path, moved_stable, manifest=manifest
-    )
-    assert not activation_manifest.is_grandfathered(
-        tmp_path, moved_legacy, manifest=manifest
-    )
+    assert activation_manifest.is_grandfathered(tmp_path, moved_stable, manifest=manifest)
+    assert not activation_manifest.is_grandfathered(tmp_path, moved_legacy, manifest=manifest)
     moved_legacy.rename(legacy)
     legacy.write_text(
         legacy.read_text(encoding="utf-8") + "\nChanged after activation.\n",
@@ -304,8 +342,7 @@ def test_concurrent_first_activation_has_one_valid_immutable_winner(tmp_path: Pa
     gate = context.Event()
     output = context.Queue()
     processes = [
-        context.Process(target=_ensure_worker, args=(str(tmp_path), gate, output))
-        for _ in range(3)
+        context.Process(target=_ensure_worker, args=(str(tmp_path), gate, output)) for _ in range(3)
     ]
     for process in processes:
         process.start()
@@ -399,9 +436,7 @@ def test_rebuildable_indexes_and_registry_creation_do_not_move_the_boundary(
     refs.path.unlink()
     refs.rebuild_all()
     relation_registry.save_registry(tmp_path, relation_registry.empty_proposal())
-    semantic_language_registry.save_registry(
-        tmp_path, semantic_language_registry.empty_proposal()
-    )
+    semantic_language_registry.save_registry(tmp_path, semantic_language_registry.empty_proposal())
 
     assert activation_manifest.ensure_manifest(tmp_path) == manifest
     assert path.read_bytes() == before
@@ -442,9 +477,7 @@ def test_pure_activation_census_is_sorted_indexed_and_duplicate_ids_fail_closed(
 @pytest.mark.parametrize(
     "candidate",
     [
-        activation_manifest.ActivationCandidate(
-            "../escape.md", "a" * 64, None
-        ),
+        activation_manifest.ActivationCandidate("../escape.md", "a" * 64, None),
         activation_manifest.ActivationCandidate(
             "Knowledge Base/Notes/Insights/page.md", "not-a-hash", None
         ),
@@ -480,14 +513,7 @@ def test_unreadable_governed_markdown_fails_census_and_semantic_context(
     unreadable = tmp_path / "Knowledge Base/Notes/Insights/unreadable.md"
     unreadable.parent.mkdir(parents=True)
     unreadable.write_bytes(b"\xff\xfe")
-    candidate_source = (
-        "---\n"
-        "title: Candidate\n"
-        "type: insight\n"
-        "status: active\n"
-        "---\n\n"
-        "## Relations\n"
-    )
+    candidate_source = "---\ntitle: Candidate\ntype: insight\nstatus: active\n---\n\n## Relations\n"
     candidate = semantic_contract.build_page_state(
         tmp_path,
         "Knowledge Base/Notes/Insights/candidate.md",

--- a/tests/test_bounded_retrieval.py
+++ b/tests/test_bounded_retrieval.py
@@ -1,0 +1,320 @@
+"""Structural gates for foreground retrieval cost.
+
+These tests warm the rebuildable lexical sidecar first, then prove the request
+path is bounded to indexed candidates instead of returning to the Markdown
+corpus as a prerequisite to recall.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from exomem import bm25, freshness, lexstore, readiness, semantic_index
+from exomem import find as find_module
+
+pytestmark = pytest.mark.skipif(
+    not lexstore.fts5_available(), reason="this SQLite build lacks FTS5"
+)
+
+
+def _write_page(root: Path, rel_path: str, body: str) -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    page_id = uuid.uuid5(uuid.NAMESPACE_URL, f"bounded-retrieval:{rel_path}")
+    path.write_text(
+        "---\n"
+        "type: insight\n"
+        f"title: {path.stem}\n"
+        f"exomem_id: {page_id}\n"
+        "status: active\n"
+        "updated: 2026-07-22\n"
+        "---\n\n"
+        f"# {path.stem}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_live_freshness(root: Path, paths: list[Path]) -> None:
+    vault_entries = [(str(path), freshness.stat_signature(path)) for path in paths]
+    kb_entries = [
+        entry for entry in vault_entries if Path(entry[0]).is_relative_to(root / "Knowledge Base")
+    ]
+    freshness.seed(root, "kb", kb_entries)
+    freshness.seed(root, "vault", vault_entries)
+
+
+def test_warm_keyword_unit_recall_hydrates_only_indexed_parent_candidates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/target.md",
+        "- [runtime reliability] bounded recall needle ^target",
+    )
+    pages = [target]
+    for index in range(60):
+        pages.append(
+            _write_page(
+                tmp_path,
+                f"Knowledge Base/Notes/filler-{index:03d}.md",
+                f"- [observation] unrelated filler {index} ^filler-{index}",
+            )
+        )
+    _seed_live_freshness(tmp_path, pages)
+    snapshot = find_module.FreshnessSnapshot(tmp_path)
+    assert lexstore.search_semantic_units(
+        tmp_path,
+        "bounded recall needle",
+        k=10,
+        scope="kb",
+        freshness=snapshot.kb(),
+    )
+
+    walked = 0
+    reparsed: list[str] = []
+    original_walk = find_module._walk_md
+    original_state = semantic_index.current_parent_index_state
+
+    def observed_walk(*args: Any, **kwargs: Any) -> Any:
+        nonlocal walked
+        walked += 1
+        return original_walk(*args, **kwargs)
+
+    def observed_state(root: Path, path: Path | str, **kwargs: Any) -> Any:
+        reparsed.append(Path(path).as_posix())
+        return original_state(root, path, **kwargs)
+
+    monkeypatch.setattr(find_module, "_walk_md", observed_walk)
+    monkeypatch.setattr(semantic_index, "current_parent_index_state", observed_state)
+
+    hits = find_module.find(
+        tmp_path,
+        query="bounded recall needle",
+        scope="kb-only",
+        mode="keyword",
+        graph=False,
+        result_level="unit",
+        limit=5,
+    )
+
+    assert [hit.parent_path for hit in hits] == ["Knowledge Base/Notes/target.md"]
+    assert walked == 0
+    assert reparsed == [target.relative_to(tmp_path).as_posix()]
+
+
+def test_warm_keyword_page_recall_never_walks_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/page-target.md",
+        "bounded page recall needle",
+    )
+    pages = [target]
+    for index in range(60):
+        pages.append(
+            _write_page(
+                tmp_path,
+                f"Knowledge Base/Notes/page-filler-{index:03d}.md",
+                f"unrelated page filler {index}",
+            )
+        )
+    _seed_live_freshness(tmp_path, pages)
+    lexstore.ensure_fresh(tmp_path)
+
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("warm keyword recall must query the lexical sidecar")
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden)
+    hits = find_module.find(
+        tmp_path,
+        query="bounded page recall needle",
+        scope="kb-only",
+        mode="keyword",
+        graph=False,
+        result_level="page",
+        limit=5,
+    )
+
+    assert [hit.path for hit in hits] == [target.relative_to(tmp_path).as_posix()]
+
+
+def test_warm_hybrid_unit_recall_never_builds_all_parent_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _write_page(
+        tmp_path,
+        "Knowledge Base/Notes/hybrid-target.md",
+        "- [runtime reliability] bounded hybrid needle ^hybrid-target",
+    )
+    pages = [target]
+    for index in range(60):
+        pages.append(
+            _write_page(
+                tmp_path,
+                f"Knowledge Base/Notes/hybrid-filler-{index:03d}.md",
+                f"- [observation] unrelated hybrid filler {index} ^hybrid-{index}",
+            )
+        )
+    _seed_live_freshness(tmp_path, pages)
+    lexstore.ensure_fresh(tmp_path)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(readiness, "should_defer", lambda lane: lane == "embeddings")
+
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("hybrid unit recall must not build an all-parent projection")
+
+    monkeypatch.setattr(find_module, "_eligible_unit_records", forbidden)
+    hits = find_module.find(
+        tmp_path,
+        query="bounded hybrid needle",
+        scope="kb-only",
+        mode="hybrid",
+        graph=False,
+        rerank=False,
+        result_level="unit",
+        limit=5,
+    )
+
+    assert hits[0].parent_path == target.relative_to(tmp_path).as_posix()
+
+
+def test_vector_unit_recall_hydrates_only_the_bounded_winner_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = [
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/vector-{index:03d}.md",
+            f"- [observation] vector payload {index} ^vector-{index}",
+        )
+        for index in range(40)
+    ]
+    _seed_live_freshness(tmp_path, pages)
+    lexstore.ensure_fresh(tmp_path)
+    states = [semantic_index.build_parent_index_state(tmp_path, page) for page in pages]
+    vector_hits = [
+        SimpleNamespace(
+            unit_ref=state.document.units[0].unit_ref,
+            parent_path=page.relative_to(tmp_path).as_posix(),
+            parent_generation=state.parent_generation,
+            cosine=1.0 - index / 100.0,
+        )
+        for index, (page, state) in enumerate(zip(pages[:21], states[:21], strict=True))
+    ]
+    monkeypatch.setattr(
+        find_module,
+        "_vector_unit_candidates",
+        lambda *_args, **_kwargs: (
+            vector_hits,
+            {"status": "participated", "backend": "bounded-test"},
+            "kb",
+        ),
+    )
+    reparsed: list[str] = []
+    original_state = semantic_index.current_parent_index_state
+
+    def observed_state(root: Path, path: Path | str, **kwargs: Any) -> Any:
+        reparsed.append(Path(path).as_posix())
+        return original_state(root, path, **kwargs)
+
+    monkeypatch.setattr(semantic_index, "current_parent_index_state", observed_state)
+
+    hits = find_module.find(
+        tmp_path,
+        query="vector-only-no-literal",
+        scope="kb-only",
+        mode="vector",
+        graph=False,
+        result_level="unit",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert len(reparsed) == 20
+
+
+def test_warm_outside_kb_widening_queries_lexstore_without_python_bm25(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = [
+        _write_page(tmp_path, "Knowledge Base/Notes/inside.md", "inside only"),
+        _write_page(tmp_path, "Reference/target.md", "outside bounded needle"),
+    ]
+    for index in range(60):
+        pages.append(
+            _write_page(
+                tmp_path,
+                f"Reference/filler-{index:03d}.md",
+                f"unrelated filler {index}",
+            )
+        )
+    _seed_live_freshness(tmp_path, pages)
+    snapshot = find_module.FreshnessSnapshot(tmp_path)
+    assert lexstore.search_bm25(
+        tmp_path,
+        "outside bounded needle",
+        10,
+        scope="vault",
+        freshness=snapshot.vault(),
+    )
+
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("warm widening must not rebuild or query Python BM25")
+
+    monkeypatch.setattr(bm25, "search", forbidden)
+    monkeypatch.setattr(find_module, "_outside_kb_keyword_paths", forbidden)
+
+    hits = find_module._find_outside_kb(
+        tmp_path,
+        query="outside bounded needle",
+        query_norm="outside bounded needle",
+        types=None,
+        projects=None,
+        tags=None,
+        limit=5,
+        snapshot=snapshot,
+    )
+
+    assert [hit.path for hit in hits] == ["Reference/target.md"]
+    assert hits[0].outside_kb is True
+
+
+def test_unavailable_outside_lexstore_never_walks_the_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_page(tmp_path, "Reference/target.md", "outside unavailable needle")
+    monkeypatch.setattr(lexstore, "search_bm25", lambda *_args, **_kwargs: None)
+
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("an unavailable sidecar must not trigger a vault walk")
+
+    monkeypatch.setattr(bm25, "search", forbidden)
+    monkeypatch.setattr(find_module, "_outside_kb_keyword_paths", forbidden)
+    failed: list[str] = []
+
+    hits = find_module._find_outside_kb(
+        tmp_path,
+        query="outside unavailable needle",
+        query_norm="outside unavailable needle",
+        types=None,
+        projects=None,
+        tags=None,
+        limit=5,
+        failed_out=failed,
+    )
+
+    assert hits == []
+    assert failed == ["outside_kb_lexical"]

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -6,7 +6,10 @@ asserting the human vs `--json` envelope output and the 0/1/2 exit-code contract
 
 from __future__ import annotations
 
+import importlib
 import json
+import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -20,9 +23,7 @@ _INSIGHT = "Knowledge Base/Notes/Insights/progressive-disclosure-without-mode-fr
 
 @pytest.fixture(autouse=True)
 def _isolated_writer_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv(
-        "EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-lease-state")
-    )
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "writer-lease-state"))
     writer_lease.reset_managers_for_tests()
     yield
     writer_lease.reset_managers_for_tests()
@@ -122,7 +123,11 @@ def test_ask_memory_semantic_unit_filters(vault: Path, capsys) -> None:
 
 def test_read_memory_reads_a_page(vault: Path, capsys) -> None:
     code, out, _ = _run(
-        ["read_memory", "Notes/Insights/progressive-disclosure-without-mode-fragmentation", "--json"],
+        [
+            "read_memory",
+            "Notes/Insights/progressive-disclosure-without-mode-fragmentation",
+            "--json",
+        ],
         capsys,
     )
     assert code == 0
@@ -274,9 +279,12 @@ def test_remember_write(vault: Path, capsys) -> None:
     code, out, _ = _run(
         [
             "remember",
-            "--title", "CLI can write",
-            "--content", "# CLI can write\n\n## Claim\n\nThe kb CLI writes notes.\n",
-            "--field", "status=draft",
+            "--title",
+            "CLI can write",
+            "--content",
+            "# CLI can write\n\n## Claim\n\nThe kb CLI writes notes.\n",
+            "--field",
+            "status=draft",
             "--json",
         ],
         capsys,
@@ -319,10 +327,14 @@ def test_remember_unicode_title_with_explicit_slug(vault: Path, capsys) -> None:
     code, out, err = _run(
         [
             "remember",
-            "--title", "睡眠",
-            "--slug", "sleep",
-            "--content", "## 要約\n\n本文。\n",
-            "--field", "status=draft",
+            "--title",
+            "睡眠",
+            "--slug",
+            "sleep",
+            "--content",
+            "## 要約\n\n本文。\n",
+            "--field",
+            "status=draft",
             "--json",
         ],
         capsys,
@@ -339,11 +351,16 @@ def test_remember_field_escape(vault: Path, capsys) -> None:
     code, out, _ = _run(
         [
             "remember",
-            "--title", "Field escape works",
-            "--content", "# Field escape works\n\n## Question\n\nq\n",
-            "--field", "note_type=research-note",
-            "--field", "project=project-alpha",
-            "--field", "status=draft",
+            "--title",
+            "Field escape works",
+            "--content",
+            "# Field escape works\n\n## Question\n\nq\n",
+            "--field",
+            "note_type=research-note",
+            "--field",
+            "project=project-alpha",
+            "--field",
+            "status=draft",
             "--json",
         ],
         capsys,
@@ -570,9 +587,12 @@ def test_malformed_field_exits_2(vault: Path, capsys) -> None:
     code, _out, err = _run(
         [
             "remember",
-            "--title", "x",
-            "--content", "# x\n\n## Claim\n\ny\n",
-            "--field", "bogus",
+            "--title",
+            "x",
+            "--content",
+            "# x\n\n## Claim\n\ny\n",
+            "--field",
+            "bogus",
         ],
         capsys,
     )
@@ -629,9 +649,7 @@ def test_process_media_cli_process_status_and_retry(vault: Path, capsys) -> None
     assert claimed is not None
     store.mark(claimed.id, media_jobs.BLOCKED, "ExtractionUnavailable: engine absent")
 
-    code, out, err = _run(
-        ["process_media", "--operation", "status", "--json"], capsys
-    )
+    code, out, err = _run(["process_media", "--operation", "status", "--json"], capsys)
     assert code == 0, err
     status = json.loads(out.strip().splitlines()[-1])["data"]
     assert status["counts"][media_jobs.BLOCKED] == 1
@@ -669,9 +687,12 @@ def test_unknown_field_key_rejected(vault: Path, capsys) -> None:
     code, _out, err = _run(
         [
             "remember",
-            "--title", "x",
-            "--content", "# x\n\n## Claim\n\ny\n",
-            "--field", "bogus=1",
+            "--title",
+            "x",
+            "--content",
+            "# x\n\n## Claim\n\ny\n",
+            "--field",
+            "bogus=1",
         ],
         capsys,
     )
@@ -687,6 +708,44 @@ def test_simple_ask_alias_uses_compact_product_defaults(vault: Path, capsys) -> 
     assert isinstance(payload["data"], list)
     assert payload["data"], "ask should surface fixture notes"
     assert "excerpt" not in payload["data"][0]
+
+
+def test_legacy_find_alias_matches_simple_ask(vault: Path, capsys) -> None:
+    code, out, err = _run(["find", "metabolism", "--json"], capsys)
+    assert code == 0, err
+    payload = json.loads(out.strip().splitlines()[-1])
+    assert payload["success"] is True
+    assert payload["data"], "find should remain a compatibility alias for ask"
+    assert "excerpt" not in payload["data"][0]
+
+
+def test_legacy_find_lean_cli_skips_missing_model_lanes_without_warnings(
+    vault: Path,
+    capsys,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main_module = importlib.import_module("exomem.__main__")
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_RANKING",
+        "EXOMEM_DISABLE_CLIP",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(main_module, "_module_available", lambda _name: False)
+    caplog.set_level(logging.DEBUG)
+
+    code, out, err = _run(["find", "metabolism", "--json"], capsys)
+
+    assert code == 0, err
+    assert json.loads(out.strip().splitlines()[-1])["data"]
+    assert os.environ["EXOMEM_DISABLE_EMBEDDINGS"] == "1"
+    assert os.environ["EXOMEM_DISABLE_RANKING"] == "1"
+    assert os.environ["EXOMEM_DISABLE_CLIP"] == "1"
+    diagnostics = "\n".join(record.getMessage() for record in caplog.records)
+    assert "No module named 'torch'" not in diagnostics
+    assert "sentence-transformers not installed" not in diagnostics
+    assert "search unavailable" not in diagnostics
 
 
 def test_simple_ask_alias_can_request_deep_context(vault: Path, capsys) -> None:
@@ -807,8 +866,6 @@ def test_simple_review_human_output_and_triage(vault: Path, capsys) -> None:
     assert triage["state"] == "dismissed"
     assert (vault / "Knowledge Base/.review-state.json").exists()
 
-    code4, out4, err4 = _run(
-        ["review", "reopen", item["ref"], "--json"], capsys
-    )
+    code4, out4, err4 = _run(["review", "reopen", item["ref"], "--json"], capsys)
     assert code4 == 0, err4
     assert json.loads(out4.strip().splitlines()[-1])["data"]["state"] == "open"

--- a/tests/test_cli_core_ops.py
+++ b/tests/test_cli_core_ops.py
@@ -739,9 +739,9 @@ def test_legacy_find_lean_cli_skips_missing_model_lanes_without_warnings(
 
     assert code == 0, err
     assert json.loads(out.strip().splitlines()[-1])["data"]
-    assert os.environ["EXOMEM_DISABLE_EMBEDDINGS"] == "1"
-    assert os.environ["EXOMEM_DISABLE_RANKING"] == "1"
-    assert os.environ["EXOMEM_DISABLE_CLIP"] == "1"
+    assert "EXOMEM_DISABLE_EMBEDDINGS" not in os.environ
+    assert "EXOMEM_DISABLE_RANKING" not in os.environ
+    assert "EXOMEM_DISABLE_CLIP" not in os.environ
     diagnostics = "\n".join(record.getMessage() for record in caplog.records)
     assert "No module named 'torch'" not in diagnostics
     assert "sentence-transformers not installed" not in diagnostics

--- a/tests/test_cli_ops.py
+++ b/tests/test_cli_ops.py
@@ -46,6 +46,7 @@ def test_http_status_mapping() -> None:
     assert cli_ops.http_status_for("ENTITY_AMBIGUOUS") == 409
     assert cli_ops.http_status_for("WRITER_FENCED") == 409
     assert cli_ops.http_status_for("MUTATION_BUSY") == 409
+    assert cli_ops.http_status_for("MUTATION_WARMING") == 409
     assert cli_ops.http_status_for("MUTATION_LOCK_UNAVAILABLE") == 503
     assert cli_ops.http_status_for("INGRESS_BYPASSED") == 403
     assert cli_ops.http_status_for("INVALID_NOTE") == 400
@@ -85,7 +86,7 @@ def test_batch_write_error_uses_shared_public_payload_and_conflict_status(
     assert cli_ops.http_status_for(code) == 409
 
 
-@pytest.mark.parametrize("code", ["MUTATION_BUSY", "MUTATION_LOCK_UNAVAILABLE"])
+@pytest.mark.parametrize("code", ["MUTATION_BUSY", "MUTATION_WARMING", "MUTATION_LOCK_UNAVAILABLE"])
 def test_mutation_lock_errors_have_actionable_remediation(code: str) -> None:
     error = cli_ops.error_dict(cli_ops.OpError(code, "hosted mutation unavailable"))
     assert error["code"] == code

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -154,6 +154,30 @@ def test_live_event_patch_makes_hot_reads_census_free(
     assert second.pages[_PAGE_REL].title == "Event patched"
 
 
+def test_non_markdown_event_does_not_evict_or_corrupt_warm_context(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    assert semantic_contract.build_corpus_context(vault) is first
+    schema = vault / "Knowledge Base" / "_Schema"
+    schema.mkdir(parents=True, exist_ok=True)
+    manifest = schema / "semantic-activation.yaml"
+    manifest.write_text("schema_version: 1\ncontract_version: 1\npages: []\n", encoding="utf-8")
+
+    semantic_contract.publish_corpus_files_changed(vault, changed=(manifest,))
+
+    def fail_census(*args, **kwargs):
+        raise AssertionError("an unrelated non-Markdown event must keep the context warm")
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", fail_census)
+    assert semantic_contract.build_corpus_context(vault) is first
+
+
 def test_writer_preflight_self_heals_exact_page_before_delayed_event(vault: Path) -> None:
     semantic_contract.build_corpus_context(vault)
     freshness.seed(

--- a/tests/test_corpus_context_cache.py
+++ b/tests/test_corpus_context_cache.py
@@ -9,25 +9,29 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from exomem import relation_registry, semantic_contract, semantic_language_registry
+from exomem import (
+    activation_manifest,
+    freshness,
+    relation_registry,
+    semantic_contract,
+    semantic_language_registry,
+    semantic_writes,
+)
+from exomem import find as find_module
+from exomem.vault import WikilinkResolver
 
 _PAGE_REL = "Knowledge Base/Notes/Insights/one.md"
 
 
 def _page(*, title: str = "Page", body: str = "Body.\n") -> str:
-    return (
-        "---\n"
-        f"title: {title}\n"
-        "type: insight\n"
-        "status: active\n"
-        "project: atlas\n"
-        "---\n\n"
-        f"{body}"
-    )
+    return f"---\ntitle: {title}\ntype: insight\nstatus: active\nproject: atlas\n---\n\n{body}"
 
 
 @pytest.fixture(autouse=True)
@@ -36,8 +40,10 @@ def _clean_cache(monkeypatch: pytest.MonkeyPatch):
     # exercise it, so opt back in and start cold.
     monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
     semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
     yield
     semantic_contract.reset_corpus_context_cache()
+    freshness.clear()
 
 
 @pytest.fixture()
@@ -67,6 +73,474 @@ def test_content_change_rebuilds(vault: Path) -> None:
     second = semantic_contract.build_corpus_context(vault)
     assert second is not first
     assert second.pages[_PAGE_REL].source_hash != first.pages[_PAGE_REL].source_hash
+
+
+def test_markdown_change_reconciles_without_full_rebuild(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    (vault / _PAGE_REL).write_text(
+        _page(title="One", body="Incrementally refreshed body.\n"),
+        encoding="utf-8",
+    )
+
+    def fail_full_rebuild(*args, **kwargs):
+        raise AssertionError("a Markdown delta must not rebuild the whole corpus")
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", fail_full_rebuild)
+    second = semantic_contract.build_corpus_context(vault)
+
+    assert second is not first
+    assert second.pages[_PAGE_REL].source_hash != first.pages[_PAGE_REL].source_hash
+    assert second.pages[_PAGE_REL].title == "One"
+
+
+def test_markdown_delete_reconciles_without_full_rebuild(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    semantic_contract.build_corpus_context(vault)
+    removed = "Knowledge Base/Notes/Insights/two.md"
+    (vault / removed).unlink()
+
+    def fail_full_rebuild(*args, **kwargs):
+        raise AssertionError("a Markdown deletion must not rebuild the whole corpus")
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", fail_full_rebuild)
+    second = semantic_contract.build_corpus_context(vault)
+
+    assert removed not in second.pages
+    assert all(entry.path != removed for entry in second.identity_census.entries)
+
+
+def test_incremental_reconcile_matches_full_rebuild(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    semantic_contract.build_corpus_context(vault)
+    (vault / _PAGE_REL).write_text(
+        _page(title="Incremental", body="Changed with the same governed rules.\n"),
+        encoding="utf-8",
+    )
+    incremental = semantic_contract.build_corpus_context(vault)
+
+    semantic_contract.reset_corpus_context_cache()
+    monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
+    rebuilt = semantic_contract.build_corpus_context(vault)
+
+    assert incremental.as_dict() == rebuilt.as_dict()
+
+
+def test_live_event_patch_makes_hot_reads_census_free(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    pages = tuple(vault.rglob("*.md"))
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in pages),
+    )
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="Event patched"), encoding="utf-8")
+    freshness.on_files_changed(vault, changed=(page,))
+    semantic_contract.on_corpus_files_changed(vault, changed=(page,))
+
+    def fail_census(*args, **kwargs):
+        raise AssertionError("a live, event-patched cache must not stat-walk the vault")
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", fail_census)
+    second = semantic_contract.build_corpus_context(vault)
+
+    assert second is not first
+    assert second.pages[_PAGE_REL].title == "Event patched"
+
+
+def test_writer_preflight_self_heals_exact_page_before_delayed_event(vault: Path) -> None:
+    semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    semantic_contract.build_corpus_context(vault)
+
+    # Model the disk-visible window before a watcher/out-of-band publisher has
+    # advanced the freshness token. Preflight already owns these exact guarded
+    # bytes, so it must repair that one page locally instead of rejecting a
+    # valid current state against the lagging cache.
+    page = vault / _PAGE_REL
+    page.write_text(_page(title="Visible before event", body="Current bytes.\n"), encoding="utf-8")
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=_PAGE_REL,
+        after_source=_page(title="Visible before event", body="Next bytes.\n"),
+        operation="observe",
+    )
+
+    assert preflight.before_corpus.pages[_PAGE_REL] == preflight.before
+    assert not any(
+        finding.code == "SEMANTIC_CORPUS_STATE_MISMATCH"
+        for finding in preflight.contract_result.findings
+    )
+
+
+def test_atomic_event_publish_keeps_concurrent_page_changes(vault: Path) -> None:
+    semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    first = vault / _PAGE_REL
+    second = vault / "Knowledge Base/Notes/Insights/two.md"
+    first.write_text(_page(title="First concurrent"), encoding="utf-8")
+    second.write_text(_page(title="Second concurrent"), encoding="utf-8")
+    start = threading.Barrier(2)
+
+    def publish(path: Path) -> None:
+        start.wait(timeout=5)
+        semantic_contract.publish_corpus_files_changed(vault, changed=(path,))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(publish, path) for path in (first, second)]
+        for future in futures:
+            future.result(timeout=10)
+
+    current = semantic_contract.build_corpus_context(vault)
+    assert current.pages[_PAGE_REL].title == "First concurrent"
+    assert current.pages["Knowledge Base/Notes/Insights/two.md"].title == ("Second concurrent")
+
+
+def test_cold_build_absorbs_markdown_churn_instead_of_discarding_cache(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_build = semantic_contract._build_corpus_context_uncached
+    builds = 0
+
+    def edit_after_first_build(*args, **kwargs):
+        nonlocal builds
+        builds += 1
+        context = real_build(*args, **kwargs)
+        if builds == 1:
+            (vault / _PAGE_REL).write_text(_page(title="Changed during build"), encoding="utf-8")
+        return context
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", edit_after_first_build)
+    first = semantic_contract.build_corpus_context(vault)
+    second = semantic_contract.build_corpus_context(vault)
+
+    assert builds == 1
+    assert first.pages[_PAGE_REL].title == "Changed during build"
+    assert second is first
+
+
+def test_concurrent_cold_builds_share_one_uncached_result(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_build = semantic_contract._build_corpus_context_uncached
+    release_build = threading.Event()
+    duplicate_entered = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def slow_build(*args, **kwargs):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            if calls > 1:
+                duplicate_entered.set()
+        assert release_build.wait(timeout=5)
+        return real_build(*args, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", slow_build)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(semantic_contract.build_corpus_context, vault) for _ in range(2)]
+        duplicated = duplicate_entered.wait(timeout=0.5)
+        (vault / _PAGE_REL).write_text(_page(title="Current during flight"), encoding="utf-8")
+        release_build.set()
+        results = [future.result(timeout=10) for future in futures]
+
+    assert duplicated is False
+    assert calls == 1
+    assert results[0] is results[1]
+    assert results[0].pages[_PAGE_REL].title == "Current during flight"
+
+
+def test_cold_builds_with_different_registry_inputs_serialize_then_refresh(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_build = semantic_contract._build_corpus_context_uncached
+    real_census = semantic_contract._corpus_census
+    first_build_entered = threading.Event()
+    current_census_seen = threading.Event()
+    release_first_build = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+    active = 0
+    max_active = 0
+
+    def tracked_build(*args, **kwargs):
+        nonlocal active, calls, max_active
+        with calls_lock:
+            calls += 1
+            active += 1
+            max_active = max(max_active, active)
+            if calls == 1:
+                first_build_entered.set()
+        if calls == 1:
+            assert release_first_build.wait(timeout=5)
+        try:
+            return real_build(*args, **kwargs)
+        finally:
+            with calls_lock:
+                active -= 1
+
+    def observed_census(root: Path):
+        census = real_census(root)
+        if census is not None and any(
+            entry[0] == "Knowledge Base/_Schema/relation-registry.yaml" and entry[1] == "cfg"
+            for entry in census
+        ):
+            current_census_seen.set()
+        return census
+
+    monkeypatch.setattr(semantic_contract, "_build_corpus_context_uncached", tracked_build)
+    monkeypatch.setattr(semantic_contract, "_corpus_census", observed_census)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first_future = pool.submit(semantic_contract.build_corpus_context, vault)
+        assert first_build_entered.wait(timeout=5)
+        registry_path = vault / "Knowledge Base" / "_Schema" / "relation-registry.yaml"
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(
+            "schema_version: 1\nextensions:\n  science.replicates:\n"
+            "    parent: supports\n    description: Independent reproduction\n",
+            encoding="utf-8",
+        )
+        current_hash = relation_registry.load_registry(vault).extension_hash
+        second_future = pool.submit(semantic_contract.build_corpus_context, vault)
+        assert current_census_seen.wait(timeout=5)
+        release_first_build.set()
+        first = first_future.result(timeout=10)
+        second = second_future.result(timeout=10)
+
+    assert calls == 2
+    assert max_active == 1
+    assert first.registry.extension_hash != current_hash
+    assert second.registry.extension_hash == current_hash
+
+
+def test_cold_cache_publication_serializes_with_file_events(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    (vault / "Knowledge Base" / "_access.yaml").write_text("readonly: []\n", encoding="utf-8")
+    page = vault / _PAGE_REL
+    real_census = semantic_contract._corpus_census
+    publish_now = threading.Event()
+    page_written = threading.Event()
+    publish_done = threading.Event()
+    census_calls = 0
+
+    def census_with_racing_event(root: Path):
+        nonlocal census_calls
+        census_calls += 1
+        snapshot = real_census(root)
+        if census_calls == 2:
+            publish_now.set()
+            assert page_written.wait(timeout=5)
+            # On the unsafe implementation publication completes here and is
+            # then overwritten. The fixed boundary deliberately keeps it
+            # waiting until the cold context is captioned and installed.
+            publish_done.wait(timeout=0.25)
+        return snapshot
+
+    def publish_edit() -> None:
+        assert publish_now.wait(timeout=5)
+        page.write_text(_page(title="Event after cold census"), encoding="utf-8")
+        page_written.set()
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+        publish_done.set()
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", census_with_racing_event)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(publish_edit)
+        semantic_contract.build_corpus_context(vault)
+        future.result(timeout=10)
+
+    current = semantic_contract.build_corpus_context(vault)
+    assert current.pages[_PAGE_REL].title == "Event after cold census"
+
+
+def test_event_delta_rejects_reparse_markdown_like_full_identity_census(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    semantic_contract.build_corpus_context(vault)
+    page = vault / _PAGE_REL
+    real_lstat = Path.lstat
+    fake_info = SimpleNamespace(st_mode=real_lstat(page).st_mode)
+
+    def lstat_with_reparse(path: Path):
+        return fake_info if path == page else real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", lstat_with_reparse)
+    monkeypatch.setattr(
+        semantic_contract.vault,
+        "_is_reparse",
+        lambda info: info is fake_info,
+    )
+
+    with pytest.raises(activation_manifest.ActivationManifestError) as raised:
+        semantic_contract.publish_corpus_files_changed(vault, changed=(page,))
+
+    assert raised.value.code == "IDENTITY_CENSUS_UNSAFE_ENTRY"
+    cache_key = semantic_contract._corpus_cache_key(vault)
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+
+    # A later valid event cannot skip over the rejected delta and re-caption
+    # the old context with a newer freshness token.
+    other = vault / "Knowledge Base/Notes/Insights/two.md"
+    other.write_text(_page(title="Later valid event"), encoding="utf-8")
+    semantic_contract.publish_corpus_files_changed(vault, changed=(other,))
+    assert cache_key not in semantic_contract._CORPUS_CONTEXT_CACHE
+
+    def cold_oracle_required(*args, **kwargs):
+        raise AssertionError("next request must use the full safety oracle")
+
+    monkeypatch.setattr(
+        semantic_contract,
+        "_build_corpus_context_uncached",
+        cold_oracle_required,
+    )
+    with pytest.raises(AssertionError, match="full safety oracle"):
+        semantic_contract.build_corpus_context(vault)
+
+
+def test_event_delete_rejects_missing_leaf_below_reparse_ancestor(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    semantic_contract.build_corpus_context(vault)
+    page = vault / _PAGE_REL
+    page.unlink()
+    unsafe_ancestor = page.parent
+    real_lstat = Path.lstat
+    fake_info = SimpleNamespace(st_mode=real_lstat(unsafe_ancestor).st_mode)
+
+    def lstat_with_reparse(path: Path):
+        return fake_info if path == unsafe_ancestor else real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", lstat_with_reparse)
+    monkeypatch.setattr(
+        semantic_contract.vault,
+        "_is_reparse",
+        lambda info: info is fake_info,
+    )
+
+    with pytest.raises(activation_manifest.ActivationManifestError) as raised:
+        semantic_contract.publish_corpus_files_changed(vault, deleted=(_PAGE_REL,))
+
+    assert raised.value.code == "IDENTITY_CENSUS_UNSAFE_ENTRY"
+
+
+def test_candidate_with_stable_topology_rederives_only_its_own_facts(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    before = semantic_contract.build_corpus_context(vault)
+    candidate = semantic_contract.build_page_state(
+        vault,
+        _PAGE_REL,
+        _page(title="One", body="A changed semantic payload.\n"),
+        relation_registry=relation_registry.load_registry(vault),
+        language_registry=semantic_language_registry.load_registry(vault),
+    )
+    expected_pages = dict(before.pages)
+    expected_pages[_PAGE_REL] = candidate
+    expected = semantic_contract._context_from_state_map(
+        vault,
+        expected_pages,
+        before.registry,
+        before.identity_census.with_page(candidate),
+    )
+    real_derive = semantic_contract._derive_relation_facts
+
+    def derive_candidate_only(root, states, resolver, registry, **kwargs):
+        assert tuple(states) == (_PAGE_REL,)
+        return real_derive(root, states, resolver, registry, **kwargs)
+
+    monkeypatch.setattr(semantic_contract, "_derive_relation_facts", derive_candidate_only)
+
+    actual = before.with_candidate(candidate)
+
+    assert actual.as_dict() == expected.as_dict()
+
+
+def test_corpus_entries_prime_writer_resolver_without_full_vault_build(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    find_module.clear_cache()
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+
+    def fail_full_build(self):
+        raise AssertionError("writer resolver must be primed from corpus entries")
+
+    monkeypatch.setattr(WikilinkResolver, "_build", fail_full_build)
+    find_module.prime_resolver_from_entries(vault, context.resolver_entries)
+    snapshot = find_module.writer_resolver_snapshot(vault)
+
+    assert snapshot.full_paths == context.resolver_full_paths
+
+
+def test_corpus_entries_do_not_prime_resolver_after_freshness_changes(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    expected = freshness.triple(vault, "vault")
+    assert expected is not None
+    page = vault / "Knowledge Base/Notes/Insights/two.md"
+    page.write_text(_page(title="Changed after preflight"), encoding="utf-8")
+    freshness.on_files_changed(vault, changed=(page,))
+
+    def fail_stale_prime(*args, **kwargs):
+        raise AssertionError("stale preflight entries must not seed the resolver")
+
+    monkeypatch.setattr(WikilinkResolver, "from_entries", fail_stale_prime)
+    result = find_module.prime_resolver_from_entries(
+        vault,
+        context.resolver_entries,
+        expected_freshness=expected,
+    )
+
+    assert result is None
 
 
 def test_mtime_preserving_sync_edit_rebuilds(vault: Path) -> None:
@@ -113,9 +587,7 @@ def test_removed_page_rebuilds(vault: Path) -> None:
 
 def test_access_config_change_rebuilds(vault: Path) -> None:
     first = semantic_contract.build_corpus_context(vault)
-    (vault / "Knowledge Base" / "_access.yaml").write_text(
-        "readonly:\n- Notes\n", encoding="utf-8"
-    )
+    (vault / "Knowledge Base" / "_access.yaml").write_text("readonly:\n- Notes\n", encoding="utf-8")
     second = semantic_contract.build_corpus_context(vault)
     assert second is not first
 
@@ -164,9 +636,26 @@ def test_synthetic_registry_bypasses_cache(vault: Path) -> None:
     assert second is not first
 
 
-def test_kill_switch_disables_cache(
-    vault: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_live_event_cache_rejects_synthetic_language_registry(vault: Path) -> None:
+    first = semantic_contract.build_corpus_context(vault)
+    freshness.seed(
+        vault,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault.rglob("*.md")),
+    )
+    assert semantic_contract.build_corpus_context(vault) is first
+    disk_language = semantic_language_registry.load_registry(vault)
+    synthetic = dataclasses.replace(disk_language, content_hash="0" * 64)
+
+    second = semantic_contract.build_corpus_context(
+        vault,
+        language_registry=synthetic,
+    )
+
+    assert second is not first
+
+
+def test_kill_switch_disables_cache(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EXOMEM_DISABLE_CORPUS_CACHE", "1")
     first = semantic_contract.build_corpus_context(vault)
     second = semantic_contract.build_corpus_context(vault)

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -27,15 +27,11 @@ def _stub_embeddings(monkeypatch: pytest.MonkeyPatch):
 
     def upsert_status(root, paths):
         ups.append(list(paths))
-        return embeddings.EmbeddingSyncStatus(
-            "completed", "embedding_upsert_completed", len(paths)
-        )
+        return embeddings.EmbeddingSyncStatus("completed", "embedding_upsert_completed", len(paths))
 
     def delete_status(root, rels):
         dels.append(list(rels))
-        return embeddings.EmbeddingSyncStatus(
-            "completed", "embedding_delete_completed", len(rels)
-        )
+        return embeddings.EmbeddingSyncStatus("completed", "embedding_delete_completed", len(rels))
 
     monkeypatch.setattr(embeddings, "upsert_after_write_status", upsert_status)
     monkeypatch.setattr(embeddings, "delete_after_remove_status", delete_status)
@@ -101,9 +97,7 @@ def _spy_media_and_text_dispatch(monkeypatch: pytest.MonkeyPatch) -> dict[str, l
     monkeypatch.setattr(
         file_watcher.index_sync,
         "upsert_after_write",
-        lambda root, paths, **kwargs: calls["upsert"].append(
-            (root, list(paths), dict(kwargs))
-        ),
+        lambda root, paths, **kwargs: calls["upsert"].append((root, list(paths), dict(kwargs))),
     )
     monkeypatch.setattr(
         file_watcher.index_sync,
@@ -112,15 +106,11 @@ def _spy_media_and_text_dispatch(monkeypatch: pytest.MonkeyPatch) -> dict[str, l
     )
     monkeypatch.setattr(
         "exomem.vault.on_inbound_files_changed",
-        lambda root, up, deleted: calls["inbound"].append(
-            (root, list(up), list(deleted))
-        ),
+        lambda root, up, deleted: calls["inbound"].append((root, list(up), list(deleted))),
     )
     monkeypatch.setattr(
         "exomem.find.on_resolver_files_changed",
-        lambda root, up, deleted: calls["resolver"].append(
-            (root, list(up), list(deleted))
-        ),
+        lambda root, up, deleted: calls["resolver"].append((root, list(up), list(deleted))),
     )
     return calls
 
@@ -165,6 +155,7 @@ def test_supported_audio_event_reconciles_under_writer_authority(
                 depth -= 1
 
     monkeypatch.setattr(writer_lease, "get_manager", lambda: Manager())
+
     def reconcile_media(*_args, commit_guard=None, **_kwargs):  # noqa: ANN001
         assert depth == 0
         assert commit_guard is not None
@@ -413,7 +404,6 @@ def test_live_import_burst_defers_semantic_indexing(
     assert "live import/sync burst" in caplog.text
 
 
-
 def test_dispatch_thread_uses_quiet_policy_for_burst_coalescing(
     vault, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -523,6 +513,46 @@ def test_self_write_upsert_suppressed(vault, monkeypatch: pytest.MonkeyPatch) ->
     assert ups == [] and dels == []
 
 
+def test_self_write_publishes_semantic_corpus_delta(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[Path], list[str]]] = []
+    monkeypatch.setattr(file_watcher.freshness, "event_indexes_enabled", lambda: True)
+    monkeypatch.setattr(
+        "exomem.semantic_contract.publish_corpus_files_changed",
+        lambda root, *, changed=(), deleted=(): calls.append(
+            (list(changed), [str(path) for path in deleted])
+        ),
+    )
+    path = vault / "Knowledge Base" / "Notes" / "semantic-cache-write.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# cache patch\n", encoding="utf-8")
+
+    file_watcher.register_self_write(vault, [path])
+
+    assert calls == [([path], [])]
+
+
+def test_external_batch_publishes_semantic_corpus_delta(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_embeddings(monkeypatch)
+    calls: list[tuple[list[Path], list[str]]] = []
+    monkeypatch.setattr(
+        "exomem.semantic_contract.publish_corpus_files_changed",
+        lambda root, *, changed=(), deleted=(): calls.append(
+            (list(changed), [str(path) for path in deleted])
+        ),
+    )
+    watcher = file_watcher.FileWatcher(vault)
+    path = vault / "Knowledge Base" / "Notes" / "semantic-cache-external.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# external cache patch\n", encoding="utf-8")
+    watcher._record(path, deleted=False)
+
+    watcher._flush()
+
+    assert calls == [([path], [])]
+
+
 def test_external_edit_after_self_write_dispatches(vault, monkeypatch: pytest.MonkeyPatch) -> None:
     ups, _dels = _stub_embeddings(monkeypatch)
     file_watcher.clear_self_write_registry()
@@ -622,7 +652,11 @@ def _spy_reconcile_fanout(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
     """Capture the reconcile dispatch seams: inbound + resolver publishes, the
     KB-filtered embed heal (index_sync), and the bm25 pre-warm."""
     calls: dict[str, list] = {
-        "inbound": [], "resolver": [], "upsert": [], "delete": [], "warm": [],
+        "inbound": [],
+        "resolver": [],
+        "upsert": [],
+        "delete": [],
+        "warm": [],
     }
     monkeypatch.setattr(
         "exomem.vault.on_inbound_files_changed",
@@ -633,11 +667,13 @@ def _spy_reconcile_fanout(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
         lambda root, up, dl: calls["resolver"].append((list(up), list(dl))),
     )
     monkeypatch.setattr(
-        file_watcher.index_sync, "upsert_after_write",
+        file_watcher.index_sync,
+        "upsert_after_write",
         lambda root, paths, **_kw: calls["upsert"].append(list(paths)),
     )
     monkeypatch.setattr(
-        file_watcher.index_sync, "delete_after_remove",
+        file_watcher.index_sync,
+        "delete_after_remove",
         lambda root, rels: calls["delete"].append(list(rels)),
     )
     monkeypatch.setattr("exomem.bm25.warm", lambda root, scope: calls["warm"].append(scope))
@@ -827,6 +863,7 @@ def test_periodic_media_reconcile_runs_under_writer_authority(
                 depth -= 1
 
     monkeypatch.setattr(writer_lease, "get_manager", lambda: Manager())
+
     def reconcile_all_media(_root: Path, *, limit: int, reconcile_one=None) -> int:
         assert limit > 0
         assert depth == 0
@@ -836,6 +873,7 @@ def test_periodic_media_reconcile_runs_under_writer_authority(
         return 1
 
     monkeypatch.setattr(media_processing, "reconcile_all_media", reconcile_all_media)
+
     def reconcile_media(*_args, commit_guard=None, **_kwargs):  # noqa: ANN001
         assert depth == 0
         assert commit_guard is not None
@@ -889,6 +927,7 @@ def test_periodic_media_reconcile_yields_mutation_boundary_between_artifacts(
         return 3
 
     monkeypatch.setattr(media_processing, "reconcile_all_media", reconcile_all_media)
+
     def reconcile_media(*_args, commit_guard=None, **_kwargs):  # noqa: ANN001
         assert depth == 0
         assert commit_guard is not None

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -246,6 +246,19 @@ def test_auto_widen_relaxed_gate_partial_token_match(vault: Path) -> None:
     assert any(h.path == rel for h in hits)
 
 
+def test_auto_widen_python_backend_honors_nonrepairing_contract(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Python rollback rung accepts the sidecar repair policy unchanged."""
+    monkeypatch.setenv("EXOMEM_LEXICAL_BACKEND", "python")
+    monkeypatch.setattr(find_module, "_bounded_lexical_repair_allowed", lambda _key: False)
+    rel = _make_x3_tracker(vault)
+
+    hits = find_module.find(vault, query="X3 rep progression tracking")
+
+    assert any(h.path == rel for h in hits)
+
+
 def test_kb_only_scope_does_not_widen_to_tracker(vault: Path) -> None:
     rel = _make_x3_tracker(vault)
     hits = find_module.find(vault, query="X3", scope="kb-only")

--- a/tests/test_find_structured_filters.py
+++ b/tests/test_find_structured_filters.py
@@ -137,12 +137,7 @@ def test_generic_filter_and_shortcuts_intersect_in_filter_only_order(
 
 
 def test_category_alias_is_resolved_before_candidate_work(filter_vault: Path) -> None:
-    registry = (
-        filter_vault
-        / "Knowledge Base"
-        / "_Schema"
-        / "semantic-language-registry.yaml"
-    )
+    registry = filter_vault / "Knowledge Base" / "_Schema" / "semantic-language-registry.yaml"
     registry.parent.mkdir(parents=True, exist_ok=True)
     registry.write_text(
         "schema_version: 1\n"
@@ -180,12 +175,7 @@ def test_hot_cache_tracks_registry_changes_for_unit_filters(
         priority=99,
         observations="- [configuration] Registry-sensitive unit ^registry-cache",
     )
-    registry = (
-        filter_vault
-        / "Knowledge Base"
-        / "_Schema"
-        / "semantic-language-registry.yaml"
-    )
+    registry = filter_vault / "Knowledge Base" / "_Schema" / "semantic-language-registry.yaml"
 
     def write_registry(*, configuration_target: str) -> None:
         other = "rule" if configuration_target == "config" else "config"
@@ -213,9 +203,7 @@ def test_hot_cache_tracks_registry_changes_for_unit_filters(
         filters={"page.frontmatter:/metadata/priority": {"$eq": 99}},
         limit=20,
     )
-    assert [hit.path for hit in first] == [
-        "Knowledge Base/Notes/registry-cache-target.md"
-    ]
+    assert [hit.path for hit in first] == ["Knowledge Base/Notes/registry-cache-target.md"]
 
     # Same request, no explicit cache clear: registry content is answer
     # freshness whenever unit predicates participate in eligibility.
@@ -302,9 +290,7 @@ def test_python_lexical_backend_preserves_unit_filter_eligibility(
         limit=20,
     )
 
-    assert [hit.as_dict()["parent_path"] for hit in hits] == [
-        "Knowledge Base/Notes/split-units.md"
-    ]
+    assert [hit.as_dict()["parent_path"] for hit in hits] == ["Knowledge Base/Notes/split-units.md"]
 
 
 def test_page_matched_units_are_bounded_and_report_truncation(
@@ -317,8 +303,7 @@ def test_page_matched_units_are_bounded_and_report_truncation(
         updated="2026-01-06",
         priority=77,
         observations="\n".join(
-            f"- [config] Matching unit {index} #auth ^cap-{index}"
-            for index in range(7)
+            f"- [config] Matching unit {index} #auth ^cap-{index}" for index in range(7)
         ),
     )
     hits = find_module.find(
@@ -401,12 +386,7 @@ def test_text_unit_recall_falls_back_when_registry_makes_fts_rows_stale(
         priority=90,
         observations="- [configuration] registry needle ^registry-text",
     )
-    registry = (
-        filter_vault
-        / "Knowledge Base"
-        / "_Schema"
-        / "semantic-language-registry.yaml"
-    )
+    registry = filter_vault / "Knowledge Base" / "_Schema" / "semantic-language-registry.yaml"
 
     def write_registry(description: str) -> None:
         registry.parent.mkdir(parents=True, exist_ok=True)
@@ -440,9 +420,7 @@ def test_text_unit_recall_falls_back_when_registry_makes_fts_rows_stale(
         filters={"page.frontmatter:/metadata/priority": {"$eq": 90}},
         limit=20,
     )
-    assert [hit.as_dict()["unit_ref"] for hit in second] == [
-        first[0].as_dict()["unit_ref"]
-    ]
+    assert [hit.as_dict()["unit_ref"] for hit in second] == [first[0].as_dict()["unit_ref"]]
 
 
 def test_python_unit_ranking_breaks_zero_score_ties_toward_active_parent(
@@ -498,9 +476,7 @@ def test_python_unit_ranking_breaks_zero_score_ties_toward_active_parent(
         prefer_active=False,
         limit=20,
     )
-    assert path_order[0].as_dict()["parent_path"] == (
-        "Knowledge Base/Notes/a-superseded.md"
-    )
+    assert path_order[0].as_dict()["parent_path"] == ("Knowledge Base/Notes/a-superseded.md")
 
 
 def test_invalid_filter_fails_before_candidate_search(
@@ -537,9 +513,7 @@ def test_real_vector_lane_ranks_only_filter_eligible_parents(
         value /= np.linalg.norm(value)
         return value
 
-    index.upsert_file(
-        "Knowledge Base/Notes/draft.md", ["draft"], np.stack([vector(1.0)]), 1.0
-    )
+    index.upsert_file("Knowledge Base/Notes/draft.md", ["draft"], np.stack([vector(1.0)]), 1.0)
     index.upsert_file(
         "Knowledge Base/Notes/matching.md",
         ["matching"],
@@ -581,13 +555,7 @@ def test_scene_frame_candidate_inherits_its_emitted_parent_eligibility(
     filter_vault: Path,
 ) -> None:
     parent = filter_vault / "Knowledge Base" / "Evidence" / "video.mp4.md"
-    child = (
-        filter_vault
-        / "Knowledge Base"
-        / "Evidence"
-        / "video.mp4.frames"
-        / "frame.jpg.md"
-    )
+    child = filter_vault / "Knowledge Base" / "Evidence" / "video.mp4.frames" / "frame.jpg.md"
     parent.parent.mkdir(parents=True, exist_ok=True)
     child.parent.mkdir(parents=True, exist_ok=True)
     parent.write_text(
@@ -611,7 +579,7 @@ def test_scene_frame_candidate_inherits_its_emitted_parent_eligibility(
     assert "Knowledge Base/Evidence/video.mp4.frames/frame.jpg.md" in eligible
 
 
-def test_auto_widen_pushes_exact_outside_eligibility_into_bm25(
+def test_auto_widen_pushes_exact_outside_eligibility_into_lexstore(
     filter_vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     active = filter_vault / "Projects" / "active.md"
@@ -627,7 +595,7 @@ def test_auto_widen_pushes_exact_outside_eligibility_into_bm25(
     )
     captured: dict[str, object] = {}
 
-    def fake_bm25_search(
+    def fake_lexstore_search(
         _root: Path,
         _query: str,
         k: int,
@@ -637,9 +605,9 @@ def test_auto_widen_pushes_exact_outside_eligibility_into_bm25(
         captured["allowed_paths"] = kwargs.get("allowed_paths")
         return [("Projects/active.md", 1.0)]
 
-    from exomem import bm25
+    from exomem import lexstore
 
-    monkeypatch.setattr(bm25, "search", fake_bm25_search)
+    monkeypatch.setattr(lexstore, "search_bm25", fake_lexstore_search)
     hits = find_module._find_outside_kb(
         filter_vault,
         query="outside-marker",

--- a/tests/test_hosted_private_routes.py
+++ b/tests/test_hosted_private_routes.py
@@ -153,9 +153,7 @@ class IsolatedInvoker:
 
 class WriterBackedInvoker:
     def __init__(self, state_dir: Path) -> None:
-        self.manager = writer_lease.LeaseManager(
-            writer_lease.LeaseConfig(state_dir=state_dir)
-        )
+        self.manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=state_dir))
         self.calls: list[dict[str, Any]] = []
 
     def __call__(
@@ -484,27 +482,15 @@ def _hosted_bootstrap_tool_refs(payload: object) -> set[str]:
             for child_key, child in value.items():
                 if child_key in known_names and key not in _ACTION_VOCABULARY_MAPS:
                     refs.add(child_key)
-                if (
-                    child_key == "tool"
-                    and isinstance(child, str)
-                    and child in known_names
-                ):
+                if child_key == "tool" and isinstance(child, str) and child in known_names:
                     refs.add(child)
                     continue
-                if (
-                    child_key == "route"
-                    and isinstance(child, str)
-                    and child in known_names
-                ):
+                if child_key == "route" and isinstance(child, str) and child in known_names:
                     refs.add(child)
                     continue
-                if child_key in structured_lists and isinstance(
-                    child, (list, tuple)
-                ):
+                if child_key in structured_lists and isinstance(child, (list, tuple)):
                     refs.update(
-                        item
-                        for item in child
-                        if isinstance(item, str) and item in known_names
+                        item for item in child if isinstance(item, str) and item in known_names
                     )
                 walk(child, key=str(child_key))
             return
@@ -560,9 +546,7 @@ def test_hosted_bootstrap_profiles_match_private_command_contract(
     exported_tuple = tuple(command["name"] for command in contract["commands"])
     expected_tuple = tuple(
         command.name
-        for command in commands_module.product_commands_for(
-            "rest", expose_tier2=tier2_enabled
-        )
+        for command in commands_module.product_commands_for("rest", expose_tier2=tier2_enabled)
     )
     assert exported_tuple == expected_tuple
 
@@ -577,9 +561,7 @@ def test_hosted_bootstrap_profiles_match_private_command_contract(
         active = payload["active_capabilities"]
         assert active["surface"] == "hosted"
         assert active["profile"] == "private-command-router"
-        assert active["tier2_policy"] == (
-            "enabled" if tier2_enabled else "disabled"
-        )
+        assert active["tier2_policy"] == ("enabled" if tier2_enabled else "disabled")
         assert active["available_product_tools"] == sorted(exported_tuple)
         assert _hosted_bootstrap_tool_refs(payload) <= set(exported_tuple)
         assert "read_media" not in _hosted_bootstrap_tool_refs(payload)
@@ -614,14 +596,15 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
     command_path = f"/private/exomem/v1/agent/{profile}/command"
 
     assert client.get(contract_path).status_code == 401
-    assert client.post(f"{command_path}/remember", json=_remember_body("no auth")).status_code == 401
+    assert (
+        client.post(f"{command_path}/remember", json=_remember_body("no auth")).status_code == 401
+    )
     contract_response = client.get(contract_path, headers=headers)
     assert contract_response.status_code == 200, contract_response.text
     contract = contract_response.json()
     command_names = tuple(command["name"] for command in contract["commands"])
     expected = tuple(
-        command.name
-        for command in commands_module.product_commands_for_profile(profile, "rest")
+        command.name for command in commands_module.product_commands_for_profile(profile, "rest")
     )
     assert command_names == expected
     assert contract["agent_profile"]["profile"] == profile
@@ -646,9 +629,10 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
         assert active["surface"] == "hosted-agent"
         assert active["tier2_policy"] == "disabled"
         assert active["available_product_tools"] == sorted(expected)
-        assert active["active_capability_sha256"] == contract["agent_profile"][
-            "active_capability_sha256"
-        ]
+        assert (
+            active["active_capability_sha256"]
+            == contract["agent_profile"]["active_capability_sha256"]
+        )
         assert _hosted_bootstrap_tool_refs(payload) <= set(expected)
 
     mutation_headers = _headers(
@@ -713,10 +697,7 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
             json=body,
         )
         assert excluded_while_quiesced.status_code == 404
-        assert (
-            excluded_while_quiesced.json()["error"]["code"]
-            == "COMMAND_NOT_FOUND"
-        )
+        assert excluded_while_quiesced.json()["error"]["code"] == "COMMAND_NOT_FOUND"
         assert len(invoker.calls) == calls_before_exclusion
 
     rejected_while_quiesced = client.post(
@@ -729,10 +710,7 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
         json=_remember_body("must not pass mutation admission"),
     )
     assert rejected_while_quiesced.status_code == 503
-    assert (
-        rejected_while_quiesced.json()["error"]["code"]
-        == "HOSTED_MUTATION_NOT_ADMITTED"
-    )
+    assert rejected_while_quiesced.json()["error"]["code"] == "HOSTED_MUTATION_NOT_ADMITTED"
     assert len(invoker.calls) == calls_before_exclusion
 
     unknown = client.get(
@@ -748,10 +726,7 @@ def test_hosted_agent_profile_routes_enforce_contract_and_bootstrap(
         json=_remember_body("unknown profile"),
     )
     assert unknown_command.status_code == 400
-    assert (
-        unknown_command.json()["error"]["code"]
-        == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"
-    )
+    assert unknown_command.json()["error"]["code"] == "HOSTED_SURFACE_PROFILE_UNSUPPORTED"
     assert len(invoker.calls) == calls_before_exclusion
 
 
@@ -1074,6 +1049,38 @@ def test_hosted_busy_error_preserves_only_allowlisted_public_identity(
     assert "private-detail-sentinel" not in response.text
 
 
+def test_hosted_warming_error_preserves_retry_contract(tmp_path: Path) -> None:
+    client, config, _lifecycle, _invoker = _cell(
+        tmp_path,
+        cell_id="cell-public-warming-error",
+        credential="public-warming-service-credential-0001",
+        invoker=MutationErrorInvoker(
+            "MUTATION_WARMING",
+            status="retryable",
+            committed=False,
+            retry_after_ms=750,
+        ),
+    )
+
+    response = client.post(
+        "/private/exomem/v1/command/remember",
+        headers=_headers(config),
+        json=_remember_body("HOSTED-WARMING-ERROR"),
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["error"] == {
+        "code": "MUTATION_WARMING",
+        "message": "hosted command failed",
+        "remediation": None,
+        "status": "retryable",
+        "committed": False,
+        "retry_after_ms": 750,
+        "request_id": DEFAULT_REQUEST_ID,
+        "receipt_id": "0123456789abcdef",
+    }
+
+
 def test_hosted_pending_error_omits_absent_public_idempotency_key(
     tmp_path: Path,
 ) -> None:
@@ -1171,9 +1178,7 @@ def test_mixed_command_route_admits_only_resolved_read_operations(
     )
     headers = _headers(config)
     if admission_state == "authority-down":
-        lifecycle.set_mutation_authority(
-            False, reason_code="HOSTED_MUTATION_AUTHORITY_UNAVAILABLE"
-        )
+        lifecycle.set_mutation_authority(False, reason_code="HOSTED_MUTATION_AUTHORITY_UNAVAILABLE")
     else:
         lifecycle.quiesce(timeout=1)
 

--- a/tests/test_install_parity.py
+++ b/tests/test_install_parity.py
@@ -1,0 +1,206 @@
+"""Fast CLI provenance and managed service/CLI release-parity contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_version(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    command = textwrap.dedent(
+        f"""
+        import builtins
+        import sys
+
+        blocked = {{"torch", "sentence_transformers", "PIL", "faster_whisper"}}
+        original = builtins.__import__
+        def guarded(name, *args, **kwargs):
+            if name.split(".", 1)[0] in blocked:
+                raise AssertionError(f"optional model import: {{name}}")
+            return original(name, *args, **kwargs)
+        builtins.__import__ = guarded
+
+        from exomem.__main__ import main
+        raise SystemExit(main({list(args)!r}))
+        """
+    )
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-c", command],
+        cwd=ROOT,
+        env=run_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_version_json_is_cheap_and_reports_managed_release_mismatch() -> None:
+    manifest = ROOT / "tests" / "install_fixtures" / "managed-install.json"
+    result = _run_version(
+        "--version",
+        "--json",
+        env={"EXOMEM_MANAGED_INSTALL_MANIFEST": str(manifest)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    report = json.loads(result.stdout)
+    assert set(report) == {
+        "version",
+        "python_executable",
+        "install_source",
+        "local_profile",
+        "managed_service_version",
+        "managed_service_profile",
+        "managed_service_target",
+        "effective_route",
+        "version_match",
+        "manifest_status",
+    }
+    assert report["managed_service_version"] == "99.1.0"
+    assert report["managed_service_profile"] == "media"
+    assert report["local_profile"] == "lean"
+    assert report["effective_route"] == "direct"
+    assert report["version_match"] is False
+    assert "TOP SECRET" not in result.stdout
+    assert "also secret" not in result.stdout
+
+
+def test_version_json_rejects_service_target_url_credentials(tmp_path: Path) -> None:
+    manifest = tmp_path / "managed-install.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "service_target": (
+                    "https://manifest-user:userinfo-secret@example.test:8443"
+                    "?token=query-secret#fragment-secret"
+                ),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_version(
+        "--version",
+        "--json",
+        env={"EXOMEM_MANAGED_INSTALL_MANIFEST": str(manifest)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["managed_service_target"] is None
+    assert "manifest-user" not in result.stdout
+    assert "userinfo-secret" not in result.stdout
+    assert "query-secret" not in result.stdout
+    assert "fragment-secret" not in result.stdout
+
+
+def test_plain_version_is_a_single_stable_line() -> None:
+    result = _run_version(
+        "--version",
+        env={
+            "EXOMEM_MANAGED_INSTALL_MANIFEST": str(
+                ROOT / "tests" / "install_fixtures" / "absent-managed-install.json"
+            )
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith("exomem ")
+    assert result.stdout.count("\n") == 1
+    assert result.stderr == ""
+
+
+def _run_unix_sync(mode: str, *, tool_present: bool) -> subprocess.CompletedProcess[str]:
+    listed = "printf '%s\\n' 'exomem v0.4.1'" if tool_present else ":"
+    command = (
+        "uv() { "
+        'if [ "$1 $2" = "tool list" ]; then '
+        f"{listed}; "
+        "else printf 'UV_CALL %s\\n' \"$*\"; fi; }; "
+        f'. "{ROOT / "scripts" / "_service-common.sh"}"; '
+        f'exomem_sync_uv_cli "{mode}" "1.2.3"'
+    )
+    return subprocess.run(
+        ["bash", "-c", command],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _require_bash(result: subprocess.CompletedProcess[str]) -> None:
+    # Codex's Windows sandbox can resolve Git Bash but blocks its signal-pipe
+    # bootstrap.  This is an execution-boundary failure, not a script result;
+    # normal Windows and Unix CI still exercise the behavior below.
+    startup = result.stdout.replace("\x00", "")
+    if result.returncode and "Bash/Service/CreateInstance/E_ACCESSDENIED" in startup:
+        pytest.skip("sandbox blocked Git Bash startup")
+    if result.returncode and "couldn't create signal pipe, Win32 error 5" in startup:
+        pytest.skip("sandbox blocked Git Bash startup")
+
+
+def test_unix_auto_syncs_existing_uv_tool_to_exact_service_release() -> None:
+    result = _run_unix_sync("auto", tool_present=True)
+
+    _require_bash(result)
+    assert result.returncode == 0, result.stderr
+    assert "UV_CALL tool install --force exomem==1.2.3" in result.stdout
+
+
+def test_unix_auto_never_installs_an_absent_uv_tool() -> None:
+    result = _run_unix_sync("auto", tool_present=False)
+
+    _require_bash(result)
+    assert result.returncode == 0, result.stderr
+    assert "UV_CALL tool install" not in result.stdout
+
+
+def test_unix_always_may_install_and_never_skips() -> None:
+    always = _run_unix_sync("always", tool_present=False)
+    never = _run_unix_sync("never", tool_present=True)
+
+    _require_bash(always)
+    _require_bash(never)
+    assert always.returncode == 0, always.stderr
+    assert "UV_CALL tool install --force exomem==1.2.3" in always.stdout
+    assert never.returncode == 0, never.stderr
+    assert "UV_CALL tool install" not in never.stdout
+
+
+def test_upgrade_scripts_defer_cli_sync_until_live_version_is_verified() -> None:
+    windows = (ROOT / "scripts" / "upgrade.ps1").read_text(encoding="utf-8")
+    unix = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
+
+    assert 'ValidateSet("auto", "always", "never")' in windows
+    assert '$CliSync = "auto"' in windows
+    assert "Sync-ExomemUvCli" in windows
+    assert windows.index("if ($SkipRestart)") < windows.index("Sync-ExomemUvCli")
+    assert windows.index("Serving version:") < windows.index("Sync-ExomemUvCli")
+
+    assert "--cli-sync" in unix
+    assert 'exomem_sync_uv_cli "$CLI_SYNC" "$SERVED"' in unix
+    assert unix.index('if [[ "$SKIP_RESTART" -eq 1 ]]') < unix.index(
+        'exomem_sync_uv_cli "$CLI_SYNC" "$SERVED"'
+    )
+    assert unix.index("Serving version:") < unix.index('exomem_sync_uv_cli "$CLI_SYNC" "$SERVED"')
+
+
+def test_bootstrap_upgrades_an_existing_uv_tool_instead_of_leaving_it_stale() -> None:
+    install = (ROOT / "scripts" / "install.sh").read_text(encoding="utf-8")
+
+    assert "uv tool list" in install
+    assert "uv tool upgrade exomem" in install

--- a/tests/test_instant_start.py
+++ b/tests/test_instant_start.py
@@ -60,8 +60,14 @@ def _reset_readiness(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_components_tuple_and_initial_state() -> None:
-    """The four coordinated components, and the never-warmed default state."""
-    assert readiness.COMPONENTS == ("lexical", "embeddings", "reranker", "clip")
+    """The coordinated components, and the never-warmed default state."""
+    assert readiness.COMPONENTS == (
+        "lexical",
+        "semantic_corpus",
+        "embeddings",
+        "reranker",
+        "clip",
+    )
     assert readiness.is_warming() is False
     assert readiness.warming_info() is None
     for c in readiness.COMPONENTS:
@@ -151,7 +157,12 @@ def test_warming_info_shape_and_transitions() -> None:
 
     readiness.mark_ready("lexical")
     info2 = readiness.warming_info()
-    assert set(info2["components"]) == {"embeddings", "reranker", "clip"}
+    assert set(info2["components"]) == {
+        "semantic_corpus",
+        "embeddings",
+        "reranker",
+        "clip",
+    }
 
     readiness.finish_warm()
     assert readiness.warming_info() is None
@@ -240,7 +251,6 @@ def test_model_preload_allowed_defaults_lazy_in_normal_mode(
     assert warmup.model_preload_allowed("normal") is True
 
 
-
 def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -264,6 +274,36 @@ def test_warm_all_marks_components_ready_in_lexical_embeddings_reranker_clip_ord
     assert call_order == ["lexical", "embeddings", "reranker", "clip"]
     for c in readiness.COMPONENTS:
         assert readiness.is_ready(c) is True
+
+
+def test_warm_all_marks_lexical_ready_before_semantic_corpus_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rebuildable semantic corpus can be slow on a large vault, so it must
+    not sit in front of restart retrieval.  Lexical caches and their readiness
+    signal land first; semantic warming remains background follow-up work."""
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    call_order: list[str] = []
+
+    monkeypatch.setattr(
+        warmup,
+        "warm_caches",
+        lambda vr, **_kw: call_order.append("lexical") or {},
+    )
+
+    def _semantic_warm(_vault_root: Path) -> None:
+        assert readiness.is_ready("lexical") is True
+        call_order.append("semantic")
+
+    monkeypatch.setattr(
+        "exomem.semantic_contract.build_corpus_context",
+        _semantic_warm,
+    )
+
+    warmup.warm_all(tmp_path)
+
+    assert call_order == ["lexical", "semantic"]
+    assert readiness.is_ready("semantic_corpus") is True
 
 
 def test_warm_all_skips_model_preloads_when_embeddings_disabled(
@@ -290,6 +330,24 @@ def test_warm_all_skips_model_preloads_when_embeddings_disabled(
     assert readiness.is_ready("embeddings") is True
     assert readiness.is_ready("reranker") is True
     assert readiness.is_ready("clip") is True
+
+
+def test_warm_all_primes_semantic_corpus_even_when_cpu_preload_is_quiet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_MODE", "quiet")
+    monkeypatch.setenv("EXOMEM_DISABLE_EMBEDDINGS", "1")
+    warmed: list[Path] = []
+    monkeypatch.setattr(warmup, "warm_caches", lambda vr, **_kw: {})
+    monkeypatch.setattr(
+        "exomem.semantic_contract.build_corpus_context",
+        lambda root: warmed.append(Path(root)),
+    )
+
+    durations = warmup.warm_all(tmp_path)
+
+    assert warmed == [tmp_path]
+    assert "semantic_corpus" in durations
 
 
 def test_warm_all_quiet_mode_skips_preloads_but_marks_ready(
@@ -336,9 +394,7 @@ def test_warm_all_quiet_mode_replays_deferred_write_embeds(
         drained_calls.append((vr, list(paths)))
         return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
 
-    monkeypatch.setattr(
-        embeddings, "upsert_after_write_status", completed
-    )
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", completed)
 
     readiness.begin_warm()
     some_paths = (tmp_path / "a.md", tmp_path / "b.md")
@@ -374,9 +430,7 @@ def test_warm_caches_gates_matrix_warm_on_preload_models(
     assert "clip_matrix" not in d_quiet
     assert calls == []
 
-    d_default = warmup.warm_caches(
-        tmp_path, preload_models=True, preload_cpu_caches=True
-    )
+    d_default = warmup.warm_caches(tmp_path, preload_models=True, preload_cpu_caches=True)
     assert "embedding_matrix" in d_default
     assert "clip_matrix" in d_default
     assert calls == [1, 1]
@@ -398,6 +452,7 @@ def test_warm_caches_quiet_skips_cpu_and_vector_warmup(
         def inner(*_args, **_kwargs):
             forbidden.append(name)
             raise AssertionError(f"{name} should not warm in quiet mode")
+
         return inner
 
     monkeypatch.setattr(bm25, "warm", _forbid("bm25"))
@@ -456,9 +511,7 @@ def test_warm_all_drains_deferred_write_embeds_after_embeddings_ready(
         drained_calls.append((vr, list(paths)))
         return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
 
-    monkeypatch.setattr(
-        embeddings, "upsert_after_write_status", completed
-    )
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", completed)
 
     readiness.begin_warm()  # so the manual defer() below actually records
     some_paths = (tmp_path / "a.md", tmp_path / "b.md")
@@ -495,9 +548,7 @@ def test_warm_all_drains_deferred_write_embeds_even_when_bge_preload_fails(
         drained_calls.append((vr, list(paths)))
         return embeddings.EmbeddingSyncStatus("completed", "test", len(paths))
 
-    monkeypatch.setattr(
-        embeddings, "upsert_after_write_status", completed
-    )
+    monkeypatch.setattr(embeddings, "upsert_after_write_status", completed)
 
     readiness.begin_warm()  # so the manual defer() below actually records
     some_paths = (tmp_path / "a.md", tmp_path / "b.md")
@@ -796,9 +847,7 @@ def test_op_find_warming_envelope_mid_warm_then_bare_list_after_finish(
 # ============================================================================
 
 
-def test_bm25_build_lock_serializes_concurrent_cold_builds(
-    vault: Path, monkeypatch
-) -> None:
+def test_bm25_build_lock_serializes_concurrent_cold_builds(vault: Path, monkeypatch) -> None:
     """Two threads racing .search() on a cold BM25Index must produce exactly
     ONE _build() call — the loser waits on the build lock and reuses the
     winner's freshly-cached corpus instead of rebuilding.
@@ -869,9 +918,7 @@ def test_upsert_after_write_defers_during_warm_without_loading_model(
     drained_vault, drained_paths, receipts = drained[0]
     assert drained_vault == tmp_path
     assert list(drained_paths) == [md_path]
-    assert [receipt.rel_path for receipt in receipts] == [
-        "Knowledge Base/Notes/probe.md"
-    ]
+    assert [receipt.rel_path for receipt in receipts] == ["Knowledge Base/Notes/probe.md"]
     assert readiness.mark_ready("embeddings") == []  # drained exactly once
 
 
@@ -954,9 +1001,7 @@ def test_uppercase_markdown_warm_defer_has_durable_receipt(
     assert item_vault == tmp_path
     assert list(item_paths) == [path]
     assert list(receipts) == deferred_index.snapshot(tmp_path)
-    assert [receipt.rel_path for receipt in receipts] == [
-        "Knowledge Base/Notes/uppercase.MD"
-    ]
+    assert [receipt.rel_path for receipt in receipts] == ["Knowledge Base/Notes/uppercase.MD"]
 
 
 @pytest.mark.parametrize(
@@ -984,9 +1029,7 @@ def test_warm_replay_receipt_outcomes_and_no_second_defer(
     rel = path.relative_to(tmp_path).as_posix()
     [receipt] = deferred_index.add_receipts(tmp_path, [rel])
     readiness.begin_warm()
-    assert readiness.defer(
-        "embeddings", (tmp_path, (path,), (receipt,))
-    ) is True
+    assert readiness.defer("embeddings", (tmp_path, (path,), (receipt,))) is True
 
     if preload_succeeds:
         monkeypatch.setattr(embeddings, "get_model", lambda: object())
@@ -1027,13 +1070,9 @@ def test_disabled_warm_drains_memory_but_preserves_durable_receipt(
     path = tmp_path / "Knowledge Base" / "Notes" / "disabled.md"
     path.parent.mkdir(parents=True)
     path.write_text("# disabled\n", encoding="utf-8")
-    [receipt] = deferred_index.add_receipts(
-        tmp_path, [path.relative_to(tmp_path).as_posix()]
-    )
+    [receipt] = deferred_index.add_receipts(tmp_path, [path.relative_to(tmp_path).as_posix()])
     readiness.begin_warm()
-    assert readiness.defer(
-        "embeddings", (tmp_path, (path,), (receipt,))
-    ) is True
+    assert readiness.defer("embeddings", (tmp_path, (path,), (receipt,))) is True
     monkeypatch.setattr(
         embeddings,
         "upsert_after_write_status",

--- a/tests/test_lexical_backend_fallback.py
+++ b/tests/test_lexical_backend_fallback.py
@@ -9,6 +9,7 @@ lanes this backend serves.
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -103,10 +104,14 @@ def test_kill_switch_forces_python_rung(tmp_path, monkeypatch):
     assert not lexstore.lexical_path(tmp_path).exists()
 
 
-def test_unavailable_fts5_serves_python_rung_without_degradation(tmp_path, monkeypatch):
+def test_unavailable_fts5_keeps_primary_python_rung_but_marks_widening_unavailable(
+    tmp_path, monkeypatch
+):
     """Forced FTS5-unavailable (the custom-build shape): bm25.search answers
-    from rank-bm25, find() records NO lane degradation for the fallback, and
-    the keyword lane still works. Runs on every install."""
+    from rank-bm25 and the keyword lane still works. The optional outside-KB
+    lane reports its maintained index as unavailable instead of launching a
+    second whole-vault Python build. Runs on every install."""
+
     def _boom(conn):
         raise sqlite3.OperationalError("no such module: fts5")
 
@@ -122,12 +127,17 @@ def test_unavailable_fts5_serves_python_rung_without_degradation(tmp_path, monke
     degraded: list[str] = []
     failed: list[str] = []
     out = find_module.find(
-        tmp_path, query="terraform locking", mode="hybrid", limit=5,
-        degraded_out=degraded, failed_out=failed,
+        tmp_path,
+        query="terraform locking",
+        mode="hybrid",
+        limit=5,
+        degraded_out=degraded,
+        failed_out=failed,
     )
     assert out and out[0].path == "Knowledge Base/doc.md"
-    assert find_module.degradation_counts() == before  # fallback is silent
-    assert "bm25" not in failed and "keyword" not in failed
+    after = find_module.degradation_counts()
+    assert after.get("outside_kb_lexical", 0) == before.get("outside_kb_lexical", 0) + 1
+    assert failed == ["outside_kb_lexical"]
     assert not lexstore.lexical_path(tmp_path).exists()
 
 
@@ -141,8 +151,13 @@ def test_hybrid_find_end_to_end_under_fts5(tmp_path):
     degraded: list[str] = []
     failed: list[str] = []
     out = find_module.find(
-        tmp_path, query="distributed tracing", mode="hybrid", limit=5,
-        timings=t, degraded_out=degraded, failed_out=failed,
+        tmp_path,
+        query="distributed tracing",
+        mode="hybrid",
+        limit=5,
+        timings=t,
+        degraded_out=degraded,
+        failed_out=failed,
     )
     assert out and out[0].path == "Knowledge Base/hit.md"
     assert out[0].bm25_rank == 1
@@ -191,9 +206,7 @@ def test_bm25_match_sets_agree_between_backends(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("backend", ["python", "fts5"])
-def test_bm25_allowed_paths_are_applied_before_top_k(
-    tmp_path, monkeypatch, backend
-):
+def test_bm25_allowed_paths_are_applied_before_top_k(tmp_path, monkeypatch, backend):
     """An eligible lower-ranked page must not be buried by excluded hits."""
     if backend == "fts5" and not _HAS_FTS5:
         pytest.skip("SQLite build lacks FTS5")
@@ -227,34 +240,53 @@ def test_bm25_allowed_paths_are_applied_before_top_k(
 def _parity_corpus(root: Path) -> None:
     """Pages engineered to stress every clause of the substring contract."""
     _write_page(root, "Knowledge Base/plain.md", "employment contract terms", updated="2026-03-01")
-    _write_page(root, "Knowledge Base/midword.md", "the xylophones sang loudly", updated="2026-02-01")
-    _write_page(root, "Knowledge Base/title-only.md", "unrelated body", title="Budget Overview", updated="2026-04-01")
+    _write_page(
+        root, "Knowledge Base/midword.md", "the xylophones sang loudly", updated="2026-02-01"
+    )
+    _write_page(
+        root,
+        "Knowledge Base/title-only.md",
+        "unrelated body",
+        title="Budget Overview",
+        updated="2026-04-01",
+    )
     _write_page(root, "Knowledge Base/short.md", "xq marks the spot", updated="2026-01-15")
-    _write_page(root, "Knowledge Base/meta.md", "growth was 42% in snake_case", updated="2026-01-10")
-    _write_page(root, "Knowledge Base/uni.md", "tere tulemast Tallinnasse sõbrad", updated="2026-01-05")
-    _write_page(root, "Knowledge Base/sub/nested.md", "employment law contract precedent", updated="2026-05-01")
-    _write_page(root, "Knowledge Base/index.md", "employment xylophones budget xq", updated="2026-06-01")
+    _write_page(
+        root, "Knowledge Base/meta.md", "growth was 42% in snake_case", updated="2026-01-10"
+    )
+    _write_page(
+        root, "Knowledge Base/uni.md", "tere tulemast Tallinnasse sõbrad", updated="2026-01-05"
+    )
+    _write_page(
+        root,
+        "Knowledge Base/sub/nested.md",
+        "employment law contract precedent",
+        updated="2026-05-01",
+    )
+    _write_page(
+        root, "Knowledge Base/index.md", "employment xylophones budget xq", updated="2026-06-01"
+    )
     _write_page(root, "Knowledge Base/punct.md", "+++ ~~~ !!!", updated="2026-01-02")
     _write_page(root, "Knowledge Base/same-date-b.md", "twin content marker", updated="2026-02-02")
     _write_page(root, "Knowledge Base/same-date-a.md", "twin content marker", updated="2026-02-02")
 
 
 _PARITY_QUERIES = [
-    "contract employment",     # multi-token, order-free
-    "ylophon",                 # mid-word
-    "budget",                  # title-only match
-    "xq",                      # 2-char needle
-    "q",                       # 1-char needle
-    "42%",                     # LIKE metachar %
-    "e_c",                     # LIKE metachar _
-    "sõbra",                   # non-ASCII
-    "tallinnasse",             # case-folding
-    "~~~",                     # punctuation-only page
-    "twin marker",             # tie on updated → path tie-break
-    "xq spot",                 # short + indexable token mix
-    "employment",              # multiple matches, ordering
-    "zzz-no-such-token",       # empty result
-    "",                        # empty query → empty lane
+    "contract employment",  # multi-token, order-free
+    "ylophon",  # mid-word
+    "budget",  # title-only match
+    "xq",  # 2-char needle
+    "q",  # 1-char needle
+    "42%",  # LIKE metachar %
+    "e_c",  # LIKE metachar _
+    "sõbra",  # non-ASCII
+    "tallinnasse",  # case-folding
+    "~~~",  # punctuation-only page
+    "twin marker",  # tie on updated → path tie-break
+    "xq spot",  # short + indexable token mix
+    "employment",  # multiple matches, ordering
+    "zzz-no-such-token",  # empty result
+    "",  # empty query → empty lane
 ]
 
 
@@ -309,3 +341,106 @@ def test_keyword_parity_after_edit_and_delete(tmp_path, monkeypatch):
     assert indexed == reference
     assert "Knowledge Base/late.md" in indexed
     assert "Knowledge Base/plain.md" not in indexed
+
+
+# ------------------------------------------------ foreground repair boundary
+
+
+@needs_fts5
+def test_nonrepairing_searches_return_none_and_schedule_one_background_repair(
+    tmp_path, monkeypatch
+):
+    """A missing sidecar never turns a foreground request into a corpus build.
+
+    All three search APIs share one per-vault repair flight, so a burst of
+    callers remains cheap while the maintained sidecar catches up once.
+    """
+    _write_page(tmp_path, "Knowledge Base/a.md", "one searchable decision")
+    store = lexstore.get_store(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    calls = 0
+
+    def _background_repair():
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait(timeout=5)
+        finished.set()
+
+    monkeypatch.setattr(store, "ensure_fresh", _background_repair)
+
+    assert lexstore.search_bm25(tmp_path, "searchable", 5, repair=False) is None
+    assert started.wait(timeout=2)
+    assert lexstore.search_substring(tmp_path, "searchable", repair=False) is None
+    assert lexstore.search_semantic_units(tmp_path, "decision", 5, repair=False) is None
+    assert calls == 1
+    assert not lexstore.lexical_path(tmp_path).exists()
+
+    release.set()
+    assert finished.wait(timeout=2)
+
+
+@needs_fts5
+def test_nonrepairing_search_does_not_heal_a_stale_sidecar(tmp_path, monkeypatch):
+    """Detected drift is handed to the repair worker, never healed inline."""
+    _write_page(tmp_path, "Knowledge Base/a.md", "stable searchable payload")
+    assert lexstore.search_bm25(tmp_path, "searchable", 5)
+    store = lexstore.get_store(tmp_path)
+
+    _write_page(tmp_path, "Knowledge Base/b.md", "new drifted payload")
+    current = bm25.corpus_key(tmp_path, "kb")
+    repairs: list[str] = []
+    repair_started = threading.Event()
+    repair_release = threading.Event()
+    repair_finished = threading.Event()
+
+    def _forbidden_rebuild(*_args, **_kwargs):
+        repairs.append("rebuild")
+        raise AssertionError("foreground search rebuilt the lexical sidecar")
+
+    def _forbidden_heal(*_args, **_kwargs):
+        repairs.append("heal")
+        raise AssertionError("foreground search healed the lexical sidecar")
+
+    def _background_repair():
+        repair_started.set()
+        repair_release.wait(timeout=5)
+        repair_finished.set()
+
+    monkeypatch.setattr(store, "_rebuild", _forbidden_rebuild)
+    monkeypatch.setattr(store, "_heal_delta", _forbidden_heal)
+    monkeypatch.setattr(store, "ensure_fresh", _background_repair)
+
+    assert (
+        lexstore.search_bm25(
+            tmp_path,
+            "drifted",
+            5,
+            freshness=current,
+            repair=False,
+        )
+        is None
+    )
+    assert repairs == []
+    assert repair_started.wait(timeout=2)
+    repair_release.set()
+    assert repair_finished.wait(timeout=2)
+
+
+@needs_fts5
+def test_nonrepairing_search_serves_an_already_fresh_sidecar(tmp_path):
+    _write_page(tmp_path, "Knowledge Base/a.md", "stable searchable payload")
+    assert lexstore.search_bm25(tmp_path, "searchable", 5)
+    current = bm25.corpus_key(tmp_path, "kb")
+
+    hits = lexstore.search_bm25(
+        tmp_path,
+        "searchable",
+        5,
+        freshness=current,
+        repair=False,
+    )
+
+    assert hits and hits[0][0] == "Knowledge Base/a.md"

--- a/tests/test_retrieval_explainability.py
+++ b/tests/test_retrieval_explainability.py
@@ -15,10 +15,12 @@ from exomem import (
     epistemic_graph,
     find_candidates,
     readiness,
+    semantic_index,
 )
 from exomem import (
     find as find_module,
 )
+from exomem.embedding_index import SemanticUnitVectorHit
 from exomem.ranking_config import RankingConfig
 from exomem.retrieval_explain import RetrievalTrace, attach_hit_explanations
 
@@ -585,19 +587,30 @@ def test_unit_vector_success_marks_lexical_non_applicable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _write_unit_page(tmp_path)
-
-    class UnitVectorHit:
-        def __init__(self, unit_ref: str, cosine: float) -> None:
-            self.unit_ref = unit_ref
-            self.cosine = cosine
+    rel = _write_unit_page(tmp_path)
+    state = semantic_index.current_parent_index_state(tmp_path, rel)
 
     class FakeUnitIndex:
         def search_semantic_units(
-            self, _query_vector, *, k: int, allowed_unit_refs: set[str]
+            self,
+            _query_vector,
+            *,
+            k: int,
+            allowed_unit_refs: set[str],
+            validate: bool,
         ):
+            assert validate is False
             unit_ref = sorted(allowed_unit_refs)[0]
-            return [UnitVectorHit(unit_ref, 0.876543219)]
+            return [
+                SemanticUnitVectorHit(
+                    unit_ref,
+                    rel,
+                    state.parent_generation,
+                    state.parent_source_hash,
+                    state.parser_version,
+                    0.876543219,
+                )
+            ]
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setattr(
@@ -637,19 +650,30 @@ def test_unit_hybrid_vector_only_is_single_lane_without_fabricated_fusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _write_unit_page(tmp_path)
-
-    class UnitVectorHit:
-        def __init__(self, unit_ref: str, cosine: float) -> None:
-            self.unit_ref = unit_ref
-            self.cosine = cosine
+    rel = _write_unit_page(tmp_path)
+    state = semantic_index.current_parent_index_state(tmp_path, rel)
 
     class FakeUnitIndex:
         def search_semantic_units(
-            self, _query_vector, *, k: int, allowed_unit_refs: set[str]
+            self,
+            _query_vector,
+            *,
+            k: int,
+            allowed_unit_refs: set[str],
+            validate: bool,
         ):
+            assert validate is False
             unit_ref = sorted(allowed_unit_refs)[0]
-            return [UnitVectorHit(unit_ref, 0.7654321)]
+            return [
+                SemanticUnitVectorHit(
+                    unit_ref,
+                    rel,
+                    state.parent_generation,
+                    state.parent_source_hash,
+                    state.parser_version,
+                    0.7654321,
+                )
+            ]
 
     monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
     monkeypatch.setattr(

--- a/tests/test_semantic_unit_recall.py
+++ b/tests/test_semantic_unit_recall.py
@@ -55,12 +55,15 @@ def _rich(
     content: str,
     tags: str | None = None,
     context: str | None = None,
+    relations: str | None = None,
 ) -> str:
     metadata = [f"- category: {category}", f"- id: {anchor}"]
     if tags is not None:
         metadata.append(f"- tags: {tags}")
     if context is not None:
         metadata.append(f"- context: {context}")
+    if relations is not None:
+        metadata.append(f"- relations: {relations}")
     metadata_text = "\n".join(metadata)
     return f"## {kind.title()}\n{metadata_text}\n\n{content}\n"
 
@@ -252,7 +255,7 @@ def test_unit_keyword_mode_requires_every_literal_query_token(tmp_path: Path) ->
     assert [hit.as_dict()["source_anchor"] for hit in hits] == ["all-keywords"]
 
 
-def test_unit_vector_lane_filters_exact_refs_before_ranking(
+def test_unit_vector_lane_filters_exact_parents_after_bounded_ranking(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -287,11 +290,12 @@ def test_unit_vector_lane_filters_exact_refs_before_ranking(
         lambda _texts, *, is_query: np.stack([_vector(1.0)]),
     )
 
-    observed: list[set[str]] = []
+    observed: list[tuple[set[str] | None, bool]] = []
     original_search = index.search_semantic_units
 
     def observed_search(*args: Any, **kwargs: Any) -> Any:
-        observed.append(set(kwargs["allowed_unit_refs"]))
+        allowed = kwargs["allowed_unit_refs"]
+        observed.append((set(allowed) if allowed is not None else None, kwargs["validate"]))
         return original_search(*args, **kwargs)
 
     monkeypatch.setattr(index, "search_semantic_units", observed_search)
@@ -306,11 +310,7 @@ def test_unit_vector_lane_filters_exact_refs_before_ranking(
         limit=10,
     )
 
-    expected_refs = {
-        states[0].document.units[0].unit_ref,
-        states[1].document.units[0].unit_ref,
-    }
-    assert observed == [expected_refs]
+    assert observed == [(None, False)]
     payloads = [hit.as_dict() for hit in hits]
     assert [payload["source_anchor"] for payload in payloads] == [
         "active-vector",
@@ -318,6 +318,87 @@ def test_unit_vector_lane_filters_exact_refs_before_ranking(
     ]
     assert [payload["signals"]["vector_rank"] for payload in payloads] == [1, 2]
     assert all("bm25_rank" not in payload["signals"] for payload in payloads)
+
+
+def test_unit_vector_category_filter_is_pushed_down_before_candidate_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index = embeddings.get_embedding_index(tmp_path)
+    for rank in range(20):
+        page = _write_page(
+            tmp_path,
+            f"architecture-{rank:02d}",
+            body=f"- [architecture] higher vector candidate {rank} ^architecture-{rank}",
+        )
+        state = semantic_index.build_parent_index_state(tmp_path, page)
+        index.upsert_semantic_units(
+            state,
+            np.stack([_vector(1.0, rank / 100.0)]),
+            1.0,
+        )
+    target = _write_page(
+        tmp_path,
+        "reliability-target",
+        body="- [reliability] exact category target ^reliability-target",
+    )
+    target_state = semantic_index.build_parent_index_state(tmp_path, target)
+    index.upsert_semantic_units(target_state, np.stack([_vector(0.1, 1.0)]), 1.0)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda _texts, *, is_query: np.stack([_vector(1.0)]),
+    )
+
+    failed: list[str] = []
+    hits = find_module.find(
+        tmp_path,
+        query="vector-only-no-literal",
+        scope="kb-only",
+        mode="vector",
+        graph=False,
+        result_level="unit",
+        categories=["reliability"],
+        failed_out=failed,
+        limit=1,
+    )
+
+    assert [hit.as_dict()["source_anchor"] for hit in hits] == ["reliability-target"]
+    assert failed == []
+
+
+def test_rich_unit_recall_preserves_typed_relations(tmp_path: Path) -> None:
+    _write_page(
+        tmp_path,
+        "rich-relations",
+        body=_rich(
+            kind="decision",
+            category="architecture",
+            anchor="bounded-sidecar",
+            content="Use the bounded lexical sidecar for foreground recall.",
+            relations="evidenced_by: [[Knowledge Base/Sources/Latency benchmark]]",
+        ),
+    )
+
+    hits = find_module.find(
+        tmp_path,
+        query="bounded lexical sidecar",
+        scope="kb-only",
+        mode="keyword",
+        graph=False,
+        result_level="unit",
+        limit=5,
+    )
+
+    assert hits[0].as_dict()["relations"] == [
+        {
+            "kind": "evidenced_by",
+            "target": "[[Knowledge Base/Sources/Latency benchmark]]",
+            "raw": "evidenced_by: [[Knowledge Base/Sources/Latency benchmark]]",
+            "line": 6,
+        }
+    ]
 
 
 def test_unit_vector_lane_rejects_stale_rows_before_top_k(tmp_path: Path) -> None:

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from exomem import readiness
 from exomem import vault as vault_module
 from exomem import writer_lease as writer_lease_module
 from exomem.cli_ops import OpError, error_dict, http_status_for
@@ -30,9 +31,7 @@ from exomem.writer_lease import (
 
 
 def _committed_error(tmp_path: Path, *, targets: tuple[str, ...] = ("note.md",)):
-    raw = PermissionError(
-        f"{tmp_path}/.exomem-batch-{'a' * 32}/stage-0.tmp: raw storage detail"
-    )
+    raw = PermissionError(f"{tmp_path}/.exomem-batch-{'a' * 32}/stage-0.tmp: raw storage detail")
     error = vault_module.BatchWriteError(
         "BATCH_CLEANUP_INCOMPLETE",
         vault_module.BatchTargetSummary(len(targets), targets, 0),
@@ -198,9 +197,7 @@ class StoreClient:
         return LeaseRecord.from_json(self.store.status("main"))
 
     def renew(self, fencing_token: int) -> LeaseRecord:
-        return LeaseRecord.from_json(
-            self.store.renew("main", self.replica_id, fencing_token, 10)
-        )
+        return LeaseRecord.from_json(self.store.renew("main", self.replica_id, fencing_token, 10))
 
     def release(self, fencing_token: int) -> LeaseRecord:
         return LeaseRecord.from_json(self.store.release("main", self.replica_id, fencing_token))
@@ -312,11 +309,14 @@ def test_read_only_invocation_bypasses_held_mutation_boundary(tmp_path: Path) ->
     assert entered.wait(1.0)
     manager = LeaseManager(LeaseConfig(state_dir=state_root))
     try:
-        assert manager.invoke(
-            _command(writes=False, leaf=lambda _vault: "read"),
-            (vault,),
-            {},
-        ) == "read"
+        assert (
+            manager.invoke(
+                _command(writes=False, leaf=lambda _vault: "read"),
+                (vault,),
+                {},
+            )
+            == "read"
+        )
     finally:
         release.set()
         thread.join(timeout=2.0)
@@ -509,26 +509,18 @@ def _recording_product_command(command, calls: list[dict], result: str):  # noqa
     ("command_name", "kwargs"),
     [
         pytest.param("connect_memory", {}, id="connect-default-suggest-links"),
-        pytest.param(
-            "connect_memory", {"operation": "suggest-links"}, id="connect-suggest-links"
-        ),
+        pytest.param("connect_memory", {"operation": "suggest-links"}, id="connect-suggest-links"),
         pytest.param(
             "connect_memory",
             {"operation": "suggest-relations"},
             id="connect-suggest-relations",
         ),
         pytest.param("connect_memory", {"operation": "context"}, id="connect-context"),
-        pytest.param(
-            "connect_memory", {"operation": "graph-context"}, id="connect-graph-context"
-        ),
-        pytest.param(
-            "connect_memory", {"operation": "inbound-links"}, id="connect-inbound-links"
-        ),
+        pytest.param("connect_memory", {"operation": "graph-context"}, id="connect-graph-context"),
+        pytest.param("connect_memory", {"operation": "inbound-links"}, id="connect-inbound-links"),
         pytest.param("adopt_vault", {}, id="adopt-default-scan-only"),
         pytest.param("adopt_vault", {"mode": "scan-only"}, id="adopt-scan-only"),
-        pytest.param(
-            "observe_memory", {"operation": "validate"}, id="observe-validate"
-        ),
+        pytest.param("observe_memory", {"operation": "validate"}, id="observe-validate"),
     ],
 )
 def test_read_only_product_operations_bypass_unreachable_coordinator(
@@ -598,9 +590,7 @@ def test_explicit_process_media_hash_yields_global_guard_and_replays_idempotentl
         mutation_timeout_seconds=0.05,
     )
     command = next(
-        command
-        for command in product_commands_for("mcp")
-        if command.name == "process_media"
+        command for command in product_commands_for("mcp") if command.name == "process_media"
     )
     monkeypatch.setattr(writer_lease_module, "get_manager", lambda: manager)
     hash_started = threading.Event()
@@ -705,9 +695,7 @@ def test_pathless_process_media_propagates_per_artifact_mutation_busy(
     )
     monkeypatch.setattr(writer_lease_module, "get_manager", lambda: manager)
     command = next(
-        command
-        for command in product_commands_for("mcp")
-        if command.name == "process_media"
+        command for command in product_commands_for("mcp") if command.name == "process_media"
     )
     held = threading.Event()
     release = threading.Event()
@@ -812,25 +800,17 @@ def test_omitted_selector_fails_closed_when_leaf_default_is_not_known_read_only(
 @pytest.mark.parametrize(
     ("command_name", "kwargs"),
     [
-        pytest.param(
-            "connect_memory", {"operation": "create-entity"}, id="connect-create-entity"
-        ),
+        pytest.param("connect_memory", {"operation": "create-entity"}, id="connect-create-entity"),
         pytest.param(
             "connect_memory", {"operation": "accept-relation"}, id="connect-accept-relation"
         ),
         pytest.param("connect_memory", {"operation": ""}, id="connect-empty"),
         pytest.param("connect_memory", {"operation": None}, id="connect-explicit-none"),
         pytest.param("connect_memory", {"operation": "entity"}, id="connect-nonexistent-entity"),
-        pytest.param(
-            "connect_memory", {"operation": "future-read-mode"}, id="connect-future-mode"
-        ),
+        pytest.param("connect_memory", {"operation": "future-read-mode"}, id="connect-future-mode"),
         pytest.param("adopt_vault", {"mode": "save-manifest"}, id="adopt-save-manifest"),
-        pytest.param(
-            "adopt_vault", {"mode": "copy-as-sources"}, id="adopt-copy-as-sources"
-        ),
-        pytest.param(
-            "adopt_vault", {"mode": "compile-selected"}, id="adopt-compile-selected"
-        ),
+        pytest.param("adopt_vault", {"mode": "copy-as-sources"}, id="adopt-copy-as-sources"),
+        pytest.param("adopt_vault", {"mode": "compile-selected"}, id="adopt-compile-selected"),
         pytest.param("adopt_vault", {"mode": ""}, id="adopt-empty"),
         pytest.param("adopt_vault", {"mode": None}, id="adopt-explicit-none"),
         pytest.param("adopt_vault", {"mode": "future-mode"}, id="adopt-future-mode"),
@@ -838,9 +818,7 @@ def test_omitted_selector_fails_closed_when_leaf_default_is_not_known_read_only(
         pytest.param("observe_memory", {"operation": "add"}, id="observe-add"),
         pytest.param("observe_memory", {"operation": "update"}, id="observe-update"),
         pytest.param("observe_memory", {"operation": "remove"}, id="observe-remove"),
-        pytest.param(
-            "observe_memory", {"operation": "future-mode"}, id="observe-future-mode"
-        ),
+        pytest.param("observe_memory", {"operation": "future-mode"}, id="observe-future-mode"),
         pytest.param("remember", {}, id="generic-write-capable-command"),
     ],
 )
@@ -1099,8 +1077,7 @@ def test_identical_orphaned_pending_reports_acknowledgement_uncertain(
     )[0]
     with sqlite3.connect(manager.idempotency.path) as connection:
         connection.execute(
-            "INSERT INTO mutations(key, digest, state, updated_at) "
-            "VALUES (?, ?, 'pending', ?)",
+            "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
             (key, digest, 100.0),
         )
 
@@ -1187,6 +1164,30 @@ def test_different_identity_busy_is_precommit(tmp_path: Path) -> None:
     worker.join(timeout=2)
     assert outcome == ["committed"]
     assert first_calls == ["first"]
+
+
+def test_mutation_during_semantic_warm_returns_without_holding_boundary(
+    tmp_path: Path,
+) -> None:
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path))
+    calls: list[str] = []
+    command = _command(writes=True, leaf=lambda: calls.append("called"))
+    readiness.begin_warm()
+    readiness.mark_ready("lexical")
+    try:
+        with pytest.raises(OpError) as warming:
+            manager.invoke(command, (), {}, mutation_request_id="warm-request")
+    finally:
+        readiness.reset()
+
+    assert warming.value.code == "MUTATION_WARMING"
+    payload = error_dict(warming.value)
+    assert payload["status"] == "retryable"
+    assert payload["committed"] is False
+    assert payload["retry_after_ms"] == 750
+    assert payload["request_id"] == "warm-request"
+    assert calls == []
+    assert writer_lease_module.active_mutation_snapshot()["state"] == "free"
 
 
 def test_postcommit_error_cannot_escape_as_precommit_retryable(tmp_path: Path) -> None:
@@ -1281,9 +1282,7 @@ def test_uncommitted_result_receipt_failure_does_not_claim_commit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls = 0
-    manager = LeaseManager(
-        LeaseConfig(state_dir=tmp_path / "state"), idempotency_wait_seconds=0
-    )
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"), idempotency_wait_seconds=0)
 
     def validate_only() -> dict[str, bool]:
         nonlocal calls
@@ -1345,9 +1344,7 @@ def test_hosted_audit_does_not_hold_mutation_boundary(
         return "audited"
 
     audit = SimpleNamespace(name="maintain_memory", read_only=False, leaf=audit_leaf)
-    mutation = SimpleNamespace(
-        name="remember", read_only=False, leaf=lambda _vault: "committed"
-    )
+    mutation = SimpleNamespace(name="remember", read_only=False, leaf=lambda _vault: "committed")
     monkeypatch.setattr(writer_lease_module, "content_private_logging_enabled", lambda: True)
 
     def run_audit() -> None:
@@ -1385,12 +1382,8 @@ def test_hosted_public_audit_routes_bypass_boundary_held_by_other_manager(
     state_dir = tmp_path / "shared-state"
     vault = tmp_path / "vault"
     vault.mkdir()
-    holder = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0
-    )
-    auditor = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0
-    )
+    holder = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
+    auditor = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
     boundary_held = threading.Event()
     release_boundary = threading.Event()
 
@@ -1444,12 +1437,8 @@ def test_hosted_mutation_previews_bypass_boundary_held_by_other_manager(
     state_dir = tmp_path / "shared-state"
     vault = tmp_path / "vault"
     vault.mkdir()
-    holder = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0
-    )
-    previewer = LeaseManager(
-        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0
-    )
+    holder = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
+    previewer = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
     boundary_held = threading.Event()
     release_boundary = threading.Event()
 
@@ -1461,9 +1450,7 @@ def test_hosted_mutation_previews_bypass_boundary_held_by_other_manager(
     worker = threading.Thread(target=hold_boundary, daemon=True)
     worker.start()
     assert boundary_held.wait(timeout=2)
-    monkeypatch.setattr(
-        writer_lease_module, "content_private_logging_enabled", lambda: True
-    )
+    monkeypatch.setattr(writer_lease_module, "content_private_logging_enabled", lambda: True)
     command = SimpleNamespace(
         name=command_name,
         read_only=False,
@@ -1471,10 +1458,7 @@ def test_hosted_mutation_previews_bypass_boundary_held_by_other_manager(
     )
 
     try:
-        assert (
-            previewer.invoke(command, (vault,), kwargs, read_only=True)
-            == "previewed"
-        )
+        assert previewer.invoke(command, (vault,), kwargs, read_only=True) == "previewed"
     finally:
         release_boundary.set()
         worker.join(timeout=2)
@@ -1500,27 +1484,36 @@ def test_explicit_idempotency_is_isolated_by_principal(tmp_path: Path) -> None:
     manager = LeaseManager(LeaseConfig(state_dir=tmp_path))
     command = _command(writes=True, leaf=lambda: calls.append("write") or len(calls))
 
-    assert manager.invoke(
-        command,
-        (),
-        {},
-        idempotency_key="same-public-key",
-        idempotency_principal_scope="principal:alice",
-    ) == 1
-    assert manager.invoke(
-        command,
-        (),
-        {},
-        idempotency_key="same-public-key",
-        idempotency_principal_scope="principal:bob",
-    ) == 2
-    assert manager.invoke(
-        command,
-        (),
-        {},
-        idempotency_key="same-public-key",
-        idempotency_principal_scope="principal:alice",
-    ) == 1
+    assert (
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="same-public-key",
+            idempotency_principal_scope="principal:alice",
+        )
+        == 1
+    )
+    assert (
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="same-public-key",
+            idempotency_principal_scope="principal:bob",
+        )
+        == 2
+    )
+    assert (
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="same-public-key",
+            idempotency_principal_scope="principal:alice",
+        )
+        == 1
+    )
     assert calls == ["write", "write"]
 
 
@@ -1722,11 +1715,14 @@ def _invalid_committed_payloads(valid: dict) -> list[tuple[str, dict]]:
     add("boolean omitted", lambda value: value["outcome"].update(omitted_target_count=False))
     add("mismatched omitted", lambda value: value["outcome"].update(omitted_target_count=1))
     add("targets not list", lambda value: value["outcome"].update(targets=("note.md",)))
-    add("too many targets", lambda value: value["outcome"].update(
-        affected_count=17,
-        targets=[f"note-{index}.md" for index in range(17)],
-        omitted_target_count=0,
-    ))
+    add(
+        "too many targets",
+        lambda value: value["outcome"].update(
+            affected_count=17,
+            targets=[f"note-{index}.md" for index in range(17)],
+            omitted_target_count=0,
+        ),
+    )
     for name, target in (
         ("empty target", ""),
         ("absolute target", "/vault/note.md"),
@@ -1851,8 +1847,7 @@ def test_corrupt_implicit_committed_failure_timestamp_fails_closed_without_reinv
         manager.invoke(command, (), {}, **marker)
     with sqlite3.connect(manager.idempotency.path) as connection:
         connection.execute(
-            "UPDATE mutations SET updated_at = 'corrupt' "
-            "WHERE state = 'committed_failure'"
+            "UPDATE mutations SET updated_at = 'corrupt' WHERE state = 'committed_failure'"
         )
 
     with pytest.raises(OpError) as blocked:
@@ -2262,7 +2257,5 @@ def test_public_coordination_command_forwards_its_injected_vault(
         return {"mutation_boundary": {"state": "free"}}
 
     monkeypatch.setattr(writer_lease, "coordination_status", fake_status)
-    assert commands.op_coordination_status(vault) == {
-        "mutation_boundary": {"state": "free"}
-    }
+    assert commands.op_coordination_status(vault) == {"mutation_boundary": {"state": "free"}}
     assert observed == [vault]


### PR DESCRIPTION
## Summary

- restore bounded warm retrieval and guarded-write performance with event-maintained semantic corpus state, indexed semantic-unit/category recall, bounded lexical repair, and rich typed relation projection
- keep restart-time semantic warm-up outside the mutation boundary with retryable `MUTATION_WARMING`, exact-page event-lag repair, and fail-closed alias/reparse continuity handling
- align lean CLI/service installs, preserve `exomem find`, expose cheap version provenance, and skip absent local ML lanes without raw Torch/sentence-transformers warnings

## Verification

- focused final matrix: 407 passed (1 Windows named-pipe test deselected)
- post-hardening semantic/retrieval/safety matrix: 132 passed (1 Windows named-pipe test deselected)
- privacy/public artifact tests: 53 passed; repository validator clean across 1,563 inputs
- independent verifier: 259 passed, 3 Git Bash platform skips
- 2k pages: validate median/p95 27.5/31.0 ms; commit median/p95 95.4/113.0 ms
- 8k pages: validate median/p95 70.6/73.7 ms; commit median/p95 115.9/118.1 ms
- Ruff and format checks clean; OpenSpec strict validation clean; sdist and wheel build clean

## Delivery note

OpenSpec task 6.5 intentionally remains post-merge: validate the live managed connector and guarded commit/read-back after the release is deployed, without recording private content.