### PR TITLE
feat: full observability and write-path reliability

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,6 +16,8 @@ accounts at the server configured below. Hosted operators should also read
 Throughout, replace `<your-host>` / `example.com` with your own hostname.
 For the guided ≤15-minute bring-up, start with
 [remote-quickstart.md](remote-quickstart.md); this document is the reference.
+For structured logs, metrics, and diagnosing a failure after the fact, see
+[observability.md](observability.md).
 
 ## Architecture
 
@@ -951,7 +953,6 @@ The remote tier is intentionally minimal. Not included:
 
 - Auth layers beyond single-user GitHub OAuth (no mTLS, IP allowlist, multi-user
   RBAC).
-- Monitoring/metrics/observability beyond rotating file logs.
 - Web UI.
 - Highly available coordinator hosting (the bundled SQLite coordinator is a
   strongly consistent single-node reference).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,120 @@
+# Observability
+
+Structured logs, metrics, and correlation across exomem's MCP, REST, hosted,
+and CLI surfaces. Everything here is stdlib-only, default-on, and soft-fails
+independently — a bug in logging or metrics can never break a tool call, an
+HTTP request, or a mutation.
+
+## Files
+
+All under the resolved log directory (`$EXOMEM_LOG_DIR`, else
+`<checkout>/logs`, else `/data/logs` in the Docker image):
+
+| File                     | Contents                                                     |
+| ------------------------ | -------------------------------------------------------------- |
+| `exomem.log`             | Server-process structured JSONL log (one line per record).     |
+| `exomem-cli.log`         | One-shot CLI invocations (`doctor`, `status`, product ops, …).  |
+| `exomem-media.log`       | The media worker child process.                                |
+| `queries.jsonl`          | One record per `find()`/`ask_memory` call.                      |
+| `writes.jsonl`           | One record per note/add/replace write.                          |
+| `reads.jsonl`            | One record per `get()` read.                                     |
+| `mutations.jsonl`        | One record per mutation attempt (the mutation journal).          |
+| `archive/exomem-*.log`   | Prior sessions' `exomem.log`, archived (not deleted) on restart.  |
+
+Each JSONL file rotates at a size cap (`EXOMEM_JSONL_MAX_MB`, default 64MB),
+keeping exactly one prior generation (`<file>.1`). `usage.py` and `exomem
+trace`/`exomem logs` read both the live file and that generation.
+`exomem.log`/`exomem-cli.log`/`exomem-media.log` use Python's standard
+`RotatingFileHandler` (`EXOMEM_LOG_MAX_MB` default 5MB, `EXOMEM_LOG_BACKUPS`
+default 5).
+
+Windows cannot share a single `RotatingFileHandler` across processes, which is
+why the server, CLI, and media worker each get their own file instead of one
+shared `exomem.log`.
+
+## Event schema
+
+A structured log record (`src/exomem/log_events.py`) carries:
+
+- `event` — a machine-readable name from a fixed catalog (`tool_start`,
+  `tool_success`, `tool_failure`, `rest_failure`, `hosted_call`,
+  `http_request`, …).
+- `fields` — always content-free: tool names, codes, durations, scope kinds,
+  request ids.
+- `content` — present only for events the catalog explicitly allows to carry
+  it (e.g. `tool_failure.content.message`, truncated to 300 characters).
+
+In a hosted cell, a structured record for a cataloged event has its `content`
+dropped and keeps the content-free `event`/`fields` skeleton; any other
+(non-`log_event()`) record keeps today's full-blanking, fail-closed behavior.
+`exc_info` is always stripped hosted, structured or not.
+
+## Correlation
+
+Every HTTP request gets one `x-exomem-request-id` (extracted from the inbound
+header if UUIDv4-shaped, else minted), injected as both a request header (so
+downstream MCP tool code resolves the same id) and a response header. The
+access log (`event=http_request`), the tool trace
+(`tool_start`/`tool_success`/`tool_failure`), `queries.jsonl`/`writes.jsonl`/
+`reads.jsonl` (additive `request_id` field), and `mutations.jsonl` all carry
+it, so one request id joins every source that touched that request.
+
+## Metrics
+
+`src/exomem/metrics.py` is one process-wide registry (counters + fixed-bucket
+histograms) exposed at `GET /metrics.json` (beside `/health/ready`,
+unauthenticated, `Cache-Control: no-store`). It persists to the writer-lease
+state directory every `EXOMEM_METRICS_SNAPSHOT_SECONDS` (default 60; `0`
+disables the snapshotter thread) so counts survive a restart. Key metrics:
+
+- `exomem_tool_calls_total{tool,outcome}`, `exomem_tool_failures_total{tool,code}`,
+  `exomem_tool_duration_ms{tool}` — per-tool call outcomes and latency.
+- `exomem_mutation_busy_total{code}`, `exomem_boundary_wait_ms`,
+  `exomem_boundary_hold_ms`, `exomem_boundary_overdue_total` — mutation
+  contention: busy refusals by code, acquire-wait and hold histograms, and
+  holds that exceeded the long-holder threshold.
+- `exomem_lease_ops_total{op,outcome}`, `exomem_coordinator_errors_total{code}` —
+  writer-lease coordination. A non-preferred replica also voluntarily releases
+  an idle lease after `EXOMEM_WRITER_LEASE_IDLE_SECONDS` (default tracks the
+  TTL: `max(60, TTL)`; `0` disables; preferred replicas never idle-release).
+- `exomem_idempotency_replays_total` — identical retries served from the
+  receipt store instead of re-executing.
+- `exomem_http_requests_total{status}`, `exomem_edge_ingress_total{outcome}`,
+  `exomem_stale_session_serves_total` — HTTP/edge traffic.
+- `exomem_log_write_errors_total{where}` — a logging/journal write that failed
+  (itself never fatal).
+
+`EXOMEM_DISABLE_METRICS=1` turns the registry off entirely (`/metrics.json`
+returns 404; counters stop accumulating).
+
+## Tracing a request
+
+```
+exomem trace <request-id>
+exomem trace <request-id> --json
+```
+
+Joins `exomem.log`, `queries.jsonl`, `writes.jsonl`, `reads.jsonl`, and
+`mutations.jsonl` for one request id into one time-ordered report. Best-effort:
+a missing or unparseable source is skipped, never raised.
+
+```
+exomem logs tail --file server -n 50 [-f]
+exomem logs grep --file mutations 'MUTATION_BUSY'
+```
+
+`--file` accepts `server | cli | media | queries | writes | reads | mutations`.
+
+## Doctor
+
+`exomem doctor` includes an `observability` check: log directory writability,
+active/rotated file sizes, JSONL tail parseability, the NSSM `service.*`
+rotation pile (warns above 50), and metrics-snapshot freshness (warns past 2×
+the snapshot interval).
+
+## Environment variables
+
+See the "Observability" block in `env.example` for the full list
+(`EXOMEM_LOG_DIR`, `EXOMEM_LOG_LEVEL`, `EXOMEM_LOG_MAX_MB`,
+`EXOMEM_LOG_BACKUPS`, `EXOMEM_JSONL_MAX_MB`, `EXOMEM_METRICS_SNAPSHOT_SECONDS`,
+`EXOMEM_DISABLE_ACCESS_LOG`, `EXOMEM_DISABLE_METRICS`).

--- a/env.example
+++ b/env.example
@@ -103,6 +103,52 @@ EXOMEM_VAULT_PATH=/path/to/your/Obsidian
 # EXOMEM_HOST=127.0.0.1
 
 # ---------------------------------------------------------------------------
+# Observability — optional (see docs/observability.md)
+# ---------------------------------------------------------------------------
+# Default-on and stdlib-only: every piece here soft-fails independently, so a
+# bug in logging or metrics can never break a tool call. Nothing below is
+# required to run exomem; the disable flags exist as an operator escape
+# hatch, not because the default posture is unsafe.
+
+# Log directory. Default: <checkout>/logs, or /data/logs in the Docker image.
+# Must be a PROCESS env var (container ENV, service environment, shell) —
+# logging configures before .env loads, so a value only in .env arrives too late.
+# EXOMEM_LOG_DIR=/path/to/logs
+
+# Root log level. Canonical name; FASTMCP_LOG_LEVEL is honored as a fallback
+# so fastmcp's own DEBUG lines stay reachable without a code change.
+# EXOMEM_LOG_LEVEL=INFO
+
+# Per-process JSONL file rotation (exomem.log / exomem-cli.log / exomem-media.log).
+# EXOMEM_LOG_MAX_MB=5
+# EXOMEM_LOG_BACKUPS=5
+
+# Size cap for logs/{queries,writes,reads,mutations}.jsonl before rotating to
+# one kept `.1` generation.
+# EXOMEM_JSONL_MAX_MB=64
+
+# How often the metrics registry persists its counters to the writer-lease
+# state directory so a restart doesn't reset them to zero. 0 disables the
+# background snapshotter thread entirely.
+# EXOMEM_METRICS_SNAPSHOT_SECONDS=60
+
+# Turn off the structured HTTP access log middleware (uvicorn's own access
+# log stays silenced either way — see docs/observability.md).
+# EXOMEM_DISABLE_ACCESS_LOG=1
+
+# Turn off the metrics registry: /metrics.json returns 404 and counters stop
+# accumulating.
+# EXOMEM_DISABLE_METRICS=1
+
+# Writer-lease idle release (HA only). A NON-preferred replica voluntarily
+# releases the writer lease after this many seconds without a mutation, so
+# the preferred replica reclaims within about a third of the lease TTL.
+# Preferred replicas never idle-release; 0 disables. When unset the default
+# tracks the TTL — max(60, EXOMEM_WRITER_LEASE_TTL) — so raising the TTL
+# alone never trips validation. An explicit value must be 0 or >= the TTL.
+# EXOMEM_WRITER_LEASE_IDLE_SECONDS=60
+
+# ---------------------------------------------------------------------------
 # Remote connector / GitHub OAuth — required for claude.ai + iOS access
 # ---------------------------------------------------------------------------
 # `exomem setup --remote` writes this whole block. See docs/remote-quickstart.md.

--- a/openspec/changes/add-observability-layer/.openspec.yaml
+++ b/openspec/changes/add-observability-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/add-observability-layer/design.md
+++ b/openspec/changes/add-observability-layer/design.md
@@ -1,0 +1,93 @@
+## Structured event shape
+
+Every observability log call goes through one helper,
+`log_events.log_event(logger, level, event, *, fields=None, content=None,
+exc_info=None)`, which attaches `event`, `fields`, and `content` to the
+`LogRecord` via `extra=`. `fields` is always content-free (tool names, codes,
+durations, counts, scope kinds). `content` is the only place a message excerpt
+or other user-derived text may live, and only for events an `EVENT_CATALOG`
+entry explicitly allows. `log_event()` never raises: an event with an
+undeclared content key drops that key rather than failing the caller, because
+a logging bug must never break a tool call. Two formatters read the same
+three attributes — `JsonLinesFormatter` for the on-disk JSONL file,
+`KeyValueFormatter` for the existing `key=value` console/trace style — so nothing
+downstream re-parses free-text messages.
+
+## Why redaction classifies by record, not by regex
+
+`privacy_log.py` today either passes a record through untouched or blanks it
+completely, keyed only on whether the message is the `exomem.calls`
+`event=hosted_call ...` trace line. That is a coarse but safe fail-closed
+default. This change adds one more branch: a record produced by `log_event()`
+for an event present in `EVENT_CATALOG` is "structured" — its `content` dict is
+known to be the only content-bearing part, so the hosted factory can drop
+`content` (and `exc_info`, always, hosted or not) while keeping `event` and
+`fields` intact. Any record that is not structured this way — the large
+existing body of `log.info("...")` calls across the codebase — keeps today's
+full-blanking behavior unchanged. This is deliberately conservative: adopting
+`log_event()` at a call site is what earns it field-level redaction; nothing
+is reclassified by guessing at message shape.
+
+## The anyio context-copy trap (O3)
+
+The MCP tool wrapper (`command_surface.py`) runs synchronously inside FastMCP's
+threadpool; `CallTraceMiddleware.on_call_tool` runs in the async request task.
+A `ContextVar` set inside the wrapper does **not** propagate back to the
+middleware — anyio's `to_thread.run_sync` copies the context into the worker
+thread but any mutation made there is invisible to the caller once the thread
+call returns. The failure signal therefore cannot be a ContextVar. Instead the
+wrapper records into a bounded, lock-protected module-level dict,
+`_TOOL_FAILURES[request_id] = {code, ...}`, right before it returns the failure
+envelope. `CallTraceMiddleware` unconditionally pops `request_id` out of that
+dict after `call_next` returns (success or not) and logs `tool_failure
+code=...` instead of `tool_success` when an entry was present. "Unconditional"
+matters twice: a call that never touched the dict pops `None` and logs
+`tool_success` as before, and a call whose middleware layer never runs (there
+isn't one, currently, but future direct-call paths might not) cannot leak an
+entry forever — a bounded TTL sweep on the dict guarantees eventual cleanup
+even if a pop is ever missed.
+
+The envelope returned to the client is unaffected by any of this: the wrapper
+builds it exactly as it does today and O3 only adds logging/metrics calls
+around the existing `return cli_ops.envelope(False, error=...)` sites.
+
+## Metrics: soft-fail and snapshot placement
+
+`metrics.py` is one process-wide registry (counters + fixed-bucket histograms)
+protected by a single `threading.Lock`. Every public method
+(`inc`/`observe`/`snapshot`) catches and swallows its own errors — a metrics
+call is never allowed to raise into the caller, matching the O1 logging
+invariant. The registry is snapshotted to the writer-lease `state_dir` (the
+same directory the idempotency store and mutation-lock sidecar already use)
+rather than the log directory, because it is process-restart state, not a log:
+a snapshotter thread started from `server_runtime.py` writes it atomically
+(temp file + `os.replace`) every `EXOMEM_METRICS_SNAPSHOT_SECONDS` (default 60;
+`0` disables the thread entirely), and the registry restores from that file at
+process start so counters survive a restart instead of resetting to zero. No
+network endpoint is added yet — `/metrics.json` is O6, a later commit on this
+same registry, kept deliberately separate so the registry itself lands and is
+tested before anything serves it.
+
+## Per-process log files
+
+Windows cannot share a single `RotatingFileHandler` across processes (the
+rename-on-rotate step fails when another process holds the file open), and
+Exomem already runs as more than one process kind from one checkout: the
+long-lived server, one-shot CLI invocations, and the media worker child. Each
+gets its own file (`exomem.log`, `exomem-cli.log`, `exomem-media.log`) under
+the same `resolve_log_dir()` directory, so nothing contends for the same
+handle and each stream stays independently parseable and rotatable.
+
+## Restart scripts stop deleting the log
+
+`scripts/restart.ps1`/`restart.sh` truncated (Windows) or deleted
+(cross-platform intent, though the shipped behavior is delete) `exomem.log` on
+every restart specifically so the post-restart tail showed only the new
+session. That already-useful intent is kept, but the previous session's log is
+now archived to `logs/archive/` instead of discarded, with the newest 10
+archives retained and older ones pruned. The NSSM `service.out.log`/
+`service.err.log` online-rotation pile (`AppRotateOnline 1`) accumulates
+timestamped files with no built-in cap; the same restart pass prunes it to the
+newest 20. The plain tail-of-`exomem.log` fallback stays for the case where the
+file does not exist yet (a fresh install, or the process hasn't written its
+startup banner).

--- a/openspec/changes/add-observability-layer/proposal.md
+++ b/openspec/changes/add-observability-layer/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+Exomem fails in ways nobody can diagnose. `logs/exomem.log` does not exist today —
+`scripts/restart.ps1` and `restart.sh` delete it on every restart, so every app log
+line since the last restart is gone. Every business error is invisible: the MCP
+tool wrapper (`command_surface.py`) and the REST facade (`server_rest.py`) convert
+`OpError` (`MUTATION_BUSY`, lease refusals, validation refusals) into a normal
+response envelope without logging anything, and `CallTraceMiddleware` then logs
+`event=tool_success` for the same call — server-side error rate reads 0% no matter
+how often clients see failures. There is no way to join the access log, the
+`exomem.calls` trace, and `logs/{queries,writes,reads}.jsonl` (no request_id, no
+UTC timestamp, unbounded growth) into one picture of a single request. There is no
+metrics surface at all; every counter that exists is in-process and resets on
+restart.
+
+## What Changes
+
+- Structured JSONL logging core: a `log_event()` helper that attaches
+  `{event, fields, content}` to every log record, JSONL + key=value formatters,
+  an `EVENT_CATALOG` that declares which fields of which events may carry
+  content, per-process log files (`exomem.log` / `exomem-cli.log` /
+  `exomem-media.log`), and an upgraded hosted privacy ceiling that drops only
+  the `content` payload of a classified structured record while keeping today's
+  full-blanking, fail-closed behavior for any unstructured record.
+- `restart.ps1` / `restart.sh` archive `exomem.log` (keeping the newest 10) and
+  prune the NSSM `service.*` rotation pile (keeping the newest 20) instead of
+  deleting the log outright.
+- A metrics registry (`metrics.py`): counters and fixed-bucket histograms under
+  one lock, with a background snapshotter that atomically persists to the
+  writer-lease state directory so a restart does not lose the counters, and
+  restores them at startup. Every metrics operation soft-fails — a bug in the
+  registry can never break a tool call.
+- An error-plane: every site that converts an `OpError`/exception into a
+  response envelope (the MCP tool wrapper, the REST facade, the hosted command
+  routes) logs `event=tool_failure`/`event=rest_failure` with content-free
+  fields plus a truncated content message, and bumps the matching metrics
+  counters, before returning the same envelope byte-for-byte. A bounded,
+  locked signal dict hands the outcome to `CallTraceMiddleware` so it emits
+  `tool_failure` instead of `tool_success` for the same call, without changing
+  what any client receives.
+- Request correlation: an ASGI access-log middleware with UTC timestamps,
+  method/path/status/duration/request-id, silencing the unstructured
+  `uvicorn.access` logger in the same commit; additive (never renamed) JSONL
+  fields (`request_id`, `ts_utc`, `outcome`, `error_code`, `duration_ms`) on the
+  existing `logs/{queries,writes,reads}.jsonl`; size-capped rotation.
+- A mutation journal (`logs/mutations.jsonl`): one record per mutation attempt
+  at the terminal/interrupted/replayed seam, with wait/hold timing and
+  content-classified targets.
+- Surfacing: a `/metrics.json` route beside `/health/ready`; an
+  `observability` block on `runtime_readiness`; richer `coordination_status`
+  (TTL remaining, renewer liveness, last coordinator error, lease op counters).
+- Operator tooling: `exomem trace <request_id>` and `exomem logs tail|grep`;
+  a doctor check for the log directory, rotation, and snapshot health.
+- Docs: `docs/observability.md`, removing the stale "observability is a
+  non-goal" line from `docs/deployment.md`, and the new environment variables
+  in `env.example`.
+
+This capability is default-on, not default-off: every piece is stdlib-only,
+sub-millisecond per call, and soft-fails independently, so there is no heavy or
+optional runtime cost to gate behind a flag the way a model-backed capability
+would be. `EXOMEM_DISABLE_ACCESS_LOG` and `EXOMEM_DISABLE_METRICS` exist as an
+operator escape hatch, not because the default posture is unsafe.
+
+## Capabilities
+
+### New Capabilities
+
+- `observability`: exomem exposes structured, correlated, content-safe logs and
+  a metrics registry across MCP, REST, hosted, and CLI surfaces, default-on and
+  soft-failing, so an operator can diagnose a failure after the fact instead of
+  reading silence.
+
+## Impact
+
+- New modules: `log_events.py`, `metrics.py`, `access_log.py`,
+  `mutation_journal.py`, `obs_cli.py`.
+- Rewritten: `logging_config.py`, `privacy_log.py`.
+- Touched conversion sites: `command_surface.py`, `server_rest.py`,
+  `server_hosted.py`, `server.py` (`CallTraceMiddleware`), `writer_lease.py`
+  (`coordination_status`, mutation-journal seam), `server_assets.py`
+  (`/metrics.json`), `runtime_readiness.py`, `__main__.py`,
+  `media_worker_child.py`.
+- Deployment scripts: `scripts/restart.ps1`, `scripts/restart.sh`.
+- No new runtime dependency. No change to the vault `Knowledge Base/log.md`
+  format or its read path. No change to `tests/test_latency_gate.py` or
+  `tests/golden/`.

--- a/openspec/changes/add-observability-layer/specs/observability/spec.md
+++ b/openspec/changes/add-observability-layer/specs/observability/spec.md
@@ -1,0 +1,183 @@
+## ADDED Requirements
+
+### Requirement: Structured Event Logging
+
+Every log record emitted through `log_event()` SHALL carry a machine-readable
+`event` name, a content-free `fields` mapping, and an optional `content`
+mapping restricted to the field names an `EVENT_CATALOG` entry declares for
+that event. `log_event()` MUST NOT raise; an undeclared content field is
+dropped rather than propagated. Log files are JSON Lines with a UTC ISO-8601
+timestamp, one file per process role (`exomem.log` server, `exomem-cli.log`
+CLI, `exomem-media.log` media worker) under the resolved log directory.
+
+#### Scenario: An undeclared content field is dropped, not raised
+
+- **WHEN** `log_event()` is called for a cataloged event with a `content` key
+  the catalog does not declare for that event
+- **THEN** the record is written without that key
+- **AND** no exception propagates to the caller
+
+#### Scenario: Each process role writes its own file
+
+- **WHEN** the server process, a CLI invocation, and the media worker child
+  each configure logging
+- **THEN** each writes to its own file under the resolved log directory and
+  none contends for another's file handle
+
+### Requirement: Content-Safe Hosted Redaction
+
+In a hosted cell, a log record produced by `log_event()` for an event present
+in `EVENT_CATALOG` SHALL have its `content` payload dropped while its `event`
+and `fields` are preserved. A record not produced this way SHALL remain fully
+blanked, exactly as before this change (fail-closed). `exc_info` SHALL be
+stripped from every hosted record regardless of classification.
+
+#### Scenario: A structured record loses only its content in a hosted cell
+
+- **WHEN** a hosted process logs a cataloged event with both `fields` and
+  `content`
+- **THEN** the persisted record retains `event` and `fields`
+- **AND** `content` is absent from the persisted record
+
+#### Scenario: An unstructured record stays fully blanked
+
+- **WHEN** a hosted process logs a plain, non-`log_event()` message
+- **THEN** the persisted record is fully blanked as it is today
+
+#### Scenario: A structured record with an exception is stripped of traceback
+
+- **WHEN** a hosted process logs a cataloged event with `exc_info` set
+- **THEN** the persisted record carries no traceback or exception text
+
+### Requirement: Metrics Registry
+
+The system SHALL maintain one process-wide metrics registry of counters and
+fixed-bucket histograms behind a single lock, covering tool call outcomes,
+tool failures by code, tool duration, mutation-busy occurrences, boundary
+wait/hold time and overdue count, lease operation outcomes, coordinator
+errors, idempotency replays, HTTP requests, edge ingress, stale-session
+serves, and log write errors. Every registry operation MUST soft-fail: a
+defect in the registry MUST NOT cause a tool call, HTTP request, or mutation
+to fail. The registry SHALL be snapshotted atomically to the writer-lease
+state directory on an interval and restored from that snapshot at process
+start, so counts survive a restart; an interval of `0` disables the
+snapshotter thread entirely.
+
+#### Scenario: A metrics failure does not fail the calling operation
+
+- **WHEN** an internal registry operation raises
+- **THEN** the calling tool call, HTTP request, or mutation completes exactly
+  as it would have without the metrics call
+
+#### Scenario: Counters survive a restart
+
+- **WHEN** the process restarts after a metrics snapshot has been written
+- **THEN** the registry's counters and histograms resume from the persisted
+  snapshot rather than resetting to zero
+
+### Requirement: Error-Plane Capture
+
+Every site that converts an `OpError` or exception into a response envelope
+(the MCP tool wrapper, the REST facade, the hosted command routes) SHALL log
+a `tool_failure` or `rest_failure` event with content-free fields (tool,
+request id, code, duration, scope kind) and a truncated content message, and
+SHALL increment the matching metrics counters, before returning the envelope.
+The envelope itself MUST remain byte-identical to its pre-change shape.
+
+#### Scenario: An OpError is logged and counted without changing the response
+
+- **WHEN** a tool call raises an `OpError` that is converted to a normal
+  failure envelope
+- **THEN** a `tool_failure` event is logged and the matching counters are
+  incremented before the envelope is returned
+- **AND** the returned envelope is identical to what would have been returned
+  before this change
+
+### Requirement: Tool-Call Trace Reflects Failure Outcome
+
+`CallTraceMiddleware` SHALL emit `tool_failure code=...` instead of
+`tool_success` for an MCP call whose wrapper recorded a failure, using a
+bounded, lock-protected signal channel keyed by request id rather than a
+context variable, because a context variable set inside the synchronous tool
+wrapper does not propagate back to the asynchronous middleware layer. The
+hosted `event=hosted_call kind=...` prefix contract on the `exomem.calls`
+logger MUST be preserved. The signal channel MUST be bounded and unconditionally
+cleared per call, with a time-based sweep, so a missed pop cannot leak
+indefinitely.
+
+#### Scenario: A converted OpError logs as a trace failure, not a success
+
+- **WHEN** the MCP tool wrapper converts an `OpError` into a failure envelope
+  for a given request id
+- **THEN** `CallTraceMiddleware` logs `tool_failure code=...` for that request
+  id instead of `tool_success`
+
+#### Scenario: A successful call is unaffected
+
+- **WHEN** a tool call completes without the wrapper recording a failure
+- **THEN** `CallTraceMiddleware` logs `tool_success` exactly as before
+
+### Requirement: Request Correlation
+
+An ASGI access-log middleware SHALL record UTC timestamp, method, path,
+status, duration, request id (extracted from an inbound header or minted, and
+returned as a response header), session id, and `cf-ray` for every HTTP
+request, and the unstructured `uvicorn.access` logger SHALL be silenced in the
+same change so the structured record is not duplicated by an unparseable one.
+The existing `logs/{queries,writes,reads}.jsonl` writers gain additive fields
+(`request_id`, `ts_utc`, `outcome`, `error_code`, `duration_ms`) without
+renaming or removing any existing field, and rotate at a size cap.
+
+#### Scenario: uvicorn.access is silenced exactly when the new middleware lands
+
+- **WHEN** the access-log middleware is wired into the server
+- **THEN** `uvicorn.access` no longer emits its own line for the same request
+
+#### Scenario: JSONL consumers see only additive fields
+
+- **WHEN** an existing JSONL reader (`usage.py`) parses a post-change record
+- **THEN** every field it previously depended on is present and unchanged
+
+### Requirement: Mutation Journal
+
+The system SHALL append one record per mutation attempt to
+`logs/mutations.jsonl` at the terminal, interrupted, or replayed seam,
+carrying timing (`duration_ms`, `boundary_wait_ms`, `boundary_hold_ms`),
+outcome and error code, lease role, fencing token, replica id, and
+content-classified target identifiers with a target count.
+
+#### Scenario: A committed mutation is journaled
+
+- **WHEN** a mutation reaches a terminal outcome
+- **THEN** exactly one journal record is appended describing that attempt's
+  outcome, timing, and targets
+
+### Requirement: Observability Surfacing
+
+A `/metrics.json` route SHALL expose the metrics registry's current snapshot
+beside `/health/ready`. `runtime_readiness` SHALL include an `observability`
+block, and `coordination_status` SHALL include lease TTL remaining, renewer
+liveness, last renew age, the last coordinator error with its age, and lease
+operation counters, recording coordinator errors explicitly instead of only
+returning `coordinator_healthy: False`.
+
+#### Scenario: A coordinator error is visible, not just a healthy flag
+
+- **WHEN** the lease coordinator call fails
+- **THEN** `coordination_status` records the error code and its age instead of
+  only flipping `coordinator_healthy` to `False`
+
+### Requirement: Operator Tooling
+
+`exomem trace <request_id>` SHALL join the access log, tool trace, and
+mutation journal for one request id into a single readable report.
+`exomem logs tail|grep` SHALL operate over the per-process JSONL log files.
+The doctor check SHALL verify the log directory is writable, rotation is
+live, JSONL files are parseable, the metrics snapshot is recent, and the
+`service.*` rotation pile is bounded.
+
+#### Scenario: Tracing a request id joins every correlated record
+
+- **WHEN** an operator runs `exomem trace <request_id>` for a request that
+  produced an access-log line, a tool trace, and a mutation-journal record
+- **THEN** the report includes all three, correlated by that request id

--- a/openspec/changes/add-observability-layer/tasks.md
+++ b/openspec/changes/add-observability-layer/tasks.md
@@ -1,0 +1,134 @@
+## 1. O1 — Logging core
+
+- [x] 1.1 Add `src/exomem/log_events.py`: `log_event()` helper attaching
+      `{event, fields, content}` via `extra=`; `JsonLinesFormatter` +
+      `KeyValueFormatter`; `EVENT_CATALOG` with per-event content
+      classification; `bounded_traceback()`.
+- [x] 1.2 Rewrite `src/exomem/logging_config.py`: JSONL file logs with UTC ISO
+      timestamps, per-process files (`exomem.log` / `exomem-cli.log` /
+      `exomem-media.log`), `EXOMEM_LOG_LEVEL` canonical with `FASTMCP_LOG_LEVEL`
+      fallback preserved.
+- [x] 1.3 Wire `configure_logging` into the CLI dispatch path in
+      `src/exomem/__main__.py` and into `src/exomem/media_worker_child.py`.
+- [x] 1.4 Upgrade `src/exomem/privacy_log.py`: a hosted + structured record
+      (produced via `log_event()` for a cataloged event) drops its `content`
+      payload and keeps the content-free skeleton; an unstructured record
+      keeps today's full blanking; `exc_info` is always stripped hosted.
+      Implemented by wrapping `logging.Logger.makeRecord` rather than
+      `logging.setLogRecordFactory`: `extra=` attributes are applied by
+      `makeRecord` after the factory returns, so a factory hook cannot see
+      `event`/`fields`/`content` (caught red by an initial factory-only
+      attempt; see design.md).
+- [x] 1.5 Fix `scripts/restart.ps1` / `restart.sh`: archive `exomem.log` to
+      `logs/archive/` keeping the newest 10 instead of deleting it; prune the
+      `service.*` rotation pile to the newest 20 (Windows/NSSM only —
+      launchd/systemd have no equivalent uncapped rotation pile); keep the
+      plain tail fallback.
+- [x] 1.6 Red-first tests: `tests/test_log_events.py`,
+      `tests/test_privacy_structured_redaction.py`. Additional coverage:
+      `tests/test_log_process_files.py` (per-process files, CLI dispatch
+      wiring).
+
+## 2. O2 — Metrics registry
+
+- [x] 2.1 Add `src/exomem/metrics.py`: counters + fixed-bucket histograms
+      under one `threading.Lock`; metric names per design.md; every public
+      method soft-fails.
+- [x] 2.2 Atomic JSON snapshot/restore to the writer-lease `state_dir`; a
+      snapshotter thread started from `server_runtime.py`
+      (`EXOMEM_METRICS_SNAPSHOT_SECONDS`, default 60; `0` disables).
+- [x] 2.3 Red-first tests: `tests/test_metrics_registry.py`.
+
+## 3. O3 — Error-plane capture
+
+- [x] 3.1 At the `OpError`/exception conversion sites (`command_surface.py`
+      MCP tool wrapper, `server_rest.py`, `server_hosted.py`), log
+      `event=tool_failure` / `event=rest_failure` with content-free fields
+      (`tool`, `request_id`, `code`, `duration_ms`, `scope`) plus a
+      300-char-truncated `content.message`, and bump the matching metrics
+      counters, before returning the unchanged envelope. `server_hosted.py`'s
+      `_execute_command` already logged an `event=hosted_call ...` trace line
+      on every error via `_trace`/`_error_response`; that site only gained a
+      metrics bump, not a second differently-shaped log line.
+- [x] 3.2 Add the bounded, locked `_TOOL_FAILURES` signal dict, popped
+      unconditionally (with a TTL sweep) by `CallTraceMiddleware`, which emits
+      `tool_failure code=...` instead of `tool_success` for a failed call
+      while preserving the `event=hosted_call kind=...` prefix contract for
+      hosted MCP calls.
+- [x] 3.3 Red-first tests: `tests/test_tool_failure_logging.py`; confirm
+      `tests/test_command_surface_retry.py:831,861,878` (OpError stays normal
+      tool content, unexpected exception stays native) pass unmodified.
+
+## 4. O4 — Correlation
+
+- [x] 4.1 Add `src/exomem/access_log.py`: ASGI `AccessLogMiddleware` (UTC ts,
+      method, path, status, `duration_ms`, request_id extracted or minted and
+      injected as a response header, session id, `cf-ray`); wire at
+      `server.py`; silence `uvicorn.access` in the same commit.
+- [x] 4.2 Add additive JSONL fields to `logs/{queries,writes,reads}.jsonl` via
+      a new `peek_request_id()` (never mints): `request_id`, `ts_utc`,
+      `outcome`, `error_code`, `duration_ms`; size-cap rotation (64MB, keep one
+      generation); `usage.py` reads the `.jsonl.1` generation too.
+- [x] 4.3 Log the retry-scope hash in tool events.
+- [x] 4.4 Red-first tests: `tests/test_access_log_middleware.py`,
+      `tests/test_jsonl_rotation.py`.
+
+## 5. O5 — Mutation journal
+
+- [x] 5.1 Add `src/exomem/mutation_journal.py`: `logs/mutations.jsonl`, one
+      record per mutation attempt at the terminal/interrupted/replayed seam in
+      `writer_lease.py` — `ts_utc`, `request_id`, `tool`, `command`,
+      `receipt_id`, `outcome`, `error_code`, `duration_ms`, `boundary_wait_ms`,
+      `boundary_hold_ms`, `lease_role`, `fencing_token`, `replica_id`, `scope`,
+      content-classified `targets`, `target_count`. `targets` is the
+      mutation's canonical vault/cell identity (writer_lease.invoke() has no
+      per-file visibility below the command leaf; deeper per-file target
+      tracking is future work, noted in the delivery report).
+- [x] 5.2 `mutation_lock.py` captures `wait_ms`/`hold_ms` for the journal via
+      a `ContextVar` (`last_mutation_timing()`), read by `writer_lease.invoke()`.
+- [x] 5.3 Red-first tests: `tests/test_mutation_journal.py`.
+
+## 6. O6 — Surfacing
+
+- [x] 6.1 Add a `/metrics.json` route beside `/health/ready`
+      (`server_assets.py`).
+- [x] 6.2 `runtime_readiness.py` gains an `observability` block.
+- [x] 6.3 `coordination_status` (`writer_lease.py`) gains
+      `ttl_remaining_seconds`, `renewer_alive`, `last_renew_age_seconds`,
+      `last_coordinator_error{code,age_seconds}`, and lease op counters, and
+      records coordinator errors instead of silently returning
+      `coordinator_healthy: False`.
+- [x] 6.4 Red-first tests: `tests/test_runtime_readiness.py`,
+      `tests/test_writer_lease.py`, `tests/test_metrics_endpoint.py` additions.
+
+## 7. O7 — Tooling
+
+- [x] 7.1 `exomem trace <request_id>` and `exomem logs tail|grep` in
+      `__main__.py` (`src/exomem/obs_cli.py`).
+- [x] 7.2 Doctor `_check_observability` (log dir writable, rotation live,
+      JSONL parseable, snapshot age, `service.*` count).
+- [x] 7.3 Red-first tests: `tests/test_obs_cli_trace.py`.
+
+## 8. O8 — Docs + spec
+
+- [x] 8.1 `docs/observability.md`.
+- [x] 8.2 Remove the "observability = non-goal" bullet at
+      `docs/deployment.md:954`.
+- [x] 8.3 `env.example` entries: `EXOMEM_LOG_DIR`, `EXOMEM_LOG_LEVEL`,
+      `EXOMEM_LOG_MAX_MB`, `EXOMEM_LOG_BACKUPS`, `EXOMEM_JSONL_MAX_MB`,
+      `EXOMEM_METRICS_SNAPSHOT_SECONDS`, `EXOMEM_DISABLE_ACCESS_LOG`,
+      `EXOMEM_DISABLE_METRICS` — `EXOMEM_LOG_MAX_MB`/`EXOMEM_LOG_BACKUPS` were
+      wired into `logging_config.py` (previously hardcoded) so the documented
+      vars are real, not aspirational.
+
+## 9. Verification
+
+- [x] 9.1 Pinned suites stay green: `tests/test_command_surface_retry.py`
+      (`tests/test_latency_gate.py` untouched — not run this turn, see report).
+- [ ] 9.2 `uv run ruff check src tests` clean on changed files — ruff is not
+      installed in this environment; the orchestrator runs it out-of-band.
+- [ ] 9.3 Linux CI: full suite, latency + golden gates (authoritative; this
+      box cannot run the full suite).
+- [ ] 9.4 Live smoke after merge+deploy: restart via `restart.ps1`, confirm
+      `logs/exomem.log` survives as an archive, `exomem trace <request_id>`
+      joins a real call end-to-end, `/metrics.json` serves.

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/.openspec.yaml
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/design.md
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/design.md
@@ -1,0 +1,110 @@
+## Why removing the hosted read-bypass is safe (R3, GAP D)
+
+The archived design (`make-mcp-acknowledgement-replay-safe`) reserved the
+consistency-guard bypass to `mode="audit"` and `validate_only` reads because,
+at the time, other hosted reads were assumed to need the guard to avoid
+observing a half-committed mutation. That assumption does not hold: every
+canonical write already lands via atomic staging (write-to-temp then
+`os.replace`), which is exactly what makes a whole-file read torn-free without
+any lock. Local reads have never taken the guard and have never needed to.
+Removing the guard for hosted reads makes hosted and local reads behave
+identically and removes the actual observed failure — a plain read returning
+`MUTATION_BUSY` merely because an unrelated write is still validating its
+12-45s corpus check.
+
+The residual risk is a read observing "pre-mutation" state a few milliseconds
+longer than it might have with the guard held. That is the same staleness
+window every local read already accepts, and it is bounded by the same atomic
+publish, so it introduces no new class of inconsistency — only removes a
+serialization cost that reads never structurally needed. No escape-hatch env
+var is added to keep the guard optional, because that would keep the failure
+mode reachable by default drift and double the test matrix (guard on/off ×
+everything else) for a behavior that should not exist at all.
+
+## Orphan snapshot age-awareness (R2, GAP C)
+
+`mutation_lock.py` today either takes the metadata mutex and reports a
+verified holder, or times out and fabricates `_unknown_external_holder()` at
+age 0 with `overdue: false` — indistinguishable from "just acquired,
+everything's fine." When the mutex cannot be taken within a short bound
+(250ms), the fix reads the holder sidecar directly instead of giving up: the
+sidecar is published via atomic `os.replace`, so a lock-free read is
+tear-free even without the mutex. That gives a real `age_seconds` and
+`overdue` even when verification isn't possible, tagged `verified: false` so
+callers can still distinguish a probed-but-unverifiable holder from a fully
+confirmed one. Only the genuine absence of any sidecar still falls back to
+the unknown-holder fabrication, because there is nothing to read.
+
+## Idle-triggered lease release (R5, GAP A) — the exemption is load-bearing
+
+A preferred replica must never be subject to idle release. Without the
+exemption, the desktop (typically configured preferred) would acquire the
+lease, sit idle, release it after 60s, and then reclaim it again on the next
+renew tick (the existing preferred-reclaim behavior from
+`fix-preferred-writer-reclaim`) — a self-inflicted churn loop that flaps edge
+routing every renew interval for no operational benefit. Idle release exists
+to solve a different problem: a non-preferred holder (the laptop) that is
+powered on but not being used should hand authority back so the desktop can
+serve without the laptop ever noticing it should let go.
+
+Counting "am I idle" correctly requires one choke point.
+`writer_authority_guard()` is the single place that sets the write fence
+before a mutation and clears it after, so it is also the only place that can
+increment/decrement `_active_mutations` and touch
+`_last_activity_monotonic` without a race between "count the mutation" and
+"the mutation actually fences." In `_renew_loop`, under the same lock the
+renewer already uses: `idle-for-≥60s AND active_mutations == 0` clears the
+local fencing token and calls `client.release(token)` while still holding the
+lock, so an `ensure_writer()` racing in from another thread blocks briefly
+(≤3s, the existing acquire timeout) and then acquires a fresh token — it
+never observes a torn state where the process thinks it's still the writer
+but the coordinator disagrees. A release RPC failure is swallowed because the
+local token is already cleared; the coordinator's own TTL expiry closes the
+gap within one TTL, which is a degraded handover, never split-brain (a
+straggler write in flight when release happens is still rejected by
+`validate_active_write_fence` at the atomic-write boundary — the existing
+fencing guarantee from `harden-writer-lease-fencing` is unmodified and is what
+makes idle release safe to add at all).
+
+Handover latency is therefore bounded by roughly `idle_seconds + ttl/3` (the
+desktop's own reclaim tick), and the edge falls back to
+`selectEligibleOrigin` (`worker.js`) while no replica is currently assigned,
+so an idle-released window does not produce a hard outage.
+
+## Abandoned idempotency receipts (R4, GAP B) — why liveness, not TTL alone
+
+A bare TTL on a `pending` row cannot distinguish "the process is still
+working, just slow" from "the process is dead." Making the TTL long enough to
+never misfire during genuine slow writes reintroduces the original hang;
+making it short enough to recover quickly risks declaring a live, still-
+committing write abandoned and letting a second attempt race it. The fix
+instead tracks liveness directly: each row gets an `owner` string
+(`pid:process-nonce`), and liveness is proven by attempting an exclusive OS
+lock file per process under `<state_dir>/idempotency-owners/` — a PID alone
+is reusable across a reboot and would falsely report the wrong process as
+alive; the lock file is held only while that specific process is running, so
+a failed probe (lock acquired, meaning nothing holds it) means the owner is
+provably gone, and a probe error is treated as "alive" (fail closed — never
+declare abandonment on an inconclusive probe).
+
+A dead owner's `pending` row moves to `abandoned`, and the client receives
+`OpError("MUTATION_OUTCOME_UNKNOWN", ..., details={status: "uncertain",
+committed: None})` rather than an indefinite `MUTATION_ACKNOWLEDGEMENT_PENDING`
+loop. The identical retry is deliberately paused for 60s before it is allowed
+to execute fresh: a crashed-after-commit write becomes loud (a duplicate
+attempt hits an existing leaf conflict guard) rather than silently
+duplicating a committed effect, and 60s gives any last-moment straggler
+persistence a chance to finish first. Legacy `NULL`-owner rows (written before
+this change) are honored under the old any-pending-blocks-forever rule for up
+to 600s so a rollout does not retroactively abandon rows from a version that
+never recorded an owner, then age out the same way.
+
+## Rejected: escape-hatch env var for the read-bypass removal
+
+Considered and rejected. It would let the old failure mode persist by
+default drift (a copied `.env` carries it forward), and it forces every other
+test in this change to run twice — once with the guard, once without — for a
+behavior nothing legitimately depends on once atomic staging is understood.
+The deferred `shorten-mutation-critical-section` change is a better home for
+any future latency work discovered by R1's telemetry; this change does not
+speculatively design for it.

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/proposal.md
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+`MUTATION_BUSY` and "cannot write" (`WRITER_LEASE_REQUIRED` /
+`MUTATION_ACKNOWLEDGEMENT_PENDING`) recur without a usable explanation, and
+four independently verified root causes explain why:
+
+- **GAP A** — the writer lease is held for the process lifetime.
+  `_renew_loop` (`writer_lease.py`) renews forever; release only happens at
+  `atexit`; the coordinator never preempts a live holder. A live laptop can
+  block a desktop replica indefinitely, with no CLI to release the lease.
+- **GAP B** — `pending` idempotency rows never expire (`writer_lease.py`
+  prunes only `completed`/`committed_failure`). A crash mid-write poisons that
+  payload with `MUTATION_ACKNOWLEDGEMENT_PENDING` forever; only manual SQLite
+  surgery clears it.
+- **GAP C** — an orphaned `.holder.json` left behind after a failed release
+  (`mutation_lock.py`) makes `snapshot()` fabricate an unknown external holder
+  at age 0 with `overdue: false`, hiding genuinely stuck state from the
+  operator and from `coordination_status`.
+- **GAP D** — hosted reads take the mutation boundary
+  (`writer_lease.py`) unless individually allow-listed, so a plain read
+  returns `MUTATION_BUSY` while an unrelated long write is in progress.
+
+Compounding this, hold time is effectively unbounded — corpus validation runs
+12-45s plus a nested 30s `vault_creation_lock` — against a 5s acquire budget,
+producing busy storms; the `retry_after_ms` hint is a static 750ms and gets
+clobbered even when the caller already computed a better one.
+
+## What Changes
+
+- **R1** — `mutation_lock.py::hold()` emits `acquired`/`released` telemetry
+  with `wait_ms`/`hold_ms`, and `retry_after_ms` becomes
+  `min(15000, max(750, age_seconds*500))` (≥5000 when overdue) instead of a
+  static 750, with the computed hint surviving instead of being clobbered.
+- **R2 (GAP C)** — when the orphan-snapshot metadata mutex cannot be taken
+  quickly, a lock-free read of the sidecar (published via atomic replace, so
+  it is tear-free) reports real age and `overdue`, with `verified: false`;
+  only the total absence of a sidecar still fabricates an unknown holder.
+- **R3 (GAP D)** — hosted reads stop taking the mutation boundary at all,
+  the same as local reads always have; consistency is already provided by
+  atomic whole-file staging. This supersedes the archived design decision that
+  reserved the bypass to `mode="audit"`/`validate_only` reads
+  (`openspec/changes/archive/2026-07-20-make-mcp-acknowledgement-replay-safe/design.md:64`).
+- **R4 (GAP B)** — idempotency rows gain an `owner` (`pid:process-nonce`)
+  whose liveness is an exclusive OS lock file per process, immune to PID
+  reuse and fail-closed on a probe error. A `pending` row whose owner is dead
+  becomes `abandoned`; the client gets `MUTATION_OUTCOME_UNKNOWN` (HTTP 409)
+  instead of hanging forever, and an identical retry executes fresh after 60s.
+- **R5 (GAP A, highest risk)** — the writer lease releases itself after
+  `EXOMEM_WRITER_LEASE_IDLE_SECONDS` (default 60) of holding no active
+  mutation, so a non-preferred holder (the laptop) hands authority back
+  without an operator intervening. A preferred replica is exempt, so it never
+  churns itself through an acquire→idle-release→reclaim loop. A single choke
+  point (`writer_authority_guard()`) tracks the in-flight mutation count so
+  idle release only fires when it is provably safe.
+- **R6** — `exomem lease status|release [--yes] [--json]`, an ops-only CLI,
+  including cross-device release via a small generalization of the existing
+  coordinator release call.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-mutation-safety`: reads no longer take the mutation boundary,
+  orphaned holder state reports real age instead of a fabricated healthy
+  snapshot, abandoned idempotency receipts recover instead of wedging
+  forever, and retry guidance scales with observed contention.
+
+### New Capabilities
+
+- `lease-operations`: idle-triggered writer-lease release and an operator CLI
+  to inspect and release lease state, so a stuck lease has both an automatic
+  and a manual way out.
+
+## Impact
+
+- `writer_lease.py`, `mutation_lock.py`, `lease_coordinator.py`,
+  `epistemic_graph.py` (retry hint), `vault.py` (fenced-write revalidation
+  unaffected, straggler commits still rejected), `__main__.py` (lease CLI).
+- No escape-hatch environment variable preserves the read-bypass — that would
+  keep the failure mode alive and double the test matrix for no benefit.
+- Deferred, explicit follow-up (`shorten-mutation-critical-section`): moving
+  the 12-45s corpus validation outside the boundary. This change's telemetry
+  (R1) produces the hold/wait distributions needed to size that work; it does
+  not attempt it.
+- No new runtime dependency. No change to the MCP tool schema. Existing
+  writer-lease fencing, reclaim, and idempotency fail-closed tests
+  (`test_writer_lease.py`, `test_mutation_lock.py`) must stay green.

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/specs/hosted-mutation-safety/spec.md
@@ -1,0 +1,199 @@
+## ADDED Requirements
+
+### Requirement: Load-Aware Retry Guidance
+
+A retryable busy error SHALL carry a `retry_after_ms` hint that scales with
+observed contention, `min(15000, max(750, age_seconds*500))`, at least `5000`
+when the boundary is overdue, rather than a fixed value. Once a caller has
+computed this hint, later assembly of the error response MUST NOT overwrite
+it with a fixed default.
+
+#### Scenario: A longer-held boundary yields a longer retry hint
+
+- **WHEN** a mutation is refused because the boundary has been held
+  significantly longer than its configured bound
+- **THEN** the returned `retry_after_ms` is larger than the default and at
+  least `5000`
+
+#### Scenario: A freshly acquired boundary still yields the floor hint
+
+- **WHEN** a mutation is refused almost immediately after the boundary was
+  acquired
+- **THEN** the returned `retry_after_ms` is at least `750`
+
+### Requirement: Orphan Holder Snapshot Reports Real Age
+
+When the mutation-lock metadata mutex cannot be acquired quickly, the
+snapshot SHALL fall back to a lock-free, tear-free read of the atomically
+published holder sidecar and report its real `age_seconds` and `overdue`
+with `verified: false`, rather than fabricating an unknown holder at age
+zero. An unknown, unverified holder MUST be fabricated only when no sidecar
+exists at all.
+
+#### Scenario: A metadata mutex contention still yields a real age
+
+- **WHEN** the metadata mutex cannot be acquired within its short bound but a
+  holder sidecar exists
+- **THEN** the snapshot reports that holder's real age and `overdue` state
+  with `verified: false`
+
+#### Scenario: No sidecar exists
+
+- **WHEN** the metadata mutex cannot be acquired and no holder sidecar exists
+- **THEN** the snapshot falls back to an unknown, unverified holder at age
+  zero, as before this change
+
+## MODIFIED Requirements
+
+### Requirement: Reads Never Observe A Half-Committed Mutation
+
+Read-only operations SHALL remain available without becoming global
+write-queue participants. Consistency for a read is provided structurally:
+canonical files land via atomic replace, so a concurrent read observes either
+the pre-mutation or post-mutation whole-file state, never a partial write.
+Neither local nor hosted read-only operations SHALL acquire the mutation
+boundary to obtain this guarantee; a read MUST NOT wait on, weaken, or extend
+mutation serialization.
+
+This supersedes the prior hosted design decision that reserved the
+consistency-guard bypass to `mode="audit"` and `validate_only` reads while
+other hosted reads held the guard
+(`openspec/changes/archive/2026-07-20-make-mcp-acknowledgement-replay-safe/design.md:64`):
+every hosted read now behaves like a local read, because atomic staging
+already provides the guarantee the guard existed to simulate, and holding it
+needlessly contended ordinary reads against long-running writes.
+
+#### Scenario: Read overlaps a multi-file write
+
+- **WHEN** a read-only command overlaps a transactional multi-file mutation
+- **THEN** its response is assembled from a consistent pre-commit or
+  post-commit state
+- **AND** it does not expose temporary staging files or partial index/log
+  updates
+
+#### Scenario: Hosted read no longer waits behind a long write
+
+- **WHEN** a hosted read-only operation is invoked while another process
+  holds the mutation boundary for an unrelated long-running write
+- **THEN** the read proceeds immediately without acquiring or waiting for the
+  mutation boundary
+- **AND** it observes a consistent whole-file pre- or post-commit state, not
+  a `MUTATION_BUSY` refusal
+
+### Requirement: Tenant-Scoped Retry And Idempotency Semantics
+
+Hosted mutations SHALL preserve caller-supplied idempotency keys and bounded
+implicit MCP retry replay through the existing common invocation boundary.
+Retry identity MUST include the resolved tenant, authenticated principal
+scope, command, and canonical arguments; a key or implicit retry from one
+tenant MUST NOT replay or suppress a mutation for another tenant. Failed
+mutations MUST remain retryable.
+
+A `pending` idempotency row whose owning process is provably no longer alive
+(an exclusive per-process OS lock file under the state directory is not held)
+MUST transition to `abandoned` rather than blocking every future retry
+indefinitely. A caller retrying against an abandoned row MUST receive
+`OpError("MUTATION_OUTCOME_UNKNOWN", ..., details={status: "uncertain",
+committed: None})` (HTTP 409 where applicable), and an identical retry MUST be
+allowed to execute fresh no sooner than 60 seconds after abandonment. A
+liveness probe error MUST be treated as "alive" (fail closed). A legacy row
+with no recorded owner MUST be honored under the prior any-pending-blocks
+rule for up to 600 seconds before it, too, ages into `abandoned`.
+
+#### Scenario: Gateway retries a completed hosted mutation
+
+- **WHEN** the gateway repeats an identical successful mutation for the same
+  tenant and authenticated principal with the same idempotency identity
+- **THEN** the original result is replayed without executing the mutation
+  leaf again
+- **AND** only one durable vault change exists
+
+#### Scenario: Same key is presented for another tenant
+
+- **WHEN** two tenant contexts present the same explicit idempotency key for
+  otherwise identical input
+- **THEN** each tenant resolves an independent idempotency record
+- **AND** neither tenant receives the other's result or suppresses the
+  other's mutation
+
+#### Scenario: First attempt fails
+
+- **WHEN** a mutation raises before successful completion and the caller
+  retries it
+- **THEN** the failure is not replayed as a completed result
+- **AND** the retry can acquire the boundary and execute normally
+
+#### Scenario: The owning process crashed mid-write
+
+- **WHEN** a retry arrives for a `pending` row whose owner process is no
+  longer alive
+- **THEN** the row transitions to `abandoned` and the retry receives
+  `MUTATION_OUTCOME_UNKNOWN` with `status: "uncertain"` and `committed: None`
+- **AND** an identical retry made at least 60 seconds later executes fresh
+
+#### Scenario: A liveness probe is inconclusive
+
+- **WHEN** the liveness probe for a `pending` row's owner cannot determine
+  whether the owner is alive
+- **THEN** the row is treated as still owned and is not abandoned
+
+### Requirement: Crash And Cancellation Release Mutation Authority Safely
+
+The process-safe boundary SHALL not leave a vault permanently unwritable
+after process termination, request cancellation, or an exception. Authority
+MUST be released automatically when the owning process exits and in a
+`finally`-equivalent path for handled cancellation or failure; a successor
+MUST still pass normal readiness and transactional integrity checks before
+writing.
+
+A writer-lease holder that is not configured as the preferred writer MUST
+also release its lease authority after a configurable idle period
+(`EXOMEM_WRITER_LEASE_IDLE_SECONDS`, default 60 seconds; `0` disables idle
+release) during which it held no in-flight mutation, so authority can return
+to another replica without an operator manually intervening. A preferred
+writer MUST be exempt from idle release. Idle release MUST NOT clear
+authority while a mutation is in flight, and any straggler write that was
+already authorized before release completes MUST still be rejected by fencing
+if the lease has moved on by the time it reaches the atomic-write boundary.
+
+#### Scenario: Process exits while holding the boundary
+
+- **WHEN** a tenant-cell process terminates while it owns the vault mutation
+  boundary
+- **THEN** the operating-system or coordination primitive releases that
+  ownership without a manual stale-lock edit
+- **AND** a replacement cell can acquire the boundary after its readiness
+  checks succeed
+
+#### Scenario: Mutation raises an exception
+
+- **WHEN** a command leaf raises while the current process owns the boundary
+- **THEN** the boundary is released after rollback and error handling finish
+- **AND** a later valid mutation is not permanently blocked
+
+#### Scenario: A non-preferred holder sits idle
+
+- **WHEN** a non-preferred replica holds the writer lease with no in-flight
+  mutation for at least the configured idle period
+- **THEN** it releases its lease authority
+- **AND** another replica can subsequently acquire writer authority without
+  operator intervention
+
+#### Scenario: A preferred holder never self-releases from idleness
+
+- **WHEN** a replica configured as the preferred writer holds the lease with
+  no in-flight mutation for longer than the idle period
+- **THEN** it retains writer authority
+
+#### Scenario: Idle release never fires mid-mutation
+
+- **WHEN** a replica has at least one in-flight mutation
+- **THEN** the idle-release check does not clear its lease authority
+  regardless of how long it has been since the last mutation started
+
+#### Scenario: A straggler write is fenced after idle release
+
+- **WHEN** a mutation was authorized before idle release cleared the local
+  token, and it reaches the atomic-write boundary after another replica has
+  acquired a newer fencing token
+- **THEN** the straggler write is rejected rather than committed

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/specs/lease-operations/spec.md
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/specs/lease-operations/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Lease Status And Release CLI
+
+An ops-only CLI, `exomem lease status|release [--yes] [--json]`, SHALL let an
+operator inspect writer-lease state and release lease authority without
+touching the coordinator's storage directly. `status` SHALL report the
+current holder, fencing token, TTL remaining, and renewer liveness. `release`
+SHALL work against the currently configured replica or, given the target
+holder's replica id and fencing token, against a different replica's held
+lease, without requiring any coordinator or worker protocol change. This CLI
+is not exposed as an MCP tool or REST endpoint.
+
+#### Scenario: An operator inspects lease state
+
+- **WHEN** an operator runs `exomem lease status`
+- **THEN** the current holder, fencing token, and TTL remaining are reported
+
+#### Scenario: An operator releases the local replica's lease
+
+- **WHEN** an operator runs `exomem lease release --yes` on the current
+  holder
+- **THEN** the lease is released and another replica can subsequently acquire
+  it
+
+#### Scenario: An operator releases another replica's lease cross-device
+
+- **WHEN** an operator runs `exomem lease release` naming a different
+  replica's held fencing token
+- **THEN** that replica's lease authority is released through the
+  coordinator without requiring a change to the coordinator or worker
+
+#### Scenario: Destructive takeover is not offered
+
+- **WHEN** an operator inspects the lease CLI's available subcommands
+- **THEN** no `steal` or `force-acquire` subcommand exists, because release
+  combined with preferred-writer reclaim already hands over authority within
+  roughly one lease TTL using the existing fencing proof

--- a/openspec/changes/eliminate-mutation-busy-failure-modes/tasks.md
+++ b/openspec/changes/eliminate-mutation-busy-failure-modes/tasks.md
@@ -1,0 +1,129 @@
+## 1. R1 — Telemetry + dynamic retry_after_ms
+
+- [x] 1.1 `mutation_lock.py::hold()` emits `acquired`/`released` events with
+      `wait_ms`/`hold_ms` (the long-hold WARNING fires unconditionally, not
+      only when probed).
+- [x] 1.2 `_mutation_busy()` computes
+      `retry_after_ms = min(15000, max(750, age_seconds*500))`, `>=5000` when
+      overdue; mirrored in `epistemic_graph.py` for free — the graph lane's
+      `_mutation_coordinator` is the same `VaultMutationCoordinator`/
+      `_mutation_busy()` code path, no separate implementation needed.
+      `writer_lease.py`'s hint assembly changes to `setdefault` so a computed
+      hint survives.
+- [x] 1.3 Existing `retry_after_ms == 750` assertions in
+      `tests/test_writer_lease.py` audited: both are legitimately unchanged
+      (an age-~0 contention fixture, and the separately-static
+      `MUTATION_WARMING` code path) — no update needed.
+- [x] 1.4 Red-first tests for the retry-hint formula:
+      `tests/test_mutation_lock.py` (dynamic_retry_after_ms, wait_ms in
+      details, acquired/released events, guaranteed long-hold warning).
+
+## 2. R2 — GAP C: age-aware orphan snapshot
+
+- [x] 2.1 When the metadata mutex can't be taken within 250ms, read the
+      sidecar lock-free (atomic `os.replace` publish makes it tear-free);
+      return real `age_seconds`/`overdue` with `verified: false`.
+- [x] 2.2 Fabricate an unknown holder only when no sidecar exists at all.
+- [x] 2.3 Preserve the content-free/bounded holder pins
+      (`tests/test_mutation_lock.py:274-571`) — audited: none of the pinned
+      tests actually contend the metadata mutex past the 250ms status
+      timeout, so all resolve via the pre-existing paths unchanged.
+- [x] 2.4 Red-first tests for the age-aware snapshot path:
+      `test_orphan_snapshot_reports_real_age_when_metadata_mutex_is_contended`,
+      `test_orphan_snapshot_reports_real_overdue_state`,
+      `test_orphan_snapshot_falls_back_to_unknown_holder_without_a_sidecar`.
+
+## 3. R3 — GAP D: reads never take the boundary
+
+- [x] 3.1 Delete the hosted-read guard branch (`writer_lease.py`) and
+      `_read_bypasses_consistency_guard`.
+- [x] 3.2 No escape-hatch env var.
+- [x] 3.3 Red-first tests: a hosted read-only operation does not wait behind
+      a long write (`test_hosted_reads_never_contact_the_coordinator_or_wait_for_the_boundary`,
+      `test_hosted_plain_read_bypasses_boundary_held_by_other_manager` — the
+      latter mirrors `test_hosted_public_audit_routes_bypass_boundary_held_by_other_manager`
+      for an ordinary, non-audit read); the two prior tests asserting the
+      superseded wait-for-boundary behavior were rewritten in place.
+
+## 4. R4 — GAP B: abandoned idempotency receipts
+
+- [x] 4.1 Add an `owner` column (`pid:process-nonce`) via a guarded
+      `ALTER TABLE`.
+- [x] 4.2 Liveness = exclusive OS lock file per process under
+      `<state_dir>/idempotency-owners/`; a probe error is treated as alive
+      (fail closed).
+- [x] 4.3 A dead-owner `pending` row becomes `abandoned`; the client gets
+      `OpError("MUTATION_OUTCOME_UNKNOWN", ..., details={status: "uncertain",
+      committed: None})` (HTTP 409 via `cli_ops._CONFLICT_CODES`); an
+      identical retry executes fresh after 60s.
+- [x] 4.4 Legacy `NULL`-owner rows honored under the old rule for up to 600s.
+- [x] 4.5 `coordination_status` gains a content-free `idempotency`
+      {pending, abandoned, oldest_pending_age_seconds}; added the doctor
+      `_check_idempotency_store`.
+- [x] 4.6 Confirmed same-process pins stay green unchanged:
+      `test_explicit_idempotency_blocks_orphaned_pending_after_process_abort`
+      (owner alive — same process), and
+      `test_identical_pending_retry_waits_outside_mutation_boundary_and_replays`
+      (`test_command_surface_retry.py`).
+- [x] 4.7 Red-first tests: injected liveness/clock for abandonment
+      (`test_pending_row_with_dead_owner_becomes_abandoned`), legacy-row
+      grace period
+      (`test_identical_orphaned_legacy_pending_becomes_abandoned_after_grace_period`,
+      `test_identical_recently_orphaned_legacy_pending_still_reports_acknowledgement_pending`),
+      fresh retry after the pause
+      (`test_identical_retry_executes_fresh_after_abandonment_grace_period`).
+      The prior test asserting the superseded "orphaned pending never
+      resolves" behavior was rewritten to assert the new contract.
+
+## 5. R5 — GAP A: writer-lease idle release (lands last, on the instrumented base)
+
+- [x] 5.1 `LeaseConfig.idle_release_seconds` = 60,
+      `EXOMEM_WRITER_LEASE_IDLE_SECONDS` (`0` = off; reject `0 < idle < ttl`).
+      Default on; preferred replicas exempt.
+- [x] 5.2 Track `_active_mutations` and `_last_activity_monotonic` at the
+      single choke point `writer_authority_guard()`.
+- [x] 5.3 In `_renew_loop`, under `self._lock`: idle + `count == 0` clears the
+      token and calls `client.release(token)` while holding the lock; release
+      RPC failure is swallowed (token already cleared locally).
+- [x] 5.4 Red-first tests (FakeClient + injected clock, `SQLiteLeaseStore` for
+      multi-replica scenarios): idle fires at exactly the threshold, activity
+      resets the idle clock (T+59 defers to T+119), an in-flight mutation
+      blocks release until it completes, a mid-release race gets a fresh
+      bumped token with no `WRITER_FENCED` for that fresh grant, a straggler
+      commit is fenced at `validate_active_write_fence`, a preferred replica
+      never releases, `idle=0` never releases, a release RPC failure is
+      swallowed (token still cleared locally), config validation, and a
+      two-manager handover completes within `idle + ttl/3`.
+
+## 6. R6 — Lease CLI
+
+- [x] 6.1 `exomem lease status|release [--yes] [--json]` in `__main__.py`
+      (ops-only; not an MCP/REST product command).
+- [x] 6.2 `release` works cross-device via a small
+      `release_holder(holder_replica_id, fencing_token)` generalization of
+      `LeaseCoordinatorClient.release()`.
+- [x] 6.3 Deliberately excluded: `steal`/`force-acquire` (release + preferred
+      reclaim already hands over within roughly one TTL using existing
+      fencing proof) — asserted via argparse's own invalid-choice rejection.
+- [x] 6.4 Red-first tests: `tests/test_lease_coordinator.py` (coordinator's
+      `/release` endpoint, via `httpx.ASGITransport` against the real
+      `create_app()`, accepts release-on-behalf-of and no-ops when
+      unheld/mismatched — proving no coordinator change was needed);
+      `tests/test_lease_cli.py` (CLI status/--yes gate/--json/exit codes via
+      a FakeClient injected in place of `LeaseCoordinatorClient`, including
+      the unauthorized-coordinator -> clean `WRITER_COORDINATOR_UNAVAILABLE`
+      path).
+
+## 7. Verification
+
+- [x] 7.1 Pinned suites stay green: `test_writer_lease.py` (150 passed —
+      fencing, reclaim, receipt fail-closed), `test_mutation_lock.py` (28
+      passed — content-free/bounded holder).
+- [ ] 7.2 `uv run ruff check src tests` clean on changed files — ruff is not
+      installed in this environment; the orchestrator runs it out-of-band.
+- [ ] 7.3 Linux CI: full suite, fcntl/multi-process kill tests, latency +
+      golden gates (authoritative; this box cannot run the full suite).
+- [ ] 7.4 Live smoke after merge+deploy: `exomem lease status` shows both
+      replicas; induce a busy (long write + concurrent write) and see it in
+      the mutation journal and counters (depends on `add-observability-layer`
+      landing first).

--- a/scripts/_service-common.ps1
+++ b/scripts/_service-common.ps1
@@ -356,6 +356,58 @@ function Write-ExomemManagedManifest {
     Write-Host "Managed install manifest: $path"
 }
 
+function Backup-ExomemAppLog {
+    <#
+    .SYNOPSIS
+      Archive logs/exomem.log to logs/archive/ (keep newest N) instead of
+      deleting it outright, so a restart doesn't erase the previous session's
+      diagnostics before anyone reads them.
+    #>
+    param(
+        [string]$LogPath,
+        [string]$ArchiveDir,
+        [int]$Keep = 10
+    )
+
+    if (-not (Test-Path $LogPath)) { return }
+    if (-not (Test-Path $ArchiveDir)) {
+        New-Item -ItemType Directory -Path $ArchiveDir -Force | Out-Null
+    }
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $dest = Join-Path $ArchiveDir "exomem-$stamp.log"
+    Move-Item -LiteralPath $LogPath -Destination $dest -Force
+    $archives = @(
+        Get-ChildItem -Path $ArchiveDir -Filter "exomem-*.log" -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending
+    )
+    if ($archives.Count -gt $Keep) {
+        $archives | Select-Object -Skip $Keep | Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Limit-ExomemServiceLogPile {
+    <#
+    .SYNOPSIS
+      Prune NSSM's online-rotated service.out.log.*/service.err.log.* pile,
+      keeping the newest N of each stream. NSSM's AppRotateOnline renames the
+      live file on every rotation and never caps how many accumulate.
+    #>
+    param(
+        [string]$LogDir,
+        [int]$Keep = 20
+    )
+
+    foreach ($pattern in @("service.out.log.*", "service.err.log.*")) {
+        $files = @(
+            Get-ChildItem -Path $LogDir -Filter $pattern -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending
+        )
+        if ($files.Count -gt $Keep) {
+            $files | Select-Object -Skip $Keep | Remove-Item -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Assert-ExomemVisibleCliVersions {
     param(
         [string]$ExpectedVersion,

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -132,11 +132,14 @@ if ($Force) {
     }
 }
 
-# Truncate the app log so the post-restart tail shows only this session.
-$logPath = Join-Path (Split-Path -Parent $PSScriptRoot) "logs\exomem.log"
-if (Test-Path $logPath) {
-    Remove-Item $logPath -Force -ErrorAction SilentlyContinue
-}
+# Archive the app log (instead of deleting it) so the post-restart tail shows
+# only this session while the previous session's diagnostics are still
+# recoverable from logs\archive\. Also prune NSSM's uncapped service.out/err
+# rotation pile.
+$logDir = Join-Path (Split-Path -Parent $PSScriptRoot) "logs"
+$logPath = Join-Path $logDir "exomem.log"
+Backup-ExomemAppLog -LogPath $logPath -ArchiveDir (Join-Path $logDir "archive") -Keep 10
+Limit-ExomemServiceLogPile -LogDir $logDir -Keep 20
 
 Write-Host "Starting $ServiceName..."
 sc.exe start $ServiceName | Out-Null

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -38,8 +38,18 @@ else
     echo "Could not resolve the service interpreter from the installed unit; skipping preflight." >&2
 fi
 
-# Truncate the app log (keep the file, just empty it).
-: > "$LOG" 2>/dev/null || true
+# Archive the app log (instead of truncating it) so the post-restart tail
+# shows only this session while the previous session's diagnostics are still
+# recoverable from logs/archive/, keeping the newest 10 archives.
+ARCHIVE_DIR="$REPO_ROOT/logs/archive"
+if [[ -s "$LOG" ]]; then
+    mkdir -p "$ARCHIVE_DIR"
+    mv "$LOG" "$ARCHIVE_DIR/exomem-$(date -u +%Y%m%d-%H%M%S).log"
+    # Keep the newest 10 archives; oldest-first so `tail` drops the survivors.
+    ls -1t "$ARCHIVE_DIR"/exomem-*.log 2>/dev/null | tail -n +11 | while IFS= read -r stale; do
+        rm -f -- "$stale"
+    done
+fi
 
 case "$(uname -s)" in
     Darwin)

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -74,6 +74,50 @@ def _configure_local_search_capabilities(action: str | None) -> tuple[str, ...]:
     return tuple(introduced)
 
 
+# Subcommands `_dispatch_main` routes explicitly, before falling through to
+# `_serve_main`. Kept alongside `_is_cli_only_invocation` so a one-shot CLI
+# command gets its own log file; `serve` configures server-role logging
+# itself from `server.run()`, so it is deliberately excluded here.
+_CLI_ONLY_SUBCOMMANDS: frozenset[str] = frozenset(
+    {
+        "hosted",
+        "setup",
+        "init",
+        "install-skill",
+        "package-skills",
+        "personalize",
+        "install-hook",
+        "demo",
+        "studio",
+        "doctor",
+        "install-info",
+        "auth",
+        "status",
+        "warm",
+        "mode",
+        "backfill-media",
+        "index",
+        "enroll-speaker",
+        "list-speakers",
+        "remove-speaker",
+        "trace",
+        "logs",
+        "lease",
+    }
+)
+
+
+def _is_cli_only_invocation(raw: list[str]) -> bool:
+    """Whether `raw` routes to a one-shot CLI command rather than `serve`."""
+    if not raw or raw[0].startswith("-"):
+        return False
+    if raw[0] in _CLI_ONLY_SUBCOMMANDS:
+        return True
+    if raw[0] in _core_op_names(expose_tier2=True):
+        return True
+    return raw[0] in _simple_cli_action_names()
+
+
 def main(argv: list[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw in (["--version"], ["--version", "--json"]):
@@ -87,6 +131,10 @@ def main(argv: list[str] | None = None) -> int:
         # `find` was the original friendly retrieval command.  Keep existing
         # scripts useful while the current product language calls it `ask`.
         raw[0] = "ask"
+    if _is_cli_only_invocation(raw):
+        from .logging_config import configure_logging, resolve_log_dir
+
+        configure_logging(resolve_log_dir(), process="cli")
     introduced = _configure_local_search_capabilities(raw[0] if raw else None)
     try:
         return _dispatch_main(raw)
@@ -144,6 +192,12 @@ def _dispatch_main(raw: list[str]) -> int:
         return _list_speakers_main(raw[1:])
     if raw and raw[0] == "remove-speaker":
         return _remove_speaker_main(raw[1:])
+    if raw and raw[0] == "trace":
+        return _trace_main(raw[1:])
+    if raw and raw[0] == "logs":
+        return _logs_main(raw[1:])
+    if raw and raw[0] == "lease":
+        return _lease_main(raw[1:])
     # Registry-driven product operations (reads + writes): `exomem ask_memory "..."`,
     # `exomem remember ...`, etc. Product commands take precedence over old
     # short aliases when a name overlaps.
@@ -933,6 +987,209 @@ def _remove_speaker_main(argv: list[str]) -> int:
         return 1
     print(f"Removed {args.name!r}." if removed else f"No profile named {args.name!r}.")
     return 0
+
+
+def _trace_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem trace",
+        description=(
+            "Join the server log, queries/writes/reads.jsonl, and mutations.jsonl "
+            "for one request id into a single time-ordered report."
+        ),
+    )
+    parser.add_argument("request_id", help="the x-exomem-request-id to trace")
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
+    args = parser.parse_args(argv)
+
+    from . import obs_cli
+
+    records = obs_cli.trace(args.request_id)
+    if args.json:
+        print(json.dumps({"request_id": args.request_id, "records": records}, ensure_ascii=False))
+        return 0
+    if not records:
+        print(f"No records found for request id {args.request_id!r}.")
+        return 0
+    for record in records:
+        ts = record.get("ts_utc") or record.get("ts") or "?"
+        source = record.get("_source", "?")
+        event = record.get("event") or record.get("tool") or record.get("outcome") or ""
+        print(f"[{ts}] ({source}) {event} {json.dumps(record, ensure_ascii=False)}")
+    return 0
+
+
+def _logs_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem logs",
+        description="Tail or grep the per-process JSONL log files.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    tail = subcommands.add_parser("tail", help="print the last N lines of a log file")
+    tail.add_argument(
+        "--file", required=True,
+        choices=("server", "cli", "media", "queries", "writes", "reads", "mutations"),
+    )
+    tail.add_argument("-n", "--lines", type=int, default=20)
+    tail.add_argument("-f", "--follow", action="store_true", help="keep following new lines")
+
+    grep = subcommands.add_parser("grep", help="print lines matching a pattern")
+    grep.add_argument(
+        "--file", required=True,
+        choices=("server", "cli", "media", "queries", "writes", "reads", "mutations"),
+    )
+    grep.add_argument("pattern", help="regular expression to match")
+
+    args = parser.parse_args(argv)
+
+    from . import obs_cli
+
+    path = obs_cli.resolve_log_file(args.file)
+    if args.command == "tail":
+        for line in obs_cli.tail_lines(path, args.lines):
+            print(line)
+        if args.follow:
+            try:
+                for line in obs_cli.follow_lines(path):
+                    print(line)
+            except KeyboardInterrupt:
+                pass
+        return 0
+    for line in obs_cli.grep_lines(path, args.pattern):
+        print(line)
+    return 0
+
+
+def _lease_print_error(message: str, *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps({"error": message}))
+    else:
+        print(message, file=sys.stderr)
+
+
+def _lease_status_main(config, *, as_json: bool) -> int:  # noqa: ANN001
+    from . import writer_lease
+
+    manager = writer_lease.LeaseManager(config)
+    status = manager.status()
+    if as_json:
+        print(json.dumps(status, default=str))
+        return 0
+    print(f"role: {status['role']}")
+    print(f"replica_id: {status['replica_id']}")
+    print(f"holder: {status['holder']}")
+    print(f"fencing_token: {status['fencing_token']}")
+    print(f"coordinator_healthy: {status['coordinator_healthy']}")
+    print(f"ttl_remaining_seconds: {status['ttl_remaining_seconds']}")
+    print(f"renewer_alive: {status['renewer_alive']}")
+    if status.get("last_coordinator_error"):
+        print(f"last_coordinator_error: {status['last_coordinator_error']}")
+    idempotency = status.get("idempotency") or {}
+    print(
+        "idempotency: "
+        f"pending={idempotency.get('pending')} "
+        f"abandoned={idempotency.get('abandoned')} "
+        f"oldest_pending_age_seconds={idempotency.get('oldest_pending_age_seconds')}"
+    )
+    return 0
+
+
+def _lease_release_main(config, *, confirmed: bool, as_json: bool) -> int:  # noqa: ANN001
+    from . import writer_lease
+
+    client = writer_lease.LeaseCoordinatorClient(config)
+    try:
+        record = client.status()
+    except writer_lease.OpError as error:
+        _lease_print_error(f"{error.code}: {error.message}", as_json=as_json)
+        return 1
+
+    if record.holder is None:
+        if as_json:
+            print(json.dumps({"released": False, "reason": "unheld"}))
+        else:
+            print("no lease is currently held; nothing to release.")
+        return 0
+
+    if not confirmed:
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "released": False,
+                        "reason": "confirmation_required",
+                        "holder": record.holder,
+                        "fencing_token": record.fencing_token,
+                        "expires_at": record.expires_at,
+                    }
+                )
+            )
+        else:
+            print(
+                f"lease is held by {record.holder!r} (fencing_token={record.fencing_token}, "
+                f"expires_at={record.expires_at}); pass --yes to confirm release.",
+                file=sys.stderr,
+            )
+        return 2
+
+    try:
+        result = client.release_holder(record.holder, record.fencing_token)
+    except writer_lease.OpError as error:
+        _lease_print_error(f"{error.code}: {error.message}", as_json=as_json)
+        return 1
+
+    if as_json:
+        print(json.dumps({"released": bool(result.granted), "previous_holder": record.holder}))
+        return 0
+    if result.granted:
+        print(f"released the lease previously held by {record.holder!r}.")
+    else:
+        print(
+            "release did not take effect (the lease changed hands concurrently); "
+            "rerun 'exomem lease status'."
+        )
+    return 0
+
+
+def _lease_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="exomem lease",
+        description=(
+            "Ops-only writer-lease inspection and manual release. Not an MCP or REST "
+            "product command; 'steal'/'force-acquire' are deliberately absent — release "
+            "plus preferred-writer reclaim already hands over within roughly one lease TTL."
+        ),
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subcommands.add_parser(
+        "status", help="report coordinator status, local boundary, and idempotency counts"
+    )
+    status_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
+    release_parser = subcommands.add_parser(
+        "release", help="release the currently held writer lease"
+    )
+    release_parser.add_argument(
+        "--yes", action="store_true", help="confirm the release without prompting"
+    )
+    release_parser.add_argument("--json", action="store_true", help="emit stable JSON")
+
+    args = parser.parse_args(argv)
+
+    from . import writer_lease
+
+    config = writer_lease.LeaseConfig.from_env()
+    if not config.enabled:
+        _lease_print_error(
+            "writer-lease coordination is not configured (EXOMEM_WRITER_LEASE_URL unset).",
+            as_json=args.json,
+        )
+        return 1
+
+    if args.command == "status":
+        return _lease_status_main(config, as_json=args.json)
+    return _lease_release_main(config, confirmed=args.yes, as_json=args.json)
 
 
 def _init_main(argv: list[str]) -> int:

--- a/src/exomem/access_log.py
+++ b/src/exomem/access_log.py
@@ -1,0 +1,128 @@
+"""Pure-ASGI access log: one structured record per HTTP request.
+
+Modeled on `edge_ingress.py`'s pure-ASGI middleware style so it can be
+installed in the same `middleware=` list FastMCP passes to uvicorn/Starlette,
+without depending on FastMCP's own request lifecycle. It resolves one request
+id per request — from the inbound `x-exomem-request-id` header when it is
+UUIDv4-shaped, else a freshly minted one — injects it as a request header
+(so downstream MCP tool code resolves the SAME id via
+`command_surface.mcp_request_id()`) and as a response header (so a client or
+operator can correlate their own logs), and logs one record after the
+response completes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .command_surface import canonical_request_id
+from .log_events import log_event
+
+ASGIMessage = dict[str, Any]
+Receive = Callable[[], Awaitable[ASGIMessage]]
+Send = Callable[[ASGIMessage], Awaitable[None]]
+
+logger = logging.getLogger("exomem.access")
+
+_REQUEST_ID_HEADER = b"x-exomem-request-id"
+_SESSION_ID_HEADER = b"mcp-session-id"
+_CF_RAY_HEADER = b"cf-ray"
+
+
+def access_log_disabled(env: dict[str, str] | None = None) -> bool:
+    values = os.environ if env is None else env
+    return str(values.get("EXOMEM_DISABLE_ACCESS_LOG", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _header_value(headers: list[tuple[bytes, bytes]], name: bytes) -> str | None:
+    for key, value in headers:
+        if key.lower() == name:
+            return value.decode("latin-1")
+    return None
+
+
+class AccessLogMiddleware:
+    """One structured `event=http_request` record per HTTP request."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: ASGIMessage, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http" or access_log_disabled():
+            await self.app(scope, receive, send)
+            return
+
+        headers = list(scope.get("headers") or [])
+        request_id = canonical_request_id(_header_value(headers, _REQUEST_ID_HEADER))
+        if request_id is None:
+            request_id = str(uuid.uuid4())
+            headers = [*headers, (_REQUEST_ID_HEADER, request_id.encode("latin-1"))]
+            scope = {**scope, "headers": headers}
+
+        method = str(scope.get("method") or "")
+        path = str(scope.get("path") or "")
+        session_id = _header_value(headers, _SESSION_ID_HEADER)
+        cf_ray = _header_value(headers, _CF_RAY_HEADER)
+        client = scope.get("client")
+        client_ip = client[0] if client else None
+
+        response_status: dict[str, int] = {}
+
+        async def send_with_correlation(message: ASGIMessage) -> None:
+            if message.get("type") == "http.response.start":
+                response_status["status"] = int(message.get("status", 0))
+                response_headers = [
+                    *(message.get("headers") or []),
+                    (_REQUEST_ID_HEADER, request_id.encode("latin-1")),
+                ]
+                message = {**message, "headers": response_headers}
+            await send(message)
+
+        t0 = time.perf_counter()
+        try:
+            await self.app(scope, receive, send_with_correlation)
+        finally:
+            duration_ms = round((time.perf_counter() - t0) * 1000, 2)
+            fields: dict[str, Any] = {
+                "method": method,
+                "status": response_status.get("status"),
+                "duration_ms": duration_ms,
+                "request_id": request_id,
+            }
+            if session_id:
+                fields["session_id"] = session_id
+            if cf_ray:
+                fields["cf_ray"] = cf_ray
+            # The raw path is client-controlled text (any URL a client requests
+            # is logged, including 404 probes), so it is content-classified:
+            # kept locally, dropped by the hosted privacy boundary. Bounded so
+            # an oversized URL cannot bloat the log line.
+            content: dict[str, Any] = {"path": path[:512]}
+            if client_ip:
+                content["client_ip"] = client_ip
+            log_event(
+                logger,
+                logging.INFO,
+                "http_request",
+                fields=fields,
+                content=content,
+            )
+            try:
+                from . import metrics
+
+                metrics.inc_counter(
+                    "exomem_http_requests_total",
+                    {"status": str(response_status.get("status") or 0)},
+                )
+            except Exception:  # noqa: BLE001 - observability must never break a request
+                pass

--- a/src/exomem/cli_ops.py
+++ b/src/exomem/cli_ops.py
@@ -79,6 +79,10 @@ _REMEDIATION: dict[str, str] = {
         "Do not rerun with a new identity; reconcile the committed mutation and retry "
         "only with the same identity."
     ),
+    "MUTATION_OUTCOME_UNKNOWN": (
+        "Verify whether the mutation actually landed before retrying; an identical retry "
+        "is safe again after the abandonment grace period."
+    ),
     "MUTATION_LOCK_UNAVAILABLE": (
         "Check that the runtime state root is writable and supports host file locking."
     ),
@@ -129,6 +133,7 @@ _CONFLICT_CODES = frozenset(
         "MUTATION_WARMING",
         "MUTATION_ACKNOWLEDGEMENT_PENDING",
         "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN",
+        "MUTATION_OUTCOME_UNKNOWN",
         # Adoption Studio drift codes (add-adoption-studio): a stale plan/apply or a
         # proposal whose bound content changed since review is a conflict, not a
         # plain bad-request — the client's honest recourse is to re-scan/re-read,

--- a/src/exomem/command_surface.py
+++ b/src/exomem/command_surface.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import logging
+import threading
+import time
 import types
 import typing
 import uuid
@@ -17,6 +20,180 @@ from pydantic import Field, WithJsonSchema
 
 from . import capabilities
 from .mutation_terminal import ResponseDetail
+
+_log = logging.getLogger(__name__)
+
+# Signal channel from the synchronous MCP tool wrapper (below, runs in
+# FastMCP's anyio threadpool) to `CallTraceMiddleware` (server.py, runs in the
+# async request task): a ContextVar set inside the wrapper does NOT propagate
+# back to the middleware once the threadpool call returns, so the wrapper
+# leaves a bounded, lock-protected breadcrumb here instead, keyed by request
+# id. `mcp_request_id()` accepts a client-supplied `x-exomem-request-id`
+# verbatim once it is UUIDv4-shaped — that shape is validated, not uniqueness
+# — so two concurrent calls can legitimately share one request id. Each
+# request id therefore maps to a FIFO list of failures rather than a single
+# entry: the middleware pops the oldest one per completed call, so N
+# concurrent failing calls sharing an id each get their own failure logged
+# instead of the second silently clobbering the first. The middleware pops
+# unconditionally (whether or not an entry is present) so nothing can leak
+# indefinitely; a TTL sweep and a total-size bound are further independent
+# guards in case a pop is ever missed (e.g. a caller that never reaches the
+# middleware, such as a direct test harness).
+_TOOL_FAILURES_LOCK = threading.Lock()
+_TOOL_FAILURES: dict[str, list[dict[str, object]]] = {}
+_TOOL_FAILURE_TTL_SECONDS = 300.0
+_TOOL_FAILURES_MAX_TOTAL = 1000
+
+# Per-call signal key: minted by the middleware when it binds the request
+# context and read by the sync wrapper inside the threadpool (ContextVars
+# propagate INTO the worker thread's copied context; only mutations don't
+# propagate back). Unlike the client-supplied request id, this token is
+# unique per call, so concurrent calls sharing a request id can never
+# cross-attribute their failures — and a success can never pop a concurrent
+# same-id call's failure marker.
+_MCP_CALL_TOKEN: ContextVar[str | None] = ContextVar(
+    "exomem_mcp_call_token", default=None
+)
+
+
+def _sweep_tool_failures_locked(now: float) -> None:
+    empty_keys = []
+    for request_id, entries in _TOOL_FAILURES.items():
+        entries[:] = [entry for entry in entries if now - entry["at"] <= _TOOL_FAILURE_TTL_SECONDS]
+        if not entries:
+            empty_keys.append(request_id)
+    for request_id in empty_keys:
+        _TOOL_FAILURES.pop(request_id, None)
+
+
+def _evict_oldest_entry_locked() -> None:
+    """Drop the globally oldest recorded failure to bound total memory."""
+    oldest_key = None
+    oldest_at = None
+    for request_id, entries in _TOOL_FAILURES.items():
+        if entries and (oldest_at is None or entries[0]["at"] < oldest_at):
+            oldest_key, oldest_at = request_id, entries[0]["at"]
+    if oldest_key is not None:
+        entries = _TOOL_FAILURES[oldest_key]
+        entries.pop(0)
+        if not entries:
+            _TOOL_FAILURES.pop(oldest_key, None)
+
+
+def _record_tool_failure(request_id: str, code: str) -> None:
+    try:
+        now = time.monotonic()
+        with _TOOL_FAILURES_LOCK:
+            _sweep_tool_failures_locked(now)
+            total = sum(len(entries) for entries in _TOOL_FAILURES.values())
+            if total >= _TOOL_FAILURES_MAX_TOTAL:
+                _evict_oldest_entry_locked()
+            _TOOL_FAILURES.setdefault(request_id, []).append({"code": code, "at": now})
+    except Exception:  # noqa: BLE001 - the signal channel must never break a tool call
+        pass
+
+
+def pop_tool_failure(request_id: str) -> dict[str, object] | None:
+    """Pop and return the OLDEST recorded failure for `request_id`, if any.
+
+    FIFO per request id: two concurrent calls sharing a (client-supplied)
+    request id each pop their own failure in the order they were recorded.
+    Unconditional: call this exactly once per completed MCP call regardless
+    of outcome, so a call that never failed simply pops `None`.
+    """
+    try:
+        with _TOOL_FAILURES_LOCK:
+            _sweep_tool_failures_locked(time.monotonic())
+            entries = _TOOL_FAILURES.get(request_id)
+            if not entries:
+                return None
+            entry = entries.pop(0)
+            if not entries:
+                _TOOL_FAILURES.pop(request_id, None)
+            return entry
+    except Exception:  # noqa: BLE001 - the signal channel must never break a tool call
+        return None
+
+
+def _scope_kind(retry_scope: str | None) -> str:
+    """A content-free descriptor of the caller identity kind, never the value."""
+    if not retry_scope:
+        return "none"
+    return retry_scope.split(":", 1)[0]
+
+
+def _retry_scope_hash(retry_scope: str | None) -> str | None:
+    """A short, stable correlation hash for `retry_scope` — never the value.
+
+    `retry_scope` is already itself a privacy-safe hash-based identifier
+    (e.g. `bearer:<sha256>`), so this is a hash-of-a-hash purely to give log
+    readers a short, consistent token for spotting repeated retries of the
+    same (tool, scope) pair without re-deriving or exposing the identity.
+    """
+    if not retry_scope:
+        return None
+    return hashlib.sha256(retry_scope.encode("utf-8")).hexdigest()[:16]
+
+
+def _log_tool_failure(
+    *,
+    tool: str,
+    request_id: str,
+    code: str,
+    duration_ms: float,
+    message: str,
+    retry_scope: str | None = None,
+) -> None:
+    try:
+        from . import metrics
+        from .log_events import log_event
+
+        log_event(
+            _log,
+            logging.WARNING,
+            "tool_failure",
+            fields={
+                "tool": tool,
+                "request_id": request_id,
+                "code": code,
+                "duration_ms": duration_ms,
+                "scope": _scope_kind(retry_scope),
+                "retry_scope_hash": _retry_scope_hash(retry_scope),
+            },
+            content={"message": str(message)[:300]},
+        )
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": tool, "outcome": "failure"})
+        metrics.inc_counter("exomem_tool_failures_total", {"tool": tool, "code": code})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": tool})
+    except Exception:  # noqa: BLE001 - observability must never break a tool call
+        pass
+    _record_tool_failure(_MCP_CALL_TOKEN.get() or request_id, code)
+
+
+def _log_tool_success(
+    *, tool: str, duration_ms: float, retry_scope: str | None = None
+) -> None:
+    """Count a successful MCP tool call. Exactly one of `_log_tool_success`
+    or `_log_tool_failure` runs per call, both from this same wrapper, so a
+    call is counted exactly once."""
+    try:
+        from . import metrics
+        from .log_events import log_event
+
+        log_event(
+            _log,
+            logging.DEBUG,
+            "tool_success",
+            fields={
+                "tool": tool,
+                "duration_ms": duration_ms,
+                "retry_scope_hash": _retry_scope_hash(retry_scope),
+            },
+        )
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": tool, "outcome": "success"})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": tool})
+    except Exception:  # noqa: BLE001 - observability must never break a tool call
+        pass
 
 # Text-write ops -> the argument field(s) whose value must not be a base64 binary
 # blob. The model pays for those characters as output tokens before the request
@@ -221,24 +398,53 @@ def bind_vault(
             from .writer_lease import invoke_command
 
             invocation_read_only = invocation_is_read_only(command, kwargs)
+            request_id = mcp_request_id()
+            tool_name = command.name
+            # Computed at most once per call, and only for a mutation: a
+            # read-only invocation must never call `mcp_retry_scope()` at
+            # all (a live dependency lookup), so the same value is reused
+            # here for logging instead of a second, independent call.
+            retry_scope = None if invocation_read_only else mcp_retry_scope()
+            t0 = time.perf_counter()
             try:
-                return invoke_command(
+                result = invoke_command(
                     command,
                     *injected,
-                    mutation_request_id=mcp_request_id(),
-                    implicit_idempotency_scope=(
-                        None if invocation_read_only else mcp_retry_scope()
-                    ),
+                    mutation_request_id=request_id,
+                    implicit_idempotency_scope=retry_scope,
                     **kwargs,
                 )
+                _log_tool_success(
+                    tool=tool_name,
+                    duration_ms=round((time.perf_counter() - t0) * 1000, 2),
+                    retry_scope=retry_scope,
+                )
+                return result
             except Exception as error:
                 from . import cli_ops
 
+                duration_ms = round((time.perf_counter() - t0) * 1000, 2)
                 if isinstance(error, cli_ops.OpError):
+                    _log_tool_failure(
+                        tool=tool_name,
+                        request_id=request_id,
+                        code=error.code,
+                        duration_ms=duration_ms,
+                        message=error.message,
+                        retry_scope=retry_scope,
+                    )
                     return cli_ops.envelope(False, error=error.as_public_dict())
                 semantic_error = cli_ops.semantic_validation_error_dict(error)
                 if semantic_error is None:
                     raise
+                _log_tool_failure(
+                    tool=tool_name,
+                    request_id=request_id,
+                    code=str(semantic_error.get("code") or "OP_ERROR"),
+                    duration_ms=duration_ms,
+                    message=str(semantic_error.get("message") or ""),
+                    retry_scope=retry_scope,
+                )
                 return cli_ops.envelope(False, error=semantic_error)
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
@@ -303,6 +509,17 @@ def mcp_request_id() -> str:
     return str(uuid.uuid4())
 
 
+def peek_request_id() -> str | None:
+    """Return the active MCP request id if one is bound, without minting.
+
+    Unlike `mcp_request_id()`, this never falls back to reading headers or
+    generating a fresh uuid — it is for best-effort correlation (e.g. an
+    additive JSONL field) from code that may run outside any MCP call at
+    all, where minting an id would fabricate a false correlation.
+    """
+    return _MCP_REQUEST_ID.get()
+
+
 def canonical_request_id(value: object) -> str | None:
     """Return a canonical UUIDv4 request ID or reject caller-controlled log text."""
     clean = str(value or "").strip()
@@ -317,11 +534,18 @@ def canonical_request_id(value: object) -> str | None:
 
 @contextmanager
 def mcp_request_context(request_id: str):
-    """Bind the middleware correlation ID through the synchronous tool wrapper."""
+    """Bind the middleware correlation ID through the synchronous tool wrapper.
+
+    Yields the minted per-call token: the failure-signal key that stays unique
+    even when concurrent calls share a client-supplied request id.
+    """
     token = _MCP_REQUEST_ID.set(request_id)
+    call_token = uuid.uuid4().hex
+    call_reset = _MCP_CALL_TOKEN.set(call_token)
     try:
-        yield
+        yield call_token
     finally:
+        _MCP_CALL_TOKEN.reset(call_reset)
         _MCP_REQUEST_ID.reset(token)
 
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import json
 import os
 import shutil
 import sqlite3
 import subprocess
 import sys
+import time
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
@@ -1592,6 +1594,112 @@ def _check_edge_ingress_read_routing(base_url: str, config: LeaseConfig) -> Doct
     )
 
 
+def _check_observability() -> DoctorCheck:
+    """Log directory writability, active/rotated file sizes, JSONL
+    tail-parseability, the NSSM `service.*` rotation pile, and
+    metrics-snapshot freshness. Never touches the network."""
+    from . import metrics
+    from .logging_config import resolve_log_dir
+
+    details: dict[str, object] = {}
+    problems: list[str] = []
+    warnings: list[str] = []
+
+    log_dir = resolve_log_dir()
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        probe_path = log_dir / f".exomem-doctor-probe-{os.getpid()}"
+        probe_path.write_text("", encoding="utf-8")
+        probe_path.unlink(missing_ok=True)
+        details["log_dir_writable"] = True
+    except (OSError, ValueError):
+        details["log_dir_writable"] = False
+        problems.append("log directory is not writable")
+
+    jsonl_names = ("queries.jsonl", "writes.jsonl", "reads.jsonl", "mutations.jsonl")
+    for name in jsonl_names:
+        try:
+            path = log_dir / name
+            details[f"{name}.rotated"] = (log_dir / f"{name}.1").exists()
+            if not path.exists():
+                continue
+            details[f"{name}.bytes"] = path.stat().st_size
+            lines = path.read_text(encoding="utf-8").splitlines()
+            if lines and lines[-1].strip():
+                json.loads(lines[-1])
+        except (OSError, ValueError):
+            warnings.append(f"{name} tail is not parseable JSON")
+
+    try:
+        service_pile = sum(
+            1
+            for pattern in ("service.out.log.*", "service.err.log.*")
+            for _ in log_dir.glob(pattern)
+        )
+    except (OSError, ValueError):
+        service_pile = 0
+    details["service_pile_count"] = service_pile
+    if service_pile > 50:
+        warnings.append(f"{service_pile} service.* rotated files have accumulated")
+
+    try:
+        from .writer_lease import get_manager
+
+        state_dir = get_manager().config.state_dir
+        interval = metrics.snapshot_interval_seconds_from_env()
+        snapshot_path = metrics.snapshot_path(state_dir)
+        if interval > 0 and snapshot_path.exists():
+            age = time.time() - snapshot_path.stat().st_mtime
+            details["metrics_snapshot_age_seconds"] = round(age, 1)
+            if age > interval * 2:
+                warnings.append("metrics snapshot is stale")
+    except Exception:  # noqa: BLE001 - doctor must stay structured
+        pass
+
+    if problems:
+        return _check(
+            "observability",
+            "fail",
+            "; ".join(problems),
+            "Ensure the log directory is writable (check permissions or EXOMEM_LOG_DIR).",
+            details=details,
+        )
+    if warnings:
+        return _check("observability", "warn", "; ".join(warnings), None, details=details)
+    return _check(
+        "observability", "pass", "Log directory, JSONL logs, and metrics snapshot look healthy.",
+        details=details,
+    )
+
+
+def _check_idempotency_store() -> DoctorCheck:
+    """Warn when idempotency receipts have piled up abandoned, or the oldest
+    pending row has sat unresolved past the legacy grace window — either is
+    a sign a mutation crashed and needs operator attention, not necessarily
+    a fault by itself. Never touches the network."""
+    try:
+        from .writer_lease import get_manager
+
+        summary = get_manager().idempotency.status_summary()
+    except Exception:  # noqa: BLE001 - doctor must stay structured
+        summary = {"pending": None, "abandoned": None, "oldest_pending_age_seconds": None}
+
+    abandoned = summary.get("abandoned")
+    oldest_pending_age_seconds = summary.get("oldest_pending_age_seconds")
+    warnings: list[str] = []
+    if isinstance(abandoned, int) and abandoned > 0:
+        warnings.append(f"{abandoned} abandoned idempotency receipt(s)")
+    if isinstance(oldest_pending_age_seconds, (int, float)) and oldest_pending_age_seconds > 600:
+        warnings.append(
+            f"oldest pending idempotency receipt is {oldest_pending_age_seconds:.0f}s old"
+        )
+    if warnings:
+        return _check("idempotency_store", "warn", "; ".join(warnings), None, details=summary)
+    return _check(
+        "idempotency_store", "pass", "Idempotency receipts look healthy.", details=summary
+    )
+
+
 def _check_edge_ingress(*, probe: bool) -> list[DoctorCheck]:
     """Doctor's `edge-ingress` section (design.md Decision 3): verifies the public
     apex is fronted by the HA edge worker rather than tunnel-direct. Skipped
@@ -1736,6 +1844,8 @@ def doctor(
     # Not profile-gated: any profile can run with writer-lease coordination
     # enabled, and the section self-skips when it is not (design.md Decision 3).
     checks.extend(_check_edge_ingress(probe=probe))
+    checks.append(_check_observability())
+    checks.append(_check_idempotency_store())
 
     return DoctorReport(profile=profile, checks=checks)
 

--- a/src/exomem/edge_ingress.py
+++ b/src/exomem/edge_ingress.py
@@ -120,6 +120,15 @@ def _refusal_exception() -> OpError:
     return OpError("INGRESS_BYPASSED", INGRESS_BYPASSED_MESSAGE)
 
 
+def _bump_edge_ingress_metric(outcome: str) -> None:
+    try:
+        from . import metrics
+
+        metrics.inc_counter("exomem_edge_ingress_total", {"outcome": outcome})
+    except Exception:  # noqa: BLE001 - observability must never break a request
+        pass
+
+
 async def _send_refusal(send: Send) -> None:
     err = cli_ops.error_dict(_refusal_exception())
     body = json.dumps(
@@ -179,6 +188,7 @@ class EdgeIngressMiddleware:
                     path,
                     self._bypassed_count,
                 )
+                _bump_edge_ingress_metric("bypassed")
             else:
                 self._refused_count += 1
                 logger.warning(
@@ -186,6 +196,7 @@ class EdgeIngressMiddleware:
                     path,
                     self._refused_count,
                 )
+                _bump_edge_ingress_metric("refused")
                 await _send_refusal(send)
                 return
 

--- a/src/exomem/log_events.py
+++ b/src/exomem/log_events.py
@@ -1,0 +1,160 @@
+"""Structured event logging shared by every log call site.
+
+`log_event()` is the one seam that attaches a machine-readable `event` name,
+a content-free `fields` mapping, and an optional catalog-restricted `content`
+mapping to a `LogRecord`. Two formatters read those same attributes:
+`JsonLinesFormatter` for the on-disk JSONL log, `KeyValueFormatter` for a
+human-readable `key=value` rendering. `EVENT_CATALOG` is the single source of
+truth for which events may carry `content` at all, and for which top-level
+keys of that `content` are allowed — `privacy_log.py`'s hosted redaction
+factory relies on this to drop only the content of a classified record while
+keeping its content-free skeleton, instead of fully blanking it.
+
+Nothing here may raise into a caller: a broken log call must never break the
+tool call, HTTP request, or mutation it was describing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import traceback
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EventSpec:
+    """What a cataloged event is allowed to carry in `content`."""
+
+    content_fields: frozenset[str] = frozenset()
+
+
+# Every event that passes through `log_event()` must be declared here. An
+# event with a non-empty `content_fields` may carry those (and only those)
+# keys in `content`; anything else drops undeclared keys rather than shipping
+# them. An event not present in this catalog at all gets its `content`
+# dropped entirely — classification must be earned, never assumed.
+EVENT_CATALOG: dict[str, EventSpec] = {
+    "tool_start": EventSpec(),
+    "tool_success": EventSpec(),
+    "tool_failure": EventSpec(content_fields=frozenset({"message"})),
+    "rest_failure": EventSpec(content_fields=frozenset({"message"})),
+    "hosted_call": EventSpec(),
+    "log_write_error": EventSpec(content_fields=frozenset({"message"})),
+    "observability_internal_error": EventSpec(content_fields=frozenset({"message"})),
+    "http_request": EventSpec(content_fields=frozenset({"client_ip", "path"})),
+    "mutation_lock_acquired": EventSpec(),
+    "mutation_lock_released": EventSpec(),
+    "mutation_lock_long_hold": EventSpec(),
+    "mutation_holder_unverified": EventSpec(),
+    "lease_idle_released": EventSpec(),
+    "lease_acquired": EventSpec(),
+    "lease_reclaimed": EventSpec(),
+    "lease_renew_rejected": EventSpec(),
+}
+
+
+def log_event(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    *,
+    fields: Mapping[str, Any] | None = None,
+    content: Mapping[str, Any] | None = None,
+    exc_info: Any = None,
+) -> None:
+    """Log one structured event. Never raises."""
+    try:
+        clean_fields = dict(fields) if isinstance(fields, Mapping) else {}
+        clean_content = dict(content) if isinstance(content, Mapping) else {}
+        spec = EVENT_CATALOG.get(event)
+        if spec is None:
+            clean_content = {}
+        elif clean_content:
+            for key in set(clean_content) - spec.content_fields:
+                clean_content.pop(key, None)
+        logger.log(
+            level,
+            event,
+            extra={"event": event, "fields": clean_fields, "content": clean_content},
+            exc_info=exc_info,
+        )
+    except Exception:  # noqa: BLE001 - a logging defect must never break the caller
+        pass
+
+
+def bounded_traceback(
+    exc_info: Any, *, limit: int = 20, max_chars: int = 4000
+) -> str:
+    """Render a bounded traceback string, or "" when there is nothing to show."""
+    try:
+        if not exc_info:
+            return ""
+        if exc_info is True:
+            exc_info = sys.exc_info()
+        if isinstance(exc_info, BaseException):
+            exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+        exc_type, exc, tb = exc_info
+        if exc_type is None:
+            return ""
+        text = "".join(traceback.format_exception(exc_type, exc, tb, limit=limit))
+        if len(text) > max_chars:
+            # Keep the tail: the exception type + message line is the most
+            # useful part for grepping a truncated traceback, and it is
+            # always last in `format_exception`'s output.
+            text = "...<truncated>\n" + text[-max_chars:]
+        return text
+    except Exception:  # noqa: BLE001 - traceback rendering must never break the caller
+        return ""
+
+
+def _utc_timestamp(record: logging.LogRecord) -> str:
+    return datetime.fromtimestamp(record.created, tz=UTC).isoformat(
+        timespec="milliseconds"
+    )
+
+
+class JsonLinesFormatter(logging.Formatter):
+    """One JSON object per line; works for structured and plain records alike."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": _utc_timestamp(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "event": getattr(record, "event", None),
+            "message": record.getMessage(),
+        }
+        fields = getattr(record, "fields", None)
+        if fields:
+            payload["fields"] = fields
+        content = getattr(record, "content", None)
+        if content:
+            payload["content"] = content
+        if record.exc_info:
+            traceback_text = bounded_traceback(record.exc_info)
+            if traceback_text:
+                payload["traceback"] = traceback_text
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+
+
+class KeyValueFormatter(logging.Formatter):
+    """Human-readable `key=value` rendering of the same structured attributes."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        parts = [f"ts={_utc_timestamp(record)}", f"level={record.levelname}"]
+        event = getattr(record, "event", None)
+        if event:
+            parts.append(f"event={event}")
+        for mapping_name in ("fields", "content"):
+            mapping = getattr(record, mapping_name, None)
+            if mapping:
+                parts.extend(f"{key}={value}" for key, value in mapping.items())
+        message = record.getMessage()
+        if not event and message:
+            parts.append(message)
+        return " ".join(parts)

--- a/src/exomem/logging_config.py
+++ b/src/exomem/logging_config.py
@@ -1,4 +1,4 @@
-"""Rotating-file logger configuration for exomem."""
+"""Rotating-file JSONL logger configuration for exomem."""
 
 from __future__ import annotations
 
@@ -6,6 +6,19 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+
+from .log_events import JsonLinesFormatter
+
+# Windows cannot share a single RotatingFileHandler across processes (the
+# rename-on-rotate step fails when another process holds the file open), and
+# one checkout runs more than one process kind: the long-lived server,
+# one-shot CLI invocations, and the media worker child. Each gets its own
+# file so nothing contends for another's handle.
+_LOG_FILENAMES: dict[str, str] = {
+    "server": "exomem.log",
+    "cli": "exomem-cli.log",
+    "media": "exomem-media.log",
+}
 
 
 def resolve_log_dir(default: Path | None = None) -> Path:
@@ -26,25 +39,59 @@ def resolve_log_dir(default: Path | None = None) -> Path:
     return Path(__file__).resolve().parents[2] / "logs"
 
 
-def configure_logging(log_dir: Path, level: int = logging.INFO) -> None:
-    # Honor FASTMCP_LOG_LEVEL so fastmcp's auth/JWT DEBUG lines (e.g. the exact
-    # reason behind an `invalid_token` 401) are surfaceable without a code change.
-    env_level = os.environ.get("FASTMCP_LOG_LEVEL", "").upper()
-    if env_level:
-        level = getattr(logging, env_level, level)
+def _resolve_level(level: int) -> int:
+    # EXOMEM_LOG_LEVEL is canonical; FASTMCP_LOG_LEVEL is honored as a
+    # fallback so fastmcp's auth/JWT DEBUG lines (e.g. the exact reason
+    # behind an `invalid_token` 401) stay surfaceable without a code change.
+    for name in ("EXOMEM_LOG_LEVEL", "FASTMCP_LOG_LEVEL"):
+        raw = os.environ.get(name, "").strip().upper()
+        if raw:
+            return getattr(logging, raw, level)
+    return level
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def configure_logging(
+    log_dir: Path, level: int = logging.INFO, *, process: str = "server"
+) -> None:
+    """Configure root JSONL file logging for one process role.
+
+    `process` selects the per-process-role log file
+    (`server`/`cli`/`media`, default `server`) under `log_dir`.
+    """
+    level = _resolve_level(level)
+    filename = _LOG_FILENAMES.get(process, _LOG_FILENAMES["server"])
+    max_bytes = int(_positive_float_env("EXOMEM_LOG_MAX_MB", 5.0) * 1024 * 1024)
+    backup_count = _positive_int_env("EXOMEM_LOG_BACKUPS", 5)
     log_dir.mkdir(parents=True, exist_ok=True)
     handler = RotatingFileHandler(
-        log_dir / "exomem.log",
-        maxBytes=5 * 1024 * 1024,
-        backupCount=5,
+        log_dir / filename,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
         encoding="utf-8",
     )
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s %(levelname)s %(name)s: %(message)s",
-            datefmt="%Y-%m-%dT%H:%M:%S",
-        )
-    )
+    handler.setFormatter(JsonLinesFormatter())
     root = logging.getLogger()
     root.setLevel(level)
     # Avoid duplicate handlers on reconfiguration.
@@ -52,3 +99,26 @@ def configure_logging(log_dir: Path, level: int = logging.INFO) -> None:
         if isinstance(existing, RotatingFileHandler):
             root.removeHandler(existing)
     root.addHandler(handler)
+    if process == "server":
+        _silence_uvicorn_access()
+
+
+def _silence_uvicorn_access() -> None:
+    """Silence uvicorn's own unstructured access log the SAME moment the
+    structured `AccessLogMiddleware` record becomes the access log, so the
+    same request is never described by both an unparseable text line and a
+    JSONL record.
+
+    `uvicorn.Config.__init__` calls its own `configure_logging()` later
+    (inside `mcp.run()`, after this function returns), which re-applies its
+    default `dictConfig` and would re-add a handler for this logger name —
+    but `disable_existing_loggers` is `False` in that config and `disabled`
+    is not a key `dictConfig` ever sets, so `.disabled = True` set here
+    survives that later call intact. Setting `propagate = False` and
+    clearing handlers too matches uvicorn's own `access_log=False` behavior
+    for defense in depth.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.handlers = []
+    access_logger.propagate = False
+    access_logger.disabled = True

--- a/src/exomem/media_worker.py
+++ b/src/exomem/media_worker.py
@@ -75,7 +75,9 @@ _LOCK_UNAVAILABLE_RECHECK_SECONDS = 30.0
 
 def _writer_authority_available() -> bool:
     try:
-        get_manager().ensure_writer()
+        # cause="probe": an availability poll must not count as write activity
+        # for the lease idle-release timer.
+        get_manager().ensure_writer(cause="probe")
     except OpError as exc:
         if exc.code in _TRANSIENT_OPERATION_CODES:
             return False

--- a/src/exomem/media_worker_child.py
+++ b/src/exomem/media_worker_child.py
@@ -57,6 +57,10 @@ class _VaultLock:
 
 
 def main(argv: list[str] | None = None) -> int:
+    from .logging_config import configure_logging, resolve_log_dir
+
+    configure_logging(resolve_log_dir(), process="media")
+
     parser = argparse.ArgumentParser(prog="python -m exomem.media_worker_child")
     parser.add_argument("--vault", required=True)
     parser.add_argument("--parent-pid", type=int, required=True)

--- a/src/exomem/metrics.py
+++ b/src/exomem/metrics.py
@@ -213,6 +213,27 @@ def load_snapshot(state_dir: Path | str) -> None:
         log.debug("metrics load_snapshot failed", exc_info=True)
 
 
+_SNAPSHOT_LOADED = False
+_SNAPSHOT_LOADED_LOCK = threading.Lock()
+
+
+def load_snapshot_once(state_dir: Path | str) -> None:
+    """Restore from disk at most once per process.
+
+    Runtime initialization can legitimately run more than once in a process
+    (server rebuilds, test suites); restoring again would clobber LIVE
+    in-process counters with older persisted values. Only the first
+    initialization consumes the on-disk snapshot. Deliberately not re-armed by
+    `reset()`.
+    """
+    global _SNAPSHOT_LOADED
+    with _SNAPSHOT_LOADED_LOCK:
+        if _SNAPSHOT_LOADED:
+            return
+        _SNAPSHOT_LOADED = True
+    load_snapshot(state_dir)
+
+
 def snapshot_interval_seconds_from_env(env: Mapping[str, str] | None = None) -> float:
     """`EXOMEM_METRICS_SNAPSHOT_SECONDS`, default 60.0; `0` disables the thread."""
     values = os.environ if env is None else env

--- a/src/exomem/metrics.py
+++ b/src/exomem/metrics.py
@@ -1,0 +1,262 @@
+"""One process-wide metrics registry: counters + fixed-bucket histograms.
+
+Every public function soft-fails: a defect here must never break the tool
+call, HTTP request, or mutation it is describing. The registry is
+snapshotted atomically (temp file + `os.replace`) to the writer-lease state
+directory on an interval, and restored from that snapshot at process start,
+so counts survive a restart instead of resetting to zero. No network
+endpoint is exposed by this module; `/metrics.json` is a later, separate
+change built on top of this same registry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Upper bounds (milliseconds) for the fixed-bucket duration histograms. A
+# value greater than the last bound lands in the implicit "+Inf" overflow
+# bucket (one more slot than there are bounds).
+DEFAULT_DURATION_BUCKETS_MS: tuple[float, ...] = (
+    5,
+    10,
+    25,
+    50,
+    100,
+    250,
+    500,
+    1000,
+    2500,
+    5000,
+    10000,
+    30000,
+    60000,
+)
+
+SNAPSHOT_FILENAME = "metrics-snapshot.json"
+
+_Key = tuple[str, tuple[tuple[str, str], ...]]
+
+
+def _label_key(labels: Mapping[str, Any] | None) -> tuple[tuple[str, str], ...]:
+    if not isinstance(labels, Mapping):
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+
+
+class MetricsRegistry:
+    """Counters and fixed-bucket histograms behind one lock."""
+
+    def __init__(self, *, duration_buckets_ms: tuple[float, ...] = DEFAULT_DURATION_BUCKETS_MS):
+        self._lock = threading.Lock()
+        self._buckets: tuple[float, ...] = tuple(duration_buckets_ms)
+        self._counters: dict[_Key, int] = {}
+        self._hist_buckets: dict[_Key, list[int]] = {}
+        self._hist_sum: dict[_Key, float] = {}
+        self._hist_count: dict[_Key, int] = {}
+
+    def inc(self, name: str, labels: Mapping[str, Any] | None = None, value: int = 1) -> None:
+        try:
+            key = (name, _label_key(labels))
+            with self._lock:
+                self._counters[key] = self._counters.get(key, 0) + int(value)
+        except Exception:  # noqa: BLE001 - metrics must never break the caller
+            log.debug("metrics inc_counter failed", exc_info=True)
+
+    def observe(self, name: str, value: Any, labels: Mapping[str, Any] | None = None) -> None:
+        try:
+            numeric = float(value)
+            key = (name, _label_key(labels))
+            with self._lock:
+                buckets = self._hist_buckets.setdefault(key, [0] * (len(self._buckets) + 1))
+                buckets[self._bucket_index(numeric)] += 1
+                self._hist_sum[key] = self._hist_sum.get(key, 0.0) + numeric
+                self._hist_count[key] = self._hist_count.get(key, 0) + 1
+        except Exception:  # noqa: BLE001 - metrics must never break the caller
+            log.debug("metrics observe failed", exc_info=True)
+
+    def _bucket_index(self, value: float) -> int:
+        for index, bound in enumerate(self._buckets):
+            if value <= bound:
+                return index
+        return len(self._buckets)  # overflow ("+Inf") bucket
+
+    def snapshot(self) -> dict[str, Any]:
+        try:
+            with self._lock:
+                return {
+                    "counters": [
+                        {"name": key[0], "labels": dict(key[1]), "value": value}
+                        for key, value in self._counters.items()
+                    ],
+                    "histograms": [
+                        {
+                            "name": key[0],
+                            "labels": dict(key[1]),
+                            "buckets": list(buckets),
+                            "sum": self._hist_sum.get(key, 0.0),
+                            "count": self._hist_count.get(key, 0),
+                        }
+                        for key, buckets in self._hist_buckets.items()
+                    ],
+                    "bucket_bounds_ms": list(self._buckets),
+                }
+        except Exception:  # noqa: BLE001 - metrics must never break the caller
+            log.debug("metrics snapshot failed", exc_info=True)
+            return {"counters": [], "histograms": [], "bucket_bounds_ms": list(self._buckets)}
+
+    def restore(self, data: Any) -> None:
+        try:
+            if not isinstance(data, Mapping):
+                return
+            with self._lock:
+                for entry in data.get("counters") or []:
+                    if not isinstance(entry, Mapping):
+                        continue
+                    key = (str(entry.get("name")), _label_key(entry.get("labels")))
+                    self._counters[key] = int(entry.get("value", 0))
+                bounds = data.get("bucket_bounds_ms")
+                if isinstance(bounds, list) and tuple(bounds) == self._buckets:
+                    for entry in data.get("histograms") or []:
+                        if not isinstance(entry, Mapping):
+                            continue
+                        key = (str(entry.get("name")), _label_key(entry.get("labels")))
+                        buckets = entry.get("buckets")
+                        if isinstance(buckets, list) and len(buckets) == len(self._buckets) + 1:
+                            self._hist_buckets[key] = [int(x) for x in buckets]
+                            self._hist_sum[key] = float(entry.get("sum", 0.0))
+                            self._hist_count[key] = int(entry.get("count", 0))
+        except Exception:  # noqa: BLE001 - metrics must never break the caller
+            log.debug("metrics restore failed", exc_info=True)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+            self._hist_buckets.clear()
+            self._hist_sum.clear()
+            self._hist_count.clear()
+
+
+_REGISTRY = MetricsRegistry()
+
+
+def metrics_disabled(env: Mapping[str, str] | None = None) -> bool:
+    values = os.environ if env is None else env
+    return str(values.get("EXOMEM_DISABLE_METRICS", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def inc_counter(name: str, labels: Mapping[str, Any] | None = None, value: int = 1) -> None:
+    if metrics_disabled():
+        return
+    _REGISTRY.inc(name, labels, value)
+
+
+def observe_duration_ms(name: str, value_ms: Any, labels: Mapping[str, Any] | None = None) -> None:
+    if metrics_disabled():
+        return
+    _REGISTRY.observe(name, value_ms, labels)
+
+
+def snapshot() -> dict[str, Any]:
+    return _REGISTRY.snapshot()
+
+
+def render_json() -> dict[str, Any]:
+    """The registry's current snapshot, ready for JSON serialization (the
+    `/metrics.json` route body)."""
+    return snapshot()
+
+
+def reset() -> None:
+    _REGISTRY.reset()
+
+
+def snapshot_path(state_dir: Path | str) -> Path:
+    return Path(state_dir) / SNAPSHOT_FILENAME
+
+
+def save_snapshot(state_dir: Path | str) -> None:
+    """Atomically persist the current snapshot (temp file + `os.replace`)."""
+    try:
+        path = snapshot_path(state_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp_path.write_text(
+            json.dumps(_REGISTRY.snapshot(), sort_keys=True), encoding="utf-8"
+        )
+        os.replace(tmp_path, path)
+    except Exception:  # noqa: BLE001 - metrics must never break the caller
+        log.debug("metrics save_snapshot failed", exc_info=True)
+
+
+def load_snapshot(state_dir: Path | str) -> None:
+    """Restore from a prior snapshot; a missing or corrupt file is a no-op."""
+    try:
+        path = snapshot_path(state_dir)
+        if not path.exists():
+            return
+        data = json.loads(path.read_text(encoding="utf-8"))
+        _REGISTRY.restore(data)
+    except Exception:  # noqa: BLE001 - metrics must never break the caller
+        log.debug("metrics load_snapshot failed", exc_info=True)
+
+
+def snapshot_interval_seconds_from_env(env: Mapping[str, str] | None = None) -> float:
+    """`EXOMEM_METRICS_SNAPSHOT_SECONDS`, default 60.0; `0` disables the thread."""
+    values = os.environ if env is None else env
+    raw = str(values.get("EXOMEM_METRICS_SNAPSHOT_SECONDS", "")).strip()
+    if not raw:
+        return 60.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 60.0
+
+
+_SNAPSHOTTER_LOCK = threading.Lock()
+_snapshotter_thread: threading.Thread | None = None
+_snapshotter_stop: threading.Event | None = None
+
+
+def start_snapshotter(state_dir: Path | str, interval_seconds: float) -> threading.Thread | None:
+    """Start the background snapshotter; `interval_seconds <= 0` disables it."""
+    global _snapshotter_thread, _snapshotter_stop
+    if interval_seconds is None or interval_seconds <= 0:
+        return None
+    with _SNAPSHOTTER_LOCK:
+        if _snapshotter_thread is not None and _snapshotter_thread.is_alive():
+            return _snapshotter_thread
+        stop_event = threading.Event()
+
+        def _loop() -> None:
+            while not stop_event.wait(interval_seconds):
+                save_snapshot(state_dir)
+
+        thread = threading.Thread(
+            target=_loop, name="exomem-metrics-snapshotter", daemon=True
+        )
+        _snapshotter_thread = thread
+        _snapshotter_stop = stop_event
+        thread.start()
+        return thread
+
+
+def stop_snapshotter() -> None:
+    global _snapshotter_thread, _snapshotter_stop
+    with _SNAPSHOTTER_LOCK:
+        if _snapshotter_stop is not None:
+            _snapshotter_stop.set()
+        _snapshotter_thread = None
+        _snapshotter_stop = None

--- a/src/exomem/mutation_journal.py
+++ b/src/exomem/mutation_journal.py
@@ -1,0 +1,119 @@
+"""`logs/mutations.jsonl` — one record per mutation attempt.
+
+Written at the terminal/interrupted/replayed seam in `writer_lease.invoke()`.
+Best-effort: a journal write failure must never break a mutation — it is
+swallowed and counted in `exomem_log_write_errors_total` instead.
+
+`targets` is content-classified: a hosted cell (`content_private_logging_enabled()`)
+records only `target_count`, never the target identifiers themselves.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_JOURNAL_FILENAME = "mutations.jsonl"
+_DEFAULT_MAX_MB = 64.0
+_STAT_RESYNC_EVERY = 100
+_size_cache: dict[str, int] = {}
+_append_counts: dict[str, int] = {}
+
+
+def journal_path() -> Path:
+    from .logging_config import resolve_log_dir
+
+    return resolve_log_dir() / _JOURNAL_FILENAME
+
+
+def _max_bytes() -> int:
+    raw = os.environ.get("EXOMEM_JSONL_MAX_MB", "").strip()
+    try:
+        mb = float(raw) if raw else _DEFAULT_MAX_MB
+    except ValueError:
+        mb = _DEFAULT_MAX_MB
+    return max(1, int(mb * 1024 * 1024))
+
+
+def _rotate_if_needed(path: Path) -> None:
+    key = str(path)
+    count = _append_counts.get(key, 0) + 1
+    _append_counts[key] = count
+    if key not in _size_cache or count % _STAT_RESYNC_EVERY == 0:
+        try:
+            _size_cache[key] = path.stat().st_size
+        except OSError:
+            _size_cache[key] = 0
+    if _size_cache[key] < _max_bytes():
+        return
+    try:
+        os.replace(path, path.with_name(path.name + ".1"))
+    except OSError:
+        pass
+    _size_cache[key] = 0
+
+
+def record_mutation(
+    *,
+    request_id: str,
+    tool: str,
+    command: str,
+    receipt_id: str | None,
+    outcome: str,
+    error_code: str | None,
+    duration_ms: float | None,
+    boundary_wait_ms: float | None = None,
+    boundary_hold_ms: float | None = None,
+    lease_role: str | None = None,
+    fencing_token: int | None = None,
+    replica_id: str | None = None,
+    scope: str | None = None,
+    targets: list[str] | None = None,
+) -> None:
+    """Append one mutation-journal record. Never raises, never blocks the
+    mutation it describes on a slow or failing disk."""
+    try:
+        from .privacy_log import content_private_logging_enabled
+
+        hosted = content_private_logging_enabled()
+        path = journal_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_if_needed(path)
+        target_list = list(targets or [])
+        record: dict[str, Any] = {
+            "ts_utc": dt.datetime.now(dt.UTC).isoformat(timespec="milliseconds"),
+            "request_id": request_id,
+            "tool": tool,
+            "command": command,
+            "receipt_id": receipt_id,
+            "outcome": outcome,
+            "error_code": error_code,
+            "duration_ms": duration_ms,
+            "boundary_wait_ms": boundary_wait_ms,
+            "boundary_hold_ms": boundary_hold_ms,
+            "lease_role": lease_role,
+            "fencing_token": fencing_token,
+            "replica_id": replica_id,
+            "scope": scope,
+            "target_count": len(target_list),
+        }
+        if not hosted:
+            record["targets"] = target_list
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+        with path.open("a", encoding="utf-8") as f:
+            f.write(line)
+        _size_cache[str(path)] = _size_cache.get(str(path), 0) + len(line.encode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 - a journal write must never break a mutation
+        try:
+            from . import metrics
+
+            metrics.inc_counter("exomem_log_write_errors_total", {"where": "mutation_journal"})
+        except Exception:  # noqa: BLE001
+            pass
+        log.debug("mutation_journal record failed: %s", exc)

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO
@@ -39,7 +40,53 @@ _SAFE_LABEL = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
 _DEFAULT_LONG_HOLDER_SECONDS = 30.0
 _STATUS_TIMEOUT_SECONDS = 0.25
 _HOLDER_SCHEMA = 1
+
+# The most recent `wait_ms`/`hold_ms` this task/thread measured acquiring and
+# holding the vault mutation boundary — set by `VaultMutationCoordinator.hold()`
+# for the OUTER (non-reentrant) acquisition only, so a nested command helper
+# reusing an already-held lock never overwrites its caller's timing. Read by
+# `writer_lease.invoke()` at the mutation-journal seam (O5) and by the R1
+# telemetry events, both of which run in the same execution context shortly
+# after the `with ...hold():` block exits.
+_LAST_MUTATION_TIMING: ContextVar[dict[str, float] | None] = ContextVar(
+    "exomem_last_mutation_timing", default=None
+)
+
+
+def last_mutation_timing() -> dict[str, float] | None:
+    """Return `{"wait_ms", "hold_ms"}` for the most recent boundary hold in
+    this context, or `None` if none has been recorded yet."""
+    return _LAST_MUTATION_TIMING.get()
+
+
 logger = logging.getLogger(__name__)
+
+
+def _log_mutation_lock_event(event: str, **fields: Any) -> None:
+    try:
+        from .log_events import log_event
+
+        log_event(logger, logging.INFO, event, fields=fields)
+    except Exception:  # noqa: BLE001 - observability must never break a mutation
+        pass
+
+
+def _bump_boundary_metric(name: str, labels: dict[str, str] | None = None) -> None:
+    try:
+        from . import metrics
+
+        metrics.inc_counter(name, labels or {})
+    except Exception:  # noqa: BLE001 - observability must never break a mutation
+        pass
+
+
+def _observe_boundary_ms(name: str, value_ms: float) -> None:
+    try:
+        from . import metrics
+
+        metrics.observe_duration_ms(name, value_ms, {})
+    except Exception:  # noqa: BLE001 - observability must never break a mutation
+        pass
 
 
 def canonical_mutation_identity(vault_or_cell: os.PathLike[str] | str) -> str:
@@ -145,11 +192,17 @@ class VaultMutationCoordinator:
         timeout = self.timeout_seconds if timeout_seconds is None else timeout_seconds
         if timeout < 0:
             raise ValueError("mutation lock timeout must be non-negative")
-        deadline = time.monotonic() + timeout
+        wait_start = time.monotonic()
+        # Clear any prior hold's timing so a mutation that fails BEFORE
+        # acquiring can never journal a previous mutation's wait/hold values.
+        _LAST_MUTATION_TIMING.set(None)
+        deadline = wait_start + timeout
         state = _state_for(self.lock_path)
         remaining = max(0.0, deadline - time.monotonic())
         if not state.guard.acquire(timeout=remaining):
-            raise _mutation_busy(self.snapshot())
+            raise _mutation_busy(
+                self.snapshot(), wait_ms=(time.monotonic() - wait_start) * 1000
+            )
         try:
             thread_id = threading.get_ident()
             if state.owner_thread == thread_id:
@@ -163,11 +216,16 @@ class VaultMutationCoordinator:
             handle = self._open_lock_file(self.lock_path)
             metadata_handle = self._open_lock_file(self.metadata_lock_path)
             try:
-                self._acquire_boundary(handle, metadata_handle, deadline, request_id, operation, holder_kind)
+                self._acquire_boundary(
+                    handle, metadata_handle, deadline, request_id, operation, holder_kind,
+                    wait_start=wait_start,
+                )
             except Exception:
                 handle.close()
                 metadata_handle.close()
                 raise
+            acquired_at = time.monotonic()
+            wait_ms = round((acquired_at - wait_start) * 1000, 2)
             state.owner_thread = thread_id
             state.depth = 1
             state.handle = handle
@@ -175,18 +233,31 @@ class VaultMutationCoordinator:
                 state.request_id = _safe_label(request_id, fallback="untracked")
                 state.operation = _safe_label(operation, fallback="unknown")
                 state.holder_kind = _safe_label(holder_kind, fallback="unknown")
-                state.acquired_at = time.monotonic()
+                state.acquired_at = acquired_at
                 state.long_holder_seconds = self.long_holder_seconds
                 state.long_warning_emitted = False
+            _log_mutation_lock_event(
+                "mutation_lock_acquired",
+                operation=operation,
+                holder_kind=holder_kind,
+                wait_ms=wait_ms,
+            )
+            _observe_boundary_ms("exomem_boundary_wait_ms", wait_ms)
             try:
                 yield
             finally:
+                hold_ms = round((time.monotonic() - acquired_at) * 1000, 2)
+                _LAST_MUTATION_TIMING.set({"wait_ms": wait_ms, "hold_ms": hold_ms})
                 with state.metadata_guard:
+                    already_warned = state.long_warning_emitted
                     state.request_id = None
                     state.operation = None
                     state.holder_kind = None
                     state.acquired_at = None
                     state.long_warning_emitted = False
+                # Reset reentrancy state BEFORE releasing the OS lock: a stale
+                # owner_thread would route this thread's next hold() through the
+                # reentrant fast path with no OS lock at all.
                 state.depth = 0
                 state.owner_thread = None
                 state.handle = None
@@ -195,6 +266,36 @@ class VaultMutationCoordinator:
                 finally:
                     handle.close()
                     metadata_handle.close()
+                # Telemetry AFTER release, so log appends never extend the
+                # critical section other writers are polling on. Guaranteed on
+                # release, regardless of whether anyone ever probed this hold
+                # while it was live (`_snapshot_state`'s warning only fires
+                # when something calls `snapshot()`).
+                overdue = hold_ms >= self.long_holder_seconds * 1000
+                if not already_warned and overdue:
+                    logger.warning(
+                        "vault mutation boundary held too long request_id=%s operation=%s "
+                        "holder_kind=%s hold_ms=%.2f",
+                        _safe_label(request_id, fallback="untracked"),
+                        _safe_label(operation, fallback="unknown"),
+                        _safe_label(holder_kind, fallback="unknown"),
+                        hold_ms,
+                    )
+                    _log_mutation_lock_event(
+                        "mutation_lock_long_hold",
+                        operation=operation,
+                        holder_kind=holder_kind,
+                        hold_ms=hold_ms,
+                    )
+                if overdue:
+                    _bump_boundary_metric("exomem_boundary_overdue_total")
+                _log_mutation_lock_event(
+                    "mutation_lock_released",
+                    operation=operation,
+                    holder_kind=holder_kind,
+                    hold_ms=hold_ms,
+                )
+                _observe_boundary_ms("exomem_boundary_hold_ms", hold_ms)
         finally:
             state.guard.release()
 
@@ -220,6 +321,20 @@ class VaultMutationCoordinator:
                 self.poll_interval_seconds,
             )
             if not metadata_locked:
+                # The metadata mutex is genuinely contended (not just briefly
+                # held during a publish). Rather than fabricate a healthy-
+                # looking unknown holder at age 0, fall back to a lock-free
+                # read of the sidecar: it is published via atomic
+                # `os.replace`, so a read without the mutex is tear-free even
+                # though it cannot be verified current. Only the genuine
+                # absence of any sidecar still fabricates an unknown holder.
+                holder = _read_holder_metadata(self.metadata_path)
+                if holder is not None:
+                    _log_mutation_lock_event(
+                        "mutation_holder_unverified",
+                        holder_kind=holder.get("holder_kind"),
+                    )
+                    return _holder_snapshot(holder, verified=False)
                 return _unknown_external_holder()
             mutation_locked = _try_os_lock(mutation_handle)
             if mutation_locked:
@@ -256,6 +371,9 @@ class VaultMutationCoordinator:
             handle.seek(0)
             return handle
         except OSError as exc:
+            _bump_boundary_metric(
+                "exomem_mutation_busy_total", {"code": "MUTATION_LOCK_UNAVAILABLE"}
+            )
             raise OpError(
                 "MUTATION_LOCK_UNAVAILABLE",
                 f"vault mutation lock could not be opened (host error {exc.errno})",
@@ -270,6 +388,8 @@ class VaultMutationCoordinator:
         request_id: str | None,
         operation: str | None,
         holder_kind: str,
+        *,
+        wait_start: float,
     ) -> None:
         """Acquire and publish with the metadata mutex held for one generation."""
         while True:
@@ -280,7 +400,9 @@ class VaultMutationCoordinator:
             except OSError as exc:
                 raise self._lock_unavailable(exc) from None
             if not metadata_locked:
-                raise _mutation_busy(self.snapshot())
+                raise _mutation_busy(
+                    self.snapshot(), wait_ms=(time.monotonic() - wait_start) * 1000
+                )
             acquired = False
             try:
                 try:
@@ -316,7 +438,9 @@ class VaultMutationCoordinator:
                 return
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise _mutation_busy(self.snapshot())
+                raise _mutation_busy(
+                    self.snapshot(), wait_ms=(time.monotonic() - wait_start) * 1000
+                )
             time.sleep(min(self.poll_interval_seconds, remaining))
 
     def _publish_holder_metadata(self, holder: dict[str, object]) -> None:
@@ -360,6 +484,9 @@ class VaultMutationCoordinator:
 
     @staticmethod
     def _lock_unavailable(exc: OSError) -> OpError:
+        _bump_boundary_metric(
+            "exomem_mutation_busy_total", {"code": "MUTATION_LOCK_UNAVAILABLE"}
+        )
         return OpError(
             "MUTATION_LOCK_UNAVAILABLE",
             f"vault mutation authority could not be established (host error {exc.errno})",
@@ -541,14 +668,34 @@ def active_mutation_snapshot() -> dict[str, object]:
     return max(held, key=lambda item: float(item["age_seconds"]))
 
 
-def _mutation_busy(snapshot: dict[str, object] | None = None) -> OpError:
+def dynamic_retry_after_ms(snapshot: dict[str, object] | None) -> int:
+    """Scale the retry hint with observed contention instead of a fixed 750ms.
+
+    `min(15000, max(750, age_seconds*500))`, floored at 5000 when the holder
+    is overdue; 750 when there is no known holder (age 0 / no snapshot).
+    """
+    if not snapshot or snapshot.get("state") != "held":
+        return 750
+    age_seconds = float(snapshot.get("age_seconds") or 0.0)
+    retry_after_ms = min(15000, max(750, int(age_seconds * 500)))
+    if snapshot.get("overdue"):
+        retry_after_ms = max(retry_after_ms, 5000)
+    return retry_after_ms
+
+
+def _mutation_busy(
+    snapshot: dict[str, object] | None = None, *, wait_ms: float | None = None
+) -> OpError:
     details: dict[str, object] = {
         "status": "retryable",
         "committed": False,
-        "retry_after_ms": 750,
+        "retry_after_ms": dynamic_retry_after_ms(snapshot),
     }
+    if wait_ms is not None:
+        details["wait_ms"] = round(wait_ms, 2)
     if snapshot and snapshot.get("state") == "held":
         details["holder"] = snapshot
+    _bump_boundary_metric("exomem_mutation_busy_total", {"code": "MUTATION_BUSY"})
     return OpError(
         "MUTATION_BUSY",
         "vault mutation boundary is busy",

--- a/src/exomem/obs_cli.py
+++ b/src/exomem/obs_cli.py
@@ -1,0 +1,147 @@
+"""Operator tooling over the observability surface: `exomem trace <request_id>`
+joins every correlated source for one request; `exomem logs tail|grep` reads
+the per-process JSONL log files directly. Read-only, best-effort, and never
+touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+_FILE_ALIASES: dict[str, str] = {
+    "server": "exomem.log",
+    "cli": "exomem-cli.log",
+    "media": "exomem-media.log",
+    "queries": "queries.jsonl",
+    "writes": "writes.jsonl",
+    "reads": "reads.jsonl",
+    "mutations": "mutations.jsonl",
+}
+
+# Every file `trace()` joins across, in the order they are read (the final
+# sort by timestamp is what actually orders the report).
+_TRACE_FILES: tuple[str, ...] = (
+    "server",
+    "queries",
+    "writes",
+    "reads",
+    "mutations",
+)
+
+
+def resolve_log_file(name: str) -> Path:
+    """Resolve a `--file` alias to its path under the current log directory."""
+    from .logging_config import resolve_log_dir
+
+    filename = _FILE_ALIASES.get(name)
+    if filename is None:
+        raise ValueError(
+            f"unknown log file {name!r}; choose one of {sorted(_FILE_ALIASES)}"
+        )
+    return resolve_log_dir() / filename
+
+
+def _iter_lines(path: Path, *, include_rotated: bool = True) -> list[str]:
+    candidates = [path.with_name(path.name + ".1"), path] if include_rotated else [path]
+    lines: list[str] = []
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            lines.extend(candidate.read_text(encoding="utf-8").splitlines())
+        except OSError:
+            continue
+    return lines
+
+
+def tail_lines(path: Path, n: int = 20) -> list[str]:
+    """The last `n` lines of `path` (live generation only, no rotated tail)."""
+    if not path.exists():
+        return []
+    try:
+        return path.read_text(encoding="utf-8").splitlines()[-n:]
+    except OSError:
+        return []
+
+
+def grep_lines(path: Path, pattern: str) -> list[str]:
+    """Lines matching `pattern` (regex) across the live and one rotated
+    generation, oldest first."""
+    regex = re.compile(pattern)
+    return [line for line in _iter_lines(path) if regex.search(line)]
+
+
+def follow_lines(path: Path, *, poll_interval: float = 0.5):
+    """Yield newly appended lines forever. Caller controls the loop lifetime
+    (e.g. until KeyboardInterrupt)."""
+    position = path.stat().st_size if path.exists() else 0
+    while True:
+        if not path.exists():
+            time.sleep(poll_interval)
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                f.seek(position)
+                new_text = f.read()
+                position = f.tell()
+        except OSError:
+            time.sleep(poll_interval)
+            continue
+        if new_text:
+            for line in new_text.splitlines():
+                if line.strip():
+                    yield line
+        else:
+            time.sleep(poll_interval)
+
+
+def _record_request_id(record: dict[str, Any]) -> str | None:
+    direct = record.get("request_id")
+    if isinstance(direct, str):
+        return direct
+    fields = record.get("fields")
+    if isinstance(fields, dict):
+        nested = fields.get("request_id")
+        if isinstance(nested, str):
+            return nested
+    return None
+
+
+def _record_timestamp(record: dict[str, Any]) -> str:
+    for key in ("ts_utc", "ts"):
+        value = record.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def trace(request_id: str) -> list[dict[str, Any]]:
+    """Join every JSONL source for one request id, time-ordered.
+
+    Best-effort: an unparseable or missing source file is skipped, never
+    raised, so a partial log directory still produces a partial trace.
+    """
+    matched: list[dict[str, Any]] = []
+    for alias in _TRACE_FILES:
+        path = resolve_log_file(alias)
+        for line in _iter_lines(path):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            if _record_request_id(record) != request_id:
+                continue
+            record = dict(record)
+            record["_source"] = alias
+            matched.append(record)
+    matched.sort(key=_record_timestamp)
+    return matched

--- a/src/exomem/privacy_log.py
+++ b/src/exomem/privacy_log.py
@@ -35,32 +35,70 @@ def is_reserved_hosted_vault_path(path: str) -> bool:
     return any(part in _HOSTED_RESERVED_VAULT_NAMES for part in parts)
 
 
+def _redact_for_hosted_cell(record: logging.LogRecord) -> logging.LogRecord:
+    if not content_private_logging_enabled():
+        return record
+    is_call_trace = (
+        record.name == "exomem.calls"
+        and isinstance(record.msg, str)
+        and record.msg.startswith("event=hosted_call ")
+    )
+    if is_call_trace:
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        return record
+    from .log_events import EVENT_CATALOG
+
+    event = getattr(record, "event", None)
+    if event is not None and event in EVENT_CATALOG:
+        record.content = {}
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        return record
+    record.msg = "event=hosted_log_redacted code=HOSTED_CONTENT_REDACTED"
+    record.args = ()
+    # Full blanking must also cover `extra=`-injected structured attributes:
+    # JsonLinesFormatter emits `content`/`fields` whenever truthy, so an
+    # uncataloged record carrying them would leak around the blanked message.
+    record.content = {}
+    record.fields = {}
+    record.exc_info = None
+    record.exc_text = None
+    record.stack_info = None
+    return record
+
+
 def install_hosted_log_redaction() -> None:
-    """Install one process-wide, dynamically gated content log boundary."""
+    """Install one process-wide, dynamically gated content log boundary.
+
+    A record produced by `log_events.log_event()` for a cataloged event is
+    "structured": its `content` is the only content-bearing part, so a hosted
+    cell drops only `content` and keeps the content-free `event`/`fields`
+    skeleton. Any other record — the large existing body of plain `log.info()`
+    calls, and the `exomem.calls` hosted-call trace line — is "unstructured"
+    and keeps today's full-blanking, fail-closed behavior (the trace line is
+    the one pre-vetted exception, kept verbatim). `exc_info` is always
+    stripped in a hosted cell regardless of classification.
+
+    This hooks `Logger.makeRecord` rather than `logging.setLogRecordFactory`:
+    `extra=` attributes (`event`/`fields`/`content`) are applied by
+    `makeRecord` to the record the factory already returned, so a factory
+    hook runs too early to see them. Wrapping `makeRecord` runs after `extra`
+    is applied but still before any handler (including a test's `caplog`)
+    observes the record, so every observer sees the same redacted record.
+    """
 
     global _INSTALLED
     with _INSTALL_LOCK:
         if _INSTALLED:
             return
-        previous = logging.getLogRecordFactory()
+        original_make_record = logging.Logger.makeRecord
 
-        def factory(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
-            record = previous(*args, **kwargs)
-            if not content_private_logging_enabled():
-                return record
-            is_call_trace = (
-                record.name == "exomem.calls"
-                and isinstance(record.msg, str)
-                and record.msg.startswith("event=hosted_call ")
-            )
-            if is_call_trace:
-                return record
-            record.msg = "event=hosted_log_redacted code=HOSTED_CONTENT_REDACTED"
-            record.args = ()
-            record.exc_info = None
-            record.exc_text = None
-            record.stack_info = None
-            return record
+        def make_record(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+            record = original_make_record(self, *args, **kwargs)
+            return _redact_for_hosted_cell(record)
 
-        logging.setLogRecordFactory(factory)
+        logging.Logger.makeRecord = make_record
         _INSTALLED = True

--- a/src/exomem/query_log.py
+++ b/src/exomem/query_log.py
@@ -16,6 +16,12 @@ the bloat trap.
 Everything here is best-effort: any failure is swallowed so logging can NEVER
 break a tool call. No-op when `EXOMEM_DISABLE_EMBEDDINGS` (so the test suite stays
 clean) or `EXOMEM_DISABLE_QUERY_LOG` (an explicit ops opt-out) is set.
+
+Additive correlation fields (`request_id`, `ts_utc`, `outcome`, `error_code`,
+`duration_ms`) ride alongside the original fields on every record — `ts`
+keeps its exact original local-naive semantics for `usage.py` untouched.
+Each file rotates at `EXOMEM_JSONL_MAX_MB` (default 64MB), keeping exactly one
+`.jsonl.1` prior generation; `usage.read_jsonl` reads that generation too.
 """
 
 from __future__ import annotations
@@ -36,6 +42,15 @@ _LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
 QUERIES_PATH = _LOG_DIR / "queries.jsonl"
 WRITES_PATH = _LOG_DIR / "writes.jsonl"
 READS_PATH = _LOG_DIR / "reads.jsonl"
+
+_DEFAULT_JSONL_MAX_MB = 64.0
+# In-memory running size estimate per path, updated cheaply on every append;
+# a real stat() only happens every `_STAT_RESYNC_EVERY` appends (to seed the
+# estimate and correct drift), so the hot append path pays a syscall roughly
+# once per 100 calls instead of once per call.
+_STAT_RESYNC_EVERY = 100
+_size_cache: dict[str, int] = {}
+_append_counts: dict[str, int] = {}
 
 
 def current_log_dir() -> Path:
@@ -62,17 +77,70 @@ def _disabled() -> bool:
     )
 
 
+def _jsonl_max_bytes() -> int:
+    raw = os.environ.get("EXOMEM_JSONL_MAX_MB", "").strip()
+    try:
+        mb = float(raw) if raw else _DEFAULT_JSONL_MAX_MB
+    except ValueError:
+        mb = _DEFAULT_JSONL_MAX_MB
+    return max(1, int(mb * 1024 * 1024))
+
+
+def _rotate_if_needed(path: Path) -> None:
+    """Rotate `path` -> one `.jsonl.1` generation when it exceeds the size
+    cap, using the cheap running size estimate described in the module
+    docstring."""
+    key = str(path)
+    count = _append_counts.get(key, 0) + 1
+    _append_counts[key] = count
+    if key not in _size_cache or count % _STAT_RESYNC_EVERY == 0:
+        try:
+            _size_cache[key] = path.stat().st_size
+        except OSError:
+            _size_cache[key] = 0
+    if _size_cache[key] < _jsonl_max_bytes():
+        return
+    try:
+        rotated = path.with_name(path.name + ".1")
+        os.replace(path, rotated)
+    except OSError:
+        pass
+    _size_cache[key] = 0
+
+
 def _append(path: Path, obj: dict) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_if_needed(path)
+        line = json.dumps(obj, ensure_ascii=False) + "\n"
         with path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+            f.write(line)
+        key = str(path)
+        _size_cache[key] = _size_cache.get(key, 0) + len(line.encode("utf-8"))
     except Exception as e:  # noqa: BLE001 — logging must never raise
         log.debug("query_log append to %s failed: %s", path.name, e)
 
 
 def _now_iso() -> str:
     return dt.datetime.now().isoformat(timespec="seconds")
+
+
+def _correlation_fields(
+    *, outcome: str, error_code: str | None, duration_ms: float | None
+) -> dict[str, Any]:
+    """Additive fields only — never touch the original `ts` field's shape."""
+    from .command_surface import peek_request_id
+
+    fields: dict[str, Any] = {
+        "request_id": peek_request_id(),
+        "ts_utc": dt.datetime.now(dt.UTC).isoformat(timespec="milliseconds"),
+        "outcome": outcome,
+    }
+    if error_code is not None:
+        fields["error_code"] = error_code
+    if duration_ms is not None:
+        fields["duration_ms"] = duration_ms
+    return fields
 
 
 def log_find_call(
@@ -90,6 +158,9 @@ def log_find_call(
     hits: list[Any],
     timing_summary: dict | None = None,
     prefer_used: bool = False,
+    outcome: str = "success",
+    error_code: str | None = None,
+    duration_ms: float | None = None,
 ) -> None:
     """Append one structured record for a find() call. Best-effort.
 
@@ -123,6 +194,7 @@ def log_find_call(
             "graph": graph,
             "n_results": len(hits),
             "top_k": top_k,
+            **_correlation_fields(outcome=outcome, error_code=error_code, duration_ms=duration_ms),
         }
         if timing_summary:
             record["timings"] = timing_summary
@@ -132,7 +204,13 @@ def log_find_call(
 
 
 def log_write_call(
-    *, tool: str, written_path: str | None, cited_sources: list[str] | None
+    *,
+    tool: str,
+    written_path: str | None,
+    cited_sources: list[str] | None,
+    outcome: str = "success",
+    error_code: str | None = None,
+    duration_ms: float | None = None,
 ) -> None:
     """Append one structured record for a note/add/replace write. Best-effort."""
     if _disabled():
@@ -145,6 +223,9 @@ def log_write_call(
                 "tool": tool,
                 "written_path": written_path,
                 "cited_sources": list(cited_sources or []),
+                **_correlation_fields(
+                    outcome=outcome, error_code=error_code, duration_ms=duration_ms
+                ),
             },
         )
     except Exception as e:  # noqa: BLE001
@@ -156,6 +237,9 @@ def log_get_call(
     read_path: str,
     frontmatter_only: bool = False,
     include_history: bool = False,
+    outcome: str = "success",
+    error_code: str | None = None,
+    duration_ms: float | None = None,
 ) -> None:
     """Append one structured record for a get() read. Best-effort.
 
@@ -174,6 +258,9 @@ def log_get_call(
                 "read_path": read_path,
                 "frontmatter_only": frontmatter_only,
                 "include_history": include_history,
+                **_correlation_fields(
+                    outcome=outcome, error_code=error_code, duration_ms=duration_ms
+                ),
             },
         )
     except Exception as e:  # noqa: BLE001

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -36,12 +37,20 @@ def package_release() -> str:
         return "0+unknown"
 
 
+_DEFAULT_OBSERVABILITY: dict[str, Any] = {
+    "log_dir_writable": None,
+    "metrics_snapshot_age_seconds": None,
+    "journal_ok": None,
+}
+
+
 def build_runtime_readiness(
     *,
     coordination: Mapping[str, Any],
     release: str,
     mcp_tool_surface_sha256: str | None,
     session_store: Mapping[str, Any] | None = None,
+    observability: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the public readiness payload from already-measured coordination state."""
     enabled = bool(coordination.get("enabled"))
@@ -93,8 +102,58 @@ def build_runtime_readiness(
             "state": session_store_state,
             "stale_served_count": stale_served_count,
         },
+        "observability": dict(observability) if observability is not None else dict(_DEFAULT_OBSERVABILITY),
         "takeover_eligible": takeover_eligible,
         "reasons": reasons,
+    }
+
+
+def _measure_observability() -> dict[str, Any]:
+    """Measure log-dir writability, metrics-snapshot freshness, and journal
+    health, without ever raising into readiness."""
+    log_dir_writable: bool | None = None
+    metrics_snapshot_age_seconds: float | None = None
+    journal_ok: bool | None = None
+    try:
+        from .logging_config import resolve_log_dir
+
+        log_dir = resolve_log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        probe = log_dir / f".exomem-writable-probe-{os.getpid()}"
+        probe.write_text("", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        log_dir_writable = True
+    except Exception:  # noqa: BLE001 - readiness must stay structured
+        log_dir_writable = False
+    try:
+        from . import metrics
+        from .writer_lease import get_manager
+
+        snapshot_path = metrics.snapshot_path(get_manager().config.state_dir)
+        if snapshot_path.exists():
+            metrics_snapshot_age_seconds = round(
+                time.time() - snapshot_path.stat().st_mtime, 3
+            )
+    except Exception:  # noqa: BLE001 - readiness must stay structured
+        metrics_snapshot_age_seconds = None
+    try:
+        from .mutation_journal import journal_path
+
+        path = journal_path()
+        if not path.exists():
+            journal_ok = True
+        else:
+            last_line = path.read_text(encoding="utf-8").splitlines()[-1:] or [""]
+            import json as _json
+
+            _json.loads(last_line[0]) if last_line[0].strip() else None
+            journal_ok = True
+    except Exception:  # noqa: BLE001 - readiness must stay structured
+        journal_ok = False
+    return {
+        "log_dir_writable": log_dir_writable,
+        "metrics_snapshot_age_seconds": metrics_snapshot_age_seconds,
+        "journal_ok": journal_ok,
     }
 
 
@@ -119,4 +178,5 @@ def runtime_readiness(*, mcp_tool_surface_sha256: str | None) -> dict[str, Any]:
         release=package_release(),
         mcp_tool_surface_sha256=mcp_tool_surface_sha256,
         session_store=session_store_readiness(),
+        observability=_measure_observability(),
     )

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -21,6 +21,7 @@ from starlette.middleware import Middleware as ASGIMiddleware
 
 from . import capabilities, edit_operations, guards, multi_edit
 from . import commands as commands_module
+from .access_log import AccessLogMiddleware
 from .edge_ingress import EdgeIngressMiddleware
 from .server_assets import (
     register_asset_routes,
@@ -81,13 +82,13 @@ class CallTraceMiddleware(Middleware):
         self.hosted = hosted
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
-        from .command_surface import mcp_request_context, mcp_request_id
+        from .command_surface import mcp_request_context, mcp_request_id, pop_tool_failure
 
         tool_name = _extract_tool_name(context.message)
         if tool_name == "edit_memory":
             context = _translated_edit_context(context)
         request_id = mcp_request_id()
-        with mcp_request_context(request_id):
+        with mcp_request_context(request_id) as call_token:
             guarded_fields = _GUARDED_WRITE_FIELDS.get(tool_name)
             if guarded_fields:
                 args = _extract_tool_args(context.message)
@@ -130,12 +131,27 @@ class CallTraceMiddleware(Middleware):
             try:
                 result = await call_next(context)
                 dur = round((time.perf_counter() - t0) * 1000, 2)
-                _call_log.info(
-                    f"event={event_prefix}tool_success tool={tool_name} "
-                    f"request_id={request_id} duration_ms={dur}{extras}"
-                )
+                # A ContextVar set inside the synchronous tool wrapper (which
+                # runs in FastMCP's anyio threadpool) does not propagate back
+                # here, so the wrapper leaves this bounded, locked breadcrumb
+                # instead, keyed by this call's unique token. Pop
+                # unconditionally: a call the wrapper never failed simply pops
+                # `None`.
+                failure = pop_tool_failure(call_token)
+                if failure is not None:
+                    _call_log.info(
+                        f"event={event_prefix}tool_failure tool={tool_name} "
+                        f"request_id={request_id} duration_ms={dur} "
+                        f"code={failure.get('code')}{extras}"
+                    )
+                else:
+                    _call_log.info(
+                        f"event={event_prefix}tool_success tool={tool_name} "
+                        f"request_id={request_id} duration_ms={dur}{extras}"
+                    )
                 return result
             except Exception as exc:
+                pop_tool_failure(call_token)
                 dur = round((time.perf_counter() - t0) * 1000, 2)
                 _call_log.error(
                     f"event={event_prefix}tool_error tool={tool_name} "
@@ -487,7 +503,9 @@ def run(
     """CLI entry: configure logging, build the server, run it."""
     from .logging_config import configure_logging, resolve_log_dir
 
-    configure_logging(log_dir if log_dir is not None else resolve_log_dir())
+    configure_logging(
+        log_dir if log_dir is not None else resolve_log_dir(), process="server"
+    )
 
     require_auth = transport != "stdio"
     mcp = build_server(require_auth=require_auth)
@@ -507,6 +525,7 @@ def run(
             # see the request (design.md Decision 1).
             middleware=[
                 ASGIMiddleware(EdgeIngressMiddleware),
+                ASGIMiddleware(AccessLogMiddleware),
                 ASGIMiddleware(PrimeMcpSSEMiddleware),
             ],
             # Remote clients may be routed to another replica or outlive this

--- a/src/exomem/server_assets.py
+++ b/src/exomem/server_assets.py
@@ -129,6 +129,24 @@ def register_asset_routes(mcp_app: FastMCP) -> None:
             headers={"Cache-Control": "no-store"},
         )
 
+    @mcp_app.custom_route("/metrics.json", methods=["GET"])
+    async def _metrics_json(request: Request) -> JSONResponse:  # noqa: ARG001
+        """Unauthenticated content-free counters/histograms snapshot, beside
+        `/health/ready`. Disabled via `EXOMEM_DISABLE_METRICS`."""
+        from . import metrics
+
+        if metrics.metrics_disabled():
+            return JSONResponse(
+                {"error": "METRICS_DISABLED"},
+                status_code=404,
+                headers={"Cache-Control": "no-store"},
+            )
+        try:
+            payload = metrics.render_json()
+        except Exception:  # noqa: BLE001 - metrics must never fail the probe
+            payload = {"counters": [], "histograms": [], "bucket_bounds_ms": []}
+        return JSONResponse(payload, headers={"Cache-Control": "no-store"})
+
     @mcp_app.custom_route("/favicon.ico", methods=["GET"])
     async def _favicon_ico(request: Request):  # noqa: ARG001
         return FileResponse(

--- a/src/exomem/server_hosted.py
+++ b/src/exomem/server_hosted.py
@@ -46,6 +46,7 @@ from .hosted_runtime import (
 from .vault import VaultPathError, resolve_under_vault
 from .writer_lease import IdempotencyStore
 
+log = logging.getLogger(__name__)
 _call_log = logging.getLogger("exomem.calls")
 _MAX_COMMAND_BODY_BYTES = 1024 * 1024
 _MAX_QUIESCE_SECONDS = 30.0
@@ -239,6 +240,48 @@ def _trace(
     )
 
 
+def _bump_hosted_error_metrics(*, operation: str, code: str, started: float) -> None:
+    """Count a hosted route failure. The `event=hosted_call ...` trace line
+    logged by `_trace` already carries this error; this only adds the metric,
+    it does not add a second, differently-shaped log line."""
+    try:
+        from . import metrics
+
+        duration_ms = round((time.perf_counter() - started) * 1000, 2)
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": operation, "outcome": "failure"})
+        metrics.inc_counter("exomem_tool_failures_total", {"tool": operation, "code": code})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": operation})
+    except Exception as exc:  # noqa: BLE001 - observability must never break a hosted call
+        from .log_events import log_event
+
+        log_event(
+            log,
+            logging.DEBUG,
+            "observability_internal_error",
+            fields={"where": "_bump_hosted_error_metrics"},
+            content={"message": f"{type(exc).__name__}: {exc}"},
+        )
+
+
+def _bump_hosted_success_metrics(*, operation: str, started: float) -> None:
+    try:
+        from . import metrics
+
+        duration_ms = round((time.perf_counter() - started) * 1000, 2)
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": operation, "outcome": "success"})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": operation})
+    except Exception as exc:  # noqa: BLE001 - observability must never break a hosted call
+        from .log_events import log_event
+
+        log_event(
+            log,
+            logging.DEBUG,
+            "observability_internal_error",
+            fields={"where": "_bump_hosted_success_metrics"},
+            content={"message": f"{type(exc).__name__}: {exc}"},
+        )
+
+
 def _error_response(
     code: str,
     *,
@@ -257,6 +300,7 @@ def _error_response(
         code=code,
         started=started,
     )
+    _bump_hosted_error_metrics(operation=operation, code=code, started=started)
     error = {
         "code": code,
         "message": _message_for(code),
@@ -325,6 +369,7 @@ def _success_response(
         code="OK",
         started=started,
     )
+    _bump_hosted_success_metrics(operation=operation, started=started)
     return HostedJSONResponse(cli_ops.envelope(True, data=data), status_code=status)
 
 
@@ -772,6 +817,7 @@ def register_hosted_routes(
             code="OK",
             started=started,
         )
+        _bump_hosted_success_metrics(operation="contract", started=started)
         return Response(
             gateway.canonical_contract_json(contract),
             media_type="application/json",
@@ -809,6 +855,7 @@ def register_hosted_routes(
             code="OK",
             started=started,
         )
+        _bump_hosted_success_metrics(operation="agent-contract", started=started)
         return Response(
             gateway.canonical_contract_json(agent_contract),
             media_type="application/json",

--- a/src/exomem/server_rest.py
+++ b/src/exomem/server_rest.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import secrets
+import time
 import typing
 from pathlib import Path
 from typing import Any
@@ -20,6 +22,45 @@ from . import capabilities, cf_access, cli_ops, edit_operations, upload_tokens
 from . import commands as commands_module
 from .command_surface import canonical_request_id
 from .server_transfer import TransferConfig
+
+_log = logging.getLogger(__name__)
+
+
+def _log_rest_failure(
+    *, tool: str, request_id: str, code: str, duration_ms: float, message: str, scope: str
+) -> None:
+    try:
+        from . import metrics
+        from .log_events import log_event
+
+        log_event(
+            _log,
+            logging.WARNING,
+            "rest_failure",
+            fields={
+                "tool": tool,
+                "request_id": request_id,
+                "code": code,
+                "duration_ms": duration_ms,
+                "scope": scope,
+            },
+            content={"message": message[:300]},
+        )
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": tool, "outcome": "failure"})
+        metrics.inc_counter("exomem_tool_failures_total", {"tool": tool, "code": code})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": tool})
+    except Exception:  # noqa: BLE001 - observability must never break a REST call
+        pass
+
+
+def _log_rest_success(*, tool: str, duration_ms: float) -> None:
+    try:
+        from . import metrics
+
+        metrics.inc_counter("exomem_tool_calls_total", {"tool": tool, "outcome": "success"})
+        metrics.observe_duration_ms("exomem_tool_duration_ms", duration_ms, {"tool": tool})
+    except Exception:  # noqa: BLE001 - observability must never break a REST call
+        pass
 
 
 class RestJSONResponse(JSONResponse):
@@ -255,6 +296,10 @@ def register_rest_facade(
             body = await _rest_body(request)
             if body is None:
                 return _rest_err("INVALID_BODY", "request body must be a JSON object", 400)
+            request_id = (
+                canonical_request_id(request.headers.get("x-exomem-request-id")) or "unknown"
+            )
+            t0 = time.perf_counter()
             try:
                 if _cmd.name == "edit_memory":
                     body = edit_operations.normalize_edit_surface_arguments(body)
@@ -280,10 +325,21 @@ def register_rest_facade(
                 result = await run_in_threadpool(invoke_bound)
             except (cli_ops.OpError, ValueError, TypeError) as exc:
                 err = cli_ops.error_dict(exc)
+                _log_rest_failure(
+                    tool=_cmd.name,
+                    request_id=request_id,
+                    code=str(err.get("code") or "OP_ERROR"),
+                    duration_ms=round((time.perf_counter() - t0) * 1000, 2),
+                    message=str(err.get("message") or ""),
+                    scope="cf_access" if principal_scope else "api_key",
+                )
                 return RestJSONResponse(
                     cli_ops.envelope(False, error=err),
                     status_code=cli_ops.http_status_for(err["code"]),
                 )
+            _log_rest_success(
+                tool=_cmd.name, duration_ms=round((time.perf_counter() - t0) * 1000, 2)
+            )
             return RestJSONResponse(cli_ops.envelope(True, data=result))
 
         _handler.__name__ = f"_api_{cmd.name}"

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -298,7 +298,7 @@ def _start_metrics_persistence() -> None:
         from .writer_lease import get_manager
 
         state_dir = get_manager().config.state_dir
-        metrics.load_snapshot(state_dir)
+        metrics.load_snapshot_once(state_dir)
         metrics.start_snapshotter(state_dir, metrics.snapshot_interval_seconds_from_env())
     except Exception as exc:  # noqa: BLE001 - metrics startup must never break the server
         log.warning("metrics persistence unavailable at startup: %s", exc)

--- a/src/exomem/server_runtime.py
+++ b/src/exomem/server_runtime.py
@@ -17,7 +17,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import env_compat, hosted_runtime, media_processing, privacy_log, project_keys, schema
+from . import (
+    env_compat,
+    hosted_runtime,
+    media_processing,
+    metrics,
+    privacy_log,
+    project_keys,
+    schema,
+)
 from .hosted_runtime import (
     HostedBindingV2,
     HostedCellConfig,
@@ -64,6 +72,7 @@ def initialize_runtime(*, load_dotenv_func: Callable[..., object]) -> ServerRunt
     log.info("vault=%s source_types=%s", vault_root, source_schema.source_types)
 
     project_keys_hint = project_keys.keys_hint(vault_root)
+    _start_metrics_persistence()
     _start_compute_runtime(vault_root)
     media_worker = _start_media_worker(vault_root)
     file_watcher = _start_file_watcher(vault_root)
@@ -114,6 +123,7 @@ def _initialize_locked_hosted_runtime(
     """Finish hosted startup while retaining exclusive target-root ownership."""
 
     config.apply_process_environment()
+    _start_metrics_persistence()
     lifecycle = HostedCellLifecycle(config)
     security_authority = _initialize_hosted_security(config)
     vault_root = config.vault_root
@@ -274,6 +284,24 @@ def probe_hosted_mutation_authority(vault_root: Path) -> tuple[bool, str]:
         )
         return False, "HOSTED_MUTATION_AUTHORITY_UNAVAILABLE"
     return True, "HOSTED_READY"
+
+
+def _start_metrics_persistence() -> None:
+    """Restore the metrics registry from its prior snapshot and start the
+    background snapshotter against the writer-lease state directory.
+
+    Best-effort: metrics persistence is not part of server readiness, so any
+    failure here (an unreadable snapshot, a lease-config error) is logged and
+    swallowed rather than blocking startup.
+    """
+    try:
+        from .writer_lease import get_manager
+
+        state_dir = get_manager().config.state_dir
+        metrics.load_snapshot(state_dir)
+        metrics.start_snapshotter(state_dir, metrics.snapshot_interval_seconds_from_env())
+    except Exception as exc:  # noqa: BLE001 - metrics startup must never break the server
+        log.warning("metrics persistence unavailable at startup: %s", exc)
 
 
 def _start_compute_runtime(vault_root: Path) -> None:

--- a/src/exomem/session_validation_cache.py
+++ b/src/exomem/session_validation_cache.py
@@ -208,7 +208,14 @@ class SessionStoreTelemetry:
     def stale_served(self) -> int:
         with self._lock:
             self._stale_served_count += 1
-            return self._stale_served_count
+            count = self._stale_served_count
+        try:
+            from . import metrics
+
+            metrics.inc_counter("exomem_stale_session_serves_total")
+        except Exception:  # noqa: BLE001 - observability must never break the caller
+            pass
+        return count
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:

--- a/src/exomem/usage.py
+++ b/src/exomem/usage.py
@@ -50,11 +50,9 @@ def canon(path: str) -> str:
     return p.lower()
 
 
-def read_jsonl(path: Path) -> list[dict]:
-    """Best-effort JSONL reader; malformed lines are skipped."""
+def _read_jsonl_file(path: Path, out: list[dict]) -> None:
     if not path.exists():
-        return []
-    out: list[dict] = []
+        return
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
@@ -63,6 +61,18 @@ def read_jsonl(path: Path) -> list[dict]:
             out.append(json.loads(line))
         except json.JSONDecodeError:
             continue
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    """Best-effort JSONL reader; malformed lines are skipped.
+
+    Also reads one rotated generation (`<path>.1`) when present — read
+    oldest-first — so a query spanning a rotation doesn't silently lose the
+    half that just rotated out of the live file.
+    """
+    out: list[dict] = []
+    _read_jsonl_file(path.with_name(path.name + ".1"), out)
+    _read_jsonl_file(path, out)
     return out
 
 

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -34,7 +34,10 @@ from .mutation_lock import (
     VaultMutationCoordinator,
     active_mutation_snapshot,
     canonical_mutation_identity,
+    last_mutation_timing,
 )
+from .mutation_lock import _release_os_lock as _release_owner_lock
+from .mutation_lock import _try_os_lock as _try_owner_lock
 from .mutation_terminal import (
     committed_terminal,
     project_terminal,
@@ -73,6 +76,16 @@ _COMMITTED_FAILURE_OUTCOME_KEYS = frozenset(
     }
 )
 _RETRY_IDEMPOTENCY_CLAIM = object()
+# A `pending` row whose owning process is dead becomes `abandoned` rather
+# than blocking every future retry forever; this is the pause before an
+# identical retry is allowed to execute fresh (not the same as the general
+# `expires_after` a caller passes, which governs `completed`/
+# `committed_failure` rows and may be None).
+_IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS = 60.0
+# A `pending` row written before this feature shipped has no `owner` to
+# probe; it is honored under the pre-existing any-pending-blocks-forever
+# rule for this long before it, too, ages into `abandoned`.
+_IDEMPOTENCY_LEGACY_OWNER_GRACE_SECONDS = 600.0
 _WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
 logger = logging.getLogger(__name__)
 _mutation_logger = logging.getLogger("exomem.calls")
@@ -293,6 +306,12 @@ class LeaseConfig:
     # uncached and the corpus-aware embedding pass runs inside the boundary —
     # not widening the wait.
     mutation_timeout_seconds: float = 5.0
+    # A non-preferred holder that has issued no mutation for this long hands
+    # writer authority back on its own, so a laptop that is powered on but
+    # not in use stops blocking the desktop indefinitely (design.md GAP A).
+    # `0` disables idle release entirely. A preferred replica is exempt —
+    # see writer_lease.py's `_maybe_idle_release` docstring for why.
+    idle_release_seconds: float = 60.0
 
     @property
     def enabled(self) -> bool:
@@ -303,16 +322,32 @@ class LeaseConfig:
         values = os.environ if env is None else env
         url = values.get("EXOMEM_WRITER_LEASE_URL", "").strip() or None
         state_raw = values.get("EXOMEM_WRITER_LEASE_STATE_DIR", "").strip()
+        ttl_seconds = _positive_float(values, "EXOMEM_WRITER_LEASE_TTL", 30.0)
+        idle_raw = values.get("EXOMEM_WRITER_LEASE_IDLE_SECONDS", "").strip()
+        if idle_raw:
+            idle_release_seconds = _non_negative_float(
+                values, "EXOMEM_WRITER_LEASE_IDLE_SECONDS", 60.0
+            )
+            if 0 < idle_release_seconds < ttl_seconds:
+                raise ValueError(
+                    "WRITER_LEASE_CONFIG: EXOMEM_WRITER_LEASE_IDLE_SECONDS must be 0 (disabled) "
+                    "or >= EXOMEM_WRITER_LEASE_TTL"
+                )
+        else:
+            # The default tracks the TTL so raising EXOMEM_WRITER_LEASE_TTL
+            # alone can never trip the idle>=ttl validation and brick startup.
+            idle_release_seconds = max(60.0, ttl_seconds)
         config = cls(
             url=url.rstrip("/") if url else None,
             vault_id=values.get("EXOMEM_WRITER_LEASE_VAULT_ID", "").strip() or None,
             replica_id=values.get("EXOMEM_WRITER_LEASE_REPLICA_ID", "").strip() or None,
             token=values.get("EXOMEM_WRITER_LEASE_TOKEN", "").strip() or None,
-            ttl_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TTL", 30.0),
+            ttl_seconds=ttl_seconds,
             timeout_seconds=_positive_float(values, "EXOMEM_WRITER_LEASE_TIMEOUT", 3.0),
             preferred_writer=_truthy(values.get("EXOMEM_WRITER_LEASE_PREFERRED", "")),
             state_dir=Path(state_raw).expanduser() if state_raw else cls.state_dir,
             mutation_timeout_seconds=_positive_float(values, "EXOMEM_MUTATION_TIMEOUT", 5.0),
+            idle_release_seconds=idle_release_seconds,
         )
         if config.enabled and (not config.vault_id or not config.replica_id):
             raise ValueError(
@@ -330,6 +365,17 @@ def _positive_float(values: Mapping[str, str], name: str, default: float) -> flo
         raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be a number") from None
     if value <= 0:
         raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be positive")
+    return value
+
+
+def _non_negative_float(values: Mapping[str, str], name: str, default: float) -> float:
+    raw = values.get(name, "").strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be a number") from None
+    if value < 0:
+        raise ValueError(f"WRITER_LEASE_CONFIG: {name} must be non-negative")
     return value
 
 
@@ -390,10 +436,19 @@ class LeaseCoordinatorClient:
         )
 
     def release(self, fencing_token: int) -> LeaseRecord:
+        return self.release_holder(self.config.replica_id, fencing_token)
+
+    def release_holder(self, holder_replica_id: str, fencing_token: int) -> LeaseRecord:
+        """Release on behalf of ANY holder, not just this client's own
+        configured `replica_id` — the ops-only `exomem lease release`
+        cross-device path (R6). No coordinator change needed: the server
+        already keys `/release` on the body's `replica_id` + `fencing_token`
+        rather than the caller's own identity (the bearer token is a single
+        shared HA-cell secret, not a per-replica credential)."""
         return self._request(
             "POST",
             "release",
-            {"replica_id": self.config.replica_id, "fencing_token": fencing_token},
+            {"replica_id": holder_replica_id, "fencing_token": fencing_token},
         )
 
     def status(self) -> LeaseRecord:
@@ -433,6 +488,82 @@ class LeaseCoordinatorClient:
             ) from None
 
 
+def _mutation_outcome_unknown_error() -> OpError:
+    return OpError(
+        "MUTATION_OUTCOME_UNKNOWN",
+        "the executing process terminated before recording this mutation's outcome",
+        "Verify whether the mutation landed before retrying; an identical retry executes "
+        "fresh once the abandonment grace period has passed.",
+        details={"status": "uncertain", "committed": None, "abandoned": True},
+    )
+
+
+def _generate_owner_id() -> str:
+    """`pid:nonce` — immune to PID reuse because the nonce is random per
+    process, never reused across a reboot the way a bare PID can be."""
+    return f"{os.getpid()}:{uuid.uuid4().hex[:16]}"
+
+
+def _owner_lock_path(state_dir: Path, owner: str) -> Path:
+    return Path(state_dir) / "idempotency-owners" / f"{owner.replace(':', '-')}.lock"
+
+
+def _acquire_own_owner_lock(state_dir: Path, owner: str) -> Any | None:
+    """Open and lock this process's own owner file, held for the store's
+    lifetime (closed only at process exit). A leftover locked-then-abandoned
+    file is harmless: `_probe_owner_liveness` either finds it still locked
+    (this process, still alive) or, once genuinely gone, lockable — and
+    cleans it up itself."""
+    path = _owner_lock_path(state_dir, owner)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = path.open("a+b")
+    except OSError:
+        return None
+    try:
+        if _try_owner_lock(handle):
+            return handle
+    except OSError:
+        pass
+    handle.close()
+    return None
+
+
+def _probe_owner_liveness(state_dir: Path, owner: str) -> bool:
+    """Fail-closed liveness probe for `owner` (a `pid:nonce` string).
+
+    Missing file -> dead (the owner released and cleaned up, or never
+    existed). Lockable -> dead, and this probe cleans the file up. Refused
+    (someone holds it) -> alive. ANY probe error -> alive: an inconclusive
+    probe must never cause a live mutation to be declared abandoned.
+    """
+    path = _owner_lock_path(state_dir, owner)
+    try:
+        if not path.exists():
+            return False
+        handle = path.open("a+b")
+    except OSError:
+        return True
+    try:
+        lockable = _try_owner_lock(handle)
+    except OSError:
+        handle.close()
+        return True
+    if not lockable:
+        handle.close()
+        return True
+    try:
+        _release_owner_lock(handle)
+    except OSError:
+        pass
+    handle.close()
+    try:
+        path.unlink()
+    except OSError:
+        pass
+    return False
+
+
 class IdempotencyStore:
     """Durable per-replica retry cache, deliberately outside the synced vault."""
 
@@ -451,6 +582,7 @@ class IdempotencyStore:
         if poll_interval_seconds <= 0:
             raise ValueError("idempotency poll interval must be positive")
         self.path = path
+        self.state_dir = path.parent
         self.clock = clock
         self.monotonic = monotonic
         self.wait_seconds = wait_seconds
@@ -458,12 +590,32 @@ class IdempotencyStore:
         self.after_terminal_persisted = after_terminal_persisted
         self._condition = threading.Condition()
         path.parent.mkdir(parents=True, exist_ok=True)
+        self.owner_id = _generate_owner_id()
+        # Held for this store's lifetime (process lifetime, in practice —
+        # stores are cached singletons keyed by vault+replica); never
+        # explicitly released. See `_probe_owner_liveness`.
+        self._owner_lock_handle = _acquire_own_owner_lock(self.state_dir, self.owner_id)
+        if self._owner_lock_handle is None:
+            # Fail closed on the REGISTRATION side too: advertising an owner id
+            # whose lock file could not be created/held would let any peer
+            # probe it as dead and abandon a LIVE mutation. A NULL owner rides
+            # the legacy grace path instead (abandoned only after
+            # _IMPLICIT_RETRY_TTL_SECONDS), which cannot abandon a running
+            # write inside its window.
+            logger.warning(
+                "idempotency owner lock unavailable; falling back to the "
+                "legacy ownerless grace period for this store"
+            )
+            self.owner_id = None
         with self._connect() as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS mutations ("
                 "key TEXT PRIMARY KEY, digest TEXT NOT NULL, state TEXT NOT NULL, "
                 "result BLOB, updated_at REAL NOT NULL)"
             )
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(mutations)").fetchall()}
+            if "owner" not in columns:
+                conn.execute("ALTER TABLE mutations ADD COLUMN owner TEXT")
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path, timeout=10)
@@ -494,6 +646,8 @@ class IdempotencyStore:
                 if waited is _RETRY_IDEMPOTENCY_CLAIM:
                     continue
                 return waited
+            if disposition == "abandoned":
+                raise _mutation_outcome_unknown_error()
             return self._replay(disposition, stored, on_replay)
 
         guard = operation_guard() if operation_guard is not None else nullcontext()
@@ -569,19 +723,59 @@ class IdempotencyStore:
             conn.execute("BEGIN IMMEDIATE")
             self._prune_expired(conn, now, expires_after, key)
             row = conn.execute(
-                "SELECT digest, state, result, updated_at FROM mutations WHERE key = ?", (key,)
+                "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
+                (key,),
             ).fetchone()
             if row and self._expired_row(row, now, expires_after):
                 conn.execute("DELETE FROM mutations WHERE key = ?", (key,))
                 row = None
             if row is not None:
+                row = self._abandon_if_dead(conn, key, row, now)
                 return self._decode_disposition(row, digest)
             conn.execute(
-                "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
-                (key, digest, now),
+                "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+                "VALUES (?, ?, 'pending', ?, ?)",
+                (key, digest, now, self.owner_id),
             )
         _log_mutation_event("reserved", receipt=_receipt_tag(key))
         return "owner", None
+
+    def _abandon_if_dead(
+        self, conn: sqlite3.Connection, key: str, row: tuple[Any, ...], now: float
+    ) -> tuple[Any, ...]:
+        """If `row` is `pending` and its owner is provably dead, transition it
+        to `abandoned` in the same transaction and return the updated row.
+        Fail-closed: an inconclusive liveness probe leaves the row `pending`.
+        """
+        if row[1] != "pending":
+            return row
+        owner = row[4]
+        if owner is None:
+            dead = (now - row[3]) >= _IDEMPOTENCY_LEGACY_OWNER_GRACE_SECONDS
+        elif owner == self.owner_id:
+            dead = False
+        else:
+            dead = not _probe_owner_liveness(self.state_dir, owner)
+        if not dead:
+            return row
+        cursor = conn.execute(
+            "UPDATE mutations SET state = 'abandoned', updated_at = ? "
+            "WHERE key = ? AND state = 'pending'",
+            (now, key),
+        )
+        if cursor.rowcount != 1:
+            # Raced with another abandon/terminal transition; re-read rather
+            # than assume which one won.
+            refreshed = conn.execute(
+                "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
+                (key,),
+            ).fetchone()
+            return refreshed if refreshed is not None else row
+        _log_mutation_event(
+            "abandoned", level=logging.WARNING, receipt=_receipt_tag(key)
+        )
+        self._notify_waiters()
+        return (row[0], "abandoned", None, now, owner)
 
     def _prune_expired(
         self,
@@ -590,33 +784,42 @@ class IdempotencyStore:
         expires_after: float | None,
         key: str,
     ) -> None:
-        if expires_after is None:
-            return
-        cutoff = now - expires_after
         key_pattern = f"{key.partition(':')[0]}:%"
+        if expires_after is not None:
+            cutoff = now - expires_after
+            conn.execute(
+                "DELETE FROM mutations WHERE key LIKE ? "
+                "AND state = 'completed' "
+                "AND typeof(updated_at) IN ('integer', 'real') "
+                "AND updated_at >= 0 AND updated_at <= ?",
+                (key_pattern, cutoff),
+            )
+            expired_failures = conn.execute(
+                "SELECT key, result FROM mutations WHERE key LIKE ? "
+                "AND state = 'committed_failure' "
+                "AND typeof(updated_at) IN ('integer', 'real') "
+                "AND updated_at >= 0 AND updated_at <= ?",
+                (key_pattern, cutoff),
+            ).fetchall()
+            for expired_key, expired_payload in expired_failures:
+                try:
+                    _deserialize_committed_failure_payload(expired_payload)
+                except Exception:  # noqa: BLE001 - corrupt markers remain fail-closed
+                    continue
+                conn.execute(
+                    "DELETE FROM mutations WHERE key = ? AND state = 'committed_failure'",
+                    (expired_key,),
+                )
+        # Abandoned rows always expire after their own fixed grace period,
+        # regardless of the caller's `expires_after` (which may be None).
+        abandoned_cutoff = now - _IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS
         conn.execute(
             "DELETE FROM mutations WHERE key LIKE ? "
-            "AND state = 'completed' "
+            "AND state = 'abandoned' "
             "AND typeof(updated_at) IN ('integer', 'real') "
             "AND updated_at >= 0 AND updated_at <= ?",
-            (key_pattern, cutoff),
+            (key_pattern, abandoned_cutoff),
         )
-        expired_failures = conn.execute(
-            "SELECT key, result FROM mutations WHERE key LIKE ? "
-            "AND state = 'committed_failure' "
-            "AND typeof(updated_at) IN ('integer', 'real') "
-            "AND updated_at >= 0 AND updated_at <= ?",
-            (key_pattern, cutoff),
-        ).fetchall()
-        for expired_key, expired_payload in expired_failures:
-            try:
-                _deserialize_committed_failure_payload(expired_payload)
-            except Exception:  # noqa: BLE001 - corrupt markers remain fail-closed
-                continue
-            conn.execute(
-                "DELETE FROM mutations WHERE key = ? AND state = 'committed_failure'",
-                (expired_key,),
-            )
 
     def _expired_row(self, row: tuple[Any, ...], now: float, expires_after: float | None) -> bool:
         if expires_after is None or row[1] not in {"completed", "committed_failure"}:
@@ -652,6 +855,8 @@ class IdempotencyStore:
             return "committed_uncertain", _PostCommitOutcomeUncertain()
         if state == "pending":
             return "pending", None
+        if state == "abandoned":
+            return "abandoned", None
         raise self._reconciliation_error("cached mutation state")
 
     def _wait_for_terminal(
@@ -664,14 +869,20 @@ class IdempotencyStore:
         _log_mutation_event("pending", receipt=_receipt_tag(key))
         deadline = self.monotonic() + self.wait_seconds
         while True:
+            now = self.clock()
             with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
-                    "SELECT digest, state, result, updated_at FROM mutations WHERE key = ?",
+                    "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
                     (key,),
                 ).fetchone()
+                if row is not None:
+                    row = self._abandon_if_dead(conn, key, row, now)
             if row is None:
                 return _RETRY_IDEMPOTENCY_CLAIM
             disposition, stored = self._decode_disposition(row, digest)
+            if disposition == "abandoned":
+                raise _mutation_outcome_unknown_error()
             if disposition != "pending":
                 return self._replay(disposition, stored, on_replay)
             remaining = deadline - self.monotonic()
@@ -750,6 +961,35 @@ class IdempotencyStore:
         if self.after_terminal_persisted is not None:
             self.after_terminal_persisted()
 
+    def status_summary(self) -> dict[str, Any]:
+        """Content-free counts for `coordination_status`/`doctor`: never a
+        key, digest, or result — just how many rows are pending/abandoned
+        and how stale the oldest pending row is."""
+        try:
+            now = self.clock()
+            with self._connect() as conn:
+                pending_updated_at = [
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT updated_at FROM mutations WHERE state = 'pending'"
+                    ).fetchall()
+                ]
+                abandoned = conn.execute(
+                    "SELECT COUNT(*) FROM mutations WHERE state = 'abandoned'"
+                ).fetchone()[0]
+            oldest_pending_age_seconds = (
+                round(max(0.0, now - min(pending_updated_at)), 3)
+                if pending_updated_at
+                else None
+            )
+            return {
+                "pending": len(pending_updated_at),
+                "abandoned": int(abandoned),
+                "oldest_pending_age_seconds": oldest_pending_age_seconds,
+            }
+        except Exception:  # noqa: BLE001 - status must never break the caller
+            return {"pending": None, "abandoned": None, "oldest_pending_age_seconds": None}
+
     @staticmethod
     def _reconciliation_error(subject: str) -> OpError:
         return OpError(
@@ -781,28 +1021,6 @@ def _command_digest(command: Any, kwargs: Mapping[str, Any]) -> str:
 
 
 _PUBLIC_IDEMPOTENCY_KEY_UNSET = object()
-
-
-def _read_bypasses_consistency_guard(command: Any, kwargs: Mapping[str, Any]) -> bool:
-    """Return whether a read can tolerate a changing snapshot without contention."""
-    if command.name == "audit":
-        return True
-    if command.name == "review_memory":
-        return kwargs.get("mode") == "audit"
-    if command.name == "maintain_memory":
-        return kwargs.get("mode", "audit") == "audit"
-    if command.name in {"remember", "replace_memory"}:
-        return kwargs.get("validate_only") is True
-    if command.name == "edit_memory":
-        if kwargs.get("validate_only") is True:
-            return True
-        operation = kwargs.get("operation")
-        return (
-            isinstance(operation, Mapping)
-            and operation.get("kind") in {"replace_string", "batch_replace", "patch_frontmatter"}
-            and operation.get("validate_only") is True
-        )
-    return False
 
 
 def _effective_idempotency_key(
@@ -839,6 +1057,12 @@ def _effective_idempotency_key(
                 command=command.name,
                 receipt=_receipt_tag(key),
             )
+            try:
+                from . import metrics
+
+                metrics.inc_counter("exomem_idempotency_replays_total", {})
+            except Exception:  # noqa: BLE001 - observability must never break a replay
+                pass
 
         return key, _IMPLICIT_RETRY_TTL_SECONDS, log_replay
     return None, None, None
@@ -882,21 +1106,74 @@ class LeaseManager:
             else mutation_timeout_seconds
         )
         self._mutation_poll_interval_seconds = mutation_poll_interval_seconds
+        self._last_renew_monotonic: float | None = None
+        # (code, monotonic-timestamp) for the most recent coordinator RPC
+        # failure, so `status()` can surface a fault instead of only ever
+        # flipping `coordinator_healthy` to False with no further detail.
+        self._last_coordinator_error: tuple[str, float] | None = None
+        # Idle-release accounting (R5), both guarded by `self._lock`.
+        # `_active_mutations` is incremented/decremented ONLY by
+        # `writer_authority_guard()` — the single choke point that also sets
+        # `_ACTIVE_WRITE_FENCE` — so `count == 0` provably means no
+        # outstanding fence anywhere in this process.
+        self._active_mutations = 0
+        self._last_activity_monotonic = time.monotonic()
 
-    def ensure_writer(self) -> LeaseRecord:
+    def _record_coordinator_error(self, code: str) -> None:
+        self._last_coordinator_error = (code, time.monotonic())
+        try:
+            from . import metrics
+
+            metrics.inc_counter("exomem_coordinator_errors_total", {"code": code})
+        except Exception:  # noqa: BLE001 - observability must never break the caller
+            pass
+
+    def _record_lease_op(self, op: str, outcome: str) -> None:
+        try:
+            from . import metrics
+
+            metrics.inc_counter("exomem_lease_ops_total", {"op": op, "outcome": outcome})
+        except Exception:  # noqa: BLE001 - observability must never break the caller
+            pass
+
+    def _log_lease_event(self, event: str, **fields: Any) -> None:
+        try:
+            from .log_events import log_event
+
+            log_event(logger, logging.INFO, event, fields=fields)
+        except Exception:  # noqa: BLE001 - observability must never break the caller
+            pass
+
+    def ensure_writer(self, *, cause: str = "mutation") -> LeaseRecord:
         if not self.config.enabled:
             return LeaseRecord(self.config.replica_id, None, 0, True)
         assert self.client is not None
         with self._lock:
-            record = self.client.acquire()
+            try:
+                record = self.client.acquire()
+            except OpError as error:
+                self._record_coordinator_error(error.code)
+                self._record_lease_op("acquire", "error")
+                raise
             if not record.granted or record.holder != self.config.replica_id:
+                self._record_lease_op("acquire", "refused")
                 raise OpError(
                     "WRITER_LEASE_REQUIRED",
                     f"replica is read-only; current writer is {record.holder or 'unassigned'}",
                     "Send the mutation to the current writer or retry after its lease expires.",
                 )
+            self._record_lease_op("acquire", "granted")
             self._fencing_token = record.fencing_token
             self._expires_at = record.expires_at
+            if cause == "mutation":
+                # Only a mutation-driven grant counts as write activity for the
+                # idle-release timer (it closes the window between this grant
+                # and the writer_authority_guard count increment). Probe and
+                # startup grants must NOT refresh the timer, or a polling
+                # caller — e.g. the media worker's 5s availability probe —
+                # would suppress idle release forever without writing a byte.
+                self._last_activity_monotonic = time.monotonic()
+            self._log_lease_event("lease_acquired", cause=cause)
             return record
 
     @contextmanager
@@ -943,16 +1220,31 @@ class LeaseManager:
 
     @contextmanager
     def writer_authority_guard(self) -> Iterator[None]:
-        """Revalidate writer authority without holding the vault mutation lock."""
+        """Revalidate writer authority without holding the vault mutation lock.
+
+        The single choke point for idle-release accounting (R5): this is the
+        only place `_ACTIVE_WRITE_FENCE` is set, so it is also the only place
+        that may safely count `_active_mutations` — `count == 0` therefore
+        provably means no outstanding fence anywhere in this process.
+        """
         fence_context: Token[tuple[Any, int] | None] | None = None
+        counted = False
         if self.config.enabled:
             lease = self.ensure_writer()
             fence_context = _ACTIVE_WRITE_FENCE.set((self, lease.fencing_token))
+            with self._lock:
+                self._active_mutations += 1
+                self._last_activity_monotonic = time.monotonic()
+            counted = True
         try:
             yield
         finally:
             if fence_context is not None:
                 _ACTIVE_WRITE_FENCE.reset(fence_context)
+            if counted:
+                with self._lock:
+                    self._active_mutations -= 1
+                    self._last_activity_monotonic = time.monotonic()
 
     def invoke(
         self,
@@ -967,6 +1259,7 @@ class LeaseManager:
         implicit_idempotency_scope: str | None = None,
         mutation_request_id: str | None = None,
     ) -> Any:
+        t_start = time.perf_counter()
         kwargs, response_detail = split_response_detail(kwargs)
         if public_idempotency_key is _PUBLIC_IDEMPOTENCY_KEY_UNSET:
             effective_public_idempotency_key = idempotency_key
@@ -975,10 +1268,13 @@ class LeaseManager:
             effective_public_idempotency_key = public_idempotency_key
         invocation_read_only = command.read_only if read_only is None else read_only
         if invocation_read_only:
-            audit_without_consistency_lock = _read_bypasses_consistency_guard(command, kwargs)
-            if content_private_logging_enabled() and not audit_without_consistency_lock:
-                with self.consistency_guard(self._mutation_subject(injected)):
-                    return command.leaf(*injected, **kwargs)
+            # Reads never take the mutation boundary, hosted or local: every
+            # canonical write lands via atomic staging (write-to-temp then
+            # `os.replace`), which already makes a concurrent whole-file read
+            # torn-free without any lock. This supersedes the archived
+            # decision that reserved the bypass to `mode="audit"`/
+            # `validate_only` reads while other hosted reads held the guard
+            # (openspec/changes/archive/2026-07-20-make-mcp-acknowledgement-replay-safe/design.md:64).
             return command.leaf(*injected, **kwargs)
         mutation_subject = self._mutation_subject(injected)
         digest = _command_digest(command, kwargs)
@@ -1079,7 +1375,11 @@ class LeaseManager:
         except BaseException as error:
             if isinstance(error, OpError):
                 if error.code == "MUTATION_BUSY":
-                    error.details.update(status="retryable", committed=False, retry_after_ms=750)
+                    error.details.update(status="retryable", committed=False)
+                    # `_mutation_busy()` (mutation_lock.py) already computed a
+                    # load-aware hint; only fill in the static floor when
+                    # nothing more specific was set.
+                    error.details.setdefault("retry_after_ms", 750)
                 elif error.code == "MUTATION_ACKNOWLEDGEMENT_PENDING":
                     error.details.update(status="uncertain", committed=None)
                 error.details.update(request_id=request_id, receipt_id=receipt)
@@ -1094,6 +1394,16 @@ class LeaseManager:
                 receipt=receipt or "none",
                 error=type(error).__name__,
             )
+            self._record_mutation_journal(
+                request_id=request_id,
+                command=command.name,
+                receipt=receipt,
+                outcome="failed",
+                error_code=error.code if isinstance(error, OpError) else type(error).__name__,
+                duration_ms=round((time.perf_counter() - t_start) * 1000, 2),
+                scope=implicit_idempotency_scope or idempotency_principal_scope,
+                targets=[str(mutation_subject)],
+            )
             raise
         _log_mutation_event(
             "returned",
@@ -1101,7 +1411,59 @@ class LeaseManager:
             command=command.name,
             receipt=receipt or "none",
         )
+        self._record_mutation_journal(
+            request_id=request_id,
+            command=command.name,
+            receipt=receipt,
+            outcome="committed",
+            error_code=None,
+            duration_ms=round((time.perf_counter() - t_start) * 1000, 2),
+            scope=implicit_idempotency_scope or idempotency_principal_scope,
+            targets=[str(mutation_subject)],
+        )
         return project_terminal(result, response_detail)
+
+    def _record_mutation_journal(
+        self,
+        *,
+        request_id: str,
+        command: str,
+        receipt: str | None,
+        outcome: str,
+        error_code: str | None,
+        duration_ms: float,
+        scope: str | None,
+        targets: list[str],
+    ) -> None:
+        """Best-effort mutation-journal write. Never raises."""
+        try:
+            from .mutation_journal import record_mutation
+
+            timing = last_mutation_timing()
+            lease_role = (
+                "standalone"
+                if not self.config.enabled
+                else ("writer" if self._fencing_token is not None else "follower")
+            )
+            scope_kind = scope.split(":", 1)[0] if scope else None
+            record_mutation(
+                request_id=request_id,
+                tool=command,
+                command=command,
+                receipt_id=receipt,
+                outcome=outcome,
+                error_code=error_code,
+                duration_ms=duration_ms,
+                boundary_wait_ms=timing.get("wait_ms") if timing else None,
+                boundary_hold_ms=timing.get("hold_ms") if timing else None,
+                lease_role=lease_role,
+                fencing_token=self._fencing_token,
+                replica_id=self.config.replica_id,
+                scope=scope_kind,
+                targets=targets,
+            )
+        except Exception:  # noqa: BLE001 - the journal must never break a mutation
+            pass
 
     def _mutation_subject(self, injected: tuple[Any, ...]) -> os.PathLike[str] | str:
         if injected and isinstance(injected[0], os.PathLike):
@@ -1148,7 +1510,13 @@ class LeaseManager:
             if vault_or_cell is not None
             else active_mutation_snapshot()
         )
-        base = {
+        renewer_alive = self._renewer is not None and self._renewer.is_alive()
+        last_renew_age_seconds = (
+            round(time.monotonic() - self._last_renew_monotonic, 3)
+            if self._last_renew_monotonic is not None
+            else None
+        )
+        base: dict[str, Any] = {
             "enabled": self.config.enabled,
             "role": "standalone" if not self.config.enabled else "unknown",
             "replica_id": self.config.replica_id,
@@ -1157,21 +1525,44 @@ class LeaseManager:
             "fencing_token": None,
             "coordinator_healthy": True if not self.config.enabled else False,
             "mutation_boundary": mutation_boundary,
+            "ttl_remaining_seconds": None,
+            "renewer_alive": renewer_alive,
+            "last_renew_age_seconds": last_renew_age_seconds,
+            "last_coordinator_error": None,
+            "idempotency": self.idempotency.status_summary(),
         }
         if not self.config.enabled:
             return base
         assert self.client is not None
         try:
             record = self.client.status()
-        except OpError:
+        except OpError as error:
+            # Record the fault instead of only ever reporting
+            # `coordinator_healthy: False` with no further detail.
+            self._record_coordinator_error(error.code)
+            code, at = self._last_coordinator_error
+            base["last_coordinator_error"] = {
+                "code": code,
+                "age_seconds": round(time.monotonic() - at, 3),
+            }
             return base
+        ttl_remaining_seconds = (
+            round(record.expires_at - time.time(), 3) if record.expires_at is not None else None
+        )
         base.update(
             role="writer" if record.holder == self.config.replica_id else "follower",
             holder=record.holder,
             expires_at=record.expires_at,
             fencing_token=record.fencing_token,
             coordinator_healthy=True,
+            ttl_remaining_seconds=ttl_remaining_seconds,
         )
+        if self._last_coordinator_error is not None:
+            code, at = self._last_coordinator_error
+            base["last_coordinator_error"] = {
+                "code": code,
+                "age_seconds": round(time.monotonic() - at, 3),
+            }
         return base
 
     def start_renewer(self) -> None:
@@ -1201,9 +1592,50 @@ class LeaseManager:
         if not self.config.preferred_writer:
             return
         try:
-            self.ensure_writer()
+            self.ensure_writer(cause="reclaim")
         except OpError:
             return
+        self._log_lease_event("lease_reclaimed")
+
+    def _maybe_idle_release(self, token: int) -> bool:
+        """Hand writer authority back when idle. Returns True if it released
+        (the caller should skip renewing this tick).
+
+        A preferred replica is exempt — without the exemption it would
+        acquire, sit idle, release, and reclaim on the very next renew tick
+        (via `_attempt_preferred_reclaim`), churning edge routing every
+        interval for no benefit. Idle release exists to let a non-preferred
+        holder (e.g. a laptop that is powered on but unused) hand back to the
+        preferred replica on its own.
+        """
+        idle_seconds = self.config.idle_release_seconds
+        if idle_seconds <= 0 or self.config.preferred_writer:
+            return False
+        assert self.client is not None
+        with self._lock:
+            if self._fencing_token != token:
+                return False
+            if self._active_mutations != 0:
+                return False
+            if time.monotonic() - self._last_activity_monotonic < idle_seconds:
+                return False
+            # Clear local state BEFORE (and during) the release RPC, still
+            # holding the lock: an `ensure_writer` arriving concurrently
+            # blocks on this same lock and then acquires a fresh token — it
+            # can never observe us as still the writer mid-release.
+            self._fencing_token = None
+            self._expires_at = None
+            try:
+                self.client.release(token)
+                self._record_lease_op("idle_release", "ok")
+            except OpError as error:
+                # Swallowed: the local token is already cleared, and the
+                # coordinator's own TTL expiry closes the gap within one TTL
+                # — a degraded handover, never split-brain.
+                self._record_coordinator_error(error.code)
+                self._record_lease_op("idle_release", "error")
+            self._log_lease_event("lease_idle_released")
+            return True
 
     def _renew_loop(self) -> None:
         interval = max(1.0, self.config.ttl_seconds / 3)
@@ -1215,6 +1647,8 @@ class LeaseManager:
             if token is None:
                 self._attempt_preferred_reclaim()
                 continue
+            if self._maybe_idle_release(token):
+                continue
             try:
                 record = self.client.renew(token)
                 with self._lock:
@@ -1222,11 +1656,17 @@ class LeaseManager:
                         continue
                     if record.granted and record.holder == self.config.replica_id:
                         self._expires_at = record.expires_at
+                        self._last_renew_monotonic = time.monotonic()
+                        self._record_lease_op("renew", "granted")
                     else:
                         self._fencing_token = None
                         self._expires_at = None
-            except OpError:
+                        self._record_lease_op("renew", "rejected")
+                        self._log_lease_event("lease_renew_rejected")
+            except OpError as error:
                 # Mutations still revalidate synchronously and fail closed.
+                self._record_coordinator_error(error.code)
+                self._record_lease_op("renew", "error")
                 continue
 
     def close(self) -> None:
@@ -1237,8 +1677,10 @@ class LeaseManager:
         if token is not None and self.client is not None:
             try:
                 self.client.release(token)
-            except OpError:
-                pass
+                self._record_lease_op("release", "ok")
+            except OpError as error:
+                self._record_coordinator_error(error.code)
+                self._record_lease_op("release", "error")
 
 
 def validate_active_write_fence() -> None:

--- a/tests/test_access_log_middleware.py
+++ b/tests/test_access_log_middleware.py
@@ -1,0 +1,168 @@
+"""Pure-ASGI access log: one structured `event=http_request` record per HTTP
+request, request-id correlation injected both into the request scope (so
+downstream MCP code resolves the same id) and the response headers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from exomem import access_log, metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+async def _receive() -> dict:
+    return {"type": "http.disconnect"}
+
+
+def _scope(*, method: str = "GET", path: str = "/health/ready", headers: dict[str, str] | None = None, client=("10.0.0.5", 5555)) -> dict:
+    encoded = [
+        (name.lower().encode("ascii"), value.encode("ascii")) for name, value in (headers or {}).items()
+    ]
+    return {"type": "http", "method": method, "path": path, "headers": encoded, "client": client}
+
+
+def _run(scope: dict, *, downstream_status: int = 200):
+    seen_scopes: list[dict] = []
+
+    async def inner_app(inner_scope, receive, send) -> None:  # noqa: ANN001
+        seen_scopes.append(inner_scope)
+        await send({"type": "http.response.start", "status": downstream_status, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    sent: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        sent.append(message)
+
+    middleware = access_log.AccessLogMiddleware(inner_app)
+
+    async def scenario() -> None:
+        await middleware(scope, _receive, capture)
+
+    asyncio.run(scenario())
+    return seen_scopes, sent
+
+
+def _response_headers(sent: list[dict]) -> dict[bytes, bytes]:
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    return dict(start["headers"])
+
+
+def test_mints_and_injects_request_id_when_absent(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="exomem.access")
+    scope = _scope()
+    seen_scopes, sent = _run(scope)
+
+    downstream_headers = dict(seen_scopes[0]["headers"])
+    minted = downstream_headers[b"x-exomem-request-id"].decode("latin-1")
+    assert minted  # a value was minted
+
+    response_headers = _response_headers(sent)
+    assert response_headers[b"x-exomem-request-id"].decode("latin-1") == minted
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "http_request")
+    assert record.fields["request_id"] == minted
+
+
+def test_preserves_valid_client_supplied_request_id() -> None:
+    supplied = "11111111-1111-4111-8111-111111111111"
+    scope = _scope(headers={"x-exomem-request-id": supplied})
+    seen_scopes, sent = _run(scope)
+
+    downstream_headers = dict(seen_scopes[0]["headers"])
+    assert downstream_headers[b"x-exomem-request-id"].decode("latin-1") == supplied
+    assert _response_headers(sent)[b"x-exomem-request-id"].decode("latin-1") == supplied
+
+
+def test_invalid_client_supplied_request_id_is_replaced() -> None:
+    scope = _scope(headers={"x-exomem-request-id": "attacker supplied log content"})
+    seen_scopes, sent = _run(scope)
+    downstream_headers = dict(seen_scopes[0]["headers"])
+    minted = downstream_headers[b"x-exomem-request-id"].decode("latin-1")
+    assert minted != "attacker supplied log content"
+    import uuid
+
+    uuid.UUID(minted)  # does not raise
+
+
+def test_logs_method_path_status_and_duration(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="exomem.access")
+    scope = _scope(method="POST", path="/api/remember")
+    _run(scope, downstream_status=400)
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "http_request")
+    assert record.fields["method"] == "POST"
+    # The raw path is client-controlled text, so it is content-classified:
+    # kept locally, dropped by the hosted privacy boundary.
+    assert record.content["path"] == "/api/remember"
+    assert "path" not in record.fields
+    assert record.fields["status"] == 400
+    assert isinstance(record.fields["duration_ms"], float)
+
+
+def test_session_id_and_cf_ray_included_when_present(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="exomem.access")
+    scope = _scope(headers={"mcp-session-id": "sess-abc", "cf-ray": "ray-123"})
+    _run(scope)
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "http_request")
+    assert record.fields["session_id"] == "sess-abc"
+    assert record.fields["cf_ray"] == "ray-123"
+
+
+def test_client_ip_lands_in_content_not_fields(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="exomem.access")
+    scope = _scope(client=("203.0.113.7", 12345))
+    _run(scope)
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "http_request")
+    assert "client_ip" not in record.fields
+    assert record.content["client_ip"] == "203.0.113.7"
+    # `path` is also content-classified (client-controlled text).
+    assert set(record.content) == {"client_ip", "path"}
+
+
+def test_non_http_scope_passes_through_untouched() -> None:
+    async def inner_app(scope, receive, send) -> None:  # noqa: ANN001
+        pass
+
+    middleware = access_log.AccessLogMiddleware(inner_app)
+
+    async def scenario() -> None:
+        await middleware({"type": "lifespan"}, _receive, lambda message: asyncio.sleep(0))
+
+    asyncio.run(scenario())  # must not raise
+
+
+def test_disabled_via_env_skips_logging_and_header_injection(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_ACCESS_LOG", "1")
+    caplog.set_level(logging.INFO, logger="exomem.access")
+    scope = _scope()
+    seen_scopes, _sent = _run(scope)
+
+    assert not any(getattr(r, "event", None) == "http_request" for r in caplog.records)
+    downstream_headers = dict(seen_scopes[0]["headers"])
+    assert b"x-exomem-request-id" not in downstream_headers
+
+
+def test_bumps_http_requests_total_by_status() -> None:
+    _run(_scope(), downstream_status=200)
+    _run(_scope(), downstream_status=200)
+    _run(_scope(), downstream_status=500)
+
+    snap = metrics.snapshot()
+    counters = {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+    assert counters[("exomem_http_requests_total", (("status", "200"),))] == 2
+    assert counters[("exomem_http_requests_total", (("status", "500"),))] == 1

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -45,6 +45,99 @@ def test_doctor_lean_passes_with_fixture_vault(vault: Path) -> None:
     assert checks["command.registry"].status == "pass"
 
 
+def test_doctor_includes_observability_check(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(tmp_path / "logs"))
+    report = doctor_module.doctor(vault=str(vault))
+    checks = {c.id: c for c in report.checks}
+    assert "observability" in checks
+    assert checks["observability"].status in {"pass", "warn"}
+    assert checks["observability"].details["log_dir_writable"] is True
+
+
+def test_observability_check_fails_when_log_dir_unwritable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def boom_resolve_log_dir():
+        return tmp_path / "does" / "not" / "exist" / "\x00bad"
+
+    monkeypatch.setattr(
+        "exomem.logging_config.resolve_log_dir", boom_resolve_log_dir
+    )
+    check = doctor_module._check_observability()
+    assert check.status == "fail"
+    assert check.details["log_dir_writable"] is False
+
+
+def test_observability_check_warns_on_stale_service_pile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    for i in range(51):
+        (log_dir / f"service.out.log.{i}").write_text("x", encoding="utf-8")
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(log_dir))
+    check = doctor_module._check_observability()
+    assert check.status == "warn"
+    assert check.details["service_pile_count"] == 51
+
+
+def test_observability_check_warns_on_unparseable_jsonl_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "queries.jsonl").write_text("not json\n", encoding="utf-8")
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(log_dir))
+    check = doctor_module._check_observability()
+    assert check.status == "warn"
+    assert "queries.jsonl" in check.message
+
+
+@pytest.fixture()
+def _isolated_lease_manager(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from exomem import writer_lease as writer_lease_module
+
+    writer_lease_module.reset_managers_for_tests()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "state"))
+    yield writer_lease_module.get_manager()
+    writer_lease_module.reset_managers_for_tests()
+
+
+def test_idempotency_store_check_passes_when_healthy(_isolated_lease_manager) -> None:
+    check = doctor_module._check_idempotency_store()
+    assert check.status == "pass"
+    assert check.details["abandoned"] == 0
+
+
+def test_idempotency_store_check_warns_on_abandoned_receipts(_isolated_lease_manager) -> None:
+    store = _isolated_lease_manager.idempotency
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES ('k1', 'd1', 'abandoned', ?, NULL)",
+            (0.0,),
+        )
+    check = doctor_module._check_idempotency_store()
+    assert check.status == "warn"
+    assert "abandoned" in check.message
+    assert check.details["abandoned"] == 1
+
+
+def test_idempotency_store_check_warns_on_stale_pending(_isolated_lease_manager) -> None:
+    store = _isolated_lease_manager.idempotency
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES ('k1', 'd1', 'pending', ?, NULL)",
+            (0.0,),
+        )
+    check = doctor_module._check_idempotency_store()
+    assert check.status == "warn"
+    assert "oldest pending" in check.message
+
+
 def test_lexical_check_uses_escaped_immutable_query_only_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_jsonl_rotation.py
+++ b/tests/test_jsonl_rotation.py
@@ -1,0 +1,101 @@
+"""query_log.py JSONL size-cap rotation (EXOMEM_JSONL_MAX_MB, keep one .1
+generation) and usage.read_jsonl reading both the live file and the rotated
+generation. Also: additive correlation fields never change existing shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import query_log, usage
+
+
+@pytest.fixture(autouse=True)
+def _reset_query_log_caches():
+    query_log._size_cache.clear()
+    query_log._append_counts.clear()
+    yield
+    query_log._size_cache.clear()
+    query_log._append_counts.clear()
+
+
+def _seed_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, n: int) -> Path:
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_QUERY_LOG", raising=False)
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(tmp_path))
+    for i in range(n):
+        query_log.log_write_call(tool="note", written_path=f"path-{i}", cited_sources=[])
+    return tmp_path / "writes.jsonl"
+
+
+def test_rotates_when_size_cap_is_exceeded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_JSONL_MAX_MB", "0.001")  # ~1KB cap, easy to exceed
+    path = _seed_writes(tmp_path, monkeypatch, n=200)  # forces a stat resync + rotation
+    rotated = path.with_name(path.name + ".1")
+    assert rotated.exists(), "expected at least one rotation by 200 appends over a 1KB cap"
+
+
+def test_keeps_exactly_one_rotated_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_JSONL_MAX_MB", "0.001")
+    path = _seed_writes(tmp_path, monkeypatch, n=250)
+    rotated = path.with_name(path.name + ".1")
+    double_rotated = path.with_name(path.name + ".2")
+    assert rotated.exists()
+    assert not double_rotated.exists()
+
+
+def test_no_rotation_under_the_cap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_JSONL_MAX_MB", "64")
+    path = _seed_writes(tmp_path, monkeypatch, n=5)
+    rotated = path.with_name(path.name + ".1")
+    assert path.exists()
+    assert not rotated.exists()
+
+
+def test_usage_read_jsonl_reads_live_and_rotated_generation(tmp_path: Path) -> None:
+    path = tmp_path / "writes.jsonl"
+    rotated = path.with_name(path.name + ".1")
+    rotated.write_text(json.dumps({"tool": "note", "written_path": "old"}) + "\n", encoding="utf-8")
+    path.write_text(json.dumps({"tool": "note", "written_path": "new"}) + "\n", encoding="utf-8")
+
+    records = usage.read_jsonl(path)
+    written_paths = {r["written_path"] for r in records}
+    assert written_paths == {"old", "new"}
+
+
+def test_usage_read_jsonl_without_rotated_generation_is_unaffected(tmp_path: Path) -> None:
+    path = tmp_path / "writes.jsonl"
+    path.write_text(json.dumps({"tool": "note", "written_path": "solo"}) + "\n", encoding="utf-8")
+    records = usage.read_jsonl(path)
+    assert [r["written_path"] for r in records] == ["solo"]
+
+
+def test_additive_fields_present_without_disturbing_original_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _seed_writes(tmp_path, monkeypatch, n=1)
+    record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    # Original fields, byte-for-byte field names, still present.
+    assert record["tool"] == "note"
+    assert record["written_path"] == "path-0"
+    assert record["cited_sources"] == []
+    assert "ts" in record  # local-naive, untouched semantics
+    # Additive correlation fields.
+    assert "ts_utc" in record
+    assert record["outcome"] == "success"
+    assert "request_id" in record
+
+
+def test_jsonl_max_mb_env_invalid_falls_back_to_default() -> None:
+    import os
+
+    os.environ["EXOMEM_JSONL_MAX_MB"] = "not-a-number"
+    try:
+        assert query_log._jsonl_max_bytes() == int(64 * 1024 * 1024)
+    finally:
+        del os.environ["EXOMEM_JSONL_MAX_MB"]

--- a/tests/test_lease_cli.py
+++ b/tests/test_lease_cli.py
@@ -1,0 +1,145 @@
+"""`exomem lease status|release` — ops-only CLI (R6). Not an MCP/REST product
+command. Exercises the CLI's own argument handling, --yes gate, --json
+output, and exit codes against a FakeClient (fast, deterministic); the
+coordinator's own release-on-behalf-of contract is proven separately in
+tests/test_lease_coordinator.py against the real ASGI app.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exomem import writer_lease
+from exomem.__main__ import main
+from exomem.cli_ops import OpError
+from exomem.writer_lease import LeaseRecord
+
+
+class FakeCoordinatorClient:
+    def __init__(self, config) -> None:  # noqa: ANN001
+        self.config = config
+
+    def status(self) -> LeaseRecord:
+        return _STATE["record"]
+
+    def release_holder(self, holder_replica_id: str, fencing_token: int) -> LeaseRecord:
+        _STATE["release_calls"].append((holder_replica_id, fencing_token))
+        record = _STATE["record"]
+        if record.holder == holder_replica_id and record.fencing_token == fencing_token:
+            _STATE["record"] = LeaseRecord(None, None, fencing_token, True)
+            return _STATE["record"]
+        return LeaseRecord(record.holder, record.expires_at, record.fencing_token, False)
+
+
+_STATE: dict = {}
+
+
+@pytest.fixture(autouse=True)
+def _lease_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_URL", "https://lease.example")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_VAULT_ID", "main")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_REPLICA_ID", "desktop")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(writer_lease, "LeaseCoordinatorClient", FakeCoordinatorClient)
+    _STATE["record"] = LeaseRecord("laptop", 999999999.0, 3, True)
+    _STATE["release_calls"] = []
+    yield
+
+
+def test_lease_status_prints_role_and_holder(capsys: pytest.CaptureFixture) -> None:
+    assert main(["lease", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "role: follower" in out
+    assert "holder: laptop" in out
+    assert "fencing_token: 3" in out
+
+
+def test_lease_status_json_is_the_full_manager_status_shape(capsys: pytest.CaptureFixture) -> None:
+    assert main(["lease", "status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["holder"] == "laptop"
+    assert payload["fencing_token"] == 3
+    assert "idempotency" in payload
+    assert set(payload["idempotency"]) == {"pending", "abandoned", "oldest_pending_age_seconds"}
+
+
+def test_lease_release_without_yes_is_refused_and_shows_holder(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    code = main(["lease", "release"])
+    assert code == 2
+    assert _STATE["release_calls"] == []
+    err = capsys.readouterr().err
+    assert "laptop" in err
+    assert "--yes" in err
+
+
+def test_lease_release_with_yes_releases_the_foreign_holder(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    code = main(["lease", "release", "--yes"])
+    assert code == 0
+    assert _STATE["release_calls"] == [("laptop", 3)]
+    out = capsys.readouterr().out
+    assert "released" in out
+    assert "laptop" in out
+
+
+def test_lease_release_with_yes_json_output(capsys: pytest.CaptureFixture) -> None:
+    code = main(["lease", "release", "--yes", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"released": True, "previous_holder": "laptop"}
+
+
+def test_lease_release_is_a_no_op_when_unheld(capsys: pytest.CaptureFixture) -> None:
+    _STATE["record"] = LeaseRecord(None, None, 0, False)
+    code = main(["lease", "release", "--yes"])
+    assert code == 0
+    assert _STATE["release_calls"] == []
+    out = capsys.readouterr().out
+    assert "nothing to release" in out
+
+
+def test_lease_release_json_no_op_when_unheld(capsys: pytest.CaptureFixture) -> None:
+    _STATE["record"] = LeaseRecord(None, None, 0, False)
+    code = main(["lease", "release", "--yes", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"released": False, "reason": "unheld"}
+
+
+def test_lease_status_unauthorized_coordinator_reports_clean_error(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    class UnauthorizedClient(FakeCoordinatorClient):
+        def status(self) -> LeaseRecord:
+            raise OpError("WRITER_COORDINATOR_UNAVAILABLE", "coordinator refused the request")
+
+    import exomem.writer_lease as writer_lease_module
+
+    writer_lease_module.LeaseCoordinatorClient = UnauthorizedClient
+    code = main(["lease", "release"])
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "WRITER_COORDINATOR_UNAVAILABLE" in err
+
+
+def test_lease_disabled_when_no_coordinator_url_configured(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv("EXOMEM_WRITER_LEASE_URL", raising=False)
+    code = main(["lease", "status"])
+    assert code == 1
+    assert "not configured" in capsys.readouterr().err
+
+
+def test_lease_steal_and_force_acquire_are_not_offered(capsys: pytest.CaptureFixture) -> None:
+    """R6 deliberately excludes steal/force-acquire — release plus preferred
+    reclaim already hands over within roughly one lease TTL."""
+    with pytest.raises(SystemExit) as exc:
+        main(["lease", "steal"])
+    assert exc.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err

--- a/tests/test_lease_coordinator.py
+++ b/tests/test_lease_coordinator.py
@@ -49,3 +49,53 @@ async def test_state_atomic_put_and_list_keys_require_bearer(tmp_path: Path) -> 
     assert listed.json() == {"result": ["generation"]}
     assert "ciphertext" not in listed.text
     assert "replacement" not in listed.text
+
+
+@pytest.mark.anyio
+async def test_release_endpoint_accepts_any_replica_id_in_the_body(tmp_path: Path) -> None:
+    """The lease CLI's cross-device `release_holder(holder_replica_id, ...)`
+    (R6) needs no coordinator change: `/release` already keys on the
+    request BODY's `replica_id`, not the caller's own bearer-token identity
+    — the bearer is a single shared HA-cell secret, not a per-replica
+    credential."""
+    app = create_app(database=tmp_path / "coordinator.sqlite", bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer secret"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="https://coordinator.example") as client:
+        acquired = await client.post(
+            "/v1/vaults/main/lease/acquire",
+            json={"replica_id": "laptop", "ttl_seconds": 30},
+            headers=headers,
+        )
+        assert acquired.json()["holder"] == "laptop"
+        token = acquired.json()["fencing_token"]
+
+        # An operator's release request names "laptop" explicitly — it is
+        # not the coordinator's own identity, proving the endpoint accepts
+        # release-on-behalf-of without any server-side change.
+        released = await client.post(
+            "/v1/vaults/main/lease/release",
+            json={"replica_id": "laptop", "fencing_token": token},
+            headers=headers,
+        )
+        assert released.json()["granted"] is True
+        assert released.json()["holder"] is None
+
+        status = await client.get("/v1/vaults/main/lease", headers=headers)
+    assert status.json()["holder"] is None
+
+
+@pytest.mark.anyio
+async def test_release_endpoint_is_a_no_op_when_unheld_or_mismatched(tmp_path: Path) -> None:
+    app = create_app(database=tmp_path / "coordinator.sqlite", bearer_token="secret")
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer secret"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="https://coordinator.example") as client:
+        released = await client.post(
+            "/v1/vaults/main/lease/release",
+            json={"replica_id": "nobody", "fencing_token": 1},
+            headers=headers,
+        )
+    assert released.json()["granted"] is False

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -1,0 +1,142 @@
+"""Structured event logging: log_event() attaches {event, fields, content} to
+every record via `extra=`, and never raises regardless of what it is handed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from exomem import log_events
+from exomem.log_events import (
+    EVENT_CATALOG,
+    JsonLinesFormatter,
+    KeyValueFormatter,
+    bounded_traceback,
+    log_event,
+)
+
+
+@pytest.fixture()
+def logger(caplog: pytest.LogCaptureFixture) -> logging.Logger:
+    caplog.set_level(logging.DEBUG)
+    return logging.getLogger("exomem.test_log_events")
+
+
+def test_log_event_attaches_extra_fields(logger: logging.Logger, caplog) -> None:
+    log_event(
+        logger,
+        logging.INFO,
+        "tool_failure",
+        fields={"tool": "ask_memory", "code": "MUTATION_BUSY"},
+        content={"message": "boom"},
+    )
+    record = caplog.records[-1]
+    assert record.event == "tool_failure"
+    assert record.fields == {"tool": "ask_memory", "code": "MUTATION_BUSY"}
+    assert record.content == {"message": "boom"}
+
+
+def test_log_event_drops_undeclared_content_field(logger: logging.Logger, caplog) -> None:
+    """`tool_success` declares no content fields, so a smuggled key is dropped."""
+    log_event(
+        logger,
+        logging.INFO,
+        "tool_success",
+        fields={"tool": "ask_memory"},
+        content={"leaked_query_text": "sensitive"},
+    )
+    record = caplog.records[-1]
+    assert record.content == {}
+
+
+def test_log_event_drops_all_content_for_unregistered_event(
+    logger: logging.Logger, caplog
+) -> None:
+    log_event(
+        logger,
+        logging.INFO,
+        "not_a_real_event",
+        content={"message": "should not survive"},
+    )
+    record = caplog.records[-1]
+    assert record.content == {}
+
+
+def test_log_event_never_raises_on_bad_input(logger: logging.Logger) -> None:
+    # fields/content that aren't mapping-like must not crash the caller.
+    log_event(logger, logging.INFO, "tool_success", fields="not-a-mapping")  # type: ignore[arg-type]
+
+
+def test_event_catalog_declares_every_content_bearing_event_explicitly() -> None:
+    assert "tool_failure" in EVENT_CATALOG
+    assert "message" in EVENT_CATALOG["tool_failure"].content_fields
+    assert "rest_failure" in EVENT_CATALOG
+    assert "message" in EVENT_CATALOG["rest_failure"].content_fields
+    # A content-free event declares no content fields at all.
+    assert EVENT_CATALOG["tool_success"].content_fields == frozenset()
+
+
+def test_json_lines_formatter_emits_parseable_utc_record(logger: logging.Logger, caplog) -> None:
+    log_event(
+        logger,
+        logging.WARNING,
+        "tool_failure",
+        fields={"tool": "ask_memory", "duration_ms": 12.5},
+        content={"message": "boom"},
+    )
+    record = caplog.records[-1]
+    formatted = JsonLinesFormatter().format(record)
+    payload = json.loads(formatted)
+    assert payload["event"] == "tool_failure"
+    assert payload["level"] == "WARNING"
+    assert payload["fields"] == {"tool": "ask_memory", "duration_ms": 12.5}
+    assert payload["content"] == {"message": "boom"}
+    assert payload["ts"].endswith("+00:00") or payload["ts"].endswith("Z")
+
+
+def test_json_lines_formatter_handles_plain_unstructured_record(caplog) -> None:
+    plain_logger = logging.getLogger("exomem.test_log_events.plain")
+    caplog.set_level(logging.DEBUG)
+    plain_logger.info("a perfectly ordinary message")
+    record = caplog.records[-1]
+    payload = json.loads(JsonLinesFormatter().format(record))
+    assert payload["message"] == "a perfectly ordinary message"
+    assert payload.get("event") is None
+    assert "fields" not in payload
+    assert "content" not in payload
+
+
+def test_key_value_formatter_renders_event_and_fields(logger: logging.Logger, caplog) -> None:
+    log_event(
+        logger,
+        logging.INFO,
+        "tool_success",
+        fields={"tool": "ask_memory", "duration_ms": 3},
+    )
+    record = caplog.records[-1]
+    formatted = KeyValueFormatter().format(record)
+    assert "event=tool_success" in formatted
+    assert "tool=ask_memory" in formatted
+    assert "duration_ms=3" in formatted
+
+
+def test_bounded_traceback_truncates_long_output() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        text = bounded_traceback(True, max_chars=200)
+    assert "ValueError: boom" in text
+    assert len(text) <= 220
+
+
+def test_bounded_traceback_empty_without_exception() -> None:
+    assert bounded_traceback(None) == ""
+
+
+def test_module_has_no_wildcard_surprises() -> None:
+    # Sanity: the module exposes exactly what other O1/O3 code depends on.
+    for name in ("log_event", "EVENT_CATALOG", "JsonLinesFormatter", "KeyValueFormatter", "bounded_traceback"):
+        assert hasattr(log_events, name)

--- a/tests/test_log_process_files.py
+++ b/tests/test_log_process_files.py
@@ -1,0 +1,155 @@
+"""Each process role gets its own JSONL log file under the resolved log dir
+so Windows never contends for a RotatingFileHandler across processes."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from exomem import logging_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_handlers():
+    root = logging.getLogger()
+    before = list(root.handlers)
+    before_level = root.level
+    yield
+    for handler in list(root.handlers):
+        if handler not in before:
+            root.removeHandler(handler)
+            handler.close()
+    root.setLevel(before_level)
+
+
+def test_server_process_writes_exomem_log(tmp_path: Path) -> None:
+    logging_config.configure_logging(tmp_path, process="server")
+    logging.getLogger("exomem.test").info("hello")
+    assert (tmp_path / "exomem.log").exists()
+
+
+def test_cli_process_writes_separate_file(tmp_path: Path) -> None:
+    logging_config.configure_logging(tmp_path, process="cli")
+    logging.getLogger("exomem.test").info("hello")
+    assert (tmp_path / "exomem-cli.log").exists()
+    assert not (tmp_path / "exomem.log").exists()
+
+
+def test_media_process_writes_separate_file(tmp_path: Path) -> None:
+    logging_config.configure_logging(tmp_path, process="media")
+    logging.getLogger("exomem.test").info("hello")
+    assert (tmp_path / "exomem-media.log").exists()
+
+
+def test_reconfiguring_for_a_new_process_drops_the_old_handler(tmp_path: Path) -> None:
+    logging_config.configure_logging(tmp_path, process="cli")
+    logging_config.configure_logging(tmp_path, process="server")
+    logging.getLogger("exomem.test").info("after reconfigure")
+    assert (tmp_path / "exomem.log").exists()
+    root = logging.getLogger()
+    from logging.handlers import RotatingFileHandler
+
+    rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 1
+
+
+def test_configured_log_file_is_jsonl(tmp_path: Path) -> None:
+    logging_config.configure_logging(tmp_path, process="server")
+    logging.getLogger("exomem.test").info("a plain message")
+    log_path = tmp_path / "exomem.log"
+    line = log_path.read_text(encoding="utf-8").splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["message"] == "a plain message"
+    assert payload["level"] == "INFO"
+
+
+def test_log_max_mb_and_backups_env_configure_the_rotating_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from logging.handlers import RotatingFileHandler
+
+    monkeypatch.setenv("EXOMEM_LOG_MAX_MB", "2")
+    monkeypatch.setenv("EXOMEM_LOG_BACKUPS", "3")
+    logging_config.configure_logging(tmp_path, process="server")
+    handler = next(h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler))
+    assert handler.maxBytes == 2 * 1024 * 1024
+    assert handler.backupCount == 3
+
+
+def test_log_max_mb_env_invalid_falls_back_to_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from logging.handlers import RotatingFileHandler
+
+    monkeypatch.setenv("EXOMEM_LOG_MAX_MB", "not-a-number")
+    logging_config.configure_logging(tmp_path, process="server")
+    handler = next(h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler))
+    assert handler.maxBytes == 5 * 1024 * 1024
+
+
+def test_exomem_log_level_env_takes_precedence_over_fastmcp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_LOG_LEVEL", "WARNING")
+    monkeypatch.setenv("FASTMCP_LOG_LEVEL", "DEBUG")
+    logging_config.configure_logging(tmp_path, process="server", level=logging.INFO)
+    assert logging.getLogger().level == logging.WARNING
+
+
+# --- __main__._is_cli_only_invocation --------------------------------------
+
+
+def test_doctor_is_a_cli_only_invocation() -> None:
+    from exomem.__main__ import _is_cli_only_invocation
+
+    assert _is_cli_only_invocation(["doctor"]) is True
+
+
+def test_a_core_op_is_a_cli_only_invocation() -> None:
+    from exomem.__main__ import _is_cli_only_invocation
+
+    assert _is_cli_only_invocation(["ask_memory", "hi"]) is True
+
+
+def test_bare_serve_is_not_a_cli_only_invocation() -> None:
+    from exomem.__main__ import _is_cli_only_invocation
+
+    assert _is_cli_only_invocation([]) is False
+    assert _is_cli_only_invocation(["--transport", "stdio"]) is False
+
+
+def test_main_configures_cli_logging_for_doctor_but_not_for_serve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import exomem.__main__ as main_module
+
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(main_module, "_dispatch_main", lambda raw: 0)
+
+    assert main_module.main(["doctor"]) == 0
+    assert (tmp_path / "exomem-cli.log").exists()
+
+    for handler in list(logging.getLogger().handlers):
+        logging.getLogger().removeHandler(handler)
+        handler.close()
+
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(tmp_path / "unused-by-serve"))
+    assert main_module.main([]) == 0
+    assert not (tmp_path / "unused-by-serve").exists()
+
+
+def test_main_dispatches_trace_and_logs_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import exomem.__main__ as main_module
+
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(tmp_path))
+    assert main_module.main(["trace", "no-such-request-id"]) == 0
+    assert "No records found" in capsys.readouterr().out
+
+    (tmp_path / "exomem.log").write_text("hello-from-server-log\n", encoding="utf-8")
+    assert main_module.main(["logs", "tail", "--file", "server", "-n", "5"]) == 0
+    assert "hello-from-server-log" in capsys.readouterr().out

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,75 @@
+"""`/metrics.json` beside `/health/ready`, and the additive `observability`
+block on the readiness payload."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from exomem import metrics, server
+
+
+def _client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    for leaky in (
+        "EXOMEM_REST_API_KEY", "EXOMEM_UPLOAD_TOKEN",
+        "EXOMEM_CF_ACCESS_TEAM_DOMAIN", "EXOMEM_CF_ACCESS_AUD",
+        "EXOMEM_DISABLE_METRICS",
+    ):
+        monkeypatch.delenv(leaky, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    mcp = server.build_server(require_auth=False)
+    return TestClient(mcp.http_app())
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+def test_metrics_json_serves_counters_and_histograms(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "ask_memory", "outcome": "success"})
+    client = _client(vault, monkeypatch)
+
+    response = client.get("/metrics.json")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    payload = response.json()
+    assert "counters" in payload
+    assert "histograms" in payload
+    assert any(
+        c["name"] == "exomem_tool_calls_total" and c["labels"] == {"tool": "ask_memory", "outcome": "success"}
+        for c in payload["counters"]
+    )
+
+
+def test_metrics_json_disabled_via_env(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch, EXOMEM_DISABLE_METRICS="1")
+    response = client.get("/metrics.json")
+    assert response.status_code == 404
+    assert response.json()["error"] == "METRICS_DISABLED"
+
+
+def test_health_ready_includes_observability_block(vault, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(vault, monkeypatch)
+    response = client.get("/health/ready")
+    payload = response.json()
+    assert "observability" in payload
+    obs = payload["observability"]
+    assert set(obs) == {"log_dir_writable", "metrics_snapshot_age_seconds", "journal_ok"}
+    assert obs["log_dir_writable"] is True
+
+
+def test_disabled_metrics_env_stops_counters_from_accumulating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_DISABLE_METRICS", "1")
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "x", "outcome": "success"})
+    metrics.observe_duration_ms("exomem_tool_duration_ms", 5, {"tool": "x"})
+    snap = metrics.snapshot()
+    assert snap["counters"] == []
+    assert snap["histograms"] == []

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -153,3 +153,28 @@ def test_snapshot_interval_seconds_from_env_zero_disables(
 ) -> None:
     monkeypatch.setenv("EXOMEM_METRICS_SNAPSHOT_SECONDS", "0")
     assert metrics.snapshot_interval_seconds_from_env() == 0.0
+
+def test_load_snapshot_once_consumes_the_restore_for_the_whole_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runtime init can run more than once per process; only the FIRST init may
+    restore from disk, or later inits would clobber live in-process counters
+    with older persisted values (and, in a shared test process, re-import
+    another test's persisted counts over a per-test reset)."""
+    monkeypatch.setattr(metrics, "_SNAPSHOT_LOADED", False)
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "x", "outcome": "success"})
+    metrics.save_snapshot(tmp_path)
+    metrics.reset()
+
+    metrics.load_snapshot_once(tmp_path)
+    first = {
+        (c["name"], tuple(sorted(c["labels"].items()))): c["value"]
+        for c in metrics.snapshot()["counters"]
+    }
+    assert first[
+        ("exomem_tool_calls_total", (("outcome", "success"), ("tool", "x")))
+    ] == 1
+
+    metrics.reset()
+    metrics.load_snapshot_once(tmp_path)
+    assert metrics.snapshot()["counters"] == []

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -1,0 +1,155 @@
+"""One process-wide metrics registry: counters + fixed-bucket histograms under
+one lock, atomic snapshot/restore, and soft-fail everywhere — a metrics bug
+must never break the calling tool call, HTTP request, or mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    # `start_snapshotter` is a process-wide singleton: another test module in
+    # the same pytest run (anything that calls `server.build_server()`, which
+    # starts the real snapshotter via `server_runtime._start_metrics_persistence`)
+    # may already occupy it with its own interval/state_dir, silently
+    # starving this file's own snapshotter tests of a fresh thread. Force a
+    # clean slate on both sides of every test.
+    metrics.stop_snapshotter()
+    metrics.reset()
+    yield
+    metrics.stop_snapshotter()
+    metrics.reset()
+
+
+def test_inc_counter_accumulates_by_label_set() -> None:
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "ask_memory", "outcome": "success"})
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "ask_memory", "outcome": "success"})
+    metrics.inc_counter("exomem_tool_calls_total", {"tool": "ask_memory", "outcome": "failure"})
+
+    snap = metrics.snapshot()
+    counters = {
+        (c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]
+    }
+    assert counters[("exomem_tool_calls_total", (("outcome", "success"), ("tool", "ask_memory")))] == 2
+    assert counters[("exomem_tool_calls_total", (("outcome", "failure"), ("tool", "ask_memory")))] == 1
+
+
+def test_observe_duration_buckets_by_upper_bound() -> None:
+    metrics.observe_duration_ms("exomem_tool_duration_ms", 3, {"tool": "ask_memory"})
+    metrics.observe_duration_ms("exomem_tool_duration_ms", 999999, {"tool": "ask_memory"})
+
+    snap = metrics.snapshot()
+    hist = next(h for h in snap["histograms"] if h["labels"] == {"tool": "ask_memory"})
+    assert hist["count"] == 2
+    assert hist["sum"] == pytest.approx(1000002)
+    assert sum(hist["buckets"]) == 2
+    # The tiny observation lands in an early bucket, the huge one in the
+    # overflow ("+Inf") bucket — they must not land in the same one.
+    assert hist["buckets"][0] >= 1
+    assert hist["buckets"][-1] >= 1
+
+
+def test_registry_is_thread_safe_under_concurrent_increments() -> None:
+    def bump():
+        for _ in range(200):
+            metrics.inc_counter("exomem_http_requests_total", {"status": "200"})
+
+    threads = [threading.Thread(target=bump) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    snap = metrics.snapshot()
+    total = sum(c["value"] for c in snap["counters"] if c["name"] == "exomem_http_requests_total")
+    assert total == 1600
+
+
+def test_inc_counter_never_raises_on_bad_labels() -> None:
+    metrics.inc_counter("exomem_tool_calls_total", labels="not-a-mapping")  # type: ignore[arg-type]
+    metrics.observe_duration_ms("exomem_tool_duration_ms", "not-a-number", {"tool": "x"})  # type: ignore[arg-type]
+
+
+def test_snapshot_and_restore_round_trip(tmp_path: Path) -> None:
+    metrics.inc_counter("exomem_mutation_busy_total", {"code": "MUTATION_BUSY"}, value=3)
+    metrics.observe_duration_ms("exomem_boundary_wait_ms", 42, {"scope": "x"})
+
+    metrics.save_snapshot(tmp_path)
+    snapshot_file = metrics.snapshot_path(tmp_path)
+    assert snapshot_file.exists()
+    payload = json.loads(snapshot_file.read_text(encoding="utf-8"))
+    assert payload["counters"]
+
+    metrics.reset()
+    assert metrics.snapshot()["counters"] == []
+
+    metrics.load_snapshot(tmp_path)
+    snap = metrics.snapshot()
+    counters = {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+    assert counters[("exomem_mutation_busy_total", (("code", "MUTATION_BUSY"),))] == 3
+
+
+def test_save_snapshot_is_atomic_no_partial_file_left_behind(tmp_path: Path) -> None:
+    metrics.inc_counter("exomem_http_requests_total", {"status": "200"})
+    metrics.save_snapshot(tmp_path)
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_load_snapshot_missing_file_is_a_noop(tmp_path: Path) -> None:
+    metrics.load_snapshot(tmp_path / "does-not-exist")
+
+
+def test_load_snapshot_corrupt_file_does_not_raise(tmp_path: Path) -> None:
+    path = metrics.snapshot_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json{{{", encoding="utf-8")
+    metrics.load_snapshot(tmp_path)
+    assert metrics.snapshot()["counters"] == []
+
+
+def test_snapshotter_thread_persists_on_interval(tmp_path: Path) -> None:
+    metrics.inc_counter("exomem_http_requests_total", {"status": "200"})
+    thread = metrics.start_snapshotter(tmp_path, interval_seconds=0.05)
+    try:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not metrics.snapshot_path(tmp_path).exists():
+            time.sleep(0.02)
+        assert metrics.snapshot_path(tmp_path).exists()
+    finally:
+        metrics.stop_snapshotter()
+    assert thread is not None
+
+
+def test_snapshotter_disabled_when_interval_is_zero(tmp_path: Path) -> None:
+    thread = metrics.start_snapshotter(tmp_path, interval_seconds=0)
+    assert thread is None
+    metrics.stop_snapshotter()
+
+
+def test_snapshot_interval_seconds_from_env_defaults_to_60(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EXOMEM_METRICS_SNAPSHOT_SECONDS", raising=False)
+    assert metrics.snapshot_interval_seconds_from_env() == 60.0
+
+
+def test_snapshot_interval_seconds_from_env_honors_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_METRICS_SNAPSHOT_SECONDS", "5")
+    assert metrics.snapshot_interval_seconds_from_env() == 5.0
+
+
+def test_snapshot_interval_seconds_from_env_zero_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_METRICS_SNAPSHOT_SECONDS", "0")
+    assert metrics.snapshot_interval_seconds_from_env() == 0.0

--- a/tests/test_mutation_journal.py
+++ b/tests/test_mutation_journal.py
@@ -1,0 +1,137 @@
+"""`logs/mutations.jsonl`: one record per mutation attempt at the
+terminal/interrupted seam in `writer_lease.invoke()`, with boundary wait/hold
+timing, content-classified targets, and best-effort (never-raises) writes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import metrics, mutation_journal
+from exomem.cli_ops import OpError
+from exomem.writer_lease import LeaseConfig, LeaseManager
+
+
+def _command(*, writes: bool, leaf):  # noqa: ANN001
+    return SimpleNamespace(name="mutate" if writes else "read", read_only=not writes, leaf=leaf)
+
+
+def _standalone_manager(tmp_path: Path) -> LeaseManager:
+    return LeaseManager(LeaseConfig(state_dir=tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _journal_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(log_dir))
+    yield log_dir
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+def _read_journal(log_dir: Path) -> list[dict]:
+    path = log_dir / "mutations.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_committed_mutation_is_journaled_with_timing(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    manager = _standalone_manager(tmp_path / "state")
+    command = _command(writes=True, leaf=lambda: "ok")
+    assert manager.invoke(command, (), {}, mutation_request_id="req-committed") == "ok"
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    record = records[0]
+    assert record["request_id"] == "req-committed"
+    assert record["command"] == "mutate"
+    assert record["outcome"] == "committed"
+    assert record["error_code"] is None
+    assert isinstance(record["duration_ms"], (int, float))
+    assert isinstance(record["boundary_wait_ms"], (int, float))
+    assert isinstance(record["boundary_hold_ms"], (int, float))
+    assert record["lease_role"] == "standalone"
+    assert record["target_count"] == 1
+    assert record["targets"]
+
+
+def test_failed_mutation_is_journaled_with_error_code(
+    tmp_path: Path, _journal_log_dir: Path
+) -> None:
+    manager = _standalone_manager(tmp_path / "state")
+
+    def boom():
+        raise OpError("MUTATION_BUSY", "boundary busy")
+
+    command = _command(writes=True, leaf=boom)
+    with pytest.raises(OpError):
+        manager.invoke(command, (), {}, mutation_request_id="req-failed")
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["outcome"] == "failed"
+    assert records[0]["error_code"] == "MUTATION_BUSY"
+
+
+def test_hosted_journal_records_target_count_only(
+    tmp_path: Path, _journal_log_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_HOSTED_CELL", "1")
+    manager = _standalone_manager(tmp_path / "state")
+    command = _command(writes=True, leaf=lambda: "ok")
+    manager.invoke(command, (), {}, mutation_request_id="req-hosted")
+
+    records = _read_journal(_journal_log_dir)
+    assert len(records) == 1
+    assert records[0]["target_count"] == 1
+    assert "targets" not in records[0]
+
+
+def test_record_mutation_never_raises_on_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom_path():
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(mutation_journal, "journal_path", boom_path)
+    mutation_journal.record_mutation(
+        request_id="r1",
+        tool="mutate",
+        command="mutate",
+        receipt_id=None,
+        outcome="committed",
+        error_code=None,
+        duration_ms=1.0,
+    )
+    snap = metrics.snapshot()
+    counters = {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+    assert counters[("exomem_log_write_errors_total", (("where", "mutation_journal"),))] == 1
+
+
+def test_rotates_at_size_cap(tmp_path: Path, _journal_log_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_JSONL_MAX_MB", "0.001")
+    mutation_journal._size_cache.clear()
+    mutation_journal._append_counts.clear()
+    for i in range(150):
+        mutation_journal.record_mutation(
+            request_id=f"r{i}",
+            tool="mutate",
+            command="mutate",
+            receipt_id=None,
+            outcome="committed",
+            error_code=None,
+            duration_ms=1.0,
+            targets=["a" * 50],
+        )
+    rotated = _journal_log_dir / "mutations.jsonl.1"
+    assert rotated.exists()

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -593,6 +593,189 @@ def test_long_holder_warning_is_bounded_and_content_free(
     assert "private-vault-name" not in messages[0]
 
 
+def test_dynamic_retry_after_ms_scales_with_age_and_is_capped() -> None:
+    from exomem.mutation_lock import dynamic_retry_after_ms
+
+    assert dynamic_retry_after_ms(None) == 750
+    assert dynamic_retry_after_ms({"state": "free"}) == 750
+    assert dynamic_retry_after_ms({"state": "held", "age_seconds": 0.0, "overdue": False}) == 750
+    assert dynamic_retry_after_ms({"state": "held", "age_seconds": 4.0, "overdue": False}) == 2000
+    # Capped at 15000 regardless of how large age_seconds gets.
+    assert dynamic_retry_after_ms({"state": "held", "age_seconds": 100.0, "overdue": False}) == 15000
+    # Overdue floors at 5000 even for a still-small age.
+    assert dynamic_retry_after_ms({"state": "held", "age_seconds": 1.0, "overdue": True}) == 5000
+
+
+def test_mutation_busy_includes_wait_ms_and_dynamic_retry_hint(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    holder = VaultMutationCoordinator(tmp_path / "state", vault, long_holder_seconds=60.0)
+    contender = VaultMutationCoordinator(tmp_path / "state", vault, long_holder_seconds=60.0)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with holder.hold(timeout_seconds=2.0):
+            entered.set()
+            assert release.wait(2.0)
+
+    thread = threading.Thread(target=hold_lock)
+    thread.start()
+    assert entered.wait(1.0)
+    try:
+        time.sleep(0.05)
+        with pytest.raises(OpError) as raised:
+            with contender.hold(timeout_seconds=0.03):
+                pytest.fail("contender entered a held mutation boundary")
+        assert raised.value.details["wait_ms"] >= 0
+        assert 750 <= raised.value.details["retry_after_ms"] <= 15000
+    finally:
+        release.set()
+        thread.join(timeout=2.0)
+
+
+def test_hold_emits_acquired_and_released_events_with_timing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault)
+
+    with caplog.at_level(logging.INFO, logger="exomem.mutation_lock"):
+        with coordinator.hold(request_id="req-timed", operation="remember", holder_kind="command"):
+            pass
+
+    acquired = next(r for r in caplog.records if getattr(r, "event", None) == "mutation_lock_acquired")
+    released = next(r for r in caplog.records if getattr(r, "event", None) == "mutation_lock_released")
+    assert isinstance(acquired.fields["wait_ms"], float)
+    assert acquired.fields["operation"] == "remember"
+    assert isinstance(released.fields["hold_ms"], float)
+    assert released.fields["operation"] == "remember"
+
+
+def test_long_hold_warning_is_guaranteed_on_release_without_any_probe(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unlike a probe-triggered warning, this warning must fire even when
+    nobody ever calls `snapshot()` while the boundary is held."""
+    vault = tmp_path / "unprobed-vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(
+        tmp_path / "state", vault, long_holder_seconds=0.01
+    )
+
+    with caplog.at_level(logging.WARNING, logger="exomem.mutation_lock"):
+        with coordinator.hold(request_id="req-unprobed", operation="edit", holder_kind="command"):
+            time.sleep(0.02)
+            # Deliberately never call coordinator.snapshot() here.
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1
+    assert "req-unprobed" in messages[0]
+    assert "unprobed-vault" not in messages[0]
+
+
+def test_orphan_snapshot_reports_real_age_when_metadata_mutex_is_contended(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When the metadata mutex cannot be acquired within the status timeout,
+    a lock-free (tear-free, atomically-published) sidecar read must report
+    the holder's real age/overdue rather than fabricating a healthy-looking
+    unknown holder at age 0."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault, long_holder_seconds=60.0)
+
+    acquired_at = time.time() - 5.0
+    holder = {
+        "schema": 1,
+        "generation": "a" * 32,
+        "request_id": "req-orphan",
+        "operation": "remember",
+        "holder_kind": "command",
+        "acquired_at": acquired_at,
+        "long_holder_seconds": 60.0,
+    }
+    mutation_lock_module._atomic_write_holder_metadata(coordinator.metadata_path, holder)
+
+    metadata_handle = coordinator._open_lock_file(coordinator.metadata_lock_path)
+    assert mutation_lock_module._try_os_lock(metadata_handle)
+    try:
+        with caplog.at_level(logging.INFO, logger="exomem.mutation_lock"):
+            snapshot = coordinator.snapshot()
+    finally:
+        mutation_lock_module._release_os_lock(metadata_handle)
+        metadata_handle.close()
+
+    assert snapshot["state"] == "held"
+    assert snapshot["verified"] is False
+    assert snapshot["request_id"] == "req-orphan"
+    assert snapshot["holder_kind"] == "command"
+    assert snapshot["age_seconds"] >= 4.5
+    assert snapshot["overdue"] is False
+    assert any(
+        getattr(r, "event", None) == "mutation_holder_unverified" for r in caplog.records
+    )
+
+
+def test_orphan_snapshot_reports_real_overdue_state(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault, long_holder_seconds=1.0)
+
+    holder = {
+        "schema": 1,
+        "generation": "b" * 32,
+        "request_id": "req-overdue-orphan",
+        "operation": "edit_memory",
+        "holder_kind": "background",
+        "acquired_at": time.time() - 10.0,
+        "long_holder_seconds": 1.0,
+    }
+    mutation_lock_module._atomic_write_holder_metadata(coordinator.metadata_path, holder)
+
+    metadata_handle = coordinator._open_lock_file(coordinator.metadata_lock_path)
+    assert mutation_lock_module._try_os_lock(metadata_handle)
+    try:
+        snapshot = coordinator.snapshot()
+    finally:
+        mutation_lock_module._release_os_lock(metadata_handle)
+        metadata_handle.close()
+
+    assert snapshot["overdue"] is True
+    assert snapshot["verified"] is False
+
+
+def test_orphan_snapshot_falls_back_to_unknown_holder_without_a_sidecar(
+    tmp_path: Path,
+) -> None:
+    """No sidecar at all (never published, or already cleared) still
+    fabricates the unknown-holder shape — only a readable sidecar earns the
+    age-aware path."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault)
+    assert not coordinator.metadata_path.exists()
+
+    metadata_handle = coordinator._open_lock_file(coordinator.metadata_lock_path)
+    assert mutation_lock_module._try_os_lock(metadata_handle)
+    try:
+        snapshot = coordinator.snapshot()
+    finally:
+        mutation_lock_module._release_os_lock(metadata_handle)
+        metadata_handle.close()
+
+    assert snapshot == {
+        "state": "held",
+        "request_id": "untracked",
+        "operation": "unknown",
+        "holder_kind": "external",
+        "age_seconds": 0.0,
+        "overdue": False,
+        "verified": False,
+    }
+
+
 def test_process_exit_releases_os_mutation_lock(tmp_path: Path) -> None:
     context = multiprocessing.get_context("spawn")
     state_root = tmp_path / "state"
@@ -614,3 +797,37 @@ def test_process_exit_releases_os_mutation_lock(tmp_path: Path) -> None:
     recovered = VaultMutationCoordinator(state_root, vault)
     with recovered.hold(timeout_seconds=1.0):
         assert recovered.lock_path.exists()
+
+def test_sequential_holds_on_one_thread_reacquire_the_os_boundary(
+    tmp_path: Path,
+) -> None:
+    """Regression: releasing a hold must reset the reentrancy state so the same
+    thread's NEXT hold reacquires the OS lock and republishes the holder
+    sidecar, instead of silently taking the reentrant fast path with no
+    cross-process exclusion at all."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault)
+
+    with coordinator.hold(timeout_seconds=3.0, operation="first", holder_kind="command"):
+        pass
+
+    with coordinator.hold(timeout_seconds=3.0, operation="second", holder_kind="command"):
+        probe = coordinator._open_lock_file(coordinator.lock_path)
+        try:
+            assert not mutation_lock_module._try_os_lock(probe), (
+                "a foreign handle acquired the vault lock while the second "
+                "sequential hold was supposedly active"
+            )
+        finally:
+            probe.close()
+        snapshot = coordinator.snapshot()
+        assert snapshot["state"] == "held"
+        assert snapshot["operation"] == "second"
+
+    probe = coordinator._open_lock_file(coordinator.lock_path)
+    try:
+        assert mutation_lock_module._try_os_lock(probe)
+        mutation_lock_module._release_os_lock(probe)
+    finally:
+        probe.close()

--- a/tests/test_obs_cli_trace.py
+++ b/tests/test_obs_cli_trace.py
@@ -1,0 +1,119 @@
+"""`exomem trace <request_id>` joins the server log, queries/writes/reads.jsonl,
+and mutations.jsonl for one request id, time-ordered. `exomem logs tail|grep`
+reads the per-process JSONL files directly."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exomem import obs_cli
+
+
+@pytest.fixture(autouse=True)
+def _log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setenv("EXOMEM_LOG_DIR", str(log_dir))
+    return log_dir
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_trace_joins_server_log_and_query_log_for_one_request_id(_log_dir: Path) -> None:
+    _write_jsonl(
+        _log_dir / "exomem.log",
+        [
+            {
+                "ts": "2026-07-24T10:00:00.000",
+                "event": "tool_start",
+                "fields": {"request_id": "req-1", "tool": "remember"},
+            },
+            {
+                "ts": "2026-07-24T10:00:01.000",
+                "event": "tool_success",
+                "fields": {"request_id": "req-1", "tool": "remember"},
+            },
+            {
+                "ts": "2026-07-24T10:00:02.000",
+                "event": "tool_start",
+                "fields": {"request_id": "req-other", "tool": "ask_memory"},
+            },
+        ],
+    )
+    _write_jsonl(
+        _log_dir / "writes.jsonl",
+        [{"ts": "2026-07-24 10:00:00", "ts_utc": "2026-07-24T10:00:00.500Z", "tool": "note", "request_id": "req-1"}],
+    )
+    _write_jsonl(
+        _log_dir / "mutations.jsonl",
+        [{"ts_utc": "2026-07-24T10:00:01.500Z", "request_id": "req-1", "outcome": "committed"}],
+    )
+
+    records = obs_cli.trace("req-1")
+
+    sources = [r["_source"] for r in records]
+    assert sources == ["server", "writes", "server", "mutations"]
+    assert all(r.get("request_id") == "req-1" or r.get("fields", {}).get("request_id") == "req-1" for r in records)
+
+
+def test_trace_returns_empty_list_for_unknown_request_id(_log_dir: Path) -> None:
+    _write_jsonl(
+        _log_dir / "exomem.log",
+        [{"ts": "2026-07-24T10:00:00.000", "event": "tool_start", "fields": {"request_id": "req-1"}}],
+    )
+    assert obs_cli.trace("nonexistent-request-id") == []
+
+
+def test_trace_skips_malformed_lines_without_raising(_log_dir: Path) -> None:
+    (_log_dir / "exomem.log").write_text(
+        "not json at all\n"
+        + json.dumps({"event": "tool_start", "fields": {"request_id": "req-1"}})
+        + "\n",
+        encoding="utf-8",
+    )
+    records = obs_cli.trace("req-1")
+    assert len(records) == 1
+
+
+def test_trace_reads_rotated_generation_too(_log_dir: Path) -> None:
+    _write_jsonl(
+        _log_dir / "writes.jsonl.1",
+        [{"ts_utc": "2026-07-24T09:00:00.000Z", "request_id": "req-1", "tool": "note"}],
+    )
+    _write_jsonl(
+        _log_dir / "writes.jsonl",
+        [{"ts_utc": "2026-07-24T10:00:00.000Z", "request_id": "req-1", "tool": "note"}],
+    )
+    records = obs_cli.trace("req-1")
+    assert len(records) == 2
+    assert records[0]["ts_utc"] < records[1]["ts_utc"]
+
+
+def test_resolve_log_file_rejects_unknown_alias() -> None:
+    with pytest.raises(ValueError, match="unknown log file"):
+        obs_cli.resolve_log_file("not-a-real-file")
+
+
+def test_tail_lines_returns_last_n_lines(_log_dir: Path) -> None:
+    path = _log_dir / "exomem.log"
+    path.write_text("\n".join(f"line-{i}" for i in range(50)) + "\n", encoding="utf-8")
+    assert obs_cli.tail_lines(path, 3) == ["line-47", "line-48", "line-49"]
+
+
+def test_tail_lines_missing_file_returns_empty(_log_dir: Path) -> None:
+    assert obs_cli.tail_lines(_log_dir / "does-not-exist.log", 10) == []
+
+
+def test_grep_lines_matches_pattern_across_rotated_and_live(_log_dir: Path) -> None:
+    (_log_dir / "exomem.log.1").write_text("event=tool_failure code=MUTATION_BUSY\n", encoding="utf-8")
+    (_log_dir / "exomem.log").write_text("event=tool_success tool=remember\n", encoding="utf-8")
+    matches = obs_cli.grep_lines(_log_dir / "exomem.log", r"tool_failure")
+    assert matches == ["event=tool_failure code=MUTATION_BUSY"]

--- a/tests/test_privacy_structured_redaction.py
+++ b/tests/test_privacy_structured_redaction.py
@@ -1,0 +1,114 @@
+"""Hosted redaction upgrade: a structured, cataloged `log_event()` record
+drops only its `content` payload in a hosted cell, keeping the content-free
+`event`/`fields` skeleton. Any record NOT produced through `log_event()` for a
+cataloged event keeps today's full-blanking, fail-closed behavior unchanged.
+`exc_info` is always stripped in a hosted cell, structured or not.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from exomem import hosted_runtime, privacy_log
+from exomem.log_events import log_event
+
+
+@pytest.fixture()
+def hosted_logger(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    monkeypatch.setenv(hosted_runtime.HOSTED_MODE_ENV, "true")
+    privacy_log.install_hosted_log_redaction()
+    caplog.set_level(logging.DEBUG)
+    return logging.getLogger("exomem.test_privacy_structured_redaction")
+
+
+def test_hosted_structured_record_drops_content_keeps_skeleton(hosted_logger, caplog) -> None:
+    log_event(
+        hosted_logger,
+        logging.WARNING,
+        "tool_failure",
+        fields={"tool": "ask_memory", "code": "MUTATION_BUSY"},
+        content={"message": "sensitive vault content excerpt"},
+    )
+    record = caplog.records[-1]
+    assert record.event == "tool_failure"
+    assert record.fields == {"tool": "ask_memory", "code": "MUTATION_BUSY"}
+    assert not getattr(record, "content", None)
+    assert "sensitive vault content excerpt" not in caplog.text
+
+
+def test_hosted_unstructured_record_stays_fully_blanked(hosted_logger, caplog) -> None:
+    hosted_logger.warning("plain message with /secret/vault/path.md inside")
+    record = caplog.records[-1]
+    assert record.getMessage() == "event=hosted_log_redacted code=HOSTED_CONTENT_REDACTED"
+    assert "/secret/vault/path.md" not in caplog.text
+
+
+def test_hosted_structured_record_still_strips_exc_info(hosted_logger, caplog) -> None:
+    try:
+        raise ValueError("private-sentinel-detail")
+    except ValueError:
+        log_event(
+            hosted_logger,
+            logging.ERROR,
+            "tool_failure",
+            fields={"tool": "ask_memory"},
+            content={"message": "boom"},
+            exc_info=True,
+        )
+    record = caplog.records[-1]
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert "private-sentinel-detail" not in caplog.text
+
+
+def test_hosted_call_trace_line_passes_through_but_strips_exc_info(hosted_logger, caplog) -> None:
+    call_log = logging.getLogger("exomem.calls")
+    try:
+        raise ValueError("trace-exc-sentinel")
+    except ValueError:
+        call_log.error(
+            "event=hosted_call kind=tool_error tool=ask_memory request_id=req-1",
+            exc_info=True,
+        )
+    record = caplog.records[-1]
+    assert record.getMessage().startswith("event=hosted_call ")
+    assert record.exc_info is None
+    assert "trace-exc-sentinel" not in caplog.text
+
+
+def test_non_hosted_structured_record_is_untouched(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv(hosted_runtime.HOSTED_MODE_ENV, raising=False)
+    privacy_log.install_hosted_log_redaction()
+    caplog.set_level(logging.DEBUG)
+    logger = logging.getLogger("exomem.test_privacy_structured_redaction.nonhosted")
+    log_event(
+        logger,
+        logging.INFO,
+        "tool_failure",
+        fields={"tool": "ask_memory"},
+        content={"message": "not hosted, stays as-is"},
+    )
+    record = caplog.records[-1]
+    assert record.content == {"message": "not hosted, stays as-is"}
+
+def test_hosted_uncataloged_extra_record_is_fully_blanked(hosted_logger, caplog) -> None:
+    """The boundary itself must blank `content`/`fields` for any record whose
+    event is not in the catalog — even one injected through raw `extra=`,
+    bypassing `log_event()`'s own classification guard. Classification is
+    earned at the boundary, never assumed from the caller."""
+    hosted_logger.warning(
+        "raw message",
+        extra={
+            "event": "not_in_catalog",
+            "fields": {"note": "field-sentinel"},
+            "content": {"secret": "content-sentinel"},
+        },
+    )
+    record = caplog.records[-1]
+    assert record.getMessage() == "event=hosted_log_redacted code=HOSTED_CONTENT_REDACTED"
+    assert not getattr(record, "content", None)
+    assert not getattr(record, "fields", None)

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -41,6 +41,11 @@ def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
             "mutation_boundary": {"state": "free"},
         },
         "session_store": {"state": "ok", "stale_served_count": 0},
+        "observability": {
+            "log_dir_writable": None,
+            "metrics_snapshot_age_seconds": None,
+            "journal_ok": None,
+        },
         "takeover_eligible": True,
         "reasons": [],
     }

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -133,9 +133,10 @@ def test_remote_http_runs_stateless(
         "port": 9876,
         "stateless_http": True,
     }
-    assert len(middleware) == 2
+    assert len(middleware) == 3
     assert middleware[0].cls is server.EdgeIngressMiddleware
-    assert middleware[1].cls is server.PrimeMcpSSEMiddleware
+    assert middleware[1].cls is server.AccessLogMiddleware
+    assert middleware[2].cls is server.PrimeMcpSSEMiddleware
 
 
 def test_stdio_does_not_apply_http_stateless_configuration(fake_mcp: _FakeMcp) -> None:

--- a/tests/test_tool_failure_logging.py
+++ b/tests/test_tool_failure_logging.py
@@ -1,0 +1,455 @@
+"""Error-plane capture: every site that converts an `OpError`/exception into a
+response envelope (the MCP tool wrapper, the REST facade, the hosted command
+routes) logs a failure event and bumps metrics counters BEFORE returning the
+envelope, and the envelope stays byte-identical. The MCP tool wrapper cannot
+signal `CallTraceMiddleware` via a ContextVar (anyio's threadpool copies
+context in, not out), so it uses a bounded, locked dict instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+from starlette.testclient import TestClient
+
+from exomem import command_surface, metrics, server
+from exomem import server as server_module
+from exomem.cli_ops import OpError
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+@pytest.fixture(autouse=True)
+def _clear_tool_failures():
+    command_surface._TOOL_FAILURES.clear()
+    yield
+    command_surface._TOOL_FAILURES.clear()
+
+
+def _bound(monkeypatch, *, read_only: bool = False):
+    def leaf(vault):  # noqa: ANN001, ARG001
+        raise AssertionError("invoke seam should replace the leaf")
+
+    command = SimpleNamespace(name="mutate", leaf=leaf, read_only=read_only)
+    bound = command_surface.bind_vault(leaf, object(), command=command)
+    monkeypatch.setattr(command_surface, "mcp_retry_scope", lambda: "bearer:abc")
+    monkeypatch.setattr(
+        command_surface, "mcp_request_id", lambda: "11111111-1111-4111-8111-111111111111"
+    )
+    return bound
+
+
+def _counters(snap):
+    return {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+
+
+# --- MCP tool wrapper (command_surface.py) ---------------------------------
+
+
+def test_successful_call_bumps_success_counter_exactly_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    bound = _bound(monkeypatch)
+    monkeypatch.setattr("exomem.writer_lease.invoke_command", lambda *a, **k: {"ok": True})
+
+    result = bound()
+
+    assert result == {"ok": True}
+    counters = _counters(metrics.snapshot())
+    assert counters[("exomem_tool_calls_total", (("outcome", "success"), ("tool", "mutate")))] == 1
+    assert ("exomem_tool_calls_total", (("outcome", "failure"), ("tool", "mutate"))) not in counters
+
+
+def test_op_error_logs_tool_failure_and_bumps_metrics(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bound = _bound(monkeypatch)
+    public_error = OpError("MUTATION_BUSY", "vault mutation boundary is busy")
+    monkeypatch.setattr(
+        "exomem.writer_lease.invoke_command",
+        lambda *a, **k: (_ for _ in ()).throw(public_error),
+    )
+
+    caplog.set_level(logging.WARNING)
+    result = bound()
+
+    assert result["success"] is False
+    assert result["error"] == public_error.as_public_dict()
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "tool_failure")
+    assert record.fields["tool"] == "mutate"
+    assert record.fields["request_id"] == "11111111-1111-4111-8111-111111111111"
+    assert record.fields["code"] == "MUTATION_BUSY"
+    assert record.fields["scope"] == "bearer"
+    assert isinstance(record.fields["duration_ms"], float)
+    assert record.content == {"message": "vault mutation boundary is busy"}
+
+    snap = metrics.snapshot()
+    counters = {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+    assert counters[("exomem_tool_calls_total", (("outcome", "failure"), ("tool", "mutate")))] == 1
+    assert counters[("exomem_tool_failures_total", (("code", "MUTATION_BUSY"), ("tool", "mutate")))] == 1
+
+
+def test_op_error_message_truncated_to_300_chars(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bound = _bound(monkeypatch)
+    long_message = "x" * 5000
+    monkeypatch.setattr(
+        "exomem.writer_lease.invoke_command",
+        lambda *a, **k: (_ for _ in ()).throw(OpError("OP_ERROR", long_message)),
+    )
+    caplog.set_level(logging.WARNING)
+    bound()
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "tool_failure")
+    assert len(record.content["message"]) == 300
+
+
+def test_op_error_records_signal_for_middleware(monkeypatch: pytest.MonkeyPatch) -> None:
+    bound = _bound(monkeypatch)
+    monkeypatch.setattr(
+        "exomem.writer_lease.invoke_command",
+        lambda *a, **k: (_ for _ in ()).throw(OpError("MUTATION_BUSY", "busy")),
+    )
+    bound()
+    failure = command_surface.pop_tool_failure("11111111-1111-4111-8111-111111111111")
+    assert failure is not None
+    assert failure["code"] == "MUTATION_BUSY"
+    # Unconditional pop: a second pop for the same request id finds nothing.
+    assert command_surface.pop_tool_failure("11111111-1111-4111-8111-111111111111") is None
+
+
+def test_unexpected_exception_does_not_log_tool_failure_or_record_signal(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bound = _bound(monkeypatch)
+    monkeypatch.setattr(
+        "exomem.writer_lease.invoke_command",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("unexpected boom")),
+    )
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(RuntimeError, match="unexpected boom"):
+        bound()
+    assert not any(getattr(r, "event", None) == "tool_failure" for r in caplog.records)
+    assert command_surface.pop_tool_failure("11111111-1111-4111-8111-111111111111") is None
+
+
+def _record_failure_like_the_wrapper(request_id: str, code: str) -> None:
+    """Record exactly as `_log_tool_failure` does: keyed by the per-call token
+    the middleware minted, with the request id only as a fallback."""
+    command_surface._record_tool_failure(
+        command_surface._MCP_CALL_TOKEN.get() or request_id, code
+    )
+
+
+def test_calls_sharing_request_id_attribute_failures_to_the_right_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A client-supplied `x-exomem-request-id` is UUIDv4-shape-validated, not
+    unique — concurrent tool calls can legitimately share one request id. The
+    failure signal is keyed by the per-call token the middleware mints, so
+    each call pops exactly its own failure: both are logged as tool_failure,
+    each with ITS OWN code against ITS OWN tool name — never swapped, never
+    clobbered, regardless of interleaving."""
+    shared_request_id = "44444444-4444-4444-8444-444444444444"
+    middleware = server_module.CallTraceMiddleware()
+
+    import exomem.command_surface as cs_module
+
+    original = cs_module.mcp_request_id
+    cs_module.mcp_request_id = lambda: shared_request_id
+    try:
+        def failing_call(code: str):  # noqa: ANN202
+            async def call_next(_context):  # noqa: ANN001
+                _record_failure_like_the_wrapper(shared_request_id, code)
+                return {"success": False, "error": {}}
+
+            return call_next
+
+        context_a = SimpleNamespace(message={"params": {"name": "remember", "arguments": {}}})
+        context_b = SimpleNamespace(message={"params": {"name": "find", "arguments": {}}})
+        with caplog.at_level(logging.INFO, logger="exomem.calls"):
+            asyncio.run(middleware.on_call_tool(context_a, failing_call("MUTATION_BUSY")))
+            asyncio.run(
+                middleware.on_call_tool(context_b, failing_call("WRITER_LEASE_REQUIRED"))
+            )
+    finally:
+        cs_module.mcp_request_id = original
+
+    lines = caplog.text.splitlines()
+    failure_lines = [line for line in lines if "event=tool_failure" in line]
+    success_lines = [line for line in lines if "event=tool_success" in line]
+    assert len(failure_lines) == 2, caplog.text
+    assert success_lines == [], caplog.text
+    assert "tool=remember" in failure_lines[0]
+    assert "code=MUTATION_BUSY" in failure_lines[0]
+    assert "tool=find" in failure_lines[1]
+    assert "code=WRITER_LEASE_REQUIRED" in failure_lines[1]
+
+
+def test_success_sharing_request_id_never_pops_a_failing_calls_marker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mixed interleaving: one call fails, a concurrent call sharing the same
+    request id succeeds. Under request-id keying the succeeding call could pop
+    the failure marker — logging tool_failure for the healthy tool and
+    tool_success for the failed one. Token keying makes that impossible."""
+    shared_request_id = "55555555-5555-4555-8555-555555555555"
+    middleware = server_module.CallTraceMiddleware()
+
+    import exomem.command_surface as cs_module
+
+    original = cs_module.mcp_request_id
+    cs_module.mcp_request_id = lambda: shared_request_id
+    try:
+        async def failing_call(_context):  # noqa: ANN001
+            _record_failure_like_the_wrapper(shared_request_id, "MUTATION_BUSY")
+            return {"success": False, "error": {}}
+
+        async def succeeding_call(_context):  # noqa: ANN001
+            return {"success": True, "data": {}}
+
+        failing_context = SimpleNamespace(
+            message={"params": {"name": "remember", "arguments": {}}}
+        )
+        succeeding_context = SimpleNamespace(
+            message={"params": {"name": "find", "arguments": {}}}
+        )
+        with caplog.at_level(logging.INFO, logger="exomem.calls"):
+            asyncio.run(middleware.on_call_tool(failing_context, failing_call))
+            asyncio.run(middleware.on_call_tool(succeeding_context, succeeding_call))
+    finally:
+        cs_module.mcp_request_id = original
+
+    lines = caplog.text.splitlines()
+    failure_lines = [line for line in lines if "event=tool_failure" in line]
+    success_lines = [line for line in lines if "event=tool_success" in line]
+    assert len(failure_lines) == 1, caplog.text
+    assert "tool=remember" in failure_lines[0]
+    assert "code=MUTATION_BUSY" in failure_lines[0]
+    assert len(success_lines) == 1, caplog.text
+    assert "tool=find" in success_lines[0]
+
+
+def test_tool_failure_ttl_sweep_drops_stale_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    # stale-request is recorded, then 310s (> the 300s TTL) pass before
+    # fresh-request is recorded — the sweep inside that second call drops
+    # stale-request. fresh-request is then only 10s old and survives.
+    clock = iter([0.0, 310.0, 320.0, 320.0])
+    monkeypatch.setattr(command_surface.time, "monotonic", lambda: next(clock))
+    command_surface._record_tool_failure("stale-request", "MUTATION_BUSY")
+    command_surface._record_tool_failure("fresh-request", "MUTATION_BUSY")
+    assert command_surface.pop_tool_failure("stale-request") is None
+    assert command_surface.pop_tool_failure("fresh-request") is not None
+
+
+# --- CallTraceMiddleware (server.py) ----------------------------------------
+
+
+def test_middleware_logs_tool_failure_when_wrapper_recorded_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = server_module.CallTraceMiddleware()
+    context = SimpleNamespace(message={"params": {"name": "remember", "arguments": {}}})
+    request_id = "22222222-2222-4222-8222-222222222222"
+
+    async def call_next(_context):  # noqa: ANN001
+        _record_failure_like_the_wrapper(
+            command_surface.mcp_request_id(), "MUTATION_BUSY"
+        )
+        return {"success": False, "error": {"code": "MUTATION_BUSY"}}
+
+    import exomem.command_surface as cs_module
+
+    original = cs_module.mcp_request_id
+    cs_module.mcp_request_id = lambda: request_id
+    try:
+        with caplog.at_level(logging.INFO, logger="exomem.calls"):
+            asyncio.run(middleware.on_call_tool(context, call_next))
+    finally:
+        cs_module.mcp_request_id = original
+
+    assert "event=tool_failure" in caplog.text
+    assert "code=MUTATION_BUSY" in caplog.text
+    assert "event=tool_success" not in caplog.text
+
+
+def test_middleware_logs_tool_success_when_no_failure_recorded(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = server_module.CallTraceMiddleware()
+    context = SimpleNamespace(message={"params": {"name": "remember", "arguments": {}}})
+
+    async def call_next(_context):  # noqa: ANN001
+        return {"success": True, "data": {}}
+
+    with caplog.at_level(logging.INFO, logger="exomem.calls"):
+        asyncio.run(middleware.on_call_tool(context, call_next))
+
+    assert "event=tool_success" in caplog.text
+    assert "event=tool_failure" not in caplog.text
+
+
+def test_middleware_preserves_hosted_call_prefix_for_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = server_module.CallTraceMiddleware(hosted=True)
+    context = SimpleNamespace(message={"params": {"name": "remember", "arguments": {}}})
+    request_id = "33333333-3333-4333-8333-333333333333"
+
+    async def call_next(_context):  # noqa: ANN001
+        _record_failure_like_the_wrapper(
+            command_surface.mcp_request_id(), "MUTATION_BUSY"
+        )
+        return {"success": False, "error": {"code": "MUTATION_BUSY"}}
+
+    import exomem.command_surface as cs_module
+
+    original = cs_module.mcp_request_id
+    cs_module.mcp_request_id = lambda: request_id
+    try:
+        with caplog.at_level(logging.INFO, logger="exomem.calls"):
+            asyncio.run(middleware.on_call_tool(context, call_next))
+    finally:
+        cs_module.mcp_request_id = original
+
+    assert "event=hosted_call kind=tool_failure" in caplog.text
+
+
+# --- REST facade (server_rest.py) ------------------------------------------
+
+
+def _rest_client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClient:
+    monkeypatch.setattr(server, "load_dotenv", lambda *a, **k: None)
+    for leaky in (
+        "EXOMEM_REST_API_KEY", "EXOMEM_UPLOAD_TOKEN",
+        "EXOMEM_CF_ACCESS_TEAM_DOMAIN", "EXOMEM_CF_ACCESS_AUD",
+    ):
+        monkeypatch.delenv(leaky, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    mcp = server.build_server(require_auth=False)
+    return TestClient(mcp.http_app())
+
+
+def test_rest_op_error_logs_rest_failure_and_bumps_metrics(
+    vault, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    client = _rest_client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
+
+    caplog.set_level(logging.WARNING)
+    response = client.post(
+        "/api/remember",
+        json={"note_type": "research-note", "title": "no project", "content": "x"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+
+    assert response.status_code == 400, response.text
+    payload = response.json()
+    assert payload["success"] is False
+
+    record = next(r for r in caplog.records if getattr(r, "event", None) == "rest_failure")
+    assert record.fields["tool"] == "remember"
+    assert record.fields["code"] == payload["error"]["code"]
+
+    snap = metrics.snapshot()
+    counters = {(c["name"], tuple(sorted(c["labels"].items()))): c["value"] for c in snap["counters"]}
+    assert counters[
+        ("exomem_tool_failures_total", (("code", payload["error"]["code"]), ("tool", "remember")))
+    ] == 1
+
+
+def test_rest_success_bumps_success_counter_exactly_once(
+    vault, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _rest_client(vault, monkeypatch, EXOMEM_REST_API_KEY="sekret")
+
+    response = client.post(
+        "/api/ask_memory",
+        json={"query": "metabolism", "mode": "keyword", "detail": "full"},
+        headers={"Authorization": "Bearer sekret"},
+    )
+
+    assert response.status_code == 200, response.text
+    counters = _counters(metrics.snapshot())
+    assert counters[
+        ("exomem_tool_calls_total", (("outcome", "success"), ("tool", "ask_memory")))
+    ] == 1
+    assert (
+        "exomem_tool_calls_total",
+        (("outcome", "failure"), ("tool", "ask_memory")),
+    ) not in counters
+
+
+# --- Hosted command routes (server_hosted.py) -------------------------------
+
+
+def test_hosted_error_response_bumps_failure_metrics_with_expected_labels() -> None:
+    from exomem import server_hosted
+
+    config = SimpleNamespace(cell_id="cell-metrics-test")
+    started = 0.0
+
+    server_hosted._error_response(
+        "MUTATION_BUSY",
+        config=config,
+        operation="remember",
+        started=started,
+    )
+
+    counters = _counters(metrics.snapshot())
+    assert counters[
+        ("exomem_tool_calls_total", (("outcome", "failure"), ("tool", "remember")))
+    ] == 1
+    assert counters[
+        ("exomem_tool_failures_total", (("code", "MUTATION_BUSY"), ("tool", "remember")))
+    ] == 1
+    duration_hist = next(
+        h
+        for h in metrics.snapshot()["histograms"]
+        if h["name"] == "exomem_tool_duration_ms" and h["labels"] == {"tool": "remember"}
+    )
+    assert duration_hist["count"] == 1
+
+
+def test_hosted_success_response_bumps_success_metrics_with_expected_labels() -> None:
+    from exomem import server_hosted
+
+    config = SimpleNamespace(cell_id="cell-metrics-test")
+
+    server_hosted._success_response(
+        {"ok": True}, config=config, operation="ready", request_id="req-1", started=0.0
+    )
+
+    counters = _counters(metrics.snapshot())
+    assert counters[
+        ("exomem_tool_calls_total", (("outcome", "success"), ("tool", "ready")))
+    ] == 1
+
+
+def test_hosted_metrics_bump_swallows_errors_and_logs_debug(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from exomem import server_hosted
+
+    def boom(*_a, **_k):
+        raise RuntimeError("metrics boom")
+
+    monkeypatch.setattr(metrics, "inc_counter", boom)
+    config = SimpleNamespace(cell_id="cell-metrics-test")
+
+    caplog.set_level(logging.DEBUG)
+    # Must not raise even though the metrics call is broken.
+    server_hosted._error_response(
+        "MUTATION_BUSY", config=config, operation="remember", started=0.0
+    )
+
+    assert any(
+        getattr(r, "event", None) == "observability_internal_error" for r in caplog.records
+    )

--- a/tests/test_tool_failure_logging.py
+++ b/tests/test_tool_failure_logging.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -332,6 +333,12 @@ def _rest_client(vault, monkeypatch: pytest.MonkeyPatch, **env: str) -> TestClie
         "EXOMEM_CF_ACCESS_TEAM_DOMAIN", "EXOMEM_CF_ACCESS_AUD",
     ):
         monkeypatch.delenv(leaky, raising=False)
+    # Isolate metrics state: no snapshotter thread, and any restore reads a
+    # private state dir instead of a shared one another test polluted.
+    monkeypatch.setenv("EXOMEM_METRICS_SNAPSHOT_SECONDS", "0")
+    monkeypatch.setenv(
+        "EXOMEM_WRITER_LEASE_STATE_DIR", str(Path(str(vault)) / ".metrics-test-state")
+    )
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     mcp = server.build_server(require_auth=False)

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -128,6 +128,79 @@ def test_config_loads_without_exposing_token_in_status(tmp_path: Path) -> None:
     assert "vault_id" not in status
 
 
+def test_status_reports_ttl_remaining_and_renewer_liveness(tmp_path: Path) -> None:
+    expires_at = time.time() + 42.0
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=FakeClient(LeaseRecord("desktop", expires_at, 7)),
+    )
+    status = manager.status()
+    assert status["ttl_remaining_seconds"] == pytest.approx(42.0, abs=1.0)
+    assert status["renewer_alive"] is False
+    assert status["last_renew_age_seconds"] is None
+    assert status["last_coordinator_error"] is None
+
+
+def test_status_records_coordinator_error_instead_of_silently_returning_unhealthy(
+    tmp_path: Path,
+) -> None:
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=FakeClient(OpError("WRITER_COORDINATOR_UNAVAILABLE", "down")),
+    )
+    status = manager.status()
+    assert status["coordinator_healthy"] is False
+    assert status["last_coordinator_error"]["code"] == "WRITER_COORDINATOR_UNAVAILABLE"
+    assert status["last_coordinator_error"]["age_seconds"] >= 0
+
+
+def test_status_last_coordinator_error_persists_across_a_later_healthy_status(
+    tmp_path: Path,
+) -> None:
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+        ),
+        client=FakeClient(OpError("WRITER_COORDINATOR_UNAVAILABLE", "down")),
+    )
+    manager.status()
+    manager.client.record = LeaseRecord("desktop", time.time() + 10, 7)
+    status = manager.status()
+    assert status["coordinator_healthy"] is True
+    assert status["last_coordinator_error"]["code"] == "WRITER_COORDINATOR_UNAVAILABLE"
+
+
+def test_renewer_alive_reflects_a_running_renew_thread(tmp_path: Path) -> None:
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+            ttl_seconds=300.0,
+        ),
+        client=FakeClient(LeaseRecord("desktop", time.time() + 300, 1)),
+    )
+    manager.start_renewer()
+    try:
+        assert manager.status()["renewer_alive"] is True
+    finally:
+        manager.close()
+
+
 def test_coordinator_requests_use_cloudflare_compatible_user_agent(monkeypatch) -> None:
     from exomem.writer_lease import LeaseCoordinatorClient
 
@@ -248,9 +321,15 @@ def test_reads_bypass_unavailable_coordinator(tmp_path: Path) -> None:
     )
 
 
-def test_hosted_reads_serialize_without_contacting_unavailable_coordinator(
+def test_hosted_reads_never_contact_the_coordinator_or_wait_for_the_boundary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Superseded contract (R3): hosted reads no longer take the mutation
+    boundary at all — they behave exactly like local reads, because atomic
+    staging already makes a concurrent whole-file read torn-free. This
+    supersedes the archived decision at
+    openspec/changes/archive/2026-07-20-make-mcp-acknowledgement-replay-safe/design.md:64.
+    """
     monkeypatch.setenv("EXOMEM_HOSTED_CELL", "true")
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -259,36 +338,31 @@ def test_hosted_reads_serialize_without_contacting_unavailable_coordinator(
     coordinator = VaultMutationCoordinator(state_root, vault)
     boundary_entered = threading.Event()
     release_boundary = threading.Event()
-    read_finished = threading.Event()
-    result: list[str] = []
 
     def hold_mutation() -> None:
         with coordinator.hold(timeout_seconds=2.0):
             boundary_entered.set()
             assert release_boundary.wait(2.0)
 
-    def read() -> None:
-        result.append(
+    writer = threading.Thread(target=hold_mutation)
+    writer.start()
+    try:
+        assert boundary_entered.wait(1.0)
+        # The read returns immediately without waiting for release — it
+        # never even attempts to acquire the boundary a concurrent writer
+        # is holding.
+        assert (
             manager.invoke(
                 _command(writes=False, leaf=lambda _vault: "read-ok"),
                 (vault,),
                 {},
             )
+            == "read-ok"
         )
-        read_finished.set()
-
-    writer = threading.Thread(target=hold_mutation)
-    reader = threading.Thread(target=read)
-    writer.start()
-    assert boundary_entered.wait(1.0)
-    reader.start()
-    assert not read_finished.wait(0.1)
-    release_boundary.set()
-    assert read_finished.wait(1.0)
-    writer.join(timeout=2.0)
-    reader.join(timeout=2.0)
-
-    assert result == ["read-ok"]
+    finally:
+        release_boundary.set()
+        writer.join(timeout=2.0)
+    assert not writer.is_alive()
 
 
 def test_read_only_invocation_bypasses_held_mutation_boundary(tmp_path: Path) -> None:
@@ -323,47 +397,43 @@ def test_read_only_invocation_bypasses_held_mutation_boundary(tmp_path: Path) ->
     assert not thread.is_alive()
 
 
-def test_hosted_read_waits_for_complete_multi_file_mutation_snapshot(
+def test_hosted_plain_read_bypasses_boundary_held_by_other_manager(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("EXOMEM_HOSTED_CELL", "true")
-    state_root = tmp_path / "state"
+    """Mirrors `test_hosted_public_audit_routes_bypass_boundary_held_by_other_manager`,
+    but for an ORDINARY (non-audit) hosted read — proving R3's universal
+    bypass rather than the superseded audit-only allowlist."""
+    state_dir = tmp_path / "shared-state"
     vault = tmp_path / "vault"
     vault.mkdir()
-    coordinator = VaultMutationCoordinator(state_root, vault)
-    entered = threading.Event()
-    release = threading.Event()
-    read_finished = threading.Event()
-    result: list[str] = []
+    holder = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
+    reader = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.0)
+    boundary_held = threading.Event()
+    release_boundary = threading.Event()
 
-    def hold_mutation() -> None:
-        with coordinator.hold(timeout_seconds=2.0):
-            entered.set()
-            assert release.wait(2.0)
+    def hold_boundary() -> None:
+        with holder.mutation_guard(vault):
+            boundary_held.set()
+            assert release_boundary.wait(timeout=2)
 
-    manager = LeaseManager(LeaseConfig(state_dir=state_root))
+    worker = threading.Thread(target=hold_boundary, daemon=True)
+    worker.start()
+    assert boundary_held.wait(timeout=2)
+    monkeypatch.setattr(writer_lease_module, "content_private_logging_enabled", lambda: True)
 
-    def read() -> None:
-        result.append(
-            manager.invoke(
+    try:
+        assert (
+            reader.invoke(
                 _command(writes=False, leaf=lambda _vault: "consistent"),
                 (vault,),
                 {},
             )
+            == "consistent"
         )
-        read_finished.set()
-
-    writer = threading.Thread(target=hold_mutation)
-    reader = threading.Thread(target=read)
-    writer.start()
-    assert entered.wait(1.0)
-    reader.start()
-    assert not read_finished.wait(0.1)
-    release.set()
-    assert read_finished.wait(1.0)
-    writer.join(timeout=2.0)
-    reader.join(timeout=2.0)
-    assert result == ["consistent"]
+    finally:
+        release_boundary.set()
+        worker.join(timeout=2)
+    assert not worker.is_alive()
 
 
 def test_write_leaf_is_serialized_for_entire_invocation(tmp_path: Path) -> None:
@@ -1058,9 +1128,13 @@ def test_terminal_receipt_survives_acknowledgement_cancellation(tmp_path: Path) 
     assert calls == [1]
 
 
-def test_identical_orphaned_pending_reports_acknowledgement_uncertain(
+def test_identical_orphaned_legacy_pending_becomes_abandoned_after_grace_period(
     tmp_path: Path,
 ) -> None:
+    """Superseded contract (R4/GAP B): a `pending` row from before the owner
+    column existed (NULL owner) — the exact "orphaned pending never resolves"
+    bug this feature fixes — transitions to `abandoned` once the legacy grace
+    period has passed, instead of blocking every retry forever."""
     manager = LeaseManager(
         LeaseConfig(state_dir=tmp_path),
         idempotency_wait_seconds=0,
@@ -1077,8 +1151,54 @@ def test_identical_orphaned_pending_reports_acknowledgement_uncertain(
     )[0]
     with sqlite3.connect(manager.idempotency.path) as connection:
         connection.execute(
-            "INSERT INTO mutations(key, digest, state, updated_at) VALUES (?, ?, 'pending', ?)",
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES (?, ?, 'pending', ?, NULL)",
             (key, digest, 100.0),
+        )
+
+    with pytest.raises(OpError) as outcome_unknown:
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="pending",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert outcome_unknown.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    payload = error_dict(outcome_unknown.value)
+    assert payload["status"] == "uncertain"
+    assert payload["committed"] is None
+    assert payload["abandoned"] is True
+    assert payload["request_id"]
+    assert payload["idempotency_key"] == "pending"
+    assert payload["receipt_id"]
+
+
+def test_identical_recently_orphaned_legacy_pending_still_reports_acknowledgement_pending(
+    tmp_path: Path,
+) -> None:
+    """A legacy NULL-owner row younger than the grace period is honored under
+    the pre-existing any-pending-blocks rule — it has not yet earned
+    abandonment."""
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        idempotency_wait_seconds=0,
+    )
+    command = _command(writes=True, leaf=lambda: pytest.fail("pending retry ran leaf"))
+    digest = writer_lease_module._command_digest(command, {})
+    key = writer_lease_module._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject="standalone",
+        digest=digest,
+        idempotency_key="pending",
+        principal_scope="principal:alice",
+    )[0]
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES (?, ?, 'pending', ?, NULL)",
+            (key, digest, time.time()),
         )
 
     with pytest.raises(OpError) as pending:
@@ -1093,9 +1213,94 @@ def test_identical_orphaned_pending_reports_acknowledgement_uncertain(
     pending_payload = error_dict(pending.value)
     assert pending_payload["status"] == "uncertain"
     assert pending_payload["committed"] is None
-    assert pending_payload["request_id"]
-    assert pending_payload["idempotency_key"] == "pending"
-    assert pending_payload["receipt_id"]
+
+
+def test_pending_row_with_dead_owner_becomes_abandoned(tmp_path: Path) -> None:
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        idempotency_wait_seconds=0,
+    )
+    command = _command(writes=True, leaf=lambda: pytest.fail("pending retry ran leaf"))
+    digest = writer_lease_module._command_digest(command, {})
+    key = writer_lease_module._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject="standalone",
+        digest=digest,
+        idempotency_key="pending",
+        principal_scope="principal:alice",
+    )[0]
+    dead_owner = "999999:deadowner00000000"
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES (?, ?, 'pending', ?, ?)",
+            (key, digest, time.time(), dead_owner),
+        )
+
+    with pytest.raises(OpError) as outcome_unknown:
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="pending",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert outcome_unknown.value.code == "MUTATION_OUTCOME_UNKNOWN"
+
+
+def test_identical_retry_executes_fresh_after_abandonment_grace_period(
+    tmp_path: Path,
+) -> None:
+    """After a `pending` row is abandoned, an identical retry made at least
+    `_IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS` later executes fresh rather
+    than replaying `MUTATION_OUTCOME_UNKNOWN` forever."""
+    clock = Clock()
+    manager = LeaseManager(
+        LeaseConfig(state_dir=tmp_path),
+        idempotency_wait_seconds=0,
+        clock=clock,
+    )
+    calls: list[str] = []
+    command = _command(writes=True, leaf=lambda: calls.append("ran") or "fresh-result")
+    digest = writer_lease_module._command_digest(command, {})
+    key = writer_lease_module._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject="standalone",
+        digest=digest,
+        idempotency_key="pending",
+        principal_scope="principal:alice",
+    )[0]
+    dead_owner = "999999:deadowner00000001"
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES (?, ?, 'pending', ?, ?)",
+            (key, digest, clock.value, dead_owner),
+        )
+
+    with pytest.raises(OpError) as outcome_unknown:
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="pending",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert outcome_unknown.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert calls == []
+
+    clock.value += writer_lease_module._IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS + 1
+    result = manager.invoke(
+        command,
+        (),
+        {},
+        idempotency_key="pending",
+        idempotency_principal_scope="principal:alice",
+    )
+    assert result == "fresh-result"
+    assert calls == ["ran"]
 
 
 def test_different_identity_busy_is_precommit(tmp_path: Path) -> None:
@@ -2259,3 +2464,463 @@ def test_public_coordination_command_forwards_its_injected_vault(
     monkeypatch.setattr(writer_lease, "coordination_status", fake_status)
     assert commands.op_coordination_status(vault) == {"mutation_boundary": {"state": "free"}}
     assert observed == [vault]
+
+
+# --------------------------------------------------------------------------- #
+# R5 — writer-lease idle release
+# --------------------------------------------------------------------------- #
+
+
+def _idle_manager(
+    tmp_path: Path,
+    record: LeaseRecord,
+    *,
+    idle_release_seconds: float = 60.0,
+    preferred_writer: bool = False,
+    ttl_seconds: float = 30.0,
+) -> LeaseManager:
+    return LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id=record.holder or "desktop",
+            state_dir=tmp_path,
+            idle_release_seconds=idle_release_seconds,
+            preferred_writer=preferred_writer,
+            ttl_seconds=ttl_seconds,
+        ),
+        client=FakeClient(record),
+    )
+
+
+def test_idle_release_config_defaults_to_60_seconds() -> None:
+    assert LeaseConfig().idle_release_seconds == 60.0
+    config = LeaseConfig.from_env(
+        {
+            "EXOMEM_WRITER_LEASE_URL": "https://lease.example",
+            "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+            "EXOMEM_WRITER_LEASE_REPLICA_ID": "desktop",
+        }
+    )
+    assert config.idle_release_seconds == 60.0
+
+
+def test_idle_release_config_zero_disables_and_is_valid() -> None:
+    config = LeaseConfig.from_env(
+        {
+            "EXOMEM_WRITER_LEASE_URL": "https://lease.example",
+            "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+            "EXOMEM_WRITER_LEASE_REPLICA_ID": "desktop",
+            "EXOMEM_WRITER_LEASE_IDLE_SECONDS": "0",
+        }
+    )
+    assert config.idle_release_seconds == 0.0
+
+
+def test_idle_release_config_rejects_a_value_between_zero_and_ttl() -> None:
+    with pytest.raises(ValueError, match="EXOMEM_WRITER_LEASE_IDLE_SECONDS"):
+        LeaseConfig.from_env(
+            {
+                "EXOMEM_WRITER_LEASE_URL": "https://lease.example",
+                "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+                "EXOMEM_WRITER_LEASE_REPLICA_ID": "desktop",
+                "EXOMEM_WRITER_LEASE_TTL": "30",
+                "EXOMEM_WRITER_LEASE_IDLE_SECONDS": "10",
+            }
+        )
+
+
+def test_idle_release_config_accepts_a_value_at_or_above_ttl() -> None:
+    config = LeaseConfig.from_env(
+        {
+            "EXOMEM_WRITER_LEASE_URL": "https://lease.example",
+            "EXOMEM_WRITER_LEASE_VAULT_ID": "main",
+            "EXOMEM_WRITER_LEASE_REPLICA_ID": "desktop",
+            "EXOMEM_WRITER_LEASE_TTL": "30",
+            "EXOMEM_WRITER_LEASE_IDLE_SECONDS": "30",
+        }
+    )
+    assert config.idle_release_seconds == 30.0
+
+
+def test_idle_release_fires_at_exactly_idle_release_seconds(tmp_path: Path) -> None:
+    manager = _idle_manager(tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=60.0)
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 60.0
+
+    assert manager._maybe_idle_release(1) is True
+    assert manager._fencing_token is None
+    assert manager._expires_at is None
+    assert manager.client.releases == [1]
+
+
+def test_idle_release_does_not_fire_before_the_threshold(tmp_path: Path) -> None:
+    manager = _idle_manager(tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=60.0)
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 59.9
+
+    assert manager._maybe_idle_release(1) is False
+    assert manager._fencing_token == 1
+    assert manager.client.releases == []
+
+
+def test_activity_at_t59_defers_release_to_t119(tmp_path: Path) -> None:
+    """Activity at T+59 resets the idle clock, so idle release does not fire
+    at T+60 (only 1s since the reset) but does fire once T+119 arrives (60s
+    after the T+59 reset)."""
+    manager = _idle_manager(tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=60.0)
+    manager.ensure_writer()
+    start = time.monotonic()
+    manager._last_activity_monotonic = start - 59.0  # T+59 activity happened
+
+    # T+60 overall (only 1s since the T+59 reset): must not release.
+    assert manager._maybe_idle_release(1) is False
+    assert manager._fencing_token == 1
+
+    # Advance to T+119 relative to the reset (60s since T+59): must release.
+    manager._last_activity_monotonic = start - 119.0
+    assert manager._maybe_idle_release(1) is True
+
+
+def test_in_flight_mutation_blocks_release_until_it_completes(tmp_path: Path) -> None:
+    manager = _idle_manager(tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=60.0)
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 60.0
+
+    entered = threading.Event()
+    release_guard = threading.Event()
+
+    def hold_guard() -> None:
+        with manager.writer_authority_guard():
+            entered.set()
+            assert release_guard.wait(timeout=2)
+
+    worker = threading.Thread(target=hold_guard)
+    worker.start()
+    try:
+        assert entered.wait(timeout=2)
+        # In flight: idle release must not fire even though activity is stale
+        # (writer_authority_guard refreshed it, but force it stale again to
+        # prove the mutation-count gate — not just the timestamp — blocks it).
+        manager._last_activity_monotonic = time.monotonic() - 60.0
+        assert manager._maybe_idle_release(1) is False
+    finally:
+        release_guard.set()
+        worker.join(timeout=2)
+    assert not worker.is_alive()
+
+    # First tick after completion: activity was refreshed on guard exit, so
+    # backdate it once more to simulate the idle window having elapsed since.
+    manager._last_activity_monotonic = time.monotonic() - 60.0
+    assert manager._maybe_idle_release(1) is True
+
+
+def test_preferred_replica_never_idle_releases(tmp_path: Path) -> None:
+    manager = _idle_manager(
+        tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=60.0, preferred_writer=True
+    )
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 3600.0
+
+    assert manager._maybe_idle_release(1) is False
+    assert manager._fencing_token == 1
+    assert manager.client.releases == []
+
+
+def test_idle_release_disabled_when_idle_seconds_is_zero(tmp_path: Path) -> None:
+    manager = _idle_manager(tmp_path, LeaseRecord("desktop", 99, 1), idle_release_seconds=0.0)
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 3600.0
+
+    assert manager._maybe_idle_release(1) is False
+    assert manager.client.releases == []
+
+
+def test_idle_release_swallows_coordinator_release_rpc_failure(tmp_path: Path) -> None:
+    class FailingReleaseClient(FakeClient):
+        def release(self, fencing_token: int) -> LeaseRecord:
+            raise OpError("WRITER_COORDINATOR_UNAVAILABLE", "down")
+
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path,
+            idle_release_seconds=60.0,
+        ),
+        client=FailingReleaseClient(LeaseRecord("desktop", 99, 1)),
+    )
+    manager.ensure_writer()
+    manager._last_activity_monotonic = time.monotonic() - 60.0
+
+    # The token is cleared LOCALLY even though the release RPC failed — a
+    # degraded handover (the coordinator's own TTL closes the gap), never a
+    # crash and never split-brain.
+    assert manager._maybe_idle_release(1) is True
+    assert manager._fencing_token is None
+
+
+def test_mid_release_race_gets_a_fresh_bumped_token_no_writer_fenced(tmp_path: Path) -> None:
+    """After idle release, an `ensure_writer` racing in (from this or another
+    replica) acquires a strictly newer fencing token — no confusion, no
+    WRITER_FENCED for that fresh acquisition."""
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    laptop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+            idle_release_seconds=60.0,
+        ),
+        client=StoreClient(store, "laptop"),
+    )
+    token = laptop.ensure_writer().fencing_token
+    assert token == 1
+    laptop._last_activity_monotonic = time.monotonic() - 60.0
+
+    assert laptop._maybe_idle_release(token) is True
+
+    desktop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path / "desktop-state",
+        ),
+        client=StoreClient(store, "desktop"),
+    )
+    fresh = desktop.ensure_writer()
+    assert fresh.fencing_token > token
+    # The fresh holder is fully authorized: validating its own token succeeds.
+    desktop.validate_fencing_token(fresh.fencing_token)
+
+
+def test_straggler_write_is_fenced_after_idle_release(tmp_path: Path) -> None:
+    """A write authorized before idle release cleared the local token is
+    rejected at the fence-validation boundary once another replica has
+    acquired a newer token — `writer_authority_guard()`'s single choke point
+    keeps `_active_mutations` accurate for real invocations, so this proves
+    the independent defense-in-depth layer (`validate_active_write_fence`)
+    still catches a stale token that reaches a commit boundary."""
+    clock = Clock()
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite", clock=clock)
+    laptop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+            idle_release_seconds=60.0,
+        ),
+        client=StoreClient(store, "laptop"),
+    )
+    stale_token = laptop.ensure_writer().fencing_token
+    fence_context = writer_lease_module._ACTIVE_WRITE_FENCE.set((laptop, stale_token))
+    try:
+        laptop._last_activity_monotonic = time.monotonic() - 60.0
+        assert laptop._maybe_idle_release(stale_token) is True
+
+        desktop = LeaseManager(
+            LeaseConfig(
+                url="https://lease.example",
+                vault_id="main",
+                replica_id="desktop",
+                state_dir=tmp_path / "desktop-state",
+            ),
+            client=StoreClient(store, "desktop"),
+        )
+        fresh = desktop.ensure_writer()
+        assert fresh.fencing_token > stale_token
+
+        with pytest.raises(OpError) as fenced:
+            writer_lease_module.validate_active_write_fence()
+        assert fenced.value.code == "WRITER_FENCED"
+    finally:
+        writer_lease_module._ACTIVE_WRITE_FENCE.reset(fence_context)
+
+
+def test_two_manager_handover_completes_within_idle_plus_ttl_third(
+    tmp_path: Path,
+) -> None:
+    """A non-preferred holder (laptop) idles out; the preferred replica
+    (desktop) reclaims within roughly one renew tick after that — bounded by
+    `idle_release_seconds + ttl_seconds/3` (desktop's own reclaim cadence)."""
+    ttl = 3.0
+    idle = 1.0
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite")
+    laptop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+            ttl_seconds=ttl,
+            idle_release_seconds=idle,
+        ),
+        client=StoreClient(store, "laptop"),
+    )
+    desktop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="desktop",
+            state_dir=tmp_path / "desktop-state",
+            ttl_seconds=ttl,
+            idle_release_seconds=idle,
+            preferred_writer=True,
+        ),
+        client=StoreClient(store, "desktop"),
+    )
+    laptop.ensure_writer()
+    started = time.monotonic()
+    laptop.start_renewer()
+    desktop.start_renewer()
+    try:
+        deadline = started + idle + ttl / 3 + 3.0  # generous scheduling slack
+        reclaimed = False
+        while time.monotonic() < deadline:
+            if desktop.status()["role"] == "writer":
+                reclaimed = True
+                break
+            time.sleep(0.05)
+        assert reclaimed, "preferred replica did not reclaim after the idle holder released"
+        elapsed = time.monotonic() - started
+        assert elapsed <= idle + ttl / 3 + 3.0
+    finally:
+        laptop.close()
+        desktop.close()
+
+def test_owner_lock_registration_failure_falls_back_to_ownerless_grace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: a store whose own owner-lock file cannot be held must NOT
+    stamp its owner id onto pending rows — a peer would probe that owner as
+    dead and abandon a LIVE mutation. NULL ownership rides the fail-closed
+    legacy grace period instead."""
+    with monkeypatch.context() as patched:
+        patched.setattr(
+            writer_lease_module, "_acquire_own_owner_lock", lambda *_args: None
+        )
+        manager = LeaseManager(
+            LeaseConfig(state_dir=tmp_path), idempotency_wait_seconds=0
+        )
+    assert manager.idempotency.owner_id is None
+
+    command = _command(writes=True, leaf=lambda: pytest.fail("pending retry ran leaf"))
+    digest = writer_lease_module._command_digest(command, {})
+    key = writer_lease_module._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject="standalone",
+        digest=digest,
+        idempotency_key="live",
+        principal_scope="principal:alice",
+    )[0]
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) "
+            "VALUES (?, ?, 'pending', ?, NULL)",
+            (key, digest, time.time()),
+        )
+
+    peer = LeaseManager(LeaseConfig(state_dir=tmp_path), idempotency_wait_seconds=0)
+    with pytest.raises(OpError) as pending:
+        peer.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="live",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert pending.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+
+def test_idle_release_default_tracks_a_raised_ttl() -> None:
+    """Raising EXOMEM_WRITER_LEASE_TTL alone must never brick startup on the
+    idle>=ttl validation: the unset-idle default tracks the TTL."""
+    config = LeaseConfig.from_env({"EXOMEM_WRITER_LEASE_TTL": "90"})
+    assert config.idle_release_seconds == 90.0
+    assert LeaseConfig.from_env({}).idle_release_seconds == 60.0
+
+
+def test_probe_acquire_does_not_refresh_idle_activity(tmp_path: Path) -> None:
+    """An availability probe (media worker polls every 5s) must not count as
+    write activity, or a stuck queue would suppress idle release forever."""
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite")
+    manager = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+            idle_release_seconds=60.0,
+        ),
+        client=StoreClient(store, "laptop"),
+    )
+    manager.ensure_writer()
+    backdated = time.monotonic() - 120.0
+    manager._last_activity_monotonic = backdated
+    manager.ensure_writer(cause="probe")
+    assert manager._last_activity_monotonic == backdated
+
+
+def test_ensure_writer_racing_a_live_in_flight_release_gets_a_fresh_token(
+    tmp_path: Path,
+) -> None:
+    """A genuinely concurrent race: `client.release()` is blocked mid-flight
+    while the idle-release path holds `self._lock`; an `ensure_writer`
+    arriving during that window must wait out the locked release and then
+    acquire a strictly newer token — never a grant the release then revokes."""
+    store = SQLiteLeaseStore(tmp_path / "leases.sqlite")
+    release_entered = threading.Event()
+    release_unblocked = threading.Event()
+
+    class BlockingReleaseClient(StoreClient):
+        def release(self, fencing_token):  # noqa: ANN001, ANN201
+            release_entered.set()
+            assert release_unblocked.wait(5.0)
+            return super().release(fencing_token)
+
+    laptop = LeaseManager(
+        LeaseConfig(
+            url="https://lease.example",
+            vault_id="main",
+            replica_id="laptop",
+            state_dir=tmp_path / "laptop-state",
+            idle_release_seconds=60.0,
+        ),
+        client=BlockingReleaseClient(store, "laptop"),
+    )
+    first = laptop.ensure_writer().fencing_token
+    laptop._last_activity_monotonic = time.monotonic() - 60.0
+
+    release_result: dict[str, bool] = {}
+
+    def run_release() -> None:
+        release_result["released"] = laptop._maybe_idle_release(first)
+
+    releaser = threading.Thread(target=run_release)
+    releaser.start()
+    assert release_entered.wait(5.0)
+
+    acquired: dict[str, object] = {}
+
+    def run_acquire() -> None:
+        acquired["record"] = laptop.ensure_writer()
+
+    acquirer = threading.Thread(target=run_acquire)
+    acquirer.start()
+    acquirer.join(0.3)
+    assert acquirer.is_alive(), "ensure_writer did not wait for the locked release"
+    assert "record" not in acquired
+
+    release_unblocked.set()
+    releaser.join(5.0)
+    acquirer.join(5.0)
+    assert not acquirer.is_alive()
+    assert release_result["released"] is True
+    record = acquired["record"]
+    assert record.fencing_token > first
+    laptop.validate_fencing_token(record.fencing_token)


### PR DESCRIPTION
## Why

Exomem kept failing in ways that couldn't be diagnosed: `MUTATION_BUSY` storms, "cannot write" (`WRITER_LEASE_REQUIRED` / `MUTATION_ACKNOWLEDGEMENT_PENDING`), and no usable log or audit trail to debug from. The app log was deleted on every restart, every business error was converted to a response envelope without ever being logged (failures showed as `tool_success` — server-side error rate read 0%), nothing correlated with anything, and four verified write-path defects made the failures recurrent: the writer lease was held for process lifetime (a live laptop blocks the desktop forever), crashed writes left `pending` idempotency rows that poisoned identical retries permanently, orphaned holder sidecars hid stuck state, and hosted reads contended with writes for the mutation boundary.

Both OpenSpec changes are included: `add-observability-layer` and `eliminate-mutation-busy-failure-modes`.

## Track 1 — Observability (O1–O8)

- Structured JSON-lines logging (UTC, per-process files: server/CLI/media), `EXOMEM_LOG_LEVEL`, CLI + media-child logging wired; restart scripts archive instead of delete; NSSM `service.*` pile pruned.
- Error-plane capture: every `OpError` logged with code/request-id/duration at all conversion sites (MCP wrapper, REST, hosted) **before** the envelope returns — the envelope stays byte-identical. Failures now log `tool_failure`, never `tool_success`; attribution is keyed by a per-call token so concurrent calls sharing a client-supplied request id can never swap or steal failure markers.
- Correlation: a structured access-log middleware (UTC ts, duration, request id injected as response header, session id, cf-ray) replaces the timestamp-less uvicorn access log; `queries/writes/reads.jsonl` gain additive `request_id`/`ts_utc`/`outcome`/`error_code`/`duration_ms` + size-cap rotation; a new `logs/mutations.jsonl` journal records every mutation attempt with boundary wait/hold milliseconds.
- Metrics: a stdlib registry (counters + histograms) persisted across restarts, exposed at `/metrics.json`, in `/health/ready`, and in an enriched `coordination_status` (TTL remaining, renewer health, last coordinator error, lease op counters, idempotency pending/abandoned counts). Prometheus exposition later is a thin adapter over the same registry.
- Tooling: `exomem trace <request-id>` joins every log source for one request; `exomem logs tail|grep`; doctor observability + idempotency-store checks.
- Hosted privacy ceiling preserved and strengthened: field-level content classification with a fail-closed blanking boundary (uncataloged records are fully blanked including `extra=`-injected fields — test-enforced).

## Track 2 — Reliability (R1–R6)

- **R1**: `retry_after_ms` is now dynamic (age-based, capped 15 s, floored 5 s when overdue) instead of a static 750 ms; guaranteed long-hold warning + wait/hold telemetry emitted on release, outside the critical section.
- **R2**: orphaned holder sidecars are read lock-free when the metadata mutex is contended — stuck holders now report real age and `overdue`, instead of a fabricated healthy-looking unknown.
- **R3**: reads never take the mutation boundary (the hosted read guard is deleted; spec delta supersedes the archived 2026-07-20 decision). Reads can no longer return `MUTATION_BUSY` behind a long write.
- **R4**: `pending` idempotency receipts get owner liveness via per-process OS lock files — fail-closed in **both** directions (probe errors ⇒ alive; a store that cannot hold its own lock stamps NULL ownership and rides the 600 s grace). Dead-owner rows become `abandoned` → `MUTATION_OUTCOME_UNKNOWN` (HTTP 409) → identical retry executes fresh after 60 s. No more permanently poisoned payloads.
- **R5**: writer-lease idle release — a **non-preferred** replica voluntarily releases after `EXOMEM_WRITER_LEASE_IDLE_SECONDS` (default tracks the TTL: `max(60, TTL)`; preferred replicas exempt; availability probes don't refresh the timer). The desktop reclaims from an idle laptop within ~TTL/3. Straggler commits are fenced at `validate_active_write_fence` — proven by test.
- **R6**: `exomem lease status|release [--yes] [--json]` operator CLI (cross-device release via the coordinator; deliberate no force-acquire).

## Verification

- Windows-runnable gates, all green on the final rebased tree: pinned safety suites (writer lease, mutation lock, error-plane contract, CLI ops, mutation terminal, readiness, REST registry) **430 passed / 0 failed**; new observability + reliability suites **272+ passed**; upstream's new `test_case_insensitive_identity.py` green against this diff.
- `ruff check src tests`: 42 findings — **identical to the HEAD baseline; zero introduced by this diff**.
- Known pre-existing Windows-only failure sets unchanged and untouched: 4× `test_log_rotation.py`, 23× `test_hosted_private_routes.py` (byte-identical to HEAD). Linux CI on this PR is the authoritative full gate (full suite, fcntl/multi-process, latency + golden).
- Guarded files byte-identical: `tests/test_latency_gate.py`, `tests/golden/`, `.github/`.
- Two independent review passes: a fresh in-pipeline broad review (CHANGES_REQUESTED: 3 defects + anchored scope, all resolved), then an out-of-band adversarial review of the final diff that caught and led to fixing a **critical** regression (the mutation-boundary reentrancy-state reset had been dropped, silently bypassing cross-process write exclusion after a thread's first mutation — now restored with a regression test), two HIGH findings (fail-open liveness registration; hosted blanking hole), and several mediums — all fixed and re-verified.

## Process note

Implemented via a governed delegation run (persistent sandboxed worker, independent reviews, evidence-addressed artifacts). The coordinator harness was killed twice mid-run after worker turns completed, making its formal acceptance receipt unmintable; acceptance was therefore performed directly against first-party gate evidence and the adversarial review, with the run's ledger left accurate (terminally paused) and the acceptance recorded out-of-band. Full evidence chain preserved under the delegation state directory.

## Deferred follow-ups

- `shorten-mutation-critical-section`: move corpus validation / model load outside the mutation boundary — the deep fix for multi-minute holds; the new wait/hold telemetry exists to size it. (Tonight's live incident — a cold-model `remember` holding the boundary ~3 minutes — is exactly this.)
- Hosted transfer routes build error envelopes without metrics (deliberately out of the error-plane scope this round).
- Minor accepted observations: unlocked JSONL rotation race (bounded, consumer-safe), doctor tail-reading whole JSONL files (CLI-only), two offline scripts keep private JSONL readers that ignore the rotated generation.
