### PR TITLE
fix(hooks): parse Codex stop events

### DIFF
--- a/src/exomem/_hooks/exomem_capture_nudge.py
+++ b/src/exomem/_hooks/exomem_capture_nudge.py
@@ -121,11 +121,44 @@ def _content_blocks(msg: dict) -> list[dict]:
         out: list[dict] = []
         for b in c:
             if isinstance(b, dict):
-                out.append(b)
+                if b.get("type") in {"input_text", "output_text"}:
+                    out.append({**b, "type": "text"})
+                else:
+                    out.append(b)
             elif isinstance(b, str):
                 out.append({"type": "text", "text": b})
         return out
     return []
+
+
+def _codex_call_output_succeeded(output: object) -> bool:
+    """Confirm a Codex function call completed without an MCP error.
+
+    Codex 0.144.x stores connector output as a timing prelude followed by an
+    ``Output:`` JSON object. There is no positive status field, so malformed or
+    missing output stays unconfirmed and must not suppress the capture check.
+    """
+    if not isinstance(output, str):
+        return False
+    match = re.search(r"(?:^|\n)Output:\s*", output)
+    if not match:
+        return False
+    try:
+        result = json.loads(output[match.end() :].strip())
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(result, dict):
+        return False
+    if result.get("error") or result.get("error_code"):
+        return False
+    error_data = result.get("error_data")
+    if isinstance(error_data, dict):
+        if error_data.get("type") == "mcp_tool_execution_error":
+            return False
+        nested = error_data.get("result")
+        if isinstance(nested, dict) and nested.get("isError") is True:
+            return False
+    return True
 
 
 def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[dict]]:
@@ -144,15 +177,53 @@ def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[dict]]:
     chunks: list[str] = []
     tools: list[dict] = []
     failed_tool_ids: set[str] = set()
+    completed_codex_tool_ids: set[str] = set()
     for line in reversed([ln for ln in raw.splitlines() if ln.strip()]):
         try:
             obj = json.loads(line)
         except Exception:
             continue
-        msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
+        payload = obj.get("payload")
+        record = (
+            payload
+            if obj.get("type") == "response_item" and isinstance(payload, dict)
+            else obj
+        )
+        msg = (
+            record.get("message")
+            if isinstance(record.get("message"), dict)
+            else record
+        )
         role = msg.get("role") if isinstance(msg, dict) else None
-        typ = obj.get("type")
-        if role == "assistant" or typ in {"assistant", "agent_message"}:
+        typ = record.get("type") if isinstance(record, dict) else None
+        if typ == "function_call_output":
+            call_id = str(record.get("call_id") or "")
+            if call_id and _codex_call_output_succeeded(record.get("output")):
+                completed_codex_tool_ids.add(call_id)
+            elif call_id:
+                failed_tool_ids.add(call_id)
+        elif typ == "function_call":
+            arguments = record.get("arguments")
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+            if not isinstance(arguments, dict):
+                arguments = {}
+            namespace = str(record.get("namespace") or "")
+            name = str(record.get("name") or "")
+            operation = str(arguments.get("operation") or "")
+            tools.append(
+                {
+                    "id": str(record.get("call_id") or ""),
+                    "name": f"{namespace}{name}",
+                    "operation": operation,
+                    "input": arguments,
+                    "requires_confirmed_output": True,
+                }
+            )
+        elif role == "assistant" or typ in {"assistant", "agent_message"}:
             for b in _content_blocks(msg):
                 if b.get("type") == "text":
                     chunks.append(b.get("text", ""))
@@ -182,7 +253,17 @@ def _latest_turn(path: str, max_bytes: int = 262_144) -> tuple[str, list[dict]]:
             ):
                 break  # reached the human prompt that began this turn
     for tool in tools:
-        tool["failed"] = bool(tool["id"] and tool["id"] in failed_tool_ids)
+        tool_id = tool["id"]
+        tool["failed"] = bool(
+            tool_id
+            and (
+                tool_id in failed_tool_ids
+                or (
+                    tool.get("requires_confirmed_output")
+                    and tool_id not in completed_codex_tool_ids
+                )
+            )
+        )
     return "".join(reversed(chunks)), tools
 
 
@@ -250,13 +331,22 @@ def main() -> int:
     if data.get("stop_hook_active") or data.get("stopHookActive"):  # already blocked once
         return 0
     tpath = data.get("transcript_path") or data.get("transcriptPath")
-    if not tpath:
+    event_assistant_text = data.get("last_assistant_message") or data.get(
+        "lastAssistantMessage"
+    )
+    if not isinstance(event_assistant_text, str):
+        event_assistant_text = ""
+    if not tpath and not event_assistant_text:
         return 0
 
     min_chars = _env_int("EXOMEM_CAPTURE_NUDGE_MIN_CHARS", 300)
     cooldown = _env_int("EXOMEM_CAPTURE_NUDGE_COOLDOWN_SEC", 300)
 
-    assistant_text, tools = _latest_turn(tpath)
+    # Codex exposes the final text directly because its transcript format is not
+    # a stable hook API. Keep transcript parsing as the Claude/older-client
+    # fallback and to retain best-effort successful-write detection.
+    transcript_text, tools = _latest_turn(tpath) if tpath else ("", [])
+    assistant_text = event_assistant_text or transcript_text
     if any(_successful_kb_write(tool) for tool in tools):  # already captured this turn
         return 0
     if re.search(r"Saved\s*(?:->|→|:)", assistant_text):

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -1680,6 +1680,90 @@ def _transcript(
     return p
 
 
+def _codex_rollout_transcript(
+    tmp_path: Path,
+    user_text: str,
+    assistant_text: str,
+) -> Path:
+    """Write the response_item envelope emitted by Codex CLI 0.144.x."""
+    lines = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": user_text}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": assistant_text}],
+            },
+        },
+    ]
+    path = tmp_path / "codex-rollout.jsonl"
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    return path
+
+
+def _codex_rollout_with_exomem_call(
+    tmp_path: Path,
+    *,
+    assistant_text: str,
+    tool_output: str,
+) -> Path:
+    """Write Codex 0.144.x function-call records around an Exomem note call."""
+    call_id = "call-exomem-note"
+    lines = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Save the conclusion."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "namespace": "mcp__codex_apps__exomem",
+                "name": "_note",
+                "arguments": json.dumps(
+                    {
+                        "note_type": "research-note",
+                        "title": "Durable conclusion",
+                        "content": "A durable conclusion.",
+                    }
+                ),
+                "call_id": call_id,
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": tool_output,
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": assistant_text}],
+            },
+        },
+    ]
+    path = tmp_path / "codex-rollout-with-tool.jsonl"
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    return path
+
+
 # --- capture (Stop) gate --------------------------------------------------------
 
 
@@ -1698,6 +1782,114 @@ def test_capture_fires_language_agnostic_japanese(tmp_path: Path) -> None:
     t = _transcript(tmp_path, "質問", jp)
     r = _run(CAPTURE_SCRIPT, {"transcript_path": str(t), "session_id": "jp"}, home)
     assert '"decision": "block"' in r.stdout
+
+
+def test_capture_reads_codex_0144_rollout_transcript(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    transcript = _codex_rollout_transcript(
+        tmp_path,
+        "What durable conclusion did we reach?",
+        "We reached a durable conclusion. " + "x" * 450,
+    )
+
+    result = _run(
+        CAPTURE_SCRIPT,
+        {"transcript_path": str(transcript), "session_id": "codex-rollout"},
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert payload["reason"].startswith("[Exomem capture check]")
+
+
+def test_capture_codex_uses_last_message_without_transcript(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run(
+        CAPTURE_SCRIPT,
+        {
+            "last_assistant_message": "We reached a durable conclusion. " + "x" * 450,
+            "session_id": "codex-last-message",
+        },
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert payload["reason"].startswith("[Exomem capture check]")
+
+
+def test_capture_codex_silent_after_successful_exomem_function_call(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    transcript = _codex_rollout_with_exomem_call(
+        tmp_path,
+        assistant_text="The durable conclusion was captured. " + "x" * 450,
+        tool_output=(
+            "Wall time: 0.25 seconds\nOutput: "
+            '{"path":"Notes/durable-conclusion.md","warnings":[]}'
+        ),
+    )
+
+    result = _run(
+        CAPTURE_SCRIPT,
+        {
+            "transcript_path": str(transcript),
+            "last_assistant_message": "The durable conclusion was captured. " + "x" * 450,
+            "session_id": "codex-write-success",
+        },
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+
+    assert result.stdout.strip() == ""
+
+
+def test_capture_codex_still_fires_after_failed_exomem_function_call(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    transcript = _codex_rollout_with_exomem_call(
+        tmp_path,
+        assistant_text="The write failed, but the conclusion is durable. " + "x" * 450,
+        tool_output=(
+            "Wall time: 0.25 seconds\nOutput:\n"
+            + json.dumps(
+                {
+                    "error": "RuntimeException: Error calling MCP tool",
+                    "error_code": "INVALID_ARGUMENT",
+                    "error_data": {
+                        "type": "mcp_tool_execution_error",
+                        "result": {"isError": True},
+                    },
+                }
+            )
+        ),
+    )
+
+    result = _run(
+        CAPTURE_SCRIPT,
+        {
+            "transcript_path": str(transcript),
+            "last_assistant_message": "The write failed, but the conclusion is durable. "
+            + "x" * 450,
+            "session_id": "codex-write-failed",
+        },
+        home,
+        {"EXOMEM_HOOK_CLIENT": "codex"},
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert payload["reason"].startswith("[Exomem capture check]")
 
 
 def test_capture_silent_on_trivial_turn(tmp_path: Path) -> None:
@@ -1817,7 +2009,9 @@ def test_capture_codex_client_accepts_camel_case_and_uses_codex_state(tmp_path: 
         home,
         {"EXOMEM_HOOK_CLIENT": "codex"},
     )
-    assert '"decision": "block"' in r.stdout
+    payload = json.loads(r.stdout)
+    assert payload["decision"] == "block"
+    assert payload["reason"].startswith("[Exomem capture check]")
     assert (home / ".codex" / ".cache" / "exomem-nudge" / "codex-cap").exists()
     assert (home / ".codex" / "exomem-capture-nudge.log").exists()
     assert not (home / ".claude" / "exomem-capture-nudge.log").exists()


### PR DESCRIPTION
## Why

Codex 0.144.x Stop events expose the stable `last_assistant_message` field and store fallback transcript records under `response_item.payload`. The capture hook only understood the older Claude transcript shape, so it could miss substantial Codex turns and could not tell a successful Exomem write from a failed one.

## What changed

- prefer Codex's stable Stop-event assistant message, with transcript fallback
- parse Codex `message`, `function_call`, and `function_call_output` rollout records
- pair tool calls and outputs by call ID
- suppress a redundant capture check only for a confirmed, parseable, non-error Exomem mutation
- keep malformed, missing, or MCP-error outputs eligible for a capture retry
- preserve the existing Claude path and official `decision: block` Stop contract

## Verification

- `python -m pytest tests/test_install_hook.py tests/test_scaffold_no_leak.py -q -k "capture or scaffold"` — 20 passed
- `uvx ruff check --select F src/exomem/_hooks/exomem_capture_nudge.py tests/test_install_hook.py` — passed
- `python -m py_compile src/exomem/_hooks/exomem_capture_nudge.py` — passed
- independent reviewer pass — green, no actionable findings
- full Windows hook file: 80 passed, 9 skipped, 3 pre-existing platform/environment failures unchanged from baseline