### PR TITLE
ops(hosted): seal live durability credentials

### DIFF
--- a/infra/secrets/ansible/etcd-s3-access-key.v1.sops.json
+++ b/infra/secrets/ansible/etcd-s3-access-key.v1.sops.json
@@ -1,0 +1,15 @@
+{
+	"k3s_etcd_s3_access_key": "ENC[AES256_GCM,data:W7vkNpoEO9ea0kERuOr6Omw0OIvr0QR8+g==,iv:KgJf4qWttWsyowL/auhv1nXNi/g8ICDbRjJPn2byMUA=,tag:s44czLUs93ORWX0YRj+pmQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6TVBhYXpVYlk4ZklYZngv\nYm1OVmY0alpObWRpUzAwQVVjYUtGcWJOejBjCjZyMkNSSllaRlorN1p0V0ZWcHNz\nMFpBZXJCR1dtNWk4MmNKK0U5R3Rnc28KLS0tIGJJckkzMmVnRnpETWExakdGcnhP\nUHJ3aFFjZjVXK2ZRdHpXR2xrY0VMOWMKIIBZVPJ9255x6EHgFM8tJ3QWuisrCGED\nLy1c6njyr+U9A3sMl5XeRS8WB3hB+bvlRxRAckM7yjxLbkxrzKNocg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:45Z",
+		"mac": "ENC[AES256_GCM,data:DaJETUShLwCFz4zZGtLY8BNjDp9OqVxiJAg6cR8L4NMkwrruNJgqfRr4LztA+RaIKYU9r0Fq75XmPOk0XyBmV3sWscLALs9F2nNuD/Y41ymYDFRp1/nb4BOu6NV5A7q3cqd9U0ZwdDojIbcB5eOH0c956y6hQ9tsurB9JvHDq/Q=,iv:NgO8LeX8z8ppi0UEHMx4PnYG5e6b/V35kmiiRHoebjY=,tag:7QmhZtq7sDFqGqixh5G5tQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/ansible/etcd-s3-secret-key.v1.sops.json
+++ b/infra/secrets/ansible/etcd-s3-secret-key.v1.sops.json
@@ -1,0 +1,15 @@
+{
+	"k3s_etcd_s3_secret_key": "ENC[AES256_GCM,data:SeH0swlagSHmeajJLwfj9NDshPcV17YPQW52wHfjhA==,iv:5jke+FoSdHOrqtV3oq6y2oRyDzuyZubEB0Hqo7O0GUE=,tag:OzjdmYkCoV/3DiFJFog1yA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZHErVjJ1VkNPWThKbkRv\nQ3RpeTMrRnpVcjB5aGpoK2NvdC9Va1d5OGhNCk9QcFUvdXI3RjVIb3diaW1yNklO\nd0RHN21uZGp2RHFhRCtIZytWQUhtMzQKLS0tIHRoSG5sNUxZaHNNNVhRRnFiejJh\nYnd4Q0oyUmNUWUZWQnVMY0pTcnNyQ0EKiXqh9on6yz1RbyEEx8wD5aKVg2EiK62p\nEt8vMaEuXNyXZjzNlCGZ2+8wrFERh2La5TvRcJ42o+XG4puwBD5Afg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:50Z",
+		"mac": "ENC[AES256_GCM,data:WQ+DFoVAZNn/UhcRxNHjqsARdjSNQMnBaA9f/m5MTYnYbLIYO/L801wJy726HV8ZYRF4AC2w0Bz0bOjYCLtJJf2xLo3Lzyw+rZyQ8F99AC20w9zvAwUAMCMhpJgLCQ3vJeudLgFnkUzhKedm/ghjCelwFl40VFC0ra5wr084y0I=,iv:eAarOPyHc+wSocHPKVs8+kvvAE4VIPWK2vFnP5DHV4A=,tag:Zacl171sbN4IXPA0EVmOdA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/escrow/etcd-snapshot-restore-key-id.v1.sops.json
+++ b/infra/secrets/escrow/etcd-snapshot-restore-key-id.v1.sops.json
@@ -1,0 +1,18 @@
+{
+	"application_key_id": "ENC[AES256_GCM,data:l6v4QKIFL5KT2sOJgyfSbiJKdzFzZseG0Q==,iv:7KolYSWOQcBXz+acxHm0C68bUriNhN/1K2xCFTceoTU=,tag:zjqmP14jj/vj4RZyRHcA8g==,type:str]",
+	"schema_version": "ENC[AES256_GCM,data:tg==,iv:4tCiP0yeXcam1wIp/MvXy4HInGzz+L2IpmM9FmTE0wI=,tag:8dtJi00HjBwRjjkR+hw2Gg==,type:int]",
+	"secret_name": "ENC[AES256_GCM,data:Iwa2c7Gwqk/jKyKTc5b5oEIfzrG71ILym7HdeA==,iv:AN7F/G5Zhw84VyzUOvNMx4+0OwhFD4ch+PX+dwuDy4s=,tag:OtUrMGmIDqgRLwhPWANItA==,type:str]",
+	"secret_version": "ENC[AES256_GCM,data:eLA=,iv:H4KXwCgcbokLMwxiTiwgyR9HjsdXWU98bFGljTFxCE8=,tag:bpOZYEp1PE0ps2p78hHQ9Q==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Rmd0TnZNY0liQ0lmNGJD\nSVhxY3RUWEVEUkVaMXJPb2pjdHNxV1VaZUgwClFybDhWRWhaTmFxT2NJNG5oSHhy\nbEpsSlhPZ3l3MjRFVG9kMTAwa1FNcmsKLS0tIFk2SU1rc25Demsvc1YzZFN0ekJG\nTXN5d3QvVlE4VWFReUZJU1lPMFY4MFkKhuOjy+0IOAcVJ1mKq7pN3Bbt+3yJ37cM\nf0YMHIWil1tOLMJe6JFJNnudIgFF8PO7RRdCljUtlQXgVAZLh1VT+g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:54Z",
+		"mac": "ENC[AES256_GCM,data:mB+Y5+tgpWZ0kr4+ixzinwNsqwSTGnL7lDyMRgjQTC/I3997LGPkpd0zo7wlPPca5u0Xbnm0mFtIBcCdX7zPvA0mxazj7icOCBz0Vhgr3k8qWXtPAIBdQi4irCFvms1XXHm6zDKs3r17hVdOzoz5BvtEC4D9qglgqMXnQNvgF/4=,iv:R5bnLd2s1qDN6poaE/ZsS0CfM/yAiD4jzyBP0Jj9T2s=,tag:dTL+gYq3KUF4jtmB1+JEVA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/escrow/etcd-snapshot-restore-key.v1.sops.json
+++ b/infra/secrets/escrow/etcd-snapshot-restore-key.v1.sops.json
@@ -1,0 +1,18 @@
+{
+	"application_key": "ENC[AES256_GCM,data:IXVejymPlyNygj9UkZ71Kx2qoCGM8U5puDgrfr7bpA==,iv:kgFqh0DEWypvMRiSPDgmqJfQk199U9EUvo4RwxhhWmI=,tag:Z76hPqHl3uPts/Lo/BMFJA==,type:str]",
+	"schema_version": "ENC[AES256_GCM,data:Zg==,iv:NHhAycBjfbUHOFPPZFVUFnqZ/DXnFCemCeylABW94Mw=,tag:QfTLbLRsS6Dtw3gFOLDBZg==,type:int]",
+	"secret_name": "ENC[AES256_GCM,data:4tn2NwycZhr2/3alMM5YNsczICmZ/jetfQ==,iv:YMwX3yNJjUlpbnGD/YhF5s6TyIgoJuXmknDpDkh8cio=,tag:GIO5JAKAYEYa66uAo+bDxA==,type:str]",
+	"secret_version": "ENC[AES256_GCM,data:iqE=,iv:Zj/NVshuOr2JlxFGvX0ZeBBR4rABdKJ7gcM0JyR4cUk=,tag:LILC/P+YpZup9waxsOIW+w==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByT0VIdFo0dUVDbWJXUUxG\nbi93K3Fkc3RmdGsrVlIyUWYvemo2c3o3dUFJCk9wN3BjMUFmdWdhNVR0bUNma0Ns\nOTAyc2RiYWYyclQvOWFNcEIyQ3FpK0EKLS0tIEpuZEdsL3MrbEVXclNLcURCN0Qw\nYXlxditwQlNCaXovU244b0JqMWhyU2sKOg6yy7zhx/WF38gzapn15csR9FRH+0iu\nObM6QBX4yYE8PTOhrQfccBCpRVVe9H8vE5KqdwwqlAfqhTkOvVagrg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:44:00Z",
+		"mac": "ENC[AES256_GCM,data:sMlbsYVyV8psSbjecZTwahl1k7x5bUkXmo2YNWjifBatkDnNg0BJmxDYuw+EpXF7MSIHIaH5O7W3uMQcYPdsyfAqJYJ2AZnry/bM/5/qFzAGHUdv+al2ycDYRltp+j7NTlqi11ayLNvAd4Rrl7iLReerzK+1h525eUEx43CexWg=,iv:QvmBSrM2ydNQmMaUz+ePfEmfpqgi/m+Pg/ox495tf/U=,tag:sRScQn06QTYaEGv42uOU7g==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/database-backup-restore-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/database-backup-restore-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:t5k=,iv:NDbtxNVgJsEH6In5RpLgdy+769tb3a6+y2XYqR3q1/4=,tag:ghZdG/UI3qblECkmhZvw3Q==,type:str]",
+	"kind": "ENC[AES256_GCM,data:DruXhIeq,iv:OXTGsl3Ig0o87McbtBREOAPGZ5i54pu0+e4sGanfAt0=,tag:yxkrzLNNoc0hiC0fW8Z3Bw==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:eiYaJej2Bv18T5g/fnTiBMbI1089,iv:TyXBXUgRCiWF/ZIfHiPhwyOfQwl1lU7vocC+vZv0F3s=,tag:RlJb5Zb77v3EBd0X7k1WkA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:ah4=,iv:a94WVcTjlZUv1ColHaWFTjY6Jeq+RBj0S68Eo22j4dw=,tag:I8pDPvNaQ7e90S8EuZv6pg==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:fr7iwoRW2Y5BSf/2PlbfCjfhEcPjxCNE8zxyooLKJeQMopyzEQ==,iv:oRI0y6FzARwyQHycdrvslJ/7iMHZYSVn0SEvTmae11c=,tag:U98BbOtUO8BUVUilEpoVhQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:k7cZ6IVG7Fzv+4CO93mv,iv:AxULBkWpcq3vPPSpb7fFkRQ1yVfeGEvK/Eecr4zJio4=,tag:xOT56RvxmdjLyQMgJ31xdg==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:JC6sAHu7nMHRAMe7mYPFvOT0b8UibTal+g==,iv:MvQ+nZAF0dnRULMYfKeMYHiBzA7u2lfUBD52KwGECcg=,tag:hU6fe3WzuQVjdomgM6rqAw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:7RgBXpcu,iv:OGc+sO3TrjUsAzoVPjruL7HYwBsiQjT+wSNwqJuicrs=,tag:OgQlpouy+lC6OqaOXIoBFA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNMXF2S21NM0NZTFZpYzQr\nV2FBK2c2eFBaNmRubGRvQktPWllFRG9pTmlRCmtyVmRHajZxVmdic00ya1VOM0Jz\nUUZYZmtvbDY2V2EvZVNscmJDTU5UK0UKLS0tIEtVelRQUklkb0hrOXQ3bXpRSmYy\nSWlTZ3llTUdyNG9MNnNobTB0bVoweFEKONyBvN+nssv0+j78t1WWr/zceX9TfX4V\nFqGsP8QWLh3Cdrl5bIqakAJWKMNEeRfdQsixQd2wsnmYA3T7/rcvkw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:35Z",
+		"mac": "ENC[AES256_GCM,data:L22qEy4xxQS7kpM2pp1nnHp2LaxseJYMJhzeF/YViCyvrKClW13zJ7uvVvJbK3qiHy5YrmZG9YqbqD7i0IQjahojrDz6keF8x1sBWaITXXzReKxT1fd1fejAM4eMn+pUYH29H5LWyuv9ZxduKn0sp/gCag+UE//5pV0Gw9IuSXc=,iv:wlVTusxLgJ9T9jgAFCo8+kJKQ/SBCzFJSzqW6Te7o08=,tag:rFCi9mQDj82YAl3qC4ZC9w==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/database-backup-restore-key.v1.sops.json
+++ b/infra/secrets/provisioner/database-backup-restore-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:Cuw=,iv:Lt6J1f393orh9DsX/HQHlNvSl3QGWw/ZbxyBe7gXoH0=,tag:Gt2T9Y/EJ9hU5S5nG+0+UA==,type:str]",
+	"kind": "ENC[AES256_GCM,data:yCKydpCN,iv:Gz1E13j1rYBl+OJnMTzqGwZraKNtvZT4FUq695qoc9M=,tag:PzQ+y1pb9xy7bszRe1H9uA==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:lJ4hMvGl8cC5STa9+D+8QUcamv09,iv:x3nGnVdLzgzzGN24xUX+bERscea4dC0SbNGVtKETBWI=,tag:qcEaAit/r0f+fYrzckBKiw==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:hB0=,iv:e1TDUjKPFB4AUja2FA+f99obWCPEcGD+lhRCiH+XPt8=,tag:+BktM+m3C6ceUrBAleAJpg==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:hrTilN3wXCIxEdihnWMQmbMWkD4dhZlBfqslNGrIxyV8Gw==,iv:CQzsNkDJt5OOoiDDvK8/ZvrRo/qOIa5y5j64WpJNsLo=,tag:YGxRlvqJirCmp0iky8uycA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:zmTJHt6x9WOkLvW8q77r,iv:FsgH7CjTBOyXDAC0Np7WlLxC87tNfxHQ1RJc+zyLP+k=,tag:1rOU+ZP9grD4sf2IPiM81A==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:N8JlZnctlcCNShkym+KWSeUS4BN9mtMwBEXKVfnbTg==,iv:U0u8Iog6AcKQtiau7NphgGIYoZKGMASRom+/c89u9/A=,tag:NcSf/HIopZzRTU6WQ0KiQQ==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:RAT8ef8X,iv:v5Jtjdi3saU56vCvz/7rzJKfg+it3ob9T/zVwRnX85E=,tag:+dQw/HxnpAjdMYrAfCQ9jA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvdk9xUVFtdWZoUmJnWEpi\ndXNMQkUxa2QyR0g0WlczMTZ6VWJkblFIWXk0Ckw5RFhqUjltaHhxZ20veE9wT3Rt\nV1cvZ1phdzdpZTJWa05SOXJ6bXBVakEKLS0tIDZWbHU4dzU5RTgyK25DVjRTS3gw\nZjdSSkc3c294NEdES05OVGY3WVRrdWcKPkZN6Uu5udLbbbQHqjk52myAFoTYbrBS\ntsWsJxipCGyVGkDMoJ8dvnjpJVem+2/Y0397tAfqmlKFIlnVLnxlvA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:40Z",
+		"mac": "ENC[AES256_GCM,data:ywcLsU6g/nCWsKGpz9jdxODMZNIcxFOrOuELQlG/GWMwx79KLzOq8vf2btFPelVisEU8QM2ogcI6fDCH1qHTymARVjGMTzQBQIiE30rVDkBRaf8c7KDWBNAEjDy6XEYW+DERaBrivVFiEPBVqqifLpooQ0Pty69diOgs+vJd1uE=,iv:/PQtMm3/JXP1V/jNq/zwka3tMjG2i50RHxfT9AFeq7E=,tag:huuprGxFIk0cGM5tg3rffg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/database-backup-upload-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/database-backup-upload-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:lDE=,iv:U0tcmGH+UM9nrvjVpvWAOMwaYb34xjeEeEGtU2jsm7g=,tag:BtXaRcg5uEzlsNgeIX4W2Q==,type:str]",
+	"kind": "ENC[AES256_GCM,data:R6UOybow,iv:G28G3OOLFFOgYXtx1zF5SXEhvAhtGeXpOlGWybXLceA=,tag:VuiG05sD3e9O4Add365CbA==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:fRFj40gyCcqRCAZsJG4fJBit/6iE,iv:KNKKBqou3ahNNPcoxGFDMoiyxSxbEa3H5bQViGm9Rwc=,tag:NwbFm8Pi41BwglEICwra4A==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:1ts=,iv:6EvDy+VIYztGN5FVq1y9lCCLSNwgyP6ecpHwPEZ75+4=,tag:s1nenxd91Eo1zE72maj7iQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:ywNniY+5hnXUiyN7cU113IEJ8Uu9y1UAs+M9eW7FrctCP84p,iv:y1NdCzAI6es8LLd005rrnyPqK/XJ7GhibfE/0STdxqE=,tag:GchrbmSVZcqeQ9S6LXB+GA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:n0dUZEPkT4vSrvfZt5eW,iv:25vat3QCFJ5r5mUaiHO8IUh9jPGukHXpk9CSDfapykI=,tag:V8zg4GCV6hRX4wXPa6Dbzg==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:mr58tAe+bIrM4+nG/dpUZbEmbNzLm51rbg==,iv:t7h/lOvk39DeDJqPPS10UL0LCfaaZki15Czv79F8cx4=,tag:yLtU1pU5uDpW9uTG9LwQdQ==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:Wj/z6S3U,iv:m3h2oFhbRXyjPZmQJklXLFKvxsUtqEJlczTjdk2jf2U=,tag:y/GYPJ7NyPYebSiRAqSMIw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwOFNjdGd6ZlVwZThwL1h2\naHJJSEl1dzZWKzgza3p1SWovZG5xNlpWeUMwCm5FcWp4OWdrOWRMalpXOXJZais1\nMUtaMm52c1NMdlpoeHhJN0dLZTdqcWMKLS0tICtxQWdWRFNralpncjlHeG1QZkNQ\nZFJEWCtsNlRYd3JOOTFlOFZxQzdQWWcKVe7gJUGWXIjQOlA5wulis5i2SNRBhPPL\nDtZhf2yvBaKz0hTvgQVcdL5dPJjA7tudI23ksLOe51jbubWuTpW7RQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:25Z",
+		"mac": "ENC[AES256_GCM,data:X/3RbrZd853NQCmu2+Hphs5b4khGiof21mmvCTafY2H2PXI5wijIFfxwcyRLfBglz1+xiOG+X7sFVJUGgGo41be0pCxwbjtzCjJbDVxE7jGfeVKMFQXymdrCLtSwYTDqCHkjII9hUbIjND4QumE8ES3Z6DVvrlMNxj6HT2rPilI=,iv:lPMFLtsu3El345ytIjdLSCjXxhlPCkxHC+AtK3XcBdg=,tag:1CXETbhjfpZ4o3+EAMm3tA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/database-backup-upload-key.v1.sops.json
+++ b/infra/secrets/provisioner/database-backup-upload-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:CnY=,iv:lZxu1of+hE7cAkTzud2d6tMzb7uj8FsxTQK3wKHTPhI=,tag:wErD+R4FYPjeIu69PKFQWg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:47Bj4JJW,iv:9A7L2i9paS8kZZOmBpUJv3kGXRrSEhbm30ej5jkqVZU=,tag:RlpwCxMSc2WhNS3/2lMduA==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:2e5D68LrqFCiiZ4eFjm00GnN8+yP,iv:xd7ecflZm0Nv1QcChyZkTjZou6G4lVOUDc6RkSaZbWs=,tag:YSeKEjm+2fHzDVi4ZnnBJA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:7gQ=,iv:+MLEjQXsvJ1RVEfz6G/tbsQLRCd02X93MCfMWOyfaF4=,tag:Lj8ylYnOg0I2ugcmkE9x4w==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:SzYxCkNiV2KgUYp1wnr94+00Y1d/cqzh5lvcqOpSBnKR,iv:gdsEAjcgNAW4WwUijkJBhbzzIuZtwA9X3WWerHtKXf0=,tag:P7RyxEmrjbjDDl7RBm8+6Q==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:wvh2aQhssVnuJy+CqhrF,iv:6pPHZOzxf4pw2F5XW39t4ZPocWCqgx7ZWkapexDfcxA=,tag:qaoUquf6q1tIfN5bX8yN/A==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:ws/fFdtu2U2lXn63ZTrZWAarOQwE/s8U1PEHR0+rUA==,iv:VSfzeKjvoFCvP1rC93UOzufPBwuj9yXMyHxcC/u3oCQ=,tag:leHExRT9z7kT/eOh7xO7lg==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:rotDYR5t,iv:6K4wUlsw/PrpNBlC29CtvmBNc1b1+8Ev8dlhEVnbnQo=,tag:+OuejP08Bdvsg6ySklkIDg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxaFpGbDk0bzl1bmdkaGdy\nYityVDdtTk41ck54Yi84MWNNVDZ4Q2hrQlRFCmpUOFNxeitSOE5Tb1g0QUVaTW5a\nTk16bHMzMzNYY2cwNjltaVUzR05HWkUKLS0tIHZNcU9pRnhYWHpNRFc2UVlDZUpB\nRUNOdVE2Lyt3ejNFMTFkZFB0dXV1UFEKsGfHz29AIyrCPdLjiqLySbQ9VlBLxVN5\nNx8880aZ2GRrARniS5RE1LtEL75YO8NYhgUdqOyBzPXwuVh+c9y00w==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:30Z",
+		"mac": "ENC[AES256_GCM,data:wlKL+qZJUGItaOIId71r4n67mvkjgPpfgVg0cDBOk8FTz1+1fzVsSJ8fcLT2bSNIKJp9QLLhl4c62Rg7r32OfZ2L5Z3aJayldCqi888AmlAVwM8dBL8oFx0FTCc/bk8G/sSKNTbz9VJP+lgjCBFqvymyhDRxNOL+TuVMDAo5qRE=,iv:VRqxEsmpA7ZfnjrF5QRzrBcjtUvnekf1lXcG6LsaiBY=,tag:bTo++IOLpJ+Y0TJdEq8uKg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-delete-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-delete-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:nqc=,iv:zDn0VFCs92VywWQekZKVHnTDbt3zeb23UyGMDPW3o7s=,tag:ix2rDOQ2lIAt1U/rwowqnA==,type:str]",
+	"kind": "ENC[AES256_GCM,data:Ol7djaW8,iv:qj9qQY61UjnC4fTQhATXapyIrgacQ/X5+4D3E/3/IHs=,tag:MauyUYNn5C3wWvwDQx5LoQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:FZUpu//fa1JNd8Mj/3uA/MiSKUVB,iv:dsoF4rIpXeZeOtoheWojmncj8w3zCFlXv80ApPRJJfM=,tag:gQ1Q3+DnDRbws1Wca8fp4A==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:h7U=,iv:z5meb5Z+BNKU1vxzPF9JctZSjC1Y7ZusYTc1os8kimw=,tag:JsfA7uzR65oJU5q2PDJD9A==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:XA9KTrrr8nNAPr9lnDPSMl90l2WrAEou7zh3/Hc=,iv:+G6Sc1Fsho3pVU+jmMFdSay0PM25qhgikZApCNhOYAw=,tag:vLKJu6VH4vMJehPuUOmeKQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:3dh5+m+Y41M8lvEnr3hM,iv:Vk8jpCJD3atZBjxhdI0Wkkt5HXuKmfuP2BrYXtBPH4U=,tag:R5Mf38IFjrFkGo2rJ2OJaQ==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:n+6fDDp+k277wVD1ukxSZ3eNGsfDSaCFCQ==,iv:p6DBmQFavIUh/q+uvCU2fu1i7XaI6uNvtm1NzZyxT3c=,tag:0G47ShByqk1y+1H5YsbpHg==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:p0ZFErbE,iv:OcDtSjf3Equ3aOLdoD1Wi6DgTEUber4GIKVF3uKtTvU=,tag:FWo20Os4nbQF4KzlxosFUg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSREZKSDYzZGVSeGNBZ1Vs\nUndwc3I2a0ZtM09xeHorbllYZ3lTeDZmUkNRCkJPL015MUdibkg1clJ2VWFZU3FU\nYno4ZmdRWVJ0anZyd2JEV241NjdBZ0EKLS0tIFA4dmZjZVMyQ1g2TEpIVTdrMHBt\nRVJoM09wVHUyRVgzMkJCVUFWYnFieGsKoNX/WNXtVIU5ea3UfUhh7mWTL5YeglaX\nkhPibq4B9+Id1gu4jqVVpJKabrw8n/wG8IAMsUJVIfJ39xo9G+HvOQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:35Z",
+		"mac": "ENC[AES256_GCM,data:uCO0uomEK+NlH4l3xCI+dEGCVcbsZG6EENGrHWH2SEkNqdqUY815LzGoyk2W5QSb7iC5r3aRl4MO90jHjJJirL7BkDQIAEyD7ardSWljprsyVyZFpWqpesyXoH/6oi/uhZDTtruRKiUdceA/k7FcT46eubbqmkQG1hDTJEp0rwI=,iv:lqxYIpQ9o6uHnm2RaeUGSV9AODRltFzJ/bMfktlgERA=,tag:m1GfypLhHurFgCSBEVfZ7A==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-delete-key.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-delete-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:rv8=,iv:aBLtqcdMEUqRIz1I6yl/j68s95frd3gw/fwZ1TjAJt0=,tag:wEkJSuOLHgfGPUQJJLp4Og==,type:str]",
+	"kind": "ENC[AES256_GCM,data:m0AcpvA2,iv:uHbt94MgE6pDWzo+6PQGeLCaWRHexbUsJg1eN2CmnjM=,tag:hLGHOY/VhRcHWp1aGWEUAg==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:anHgK117DnriUA6p+9u3N1dqHqyO,iv:YOamIl1iTR9+H040qqOcHaNA7txzbbXpD+UmzfZXra4=,tag:oYHERX7rbXHgraF9sRnWlA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:fhs=,iv:shevLsiQkT0DwC78jy5jClpT1zOZjS4EwoCoBs42yhA=,tag:fqS+uLdzwIjGv/MOTrJGjQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:33sBTz1qeuiFE+Wd8fR9gnXfFj5VXs5kn90=,iv:5dSuxGjCpMYp9y//EEHX3JMybloUWsemfAwDumE76LY=,tag:mKKz9UEw8fO4JQouRiFoDw==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:/eiq8ThgdbQLMtjFyLQk,iv:1QvXwLI/SQnkbmBBigTtVXZq1Uohw0RYDU6WJ+QZ0MA=,tag:hplPMjmqvgWZAFS5931LyQ==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:J8Q0MhWNbSNEoYKN4imH22Bd89HWH018pQ1nO1e1XQ==,iv:E/Z7YJi+BtlfW+0VHcTG4okRpDJrEWhjQ++nUU85xY8=,tag:J/b5VJx4nUU22hyvd2XpEw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:uHnLrn4g,iv:IdT6boV9Ri8LY31+Y/vk/ieCQFVscS4wnOX6Ml3dWlY=,tag:fF8OEIj88Cd5X5voJ3xTpg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTGxRa0tVQy9PeFk5Qitp\nS09teHFrN1VyejF6bXZWZmQ0ZDVYekRCK2w0Ckh4OWowQzl2QVZpK1ZrbnZ0dXlq\nQW9yb2V5ckErRE5XOVovYUFINGl6aTQKLS0tIGIyTEphY2RtUDJYZnpJMTNyUTZG\nY3cyZXBCMWFRQ0JVWTZkbGRDMlFidUEKrdFa0cJXwDXnzDTYfUyua2OhLFTQsD3Q\n40b650XQ2spDxKn3BTqDZ+qeTRkFDQAtBU0ulwHcPCbXMiBtBecJNw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:40Z",
+		"mac": "ENC[AES256_GCM,data:KhSM1ulHGxFM5O3Y6SVANf/4pTFXABv83ju3K0LYl6m/+b5PY1TDzf9cBb65LmT81VIW97ow2MWP8BIrH+wDfEao0861kHuaZ0w1hZLEj5wSBpGS+fi++j8H+wdv3NaLLcjbRAh6DhxX/94FtwXLuMB7hd0wxVxHfwDfoYCYwkw=,iv:Wx2HaHH3nEXm2yVJC0nw9RkNxclIAVaJ+gayeN+xvqk=,tag:K/EoXmBSRYiVv2JebsJc5g==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-restore-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-restore-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:aok=,iv:URjSppGAx2qM6UmkMvU6cXsPffYdm4HsPf6X8fx33sw=,tag:xy1lZAj4kkhCCG9hdu9cAg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:4K8+bQkD,iv:/UMZONZUw14bFS7eK1ygCF+CQmxxos1FOCo2CpEfYvw=,tag:HBYJQGx/wD3sG3uwowCcRQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:O3CtYky07Soq/99z773aKSqWnfyC,iv:oWBPFOYsbWAoE1AAdazYC2CHufSAhJ1r+XWQGB6vNjE=,tag:KT4UaqAkpbS5CBMKvzHygw==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:TuA=,iv:OLRLBT72cmxEf2HvlUjKenWh63tcIR3xbtA9OOce3dI=,tag:S1EDn2HQMmZP/Cj7S73N3Q==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:vA9s0323jsxROXgi4xWFmHGrKpU7lCvqBVpuyiA4,iv:S4HCYH8BrIUDdtqSo1Uc7L8nZKMwiv5rLAiYdJOfKik=,tag:3anfNG41n81bVO+ebLajcg==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:zlVDVVhMJ1xN5ZJDUqeJ,iv:ncScgkQ63SV0dbl8CKkL39FgtWKeHeIeZySNxisWwIM=,tag:i5/+6Lugd8kJ048WnZvHwQ==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:hIfFwcAi2aiZ/NmrDTlvO2p7Izx+V4BW/A==,iv:1xFK50BSBZHuzeIqi55J7FyI2aGPGDFkKlG9SqkT+6c=,tag:4vX3izOUpcX7mA01sRqEXg==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:fB+Hnajw,iv:vHQVQepngBwaZF7x+FhGElNx2fbyJXGXYa0ofex4PmY=,tag:XYFvO/4KG80zbO3iL1GoBQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLWUdhbnRzL0pEWG1WZWVz\nSU9sMUlzZU5kYitRSlpiMmV4R1hoUzFTaWo4ClI5WGw1cExNRk0zTTNGNW5TVFlu\ncmFGaGQvamlmSldxY1RGVGl0MU51ZmMKLS0tIG1RKzRwbWhubndRNTU5bnZSMVU1\nT3lWMmpTQTRaaDBscTMzcDZjY05MSkUKXSbbkuTWbgP2rhPzRxGrTRcAHsC0hv/F\nkSu3R9x6VcdG2W4BniH5Ea/WgCFqJsOdOZteyJAbf3e+OjURGLl69g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:25Z",
+		"mac": "ENC[AES256_GCM,data:jU/VCyj1tO1ifGZzMsVUPLYBkDlJCuRDajT0vugcK8HXye813+uMxa58mLvmJ3MPranSA6gs0sgLWq3oBvG8ZLuwx/xNXkrX/y0H1YyVr+U1W+xyWFsLdkdIxG8A6/UxWc+DKaHFAxY5H43a3IRBnsnWnfRostZUbUpRwexFX+g=,iv:e5tVdqC61t/W94WZ6mw/i1NFnZpBSyx8wtyStFWPtVo=,tag:R6X4yx13MXRxHrGiBtAF2g==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-restore-key.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-restore-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:W3w=,iv:2yzWCggoK1VFM6NEA1XZmnQpCoXjhUmGbROek7GTymo=,tag:nMDQJwLmwjD3/NehPBxw3Q==,type:str]",
+	"kind": "ENC[AES256_GCM,data:eT8yRYqF,iv:haBakxoObf8+5sVtRKSYQJnDYn4V3Z0EwLSToLpEKc4=,tag:qc0wvoI2xZ5jJzQZ8sn8qg==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:lvyuYm/Fm+p92ZwsMTFK/0gj/Hb+,iv:Se9gMNFBk/TBx/DbVwXZr/7Cu3cQNPb4JMdxxylIo0c=,tag:OuDXQeg8NEVLYfKQFsZxtA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:cm0=,iv:o6BcxNiTcoZ2TNBI3JePb8/GzuafPtVdiFyJY8N4tLw=,tag:LeUP7Zxr741R2sUPHdMtjg==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:UPSFkuXR+NJgngJ6qvVQFkveZIXzv9cuC0Ti,iv:LX4vaSe2FfQPGUSyQPR3PWoAqZxzeQIxTuhqvtkYK18=,tag:WxjqvJfoC1ITAb22DNzl2A==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:HN/jC5+UXARKNXFOo/ig,iv:QQx4IwOT/EK/AX38/Tle4hIg3ZUgmaGuWAyVkCGpKm4=,tag:X9/lHW9la8rF+oDbMrKRcw==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:+8xxY8cNxv+tsbPPIwUaFU+pahFLwxOy9zjUJ3psBg==,iv:2EPIJvNyjL/RaH8Cw2tbGsyw8FTn9EgCpQJWxW8G2n4=,tag:Swij/lzcwXBRtierBWmzkw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:F3EkPeXt,iv:5n+je6f1e91+ZpDZyYxEzrYPqYWx0cQ+VEBMzbRosJI=,tag:ckvlQYlYMXn9ufAF8dkBgg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArMUxEb05SMko3NEpOTlU1\nVURWOFFHQ2xnd0tWSWdZdXYxS1VnYTZUbEhvCmZOMGtkellKZmRtajQ5cE5hN3or\naTU3cmpvdG9LL2ZhQUJUbXpLcjFOaVUKLS0tIG5kenFrV2JEZ1BFM2NEay9EVWhN\nRWwvd25xZW83bnJzK2lkYU9OeXlkNVkKhvVYDtwbTXBUWBZtV4PyytTomWltTi7Z\nuSpdUfG+13RVie1Rbovap2UvIPVwvWPWPkzS922ed9MUUrKI0Is/SQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:30Z",
+		"mac": "ENC[AES256_GCM,data:4WBYpZj0rUWqfCllXVfb1Be/9zW3/0frseuS94tuhabRjmBOQH5lsHsxKF+24nnlzuDVlVXWsixETo4/ZHFrnHwJ0WswUpvd4abCtQnqjPlJZZA4oNpUTwXAQ3CagCYw6EgSWA17sNBkAMHxmhdOSsBC3Df517m/BMX9GALv3y4=,iv:3X+lM3fkj4aW8NwQatDzTUzN8c+T0JyRcy1fseN7lZM=,tag:U+xivksxyGxUZyLAILUWlw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-upload-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-upload-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:y5Q=,iv:rhnJs+DAz/F9TfL+ONaEiV2p75Ctg7DcFSMPphbpHdk=,tag:/K4iWQ27KttlS62q5yjFDg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:egsz1V2d,iv:UgqV/ipeVvf3Fk6i9jyFGYv3WUXWWmzg+bytRQwTgZo=,tag:gLKNHqH0r8H/9Dzn0LQrUw==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:GfZaTJmM1d0d3Td2CCzcBz+t0Y7s,iv:5PHn1Jqzh6DYu/1g8m94TYwC97LKfIsfCQ04NWZwstA=,tag:UEpDGDiYHJ4BAfrzNTXPXA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:rd0=,iv:nYdQ7vMpiTW+yXnmrutNUInqBszYtvuiEEE4bKXf9SE=,tag:A5YcrPzI03it8KoDscDF/Q==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:eraL1IXowe5iMj1C66VdZ9seRwVK6A7VZ2TRgqA=,iv:bffIa4ZmCoFIHxkDMQkJMTsUU3y3hQ6yPi9ayeqhkac=,tag:vxlGp89BAJi9Cy2dMjRK1Q==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:1uq3sF1GnLIflXWg9sMC,iv:W5CGw/Z4JZTPhrLyMsdAjMtWe5SlP/A8wRgNMfmbR/8=,tag:n0rrdmi1kY4gor4e2PLIxw==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:Z0Yp5Nr3KnrKOa1Bh4v+6UD4nA7jhEJ5Qw==,iv:dr8lbH3d9CUfZ1IuRgi5XybNcEIvI6vzM9JtGWRyjew=,tag:H+AnM01AZD4BkpdusQXZUA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:FrswG+hw,iv:w605+pZrw0bQ+Siw+bG1mcMURmS3HuyMjzium8Caq7E=,tag:yS6IcSf9CgwSVgJgVBfIhQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTME56YXRlS0xyMUcxK3pN\nT1hpcWY5ZFhYQUdBQ2N6dlZHenh0M2RDZzM4CkdGcytqVSs3LzJ3dmRkQWRaZlli\nMW04dVp2cEpJTW5aekNSVzc1aGZhcTgKLS0tIHluUjMvemRueDZzRTdrYklUUjBp\nUkVtRk1iVXdTSGpGRk1hNnIzZDFwWG8KKhr17w/mxrhW+6aT2Ei2SZWsG2LtCgt3\nNLwCE555F4GCwLa2Tx9p/MbIJRxrTUOjW3Cc+J9d0ocYNZWEo0VKng==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:16Z",
+		"mac": "ENC[AES256_GCM,data:L4dxwXELp6B1qNpfOrfytcQfPyRMYKrGM+mURFeHrVamlxaMQls5QK+8yzLiTfkLl3JEcL3jvNi2Jqh8USXZl0r6FHfDRQvGGMpaJ4VYkaG3pc9hauRGx/9qR6dBeyTcZYdmfXmi4xKpS3RD1GNy/a4Z0obPMceElv9HPGWa2bY=,iv:NraLwrgr4qy+N4iA+g7sS6LnFSvZf4ASAF+Eg2M4c9s=,tag:6qVSTJ2y+ksfMXmZlY55Mg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/recovery-upload-key.v1.sops.json
+++ b/infra/secrets/provisioner/recovery-upload-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:dVM=,iv:a9ieLG9rqDc9IhCFEbWtIORO/n3k0hezUEsw3LwFRG8=,tag:RBhdw78+fU3CaRgSqtwpPw==,type:str]",
+	"kind": "ENC[AES256_GCM,data:q4rjK9BI,iv:RjqcJExyw6AT/pCpgE82npSxS00DurUCZsi48UbO9J4=,tag:oocY+QfhntEg8FQAttsm9A==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:H4/dGr87j6FPbhABdCdlzByvUIpZ,iv:cgCe6H2xWE5FUtdaVAW3i/+mZ+NXk8h8tboeou3z1FU=,tag:AXojr1ojanLStv+hlSRqzQ==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:8xI=,iv:144ghs44fcmeGHQP8ehzomKI2gDchhrrB3PCNnkFcug=,tag:TuoN2KuFyHB6TbcMHx2YkA==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:jfezZb6LA1iA0rWkYrkefDoSPLVIDYMsNM8=,iv:KF9EraFbab8TMl0gwbhpJs8wn4BzPkpDaUgD0hFBZak=,tag:JPV40u3aeIk/J+8a+eVIQA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:mJbF+hefQsrZR0JK0vpo,iv:bMj2pZXyrZekXpfTEfppLoQXCD+i9D77TyjC0V2X7Z8=,tag:n4TkAuv95OtXKRuzFF/4bw==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:T/Zs32cHFNjqEHWDxX8uURCrnWYDcMJlkHY9WiaCJA==,iv:QYe6413jtf2bfHhVNxPHBhUIuqwKoWlLsQSXKcJdZG0=,tag:H1BFa/WsA9JIQWkpMFy7Ig==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:H6t5NwXx,iv:h58Omn3pqlbxy/zrPtWc8HRt4cHvr5Un8M48Fan9LH0=,tag:Nxl2AlKI7CzkrdkaMBYbDw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnanNkR1pneSs1WThlRWJt\nT3p6MU91ejBNYzBQbmpxZVdXVG5LTVh0cW1ZCk9McG9MYnk4bnY3QnJxcTdiajJl\nNU1DOFhZVm04QXErUG9yeXNBTWhyZmcKLS0tICtHbnU0dVZHV0hmTzE2Sk1rL0NE\naGRvbm5iQ0tTMXUwVit5MzNQMGQ4ajAKcjUi6+SzVlIOaEmS+oSKilwCSeb1a7qU\nrLxeYf9IcDYkfDeqA3NKhjXTcnj76/EHuGwZNbSynFKQQEaFcwVbtg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:20Z",
+		"mac": "ENC[AES256_GCM,data:+veaXx8C9YjWTPXGdN7mt3u6p3rCqZG+nnpTzUKlVXloNEFFPJTgqXEMiKkqK1NAf7E+7BvsshNdkU7EZ6xl2gmbanxC9DQRMpSibJvU9WrbYhrKem2w4+RZe2pV1cpfS2GB6FWJ+ghIpkEZP57S3hbzmetAH1MB314NfoDy2Vo=,iv:dZC92JKprj+bWRpZOHGa1AHOLVxXq97xtRYdhUMlYpQ=,tag:VR+ujXQvGk/E+Qcu5cVOqQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-delete-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-delete-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:nXk=,iv:jWXpmXajxHLG7khYOcbSaFO4aU3UKyh17TXMWT/rF34=,tag:AKKtoULJtd2lOU4hOw1PbA==,type:str]",
+	"kind": "ENC[AES256_GCM,data:n5/lxk6F,iv:Py15DhGQERqriOGBib2ybafpGhy8cFR4/3Rv0dJHm5c=,tag:nemhW+osMYX1ogtxpAHpuQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:Tez0g7uyLW1rXQbjhAjDfcd+B3vS,iv:v7fkvj+JuAhnOS9pxxccj4C/1j6iKJf8hdqVTtckoZ0=,tag:jo5ATB+mpzxxG1UYFWiNpQ==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:uHA=,iv:NTTeOVmOfesrexQcnZngjAdXIMWj2LQpudWQ6O7oxK4=,tag:z8umpLADVxHjTOiYu7MVww==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:1bWz6hhK5rmpsu3EtV74a0ongcgYxagpweYaD2GT6wQ=,iv:TKnY6zPANKLqvQYzcbkS2P1enmv1sKW9HOwPmF5Fy14=,tag:DJ2KkH+XmLIT2T/eVD/TWQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:KS/ymuy6YAC3WGjJQ2yG,iv:K44tiRF4F8KRjmKfxKNnHRza/tK+JhGjYzzzizc7/Sg=,tag:vaqHLuJpdSEmK03y4CV6Xw==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:3lZdi/DJpy3jJiNNdqb2H1IrK3lWsj2jkA==,iv:cboA3fElIzqUNBeO665ScLg6SxDe7Dm27EA/gyH/lDY=,tag:cuQE0QEJUPO94VfrXqH1YQ==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:ZGVdaCgn,iv:VPPJjuEqWYcxHeh8+H26GOL89L6Cg2PTEkJ5EiJa7Oo=,tag:j2M4jW4aaNGgJvmfyzLlWw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2RWRHV1QvSE5SaThjSW5K\nQWpBODJRL1V5LzcvN2taa2FKS3BleUhkWjJJCktXYmNPc3AzOE9yTzY2MzRteXJR\ndzRLdHBCeUdxMkNBK2tVTlFqR0FPUE0KLS0tIFpiTUpjdk1VR05QMVh4UXIza0NI\nMXFRMzFiaUZIdmZXNjBTdTdwUThRNzgKbtAybVWkXH3X212xQtermfIOwPv8uB5I\nbpRhXREVjcyAdry+Hgpmaqoy645eVCVf4SGXCAVaEbYV2ugx2w+W7A==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:05Z",
+		"mac": "ENC[AES256_GCM,data:MusUiawQNuCOOrVtdefG+fBKtV8nRTCLl+2PAq4MG+m4PoKmCnhSz/5wF+5b/X6PAIof9kEvcSr3jayu3DWjkxH5ZiR+23E1+xGq6ULXbOC6ceBQ17uGnWcpgGqe/pf+aydvoGt85c2uR2PQqNT2iEJToAD+DChmMniqrgFtv94=,iv:2RZ0yO6pF5adczPTrTr1J9Tqkl5MNG/qi72M4Ih9kLE=,tag:CLi0I3Np6BSmKL8FxP/rdg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-delete-key.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-delete-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:ohI=,iv:AoA0ZfjuaMF7KYB3vNuDD72jGoD9hG93xySzOAd6ouw=,tag:I88jh5OxhBLfZlLt0dkCaQ==,type:str]",
+	"kind": "ENC[AES256_GCM,data:y18cSub8,iv:ClnyaUW+n7pZK8Ygrk/Ey9Uzjf5qA4Int32qAB1jGoY=,tag:lRroB8C4sr7FrLdxrYFfig==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:/JGyjP+BESXlJhTDJSwCdiIZ/tdl,iv:+s4VB6pdL1QGSg1PtQbe4G9Djym0SbaL4eKWnQiFvsk=,tag:Oc2D+SJIiPbwGijQ4H4Rgw==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:m/U=,iv:RCH9iva6RRhoG4178hJOcxoi1b/52SNwpBiheda1ABQ=,tag:5uSax6VnLXTTEcfHnW4fYQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:sCMh+TEBT1MUNSP9IlV9Ep/oU1xdwqZhF+H/TSI=,iv:dv2fcab0s5dWxAG3+jEkNWBSwTx5iK5DytuLZNa8oRo=,tag:SzTNH6kEsJjXdmJ9+LTVAQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:aFguGyJQU5LEYdYFlLL/,iv:NVU9+8Rf8JUQCXDXMGDB9EL2xMdGCpp9wEbXwVG5Hvg=,tag:haS7deP3AMF/yPdDqeve/A==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:6Vaa7w+YLGTY38EIPWRBUuQPNcyOuehO0kKjOV8CHA==,iv:1/sboO5fp4TQSy/UQYmBPCdAIL5DxwND8hOKhp/8wCs=,tag:SlCrgrd146lie+ydh2ZunQ==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:lgyd0yg9,iv:8AK10CxYhQ75uGim6DTJHGUfO1e5mBd9x9bnnPVe3ac=,tag:GU7fV/1ox2g2hXt/DLq6Rg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUMWlJZlNZZWI4SlRqRVJM\nNjRsTy9TcG1hL1lzUDd6bnYwMGtlS0VlTlFjCnRKOGl3akFwd3lsQVlhbWVVVFRU\nSnF2VVh2anVibXlMNmEyM3U2TFZPMVkKLS0tIDhlMFVWZGdRTlhSMjNmU1JRd1Fq\nR2Q3bmVVaDNNcnBpVjc2MzdKd2NncUUKd4uHUsa63OCRAU+Hyul4aPFgIBhqk3qB\n67rUP478PlC2To6NodZPeIOQzfMIWNNILCyf1QCdGgCdZMu+KhsEHg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:10Z",
+		"mac": "ENC[AES256_GCM,data:PDWcfuuJ+SsK1asBnRpTrrOLNzDB81KrU8ikuG5/TBWN/eZxTK+qfkkiXJGZe79atKgAc3B3bPLJr0f4UrJImxZQ9rxN+nphDK7Rz/+ubnISnSSU9ED7a0/8/H4/f3LPAKPuopjnOsBV5JBWuWAnzKW+Gx9o8LL0hpS6rEVQiEY=,iv:avnJSxMe2Ox9UzVfa84noCtzAm7vlaEIhyd3y3sV9xo=,tag:PChLjDg4XGiNXtWVsDHd2w==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-delivery-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-delivery-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:BCg=,iv:du1g9hWB6K1HxgcBljF8ckJkkT5YA6Ve310zNRWr0LU=,tag:pH2ZvsCQLzVGdmphsS/KFg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:LYHetYpD,iv:gN0QOtmw/DPgNh7hXo1nyoKrghBwCvqM9iyCp3lfjL8=,tag:ukFVtP8BejkZ0KdkmTQyeQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:xlGTCs2bfjRfJWfUt70WNiKnii3Y,iv:5C/sT0cL9F6jmocYAANAtw9qS7KoLLsF+oDNz/1utSU=,tag:JiAuCnS5FGDYwdqy4tUg9A==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:4hw=,iv:vQYn1UupyGkyohAwUrDmi6otj5qV4SPIdf4eyBSWGfM=,tag:C1Ruw/rx2f3atR0A9nVrKg==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:1oJgWe2GnP/ehENrPfmEkSIqsElJvtjkGj0PkIEdi/27ew==,iv:u5mDfcow8ZRpClAkD8+RMjNAiNHagph5ff+ah+Z4Xao=,tag:KrZllx/IT1kxRhNQYfxq/A==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:Oqo1UXAJy6hVnyq3No8F,iv:EnSwZ6ZHjz18V8OYQwPjaHKUWRzK41VjE2remHYtc5I=,tag:TXYv7A1hOiPkD2N+TFRZ+Q==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:cXJyTJ1CoU+uf3CFeYLBg2N5ZpY2pI39VA==,iv:4r8u/SvtsOBy7LlkyFF4K2s7X6vHNLwvWa6XbvvfGB8=,tag:0/bUFZtEpVrOuOg3OQFmxA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:kOCW7biI,iv:QZG1A+dIUYIi8Ck7roqt1kP6jLaVP+s+PmndT8PSgTI=,tag:YQp2baNc8gvrE/qXiYpToQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNWll6TmZwZmp0Q29ySHJV\ndFovMW9Gd3lyS3p6V3Z5Z2M0TGJBa1lyWm1FClA5NzNlL1JnYnMzdlV6Mk9ITTVw\nblBybVlFZU43d3BMSE40bWkxUXk3N0kKLS0tIGlvVXc2VFdES3ltUmlwekllM1py\nZGFxZjZTWmdnd3VnOE5uT3RKck83YzgKstVUwSOR0gp3HMlaHn8Gn2XbezGThuLY\ncbSgzb1E3AS3fgX04+1zWkAR9MB5k+V/Wel1HDlypsfGU/dl9ZaVog==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:15Z",
+		"mac": "ENC[AES256_GCM,data:cGJRoklVgGU6toMrooU5fStUDm7IpZoHhWmBPFAUNr5Ku37Pq0Qh3DehziD+wOPlYcKBKIQYsK8ttdkZ66rOdoKwcaPEz5mpEwhYBLKIj3DMT2y/rjvPUsU7g4VarHY+GzSRaEmU8OAwCgpJrN3AK72KQTuGxc8M6ZMI1dt2Q1Q=,iv:BUH8k/jTMKswoIeB+T0BgP6cl0umzMxZNtOodrKNwgU=,tag:KP4+ejVNiwDxECzRGlIsWA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-delivery-key.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-delivery-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:uBY=,iv:IFvrHsAuWFx7AfmIyruIirf4vvHi91codQWbyyJ75LY=,tag:ZJS8/yWxyAVR+wregkf89Q==,type:str]",
+	"kind": "ENC[AES256_GCM,data:EJJLlazF,iv:BsacjV7LG9WlS2PmsaJ/QWJsXTZwgefXZHmQIXaYkTw=,tag:8fEETQGsRth14Ysy0fDmCw==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:ZzQ9c8Y7l0xjG8z0B8oS3Bb4Usx0,iv:ipf8xd6m/T/eCSdox5nFgibCRx30X9d+nQRgzXLApWU=,tag:zwWsX9vJI7ztc4KVb+PfqQ==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:8cs=,iv:pU0PfnMMdvEBWnDJJjpwzTFoIDVXyijFDSxpdXasHZg=,tag:Tu6i4B+uUUQH20KJa8HhCA==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:6O7AoaW/Nrg4BQrUNdYPx/g47kHiaylk96dsm/SE5w==,iv:wMJqQ1+n0qghktE0P4PkWoP9Gje1y5JfTfJFJOfX2BE=,tag:4soZKMNIgJ5rp1gP57YL2w==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:WPdyN0Ljo9exri1YokNM,iv:kR07ski2V/FR35Ch8+uOJho74h9f2QxnAd1CL9befRI=,tag:JRo91Aua8vzf+6gzVRtLcQ==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:ladrfvn8bpo4abcn7SfO8BeLyY92vjueBtaRUmqG1A==,iv:DgjSBoqa6nvtb7++o+metGvRND+sOJkTxwruP7PD22E=,tag:DkXycEO4U/aC+tjuqEOC/g==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:L9UufZ4e,iv:xdobD9V3n61OpJApxRzQsRakLJOeGSQE1/NTe7vbcCs=,tag:QKruvX4xVfTbk8i17Wlwpg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0R2tQekVyTVRjMktxTGtE\nVjJ0b2ZqL0RMcUJUcWlacFFWV1lPdGd1cVQ0CjZYZWNxNE9ubSs3VjIvRGJ6NFFp\nUmdJREVNeFcrL2xQRys4UG1kS1hjQzgKLS0tIENQSFZIRnBjZkJIWW5xMVNZYzJX\nWnV2Tzc2YjBXTDg1WGlsZDlqb2RnaEUKbCsUMJMdSrrNb9sVJV+Efg2FA4qWuUMZ\nUpN+Q27296yXUxWBeFW4qyp4m1DSrRUBcnC03HyOlC1MMk3PidFtbA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:20Z",
+		"mac": "ENC[AES256_GCM,data:nYoP7caTninN/0WjVzjwlCDSEwPmGVo8EQyVKkYmRmmOM6KTuh/9W3yconpvsdrTYzfXQV93dYD/dmPaIo/tJYb1CDnW4y9c5ze8c+GLs2/8jKyKRhpkXwCajb7WtpPJfIvhCZ7BXNgadBjcpkV+bE63F4/H6WqqL7OFq/SUNJ4=,iv:Ka1kghfnAXRfeBXmy0OI0MOqcHzjyOQfKzmMGuYtBXw=,tag:ExsweCwSo2G0trrFZZStxg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-restore-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-restore-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:4d0=,iv:v/HJ8f0mBPkji3nutg/f6PYxMQyEl2eTfnaX1ZeGffM=,tag:GA95pEfJCpgEPQxvXQ01fw==,type:str]",
+	"kind": "ENC[AES256_GCM,data:ZzLJePXn,iv:idyLIYlx48g3bO5ZQC7TCv+baYZ0hOBNJSmCC8W8pl8=,tag:0y4zFcl5ZwX2xW8JzPGPOA==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:FSROPwFfoGQtN2rjuImZuPJWn2fd,iv:Y46xrWV/oj9tOrDlTcB12DcDT9xjE7gyGMbRJSmAsa8=,tag:uwW/Kal7jlkG5WNtJGZghg==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:kAw=,iv:EXdMZSIB52fPCWv6ieoiSHpCRemMb7xlmAyeb/vOlI4=,tag:AAcvAfgHQtB+GSB4h1Qz3g==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:HNE7Up7YH8vhcxsjEeg5iyycsAyDuda0rA/J9seYkFf6,iv:1qPNImZhv2Q4DkY9p6VZiA8r3nbsLdPaqMsJaZg5Um4=,tag:M+M85ZFkPx5m9xNE3VGXvw==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:TiCjIOebPGa7SMN2aSe8,iv:R+deWBvB2jnTvKRv2GHGo5z9vFbjozrNbOLazz9WCSA=,tag:USJkpfU1USA2KEbTPwuzcg==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:O1XNeQVxT4E3KWUS09/tz6jbMrIBz5s+PA==,iv:SbeMbo4BpJ40+mdt49ssNt0m/0NEwR+VMUTvvkDeoTk=,tag:ikMnbxywSf+iDCoRRXV2kg==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:Kpd3+HLz,iv:Z3t9NgRU1B27npY908lF/lxOC9prXL3IMPCni0pLGU0=,tag:/oJQUe9Qg90TGHtiPCwCsw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJb2dXb3pFMUNxWlpBZmdu\nNUJhTzB2M05VSEdxTHdleExDczVRcnA3TmlRCmFUV2Y3VEJQbmJaU1BnN0hjeklu\nZ3haTUJkRUZHNGJNZlg5STlKSllhNUUKLS0tIE5zbkZhS216RVQycloxditvS0FF\nc0hkRzJNdzZSd0VLd3g3ZjZaSU14MXMKbeYbNJ73gh3eQZFbwWtz8Av41OX+VGnD\nwaDDqwMTQN9baB2uWBhh7SgKMzCERVrCFSPoMf5+wjpP9tmgYZ5ccg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:55Z",
+		"mac": "ENC[AES256_GCM,data:W3ne5iWHzAwgyMb9T2JbsbhLB2+9xxXW0L1iZcKiUd78Lyn8izwer+pgR1FmweNOxi0w8eDp5V4fXYxTHDiRj8Q8w+sBIDZQQcZy7V8nkdA/fvs/f/JJH82KVYSFvBWphV139i/TFqKWiUXURbHFmWTtAeHIG5wDr9o2+HEW8Zo=,iv:QpZ+lV++PkfLx30JhyuvnWetbOgBaRK3E/+GhdxujpM=,tag:9Nrbbjpf91faARLgTJMccw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-restore-key.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-restore-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:2Fw=,iv:eJ7JmEHczKkSlgz3bnwxERTUeAEH08mBaLI6X/8tVWE=,tag:Lw1nh8XDyJhDFLAHTH/L/g==,type:str]",
+	"kind": "ENC[AES256_GCM,data:s4y9ICNS,iv:b90vbG5VUd8XgF7I67q2SPfSvomMTo7+IH9UOfmNLfQ=,tag:YZ8t8I53CzR7w9G2Fe6IPw==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:QqyFaVnFcobA1Qua3pVajv3odRtI,iv:2Q4tv+4Hefj3oq/11S05nQPraaZ/BWqg7c+GPlAoAn8=,tag:tEIc/k2TA40tl8kjqjMwHA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:dyM=,iv:L1ynt90VPdnKCaOpB2OasuaViR1v0SWqofNNC5IrvOo=,tag:RWP+e/rfG1VpWg1QXsza/w==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:c/w6rkMyVD6IT0xwDlz0eSomK/TEt40bGJ2NipMj,iv:ArCobFq/TI+02spVuTs+qHv8Xn3JEQZ4aavJKN4UMg4=,tag:q5SCI/Jh6hZPZsJMglNjUw==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:UDkS2/nyOoSXaHYUWi1E,iv:gpGuJvgxbnT6cpUZQYJqyy44THtHKlj0J63X3F4c5ms=,tag:oNgB4xoKQmVYkwdsWVSZ2w==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:KpPZGB19mCh1ct0ymVqr/ID61IG6XB3CMmpjnAQuiw==,iv:QgV1arIHGsCl6Ql03VcqZmWO01HKotZmCkdPRz81KF8=,tag:umjTsqPxXB3vseu5gClOWg==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:H1f5vi+M,iv:mdJpjnuexiD71/BhDNgAJ8HiqvaNCzuX74mNumu9OGk=,tag:CJX8wyt5j6ewdYV4A4q/Fw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlQXp5VGhaT2Z1VUtUNkt1\nclVicVkrZGo4akRUSGJQSkdMa2dBczE4WVFNCjJLb3JZaTVYZStnVzlFRmwxVFFo\nVGpGZE03emJNMU1uUzlySlEvdU9pVk0KLS0tIGwzWStpSkZkcWczOFdINEl2RGw2\nNEhJUnhKclQvbk5zRUVWQVZZbDl2bTQKl5s6mgZUXgqfRz+5imA8ETVRSnfK7k57\nUhpdIojxgn9Wt2Elv38XfTGpJ3GT+FVQ5wYCJdEpbw8XMXnatrdnwQ==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:43:00Z",
+		"mac": "ENC[AES256_GCM,data:b3kmrPRK19sWHbZ/DXpfz4Skw+B4/OjKaPAYI8AUzezQn/lP5RY2fxMojxSaHjUTrDYYLQGPSZ6GhvLs4BofPzN8tumq6eWMaQopsHDSsaolQT8ys1rP7XHHloUg3S9fJMwqkptTc3MMQHD58iIfm3eXwIMC/U/QjFD6p8yPD7w=,iv:kGbG/GenxNhkDhf06kKnzdnoFYTqU3ULrP7e1bknB9k=,tag:kWWihs5yIl9nqqUycl7AQg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-upload-key-id.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-upload-key-id.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:sic=,iv:zP9WkDiIYWsacR1tHOZFykzU3Ww5MmM/Llcm/6TkPuM=,tag:aNaV2wqMvRC4DQnWScLzfw==,type:str]",
+	"kind": "ENC[AES256_GCM,data:BVwxclvw,iv:bcaKrZlfuU3p7m0MNDJkubhZxbSr87i/bT5SWP0erq8=,tag:hOiYH+UwevUo1ievggq4yg==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:IpH0EQiedIjRX4Bnit8F55tMH0z0,iv:ybafOGm2zeL3cKxsHgsizF2/JIqXgC5KuFYFN+SsVKQ=,tag:4DPpDjZEpYlaj1rke2kxog==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:Qjs=,iv:DmA40BhPAd7bhZrXb2MscErxFsTbeH6EnbpSYUSMn0M=,tag:BgmJMcGfy+NZ6zSZ7p0pcw==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:WsB+piEFFW7+PY3DcVeIx/i9VH5H3TthnHlhl4YjXR4=,iv:0CzuNtWrS5SFsDfTfuILQIbjpBz39kOnb2vyaXBNauU=,tag:mNkMvS2ujpAPeKRyVQNRCQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:gm9mfsS374hi9tMJazaP,iv:7UKJAmJaAqG1P07umxyqvQKs/uZ2Of28TJuiO5x18Ww=,tag:xW4hKOcyufi+dGZsjZ6r3Q==,type:str]"
+	},
+	"stringData": {
+		"application-key-id": "ENC[AES256_GCM,data:NP+ldezNiFYZ9/ItLtCVtRvZuCRm9h0t5Q==,iv:A0IPvbAc/3hKFO20lILmzhF6QpTC85q4J7vnAwV/kC8=,tag:6W+CsCd9+lrtr+piWzdRRA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:ii72lQZE,iv:h3eiMLkAZeJaFEOu+sqWJpK4j8nYMUpQ41O2BdYsq1A=,tag:Ubk9oqAqxzeWhkY1UZHuXw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPckF5VVl4Y1huQ2ZGWXNI\nTTNhdjlRdU5hbnZFTnIyVEJCakJ4bnJueERRCnB2cS9qZTFXcDZuNHA4aFQ0QVNq\nVThXYjZWRUxETW1KZ0RTdWhZL1dWZTgKLS0tIExhWG1tY214azBrN0R0Zk95VGZG\ncDg3TGY1QzlZVzgxWnJ6ZVo2QVNEaGMKoqfFpgTMFSdbk6A8VetsPOVJE/lJG/T3\nkRu/ynsT3O90OfCTaLY1ejPGWo+3YP4fjLLFnuXg8WZo8FdgWu8+Qw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:45Z",
+		"mac": "ENC[AES256_GCM,data:pCcZ9FBpYPxXfZfF9rUkFtTwshnACmKIKJKhKUtSTWmlgFPOVQXwELMVNLc0jrTGLatqi56/Ei1R/ZGw8f09dqASV++Y+rEJnugMG8WmnZR79xen7L1MOmAfUxdtSBlHM0qCgffxHWk8pZBZar/uDl2EsbZAobj5aK9qXQt2stY=,iv:1gMFrnnRdI1IxnX7ix7O/KBrm076253WhagOH1Eu2Gw=,tag:zkbtk2SCjxrYSQr6IudeYg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/infra/secrets/provisioner/user-export-upload-key.v1.sops.json
+++ b/infra/secrets/provisioner/user-export-upload-key.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:RtA=,iv:w7inu6gDolgD1FBcYWlVCVy10DL0DD8gwPDwz1E738M=,tag:wS42nptnOD4nhe6hRvhmGg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:x/UcgEaS,iv:GOsWQUQQWlhXut2L38gy4oyM2bOw4nJih7Mf0TLzKs0=,tag:yW9QZi1M4mpdojwWG3PTBQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:iAuItA0+Wc4+19emNU5JKX72pfA7,iv:4bdE9WcZqAdD2BTKQiZMcGs2slP0aEExvxAg7pr6QJY=,tag:7878x+R3Z0F+R3Tn3MqaNA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:CFg=,iv:T+pGs+oaUOtVl1atJgtftZWJzfqbDHGH1iv9o4M3rCg=,tag:e88lFAKnBLCj/0RrLIK0Yw==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:R/uIh8OniNvEl6xSfYni8xWjEO1rbEv0xcBOVqA=,iv:ilZLtu7ZDKHS0owk03avpsFxVsn4UmISw5RJzQIO4JE=,tag:eu68NbEmGra5/Tft4anVuA==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:k2MfJ5FmzrO/+wRAVLov,iv:6fnZN3y84pWc70LrftX/IBkSBxOpvQP6oULv41QmU1U=,tag:gruufopMwSwfEyeYWJYXgw==,type:str]"
+	},
+	"stringData": {
+		"application-key": "ENC[AES256_GCM,data:G6SLnPjzGfSbDT/Dm4km2Zlync5S8hYb/q2CgUJtwQ==,iv:w8pOcTdpEsQo0+WfhGbwyOqrHF6bUm/K/hu6aNb8Hxs=,tag:zPEj+HdZzamnRLOXZGWNAw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:smQxupRK,iv:jrZpzhGz0/r+nPSP9JLCctTHZ6wnHh/D8DM45i4MKBM=,tag:t+edrom5W595n2/461Z/4g==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLa1IzQVh2ci9aYkVyclUy\nTmc3QU9CZndPdHBMYnV2TTU4a21uTjl1OFVNCk8zNjhqWWRoejZENllrNzdGbmFD\nYm9FUWJUQlphVURSSGZGTjU5ZHVZYk0KLS0tIFFLTWtyRmlpaDBPU2F6VTkyelJt\nVmJuWFkxWWxYaFZ0dE9sNys0bXovOHMKKKD2vY8MmJMJChXZspvTMox1pGNwqXWB\nTOhi9QyGsluPyLJq8D0dV13b5/7n1yI7VWqi1uOYeRLbouuIHMIw7g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-07-26T10:42:50Z",
+		"mac": "ENC[AES256_GCM,data:PHx3Ph+S/o9BJmZA6JyeuyxVBbGie4EMMMK/zlyh+5h3HNV8lUPbZVZJ4H+m3KGjBEkoExQgPJhoieTh+89HciLbI+LiEI0gm6sbnzz4xfzBRwWp2eZRJoWhfQ4uRHhQNC+K7ngFNAqgxJlYVENsxQo/6gVoY1wkVQXPkGerNv4=,iv:DR9oiUcJkY4SgmnYwtocDAIMxRvi24+ugjz5RMCawwI=,tag:X6a3Kl38yF4/dzDbobgBNg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.2"
+	}
+}

--- a/openspec/changes/add-hosted-private-alpha-infrastructure/verification.md
+++ b/openspec/changes/add-hosted-private-alpha-infrastructure/verification.md
@@ -82,6 +82,13 @@ Evidence is appended as implementation gates close. A checked task means the res
 - The corrected real-account proof then held the HCP lock in one Terraform apply, proved a second mutating writer was rejected, published a distinct contended state version, operator-locked the proof workspace, duplicated the selected baseline state version as current, recovered output revision `baseline`, passed a locked refresh-only plan, unlocked, and destroyed the disposable `terraform_data` resource. The mode-`0600` content-free evidence records `concurrentWriterRejected: true`, `proofWorkspaceCleaned: true`, and the final proof-workspace preflight passed unlocked.
 - Task 6.6 is closed. HCP is now the approved state/history/locking authority; production foundation and durability applies remain separately gated by reviewed saved plans under task 16.1.
 
+## 2026-07-26 — live durability apply
+
+- The real durability root produced a mode-`0600` saved plan with SHA-256 `e2f582d6eb3c209fa677bc74d9fe1ddbed255217b4516a356dbaee800fa313a8`: exactly 15 creates, zero updates, zero replacements, and zero deletes. Independent review confirmed three private SSE-B2 AES-256 buckets, the declared governance Object Lock and lifecycle rules, eleven separately scoped application keys, `prevent_destroy` on every bucket, and sensitive markings on all 22 key/key-ID outputs.
+- `apply_saved_plan.sh` re-ran the HCP workspace preflight and policy inspector, then applied that exact saved artifact without recomputing it. The live result was 15 added, zero changed, and zero destroyed. A fresh post-apply saved plan refreshed all 15 objects and reported no changes.
+- The 22 Terraform-owned durability outputs were routed through the destination matrix into separate version-`v1` SOPS artifacts for provisioner, Ansible, and offline escrow consumers. Every artifact passed exact destination-shape validation and a fresh decrypt round-trip with the Bitwarden-escrowed age identity; no plaintext output, state, plan, or identity is committed.
+- Task 16.1 remains open until the separately reviewed foundation plan is applied and the combined redacted plan, locking, and live cost evidence is retained.
+
 ## 2026-07-14 — hardened host and K3s bootstrap
 
 - Added idempotent Ansible roles for safe package updates, a locked dedicated administrator, key-only SSH, explicit-CIDR UFW, Kubernetes forwarding rules, fail2ban, systemd time sync, bounded journal storage, unattended security updates, and `cryptsetup`.


### PR DESCRIPTION
## What changed

- add 22 destination-specific SOPS ciphertexts for the live B2 durability credentials
- cover provisioner Kubernetes Secrets, K3s/Ansible etcd upload credentials, and offline etcd restore escrow
- record the reviewed live durability apply and keep OpenSpec task 16.1 open until foundation and combined cost evidence are complete

## Live apply

The exact mode-0600 saved plan (`e2f582d6eb3c209fa677bc74d9fe1ddbed255217b4516a356dbaee800fa313a8`) was independently reviewed and applied through `apply_saved_plan.sh`:

- 15 resources added
- 0 changed
- 0 destroyed
- three private SSE-B2 AES-256 buckets
- eleven separately scoped application keys

A fresh post-apply plan refreshed all 15 resources and reported no changes. HCP workspace state is unlocked. Redacted content-free evidence is retained outside Git and backed up in Bitwarden.

## Secret handling

Each of the 22 sensitive Terraform outputs was read in-process and routed through the committed destination matrix. No plaintext output, Terraform state, saved plan, or age identity is committed. All ciphertexts use the same Bitwarden-escrowed age recipient.

## Verification

- SOPS destination/ciphertext validator — 22 artifacts passed
- fresh decrypt round-trips — 22/22 passed
- real pinned SOPS/age handoff suite — 17 passed
- focused static handoff/platform suite — 17 passed, 1 documented opt-in skip
- strict OpenSpec validation — passed
- independent saved-plan review — clean
- independent staged ciphertext/destination review — clean
- staged diff check — passed
