### PR TITLE
perf: bound broad category recall

### DIFF
--- a/openspec/changes/bound-broad-category-recall/.openspec.yaml
+++ b/openspec/changes/bound-broad-category-recall/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/bound-broad-category-recall/design.md
+++ b/openspec/changes/bound-broad-category-recall/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The exact semantic-unit lane already has a complete, branch-preserving category/kind catalog. For an empty query, SQLite orders matching units by `updated DESC`, `parent_path DESC`, then `source_order ASC`, which is the same ordering applied after hydration. The current implementation nevertheless requests every match with `LIMIT 2147483647`, validates every matching parent, reparses every matching page, and only then slices to the caller's limit.
+
+Live diagnosis separated the costs: fetching all 321 `decision` rows took about 2.6 ms and fetching three took about 0.14 ms, while validating 138 parents took about 147 ms and full hydration took about 472 ms warm. The repair must therefore bound parent validation and hydration without weakening DNF correlation, catalog readiness, access policy, or post-filter-before-limit behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make an exact, empty-query, limited category/kind unit request open work proportional to its requested result window when leading candidates are eligible.
+- Preserve deterministic result order, exact DNF category/kind semantics, scope, access-policy enforcement, catalog readiness, and selected-parent generation validation.
+- Continue past inaccessible, missing, or otherwise rejected candidates until the requested number of eligible hits is found or the catalog is exhausted.
+- Prove the bound with high-cardinality tests and make the existing aggregate-only latency harness capable of preflighting a broad category.
+
+**Non-Goals:**
+
+- Changing the semantic catalog schema, category language, public tool contract, or ranking model.
+- Optimizing non-empty hybrid/vector ranking in this change.
+- Applying an early limit to page predicates, negation, unsupported predicates, or other plans that require canonical post-filtering.
+- Consolidating all repeated parent reads or adding an order-covering SQLite index; measurements show those are secondary follow-ups.
+
+## Decisions
+
+### 1. Add a narrow ordered-prefix fast path
+
+Use the fast path only when all of the following hold: the filter algebra is complete, the normalized query is empty, the caller supplied a finite limit, and `post_filter_required` is false. Query the existing catalog from the beginning with a prefix bounded initially by `max(8, requested_limit)`. If canonical rejection underfills the result, double the prefix and recompute eligibility from that complete prefix.
+
+Each prefix retains the existing catalog readiness and current-parent validation behavior, then passes through canonical access policy and unit hydration. Stop once enough eligible records exist; final sorting and slicing remain unchanged. When the leading rows are eligible, a `limit=3` request validates and hydrates at most eight catalog rows regardless of whether the category has ten or ten thousand matches. Restarting at zero matters because ordinary live catalog writers may insert, delete, or reorder rows without advancing the persisted freshness checkpoint; an offset spanning two read transactions could otherwise skip or duplicate a candidate. A later prefix is self-contained after such a mutation.
+
+Alternatives considered:
+
+- A single `LIMIT requested_limit` query is faster but can underfill or false-empty when access policy rejects a leading parent.
+- Offset pagination avoids repeated prefix work but is not request-stable across ordinary concurrent catalog mutations.
+- Fetching and hydrating every match preserves correctness but is the measured bottleneck.
+- Denormalizing all parent/access metadata into SQLite would make more filters pushdown-safe but adds schema and migration risk that this repair does not need.
+
+### 2. Keep correctness-first exhaustive retrieval for post-filter plans
+
+If `post_filter_required` is true, keep the complete candidate seed and hydrate/evaluate it before applying the caller's limit. This preserves the existing regression where more than one ranking window of newer drafts precedes the first active result. `limit=None` also retains complete retrieval semantics.
+
+Progressive pagination for arbitrary page predicates remains a future optimization because it needs a broader canonical-filter and snapshot design.
+
+### 3. Treat catalog readiness as the whole-set freshness authority
+
+The fast path does not weaken the catalog readiness checkpoint or semantic projection identity. Each fetched prefix still uses the typed catalog result and selected-parent generation validation; any incomplete outcome remains `RETRIEVAL_INDEX_WARMING`, never an authoritative empty result. The maintained freshness checkpoint remains the authority for rows outside the selected prefix, as it already must be for notes that changed from a nonmatching category into the requested category.
+
+### 4. Extend the privacy-safe harness with a broad-cardinality preflight
+
+Keep the current exact-two-candidate profile as the default. Add an explicit broad profile that requires at least a configured candidate count and preflights with a sufficiently large untimed limit. Reports continue to expose only bucketed counts and aggregate latency distributions. The existing cold/hot latency thresholds then apply to the same fixed request shape against a genuinely broad category.
+
+## Risks / Trade-offs
+
+- **[Risk] Separate prefix reads can observe a concurrently changing catalog.** → Every expansion restarts at zero and recomputes the complete current prefix, so insertion, deletion, or reordering cannot move a candidate across an offset boundary. Typed incomplete outcomes still defer through the existing warming/repair behavior.
+- **[Risk] Access exclusions may require multiple prefixes.** → Expand geometrically until the limit or exhaustion; work grows with rejected leading rows, which correctness requires, but no longer with unrelated trailing matches.
+- **[Risk] The fast path accidentally reaches a post-filter plan.** → Gate it directly on planner output and retain the existing post-filter-before-limit regression alongside a new high-cardinality bounded-open regression.
+- **[Risk] Wall-clock tests become flaky.** → Make the CI regression assert bounded parent opens and request shape; keep percentile timing in the explicit aggregate benchmark harness.
+
+## Migration Plan
+
+No data migration is required. Deploy as a retrieval-code and test-harness change. Rollback is a code revert; the catalog remains compatible.
+
+## Open Questions
+
+None for this change. Consolidating validation and hydration into one parent-byte read is a measured follow-up if selected-parent cost remains material after this bound lands.

--- a/openspec/changes/bound-broad-category-recall/proposal.md
+++ b/openspec/changes/bound-broad-category-recall/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exact semantic-unit category retrieval currently fetches, validates, parses, and hydrates every matching parent before applying the caller's result limit. A broad category such as `decision` therefore takes hundreds of milliseconds even though SQLite can return the requested top three rows in well under a millisecond.
+
+## What Changes
+
+- Bound exact empty-query category/kind retrieval by the caller's result limit when the complete filter plan requires no canonical post-filtering.
+- Hydrate only the selected catalog parents while preserving catalog readiness, stale-repair, deterministic ordering, DNF correlation, scope, and access-policy behavior.
+- Retain the exhaustive correctness path for page predicates, negation, and other post-filter plans where early limiting could create a false empty.
+- Add high-cardinality regressions and an aggregate-only latency gate that prove parent work tracks the requested limit rather than category cardinality.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `find-recall-efficiency`: exact high-cardinality semantic-unit category/kind recall must bound selected-parent work without changing result order or post-filter correctness.
+
+## Impact
+
+- Retrieval planning and hydration in `src/exomem/find.py`.
+- Exact semantic-unit catalog query coverage and category latency regression coverage in `tests/` and `scripts/category_recall_latency.py`.
+- No public API, catalog schema, dependency, model, or migration change.

--- a/openspec/changes/bound-broad-category-recall/specs/find-recall-efficiency/spec.md
+++ b/openspec/changes/bound-broad-category-recall/specs/find-recall-efficiency/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Limited Exact Unit Recall Bounds Parent Work
+
+For an empty-query semantic-unit request with a finite limit and a complete exact category/kind plan that requires no canonical structured post-filter, the system SHALL retrieve candidates in stable catalog order through a leading prefix bounded initially by a function of the requested limit. It SHALL apply canonical access policy and selected-parent validation, geometrically expand and recompute the complete prefix when a leading candidate is rejected, and stop after the requested number of eligible hits or catalog exhaustion. Expansion MUST NOT use a moving offset across separate catalog transactions. When leading candidates are eligible, the number of parents opened MUST be independent of total matching-category cardinality. Catalog readiness, exact DNF correlation, scope, and final ordering MUST remain unchanged.
+
+#### Scenario: Broad category opens only a bounded leading window
+
+- **WHEN** at least 128 current accessible semantic units share one exact category, the normalized query is empty, and `limit=3`
+- **THEN** the three newest units are returned in the established deterministic order
+- **AND** no more than eight candidate parents are validated or hydrated
+- **AND** no Markdown scope walk occurs
+
+#### Scenario: Inaccessible leading candidates do not false-empty
+
+- **WHEN** the newest exact category candidates are excluded by canonical access policy and a later candidate is accessible
+- **AND** an ordinary catalog writer deletes or reorders a leading row between prefix reads
+- **THEN** ordered retrieval recomputes a complete expanded prefix until the accessible candidate is returned or the catalog is exhausted
+- **AND** excluded content is never returned
+
+#### Scenario: Page post-filter remains correctness-first
+
+- **WHEN** an exact category seed is combined with a page predicate and more than one bounded window of newer candidates fails that predicate
+- **THEN** the system evaluates candidates beyond those windows before applying the result limit
+- **AND** it returns the first canonically eligible result rather than an empty list
+
+#### Scenario: Incomplete catalog never becomes an authoritative empty result
+
+- **WHEN** a limited exact unit request encounters a stale, transient, unsupported, or fatal catalog outcome
+- **THEN** it preserves the typed incomplete exact-recall behavior
+- **AND** it does not return or cache an authoritative empty hit list
+
+### Requirement: Broad Category Latency Is Reproducibly Gated
+
+The aggregate category-recall latency harness SHALL support an explicit broad-cardinality preflight in addition to its selective exact-cardinality default. The broad preflight SHALL require at least a configured number of candidate parents before running timed lanes, SHALL run the same fixed empty-query exact-category request shape, and SHALL apply the existing cold and hot percentile gates. Reports MUST continue to exclude the category, query text, vault path, exact candidate count, note paths, and excerpts.
+
+#### Scenario: Broad profile rejects a selective category
+
+- **WHEN** the broad-cardinality profile requires at least 100 candidates and preflight finds fewer than 100
+- **THEN** timed lanes do not run
+- **AND** the aggregate report marks cardinality preflight as failed without exposing the exact category or paths
+
+#### Scenario: Broad profile runs the existing latency gates
+
+- **WHEN** broad preflight meets its configured minimum and the catalog is ready
+- **THEN** the harness samples the existing page/unit cold and hot lanes
+- **AND** the existing filter-eligibility and total-latency percentile thresholds determine pass or failure
+- **AND** only bucketed candidate cardinality is reported

--- a/openspec/changes/bound-broad-category-recall/tasks.md
+++ b/openspec/changes/bound-broad-category-recall/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Tests First
+
+- [x] 1.1 Add a high-cardinality exact-unit regression that proves `limit=3` returns the deterministic top three while opening at most eight candidate parents and never walking the corpus; run it and record the expected RED failure.
+- [x] 1.2 Add an access-policy regression proving rejected leading candidates expand to a later prefix without skipping across a concurrent catalog deletion, while retaining the existing post-filter-before-limit regression; run it RED.
+- [x] 1.3 Add broad-cardinality harness tests for minimum-cardinality pass/fail, preflight request sizing, aggregate-only bucketing, and unchanged selective defaults; run them RED.
+
+## 2. Bounded Retrieval Implementation
+
+- [x] 2.1 Implement restart-from-zero geometric prefix expansion so separate catalog reads cannot skip or duplicate candidates across a moving offset boundary.
+- [x] 2.2 Implement the gated bounded-prefix exact-unit fast path and stop after the requested number of eligible records; retain exhaustive behavior for post-filter plans and unlimited requests.
+- [x] 2.3 Extend `category_recall_latency.py` with an explicit broad-cardinality profile while preserving report privacy and existing percentile thresholds.
+
+## 3. Verification
+
+- [x] 3.1 Run focused category algebra, semantic-unit recall, catalog error, and latency-harness tests with embeddings disabled; document any baseline-only failures separately.
+- [x] 3.2 Run Ruff, `git diff --check`, OpenSpec validation, and the proportionate lean test suite.
+- [x] 3.3 Obtain an independent reviewer pass focused on false-empty, ordering, access-policy, and stale-catalog regressions; address every important finding.

--- a/scripts/category_recall_latency.py
+++ b/scripts/category_recall_latency.py
@@ -78,6 +78,7 @@ SAMPLE_COUNT = 30
 CORPUS_BUCKET_SIZE = 500
 CANDIDATE_BUCKET_SIZE = 5
 REQUIRED_CANDIDATE_COUNT = 2
+BROAD_MINIMUM_CANDIDATE_COUNT = 100
 PREFLIGHT_LIMIT = 10
 
 GATE_COLD_FILTER_ELIGIBILITY_MS = 100.0
@@ -234,9 +235,21 @@ def wait_for_catalog_ready(
     return result
 
 
-def check_cardinality(candidate_count: int | None, *, expected: int = REQUIRED_CANDIDATE_COUNT) -> bool:
-    """`True` only when the catalog reports exactly `expected` candidates."""
-    return candidate_count == expected
+def check_cardinality(
+    candidate_count: int | None,
+    *,
+    expected: int = REQUIRED_CANDIDATE_COUNT,
+    profile: str = "selective",
+    minimum: int = BROAD_MINIMUM_CANDIDATE_COUNT,
+) -> bool:
+    """Validate the selective exact-count or broad minimum-count preflight."""
+    if candidate_count is None:
+        return False
+    if profile == "selective":
+        return candidate_count == expected
+    if profile == "broad":
+        return candidate_count >= minimum
+    raise ValueError(f"unknown cardinality profile {profile!r}")
 
 
 # --------------------------------------------------------------------------
@@ -363,6 +376,8 @@ def run_harness(
     count_pages: Callable[[Path], int] = count_corpus_pages,
     prepare_freshness: Callable[[Path], Any] = freshness_module.rebaseline,
     run_id: str | None = None,
+    profile: str = "selective",
+    broad_minimum: int = BROAD_MINIMUM_CANDIDATE_COUNT,
 ) -> dict[str, Any]:
     """Run the full four-lane harness and return the anonymized report.
 
@@ -387,11 +402,24 @@ def run_harness(
     # walks the corpus and the supposed hot lane measures watcher absence.
     prepare_freshness(vault_root)
 
+    if profile not in {"selective", "broad"}:
+        raise ValueError(f"unknown cardinality profile {profile!r}")
+    if broad_minimum < 1:
+        raise ValueError("broad_minimum must be positive")
+    preflight_limit = max(limit, broad_minimum) if profile == "broad" else limit
     preflight = wait_for_catalog_ready(
-        op_find, vault_root, category, max_wait_s=warmup_timeout_s, limit=limit
+        op_find,
+        vault_root,
+        category,
+        max_wait_s=warmup_timeout_s,
+        limit=preflight_limit,
     )
     candidate_count = preflight["candidate_count"]
-    cardinality_ok = check_cardinality(candidate_count)
+    cardinality_ok = check_cardinality(
+        candidate_count,
+        profile=profile,
+        minimum=broad_minimum,
+    )
     report["preflight"] = {
         "catalog_status": preflight["catalog_status"],
         "candidate_count_bucket": (
@@ -426,6 +454,18 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--category", type=str, required=True, help="exact category to filter on (never written to the report)")
     ap.add_argument("--samples", type=int, default=SAMPLE_COUNT, help=f"samples per lane (default {SAMPLE_COUNT})")
     ap.add_argument("--limit", type=int, default=PREFLIGHT_LIMIT, help=f"result limit per request (default {PREFLIGHT_LIMIT})")
+    ap.add_argument(
+        "--profile",
+        choices=("selective", "broad"),
+        default="selective",
+        help="candidate-cardinality gate (default selective: exactly two)",
+    )
+    ap.add_argument(
+        "--broad-minimum",
+        type=int,
+        default=BROAD_MINIMUM_CANDIDATE_COUNT,
+        help=f"minimum candidates for --profile broad (default {BROAD_MINIMUM_CANDIDATE_COUNT})",
+    )
     ap.add_argument("--warmup-timeout", type=float, default=30.0, help="max seconds to wait for a warming catalog before the gate fails (default 30)")
     ap.add_argument("--out", type=Path, default=None, help="write the JSON report here instead of stdout")
     args = ap.parse_args(argv)
@@ -436,6 +476,8 @@ def main(argv: list[str] | None = None) -> int:
         samples=args.samples,
         limit=args.limit,
         warmup_timeout_s=args.warmup_timeout,
+        profile=args.profile,
+        broad_minimum=args.broad_minimum,
     )
     text = json.dumps(report, indent=2, sort_keys=True)
     if args.out:

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -1480,33 +1480,76 @@ def _find_semantic_units(
             # Exact eligibility is normal-table metadata only. Hybrid/vector
             # content ranking consumes this finite candidate set independently,
             # so FTS absence cannot change the catalog outcome.
-            # Category/kind rows are only the exact seed. Page predicates and
-            # other canonical filters run after hydration, so limiting this
-            # seed before post-evaluation can false-empty when the first window
-            # is ineligible. Fetch the complete finite catalog match set, then
-            # apply the caller's result limit to the eligible/ranked records.
-            exact_limit = 2_147_483_647
             with _span(timings, "filter_eligibility"):
-                catalog_result = lexstore.search_semantic_units_result(
-                    vault_root,
-                    query,
-                    k=exact_limit,
-                    clauses=dnf_clauses,
-                    scope=scope,
-                    freshness=snapshot.for_scope(scope),
-                    literal_all=mode == "keyword" and bool(query.strip()),
-                    _repair_stale=True,
-                    repair=_bounded_lexical_repair_allowed(snapshot.for_scope(scope)),
+                exact_freshness = snapshot.for_scope(scope)
+                exact_repair = _bounded_lexical_repair_allowed(exact_freshness)
+                bounded_filter_only = (
+                    not query.strip()
+                    and limit is not None
+                    and not algebra.post_filter_required
                 )
-                _set_catalog_timing_profile(timings, catalog_result.readiness)
-                if not catalog_result.readiness.complete:
-                    _raise_catalog_outcome(catalog_result.readiness)
-                indexed = list(catalog_result.value or [])
-                records = (
-                    {}
-                    if mode == "vector"
-                    else _hydrate_indexed_unit_records(vault_root, indexed, plan=plan)
-                )
+                if bounded_filter_only:
+                    # SQL and final filter-only ordering are identical. Read a
+                    # small leading prefix, apply access/current-parent checks,
+                    # and expand only when canonical rejection underfills it.
+                    # Re-reading from zero makes each prefix self-contained if a
+                    # concurrent catalog writer inserts, deletes, or reorders a
+                    # row between reads; offset pagination could skip across that
+                    # moving boundary. The common eligible path still opens only
+                    # max(8, requested_limit) rows.
+                    prefix_size = max(8, requested_limit)
+                    indexed = []
+                    records = {}
+                    while True:
+                        catalog_result = lexstore.search_semantic_units_result(
+                            vault_root,
+                            query,
+                            k=prefix_size,
+                            clauses=dnf_clauses,
+                            scope=scope,
+                            freshness=exact_freshness,
+                            _repair_stale=True,
+                            repair=exact_repair,
+                        )
+                        _set_catalog_timing_profile(timings, catalog_result.readiness)
+                        if not catalog_result.readiness.complete:
+                            _raise_catalog_outcome(catalog_result.readiness)
+                        indexed = list(catalog_result.value or [])
+                        records = _hydrate_indexed_unit_records(
+                            vault_root, indexed, plan=plan
+                        )
+                        if (
+                            len(records) >= requested_limit
+                            or len(indexed) < prefix_size
+                        ):
+                            break
+                        prefix_size *= 2
+                else:
+                    # Category/kind rows are only the exact seed. Page
+                    # predicates and other canonical filters run after
+                    # hydration, so limiting this seed before post-evaluation
+                    # can false-empty when the first window is ineligible.
+                    exact_limit = 2_147_483_647
+                    catalog_result = lexstore.search_semantic_units_result(
+                        vault_root,
+                        query,
+                        k=exact_limit,
+                        clauses=dnf_clauses,
+                        scope=scope,
+                        freshness=exact_freshness,
+                        literal_all=mode == "keyword" and bool(query.strip()),
+                        _repair_stale=True,
+                        repair=exact_repair,
+                    )
+                    _set_catalog_timing_profile(timings, catalog_result.readiness)
+                    if not catalog_result.readiness.complete:
+                        _raise_catalog_outcome(catalog_result.readiness)
+                    indexed = list(catalog_result.value or [])
+                    records = (
+                        {}
+                        if mode == "vector"
+                        else _hydrate_indexed_unit_records(vault_root, indexed, plan=plan)
+                    )
         else:
             indexed = lexstore.search_semantic_units(
                 vault_root,

--- a/tests/test_category_candidate_algebra.py
+++ b/tests/test_category_candidate_algebra.py
@@ -609,6 +609,138 @@ def test_unit_exact_candidates_are_post_filtered_before_limit(
 
 
 @needs_fts5
+def test_limited_exact_unit_recall_opens_only_a_bounded_leading_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broad exact category must not validate or hydrate every matching parent."""
+    pages = [
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/Notes/candidate-{index:03d}.md",
+            f"- [decision] broad candidate {index} ^candidate-{index}",
+        )
+        for index in range(128)
+    ]
+    _seed_live_freshness(tmp_path, pages)
+    lexstore.ensure_fresh(tmp_path)
+
+    def forbidden_walk(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("limited exact unit recall must not walk the corpus")
+
+    opened: set[str] = set()
+    original_validate = semantic_index.validate_parent_record
+    original_state = semantic_index.current_parent_index_state
+
+    def observed_validate(root: Path, **kwargs: Any) -> Any:
+        opened.add(Path(kwargs["parent_path"]).as_posix())
+        return original_validate(root, **kwargs)
+
+    def observed_state(root: Path, path: Path | str, **kwargs: Any) -> Any:
+        opened.add(Path(path).as_posix())
+        return original_state(root, path, **kwargs)
+
+    monkeypatch.setattr(find_module, "_walk_md", forbidden_walk)
+    monkeypatch.setattr(semantic_index, "validate_parent_record", observed_validate)
+    monkeypatch.setattr(semantic_index, "current_parent_index_state", observed_state)
+
+    hits = find_module.find(
+        tmp_path,
+        query="",
+        scope="kb-only",
+        mode="keyword",
+        graph=False,
+        result_level="unit",
+        categories=["decision"],
+        limit=3,
+    )
+
+    assert [hit.parent_path for hit in hits] == [
+        "Knowledge Base/Notes/candidate-127.md",
+        "Knowledge Base/Notes/candidate-126.md",
+        "Knowledge Base/Notes/candidate-125.md",
+    ]
+    assert len(opened) <= 8
+
+
+@needs_fts5
+def test_limited_exact_unit_recall_advances_past_excluded_leading_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Canonical access rejection advances rather than underfilling or scanning all."""
+    excluded = [
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/ZZ-Private/candidate-{index:03d}.md",
+            f"- [decision] excluded candidate {index} ^excluded-{index}",
+        )
+        for index in range(8)
+    ]
+    visible = _write_page(
+        tmp_path,
+        "Knowledge Base/MM-Visible/visible.md",
+        "- [decision] first visible candidate ^visible",
+    )
+    trailing = [
+        _write_page(
+            tmp_path,
+            f"Knowledge Base/AA-Trailing/candidate-{index:03d}.md",
+            f"- [decision] trailing candidate {index} ^trailing-{index}",
+        )
+        for index in range(118)
+    ]
+    pages = [*excluded, visible, *trailing]
+    _seed_live_freshness(tmp_path, pages)
+    lexstore.ensure_fresh(tmp_path)
+    (tmp_path / "Knowledge Base" / "_access.yaml").write_text(
+        "excluded:\n  - ZZ-Private\n", encoding="utf-8"
+    )
+
+    opened: set[str] = set()
+    original_validate = semantic_index.validate_parent_record
+    original_state = semantic_index.current_parent_index_state
+    original_search = lexstore.search_semantic_units_result
+    query_windows: list[tuple[int, int]] = []
+    mutated = False
+
+    def observed_validate(root: Path, **kwargs: Any) -> Any:
+        opened.add(Path(kwargs["parent_path"]).as_posix())
+        return original_validate(root, **kwargs)
+
+    def observed_state(root: Path, path: Path | str, **kwargs: Any) -> Any:
+        opened.add(Path(path).as_posix())
+        return original_state(root, path, **kwargs)
+
+    def observed_search(*args: Any, **kwargs: Any) -> Any:
+        nonlocal mutated
+        query_windows.append((kwargs["k"], kwargs.get("offset", 0)))
+        result = original_search(*args, **kwargs)
+        if not mutated:
+            mutated = True
+            removed = excluded[0].relative_to(tmp_path).as_posix()
+            assert lexstore.get_store(tmp_path).delete_rel_paths([removed]) is True
+        return result
+
+    monkeypatch.setattr(semantic_index, "validate_parent_record", observed_validate)
+    monkeypatch.setattr(semantic_index, "current_parent_index_state", observed_state)
+    monkeypatch.setattr(lexstore, "search_semantic_units_result", observed_search)
+
+    hits = find_module.find(
+        tmp_path,
+        query="",
+        scope="kb-only",
+        mode="keyword",
+        graph=False,
+        result_level="unit",
+        categories=["decision"],
+        limit=1,
+    )
+
+    assert [hit.parent_path for hit in hits] == ["Knowledge Base/MM-Visible/visible.md"]
+    assert len(opened) <= 17
+    assert query_windows == [(8, 0), (16, 0)]
+
+
+@needs_fts5
 def test_vector_unit_exact_candidates_are_post_filtered_before_limit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_category_recall_latency.py
+++ b/tests/test_category_recall_latency.py
@@ -243,6 +243,100 @@ def test_check_cardinality_exactly_two_required():
     assert crl.check_cardinality(None) is False
 
 
+def test_broad_cardinality_requires_at_least_the_configured_minimum():
+    assert crl.check_cardinality(100, profile="broad", minimum=100) is True
+    assert crl.check_cardinality(101, profile="broad", minimum=100) is True
+    assert crl.check_cardinality(99, profile="broad", minimum=100) is False
+    assert crl.check_cardinality(None, profile="broad", minimum=100) is False
+
+
+def test_broad_profile_uses_large_untimed_preflight_but_keeps_timed_limit():
+    responses = (
+        [[{"path": f"candidate-{index}.md"} for index in range(100)]]
+        + [_envelope(5.0, 1.0) for _ in range(4)]
+    )
+    op_find = FakeOpFind(responses)
+
+    report = crl.run_harness(
+        Path("/vault"),
+        "cat-a",
+        op_find=op_find,
+        reset_cache=lambda: None,
+        samples=1,
+        count_pages=lambda _vault: 2500,
+        profile="broad",
+        broad_minimum=100,
+        limit=3,
+    )
+
+    assert report["preflight"]["cardinality_ok"] is True
+    assert op_find.calls[0]["limit"] >= 100
+    assert op_find.calls[0]["include_timings"] is False
+    assert {call["limit"] for call in op_find.calls[1:]} == {3}
+
+
+def test_broad_profile_rejects_below_minimum_without_running_lanes():
+    op_find = FakeOpFind(
+        [[{"path": f"candidate-{index}.md"} for index in range(99)]]
+    )
+
+    report = crl.run_harness(
+        SECRET_VAULT,
+        SECRET_CATEGORY,
+        op_find=op_find,
+        reset_cache=lambda: None,
+        count_pages=lambda _vault: 100,
+        profile="broad",
+        broad_minimum=100,
+    )
+
+    assert report["preflight"]["cardinality_ok"] is False
+    assert report["lanes"] == {}
+    assert report["gates"] == {"pass": False, "reason": "preflight_failed"}
+    assert len(op_find.calls) == 1
+
+
+def test_broad_profile_reports_only_bucketed_candidate_cardinality():
+    op_find = FakeOpFind(
+        [[{"path": f"secret-{index}.md"} for index in range(123)]]
+        + [_envelope(5.0, 1.0) for _ in range(4)]
+    )
+
+    report = crl.run_harness(
+        SECRET_VAULT,
+        SECRET_CATEGORY,
+        op_find=op_find,
+        reset_cache=lambda: None,
+        samples=1,
+        count_pages=lambda _vault: 2413,
+        profile="broad",
+        broad_minimum=100,
+    )
+
+    blob = json.dumps(report)
+    assert SECRET_CATEGORY not in blob
+    assert str(SECRET_VAULT) not in blob
+    assert "secret-0.md" not in blob
+    assert "candidate_count" not in report["preflight"]
+    assert report["preflight"]["candidate_count_bucket"] == 125
+
+
+def test_selective_cardinality_profile_remains_the_default():
+    op_find = FakeOpFind([[{"path": "a.md"}, {"path": "b.md"}]])
+
+    report = crl.run_harness(
+        Path("/vault"),
+        "cat-a",
+        op_find=op_find,
+        reset_cache=lambda: None,
+        samples=0,
+        count_pages=lambda _vault: 100,
+    )
+
+    assert report["preflight"]["cardinality_ok"] is True
+    assert op_find.calls[0]["limit"] == crl.PREFLIGHT_LIMIT
+
+
 def test_preflight_once_reports_candidate_count():
     op_find = FakeOpFind([[{"path": "a.md"}, {"path": "b.md"}]])
     result = crl.preflight_once(op_find, Path("/vault"), "cat-a")


### PR DESCRIPTION
## What changed

- bound exact empty-query category/kind unit recall to an initial `max(8, limit)` ordered catalog prefix
- expand the prefix geometrically only when access/currentness rejection underfills the requested result
- recompute every expanded prefix from zero so concurrent catalog insertion, deletion, or reordering cannot skip across an offset boundary
- preserve exhaustive retrieval for non-empty queries, post-filter plans, and unlimited requests
- add a privacy-safe broad-cardinality profile to the category recall latency harness while keeping the selective exact-two profile as the default

## Why

Broad exact categories were fetched with `LIMIT 2147483647`, then every matching parent was validated and hydrated before the caller's small limit was applied. SQLite candidate selection was already fast; parent validation and Markdown hydration caused the observed latency.

The bounded prefix makes the common `limit=3` case independent of total category cardinality while preserving DNF correlation, access policy, typed catalog readiness, deterministic ordering, and false-empty protections.

## Verification

- `154 passed, 1 warning` across category algebra, latency harness, semantic-unit recall, catalog error/identity/diagnostics/atomic rebuild, and scaffold privacy tests
- Ruff: clean
- `git diff --check`: clean
- strict OpenSpec validation: valid
- independent review: no Critical or Important findings after the moving-catalog regression and prefix-restart fix

The whole repository suite is not a usable local Windows sandbox gate: collection includes a Unix-only `fcntl` test and a missing optional E2E helper, while the first runnable failure is `WinError 5` creating a multiprocessing named pipe. These are outside this diff; the proportionate retrieval/catalog gate above is green.
