### PR TITLE
feat(registry): publish exomem to the official MCP Registry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -136,6 +136,42 @@ jobs:
         with:
           packages-dir: dist
 
+  # Lists the server in the official MCP Registry, which is where MCP-aware
+  # clients and directories discover servers. Runs after PyPI because the
+  # registry entry points at a published package version — publishing first
+  # would advertise a version nobody can install yet.
+  #
+  # Ownership is proven two ways at once: GitHub OIDC for the io.github.Artexis10
+  # namespace, and the `mcp-name` marker in README.md, which PyPI renders as the
+  # package description. Both must agree with `name` in server.json.
+  #
+  # Gated on a repo variable and deliberately non-blocking: a registry outage or
+  # a CLI change must not fail a release that already shipped to PyPI.
+  publish-mcp-registry:
+    needs: [release-please, publish-pypi]
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_created == 'true' && vars.MCP_REGISTRY_PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        run: ./mcp-publisher publish
+
   publish-image:
     needs: [release-please, build-artifacts]
     if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_created == 'true' && vars.GHCR_PUBLISH_ENABLED == 'true' }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # exomem
 
+<!-- mcp-name: io.github.Artexis10/exomem -->
+
 [![PyPI](https://img.shields.io/pypi/v/exomem.svg)](https://pypi.org/project/exomem/)
 [![Python](https://img.shields.io/badge/python-%3E%3D3.11-3776ab.svg)](https://pypi.org/project/exomem/)
 [![CI](https://github.com/Artexis10/exomem/actions/workflows/ci.yml/badge.svg)](https://github.com/Artexis10/exomem/actions/workflows/ci.yml)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -45,6 +45,16 @@
         {
           "type": "generic",
           "path": "uv.lock"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Artexis10/exomem",
+  "title": "Exomem",
+  "description": "Local knowledge substrate for owned Markdown/Obsidian vaults, exposed through MCP, REST, and CLI with multimodal OCR/ASR/CLIP search.",
+  "version": "0.31.0",
+  "websiteUrl": "https://substratesystems.io/exomem",
+  "repository": {
+    "url": "https://github.com/Artexis10/exomem",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "exomem",
+      "version": "0.31.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**This was in #319 but did not land** — that PR merged at its first commit, so `server.json` and the `mcp-name` marker never reached `main`. The project-URL half did ship, and is confirmed live: exomem 0.31.0 on PyPI now renders all five `project_urls` including `Homepage → substratesystems.io/exomem`.

Rebased onto current `main` with versions aligned to the released 0.31.0.

## What this adds

The MCP Registry is where MCP-aware clients and directories discover servers. exomem is absent from it, with no `server.json` anywhere in the repo.

- **`server.json`** — `io.github.Artexis10/exomem`, PyPI package, stdio transport, and `websiteUrl` pointing at the product page. `websiteUrl` and `repository` were confirmed valid against the published schema before relying on them, so the listing links to the product rather than only to source.
- **`mcp-name` marker in `README.md`** — PyPI renders the README as the package description, which is where the registry looks for it.
- **Gated `publish-mcp-registry` job** in `release-please.yml`.

## Ownership is proven twice and the two must agree

GitHub OIDC covers the `io.github` namespace; separately the README marker must exactly match `name` in `server.json`. Verified they match, and that both version fields agree with `pyproject.toml` at 0.31.0.

## Drift protection

`server.json` carries the version **twice** — top level and inside `packages[]`. `release-please` now bumps both via `json`/`jsonpath` extra-files entries. Without this the registry would eventually advertise a version nobody can install.

## Safety

The publish job is gated on `MCP_REGISTRY_PUBLISH_ENABLED` and marked `continue-on-error`. A registry outage or a CLI change must not fail a release that already shipped to PyPI. **Set that variable once you have seen a run succeed** — until then this is inert.

Job order is `release-please → publish-pypi → publish-mcp-registry`, so the registry never points at a version that is not yet installable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)