### PR TITLE
docs: propose MCP call ledger (design-only OpenSpec change)

### DIFF
--- a/openspec/changes/add-mcp-call-ledger/.openspec.yaml
+++ b/openspec/changes/add-mcp-call-ledger/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-mcp-call-ledger/design.md
+++ b/openspec/changes/add-mcp-call-ledger/design.md
@@ -1,0 +1,225 @@
+## Context
+
+Exomem already has a per-call tracer. `CallTraceMiddleware` (`src/exomem/server.py:77-145`) is
+installed on both profiles — hosted (`src/exomem/server.py:241`) and local
+(`src/exomem/server.py:255`). For each call it resolves a `request_id`
+(`mcp_request_id()`, a UUIDv4 that honors an inbound `x-exomem-request-id` header,
+`src/exomem/command_surface.py:287-315`), binds it through the synchronous wrapper with
+`mcp_request_context` (`src/exomem/server.py:90`), and emits `event=tool_start` before the call
+and `event=tool_success` / `event=tool_error` after, with `tool`, `request_id`, and
+`duration_ms` (`src/exomem/server.py:126-145`).
+
+Four facts from the codebase shape the design:
+
+- **Refusals return, they do not raise.** `bind_vault`'s wrapper catches the governance error
+  and returns an envelope (`src/exomem/command_surface.py:234-242`): an `OpError` becomes
+  `cli_ops.envelope(False, error=error.as_public_dict())` (`:237-238`). The middleware's
+  `try` around `call_next` (`src/exomem/server.py:130-137`) therefore sees a normal return and
+  logs `tool_success`. The `OpError.code` never leaves the wrapper. Any outcome signal must be
+  captured **at the wrapper**, not inferred at the middleware.
+- **A privacy-safe caller identity already exists and is thrown away.** `mcp_retry_scope()`
+  (`src/exomem/command_surface.py:259-284`) derives `principal:<sha256>` from a verified
+  token subject/issuer (`:273`), `bearer:<sha256>` from an Authorization header (`:280`), or
+  `session:<id>` (`:282`). It is computed for idempotency scoping and discarded for reads.
+- **The process-wide redactor cannot be relied on.** `privacy_log.install_hosted_log_redaction`
+  (`src/exomem/privacy_log.py:38-66`) is gated on `EXOMEM_HOSTED_CELL`
+  (`content_private_logging_enabled`, `:16-26`) — off for local installs — and it *exempts*
+  `exomem.calls` `event=hosted_call` lines from redaction (`:51-57`). The ledger must be
+  redaction-safe **by construction**, independent of that flag.
+- **A durable append precedent exists, and an unbounded-growth anti-pattern exists.**
+  `query_log._append` (`src/exomem/query_log.py:65-71`) appends one JSON object per line in
+  append mode, swallowing every exception. Its three sinks — `queries.jsonl`, `writes.jsonl`,
+  `reads.jsonl` (`:36-38`) — have **no rotation** and are already multi-MB. `log.md`, by
+  contrast, rotates: size-triggered, keep newest N, tail moved byte-exact into a
+  content-addressed archive (`src/exomem/vault.py:4422-4508`).
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One durable, structured row per MCP tool call, distinguishing `ok`, `refused`, and `error`.
+- Record enough to reconstruct *what happened* (identity, timing, argument shape, target,
+  outcome, refusal code) and **nothing that leaks note content**.
+- Survive the incident: write on a read-only vault replica, outside the writer-lease boundary.
+- Make eviction, gaps, and tampering **detectable**, not silent.
+- Stay well under 1 ms per row with no fsync on the hot path.
+
+**Non-Goals**
+
+- Not metrics/OTel/spans; not aggregation; not sampling. One flat row per call.
+- Not a behavior change to any tool, envelope, latency contract, or existing log line.
+- Not a fix for the writer fail-back gap; not a reasoning/scoring surface (pure substrate).
+
+## Decisions
+
+### 1. Two-seam capture with a request-scoped outcome
+
+The identity, timing, and argument shape are known at the middleware; the outcome and refusal
+code are known only at the wrapper. Bridge them through the request scope the middleware
+**already binds**.
+
+- The `bind_vault` wrapper's outcome branch (`src/exomem/command_surface.py:234-242`) records,
+  onto a request-scoped `ContextVar`, either `outcome="refused"` with the `OpError.code`
+  (from `error.as_public_dict()`) for a returned governance envelope, or leaves the default
+  `outcome="ok"` when the leaf returns normally.
+- `CallTraceMiddleware.on_call_tool` reads that ContextVar back after `call_next` returns and
+  emits **one** ledger row at its return point (`src/exomem/server.py:131-137`) with the final
+  `outcome`; on an uncaught exception in its `except` branch (`:138-145`) it emits one row with
+  `outcome="error"` and the exception type as `error_code`.
+- Exactly one row is emitted per call, at the single point where both timing and outcome are
+  known. The row is **not** emitted at `tool_start`; the existing `tool_start` log line is
+  untouched and remains prose-only.
+
+The guard pre-check (`guards.guard_text_content`, `src/exomem/server.py:91-117`) raises before
+`call_next`, so a guarded-content rejection surfaces in the middleware `except` branch and is
+recorded as `outcome="error"`. Whether to promote guard rejections to `outcome="refused"` with
+a synthetic code is deferred (see Open Questions).
+
+### 2. The JSONL row schema
+
+One JSON object per line. Field order below is documentation only; the canonical form used for
+hashing sorts keys (Decision 8).
+
+| field | type | source / meaning |
+|---|---|---|
+| `schema_version` | int const | schema id; starts at `1` |
+| `sequence` | int | strictly monotonic, never reset, spans rotation |
+| `prev_hash` | hex string | previous row's `row_hash`; genesis = 64 zeros |
+| `row_hash` | hex string | sha256 of this row's canonical JSON excluding `row_hash` |
+| `timestamp` | string | ISO-8601 UTC wall clock (informational; `sequence` orders) |
+| `request_id` | string | `mcp_request_id()` UUIDv4 (`command_surface.py:287-315`) |
+| `tool` | string | tool name (`_extract_tool_name`, `server.py:86`) |
+| `caller_principal_hash` | string \| null | `mcp_retry_scope()` (`command_surface.py:259-284`) |
+| `arg_names` | string[] | sorted argument names present |
+| `args` | object | per name → `{ "len": int, "sha256": hex }` (value bytes, never value) |
+| `target_paths` | string[] | vault-relative path(s) the call targets, structural |
+| `outcome` | enum | `"ok"` \| `"refused"` \| `"error"` |
+| `error_code` | string \| null | `OpError.code` when refused; exception type when error |
+| `duration_ms` | number | `round((perf_counter()-t0)*1000, 2)`, as the tracer already computes |
+| `truncated` | bool | true when a bounded field was truncated to keep the row atomic |
+
+### 3. Where the file lives — outside the vault, outside the lease
+
+The ledger writes to a **host-local state directory**, not the vault and not the
+writer-lease-guarded mutation path. Default `<state_dir>/calls/ledger.jsonl`, where
+`state_dir` mirrors the writer-lease default `~/.cache/exomem`
+(`src/exomem/writer_lease.py:275`), overridable via `EXOMEM_CALL_LEDGER_DIR`. This location is
+writable even when the vault is a read-only replica and even when the writer lease is held by
+another host — which is the whole point: a ledger that cannot write during a read-only incident
+cannot explain that incident. Archives live under `<state_dir>/calls/_archive/`. Files are
+created mode `0600` where the platform supports it.
+
+### 4. Append discipline and the single-writer chain
+
+**All MCP tool calls are dispatched in the main server process** — `on_call_tool` runs there —
+so the ledger has a single *logical* writer for call rows even though the media worker spawns
+child processes. This is load-bearing and is asserted by a verification task (Decision 8,
+Open Questions). Given that:
+
+- The sequence counter, the `prev_hash` chain, and rotation are maintained by one in-process
+  appender under a cheap in-process lock (async/thread), never a cross-process lock file. A
+  lock file would add a failure mode on a read-only mount for no benefit here.
+- Each row is serialized to a single `bytes` buffer terminated by `\n` and written with one
+  `os.write` to an `O_APPEND` file descriptor. `O_APPEND` gives an atomic position advance, and
+  a single write of a bounded, newline-terminated buffer keeps each row intact even if a child
+  process has inherited the descriptor. This is why `O_APPEND` JSONL is chosen over
+  `RotatingFileHandler`, whose rename-on-rotate is not multi-process-safe on Windows when a
+  child holds the handle.
+- Rows are bounded; if `arg_names`/`args`/`target_paths` would push a row past the atomic-write
+  bound, those lists are truncated (with `truncated=true`) rather than splitting a row across
+  two writes.
+
+### 5. Redaction rule — shape and hashes, never values
+
+- For each argument: record its name, the byte length of its serialized value, and
+  `sha256(serialized value)`. Never the value.
+- `target_paths` are recorded as vault-relative structural paths (the note a write addresses),
+  not their content. Whether to hash the path itself is an Open Question.
+- `caller_principal_hash` is the already-hashed `mcp_retry_scope()` output — a raw token or
+  subject is never reachable here by construction.
+- The ledger does **not** depend on `privacy_log`'s process-wide redactor, which is
+  `EXOMEM_HOSTED_CELL`-gated (`src/exomem/privacy_log.py:16-26`) and off locally. Redaction is a
+  property of what the row builder puts in the row, enforced by the CI leak test (Decision 9).
+
+### 6. Rotation — content-addressed, sequence-continuous
+
+Mirror `log.md` (`src/exomem/vault.py:4451-4508`), not a logging handler:
+
+- Before an append, if the live file exceeds the size threshold (default modeled on
+  `LOG_ROTATE_BYTES_DEFAULT = 2_000_000`, `src/exomem/vault.py:4424`, overridable), the oldest
+  rows beyond the newest N (modeled on `LOG_ROTATE_KEEP_ENTRIES = 200`, `:4425`) are moved
+  **byte-exact** into a content-addressed `ledger-<hash>.jsonl` archive.
+- `sequence` **does not reset**, and the chain **spans the boundary**: the archived segment's
+  last `row_hash` equals the live file's first retained row's `prev_hash`. A per-archive header
+  records the archived `[first_sequence, last_sequence]` and the boundary hashes so a verifier
+  walks archive → live continuously.
+- Rotation runs in the same in-process appender under the same lock, so there is no rename race
+  with a child that inherited the descriptor.
+
+### 7. Latency budget — buffered append, no fsync
+
+Production reads are 10–13 ms; CI gates cap total at `CEIL_TOTAL_MS = 5000`
+(`tests/test_latency_gate.py`) and the semantic-write median at `VALIDATE_MEDIAN_MS = 500`
+(`scripts/semantic_write_latency.py`). A ledger row costs a handful of sha256 hashes over small
+argument blobs plus one `os.write` — microseconds, well under 1 ms. **No fsync on the hot
+path.** A hard crash may lose the last buffered rows; that loss is *detectable* as a `sequence`
+gap, and the ledger is diagnostic, not a durability-critical store, so buffered append is the
+correct trade.
+
+### 8. Per-row hash chain, not per-document
+
+Each row carries `prev_hash` = the previous row's `row_hash`, and
+`row_hash = sha256(canonical_json(row without row_hash))`, where canonical JSON sorts keys and
+uses compact separators over UTF-8. The genesis row's `prev_hash` is 64 zeros. This is **O(1)
+per append**.
+
+This adopts the good parts of the `fable-delegate` skill's `audit.jsonl` prior art —
+append-only, a monotonic sequence that makes eviction detectable, a per-entry hash, a
+`schema_version` constant, restrictive `0600` mode, redaction discipline, and a JSON Schema
+validated in CI — but **differs deliberately**: `audit.jsonl` re-hashes an accumulating
+document, which is fine for a low-frequency state machine and O(n) and wrong for a
+high-frequency event stream, so Exomem chains each row on the previous row's hash instead. And
+because there is a single in-process writer, there is no lock file.
+
+## Risks / Trade-offs
+
+- **No fsync → crash loses the buffered tail.** Mitigated: the loss shows up as a `sequence`
+  gap, so it is detectable rather than silent, and the ledger is diagnostic.
+- **Single-writer assumption.** If a future refactor dispatches MCP calls across processes, the
+  in-process chain would fork. Mitigated by a verification task asserting single-process
+  dispatch and by reserving a `writer_id` field for a per-writer-stream fallback.
+- **`target_paths` can be sensitive.** A filename can itself hint at content. Recorded because
+  it is load-bearing for forensics; bounded, host-local, `0600`. Hashing it is an Open Question.
+- **Argument-hash equality oracle.** `sha256(value)` is stable, so identical arguments hash
+  identically — an equality oracle across calls. Acceptable for shape-matching; a per-file
+  random salt would defeat it (Open Question).
+- **Archive accumulation.** Rotation bounds the *live* file, but archives accumulate like
+  `log.md`'s. An archive-pruning/retention policy is out of scope here and flagged for later.
+
+## Alternatives Considered / Rejected
+
+- **A SQLite ledger table** (like `.idempotency.sqlite`). Richer queries, but a DB write on the
+  hot path risks lock contention, colocating it with the vault breaks read-only-replica writes,
+  and retention becomes `VACUUM`. JSONL is grep-able mid-incident and matches the `query_log`
+  precedent. Rejected; a downstream loader can import the JSONL into SQLite offline.
+- **Synchronous fsync per row.** Durability, but it violates the sub-1 ms budget and the
+  no-fsync constraint, and the chain already makes loss detectable. Rejected.
+- **Reuse the `exomem.calls` process log as the ledger.** That *is* the status quo: evictable,
+  unstructured, refusals-as-successes, and coupled to the hosted redactor. Rejected — it is the
+  problem being fixed.
+- **A whole-document hash chain (`audit.jsonl` style).** O(n) per append; unusable at
+  read/write frequency. Rejected in favor of per-row chaining.
+- **`RotatingFileHandler`.** Not multi-process-safe on Windows; its rename-on-rotate fails when
+  a child holds the handle. Rejected in favor of in-process content-addressed rotation.
+- **A single global lock file for cross-process append.** Unnecessary under the single-writer
+  model and an extra failure mode on a read-only mount. Rejected.
+
+## Open Questions
+
+- Hash `target_paths`, or record vault-relative paths verbatim? (forensic value vs filename
+  leak)
+- Add a per-file random salt to argument hashes to defeat the equality oracle?
+- Confirm default-on is right, and decide an archive-pruning/retention policy (out of scope now).
+- Guard-content rejections: keep as `outcome="error"`, or promote to `outcome="refused"` with a
+  synthetic code?
+- One ledger file for reads and writes, or split them, given reads dominate call volume?

--- a/openspec/changes/add-mcp-call-ledger/proposal.md
+++ b/openspec/changes/add-mcp-call-ledger/proposal.md
@@ -1,0 +1,107 @@
+## Why
+
+Exomem already traces every MCP tool call, but the trace is **ephemeral, ambiguous, and
+mutations-only** at the durable layer. Three verified findings motivate a real ledger:
+
+1. **Trace history is evictable by volume — including the exact volume you need it for.**
+   `CallTraceMiddleware` (`src/exomem/server.py:77-145`) emits `event=tool_start` /
+   `tool_success` / `tool_error` to the logger `exomem.calls` (`src/exomem/server.py:42`).
+   The only durable sink for that logger is the rotating **process log file**. A traceback
+   storm or an ordinary burst of calls scrolls older lines out of the retained window before
+   anyone can read them — precisely during the incident whose calls you need to reconstruct.
+   There is no queryable, structured record; there is a stream of prose log lines.
+
+2. **Refusals are logged as successes.** When a governance rule refuses a call, the tool
+   wrapper `bind_vault` **returns an error envelope** rather than raising:
+   `cli_ops.envelope(False, error=error.as_public_dict())`
+   (`src/exomem/command_surface.py:234-242`). The middleware sees a normal return and emits
+   `event=tool_success` (`src/exomem/server.py:133-137`). The refusal — and its
+   `OpError.code` (`WRITER_LEASE_REQUIRED`, `SEMANTIC_IDENTITY_DUPLICATE`, `MUTATION_WARMING`)
+   — is **never durably recorded**. "The write silently did not happen" cannot be
+   reconstructed after the fact.
+
+3. **No durable per-call record exists.** The only durable per-request store is
+   `.idempotency-<vault>.sqlite` (`src/exomem/writer_lease.py:868-869`, table `mutations`
+   created at `:463`). It is **mutations-only**, **keyed** (a replay overwrites the same row),
+   and **TTL-pruned** (`_prune_expired` at `src/exomem/writer_lease.py:586`; TTLs of 600 s
+   implicit / 24 h explicit at `:54-55`). It is a replay cache, not a ledger. Reads and
+   successful writes leave no structured, queryable, tamper-evident trail at all.
+
+All three share a root cause: **the per-call tracer measures, but nothing durably records what
+it measured in a form you can query or trust.**
+
+## What Changes
+
+- Add a `call-ledger` capability: exactly **one durable, structured row per MCP tool call**,
+  capturing caller identity, timing, argument *shape* (never values), the outcome, and the
+  refusal `OpError.code` when a call was refused.
+- Capture across **two seams**, both required. `CallTraceMiddleware.on_call_tool`
+  (`src/exomem/server.py:83-145`) supplies identity, timing, and argument shape; the
+  `bind_vault` wrapper's outcome branch (`src/exomem/command_surface.py:224-242`) supplies the
+  `ok | refused | error` outcome and the `OpError.code`. Without the second seam a refusal is
+  indistinguishable from a success — which is the whole defect.
+- Write a **redacted, append-only, hash-chained JSONL ledger**, host-local — **outside the
+  vault** and **outside the writer-lease mutation boundary** — so it records even on a
+  read-only replica, during the exact incidents it exists to explain.
+- Give every row a **monotonic `sequence`** and a **`prev_hash` / `row_hash` chain** so a
+  dropped, reordered, or edited row is detectable rather than silent.
+- Record arguments as **shape + hashes only**: argument names, per-argument byte length and
+  sha256, and structural target paths. Caller identity reuses the already-computed hashed
+  principal from `mcp_retry_scope()` (`src/exomem/command_surface.py:259-284`) — privacy-safe
+  by construction and currently discarded.
+- **Rotate on the content-addressed pattern `log.md` already uses**
+  (`src/exomem/vault.py:4422-4508`): size-triggered, keep newest N, move the older tail
+  byte-exact into a `ledger-<hash>.jsonl` archive — **without resetting `sequence` or breaking
+  the chain**. This deliberately does not repeat the unbounded growth of
+  `queries.jsonl` / `reads.jsonl` / `writes.jsonl` (`src/exomem/query_log.py:36-38`).
+- Add a **CI leak test** asserting no note content reaches the ledger. No such test exists
+  today; local installs currently log `ask_memory` query text verbatim because the process-wide
+  redactor is gated on `EXOMEM_HOSTED_CELL` (`src/exomem/privacy_log.py:16-26`).
+
+### Non-Goals
+
+- **Not** fixing the writer fail-back / lease-idle-release gap. That is a separate, tracked
+  reliability issue; this change only makes the write path *observable*, it does not change it.
+- **Not** a metrics / OpenTelemetry / tracing-span system. No aggregation, no exporter, no
+  spans, no dashboards, no sampling. One flat durable row per call, and nothing more.
+- **Not** a behavior change. No tool's return value, arguments, latency contract, or the
+  existing `exomem.calls` log lines change. The ledger is a pure additive sink.
+- **Not** a reasoning surface. Per the pure-substrate constraint, the ledger **measures**; it
+  never scores, ranks, decays, or interprets a call. It runs no model.
+
+## Capabilities
+
+### New Capabilities
+
+- `call-ledger`: a redacted, append-only, hash-chained, size-bounded per-call record of every
+  MCP tool invocation, written outside the vault and outside the writer-lease boundary.
+
+### Modified Capabilities
+
+- None. A read-only audit of 72 active and 27 archived changes found no existing
+  observability, telemetry, or audit-logging capability, so this is a purely additive
+  capability with no `MODIFIED` or `REMOVED` deltas.
+
+## Impact
+
+- `src/exomem/server.py` — `CallTraceMiddleware.on_call_tool` gains a ledger-row emission at
+  the return / except point, reusing the request scope it already binds
+  (`mcp_request_context`, `src/exomem/server.py:90`).
+- `src/exomem/command_surface.py` — the `bind_vault` outcome branch (`:234-242`) records
+  `outcome` + `error_code` onto a request-scoped context the middleware reads back.
+- `src/exomem/call_ledger.py` — **new** module: row construction, canonical hashing, the chain,
+  the buffered append, and content-addressed rotation.
+- `tests/` — a new leak test plus pure-logic unit tests for the schema, chain, and rotation.
+- Configuration — new environment knobs for the ledger directory, enablement, and rotation
+  size, mirroring `EXOMEM_LOG_DIR` (`src/exomem/query_log.py:41-55`) and the writer-lease
+  `state_dir` default `~/.cache/exomem` (`src/exomem/writer_lease.py:275`).
+
+**Default and soft-fail behavior:** the ledger is **enabled by default** (it is the durable
+half of an always-installed tracer) with an `EXOMEM_DISABLE_CALL_LEDGER` kill switch mirroring
+`EXOMEM_DISABLE_QUERY_LOG`. Every ledger write is **soft-fail**: a failure to append, hash, or
+rotate is contained and never raises into the call path, exactly as `query_log._append` swallows
+its own errors (`src/exomem/query_log.py:65-71`). The ledger adds no model and performs only
+deterministic measurement, so no pure-substrate model justification applies.
+
+Backwards compatible: no existing surface, payload, or log line changes; the ledger is a new
+additive sink.

--- a/openspec/changes/add-mcp-call-ledger/specs/call-ledger/spec.md
+++ b/openspec/changes/add-mcp-call-ledger/specs/call-ledger/spec.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+### Requirement: Every MCP Call Produces Exactly One Ledger Row
+
+The system SHALL append exactly one ledger row for each completed MCP tool call — read or
+write, success or refusal or error — recorded at the single point where both the call's
+duration and its outcome are known. A call SHALL NOT produce zero rows and SHALL NOT produce
+more than one row.
+
+#### Scenario: Successful write appends one row
+
+- **WHEN** an MCP write tool call completes normally
+- **THEN** exactly one ledger row is appended for that call
+- **AND** its `outcome` is `ok`
+- **AND** its `request_id` matches the correlation id used by the call tracer
+
+#### Scenario: Read call is recorded too
+
+- **WHEN** an MCP read tool call completes normally
+- **THEN** exactly one ledger row is appended with `outcome` of `ok`
+- **AND** the row is present even though no mutation and no writer lease were involved
+
+#### Scenario: One call is never double-counted
+
+- **WHEN** a single tool call passes through both the middleware seam and the wrapper seam
+- **THEN** only one row is emitted for that call, not one per seam
+
+### Requirement: Refusals Record Their Error Code And Are Distinguishable From Successes
+
+The system SHALL record a governance refusal — a call for which the tool wrapper returns an
+error envelope rather than raising — with an `outcome` of `refused` and the refusal's
+`OpError.code`. A refused call SHALL NOT be recorded with an `outcome` of `ok`. An uncaught
+exception SHALL be recorded with an `outcome` of `error`.
+
+#### Scenario: Writer-lease refusal is recorded as a refusal
+
+- **WHEN** a write is refused because the writer lease is not held
+- **THEN** the ledger row has `outcome` of `refused`
+- **AND** `error_code` is the refusal's `OpError.code` such as `WRITER_LEASE_REQUIRED`
+
+#### Scenario: Duplicate-identity refusal is not a success
+
+- **WHEN** a write is refused for a duplicate semantic identity
+- **THEN** the ledger row has `outcome` of `refused` and `error_code` of
+  `SEMANTIC_IDENTITY_DUPLICATE`
+- **AND** the row is not recorded as `outcome` of `ok`
+
+#### Scenario: Uncaught exception is recorded as an error
+
+- **WHEN** a tool call raises an exception that the wrapper does not convert to an envelope
+- **THEN** the ledger row has `outcome` of `error`
+- **AND** `error_code` identifies the exception class rather than being null
+
+### Requirement: Arguments Are Recorded As Shape And Hash, Never Values
+
+The system SHALL record call arguments as their names, per-argument byte length and sha256, and
+structural target paths only. It SHALL NOT record any argument value, note content, or raw
+caller credential. Caller identity SHALL be recorded as the pre-hashed principal scope, never a
+raw token or subject.
+
+#### Scenario: Query text never reaches the ledger
+
+- **WHEN** an `ask_memory` call carries free-text query content in its arguments
+- **THEN** the ledger row records the argument name, its byte length, and its sha256
+- **AND** the query text itself appears nowhere in the row
+
+#### Scenario: Note body is reduced to shape
+
+- **WHEN** a write call carries note body content in its arguments
+- **THEN** the body content appears nowhere in the row
+- **AND** the addressed note path is recorded structurally in `target_paths`
+
+#### Scenario: Caller identity is a hash, not a credential
+
+- **WHEN** a call is made with a verified principal or a bearer credential
+- **THEN** `caller_principal_hash` is the hashed principal scope
+- **AND** no raw token, authorization header, or subject value appears in the row
+
+### Requirement: The Ledger Writes On A Read-Only Vault Replica
+
+The ledger SHALL be written to a host-local location outside the vault and outside the
+writer-lease mutation boundary, so that a row is recorded even when the vault is a read-only
+replica or the writer lease is held elsewhere.
+
+#### Scenario: Refused write on a read-only replica is still recorded
+
+- **WHEN** a call is refused because the vault is read-only or the lease is unavailable
+- **THEN** the ledger row for that refusal is appended successfully to the host-local ledger
+- **AND** appending the row does not itself require the writer lease or a writable vault
+
+#### Scenario: Ledger location is independent of the vault
+
+- **WHEN** the ledger path is resolved
+- **THEN** it resolves under the host-local state directory, not under the vault tree
+- **AND** it is unaffected by the vault being mounted read-only
+
+### Requirement: Rows Carry A Monotonic Sequence And Previous-Row Hash Chain
+
+Each ledger row SHALL carry a strictly increasing `sequence` and a `prev_hash` equal to the
+previous row's `row_hash`, and a `row_hash` computed as the hash of the row's canonical form
+excluding `row_hash`. Removal, reordering, or edit of any row SHALL be detectable as a sequence
+gap or a broken chain.
+
+#### Scenario: Consecutive rows chain correctly
+
+- **WHEN** two rows are appended in order
+- **THEN** the second row's `sequence` is greater than the first's
+- **AND** the second row's `prev_hash` equals the first row's `row_hash`
+
+#### Scenario: Genesis row uses the defined anchor
+
+- **WHEN** the very first row of a fresh ledger is appended
+- **THEN** its `prev_hash` is the defined genesis anchor value
+- **AND** its `sequence` is the defined starting value
+
+#### Scenario: A tampered or dropped row is detectable
+
+- **WHEN** a row is later removed or its contents altered
+- **THEN** verification detects a gap in `sequence` or a `prev_hash` that no longer matches the
+  preceding `row_hash`
+
+### Requirement: Rotation Bounds Size Without Losing Sequence Continuity
+
+The ledger SHALL rotate when the live file exceeds a configured size, moving the oldest rows
+beyond a retained newest-N window byte-exact into a content-addressed archive. Rotation SHALL
+NOT reset `sequence` and SHALL preserve the hash chain across the archive boundary.
+
+#### Scenario: Oversized live file rotates to an archive
+
+- **WHEN** the live ledger exceeds the configured rotation size
+- **THEN** the oldest rows beyond the retained window are moved byte-exact into a
+  content-addressed archive file
+- **AND** the live file retains the newest rows
+
+#### Scenario: Sequence and chain span the boundary
+
+- **WHEN** rotation moves rows into an archive
+- **THEN** `sequence` continues without reset across the boundary
+- **AND** the archived segment's last `row_hash` equals the live file's first retained row's
+  `prev_hash`
+
+### Requirement: A Ledger Write Never Breaks Or Slows The Call
+
+A failure to build, hash, append, or rotate a ledger row SHALL be contained and SHALL NOT raise
+into the tool-call path or change the call's result. The append SHALL add negligible latency and
+SHALL NOT fsync on the hot path.
+
+#### Scenario: A ledger failure is contained
+
+- **WHEN** the ledger cannot be written because of a full disk or a permission error
+- **THEN** the tool call still returns its normal result
+- **AND** the failure is swallowed rather than propagated to the caller
+
+#### Scenario: Append does not fsync on the hot path
+
+- **WHEN** a row is appended during a normal call
+- **THEN** the append does not perform an fsync in the call path
+- **AND** any rows lost to a hard crash are detectable as a later `sequence` gap
+
+### Requirement: A CI Test Asserts No Note Content Reaches The Ledger
+
+The change SHALL add a continuous-integration test that drives calls carrying known sentinel
+content and asserts that no such content, and no raw credential, appears anywhere in the ledger
+file. The test SHALL also assert the ledger file's restrictive permission where the platform
+supports it.
+
+#### Scenario: Sentinel content never appears in the ledger
+
+- **WHEN** the test drives a call whose arguments contain a unique sentinel string
+- **THEN** the sentinel string appears nowhere in the ledger file or its archives
+- **AND** the argument is instead represented by its name, length, and sha256
+
+#### Scenario: Ledger file permission is restrictive
+
+- **WHEN** the ledger file is created on a platform that supports file modes
+- **THEN** its mode is restrictive such as `0600`

--- a/openspec/changes/add-mcp-call-ledger/tasks.md
+++ b/openspec/changes/add-mcp-call-ledger/tasks.md
@@ -1,0 +1,95 @@
+## 1. Schema, hashing, and chain (pure logic first)
+
+- [ ] 1.1 Add failing unit tests for the row schema: required fields, `schema_version` constant,
+      `outcome` enum `ok|refused|error`, and the shape of `args` (`{name: {len, sha256}}`).
+- [ ] 1.2 Add failing tests for canonical JSON (sorted keys, compact separators, UTF-8) and for
+      `row_hash = sha256(canonical(row without row_hash))`.
+- [ ] 1.3 Add failing tests for the chain: `prev_hash` equals the prior `row_hash`, the genesis
+      anchor (64 zeros), a strictly increasing `sequence`, and detection of a dropped/edited row
+      as a gap or broken link.
+- [ ] 1.4 Implement `src/exomem/call_ledger.py` row construction, canonical hashing, and the
+      per-row chain to make 1.1–1.3 pass.
+
+## 2. Redaction discipline
+
+- [ ] 2.1 Add failing tests proving argument values, note body content, raw tokens, and raw
+      subjects never enter a row; only names, per-arg `len`+`sha256`, and structural
+      `target_paths` do.
+- [ ] 2.2 Implement argument reduction to shape+hash and wire `caller_principal_hash` from
+      `mcp_retry_scope()` (`src/exomem/command_surface.py:259-284`), which is currently
+      discarded.
+- [ ] 2.3 Prove the ledger is redaction-safe independent of `EXOMEM_HOSTED_CELL`, i.e. it does
+      not depend on `privacy_log.install_hosted_log_redaction`
+      (`src/exomem/privacy_log.py:38-66`).
+
+## 3. Seam A — middleware identity, timing, and single-row emission
+
+- [ ] 3.1 Add failing tests that `CallTraceMiddleware.on_call_tool`
+      (`src/exomem/server.py:83-145`) emits exactly one ledger row per call at its
+      return/except point, carrying `request_id`, `tool`, `duration_ms`, and arg shape.
+- [ ] 3.2 Emit the row reusing the request scope already bound by `mcp_request_context`
+      (`src/exomem/server.py:90`); record `outcome="error"` with the exception type in the
+      `except` branch (`:138-145`). Leave the existing `tool_start`/`tool_success` prose log
+      lines unchanged.
+
+## 4. Seam B — wrapper outcome and OpError.code
+
+- [ ] 4.1 Add failing tests that the `bind_vault` outcome branch
+      (`src/exomem/command_surface.py:234-242`) records `outcome="refused"` plus the
+      `OpError.code` onto a request-scoped context, and leaves `outcome="ok"` on normal return.
+- [ ] 4.2 Implement the request-scoped outcome ContextVar and have the middleware (Seam A) read
+      it back so a returned refusal envelope is recorded as `refused`, not `success`.
+- [ ] 4.3 Add tests covering `WRITER_LEASE_REQUIRED`, `SEMANTIC_IDENTITY_DUPLICATE`, and
+      `MUTATION_WARMING` refusal codes end to end.
+
+## 5. Append discipline and concurrency
+
+- [ ] 5.1 Add failing tests that each row is a single newline-terminated `os.write` to an
+      `O_APPEND` descriptor, that a row exceeding the atomic-write bound truncates its
+      variable-length fields with `truncated=true` rather than splitting, and that a child
+      process inheriting the descriptor cannot interleave a partial row.
+- [ ] 5.2 Implement the in-process appender (sequence + chain + append) under a cheap in-process
+      lock, mode `0600`, no cross-process lock file.
+- [ ] 5.3 Add a verification test asserting all MCP tool calls are dispatched in the main server
+      process (the single-writer assumption); reserve a `writer_id` field for a per-writer-stream
+      fallback if that assumption is ever broken.
+
+## 6. Rotation and archive
+
+- [ ] 6.1 Add failing tests for size-triggered rotation that keeps the newest N rows and moves
+      the older tail byte-exact into a content-addressed `ledger-<hash>.jsonl` archive, modeled
+      on `log.md` (`src/exomem/vault.py:4451-4508`).
+- [ ] 6.2 Add failing tests that `sequence` does not reset across rotation and that the archived
+      segment's last `row_hash` equals the live file's first retained `prev_hash`, with a
+      per-archive header recording `[first_sequence, last_sequence]` and boundary hashes.
+- [ ] 6.3 Implement rotation in the same in-process appender under the same lock (no
+      rename-on-rotate handler), writing archives under `<state_dir>/calls/_archive/`.
+
+## 7. Placement, configuration, and soft-fail
+
+- [ ] 7.1 Resolve the ledger dir host-local (default `<state_dir>/calls/`, `state_dir` mirroring
+      `~/.cache/exomem`, `src/exomem/writer_lease.py:275`), overridable via
+      `EXOMEM_CALL_LEDGER_DIR`; prove it resolves outside the vault tree and is writable when the
+      vault is read-only.
+- [ ] 7.2 Add the `EXOMEM_DISABLE_CALL_LEDGER` kill switch (mirroring `EXOMEM_DISABLE_QUERY_LOG`)
+      and make every ledger operation soft-fail, swallowing exceptions like
+      `query_log._append` (`src/exomem/query_log.py:65-71`).
+
+## 8. Tests, latency, and leak gate
+
+- [ ] 8.1 Add the CI leak test: drive calls with a unique sentinel in arguments and assert the
+      sentinel and any raw credential appear nowhere in the ledger file or its archives; assert
+      the restrictive file mode.
+- [ ] 8.2 Add a per-row latency micro-check confirming append cost stays well under 1 ms and does
+      not fsync on the hot path; confirm no regression against `tests/test_latency_gate.py`
+      (`CEIL_TOTAL_MS=5000`) and `scripts/semantic_write_latency.py` (`VALIDATE_MEDIAN_MS=500`).
+- [ ] 8.3 Add a JSON Schema for a ledger row and validate a sample of emitted rows against it in
+      CI, mirroring the `fable-delegate` `audit.jsonl` schema-in-CI discipline.
+- [ ] 8.4 Run `ruff check`, the scaffold leak check, and strict OpenSpec validation; run the lean
+      suite with embeddings/media disabled and record totals.
+
+## 9. Documentation
+
+- [ ] 9.1 Document the ledger: location, row schema, chain/verification, rotation/retention,
+      redaction guarantee, the kill switch, and how it differs from `queries.jsonl`/`reads.jsonl`/
+      `writes.jsonl` and from the `.idempotency.sqlite` replay cache.


### PR DESCRIPTION
Design-only OpenSpec change — no `src/` code. Proposes a per-call ledger to close the observability gaps a live investigation surfaced on 2026-07-24.

## Why (all verified against code/production)

1. **Trace history is evicted under load.** `CallTraceMiddleware` (`server.py:77-145`) does trace every call, but a read-only-replica traceback storm cut `exomem.log` retention to ~5 hours, evicting the tool-call history operators need. (Separately hotfixed in #317.)
2. **Refusals are logged as successes.** The tool wrapper (`command_surface.py:234-242`) returns an error envelope rather than raising, so the middleware records `event=tool_success`; the `OpError.code` is never durably captured.
3. **No durable per-call record.** The only durable per-request store is `.idempotency.sqlite` — mutations-only, keyed/overwritten, TTL-pruned.

## What

An append-only, hash-chained, redacted JSONL ledger, captured at two seams (`CallTraceMiddleware` for identity/timing/arg-shape + `command_surface` wrapper for outcome/`OpError.code`), written **outside the vault and outside the writer lease** so it records during the incidents it exists to explain. Arguments recorded as shape+hash, never values; caller identity from the already-computed `mcp_retry_scope()` principal hash. Monotonic sequence + per-row `prev_hash` chain make eviction detectable; content-addressed rotation modeled on `log.md`.

**Non-goals:** not fixing the writer fail-back; not a metrics/OTel system; not changing tool behavior.

## Validation

`openspec validate --changes --strict` → 72 passed / 0 failed; `--specs --strict` → 23 passed / 0 failed (CI's exact invocation).

## For human review — open questions (in `design.md`)

`target_paths` verbatim vs hashed (filenames can leak); argument-hash salt/oracle; whether guard-content rejections should be `refused` vs `error`; archive pruning policy; one ledger file vs split reads/writes; and the load-bearing assumption that all tool calls dispatch in the main process (a `writer_id` field is reserved as fallback). Committed as `docs:` so it triggers no release.