### PR TITLE
fix(ci): skip generated Python bytecode in secret scan

### DIFF
--- a/infra/scripts/validate.sh
+++ b/infra/scripts/validate.sh
@@ -116,4 +116,4 @@ fi
 shellcheck "${script_dir}"/*.sh
 "${trivy_bin}" fs --scanners secret --exit-code 1 --no-progress \
   --skip-dirs .git --skip-dirs .venv --skip-dirs .venv-hosted-ci \
-  --skip-dirs .terraform --skip-dirs charts "${repo_root}"
+  --skip-dirs .terraform --skip-dirs '**/__pycache__' --skip-dirs charts "${repo_root}"

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -142,6 +142,7 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
     assert (
         '"${helm_bin}" lint "${infra_dir}/helm/platform" --strict \\\n  --namespace exomem-platform'
     ) in validator
+    assert "--skip-dirs '**/__pycache__'" in validator
     assert '--skip-dirs charts "${repo_root}"' in validator
     for action_line in (
         line.strip() for line in workflow.splitlines() if line.strip().startswith("- uses:")


### PR DESCRIPTION
## What changed

- exclude recursive `**/__pycache__` directories from the hosted Trivy filesystem secret scan
- lock the exact recursive glob in the hosted CI contract test

## Why

The hosted validator runs Python suites before Trivy. Those suites generate `.pyc` files, and Trivy 0.72.0 repeatedly false-positive matched a GitHub PAT signature inside `src/exomem/governance/__pycache__/scrubber.cpython-313.pyc` after all infrastructure and provisioner checks had passed.

A bare `--skip-dirs __pycache__` does not match nested directories in pinned Trivy 0.72.0. The recursive quoted glob is required.

## Verification

- red/green focused contract test
- SHA-verified Trivy 0.72.0 black-box probe: nested pycache-only synthetic signature exits 0
- sibling source-file control with the same signature exits 1 and is reported, while pycache stays absent
- focused pytest passed
- Ruff passed
- Bash syntax and diff checks passed
- independent review clean
