### PR TITLE
feat(packaging): PyPI project URLs and MCP Registry listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,18 @@ dependencies = [
     "watchdog>=4.0",            # live file-watcher: re-embed out-of-band .md edits (lazy import; soft-fails if absent)
 ]
 
+# Rendered by PyPI as the "Project links" sidebar block. Without this table the
+# project page offers no route anywhere — not to the docs, not to the source, not
+# to the issue tracker — which is both a usability gap for anyone landing on the
+# package and a missed link from pypi.org to the project's own surfaces.
+# Key order is preserved by PyPI, and "Homepage" gets special treatment.
+[project.urls]
+Homepage = "https://substratesystems.io/exomem"
+Documentation = "https://github.com/Artexis10/exomem/blob/main/QUICKSTART.md"
+Source = "https://github.com/Artexis10/exomem"
+Changelog = "https://github.com/Artexis10/exomem/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Artexis10/exomem/issues"
+
 # Hybrid semantic search (local vector embeddings). Optional so a lean install
 # — `uv sync` — works in keyword/BM25 mode (KB_MCP_DISABLE_EMBEDDINGS=1) without
 # the ~1-2 GB torch/CUDA download. The code soft-falls back to BM25 when these


### PR DESCRIPTION
Two discovery surfaces exomem is currently absent from. Bundled because both are **package metadata that only reaches the world on the next release**, so one release delivers both.

## 1. PyPI project URLs

`pyproject.toml` had **no `[project.urls]` table at all** — not incomplete, absent. So the PyPI page renders no "Project links" block, and its navigation offers only *Project description / Release history / Download files*. Anyone landing there has no route to the docs, the repo or the issue tracker.

It is also a missed link surface: pypi.org carries Authority Score 67, and comparable projects draw real referral from it — mem0 has 58 referring links from PyPI, Zep has 32, exomem has none.

`Homepage` points at the product page rather than the repo, since PyPI gives that key special treatment.

## 2. MCP Registry listing

The registry is where MCP-aware clients and directories discover servers. exomem had **no `server.json`** and nothing referencing the registry anywhere.

Adds:
- `server.json` — `io.github.Artexis10/exomem`, PyPI package, stdio transport, and `websiteUrl` pointing at the product page
- the `mcp-name` ownership marker in `README.md`, which PyPI renders as the package description
- a gated `publish-mcp-registry` job in `release-please.yml`

**Ownership is proven two ways that must agree:** GitHub OIDC for the `io.github` namespace, and the README marker matching `server.json`'s `name`. Verified they match.

**Drift protection:** `release-please` now bumps both version fields in `server.json` via `json`/`jsonpath` extra-files. Without this the registry would eventually advertise a version nobody can install.

**Safety:** the publish job is gated on `MCP_REGISTRY_PUBLISH_ENABLED` and marked `continue-on-error`. A registry outage or a CLI change must not fail a release that already shipped to PyPI. Set the variable once you've seen the first run succeed.

## Verification

- `tomllib` parse confirms all five `Project-URL` entries resolve
- `server.json` carries all required schema fields; `websiteUrl` and `repository` confirmed valid against the published schema
- README marker string-matches `server.json`'s `name`, and the version matches `pyproject.toml`
- workflow YAML parses; job ordering is `release-please → publish-pypi → publish-mcp-registry`, so the registry never points at an unpublished version
- `QUICKSTART.md` and `CHANGELOG.md` both exist on `main`

No dependency, build or runtime surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)