### PR TITLE
fix: canonicalize path casing before stable-identity comparison

### DIFF
--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -363,7 +363,7 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
     candidate = vault_root / rel
     try:
         resolved = candidate.resolve()
-        resolved.relative_to(kb_root(vault_root).resolve())
+        kb_relative = resolved.relative_to(kb_root(vault_root).resolve())
     except (ValueError, OSError) as e:
         raise EditError(
             code="INVALID_PATH",
@@ -376,6 +376,16 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
             missing=["path"],
             reason=f"file does not exist: {rel}",
         )
+    # Return the rel-form re-spelled to the real on-disk casing, reusing the
+    # `resolved` already computed for the escape check above (no extra
+    # syscalls). On a case-insensitive filesystem a caller addressing
+    # `…/Polly/x.md` for an on-disk `…/POLLY/` would otherwise carry its own
+    # spelling into every identity comparison keyed on `rel_path`. Rebuilding
+    # from `kb_prefix()` also re-spells segment 1 to the configured KB name,
+    # matching `vault.canonical_vault_rel`; fail open to the literal form.
+    canonical = kb_relative.as_posix()
+    if canonical and canonical != ".":
+        rel = kb_prefix() + canonical
     return candidate, rel
 
 

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -47,6 +47,7 @@ from .vault import (
     content_hash,
     escape_wikilinks_for_log,
     in_append_only_tree,
+    is_casing_only_rewrite,
     kb_root,
     normalize_body_wikilinks,
     plan_log_writes,
@@ -383,9 +384,17 @@ def _resolve(vault_root: Path, path: str) -> tuple[Path, str]:
     # spelling into every identity comparison keyed on `rel_path`. Rebuilding
     # from `kb_prefix()` also re-spells segment 1 to the configured KB name,
     # matching `vault.canonical_vault_rel`; fail open to the literal form.
+    #
+    # Adopted ONLY when the rewrite is casing-only — `resolved` has followed any
+    # symlink, expanded any junction/8.3 short name and collapsed any `..`, and
+    # a rel-form silently swapped for a link's target defeats the callers that
+    # re-check it (see `vault.is_casing_only_rewrite`). Comparing two strings
+    # adds no syscalls, so the property this mirror exists for is preserved.
     canonical = kb_relative.as_posix()
     if canonical and canonical != ".":
-        rel = kb_prefix() + canonical
+        canonical = kb_prefix() + canonical
+        if is_casing_only_rewrite(canonical, rel):
+            rel = canonical
     return candidate, rel
 
 

--- a/src/exomem/link.py
+++ b/src/exomem/link.py
@@ -31,6 +31,7 @@ from .vault import (
     PlannedWrite,
     WikilinkResolver,
     batch_atomic_write,
+    canonical_vault_rel,
     escape_wikilinks_for_log,
     kb_root,
     normalize_body_wikilinks,
@@ -637,7 +638,13 @@ def link(
         )
     folder = kb_root(vault_root) / "Entities" / ENTITY_TYPE_TO_FOLDER[entity_type]
     entity_path = folder / f"{filename_slug or _sanitize_name(name)}.md"
-    rel_entity = entity_path.relative_to(vault_root).as_posix()
+    # Re-spell the destination to the real on-disk casing *before* it is bound
+    # into the draft token: creating into an existing but differently-cased
+    # entity folder would otherwise record the minted spelling as the page's
+    # identity path.
+    rel_entity = canonical_vault_rel(
+        vault_root, entity_path.relative_to(vault_root).as_posix()
+    )
     if entity_path.exists():
         raise LinkError(
             "ENTITY_EXISTS",

--- a/src/exomem/memory_refs.py
+++ b/src/exomem/memory_refs.py
@@ -164,10 +164,27 @@ class ReferenceIndex:
         if not self.available():
             return
         clean = [str(path).replace("\\", "/").lstrip("/") for path in paths]
+        # Rows are keyed by the on-disk spelling (`refresh_paths` resolves), but
+        # on a case-insensitive filesystem the caller may address the page with
+        # different casing. Delete both spellings, or the real row survives the
+        # delete and reads back as a second owner of the identity. On a
+        # case-sensitive filesystem the two spellings are the same string.
+        targets = list(
+            dict.fromkeys(
+                spelling
+                for path in clean
+                for spelling in (
+                    path,
+                    vault_module.canonical_vault_rel(self.vault_root, path),
+                )
+            )
+        )
         conn = self._connect()
         try:
             with conn:
-                conn.executemany("DELETE FROM identities WHERE path = ?", [(p,) for p in clean])
+                conn.executemany(
+                    "DELETE FROM identities WHERE path = ?", [(p,) for p in targets]
+                )
         finally:
             conn.close()
 
@@ -220,7 +237,11 @@ class ReferenceIndex:
         return self.refs_for_paths([clean]).get(clean)
 
     def refs_for_paths(self, paths: list[str]) -> dict[str, str | None]:
-        """Resolve many paths with one sidecar query or one Markdown scan."""
+        """Resolve many paths with one sidecar query or one Markdown scan.
+
+        The returned dict is keyed by the caller's own cleaned spelling; callers
+        index it by the string they passed in.
+        """
         clean = [str(path or "").replace("\\", "/").lstrip("/") for path in paths]
         wanted = list(dict.fromkeys(path for path in clean if path))
         if not wanted:
@@ -238,14 +259,27 @@ class ReferenceIndex:
                         return _refs_for_paths_from_scan(self.vault_root, wanted)
 
         resolved, indexed_paths = self._refs_from_index(wanted)
-        # Rows absent from the index may be new external files whose watcher
-        # event has not landed yet. Refresh only those exact paths; never turn
-        # an ordinary negative lookup into a full-corpus scan.
+        # Try the caller's own spelling first and canonicalize only on a miss:
+        # `canonical_vault_rel` costs a `resolve()` syscall per path, and the
+        # hit path is the common one. A miss may be a new external file whose
+        # watcher event has not landed, or a caller whose casing differs from
+        # the row's. The invariant is only that a row is keyed by the spelling
+        # `_relative_markdown` resolved to *when the row was written* — not
+        # that every live row is canonical now. Renaming a directory's casing
+        # leaves the old-cased row behind (`refresh_paths` deletes just the
+        # newly-resolved key), and `reconcile` / `rebuild_all` is what heals
+        # that. Retry those exact paths only; never turn a negative lookup
+        # into a corpus scan.
         missing = [path for path in wanted if path not in indexed_paths]
         if missing:
-            self.refresh_paths([self.vault_root / path for path in missing])
-            refreshed, _ = self._refs_from_index(missing)
-            resolved.update(refreshed)
+            canonical = {
+                path: vault_module.canonical_vault_rel(self.vault_root, path)
+                for path in missing
+            }
+            retry = list(dict.fromkeys(canonical.values()))
+            self.refresh_paths([self.vault_root / path for path in retry])
+            refreshed, _ = self._refs_from_index(retry)
+            resolved.update({path: refreshed.get(canonical[path]) for path in missing})
         return resolved
 
     def _refs_from_index(

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -55,6 +55,7 @@ from .vault import (
     PlannedWrite,
     WikilinkResolver,
     batch_atomic_write,
+    canonical_vault_rel,
     content_hash,
     ensure_canonical_h1,
     escape_wikilinks_for_log,
@@ -1428,7 +1429,11 @@ def note(
             project_registry=key_plan.registry,
             create_parents=False,
         )
-        destination = note_path.relative_to(root).as_posix()
+        # Re-spell the destination to the real on-disk casing *before* it is
+        # bound into the draft token: creating into an existing but
+        # differently-cased folder (`Polly/` vs an on-disk `POLLY/`) would
+        # otherwise record the minted spelling as the page's identity path.
+        destination = canonical_vault_rel(root, note_path.relative_to(root).as_posix())
         token_value = semantic_writes.DraftToken(
             "note", _preflight_operation, destination, render_date, registrations
         )

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -232,8 +232,21 @@ class StableIdentityCensus:
             ),
         )
 
-    def with_page(self, page: SemanticPageState) -> StableIdentityCensus:
-        entries = [entry for entry in self.entries if entry.path != page.path]
+    def with_page(
+        self, page: SemanticPageState, *, casefold_paths: bool = False
+    ) -> StableIdentityCensus:
+        """Replace the entry `page` owns, returning a new census.
+
+        `casefold_paths` is set when the vault lives on a case-insensitive
+        filesystem: the census records the real on-disk casing while a caller
+        may address the same physical file differently, so dropping only the
+        byte-equal entry would manufacture a phantom second owner in memory.
+        """
+        if casefold_paths:
+            folded = page.path.casefold()
+            entries = [entry for entry in self.entries if entry.path.casefold() != folded]
+        else:
+            entries = [entry for entry in self.entries if entry.path != page.path]
         entries.append(
             StableIdentityEntry(
                 page.path,
@@ -270,6 +283,27 @@ class StableIdentityCensus:
                 identity: list(paths) for identity, paths in self.paths_by_identity.items()
             },
         }
+
+
+def identity_owners_match(
+    owners: tuple[str, ...] | None,
+    page_path: str,
+    *,
+    folds: bool,
+) -> bool:
+    """True when `page_path` is the sole corpus owner recorded in the census.
+
+    `folds` is the vault's case-insensitivity: with it set, an owner that
+    differs from `page_path` only in casing is the SAME physical file, so it
+    must not read as a second owner. With it clear this is byte-for-byte the
+    exact-tuple comparison it replaces — genuine case-variant files on a
+    case-sensitive filesystem stay distinct and still block.
+    """
+    if owners == (page_path,):
+        return True
+    if not folds or not owners:
+        return False
+    return {owner.casefold() for owner in owners} == {page_path.casefold()}
 
 
 @dataclass(frozen=True, slots=True)
@@ -908,7 +942,9 @@ class SemanticCorpusContext:
             self.vault_root,
             pages,
             self.registry,
-            self.identity_census.with_page(state),
+            self.identity_census.with_page(
+                state, casefold_paths=vault.vault_casefolds(self.vault_root)
+            ),
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -1509,11 +1545,12 @@ def _patch_corpus_files_changed_locked(
     def relative(value: Path | str) -> str | None:
         path = Path(value)
         try:
-            return (
-                path.resolve().relative_to(root.resolve()).as_posix()
-                if path.is_absolute()
-                else _normalize_path(root, path)
-            )
+            if path.is_absolute():
+                return path.resolve().relative_to(root.resolve()).as_posix()
+            # The absolute branch already lands on real on-disk casing; a
+            # caller-cased relative delta key must be canonicalized too, or the
+            # warm-corpus patch keys a phantom sibling of the page it changed.
+            return vault.canonical_vault_rel(root, _normalize_path(root, path))
         except (OSError, ValueError):
             return None
 
@@ -1838,7 +1875,9 @@ def _build_corpus_context_uncached(
         )
     if candidate is not None:
         states[candidate.path] = candidate
-        identity_census = identity_census.with_page(candidate)
+        identity_census = identity_census.with_page(
+            candidate, casefold_paths=vault.vault_casefolds(root)
+        )
     return _context_from_state_map(
         root,
         states,
@@ -2878,16 +2917,23 @@ def _raw_findings(
     minimum_finding = _missing_semantic_unit_finding(page)
     if minimum_finding is not None:
         findings.append(minimum_finding)
-    if page.identity_kind == "exomem_id" and corpus.identity_census.paths_by_identity.get(
-        page.identity
-    ) != (page.path,):
+    owners = corpus.identity_census.paths_by_identity.get(page.identity)
+    if page.identity_kind == "exomem_id" and not identity_owners_match(
+        owners, page.path, folds=vault.vault_casefolds(corpus.vault_root)
+    ):
         findings.append(
             ContractFinding(
                 code="SEMANTIC_IDENTITY_DUPLICATE",
                 severity="error",
                 path=page.path,
                 span=None,
-                detail="the stable page identity has another corpus owner",
+                detail=(
+                    "the stable page identity has another corpus owner: "
+                    # `owners` can be None: the census and `pages` come from two
+                    # separate walks and may diverge, so name that state rather
+                    # than render a dangling colon.
+                    + (", ".join(owners) if owners else "no census entry for this page")
+                ),
                 remediation="Resolve the duplicate stable identity before writing.",
                 governed_element_identity=("identity", page.identity),
                 resolved_rule=("semantic_contract", "identity", "unique"),

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -545,7 +545,13 @@ def _posthoc_relative_path(root: Path, path: Path | str) -> str | None:
         except (OSError, ValueError):
             return None
     value = str(path).replace("\\", "/").lstrip("/")
-    return value or None
+    if not value:
+        return None
+    # Same shape as `semantic_contract._patch_corpus_files_changed_locked`: the
+    # absolute branch already lands on real on-disk casing, so a caller-cased
+    # relative path must be canonicalized too or the page silently drops out of
+    # the batch (it keys a phantom sibling the corpus has never heard of).
+    return vault.canonical_vault_rel(root, value)
 
 
 def evaluate_posthoc_batch(
@@ -1239,6 +1245,15 @@ def preflight_existing(
     if relation_disposition not in {None, "reviewed_none"}:
         raise SemanticWriteError("INVALID_RELATION_REVIEW", "relation disposition is invalid")
     root = Path(vault_root)
+    # Idempotent backstop, deliberately kept: every caller today already hands
+    # over a canonical rel (the Tier 2 writers via `resolve_under_vault`,
+    # `observe_memory` via `edit._resolve`), but this is the single choke point
+    # every governed edit funnels through, and on a case-insensitive filesystem
+    # a differently-cased spelling names the same physical page as the census
+    # entry. Re-spelling here means no future caller can key the corpus off a
+    # phantom casing. Everything below is built from `root / path`, so a
+    # re-spell stays self-consistent, and a canonical input is a no-op.
+    path = vault.canonical_vault_rel(root, path)
     before_source, primary_guard = vault.read_guarded_text(root, root / path)
     raw_before_hash = vault.content_hash(before_source)
     # The parser/corpus and public content-hash contract normalize platform
@@ -1343,7 +1358,11 @@ def preflight_existing(
         if (
             after.identity_kind != "exomem_id"
             or after.review_fingerprint is None
-            or after_corpus.identity_census.paths_by_identity.get(after.identity) != (after.path,)
+            or not semantic_contract.identity_owners_match(
+                after_corpus.identity_census.paths_by_identity.get(after.identity),
+                after.path,
+                folds=vault.vault_casefolds(root),
+            )
         ):
             raise SemanticWriteError(
                 "RELATION_REVIEW_STABLE_ID_REQUIRED",
@@ -1720,8 +1739,9 @@ def _move_state_map(
         if entry.path not in {old_path, *changed}
     )
     identity_census = semantic_contract.StableIdentityCensus(entries)
+    casefold_paths = vault.vault_casefolds(root)
     for state in changed.values():
-        identity_census = identity_census.with_page(state)
+        identity_census = identity_census.with_page(state, casefold_paths=casefold_paths)
     return (
         semantic_contract.SemanticCorpusContext.from_states(
             root,
@@ -2218,9 +2238,10 @@ def _corpus_with_recovery_states(
     identity_census = semantic_contract.StableIdentityCensus(
         tuple(entry for entry in base.identity_census.entries if entry.path not in removed_paths)
     )
+    casefold_paths = vault.vault_casefolds(root)
     for state in states:
         pages[state.path] = state
-        identity_census = identity_census.with_page(state)
+        identity_census = identity_census.with_page(state, casefold_paths=casefold_paths)
     return semantic_contract.SemanticCorpusContext.from_states(
         root,
         pages.values(),

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -3054,6 +3054,136 @@ class VaultPathError(Exception):
         super().__init__(reason)
 
 
+def _canonical_kb_segment(rel: str) -> str:
+    """Re-spell a leading KB segment to the literal ``kb_dirname()`` spelling.
+
+    On a case-insensitive filesystem the real on-disk casing of the governed
+    folder may differ from the configured name (`knowledge base` vs
+    `Knowledge Base`). The identity census keys segment 1 literally and every
+    `rel.startswith(kb_prefix())` check is byte-exact (e.g. memory_refs), so a
+    canonicalized rel-form must still lead with the configured spelling.
+    """
+    head, sep, tail = rel.partition("/")
+    kb = kb_dirname()
+    if head != kb and head.casefold() == kb.casefold():
+        return f"{kb}{sep}{tail}" if sep else kb
+    return rel
+
+
+def canonical_vault_rel(vault_root: Path, rel: str) -> str:
+    """Return `rel` re-spelled with the real on-disk casing under `vault_root`.
+
+    On a case-insensitive filesystem (Windows NTFS, macOS APFS by default) a
+    caller may address `Notes/Polly/x.md` while the directory on disk is
+    `POLLY`. Both open the same file, but identity comparisons keyed on the
+    path string then see two owners for one physical page. Non-strict
+    `Path.resolve()` returns the real casing for the components that exist and
+    preserves a not-yet-existing tail verbatim, so this handles both an edit
+    (whole path exists) and a create into an existing differently-cased parent.
+
+    Fails open: any `OSError`/`ValueError` (vault momentarily unreachable, a
+    path that escapes the root) returns `rel` unchanged — exactly today's
+    behavior. On a case-sensitive filesystem this is an identity transform for
+    existing paths.
+    """
+    try:
+        root = Path(vault_root)
+        canonical = (root / rel).resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return rel
+    if not canonical or canonical == ".":
+        return rel
+    return _canonical_kb_segment(canonical)
+
+
+# Probing the filesystem costs a couple of syscalls; the answer is a property
+# of the mount, so cache it per normcased root spelling. Tests reset it.
+# Deliberately NOT keyed on a *resolved* root: `Path.resolve()` is itself the
+# expensive syscall this cache exists to avoid (~120 us on Windows), and the
+# guard path calls this once per page — `evaluate_posthoc_batch` loops over the
+# whole vault. Two spellings of one root simply get two entries holding the
+# same answer, which is harmless because the answer describes the volume.
+_CASEFOLD_PROBE_CACHE: dict[str, bool] = {}
+_CASEFOLD_PROBE_LOCK = threading.Lock()
+
+
+def reset_casefold_probe_cache() -> None:
+    """Drop the memoized `vault_casefolds` answers (tests, vault relocation)."""
+    with _CASEFOLD_PROBE_LOCK:
+        _CASEFOLD_PROBE_CACHE.clear()
+
+
+def _probe_casefolds(root: Path) -> bool | None:
+    """Ask the filesystem whether it folds case, or None when unprobeable.
+
+    Takes one existing entry below the KB root (falling back to the vault root)
+    whose name `swapcase()`s to a purely re-cased sibling, and checks that the
+    swapped spelling both exists and is the *same* file. Returns None when no
+    suitable entry is available, so the caller can fall back to platform policy
+    instead of guessing.
+
+    Only a candidate whose swap is a pure re-casing can answer the question.
+    `swapcase()` is not length-preserving for every character — `straße` swaps
+    to `STRASSE`, `ﬁ` to `FI`, `ŉ` to `ʼN`, `İ` to `i` plus a combining dot —
+    and those spellings name a genuinely *different* file, so concluding from
+    them would report a case-folding volume as case-sensitive. Unsuitable
+    candidates are skipped rather than answered from, as is one that vanishes
+    mid-probe; only a candidate that round-trips can yield `False`.
+    """
+    for base in (kb_root(root), root):
+        try:
+            for entry in base.iterdir():
+                name = entry.name
+                swapped_name = name.swapcase()
+                if (
+                    swapped_name == name
+                    or len(swapped_name) != len(name)
+                    or swapped_name.swapcase() != name
+                    or not entry.exists()
+                ):
+                    continue
+                swapped = base / swapped_name
+                if not swapped.exists():
+                    if not entry.exists():
+                        # Deleted between the two probes: a race, not a verdict.
+                        continue
+                    return False
+                return os.path.samefile(entry, swapped)
+        except OSError:
+            continue
+    return None
+
+
+def vault_casefolds(vault_root: Path) -> bool:
+    """True when `vault_root` lives on a case-insensitive filesystem.
+
+    `EXOMEM_CASEFOLD_PATHS=1|0` overrides the answer without probing — that is
+    how Linux CI exercises the folding branch. Its reach is exactly this
+    predicate: the case-folded identity *comparison* (whether two spellings
+    count as one owner). It does not disable path canonicalization —
+    `canonical_vault_rel` / `resolve_under_vault` re-spell to the on-disk casing
+    unconditionally, on every platform. Otherwise the filesystem is probed once
+    per root; when nothing is probeable the platform default
+    (`os.path.normcase`) decides.
+    """
+    override = os.environ.get("EXOMEM_CASEFOLD_PATHS", "").strip()
+    if override in {"0", "1"}:
+        return override == "1"
+
+    root = Path(vault_root)
+    cache_key = os.path.normcase(str(root))
+    with _CASEFOLD_PROBE_LOCK:
+        cached = _CASEFOLD_PROBE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    probed = _probe_casefolds(root)
+    folds = os.path.normcase("Aa") == os.path.normcase("aa") if probed is None else probed
+    with _CASEFOLD_PROBE_LOCK:
+        _CASEFOLD_PROBE_CACHE[cache_key] = folds
+    return folds
+
+
 def resolve_under_vault(
     vault_root: Path,
     path: str,
@@ -3145,8 +3275,17 @@ def resolve_under_vault(
             reason=f"path is not a directory: {rel}",
         )
 
-    # Normalize the *returned* rel-form. resolved.relative_to(...) lowercases
-    # the drive on Windows; use the literal candidate-form for stability.
+    # Normalize the *returned* rel-form to the real on-disk casing, reusing the
+    # `resolved` computed for the escape check above (zero extra syscalls). The
+    # drive-lowercasing that made us prefer the literal candidate-form is not a
+    # concern here: `relative_to` strips the drive entirely. Fail open to the
+    # literal form if the relative computation can't be established.
+    try:
+        canonical = resolved.relative_to(vault_resolved).as_posix()
+    except ValueError:
+        canonical = ""
+    if canonical and canonical != ".":
+        rel = _canonical_kb_segment(canonical)
     return candidate, rel
 
 

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -3070,6 +3070,40 @@ def _canonical_kb_segment(rel: str) -> str:
     return rel
 
 
+def is_casing_only_rewrite(canonical: str, original: str) -> bool:
+    """True when `canonical` differs from `original` in letter casing alone.
+
+    THIS IS A SECURITY GUARD, not a nicety. `Path.resolve()` re-spells a path
+    to its real on-disk casing — but it also follows symlinks, expands Windows
+    8.3 short names and junctions, and collapses `..`. Any of those rewrite
+    *which file* the path addresses. `hosted_transfer_routes.
+    _open_bounded_vault_file` re-opens the returned rel-form component by
+    component under `O_NOFOLLOW` precisely so a symlink raises `ELOOP`; handing
+    it a rel-form that resolution already replaced with the symlink's target
+    launders the link into a real file and defeats the check. So the canonical
+    form is adopted only when the sole difference is casing; otherwise the
+    caller's own spelling is returned and the downstream guards see what the
+    caller actually asked for.
+
+    `str.casefold()` — not `os.path.normcase()`. `posixpath.normcase()` is the
+    identity function, so a normcase comparison is byte-exact on every
+    non-Windows platform: it would reject the very re-spell this module exists
+    to perform on macOS APFS and on case-folding Linux mounts (ext4 `+F`,
+    CIFS), and would make the invariant mean something different per platform.
+    `casefold()` is the Unicode-correct, platform-independent answer.
+
+    The length guard closes casefold's non-length-preserving expansions.
+    `'ß'.casefold() == 'ss'`, `'ﬁ'` folds to `'fi'`, `'İ'` to `'i'` plus a
+    combining dot — spellings that name a *genuinely different* file, so a
+    bare casefold comparison would call `straße.md -> STRASSE.md` a casing-only
+    rewrite and launder that symlink. Comparing the pre-fold lengths rejects
+    every such pair. (This is the same hazard `_probe_casefolds` documents for
+    `swapcase()`.) The guard can only ever err toward returning the caller's
+    literal form, which is the fail-open behavior this module already promises.
+    """
+    return len(canonical) == len(original) and canonical.casefold() == original.casefold()
+
+
 def canonical_vault_rel(vault_root: Path, rel: str) -> str:
     """Return `rel` re-spelled with the real on-disk casing under `vault_root`.
 
@@ -3080,6 +3114,17 @@ def canonical_vault_rel(vault_root: Path, rel: str) -> str:
     `Path.resolve()` returns the real casing for the components that exist and
     preserves a not-yet-existing tail verbatim, so this handles both an edit
     (whole path exists) and a create into an existing differently-cased parent.
+
+    Casing-only invariant: `Path.resolve()` also follows symlinks, expands
+    Windows 8.3 short names and junctions, and collapses `..` — rewrites that
+    change *which file* the rel-form addresses, laundering a symlink past the
+    `O_NOFOLLOW` guard in `hosted_transfer_routes._open_bounded_vault_file`.
+    So the resolved form is adopted only when `is_casing_only_rewrite` says the
+    sole difference from the caller's path is casing; otherwise `rel` comes
+    back untouched. A consequence: `Knowledge Base/../Knowledge Base/x.md` is
+    no longer incidentally collapsed. That is intended — vault-escape is
+    checked separately in `resolve_under_vault`, against the *resolved* path,
+    and is unaffected.
 
     Fails open: any `OSError`/`ValueError` (vault momentarily unreachable, a
     path that escapes the root) returns `rel` unchanged — exactly today's
@@ -3093,7 +3138,14 @@ def canonical_vault_rel(vault_root: Path, rel: str) -> str:
         return rel
     if not canonical or canonical == ".":
         return rel
-    return _canonical_kb_segment(canonical)
+    canonical = _canonical_kb_segment(canonical)
+    # Compare against the slash-normalized caller form: `Path` accepts `\` and
+    # a leading `/`, and `as_posix()` has already normalized those away, so
+    # comparing raw would reject a legitimate re-spell over pure spelling noise.
+    cleaned = str(rel).replace("\\", "/").lstrip("/")
+    if not is_casing_only_rewrite(canonical, cleaned):
+        return rel
+    return canonical
 
 
 # Probing the filesystem costs a couple of syscalls; the answer is a property
@@ -3280,12 +3332,19 @@ def resolve_under_vault(
     # drive-lowercasing that made us prefer the literal candidate-form is not a
     # concern here: `relative_to` strips the drive entirely. Fail open to the
     # literal form if the relative computation can't be established.
+    #
+    # Adopted ONLY when the rewrite is casing-only. `resolved` has followed any
+    # symlink, and `_open_bounded_vault_file` re-opens this rel-form under
+    # `O_NOFOLLOW` expecting to *reject* one — handing it the link's target
+    # would launder the link into a real file. See `is_casing_only_rewrite`.
     try:
         canonical = resolved.relative_to(vault_resolved).as_posix()
     except ValueError:
         canonical = ""
     if canonical and canonical != ".":
-        rel = _canonical_kb_segment(canonical)
+        canonical = _canonical_kb_segment(canonical)
+        if is_casing_only_rewrite(canonical, rel):
+            rel = canonical
     return candidate, rel
 
 

--- a/tests/test_audit_overhaul.py
+++ b/tests/test_audit_overhaul.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from exomem import audit as audit_module
 
 
@@ -141,3 +143,27 @@ def test_audit_frontmatter_compliance_flags_singular_project_on_pattern(vault: P
         if "singular-project-pattern" in f.path and "projects" in f.detail
     ]
     assert matches, [f.as_dict() for f in report.findings]
+
+
+def test_audit_unknown_category_message_names_category_and_lists_valid(
+    vault: Path,
+) -> None:
+    """`audit()` must reject unknown categories with a message that both
+    echoes the invalid name(s) back and enumerates the valid categories —
+    the incident this pins was a client (maintain_memory audit mode)
+    inventing category names ('duplicate', 'frontmatter', 'identity') and
+    getting a bare `ValueError` it couldn't self-correct from. The fix was
+    already present at HEAD (see audit.py's `audit()` validation); this
+    only guards against a future regression of the message shape."""
+    with pytest.raises(ValueError) as exc_info:
+        audit_module.audit(vault, categories=["nope"])
+
+    message = str(exc_info.value)
+    assert "unknown audit categories" in message
+    assert "['nope']" in message
+
+    valid_categories = set(audit_module.ALL_CATEGORIES) | set(
+        audit_module.OPTIONAL_CATEGORIES
+    )
+    for category in valid_categories:
+        assert category in message, (category, message)

--- a/tests/test_case_insensitive_identity.py
+++ b/tests/test_case_insensitive_identity.py
@@ -1,0 +1,345 @@
+"""Case-insensitive-filesystem path identity: guard, census fold semantics,
+canonicalization helper, and the casefold probe. Platform-free — exercises
+both EXOMEM_CASEFOLD_PATHS=1 and =0 explicitly rather than relying on the
+ambient filesystem, so Linux CI covers the fold branch too.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import memory_schema, relation_registry, semantic_contract, vault
+
+_ID_A = "00000000-0000-0000-0000-000000000001"
+_ID_B = "00000000-0000-0000-0000-000000000002"
+
+
+def _source(*, exomem_id: str | None = None) -> str:
+    fields = ["type: insight", "status: active"]
+    if exomem_id is not None:
+        fields.append(f"exomem_id: {exomem_id}")
+    return "---\n" + "\n".join(fields) + "\n---\n\nBody.\n"
+
+
+def _state(tmp_path: Path, rel_path: str, source: str) -> semantic_contract.SemanticPageState:
+    return semantic_contract.build_page_state(
+        tmp_path,
+        rel_path,
+        source,
+        relation_registry=relation_registry.core_registry(),
+        review_fingerprint="fingerprint",
+    )
+
+
+def _corpus(
+    tmp_path: Path,
+    *states: semantic_contract.SemanticPageState,
+    identity_census: semantic_contract.StableIdentityCensus | None = None,
+) -> semantic_contract.SemanticCorpusContext:
+    return semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        states,
+        registry=relation_registry.core_registry(),
+        identity_census=identity_census
+        if identity_census is not None
+        else semantic_contract.StableIdentityCensus(
+            tuple(
+                semantic_contract.StableIdentityEntry(
+                    state.path,
+                    state.identity if state.identity_kind == "exomem_id" else None,
+                )
+                for state in states
+            )
+        ),
+    )
+
+
+def _evaluate(
+    *,
+    after: semantic_contract.SemanticPageState,
+    before_corpus: semantic_contract.SemanticCorpusContext,
+    after_corpus: semantic_contract.SemanticCorpusContext,
+    operation: str = "edit",
+) -> semantic_contract.SemanticContractResult:
+    empty = memory_schema.ResolvedMemoryContracts(
+        validation="strict",
+        matched_contracts=(),
+        constraints=(),
+        conflicts=(),
+    )
+    return semantic_contract.evaluate(
+        before=None,
+        after=after,
+        operation=operation,
+        mode="precommit",
+        before_contracts=empty,
+        after_contracts=empty,
+        before_corpus=before_corpus,
+        after_corpus=after_corpus,
+        before_review=None,
+        after_review=None,
+        grandfathered=False,
+    )
+
+
+def _filesystem_casefolds(directory: Path) -> bool:
+    """Whether `directory`'s volume really opens one file under two spellings."""
+    probe = directory / "_exomem_case_probe.tmp"
+    probe.write_text("probe", encoding="utf-8")
+    try:
+        swapped = directory / "_EXOMEM_CASE_PROBE.TMP"
+        return swapped.is_file() and os.path.samefile(probe, swapped)
+    finally:
+        probe.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _clear_casefold_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("EXOMEM_CASEFOLD_PATHS", raising=False)
+    vault.reset_casefold_probe_cache()
+    yield
+    vault.reset_casefold_probe_cache()
+
+
+# ---------------- guard policy: incident shape ----------------
+
+
+def test_guard_ignores_case_variant_owner_when_folds_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The POLLY-vs-Polly incident: same physical file, caller-cased path."""
+    monkeypatch.setenv("EXOMEM_CASEFOLD_PATHS", "1")
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Research/Polly/terms.md",
+        _source(exomem_id=_ID_A),
+    )
+    census = semantic_contract.StableIdentityCensus(
+        (
+            semantic_contract.StableIdentityEntry(
+                "Knowledge Base/Notes/Research/POLLY/terms.md", _ID_A
+            ),
+        )
+    )
+    corpus = _corpus(tmp_path, page, identity_census=census)
+
+    result = _evaluate(after=page, before_corpus=corpus, after_corpus=corpus, operation="edit")
+
+    assert "SEMANTIC_IDENTITY_DUPLICATE" not in {
+        finding.code for finding in result.blocking_findings
+    }
+
+
+def test_guard_blocks_case_variant_owner_when_folds_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same shape as above, but with folding off: today's byte-for-byte behavior."""
+    monkeypatch.setenv("EXOMEM_CASEFOLD_PATHS", "0")
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Research/Polly/terms.md",
+        _source(exomem_id=_ID_A),
+    )
+    census = semantic_contract.StableIdentityCensus(
+        (
+            semantic_contract.StableIdentityEntry(
+                "Knowledge Base/Notes/Research/POLLY/terms.md", _ID_A
+            ),
+        )
+    )
+    corpus = _corpus(tmp_path, page, identity_census=census)
+
+    result = _evaluate(after=page, before_corpus=corpus, after_corpus=corpus, operation="edit")
+
+    assert "SEMANTIC_IDENTITY_DUPLICATE" in {
+        finding.code for finding in result.blocking_findings
+    }
+
+
+@pytest.mark.parametrize("folds", ["0", "1"])
+def test_guard_still_blocks_genuine_duplicate_regardless_of_folds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, folds: str
+) -> None:
+    """Two real, distinctly-named files sharing an identity always block."""
+    monkeypatch.setenv("EXOMEM_CASEFOLD_PATHS", folds)
+    page = _state(tmp_path, "Knowledge Base/Notes/Insights/page.md", _source(exomem_id=_ID_A))
+    duplicate = _state(
+        tmp_path, "Knowledge Base/Notes/Insights/duplicate.md", _source(exomem_id=_ID_A)
+    )
+    corpus = _corpus(tmp_path, page, duplicate)
+
+    result = _evaluate(
+        after=page, before_corpus=corpus, after_corpus=corpus, operation="recover"
+    )
+
+    assert "SEMANTIC_IDENTITY_DUPLICATE" in {
+        finding.code for finding in result.blocking_findings
+    }
+
+
+def test_identity_duplicate_detail_names_owner_paths(tmp_path: Path) -> None:
+    page = _state(tmp_path, "Knowledge Base/Notes/Insights/page.md", _source(exomem_id=_ID_A))
+    duplicate = _state(
+        tmp_path, "Knowledge Base/Notes/Insights/duplicate.md", _source(exomem_id=_ID_A)
+    )
+    corpus = _corpus(tmp_path, page, duplicate)
+
+    result = _evaluate(
+        after=page, before_corpus=corpus, after_corpus=corpus, operation="recover"
+    )
+
+    finding = next(
+        f for f in result.blocking_findings if f.code == "SEMANTIC_IDENTITY_DUPLICATE"
+    )
+    assert page.path in finding.detail
+    assert duplicate.path in finding.detail
+
+
+# ---------------- StableIdentityCensus.with_page fold semantics ----------------
+
+
+def test_with_page_drops_case_variant_entries_only_when_folding(tmp_path: Path) -> None:
+    old = semantic_contract.StableIdentityEntry(
+        "Knowledge Base/Notes/Research/POLLY/terms.md", _ID_A
+    )
+    census = semantic_contract.StableIdentityCensus((old,))
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Research/Polly/terms.md",
+        _source(exomem_id=_ID_A),
+    )
+
+    folded = census.with_page(page, casefold_paths=True)
+    assert folded.paths_by_identity[_ID_A] == (page.path,)
+
+    unfolded_default = census.with_page(page)
+    assert set(unfolded_default.paths_by_identity[_ID_A]) == {old.path, page.path}
+
+    unfolded_explicit = census.with_page(page, casefold_paths=False)
+    assert set(unfolded_explicit.paths_by_identity[_ID_A]) == {old.path, page.path}
+
+
+def test_with_page_exact_duplicate_path_replaced_regardless_of_folding(
+    tmp_path: Path,
+) -> None:
+    old = semantic_contract.StableIdentityEntry("Knowledge Base/Notes/Insights/page.md", _ID_A)
+    census = semantic_contract.StableIdentityCensus((old,))
+    page = _state(tmp_path, "Knowledge Base/Notes/Insights/page.md", _source(exomem_id=_ID_B))
+
+    folded = census.with_page(page, casefold_paths=True)
+    assert folded.paths_by_identity == {_ID_B: (page.path,)}
+
+
+# ---------------- vault_casefolds probe: cache + override ----------------
+
+
+def test_vault_casefolds_env_override_short_circuits_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[Path] = []
+    monkeypatch.setattr(vault, "_probe_casefolds", lambda root: calls.append(root) or True)
+
+    monkeypatch.setenv("EXOMEM_CASEFOLD_PATHS", "1")
+    assert vault.vault_casefolds(tmp_path) is True
+    monkeypatch.setenv("EXOMEM_CASEFOLD_PATHS", "0")
+    assert vault.vault_casefolds(tmp_path) is False
+    assert calls == []
+
+
+def test_vault_casefolds_probe_is_cached_per_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[Path] = []
+    original = vault._probe_casefolds
+
+    def counting(root: Path) -> bool:
+        calls.append(root)
+        return original(root)
+
+    monkeypatch.setattr(vault, "_probe_casefolds", counting)
+
+    vault.vault_casefolds(tmp_path)
+    vault.vault_casefolds(tmp_path)
+    assert len(calls) == 1
+
+    vault.reset_casefold_probe_cache()
+    vault.vault_casefolds(tmp_path)
+    assert len(calls) == 2
+
+
+# ---------------- canonical_vault_rel: fallback + KB re-spell ----------------
+
+
+def test_canonical_vault_rel_fails_open_on_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def raising_resolve(self: Path, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "resolve", raising_resolve)
+
+    rel = vault.canonical_vault_rel(tmp_path, "Knowledge Base/Notes/Polly/x.md")
+
+    assert rel == "Knowledge Base/Notes/Polly/x.md"
+
+
+def test_canonical_vault_rel_fails_open_on_value_error(tmp_path: Path) -> None:
+    rel = vault.canonical_vault_rel(tmp_path, "../outside.md")
+
+    assert rel == "../outside.md"
+
+
+def test_canonical_vault_rel_respells_kb_segment_via_monkeypatched_resolve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path
+
+    def fake_resolve(self: Path, *args, **kwargs):
+        if self == root:
+            return root
+        return root / "knowledge base" / "Notes" / "x.md"
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    rel = vault.canonical_vault_rel(root, "Knowledge Base/Notes/x.md")
+
+    assert rel == "Knowledge Base/Notes/x.md"
+
+
+def test_canonical_vault_rel_is_identity_transform_for_already_canonical_path(
+    tmp_path: Path,
+) -> None:
+    kb = tmp_path / "Knowledge Base" / "Notes"
+    kb.mkdir(parents=True)
+    (kb / "x.md").write_text("body", encoding="utf-8")
+
+    rel = vault.canonical_vault_rel(tmp_path, "Knowledge Base/Notes/x.md")
+
+    assert rel == "Knowledge Base/Notes/x.md"
+
+
+def test_canonical_vault_rel_respells_against_real_on_disk_directories(
+    tmp_path: Path,
+) -> None:
+    """Prove the re-spell, not just that it is harmless.
+
+    The two tests above assert output == input, so they would still pass if
+    `canonical_vault_rel` were `return rel`; they are kept as fail-open guards.
+    Here the caller's casing matches no directory on disk, so only a real
+    re-spell produces the expected answer. Meaningful only where the volume
+    actually folds — on a case-sensitive one `KNOWLEDGE BASE/notes/` is simply
+    a different, nonexistent path — hence the gate.
+    """
+    if not _filesystem_casefolds(tmp_path):
+        pytest.skip("the volume backing tmp_path is case-sensitive — nothing to re-spell")
+    (tmp_path / "Knowledge Base" / "Notes").mkdir(parents=True)
+
+    rel = vault.canonical_vault_rel(tmp_path, "KNOWLEDGE BASE/notes/x.md")
+
+    # Both existing directories come back in their on-disk spelling; the
+    # not-yet-existing leaf is preserved verbatim.
+    assert rel == "Knowledge Base/Notes/x.md"

--- a/tests/test_case_insensitive_identity.py
+++ b/tests/test_case_insensitive_identity.py
@@ -343,3 +343,174 @@ def test_canonical_vault_rel_respells_against_real_on_disk_directories(
     # Both existing directories come back in their on-disk spelling; the
     # not-yet-existing leaf is preserved verbatim.
     assert rel == "Knowledge Base/Notes/x.md"
+
+
+# ------------- canonical_vault_rel: the casing-ONLY security invariant -------------
+#
+# `Path.resolve()` re-spells to real on-disk casing, but it also FOLLOWS
+# SYMLINKS (and expands junctions / 8.3 short names, and collapses `..`).
+# `hosted_transfer_routes._open_bounded_vault_file` re-opens the returned
+# rel-form component by component under `O_NOFOLLOW` precisely so that a
+# symlink raises ELOOP -> INVALID_PATH -> HTTP 400. If resolution is allowed to
+# hand back the link's *target*, the guard is shown a real file and serves it:
+# the symlink is laundered past the check that exists to reject it. So the
+# canonical form may be adopted only when the sole difference is casing.
+
+
+def _symlinks_available(directory: Path) -> bool:
+    """Whether this runner can actually create a symlink (Windows: privilege)."""
+    target = directory / "_exomem_symlink_probe_target.tmp"
+    link = directory / "_exomem_symlink_probe_link.tmp"
+    target.write_text("probe", encoding="utf-8")
+    try:
+        link.symlink_to(target.name)
+    except (OSError, NotImplementedError):
+        return False
+    finally:
+        link.unlink(missing_ok=True)
+        target.unlink(missing_ok=True)
+    return True
+
+
+def _seed_symlinked_note(root: Path, *, link: str, target: str) -> None:
+    notes = root / "Knowledge Base" / "Notes"
+    notes.mkdir(parents=True, exist_ok=True)
+    (notes / target).write_text("SECRET", encoding="utf-8")
+    (notes / link).symlink_to(target)
+
+
+def test_is_casing_only_rewrite_accepts_a_pure_recasing() -> None:
+    assert vault.is_casing_only_rewrite(
+        "Knowledge Base/Notes/Research/POLLY/terms.md",
+        "Knowledge Base/Notes/Research/Polly/terms.md",
+    )
+    assert vault.is_casing_only_rewrite("Knowledge Base/Notes/x.md", "Knowledge Base/Notes/x.md")
+
+
+def test_is_casing_only_rewrite_rejects_a_different_file() -> None:
+    # A symlink swapped for its target: same directory, different name.
+    assert not vault.is_casing_only_rewrite(
+        "Knowledge Base/Notes/shared.md", "Knowledge Base/Notes/link.md"
+    )
+    # A `..` collapse is not a re-casing either.
+    assert not vault.is_casing_only_rewrite(
+        "Knowledge Base/Notes/x.md", "Knowledge Base/../Knowledge Base/Notes/x.md"
+    )
+
+
+def test_is_casing_only_rewrite_rejects_casefold_length_expansions() -> None:
+    """`casefold()` alone is not enough: it is not length-preserving.
+
+    `'ß'.casefold() == 'ss'`, `'ﬁ'` folds to `'fi'`, `'İ'` to `'i'` plus a
+    combining dot. Those spellings name a *genuinely different* file, so a bare
+    casefold comparison would call `straße.md -> STRASSE.md` a casing-only
+    rewrite and launder that symlink. The pre-fold length guard rejects them.
+    """
+    assert "straße.md".casefold() == "STRASSE.md".casefold()  # the trap
+    assert not vault.is_casing_only_rewrite("STRASSE.md", "straße.md")
+    assert not vault.is_casing_only_rewrite("fish.md", "ﬁsh.md")
+
+
+def test_canonical_vault_rel_returns_input_unchanged_when_resolution_relocates_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Platform-free twin of the symlink test below.
+
+    Stands in for any resolution that changes *which file* the path names —
+    symlink, junction, 8.3 short name — without needing the privilege to make
+    one, so every runner covers the invariant.
+    """
+    root = tmp_path
+
+    def laundering_resolve(self: Path, *args, **kwargs):
+        if self == root:
+            return root
+        return root / "Knowledge Base" / "Notes" / "shared.md"
+
+    monkeypatch.setattr(Path, "resolve", laundering_resolve)
+
+    rel = vault.canonical_vault_rel(root, "Knowledge Base/Notes/link.md")
+
+    assert rel == "Knowledge Base/Notes/link.md"
+
+
+def test_canonical_vault_rel_returns_input_unchanged_for_a_symlink(tmp_path: Path) -> None:
+    """The regression: a symlink must not be laundered into its target.
+
+    `tests/test_hosted_private_routes.py::
+    test_hosted_transfer_scope_expiry_cross_cell_and_download_isolation` is the
+    specification — it requires the download route to answer 400/INVALID_PATH
+    for `Knowledge Base/Notes/link.md -> shared.md`. That only holds while the
+    rel-form handed to the `O_NOFOLLOW` re-open still says `link.md`.
+    """
+    if not _symlinks_available(tmp_path):
+        pytest.skip("this runner cannot create symlinks (Windows privilege)")
+    _seed_symlinked_note(tmp_path, link="link.md", target="shared.md")
+
+    rel = vault.canonical_vault_rel(tmp_path, "Knowledge Base/Notes/link.md")
+
+    assert rel == "Knowledge Base/Notes/link.md"
+
+
+def test_canonical_vault_rel_returns_input_unchanged_for_a_same_length_symlink(
+    tmp_path: Path,
+) -> None:
+    """Prove the case comparison rejects it, not merely the length guard.
+
+    `link.md` and `shrd.md` are the same length, so only a real
+    case-insensitive comparison of the two spellings can tell them apart.
+    """
+    if not _symlinks_available(tmp_path):
+        pytest.skip("this runner cannot create symlinks (Windows privilege)")
+    _seed_symlinked_note(tmp_path, link="link.md", target="shrd.md")
+
+    rel = vault.canonical_vault_rel(tmp_path, "Knowledge Base/Notes/link.md")
+
+    assert rel == "Knowledge Base/Notes/link.md"
+
+
+def test_canonical_vault_rel_result_is_always_case_equal_to_its_input(tmp_path: Path) -> None:
+    """The invariant itself, asserted directly rather than via one expected value.
+
+    Whatever `canonical_vault_rel` returns for a symlinked path, it must be
+    case-insensitively equal to what the caller asked for — i.e. only the
+    casing may ever change.
+    """
+    if not _symlinks_available(tmp_path):
+        pytest.skip("this runner cannot create symlinks (Windows privilege)")
+    _seed_symlinked_note(tmp_path, link="link.md", target="shared.md")
+    requested = "Knowledge Base/Notes/link.md"
+
+    rel = vault.canonical_vault_rel(tmp_path, requested)
+
+    assert rel.casefold() == requested.casefold()
+
+
+def test_resolve_under_vault_does_not_launder_a_symlink(tmp_path: Path) -> None:
+    """The boundary `_open_bounded_vault_file` actually calls."""
+    if not _symlinks_available(tmp_path):
+        pytest.skip("this runner cannot create symlinks (Windows privilege)")
+    _seed_symlinked_note(tmp_path, link="link.md", target="shared.md")
+    requested = "Knowledge Base/Notes/link.md"
+
+    _candidate, rel = vault.resolve_under_vault(
+        tmp_path, requested, must_exist=True, must_be_file=True
+    )
+
+    assert rel == requested
+    assert rel.casefold() == requested.casefold()
+
+
+def test_edit_resolve_does_not_launder_a_symlink(tmp_path: Path) -> None:
+    """`edit._resolve` mirrors `canonical_vault_rel` and had the same hole."""
+    if not _symlinks_available(tmp_path):
+        pytest.skip("this runner cannot create symlinks (Windows privilege)")
+    from exomem import edit as edit_module
+
+    _seed_symlinked_note(tmp_path, link="link.md", target="shared.md")
+    requested = "Knowledge Base/Notes/link.md"
+
+    _candidate, rel = edit_module._resolve(tmp_path, requested)
+
+    assert rel == requested
+    assert rel.casefold() == requested.casefold()

--- a/tests/test_memory_refs.py
+++ b/tests/test_memory_refs.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import datetime as dt
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
 import yaml
 
 from exomem import add, commands, link, memory_refs, note, preserve
@@ -65,6 +67,67 @@ def test_bulk_reference_lookup_uses_index_and_refreshes_only_missing_paths(tmp_p
         second_path: memory_refs.memory_ref(second_id),
         "missing.md": None,
     }
+
+
+def test_bulk_reference_lookup_answers_phantom_casing_in_the_callers_form(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A caller may spell a page's folder differently than the disk does.
+
+    Sidecar rows are keyed by the on-disk spelling (`refresh_paths` resolves),
+    so the lookup has to canonicalize — but the answer must stay keyed by what
+    the caller passed in, because callers index the result by their own string.
+    The casefold is modelled here so the contract is pinned on Linux CI too.
+    """
+    vault = tmp_path / "vault"
+    folder = vault / "Knowledge Base" / "Notes" / "POLLY"
+    folder.mkdir(parents=True)
+    identity = memory_refs.new_id()
+    (folder / "terms.md").write_text(_page(identity), encoding="utf-8")
+    on_disk = "Knowledge Base/Notes/POLLY/terms.md"
+    phantom = "Knowledge Base/Notes/Polly/terms.md"
+
+    index = memory_refs.ReferenceIndex(vault)
+    assert index.rebuild_all() == {"indexed": 1, "duplicates": 0, "malformed": 0}
+    monkeypatch.setattr(
+        memory_refs.vault_module,
+        "canonical_vault_rel",
+        lambda _root, rel: on_disk if rel.casefold() == on_disk.casefold() else rel,
+    )
+
+    ref = memory_refs.memory_ref(identity)
+    assert index.refs_for_paths([phantom]) == {phantom: ref}
+    assert index.ref_for_path(phantom) == ref
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="phantom path casing only names the same page on a case-insensitive filesystem",
+)
+def test_delete_paths_removes_the_canonical_row_for_phantom_casing(tmp_path: Path) -> None:
+    """A delete addressed with the caller's casing must not orphan the real row.
+
+    On NTFS `.../Polly/terms.md` and `.../POLLY/terms.md` open one file, but the
+    sidecar keys rows as case-sensitive text: a stale row survives the delete and
+    then reads back as a second owner of the identity.
+    """
+    vault = tmp_path / "vault"
+    folder = vault / "Knowledge Base" / "Notes" / "POLLY"
+    folder.mkdir(parents=True)
+    identity = memory_refs.new_id()
+    page = folder / "terms.md"
+    page.write_text(_page(identity), encoding="utf-8")
+
+    index = memory_refs.ReferenceIndex(vault)
+    assert index.rebuild_all() == {"indexed": 1, "duplicates": 0, "malformed": 0}
+    assert index.resolve(identity) == "Knowledge Base/Notes/POLLY/terms.md"
+
+    page.unlink()
+    index.delete_paths(["Knowledge Base/Notes/Polly/terms.md"])
+
+    with pytest.raises(memory_refs.ReferenceError) as excinfo:
+        index.resolve(identity)
+    assert excinfo.value.code == "REFERENCE_NOT_FOUND"
 
 
 def test_legacy_negative_reference_is_indexed_without_repeat_scan(

--- a/tests/test_windows_case_insensitive_paths.py
+++ b/tests/test_windows_case_insensitive_paths.py
@@ -1,0 +1,355 @@
+"""On-box proof that a case-insensitive filesystem can no longer split one
+governed page into two identity owners.
+
+The incident: a client addressed `Knowledge Base/Notes/Research/Polly/…` while
+the directory on disk is `POLLY`. NTFS opens the same single file either way,
+but the stable-identity census recorded the real on-disk casing while the write
+pipeline carried the caller's casing, and the ownership guard compared them
+byte-for-byte — so one physical file read as having "another corpus owner" and
+every edit was refused with `SEMANTIC_IDENTITY_DUPLICATE` /
+`SEMANTIC_CONTRACT_BLOCKED`.
+
+`test_case_insensitive_identity.py` pins the policy layers platform-free (it
+models the fold via `EXOMEM_CASEFOLD_PATHS`, so Linux CI covers both branches).
+This module is the complement: it uses a REAL case-folding filesystem, with no
+env override and no monkeypatching, so it proves the canonicalization actually
+lands on the real on-disk spelling rather than a modelled one.
+
+GATED: skips unless running on Windows AND the volume backing the temp vault
+really folds case. Windows supports per-directory case sensitivity
+(`fsutil file setCaseSensitiveInfo`), so probe rather than assume — skip
+gracefully there instead of false-failing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from exomem import activation_manifest, semantic_contract
+from exomem import append_to_file as append_module
+from exomem import create_file as create_file_module
+from exomem import edit as edit_module
+from exomem import multi_edit as multi_edit_module
+from exomem import set_frontmatter_field as set_frontmatter_module
+from exomem import vault as vault_module
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="case-insensitive path aliasing only reproduces on Windows",
+)
+
+TODAY = dt.date(2026, 7, 24)
+
+_ID = "35494c6a-da47-4694-ab0c-47552571d73f"
+_LEAF = "provisional-commercial-terms.md"
+# The on-disk directory (what the identity census walks) vs. the spelling the
+# blocked client sent. Both open the same directory on NTFS.
+_REAL_DIR = "Knowledge Base/Notes/Research/POLLY"
+_PHANTOM_DIR = "Knowledge Base/Notes/Research/Polly"
+_REAL_REL = f"{_REAL_DIR}/{_LEAF}"
+_PHANTOM_REL = f"{_PHANTOM_DIR}/{_LEAF}"
+
+
+def _note_source(*, rate: str, title: str = "Provisional commercial terms") -> str:
+    """A fully contract-compliant governed page: a semantic unit and a
+    qualifying relation, so nothing but the path casing is ever in question."""
+    return (
+        "---\n"
+        f"title: {title}\n"
+        # Notes/Research/ is a canonical compiled destination and pins the type.
+        "type: research-note\n"
+        "status: active\n"
+        f"exomem_id: {_ID}\n"
+        "---\n\n"
+        "## Observations\n\n"
+        f"- [commercial term] The provisional rate is {rate} per hour #polly\n\n"
+        "## Relations\n\n"
+        "- relates_to [[Knowledge Base/Notes/Insights/rrf-fusion-beats-score-normalization]]\n"
+    )
+
+
+def _filesystem_casefolds(directory: Path) -> bool:
+    """Whether `directory`'s volume really opens one file under two spellings."""
+    probe = directory / "_exomem_case_probe.tmp"
+    probe.write_text("probe", encoding="utf-8")
+    try:
+        swapped = directory / "_EXOMEM_CASE_PROBE.TMP"
+        return swapped.is_file() and os.path.samefile(probe, swapped)
+    finally:
+        probe.unlink()
+
+
+@pytest.fixture
+def folding_vault(vault: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """The conftest vault, guaranteed to sit on a case-folding filesystem.
+
+    No `EXOMEM_CASEFOLD_PATHS` override: this module's whole point is that the
+    real probe answers correctly against a real volume.
+    """
+    if not _filesystem_casefolds(vault):
+        pytest.skip(
+            "the volume backing tmp_path is case-sensitive (per-directory case "
+            "sensitivity is enabled) — nothing to reproduce here"
+        )
+    monkeypatch.delenv("EXOMEM_CASEFOLD_PATHS", raising=False)
+    vault_module.reset_casefold_probe_cache()
+    yield vault
+    vault_module.reset_casefold_probe_cache()
+
+
+def _seed_governed_note(root: Path, *, rate: str = "37.50 EUR") -> Path:
+    """Write the governed note under the REAL on-disk casing (`POLLY`).
+
+    The activation manifest is installed deliberately. Without it the page is
+    grandfathered, and grandfathering downgrades any error the *before* state
+    already carries — which includes this very identity finding, since the
+    before state is mis-keyed too. A live vault long past activation is the
+    condition the incident actually occurred under, so pin it here or the guard
+    never gets to speak.
+    """
+    directory = root / _REAL_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    page = directory / _LEAF
+    page.write_text(_note_source(rate=rate), encoding="utf-8", newline="\n")
+    activation_manifest.ensure_manifest(root)
+    return page
+
+
+# ---------------- 1. the incident ----------------
+
+
+def test_edit_addressed_with_phantom_casing_commits_to_the_one_on_disk_page(
+    folding_vault: Path,
+) -> None:
+    """The exact production failure: ONE file on disk under `POLLY/`, addressed
+    by the caller as `Polly/`. Before the fix the census recorded `POLLY` while
+    the write pipeline carried `Polly`, the ownership guard compared them
+    case-sensitively, and the edit was refused as a duplicate identity. It must
+    now commit, and every path it records must be the real on-disk spelling.
+    """
+    page = _seed_governed_note(folding_vault)
+    # Test invariant: the two spellings are one file, not two.
+    phantom = folding_vault / _PHANTOM_REL
+    assert phantom.is_file()
+    assert os.path.samefile(page, phantom)
+
+    try:
+        result = edit_module.edit(
+            folding_vault,
+            path=_PHANTOM_REL,
+            why="land the blocked commercial-terms update",
+            old_string="37.50 EUR",
+            new_string="100.00 EUR",
+            today=TODAY,
+        )
+    except edit_module.EditError as error:  # pragma: no cover - regression path
+        pytest.fail(
+            f"a differently-cased address for the single on-disk page was refused: "
+            f"{error.code}: {error.reason}"
+        )
+
+    assert result.path == _REAL_REL
+    assert result.semantic is not None
+    assert result.semantic["path"] == _REAL_REL
+    assert result.semantic["mutated"] is True
+    assert _PHANTOM_REL not in result.semantic["written_paths"]
+    assert _REAL_REL in result.semantic["written_paths"]
+    assert "100.00 EUR" in page.read_text(encoding="utf-8")
+    # Still exactly one physical file — the fix must not have created a sibling.
+    assert sorted(p.name for p in (folding_vault / _REAL_DIR).iterdir()) == [_LEAF]
+
+
+# ---------------- 2. create into an existing differently-cased directory ----------------
+
+
+def test_create_into_differently_cased_directory_canonicalizes_only_the_parent(
+    folding_vault: Path,
+) -> None:
+    """`POLLY/` exists on disk; the caller creates into `Polly/`. The parent
+    prefix must be re-spelled to the on-disk casing, while the brand-new leaf —
+    which has no on-disk spelling yet — keeps the casing the author chose."""
+    (folding_vault / _REAL_DIR).mkdir(parents=True, exist_ok=True)
+    leaf = "Provisional-Commercial-Terms-Addendum.md"
+    payload = {
+        "path": f"{_PHANTOM_DIR}/{leaf}",
+        "content": (
+            "# Addendum\n\n"
+            "## Observations\n\n"
+            "- [commercial term] The weekly cap is 25 hours #polly\n"
+        ),
+        # Notes/Research/ is a canonical compiled destination, so the contract
+        # pins the type; unrelated to the casing behavior under test.
+        "frontmatter": {"type": "research-note", "status": "active"},
+        "today": TODAY,
+    }
+
+    draft = create_file_module.create_file(folding_vault, validate_only=True, **payload)
+    # The draft token binds the destination it was minted for; a phantom-cased
+    # second call must resolve to that same canonical destination or the commit
+    # is refused outright.
+    assert draft.destination == f"{_REAL_DIR}/{leaf}"
+
+    result = create_file_module.create_file(
+        folding_vault,
+        draft_id=draft.draft_id,
+        draft_hash=draft.draft_hash,
+        draft_token=draft.draft_token,
+        relation_disposition="reviewed_none",
+        relation_review_hash=draft.draft_hash,
+        relation_review_reason="No honest relation exists in this fixture corpus.",
+        **payload,
+    )
+
+    assert result.path == f"{_REAL_DIR}/{leaf}"
+    written = folding_vault / _REAL_DIR / leaf
+    assert written.is_file()
+    # The leaf landed with the authored casing, not a folded or re-spelled one.
+    assert [p.name for p in (folding_vault / _REAL_DIR).iterdir()] == [leaf]
+
+
+# ---------------- 3. the two resolution boundaries ----------------
+
+
+def test_resolve_under_vault_returns_the_on_disk_casing(folding_vault: Path) -> None:
+    _seed_governed_note(folding_vault)
+
+    abs_path, rel = vault_module.resolve_under_vault(
+        folding_vault, _PHANTOM_REL, must_exist=True, must_be_file=True, must_be_under_kb=True
+    )
+
+    assert rel == _REAL_REL
+    assert os.path.samefile(abs_path, folding_vault / _REAL_REL)
+
+
+def test_resolve_under_vault_canonicalizes_the_parent_of_a_missing_leaf(
+    folding_vault: Path,
+) -> None:
+    """The create path: the parent exists under another casing, the leaf does
+    not exist at all. Non-strict resolution must re-spell the former and leave
+    the latter verbatim."""
+    (folding_vault / _REAL_DIR).mkdir(parents=True, exist_ok=True)
+
+    _, rel = vault_module.resolve_under_vault(
+        folding_vault, f"{_PHANTOM_DIR}/Not-Yet-Written.md", must_be_under_kb=True
+    )
+
+    assert rel == f"{_REAL_DIR}/Not-Yet-Written.md"
+
+
+def test_edit_resolve_returns_the_on_disk_casing(folding_vault: Path) -> None:
+    _seed_governed_note(folding_vault)
+
+    candidate, rel = edit_module._resolve(folding_vault, _PHANTOM_REL)
+
+    assert rel == _REAL_REL
+    assert os.path.samefile(candidate, folding_vault / _REAL_REL)
+
+
+def test_edit_resolve_canonicalizes_a_kb_prefixless_address(folding_vault: Path) -> None:
+    """`edit` accepts a KB-relative address and re-roots it. The re-rooted form
+    must still come back in the on-disk casing."""
+    _seed_governed_note(folding_vault)
+
+    _, rel = edit_module._resolve(folding_vault, f"Notes/Research/Polly/{_LEAF}")
+
+    assert rel == _REAL_REL
+
+
+# ---------------- 4. warm-corpus delta keying ----------------
+
+
+def test_warm_corpus_delta_keys_a_phantom_cased_event_under_the_on_disk_path(
+    folding_vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A files-changed event carrying a caller-cased RELATIVE path must patch
+    the page the census already knows, not manufacture a second entry keyed
+    under the phantom spelling. (The absolute branch already resolved; the
+    relative branch did not.)"""
+    # This suite's conftest defaults the corpus cache off; the delta patch only
+    # runs against a warm entry, so opt back in for this test.
+    monkeypatch.delenv("EXOMEM_DISABLE_CORPUS_CACHE", raising=False)
+    semantic_contract.reset_corpus_context_cache()
+
+    page = _seed_governed_note(folding_vault)
+    warm = semantic_contract.build_corpus_context(folding_vault)
+    assert _REAL_REL in warm.pages, "test setup: the census must see the on-disk page"
+
+    page.write_text(
+        _note_source(rate="100.00 EUR", title="Event patched terms"),
+        encoding="utf-8",
+        newline="\n",
+    )
+    semantic_contract.on_corpus_files_changed(folding_vault, changed=(Path(_PHANTOM_REL),))
+
+    cache_key = semantic_contract._corpus_cache_key(folding_vault)
+    entry = semantic_contract._CORPUS_CONTEXT_CACHE.get(cache_key)
+    assert entry is not None, "test setup: the warm entry should still be cached"
+    patched = entry[1]
+
+    assert _PHANTOM_REL not in patched.pages
+    assert _REAL_REL in patched.pages
+    census_paths = {item.path for item in patched.identity_census.entries}
+    assert _PHANTOM_REL not in census_paths
+    assert _REAL_REL in census_paths
+    # The delta really landed on the canonical key rather than being dropped.
+    assert patched.identity_census.paths_by_identity[_ID] == (_REAL_REL,)
+    assert patched.pages[_REAL_REL].title == "Event patched terms"
+
+
+# ---------------- 5. the other write paths ----------------
+
+
+def _multi_edit(root: Path) -> str:
+    return multi_edit_module.multi_edit(
+        root,
+        path=_PHANTOM_REL,
+        why="batch the phantom-cased address",
+        edits=[{"old_string": "37.50 EUR", "new_string": "100.00 EUR"}],
+        today=TODAY,
+    ).path
+
+
+def _append(root: Path) -> str:
+    return append_module.append_to_file(
+        root,
+        path=_PHANTOM_REL,
+        # Opens a new section: the seeded page ends with `## Relations`, and a
+        # bare bullet appended there would parse as a malformed relation.
+        content="\n## Addendum\n\n- [commercial term] Weekly cap is 25 hours #polly\n",
+        today=TODAY,
+    ).path
+
+
+def _set_frontmatter(root: Path) -> str:
+    return set_frontmatter_module.set_frontmatter_field(
+        root,
+        path=_PHANTOM_REL,
+        field="domain",
+        value="commercial",
+        why="record the domain on the phantom-cased address",
+        today=TODAY,
+    ).path
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        pytest.param(_multi_edit, id="multi_edit"),
+        pytest.param(_append, id="append_to_file"),
+        pytest.param(_set_frontmatter, id="set_frontmatter_field"),
+    ],
+)
+def test_other_writers_accept_a_phantom_cased_address(
+    folding_vault: Path, writer: Callable[[Path], str]
+) -> None:
+    """Every Tier 2 writer reaches the same identity guard, so each must resolve
+    the caller's casing to the one on-disk page and report it back canonically."""
+    _seed_governed_note(folding_vault)
+
+    assert writer(folding_vault) == _REAL_REL


### PR DESCRIPTION
## What broke

A connector session was refused three times trying to edit a governed note whose on-disk directory is `POLLY` while the client addressed it as `Polly`:

```
SEMANTIC_CONTRACT_BLOCKED: semantic contract has blocking findings:
SEMANTIC_IDENTITY_DUPLICATE at Knowledge Base/Notes/Research/Polly/…:
the stable page identity has another corpus owner
```

There was no duplicate. Exactly one physical file owned the id.

The stable-identity census walks the filesystem and records **real on-disk casing**; the write pipeline carried the **caller's casing** into `page.path`. The ownership check at `semantic_contract.py` compared them with case-sensitive equality, so on a case-insensitive filesystem one file looked like two owners. `StableIdentityCensus.with_page` removed only the exact-cased entry, so the after-corpus manufactured the second owner in memory as well.

Same bug class as #129 (Windows 8.3 aliases in freshness event keys); that fix's `resolve()` canonicalization never reached the identity census or the write paths.

**The blast radius is wider than refused edits.** On a vault with no activation manifest, the identity finding is present in the *before* state too, so grandfathering collapses `blocking` to empty and the write **lands silently** — recording the phantom casing in sidecars and `log.md`.

## The fix

**Layer 1 — canonicalize at the resolution boundary.** New `vault.canonical_vault_rel` re-spells a vault-relative path to real on-disk casing (existing components canonicalized, a not-yet-existing leaf preserved, first segment re-spelled to literal `kb_dirname()`), failing open to the input on `OSError`/`ValueError`. Applied in `resolve_under_vault` and `edit._resolve` by **reusing the `resolve()` results those functions already computed** — zero added syscalls on the hot paths. Creation destinations in `note.py`/`link.py` are canonicalized before DraftToken minting; the warm-corpus delta and `_posthoc_relative_path` relative branches now canonicalize like their absolute siblings.

**Layer 2 — fold-aware ownership comparison, only where the filesystem folds.** `identity_owners_match(owners, page_path, *, folds)` with `folds` from a cached `vault_casefolds` probe (`EXOMEM_CASEFOLD_PATHS` overrides the predicate; it does *not* disable canonicalization). **With `folds=False` the comparison is byte-for-byte unchanged** — two genuinely distinct case-variant files on a case-sensitive filesystem still block.

**Layer 3 — name the collision.** The `SEMANTIC_IDENTITY_DUPLICATE` detail now lists the conflicting owner paths instead of leaving a client to guess.

`memory_refs.delete_paths` removes both spellings; `refs_for_paths` canonicalizes on index miss and re-keys to the caller's form, keeping the latency-gated hit path syscall-free.

## Verification

- **The new win32-gated suite fails 10/10 against pristine HEAD** — reproducing the production error verbatim — **and passes 10/10 with the fix.** (Measured by stubbing only the one missing symbol into an archived HEAD tree, since the fixture otherwise errors at setup.)
- **490 passed, 0 failed** across the change's files plus the #129 regression guards (`test_win32_short_name_registry.py`, `test_file_watcher.py`).
- Pre-existing Windows failures (~14 in `test_reconcile.py`, plus others in a wider 17-file sweep) were attributed to HEAD by running the same suites against a `git archive HEAD` tree — **identical failure-id sets, zero new failures.**
- `ruff check` clean, including CI's exact invocations; `mypy` clean on `memory_refs.py`.
- Real-filesystem checks on Windows: `.../Research/Polly/terms.md` → `.../Research/POLLY/terms.md`; create-into-differently-cased-parent canonicalizes the parent and preserves the authored leaf; a fully-committed `link()` create proves DraftToken binding survives.
- Platform-free tests exercise **both** `EXOMEM_CASEFOLD_PATHS=1` and `=0`, so Linux CI covers the fold branch despite running on a case-sensitive filesystem.

An independent adversarial review pass ran 764 tests, confirmed zero new failures, and produced findings that are all applied here: the `vault_casefolds` cache key no longer resolves (**147 µs → 5.5 µs per call**, ~1.47 s → ~55 ms on a 10k-page audit); `_probe_casefolds` no longer mis-answers on length-changing case mappings (`straße`→`STRASSE`, `ﬁles`→`FILES`) or memoize a TOCTOU miss; the duplicate detail no longer renders a dangling colon.

## Notes for review

- **Symlinks:** `resolve_under_vault` now returns a rel derived from a resolved path, so a vault-internal symlinked directory would report its target. This is unreachable for governed pages — the census hard-rejects any symlink under `Knowledge Base/` (verified by creating one; the build refuses) — and hosted deployments reject tree symlinks outright.
- **Pre-existing, not introduced:** a casing-only directory rename can leave a stale row in `.refs.sqlite`, because `refresh_paths` deletes only the newly-resolved key. Present identically at HEAD; `reconcile`/`rebuild_all` heals it. The justifying comment in `memory_refs.py` has been corrected to state the real invariant.
- **Deploy step:** because stale phantom-cased rows can persist in `.refs.sqlite` and the epistemic-graph sidecar (whose `delete_paths` did not get canonicalization), a post-deploy `maintain_memory mode="reconcile"` should be treated as **required**, not optional. Restarting the service after deploy also flushes any warm corpus holding phantom keys.
- **Unadvertised fix:** the phantom-cased path also broke `RELATION_REVIEW_STABLE_ID_REQUIRED`, so HEAD silently skipped writing the relation-review lifecycle record. It is written correctly now.
- Linux CI remains the authoritative gate — the full suite, latency gate, and golden tests cannot run on native Windows.
