### PR TITLE
docs(governance): OpenSpec changes for user-sovereign knowledge governance

### DIFF
--- a/openspec/changes/add-cross-domain-bridges/.openspec.yaml
+++ b/openspec/changes/add-cross-domain-bridges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-cross-domain-bridges/design.md
+++ b/openspec/changes/add-cross-domain-bridges/design.md
@@ -1,0 +1,81 @@
+# Design: add-cross-domain-bridges
+
+## Context
+
+Bridges reuse existing machinery. A bridge note is authored through the normal
+compiled-note write path (`remember`/`replace_memory`) — approval *is* the owner's
+confirmed write plus an approval event, so no new authoring surface is needed. The
+content-hash bind reuses `get_page`'s already-computed `content_hash`
+(`get_page.py:137`) — the check is a zero-extra-IO string compare. Provenance
+stripping extends the release gate's projector. Re-review reuses the review/Inbox
+queues (`attention.py`, review studio). L2 constraint strings are scope-registered
+micro-bridges the evaluator already understands (level L2 in the ladder).
+
+## Goals / Non-Goals
+
+Goals: release an abstraction where the raw source is withheld, with provenance
+into the restricted scope stripped; bind approval to content so an edited bridge
+re-reviews; a re-review lifecycle tied to source changes; honest handling of the
+"some representation must cross" reality.
+
+Non-Goals: automated abstraction generation (a local model may draft but never
+approve), a general-purpose LLM in core, preset bridge template libraries (later),
+enforcement redesign (the gate from `add-release-gate` is reused).
+
+## Decisions
+
+### D1 — Bridge = compiled note + governance frontmatter + approval grant
+Frontmatter `bridge_of: [exomem://…]`, `bridge_scope`, `bridge_review`. The note's
+own scope membership (usually none/open) governs its release; the evaluator
+releases it even when `bridge_of` targets are restricted. Approval is a
+`kind: release` grant in `_Governance/grants/` carrying `{path, content_hash,
+to_audience, options: {strip_provenance: [...]}, released_at, why}`.
+
+### D2 — Approval binds content_hash
+At release, `get_page`'s computed hash is compared to the grant's
+`content_hash`; mismatch → withhold with `RELEASE_STALE` (re-approval required).
+Zero extra IO (the hash is already computed). This kills the approve-then-edit
+laundering channel: new restricted content cannot ride an old approval.
+
+### D3 — Provenance stripping covers all channels
+For a released bridge, strip: frontmatter `sources`/`evidence`, history, and
+`## Relations` edges pointing into restricted scopes (in `op_get`/`annotate_page`),
+and hit-level `graph.seed`/`relation_match`/`superseded_by`/`parent_ref` naming
+restricted paths (in the gate's `annotate_hits`). Provenance is metadata, not
+content, so it is stripped at annotation, not in the raw serializer.
+
+### D4 — L2 constraint strings are scope-registered micro-bridges
+For the "do not assume unlimited evening capacity" case, a constraint string is
+registered directly on a scope and released at L2 wherever the rule allows — no
+note ceremony, no `bridge_of` note. The evaluator already has L2 in the ladder;
+this change wires the constraint text through the projector.
+
+### D5 — Re-review lifecycle on the existing queue
+`bridge_review` dates surface as due items in the review/Inbox queue; restricting
+or deleting a `bridge_of` source flags dependent bridges for re-review (the bridge
+is the owner's own file — never silently deleted or altered). Approval and expiry
+are receipt events (from `add-disclosure-receipts`) with provenance back to source
+content hashes.
+
+## Risks / Trade-offs
+
+- **Approval washing via embedded quotes**: a bridge body could paste restricted
+  text. Mitigation: approval binds `content_hash`, so the owner reviews the exact
+  bytes; a later edit re-reviews. The system cannot prevent the owner from
+  approving a leaky abstraction — that is a human review responsibility, made
+  visible, not automated away.
+- **Local-model drafting quality**: out of scope for correctness — a draft is a
+  suggestion the owner must approve; the non-approving-self rule is a hard
+  constraint.
+- **Source deletion vs dependent bridge**: flag for re-review, never cascade-
+  delete the owner's authored bridge.
+
+## Migration Plan
+
+Additive frontmatter + grant kind. Existing bridge-shaped notes gain governance
+only when the owner approves them. No data migration.
+
+## Open Questions
+
+None blocking. Preset bridge templates (medical workload-constraint, legal
+de-identification) land with `add-professional-presets`.

--- a/openspec/changes/add-cross-domain-bridges/proposal.md
+++ b/openspec/changes/add-cross-domain-bridges/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: add-cross-domain-bridges
+
+## Why
+
+A protected source cannot semantically influence work outside its scope without
+*some* representation crossing the boundary — pretending otherwise is dishonest.
+The sanctioned crossing is a **bridge**: a reviewed derived representation that may
+be used outside its source's restricted context. "Preserve proven process
+boundaries during the first migration" can inform general engineering without the
+client names behind it ever leaving the vault; "there is a health issue
+contributing to fatigue; do not assume unlimited evening capacity" can inform
+workload planning without the raw medical values.
+
+This change makes bridges first-class so the release gate can release an
+abstraction where it must withhold the raw source — turning "no cross-domain
+disclosure" and "maximum useful connection" from a contradiction into a governed
+workflow. It is the last core wave; the kernel, gate, tools, and receipts precede
+it.
+
+## What Changes
+
+- A **bridge is an ordinary compiled note** (living where its type belongs) plus
+  governance frontmatter — `bridge_of: [exomem://…]`, `bridge_scope: <scope>`,
+  `bridge_review: <date>` — and an approval event.
+- The release gate releases a bridge note per its own (usually open) scope **even
+  when its `bridge_of` sources are restricted**, and strips provenance pointing
+  into restricted scopes at egress (frontmatter `sources`, history, `## Relations`
+  edges, and hit-level `graph.seed`/`relation_match`/`superseded_by`) so the
+  bridge never leaks a restricted title.
+- **Approval binds content**: a bridge approval is a `kind: release` grant carrying
+  the note's `content_hash` at approval time; at release, `get_page`'s
+  already-computed hash is compared and a mismatch withholds with `RELEASE_STALE`.
+  An edited bridge requires re-approval — closing the "approve once, then edit in
+  restricted quotes" laundering channel.
+- **L2 constraint strings** are micro-bridges registered directly on a scope (no
+  note ceremony) for the workload-constraint case.
+- **Lifecycle**: `bridge_review` dates surface in the existing review/Inbox
+  queues; restricting or deleting a source flags dependent bridges for re-review
+  (never silent). Creation paths: manual authoring, LLM-proposed + user-reviewed
+  (the existing propose→confirm write flow), deterministic templates, and
+  promotion from a compiled note. An optional local model may *draft* an
+  abstraction but never approves its own output — approval is the owner's confirmed
+  write plus the approval event. No general-purpose LLM is required in core.
+
+## Capabilities
+
+### New Capabilities
+
+- `cross-domain-bridges`: reviewed, content-hash-bound derived representations
+  (bridge notes and L2 constraint strings) that the release gate may release
+  outside a restricted source's scope with provenance into that scope stripped,
+  with a re-review lifecycle tied to source changes.
+
+### Modified Capabilities
+
+- `attention-queue`: due bridge re-reviews and source-change-triggered re-reviews
+  surface in the existing review queue.
+
+## Impact
+
+- Code: `src/exomem/governance/{policy,decisions,egress}.py` (bridge frontmatter,
+  `kind: release` grants, hash-bound release, provenance stripping),
+  `governance/tool.py` (bridge propose/approve/re-approve lifecycle);
+  `src/exomem/commands.py` (`op_get` bridge annotation + provenance strip);
+  review-queue integration for `bridge_review`.
+- Tests: `tests/test_governance_bridges.py`; egress provenance-strip extension.
+- Explicitly NOT in scope: automated abstraction generation quality (a local model
+  is an optional non-approving assistant), preset bridge templates beyond the
+  workload-constraint example (those ship with `add-professional-presets`).

--- a/openspec/changes/add-cross-domain-bridges/specs/attention-queue/spec.md
+++ b/openspec/changes/add-cross-domain-bridges/specs/attention-queue/spec.md
@@ -1,0 +1,21 @@
+# attention-queue
+
+## ADDED Requirements
+
+### Requirement: Bridge re-reviews surface in the attention queue
+
+The attention/review queue SHALL surface bridges whose `bridge_review` date is due
+and bridges flagged for re-review because a `bridge_of` source was restricted or
+deleted, as read-only review items citing the exact reason. Acting on such an item
+SHALL route through the normal governed review actions and SHALL NOT silently
+alter the bridge note.
+
+#### Scenario: Due bridge appears for review
+
+- **WHEN** a bridge's `bridge_review` date has passed
+- **THEN** it appears as a review item with its reason, and is not auto-changed
+
+#### Scenario: Source-triggered re-review appears
+
+- **WHEN** a source referenced by an approved bridge is restricted or deleted
+- **THEN** the dependent bridge surfaces as a re-review item

--- a/openspec/changes/add-cross-domain-bridges/specs/cross-domain-bridges/spec.md
+++ b/openspec/changes/add-cross-domain-bridges/specs/cross-domain-bridges/spec.md
@@ -1,0 +1,70 @@
+# cross-domain-bridges
+
+## ADDED Requirements
+
+### Requirement: Bridge notes release where their sources are withheld
+
+A bridge SHALL be an ordinary compiled note carrying `bridge_of` (one or more
+restricted source refs), `bridge_scope`, and `bridge_review` frontmatter plus an
+approval grant. The release gate SHALL release a bridge note according to the
+note's own scope even when its `bridge_of` sources are restricted, and SHALL strip
+provenance pointing into a restricted scope at egress — frontmatter sources,
+history, authored relation edges, and hit-level seed/relation/supersession
+annotations — so the bridge never discloses a restricted title, path, or
+neighbour.
+
+#### Scenario: Abstraction crosses, provenance does not
+
+- **WHEN** a bridge note whose sources are restricted is released to an audience
+- **THEN** the bridge's own content is returned and no restricted source title,
+  path, or relation edge appears in the response
+
+### Requirement: Approval binds content
+
+A bridge approval SHALL be a release grant carrying the note's content hash at
+approval time. At release the gate SHALL compare the note's current content hash
+to the approved hash and SHALL withhold with a stale-release outcome on mismatch,
+requiring re-approval. An edited bridge SHALL NOT be released under a prior
+approval.
+
+#### Scenario: Edited bridge re-reviews
+
+- **WHEN** a bridge note is edited after approval and then requested
+- **THEN** the release is withheld as stale and re-approval is required
+
+#### Scenario: Unedited bridge releases
+
+- **WHEN** an approved bridge is unchanged since approval
+- **THEN** it releases at its approved level
+
+### Requirement: Constraint strings as micro-bridges
+
+A scope MAY register a constraint string released at the constraint level (L2)
+wherever a rule permits, without authoring a bridge note. The constraint string
+SHALL convey a purpose-limited instruction and SHALL contain no raw facts from the
+restricted source.
+
+#### Scenario: Workload constraint informs planning
+
+- **WHEN** a query in a planning context matches a scope with a registered
+  constraint string
+- **THEN** the constraint string is released and the raw source is not
+
+### Requirement: Bridge re-review lifecycle
+
+Due `bridge_review` dates SHALL surface in the existing review queue, and
+restricting or deleting a `bridge_of` source SHALL flag its dependent bridges for
+re-review without altering or deleting the owner's bridge note. An optional local
+model MAY draft a bridge abstraction but SHALL NOT approve its own output;
+approval SHALL be the owner's confirmed write plus the approval event.
+
+#### Scenario: Source change flags dependent bridges
+
+- **WHEN** a source referenced by a bridge is restricted or deleted
+- **THEN** the dependent bridge is flagged for re-review and is not silently
+  changed
+
+#### Scenario: A model cannot self-approve
+
+- **WHEN** a local model drafts a bridge abstraction
+- **THEN** it is not released until the owner approves it with a confirmed write

--- a/openspec/changes/add-cross-domain-bridges/tasks.md
+++ b/openspec/changes/add-cross-domain-bridges/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: add-cross-domain-bridges
+
+## 1. Bridge schema + release grant
+
+- [ ] 1.1 Red test `tests/test_governance_bridges.py`: `bridge_of`/`bridge_scope`/
+      `bridge_review` frontmatter parses; a `kind: release` grant (with
+      `content_hash`) parses; `simulate` shows the bridge decision.
+- [ ] 1.2 Extend `governance/policy.py` (release-grant kind) and
+      `governance/decisions.py` (a bridge note releases per its own scope even
+      when `bridge_of` targets are restricted).
+
+## 2. Hash-bound release at op_get
+
+- [ ] 2.1 Red test: an approved, unchanged bridge releases; an edited bridge
+      withholds with `RELEASE_STALE`.
+- [ ] 2.2 In `op_get`/`annotate_page`, compare `get_page`'s computed content hash
+      to the grant hash (zero extra IO); mismatch → withhold notice.
+
+## 3. Provenance stripping
+
+- [ ] 3.1 Red test: released bridge omits frontmatter `sources`/`evidence`,
+      history, and `## Relations` edges into restricted scopes; hit-level
+      `graph.seed`/`relation_match`/`superseded_by` naming restricted paths
+      stripped.
+- [ ] 3.2 Implement provenance strip in `annotate_page` (get) and `annotate_hits`
+      (find) for bridge releases; wire L2 constraint strings through the projector.
+
+## 4. Lifecycle + re-review
+
+- [ ] 4.1 Red test: `bridge_review` due → review-queue item; restricting/deleting
+      a `bridge_of` source → dependent bridge flagged; a local-model draft is not
+      released until owner-approved.
+- [ ] 4.2 Wire `bridge_review` into the review/Inbox queue; source-change flagging;
+      full propose→approve→re-approve lifecycle end-to-end (two audiences).
+
+## 5. Gates
+
+- [ ] 5.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_governance_bridges.py tests/test_governance_egress.py
+      tests/test_govern_memory_tool.py` green.
+- [ ] 5.2 `uv run python -m pytest tests/test_latency_gate.py -q` green.
+- [ ] 5.3 `uvx ruff check` clean; `openspec validate add-cross-domain-bridges
+      --strict` green.

--- a/openspec/changes/add-disclosure-receipts/.openspec.yaml
+++ b/openspec/changes/add-disclosure-receipts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-disclosure-receipts/design.md
+++ b/openspec/changes/add-disclosure-receipts/design.md
@@ -1,0 +1,83 @@
+# Design: add-disclosure-receipts
+
+## Context
+
+No hash-chained log exists today (verified grep); append-only is filesystem/
+policy-based (`access.py` tiers), and `log.md` is a human record. Precedents to
+reuse: `mutation_terminal.committed_terminal` (`receipt_id`/`request_id` shape),
+`privacy_log.install_hosted_log_redaction` (content never echoed),
+`hosted_portability.classify_artifact` (what may leave a boundary),
+`query_log._append` (best-effort local JSONL semantics). The chain lives under
+`_Governance/events/` (in-vault, travels with the vault) but is partitioned by a
+per-machine instance id, with the head anchored in the never-synced sidecar.
+
+## Goals / Non-Goals
+
+Goals: a proportional, plaintext-free, tamper-evident receipt for governed
+egress and policy change; deletion evidence that outlives the source without its
+plaintext; cheap chain verification in the existing audit surface; honest
+vocabulary.
+
+Non-Goals: signed checkpoints, Hosted org countersignatures, exportable
+compliance reports, budgets (all later). No plaintext in the log. No receipts for
+ungoverned recall.
+
+## Decisions
+
+### D1 — One chain per machine, sidecar-anchored
+Records live in `_Governance/events/<instance-id>/YYYY-MM.jsonl` (monthly file =
+rotation; append-only; `.jsonl` invisible to md walks). `hash = sha256(prev +
+canonical_json(record_without_hash))`; the chain head + monotonic seq are cached
+in `.governance.sqlite receipts_head` so append is O(1) without re-reading the
+tail, and truncation/rollback is detected on load (head ahead of file). Per-
+machine partitioning means Obsidian sync never forks a single seq; cross-device
+budget aggregation is a documented limitation, not silently wrong. Month
+boundaries link the first record's `prev` to the prior month's head.
+
+### D2 — Proportional emission, no plaintext
+Emit only for: governed decisions (non-L6 participation), policy changes,
+grants/revocations, deletions of governed material, budget warnings. A record
+carries refs, source/released content hashes, byte sizes, level, redaction counts,
+principal, audience, purpose, policy fingerprint, confirmation type — scope **ids
++ hashed labels**, never label text, never released content. Full-text logging is
+an explicit per-scope opt-in. Ungoverned recall writes nothing.
+
+### D3 — fsync policy split by criticality
+Policy-mutation and deletion events flush + `os.fsync` (durability matters,
+frequency is low). Disclosure/read events are buffered best-effort (protects find
+latency; `query_log._append` semantics). This keeps the receipt-append budget
+(< 3 ms amortized) off the hot recall path.
+
+### D4 — Deletion events, not in the fan-out
+`delete_file.py` emits a `{event: deletion, ...}` record after the successful
+trash move + index fan-out (`:251-269`); `recover_from_trash` emits the inverse.
+`index_sync.delete_after_remove` itself stays receipt-free (it is also called by
+move/reconcile fan-outs with different semantics). No-op on empty policy.
+
+### D5 — Chain verify as an audit category
+A new `governance_receipts` entry in `audit.ALL_CATEGORIES` + a check block
+(`audit.py:357-386` pattern) calling `receipts.verify_chain`, reachable via
+`maintain_memory(mode="audit", categories=["governance_receipts"])` with zero new
+surface. Detects edited lines, truncated tails, and broken month links; repairs
+the head-cache forward when it lags the file after a crash.
+
+## Risks / Trade-offs
+
+- **Owner can destroy the log**: acknowledged and documented — "tamper-evident,"
+  never "immutable." A break is *visible* (that is the honest behavior). Org
+  assurance comes later via Hosted checkpoints.
+- **Sidecar not restored on hosted portability**: `.governance.sqlite` (head
+  anchor, HMAC key) is per-machine and does not travel; the in-vault chain does.
+  A restore re-anchors from the chain tail — stated as a contract, not a surprise.
+- **Label privacy**: scope labels can themselves be sensitive; store scope-ids +
+  hashed labels so the log names no confidential project in the clear.
+
+## Migration Plan
+
+Additive. Absent `_Governance/`, nothing is written. `.governance.sqlite` gains
+`receipts_head` via `PRAGMA user_version`. Existing vaults gain a chain only once
+a governed event occurs.
+
+## Open Questions
+
+None blocking. Signed checkpoints and exportable reports are explicitly deferred.

--- a/openspec/changes/add-disclosure-receipts/proposal.md
+++ b/openspec/changes/add-disclosure-receipts/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: add-disclosure-receipts
+
+## Why
+
+Governed releases and policy changes currently leave no durable, verifiable
+record. For the professional use cases (legal, medical, consulting) and for the
+owner's own trust in the system, a governed release should produce a
+**tamper-evident** receipt: what representation of which item left, to which
+audience, under which policy version — without storing the plaintext that was
+released. Exomem has no hash-chained or tamper-evident log today (verified); the
+closest is the human `log.md` plus best-effort JSONL telemetry that logs query
+text in plaintext locally. This change introduces the first chained evidence
+store, deliberately scoped and proportional so ordinary personal recall stays
+silent.
+
+## What Changes
+
+- A hash-chained append-only event log under
+  `Knowledge Base/_Governance/events/<instance-id>/YYYY-MM.jsonl` — **one chain
+  per machine** so a synced vault never forks a single chain. Each record links to
+  the previous by hash; the chain head + monotonic seq are anchored in the
+  per-machine `.governance.sqlite` so truncation is detected on load.
+- **Proportional emission**: events fire only for governed decisions (any non-L6
+  participation), policy changes, grants/revocations, deletions of governed
+  material, and budget warnings. An ungoverned vault writes nothing. An optional
+  per-scope "log everything" mode exists.
+- **No plaintext**: a record carries refs, source and released **content hashes**,
+  byte sizes, representation level, redaction counts, principal, audience, declared
+  purpose, policy fingerprint, and confirmation type — never released content, and
+  scope **ids + hashed labels**, not human label text. Full-text logging is an
+  explicit opt-in.
+- **Deletion events**: `delete_file`/`recover_from_trash` emit a
+  deletion/inverse event so evidence survives source deletion without retaining
+  the protected plaintext.
+- **Chain verification** as a new `governance_receipts` audit category reachable
+  via `maintain_memory(mode="audit")`.
+
+The vocabulary is honestly "tamper-evident," never "immutable": on a personal
+instance the owner can destroy both chain and anchor. Tamper-evidence targets
+accidents, non-owner tampering, and org contexts where Hosted checkpoints
+countersign — and the docs say exactly that.
+
+## Capabilities
+
+### New Capabilities
+
+- `disclosure-evidence`: a proportional, per-machine, hash-chained,
+  plaintext-free receipt log for governed releases, policy changes, grants, and
+  deletions, with sidecar-anchored truncation detection and an audit-mode chain
+  verifier.
+
+## Impact
+
+- Code: new `src/exomem/governance/receipts.py` (chained JSONL append, head cache,
+  `verify_chain`); emission wiring in `governance/tool.py` (policy/grant/revoke —
+  fsync'd), `governance/egress.py` (release/withhold — buffered), `governance/tokens.py`
+  (mint/redeem); `src/exomem/delete_file.py` + `recover_from_trash.py` (deletion
+  events); `src/exomem/audit.py` (`governance_receipts` category in
+  `ALL_CATEGORIES`).
+- Tests: `tests/test_governance_receipts.py`; `tests/test_audit.py` extension;
+  deletion-event tests.
+- Explicitly NOT in scope: signed checkpoints (SPECULATIVE, later), Hosted org
+  checkpoints (Hosted wave), exportable compliance reports (later), budgets.

--- a/openspec/changes/add-disclosure-receipts/specs/disclosure-evidence/spec.md
+++ b/openspec/changes/add-disclosure-receipts/specs/disclosure-evidence/spec.md
@@ -1,0 +1,72 @@
+# disclosure-evidence
+
+## ADDED Requirements
+
+### Requirement: Proportional plaintext-free receipts
+
+Governed egress and policy lifecycle events SHALL be recorded as receipts, and
+ordinary ungoverned recall SHALL produce no receipt. A receipt SHALL be emitted
+for a governed disclosure decision (any release below full), a policy change, a
+grant or revocation, a deletion of governed material, and a budget warning. A
+receipt SHALL carry item refs, source and released content hashes, byte sizes,
+the representation level, redaction counts, the principal, the audience, the
+declared purpose, the policy fingerprint, and the confirmation type — and SHALL
+NOT contain released content. Scope identity SHALL be recorded as ids and hashed
+labels, never as human label text, unless an explicit per-scope full-text opt-in
+is set.
+
+#### Scenario: Ungoverned recall writes nothing
+
+- **WHEN** a query runs on a vault with no governance policy
+- **THEN** no receipt is written
+
+#### Scenario: Governed release is receipted without plaintext
+
+- **WHEN** an item is released below full to an audience
+- **THEN** a receipt records the refs, hashes, sizes, level, audience, and policy
+  fingerprint, and contains neither the released text nor the scope's label text
+
+### Requirement: Per-machine hash-chained log with truncation detection
+
+Receipts SHALL be appended to a per-machine hash-chained log under
+`_Governance/events/<instance-id>/`, each record linking to the previous by hash,
+so a synced vault never forks a single chain. The chain head and a monotonic
+sequence SHALL be anchored in the per-machine sidecar so that truncation or
+rollback of the log is detected on load. Month boundaries SHALL link across files.
+
+#### Scenario: Tamper is detected
+
+- **WHEN** a record in the log is edited or the tail is truncated and the chain is
+  verified
+- **THEN** verification reports the break
+
+#### Scenario: Sync does not fork the chain
+
+- **WHEN** two machines each append receipts to a synced vault
+- **THEN** each writes its own per-instance chain and neither corrupts the other's
+  sequence
+
+### Requirement: Deletion evidence outlives the source
+
+Deleting governed material SHALL emit a deletion receipt carrying the item's refs
+and content hashes so evidence of the deletion survives, without retaining the
+deleted plaintext. Recovery from trash SHALL emit an inverse receipt. Deletion
+receipts SHALL NOT be removed by content deletion.
+
+#### Scenario: Deletion leaves evidence, not plaintext
+
+- **WHEN** a governed page is deleted
+- **THEN** a deletion receipt records its refs and hashes, and no deleted content
+  is retained in the log
+
+### Requirement: Chain verification via audit
+
+Chain verification SHALL be exposed as an audit category reachable through
+`maintain_memory(mode="audit")`, reporting edited records, truncated tails, and
+broken cross-month links, and repairing a lagging head cache forward after a
+crash.
+
+#### Scenario: Audit verifies the chain
+
+- **WHEN** the governance-receipts audit category runs on an intact log
+- **THEN** it reports the chain valid; on a tampered log it reports the break

--- a/openspec/changes/add-disclosure-receipts/tasks.md
+++ b/openspec/changes/add-disclosure-receipts/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: add-disclosure-receipts
+
+## 1. Chained log (src/exomem/governance/receipts.py)
+
+- [ ] 1.1 Red test `tests/test_governance_receipts.py`: append + `verify_chain`;
+      tamper detection (edited line, truncated tail, broken month link);
+      head-cache repair-forward after a simulated crash (head behind file).
+- [ ] 1.2 Implement per-instance monthly JSONL, `hash = sha256(prev + canonical)`,
+      head + seq anchored in `.governance.sqlite receipts_head`.
+
+## 2. Emission wiring
+
+- [ ] 2.1 Red test: policy mutation (commit/grant/revoke/undo) emits fsync'd
+      receipts; disclosure/withhold emits buffered receipts; token mint/redeem
+      recorded. No plaintext; scope ids + hashed labels only.
+- [ ] 2.2 Wire emission in `governance/tool.py`, `governance/egress.py`,
+      `governance/tokens.py`.
+
+## 3. Deletion events
+
+- [ ] 3.1 Red test `test_delete_emits_receipt` (+ inverse on recover); no-op on
+      empty policy.
+- [ ] 3.2 Emit in `delete_file.py` after trash move + fan-out (`:251-269`);
+      inverse in `recover_from_trash.py`.
+
+## 4. Audit integration
+
+- [ ] 4.1 Red test `tests/test_audit.py::test_governance_receipts_category`.
+- [ ] 4.2 Add `governance_receipts` to `audit.ALL_CATEGORIES` + a check block
+      calling `receipts.verify_chain`; reachable via `maintain_memory(mode="audit")`.
+
+## 5. Gates
+
+- [ ] 5.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_governance_receipts.py tests/test_audit.py` green.
+- [ ] 5.2 `uv run python -m pytest tests/test_latency_gate.py -q` green (receipt
+      append off the hot path; buffered disclosure events).
+- [ ] 5.3 `uvx ruff check` clean; `openspec validate add-disclosure-receipts
+      --strict` green.

--- a/openspec/changes/add-governance-kernel/.openspec.yaml
+++ b/openspec/changes/add-governance-kernel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-governance-kernel/design.md
+++ b/openspec/changes/add-governance-kernel/design.md
@@ -1,0 +1,102 @@
+# Design: add-governance-kernel
+
+## Context
+
+The kernel reuses proven Exomem patterns rather than inventing machinery.
+Fingerprinted live reload: `access._load_config`/`policy_fingerprint`
+(`access.py:59-135`) — content-hash based so a timestamp-preserving edit still
+invalidates. Sidecars: `sidecar_store.apply_sidecar_pragmas` + `ensure_meta_table`
++ `SystemRandom` seeding (`:56-63`), path via `index_paths` convention
+(`vault_root/<kb>/.governance.sqlite`). Selector inputs already exist as
+frontmatter-derived fields on `ParsedPage` and as taxonomy sources
+(`project_keys`, tags, `entity_types`, `semantic_language_registry`); the
+selector compiler can reuse `structured_filters` idioms. Nothing here runs a
+model — consistent with `openspec/config.yaml` "pure substrate."
+
+## Goals / Non-Goals
+
+Goals: a canonical, human-readable, user-owned policy source; a deterministic
+compiler with an empty-policy fast path; query-time scope membership that serves
+find *and* the non-find read surfaces; a pure, testable ceiling evaluator; zero
+enforcement (inspection only) this change.
+
+Non-Goals: egress filtering, notices, redaction, tokens, receipts, bridges, the
+`govern_memory` tool (all later changes). No index-time membership table. No
+policy engine dependency (Cedar/OPA/Casbin — see the plan's §8 rejection).
+
+## Decisions
+
+### D1 — Canonical policy = strict YAML in the vault, compiled to a sidecar
+Source of truth is `_Governance/**.yaml` (syncable, diffable, travels with the
+vault). The `.governance.sqlite` snapshot is a derived convenience for
+cross-process inspection/doctor, rebuildable from the YAML and never the
+enforcement authority. This keeps "everything is a user-owned file" true for
+policy itself and lets backup/restore/adoption inherit governance for free.
+Rejected engines (Cedar/OPA/Oso/pycasbin/SpiceDB) per the plan: none is a mature
+in-process pure-Python fit that also expresses representation ceilings.
+
+### D2 — Fingerprint + empty fast path
+`policy.load(vault_root)` mirrors `access._load_config`: stat `_Governance/`;
+missing → process-cached `EMPTY_POLICY` singleton, fingerprint `"missing"`;
+present → per-file stat-signature tuple over the bounded YAML set, content hash
+on signature change. Every downstream hook's first line is
+`pol = policy.load(root); if pol.empty: return <no-op>`. One dir-stat per request
+— the same cost class find already pays for `_access.yaml`.
+
+### D3 — Conflicted-copy refusal
+Because `_Governance/` sits in a synced vault, Obsidian can drop
+`rules (conflicted copy).yaml`. The compiler refuses to compile when a
+`(conflicted copy)` sibling is present, surfacing it for resolution rather than
+nondeterministically merging or silently ignoring the user's edit. Fail-closed:
+a refused compile keeps the last good snapshot and reports the conflict.
+
+### D4 — Membership at query time, memoized — not an index-time table
+Selectors read frontmatter the pipeline already holds. An index-time membership
+table would become a fifth derived component in the `index_sync` fan-out with its
+own drift class for `audit` to police, and would force a full-vault recompute on
+every policy change. Instead, `membership.evaluate(page, policy)` runs against the
+in-hand `ParsedPage`, memoized per `(fingerprint, path, mtime_ns)` with a bounded
+LRU. Policy change = O(1) memo invalidation by fingerprint. Non-find surfaces
+(get/overview/graph/read_media) already hold or cheaply parse the page.
+
+### D5 — Pure lattice evaluator, order-free
+`decide(item, audience, purpose, grants) -> Decision` computes
+`min(org_cap, max(exceptions_and_grants, min(standing_rules)))`, default OPEN
+(L6). All matching rules participate; min/max are commutative, so there is no
+rule ordering, no priority integers, no specificity algebra — conflicts are
+impossible by construction and `explain` can render the participating chain.
+Purpose-absence is deterministic: a purpose-conditioned *allow* does not fire
+when purpose is undeclared; an "outside purpose P" *restriction* does. Purpose is
+model-declared, therefore advisory (opt-in per rule), never in a cache key. The
+function is pure (no IO beyond the passed-in compiled policy + grants) → property
+tests.
+
+### D6 — Sidecar holds dynamic state, not membership
+`.governance.sqlite` (this change: `compiled_policy` snapshot + meta only; later
+changes add `session_grants`/`withhold_tokens`/`proposals`/`receipts_head`). It
+is per-machine, never synced, rebuildable. Membership memo is in-process, not
+persisted.
+
+## Risks / Trade-offs
+
+- **Directory fingerprint heavier than a single file**: bounded to the policy
+  YAML set, per-file stat tuples, content hash only on signature change — same
+  guarantee as `access.py:78`. Pinned by a timestamp-preserving-replace test.
+- **Selector expressiveness creep**: schema v1 frozen small (paths glob, projects,
+  tags, types, classes, explicit refs, plus `exclude`); new expressiveness needs
+  a new change.
+- **Membership memo staleness**: keyed on `mtime_ns` + fingerprint, so an
+  out-of-band edit or a policy change invalidates the entry.
+
+## Migration Plan
+
+Absent `_Governance/` → `EMPTY_POLICY`, zero behavior change anywhere. Existing,
+adopted, exported, restored vaults need no migration. `governance_version: 1`;
+unknown future fields are a compile error (fail-closed), unknown *files* in
+`_Governance/` are ignored with a warning (forward-compat).
+
+## Open Questions
+
+None blocking. The `class:` selector's detector set (secret/pii) is defined where
+first used (`add-release-gate` ships the secret detector for the default-on
+credential block).

--- a/openspec/changes/add-governance-kernel/proposal.md
+++ b/openspec/changes/add-governance-kernel/proposal.md
@@ -1,0 +1,83 @@
+# Proposal: add-governance-kernel
+
+## Why
+
+Exomem today offers exactly two dispositions for a source: fully indexable or
+`excluded` (invisible). There is nothing between "the model can see everything"
+and "the model can see nothing" — no way for the owner to say *this project's
+architecture may inform my thinking but its client names must never leave the
+vault*. The product goal is **maximum connection under user control, with minimal
+unintended disclosure**: one broadly connected vault where *internal
+discoverability* and *external releasability* are separate, deterministic,
+user-controlled planes.
+
+This change lands the **kernel** — the policy representation, compiler, and pure
+decision evaluator — with **no enforcement yet**. It is inspection-only: it can
+load `_Governance/` policy, resolve which pages a scope covers, and answer "what
+is the effective disclosure ceiling for this item, audience, and purpose?" —
+but nothing in the retrieval or read path consults it until `add-release-gate`.
+Landing the kernel alone keeps the risky change (touching egress) small and lets
+the evaluator be proven against fixtures first.
+
+The design obeys the repo constitution (`openspec/config.yaml`): pure substrate —
+the server measures, the brain reasons. The evaluator is a pure Python function
+over compiled tables; no model, no network, no confidence floats. Absent
+`_Governance/`, the compiler yields an `OPEN` policy and every downstream caller
+short-circuits — a governed feature that is default-off and soft-failing.
+
+## What Changes
+
+- New in-vault policy home `Knowledge Base/_Governance/` (strict YAML, JSON-Schema
+  validated): `scopes/*.yaml` (membership selectors + excludes),
+  `rules/*.yaml` (audience + purpose + disclosure ceiling L0–L6 + options),
+  `grants/*.yaml` (standing exceptions). One document per file; ULID ids;
+  `governance_version: 1`.
+- A live-reload loader with a content fingerprint, mirroring `access.py`'s
+  `policy_fingerprint` (`:78`): missing dir → cached `EMPTY_POLICY` singleton;
+  present → per-file stat-signature → content hash on change. Refuses to compile
+  when an Obsidian-style `(conflicted copy)` sibling is present (fail-closed).
+- A compiled snapshot in a per-machine sidecar `.governance.sqlite`
+  (`sidecar_store` pragmas/meta), keyed by fingerprint — for cross-process
+  inspection and doctor, never as the enforcement authority.
+- Query-time **membership** evaluation of selectors against the already-parsed
+  `ParsedPage`, memoized per `(fingerprint, path, mtime)` — not an index-time
+  table (no fifth derived component in the `index_sync` fan-out).
+- A **pure decision evaluator**: `ceiling = min(org_cap, max(grants,
+  min(standing_rules)))`, default OPEN (L6). Order-free lattice — conflicts are
+  impossible by construction.
+- `_Governance` added to `find_corpus.EXCLUDED_DIR_NAMES` so policy files never
+  index as content. A generic `_scaffold/_Governance/README.md` (leak-guard-safe).
+
+## Capabilities
+
+### New Capabilities
+
+- `governance-kernel`: deterministic, local-first policy representation
+  (`_Governance/` YAML), a fingerprinted compiler with an empty-policy fast path
+  and conflicted-copy refusal, query-time memoized scope membership, and a pure
+  disclosure-ceiling evaluator over an order-free lattice.
+
+### Modified Capabilities
+
+(none — the kernel's internal read leaves are registry-level plumbing;
+`command-surface` requirements gain new operations automatically, per the
+relation-acceptance-queue precedent. No user-facing tool ships in this change.)
+
+## Impact
+
+- Code: new package `src/exomem/governance/` — `policy.py` (load + fingerprint +
+  EMPTY_POLICY + conflicted-copy refusal), `compile.py` (snapshot into
+  `.governance.sqlite`), `membership.py` (selector evaluation + memo),
+  `decisions.py` (pure lattice + `Decision` dataclass), `store.py` (sidecar
+  tables skeleton), `__init__.py` (facade). Edits: `src/exomem/index_paths.py`
+  (governance sidecar path), `src/exomem/find_corpus.py` (one
+  `EXCLUDED_DIR_NAMES` entry), `src/exomem/_scaffold/_Governance/README.md`.
+- Tests: `tests/test_governance_policy.py`, `tests/test_governance_store.py`,
+  `tests/test_governance_membership.py`, `tests/test_governance_decisions.py`,
+  `tests/test_governance_overhead.py` (empty-policy short-circuit); scaffold
+  no-leak (`tests/test_scaffold_no_leak.py`) must stay green.
+- No new runtime dependencies (stdlib + existing `pyyaml`); all governance tests
+  run in the lean lane (`EXOMEM_DISABLE_EMBEDDINGS=1`) — the evaluator needs no
+  models.
+- Explicitly NOT in scope: any egress enforcement, notices, redaction, the
+  `govern_memory` tool, receipts, bridges. Those are separate changes.

--- a/openspec/changes/add-governance-kernel/specs/governance-kernel/spec.md
+++ b/openspec/changes/add-governance-kernel/specs/governance-kernel/spec.md
@@ -1,0 +1,98 @@
+# governance-kernel
+
+## ADDED Requirements
+
+### Requirement: Canonical policy source in the vault
+
+Governance policy SHALL be authored as strict YAML documents under
+`Knowledge Base/_Governance/` — `scopes/*.yaml`, `rules/*.yaml`, `grants/*.yaml` —
+one document per file, each carrying an immutable ULID `id` and
+`governance_version: 1`. The policy source SHALL be the authority; any compiled
+representation SHALL be derived and rebuildable from it. `_Governance/` SHALL be
+excluded from the content index so policy files are never returned as knowledge.
+
+#### Scenario: Policy files are not indexed as content
+
+- **WHEN** a `find`/`ask_memory` query runs on a vault with `_Governance/` policy
+  files
+- **THEN** no policy file appears as a hit
+
+#### Scenario: Unknown version fails closed
+
+- **WHEN** a policy file declares a `governance_version` the kernel does not
+  recognize, or carries an unknown field
+- **THEN** the compile fails closed with a clear finding and the last good policy
+  remains in effect
+
+### Requirement: Fingerprinted compile with empty-policy fast path
+
+The kernel SHALL load policy through a content fingerprint that changes whenever
+any policy file's bytes change, even under a timestamp-preserving replacement.
+When no `_Governance/` directory exists, the kernel SHALL yield a cached OPEN
+(empty) policy with a stable "missing" fingerprint and SHALL short-circuit all
+downstream governance work. The compile SHALL refuse when a `(conflicted copy)`
+sibling policy file is present, keeping the last good compiled snapshot and
+surfacing the conflict.
+
+#### Scenario: Empty policy short-circuits
+
+- **WHEN** the kernel loads a vault with no `_Governance/` directory
+- **THEN** it returns the OPEN singleton without opening the governance sidecar,
+  and any decision resolves to full disclosure (L6)
+
+#### Scenario: Timestamp-preserving edit still invalidates
+
+- **WHEN** a policy file's content changes but its mtime is preserved
+- **THEN** the fingerprint changes and the recompiled policy takes effect
+
+#### Scenario: Conflicted copy refuses compile
+
+- **WHEN** a `(conflicted copy)` policy sibling is present
+- **THEN** the compile refuses, the prior compiled snapshot remains in effect,
+  and the conflict is reported for resolution
+
+### Requirement: Query-time scope membership
+
+Scope membership SHALL be evaluated at query time against an already-parsed page
+using the scope's selectors (path globs, projects, tags, types, detector classes,
+explicit refs) minus its `exclude` selectors, memoized per
+`(policy_fingerprint, path, mtime)`. Membership SHALL NOT be materialized as an
+index-time table and SHALL NOT add a component to the deletion/upsert fan-out. A
+policy change SHALL invalidate membership by fingerprint mismatch.
+
+#### Scenario: Selector kinds resolve membership
+
+- **WHEN** a page matches a scope by any selector kind and is not caught by an
+  `exclude` selector
+- **THEN** the page is a member of that scope
+
+#### Scenario: Policy change invalidates the memo
+
+- **WHEN** the policy fingerprint changes
+- **THEN** previously memoized membership is recomputed against the new policy
+
+### Requirement: Pure order-free disclosure evaluator
+
+The kernel SHALL expose a pure function mapping `(item, audience, purpose,
+active grants)` to a disclosure ceiling, computed as
+`min(org_cap, max(grants_and_exceptions, min(standing_rules)))` with a default of
+full disclosure when no rule matches. The function SHALL be free of IO beyond its
+compiled-policy and grant inputs, SHALL be order-independent (no rule priority),
+and SHALL treat an undeclared purpose deterministically: a purpose-conditioned
+allowance does not apply, while an "outside purpose" restriction does.
+
+#### Scenario: Most restrictive standing rule wins, a grant lifts it, org caps all
+
+- **WHEN** multiple standing rules, a grant, and an org rule all match an item
+- **THEN** the ceiling is the org cap applied over the grant applied over the
+  minimum standing rule, independent of the order the rules were authored
+
+#### Scenario: Default is full disclosure
+
+- **WHEN** no rule matches an item for a given audience
+- **THEN** the ceiling is full (L6)
+
+#### Scenario: Undeclared purpose is deterministic
+
+- **WHEN** a rule allows an item only for purpose P and no purpose is declared
+- **THEN** the allowance does not fire; and an "outside P" restriction does fire

--- a/openspec/changes/add-governance-kernel/tasks.md
+++ b/openspec/changes/add-governance-kernel/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: add-governance-kernel
+
+## 1. Policy source + loader (src/exomem/governance/policy.py)
+
+- [ ] 1.1 Red tests `tests/test_governance_policy.py`: strict-YAML parse of
+      scopes/rules/grants (unknown key → finding; bad ceiling → finding; empty
+      dir → EMPTY singleton); fingerprint stability + change detection on a
+      timestamp-preserving replace (`test_access.py:111` analogue);
+      conflicted-copy sibling refuses compile.
+- [ ] 1.2 Implement `policy.load(vault_root)` mirroring
+      `access._load_config`/`policy_fingerprint` (`access.py:59-135`): frozen
+      dataclasses `Scope`/`Rule`/`StandingGrant`, findings-not-exceptions
+      validation, dir stat-signature + content fingerprint cache, `EMPTY_POLICY`.
+
+## 2. Sidecar + compiled snapshot (compile.py, store.py)
+
+- [ ] 2.1 Red test `tests/test_governance_store.py`: sidecar create with
+      `sidecar_store` pragmas/meta + `PRAGMA user_version`; `compiled_policy`
+      snapshot roundtrip keyed by fingerprint.
+- [ ] 2.2 Implement `compile.py` (normalized snapshot writer) + `store.py`
+      skeleton; add `governance_sidecar_path` to `index_paths.py`.
+
+## 3. Membership (membership.py)
+
+- [ ] 3.1 Red test `tests/test_governance_membership.py`: each selector kind
+      (glob, project, tag, type, class, ref) + `exclude` selectors + memo
+      invalidation on fingerprint/mtime change.
+- [ ] 3.2 Implement `membership.evaluate(page, policy)` against `ParsedPage`
+      (reuse `structured_filters`/`find_corpus` idioms), bounded
+      `(fingerprint, path, mtime_ns)` LRU memo.
+
+## 4. Decision evaluator (decisions.py)
+
+- [ ] 4.1 Red test `tests/test_governance_decisions.py`: lattice truth-table
+      (org cap dominates; grant elevates over standing min; default OPEN);
+      purity (same inputs → same output, no IO); undeclared-purpose semantics.
+- [ ] 4.2 Implement `decide(...)` + `Decision` dataclass
+      (`level, scope_ids, rule_ids, options, notice, bridge`) + session-grant
+      read hook from `store`.
+
+## 5. Fast path + corpus hygiene + scaffold
+
+- [ ] 5.1 Red test `tests/test_governance_overhead.py::test_empty_policy_short_circuit`
+      (load → singleton, `decide_paths` returns a no-op map without opening the
+      sidecar).
+- [ ] 5.2 Add `_Governance` to `find_corpus.EXCLUDED_DIR_NAMES` (`:20`); test an
+      md planted there never surfaces in `find`.
+- [ ] 5.3 Add generic `src/exomem/_scaffold/_Governance/README.md`; keep
+      `tests/test_scaffold_no_leak.py` green.
+
+## 6. Command surface (inspection entry points)
+
+- [ ] 6.1 Register the internal kernel read leaves used later by
+      `explain`/`simulate` (no user-facing tool this change); registry test.
+
+## 7. Gates
+
+- [ ] 7.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_governance_policy.py tests/test_governance_store.py
+      tests/test_governance_membership.py tests/test_governance_decisions.py
+      tests/test_governance_overhead.py tests/test_scaffold_no_leak.py` green.
+- [ ] 7.2 `uv run python -m pytest tests/test_latency_gate.py -q` green (no
+      governance on the find path yet — must be untouched).
+- [ ] 7.3 `uvx ruff check` clean; `openspec validate add-governance-kernel
+      --strict` green.

--- a/openspec/changes/add-governance-tools/.openspec.yaml
+++ b/openspec/changes/add-governance-tools/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-governance-tools/design.md
+++ b/openspec/changes/add-governance-tools/design.md
@@ -1,0 +1,100 @@
+# Design: add-governance-tools
+
+## Context
+
+Reuses verified machinery. Mutation safety: `writer_lease.invoke_command`
+(lease + idempotency), `mutation_terminal.committed_terminal` (`:82`, receipt
+envelope). Consume-once nonces: `hosted_transfer.consume_transfer_jti`
+(`:333-353`) — the correct primitive, distinct from the idempotency *replay*
+store (`writer_lease.IdempotencyStore`), which returns a cached result on
+key reuse rather than refusing a spent nonce. Fingerprint-guarded commit:
+`relation_registry.save_registry` (`:230-252`, `STALE_*` on `expected_hash`
+mismatch). Mixed read/write dispatch: `commands.invocation_is_read_only`
+(`:5442`, per-command action allowlists). Bootstrap payload:
+`op_bootstrap:211` (versioned, code-authored, `content_included: False`).
+
+## Goals / Non-Goals
+
+Goals: one natural-language authoring tool; safe propose→commit that cannot be
+replayed or applied against drifted state; zero-friction release-time grants;
+revoke/undo that keep history and dependent grants coherent; a teaching surface
+so any client uses the operations correctly.
+
+Non-Goals: receipts persistence internals (next change), bridges, presets, a
+policy UI. No model call in the enforcement or validation path — the LLM proposes,
+Exomem decides.
+
+## Decisions
+
+### D1 — One tool, operation-routed
+`govern_memory(operation=...)` matches Exomem's multi-operation tool style and
+respects client tool-count limits. `list`/`explain`/`simulate`/`declare(read)`
+classify read-only via a new `_GOVERN_MEMORY_READ_ONLY_ACTIONS` set in
+`invocation_is_read_only`; `commit`/`grant`/`revoke`/`suspend`/`resume`/`undo`
+write and ride the lease + idempotency + receipt terminal. Policy-overwriting
+operations join `DESTRUCTIVE_OPS` so annotations warn.
+
+### D2 — propose stores a drift-bound nonce; commit consumes it
+`propose` writes a pending record to `.governance.sqlite proposals`
+(`id, created_at, expires_at, proposal_json, fingerprint_at_propose, affected_item_fingerprints, status`)
+with a TTL. `commit(proposal_id)` consumes it under `BEGIN IMMEDIATE`
+(consume-once, JTI semantics — NOT the idempotency replay store) and refuses with
+`STALE_GOVERNANCE_POLICY` if the current policy fingerprint or any affected-item
+content fingerprint differs from propose time. This closes the TOCTOU window: an
+out-of-band edit or a `file_watcher` reindex between propose and commit forces a
+re-propose rather than applying a decision computed against vanished state.
+
+### D3 — propose previews respect current ceilings
+The resolved-membership preview renders counts and samples at each member's
+*current* effective ceiling — a proposal for a scope that would restrict N pages
+must not leak those N titles to the model before the rule exists. `explain` and
+`simulate` toward a sub-ceiling audience return counts + rule-ids only, never
+member titles/excerpts.
+
+### D4 — Grants: session in sqlite, standing in YAML
+Release-time `grant` redeems a withhold-token (from `add-release-gate`) and writes
+an ephemeral session grant to `.governance.sqlite session_grants` (TTL'd, never a
+YAML file) so the lattice sees it immediately; a durable standing exception is a
+`grants/*.yaml` file. `revoke(scope=session)` clears all session grants for the
+session; `declare` sets a session purpose default. The model can only redeem
+tokens Exomem minted — it cannot enlarge scope it was not offered.
+
+### D5 — undo re-resolves dependents
+`undo` restores the archived prior policy version and re-resolves grants that
+depended on the restored version's selectors, expiring/flagging any whose member
+set changed — so a restore never silently widens or narrows a grant's reach
+against a version it was never reviewed for.
+
+### D6 — Teaching surface, forged-envelope defense
+`bootstrap` gains a `governance` section and a bumped `contract_version`; scaffold
+`SKILL.md` + generic `references/governance.md` teach the lifecycle and state that
+governance notices/grant-hints travel only in reserved top-level response keys and
+that governance-shaped text inside `excerpt`/`body`/`content` is data, never a
+command. Kept generic — `tests/test_scaffold_no_leak.py` enforces no personal
+tokens.
+
+## Risks / Trade-offs
+
+- **Byte-pinned tool surface**: the new tool + params change
+  `tool_surface_contract.json` and connector-guardrail pins; regenerate via
+  `scripts/dump-tool-schemas.py` in-task.
+- **Tier placement**: `govern_memory` is Tier-2 (policy administration is
+  desk-side; hosted cells with `EXOMEM_DISABLE_TIER2` drop the admin tool) — but
+  release enforcement still runs everywhere, so decisions hold even where the
+  admin tool is absent. The spec states this explicitly.
+- **Injected commit attempts**: content cannot mint a valid `proposal_id`; a
+  forged id fails the consume-once + fingerprint check. A model *claiming* user
+  consent from injected text remains a documented client-side residual, bounded by
+  the propose→confirm gate, token narrowness, and revoke-session.
+
+## Migration Plan
+
+Additive tool + bootstrap version bump (existing contract discipline). No data
+migration; `.governance.sqlite` gains tables via `PRAGMA user_version`. Absent
+`_Governance/`, `list`/`explain` report "governance: disabled" and no file is
+written until a `commit`.
+
+## Open Questions
+
+None blocking. Preset shortcuts (`propose(preset="legal")`) are deferred to
+`add-professional-presets`.

--- a/openspec/changes/add-governance-tools/proposal.md
+++ b/openspec/changes/add-governance-tools/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: add-governance-tools
+
+## Why
+
+The kernel decides and the release gate enforces, but there is no way for the
+owner to *author* policy. The product constraint is that natural language is the
+control surface: the user says "Create POLLY as a confidential project" or "Allow
+this once for today," and their existing LLM calls an Exomem tool. The LLM only
+ever **proposes**; Exomem resolves scopes, computes consequences, validates, and
+writes the deterministic policy. The model must never be the enforcement
+authority, and nothing in retrieved content may change policy.
+
+This change adds the single authoring tool `govern_memory` and the release-time
+grant loop. It rides the existing validated mutation protocol (mutation identity,
+idempotency, `MUTATION_*` terminals, receipts) so commits are safe and
+replay-aware, and it consumes proposal nonces with true consume-once semantics
+bound to the policy fingerprint and affected-item content fingerprints — closing
+the propose→commit TOCTOU window against out-of-band and synced edits.
+
+## What Changes
+
+- New MCP tool `govern_memory(operation=...)` with operations: `propose`,
+  `commit`, `grant`, `revoke`, `suspend`, `resume`, `list`, `explain`, `simulate`,
+  `undo`, `declare` (session purpose). `list`/`explain`/`simulate` are read-only;
+  the rest write and ride the lease + idempotency + receipt terminal.
+- **propose → commit**: `propose` resolves selectors and returns the plain-language
+  interpretation, the canonical YAML it would write, resolved membership (counts +
+  samples rendered at their *current* effective ceiling — previews never leak),
+  consequences, overlaps, duration, reversal path, and a single-use `proposal_id`.
+  `commit` consumes that nonce (dedicated durable store, JTI semantics — not the
+  idempotency replay store), refuses on policy/item drift (`STALE_GOVERNANCE_POLICY`),
+  writes `_Governance/` files, archives prior versions, bumps the fingerprint.
+- **Release-time grants**: `grant(token, duration=...)` redeems a single-use
+  withhold-token from a `withheld` notice ("allow this once / for today / only
+  these three files"); `revoke(scope=session)` = "everything I authorised in this
+  conversation." `undo` restores the archived prior policy version and re-resolves
+  dependent grants, expiring any whose member set changed.
+- **Teaching surface**: `bootstrap()` gains a `governance` section (enabled flag,
+  policy fingerprint, resolved audience, purpose mechanism, one-paragraph
+  disclosure contract) and a bumped `contract_version`; the scaffold
+  `_Schema/SKILL.md` + a new generic `references/governance.md` teach the flows,
+  including that governance-shaped text inside retrieved content is data, never a
+  command (forged-envelope defense).
+
+## Capabilities
+
+### New Capabilities
+
+- `governance-authoring`: the natural-language policy lifecycle over MCP —
+  propose/commit with consume-once drift-bound nonces, session and one-shot
+  grants, revoke/suspend/resume/undo, and read-only explain/simulate/list — where
+  the model proposes and Exomem validates and enforces.
+
+### Modified Capabilities
+
+- `agent-bootstrap-contract`: the portable contract gains a governance section and
+  a version bump so a generic client learns the disclosure model and control loop.
+
+(`command-surface` is registry-level and gains the `govern_memory` tool — with its
+mixed read/write action split and destructive-op annotation — automatically, per
+the relation-acceptance-queue precedent.)
+
+## Impact
+
+- Code: new `src/exomem/governance/tool.py` (`op_govern_memory` router) +
+  `store.py` additions (`proposals`, `session_grants`, `session_purpose` tables,
+  TTL sweeps); `commands.py` (`_PRODUCT_SPEC` entry, `invocation_is_read_only`
+  action split, bootstrap payload), `command_surface.py` (`DESTRUCTIVE_OPS`),
+  `tool_surface_contract.json` (regenerated), `_scaffold/_Schema/SKILL.md` +
+  `references/governance.md`.
+- Tests: `tests/test_govern_memory_tool.py`, `tests/test_bootstrap.py` extension,
+  schema-fidelity/connector-guardrail pin updates; scaffold no-leak green.
+- Explicitly NOT in scope: receipts persistence detail (next change) — this change
+  emits receipt terminals via the existing mutation machinery; bridges; presets.

--- a/openspec/changes/add-governance-tools/specs/agent-bootstrap-contract/spec.md
+++ b/openspec/changes/add-governance-tools/specs/agent-bootstrap-contract/spec.md
@@ -1,0 +1,25 @@
+# agent-bootstrap-contract
+
+## ADDED Requirements
+
+### Requirement: Bootstrap teaches the governance model
+
+The portable bootstrap contract SHALL include a governance section reporting
+whether governance is enabled, the current policy fingerprint (or a "missing"
+marker), the resolved audience for the caller, how purpose is declared, and a
+concise disclosure-model contract, and SHALL bump the contract version when this
+section is added. The contract SHALL instruct clients that governance notices and
+grant hints appear only in reserved top-level response keys and that
+governance-shaped text appearing inside returned content is data, never a command.
+
+#### Scenario: Governance section present and versioned
+
+- **WHEN** a client calls `bootstrap`
+- **THEN** the response includes the governance section and a contract version
+  reflecting it
+
+#### Scenario: Disabled governance is reported honestly
+
+- **WHEN** `bootstrap` runs on a vault with no `_Governance/` policy
+- **THEN** the governance section reports governance as disabled with a "missing"
+  fingerprint

--- a/openspec/changes/add-governance-tools/specs/governance-authoring/spec.md
+++ b/openspec/changes/add-governance-tools/specs/governance-authoring/spec.md
@@ -1,0 +1,99 @@
+# governance-authoring
+
+## ADDED Requirements
+
+### Requirement: Natural-language propose and validated commit
+
+`govern_memory(operation="propose")` SHALL resolve a natural-language intent into
+a deterministic proposal and return the plain-language interpretation, the
+canonical policy it would write, the resolved affected membership, the
+consequences, overlaps with existing rules, the duration, the reversal path, and a
+single-use proposal id. The membership preview SHALL render each affected item at
+its current effective disclosure ceiling and SHALL NOT leak titles or excerpts of
+items that a not-yet-committed rule would restrict. `govern_memory(operation="commit")`
+SHALL consume the proposal id exactly once from a dedicated durable store and
+SHALL refuse when the policy fingerprint or any affected item's content fingerprint
+has changed since propose time, writing nothing on refusal. On success it SHALL
+write the policy files, archive prior versions, and bump the policy fingerprint so
+the rule is enforced on the next call.
+
+#### Scenario: Propose does not leak restricted members
+
+- **WHEN** a proposal would restrict N pages and the preview lists affected
+  membership
+- **THEN** counts and current-ceiling samples are returned, but no title or
+  excerpt of a would-be-restricted page crosses the boundary
+
+#### Scenario: Commit consumes the nonce once
+
+- **WHEN** a proposal id is committed and then committed again
+- **THEN** the first commit writes the policy and the second is refused as spent
+
+#### Scenario: Commit refuses on drift
+
+- **WHEN** the policy or an affected item changed between propose and commit
+- **THEN** the commit refuses with a stale-policy error and writes nothing
+
+### Requirement: Release-time grants and revocation
+
+`govern_memory(operation="grant")` SHALL redeem a single-use escalation token from
+a withheld notice to lift disclosure for a bounded audience, item set, level, and
+duration, recording an ephemeral session grant that the evaluator applies
+immediately. The model SHALL only be able to redeem tokens Exomem minted and SHALL
+NOT be able to author a grant broader than the token's bounds.
+`govern_memory(operation="revoke")` SHALL revoke a grant, and `revoke` scoped to
+the session SHALL clear every grant authored in that conversation immediately.
+
+#### Scenario: Allow this once
+
+- **WHEN** a user says to allow a withheld item once and the model redeems its
+  token
+- **THEN** the item is disclosed at the token's bound level for the session, and a
+  second use of the same token is refused
+
+#### Scenario: Revoke the conversation's grants
+
+- **WHEN** the user revokes everything authorised in the session
+- **THEN** all session grants are cleared and the next query re-applies the
+  standing policy
+
+### Requirement: Suspend, resume, undo with coherent dependents
+
+`govern_memory` SHALL support suspending and resuming a whole rule-set and undoing
+the last policy change by restoring its archived prior version. `undo` SHALL
+re-resolve grants that depended on the restored version's selectors and SHALL
+expire or flag any whose member set changed, so a restore never silently widens or
+narrows a grant against a version it was not reviewed for.
+
+#### Scenario: Undo restores and reconciles
+
+- **WHEN** the last policy change is undone
+- **THEN** the prior policy version is restored and any grant whose resolved
+  members changed is expired or flagged for review
+
+### Requirement: Read-only inspection operations
+
+`govern_memory` `list`, `explain`, and `simulate` SHALL be read-only and SHALL NOT
+write policy or state. `explain` SHALL show the effective policy for an item, scope,
+or audience after layering, with the participating rule chain. `simulate` SHALL
+dry-run a query or item release. Toward an audience below an item's ceiling, these
+operations SHALL return counts and rule ids only, never titles or excerpts of
+restricted items.
+
+#### Scenario: Explain shows the effective chain
+
+- **WHEN** `explain` is called for an item and audience
+- **THEN** it returns the effective ceiling and the ordered participating rules
+  without leaking restricted content
+
+### Requirement: Enforcement is independent of the authoring tool
+
+Release enforcement SHALL apply on every surface regardless of whether the
+`govern_memory` authoring tool is exposed. Where the Tier-2 admin tool is disabled,
+existing policy SHALL still be enforced.
+
+#### Scenario: Enforcement without the admin tool
+
+- **WHEN** the governance authoring tool is not exposed on a surface but policy
+  exists
+- **THEN** recall and reads on that surface still honor the disclosure decisions

--- a/openspec/changes/add-governance-tools/tasks.md
+++ b/openspec/changes/add-governance-tools/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: add-governance-tools
+
+## 1. Tool router skeleton (src/exomem/governance/tool.py)
+
+- [ ] 1.1 Red test `tests/test_govern_memory_tool.py`: `list`/`explain`/`simulate`
+      classify read-only via `invocation_is_read_only`; write ops classify
+      writing.
+- [ ] 1.2 Implement `op_govern_memory(vault_root, operation, ...)` router +
+      `_GOVERN_MEMORY_READ_ONLY_ACTIONS` in `commands.py:5442`.
+
+## 2. propose / commit with drift-bound nonce
+
+- [ ] 2.1 Red test: propose returns interpretation + canonical YAML + membership
+      preview (rendered at current ceiling, no restricted titles) + consequences +
+      proposal_id; commit consumes once; re-commit refused; commit refuses on
+      policy/item fingerprint drift (`STALE_GOVERNANCE_POLICY`).
+- [ ] 2.2 Implement `proposals` table (TTL, fingerprint_at_propose,
+      affected_item_fingerprints) in `store.py`; commit under `BEGIN IMMEDIATE`;
+      atomic YAML write + prior-version archive + fingerprint bump; `undo` inverse.
+
+## 3. grant / revoke / suspend / resume / declare
+
+- [ ] 3.1 Red test: grant redeems a withhold-token → session grant the lattice
+      sees; second use refused; `revoke(scope=session)` clears all; `declare`
+      sets session purpose; suspend/resume toggle a rule-set.
+- [ ] 3.2 Implement `session_grants`/`session_purpose` tables (TTL sweeps); grant
+      bounded by token; `undo` re-resolves dependent grants and expires drifted
+      ones.
+
+## 4. Registration + destructive annotation
+
+- [ ] 4.1 Add `_PRODUCT_SPEC` entry (Tier-2, writes=True) + `DESTRUCTIVE_OPS`
+      membership for policy-overwriting ops; regenerate
+      `tool_surface_contract.json` via `scripts/dump-tool-schemas.py`.
+- [ ] 4.2 Update `test_mcp_schema_fidelity.py`/`test_tool_surface_contract.py`/
+      `test_connector_guardrails.py` pins; CLI + REST smoke
+      (`kb govern_memory list --json`).
+
+## 5. Bootstrap + teaching surface
+
+- [ ] 5.1 Red test `tests/test_bootstrap.py::test_bootstrap_reports_governance`;
+      add the `governance` payload section + bump `contract_version` in
+      `op_bootstrap`.
+- [ ] 5.2 Add generic `_scaffold/_Schema/references/governance.md` + `SKILL.md`
+      section (lifecycle + forged-envelope rule); `tests/test_scaffold_no_leak.py`
+      green.
+
+## 6. Gates
+
+- [ ] 6.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_govern_memory_tool.py tests/test_bootstrap.py
+      tests/test_mcp_schema_fidelity.py tests/test_tool_surface_contract.py
+      tests/test_connector_guardrails.py tests/test_scaffold_no_leak.py` green.
+- [ ] 6.2 `uv run python -m pytest tests/test_latency_gate.py -q` green.
+- [ ] 6.3 `uvx ruff check` clean; `openspec validate add-governance-tools
+      --strict` green.

--- a/openspec/changes/add-release-gate/.openspec.yaml
+++ b/openspec/changes/add-release-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-release-gate/design.md
+++ b/openspec/changes/add-release-gate/design.md
@@ -1,0 +1,129 @@
+# Design: add-release-gate
+
+## Context
+
+Verified anchors. The recall serialize block is `commands.py:908-922`
+(`Hit.as_dict`/`as_compact_dict` + ref attachment); `hits = find_module.find(...)`
+returns at `:901`; `assemble_pack` runs at `:905`. The find hot-cache stores
+deep copies of `Hit`s shared across principals (`find.py:1063-1067`). The one
+dispatcher shared by MCP/REST/hosted/CLI is `writer_lease.invoke_command`
+(`:1279`); `bind_vault` (`command_surface.py:211-243`) covers MCP only, and the
+`EXOMEM_RETRIEVE_INJECT` hook reaches memory over REST-then-CLI — the two paths
+that skip `bind_vault`. Per-request identity is already derivable
+(`command_surface.mcp_retry_scope:259`) but is used only for write idempotency and
+never threaded to read leaves. Withhold-tokens reuse the hosted transfer-grant v2
++ `consume_transfer_jti` pattern (`hosted_transfer.py:218-353`); the HMAC key is a
+per-machine `SystemRandom` value in the sidecar meta (`sidecar_store` precedent),
+never an env secret, never synced.
+
+## Goals / Non-Goals
+
+Goals: enforce the kernel's ceilings on every content-returning surface with no
+leak channel (metadata, counts, scores, graph seeds, provenance, errors);
+preserve baseline behavior and latency for ungoverned vaults; ship the default-on
+credential scrubber; make the projector the single serializer so a missed surface
+fails closed loudly.
+
+Non-Goals: the `govern_memory` tool, receipts, bridges, L4 redaction span maps,
+budgets. No change to ranking/recall for permitted items. No new model call
+anywhere.
+
+## Decisions
+
+### D1 — Enforce at `invoke_command`, second pass at `bind_vault`
+The terminal secret scrubber + withheld cross-check live in a shared
+`governance.egress.postfilter(command_name, result, vault_root)` called inside
+`writer_lease.invoke_command` (covers MCP/REST/hosted/CLI in one place), with a
+second call in the `bind_vault` wrapper where FastMCP context is live (MCP
+defense-in-depth). This removes the entire REST/CLI/retrieve-inject bypass class.
+The walker special-cases MCP `ToolResult` content blocks (scan text blocks only,
+never image bytes from `op_get_video_frames`). Documented residuals: hand-
+registered adoption tools and the transfer routes bypass `invoke_command` and get
+explicit `postfilter` calls at their handlers; `query_log` records hits
+pre-annotation into the never-synced local `logs/` (existing local-trust-domain
+behavior).
+
+### D2 — Decisions in op_find, cache stays principal-free
+`governance.egress.annotate_hits(vault_root, hits, principal, purpose)` runs at
+`commands.py:901→902`, strictly after `find()` returns and before
+`assemble_pack` (`:905`) and serialize (`:908`). Nothing principal-dependent
+enters `find()` or `_FIND_CACHE`; a separate small memo keys decisions per
+`(fingerprint, path, audience, purpose, grants-hash)`. A two-principal cache test
+pins that cached `Hit` copies carry `decision=None`. Purpose never enters the
+`_FIND_CACHE` key (would let model-declared purpose bust the relevance cache).
+
+### D3 — Per-level projector is the only serializer
+`project(payload, level)` is the sole path to a wire dict. Level allow-lists: L0
+nothing (item omitted); L1 rule-id + scope-label only; L2 +constraint string;
+scores/signals/`graph.seed`/`relation_match`/`matched_units`/`superseded_by`/
+`parent_ref` only at L5–L6, and any of them naming a sub-notice path stripped at
+every level. `find_types` raw serializers are removed from the egress path; a
+command with no registered projector fails closed (cannot emit
+path/title/excerpt) — a missed surface becomes a loud test failure. This collapses
+the metadata/score/provenance oracle class into one grep-able invariant.
+
+### D4 — Request-deterministic backfill; L0 silent
+Withheld slots are refilled from a pre-committed over-fetch pool so the shown
+count is a function of the request, not of how many items were withheld. At pool
+exhaustion, L1+ scopes still show their notice; **L0 scopes return a silently
+shorter list** — a fixed "governance active" marker would itself be an existence
+oracle for a silent scope. Graph-expanded hits whose only provenance is a
+withheld seed are dropped post-hoc (they return only if they matched a lane on
+their own), plus `guard_seed` in `graph_context`.
+
+### D5 — Canonical audience, threaded, fail-closed
+`governance.principal` exposes one `RequestPrincipal(audience_id, session_id,
+purpose)` via a contextvar + `request_scope()` (clone of
+`capabilities.active_surface` / `mcp_request_context` set/reset). Set-points:
+`bind_vault` wrapper (MCP, where `mcp_retry_scope` already binds), `_rest_gate`
+(REST), hosted invoke wrapper (cell principal), `__main__` (CLI = `owner`). One
+normalization maps OAuth `sub`/`iss`, CF-Access claims, REST key, and stdio to a
+single comparable id so a grant authored on one surface matches the same human on
+another. Unresolved-but-expected identity fails closed to most-restrictive, never
+OPEN. `purpose` is an optional param on the recall leaves; `derive_params`
+propagates it to REST/CLI.
+
+### D6 — Withhold-tokens: content-fingerprint-bound, consume-once, box-local
+Token wire form `wh1.<jti>.<exp>.<hmac>`, HMAC over
+`{jti, item-fingerprints, audience, exp}`. Bound to **content fingerprints**, not
+paths, so a content swap after mint fails closed (with a one-step fresh-escalation
+hint — no re-confirm treadmill) and approval-by-substitution is impossible.
+Consumed once under `BEGIN IMMEDIATE` in `.governance.sqlite withhold_tokens`
+(JTI-consume semantics); TTL sweep opportunistic. HMAC key is per-machine sidecar
+meta. "Session" on stdio is the canonical audience + lease identity, never a
+shared `session_id`.
+
+### D7 — Always-on credential scrubber
+The secret scrubber is content-pattern-based and policy-independent: it runs even
+on the empty-policy fast path (the one intentional ungoverned behavior change).
+Compiled alternation over private-key blocks, AWS/GitHub/JWT/bearer shapes, and
+high-entropy tokens; a structural-field allowlist (`content_hash`, `ref`,
+`fingerprint`, `expected_hash`) prevents false positives. A standing rule disables
+it. Budget target < 2 ms per 100 KB result, pinned by the overhead micro-gate.
+
+## Risks / Trade-offs
+
+- **`bind_vault` is not the universal choke point** (verified): mitigated by D1
+  (`invoke_command` primary). A startup assertion checks every product command
+  resolves to a projector-registered leaf.
+- **Byte-pinned tool surface**: adding `purpose` changes
+  `tool_surface_contract.json` and schema-fidelity pins; regenerate via
+  `scripts/dump-tool-schemas.py` in-task, never hand-edit.
+- **Latency gate bypasses `op_find`** (calls `find()` directly): governance
+  overhead is invisible to it, so a new `test_governance_overhead.py` micro-gate
+  measures at the `op_find` level over the same `gen_dense_vault` corpus; existing
+  ceilings untouched.
+- **Scrubber false positives**: allowlist by structural key name before the
+  pattern scan; test pins zero mutations on a representative result corpus.
+
+## Migration Plan
+
+Empty policy → fast path; only the credential scrubber changes behavior on an
+ungoverned vault (owner-confirmed default-on, one rule to disable). Tool-surface
+regen is the only artifact churn. No data migration.
+
+## Open Questions
+
+None blocking. L4 redaction detail (span maps) and budgets are explicitly later
+changes; this change ships L0/L1/L2/L3/L5/L6 with L4 falling back to L3 abstract
+until `add-redaction-levels` lands.

--- a/openspec/changes/add-release-gate/proposal.md
+++ b/openspec/changes/add-release-gate/proposal.md
@@ -1,0 +1,102 @@
+# Proposal: add-release-gate
+
+## Why
+
+`add-governance-kernel` can decide a disclosure ceiling but nothing enforces it.
+This change is the **release plane**: it makes every content-returning surface
+render only what each item's decision permits, and it introduces the disclosure
+ladder that turns a single "ceiling" into a concrete representation on the wire.
+
+The separation of planes is the whole product thesis: retrieval stays broad and
+creative over the full indexed corpus (the relevance plane is unchanged), but a
+deterministic gate sits between ranked candidates and the response, so *internal
+discoverability never implies external releasability*. Titles, paths, counts,
+snippets, graph neighbours, and ranking signals are all "release" — not just
+bodies — so the gate operates on structured candidates before serialization, not
+on finished text.
+
+Two verified code realities shape the design. First, the one dispatcher shared by
+MCP, REST, hosted, and CLI is `writer_lease.invoke_command` — **not**
+`command_surface.bind_vault` (which is MCP-only); the `EXOMEM_RETRIEVE_INJECT`
+hook deliberately travels the REST/CLI paths that bypass `bind_vault`, so the
+terminal scrubber and post-filter must sit at `invoke_command`. Second, the find
+hot-cache stores deep copies of `Hit` objects shared across principals, so
+decisions must be computed in `op_find` *after* `find()` returns — never inside
+`find()`, or one principal's decisions would be cached for another.
+
+This change also ships the **default-on credential egress block** (confirmed with
+the owner): a deterministic secret scrubber that blocks credential-shaped strings
+at egress even on an ungoverned vault, with one standing rule to disable it. It is
+the single intentional behavior change for vaults with no `_Governance/`.
+
+## What Changes
+
+- A **disclosure ladder** L0 `none` → L1 `notice` → L2 `constraint` → L3
+  `abstract` → L4 `excerpt_redacted` → L5 `excerpt` → L6 `full`. A rule sets a
+  ceiling; the assembler renders the highest permitted, lowest sufficient
+  representation.
+- A **per-level projector** `project(payload, level)` that is the *only* path from
+  a Hit / page / pack element / unit to a wire dict. Raw serializers
+  (`Hit.as_dict`/`as_compact_dict`, etc.) are removed from the egress path.
+  Ranking signals, `graph.seed`, `relation_match`, `matched_units`,
+  `superseded_by`, `parent_ref` are content oracles — emitted only at L5–L6, and
+  stripped at every level when they name a sub-notice path. A command with no
+  registered projector **fails closed** (cannot emit path/title/excerpt).
+- **Decision annotation in `op_find`** strictly after `find()` returns
+  (`commands.py:901→902`): withheld items dropped and replaced by notices;
+  count backfilled from a pre-committed over-fetch pool so the shown count is
+  request-deterministic; graph-expanded hits whose only provenance is a withheld
+  seed dropped. The shared `_FIND_CACHE` stays principal-free; a separate memo
+  keys decisions per `(fingerprint, path, audience, purpose, grants-hash)`.
+- **Canonical audience** resolved at each surface boundary (MCP/REST/hosted/CLI)
+  into one comparable id space; stdio/CLI = `owner`; unresolved-but-expected
+  fails closed to most-restrictive. Threaded to every read leaf. `purpose` added
+  as an optional param on the recall leaves.
+- **Withhold-tokens**: single-use HMAC capability tokens bound to
+  `(audience, item content-fingerprints, max level, TTL)`, minted into `withheld`
+  notices, consumed once in a per-machine sidecar store — a second instantiation
+  of the hosted transfer-grant-v2 + JTI pattern.
+- **Terminal secret scrubber + withheld cross-check** in
+  `writer_lease.invoke_command`, covering MCP/REST/hosted/CLI, with an MCP-layer
+  second pass in `bind_vault`. Always-on (credential block); structural-field
+  allowlist prevents false positives on `content_hash`/`ref` fields.
+- Enforcement extended to `op_get`, the graph lane, deep packs, media/dataset,
+  and transfer-download issuance. `read_media` frames and download grants mint
+  only after a release decision.
+
+## Capabilities
+
+### New Capabilities
+
+- `release-gate`: a deterministic per-item release plane — disclosure ladder,
+  single per-level projector, decision annotation with request-deterministic
+  backfill, canonical audience resolution, single-use withhold-tokens, and an
+  always-on terminal secret scrubber at the shared dispatcher — enforced across
+  every content-returning surface with an empty-policy fast path.
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: the hot cache stays principal-free; decisions are a
+  separate per-request memo, never a cache-key fragment.
+- `context-packs`: pack elements carry decisions and never contain sub-notice
+  content.
+- `graph-find-ranking`: graph expansion never seeds from a sub-notice item and
+  strips provenance naming withheld paths.
+- `get-payload-shape`: `get`/`read_memory` render at the item's decision level.
+
+## Impact
+
+- Code: new `src/exomem/governance/{principal,egress,scrubber,tokens}.py`;
+  edits to `commands.py` (annotate at `op_find` `:901→902`; `op_get`,
+  `op_graph_context`, `op_get_video_frames`, `op_transfer_artifact` gating;
+  `purpose` params), `find_types.py` (decision-aware projection + `Hit.decision`),
+  `find.py` (backfill pool, graph-seed guard, decision memo), `context_pack.py`,
+  `command_surface.py` (audience contextvar beside `mcp_retry_scope`; MCP
+  second-pass filter), `writer_lease.py` (terminal postfilter + scrubber call),
+  `server_rest.py`, `server_hosted.py`, `__main__.py` (per-surface audience
+  set-points), `tool_surface_contract.json` (regenerated for the `purpose` param).
+- Tests: `tests/test_governance_egress.py`, `test_governance_principal.py`,
+  `test_governance_tokens.py`, `test_governance_postfilter.py`, plus surface
+  parity and overhead micro-gate; existing goldens + latency gate stay green.
+- Explicitly NOT in scope: the `govern_memory` authoring tool (next change),
+  receipts, bridges, redaction span maps (L4 detail), budgets.

--- a/openspec/changes/add-release-gate/specs/context-packs/spec.md
+++ b/openspec/changes/add-release-gate/specs/context-packs/spec.md
@@ -1,0 +1,22 @@
+# context-packs
+
+## ADDED Requirements
+
+### Requirement: Deep packs honor release decisions
+
+Deep context packs SHALL be assembled only from items that have passed the release
+gate, and each pack element SHALL carry its decision. A pack SHALL NOT contain the
+content, claims, neighborhood, or contradictions of any item released below its
+excerpt level, and the pack header SHALL carry the governance context (policy
+fingerprint and any withheld notices) rather than sub-notice content.
+
+#### Scenario: Withheld item is absent from the pack
+
+- **WHEN** a pack is assembled for a query whose candidates include a withheld item
+- **THEN** that item's content, claims, and neighborhood do not appear in the pack,
+  and its withholding is represented only by a notice in the pack header
+
+#### Scenario: Permitted pack elements are unchanged
+
+- **WHEN** a pack is assembled with no governed items
+- **THEN** the pack is identical to baseline

--- a/openspec/changes/add-release-gate/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/add-release-gate/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,23 @@
+# find-recall-efficiency
+
+## ADDED Requirements
+
+### Requirement: Release decisions do not fragment the recall cache
+
+Governance release decisions SHALL NOT be stored in the `find` hot cache and SHALL
+NOT be part of its key. The hot cache SHALL remain keyed on content and policy
+fingerprints only, storing principal-free candidates; release decisions SHALL be
+computed per request after a cache hit and memoized separately. Declared purpose
+SHALL NOT enter the recall cache key.
+
+#### Scenario: Cache hit still decides per principal
+
+- **WHEN** a query result is served from the hot cache to a second audience
+- **THEN** decisions are recomputed for that audience and no cached candidate
+  carries a prior audience's decision
+
+#### Scenario: Purpose does not bust the recall cache
+
+- **WHEN** the same query is issued with different declared purposes
+- **THEN** both are served from the same cached candidate set, with decisions
+  applied afterward

--- a/openspec/changes/add-release-gate/specs/get-payload-shape/spec.md
+++ b/openspec/changes/add-release-gate/specs/get-payload-shape/spec.md
@@ -1,0 +1,27 @@
+# get-payload-shape
+
+## ADDED Requirements
+
+### Requirement: Direct reads render at the release decision level
+
+`get`/`read_memory` SHALL render a governed page at its release decision's level
+for the requesting audience: full frontmatter and body only at full disclosure;
+a bounded excerpt at excerpt levels; an approved abstraction or constraint at
+those levels; and, below notice, a response byte-identical to a missing path. At
+any level below full, the response SHALL NOT include provenance fields (sources,
+history, relation edges, supersession pointers) that name a sub-notice item.
+
+#### Scenario: Governed page renders at its ceiling
+
+- **WHEN** a page whose decision is an excerpt level is read
+- **THEN** the response carries a bounded excerpt and not the full body
+
+#### Scenario: Sub-notice read is indistinguishable from missing
+
+- **WHEN** a page whose decision is below notice is read by that audience
+- **THEN** the response is byte-identical to a nonexistent-path response
+
+#### Scenario: Ungoverned page is unchanged
+
+- **WHEN** a page with no matching governance rule is read
+- **THEN** the response is identical to current behavior

--- a/openspec/changes/add-release-gate/specs/graph-find-ranking/spec.md
+++ b/openspec/changes/add-release-gate/specs/graph-find-ranking/spec.md
@@ -1,0 +1,30 @@
+# graph-find-ranking
+
+## ADDED Requirements
+
+### Requirement: Graph expansion respects release decisions
+
+The graph lane SHALL NOT surface a hit whose only provenance is expansion from a
+seed item released below notice for the requesting audience — such hits SHALL be
+dropped unless they matched a retrieval lane on their own. Graph provenance
+annotations (seed page, relation match, supersession pointers) SHALL be stripped
+from any returned hit when they name a sub-notice item, and `graph-context` SHALL
+apply the same guard to its seeds, nodes, and edge endpoints.
+
+#### Scenario: Withheld seed does not smuggle neighbours
+
+- **WHEN** a restricted page is a strong match and its graph neighbour would
+  surface only via expansion from it
+- **THEN** the neighbour is dropped, and it returns only if it matched a lexical
+  or vector lane on its own
+
+#### Scenario: Seed annotations never name withheld pages
+
+- **WHEN** a permitted hit carries a graph provenance annotation referencing a
+  sub-notice page
+- **THEN** the annotation is stripped from the response
+
+#### Scenario: Ungoverned expansion unchanged
+
+- **WHEN** no governance rule matches any seed or neighbour
+- **THEN** graph expansion and its annotations are identical to current behavior

--- a/openspec/changes/add-release-gate/specs/release-gate/spec.md
+++ b/openspec/changes/add-release-gate/specs/release-gate/spec.md
@@ -1,0 +1,142 @@
+# release-gate
+
+## ADDED Requirements
+
+### Requirement: Disclosure ladder and single per-level projector
+
+The release plane SHALL support an ordered disclosure ladder — L0 none, L1
+notice, L2 constraint, L3 abstract, L4 redacted excerpt, L5 excerpt, L6 full —
+and SHALL render each item at the highest permitted, lowest sufficient level for
+its decision. A single per-level projector SHALL be the only path from any
+candidate (hit, page, pack element, unit) to a wire representation. Ranking
+signals, graph seed provenance, relation-match annotations, matched units,
+supersession pointers, and parent references SHALL appear only at L5–L6 and SHALL
+be stripped at every level when they name a sub-notice item. Any content-returning
+command without a registered projector SHALL fail closed, emitting no path,
+title, or excerpt.
+
+#### Scenario: Low levels strip metadata oracles
+
+- **WHEN** an item is released at L1
+- **THEN** the response carries only its rule id and scope label, and no score,
+  signal, graph seed, relation match, matched unit, supersession pointer, or path
+
+#### Scenario: Scores only at high levels
+
+- **WHEN** an item is released below L5
+- **THEN** no ranking signal or similarity score for it crosses the boundary
+
+#### Scenario: Unregistered surface fails closed
+
+- **WHEN** a content-returning command has no registered projector
+- **THEN** it emits no path, title, or excerpt, and the omission is a test failure
+
+### Requirement: Decision annotation and request-deterministic counts
+
+Release decisions SHALL be computed after retrieval returns and before response
+assembly, per item, keyed on the caller's audience and declared purpose and the
+active grants. Withheld items SHALL be replaced by next-best permitted candidates
+drawn from a pre-committed over-fetch pool so the shown result count is a function
+of the request, not of how many items were withheld. When the pool is exhausted,
+L1-and-above scopes SHALL still emit their notice while L0 scopes SHALL return a
+silently shorter list. The shared retrieval hot cache SHALL remain principal-free;
+decisions SHALL be a separate per-request memo and SHALL NOT fragment the recall
+cache by audience or purpose.
+
+#### Scenario: Withholding does not change the visible count
+
+- **WHEN** a query would return N permitted items and some candidates are withheld
+  while the over-fetch pool can still fill N
+- **THEN** exactly N items are returned and the count does not reveal that any
+  were withheld
+
+#### Scenario: Cache stays principal-free
+
+- **WHEN** two different audiences run the same query and the second hits the
+  retrieval cache
+- **THEN** the second response carries its own decisions and no cached candidate
+  copy carries another audience's decision
+
+### Requirement: Canonical audience resolution, threaded and fail-closed
+
+Every content-returning read SHALL resolve a canonical audience at its surface
+boundary — MCP OAuth principal, REST key scope, hosted cell principal, or `owner`
+for stdio/CLI — normalized into one comparable identity space, and SHALL thread it
+to the release decision. A grant authored against one surface SHALL match the same
+principal on another surface. When identity should resolve but cannot, the release
+decision SHALL fail closed to the most restrictive outcome, never to full
+disclosure.
+
+#### Scenario: Same principal across surfaces
+
+- **WHEN** the same human queries via MCP and via REST
+- **THEN** a grant authored for that principal applies on both
+
+#### Scenario: Unresolved identity denies
+
+- **WHEN** an authenticated surface cannot resolve the expected principal
+- **THEN** the decision is most-restrictive, not OPEN
+
+### Requirement: Single-use content-bound escalation tokens
+
+A withheld or abstracted item MAY carry a single-use escalation token bound to the
+audience, the item's content fingerprints, a maximum level, and an expiry, minted
+with a per-machine secret and consumed exactly once in a per-machine store. A
+token SHALL NOT authorize a level above its bound maximum, SHALL NOT be replayable
+across sessions or clients, and SHALL fail closed when the referenced item's
+content has changed since minting, offering a fresh escalation rather than
+disclosing changed content.
+
+#### Scenario: Single use, bounded
+
+- **WHEN** an escalation token is redeemed
+- **THEN** it discloses at most its bound level, and a second redemption is
+  refused
+
+#### Scenario: Content drift invalidates the token
+
+- **WHEN** the item's content changed after the token was minted
+- **THEN** redemption is refused and a fresh escalation referencing the new
+  content is offered
+
+### Requirement: Terminal secret scrubber at the shared dispatcher
+
+An always-on deterministic secret scrubber SHALL run at the dispatcher shared by
+the MCP, REST, hosted, and CLI surfaces, over the final result of every
+content-returning command, blocking credential-shaped strings from crossing the
+boundary and replacing them with a notice. The scrubber SHALL run even when no
+governance policy is present, SHALL allowlist structural identifier fields
+(content hashes, refs, fingerprints) to avoid false positives, and MAY be disabled
+by an explicit standing rule.
+
+#### Scenario: Credential blocked on an ungoverned vault
+
+- **WHEN** a result contains a private key block or an API-key-shaped token and no
+  `_Governance/` policy exists
+- **THEN** the credential value does not cross the boundary and a notice reports
+  the block
+
+#### Scenario: Structural identifiers are not false positives
+
+- **WHEN** a result contains legitimate content hashes and `exomem://` refs
+- **THEN** the scrubber leaves them intact
+
+#### Scenario: Every surface is covered
+
+- **WHEN** the same restricted query is issued over MCP, REST, and CLI (including
+  the retrieve-inject hook path)
+- **THEN** all three responses carry field-identical projections with no
+  sub-notice paths or excerpts
+
+### Requirement: Empty-policy fast path
+
+When no `_Governance/` policy exists, the release plane SHALL short-circuit to
+baseline behavior plus the always-on secret scrubber, preserving current response
+shape and latency. The credential scrubber SHALL be the only behavioral difference
+for an ungoverned vault.
+
+#### Scenario: Ungoverned recall is baseline
+
+- **WHEN** a query runs on a vault with no `_Governance/` directory
+- **THEN** results match baseline except that credential-shaped strings are
+  blocked, and the latency gate is unchanged

--- a/openspec/changes/add-release-gate/tasks.md
+++ b/openspec/changes/add-release-gate/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: add-release-gate
+
+## 1. Principal / audience (src/exomem/governance/principal.py)
+
+- [ ] 1.1 Red test `tests/test_governance_principal.py`: per-surface resolver
+      (fake FastMCP deps via monkeypatch; REST scope passthrough; owner default);
+      unresolved-but-expected fails closed to most-restrictive.
+- [ ] 1.2 Implement `RequestPrincipal` + contextvar + `request_scope()` (clone of
+      `capabilities.active_surface`); set-points in `bind_vault` wrapper
+      (`command_surface.py:211`, beside `mcp_retry_scope`), `server_rest.py:267`,
+      hosted invoke wrapper, `__main__.py:2037`; one canonical-audience normalizer.
+
+## 2. Projector + decision annotation (egress.py, find_types.py)
+
+- [ ] 2.1 Red test `tests/test_governance_egress.py::test_op_find_annotates_and_filters`:
+      withheld hit → notice; permitted hit → decision; pack excludes withheld;
+      graph seed / relation_match naming withheld path scrubbed.
+- [ ] 2.2 Implement `project(payload, level)` per-level allow-list as the only
+      serializer; add `decision` to `Hit`/`SemanticUnitHit`; remove raw
+      serializers from the egress path; unregistered-projector fail-closed.
+- [ ] 2.3 Insert `annotate_hits` at `commands.py:901→902` (after `find()`, before
+      `assemble_pack`); request-deterministic backfill from an over-fetch pool;
+      L0 silent at pool exhaustion.
+
+## 3. Cache invariant
+
+- [ ] 3.1 Red test `test_governance_egress.py::test_find_hot_cache_stays_principal_free`
+      (two audiences; cached second call; cached copies carry `decision=None`);
+      separate decision memo keyed `(fingerprint, path, audience, purpose,
+      grants-hash)`. No production change to `_FIND_CACHE` key expected.
+
+## 4. get / graph / packs / purpose param
+
+- [ ] 4.1 Red tests `test_get_respects_decision_levels`,
+      `test_graph_context_guard_seed_governed`, pack-decision test.
+- [ ] 4.2 `annotate_page` in `op_get` (`commands.py:1838+`); `guard_seed` in
+      `op_graph_context`/`epistemic_graph`; pack elements carry decisions.
+- [ ] 4.3 Add `purpose` param to `op_find`/`op_ask_memory`/`op_read_memory`/
+      `op_graph_context`; regenerate `tool_surface_contract.json` via
+      `scripts/dump-tool-schemas.py`; update `test_mcp_schema_fidelity.py` /
+      `test_tool_surface_contract.py` / `test_connector_guardrails.py` pins.
+
+## 5. Withhold-tokens (tokens.py)
+
+- [ ] 5.1 Red test `tests/test_governance_tokens.py`: mint/verify/expire/
+      single-use-redeem/sweep; content-fingerprint binding; drift refuses.
+- [ ] 5.2 Implement `wh1.` token format, per-machine sidecar HMAC key,
+      `BEGIN IMMEDIATE` consume-once; withheld notices embed tokens.
+
+## 6. Terminal scrubber + postfilter (scrubber.py, egress.postfilter)
+
+- [ ] 6.1 Red test `tests/test_governance_postfilter.py`: credential patterns
+      (keys/JWT/high-entropy); no false positive on `content_hash`/`ref` fields;
+      withheld-path cross-check; `ToolResult` text-block-only handling.
+- [ ] 6.2 Implement `scrubber.py` (always-on) + `egress.postfilter`; call in
+      `writer_lease.invoke_command` (primary) + `bind_vault` (MCP second pass);
+      explicit calls at adoption tools + transfer routes; startup assertion that
+      every product command resolves to a projector-registered leaf.
+- [ ] 6.3 Red tests `test_release_gate_runs_on_rest_surface`,
+      `test_release_gate_runs_on_cli_surface`,
+      `test_retrieve_inject_hook_respects_release` (surface parity).
+
+## 7. Transfer / media gating
+
+- [ ] 7.1 Red tests `test_transfer_download_denies_below_l6`,
+      `test_read_media_frames_gated`.
+- [ ] 7.2 `op_transfer_artifact` download-target selection and
+      `op_get_video_frames` consult the release decision before minting/returning.
+
+## 8. Gates
+
+- [ ] 8.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_governance_egress.py tests/test_governance_principal.py
+      tests/test_governance_tokens.py tests/test_governance_postfilter.py
+      tests/test_find.py tests/test_context_pack.py` green.
+- [ ] 8.2 New `tests/test_governance_overhead.py`: `op_find` empty-policy delta
+      < 5 ms median over `gen_dense_vault` 2k; scrubber < 2 ms per 100 KB.
+- [ ] 8.3 `uv run python -m pytest tests/test_latency_gate.py -q` +
+      `tests/test_retrieval_golden.py` (embeddings lane) green — thresholds and
+      goldens unchanged.
+- [ ] 8.4 `uvx ruff check` clean; `openspec validate add-release-gate --strict`
+      green.

--- a/openspec/changes/fix-excluded-tier-read-paths/.openspec.yaml
+++ b/openspec/changes/fix-excluded-tier-read-paths/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/fix-excluded-tier-read-paths/design.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/design.md
@@ -1,0 +1,74 @@
+# Design: fix-excluded-tier-read-paths
+
+## Context
+
+`access.access_tier(vault_root, rel_path)` (`access.py:161`) already resolves any
+vault-relative path to one of `excluded` / `readonly` / `append-only` /
+`read-write`, live-reloaded on content hash (`access.py:78`). `is_indexable`
+(`:181`) is `True` for everything except `excluded`. Index-time lanes call it
+(`find_corpus.py:240`, `embeddings.py:1356`, `claims.py:532`); the direct-read
+surfaces do not. `review_context.py` is the in-repo reference for enforcing the
+tier on a read path. This change is pure enforcement wiring — no new policy.
+
+## Goals / Non-Goals
+
+Goals: every read surface that can return or enumerate a page consults the same
+tier resolver the index lanes already trust; excluded refusal is
+indistinguishable from absence; the graph lane treats excluded pages as
+non-existent for seeding, expansion, and edges.
+
+Non-Goals: representation ceilings, redaction, audience/purpose, any
+`_Governance/` file (all deferred to the governance changes). No change to what
+`excluded` *means* — only where it is honored. No change to `readonly` /
+`append-only` semantics.
+
+## Decisions
+
+### D1 — One helper, applied at each surface's resolve point
+Add a small `access.refuse_if_excluded(vault_root, rel_path)` returning a
+uniform sentinel/raise, and call it immediately after each surface normalizes a
+path to vault-relative form: `get_page` after path validation
+(`get_page.py:103-117`), `query_data` and `video_frames` after
+`resolve_under_vault`. This keeps the tier check in one place and mirrors
+`review_context`'s existing usage.
+
+### D2 — Refusal is byte-identical to NOT_FOUND
+An excluded `get_page`/`read_media`/`query_dataset` returns the exact error code,
+shape, and message a missing path returns, and never interpolates the probed
+path. Rationale: a distinct "forbidden" error, or a path echo, tells a caller the
+item exists — the same existence-oracle class the governance release plane later
+guards against. Absence and denial must be indistinguishable at the boundary.
+
+### D3 — overview prunes, not annotates
+`overview` removes excluded subtrees from the `os.walk` (dir-prune) and skips
+excluded files, so they contribute to neither the tree nor any count. It does not
+emit a "hidden: N" marker — that count would itself leak subtree size.
+
+### D4 — Graph lane filters at three points
+`graph_context` applies `is_indexable` to (a) seed resolution, (b) node
+materialization, and (c) edge endpoints — an excluded page is never a seed,
+never surfaces as a neighbour, and never appears as either end of a returned
+edge. This matches the `find` hit-assembly filter (`find.py:2601`) that the graph
+lane currently bypasses.
+
+## Risks / Trade-offs
+
+- **Existing fixtures with excluded trees shift**: `overview` counts and any test
+  asserting on excluded content change. Resolution: audit `tests/test_overview.py`
+  goldens within this change rather than discovering the drift in CI.
+- **Performance**: one extra `access_tier` call per read; the config is cached on
+  content hash, so cost is a dict lookup. Graph filtering adds an `is_indexable`
+  check per candidate node (≤ the node cap, ~40) — negligible.
+- **Over-refusal**: a caller legitimately reading an excluded path they own now
+  gets NOT_FOUND. This is the intended contract ("truly private"); such content is
+  reachable only by removing it from `excluded` in `_access.yaml`.
+
+## Migration Plan
+
+Additive enforcement; no data migration. Behavior change is limited to excluded
+paths, which by definition were meant to be invisible. No config format change.
+
+## Open Questions
+
+None blocking. Follow-up: whether `list_inbound_links` / `provenance_report`
+need the same gate (tracked under the release-gate change's coverage sweep).

--- a/openspec/changes/fix-excluded-tier-read-paths/proposal.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: fix-excluded-tier-read-paths
+
+## Why
+
+`_access.yaml`'s `excluded` tier is documented as "truly private — invisible to
+find/embedding AND unwritable" (`access.py:1-9`, `39`). That contract holds only
+at index time. Direct-read surfaces never consult `access.is_indexable`, so an
+`excluded` page is still fully readable and enumerable by any caller who knows or
+guesses its path:
+
+- `get_page.get_page` (`get_page.py:68`) has no tier check — only the reserved
+  hosted-vault-name guard (`:81`).
+- `overview.overview` (`overview.py:106`) walks the tree with `os.walk` and zero
+  `access` imports — excluded subtrees are listed and counted.
+- `query_data.query_data` and `video_frames.get_frames` (`:95`) resolve paths
+  under the vault with no tier gate.
+- The graph lane `epistemic_graph.graph_context` (`:825`) seeds and materializes
+  nodes without `is_indexable`, so an excluded page surfaces as a neighbour.
+
+`review_context.py` already enforces the tier on its read paths (`:73`, `:243`,
+`:332`, `:396`) — this change brings the remaining direct-read surfaces up to
+that same standard. It is a correctness/privacy fix in its own right and a
+prerequisite for the governance release plane, which layers representation-level
+ceilings on top of a trustworthy `excluded` floor.
+
+## What Changes
+
+- `get_page`, `overview`, `query_dataset`/`query_data`, `read_media`/`video_frames`,
+  and the graph-context lane consult `access.access_tier` / `access.is_indexable`
+  and refuse or omit `excluded` paths.
+- Refusal is **indistinguishable from absence**: an excluded direct read returns
+  the same shape and text as a genuine `NOT_FOUND`, and never echoes the probed
+  path — otherwise the error itself is an existence oracle.
+- `overview` prunes excluded subtrees from the walk and from all counts.
+- The graph lane filters excluded pages from seeds, nodes, and edges (never a
+  seed, never a neighbour, never an edge endpoint).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `get-payload-shape`: `get`/`read_memory` refuse `excluded` paths
+  indistinguishably from missing.
+- `vault-overview`: `overview` hides excluded subtrees from structure and counts.
+- `graph-find-ranking`: the graph-context lane never seeds from or returns
+  excluded pages.
+
+(`query_dataset` and `read_media` are Tier-2 command-surface ops; their
+enforcement is registry-level and asserted at the command layer.)
+
+## Impact
+
+- Code: `src/exomem/get_page.py`, `src/exomem/overview.py`,
+  `src/exomem/query_data.py`, `src/exomem/video_frames.py`,
+  `src/exomem/epistemic_graph.py` (graph_context seed/node/edge filtering).
+- Tests: new `tests/test_access_read_paths.py` (per-surface refusal + absence
+  indistinguishability + graph seed/neighbour exclusion + command-layer sweep);
+  `tests/test_overview.py` fixtures audited for excluded-tree count shifts.
+- No new dependencies; no schema changes. Existing `test_access.py` remains the
+  index-time reference.
+- Explicitly NOT in scope: representation-level ceilings, redaction, any
+  `_Governance/` machinery (those land in `add-governance-kernel` /
+  `add-release-gate`).

--- a/openspec/changes/fix-excluded-tier-read-paths/specs/get-payload-shape/spec.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/specs/get-payload-shape/spec.md
@@ -1,0 +1,31 @@
+# get-payload-shape
+
+## ADDED Requirements
+
+### Requirement: Direct reads honor the excluded access tier
+
+`get`/`read_memory` (and the Tier-2 direct-content reads `query_dataset` and
+`read_media`) SHALL consult the `_access.yaml` access tier for the requested
+path and SHALL refuse any path resolving to the `excluded` tier. The refusal
+SHALL be indistinguishable from a genuinely missing path: identical error code,
+identical response shape, identical message text, and no echo of the requested
+path. No frontmatter, body, dataset row, media frame, or metadata of an excluded
+page SHALL cross the boundary through these surfaces.
+
+#### Scenario: Excluded page reads as missing
+
+- **WHEN** `get`/`read_memory` is called with a path under an `excluded` subtree
+- **THEN** the response is byte-identical in code, shape, and text to the
+  response for a nonexistent path, and does not contain the requested path
+
+#### Scenario: Excluded dataset and media are refused
+
+- **WHEN** `query_dataset` targets an excluded data file, or `read_media` targets
+  an excluded media artifact
+- **THEN** the operation refuses with the missing-path contract and returns no
+  rows and no frames
+
+#### Scenario: Indexable content is unaffected
+
+- **WHEN** a `read-write`, `readonly`, or `append-only` path is read
+- **THEN** the response is unchanged from current behavior

--- a/openspec/changes/fix-excluded-tier-read-paths/specs/graph-find-ranking/spec.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/specs/graph-find-ranking/spec.md
@@ -1,0 +1,25 @@
+# graph-find-ranking
+
+## ADDED Requirements
+
+### Requirement: Graph context excludes excluded-tier pages
+
+The graph-context lane (`connect_memory(operation="graph-context")` and the
+graph expansion feeding `find`) SHALL apply the `excluded` access tier at three
+points: seed resolution, node materialization, and edge endpoints. An
+`excluded`-tier page SHALL NOT be usable as a seed, SHALL NOT surface as a
+neighbour node, and SHALL NOT appear as either endpoint of a returned edge. This
+brings the graph lane to parity with `find` hit assembly, which already filters
+excluded pages.
+
+#### Scenario: Excluded page is never a seed
+
+- **WHEN** graph-context is requested seeded on an excluded page (by path or via
+  a query that would resolve to it)
+- **THEN** the lane treats the seed as absent and returns no neighbourhood
+  derived from it
+
+#### Scenario: Excluded page is never a neighbour or edge endpoint
+
+- **WHEN** an excluded page is a graph neighbour of a permitted seed
+- **THEN** it is omitted from the returned nodes and no edge naming it is returned

--- a/openspec/changes/fix-excluded-tier-read-paths/specs/vault-overview/spec.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/specs/vault-overview/spec.md
@@ -1,0 +1,22 @@
+# vault-overview
+
+## ADDED Requirements
+
+### Requirement: Overview hides excluded subtrees
+
+`overview`/`browse_memory` SHALL prune `excluded`-tier subtrees from the reported
+folder tree and from every count and coverage figure it emits. An excluded folder
+or file SHALL NOT appear in the structure, SHALL NOT be sampled, and SHALL NOT
+contribute to any aggregate. The report SHALL NOT emit a residual "hidden N"
+marker for excluded content, because that count leaks subtree size.
+
+#### Scenario: Excluded subtree is absent from structure and counts
+
+- **WHEN** `overview` runs on a vault containing an `excluded` subtree
+- **THEN** neither the subtree nor its files appear in the tree, and no count,
+  frontmatter-coverage figure, or sample includes them
+
+#### Scenario: Non-excluded structure is unchanged
+
+- **WHEN** `overview` runs on a vault with no excluded subtrees
+- **THEN** the report is identical to current behavior

--- a/openspec/changes/fix-excluded-tier-read-paths/tasks.md
+++ b/openspec/changes/fix-excluded-tier-read-paths/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: fix-excluded-tier-read-paths
+
+## 1. Shared enforcement helper
+
+- [ ] 1.1 Add `access.refuse_if_excluded(vault_root, rel_path)` (or reuse
+      `is_indexable`) returning a uniform decision, beside the existing
+      `writable_reason` (`access.py:186`). Red-first unit test in
+      `tests/test_access_read_paths.py` for tier resolution on each surface's
+      path form.
+
+## 2. get_page / read_memory
+
+- [ ] 2.1 Red test `test_get_page_refuses_excluded_path`: seed `_access.yaml`
+      per the `test_access.py:59` fixture pattern; assert an excluded read is
+      byte-identical (code + shape + text) to a NOT_FOUND read and does not echo
+      the path.
+- [ ] 2.2 Enforce in `get_page.get_page` after path normalization
+      (`get_page.py:103-117`, beside the reserved-name guard `:81`), raising the
+      existing missing-path error.
+- [ ] 2.3 Verify `op_get`/`op_read_memory` at the command layer inherit the
+      refusal (unit-read path `semantic_unit_read` too).
+
+## 3. overview / browse_memory
+
+- [ ] 3.1 Red test `test_overview_hides_excluded_tree` (+ counts exclude them).
+- [ ] 3.2 Dir-prune in the `os.walk` loop (`overview.py:133-144`) and per-file
+      skip (`:154`) via `access.access_tier` on the vault-relative path; no
+      "hidden N" marker.
+- [ ] 3.3 Audit `tests/test_overview.py` fixtures/goldens for count shifts.
+
+## 4. query_dataset / read_media
+
+- [ ] 4.1 Red tests `test_query_dataset_refuses_excluded`,
+      `test_read_media_refuses_excluded`.
+- [ ] 4.2 Enforce in `query_data.query_data` after `resolve_under_vault`
+      (`query_data.py:466-468`) and in `video_frames.get_frames` (`:95`) after
+      its resolve, using the missing-path contract.
+
+## 5. Graph lane
+
+- [ ] 5.1 Red test `test_graph_context_never_seeds_or_returns_excluded`
+      (seed-by-path, seed-by-query, and neighbour cases).
+- [ ] 5.2 Filter seeds, node materialization, and edge endpoints in
+      `epistemic_graph.graph_context` (`:825-990`) via `access.is_indexable`,
+      following the `review_context.py:73/:243` pattern.
+
+## 6. Sweep + gates
+
+- [ ] 6.1 Parametrized command-layer test asserting `read_memory`,
+      `browse_memory`, `query_dataset`, `read_media`, and
+      `connect_memory(graph-context)` all refuse an excluded path.
+- [ ] 6.2 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_access_read_paths.py tests/test_overview.py
+      tests/test_epistemic_graph.py` green.
+- [ ] 6.3 `uv run python -m pytest tests/test_latency_gate.py -q` green
+      (thresholds untouched).
+- [ ] 6.4 `uvx ruff check` clean on changed files; `openspec validate
+      fix-excluded-tier-read-paths --strict` green.

--- a/openspec/changes/fix-media-deletion-propagation/.openspec.yaml
+++ b/openspec/changes/fix-media-deletion-propagation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/fix-media-deletion-propagation/design.md
+++ b/openspec/changes/fix-media-deletion-propagation/design.md
@@ -1,0 +1,74 @@
+# Design: fix-media-deletion-propagation
+
+## Context
+
+`index_sync.delete_after_remove(vault_root, rel_paths)` (`:606`) is the single
+deletion fan-out, called by `delete_file` (`:257`) and `delete_directory`
+(`:237`). It dispatches to lexstore, memory_refs, epistemic_graph, and
+`embeddings.delete_after_remove_status` (`embeddings.py:1275`, text
+`EmbeddingIndex.delete_file` only). `ClipIndex.delete` (`clip_index.py:180`,
+does `dual_delete` + `DELETE FROM images`) and `scene_frames.clear_scene_frames`
+(`:59`) both exist but are unreachable from deletion. The binaries and frame
+sidecars are `Evidence`/append-only originals — but their **derived index rows**
+are rebuildable sidecar state that should track deletion.
+
+## Goals / Non-Goals
+
+Goals: a deleted image/video/frame leaves no CLIP row and no orphan `.frames/`
+directory; deleting a media binary triggers index cleanup; a reconcile pass
+heals vaults that already have orphans.
+
+Non-Goals: deleting append-only originals themselves (unchanged — trash
+semantics only), governance/retention policy, deletion audit events (deferred to
+`add-disclosure-receipts`), any change to how CLIP rows are *created*.
+
+## Decisions
+
+### D1 — CLIP purge as a fan-out component, best-effort
+Add a `clip` component to `delete_after_remove` (`:620-632` component list)
+calling a new `embeddings.delete_clip_after_remove(vault_root, rels)` that resolves
+the CLIP index and calls `ClipIndex.delete` for the removed path and each
+`<video>.frames/` child. Wrap in the same `_legacy_component` best-effort guard
+the other components use, so a missing CLIP extra (soft-fail) never breaks a
+delete. Rationale: keeps CLIP consistent with the other four sidecars, single
+fan-out point, no new call sites to keep in sync.
+
+### D2 — Scene-frame cleanup on the same fan-out
+For a removed video, the fan-out also calls
+`scene_frames.clear_scene_frames(vault_root, video_abs)` and passes the frame
+sidecar `.md` rels through the existing lexical/embedding components (they are
+`.md` paths — expand them into the fan-out's path set). Guard no-ops when no
+`.frames/` exists.
+
+### D3 — Widen the delete_file fan-out gate for media binaries
+`delete_file.py:254` currently gates fan-out on `.md`. Change: if the removed
+path is a media binary (by extension via `media_types`), call
+`delete_after_remove` with `[rel_binary] + frame_children`; non-md non-media
+keeps current behavior (no fan-out needed). This closes the "delete the binary,
+orphan every derived row" hole.
+
+### D4 — Reconcile heals existing orphans
+The existing `reconcile` sweep that prunes stale embeddings gains the same CLIP +
+`.frames/` orphan detection, so a vault that already lost content through the gap
+is repaired idempotently — not only future deletes. Drift is seeded manually in
+the test.
+
+## Risks / Trade-offs
+
+- **CLIP extra absent (lean install)**: `get_clip_index` soft-fails; the
+  best-effort component wrapper must swallow that and not fail the delete. Test
+  both with and without the extra.
+- **Frame directory races the watcher**: `file_watcher` may observe the `.frames/`
+  removal; `register_self_delete` already suppresses the writer's own events —
+  extend the suppression to the frame children to avoid a re-index echo.
+- **Idempotency**: deleting an already-clean path (no CLIP rows) must be a no-op,
+  not an error — asserted.
+
+## Migration Plan
+
+Additive fan-out + a reconcile heal. No data migration; the reconcile pass is the
+migration for already-orphaned vaults and is safe to run repeatedly.
+
+## Open Questions
+
+None blocking.

--- a/openspec/changes/fix-media-deletion-propagation/proposal.md
+++ b/openspec/changes/fix-media-deletion-propagation/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: fix-media-deletion-propagation
+
+## Why
+
+Deleting a page fans out to every derived index through
+`index_sync.delete_after_remove` (`:606`) — lexical/BM25, embedding chunks,
+semantic-unit vectors, graph nodes/edges, memory refs, resolver/freshness caches
+all purge correctly. Two media-derived artifacts do not:
+
+- **CLIP image/frame vectors survive.** `ClipIndex.delete` exists
+  (`clip_index.py:180`) but is called from no deletion path — only from backfill,
+  find candidates, the media worker, and warmup. A deleted image or video leaves
+  stale visual-search rows that still return the removed content by `clip_score`.
+- **Scene-frame `.frames/` derivatives survive a single-file delete.**
+  `scene_frames.clear_scene_frames` (`:59`) runs only on re-processing, not on
+  deletion. Deleting a video's `.md` sidecar orphans the sibling `<video>.frames/`
+  directory and its per-frame CLIP rows.
+
+Worse, `delete_file` gates the entire fan-out on `rel_path.lower().endswith(".md")`
+(`delete_file.py:254`), so deleting a media **binary** triggers no fan-out at all.
+
+This is a correctness/right-to-erasure defect on its own, and a hard prerequisite
+for the governance deletion story (a governed source must leave no visually
+searchable residue). It is deliberately scoped as a standalone fix so it can land
+independently of the governance kernel.
+
+## What Changes
+
+- `index_sync.delete_after_remove` gains a `clip` component that purges the CLIP
+  rows for the removed path and, for a video, its `<video>.frames/` children.
+- The fan-out also invokes `scene_frames.clear_scene_frames` for a removed video
+  so frame sidecars and the `.frames/` directory are cleaned.
+- `delete_file`'s `.md`-only fan-out gate widens: a removed **media binary**
+  (detected via `media_types`) enters the fan-out with its frame children,
+  instead of silently skipping index cleanup.
+- `reconcile` heals pre-existing orphans (stale CLIP rows, dangling `.frames/`)
+  so vaults that already lost content are repaired, not just future deletes.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-vault-portability`: the deletion propagation contract this capability
+  relies on for quiesced export/delete now covers CLIP and scene-frame
+  derivatives, so a deleted artifact leaves no searchable residue in any sidecar.
+
+(The core deletion behavior is not otherwise a named capability; this change is
+primarily an implementation-correctness fix asserted by tests.)
+
+## Impact
+
+- Code: `src/exomem/index_sync.py` (new `clip` fan-out component),
+  `src/exomem/delete_file.py` (media-binary fan-out gate),
+  `src/exomem/embeddings.py` (a clip-delete status helper mirroring
+  `delete_after_remove_status`), `src/exomem/scene_frames.py` (no-op-if-absent
+  guard), `src/exomem/reconcile.py` (orphan healing).
+- Tests: new `tests/test_media_deletion_propagation.py`.
+- No new dependencies; no schema changes.
+- Explicitly NOT in scope: governance, retention policy, deletion **events**
+  (those land in `add-disclosure-receipts`). This change only closes the purge
+  gap.

--- a/openspec/changes/fix-media-deletion-propagation/specs/hosted-vault-portability/spec.md
+++ b/openspec/changes/fix-media-deletion-propagation/specs/hosted-vault-portability/spec.md
@@ -1,0 +1,36 @@
+# hosted-vault-portability
+
+## ADDED Requirements
+
+### Requirement: Deletion purges media-derived index residue
+
+When a page, media sidecar, or media binary is deleted, the deletion fan-out
+SHALL purge every derived index row for that artifact, including CLIP
+image/frame vectors and scene-frame derivatives, leaving no sidecar through which
+the deleted content remains searchable. Deleting a media binary SHALL trigger the
+same fan-out as deleting a Markdown page. A reconcile pass SHALL heal
+pre-existing orphaned CLIP rows and `.frames/` directories idempotently.
+
+#### Scenario: Deleting an image purges its CLIP rows
+
+- **WHEN** an image (or its sidecar) is deleted
+- **THEN** its CLIP vectors are removed and a subsequent visual search cannot
+  return the deleted image
+
+#### Scenario: Deleting a video clears frame derivatives
+
+- **WHEN** a video is deleted
+- **THEN** its `<video>.frames/` directory, per-frame sidecars, and per-frame
+  CLIP rows are removed
+
+#### Scenario: Deleting a media binary triggers fan-out
+
+- **WHEN** a media binary is deleted directly
+- **THEN** the deletion fan-out runs for it (not skipped as non-Markdown) and all
+  its derived index rows are purged
+
+#### Scenario: Reconcile heals prior orphans
+
+- **WHEN** a vault contains CLIP rows or `.frames/` directories orphaned by a
+  prior deletion and reconcile runs
+- **THEN** the orphans are removed, and running reconcile again changes nothing

--- a/openspec/changes/fix-media-deletion-propagation/tasks.md
+++ b/openspec/changes/fix-media-deletion-propagation/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: fix-media-deletion-propagation
+
+## 1. CLIP purge in the fan-out
+
+- [ ] 1.1 Red test `tests/test_media_deletion_propagation.py::test_delete_after_remove_drops_clip_rows`:
+      insert rows via `ClipIndex.upsert`, run `delete_after_remove`, assert rows
+      gone and the CLIP generation token bumped.
+- [ ] 1.2 Add `embeddings.delete_clip_after_remove(vault_root, rels)` mirroring
+      `delete_after_remove_status`; wire a best-effort `clip` component into
+      `index_sync.delete_after_remove` (`:620-632`), guarded by `_legacy_component`.
+- [ ] 1.3 Assert no-op when the CLIP extra is absent (lean install) — delete still
+      succeeds.
+
+## 2. Scene-frame cleanup
+
+- [ ] 2.1 Red test `test_delete_after_remove_clears_scene_frames`.
+- [ ] 2.2 Fan-out calls `scene_frames.clear_scene_frames(root, video_abs)` for a
+      removed video and routes frame sidecar `.md` rels through the existing
+      lexical/embedding components; no-op guard when no `.frames/` exists.
+
+## 3. Media-binary fan-out gate
+
+- [ ] 3.1 Red test `test_delete_file_media_binary_enters_fanout`.
+- [ ] 3.2 Widen `delete_file.py:254`: a removed media binary (via `media_types`)
+      calls `delete_after_remove([rel_binary] + frame_children)`; extend
+      `register_self_delete` suppression to the frame children.
+
+## 4. Reconcile healing
+
+- [ ] 4.1 Red test `test_reconcile_heals_clip_and_frame_orphans` (seed drift
+      manually; assert idempotent).
+- [ ] 4.2 Add CLIP + `.frames/` orphan detection to the `reconcile` sweep that
+      already prunes embeddings.
+
+## 5. Gates
+
+- [ ] 5.1 `PYTHONPATH=src EXOMEM_DISABLE_EMBEDDINGS=1 uv run python -m pytest -q
+      tests/test_media_deletion_propagation.py tests/test_index_sync.py
+      tests/test_scene_frames.py` green.
+- [ ] 5.2 `uv run python -m pytest tests/test_latency_gate.py -q` green.
+- [ ] 5.3 `uvx ruff check` clean on changed files; `openspec validate
+      fix-media-deletion-propagation --strict` green.


### PR DESCRIPTION
## What

Locks in the approved plan for **user-sovereign knowledge governance** — a governed egress boundary where *internal discoverability* and *external releasability* are separate, deterministic, user-controlled planes, authored in natural language over MCP. This PR is **spec-only** (seven OpenSpec changes, no implementation yet) so the architecture can be reviewed before any code lands.

Full plan: `~/.claude/plans/use-exomem-for-this-toasty-pony.md` (investigation + adversarial review + integration mapping).

## The seven changes (dependency-ordered)

| Wave | Change | Essence |
|---|---|---|
| 0 | `fix-excluded-tier-read-paths` | Enforce the `excluded` tier on get/overview/query_dataset/read_media/graph reads (index-time only today — a pre-existing privacy gap), refusing indistinguishably from absence |
| 0 | `fix-media-deletion-propagation` | Wire `ClipIndex.delete` + scene-frame cleanup into the deletion fan-out so deleted media leaves no searchable residue |
| 1 | `add-governance-kernel` | `_Governance/` YAML policy, fingerprinted compiler with empty-policy fast path + conflicted-copy refusal, query-time memoized membership, pure order-free disclosure evaluator — **inspection only** |
| 2 | `add-release-gate` | Disclosure ladder L0–L6, single per-level projector as the only serializer, request-deterministic backfill, canonical audience, content-bound single-use withhold-tokens, always-on secret scrubber at the shared `invoke_command` dispatcher |
| 3 | `add-governance-tools` | The `govern_memory` NL lifecycle: propose/commit with drift-bound consume-once nonces, grant/revoke/undo, read-only explain/simulate + bootstrap/scaffold teaching |
| 4 | `add-disclosure-receipts` | Proportional, per-machine, hash-chained, plaintext-free release receipts with audit-mode chain verification |
| 5 | `add-cross-domain-bridges` | Content-hash-bound reviewed abstractions released where their restricted sources are withheld, provenance stripped |

## Design decisions verified against the code

- **`invoke_command` is the universal choke point**, not `bind_vault` (which is MCP-only) — REST/CLI and the `EXOMEM_RETRIEVE_INJECT` hook bypass `bind_vault`, so the scrubber + post-filter sit at the shared dispatcher.
- **Decisions annotate in `op_find` after `find()` returns** — the hot cache stores principal-shared deep copies, so nothing principal-dependent may enter it; a separate memo carries decisions.
- **Membership is query-time memoized**, not an index-time table (no fifth `index_sync` fan-out component).
- **Default-on credential egress block** is the single intentional behavior change for ungoverned vaults (owner-confirmed; one rule to disable).

## Guarantees baked into the specs

- Ungoverned vaults: baseline behavior + latency preserved (empty-policy fast path); credential scrubber is the only delta.
- No leak channel: titles/paths/counts/scores/graph-seeds/provenance are all "release", gated by one projector that **fails closed** for unregistered surfaces.
- Local-first, pure-substrate (no model in the decision path), no new runtime deps.
- Collision-free with the live Hosted deploy lane (touches no `infra/` files).

## Verification

- All seven pass `openspec validate <change> --strict` on both the local `openspec` 1.6.0 and the CI `@fission-ai/openspec` binary.
- `openspec validate --specs --strict`: 23/23 existing specs pass.
- Scope: 41 files, all under `openspec/changes/`. No implementation, no `src/` changes.

## Not in scope (deliberately deferred)

Wave-6 depth changes: `add-redaction-levels` (L4 span maps), `add-disclosure-budgets`, `add-professional-presets`, `add-governance-elicitation`, `add-org-governance` (Hosted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYC2uXaXverLQQksPtwyHT