### PR TITLE
feat: move semantic validation and model loading outside the mutation boundary

### DIFF
--- a/openspec/changes/shorten-mutation-critical-section/.openspec.yaml
+++ b/openspec/changes/shorten-mutation-critical-section/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/shorten-mutation-critical-section/design.md
+++ b/openspec/changes/shorten-mutation-critical-section/design.md
@@ -1,0 +1,238 @@
+## Current-state call chain (verified anchors, tree = post-#320)
+
+`remember`: `invoke_command` (`writer_lease.py:1721`) -> `LeaseManager.invoke`
+(`:1249`; read bypass `:1269-1278`; warming gate `:1299-1324`) -> `idempotency.run`
+with `operation_guard = mutation_guard` (`:1357-1374`; `process_media` is
+already narrow via `writer_authority_guard` — the `narrow_media_commit`
+precedent `:1353-1364`) -> leaf `op_remember` (`commands.py:3512`) -> `note()`
+(`note.py:1305`). Inside the held boundary today:
+
+1. `note.py:1445-1594` resolver snapshot, normalization, render, guarded reads.
+2. `note.py:1488` `semantic_writes.preflight_creation` (`sw:2705`) ->
+   `_evaluate_structural` (`sw:2659`, `build_corpus_context` `sc:1607`) +
+   `relation_review.revalidate_prepared_creation_draft` (`rr:3174` ->
+   `_attempt` `rr:2930`: corpus build AGAIN, `with_candidate` `sc:919`,
+   evaluate, `_validation`).
+3. `note.py:1613` `semantic_writes.commit_creation` (`sw:2770`) ->
+   `commit_creation_draft` (`rr:3496`): preliminary `_attempt` + `_commit_plan`
+   (`rr:3565`, 3rd validation), `ensure_manifest` (`am:552-566`, takes
+   `vault_creation_lock("activation-manifest")`), `vault_creation_lock("semantic-creation")`
+   (`rr:3593`) -> `_attempt` in-lock (`rr:3594`, 4th validation) ->
+   `vault.batch_atomic_write` (`vault:2638`; fence `vault:2846`;
+   embedding-sidecar fan-out `vault:2684-2690` — CAN LOAD THE MODEL COLD).
+4. `note.py:1626-1675` advisory pass (`corpus_aware.suggest_related`, cosine
+   embed — cold = minutes) after commit, still inside the boundary.
+
+Existing-page family (`edit_memory`/`observe_memory`/`append_to_file`/
+`set_frontmatter_field`/`create_file`) -> `preflight_existing` (`sw:1227`,
+corpus `sw:1274`, freshness sandwich `sw:1273-1280`) + `commit_existing`
+(`sw:1634`, creation lock `sw:1675`). `replace_memory` reuses
+`note(_return_prepared=True)` (`note.py:236/1602`) then `commit_creation`
+(`replace.py:630`).
+
+Hoistable out of the boundary: corpus build, `with_candidate`, `evaluate`,
+`_validation`, `_commit_plan` shaping, normalization, the advisory pass, and
+model load. What must stay inside the boundary: `ensure_manifest`,
+`vault_creation_lock` sections, `batch_atomic_write` (fence + commit + index
+fan-out), the O(1) identity/artifact/destination freshness checks, and the
+census recheck itself.
+
+## Census validity token
+
+`semantic_contract._corpus_census(root)` (`sc:1135-1210`, from
+`clear-agent-facing-friction`; cached at `_CORPUS_CONTEXT_CACHE` `sc:1094`)
+covers every KB/vault `.md` file plus `_access.yaml` and the two `_Schema`
+registry files as `(rel_path, kind, size, mtime_ns)`, returning `None` on an
+unsafe tree (symlink/reparse ancestor). Cost is one stat walk (sub-second at
+2.4k pages, logged as `census_ms`). The existing delta machinery
+(`_markdown_census_delta`, `sc:1286`) already bounds in-boundary
+revalidation to changed pages when a full rebuild is needed.
+
+Four gaps had to be resolved before this census could double as a reuse
+token:
+
+1. **Documented residual** — byte-identical size and identical 100ns-mtime
+   in-place replacement is the same residual the corpus cache already
+   accepts today (`sc:1085-1093`); accepted here too, unchanged.
+2. **Identity races are structurally safe** — a new path colliding on stable
+   identity flips the census (a new file entry), so the delta machinery and
+   in-boundary revalidation still catch `DRAFT_ID_IN_USE` on mismatch.
+3. **REAL GAP — relation-review artifacts and lifecycle sidecars.**
+   `review_artifact_path` (`rr:558`), `lifecycle_decision_path` (`rr:579`),
+   and `lifecycle_prepared_path` (`rr:587`) all live under
+   `<KB>/_Schema/relation-reviews/`, and `_corpus_census` only walks `.md`
+   files — these are JSON, so they are invisible to the plain corpus census.
+   The token is therefore `(corpus_census, relation_review_census)`, where
+   the second element is a scandir-census of that whole directory tree
+   (flat artifact files plus the `lifecycle/<page_identity>/` sidecars),
+   using the same alias-refusal safety rule as the strict corpus walk. The
+   reuse path additionally keeps every artifact/lifecycle/destination
+   inspection fresh at O(1) cost regardless of token match, as a second
+   independent safety margin on top of the extended token. If either half
+   cannot be censused cheaply, the whole token is `None`, which forces
+   always-fresh in-boundary revalidation — never reuse.
+4. **Sandwich capture** — the token is computed both before and after
+   preflight; an unequal before/after pair collapses to `token=None`,
+   mirroring the existing `freshness.triple` sandwich (`sw:1273-1280`).
+
+## Guard narrowing (`writer_lease.py`)
+
+Generalize the existing narrow-guard branch (`:1353-1364`, today scoped to
+`process_media`) to `narrow_boundary = narrow_media_commit or
+(command.name in _NARROW_BOUNDARY_COMMANDS and not
+os.environ.get("EXOMEM_WIDE_MUTATION_BOUNDARY"))`; narrowed commands get
+`writer_authority_guard` as their `operation_guard` instead of the full
+mutation boundary. `_NARROW_BOUNDARY_COMMANDS` grows in step with the commit
+sequence: `{"remember"}` first, then `+ replace_memory, edit_memory,
+observe_memory`. `EXOMEM_WIDE_MUTATION_BOUNDARY` is the escape hatch back to
+today's wide-boundary behavior for the whole narrowed set.
+
+The Tier-2 file leaves (`create_file`/`append_to_file`) resolve differently
+than a plain name addition: every product surface (MCP/CLI/REST) reaches
+them exclusively through one consolidated command, `manage_memory_file`,
+whose `operation` argument also dispatches `move`/`delete`/`recover`/`list`/
+`trash-list` — routes through `commit_move`/`commit_recovery`, both
+explicitly out of scope for this change and not self-guarding. Adding
+`"manage_memory_file"` to `_NARROW_BOUNDARY_COMMANDS` outright would have
+narrowed those too and silently dropped their only serialization. Instead, a
+second predicate mirrors the existing `narrow_media_commit` precedent
+exactly — `narrow_tier2_file_commit = command.name == "manage_memory_file"
+and kwargs.get("operation") in {"create", "append"} and not
+os.environ.get("EXOMEM_WIDE_MUTATION_BOUNDARY")` — narrowing only the two
+operations that reach `commit_creation`/`commit_existing`.
+
+## Boundary moves into the commit seam (`semantic_writes.py`)
+
+`commit_creation` and `commit_existing` acquire
+`active_manager().mutation_guard(root, request_id=active_mutation_request_id(),
+operation=<command>, holder_kind="command")` around their entire bodies,
+including `ensure_manifest` and the `vault_creation_lock` section. For
+callers that are not on the narrowed-command list, the inner hold is
+reentrant (`mutation_lock.py:207-214`) against the outer boundary they
+already hold — this is what makes per-command gating safe to land as a pure
+refactor before any guard actually narrows: nothing changes for a caller
+still holding the wide boundary, because the inner acquire is a no-op
+re-entry, not a second lock.
+
+## In-boundary check and bounded revalidation
+
+- **Creation.** `commit_creation_draft` splits: the preliminary `_attempt` +
+  `_commit_plan` pass (`rr:3565-3589`) — pure validation, no shared state
+  touched — hoists into `prepare_commit_creation_draft(...)`, which runs
+  before any boundary is acquired. `_attempt` gains
+  `reuse: _PrevalidatedAttempt | None`. Inside the boundary and creation
+  lock, a fresh census token is computed and compared against the one
+  captured when `reuse` was built; on an exact match, `_attempt` substitutes
+  the pre-boundary `(before_corpus, candidate, result, validation)` in place
+  of rebuilding them, but the identity/artifact/destination checks
+  (`rr:2946-3025`) always execute against live filesystem state regardless
+  of token match. On a mismatch (or `token=None`), `_attempt` falls straight
+  through to today's full computation — unchanged behavior, just a wasted
+  reuse attempt.
+- **Existing pages.** On a token match, `commit_existing` commits using the
+  pre-boundary preflight as today. On a mismatch, it re-runs
+  `preflight_existing` warm with `expected_before_hash=preflight.before.source_hash`
+  and the original `transition_token`, surfacing `STALE_SEMANTIC_WRITE` or
+  `SEMANTIC_CONTRACT_BLOCKED` exactly as the existing cross-invocation replay
+  path already does, then commits against the fresh result.
+
+## Model pre-warm
+
+Both commit paths make a best-effort `embeddings.get_model()` call before
+acquiring the boundary, guarded by `EXOMEM_DISABLE_EMBEDDINGS` and
+`readiness.should_defer("embeddings")`, with failures swallowed — a warm
+load never blocks or fails a commit, it only removes the chance of a cold
+load happening inside the boundary. `note()`'s post-commit advisory pass
+(`corpus_aware.suggest_related`) exits the boundary automatically once the
+guard around it is narrow, since it already runs after `commit_creation`
+returns.
+
+## Telemetry
+
+`exomem_prevalidated_commit_total{outcome="reused"|"revalidated"|"unavailable"}`
+plus a matching log event. `exomem_boundary_hold_ms` and the mutation
+journal's hold fields, both added by `eliminate-mutation-busy-failure-modes`
+R1, are the acceptance measurement for the narrowed hold — no new timing
+mechanism is introduced here.
+
+## Worst case and lock ordering
+
+Worst-case in-boundary time is the token stat-walk (~50-300ms observed at
+2.4k pages) plus, on a mismatch, one warm delta-reconciled revalidation
+(seconds) — the hard ceiling is today's full warm validation, and that only
+triggers on a concurrent config/registry change or an unsafe census, not on
+the common path. Typical hold becomes census-check + creation-lock +
+`batch_atomic_write` — sub-second to low seconds, down from the multi-minute
+worst case observed in the 2026-07-25 incident.
+
+Lock ordering is unchanged, now made explicit: boundary acquired before
+`vault_creation_lock`, never the reverse. The `lexical-catalog-publication`
+background publisher (`lexstore.py:905-927`) takes the creation lock without
+the mutation boundary by design — that is unchanged. `_HELD_LOCKS` nesting
+refusal (`vault.py:383-385`) already enforces no creation-lock nesting, so
+narrowing the outer guard cannot introduce a new nesting hazard there.
+
+## Untouched invariants
+
+Single-writer semantics; fencing (`validate_active_write_fence` inside
+`batch_atomic_write` under the held boundary, `vault:2846`); content-free
+holder metadata; the `MUTATION_BUSY` wire shape (a busy from the inner guard
+still deletes the pending idempotency row via `run`'s `leaf_returned=False`
+path, identical to today); the read bypass. A pre-boundary validation
+failure (`SEMANTIC_CONTRACT_BLOCKED`, `SEMANTIC_CREATION_FAILED` via
+`_translate` `rr:3136-3146`, `NoteError` `note.py:1501-1502`) raises before
+any boundary exists to acquire — the exact incident class from 2026-07-25
+(a multi-minute hold caused by validation and a cold model load happening
+*inside* the boundary) structurally cannot recur once a command is on the
+narrowed list.
+
+## Risks (ranked)
+
+1. **Stale relation-review/lifecycle state under token reuse** — mitigated
+   by the extended token plus the always-fresh artifact/lifecycle/
+   destination checks on every `_attempt` call; any sidecar input that
+   cannot be censused cheaply degrades the whole token to `None`, never to a
+   silently-stale reuse.
+2. **New `STALE_SEMANTIC_WRITE` surfacing within one invocation** for
+   interleavings that previously hit `MUTATION_BUSY` under the wide
+   boundary — this is semantically honest (the write really did race a
+   change), not a regression, and is documented as an accepted behavior
+   change in the spec delta below.
+3. **Census false-match residual** — identical to today's corpus-cache
+   residual; physical write safety is still enforced by `PathGuard`s and
+   `create_only` at commit time regardless of what the token says.
+4. **In-boundary full rebuild on a concurrent config/registry change** —
+   rare, bounded at today's warm cost, and visible via the existing
+   long-hold warning and `exomem_boundary_overdue_total`.
+5. **Journal timing expectations** — `tests/test_mutation_journal.py` now
+   measures narrower holds for narrowed commands, which is the intended
+   effect; the nested-hold timing rule (`mutation_lock.py:44-53`) protects
+   the outer record for any caller still holding the wide boundary.
+6. **Hosted flows already holding an outer boundary see no latency gain**
+   from a narrowed inner acquire (it is reentrant) — acceptable, and not a
+   regression versus today.
+
+## Out of scope
+
+`commit_move`/`commit_recovery`, `adopt`/`adoption_run`, `audit_fix`,
+`reconcile`, `knowledge_packs`, media commands (already narrow), the
+`EXOMEM_MUTATION_TIMEOUT`/edge acquire budgets, the creation-lock 30s
+timeout, corpus-cache internals, and any change to what the semantic
+contract accepts or rejects.
+
+## Commit sequencing
+
+Each commit is independently gated and Windows-verifiable; see `tasks.md`
+for the full checklist:
+
+1. `docs(openspec)` — this change's artifacts.
+2. `refactor` — census token, preflight plumbing, and the `_attempt`/
+   `commit_creation_draft` split, with the full-leaf guard still wrapping
+   everything, so behavior is bit-identical to before the refactor.
+3. `feat` — narrow the guard for `remember` (`_NARROW_BOUNDARY_COMMANDS = {"remember"}`),
+   wire the pre-warm and the new counter, red-first tests for the actual
+   boundary-hold reduction.
+4. `feat` — extend the narrowed set to `replace_memory` and the existing-page
+   family, plus interleaving tests.
+5. `chore` — `tasks.md` checkbox cleanup and doc touch-up; Linux CI remains
+   the authoritative full-suite gate.

--- a/openspec/changes/shorten-mutation-critical-section/proposal.md
+++ b/openspec/changes/shorten-mutation-critical-section/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+One governed `remember` currently performs FOUR full corpus validations and up
+to two embedding-model touchpoints INSIDE the vault mutation boundary,
+against a 5s acquire budget for waiters. A cold model load inside the lock
+held the live boundary ~3 minutes on 2026-07-25. `eliminate-mutation-busy-failure-modes`
+(R1) added the hold/wait telemetry that surfaces this distribution but
+deliberately deferred fixing it. This change moves validation and model
+loading before the boundary; the boundary covers only the commit.
+
+## What Changes
+
+- **Narrow guard per command** (`writer_lease.py`): a configurable
+  `_NARROW_BOUNDARY_COMMANDS` set makes `remember`, `replace_memory`, and the
+  existing-page family (`edit_memory`, `observe_memory`, `append_to_file`,
+  `set_frontmatter_field`, `create_file`) acquire `writer_authority_guard`
+  instead of the full mutation boundary as their `operation_guard`, mirroring
+  the existing `narrow_media_commit` precedent. An `EXOMEM_WIDE_MUTATION_BOUNDARY`
+  environment variable is the kill switch back to today's behavior.
+- **Boundary moves into the commit seam** (`semantic_writes.py`):
+  `commit_creation` and `commit_existing` acquire the vault mutation boundary
+  around their entire bodies (including `ensure_manifest` and
+  `vault_creation_lock`), so corpus validation, relation-review evaluation,
+  and embedding-model touchpoints that currently run pre-commit inside the
+  old wide boundary now run before any boundary is held at all.
+- **Census validity token** (`semantic_contract.py`): a new
+  `corpus_validity_token(root)` extends the existing corpus census
+  (`_corpus_census`) with a scandir-census of the relation-review artifact
+  and lifecycle sidecar directories, closing the one input class the plain
+  corpus census does not cover. `None` on anything that cannot be censused
+  cheaply, which forces full in-boundary revalidation rather than reuse.
+- **Bounded in-boundary revalidation**: preflight results captured before the
+  boundary carry a `census_token`. On commit, a fresh token is compared; an
+  exact match reuses the pre-boundary corpus build/evaluate/validation
+  results (identity, artifact-reservation, and destination-occupancy checks
+  always re-run fresh, token match or not); a mismatch falls back to a full
+  warm revalidation, bounded at today's worst-case cost.
+- **Model pre-warm**: best-effort embedding-model load moves before the
+  boundary in both commit paths, so a cold load can no longer hold the
+  boundary for the multi-minute duration observed in the 2026-07-25 incident.
+- **Telemetry**: `exomem_prevalidated_commit_total{outcome="reused"|"revalidated"|"unavailable"}`
+  plus a log event; `exomem_boundary_hold_ms` and the mutation journal's hold
+  fields (from `eliminate-mutation-busy-failure-modes` R1) are the acceptance
+  measurement for the narrowed hold.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-mutation-safety`: the mutation boundary for narrowed commands now
+  covers only the commit seam — canonical write, index/log updates, and
+  fencing — not corpus validation or model loading; reuse of pre-boundary
+  validation is permitted only under an exact census-token match; a mismatch
+  falls back to bounded in-boundary revalidation with unchanged verdicts;
+  pre-boundary validation failure never acquires the boundary at all;
+  `MUTATION_BUSY` wire shape and fencing guarantees are unchanged.
+
+### New Capabilities
+
+- `write-latency`: bounded boundary-hold semantics for governed semantic
+  writes, the census-token validity contract that governs safe reuse, and
+  revalidation-outcome telemetry.
+
+## Impact
+
+- `src/exomem/writer_lease.py` — `_NARROW_BOUNDARY_COMMANDS`, narrow-guard
+  predicate, `EXOMEM_WIDE_MUTATION_BOUNDARY` kill switch.
+- `src/exomem/semantic_contract.py` — `corpus_validity_token(root)`.
+- `src/exomem/semantic_writes.py` — `census_token` on `CreationPreflight`/
+  `ExistingPreflight`; narrowed guard, token check, and revalidate-on-mismatch
+  in `commit_creation`/`commit_existing`; embeddings pre-warm.
+- `src/exomem/relation_review.py` — `prepare_commit_creation_draft` split out
+  of `commit_creation_draft`; `_attempt(reuse=...)`; `_PrevalidatedAttempt`.
+- Metrics/log events — the new prevalidated-commit counter, using existing
+  observability helpers only.
+- No changes to `mutation_lock.py`, `vault.py`, `tests/golden/`, `.github/`,
+  or `tests/test_latency_gate.py`.
+- No new runtime dependency. No change to what the semantic contract accepts
+  or rejects — only when validation runs relative to the mutation boundary.
+- This change lands in independently gated commits (docs, pure refactor,
+  narrow `remember`, extend to the existing-page family, cleanup); see
+  `tasks.md`. Turn 1 covers only the docs and the pure refactor — the guard
+  narrowing itself (and therefore any observable boundary-hold change) lands
+  in a later commit.

--- a/openspec/changes/shorten-mutation-critical-section/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/shorten-mutation-critical-section/specs/hosted-mutation-safety/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: One Process-Safe Mutation Boundary Per Vault
+
+The system SHALL serialize every operation that can modify a vault's
+canonical Markdown, media, governed indexes, logs, or mutation-owned runtime
+state through one process-safe boundary keyed by the vault's canonical
+identity. MCP, REST, CLI, transfer routes, and background workers MUST NOT
+maintain independent write locks or bypass that boundary.
+
+For a command on the narrowed-boundary set, the boundary the command holds
+MUST cover only the commit seam — the canonical write, index/log updates,
+and fencing — not corpus validation, relation-review evaluation, or
+embedding-model loading, all of which MUST complete before the boundary is
+acquired. A validation failure that occurs before the boundary is acquired
+MUST raise without ever acquiring it. This narrowing MUST NOT change the
+`MUTATION_BUSY` wire shape, the fencing guarantee at the atomic-write
+boundary, or the outcome of any semantic-contract verdict; it only changes
+when validation runs relative to lock acquisition. A command not on the
+narrowed-boundary set, or with the wide-boundary escape hatch set, continues
+to hold the boundary across its entire mutation section as before.
+
+#### Scenario: Concurrent commands from different product surfaces
+
+- **WHEN** MCP and REST submit write-capable commands against the same vault at the same time
+- **THEN** at most one command executes its mutation section at a time
+- **AND** both commands reach the same existing command leaves after acquiring the shared boundary
+
+#### Scenario: Separate processes target the same vault
+
+- **WHEN** two Exomem processes resolve different path spellings to the same canonical vault and attempt mutations concurrently
+- **THEN** they contend on the same process-safe vault boundary
+- **AND** they cannot both enter their mutation sections
+
+#### Scenario: A narrowed command holds the boundary only around its commit
+
+- **WHEN** a command on the narrowed-boundary set (for example `remember`) runs corpus validation and a possible embedding-model load ahead of committing
+- **THEN** the mutation boundary is acquired only immediately before the commit seam (canonical write, index/log updates, fencing)
+- **AND** the validation and any model load already completed before acquisition are not repeated inside the held boundary
+
+#### Scenario: Pre-boundary validation fails before any lock is touched
+
+- **WHEN** pre-commit semantic-contract validation for a narrowed command raises a blocking error
+- **THEN** the error is returned to the caller without the mutation boundary ever having been acquired
+- **AND** the vault is unchanged, exactly as if the boundary had been acquired and immediately released

--- a/openspec/changes/shorten-mutation-critical-section/specs/write-latency/spec.md
+++ b/openspec/changes/shorten-mutation-critical-section/specs/write-latency/spec.md
@@ -26,47 +26,55 @@ a cold embedding-model load.
 - **AND** the mutation snapshot observed at the moment of that load attempt
   reports no in-flight mutation for this write
 
-### Requirement: Census-Token Validity Governs Pre-Boundary Reuse
+### Requirement: Validity-Stamp Admission Governs Pre-Boundary Reuse
 
-A pre-boundary preflight result SHALL carry a census-validity token —
-derived from a stat-level census of every corpus input plus a scandir-census
-of the relation-review artifact and lifecycle sidecar directories — captured
-as a before/after sandwich around the preflight. Inside the boundary, a
-freshly computed token SHALL be compared against the captured one; the
-pre-boundary corpus build, evaluation, and validation results MAY be reused
-only on an exact match. Identity, artifact-reservation, and
-destination-occupancy checks MUST always be re-executed against live
-filesystem state inside the boundary regardless of token match. A token
-mismatch, or a token that is `None` because some input could not be censused
-cheaply or the sandwich disagreed, MUST fall back to a full, bounded
-in-boundary revalidation rather than reusing any pre-boundary result, and
-MUST produce the same semantic-contract verdict a fresh evaluation would
-produce.
+A pre-boundary preflight result SHALL carry a validity stamp composed of:
+the corpus census the preflight's own corpus build already walked (never a
+second stat-walk — the CI write-latency gate holds preflight to one walk
+total), a scandir-census of the relation-review artifact and lifecycle
+sidecar directories, and the boundary commit-generation read at preflight
+ENTRY. The commit-generation is a monotonic per-vault counter advanced on
+every mutation-guard exit while the boundary is still held, so every
+governed writer moves it. Inside the boundary, admission SHALL compare only
+the commit-generation and a fresh sidecar census against the stamp — an
+O(sidecars) check with no corpus stat-walk; the pre-boundary corpus build,
+evaluation, and validation results MAY be reused only when both match.
+Identity, artifact-reservation, and destination-occupancy checks MUST always
+be re-executed against live filesystem state inside the boundary regardless
+of stamp match. A stamp mismatch, or a stamp that is `None` because an input
+could not be censused cheaply or the commit-generation could not be read
+(fail closed), MUST fall back to a full, bounded in-boundary revalidation
+rather than reusing any pre-boundary result, and MUST produce the same
+semantic-contract verdict a fresh evaluation would produce. Edits made
+outside any governed writer (external tools, sync) are outside the stamp's
+detection — for those, the same write-time protections the wide boundary
+relied on (path guards, `create_only`, target freshness) still apply.
 
-#### Scenario: An exact census match reuses pre-boundary validation
+#### Scenario: A current stamp reuses pre-boundary validation
 
-- **WHEN** the census token recomputed inside the boundary exactly matches
-  the token captured for the pre-boundary preflight
+- **WHEN** the commit-generation inside the boundary equals the one captured
+  at preflight entry and the fresh sidecar census matches the stamp
 - **THEN** the commit reuses the pre-boundary corpus build, evaluation, and
-  validation results instead of rebuilding them
+  validation results instead of rebuilding them, without a corpus stat-walk
 - **AND** the identity, artifact-reservation, and destination-occupancy
   checks still run fresh against live filesystem state
 
-#### Scenario: A sibling write between preflight and commit invalidates reuse
+#### Scenario: A governed commit between preflight and commit invalidates reuse
 
-- **WHEN** another write changes corpus, relation-review, or lifecycle state
-  between the pre-boundary preflight and the in-boundary commit
-- **THEN** the freshly computed census token does not match the captured one
+- **WHEN** any governed writer commits (exiting a mutation guard) between
+  the pre-boundary preflight and the in-boundary admission check
+- **THEN** the commit-generation no longer matches the captured stamp
 - **AND** the commit falls back to a full in-boundary revalidation that
   produces the same verdict a fresh evaluation would have produced, rather
   than reusing stale results
 
-#### Scenario: An uncensusable tree never reuses pre-boundary validation
+#### Scenario: An uncensusable tree or unreadable counter never reuses
 
-- **WHEN** the corpus tree, or the relation-review artifact and lifecycle
-  sidecar directories, cannot be censused cheaply (for example an unsafe
-  symlink or reparse point)
-- **THEN** the census token is `None`
+- **WHEN** the corpus tree or the relation-review artifact and lifecycle
+  sidecar directories cannot be censused cheaply (for example an unsafe
+  symlink or reparse point), or the boundary commit-generation cannot be
+  read for any reason other than never having been written
+- **THEN** the validity stamp is `None`
 - **AND** the commit always performs a full in-boundary revalidation, never
   a reuse
 

--- a/openspec/changes/shorten-mutation-critical-section/specs/write-latency/spec.md
+++ b/openspec/changes/shorten-mutation-critical-section/specs/write-latency/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Bounded Mutation-Boundary Hold For Governed Semantic Writes
+
+For a command on the narrowed-boundary set, the vault mutation boundary
+SHALL be held only across the commit seam of a governed semantic write —
+canonical write, index/log updates, and fencing — not across corpus
+validation, relation-review evaluation, or embedding-model loading. The
+worst-case in-boundary time SHALL be bounded by one census check plus, on a
+census mismatch, one warm delta-reconciled revalidation; it MUST NOT include
+a cold embedding-model load.
+
+#### Scenario: A slow validator does not extend the held boundary
+
+- **WHEN** pre-commit corpus validation for a narrowed command takes several
+  seconds
+- **THEN** that time is spent before the mutation boundary is acquired
+- **AND** the measured boundary hold for the commit does not include it
+
+#### Scenario: A cold embedding-model load never happens inside the boundary
+
+- **WHEN** the embedding model has not yet been loaded in this process and a
+  narrowed command's commit path would otherwise trigger a cold load
+- **THEN** the load is attempted, best-effort, before the boundary is
+  acquired
+- **AND** the mutation snapshot observed at the moment of that load attempt
+  reports no in-flight mutation for this write
+
+### Requirement: Census-Token Validity Governs Pre-Boundary Reuse
+
+A pre-boundary preflight result SHALL carry a census-validity token —
+derived from a stat-level census of every corpus input plus a scandir-census
+of the relation-review artifact and lifecycle sidecar directories — captured
+as a before/after sandwich around the preflight. Inside the boundary, a
+freshly computed token SHALL be compared against the captured one; the
+pre-boundary corpus build, evaluation, and validation results MAY be reused
+only on an exact match. Identity, artifact-reservation, and
+destination-occupancy checks MUST always be re-executed against live
+filesystem state inside the boundary regardless of token match. A token
+mismatch, or a token that is `None` because some input could not be censused
+cheaply or the sandwich disagreed, MUST fall back to a full, bounded
+in-boundary revalidation rather than reusing any pre-boundary result, and
+MUST produce the same semantic-contract verdict a fresh evaluation would
+produce.
+
+#### Scenario: An exact census match reuses pre-boundary validation
+
+- **WHEN** the census token recomputed inside the boundary exactly matches
+  the token captured for the pre-boundary preflight
+- **THEN** the commit reuses the pre-boundary corpus build, evaluation, and
+  validation results instead of rebuilding them
+- **AND** the identity, artifact-reservation, and destination-occupancy
+  checks still run fresh against live filesystem state
+
+#### Scenario: A sibling write between preflight and commit invalidates reuse
+
+- **WHEN** another write changes corpus, relation-review, or lifecycle state
+  between the pre-boundary preflight and the in-boundary commit
+- **THEN** the freshly computed census token does not match the captured one
+- **AND** the commit falls back to a full in-boundary revalidation that
+  produces the same verdict a fresh evaluation would have produced, rather
+  than reusing stale results
+
+#### Scenario: An uncensusable tree never reuses pre-boundary validation
+
+- **WHEN** the corpus tree, or the relation-review artifact and lifecycle
+  sidecar directories, cannot be censused cheaply (for example an unsafe
+  symlink or reparse point)
+- **THEN** the census token is `None`
+- **AND** the commit always performs a full in-boundary revalidation, never
+  a reuse
+
+### Requirement: Revalidation-Outcome Telemetry
+
+Every commit for a narrowed-boundary command SHALL record whether its
+pre-boundary validation was reused, revalidated on a census mismatch, or
+unavailable (no pre-boundary result to compare), as a counter labeled by
+outcome and an accompanying log event. This telemetry, together with the
+existing `exomem_boundary_hold_ms` measurement and the mutation journal's
+hold fields, is the mechanism for observing whether the narrowed boundary
+achieves its latency goal in production.
+
+#### Scenario: A reused commit is counted separately from a revalidated one
+
+- **WHEN** a commit reuses pre-boundary validation under an exact census
+  match
+- **THEN** `exomem_prevalidated_commit_total{outcome="reused"}` increments
+- **AND** a commit that instead falls back to in-boundary revalidation
+  increments `exomem_prevalidated_commit_total{outcome="revalidated"}`
+  instead

--- a/openspec/changes/shorten-mutation-critical-section/tasks.md
+++ b/openspec/changes/shorten-mutation-critical-section/tasks.md
@@ -1,0 +1,157 @@
+## 1. C1 — docs(openspec): change artifacts
+
+- [x] 1.1 `proposal.md`, `design.md`, `.openspec.yaml`.
+- [x] 1.2 `specs/hosted-mutation-safety/spec.md` (MODIFIED) and
+      `specs/write-latency/spec.md` (ADDED).
+- [x] 1.3 `tasks.md` (this file).
+
+## 2. C2 — refactor: census token + preflight plumbing (no boundary movement)
+
+- [x] 2.1 `semantic_contract.corpus_validity_token(root)`: extends
+      `_corpus_census` with a scandir-census of the relation-review artifact
+      and lifecycle sidecar directories (`_Schema/relation-reviews/`);
+      returns `None` on an unsafe tree or when either half cannot be
+      censused cheaply. Red-first unit tests: unsafe tree -> `None`;
+      review-artifact change flips the token; config change flips the token.
+- [x] 2.2 `CreationPreflight.census_token` / `ExistingPreflight.census_token`
+      (default `None`), captured as a before/after sandwich around
+      `preflight_creation` (`sw:2705`) and `preflight_existing` (`sw:1227`);
+      an unequal sandwich collapses to `None`, mirroring the
+      `freshness.triple` sandwich (`sw:1273-1280`).
+- [x] 2.3 `relation_review.py`: split `commit_creation_draft` (`rr:3496`) —
+      hoist the preliminary `_attempt` + `_commit_plan` pass (`rr:3565-3589`)
+      into `prepare_commit_creation_draft(...)`. `_attempt` (`rr:2930`)
+      gains `reuse: _PrevalidatedAttempt | None = None`; on a matching fresh
+      token it reuses `(before_corpus, candidate, result, validation)` and
+      skips only `build_corpus_context`/`build_page_state`/`evaluate`/
+      `_validation` — identity/artifact/destination checks
+      (`rr:2946-3025`) always run fresh; on a mismatch it falls through to
+      today's full path, unit-tested directly.
+- [x] 2.4 `semantic_writes.py`: extract the revalidate-on-mismatch helper
+      for `commit_existing` — re-runs `preflight_existing` warm with
+      `expected_before_hash=preflight.before.source_hash` and the original
+      `transition_token`. Present and unit-tested this commit; not yet
+      reachable from a production call path (wired in C4).
+- [x] 2.5 Gate: `tests/test_semantic_creation_writers.py`, `tests/test_note.py`,
+      `tests/test_corpus_context_cache.py`, `tests/test_replace.py`, plus the
+      new token/reuse/revalidation unit tests, all green; the full-leaf
+      mutation guard still wraps every path this commit touches, so verdicts
+      and behavior are bit-identical to before the refactor.
+
+## 3. C3 — feat: narrow the boundary for `remember`
+
+- [x] 3.1 `writer_lease.py`: generalize the `narrow_media_commit` branch into
+      `_NARROW_BOUNDARY_COMMANDS = {"remember"}` plus the
+      `EXOMEM_WIDE_MUTATION_BOUNDARY` kill switch.
+- [x] 3.2 `relation_review.py`: split `commit_creation_draft` further —
+      `commit_prepared_creation_draft(prepared, ...)` now takes an
+      already-`prepare_commit_creation_draft`-validated draft and does only
+      `ensure_manifest` + the creation lock + the in-lock `_attempt`/
+      `_commit_plan` + the atomic write; `commit_creation_draft` becomes a
+      thin one-call wrapper composing both phases for callers that don't
+      narrow their boundary. `_commit_plan` gains a `reuse_result` hint so
+      its own reviewed-none re-evaluation is also skipped on a proven
+      census-token match (the redundant work `_attempt`'s own `reuse`
+      parameter did not cover). `semantic_writes.commit_creation` calls
+      `prepare_commit_creation_draft` before acquiring
+      `active_manager().mutation_guard(...)`, then
+      `commit_prepared_creation_draft` inside it — so the boundary covers
+      only `ensure_manifest` + the creation lock + the commit, not the
+      pre-commit corpus/relation-review validation.
+- [x] 3.3 Embeddings pre-warm (`semantic_writes._prewarm_embeddings`) before
+      boundary acquisition in `commit_creation`, guarded by
+      `EXOMEM_DISABLE_EMBEDDINGS` + `readiness.should_defer("embeddings")`,
+      failures swallowed.
+- [x] 3.4 `exomem_prevalidated_commit_total{outcome=...}` counter + the
+      `prevalidated_commit` cataloged log event, emitted from
+      `relation_review.commit_prepared_creation_draft`'s in-lock `_attempt`
+      call site.
+- [x] 3.5 Red-first tests in `tests/test_shorten_critical_section.py`:
+      bounded hold under a slow validator (bug-injection-verified: the
+      hold-covers-validation bug this change fixes reproduces as red),
+      pre-boundary failure never acquires (bug-injection-verified) with a
+      baseline-identical error, embeddings pre-warm observes a free
+      boundary, `MUTATION_BUSY` shape unchanged under a narrow hold,
+      census-mismatch fallback reachable and exercised end-to-end for
+      `remember`. Concurrent-writers coverage deferred — the single-mismatch
+      and single-busy-contender tests already exercise the relevant
+      interleavings; a dedicated multi-thread `remember` stress test can
+      follow in C4 alongside the existing-page family's own concurrency
+      tests.
+- [x] 3.6 Gate: `tests/test_writer_lease.py`, `tests/test_mutation_lock.py`,
+      `tests/test_command_surface_retry.py`, `tests/test_note.py`,
+      `tests/test_note_suggestions_knob.py`, `tests/test_mutation_journal.py`,
+      `tests/test_shorten_critical_section.py`; plus
+      `tests/test_semantic_creation_writers.py`,
+      `tests/test_corpus_context_cache.py`, `tests/test_replace.py`.
+
+## 4. C4 — feat: extend to `replace_memory` and the existing-page family
+
+- [x] 4.1 `_NARROW_BOUNDARY_COMMANDS` grows to
+      `{"remember", "replace_memory", "edit_memory", "observe_memory"}`
+      (resolved from `_PRODUCT_SPEC` in `commands.py`: every one of
+      `edit_memory`'s four edit/multi_edit/set_take/set_frontmatter_field
+      sub-modes and `observe_memory` route to `commit_existing`;
+      `replace_memory` routes to `commit_creation`, already self-guarding
+      since C3). The Tier-2 file leaves (`create_file`/`append_to_file`) are
+      exposed only through the single consolidated `manage_memory_file`
+      product command (resolved from `_SPEC` vs. `_PRODUCT_SPEC`: `_SPEC`'s
+      raw per-leaf names are not reachable through any live invocation path
+      today — `_PRODUCT_SPEC`/`PRODUCT_COMMANDS` is what every surface
+      dispatches through). Since `manage_memory_file` also carries
+      `move`/`delete`/`recover`/`list`/`trash-list` (routed through
+      `commit_move`/`commit_recovery`, explicitly out of scope and not
+      self-guarding), a blanket add would have narrowed those too and lost
+      their only serialization. Added a `narrow_tier2_file_commit` predicate
+      instead, mirroring the existing `narrow_media_commit` precedent
+      exactly: `command.name == "manage_memory_file" and
+      kwargs.get("operation") in {"create", "append"}` (plus the kill
+      switch) — narrows only the two operations that reach `commit_creation`/
+      `commit_existing`, leaving move/delete/recover/list on the wide
+      boundary unchanged.
+- [x] 4.2 `commit_existing` acquires the mutation boundary around its full
+      body (fresh census-token check, `_revalidate_existing_preflight` on a
+      mismatch or `census_token=None`, `manifest_install_required`,
+      resolver-freshness priming, the creation lock, and the atomic write —
+      all inside); embeddings pre-warm before acquisition, mirroring
+      `commit_creation`.
+- [x] 4.3 Interleaving tests for the existing-page family in
+      `tests/test_shorten_critical_section.py`: two concurrent `edit_memory`
+      writers on different pages both succeed under the narrow boundary (one
+      benign `PATH_GUARD_CHANGED` retry on a shared log/index auxiliary is
+      accepted and documented as a new, honest interleaving this change can
+      surface — never silent corruption); a sibling write racing between
+      `preflight_existing` and `commit_existing` is caught by the census
+      mismatch and revalidated, surfacing `STALE_SEMANTIC_WRITE` exactly as
+      the existing cross-invocation path already did (bug-injection-verified
+      red: without the wiring this same race instead falls through to the
+      less specific PathGuard-level `PATH_GUARD_CONTENT`). Census-mismatch
+      fallback for creation was already covered in C3
+      (`test_remember_commit_revalidates_on_a_census_mismatch_between_prepare_and_commit`)
+      — not duplicated.
+- [x] 4.4 Gate: the C3 suite set plus `tests/test_semantic_creation_writers.py`,
+      `tests/test_mutation_concurrency.py`, `tests/test_corpus_context_cache.py`,
+      `tests/test_replace.py`, and the edit/observe suites
+      (`test_edit_heading.py`, `test_edit_operations.py`,
+      `test_edit_surgical_replace.py`, `test_edit_validate_only.py`,
+      `test_get_edit_roundtrip.py`, `test_multi_edit.py`,
+      `test_observe_memory.py`).
+
+## 5. C5 — chore: cleanup
+
+- [x] 5.1 `tasks.md` checkbox pass (this pass).
+- [ ] 5.2 Linux CI is authoritative for the full suite, latency gate, and
+      golden gate — this Windows box cannot run them
+      (`fable-delegate-claude-only-windows` harness constraint).
+
+## 6. Verification
+
+- [x] 6.1 C1-C4 pinned suites stay green on Windows (see 2.5, 3.6, 4.4).
+- [ ] 6.2 `uv run ruff check src tests` clean on changed files — ruff is not
+      installed in this environment; the orchestrator runs it out-of-band.
+- [ ] 6.3 Linux CI: full suite, latency + golden gates (authoritative; this
+      box cannot run them).
+- [ ] 6.4 Live smoke after merge + deploy: induce a `remember` under a
+      slow/cold validator and confirm `exomem_boundary_hold_ms` and the
+      mutation journal show a narrowed hold, not the pre-change multi-minute
+      one.

--- a/src/exomem/append_to_file.py
+++ b/src/exomem/append_to_file.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from . import semantic_writes
 from .vault import (
+    PathGuardError,
     PlannedWrite,
     VaultPathError,
     batch_atomic_write,
@@ -238,12 +239,31 @@ def append_to_file(
         semantic = committed.as_dict()
     else:
         writes = [*log_plan.writes, PlannedWrite(abs_path, new_text, guard=primary_guard)]
-        try:
-            batch_atomic_write(writes, vault_root=vault_root)
-        except Exception as error:
-            log.exception("append_to_file write failed for %s", rel_path)
-            warnings.append(f"partial write — reconcile on desktop: {error}")
-            raise
+        # Non-semantic append targets have no self-guarding commit seam, so
+        # this leaf takes the mutation boundary itself (a reentrant no-op
+        # for callers that still hold the full-leaf guard).
+        from .writer_lease import active_manager, active_mutation_request_id
+
+        with active_manager().mutation_guard(
+            vault_root,
+            request_id=active_mutation_request_id(),
+            operation="file_append_commit",
+            holder_kind="command",
+        ):
+            try:
+                batch_atomic_write(writes, vault_root=vault_root)
+            except PathGuardError as error:
+                raise AppendError(
+                    code="STALE_WRITE",
+                    reason=(
+                        "a concurrent write updated this file or a shared "
+                        f"auxiliary during commit; re-read and retry ({error})"
+                    ),
+                ) from error
+            except Exception as error:
+                log.exception("append_to_file write failed for %s", rel_path)
+                warnings.append(f"partial write — reconcile on desktop: {error}")
+                raise
 
     return AppendResult(
         path=rel_path,

--- a/src/exomem/create_directory.py
+++ b/src/exomem/create_directory.py
@@ -77,46 +77,60 @@ def create_directory(
             ),
         )
 
-    already_existed = abs_path.exists()
-    if already_existed and not abs_path.is_dir():
-        raise CreateDirectoryError(
-            code="NOT_A_DIR",
-            reason=f"{rel_path} exists but is not a directory",
-        )
+    # A raw mkdir mutates the vault tree, so this leaf takes the mutation
+    # boundary itself (a reentrant no-op for callers that still hold the
+    # full-leaf guard); the existence check runs under the boundary so
+    # concurrent creates stay idempotent instead of racing.
+    from .writer_lease import active_manager, active_mutation_request_id
 
-    if not already_existed:
-        try:
-            abs_path.mkdir(parents=parents, exist_ok=False)
-        except FileNotFoundError as e:
+    with active_manager().mutation_guard(
+        vault_root,
+        request_id=active_mutation_request_id(),
+        operation="directory_create_commit",
+        holder_kind="command",
+    ):
+        already_existed = abs_path.exists()
+        if already_existed and not abs_path.is_dir():
             raise CreateDirectoryError(
-                code="MISSING_PARENT",
-                reason=(
-                    f"intermediate folders missing for {rel_path}; "
-                    f"call with parents=true or create them first ({e})"
-                ),
-            ) from e
-        except OSError as e:
-            raise CreateDirectoryError(
-                code="MKDIR_FAILED",
-                reason=f"could not create {rel_path}: {e}",
-            ) from e
+                code="NOT_A_DIR",
+                reason=f"{rel_path} exists but is not a directory",
+            )
 
-    warnings: list[str] = []
-    if not already_existed:
-        today = today or dt.date.today()
-        date_iso = today.isoformat()
-        log_body = "Created directory via exomem Tier 2."
-        if curated and allow_curated:
-            log_body += f" allow_curated=true (target tree: {curated})."
-        log_warning = write_log_entry(
-            vault_root,
-            date_iso=date_iso,
-            op="create_directory",
-            rel_path_no_ext=rel_path,
-            body=log_body,
-        )
-        if log_warning:
-            warnings.append(log_warning)
+        if not already_existed:
+            try:
+                abs_path.mkdir(parents=parents, exist_ok=False)
+            except FileNotFoundError as e:
+                raise CreateDirectoryError(
+                    code="MISSING_PARENT",
+                    reason=(
+                        f"intermediate folders missing for {rel_path}; "
+                        f"call with parents=true or create them first ({e})"
+                    ),
+                ) from e
+            except OSError as e:
+                raise CreateDirectoryError(
+                    code="MKDIR_FAILED",
+                    reason=f"could not create {rel_path}: {e}",
+                ) from e
+
+        # The log.md entry is governed shared state — written under the same
+        # boundary hold as the mkdir it records.
+        warnings: list[str] = []
+        if not already_existed:
+            today = today or dt.date.today()
+            date_iso = today.isoformat()
+            log_body = "Created directory via exomem Tier 2."
+            if curated and allow_curated:
+                log_body += f" allow_curated=true (target tree: {curated})."
+            log_warning = write_log_entry(
+                vault_root,
+                date_iso=date_iso,
+                op="create_directory",
+                rel_path_no_ext=rel_path,
+                body=log_body,
+            )
+            if log_warning:
+                warnings.append(log_warning)
 
     return CreateDirectoryResult(
         path=rel_path, created=not already_existed, warnings=warnings

--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -374,12 +374,44 @@ def create_file(
         writes.append(
             PlannedWrite(path=abs_path, content=full_text, guard=existing_guard)
         )
-        try:
-            batch_atomic_write(writes, vault_root=vault_root)
-        except Exception as e:
-            log.exception("create_file write failed for %s", rel_path)
-            warnings.append(f"partial write — reconcile on desktop: {e}")
-            raise
+        # Non-semantic targets have no self-guarding commit seam, so this
+        # leaf takes the mutation boundary itself (a reentrant no-op for
+        # callers that still hold the full-leaf guard). Without it, a
+        # narrowed command surface would write governed log/index state —
+        # and race concurrent creates — with no boundary at all.
+        from .writer_lease import active_manager, active_mutation_request_id
+
+        with active_manager().mutation_guard(
+            vault_root,
+            request_id=active_mutation_request_id(),
+            operation="file_create_commit",
+            holder_kind="command",
+        ):
+            if not existing_file and not overwrite and abs_path.exists():
+                # Re-check under the boundary: a concurrent create landed
+                # after the pre-boundary existence check.
+                raise CreateFileError(
+                    code="FILE_EXISTS",
+                    reason=(
+                        f"{rel_path} was created concurrently. Pass "
+                        f"`overwrite=true` to replace, or use `edit` / "
+                        f"`append_to_file` for surgical changes."
+                    ),
+                )
+            try:
+                batch_atomic_write(writes, vault_root=vault_root)
+            except vault_module.PathGuardError as e:
+                raise CreateFileError(
+                    code="STALE_WRITE",
+                    reason=(
+                        "a concurrent write updated a shared file (log/index) "
+                        f"during commit; retry the operation ({e})"
+                    ),
+                ) from e
+            except Exception as e:
+                log.exception("create_file write failed for %s", rel_path)
+                warnings.append(f"partial write — reconcile on desktop: {e}")
+                raise
 
     return CreateFileResult(
         path=rel_path,

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from . import corpus_aware, indexes, semantic_writes
 from . import find as find_module
+from .cli_ops import OpError
 from .kbdir import kb_prefix
 from .vault import (
     PlannedWrite,
@@ -751,6 +752,12 @@ def commit_edit(
         )
     except semantic_writes.SemanticWriteError as error:
         raise EditError(error.code, ["semantic"], error.reason) from error
+    except OpError:
+        # Ordinary boundary contention (MUTATION_BUSY/MUTATION_WARMING) from
+        # the commit seam's own guard is not a partial write — nothing was
+        # written. Let it surface with its retryable envelope instead of a
+        # false partial-write alarm.
+        raise
     except Exception as e:
         log.exception("partial write during edit(); some files may be updated")
         warnings.append(f"partial write — reconcile on desktop: {e}")

--- a/src/exomem/log_events.py
+++ b/src/exomem/log_events.py
@@ -55,6 +55,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     "lease_acquired": EventSpec(),
     "lease_reclaimed": EventSpec(),
     "lease_renew_rejected": EventSpec(),
+    "prevalidated_commit": EventSpec(),
 }
 
 

--- a/src/exomem/relation_review.py
+++ b/src/exomem/relation_review.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import stat
@@ -55,6 +56,34 @@ _LIFECYCLE_ATOMIC_RESIDUE = re.compile(
 _LIFECYCLE_OPERATIONS = frozenset(
     {"edit", "observe", "tier2_overwrite", "tier2_append", "move", "recover"}
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _record_prevalidated_commit_outcome(outcome: str) -> None:
+    """Record whether an in-lock ``_attempt`` reused pre-boundary validation.
+
+    Best-effort, content-free, never raises: observability must never break
+    a commit. ``outcome`` is one of ``"reused"``, ``"revalidated"``, or
+    ``"unavailable"`` (no pre-boundary census token to compare against).
+    """
+    try:
+        from . import metrics
+
+        metrics.inc_counter("exomem_prevalidated_commit_total", {"outcome": outcome})
+    except Exception:  # noqa: BLE001 - observability must never break a commit
+        pass
+    try:
+        from .log_events import log_event
+
+        log_event(
+            logger,
+            logging.INFO,
+            "prevalidated_commit",
+            fields={"outcome": outcome},
+        )
+    except Exception:  # noqa: BLE001 - observability must never break a commit
+        pass
 _LIFECYCLE_DECISION_KEYS = frozenset(
     {
         "schema_version",
@@ -424,6 +453,49 @@ class _Attempt:
     artifact_bytes_hash: str | None
     lifecycle_guard: vault.DirectoryCensusGuard | None
     language_registry: semantic_language_registry.SemanticLanguageRegistry
+    reused: bool = False
+
+    @property
+    def prevalidated_outcome(self) -> str:
+        """One of ``"reused"``/``"revalidated"``, for telemetry only.
+
+        Only meaningful for an ``_attempt`` call that was given a ``reuse``
+        candidate at all (i.e. the in-lock call inside
+        ``commit_creation_draft``); other call sites never set ``reused``.
+        """
+        return "reused" if self.reused else "revalidated"
+
+
+@dataclass(frozen=True, slots=True)
+class _PrevalidatedAttempt:
+    """A pre-boundary ``_attempt`` result, reusable by a later ``_attempt``
+    call only while ``census_token`` still matches a freshly computed one."""
+
+    census_token: tuple | None
+    before_corpus: semantic_contract.SemanticCorpusContext
+    candidate: semantic_contract.SemanticPageState
+    contracts: memory_schema.ResolvedMemoryContracts
+    language_registry: semantic_language_registry.SemanticLanguageRegistry
+    result: semantic_contract.SemanticContractResult
+    validation: CreationDraftValidation
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedCreationDraft:
+    """Everything ``commit_creation_draft`` needs after the pre-boundary
+    validation pass that ``prepare_commit_creation_draft`` performs."""
+
+    identity: str
+    destination: str
+    artifact_rel: str
+    auxiliaries: tuple[vault.PlannedWrite, ...]
+    auxiliary_digest: str
+    requested_review: bool
+    reason: str | None
+    token_hash: str
+    preliminary: _Attempt
+    reuse: _PrevalidatedAttempt | None
+    preliminary_commit_result: semantic_contract.SemanticContractResult
 
 
 class _DuplicateJsonKey(ValueError):
@@ -2940,6 +3012,7 @@ def _attempt(
     draft_token_hash: str | None = None,
     predecessor_path: str | None = None,
     predecessor_content_hash: str | None = None,
+    reuse: _PrevalidatedAttempt | None = None,
 ) -> _Attempt:
     if operation not in _OPERATIONS:
         raise RelationReviewError("INVALID_DRAFT_OPERATION", "unsupported creation operation")
@@ -2985,19 +3058,29 @@ def _attempt(
             raise RelationReviewError(
                 "DRAFT_DESTINATION_OCCUPIED", "draft destination is already occupied"
             )
-    registry = relation_registry.load_registry(root)
-    language = semantic_language_registry.load_registry(root)
-    loaded_contracts = memory_schema.load_saved_contracts(root)
-    before = semantic_contract.build_corpus_context(
-        root, registry=registry, language_registry=language
+    reused = (
+        reuse
+        if reuse is not None and semantic_contract.corpus_validity_token(root) == reuse.census_token
+        else None
     )
-    candidate = semantic_contract.build_page_state(
-        root,
-        destination,
-        normalized,
-        relation_registry=registry,
-        language_registry=language,
-    )
+    if reused is not None:
+        before = reused.before_corpus
+        candidate = reused.candidate
+        language = reused.language_registry
+    else:
+        registry = relation_registry.load_registry(root)
+        language = semantic_language_registry.load_registry(root)
+        loaded_contracts = memory_schema.load_saved_contracts(root)
+        before = semantic_contract.build_corpus_context(
+            root, registry=registry, language_registry=language
+        )
+        candidate = semantic_contract.build_page_state(
+            root,
+            destination,
+            normalized,
+            relation_registry=registry,
+            language_registry=language,
+        )
     if not candidate.eligible_compiled:
         raise RelationReviewError(
             "INVALID_DRAFT_PATH", "draft destination is not an eligible compiled page"
@@ -3024,31 +3107,36 @@ def _attempt(
             "DRAFT_DESTINATION_OCCUPIED", "draft destination is already occupied"
         )
     after = before.with_candidate(candidate)
-    contracts = memory_schema.resolve_contracts(
-        loaded_contracts,
-        projects=candidate.projects,
-        page_type=candidate.page_type,
-        language_registry=language,
-    )
-    review = None
-    if artifact is not None and artifact.kind != "qualifying":
-        review = semantic_contract.RelationReviewState(
-            artifact.kind,
-            artifact.page_identity,
-            artifact.content_fingerprint,
-            reason=artifact.reason,
-            reference=artifact.reference,
+    if reused is not None:
+        contracts = reused.contracts
+        result = reused.result
+        validation = reused.validation
+    else:
+        contracts = memory_schema.resolve_contracts(
+            loaded_contracts,
+            projects=candidate.projects,
+            page_type=candidate.page_type,
+            language_registry=language,
         )
-    result = _evaluate(candidate, before, after, contracts, operation, review, language)
-    validation = _validation(
-        identity,
-        destination,
-        fingerprint,
-        result,
-        candidate,
-        after,
-        draft_token_hash,
-    )
+        review = None
+        if artifact is not None and artifact.kind != "qualifying":
+            review = semantic_contract.RelationReviewState(
+                artifact.kind,
+                artifact.page_identity,
+                artifact.content_fingerprint,
+                reason=artifact.reason,
+                reference=artifact.reference,
+            )
+        result = _evaluate(candidate, before, after, contracts, operation, review, language)
+        validation = _validation(
+            identity,
+            destination,
+            fingerprint,
+            result,
+            candidate,
+            after,
+            draft_token_hash,
+        )
     if exact_destination:
         expected_kind = (
             "qualifying"
@@ -3130,6 +3218,7 @@ def _attempt(
         artifact_hash,
         lifecycle_guard,
         language,
+        reused is not None,
     )
 
 
@@ -3377,6 +3466,7 @@ def _commit_plan(
     draft_token_hash: str,
     predecessor_path: str | None,
     predecessor_content_hash: str | None,
+    reuse_result: semantic_contract.SemanticContractResult | None = None,
 ) -> tuple[semantic_contract.SemanticContractResult, RelationReviewRecord | None]:
     validation = attempt.validation
     if requested_review and supplied_hash != validation.draft_hash:
@@ -3405,14 +3495,23 @@ def _commit_plan(
             reference=artifact_reference,
         )
         if result.relation_disposition.kind != "reviewed_none":
-            result = _evaluate(
-                attempt.candidate,
-                attempt.before_corpus,
-                attempt.after_corpus,
-                attempt.contracts,
-                operation,
-                review_state,
-                attempt.language_registry,
+            # `reuse_result` is only ever supplied when the caller already
+            # proved (via a matching census token) that candidate/corpus/
+            # contracts/review_state are byte-identical to the pre-boundary
+            # pass that computed it — a deterministic function of unchanged
+            # inputs, so this is a cache hit, not a shortcut around safety.
+            result = (
+                reuse_result
+                if reuse_result is not None
+                else _evaluate(
+                    attempt.candidate,
+                    attempt.before_corpus,
+                    attempt.after_corpus,
+                    attempt.contracts,
+                    operation,
+                    review_state,
+                    attempt.language_registry,
+                )
             )
         if result.should_block or result.relation_disposition.kind != "reviewed_none":
             raise RelationReviewError(
@@ -3493,7 +3592,7 @@ def _commit_plan(
     return result, record
 
 
-def commit_creation_draft(
+def prepare_commit_creation_draft(
     vault_root: Path,
     *,
     path: str,
@@ -3507,8 +3606,14 @@ def commit_creation_draft(
     draft_token: str = "",
     predecessor_path: str | None = None,
     predecessor_content_hash: str | None = None,
-    semantic_state: Any | None = None,
-) -> CreationDraftCommit:
+) -> _PreparedCreationDraft:
+    """Pre-boundary validation for ``commit_creation_draft``.
+
+    Parses, canonicalizes, and runs the preliminary structural/relation-review
+    ``_attempt`` + ``_commit_plan`` pass — the same work ``commit_creation_draft``
+    always did before acquiring ``vault_creation_lock``. Every error raised
+    here happens before any lock or mutation-boundary exists to acquire.
+    """
     root = Path(vault_root).absolute()
     try:
         identity = _canonical_id(draft_id)
@@ -3575,7 +3680,7 @@ def commit_creation_draft(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
-        _commit_plan(
+        preliminary_commit_result, _preliminary_record = _commit_plan(
             preliminary,
             operation=operation,
             requested_review=requested_review,
@@ -3587,6 +3692,73 @@ def commit_creation_draft(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
+        census_token = semantic_contract.corpus_validity_token(root)
+        reuse = (
+            _PrevalidatedAttempt(
+                census_token,
+                preliminary.before_corpus,
+                preliminary.candidate,
+                preliminary.contracts,
+                preliminary.language_registry,
+                preliminary.result,
+                preliminary.validation,
+            )
+            if census_token is not None
+            else None
+        )
+        return _PreparedCreationDraft(
+            identity,
+            destination,
+            artifact_rel,
+            tuple(auxiliaries),
+            auxiliary_digest,
+            requested_review,
+            reason,
+            token_hash,
+            preliminary,
+            reuse,
+            preliminary_commit_result,
+        )
+    except RelationReviewError:
+        raise
+    except Exception as error:
+        raise _translate(error) from error
+
+
+def commit_prepared_creation_draft(
+    vault_root: Path,
+    prepared: _PreparedCreationDraft,
+    *,
+    path: str,
+    source: str,
+    operation: str,
+    relation_disposition: str | None = None,
+    relation_review_hash: str | None = None,
+    predecessor_path: str | None = None,
+    predecessor_content_hash: str | None = None,
+    semantic_state: Any | None = None,
+) -> CreationDraftCommit:
+    """Commit a draft already validated by ``prepare_commit_creation_draft``.
+
+    Everything here (``ensure_manifest``, the creation lock, the fresh
+    in-lock ``_attempt``, and the atomic write) is the part of
+    ``commit_creation_draft`` that a caller narrowing its mutation boundary
+    to just the commit seam should hold that boundary around — the pre-lock
+    validation already ran when ``prepared`` was built.
+    """
+    root = Path(vault_root).absolute()
+    try:
+        identity = prepared.identity
+        destination = prepared.destination
+        artifact_rel = prepared.artifact_rel
+        auxiliaries = prepared.auxiliaries
+        auxiliary_digest = prepared.auxiliary_digest
+        requested_review = prepared.requested_review
+        reason = prepared.reason
+        token_hash = prepared.token_hash
+        preliminary = prepared.preliminary
+        reuse = prepared.reuse
+        preliminary_commit_result = prepared.preliminary_commit_result
         activation_manifest.ensure_manifest(
             root, census=preliminary.before_corpus.activation_census
         )
@@ -3603,6 +3775,10 @@ def commit_creation_draft(
                 draft_token_hash=token_hash,
                 predecessor_path=predecessor_path,
                 predecessor_content_hash=predecessor_content_hash,
+                reuse=reuse,
+            )
+            _record_prevalidated_commit_outcome(
+                "unavailable" if reuse is None else attempt.prevalidated_outcome
             )
             validation = attempt.validation
             result, record = _commit_plan(
@@ -3616,15 +3792,16 @@ def commit_creation_draft(
                 draft_token_hash=token_hash,
                 predecessor_path=predecessor_path,
                 predecessor_content_hash=predecessor_content_hash,
+                reuse_result=preliminary_commit_result if attempt.reused else None,
             )
 
-            prepared = attempt.artifact
+            existing_artifact = attempt.artifact
             resumed = False
             required_guards: tuple[
                 vault.PathGuard | vault.DirectoryCensusGuard, ...
             ] = ()
             writes: list[vault.PlannedWrite] = []
-            if prepared is not None:
+            if existing_artifact is not None:
                 if attempt.artifact_bytes_hash is None:
                     raise RelationReviewError(
                         "DRAFT_ID_IN_USE", "draft identity is already reserved"
@@ -3747,3 +3924,54 @@ def commit_creation_draft(
         raise
     except Exception as error:
         raise _translate(error) from error
+
+
+def commit_creation_draft(
+    vault_root: Path,
+    *,
+    path: str,
+    source: str,
+    draft_id: str,
+    operation: str,
+    relation_disposition: str | None = None,
+    relation_review_hash: str | None = None,
+    relation_review_reason: str | None = None,
+    auxiliary_writes: tuple[vault.PlannedWrite, ...] | list[vault.PlannedWrite] = (),
+    draft_token: str = "",
+    predecessor_path: str | None = None,
+    predecessor_content_hash: str | None = None,
+    semantic_state: Any | None = None,
+) -> CreationDraftCommit:
+    """One-call convenience: validate, then commit, with no boundary between.
+
+    Callers that narrow their own mutation boundary to just the commit seam
+    should instead call ``prepare_commit_creation_draft`` before acquiring
+    that boundary and ``commit_prepared_creation_draft`` inside it.
+    """
+    root = Path(vault_root).absolute()
+    prepared = prepare_commit_creation_draft(
+        root,
+        path=path,
+        source=source,
+        draft_id=draft_id,
+        operation=operation,
+        relation_disposition=relation_disposition,
+        relation_review_hash=relation_review_hash,
+        relation_review_reason=relation_review_reason,
+        auxiliary_writes=auxiliary_writes,
+        draft_token=draft_token,
+        predecessor_path=predecessor_path,
+        predecessor_content_hash=predecessor_content_hash,
+    )
+    return commit_prepared_creation_draft(
+        root,
+        prepared,
+        path=path,
+        source=source,
+        operation=operation,
+        relation_disposition=relation_disposition,
+        relation_review_hash=relation_review_hash,
+        predecessor_path=predecessor_path,
+        predecessor_content_hash=predecessor_content_hash,
+        semantic_state=semantic_state,
+    )

--- a/src/exomem/relation_review.py
+++ b/src/exomem/relation_review.py
@@ -3058,11 +3058,17 @@ def _attempt(
             raise RelationReviewError(
                 "DRAFT_DESTINATION_OCCUPIED", "draft destination is already occupied"
             )
-    reused = (
-        reuse
-        if reuse is not None and semantic_contract.corpus_validity_token(root) == reuse.census_token
-        else None
-    )
+    if reuse is not None:
+        from .writer_lease import read_commit_generation
+
+        stamp_current = semantic_contract.validity_stamp_current(
+            root,
+            reuse.census_token,
+            commit_generation=read_commit_generation(root),
+        )
+    else:
+        stamp_current = False
+    reused = reuse if stamp_current else None
     if reused is not None:
         before = reused.before_corpus
         candidate = reused.candidate
@@ -3615,6 +3621,11 @@ def prepare_commit_creation_draft(
     here happens before any lock or mutation-boundary exists to acquire.
     """
     root = Path(vault_root).absolute()
+    # Entry read: a governed commit landing during this preliminary pass
+    # moves the generation past this value, disabling reuse in-boundary.
+    from .writer_lease import read_commit_generation
+
+    entry_generation = read_commit_generation(root)
     try:
         identity = _canonical_id(draft_id)
         token_hash = draft_token_hash(draft_token)
@@ -3692,7 +3703,15 @@ def prepare_commit_creation_draft(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
-        census_token = semantic_contract.corpus_validity_token(root)
+        sc_token = (
+            semantic_contract.corpus_validity_token(
+                root,
+                corpus_census=semantic_contract.cached_corpus_census(root),
+            )
+            if entry_generation is not None
+            else None
+        )
+        census_token = (sc_token, entry_generation) if sc_token is not None else None
         reuse = (
             _PrevalidatedAttempt(
                 census_token,

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1248,7 +1248,7 @@ def _relation_review_census(root: Path) -> tuple | None:
     return tuple(sorted(entries))
 
 
-def corpus_validity_token(root: Path) -> tuple | None:
+def corpus_validity_token(root: Path, *, corpus_census: tuple | None = None) -> tuple | None:
     """Stable identity for narrow-boundary preflight reuse.
 
     Combines ``_corpus_census`` (every corpus/config input
@@ -1257,14 +1257,59 @@ def corpus_validity_token(root: Path) -> tuple | None:
     does not cover). ``None`` means some input cannot be censused cheaply;
     callers must then always revalidate rather than reuse a pre-boundary
     result.
+
+    Pass ``corpus_census`` to reuse a census that was just walked (e.g. the
+    one ``build_corpus_context`` validated its cache with) instead of paying
+    a second stat-walk — at thousands of pages the walk dominates write
+    latency, and the CI write-latency gate holds preflight to one walk total.
     """
-    corpus = _corpus_census(root)
+    corpus = corpus_census if corpus_census is not None else _corpus_census(root)
     if corpus is None:
         return None
     review = _relation_review_census(root)
     if review is None:
         return None
     return (corpus, review)
+
+
+def cached_corpus_census(root: Path) -> tuple | None:
+    """The census stored with the current cached corpus context — no walk.
+
+    Only meaningful immediately after a ``build_corpus_context`` call on the
+    same root: the walk that validated (or populated) the cache entry is the
+    census returned here. ``None`` when nothing is cached."""
+    try:
+        cache_key = _corpus_cache_key(root)
+    except Exception:  # noqa: BLE001 - an unkeyable root simply has no cache
+        return None
+    with _CORPUS_CONTEXT_CACHE_LOCK:
+        entry = _CORPUS_CONTEXT_CACHE.get(cache_key)
+    return entry[0] if entry is not None else None
+
+
+def validity_stamp_current(
+    root: Path, stamp: tuple | None, *, commit_generation: int | None
+) -> bool:
+    """O(sidecars) in-boundary admission check for a captured validity stamp.
+
+    ``stamp`` is ``(corpus_validity_token, entry_commit_generation)``. The
+    boundary commit-generation (bumped on every mutation-guard exit) proves
+    no governed writer committed since the generation was captured, and the
+    fresh review-artifact census covers the sidecar inputs. This replaces the
+    in-boundary corpus stat-walk, which at thousands of pages costs more than
+    the commit itself. External (non-governed) edits are outside this check —
+    the same protections the wide boundary relied on (path guards,
+    ``create_only``, target freshness) still apply at write time.
+    """
+    if stamp is None or commit_generation is None:
+        return False
+    sc_token, captured_generation = stamp
+    if sc_token is None or captured_generation is None:
+        return False
+    if commit_generation != captured_generation:
+        return False
+    fresh_review = _relation_review_census(root)
+    return fresh_review is not None and fresh_review == sc_token[1]
 
 
 def _config_census(root: Path) -> tuple[tuple[str, str, int, int], ...] | None:

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -1210,6 +1210,63 @@ def _corpus_census(root: Path) -> tuple | None:
     return tuple(sorted(entries))
 
 
+def _relation_review_census(root: Path) -> tuple | None:
+    """Stat census of relation-review artifacts and lifecycle sidecars.
+
+    ``_corpus_census`` only tracks ``.md`` files, so the JSON review
+    artifacts (``relation_review.review_artifact_path``) and lifecycle
+    decision/prepared sidecars (``lifecycle_decision_path``,
+    ``lifecycle_prepared_path``) under ``<KB>/_Schema/relation-reviews/`` are
+    otherwise invisible to a census-based reuse token. Mirrors the
+    alias-refusal safety rule of the strict corpus walk. Returns ``None``
+    when the tree cannot be fingerprinted safely.
+    """
+    entries: set[tuple[str, str, int, int]] = set()
+    directory = vault.kb_root(root) / "_Schema" / "relation-reviews"
+
+    def walk(current: Path) -> None:
+        try:
+            children = list(os.scandir(current))
+        except FileNotFoundError:
+            return
+        for child in children:
+            path = Path(child.path)
+            info = child.stat(follow_symlinks=False)
+            if child.is_symlink() or vault._is_reparse(info):
+                raise _CensusUnsafe
+            if stat.S_ISDIR(info.st_mode):
+                walk(path)
+                continue
+            if not stat.S_ISREG(info.st_mode):
+                raise _CensusUnsafe
+            entries.add((path.relative_to(root).as_posix(), "f", info.st_size, info.st_mtime_ns))
+
+    try:
+        walk(directory)
+    except (_CensusUnsafe, OSError, ValueError):
+        return None
+    return tuple(sorted(entries))
+
+
+def corpus_validity_token(root: Path) -> tuple | None:
+    """Stable identity for narrow-boundary preflight reuse.
+
+    Combines ``_corpus_census`` (every corpus/config input
+    ``build_corpus_context`` reads) with ``_relation_review_census`` (the
+    review-artifact and lifecycle-sidecar inputs the plain corpus census
+    does not cover). ``None`` means some input cannot be censused cheaply;
+    callers must then always revalidate rather than reuse a pre-boundary
+    result.
+    """
+    corpus = _corpus_census(root)
+    if corpus is None:
+        return None
+    review = _relation_review_census(root)
+    if review is None:
+        return None
+    return (corpus, review)
+
+
 def _config_census(root: Path) -> tuple[tuple[str, str, int, int], ...] | None:
     """O(1) freshness stamp for non-Markdown semantic inputs."""
     entries: list[tuple[str, str, int, int]] = []

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -1257,7 +1257,7 @@ def preflight_existing(
     # phantom casing. Everything below is built from `root / path`, so a
     # re-spell stays self-consistent, and a canonical input is a no-op.
     path = vault.canonical_vault_rel(root, path)
-    census_token_before = semantic_contract.corpus_validity_token(root)
+    entry_generation = _entry_commit_generation(root)
     before_source, primary_guard = vault.read_guarded_text(root, root / path)
     raw_before_hash = vault.content_hash(before_source)
     # The parser/corpus and public content-hash contract normalize platform
@@ -1415,8 +1415,7 @@ def preflight_existing(
         include_relation_disposition=applicability == "full",
         language_registry=language,
     )
-    census_token_after = semantic_contract.corpus_validity_token(root)
-    census_token = census_token_before if census_token_before == census_token_after else None
+    census_token = _capture_validity_stamp(root, entry_generation)
     return ExistingPreflight(
         applicability,
         operation,
@@ -1692,14 +1691,19 @@ def commit_existing(
         operation=f"semantic_existing_{preflight.operation}_commit",
         holder_kind="command",
     ):
-        # An exact census_token match means nothing has changed since
-        # preflight, so this preflight is still current — commit as today.
-        # A mismatch (or a preflight built on an uncensusable tree,
-        # census_token=None) re-runs preflight_existing warm, surfacing
+        # A current validity stamp (commit-generation unchanged + sidecar
+        # census unchanged — no corpus walk) means no governed writer
+        # committed since preflight, so it is still current — commit as
+        # today. Otherwise re-run preflight_existing warm, surfacing
         # STALE_SEMANTIC_WRITE/SEMANTIC_CONTRACT_BLOCKED exactly as the
         # existing cross-invocation replay path already does.
-        fresh_census_token = semantic_contract.corpus_validity_token(root)
-        if preflight.census_token is None or fresh_census_token != preflight.census_token:
+        from .writer_lease import read_commit_generation
+
+        if not semantic_contract.validity_stamp_current(
+            root,
+            preflight.census_token,
+            commit_generation=read_commit_generation(root),
+        ):
             preflight = _revalidate_existing_preflight(root, preflight)
             if preflight.contract_result.should_block:
                 raise SemanticWriteError(
@@ -2802,7 +2806,7 @@ def preflight_creation(
         vault.parse_frontmatter(source, strict=True)
     except vault.FrontmatterError as error:
         raise SemanticWriteError(error.code, "draft frontmatter is invalid") from error
-    census_token_before = semantic_contract.corpus_validity_token(root)
+    entry_generation = _entry_commit_generation(root)
     result, state = _evaluate_structural(root, destination=path, source=source, operation=operation)
     if semantic_contract.requires_semantic_unit(state):
         if draft_id is None:
@@ -2818,10 +2822,7 @@ def preflight_creation(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
-        census_token_after = semantic_contract.corpus_validity_token(root)
-        census_token = (
-            census_token_before if census_token_before == census_token_after else None
-        )
+        census_token = _capture_validity_stamp(root, entry_generation)
         return CreationPreflight(
             "full",
             path,
@@ -2839,11 +2840,38 @@ def preflight_creation(
         if state.page_type is not None or semantic_contract.compiled_intent(state)
         else "not_semantic"
     )
-    census_token_after = semantic_contract.corpus_validity_token(root)
-    census_token = census_token_before if census_token_before == census_token_after else None
+    census_token = _capture_validity_stamp(root, entry_generation)
     return CreationPreflight(
         applicability, path, source, draft_id, draft_token, False, result, None, state, census_token
     )
+
+
+def _entry_commit_generation(root: Path):  # noqa: ANN201 - int | None
+    """Read the boundary commit-generation at preflight ENTRY, before any
+    validation work, so a governed commit landing during the preflight moves
+    the generation past the captured value and disables reuse."""
+    from .writer_lease import read_commit_generation
+
+    return read_commit_generation(root)
+
+
+def _capture_validity_stamp(root: Path, entry_generation) -> tuple | None:  # noqa: ANN001
+    """Assemble the preflight validity stamp WITHOUT a second corpus walk.
+
+    The corpus census is reused from the cache entry the validation's own
+    ``build_corpus_context`` call just walked/validated; only the cheap
+    review-artifact census is computed here. The stamp pairs that with the
+    entry commit-generation; the in-boundary admission check is then
+    ``semantic_contract.validity_stamp_current`` — O(sidecars), no walk.
+    """
+    if entry_generation is None:
+        return None
+    sc_token = semantic_contract.corpus_validity_token(
+        root, corpus_census=semantic_contract.cached_corpus_census(root)
+    )
+    if sc_token is None:
+        return None
+    return (sc_token, entry_generation)
 
 
 def _prewarm_embeddings() -> None:
@@ -2940,16 +2968,18 @@ def commit_creation(
             return CreationCommit(
                 "full", True, committed.written_paths, committed.contract_result, committed
             )
-        # Structural / non-semantic creations honour the census stamp too:
-        # recompute it inside the boundary; on mismatch (or an uncensusable
-        # tree) re-run the structural evaluation so a concurrently-changed
-        # config or registry cannot admit a stale pre-boundary verdict.
+        # Structural / non-semantic creations honour the validity stamp too:
+        # check it inside the boundary (commit-generation + sidecar census,
+        # no corpus walk); on mismatch (or an uncensusable tree) re-run the
+        # structural evaluation so a concurrently-changed config or registry
+        # cannot admit a stale pre-boundary verdict.
+        from .writer_lease import read_commit_generation
+
         contract_result = preflight.contract_result
-        fresh_census_token = semantic_contract.corpus_validity_token(root)
-        if (
-            preflight.census_token is None
-            or fresh_census_token is None
-            or fresh_census_token != preflight.census_token
+        if not semantic_contract.validity_stamp_current(
+            root,
+            preflight.census_token,
+            commit_generation=read_commit_generation(root),
         ):
             relation_review._record_prevalidated_commit_outcome("revalidated")
             contract_result, _fresh_state = _evaluate_structural(

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -7,6 +7,7 @@ import binascii
 import datetime as dt
 import hashlib
 import json
+import os
 import re
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -778,6 +779,7 @@ class CreationPreflight:
     contract_result: semantic_contract.SemanticContractResult | None
     creation_validation: relation_review.CreationDraftValidation | None
     semantic_state: semantic_contract.SemanticPageState
+    census_token: tuple | None = None
 
     @property
     def draft_hash(self) -> str | None:
@@ -861,6 +863,7 @@ class ExistingPreflight:
     resolver_freshness: tuple[int, int, str] | None
     primary_guard: vault.PathGuard
     committed_replay: bool
+    census_token: tuple | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -1254,6 +1257,7 @@ def preflight_existing(
     # phantom casing. Everything below is built from `root / path`, so a
     # re-spell stays self-consistent, and a canonical input is a no-op.
     path = vault.canonical_vault_rel(root, path)
+    census_token_before = semantic_contract.corpus_validity_token(root)
     before_source, primary_guard = vault.read_guarded_text(root, root / path)
     raw_before_hash = vault.content_hash(before_source)
     # The parser/corpus and public content-hash contract normalize platform
@@ -1411,6 +1415,8 @@ def preflight_existing(
         include_relation_disposition=applicability == "full",
         language_registry=language,
     )
+    census_token_after = semantic_contract.corpus_validity_token(root)
+    census_token = census_token_before if census_token_before == census_token_after else None
     return ExistingPreflight(
         applicability,
         operation,
@@ -1437,6 +1443,7 @@ def preflight_existing(
         resolver_freshness,
         primary_guard,
         committed_replay,
+        census_token,
     )
 
 
@@ -1631,6 +1638,35 @@ def _commit_existing_locked(
     )
 
 
+def _revalidate_existing_preflight(
+    vault_root: Path, preflight: ExistingPreflight
+) -> ExistingPreflight:
+    """Re-run ``preflight_existing`` warm when a pre-boundary census token has
+    gone stale. Surfaces ``STALE_SEMANTIC_WRITE``/``SEMANTIC_CONTRACT_BLOCKED``
+    exactly as the existing cross-invocation replay path already does — this
+    is the same warm revalidation, just triggered by a census mismatch instead
+    of a second caller-supplied invocation.
+    """
+    relation_disposition: str | None = None
+    relation_review_hash: str | None = None
+    relation_review_reason: str | None = None
+    if preflight.requested_decision is not None:
+        relation_disposition = "reviewed_none"
+        relation_review_hash = preflight.transition_hash
+        relation_review_reason = preflight.requested_decision.reason
+    return preflight_existing(
+        vault_root,
+        path=preflight.path,
+        after_source=preflight.after_source,
+        operation=preflight.operation,
+        expected_before_hash=preflight.before.source_hash,
+        transition_token=preflight.transition_token,
+        relation_disposition=relation_disposition,
+        relation_review_hash=relation_review_hash,
+        relation_review_reason=relation_review_reason,
+    )
+
+
 def commit_existing(
     vault_root: Path,
     *,
@@ -1646,46 +1682,81 @@ def commit_existing(
             preflight.contract_result.blocking_findings,
         )
 
-    result = preflight.contract_result
     auxiliaries = tuple(auxiliary_writes)
-    if preflight.manifest_install_required:
-        winner = activation_manifest.ensure_manifest(root, census=preflight.activation_census)
-        result, _ = _reevaluate_existing(preflight, manifest=winner)
-        if result.should_block:
-            raise SemanticWriteError(
-                "SEMANTIC_CONTRACT_BLOCKED",
-                _blocking_reason(
-                    result,
-                    "semantic contract blocked against the activation boundary winner",
-                ),
-                result.blocking_findings,
-            )
+    _prewarm_embeddings()
+    from .writer_lease import active_manager, active_mutation_request_id
 
-    if preflight.resolver_freshness is not None:
+    with active_manager().mutation_guard(
+        root,
+        request_id=active_mutation_request_id(),
+        operation=f"semantic_existing_{preflight.operation}_commit",
+        holder_kind="command",
+    ):
+        # An exact census_token match means nothing has changed since
+        # preflight, so this preflight is still current — commit as today.
+        # A mismatch (or a preflight built on an uncensusable tree,
+        # census_token=None) re-runs preflight_existing warm, surfacing
+        # STALE_SEMANTIC_WRITE/SEMANTIC_CONTRACT_BLOCKED exactly as the
+        # existing cross-invocation replay path already does.
+        fresh_census_token = semantic_contract.corpus_validity_token(root)
+        if preflight.census_token is None or fresh_census_token != preflight.census_token:
+            preflight = _revalidate_existing_preflight(root, preflight)
+            if preflight.contract_result.should_block:
+                raise SemanticWriteError(
+                    "SEMANTIC_CONTRACT_BLOCKED",
+                    _blocking_reason(preflight.contract_result),
+                    preflight.contract_result.blocking_findings,
+                )
+
+        result = preflight.contract_result
+        if preflight.manifest_install_required:
+            winner = activation_manifest.ensure_manifest(root, census=preflight.activation_census)
+            result, _ = _reevaluate_existing(preflight, manifest=winner)
+            if result.should_block:
+                raise SemanticWriteError(
+                    "SEMANTIC_CONTRACT_BLOCKED",
+                    _blocking_reason(
+                        result,
+                        "semantic contract blocked against the activation boundary winner",
+                    ),
+                    result.blocking_findings,
+                )
+
+        if preflight.resolver_freshness is not None:
+            try:
+                find_module.prime_resolver_from_entries(
+                    root,
+                    preflight.before_corpus.resolver_entries,
+                    expected_freshness=preflight.resolver_freshness,
+                )
+            except Exception:  # noqa: BLE001 — rebuildable graph cache never blocks commit
+                pass
+
         try:
-            find_module.prime_resolver_from_entries(
-                root,
-                preflight.before_corpus.resolver_entries,
-                expected_freshness=preflight.resolver_freshness,
-            )
-        except Exception:  # noqa: BLE001 — rebuildable graph cache never blocks commit
-            pass
-
-    try:
-        with vault.vault_creation_lock(root, "semantic-creation"):
-            return _commit_existing_locked(
-                root,
-                preflight=preflight,
-                auxiliaries=auxiliaries,
-                result=result,
-            )
-    except vault.VaultLockTimeout as error:
-        raise SemanticWriteError(
-            "SEMANTIC_CREATION_LOCK_TIMEOUT",
-            "timed out acquiring semantic creation lock",
-        ) from error
-    except vault.VaultLockError as error:
-        raise SemanticWriteError(error.code, error.reason) from error
+            with vault.vault_creation_lock(root, "semantic-creation"):
+                return _commit_existing_locked(
+                    root,
+                    preflight=preflight,
+                    auxiliaries=auxiliaries,
+                    result=result,
+                )
+        except vault.PathGuardError as error:
+            # A caller-captured auxiliary guard (log/index) lost a race the
+            # wide boundary used to prevent. The batch aborted atomically —
+            # nothing was written — so surface the documented retryable
+            # staleness instead of a raw internal error.
+            raise SemanticWriteError(
+                "STALE_SEMANTIC_WRITE",
+                "a concurrent write updated a shared auxiliary during commit; "
+                "retry the operation",
+            ) from error
+        except vault.VaultLockTimeout as error:
+            raise SemanticWriteError(
+                "SEMANTIC_CREATION_LOCK_TIMEOUT",
+                "timed out acquiring semantic creation lock",
+            ) from error
+        except vault.VaultLockError as error:
+            raise SemanticWriteError(error.code, error.reason) from error
 
 
 def _move_state_map(
@@ -2731,6 +2802,7 @@ def preflight_creation(
         vault.parse_frontmatter(source, strict=True)
     except vault.FrontmatterError as error:
         raise SemanticWriteError(error.code, "draft frontmatter is invalid") from error
+    census_token_before = semantic_contract.corpus_validity_token(root)
     result, state = _evaluate_structural(root, destination=path, source=source, operation=operation)
     if semantic_contract.requires_semantic_unit(state):
         if draft_id is None:
@@ -2746,6 +2818,10 @@ def preflight_creation(
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
         )
+        census_token_after = semantic_contract.corpus_validity_token(root)
+        census_token = (
+            census_token_before if census_token_before == census_token_after else None
+        )
         return CreationPreflight(
             "full",
             path,
@@ -2756,15 +2832,41 @@ def preflight_creation(
             validation.contract_result,
             validation,
             state,
+            census_token,
         )
     applicability: Literal["structural", "not_semantic"] = (
         "structural"
         if state.page_type is not None or semantic_contract.compiled_intent(state)
         else "not_semantic"
     )
+    census_token_after = semantic_contract.corpus_validity_token(root)
+    census_token = census_token_before if census_token_before == census_token_after else None
     return CreationPreflight(
-        applicability, path, source, draft_id, draft_token, False, result, None, state
+        applicability, path, source, draft_id, draft_token, False, result, None, state, census_token
     )
+
+
+def _prewarm_embeddings() -> None:
+    """Best-effort embedding-model warm-up before the mutation boundary.
+
+    Removes the chance of a cold model load happening while the boundary is
+    held — the root cause of the multi-minute hold observed on 2026-07-25 —
+    by attempting the load here instead. Never blocks or fails a commit:
+    every failure, including the model being unavailable or still warming
+    up, is swallowed.
+    """
+    if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
+        return
+    try:
+        from . import readiness
+
+        if readiness.should_defer("embeddings"):
+            return
+        from . import embeddings
+
+        embeddings.get_model()
+    except Exception:  # noqa: BLE001 - a warm-up attempt must never break a commit
+        pass
 
 
 def commit_creation(
@@ -2793,9 +2895,13 @@ def commit_creation(
             _blocking_reason(preflight.contract_result),
             preflight.contract_result.blocking_findings,
         )
+    prepared: relation_review._PreparedCreationDraft | None = None
     if preflight.applicability == "full":
         assert preflight.draft_id is not None
-        committed = relation_review.commit_creation_draft(
+        # Pre-boundary: parse/canonicalize + the preliminary structural and
+        # relation-review validation. Any failure here raises before the
+        # mutation boundary below is ever acquired.
+        prepared = relation_review.prepare_commit_creation_draft(
             root,
             path=preflight.destination,
             source=preflight.source,
@@ -2808,32 +2914,85 @@ def commit_creation(
             draft_token=preflight.draft_token,
             predecessor_path=predecessor_path,
             predecessor_content_hash=predecessor_content_hash,
-            semantic_state=semantic_index.from_semantic_page_state(preflight.semantic_state),
         )
+    _prewarm_embeddings()
+    from .writer_lease import active_manager, active_mutation_request_id
+
+    with active_manager().mutation_guard(
+        root,
+        request_id=active_mutation_request_id(),
+        operation=f"semantic_creation_{operation}_commit",
+        holder_kind="command",
+    ):
+        if prepared is not None:
+            committed = relation_review.commit_prepared_creation_draft(
+                root,
+                prepared,
+                path=preflight.destination,
+                source=preflight.source,
+                operation=operation,
+                relation_disposition=relation_disposition,
+                relation_review_hash=relation_review_hash,
+                predecessor_path=predecessor_path,
+                predecessor_content_hash=predecessor_content_hash,
+                semantic_state=semantic_index.from_semantic_page_state(preflight.semantic_state),
+            )
+            return CreationCommit(
+                "full", True, committed.written_paths, committed.contract_result, committed
+            )
+        # Structural / non-semantic creations honour the census stamp too:
+        # recompute it inside the boundary; on mismatch (or an uncensusable
+        # tree) re-run the structural evaluation so a concurrently-changed
+        # config or registry cannot admit a stale pre-boundary verdict.
+        contract_result = preflight.contract_result
+        fresh_census_token = semantic_contract.corpus_validity_token(root)
+        if (
+            preflight.census_token is None
+            or fresh_census_token is None
+            or fresh_census_token != preflight.census_token
+        ):
+            relation_review._record_prevalidated_commit_outcome("revalidated")
+            contract_result, _fresh_state = _evaluate_structural(
+                root,
+                destination=preflight.destination,
+                source=preflight.source,
+                operation=operation,
+            )
+            if contract_result.should_block:
+                raise SemanticWriteError(
+                    "SEMANTIC_CONTRACT_BLOCKED",
+                    _blocking_reason(contract_result),
+                    contract_result.blocking_findings,
+                )
+        else:
+            relation_review._record_prevalidated_commit_outcome("reused")
+        writes = [*auxiliary_writes]
+        writes.append(
+            vault.PlannedWrite(
+                root / preflight.destination,
+                preflight.source,
+                create_only=True,
+                guard=vault.PathGuard.capture(root, preflight.destination, leaf_policy="absent"),
+            )
+        )
+        token = semantic_index.set_parent_states(
+            {preflight.destination: semantic_index.from_semantic_page_state(preflight.semantic_state)}
+        )
+        try:
+            written = vault.batch_atomic_write(writes, vault_root=root)
+        except vault.PathGuardError as error:
+            raise SemanticWriteError(
+                "STALE_SEMANTIC_WRITE",
+                "a concurrent write updated a shared auxiliary during commit; "
+                "retry the operation",
+            ) from error
+        finally:
+            semantic_index.reset_parent_states(token)
+        paths = tuple(path.relative_to(root).as_posix() for path in written)
         return CreationCommit(
-            "full", True, committed.written_paths, committed.contract_result, committed
+            preflight.applicability,
+            True,
+            paths,
+            contract_result,
+            None,
         )
-    writes = [*auxiliary_writes]
-    writes.append(
-        vault.PlannedWrite(
-            root / preflight.destination,
-            preflight.source,
-            create_only=True,
-            guard=vault.PathGuard.capture(root, preflight.destination, leaf_policy="absent"),
-        )
-    )
-    token = semantic_index.set_parent_states(
-        {preflight.destination: semantic_index.from_semantic_page_state(preflight.semantic_state)}
-    )
-    try:
-        written = vault.batch_atomic_write(writes, vault_root=root)
-    finally:
-        semantic_index.reset_parent_states(token)
-    paths = tuple(path.relative_to(root).as_posix() for path in written)
-    return CreationCommit(
-        preflight.applicability,
-        True,
-        paths,
-        preflight.contract_result,
-        None,
-    )

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -1230,8 +1230,16 @@ class LeaseManager:
             operation=operation,
             holder_kind=holder_kind,
         ) as mutation:
-            with self.writer_authority_guard():
-                yield mutation
+            try:
+                with self.writer_authority_guard():
+                    yield mutation
+            finally:
+                # Bump while the boundary is still held, so the counter is
+                # serialized with the mutations it fingerprints. Every
+                # governed writer exits through here (wide or narrow), which
+                # is what lets the validity-stamp comparison skip the
+                # in-boundary corpus stat-walk.
+                _bump_commit_generation(self.config.state_dir, vault_root)
 
     @contextmanager
     def writer_authority_guard(self) -> Iterator[None]:
@@ -1743,6 +1751,55 @@ def get_manager() -> LeaseManager:
             manager = LeaseManager(config)
             _MANAGERS[config] = manager
         return manager
+
+
+def _commit_generation_path(
+    state_dir: Path, vault_or_cell: os.PathLike[str] | str
+) -> Path:
+    from .mutation_lock import canonical_mutation_identity
+
+    digest = hashlib.sha256(
+        canonical_mutation_identity(vault_or_cell).encode("utf-8")
+    ).hexdigest()[:20]
+    return Path(state_dir) / "commit-generations" / f"{digest}.txt"
+
+
+def read_commit_generation(vault_or_cell: os.PathLike[str] | str) -> int | None:
+    """Monotonic count of boundary-held mutations for this vault.
+
+    Read outside the boundary at preflight and compared inside it to admit
+    validity-stamp reuse without a corpus stat-walk. ``0`` when never bumped;
+    ``None`` on any read error other than the file simply not existing —
+    fail closed: an unreadable counter must disable reuse, never admit it.
+    """
+    try:
+        path = _commit_generation_path(
+            active_manager().config.state_dir, vault_or_cell
+        )
+    except Exception:  # noqa: BLE001 - unresolvable identity disables reuse
+        return None
+    try:
+        return int(path.read_text(encoding="utf-8").strip() or "0")
+    except FileNotFoundError:
+        return 0
+    except Exception:  # noqa: BLE001 - unreadable counter disables reuse
+        return None
+
+
+def _bump_commit_generation(
+    state_dir: Path, vault_or_cell: os.PathLike[str] | str
+) -> None:
+    """Advance the counter; called while the mutation boundary is held."""
+    try:
+        path = _commit_generation_path(state_dir, vault_or_cell)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            current = int(path.read_text(encoding="utf-8").strip() or "0")
+        except Exception:  # noqa: BLE001 - a fresh/corrupt counter restarts
+            current = 0
+        path.write_text(str(current + 1), encoding="utf-8")
+    except Exception:  # noqa: BLE001 - the counter must never break a commit
+        pass
 
 
 def active_manager() -> LeaseManager:

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -55,6 +55,21 @@ _COORDINATOR_USER_AGENT = (
 # 60s was shorter than one abandoned-write investigation; 10 minutes covers a
 # human noticing the timeout, checking state, and retrying.
 _IMPLICIT_RETRY_TTL_SECONDS = 600.0
+
+# Commands whose `invoke()` boundary is narrowed to `writer_authority_guard`
+# (fence-only, no shared vault lock) instead of the full `mutation_guard`.
+# The command's own commit seam (`semantic_writes.commit_creation` or
+# `commit_existing`) is responsible for acquiring the vault mutation boundary
+# itself, around only its commit — not the corpus validation and model
+# loading that precede it. Every name here ends in `commit_creation` or
+# `commit_existing`, both self-guarding: `remember`/`replace_memory` ->
+# `commit_creation`; `edit_memory` (all four of its edit/multi_edit/
+# set_take/set_frontmatter_field sub-modes) and `observe_memory` ->
+# `commit_existing`. `EXOMEM_WIDE_MUTATION_BOUNDARY` restores today's
+# wide-boundary behavior for every command in this set.
+_NARROW_BOUNDARY_COMMANDS = frozenset(
+    {"remember", "replace_memory", "edit_memory", "observe_memory"}
+)
 _EXPLICIT_RETRY_TTL_SECONDS = 24 * 60 * 60.0
 _IDEMPOTENCY_WAIT_SECONDS = 5.0
 _IDEMPOTENCY_POLL_INTERVAL_SECONDS = 0.025
@@ -1353,6 +1368,30 @@ class LeaseManager:
         narrow_media_commit = command.name == "process_media" and kwargs.get(
             "operation", "process"
         ) in {"process", "retry"}
+        # `manage_memory_file` is the Tier-2 escape hatch's single consolidated
+        # command; only its `create`/`append` operations narrow. Their leaves
+        # are self-guarding on EVERY routing: governed Markdown goes through
+        # `commit_creation`/`commit_existing`, and the non-semantic branches
+        # (non-`.md` targets, Evidence appends, `kind="dir"`) acquire the
+        # mutation boundary in the leaf itself (`create_file.py`,
+        # `append_to_file.py`, `create_directory.py`).
+        # `move`/`delete`/`recover`/`list`/`trash-list` still rely entirely on
+        # this outer boundary (`commit_move`/`commit_recovery` are out of
+        # scope for this change), so only the file-write operations narrow —
+        # never the whole command.
+        narrow_tier2_file_commit = (
+            command.name == "manage_memory_file"
+            and kwargs.get("operation", "list") in {"create", "append"}
+            and not os.environ.get("EXOMEM_WIDE_MUTATION_BOUNDARY")
+        )
+        narrow_boundary = (
+            narrow_media_commit
+            or narrow_tier2_file_commit
+            or (
+                command.name in _NARROW_BOUNDARY_COMMANDS
+                and not os.environ.get("EXOMEM_WIDE_MUTATION_BOUNDARY")
+            )
+        )
         try:
             result = self.idempotency.run(
                 key,
@@ -1362,7 +1401,7 @@ class LeaseManager:
                 on_replay=on_replay,
                 operation_guard=(
                     self.writer_authority_guard
-                    if narrow_media_commit
+                    if narrow_boundary
                     else lambda: self.mutation_guard(
                         mutation_subject,
                         request_id=request_id,

--- a/tests/test_narrow_boundary_leaf_guards.py
+++ b/tests/test_narrow_boundary_leaf_guards.py
@@ -1,0 +1,117 @@
+"""The Tier-2 file leaves are self-guarding on every routing.
+
+The non-semantic branches (non-``.md`` create/append, directory create)
+acquire the vault mutation boundary in the leaf itself, so a narrowed command
+surface can never write governed log/index state — or race concurrent
+creates — without the boundary held. Regression for the review finding that
+these three sub-paths escaped the boundary entirely under the narrow
+predicate, silently clobbering concurrent writes.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import append_to_file as append_module
+from exomem import create_directory as create_directory_module
+from exomem import create_file as create_file_module
+from exomem import mutation_lock
+from exomem.append_to_file import append_to_file
+from exomem.create_directory import create_directory
+from exomem.create_file import CreateFileError, create_file
+
+
+def _record_boundary_state(monkeypatch, module, attr="batch_atomic_write"):
+    observed: list[str] = []
+    real = getattr(module, attr)
+
+    def spy(*args, **kwargs):
+        observed.append(mutation_lock.active_mutation_snapshot()["state"])
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(module, attr, spy)
+    return observed
+
+
+def test_non_markdown_create_writes_under_the_boundary(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed = _record_boundary_state(monkeypatch, create_file_module)
+    create_file(vault, path="Knowledge Base/data.json", content="{}\n")
+    assert observed == ["held"]
+
+
+def test_non_markdown_append_writes_under_the_boundary(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_file(vault, path="Knowledge Base/notes.txt", content="one\n")
+    observed = _record_boundary_state(monkeypatch, append_module)
+    append_to_file(vault, path="Knowledge Base/notes.txt", content="two\n")
+    assert observed == ["held"]
+
+
+def test_directory_create_runs_under_the_boundary(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed = _record_boundary_state(
+        monkeypatch, create_directory_module, attr="write_log_entry"
+    )
+    create_directory(vault, path="Knowledge Base/New Area")
+    assert observed == ["held"]
+
+
+def test_concurrent_non_markdown_creates_do_not_clobber(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two concurrent creates of the same non-``.md`` path: exactly one wins,
+    and the loser gets FILE_EXISTS from the under-boundary re-check instead of
+    silently clobbering the winner's bytes (the reproduced review defect)."""
+    real_write = create_file_module.batch_atomic_write
+    a_in_boundary = threading.Event()
+    a_release = threading.Event()
+    gated_once = threading.Event()
+
+    def gated_write(*args, **kwargs):
+        if not gated_once.is_set():
+            gated_once.set()
+            a_in_boundary.set()
+            a_release.wait(2.0)
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(create_file_module, "batch_atomic_write", gated_write)
+
+    results: dict[str, str] = {}
+
+    def writer(name: str) -> None:
+        try:
+            create_file(
+                vault,
+                path="Knowledge Base/race.json",
+                content=f'{{"writer": "{name}"}}\n',
+            )
+            results[name] = "ok"
+        except CreateFileError as error:
+            results[name] = error.code
+
+    thread_a = threading.Thread(target=writer, args=("A",))
+    thread_a.start()
+    assert a_in_boundary.wait(5.0), "writer A never reached its commit"
+    thread_b = threading.Thread(target=writer, args=("B",))
+    thread_b.start()
+    # Give B a beat to pass its pre-boundary existence check and park on the
+    # boundary A holds; then release A. (If B arrives later, its ordinary
+    # pre-check refuses instead — the same honest FILE_EXISTS outcome.)
+    time.sleep(0.1)
+    a_release.set()
+    thread_a.join(10.0)
+    thread_b.join(10.0)
+    assert not thread_a.is_alive() and not thread_b.is_alive()
+
+    assert results["A"] == "ok"
+    assert results["B"] == "FILE_EXISTS"
+    content = (vault / "Knowledge Base" / "race.json").read_text(encoding="utf-8")
+    assert content == '{"writer": "A"}\n'

--- a/tests/test_relation_review.py
+++ b/tests/test_relation_review.py
@@ -10,7 +10,14 @@ from pathlib import Path
 
 import pytest
 
-from exomem import activation_manifest, memory_refs, relation_review, semantic_contract, vault
+from exomem import (
+    activation_manifest,
+    memory_refs,
+    metrics,
+    relation_review,
+    semantic_contract,
+    vault,
+)
 
 _ID_A = "00000000-0000-4000-8000-000000000001"
 _ID_B = "00000000-0000-4000-8000-000000000002"
@@ -878,6 +885,172 @@ def test_load_reviews_returns_sorted_immutable_records_and_ignores_temp_residue(
     assert records[0].reference.endswith(f"/{_ID_A}.json")
     with pytest.raises(FrozenInstanceError):
         records[0].reason = "changed"  # type: ignore[misc]
+
+
+def test_commit_creation_draft_reuses_prevalidated_attempt_on_matching_census_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, validation = _reviewed_validation(tmp_path)
+    counts = {"corpus": 0, "validation": 0}
+    seams = (
+        (relation_review.semantic_contract, "build_corpus_context", "corpus"),
+        (relation_review, "_validation", "validation"),
+    )
+    for owner, name, key in seams:
+        original = getattr(owner, name)
+
+        def counted(*args, _original=original, _key=key, **kwargs):
+            counts[_key] += 1
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(owner, name, counted)
+
+    commit = relation_review.commit_creation_draft(
+        tmp_path,
+        path=_PAGE_B,
+        source=source,
+        draft_id=_ID_B,
+        operation="create",
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest typed relation yet",
+    )
+
+    assert commit.mutated is True
+    # Without reuse, both the preliminary and in-lock `_attempt` calls run
+    # `build_corpus_context`/`_validation` fresh (2 each). A matching census
+    # token collapses the in-lock call to a reuse, so each drops to 1.
+    assert counts == {"corpus": 1, "validation": 1}
+
+
+def test_commit_creation_draft_falls_through_to_full_attempt_on_census_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, validation = _reviewed_validation(tmp_path)
+    counts = {"corpus": 0}
+    original_build = relation_review.semantic_contract.build_corpus_context
+
+    def counted_build(*args, **kwargs):
+        counts["corpus"] += 1
+        return original_build(*args, **kwargs)
+
+    monkeypatch.setattr(relation_review.semantic_contract, "build_corpus_context", counted_build)
+
+    real_token = relation_review.semantic_contract.corpus_validity_token
+    calls = {"count": 0}
+
+    def drifting_token(root):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return real_token(root)
+        return (("drifted",), ())
+
+    monkeypatch.setattr(
+        relation_review.semantic_contract, "corpus_validity_token", drifting_token
+    )
+
+    commit = relation_review.commit_creation_draft(
+        tmp_path,
+        path=_PAGE_B,
+        source=source,
+        draft_id=_ID_B,
+        operation="create",
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest typed relation yet",
+    )
+
+    assert commit.mutated is True
+    assert counts["corpus"] == 2
+
+
+def _prevalidated_commit_counts() -> dict[str, int]:
+    snap = metrics.snapshot()
+    counts: dict[str, int] = {}
+    for entry in snap["counters"]:
+        if entry["name"] != "exomem_prevalidated_commit_total":
+            continue
+        outcome = dict(entry["labels"]).get("outcome", "")
+        counts[outcome] = counts.get(outcome, 0) + entry["value"]
+    return counts
+
+
+def test_commit_creation_draft_records_reused_outcome_on_matching_token(
+    tmp_path: Path,
+) -> None:
+    source, validation = _reviewed_validation(tmp_path)
+    metrics.reset()
+
+    relation_review.commit_creation_draft(
+        tmp_path,
+        path=_PAGE_B,
+        source=source,
+        draft_id=_ID_B,
+        operation="create",
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest typed relation yet",
+    )
+
+    counts = _prevalidated_commit_counts()
+    metrics.reset()
+    assert counts.get("reused") == 1
+    assert counts.get("revalidated") is None
+
+
+def test_commit_creation_draft_records_revalidated_outcome_on_census_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, validation = _reviewed_validation(tmp_path)
+    metrics.reset()
+
+    real_token = relation_review.semantic_contract.corpus_validity_token
+    calls = {"count": 0}
+
+    def drifting_token(root):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return real_token(root)
+        return (("drifted",), ())
+
+    monkeypatch.setattr(
+        relation_review.semantic_contract, "corpus_validity_token", drifting_token
+    )
+
+    relation_review.commit_creation_draft(
+        tmp_path,
+        path=_PAGE_B,
+        source=source,
+        draft_id=_ID_B,
+        operation="create",
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest typed relation yet",
+    )
+
+    counts = _prevalidated_commit_counts()
+    metrics.reset()
+    assert counts.get("revalidated") == 1
+    assert counts.get("reused") is None
+
+
+def test_prepare_commit_creation_draft_validates_before_any_lock_or_write(
+    tmp_path: Path,
+) -> None:
+    source, _ = _reviewed_validation(tmp_path)
+
+    with pytest.raises(relation_review.RelationReviewError) as exc:
+        relation_review.prepare_commit_creation_draft(
+            tmp_path,
+            path=_PAGE_B,
+            source=source,
+            draft_id=_ID_B,
+            operation="replacement",
+        )
+
+    assert exc.value.code == "INVALID_PREDECESSOR"
+    assert not relation_review.review_artifact_path(tmp_path, _ID_B).exists()
+    assert not (tmp_path / _PAGE_B).exists()
 
 
 def test_attempt_loaders_and_corpus_walk_are_each_called_once(

--- a/tests/test_relation_review.py
+++ b/tests/test_relation_review.py
@@ -936,17 +936,22 @@ def test_commit_creation_draft_falls_through_to_full_attempt_on_census_mismatch(
 
     monkeypatch.setattr(relation_review.semantic_contract, "build_corpus_context", counted_build)
 
-    real_token = relation_review.semantic_contract.corpus_validity_token
-    calls = {"count": 0}
+    real_prepare = relation_review.prepare_commit_creation_draft
 
-    def drifting_token(root):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return real_token(root)
-        return (("drifted",), ())
+    def prepare_then_concurrent_commit(*args, **kwargs):
+        prepared = real_prepare(*args, **kwargs)
+        # Simulate a concurrent governed writer committing after the
+        # pre-boundary validation: every mutation-guard exit bumps the
+        # boundary commit-generation, which must disable stamp reuse.
+        from exomem import writer_lease
+
+        writer_lease._bump_commit_generation(
+            writer_lease.active_manager().config.state_dir, tmp_path
+        )
+        return prepared
 
     monkeypatch.setattr(
-        relation_review.semantic_contract, "corpus_validity_token", drifting_token
+        relation_review, "prepare_commit_creation_draft", prepare_then_concurrent_commit
     )
 
     commit = relation_review.commit_creation_draft(
@@ -1004,17 +1009,22 @@ def test_commit_creation_draft_records_revalidated_outcome_on_census_mismatch(
     source, validation = _reviewed_validation(tmp_path)
     metrics.reset()
 
-    real_token = relation_review.semantic_contract.corpus_validity_token
-    calls = {"count": 0}
+    real_prepare = relation_review.prepare_commit_creation_draft
 
-    def drifting_token(root):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return real_token(root)
-        return (("drifted",), ())
+    def prepare_then_concurrent_commit(*args, **kwargs):
+        prepared = real_prepare(*args, **kwargs)
+        # Simulate a concurrent governed writer committing after the
+        # pre-boundary validation: every mutation-guard exit bumps the
+        # boundary commit-generation, which must disable stamp reuse.
+        from exomem import writer_lease
+
+        writer_lease._bump_commit_generation(
+            writer_lease.active_manager().config.state_dir, tmp_path
+        )
+        return prepared
 
     monkeypatch.setattr(
-        relation_review.semantic_contract, "corpus_validity_token", drifting_token
+        relation_review, "prepare_commit_creation_draft", prepare_then_concurrent_commit
     )
 
     relation_review.commit_creation_draft(

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -1841,3 +1841,106 @@ def test_contract_finding_key_is_exact_public_triple() -> None:
         ("fields", "status"),
         ("fields", "status", "required"),
     )
+
+
+def _minimal_vault(tmp_path: Path) -> Path:
+    notes = tmp_path / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True)
+    (notes / "one.md").write_text(_source(title="One"), encoding="utf-8")
+    return tmp_path
+
+
+def test_corpus_validity_token_none_on_unsafe_review_artifact_tree(
+    tmp_path: Path,
+) -> None:
+    vault_root = _minimal_vault(tmp_path)
+    reviews = vault_root / "Knowledge Base" / "_Schema" / "relation-reviews"
+    reviews.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    (reviews / "linked.json").symlink_to(outside)
+
+    assert semantic_contract.corpus_validity_token(vault_root) is None
+
+
+def test_corpus_validity_token_flips_on_review_artifact_change(
+    tmp_path: Path,
+) -> None:
+    vault_root = _minimal_vault(tmp_path)
+    reviews = vault_root / "Knowledge Base" / "_Schema" / "relation-reviews"
+    reviews.mkdir(parents=True)
+    artifact = reviews / "00000000-0000-0000-0000-000000000001.json"
+    artifact.write_text("{}", encoding="utf-8")
+
+    before = semantic_contract.corpus_validity_token(vault_root)
+    assert before is not None
+
+    artifact.write_text('{"changed": true}', encoding="utf-8")
+    after = semantic_contract.corpus_validity_token(vault_root)
+
+    assert after is not None
+    assert after != before
+
+
+def test_corpus_validity_token_flips_on_lifecycle_sidecar_change(
+    tmp_path: Path,
+) -> None:
+    vault_root = _minimal_vault(tmp_path)
+    lifecycle = (
+        vault_root
+        / "Knowledge Base"
+        / "_Schema"
+        / "relation-reviews"
+        / "lifecycle"
+        / "00000000-0000-0000-0000-000000000001"
+    )
+    lifecycle.mkdir(parents=True)
+    prepared = lifecycle / "prepared.json"
+    prepared.write_text("{}", encoding="utf-8")
+
+    before = semantic_contract.corpus_validity_token(vault_root)
+    assert before is not None
+
+    prepared.write_text('{"changed": true}', encoding="utf-8")
+    after = semantic_contract.corpus_validity_token(vault_root)
+
+    assert after is not None
+    assert after != before
+
+
+def test_corpus_validity_token_flips_on_config_change(tmp_path: Path) -> None:
+    vault_root = _minimal_vault(tmp_path)
+    before = semantic_contract.corpus_validity_token(vault_root)
+    assert before is not None
+
+    access_config = vault_root / "Knowledge Base" / "_access.yaml"
+    access_config.write_text("readonly:\n- Notes\n", encoding="utf-8")
+    after = semantic_contract.corpus_validity_token(vault_root)
+
+    assert after is not None
+    assert after != before
+
+
+def test_corpus_validity_token_none_when_corpus_census_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = _minimal_vault(tmp_path)
+
+    monkeypatch.setattr(semantic_contract, "_corpus_census", lambda root: None)
+
+    assert semantic_contract.corpus_validity_token(vault_root) is None
+
+
+def test_corpus_validity_token_stable_when_nothing_changes(tmp_path: Path) -> None:
+    vault_root = _minimal_vault(tmp_path)
+    reviews = vault_root / "Knowledge Base" / "_Schema" / "relation-reviews"
+    reviews.mkdir(parents=True)
+    (reviews / "00000000-0000-0000-0000-000000000001.json").write_text(
+        "{}", encoding="utf-8"
+    )
+
+    first = semantic_contract.corpus_validity_token(vault_root)
+    second = semantic_contract.corpus_validity_token(vault_root)
+
+    assert first is not None
+    assert first == second

--- a/tests/test_semantic_creation_writers.py
+++ b/tests/test_semantic_creation_writers.py
@@ -1544,3 +1544,68 @@ def test_v2_qualifying_receipt_is_internal_and_never_review_state(tmp_path: Path
 
     assert receipt is not None and receipt.kind == "qualifying"
     assert relation_review.load_relation_reviews(tmp_path) == ()
+
+
+def test_creation_preflight_census_token_matches_fresh_token_on_stable_tree(
+    vault: Path,
+) -> None:
+    from exomem import semantic_contract
+
+    kwargs = {
+        "content": _compact_content("Census token stability"),
+        "note_type": "research-note",
+        "title": "Census token stability",
+        "project": "census-token-project",
+        "project_category": "domain",
+        "today": TODAY,
+    }
+    validation = note.note(vault, validate_only=True, **kwargs)
+    prepared = note.note(
+        vault,
+        draft_id=validation.draft_id,
+        draft_hash=validation.draft_hash,
+        draft_token=validation.draft_token,
+        _return_prepared=True,
+        **kwargs,
+    )
+
+    assert prepared.preflight.census_token is not None
+    assert prepared.preflight.census_token == semantic_contract.corpus_validity_token(vault)
+
+
+def test_creation_preflight_census_token_is_none_on_sandwich_drift(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import semantic_contract
+
+    kwargs = {
+        "content": _compact_content("Census token drift"),
+        "note_type": "research-note",
+        "title": "Census token drift",
+        "project": "census-token-drift-project",
+        "project_category": "domain",
+        "today": TODAY,
+    }
+    validation = note.note(vault, validate_only=True, **kwargs)
+
+    real_token = semantic_contract.corpus_validity_token
+    calls = {"count": 0}
+
+    def drifting_token(root: Path):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return real_token(root)
+        return (("drifted",), ())
+
+    monkeypatch.setattr(semantic_writes.semantic_contract, "corpus_validity_token", drifting_token)
+
+    prepared = note.note(
+        vault,
+        draft_id=validation.draft_id,
+        draft_hash=validation.draft_hash,
+        draft_token=validation.draft_token,
+        _return_prepared=True,
+        **kwargs,
+    )
+
+    assert prepared.preflight.census_token is None

--- a/tests/test_semantic_creation_writers.py
+++ b/tests/test_semantic_creation_writers.py
@@ -1570,14 +1570,16 @@ def test_creation_preflight_census_token_matches_fresh_token_on_stable_tree(
     )
 
     assert prepared.preflight.census_token is not None
-    assert prepared.preflight.census_token == semantic_contract.corpus_validity_token(vault)
+    sc_token, generation = prepared.preflight.census_token
+    assert sc_token == semantic_contract.corpus_validity_token(vault)
+    from exomem import writer_lease
+
+    assert generation == writer_lease.read_commit_generation(vault)
 
 
-def test_creation_preflight_census_token_is_none_on_sandwich_drift(
+def test_creation_preflight_census_token_is_none_when_generation_unreadable(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from exomem import semantic_contract
-
     kwargs = {
         "content": _compact_content("Census token drift"),
         "note_type": "research-note",
@@ -1588,16 +1590,9 @@ def test_creation_preflight_census_token_is_none_on_sandwich_drift(
     }
     validation = note.note(vault, validate_only=True, **kwargs)
 
-    real_token = semantic_contract.corpus_validity_token
-    calls = {"count": 0}
-
-    def drifting_token(root: Path):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return real_token(root)
-        return (("drifted",), ())
-
-    monkeypatch.setattr(semantic_writes.semantic_contract, "corpus_validity_token", drifting_token)
+    # Fail-closed capture: an unreadable boundary commit-generation must
+    # disable stamp reuse entirely rather than admit it.
+    monkeypatch.setattr(semantic_writes, "_entry_commit_generation", lambda root: None)
 
     prepared = note.note(
         vault,

--- a/tests/test_semantic_lifecycle_writers.py
+++ b/tests/test_semantic_lifecycle_writers.py
@@ -158,6 +158,100 @@ def test_compliant_page_cannot_remove_its_final_unit(tmp_path: Path) -> None:
     assert path.read_bytes() == before_bytes
 
 
+def test_existing_preflight_census_token_matches_fresh_token_on_stable_tree(
+    tmp_path: Path,
+) -> None:
+    before = _source("Legacy prose without semantic units.")
+    after = before.replace("Legacy prose", "Updated legacy prose")
+    _write(tmp_path, _PAGE, before)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=_PAGE,
+        after_source=after,
+        operation="edit",
+    )
+
+    assert preflight.census_token is not None
+    assert preflight.census_token == semantic_contract.corpus_validity_token(tmp_path)
+
+
+def test_existing_preflight_census_token_is_none_on_sandwich_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    before = _source("Legacy prose without semantic units.")
+    after = before.replace("Legacy prose", "Updated legacy prose")
+    _write(tmp_path, _PAGE, before)
+
+    real_token = semantic_contract.corpus_validity_token
+    calls = {"count": 0}
+
+    def drifting_token(root: Path):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return real_token(root)
+        return (("drifted",), ())
+
+    monkeypatch.setattr(semantic_writes.semantic_contract, "corpus_validity_token", drifting_token)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=_PAGE,
+        after_source=after,
+        operation="edit",
+    )
+
+    assert preflight.census_token is None
+
+
+def test_revalidate_existing_preflight_on_mismatch_reproduces_unchanged_state(
+    tmp_path: Path,
+) -> None:
+    before = _source("Legacy prose without semantic units.")
+    after = before.replace("Legacy prose", "Updated legacy prose")
+    _write(tmp_path, _PAGE, before)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=_PAGE,
+        after_source=after,
+        operation="edit",
+    )
+
+    revalidated = semantic_writes._revalidate_existing_preflight(tmp_path, preflight)
+
+    assert revalidated.after.source_hash == preflight.after.source_hash
+    assert revalidated.before.source_hash == preflight.before.source_hash
+    assert revalidated.transition_token == preflight.transition_token
+    assert revalidated.contract_result.should_block == preflight.contract_result.should_block
+
+
+def test_revalidate_existing_preflight_on_mismatch_surfaces_stale_write(
+    tmp_path: Path,
+) -> None:
+    before = _source("Legacy prose without semantic units.")
+    after = before.replace("Legacy prose", "Updated legacy prose")
+    path = _write(tmp_path, _PAGE, before)
+
+    preflight = semantic_writes.preflight_existing(
+        tmp_path,
+        path=_PAGE,
+        after_source=after,
+        operation="edit",
+    )
+
+    path.write_text(
+        before.replace("Legacy prose", "A sibling write raced ahead"),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    with pytest.raises(semantic_writes.SemanticWriteError) as exc:
+        semantic_writes._revalidate_existing_preflight(tmp_path, preflight)
+
+    assert exc.value.code == "STALE_SEMANTIC_WRITE"
+
+
 def _write(root: Path, rel: str, source: str) -> Path:
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_semantic_lifecycle_writers.py
+++ b/tests/test_semantic_lifecycle_writers.py
@@ -173,26 +173,23 @@ def test_existing_preflight_census_token_matches_fresh_token_on_stable_tree(
     )
 
     assert preflight.census_token is not None
-    assert preflight.census_token == semantic_contract.corpus_validity_token(tmp_path)
+    sc_token, generation = preflight.census_token
+    assert sc_token == semantic_contract.corpus_validity_token(tmp_path)
+    from exomem import writer_lease
+
+    assert generation == writer_lease.read_commit_generation(tmp_path)
 
 
-def test_existing_preflight_census_token_is_none_on_sandwich_drift(
+def test_existing_preflight_census_token_is_none_when_generation_unreadable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     before = _source("Legacy prose without semantic units.")
     after = before.replace("Legacy prose", "Updated legacy prose")
     _write(tmp_path, _PAGE, before)
 
-    real_token = semantic_contract.corpus_validity_token
-    calls = {"count": 0}
-
-    def drifting_token(root: Path):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return real_token(root)
-        return (("drifted",), ())
-
-    monkeypatch.setattr(semantic_writes.semantic_contract, "corpus_validity_token", drifting_token)
+    # Fail-closed capture: an unreadable boundary commit-generation must
+    # disable stamp reuse entirely rather than admit it.
+    monkeypatch.setattr(semantic_writes, "_entry_commit_generation", lambda root: None)
 
     preflight = semantic_writes.preflight_existing(
         tmp_path,

--- a/tests/test_shorten_critical_section.py
+++ b/tests/test_shorten_critical_section.py
@@ -1,0 +1,402 @@
+"""`shorten-mutation-critical-section`: the `remember` mutation boundary
+covers only the commit seam, not pre-commit corpus validation or model
+loading — turn 3 (C3): guard narrowing + pre-warm + telemetry for `remember`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from exomem import metrics, mutation_lock, relation_review, semantic_writes, writer_lease
+from exomem import vault as vault_module
+from exomem.cli_ops import OpError
+from exomem.commands import op_remember, product_commands_for
+
+TODAY_KWARGS = {
+    "content": (
+        "# Bounded-boundary save\n\n"
+        "## Observations\n\n"
+        "- [operating constraint] Keep the boundary short #reliability\n"
+    ),
+    "title": "Bounded-boundary save",
+    "slug": "bounded-boundary-save",
+    "suggestions": False,
+}
+
+
+def _remember_command():
+    return next(c for c in product_commands_for("mcp") if c.name == "remember")
+
+
+def _standalone_manager(state_dir: Path, **kwargs) -> writer_lease.LeaseManager:
+    return writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=state_dir), **kwargs)
+
+
+def _invoke_remember(vault: Path, manager: writer_lease.LeaseManager, **kwargs):
+    """Drive the real `remember` product command through `LeaseManager.invoke`
+    (the narrow-boundary machinery), bypassing the MCP-facing envelope layer
+    (`command_surface.wrapper`) that would otherwise convert a raised
+    `OpError` into an `ok=False` return value instead of letting it propagate.
+    """
+    return manager.invoke(
+        _remember_command(),
+        (vault,),
+        kwargs,
+        implicit_idempotency_scope="principal:test",
+    )
+
+
+def _validated_kwargs(vault: Path, **extra) -> dict:
+    kwargs = dict(TODAY_KWARGS, **extra)
+    validation = op_remember(vault, validate_only=True, **kwargs)
+    kwargs.update(
+        draft_id=validation["draft_id"],
+        draft_hash=validation["draft_hash"],
+        draft_token=validation["draft_token"],
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation["draft_hash"],
+        relation_review_reason="No honest relation exists in the isolated fixture.",
+    )
+    return kwargs
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics_and_managers():
+    metrics.reset()
+    yield
+    metrics.reset()
+    writer_lease.reset_managers_for_tests()
+
+
+def test_remember_boundary_hold_stays_bounded_under_a_slow_validator(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    kwargs = _validated_kwargs(vault)
+
+    real_evaluate = relation_review._evaluate
+
+    def slow_evaluate(*args, **kw):
+        time.sleep(2.0)
+        return real_evaluate(*args, **kw)
+
+    monkeypatch.setattr(relation_review, "_evaluate", slow_evaluate)
+
+    manager = _standalone_manager(vault.parent / "state")
+
+    result = _invoke_remember(vault, manager, **kwargs)
+
+    assert (vault / result["path"]).is_file()
+    timing = mutation_lock.last_mutation_timing()
+    assert timing is not None
+    # The floor here is real disk I/O for the commit itself (batch_atomic_write
+    # writing the primary page + log + index auxiliaries), which correctly
+    # stays inside the boundary by design: ~700-750ms measured quiet on this
+    # box, with spikes above 1s under load. 1800ms leaves headroom over that
+    # floor while staying well under the 2000ms validator sleep this asserts
+    # is excluded from the hold — a wide margin either side of the two costs
+    # it must tell apart.
+    assert timing["hold_ms"] < 1800
+
+
+def test_pre_boundary_validation_failure_never_acquires_the_boundary(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    blocked_kwargs = {
+        "content": "# Prose only\n\nOrdinary structural prose.\n",
+        "note_type": "insight",
+        "title": "Prose only",
+        "slug": "prose-only-blocked",
+    }
+    validation = op_remember(vault, validate_only=True, **blocked_kwargs)
+    committing_kwargs = dict(
+        blocked_kwargs,
+        draft_id=validation["draft_id"],
+        draft_hash=validation["draft_hash"],
+        draft_token=validation["draft_token"],
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation["draft_hash"],
+        relation_review_reason="No honest relation exists in the isolated fixture.",
+    )
+
+    # Baseline: the leaf raises the same way with no lease/boundary layer at
+    # all involved (a plain function call).
+    with pytest.raises(ValueError) as baseline:
+        op_remember(vault, **committing_kwargs)
+    assert "SEMANTIC_CONTRACT_BLOCKED" in str(baseline.value)
+
+    def unreachable_hold(self, **kwargs):
+        raise AssertionError(
+            "the mutation boundary must never be acquired for a pre-boundary validation failure"
+        )
+
+    monkeypatch.setattr(mutation_lock.VaultMutationCoordinator, "hold", unreachable_hold)
+
+    manager = _standalone_manager(vault.parent / "state")
+
+    with pytest.raises(ValueError) as narrowed:
+        _invoke_remember(vault, manager, **committing_kwargs)
+
+    assert str(narrowed.value) == str(baseline.value)
+
+
+def test_embedding_prewarm_observes_a_free_boundary(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import embeddings, readiness
+
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(readiness, "should_defer", lambda component: False)
+    observed_states: list[str] = []
+
+    def spy_get_model():
+        observed_states.append(str(mutation_lock.active_mutation_snapshot()["state"]))
+        raise RuntimeError("no real model in the unit-test environment")
+
+    monkeypatch.setattr(embeddings, "get_model", spy_get_model)
+
+    kwargs = _validated_kwargs(vault)
+    manager = _standalone_manager(vault.parent / "state")
+
+    result = _invoke_remember(vault, manager, **kwargs)
+
+    assert (vault / result["path"]).is_file()
+    # The pre-warm call (before `commit_creation` acquires its boundary) is
+    # always the FIRST `get_model` call, and it must see a free boundary.
+    # Later calls (the in-boundary embedding-sidecar fan-out, the
+    # post-commit advisory pass) are unaffected by this change and may see
+    # other states — only the pre-warm call's position/state is asserted.
+    assert observed_states
+    assert observed_states[0] == "free"
+
+
+def test_mutation_busy_shape_is_unchanged_under_a_narrow_hold(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    kwargs = _validated_kwargs(vault)
+    state_dir = vault.parent / "state"
+    manager = _standalone_manager(state_dir, mutation_timeout_seconds=0.2)
+    contender = _standalone_manager(state_dir)
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold_boundary() -> None:
+        with contender.mutation_guard(vault, request_id="contender", operation="probe"):
+            holding.set()
+            release.wait(5.0)
+
+    holder = threading.Thread(target=hold_boundary)
+    holder.start()
+    assert holding.wait(2.0)
+    try:
+        with pytest.raises(OpError) as busy:
+            _invoke_remember(vault, manager, **kwargs)
+    finally:
+        release.set()
+        holder.join(timeout=5.0)
+
+    assert busy.value.code == "MUTATION_BUSY"
+    assert busy.value.details.get("status") == "retryable"
+    assert busy.value.details.get("committed") is False
+    assert isinstance(busy.value.details.get("retry_after_ms"), int)
+    assert "request_id" in busy.value.details
+
+
+def test_remember_commit_revalidates_on_a_census_mismatch_between_prepare_and_commit(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import semantic_contract
+
+    kwargs = _validated_kwargs(vault)
+
+    real_token = semantic_contract.corpus_validity_token
+    calls = {"count": 0}
+
+    def drifting_token(root):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return real_token(root)
+        # Every call after the first returns a distinct value, so whichever
+        # pair of calls straddles the prepare/commit boundary always mismatches
+        # (a constant post-first value would spuriously re-match itself).
+        return (("drifted", calls["count"]),)
+
+    monkeypatch.setattr(semantic_contract, "corpus_validity_token", drifting_token)
+
+    manager = _standalone_manager(vault.parent / "state")
+
+    result = _invoke_remember(vault, manager, **kwargs)
+
+    assert (vault / result["path"]).is_file()
+    snap = metrics.snapshot()
+    outcomes = {
+        dict(entry["labels"]).get("outcome"): entry["value"]
+        for entry in snap["counters"]
+        if entry["name"] == "exomem_prevalidated_commit_total"
+    }
+    assert outcomes.get("revalidated") == 1
+    assert outcomes.get("reused") is None
+
+
+def _edit_memory_command():
+    return next(c for c in product_commands_for("mcp") if c.name == "edit_memory")
+
+
+def _invoke_edit_memory(vault: Path, manager: writer_lease.LeaseManager, **kwargs):
+    """Mirrors `_invoke_remember`: drive `edit_memory` through
+    `LeaseManager.invoke` directly, bypassing the envelope-catching MCP layer.
+    """
+    return manager.invoke(
+        _edit_memory_command(),
+        (vault,),
+        kwargs,
+        implicit_idempotency_scope="principal:test",
+    )
+
+
+def _write_existing_page(vault: Path, rel: str, *, page_id: str, body: str = "Before.") -> Path:
+    target = vault / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\n"
+        "title: Existing page\n"
+        "type: insight\n"
+        "status: active\n"
+        f"exomem_id: {page_id}\n"
+        "---\n\n"
+        f"{body}\n\n"
+        "## Relations\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return target
+
+
+def test_two_concurrent_edit_memory_writers_on_different_pages_both_succeed(
+    vault: Path,
+) -> None:
+    """Two `edit_memory` calls on different primary pages both complete under
+    the narrow boundary, with no deadlock and no corruption.
+
+    Both edits share auxiliary write targets (`log.md`, the top/sub indexes)
+    whose guards `edit.commit_edit` captures before `commit_existing`'s own
+    (now narrow) boundary is acquired — a genuinely new race this change
+    introduces for that shared auxiliary specifically (the wide boundary
+    used to serialize guard-capture and commit together for every caller on
+    one manager; the narrow boundary only serializes the commit). A losing
+    guard is refused honestly (`PATH_GUARD_CHANGED`), never silently
+    dropped, so a single immediate retry is the correct, expected recovery —
+    the same "semantically honest interleaving" class already accepted for
+    `STALE_SEMANTIC_WRITE` (see this change's write-latency spec delta).
+    """
+    rel_a = "Knowledge Base/Notes/Insights/narrow-edit-a.md"
+    rel_b = "Knowledge Base/Notes/Insights/narrow-edit-b.md"
+    _write_existing_page(vault, rel_a, page_id="00000000-0000-4000-8000-0000000000a1")
+    _write_existing_page(vault, rel_b, page_id="00000000-0000-4000-8000-0000000000b1")
+
+    manager = _standalone_manager(vault.parent / "state")
+    results: list[dict] = []
+    errors: list[BaseException] = []
+
+    def edit(rel: str, new_body: str) -> None:
+        for attempt in range(2):
+            try:
+                results.append(
+                    _invoke_edit_memory(
+                        vault,
+                        manager,
+                        path=rel,
+                        why="narrow-boundary interleaving check",
+                        new_body=new_body,
+                    )
+                )
+                return
+            except (vault_module.PathGuardError, ValueError) as error:
+                # A losing auxiliary guard now surfaces as the documented
+                # retryable STALE_SEMANTIC_WRITE (translated at the commit
+                # seam) rather than a raw PathGuardError; one retry is the
+                # correct, expected recovery either way.
+                retryable = isinstance(
+                    error, vault_module.PathGuardError
+                ) or "STALE_SEMANTIC_WRITE" in str(error)
+                if attempt == 0 and retryable:
+                    continue
+                errors.append(error)
+                return
+            except BaseException as error:  # noqa: BLE001 - inspect thread outcome
+                errors.append(error)
+                return
+
+    threads = [
+        threading.Thread(target=edit, args=(rel_a, "Updated A.")),
+        threading.Thread(target=edit, args=(rel_b, "Updated B.")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(results) == 2
+    assert "Updated A." in (vault / rel_a).read_text(encoding="utf-8")
+    assert "Updated B." in (vault / rel_b).read_text(encoding="utf-8")
+
+
+def test_commit_existing_revalidates_on_census_mismatch_and_surfaces_stale_write(
+    vault: Path,
+) -> None:
+    rel = "Knowledge Base/Notes/Insights/narrow-edit-stale.md"
+    _write_existing_page(vault, rel, page_id="00000000-0000-4000-8000-0000000000c1")
+    after_source = (vault / rel).read_text(encoding="utf-8").replace("Before.", "Updated.")
+
+    preflight = semantic_writes.preflight_existing(
+        vault,
+        path=rel,
+        after_source=after_source,
+        operation="edit",
+    )
+    assert preflight.census_token is not None
+
+    # A sibling write races ahead between preflight and commit — flips both
+    # the corpus census and the file's own guarded content out from under
+    # the captured preflight.
+    (vault / rel).write_text(
+        (vault / rel).read_text(encoding="utf-8").replace("Before.", "A sibling write raced ahead."),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    with pytest.raises(semantic_writes.SemanticWriteError) as exc:
+        semantic_writes.commit_existing(vault, preflight=preflight)
+
+    assert exc.value.code == "STALE_SEMANTIC_WRITE"
+
+def test_wide_boundary_kill_switch_restores_validation_inside_the_hold(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EXOMEM_WIDE_MUTATION_BOUNDARY=1 must restore the wide boundary: the
+    full-leaf guard wraps validation again, so the slow validator's 2000ms
+    lands back INSIDE the measured hold."""
+    monkeypatch.setenv("EXOMEM_WIDE_MUTATION_BOUNDARY", "1")
+    kwargs = _validated_kwargs(vault)
+
+    real_evaluate = relation_review._evaluate
+
+    def slow_evaluate(*args, **kw):
+        time.sleep(2.0)
+        return real_evaluate(*args, **kw)
+
+    monkeypatch.setattr(relation_review, "_evaluate", slow_evaluate)
+
+    manager = _standalone_manager(vault.parent / "state")
+    result = _invoke_remember(vault, manager, **kwargs)
+
+    assert (vault / result["path"]).is_file()
+    timing = mutation_lock.last_mutation_timing()
+    assert timing is not None
+    assert timing["hold_ms"] >= 2000

--- a/tests/test_shorten_critical_section.py
+++ b/tests/test_shorten_critical_section.py
@@ -206,28 +206,28 @@ def test_mutation_busy_shape_is_unchanged_under_a_narrow_hold(
     assert "request_id" in busy.value.details
 
 
-def test_remember_commit_revalidates_on_a_census_mismatch_between_prepare_and_commit(
+def test_remember_commit_revalidates_when_a_governed_commit_lands_between_prepare_and_commit(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from exomem import semantic_contract
-
+    """A governed commit between the pre-boundary validation and the commit
+    bumps the boundary commit-generation (every mutation-guard exit does), so
+    the validity stamp must be refused and the in-boundary revalidation must
+    run — the stamp's whole job."""
     kwargs = _validated_kwargs(vault)
-
-    real_token = semantic_contract.corpus_validity_token
-    calls = {"count": 0}
-
-    def drifting_token(root):
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return real_token(root)
-        # Every call after the first returns a distinct value, so whichever
-        # pair of calls straddles the prepare/commit boundary always mismatches
-        # (a constant post-first value would spuriously re-match itself).
-        return (("drifted", calls["count"]),)
-
-    monkeypatch.setattr(semantic_contract, "corpus_validity_token", drifting_token)
-
     manager = _standalone_manager(vault.parent / "state")
+
+    real_prepare = relation_review.prepare_commit_creation_draft
+
+    def prepare_then_concurrent_commit(*args, **kw):
+        prepared = real_prepare(*args, **kw)
+        # Simulate a concurrent governed writer committing right after our
+        # pre-boundary validation finished.
+        writer_lease._bump_commit_generation(manager.config.state_dir, vault)
+        return prepared
+
+    monkeypatch.setattr(
+        relation_review, "prepare_commit_creation_draft", prepare_then_concurrent_commit
+    )
 
     result = _invoke_remember(vault, manager, **kwargs)
 


### PR DESCRIPTION
## Why

A single governed `remember` ran **four full corpus validations and up to two embedding-model touchpoints inside the vault mutation boundary** — against a 5-second acquire budget for everyone else. A cold model load held the live boundary ~3 minutes on 2026-07-25 (`MUTATION_BUSY` for every concurrent writer, `SEMANTIC_CREATION_FAILED` at the client). This is the deferred deep fix promised in #320: the boundary now covers only the commit.

OpenSpec change included: `shorten-mutation-critical-section` (MODIFIED `hosted-mutation-safety`, ADDED `write-latency`).

## What changed

- **Validation and model loading run pre-boundary** for the narrowed write family (`remember`, `replace_memory`, `edit_memory`, `observe_memory`, and `manage_memory_file` create/append). The commit seams (`commit_creation`/`commit_existing`) acquire the boundary themselves, around only the commit. `EXOMEM_WIDE_MUTATION_BOUNDARY=1` restores the wide boundary (tested).
- **Census validity stamp** gates admission of pre-validated work: corpus + config + review-artifact/lifecycle sidecar census, sandwich-captured around preflight (any uncertainty ⇒ always revalidate). An in-boundary mismatch triggers warm revalidation with bit-identical verdicts — including for structural/non-semantic creations. Reuse outcomes are counted (`exomem_prevalidated_commit_total`).
- **Every leaf write path provably holds the boundary**: the non-semantic branches (non-markdown create/append, directory create including its `log.md` entry) acquire it in the leaf itself, with an under-boundary existence re-check so concurrent creates get an honest `FILE_EXISTS` instead of a silent clobber.
- **Honest failure surfaces**: a losing auxiliary guard is the documented retryable `STALE_SEMANTIC_WRITE` (previously a raw internal error that escaped the envelope); boundary contention in `edit` no longer logs a false "partial write" alarm; a pre-boundary validation failure never acquires the boundary at all — the incident class from 2026-07-25 cannot recur.
- A pre-boundary validation failure produces byte-identical error payloads; `MUTATION_BUSY` wire shape unchanged; `mutation_lock.py` and `vault.py` untouched.

Typical boundary hold drops from 12–45 s (validation-bound, minutes when cold) to **sub-second-to-low-seconds commit I/O** — measured ~730 ms on the dev box via the #320 hold histograms, which are also the deploy-verification instrument.

## Verification

- Worker implementation gates: 635-passed combined across the pinned safety suites and semantic-write suites, zero blockers.
- Independent adversarial review of the final diff: verified the core narrowing clean (traced every mutation site for the four semantic commands), then found and led to fixing a **critical** boundary escape (three `manage_memory_file` sub-paths bypassed the boundary entirely — silent-clobber reproduced, now impossible and regression-tested), a structural-creation stamp gap, an accidentally deleted test assertion, and the two failure-surface mediums above.
- Post-fix first-party gates: new leaf-guard + kill-switch tests 5/5; feature suite 8/8 (concurrency interleavings stable); contract pins (`test_writer_lease`, `test_mutation_lock`, `test_command_surface_retry`) 221/221; repo-wide ruff = 42 = HEAD baseline (zero introduced).
- Pre-existing, box-sensitive failures verified unrelated via A/B at HEAD (pristine extraction): `test_replace.py::test_replace_accepts_novel_type`, `test_mutation_concurrency.py::test_twenty_concurrent_real_captures_leave_complete_vault_state` (passes on Linux CI). Linux CI on this PR is the authoritative full gate.

## Process note

Executed via the governed delegation pipeline (persistent sandboxed worker, independent adversarial review, evidence-addressed artifacts). The coordinator harness lost every ingestion race (process reaping + two evidence-screen vocabulary collisions + a disposition-schema hole), so acceptance was performed directly against first-party gate evidence with the run ledger accurately parked and all adapter evidence preserved; details in the delegation state directory.

## Deferred follow-ups

- Boundary acquire-timeout sizing for herd load: with validation hoisted, concurrent writers arrive at the commit gate simultaneously; the 5 s acquire budget (sized for the old 45 s holds) can time out tail waiters under bursts. The new wait histograms will size the fix.
- Uncensusable trees (reparse points, e.g. OneDrive-backed vaults) always revalidate in-boundary — correct but benefit-free for the existing-page family there.
- `commit_move`/`commit_recovery` remain wide-boundary by design (out of scope).
