### PR TITLE
feat: add manual cold standby operations

### DIFF
--- a/deploy/cold-standby/config.example.json
+++ b/deploy/cold-standby/config.example.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "host": {
+    "id": "standby-host",
+    "role": "laptop",
+    "peer_id": "primary-host"
+  },
+  "health": {
+    "local_url": "https://standby.ops.example.test/health/ready",
+    "peer_url": "https://primary.ops.example.test/health/ready",
+    "stable_url": "https://exomem.example.test/health/ready",
+    "oauth_discovery_url": "https://exomem.example.test/.well-known/oauth-authorization-server"
+  },
+  "services": {
+    "exomem": "Exomem",
+    "cloudflared": "cloudflared"
+  },
+  "tunnels": {
+    "local_name": "standby-tunnel",
+    "local_id": "22222222-2222-4222-8222-222222222222",
+    "peer_name": "primary-tunnel",
+    "peer_id": "11111111-1111-4111-8111-111111111111",
+    "stable_hostname": "exomem.example.test",
+    "local_operational_hostname": "standby.ops.example.test",
+    "peer_operational_hostname": "primary.ops.example.test",
+    "config_path": "operator-config/cloudflared/config.yml",
+    "origin_service_url": "http://127.0.0.1:8765"
+  },
+  "cloudflare": {
+    "api_token_environment": "CLOUDFLARE_API_TOKEN",
+    "zone_id_environment": "CLOUDFLARE_ZONE_ID"
+  },
+  "syncthing": {
+    "api_url": "http://127.0.0.1:8384",
+    "api_key_environment": "SYNCTHING_API_KEY",
+    "folder_id": "vault",
+    "folder_path": "syncthing-shared",
+    "peer_device_id": "peer-device-id",
+    "intent_relative_path": ".exomem-state/desired-host.json"
+  },
+  "state": {
+    "journal_path": "operator-state/journal.json",
+    "intent_path": "syncthing-shared/.exomem-state/desired-host.json",
+    "manifest_path": "syncthing-shared/.exomem-state/manifest-standby-host.json",
+    "peer_manifest_path": "syncthing-shared/.exomem-state/manifest-primary-host.json"
+  },
+  "identity_environment": {
+    "dotenv_path": "operator-config/exomem.env",
+    "base_url": "EXOMEM_BASE_URL",
+    "github_client_id": "GITHUB_CLIENT_ID",
+    "github_client_secret": "GITHUB_CLIENT_SECRET",
+    "github_username": "EXOMEM_GITHUB_USERNAME",
+    "github_user_id": "EXOMEM_GITHUB_USER_ID",
+    "jwt_signing_key": "EXOMEM_JWT_SIGNING_KEY",
+    "instance_id": "EXOMEM_INSTANCE_ID"
+  },
+  "operations": {
+    "probe_attempts": 3,
+    "probe_delay_seconds": 2,
+    "desktop_logon_delay_seconds": 30
+  }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -401,41 +401,36 @@ service name, so it keeps working across the rename. Verify with
 
 ## Deploying on a second machine (multi-host)
 
-Each machine runs its own Exomem process and local vault replica. If both replicas
-can mutate a Syncthing-replicated vault, enable the writer lease below: Syncthing
-replicates files, while the coordinator guarantees that only one Exomem host writes.
-Without a lease, keep exactly one host writable. The non-obvious per-host parts:
+Each machine has its own Exomem process and local vault replica. Replication moves
+files; it does not decide which process may write. Choose the operating model that
+fits the downtime, automation, and operational complexity you actually want:
 
-- **Its own public hostname.** `EXOMEM_BASE_URL` and the connector URL are
-  per-host. Tailscale gives each node a distinct `<node>.<tailnet>.ts.net`
-  automatically (`tailscale funnel status`); for Cloudflare, give each host a
-  distinct subdomain (e.g. `kb.example.com`, `kb-laptop.example.com`) via
-  `pwsh -File scripts/setup-cloudflared.ps1 -Hostname <this-host> -TunnelName <unique-name>`.
-  ngrok's free tier gives one static dev domain **per account**, not per host —
-  a second host needs Cloudflare (or a paid ngrok domain) for its own hostname.
-- **Its own GitHub OAuth App.** A GitHub OAuth App allows exactly **one**
-  Authorization callback URL, so you *cannot* reuse another host's app — its
-  callback points at the other host and GitHub rejects the redirect with "The
-  redirect_uri is not associated with this application." Create a second app (e.g.
-  `exomem (laptop)`) with callback `https://<this-host>.example.com/auth/callback`
-  and put *its* `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` in this machine's
-  `.env`.
-- **Its own `.env` and connector.** Set `EXOMEM_VAULT_PATH` to this machine's vault
-  root. In claude.ai, add a separate connector pointing at this host's `/mcp` URL
-  (the URL usually isn't editable in place, so delete + re-add to repoint).
-- **Its own embedding stack (GPU).** Hybrid `find` needs `torch` +
-  `sentence-transformers` (the optional `embeddings` extra) in the host's `.venv` —
-  `uv sync --extra embeddings` installs them, pulling the pinned `cu132` torch
-  which ships Blackwell `sm_120`, so any RTX 50-series GPU works. **If a host was
-  synced without the extra**, `find` silently degrades to keyword/BM25 and the log
-  shows the vector path failing to import torch — `uv sync --extra embeddings` on
-  that host fixes it. Verify the GPU path:
-  `uv run python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_arch_list())"`
-  → expect `True` and `sm_120` in the list, plus the startup log line
-  `embedding model ready ... on cuda`. (Default PyPI Windows torch is CPU-only,
-  which is why the explicit CUDA index in `pyproject.toml` exists.)
+| Model | Normal operation | What it gives you | Trade-off |
+|---|---|---|---|
+| Single host | One service and one public URL | Lowest operational overhead | The service is unavailable while that host is off or asleep. |
+| [Manual cold standby](runbooks/cold-standby.md) | Desktop normally active; laptop is demand-start and promoted by an explicit guarded command | One stable connector URL and a recoverable copy without an always-on lease/edge control plane | Planned handoff has bounded downtime; ambiguous/partitioned evidence refuses; forced recovery can lose or fork unreplicated state. |
+| Automatic writer-lease HA | Two replicas, coordinator/lease, and a stable edge route | Automatic active-writer selection and continued reads/failover under the documented HA contract | More moving parts: coordinator, lease, shared OAuth state, edge routing, and release-parity operations. |
 
-### Single-writer lease and automatic laptop takeover
+None is universally preferred. Choose single host when downtime is acceptable,
+manual cold standby when you prefer a deliberate recovery procedure, and automatic
+HA when its availability benefit is worth operating the coordination stack.
+
+### Independent second host with its own URL
+
+If the second machine is an independent deployment rather than manual cold standby
+or automatic HA, give it its own public hostname, OAuth app, `.env`, and connector.
+A GitHub OAuth App accepts one callback URL, so create a separate app whose callback
+is `https://<second-host>/auth/callback`; put that app's client ID and secret in the
+second host's `.env`. Set its own `EXOMEM_BASE_URL` and `EXOMEM_VAULT_PATH`, and add
+a second connector pointing at that host's `/mcp` URL.
+
+Hybrid `find` also needs the embeddings stack on each host independently. Run
+`uv sync --extra embeddings` there and verify the GPU path with
+`uv run python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_arch_list())"`.
+For an RTX 50-series GPU, expect `True`, `sm_120`, and the startup log line saying
+the embedding model is ready on CUDA; otherwise `find` falls back to keyword/BM25.
+
+### Automatic single-writer lease and laptop takeover
 
 The lease is replication-agnostic. It decides which replica may mutate; it does
 not copy vault files. This desktop/laptop example uses Syncthing, but self-hosters

--- a/docs/runbooks/cold-standby.md
+++ b/docs/runbooks/cold-standby.md
@@ -1,0 +1,295 @@
+# Manual cold standby (Windows)
+
+Manual cold standby is the middle option between accepting one-host downtime and
+operating automatic writer-lease HA. The desktop is normally the active host.
+The laptop is a recoverable, manually activated copy. This profile preserves one
+stable MCP URL and one connector definition, but it deliberately does **not**
+provide automatic failover or distributed consensus.
+
+Use this runbook only after installing the opt-in cold-standby tooling. A normal
+Exomem install or upgrade does not change service start mode, Cloudflare routing,
+OAuth, Syncthing, or any existing HA deployment.
+
+For a neutral comparison with single-host and automatic writer-lease HA, see
+[deployment options](../deployment.md#deploying-on-a-second-machine-multi-host).
+
+## What is active
+
+There are two distinct Cloudflare named tunnels, one per host. Both `cloudflared`
+connectors may stay running. The stable hostname is a CNAME to exactly one tunnel
+at a time; switching it uses:
+
+```powershell
+cloudflared tunnel route dns --overwrite-dns <target-tunnel> <stable-hostname>
+```
+
+That is not the same thing as starting two connectors for one tunnel. Do not copy
+one tunnel credential to both computers: Cloudflare can treat them as replicas and
+send requests to either origin.
+
+Each host also has a direct operational hostname. Its tunnel ingress must expose
+only bounded health/readiness endpoints, such as `/health/ready`. It must not
+forward `/mcp`, OAuth, REST mutation, artifact transfer, or other write-capable
+paths. The stable hostname is the only public MCP/OAuth endpoint.
+
+The `scripts/cold-standby.ps1` command records a bounded local journal and a
+replicated desired-host marker. The marker is helpful evidence, not a lock or a
+claim of authority. Syncthing is replication, not consensus.
+
+## Prerequisites
+
+Before enabling the profile, have all of the following in place:
+
+- Two Windows hosts with independently installed, compatible Exomem releases and
+  a replicated vault. Keep the desktop as the intended normal primary and the
+  laptop as standby.
+- Syncthing working between the hosts. Its REST API key must be available through
+  the environment-variable name configured for that host, and the target folder
+  must be fully idle with no pending files or bytes before a normal transition.
+- Two **distinct** Cloudflare named tunnels and two direct operational hostnames.
+  The signed-in `cloudflared` identity on each host must be permitted to change
+  the stable DNS route. A scoped Cloudflare API token with DNS-read access and the
+  zone ID must be available through the configured environment-variable names so
+  the command can independently verify the exact CNAME target. See Cloudflare's
+  [tunnel DNS routing documentation](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/dns/).
+- One stable public hostname, for example `https://kb.example.com`. It remains
+  the value of `EXOMEM_BASE_URL` and the existing connector URL on both hosts.
+- A local Exomem readiness response configured with a public-safe,
+  non-secret `EXOMEM_INSTANCE_ID` unique to each host. It is the identity used to
+  prove the public hostname reached the intended origin.
+- A host-owned configuration JSON file outside the repository, plus a local
+  journal path and a replicated desired-host-marker path outside `Knowledge Base/`.
+  Do not put credentials, raw identities, or the marker in the Git checkout.
+
+The command reads Cloudflare and Syncthing credentials only from the named local
+environment variables. It must not print, commit, journal, or replicate them.
+
+## Configure both hosts and prove identity parity
+
+Start from `deploy/cold-standby/config.example.json`, copy it to a protected
+location on each host, and replace only generic placeholders. The two files have
+opposite local/peer values; they are not a single shared config file. Required
+values cover the local role and host IDs, local/peer/stable readiness URLs,
+service names, distinct tunnel names and UUIDs, the stable hostname, both direct
+operational hostnames, the local
+`cloudflared` config path, Cloudflare token/zone environment-variable names,
+Syncthing folder/device/API, and paths for the journal, marker, peer manifests,
+and effective Exomem `.env` file.
+
+Keep this effective identity contract identical on both hosts:
+
+- normalized `EXOMEM_BASE_URL` and stable OAuth callback;
+- GitHub OAuth client ID and client secret;
+- allowed GitHub login and numeric user ID; and
+- `EXOMEM_JWT_SIGNING_KEY`.
+
+The command compares the named values in the configured service `.env` with the
+actual NSSM `AppEnvironmentExtra` snapshot used by the Windows service;
+it derives the callback as `<EXOMEM_BASE_URL>/auth/callback`, and requires that
+`EXOMEM_INSTANCE_ID` match the configured local host ID. It publishes and compares
+only fingerprints of the shared values. A mismatch
+refuses activation and handoff; never “fix” it by copying a secret into a
+Syncthing folder or pasting it into terminal output.
+
+Configure only after both files and tunnel ingress rules are ready:
+
+```powershell
+$config = '<protected-config-path>/desktop.json'
+pwsh -File scripts/cold-standby.ps1 Configure -ConfigPath $config -WhatIf
+pwsh -File scripts/cold-standby.ps1 Configure -ConfigPath $config
+```
+
+`Configure` puts Exomem into demand-start mode on both hosts. The laptop remains
+manual. On the desktop it installs a delayed, current-user logon task that runs
+the same guarded `Activate -IfUnserved` transition after the network is expected
+to be available. The task leaves Exomem stopped if the laptop, the stable endpoint,
+Syncthing state, or replicated intent is active or ambiguous.
+
+`Configure` also verifies that the named `cloudflared` Windows service actually
+runs the configured YAML and local tunnel. When it changes the managed ingress
+block, it restarts that service and waits for the named tunnel to reconnect before
+reporting success. That expected restart can make a long-lived MCP session perform
+its normal reconnect handshake; routine status and transitions do not restart the
+tunnel.
+
+The service installer snapshots `.env` into NSSM and can reset service start
+settings. After changing `.env`, re-running `scripts/install-service.ps1`, or
+replacing the service registration, reinstall/restart the service, rerun `Configure`
+on that host, and inspect `Status` before relying on boot recovery.
+
+## Read status before every live action
+
+`Status` is read-only. It reports local and peer service health, stable-endpoint
+health, Syncthing convergence, desired-host intent, tunnel evidence, identity
+fingerprints, and the next safe action. It does not infer that an unreachable
+peer is powered off.
+
+```powershell
+pwsh -File scripts/cold-standby.ps1 Status -ConfigPath $config
+pwsh -File scripts/cold-standby.ps1 Status -ConfigPath $config -Json
+```
+
+Interpret it conservatively:
+
+- A ready desktop with a stopped laptop and a healthy stable endpoint means no
+  transition is needed.
+- A ready peer or ready stable endpoint means do not activate locally.
+- Both origins ready, unknown tunnel/Syncthing evidence, stale replication, or
+  conflicting desired-host intent is an unsafe state. Do not select a winner by
+  guesswork; leave services and DNS unchanged and resolve the named evidence.
+
+For any mutating action, first dry-run the same configuration:
+
+```powershell
+pwsh -File scripts/cold-standby.ps1 Activate -ConfigPath $config -WhatIf
+pwsh -File scripts/cold-standby.ps1 Handoff -ConfigPath $config -WhatIf
+```
+
+`-WhatIf` evaluates the transition plan but must not alter services, scheduled
+tasks, files, tunnel configuration, or DNS.
+
+## Planned laptop activation and return to desktop
+
+Do not promote the laptop while the desktop or the stable endpoint is healthy.
+For planned movement, run the handoff on the active source first. It checks source
+and peer replication plus identity parity, writes the next desired-host generation,
+and proves that exact generation reached the peer before stopping the source and
+pointing the stable hostname at the target tunnel. It never starts a remote Windows
+service. On the first-ever handoff the marker may be absent; that bootstrap is
+accepted only while the source service, source readiness, stable route, target
+inactivity, replication, and identity parity all agree.
+
+On the desktop:
+
+```powershell
+$desktopConfig = '<protected-config-path>/desktop.json'
+pwsh -File scripts/cold-standby.ps1 Handoff -ConfigPath $desktopConfig -WhatIf
+pwsh -File scripts/cold-standby.ps1 Handoff -ConfigPath $desktopConfig
+```
+
+Expect a bounded outage: the source is stopped before the target starts. On the
+laptop, start the target through the same local guard:
+
+```powershell
+$laptopConfig = '<protected-config-path>/laptop.json'
+pwsh -File scripts/cold-standby.ps1 Activate -ConfigPath $laptopConfig
+```
+
+Activation validates configuration and parity, requires conclusive Syncthing and
+peer/stable evidence, writes intent, starts the local service, verifies local
+readiness and its instance ID, moves stable DNS, then verifies both the Cloudflare
+target and public readiness/OAuth metadata. It succeeds only when the stable URL
+reports the expected local instance ID and stable base URL.
+
+Returning to desktop is symmetric: run `Handoff` on the active laptop, then run
+`Activate` locally on the desktop. A desktop reboot is not a shortcut around this
+ordering: its delayed task uses `Activate -IfUnserved` and should remain stopped
+when any laptop or stable evidence is unsafe.
+
+## One URL and expected connector behaviour
+
+Keep the same connector definition and URL:
+
+```text
+https://<stable-hostname>/mcp
+```
+
+Do not create a second connector for the laptop and do not change the GitHub OAuth
+callback to a direct hostname. After shared OAuth storage is removed, the target
+host may not have the client registration or session that the previous host held.
+The existing connector URL remains correct; reconnect it, allow Dynamic Client
+Registration to run again if requested, and complete GitHub authorization again.
+
+One reconnect/registration/reauthorization after a host switch is expected. Repeated
+reauthorization, a changed URL, or an identity-parity failure is not normal failover
+behaviour—stop and inspect `Status`, the service logs, and the public OAuth
+discovery endpoint.
+
+## Unplanned desktop recovery and disaster activation
+
+Normal recovery remains fail-closed. On the desktop, wait for Syncthing evidence,
+run `Status`, and use a normal local `Activate` only when the laptop and stable
+endpoint are conclusively inactive and the replicated intent permits desktop
+service. Peer unreachability is not proof that the laptop is off; a partition can
+make both machines believe they are alone.
+
+If the source is unavailable and the recovery cannot satisfy only the allowed
+peer/Syncthing guards, an operator can make an explicit disaster decision:
+
+```powershell
+pwsh -File scripts/cold-standby.ps1 Activate -ConfigPath $desktopConfig `
+  -Force `
+  -Acknowledge 'I ACKNOWLEDGE SPLIT-BRAIN AND DATA-LOSS RISK'
+```
+
+The acknowledgement must match the literal shown above. `-Force` may bypass only
+peer-unreachable, conflicting-intent, or Syncthing-completion evidence. It cannot
+bypass invalid configuration, shared-identity mismatch, local readiness, DNS route
+mutation, tunnel verification, or public readiness/OAuth verification. Record the
+terminal output: it names every guard actually bypassed.
+
+Forced recovery can create a fork or discard newer writes present only on the
+unreachable host. Bytes that had not replicated before that host failed are
+unrecoverable by standby activation. Reconcile Syncthing conflicts and inspect the
+vault before treating a forced recovery as complete.
+
+## Partial transition and journal recovery
+
+Do not blindly rerun `Activate` after an interrupted DNS transition. First collect
+the local operation journal, current stable DNS target, direct readiness from both
+operational hostnames, public stable readiness, and Syncthing state. Do not paste
+secrets or raw identity values into incident notes.
+
+An interrupted activation may be completed only when all of these agree: the
+journaled phase permits replay, Cloudflare reports the stable record on the local
+tunnel, and the public readiness response reports the expected local instance ID.
+Otherwise use compensation: restore the known previous route, stop a newly started
+target, and verify both origins before retrying. If the previous route is unknown
+or the target might be active, leave the source stopped and follow the command's
+`operator_recovery_required` terminal rather than risking two writers.
+
+For a handoff that stopped the source but could not move or verify the route, first
+prove the target inactive. Compensation then writes and proves delivery of a newer
+cancellation generation naming the source before it restores the prior route and
+restarts/verifies the source. If target inactivity cannot be proven, preserve the
+single-active-service invariant and recover manually from the exact journal state.
+
+## Staged personal cutover from automatic HA
+
+This is a deployment migration, not an in-place toggle. The repository's existing
+automatic writer-lease HA implementation remains supported; do not remove it from
+the product while adopting this profile for one personal deployment.
+
+1. Ship and test the tooling first. It is default-off: do not change service
+   startup, public routing, OAuth, or HA environment yet.
+2. Back up both effective `.env` files, both tunnel configurations, service startup
+   settings, the Worker/Durable Object configuration, and its secrets. Confirm both
+   vault replicas are fully converged and run compatible Exomem releases.
+3. Create/harden the two distinct named tunnels. Give both tunnel configs the
+   stable hostname, but make each direct operational hostname health/readiness-only.
+   Install the local cold-standby configuration on both hosts while the HA edge
+   remains live.
+4. Run `Status` and all `-WhatIf` actions on both hosts. Prove each direct tunnel
+   via a temporary hostname; do not alter the connector or stable hostname yet.
+5. Quiesce connector writes and stop the laptop service. Remove
+   `EXOMEM_WRITER_LEASE_*` and `EXOMEM_OAUTH_STORAGE_*` from the effective service
+   environments on both hosts. Preserve the stable base URL, GitHub OAuth settings,
+   allowed identity, JWT signing key, and vault paths.
+6. Start the desktop in standalone mode. Detach the HA Worker's stable-hostname
+   route binding **before** direct tunnel routing. Verify the direct desktop path,
+   then point stable DNS to the desktop tunnel and verify OAuth discovery, a
+   reconnect/authorization using the existing connector definition, an authenticated
+   read, and one governed write.
+7. Re-run `Configure` to enforce demand-start and desktop boot recovery. Exercise a
+   controlled desktop-to-laptop handoff and laptop-to-desktop return, including
+   Syncthing convergence and any expected connector reauthorization.
+8. Keep the Worker/Durable Object deployment and rollback material intact, with the
+   stable-hostname route detached, for a bounded rollback window. Only after that
+   window closes may you retire the personal Worker/Durable Object deployment and
+   its secrets.
+
+If direct routing, OAuth, authenticated reads, or a governed write fails, stop the
+standalone service, restore the backed-up HA environment and tunnel configuration,
+restore the Worker's stable-hostname route binding and DNS path, start the existing
+replicas, run their HA doctor/readiness gates, and only then reopen writes. Do not
+delete the Worker, Durable Object, or rollback secrets before this window has passed.

--- a/env.example
+++ b/env.example
@@ -173,6 +173,11 @@ EXOMEM_GITHUB_USER_ID=
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
 EXOMEM_JWT_SIGNING_KEY=
 
+# Optional manual cold-standby readiness identity. This is a public, non-secret
+# host label used only by /health/ready (for example: desktop-01). It must match
+# [A-Za-z0-9][A-Za-z0-9._-]{0,63}; invalid values are reported as null.
+# EXOMEM_INSTANCE_ID=
+
 # HA only: all three values must be the SAME non-empty random bearer. The
 # coordinator enforces it; replicas use it for leases and authoritative auth state.
 # EXOMEM_LEASE_COORDINATOR_TOKEN=

--- a/openspec/changes/add-manual-cold-standby/.openspec.yaml
+++ b/openspec/changes/add-manual-cold-standby/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/add-manual-cold-standby/design.md
+++ b/openspec/changes/add-manual-cold-standby/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Exomem already supports two different ends of the deployment spectrum: a standalone host that accepts downtime and a continuously available two-replica topology using a writer lease, shared OAuth state, and a Cloudflare Worker/Durable Object edge. The requested middle ground is a normally single-host Windows deployment with a deliberately activated laptop copy, one unchanged MCP URL, and no custom always-on HA control plane.
+
+The vault remains externally replicated by Syncthing. Syncthing can report convergence but is not distributed consensus, so no script can prove that an unreachable peer is powered off rather than partitioned. The design therefore automates normal ordering and refuses ambiguous promotion; a deliberate disaster override remains an operator decision.
+
+Each host already has its own Cloudflare named tunnel and operational hostname. The stable public hostname, GitHub OAuth callback, `EXOMEM_BASE_URL`, GitHub identity, and JWT signing key remain identical across hosts. Host-specific configuration and credentials must remain outside the repository.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep one stable MCP URL and one connector definition across desktop and laptop operation.
+- Keep exactly one Exomem service active during normal operation and planned handoff.
+- Encode configuration, status, activation, handoff, rollback, and refusal behavior in a repository-owned command.
+- Require observable replication, peer, runtime, and routing evidence before exposing a host.
+- Make the laptop demand-start and let the desktop recover its primary role through a guarded startup action rather than an unconditional auto-start.
+- Remove the personal deployment's Worker, Durable Object, writer-lease, and shared OAuth availability dependencies only after the direct path is proven.
+- Preserve the existing automatic HA product path unchanged for operators who choose it.
+
+**Non-Goals:**
+
+- Automatic zero-downtime failover, remote power control, or transparent failback.
+- Distributed consensus, offline multi-writer merging, CRDT conversion, or claiming that a Syncthing marker is a lock.
+- Recovering bytes that never replicated off a failed host.
+- Eliminating the existing multi-host writer-lease or Cloudflare HA implementation from the repository.
+- Making the first implementation cross-platform; the operator path targets the existing NSSM/cloudflared Windows deployment.
+
+## Decisions
+
+### Use distinct named tunnels and switch only the stable DNS route
+
+Both per-host `cloudflared` connectors may remain running because they terminate distinct named tunnels. Each tunnel config accepts the stable hostname, but `cloudflared tunnel route dns --overwrite-dns <target-tunnel> <stable-hostname>` maps that hostname to exactly one tunnel at a time. The direct operational hostname exposes only bounded health/readiness paths; it must not expose `/mcp` or other mutation-capable routes once the writer lease is removed.
+
+This is preferred over copying one named-tunnel credential to both machines: two simultaneous connectors for one named tunnel form a Cloudflare replica set and can distribute requests nondeterministically. It is also preferred over keeping the HA Worker merely as a manual router because the Worker, Durable Object, lease authority, and shared OAuth store would remain write-path dependencies. Separate connector URLs were rejected because they would require multiple MCP definitions and OAuth registrations.
+
+### Put the operating state machine in one generic PowerShell entrypoint
+
+Add `scripts/cold-standby.ps1` with `Configure`, `Status`, `Activate`, and `Handoff` actions plus `-WhatIf`. The same script runs on either host and loads a validated per-host JSON configuration from a user-owned location outside Git. Configuration names the local role and host ID, local and peer health URLs, stable hostname, local and peer tunnel names, Windows service names, Syncthing endpoint/folder/device identifiers, and an advisory state-file path. Secrets remain in the existing Cloudflare and Syncthing credential stores and are never printed or committed.
+
+`Status` is strictly read-only and returns both human-readable and JSON views of service state, local and peer health, stable-endpoint health, Syncthing convergence, desired-host intent, tunnel availability, and the next safe action. `-WhatIf` evaluates the same preconditions and prints the exact action plan without changing services, files, tunnel configuration, or DNS.
+
+The command records a bounded local operation journal and an advisory desired-host marker in a configured Syncthing-replicated location outside `Knowledge Base/`. The marker reduces accidental restart overlap and carries a monotonically increasing generation, but it is never described or used as distributed authority. Each host also publishes a redacted deployment-identity manifest containing its host ID and fingerprints of the shared base-URL/OAuth/identity/signing-key contract. Peer health, identity parity, and convergence checks remain mandatory; raw credentials and identity values are never copied into the manifest.
+
+Each Exomem origin exposes its configured non-secret host ID in the bounded readiness response. Public verification requires both the expected stable OAuth metadata and the expected host ID, so a healthy response from stale DNS, the prior tunnel, or the wrong origin cannot complete a transition.
+
+### Make Exomem demand-start on both hosts and guard desktop boot recovery
+
+`Configure` sets the Exomem service to demand-start on both hosts. The laptop never activates automatically. On the desktop, `Configure` installs a current-user scheduled task triggered at logon, with a configurable delay, that invokes a guarded `Activate -IfUnserved` after network availability. The guard waits for local Syncthing convergence, reads the replicated desired-host intent, and probes both the stable and laptop operational health endpoints before starting Exomem. Any evidence that the laptop is active, or any ambiguous/unavailable prerequisite, leaves the desktop service stopped.
+
+The distinct `cloudflared` services may remain automatic because an inactive host's direct tunnel is health-only and the stable DNS record selects only one tunnel. This removes the fragile requirement that a person remember to stop one tunnel connector before starting another.
+
+### Promotion and handoff are fail-closed ordered transitions
+
+`Activate` performs these phases:
+
+1. Validate configuration, local role, service state, Cloudflare command access, and Syncthing API access.
+2. Require the local folder to be idle with no pending items/bytes and, when a peer device is configured, require peer completion evidence.
+3. Probe the peer and stable endpoints repeatedly over a bounded window. A healthy peer refuses activation. An unreachable peer with conflicting desired-host intent also refuses unless disaster override is explicit.
+4. Write the next desired-host generation, start local Exomem, and require local `/health/ready` before changing public routing.
+5. Point the stable hostname at the local named tunnel, verify the Cloudflare DNS record targets that exact tunnel, then poll the public readiness and OAuth discovery endpoints until they report the expected local host ID and stable base URL.
+6. Commit the journal terminal. On a pre-route failure, stop the newly started service. On a post-route verification failure, restore the prior route when known, stop the local service, and report the incomplete/rolled-back state.
+
+A fresh activation always refuses a pre-existing healthy stable endpoint. Replay of an interrupted local journal is a separate recovery path: it may reconcile and complete only when the journal proves the expected phase and previous route, Cloudflare reports the stable record on the local tunnel, and the public readiness response reports the local host ID. Any mismatch enters compensation or operator recovery instead of being treated as a new activation.
+
+`Handoff` runs on the active source host. It first requires local and peer Syncthing completion, writes intent for the target, then waits until Syncthing confirms that the new intent generation reached the peer. Only then does it stop local Exomem gracefully, move the stable route to the target tunnel, and leave an explicit bounded outage until the target's guarded activation succeeds. It never starts a remote Windows service. The target can activate through its logon task or the same local command.
+
+The handoff journal records the prior route and whether the source was running. If route movement or verification fails after the source stops, compensation first restores the prior route and proves the target is still inactive before restarting and verifying the source. If target inactivity, route restoration, or source readiness cannot be proven, the source stays stopped and the terminal reports the exact operator recovery state; compensation never risks starting both services.
+
+### Keep disaster override explicit and narrow
+
+Normal actions never steal authority or bypass stale-copy checks. A forced activation requires both a force switch and a literal data-loss/split-brain acknowledgement. It may bypass peer-unreachable or Syncthing-completion evidence, but it cannot bypass invalid configuration, local runtime readiness, failed DNS mutation, or failed public verification. The terminal output must name every bypassed guard.
+
+### Treat failover authentication as reconnectable, not shared
+
+Both hosts retain the same stable base URL, GitHub OAuth application, allowed GitHub identity, and JWT signing key. After shared OAuth storage is removed, session and dynamic-client records are local to each host; the existing connector may require a reconnect/registration handshake and GitHub reauthorization after a host switch. The URL and MCP definition do not change, and the operator command must distinguish this expected reconnect flow from a routing failure.
+
+## Risks / Trade-offs
+
+- **Network partition can look like peer shutdown** -> Default promotion also checks replicated intent, stable routing, repeated peer probes, and Syncthing evidence, then refuses conflicting or incomplete state. No documentation claims this equals consensus; disaster override is explicit.
+- **Latest writes may not have replicated before a crash** -> Normal activation requires convergence evidence. If the source died before convergence, the runbook states that recovery can only use the newest bytes present locally.
+- **DNS cutover or edge propagation can partially succeed** -> Activation journals the previous target, polls the public path, and compensates to the previous route when known. The service is stopped if the new public path cannot be proven.
+- **A healthy public probe can come from the prior tunnel** -> Cloudflare route inspection and the readiness host ID must both identify the intended tunnel/origin before a transition commits.
+- **Shared authentication configuration can drift between hosts** -> A replicated redacted parity manifest fingerprints the effective shared contract; activation and handoff fail before mutation on any mismatch.
+- **Handoff can fail after stopping the source** -> Restore the prior route and restart the source only after proving the target inactive; otherwise preserve the single-service invariant and require explicit recovery.
+- **Desktop reboot could overlap an active laptop** -> Exomem itself is demand-start; the desktop scheduled task fails closed when the stable endpoint, laptop health endpoint, desired-host marker, or sync state indicates standby activity or ambiguity.
+- **Direct operational hostnames become an alternate write path** -> Tunnel ingress exposes health/readiness only on direct hostnames; MCP, OAuth, REST mutation, and transfer paths are served only through the selected stable hostname.
+- **Local OAuth sessions do not follow DNS** -> Keep the connector definition, allow one expected reauthorization after a switch, and document that repeated reauthorization indicates a real configuration problem.
+- **The operator depends on Cloudflare and Syncthing CLIs/APIs** -> `Configure` validates required access without printing secrets, `Status` reports actionable remediation, and the capability remains default-off.
+
+## Migration Plan
+
+1. Ship the script, example configuration, tests, and runbook without changing any installed service or public route.
+2. Back up both `.env` files, both tunnel configs, the current Worker/Durable Object configuration, and service startup settings. Confirm both vault replicas are up to date and on compatible Exomem releases.
+3. Configure each distinct tunnel to accept the stable hostname while restricting its direct operational hostname to health/readiness. Install the cold-standby config on both hosts; keep the HA edge live during this preparation.
+4. Exercise `Status` and `-WhatIf` on both hosts, then test each direct tunnel through a temporary hostname without changing the connector.
+5. Quiesce connector writes. Stop the laptop Exomem service. Remove `EXOMEM_WRITER_LEASE_*` and `EXOMEM_OAUTH_STORAGE_*` from both effective service environments while preserving the stable base URL, GitHub OAuth settings, JWT signing key, and vault paths.
+6. Start the desktop in standalone mode, detach the HA Worker's route binding from the stable hostname, point the stable DNS record directly at the desktop tunnel, and verify OAuth discovery, connector reconnect/authorization, authenticated read, and one governed write through the existing MCP definition.
+7. Configure both Exomem services for demand-start and enable the guarded desktop startup task. Run a controlled desktop-to-laptop activation and laptop-to-desktop handoff, including Syncthing convergence and connector reauthorization.
+8. Keep the Worker/Durable Object deployment intact but with its stable-hostname route binding detached for a bounded rollback window. After the window, remove the personal deployment and its secrets; do not delete the repository's HA implementation.
+
+Rollback stops the standalone service, restores the backed-up HA environment and tunnel configs, restores the Worker's stable-hostname route binding and DNS path, starts both replicas, and runs the existing HA doctor/readiness gates before reopening writes.
+
+## Open Questions
+
+No product-level questions remain. Probe counts, timeouts, and scheduled-task delay are implementation defaults that must be configurable and covered by deterministic tests.

--- a/openspec/changes/add-manual-cold-standby/proposal.md
+++ b/openspec/changes/add-manual-cold-standby/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Operators who value a simple, normally single-host Exomem deployment currently have to choose between accepting no standby or operating the full automatic multi-replica lease, shared-session, and edge-routing stack. A manual cold-standby profile should preserve one stable MCP URL and a recoverable laptop copy while moving failover discipline into a guarded local command instead of an always-on HA control plane.
+
+## What Changes
+
+- Add an opt-in, default-off manual cold-standby deployment profile for two Windows hosts with externally replicated vaults and distinct Cloudflare named tunnels.
+- Add one repository-owned PowerShell entrypoint for configuration, status, local activation, handoff, and dry-run planning.
+- Require fail-closed promotion checks for peer inactivity, replication freshness, local runtime readiness, and stable-hostname routing; ambiguous state leaves services and DNS unchanged.
+- Keep one stable public MCP URL by moving its Cloudflare DNS route between the existing per-host tunnels rather than sharing one tunnel connector or retaining the HA Worker as a routing dependency.
+- Keep only the active host's Exomem service running; the laptop remains demand-start, and desktop startup is guarded against an already-healthy standby.
+- Document staged cutover, connector reauthorization expectations, disaster override semantics, rollback, and the unavoidable stale-copy/network-partition limitations.
+- Preserve the existing automatic multi-host writer-lease and Cloudflare HA deployment as a separate supported option; this change does not remove product HA code.
+
+## Capabilities
+
+### New Capabilities
+
+- `manual-cold-standby`: Guarded single-active-host configuration, promotion, handoff, stable-hostname routing, status, rollback, and operator documentation for an externally replicated two-host deployment.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a generic Windows operator script and focused contract tests under `scripts/` and `tests/`.
+- Adds a self-hosted cold-standby runbook and updates `docs/deployment.md` to distinguish manual standby from automatic HA.
+- Uses existing Windows service, local readiness, Syncthing, Cloudflare named-tunnel, and DNS-routing surfaces; no model or server-side reasoning capability is introduced.
+- Personal deployment migration can later retire its Worker, Durable Object, shared OAuth storage, and writer-lease environment only after direct routing is verified. The repository's optional HA implementation remains intact.

--- a/openspec/changes/add-manual-cold-standby/specs/manual-cold-standby/spec.md
+++ b/openspec/changes/add-manual-cold-standby/specs/manual-cold-standby/spec.md
@@ -1,0 +1,205 @@
+## ADDED Requirements
+
+### Requirement: Cold standby is explicit and default-off
+
+The system SHALL provide a manual cold-standby deployment profile that is inactive unless an operator explicitly configures it. Installing or upgrading Exomem without configuring this profile MUST NOT change Windows service startup, Cloudflare tunnel configuration, DNS, OAuth configuration, writer coordination, or vault files.
+
+#### Scenario: Ordinary install ignores cold standby
+
+- **WHEN** Exomem is installed or upgraded without running the cold-standby configuration action
+- **THEN** existing service, tunnel, DNS, OAuth, coordination, and vault state remain unchanged
+
+### Requirement: One generic local operator command
+
+The project SHALL provide one Windows PowerShell entrypoint with `Configure`, `Status`, `Activate`, and `Handoff` actions. It SHALL load validated host-specific configuration from outside the repository, MUST NOT commit or print credentials, and SHALL support `-WhatIf` for every mutating action.
+
+#### Scenario: Dry run plans without mutation
+
+- **WHEN** an operator invokes a mutating action with `-WhatIf`
+- **THEN** the command evaluates the same preconditions and reports the ordered plan
+- **AND** it does not change services, scheduled tasks, files, tunnel configuration, DNS, or public routing
+
+#### Scenario: Invalid local configuration
+
+- **WHEN** required host, tunnel, health, service, or Syncthing configuration is missing or inconsistent
+- **THEN** the command exits nonzero with actionable remediation
+- **AND** no operational state is changed
+
+### Requirement: Status is bounded and read-only
+
+`Status` SHALL report local and peer service health, stable-endpoint health, Syncthing convergence, desired-host intent, named-tunnel availability, and the next safe operator action in both human-readable and JSON forms. It MUST remain read-only even when checks fail or external dependencies are unavailable.
+
+#### Scenario: Status observes a healthy desktop primary
+
+- **WHEN** the desktop service is ready, the laptop service is stopped, replication is converged, and the stable endpoint is healthy
+- **THEN** status identifies the desktop as the active host
+- **AND** it reports laptop activation as unnecessary
+- **AND** it changes no local or remote state
+
+#### Scenario: Status dependency is unavailable
+
+- **WHEN** Syncthing, Cloudflare, or a health endpoint cannot be queried
+- **THEN** status reports that dependency as unknown or unavailable with remediation
+- **AND** it does not infer that the peer is safely offline
+
+#### Scenario: Both Exomem origins appear ready
+
+- **WHEN** local and peer health probes both report ready
+- **THEN** status reports an unsafe ambiguous state rather than selecting an active host
+- **AND** it offers no mutating next action
+
+### Requirement: Stable routing uses distinct named tunnels
+
+The profile SHALL preserve one stable MCP hostname and SHALL route it to exactly one of two distinct per-host Cloudflare named tunnels. Both named-tunnel connectors MAY remain running concurrently. When the profile is active, each direct operational hostname MUST forward only bounded health/readiness paths and MUST NOT expose MCP, OAuth, REST mutation, or artifact-transfer paths.
+
+#### Scenario: Both tunnel connectors are running
+
+- **WHEN** desktop and laptop `cloudflared` services are both connected to their distinct named tunnels
+- **THEN** the stable hostname resolves through only the selected host tunnel
+- **AND** Cloudflare does not treat the two hosts as connectors in one load-balanced tunnel replica set
+
+#### Scenario: Direct hostname receives an MCP request
+
+- **WHEN** a client sends an MCP request to a host's direct operational hostname
+- **THEN** tunnel ingress refuses or does not forward that request to Exomem
+- **AND** the same hostname can still serve the configured health/readiness probe
+
+### Requirement: Activation fails closed on unsafe evidence
+
+Normal `Activate` SHALL validate command access, local role, local service state, local runtime readiness, Syncthing API access, local folder convergence, configured peer completion, repeated peer health, stable-endpoint health, desired-host intent, and the redacted shared-configuration fingerprint published by each host. A healthy peer, stale or unknown replication state, conflicting intent, shared-configuration mismatch, unavailable required evidence, or ambiguous network state MUST refuse activation before public routing changes.
+
+#### Scenario: Peer is still serving
+
+- **WHEN** repeated probes show that the peer Exomem origin is ready
+- **THEN** activation exits nonzero before starting the local Exomem service or changing DNS
+
+#### Scenario: Replication is not converged
+
+- **WHEN** the local folder has pending items or bytes, or configured peer completion is below the required terminal state
+- **THEN** activation exits nonzero with Syncthing remediation
+- **AND** service and routing state remain unchanged
+
+#### Scenario: Unreachable peer conflicts with desired-host intent
+
+- **WHEN** the peer is unreachable but the latest converged desired-host marker names that peer
+- **THEN** normal activation treats the state as ambiguous and refuses
+- **AND** it does not describe peer unreachability as proof of shutdown
+
+#### Scenario: Stable endpoint is already healthy
+
+- **WHEN** the stable endpoint is healthy before local activation begins
+- **THEN** normal activation refuses because another serving origin may still be active
+- **AND** it does not start the local service or change DNS
+
+#### Scenario: Shared authentication configuration has drifted
+
+- **WHEN** the local and peer manifests disagree on the stable base URL, OAuth application/callback, allowed identity, or JWT signing-key fingerprint
+- **THEN** activation exits nonzero before starting the local service or changing DNS
+- **AND** diagnostics identify the mismatched field without printing the raw identity or signing key
+
+### Requirement: Successful activation follows safe ordering
+
+After all normal guards pass, `Activate` SHALL record the next desired-host generation, start local Exomem, require local readiness, route the stable hostname to the local named tunnel, verify that Cloudflare records the expected tunnel target, and verify the public readiness and OAuth discovery paths in that order. The bounded readiness response SHALL expose a configured non-secret host ID. `Activate` SHALL not report success until the public response reports the expected local host ID and the expected stable base URL.
+
+#### Scenario: Laptop activation succeeds
+
+- **WHEN** the desktop is inactive, replication is converged, intent permits laptop activation, local Exomem becomes ready, and the stable route verifies
+- **THEN** the laptop becomes the only running Exomem service
+- **AND** the unchanged stable MCP hostname serves the laptop
+- **AND** the operation journal records a successful terminal
+
+#### Scenario: Public verification fails after route change
+
+- **WHEN** local readiness succeeds but the stable public readiness or OAuth discovery check fails after DNS mutation
+- **THEN** activation restores the previous route when it is known
+- **AND** it stops the newly started local service
+- **AND** it reports whether rollback completed or operator recovery is required
+
+#### Scenario: Old tunnel remains healthy after route mutation
+
+- **WHEN** Cloudflare route mutation was requested but the public readiness response still reports the previous host ID
+- **THEN** activation does not commit success
+- **AND** it compensates or reports operator recovery even if readiness and OAuth metadata are otherwise healthy
+
+#### Scenario: Interrupted activation is replayed
+
+- **WHEN** a local journal shows interruption after route mutation and before terminal commit
+- **THEN** recovery may complete only if the journaled phase and previous route are consistent, Cloudflare reports the stable record on the local tunnel, and public readiness reports the local host ID
+- **AND** any mismatch enters compensation or operator recovery rather than a fresh activation
+
+### Requirement: Desktop boot recovery is guarded
+
+`Configure` SHALL set Exomem to demand-start on both hosts. It SHALL keep laptop activation manual and SHALL support a desktop current-user logon task, with a configurable delay, that invokes a guarded activate-if-unserved action only after network and Syncthing checks. Any evidence of active laptop service or ambiguous intent, replication, peer, or stable-endpoint state MUST leave desktop Exomem stopped.
+
+#### Scenario: Desktop boots while laptop serves the stable URL
+
+- **WHEN** the desktop startup task runs and either the laptop health endpoint or stable endpoint is healthy
+- **THEN** the desktop Exomem service remains stopped
+- **AND** no DNS route is changed
+
+#### Scenario: Desktop boots as intended primary
+
+- **WHEN** converged intent names the desktop, the laptop is inactive, required health checks are conclusive, and Syncthing is converged
+- **THEN** the startup task may activate desktop through the same guarded transition used by the interactive command
+
+### Requirement: Handoff preserves a single active service
+
+`Handoff` SHALL require source and configured peer replication completion and shared-configuration parity, record intent for the target, and then require evidence that the peer received that exact new intent generation before gracefully stopping the local Exomem service and moving the stable route to the target tunnel. It MUST NOT remotely start the target service or keep the source service running while waiting for target activation. If routing or verification fails after source shutdown, compensation SHALL restore the prior route and restart the source only after proving the target remains inactive; otherwise it SHALL keep the source stopped and report operator recovery.
+
+#### Scenario: Laptop hands back to desktop
+
+- **WHEN** laptop is active and both Syncthing replicas are complete
+- **THEN** handoff records desktop intent and proves that generation reached the desktop before stopping laptop Exomem and selecting the desktop tunnel
+- **AND** it reports a bounded outage until guarded desktop activation succeeds
+
+#### Scenario: Peer replication completion is unknown
+
+- **WHEN** handoff cannot prove the configured peer has received the latest replicated state
+- **THEN** normal handoff refuses before stopping the source service or moving the route
+
+#### Scenario: Route movement fails after source shutdown
+
+- **WHEN** handoff has stopped the source but cannot move or verify the stable route on the target tunnel
+- **THEN** it restores the prior route and restarts the source only if target inactivity is conclusively proven
+- **AND** otherwise it leaves the source stopped and reports the exact recovery steps without risking two active services
+
+### Requirement: Disaster override is explicit and narrow
+
+A forced activation SHALL require a force switch plus a literal acknowledgement of split-brain and data-loss risk. It MAY bypass only peer-unreachable, conflicting-intent, or Syncthing-completion guards. It MUST NOT bypass configuration validation, local runtime readiness, DNS mutation success, or public verification, and its terminal output SHALL enumerate every bypassed guard.
+
+#### Scenario: Force switch without acknowledgement
+
+- **WHEN** an operator supplies the force switch without the required literal acknowledgement
+- **THEN** activation refuses before changing state
+
+#### Scenario: Acknowledged disaster activation
+
+- **WHEN** an operator supplies both required override inputs and local runtime and routing checks succeed
+- **THEN** activation may proceed despite explicitly named peer or replication uncertainty
+- **AND** the journal and terminal output record each bypassed guard
+
+### Requirement: Connector identity survives host switches
+
+Both hosts SHALL use the same stable `EXOMEM_BASE_URL`, GitHub OAuth application and callback, allowed GitHub identity, and JWT signing key. The operator SHALL compare redacted fingerprints of this effective configuration before activation or handoff and MUST NOT print or replicate raw credentials or identity values. Switching hosts MUST NOT require changing or recreating the MCP connector definition. Documentation SHALL explain that host-local OAuth session and dynamic-client state may require reconnect/registration and GitHub reauthorization after a switch once shared OAuth storage is removed.
+
+#### Scenario: Existing connector reaches newly active host
+
+- **WHEN** DNS now selects the other host and the client's prior session is absent there
+- **THEN** the existing connector URL remains valid
+- **AND** the operator is instructed to reconnect or reauthorize the existing connector rather than create a second definition
+
+#### Scenario: Both hosts share the connector identity contract
+
+- **WHEN** the operator compares the two host manifests before a transition
+- **THEN** normalized base URL, OAuth application/callback, allowed-identity fingerprint, and signing-key fingerprint match
+- **AND** no raw identity, client secret, or signing key appears in output or replicated state
+
+### Requirement: Migration and rollback remain staged
+
+The runbook SHALL separate tooling installation from live cutover, require backups and convergence before removing HA environment, detach the HA Worker's stable-hostname route binding before direct tunnel routing, verify the direct desktop path before retiring the personal Worker/Durable Object deployment, and retain a bounded rollback window. It SHALL explicitly state that the existing product HA implementation remains supported and that unreplicated bytes cannot be recovered by standby activation.
+
+#### Scenario: Direct cutover fails verification
+
+- **WHEN** the standalone desktop path fails OAuth, readiness, authenticated read, or governed-write verification
+- **THEN** the runbook directs the operator to restore the backed-up HA environment and stable Worker route
+- **AND** it does not authorize deleting the Worker, Durable Object, or rollback secrets

--- a/openspec/changes/add-manual-cold-standby/tasks.md
+++ b/openspec/changes/add-manual-cold-standby/tasks.md
@@ -1,48 +1,48 @@
 ## 1. Test Harness and Configuration Contract
 
-- [ ] 1.1 Add a focused pytest harness that invokes PowerShell with temporary host configuration and fake service, HTTP, Syncthing, Cloudflare, scheduled-task, filesystem, and clock adapters.
-- [ ] 1.2 Add failing tests for default-off behavior, required-field validation, host/tunnel identity conflicts, shared-configuration fingerprint mismatch, secret and identity redaction, human/JSON terminals, `Status`, and mutation-free `-WhatIf`.
-- [ ] 1.3 Implement the generic `scripts/cold-standby.ps1` command shell, validated external JSON configuration, dependency adapters, bounded journal schema, advisory desired-host state format, and redacted per-host identity manifest until the configuration/status tests pass.
-- [ ] 1.4 Add a generic example configuration with no personal hostnames, account identifiers, credentials, or vault paths.
+- [x] 1.1 Add a focused pytest harness that invokes PowerShell with temporary host configuration and fake service, HTTP, Syncthing, Cloudflare, scheduled-task, filesystem, and clock adapters.
+- [x] 1.2 Add failing tests for default-off behavior, required-field validation, host/tunnel identity conflicts, shared-configuration fingerprint mismatch, secret and identity redaction, human/JSON terminals, `Status`, and mutation-free `-WhatIf`.
+- [x] 1.3 Implement the generic `scripts/cold-standby.ps1` command shell, validated external JSON configuration, dependency adapters, bounded journal schema, advisory desired-host state format, and redacted per-host identity manifest until the configuration/status tests pass.
+- [x] 1.4 Add a generic example configuration with no personal hostnames, account identifiers, credentials, or vault paths.
 
 ## 2. Readiness and Safety Planning
 
-- [ ] 2.1 Add failing tests for local service/readiness checks including the non-secret host ID, repeated peer and stable-endpoint probes, named-tunnel availability, Syncthing idle/pending-byte state, peer completion, desired-host generations, shared-configuration parity, and unknown dependency handling.
-- [ ] 2.2 Implement bounded read-only probes and the pure transition planner so every refusal names the failed evidence and the next safe action.
-- [ ] 2.3 Add regression tests proving that a healthy peer, stale or unknown replication, conflicting intent, and ambiguous network evidence refuse before service or DNS mutation.
+- [x] 2.1 Add failing tests for local service/readiness checks including the non-secret host ID, repeated peer and stable-endpoint probes, named-tunnel availability, Syncthing idle/pending-byte state, peer completion, desired-host generations, shared-configuration parity, and unknown dependency handling.
+- [x] 2.2 Implement bounded read-only probes and the pure transition planner so every refusal names the failed evidence and the next safe action.
+- [x] 2.3 Add regression tests proving that a healthy peer, stale or unknown replication, conflicting intent, and ambiguous network evidence refuse before service or DNS mutation.
 
 ## 3. Activation, Compensation, and Disaster Override
 
-- [ ] 3.1 Add failing tests for the complete activation order: validate, converge and compare host manifests, probe, write intent, start local service, verify local readiness, switch stable DNS, verify the Cloudflare tunnel target, verify public readiness host identity/OAuth, then commit the journal terminal.
-- [ ] 3.2 Implement normal `Activate` and `Activate -IfUnserved` using the tested planner and injected mutation adapters.
-- [ ] 3.3 Add failing tests for failures before routing, failures after routing, a healthy response from the previous tunnel, known-route compensation, unknown-route recovery output, and idempotent replay after a completed or interrupted local journal. Prove interrupted replay completes only when the journal phase, Cloudflare tunnel target, and public host ID all agree.
-- [ ] 3.4 Implement compensation so failed activation restores the known previous route when possible, stops a newly started service, and reports a decisive rolled-back or operator-recovery terminal.
-- [ ] 3.5 Add tests and implementation for the two-part disaster override, allowed bypass set, non-bypassable local/routing checks, and explicit enumeration of every bypassed guard.
+- [x] 3.1 Add failing tests for the complete activation order: validate, converge and compare host manifests, probe, write intent, start local service, verify local readiness, switch stable DNS, verify the Cloudflare tunnel target, verify public readiness host identity/OAuth, then commit the journal terminal.
+- [x] 3.2 Implement normal `Activate` and `Activate -IfUnserved` using the tested planner and injected mutation adapters.
+- [x] 3.3 Add failing tests for failures before routing, failures after routing, a healthy response from the previous tunnel, known-route compensation, unknown-route recovery output, and idempotent replay after a completed or interrupted local journal. Prove interrupted replay completes only when the journal phase, Cloudflare tunnel target, and public host ID all agree.
+- [x] 3.4 Implement compensation so failed activation restores the known previous route when possible, stops a newly started service, and reports a decisive rolled-back or operator-recovery terminal.
+- [x] 3.5 Add tests and implementation for the two-part disaster override, allowed bypass set, non-bypassable local/routing checks, and explicit enumeration of every bypassed guard.
 
 ## 4. Service and Tunnel Configuration
 
-- [ ] 4.1 Add failing tests that `Configure` changes only explicitly selected cold-standby resources, sets Exomem demand-start on both roles, keeps laptop activation manual, and remains idempotent.
-- [ ] 4.2 Implement guarded Windows service startup configuration and the delayed desktop current-user logon task that calls the same activate-if-unserved transition after network availability.
-- [ ] 4.3 Add failing tests for distinct named-tunnel validation, stable-hostname ingress on both tunnels, health-only direct operational ingress, atomic config backup/write, and refusal to expose direct MCP/OAuth/REST/transfer paths.
-- [ ] 4.4 Implement tunnel-config preparation and stable DNS routing through `cloudflared tunnel route dns --overwrite-dns`, preserving existing unrelated ingress rules and producing recoverable backups.
+- [x] 4.1 Add failing tests that `Configure` changes only explicitly selected cold-standby resources, sets Exomem demand-start on both roles, keeps laptop activation manual, and remains idempotent.
+- [x] 4.2 Implement guarded Windows service startup configuration and the delayed desktop current-user logon task that calls the same activate-if-unserved transition after network availability.
+- [x] 4.3 Add failing tests for distinct named-tunnel validation, stable-hostname ingress on both tunnels, health-only direct operational ingress, atomic config backup/write, and refusal to expose direct MCP/OAuth/REST/transfer paths.
+- [x] 4.4 Implement tunnel-config preparation and stable DNS routing through `cloudflared tunnel route dns --overwrite-dns`, preserving existing unrelated ingress rules and producing recoverable backups.
 
 ## 5. Handoff
 
-- [ ] 5.1 Add failing tests for source and peer convergence and identity-parity gates, desired-target generation, confirmed delivery of that new generation, graceful local stop before route movement, bounded outage reporting, and the prohibition on remote service start.
-- [ ] 5.2 Add failing compensation tests for route or verification failure after source shutdown: restore/restart only when the target is conclusively inactive, otherwise keep the source stopped and emit exact recovery state.
-- [ ] 5.3 Implement `Handoff` and its compensation/recovery terminals using the same journal, Syncthing, service, and routing adapters.
-- [ ] 5.4 Add a desktop-to-laptop and laptop-to-desktop simulated round trip proving that only one fake Exomem service is active at every committed transition.
+- [x] 5.1 Add failing tests for source and peer convergence and identity-parity gates, desired-target generation, confirmed delivery of that new generation, graceful local stop before route movement, bounded outage reporting, and the prohibition on remote service start.
+- [x] 5.2 Add failing compensation tests for route or verification failure after source shutdown: restore/restart only when the target is conclusively inactive, otherwise keep the source stopped and emit exact recovery state.
+- [x] 5.3 Implement `Handoff` and its compensation/recovery terminals using the same journal, Syncthing, service, and routing adapters.
+- [x] 5.4 Add a desktop-to-laptop and laptop-to-desktop simulated round trip proving that only one fake Exomem service is active at every committed transition.
 
 ## 6. Operator Documentation
 
-- [ ] 6.1 Add `docs/runbooks/cold-standby.md` covering prerequisites, configuration and identity parity, normal status, laptop activation, desktop recovery, expected connector reconnect/reauthorization, disaster override, partial-transition recovery, and rollback.
-- [ ] 6.2 Update `docs/deployment.md` to compare single-host, manual cold standby, and automatic writer-lease HA without presenting one as universally preferred.
-- [ ] 6.3 Document the staged personal cutover: backup, tunnel hardening, dry runs, HA Worker route detachment, standalone desktop verification, stable DNS switch, HA environment removal, controlled failover/handoff, rollback window, and only then retirement of the personal Worker/Durable Object deployment.
-- [ ] 6.4 Explicitly document that Syncthing intent is advisory rather than consensus, network partitions normally refuse, forced recovery can lose or fork state, and unreplicated bytes are unrecoverable.
+- [x] 6.1 Add `docs/runbooks/cold-standby.md` covering prerequisites, configuration and identity parity, normal status, laptop activation, desktop recovery, expected connector reconnect/reauthorization, disaster override, partial-transition recovery, and rollback.
+- [x] 6.2 Update `docs/deployment.md` to compare single-host, manual cold standby, and automatic writer-lease HA without presenting one as universally preferred.
+- [x] 6.3 Document the staged personal cutover: backup, tunnel hardening, dry runs, HA Worker route detachment, standalone desktop verification, stable DNS switch, HA environment removal, controlled failover/handoff, rollback window, and only then retirement of the personal Worker/Durable Object deployment.
+- [x] 6.4 Explicitly document that Syncthing intent is advisory rather than consensus, network partitions normally refuse, forced recovery can lose or fork state, and unreplicated bytes are unrecoverable.
 
 ## 7. Verification and Delivery
 
-- [ ] 7.1 Run the focused cold-standby and service-installer tests with sandbox-safe temporary paths, plus Ruff on any Python test/support code.
-- [ ] 7.2 Run `openspec validate add-manual-cold-standby --strict` and the existing public-artifact/leak guards for all committed examples and documentation.
-- [ ] 7.3 Exercise `Status`, `Configure -WhatIf`, `Activate -WhatIf`, and `Handoff -WhatIf` against sanitized representative desktop and laptop configurations and preserve the command evidence in the PR.
-- [ ] 7.4 Independently review split-brain refusal, direct-origin exposure, secret handling, compensation, default-off behavior, and the promise that the existing automatic HA implementation remains unchanged.
+- [x] 7.1 Run the focused cold-standby and service-installer tests with sandbox-safe temporary paths, plus Ruff on any Python test/support code.
+- [x] 7.2 Run `openspec validate add-manual-cold-standby --strict` and the existing public-artifact/leak guards for all committed examples and documentation.
+- [x] 7.3 Exercise `Status`, `Configure -WhatIf`, `Activate -WhatIf`, and `Handoff -WhatIf` against sanitized representative desktop and laptop configurations and preserve the command evidence in the PR.
+- [x] 7.4 Independently review split-brain refusal, direct-origin exposure, secret handling, compensation, default-off behavior, and the promise that the existing automatic HA implementation remains unchanged.

--- a/openspec/changes/add-manual-cold-standby/tasks.md
+++ b/openspec/changes/add-manual-cold-standby/tasks.md
@@ -1,0 +1,48 @@
+## 1. Test Harness and Configuration Contract
+
+- [ ] 1.1 Add a focused pytest harness that invokes PowerShell with temporary host configuration and fake service, HTTP, Syncthing, Cloudflare, scheduled-task, filesystem, and clock adapters.
+- [ ] 1.2 Add failing tests for default-off behavior, required-field validation, host/tunnel identity conflicts, shared-configuration fingerprint mismatch, secret and identity redaction, human/JSON terminals, `Status`, and mutation-free `-WhatIf`.
+- [ ] 1.3 Implement the generic `scripts/cold-standby.ps1` command shell, validated external JSON configuration, dependency adapters, bounded journal schema, advisory desired-host state format, and redacted per-host identity manifest until the configuration/status tests pass.
+- [ ] 1.4 Add a generic example configuration with no personal hostnames, account identifiers, credentials, or vault paths.
+
+## 2. Readiness and Safety Planning
+
+- [ ] 2.1 Add failing tests for local service/readiness checks including the non-secret host ID, repeated peer and stable-endpoint probes, named-tunnel availability, Syncthing idle/pending-byte state, peer completion, desired-host generations, shared-configuration parity, and unknown dependency handling.
+- [ ] 2.2 Implement bounded read-only probes and the pure transition planner so every refusal names the failed evidence and the next safe action.
+- [ ] 2.3 Add regression tests proving that a healthy peer, stale or unknown replication, conflicting intent, and ambiguous network evidence refuse before service or DNS mutation.
+
+## 3. Activation, Compensation, and Disaster Override
+
+- [ ] 3.1 Add failing tests for the complete activation order: validate, converge and compare host manifests, probe, write intent, start local service, verify local readiness, switch stable DNS, verify the Cloudflare tunnel target, verify public readiness host identity/OAuth, then commit the journal terminal.
+- [ ] 3.2 Implement normal `Activate` and `Activate -IfUnserved` using the tested planner and injected mutation adapters.
+- [ ] 3.3 Add failing tests for failures before routing, failures after routing, a healthy response from the previous tunnel, known-route compensation, unknown-route recovery output, and idempotent replay after a completed or interrupted local journal. Prove interrupted replay completes only when the journal phase, Cloudflare tunnel target, and public host ID all agree.
+- [ ] 3.4 Implement compensation so failed activation restores the known previous route when possible, stops a newly started service, and reports a decisive rolled-back or operator-recovery terminal.
+- [ ] 3.5 Add tests and implementation for the two-part disaster override, allowed bypass set, non-bypassable local/routing checks, and explicit enumeration of every bypassed guard.
+
+## 4. Service and Tunnel Configuration
+
+- [ ] 4.1 Add failing tests that `Configure` changes only explicitly selected cold-standby resources, sets Exomem demand-start on both roles, keeps laptop activation manual, and remains idempotent.
+- [ ] 4.2 Implement guarded Windows service startup configuration and the delayed desktop current-user logon task that calls the same activate-if-unserved transition after network availability.
+- [ ] 4.3 Add failing tests for distinct named-tunnel validation, stable-hostname ingress on both tunnels, health-only direct operational ingress, atomic config backup/write, and refusal to expose direct MCP/OAuth/REST/transfer paths.
+- [ ] 4.4 Implement tunnel-config preparation and stable DNS routing through `cloudflared tunnel route dns --overwrite-dns`, preserving existing unrelated ingress rules and producing recoverable backups.
+
+## 5. Handoff
+
+- [ ] 5.1 Add failing tests for source and peer convergence and identity-parity gates, desired-target generation, confirmed delivery of that new generation, graceful local stop before route movement, bounded outage reporting, and the prohibition on remote service start.
+- [ ] 5.2 Add failing compensation tests for route or verification failure after source shutdown: restore/restart only when the target is conclusively inactive, otherwise keep the source stopped and emit exact recovery state.
+- [ ] 5.3 Implement `Handoff` and its compensation/recovery terminals using the same journal, Syncthing, service, and routing adapters.
+- [ ] 5.4 Add a desktop-to-laptop and laptop-to-desktop simulated round trip proving that only one fake Exomem service is active at every committed transition.
+
+## 6. Operator Documentation
+
+- [ ] 6.1 Add `docs/runbooks/cold-standby.md` covering prerequisites, configuration and identity parity, normal status, laptop activation, desktop recovery, expected connector reconnect/reauthorization, disaster override, partial-transition recovery, and rollback.
+- [ ] 6.2 Update `docs/deployment.md` to compare single-host, manual cold standby, and automatic writer-lease HA without presenting one as universally preferred.
+- [ ] 6.3 Document the staged personal cutover: backup, tunnel hardening, dry runs, HA Worker route detachment, standalone desktop verification, stable DNS switch, HA environment removal, controlled failover/handoff, rollback window, and only then retirement of the personal Worker/Durable Object deployment.
+- [ ] 6.4 Explicitly document that Syncthing intent is advisory rather than consensus, network partitions normally refuse, forced recovery can lose or fork state, and unreplicated bytes are unrecoverable.
+
+## 7. Verification and Delivery
+
+- [ ] 7.1 Run the focused cold-standby and service-installer tests with sandbox-safe temporary paths, plus Ruff on any Python test/support code.
+- [ ] 7.2 Run `openspec validate add-manual-cold-standby --strict` and the existing public-artifact/leak guards for all committed examples and documentation.
+- [ ] 7.3 Exercise `Status`, `Configure -WhatIf`, `Activate -WhatIf`, and `Handoff -WhatIf` against sanitized representative desktop and laptop configurations and preserve the command evidence in the PR.
+- [ ] 7.4 Independently review split-brain refusal, direct-origin exposure, secret handling, compensation, default-off behavior, and the promise that the existing automatic HA implementation remains unchanged.

--- a/scripts/cold-standby.ps1
+++ b/scripts/cold-standby.ps1
@@ -1037,7 +1037,10 @@ function Get-NativeAdapter {
                 try { $modifiedTime = [DateTimeOffset]::Parse($modifiedText, [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::RoundtripKind) } catch { return @{ state = 'unknown'; generation = $null; marker_version = $null } }
                 $fractionMatch = [regex]::Match($modifiedText, '\.(?<fraction>[0-9]+)(?:Z|[+-][0-9]{2}:[0-9]{2})$')
                 $modifiedNs = if ($fractionMatch.Success) { [int64]($fractionMatch.Groups['fraction'].Value.PadRight(9, '0').Substring(0, 9)) } else { 0 }
-                if ([int64]$modifiedTime.ToUnixTimeSeconds() -ne [int64]$markerVersion.modified_s -or $modifiedNs -ne [int64]$markerVersion.modified_ns -or [int64]$file.local.size -ne [int64]$markerVersion.size) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                # PowerShell DateTime ticks resolve to 100 ns even when Syncthing
+                # reports a Linux filesystem's full nanosecond timestamp.
+                $modifiedNsAtPowerShellPrecision = $modifiedNs - ($modifiedNs % 100)
+                if ([int64]$modifiedTime.ToUnixTimeSeconds() -ne [int64]$markerVersion.modified_s -or $modifiedNsAtPowerShellPrecision -ne [int64]$markerVersion.modified_ns -or [int64]$file.local.size -ne [int64]$markerVersion.size) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
                 $globalProperties = if ($null -ne $file.global) { @($file.global.PSObject.Properties.Name) } else { @() }
                 if ('version' -notin $globalProperties) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
                 $localVector = (@($file.local.version) | ForEach-Object { [string]$_ }) -join ','

--- a/scripts/cold-standby.ps1
+++ b/scripts/cold-standby.ps1
@@ -1,0 +1,1263 @@
+<#
+.SYNOPSIS
+  Operates Exomem's opt-in manual cold-standby profile.
+
+.DESCRIPTION
+  The profile is inactive until Configure is explicitly run with a host-owned
+  configuration file outside the repository. Status is always read-only.
+
+  Forced activation requires both -Force and the exact acknowledgement:
+  I ACKNOWLEDGE SPLIT-BRAIN AND DATA-LOSS RISK
+
+  Syncthing and the desired-host marker are advisory evidence, not a lock or a
+  consensus protocol. An unreachable peer is never silently treated as stopped.
+
+  -AdapterPath is a documented operational simulation seam. A complete adapter
+  may replace service, HTTP, Syncthing, Cloudflare, scheduled-task, filesystem,
+  and clock surfaces. Without it, this command uses native Windows, HTTP,
+  Syncthing, cloudflared, and Cloudflare DNS API surfaces and fails closed.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('Configure', 'Status', 'Activate', 'Handoff')]
+    [string]$Action,
+    [Parameter(Mandatory)]
+    [string]$ConfigPath,
+    [switch]$Json,
+    [switch]$IfUnserved,
+    [switch]$Force,
+    [string]$Acknowledge,
+    [string]$AdapterPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ForceAcknowledgement = 'I ACKNOWLEDGE SPLIT-BRAIN AND DATA-LOSS RISK'
+$script:ActiveAdapter = $null
+
+function Get-OptionalValue {
+    param([hashtable]$Value, [string]$Name, [object]$Default = $null)
+    if ($null -ne $Value -and $Value.ContainsKey($Name)) { return $Value[$Name] }
+    return $Default
+}
+
+function Write-Terminal {
+    param([hashtable]$Terminal, [int]$ExitCode = 0)
+    if (-not $Terminal.ContainsKey('action')) { $Terminal.action = $Action }
+    if (-not $Terminal.ContainsKey('trace')) {
+        $traceItems = if ($null -ne $script:ActiveAdapter) { @(Invoke-Adapter $script:ActiveAdapter 'GetTrace') } else { @() }
+        $Terminal.trace = @($traceItems)
+    }
+    if ($Json) {
+        $Terminal | ConvertTo-Json -Depth 20 -Compress
+    } else {
+        "[$($Terminal.action)] $($Terminal.terminal)"
+        if ($Terminal.ContainsKey('active_host')) { "Active host: $($Terminal.active_host)" }
+        if ($Terminal.ContainsKey('reasons') -and @($Terminal.reasons).Count) { "Reasons: $(@($Terminal.reasons) -join '; ')" }
+        if ($Terminal.ContainsKey('next_action')) { "Next safe action: $($Terminal.next_action)" }
+        if ($Terminal.ContainsKey('bypassed_guards') -and @($Terminal.bypassed_guards).Count) { "Bypassed guards: $(@($Terminal.bypassed_guards) -join '; ')" }
+        if ($Terminal.ContainsKey('evidence')) { "Evidence: $($Terminal.evidence | ConvertTo-Json -Depth 8 -Compress)" }
+    }
+    exit $ExitCode
+}
+
+function Invoke-Adapter {
+    param([hashtable]$Adapter, [string]$Name, [object[]]$Arguments = @())
+    if (-not $Adapter.ContainsKey($Name) -or $null -eq $Adapter[$Name]) { throw "Adapter does not provide required operation '$Name'." }
+    & $Adapter[$Name] @Arguments
+}
+
+function ConvertTo-NormalizedOrigin {
+    param([string]$Value)
+    $uri = [Uri]$Value.Trim()
+    if (-not $uri.IsAbsoluteUri -or $uri.Scheme -ne 'https' -or -not [string]::IsNullOrEmpty($uri.UserInfo) -or -not [string]::IsNullOrEmpty($uri.Query) -or -not [string]::IsNullOrEmpty($uri.Fragment) -or $uri.AbsolutePath -notin @('', '/')) {
+        throw 'The shared base URL and OAuth issuer must be a bare HTTPS origin with no path, query, fragment, or user information.'
+    }
+    return $uri.AbsoluteUri.TrimEnd('/').ToLowerInvariant()
+}
+
+function Get-UrlOrigin {
+    param([string]$Value)
+    $uri = [Uri]$Value
+    $builder = [UriBuilder]$uri
+    $builder.Path = ''
+    $builder.Query = ''
+    $builder.Fragment = ''
+    $builder.Uri.AbsoluteUri.TrimEnd('/').ToLowerInvariant()
+}
+
+function Get-Sha256 {
+    param([string]$Value)
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+}
+
+function Assert-RequiredConfig {
+    param([hashtable]$Config, [string]$Field)
+    $value = $Config
+    foreach ($segment in $Field.Split('.')) {
+        if ($value -isnot [hashtable] -or -not $value.ContainsKey($segment)) { throw "Configuration requires '$Field'." }
+        $value = $value[$segment]
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$value)) { throw "Configuration requires '$Field'." }
+}
+
+function Get-Config {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "Configuration file was not found: $Path" }
+    $resolvedConfigPath = [IO.Path]::GetFullPath((Resolve-Path -LiteralPath $Path).Path)
+    $repositoryRoot = [IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot)).TrimEnd('\', '/')
+    if ($resolvedConfigPath.StartsWith("$repositoryRoot$([IO.Path]::DirectorySeparatorChar)", [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Operational cold-standby configuration must be copied to a host-owned path outside the repository.'
+    }
+    try { $config = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -AsHashtable } catch { throw 'Configuration is not valid JSON.' }
+    if ($config -isnot [hashtable]) { throw 'Configuration root must be a JSON object.' }
+
+    $required = @(
+        'schema_version', 'host.id', 'host.role', 'host.peer_id',
+        'health.local_url', 'health.peer_url', 'health.stable_url', 'health.oauth_discovery_url',
+        'services.exomem', 'services.cloudflared',
+        'tunnels.local_name', 'tunnels.local_id', 'tunnels.peer_name', 'tunnels.peer_id',
+        'tunnels.stable_hostname', 'tunnels.local_operational_hostname', 'tunnels.peer_operational_hostname', 'tunnels.config_path', 'tunnels.origin_service_url',
+        'cloudflare.api_token_environment', 'cloudflare.zone_id_environment',
+        'syncthing.api_url', 'syncthing.api_key_environment', 'syncthing.folder_id', 'syncthing.folder_path', 'syncthing.peer_device_id', 'syncthing.intent_relative_path',
+        'state.journal_path', 'state.intent_path', 'state.manifest_path', 'state.peer_manifest_path',
+        'identity_environment.dotenv_path', 'identity_environment.base_url', 'identity_environment.github_client_id', 'identity_environment.github_client_secret',
+        'identity_environment.github_username', 'identity_environment.github_user_id', 'identity_environment.jwt_signing_key', 'identity_environment.instance_id',
+        'operations.probe_attempts', 'operations.probe_delay_seconds', 'operations.desktop_logon_delay_seconds'
+    )
+    foreach ($field in $required) { Assert-RequiredConfig $config $field }
+
+    $configDirectory = Split-Path -Parent $resolvedConfigPath
+    foreach ($pathRef in @(
+        @{ container = $config.tunnels; field = 'config_path' },
+        @{ container = $config.state; field = 'journal_path' },
+        @{ container = $config.state; field = 'intent_path' },
+        @{ container = $config.state; field = 'manifest_path' },
+        @{ container = $config.state; field = 'peer_manifest_path' },
+        @{ container = $config.syncthing; field = 'folder_path' },
+        @{ container = $config.identity_environment; field = 'dotenv_path' }
+    )) {
+        $container = $pathRef.container
+        $field = [string]$pathRef.field
+        if (-not [IO.Path]::IsPathRooted([string]$container[$field])) { $container[$field] = [IO.Path]::GetFullPath((Join-Path $configDirectory ([string]$container[$field]))) }
+    }
+
+    if ([int]$config.schema_version -ne 1) { throw 'Configuration schema_version must be 1.' }
+    foreach ($identity in @($config.host.id, $config.host.peer_id)) {
+        if ([string]$identity -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$') { throw 'host identities must be public-safe identifiers.' }
+    }
+    if ($config.host.role -notin @('desktop', 'laptop')) { throw 'host.role must be desktop or laptop.' }
+    if ($config.host.id -eq $config.host.peer_id) { throw 'host and peer identities must be distinct.' }
+    if ($config.tunnels.local_name -eq $config.tunnels.peer_name) { throw 'local and peer tunnel names must be distinct.' }
+    if ($config.tunnels.local_id -eq $config.tunnels.peer_id) { throw 'local and peer tunnel IDs must be distinct.' }
+    foreach ($tunnelId in @($config.tunnels.local_id, $config.tunnels.peer_id)) {
+        $parsed = [guid]::Empty
+        if (-not [guid]::TryParse([string]$tunnelId, [ref]$parsed)) { throw 'tunnel IDs must be Cloudflare UUIDs.' }
+    }
+    if ($config.health.local_url -eq $config.health.peer_url) { throw 'local and peer health URLs must be distinct.' }
+    foreach ($url in @($config.health.local_url, $config.health.peer_url, $config.health.stable_url, $config.health.oauth_discovery_url, $config.syncthing.api_url, $config.tunnels.origin_service_url)) {
+        $uri = [Uri][string]$url
+        if (-not $uri.IsAbsoluteUri -or $uri.Scheme -notin @('http', 'https')) { throw "Invalid absolute HTTP(S) URL: $url" }
+    }
+    $stableUri = [Uri]$config.health.stable_url
+    $oauthUri = [Uri]$config.health.oauth_discovery_url
+    $localUri = [Uri]$config.health.local_url
+    if ($stableUri.Host -ne $config.tunnels.stable_hostname -or $oauthUri.Host -ne $config.tunnels.stable_hostname) { throw 'stable readiness, OAuth discovery, and stable hostname must share one host.' }
+    if ($localUri.Host -ne $config.tunnels.local_operational_hostname) { throw 'local readiness URL must use local_operational_hostname.' }
+    $peerUri = [Uri]$config.health.peer_url
+    if ($peerUri.Host -ne $config.tunnels.peer_operational_hostname) { throw 'peer readiness URL must use peer_operational_hostname.' }
+    if (@(@($localUri.Host, $peerUri.Host, $stableUri.Host) | Select-Object -Unique).Count -ne 3) { throw 'local, peer, and stable readiness origins must be distinct.' }
+    if ($peerUri.Scheme -ne 'https' -or $stableUri.Scheme -ne 'https' -or $oauthUri.Scheme -ne 'https') { throw 'peer, stable, and OAuth evidence URLs must use HTTPS.' }
+    if ($stableUri.AbsolutePath.TrimEnd('/') -ne '/health/ready' -or $localUri.AbsolutePath.TrimEnd('/') -ne '/health/ready' -or $peerUri.AbsolutePath.TrimEnd('/') -ne '/health/ready') { throw 'local, peer, and stable readiness URLs must end with /health/ready.' }
+    if ($oauthUri.AbsolutePath.TrimEnd('/') -ne '/.well-known/oauth-authorization-server') { throw 'OAuth discovery URL must use /.well-known/oauth-authorization-server.' }
+
+    $paths = @($config.state.journal_path, $config.state.intent_path, $config.state.manifest_path, $config.state.peer_manifest_path)
+    if (@($paths | Select-Object -Unique).Count -ne $paths.Count) { throw 'journal, intent, and manifest paths must be distinct.' }
+    if ($config.state.intent_path -match '(?i)(knowledge[ _-]*base|\\notes\\|/notes/)') { throw 'The advisory intent path must be outside Knowledge Base.' }
+    $repositoryPrefix = "$repositoryRoot$([IO.Path]::DirectorySeparatorChar)"
+    foreach ($operationalPath in @($config.tunnels.config_path, $config.state.journal_path, $config.state.intent_path, $config.state.manifest_path, $config.state.peer_manifest_path, $config.syncthing.folder_path)) {
+        if ([IO.Path]::GetFullPath([string]$operationalPath).StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) { throw 'Tunnel, Syncthing, journal, intent, and manifest paths must remain outside the repository.' }
+    }
+    $syncRoot = [IO.Path]::GetFullPath([string]$config.syncthing.folder_path).TrimEnd('\', '/')
+    $syncPrefix = "$syncRoot$([IO.Path]::DirectorySeparatorChar)"
+    foreach ($replicatedPath in @($config.state.intent_path, $config.state.manifest_path, $config.state.peer_manifest_path)) {
+        if (-not [IO.Path]::GetFullPath([string]$replicatedPath).StartsWith($syncPrefix, [StringComparison]::OrdinalIgnoreCase)) { throw 'Intent and both identity manifests must be inside the configured Syncthing folder.' }
+    }
+    if ([IO.Path]::GetFullPath([string]$config.state.journal_path).StartsWith($syncPrefix, [StringComparison]::OrdinalIgnoreCase)) { throw 'The local operation journal must remain outside the Syncthing folder.' }
+    $expectedIntentPath = [IO.Path]::GetFullPath((Join-Path $syncRoot ([string]$config.syncthing.intent_relative_path).Replace('/', [IO.Path]::DirectorySeparatorChar)))
+    if ($expectedIntentPath -ne [IO.Path]::GetFullPath([string]$config.state.intent_path)) { throw 'state.intent_path must match syncthing.folder_path plus syncthing.intent_relative_path.' }
+    if ([int]$config.operations.probe_attempts -lt 2 -or [int]$config.operations.probe_attempts -gt 10) { throw 'operations.probe_attempts must be between 2 and 10.' }
+    if ([int]$config.operations.probe_delay_seconds -lt 0 -or [int]$config.operations.probe_delay_seconds -gt 30) { throw 'operations.probe_delay_seconds must be between 0 and 30.' }
+    if ([int]$config.operations.desktop_logon_delay_seconds -lt 10 -or [int]$config.operations.desktop_logon_delay_seconds -gt 600) { throw 'operations.desktop_logon_delay_seconds must be between 10 and 600.' }
+    return $config
+}
+
+function Read-DotenvMap {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "Effective service environment file was not found: $Path" }
+    $values = @{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -notmatch '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') { continue }
+        $name = $Matches[1]
+        $value = $Matches[2].Trim()
+        if ($value.Length -ge 2 -and (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'")))) { $value = $value.Substring(1, $value.Length - 2) }
+        $values[$name] = $value
+    }
+    return $values
+}
+
+function Get-IdentityContract {
+    param([hashtable]$Config, [hashtable]$Adapter, [switch]$AllowUnavailable)
+    $names = $Config.identity_environment
+    $raw = @{}
+    $missing = [System.Collections.Generic.List[string]]::new()
+    try { $dotenv = Read-DotenvMap ([string]$names.dotenv_path) } catch {
+        if ($AllowUnavailable) { return @{ state = 'unavailable'; missing = @('dotenv_path'); manifest = $null; expected_base_url = $null } }
+        throw
+    }
+    try { $serviceEnvironment = Invoke-Adapter $Adapter 'GetServiceEnvironment' @($Config.services.exomem) } catch { $serviceEnvironment = @{ state = 'unknown'; values = @{} } }
+    if ($serviceEnvironment.state -ne 'known' -or $serviceEnvironment.values -isnot [hashtable]) {
+        if ($AllowUnavailable) { return @{ state = 'unavailable'; missing = @('service_environment'); manifest = $null; expected_base_url = $null } }
+        throw 'The effective NSSM AppEnvironmentExtra could not be read.'
+    }
+    $drift = [System.Collections.Generic.List[string]]::new()
+    foreach ($name in @('base_url', 'github_client_id', 'github_client_secret', 'github_username', 'github_user_id', 'jwt_signing_key', 'instance_id')) {
+        $environmentName = [string]$names[$name]
+        $dotenvValue = if ($dotenv.ContainsKey($environmentName)) { [string]$dotenv[$environmentName] } else { $null }
+        $value = if ($serviceEnvironment.values.ContainsKey($environmentName)) { [string]$serviceEnvironment.values[$environmentName] } else { $null }
+        if ($dotenvValue -ne $value) { $drift.Add($name) }
+        if ([string]::IsNullOrWhiteSpace($value)) { $missing.Add($name) } else { $raw[$name] = $value.Trim() }
+    }
+    if ($missing.Count) {
+        if ($AllowUnavailable) { return @{ state = 'unavailable'; missing = @($missing); manifest = $null; expected_base_url = $null } }
+        throw "Effective identity configuration is unavailable for: $($missing -join ', ')."
+    }
+    if ($drift.Count) {
+        if ($AllowUnavailable) { return @{ state = 'drift'; missing = @($drift); manifest = $null; expected_base_url = $null } }
+        throw "NSSM AppEnvironmentExtra differs from the configured dotenv for: $($drift -join ', '). Rerun install-service.ps1, then Configure."
+    }
+    if ($raw.instance_id -ne $Config.host.id) {
+        if ($AllowUnavailable) { return @{ state = 'drift'; missing = @('instance_id'); manifest = $null; expected_base_url = $null } }
+        throw 'Effective EXOMEM_INSTANCE_ID does not match configured host.id.'
+    }
+    try { $baseUrl = ConvertTo-NormalizedOrigin $raw.base_url } catch {
+        if ($AllowUnavailable) { return @{ state = 'drift'; missing = @('base_url'); manifest = $null; expected_base_url = $null } }
+        throw
+    }
+    if ($baseUrl -ne (Get-UrlOrigin $Config.health.stable_url)) {
+        if ($AllowUnavailable) { return @{ state = 'drift'; missing = @('base_url'); manifest = $null; expected_base_url = $null } }
+        throw 'Effective EXOMEM_BASE_URL must equal the stable readiness origin.'
+    }
+    $callback = "$baseUrl/auth/callback"
+    $manifest = @{
+        schema_version = 1
+        host_id = $Config.host.id
+        fingerprints = @{
+            stable_base_url = Get-Sha256 $baseUrl
+            github_oauth_client_id = Get-Sha256 $raw.github_client_id
+            github_oauth_client_secret = Get-Sha256 $raw.github_client_secret
+            github_oauth_callback = Get-Sha256 $callback
+            allowed_github_username = Get-Sha256 $raw.github_username.ToLowerInvariant()
+            allowed_github_user_id = Get-Sha256 $raw.github_user_id
+            jwt_signing_key = Get-Sha256 $raw.jwt_signing_key
+        }
+    }
+    @{ state = 'available'; manifest = $manifest; expected_base_url = $baseUrl }
+}
+
+function Read-JsonEvidence {
+    param([hashtable]$Adapter, [string]$Path)
+    try {
+        $value = Invoke-Adapter $Adapter 'ReadJson' @($Path)
+        if ($null -eq $value) { return @{ state = 'absent'; value = $null } }
+        if ($value -isnot [hashtable]) { return @{ state = 'invalid'; value = $null } }
+        return @{ state = 'present'; value = $value }
+    } catch { return @{ state = 'unknown'; value = $null } }
+}
+
+function Test-Intent {
+    param([hashtable]$IntentEvidence, [hashtable]$Config)
+    if ($IntentEvidence.state -ne 'present') { return $IntentEvidence.state }
+    $intent = $IntentEvidence.value
+    if (-not $intent.ContainsKey('desired_host') -or $intent.desired_host -notin @($Config.host.id, $Config.host.peer_id)) { return 'invalid' }
+    $generation = [int64]0
+    if (-not $intent.ContainsKey('generation') -or -not [int64]::TryParse([string]$intent.generation, [ref]$generation) -or $generation -lt 1) { return 'invalid' }
+    return 'present'
+}
+
+function Get-ManifestMismatchReasons {
+    param([hashtable]$Identity, [hashtable]$LocalEvidence, [hashtable]$PeerEvidence, [hashtable]$Config)
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($Identity.state -ne 'available') { $reasons.Add('effective shared configuration is unavailable'); return @($reasons) }
+    foreach ($entry in @(@{ label = 'local'; evidence = $LocalEvidence }, @{ label = 'peer'; evidence = $PeerEvidence })) {
+        $schemaVersion = [int]0
+        $validSchema = $entry.evidence.state -eq 'present' -and [int]::TryParse([string](Get-OptionalValue $entry.evidence.value 'schema_version' 0), [ref]$schemaVersion) -and $schemaVersion -eq 1
+        if ($entry.evidence.state -ne 'present' -or
+            -not $validSchema -or
+            -not $entry.evidence.value.ContainsKey('fingerprints') -or
+            $entry.evidence.value.fingerprints -isnot [hashtable]) {
+            $reasons.Add("shared configuration $($entry.label) manifest is unavailable")
+            continue
+        }
+        $expectedHost = if ($entry.label -eq 'local') { $Config.host.id } else { $Config.host.peer_id }
+        if ((Get-OptionalValue $entry.evidence.value 'host_id') -ne $expectedHost) {
+            $reasons.Add("shared configuration $($entry.label) manifest identifies the wrong host")
+        }
+        foreach ($field in @('stable_base_url', 'github_oauth_client_id', 'github_oauth_client_secret', 'github_oauth_callback', 'allowed_github_username', 'allowed_github_user_id', 'jwt_signing_key')) {
+            $actual = Get-OptionalValue $entry.evidence.value.fingerprints $field
+            $expected = $Identity.manifest.fingerprints[$field]
+            if ($actual -ne $expected) { $reasons.Add("shared configuration fingerprint mismatch: $field") }
+        }
+    }
+    @($reasons | Select-Object -Unique)
+}
+
+function Invoke-BoundedProbe {
+    param([hashtable]$Adapter, [string]$Url, [int]$Attempts, [int]$DelaySeconds)
+    $results = [System.Collections.Generic.List[hashtable]]::new()
+    for ($index = 0; $index -lt $Attempts; $index++) {
+        try {
+            $result = Invoke-Adapter $Adapter 'Probe' @($Url)
+            if ($result -isnot [hashtable] -or -not $result.ContainsKey('state')) { $result = @{ state = 'unknown' } }
+        } catch { $result = @{ state = 'unknown' } }
+        $results.Add($result)
+        if ($index -lt ($Attempts - 1) -and $DelaySeconds -gt 0) { Invoke-Adapter $Adapter 'Sleep' @($DelaySeconds) | Out-Null }
+    }
+    $states = @($results | ForEach-Object { [string]$_.state } | Select-Object -Unique)
+    $summary = @{
+        state = if ($states.Count -eq 1) { $states[0] } else { 'ambiguous' }
+        samples = $Attempts
+        observed_ready = ('ready' -in $states)
+        observed_inactive = ('inactive' -in $states)
+        observed_unserved = ('unserved' -in $states)
+    }
+    $last = $results[$results.Count - 1]
+    foreach ($field in @('instance_id', 'status_code')) { if ($last.ContainsKey($field)) { $summary[$field] = $last[$field] } }
+    return $summary
+}
+
+function Get-Evidence {
+    param([hashtable]$Config, [hashtable]$Adapter)
+    $attempts = [int]$Config.operations.probe_attempts
+    $delay = [int]$Config.operations.probe_delay_seconds
+    try { $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem) } catch { $service = @{ state = 'unknown' } }
+    try { $sync = Invoke-Adapter $Adapter 'GetSyncthing' @($Config.syncthing) } catch { $sync = @{ api = 'unavailable' } }
+    try { $localTunnel = Invoke-Adapter $Adapter 'GetTunnel' @($Config.tunnels.local_name) } catch { $localTunnel = @{ state = 'unknown' } }
+    try { $peerTunnel = Invoke-Adapter $Adapter 'GetTunnel' @($Config.tunnels.peer_name) } catch { $peerTunnel = @{ state = 'unknown' } }
+    try { $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels) } catch { $route = @{ state = 'unknown'; tunnel_id = $null; target = $null } }
+    try { $oauth = Invoke-Adapter $Adapter 'ProbeOAuth' @($Config.health.oauth_discovery_url) } catch { $oauth = @{ state = 'unknown' } }
+    $identity = Get-IdentityContract $Config $Adapter -AllowUnavailable
+    $intent = Read-JsonEvidence $Adapter $Config.state.intent_path
+    $intent.state = Test-Intent $intent $Config
+    $journal = Read-JsonEvidence $Adapter $Config.state.journal_path
+    $localManifest = Read-JsonEvidence $Adapter $Config.state.manifest_path
+    $peerManifest = Read-JsonEvidence $Adapter $Config.state.peer_manifest_path
+    @{
+        service = $service
+        local_health = Invoke-BoundedProbe $Adapter $Config.health.local_url $attempts $delay
+        peer_health = Invoke-BoundedProbe $Adapter $Config.health.peer_url $attempts $delay
+        stable_health = Invoke-BoundedProbe $Adapter $Config.health.stable_url $attempts $delay
+        stable_oauth = $oauth
+        syncthing = $sync
+        local_tunnel = $localTunnel
+        peer_tunnel = $peerTunnel
+        route = $route
+        intent = $intent
+        journal = $journal
+        identity = $identity
+        local_manifest = $localManifest
+        peer_manifest = $peerManifest
+    }
+}
+
+function Test-SyncthingConverged {
+    param([hashtable]$Sync)
+    return (Get-OptionalValue $Sync 'api') -eq 'reachable' -and
+        (Get-OptionalValue $Sync 'folder_state') -eq 'idle' -and
+        [int64](Get-OptionalValue $Sync 'pending_items' -1) -eq 0 -and
+        [int64](Get-OptionalValue $Sync 'pending_bytes' -1) -eq 0 -and
+        [bool](Get-OptionalValue $Sync 'peer_complete' $false) -and
+        [double](Get-OptionalValue $Sync 'peer_completion' -1) -ge 100
+}
+
+function Get-StatusReasons {
+    param([hashtable]$Evidence, [hashtable]$Config)
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($Evidence.local_health.observed_ready -and $Evidence.peer_health.observed_ready) { $reasons.Add('both origins report ready') }
+    foreach ($probe in @(@{ name = 'local'; value = $Evidence.local_health }, @{ name = 'peer'; value = $Evidence.peer_health }, @{ name = 'stable endpoint'; value = $Evidence.stable_health })) {
+        if ($probe.value.state -in @('unknown', 'unreachable', 'ambiguous')) { $reasons.Add("$($probe.name) health is unknown") }
+    }
+    if ($Evidence.local_health.state -eq 'unserved' -and $Evidence.local_tunnel.state -ne 'connected') { $reasons.Add('local origin is unserved but tunnel state is not connected') }
+    if ($Evidence.peer_health.state -eq 'unserved' -and $Evidence.peer_tunnel.state -ne 'connected') { $reasons.Add('peer origin is unserved but tunnel state is not connected') }
+    if ($Evidence.stable_health.state -eq 'unserved' -and $Evidence.route.state -ne 'known') { $reasons.Add('stable endpoint is unserved and its route is unknown') }
+    if ((Get-OptionalValue $Evidence.syncthing 'api') -ne 'reachable') { $reasons.Add('Syncthing status is unknown') }
+    elseif (-not (Test-SyncthingConverged $Evidence.syncthing)) { $reasons.Add('Syncthing is not converged') }
+    if ($Evidence.local_tunnel.state -notin @('connected', 'disconnected')) { $reasons.Add('local tunnel state is unknown') }
+    if ($Evidence.peer_tunnel.state -notin @('connected', 'disconnected')) { $reasons.Add('peer tunnel state is unknown') }
+    if ($Evidence.route.state -ne 'known') { $reasons.Add('stable DNS route is unknown') }
+    if ($Evidence.intent.state -in @('unknown', 'invalid')) { $reasons.Add('desired-host intent is unknown') }
+    foreach ($reason in @(Get-ManifestMismatchReasons $Evidence.identity $Evidence.local_manifest $Evidence.peer_manifest $Config)) { $reasons.Add([string]$reason) }
+    @($reasons | Select-Object -Unique)
+}
+
+function Get-ActivationReasons {
+    param([hashtable]$Evidence, [hashtable]$Config, [switch]$GuardedBoot)
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($Evidence.service.state -ne 'stopped') { $reasons.Add('local Exomem service is not conclusively stopped') }
+    if ($Evidence.local_health.state -eq 'ready') { $reasons.Add('local origin is unexpectedly ready before activation') }
+    if ($Evidence.local_health.state -in @('unknown', 'ambiguous')) { $reasons.Add('local pre-activation health is unknown') }
+    if ($Evidence.local_tunnel.state -ne 'connected') { $reasons.Add('local named tunnel is not connected') }
+    if ((Get-OptionalValue $Evidence.syncthing 'api') -ne 'reachable') { $reasons.Add('Syncthing API is unavailable') }
+    elseif (-not (Test-SyncthingConverged $Evidence.syncthing)) { $reasons.Add('Syncthing is not converged') }
+    $plannedPeerUnserved = $Evidence.peer_health.state -eq 'unserved' -and $Evidence.peer_tunnel.state -eq 'connected'
+    if ($Evidence.peer_health.observed_ready) { $reasons.Add('peer is ready') }
+    elseif ($Evidence.peer_health.state -ne 'inactive' -and -not $plannedPeerUnserved) { $reasons.Add('peer inactivity is unproven') }
+    if ($Evidence.stable_health.observed_ready) { $reasons.Add('stable endpoint is already ready') }
+    else {
+        $routeIsConnected = ((Test-ExpectedRoute $Evidence.route $Config.tunnels.local_id) -and $Evidence.local_tunnel.state -eq 'connected') -or
+            ((Test-ExpectedRoute $Evidence.route $Config.tunnels.peer_id) -and $Evidence.peer_tunnel.state -eq 'connected')
+        $plannedStableUnserved = $Evidence.stable_health.state -eq 'unserved' -and $routeIsConnected
+        if ($Evidence.stable_health.state -ne 'inactive' -and -not $plannedStableUnserved) { $reasons.Add('stable endpoint state is ambiguous') }
+    }
+    if ($Evidence.intent.state -in @('unknown', 'invalid')) { $reasons.Add('desired-host intent is unavailable or invalid') }
+    elseif ($Evidence.intent.state -eq 'present' -and $Evidence.intent.value.desired_host -eq $Config.host.peer_id) { $reasons.Add('desired-host intent names peer') }
+    foreach ($reason in @(Get-ManifestMismatchReasons $Evidence.identity $Evidence.local_manifest $Evidence.peer_manifest $Config)) { $reasons.Add([string]$reason) }
+    if ($GuardedBoot) {
+        if ($Config.host.role -ne 'desktop') { $reasons.Add('activate-if-unserved is desktop-only') }
+        if ($Evidence.intent.state -ne 'present' -or $Evidence.intent.value.desired_host -ne $Config.host.id) { $reasons.Add('activate-if-unserved requires intent naming desktop') }
+    }
+    @($reasons | Select-Object -Unique)
+}
+
+function Get-HandoffReasons {
+    param([hashtable]$Evidence, [hashtable]$Config)
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($Evidence.service.state -ne 'running') { $reasons.Add('source service is not running') }
+    if ($Evidence.local_health.state -ne 'ready' -or (Get-OptionalValue $Evidence.local_health 'instance_id') -ne $Config.host.id) { $reasons.Add('source runtime readiness is not proven') }
+    $targetInactive = -not $Evidence.peer_health.observed_ready -and ($Evidence.peer_health.state -eq 'inactive' -or ($Evidence.peer_health.state -eq 'unserved' -and $Evidence.peer_tunnel.state -eq 'connected'))
+    if (-not $targetInactive) { $reasons.Add('target inactivity is not proven') }
+    if ($Evidence.stable_health.state -ne 'ready' -or (Get-OptionalValue $Evidence.stable_health 'instance_id') -ne $Config.host.id) { $reasons.Add('stable endpoint does not identify the source host') }
+    if ($Evidence.route.state -ne 'known' -or $Evidence.route.tunnel_id -ne $Config.tunnels.local_id) { $reasons.Add('stable route does not select the source tunnel') }
+    if ($Evidence.local_tunnel.state -ne 'connected' -or $Evidence.peer_tunnel.state -ne 'connected') { $reasons.Add('both named tunnels must be connected') }
+    if ((Get-OptionalValue $Evidence.syncthing 'api') -ne 'reachable' -or -not (Test-SyncthingConverged $Evidence.syncthing)) { $reasons.Add('source and peer replication completion are required') }
+    if ($Evidence.intent.state -in @('unknown', 'invalid')) { $reasons.Add('desired-host intent is unavailable or invalid') }
+    elseif ($Evidence.intent.state -eq 'present' -and $Evidence.intent.value.desired_host -ne $Config.host.id) { $reasons.Add('desired-host intent must name the active source') }
+    foreach ($reason in @(Get-ManifestMismatchReasons $Evidence.identity $Evidence.local_manifest $Evidence.peer_manifest $Config)) { $reasons.Add([string]$reason) }
+    if ($Evidence.identity.state -eq 'available') {
+        $oauthIssuer = Get-OptionalValue $Evidence.stable_oauth 'issuer'
+        if ($Evidence.stable_oauth.state -ne 'ready' -or [string]::IsNullOrWhiteSpace([string]$oauthIssuer) -or (ConvertTo-NormalizedOrigin ([string]$oauthIssuer)) -ne $Evidence.identity.expected_base_url) { $reasons.Add('stable OAuth discovery does not match the shared base URL') }
+    }
+    @($reasons | Select-Object -Unique)
+}
+
+function Write-OperationJson {
+    param([hashtable]$Adapter, [string]$Path, [hashtable]$Value)
+    Invoke-Adapter $Adapter 'WriteJson' @($Path, $Value) | Out-Null
+}
+
+function Get-NextGeneration {
+    param([hashtable]$Adapter, [hashtable]$IntentEvidence)
+    $now = [int64](Invoke-Adapter $Adapter 'Now')
+    $previous = if ($IntentEvidence.state -eq 'present') { [int64]$IntentEvidence.value.generation } else { 0 }
+    [Math]::Max([int64]($previous + 1), [int64]$now)
+}
+
+function Get-TunnelPolicy {
+    param([hashtable]$Config)
+    @{
+        config_path = $Config.tunnels.config_path
+        stable_hostname = $Config.tunnels.stable_hostname
+        operational_hostname = $Config.tunnels.local_operational_hostname
+        origin_service_url = $Config.tunnels.origin_service_url
+        local_name = $Config.tunnels.local_name
+        local_id = $Config.tunnels.local_id
+        stable = 'forward-all'
+        direct = @('/health', '/health/ready')
+        direct_fallback = 'http_status:404'
+    }
+}
+
+function Test-ExpectedRoute {
+    param([hashtable]$Route, [string]$TunnelId)
+    if ($Route.state -ne 'known' -or $Route.tunnel_id -ne $TunnelId) { return $false }
+    $target = ([string](Get-OptionalValue $Route 'target' '')).TrimEnd('.').ToLowerInvariant()
+    return $target -eq "$($TunnelId.ToLowerInvariant()).cfargotunnel.com"
+}
+
+function Test-PublicHost {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Identity, [string]$ExpectedHost)
+    $readiness = Invoke-BoundedProbe $Adapter $Config.health.stable_url ([int]$Config.operations.probe_attempts) ([int]$Config.operations.probe_delay_seconds)
+    try { $oauth = Invoke-Adapter $Adapter 'ProbeOAuth' @($Config.health.oauth_discovery_url) } catch { $oauth = @{ state = 'unknown' } }
+    $oauthMatches = $false
+    if ($oauth.state -eq 'ready' -and $oauth.ContainsKey('issuer')) {
+        try { $oauthMatches = (ConvertTo-NormalizedOrigin ([string]$oauth.issuer)) -eq $Identity.expected_base_url } catch { $oauthMatches = $false }
+    }
+    @{
+        ready = ($readiness.state -eq 'ready' -and (Get-OptionalValue $readiness 'instance_id') -eq $ExpectedHost -and $oauthMatches)
+        readiness = $readiness
+        oauth = @{ state = $oauth.state; issuer_matches = $oauthMatches }
+    }
+}
+
+function Confirm-ExactIntentDelivery {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Journal)
+    $intent = Read-JsonEvidence $Adapter $Config.state.intent_path
+    $intent.state = Test-Intent $intent $Config
+    if ($intent.state -ne 'present' -or [int64]$intent.value.generation -ne [int64]$Journal.generation -or $intent.value.desired_host -ne $Journal.desired_host) {
+        return @{ delivered = $false; reason = 'the current desired-host marker does not match the journaled handoff' }
+    }
+    try { $marker = Invoke-Adapter $Adapter 'GetMarkerVersion' @($Config.state.intent_path) } catch { return @{ delivered = $false; reason = 'the current desired-host marker could not be versioned' } }
+    if ([int64]$marker.generation -ne [int64]$Journal.generation -or [string]::IsNullOrWhiteSpace([string]$marker.version)) {
+        return @{ delivered = $false; reason = 'the current desired-host marker version does not match its generation' }
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string](Get-OptionalValue $Journal 'marker_version')) -and $Journal.marker_version -ne $marker.version) {
+        return @{ delivered = $false; reason = 'the current desired-host marker was replaced after the operation was journaled' }
+    }
+    $Journal.marker_version = $marker.version
+    $delivery = $null
+    for ($index = 0; $index -lt [int]$Config.operations.probe_attempts; $index++) {
+        try { $delivery = Invoke-Adapter $Adapter 'GetIntentDelivery' @($Config.syncthing, [int64]$Journal.generation, $Config.state.intent_path) } catch { $delivery = @{ state = 'unknown'; generation = $null; marker_version = $null } }
+        if ($delivery.state -eq 'delivered' -and [int64]$delivery.generation -eq [int64]$Journal.generation -and $delivery.marker_version -eq $marker.version) { break }
+        if ($index -lt ([int]$Config.operations.probe_attempts - 1) -and [int]$Config.operations.probe_delay_seconds -gt 0) { Invoke-Adapter $Adapter 'Sleep' @([int]$Config.operations.probe_delay_seconds) | Out-Null }
+    }
+    if ($delivery.state -ne 'delivered' -or [int64]$delivery.generation -ne [int64]$Journal.generation -or $delivery.marker_version -ne $marker.version) {
+        return @{ delivered = $false; reason = 'the target did not prove receipt of the exact new desired-host generation' }
+    }
+    if ($delivery.ContainsKey('syncthing_version')) { $Journal.syncthing_version = $delivery.syncthing_version }
+    return @{ delivered = $true; reason = $null }
+}
+
+function Save-Journal {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Journal)
+    $Journal.schema_version = 1
+    Write-OperationJson $Adapter $Config.state.journal_path $Journal
+}
+
+function Invoke-ActivationCompensation {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Journal, [string]$Failure)
+    $restored = $false
+    if (-not [string]::IsNullOrWhiteSpace([string]$Journal.previous_route)) {
+        try {
+            $restoredRoute = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+            if (-not (Test-ExpectedRoute $restoredRoute ([string]$Journal.previous_route))) {
+                Invoke-Adapter $Adapter 'SetRoute' @([string]$Journal.previous_route, $Config.tunnels.stable_hostname) | Out-Null
+                $restoredRoute = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+            }
+            $restored = Test-ExpectedRoute $restoredRoute ([string]$Journal.previous_route)
+        } catch { $restored = $false }
+    }
+    if ([bool](Get-OptionalValue $Journal 'started_service' $false)) {
+        try {
+            $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+            if ($service.state -eq 'running') { Invoke-Adapter $Adapter 'StopService' @($Config.services.exomem) | Out-Null }
+            $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+            if ($service.state -ne 'stopped') { $restored = $false }
+        } catch { $restored = $false }
+    }
+    $terminal = if ($restored) { 'rolled_back' } else { 'operator_recovery_required' }
+    $Journal.phase = 'terminal'
+    $Journal.terminal = $terminal
+    $Journal.failure = $Failure
+    Save-Journal $Adapter $Config $Journal
+    Write-Terminal @{
+        terminal = $terminal
+        reasons = @($Failure)
+        next_action = if ($restored) { 'verify the previous host before retrying' } else { 'keep both services stopped; inspect DNS target and both direct readiness endpoints' }
+        bypassed_guards = @((Get-OptionalValue $Journal 'bypassed_guards' @()))
+    } 2
+}
+
+function Invoke-ActivationReplay {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Evidence)
+    if ($Evidence.journal.state -ne 'present') { return }
+    $journal = $Evidence.journal.value
+    if ($journal.action -ne 'Activate' -or $journal.desired_host -ne $Config.host.id) { return }
+    if ($journal.terminal -eq 'activated') {
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        $public = Test-PublicHost $Adapter $Config $Evidence.identity $Config.host.id
+        if ((Test-ExpectedRoute $route $Config.tunnels.local_id) -and $public.ready) {
+            Write-Terminal @{ terminal = 'already_activated'; route_target = $route.target; next_action = 'none: local host is already serving'; bypassed_guards = @($journal.bypassed_guards) }
+        }
+        return
+    }
+    if ($journal.phase -in @('intent_written', 'starting_service', 'service_started', 'routing', 'route_changed', 'public_verified')) {
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        if (Test-ExpectedRoute $route $Config.tunnels.local_id) {
+            if ([string]::IsNullOrWhiteSpace([string]$journal.previous_route)) { Invoke-ActivationCompensation $Adapter $Config $journal 'interrupted activation has no known previous route' }
+            $public = Test-PublicHost $Adapter $Config $Evidence.identity $Config.host.id
+            if ($public.ready) {
+                $journal.phase = 'terminal'
+                $journal.terminal = 'activated'
+                Save-Journal $Adapter $Config $journal
+                Write-Terminal @{ terminal = 'recovered_activation'; route_target = $route.target; next_action = 'none: interrupted activation was verified and committed'; bypassed_guards = @((Get-OptionalValue $journal 'bypassed_guards' @())) }
+            }
+            Invoke-ActivationCompensation $Adapter $Config $journal 'interrupted activation route points local but public identity is not proven'
+        }
+        if (-not [string]::IsNullOrWhiteSpace([string]$journal.previous_route) -and (Test-ExpectedRoute $route ([string]$journal.previous_route))) {
+            $journal.started_service = $true
+            Invoke-ActivationCompensation $Adapter $Config $journal 'interrupted activation was observed before route movement'
+        }
+        Invoke-ActivationCompensation $Adapter $Config $journal 'interrupted activation route state is unknown or inconsistent'
+    }
+    return
+}
+
+function Invoke-HandoffCompensation {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Journal, [string]$Failure)
+    $attempts = [int]$Config.operations.probe_attempts
+    $delay = [int]$Config.operations.probe_delay_seconds
+    $target = Invoke-BoundedProbe $Adapter $Config.health.peer_url $attempts $delay
+    try { $targetTunnel = Invoke-Adapter $Adapter 'GetTunnel' @($Config.tunnels.peer_name) } catch { $targetTunnel = @{ state = 'unknown' } }
+    $targetInactive = -not $target.observed_ready -and ($target.state -eq 'inactive' -or ($target.state -eq 'unserved' -and $targetTunnel.state -eq 'connected'))
+    if (-not $targetInactive) {
+        $Journal.phase = 'terminal'
+        $Journal.terminal = 'operator_recovery_required'
+        $Journal.failure = $Failure
+        Save-Journal $Adapter $Config $Journal
+        Write-Terminal @{
+            terminal = 'operator_recovery_required'
+            reasons = @($Failure, 'target inactivity is not conclusively proven; source remains stopped')
+            next_action = 'do not start the source; determine which host is active and inspect the stable route'
+        } 2
+    }
+
+    # Cancel the target's replicated activation permission before restarting the
+    # source. Without this second delivered generation, a target-local guard could
+    # race compensation and start while the source is coming back.
+    $cancelGeneration = [Math]::Max([int64]$Journal.generation + 1, [int64](Invoke-Adapter $Adapter 'Now'))
+    $cancelIntent = @{ schema_version = 1; desired_host = $Config.host.id; generation = $cancelGeneration; advisory = $true }
+    Write-OperationJson $Adapter $Config.state.intent_path $cancelIntent
+    $cancelMarker = Invoke-Adapter $Adapter 'GetMarkerVersion' @($Config.state.intent_path)
+    $Journal.phase = 'compensation_intent_written'
+    $Journal.generation = $cancelGeneration
+    $Journal.desired_host = $Config.host.id
+    $Journal.marker_version = $cancelMarker.version
+    Save-Journal $Adapter $Config $Journal
+    $cancelDelivery = $null
+    for ($index = 0; $index -lt $attempts; $index++) {
+        try { $cancelDelivery = Invoke-Adapter $Adapter 'GetIntentDelivery' @($Config.syncthing, $cancelGeneration, $Config.state.intent_path) } catch { $cancelDelivery = @{ state = 'unknown'; generation = $null; marker_version = $null } }
+        if ($cancelDelivery.state -eq 'delivered' -and [int64]$cancelDelivery.generation -eq $cancelGeneration -and $cancelDelivery.marker_version -eq $cancelMarker.version) { break }
+        if ($index -lt ($attempts - 1) -and $delay -gt 0) { Invoke-Adapter $Adapter 'Sleep' @($delay) | Out-Null }
+    }
+    if ($cancelDelivery.state -ne 'delivered' -or [int64]$cancelDelivery.generation -ne $cancelGeneration -or $cancelDelivery.marker_version -ne $cancelMarker.version) {
+        $Journal.phase = 'terminal'; $Journal.terminal = 'operator_recovery_required'; $Journal.failure = $Failure; Save-Journal $Adapter $Config $Journal
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @($Failure, 'source restart cancellation intent did not reach the target'); next_action = 'keep the source stopped; establish the desired host and exact generation on both machines' } 2
+    }
+    $target = Invoke-BoundedProbe $Adapter $Config.health.peer_url $attempts $delay
+    try { $targetTunnel = Invoke-Adapter $Adapter 'GetTunnel' @($Config.tunnels.peer_name) } catch { $targetTunnel = @{ state = 'unknown' } }
+    $targetInactive = -not $target.observed_ready -and ($target.state -eq 'inactive' -or ($target.state -eq 'unserved' -and $targetTunnel.state -eq 'connected'))
+    if (-not $targetInactive) {
+        $Journal.phase = 'terminal'; $Journal.terminal = 'operator_recovery_required'; $Journal.failure = $Failure; Save-Journal $Adapter $Config $Journal
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @($Failure, 'target became active or ambiguous after cancellation delivery'); next_action = 'keep the source stopped and determine which host is serving' } 2
+    }
+
+    $restored = $false
+    $sourceStarted = $false
+    try {
+        Invoke-Adapter $Adapter 'SetRoute' @([string]$Journal.previous_route, $Config.tunnels.stable_hostname) | Out-Null
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        if (Test-ExpectedRoute $route ([string]$Journal.previous_route)) {
+            Invoke-Adapter $Adapter 'StartService' @($Config.services.exomem) | Out-Null
+            $sourceStarted = $true
+            $local = Invoke-BoundedProbe $Adapter $Config.health.local_url $attempts $delay
+            if ($local.state -eq 'ready' -and (Get-OptionalValue $local 'instance_id') -eq $Config.host.id) {
+                $public = Test-PublicHost $Adapter $Config $Journal.identity $Config.host.id
+                $restored = $public.ready
+            }
+        }
+    } catch { $restored = $false }
+    if ($sourceStarted -and -not $restored) {
+        try { Invoke-Adapter $Adapter 'StopService' @($Config.services.exomem) | Out-Null } catch {}
+    }
+    $Journal.phase = 'terminal'
+    $Journal.terminal = if ($restored) { 'rolled_back' } else { 'operator_recovery_required' }
+    $Journal.failure = $Failure
+    Save-Journal $Adapter $Config $Journal
+    Write-Terminal @{
+        terminal = $Journal.terminal
+        reasons = @($Failure)
+        next_action = if ($restored) { 'source was restored and verified; inspect intent before retrying' } else { 'keep the peer stopped; inspect route, source readiness, and journal before recovery' }
+    } 2
+}
+
+function Invoke-HandoffTransition {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Journal)
+    $public = @{ state = 'unknown' }
+    try {
+        $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+        if ($service.state -eq 'running') {
+            $Journal.phase = 'stopping_source'
+            Save-Journal $Adapter $Config $Journal
+            Invoke-Adapter $Adapter 'StopService' @($Config.services.exomem) | Out-Null
+        } elseif ($service.state -ne 'stopped') {
+            throw 'source service state is unknown during handoff replay'
+        }
+        $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+        if ($service.state -ne 'stopped') { throw 'source service did not stop conclusively' }
+        $Journal.phase = 'source_stopped'
+        Save-Journal $Adapter $Config $Journal
+
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        if (-not (Test-ExpectedRoute $route $Config.tunnels.peer_id)) {
+            $Journal.phase = 'routing'
+            Save-Journal $Adapter $Config $Journal
+            Invoke-Adapter $Adapter 'SetRoute' @($Config.tunnels.peer_name, $Config.tunnels.stable_hostname) | Out-Null
+        }
+        $Journal.phase = 'route_changed'
+        Save-Journal $Adapter $Config $Journal
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        if (-not (Test-ExpectedRoute $route $Config.tunnels.peer_id)) { throw 'Cloudflare DNS does not target the configured target tunnel ID' }
+        $public = Invoke-BoundedProbe $Adapter $Config.health.stable_url ([int]$Config.operations.probe_attempts) ([int]$Config.operations.probe_delay_seconds)
+        if ($public.state -eq 'ready' -and (Get-OptionalValue $public 'instance_id') -ne $Config.host.peer_id) { throw 'public readiness still identifies the previous source after route movement' }
+        if ($public.state -in @('ambiguous', 'unknown')) { throw 'public route state is ambiguous after handoff' }
+    } catch { Invoke-HandoffCompensation $Adapter $Config $Journal $_.Exception.Message }
+    $Journal.phase = 'terminal'
+    $Journal.terminal = if ($public.state -eq 'ready' -and (Get-OptionalValue $public 'instance_id') -eq $Config.host.peer_id) { 'handoff_complete' } else { 'handoff_pending_activation' }
+    $Journal.Remove('identity')
+    Save-Journal $Adapter $Config $Journal
+    Write-Terminal @{
+        terminal = $Journal.terminal
+        outage = if ($Journal.terminal -eq 'handoff_pending_activation') { 'bounded until target-local guarded Activate succeeds' } else { 'target already verified ready' }
+        next_action = 'activate the target locally; this command never starts a remote service'
+    }
+}
+
+function Invoke-HandoffReplay {
+    param([hashtable]$Adapter, [hashtable]$Config, [hashtable]$Evidence)
+    if ($Evidence.journal.state -ne 'present') { return }
+    $journal = $Evidence.journal.value
+    if ($journal.action -ne 'Handoff') { return }
+    if ($journal.desired_host -ne $Config.host.peer_id -and $journal.terminal -notin @('rolled_back')) {
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @('handoff journal target does not match this host peer'); next_action = 'keep both services stopped until intent and journal ownership are reconciled' } 2
+    }
+    if ($journal.terminal -in @('handoff_complete', 'handoff_pending_activation')) {
+        $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+        $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+        if ($service.state -eq 'stopped' -and (Test-ExpectedRoute $route $Config.tunnels.peer_id)) {
+            Write-Terminal @{ terminal = 'already_handed_off'; route_target = $route.target; next_action = 'activate the target locally if it is not already ready' }
+        }
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @('completed handoff journal disagrees with the observed service or route'); next_action = 'do not start either service until the stable route and both direct endpoints are known' } 2
+    }
+    if ($journal.terminal -in @('rolled_back', 'operator_recovery_required')) { return }
+
+    $replayable = @('intent_writing', 'intent_written', 'intent_delivered', 'stopping_source', 'source_stopped', 'routing', 'route_changed')
+    if ($journal.phase -notin $replayable -and $journal.terminal -ne 'intent_delivery_unproven') { return }
+    if ($journal.phase -eq 'intent_writing') {
+        $intent = Read-JsonEvidence $Adapter $Config.state.intent_path
+        $intent.state = Test-Intent $intent $Config
+        if ($intent.state -ne 'present' -or [int64]$intent.value.generation -ne [int64]$journal.generation -or $intent.value.desired_host -ne $journal.desired_host) {
+            $journal.phase = 'terminal'; $journal.terminal = 'interrupted_before_intent'; Save-Journal $Adapter $Config $journal
+            Write-Terminal @{ terminal = 'interrupted_before_intent'; reasons = @('handoff stopped before a matching target intent was durably written'); next_action = 'rerun Handoff; the source and route were not intentionally changed' } 2
+        }
+        $marker = Invoke-Adapter $Adapter 'GetMarkerVersion' @($Config.state.intent_path)
+        $journal.marker_version = $marker.version
+        $journal.phase = 'intent_written'
+        $journal.terminal = $null
+        Save-Journal $Adapter $Config $journal
+    }
+    $delivery = Confirm-ExactIntentDelivery $Adapter $Config $journal
+    if (-not $delivery.delivered) {
+        $journal.phase = 'intent_written'; $journal.terminal = 'intent_delivery_unproven'; Save-Journal $Adapter $Config $journal
+        Write-Terminal @{ terminal = 'intent_delivery_unproven'; reasons = @($delivery.reason); next_action = 'leave the source serving; restore replication, then rerun Handoff to retry this exact generation' } 2
+    }
+    $journal.phase = 'intent_delivered'
+    $journal.terminal = $null
+    Save-Journal $Adapter $Config $journal
+
+    $service = Invoke-Adapter $Adapter 'GetService' @($Config.services.exomem)
+    $route = Invoke-Adapter $Adapter 'GetRoute' @($Config.cloudflare, $Config.tunnels)
+    if ($service.state -eq 'running' -and (Test-ExpectedRoute $route $Config.tunnels.peer_id)) {
+        $journal.phase = 'terminal'; $journal.terminal = 'operator_recovery_required'; Save-Journal $Adapter $Config $journal
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @('source is running while the stable route selects the target'); next_action = 'do not start the target; inspect both direct endpoints and choose one source of truth' } 2
+    }
+    if ($service.state -notin @('running', 'stopped') -or $route.state -ne 'known') {
+        $journal.phase = 'terminal'; $journal.terminal = 'operator_recovery_required'; Save-Journal $Adapter $Config $journal
+        Write-Terminal @{ terminal = 'operator_recovery_required'; reasons = @('interrupted handoff service or route state is unknown'); next_action = 'keep both services stopped until the route and direct endpoints are known' } 2
+    }
+    Invoke-HandoffTransition $Adapter $Config $journal
+}
+
+function Invoke-NativeCommand {
+    param([string]$Executable, [object[]]$Arguments)
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $Executable
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $Arguments) { [void]$startInfo.ArgumentList.Add([string]$argument) }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) { throw "$Executable could not be started." }
+    if (-not $process.WaitForExit(15000)) {
+        try { $process.Kill($true) } catch {}
+        throw "$Executable timed out after 15 seconds."
+    }
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    if ($process.ExitCode -ne 0) { throw "$Executable failed with exit code $($process.ExitCode)." }
+    if ([string]::IsNullOrEmpty($stdout)) { return @() }
+    return @($stdout)
+}
+
+function Get-ManagedTunnelText {
+    param([string]$Existing, [hashtable]$Policy)
+    $begin = '  # exomem-cold-standby:begin'
+    $end = '  # exomem-cold-standby:end'
+    $without = [regex]::Replace($Existing, "(?ms)^\s*# exomem-cold-standby:begin\r?\n.*?^\s*# exomem-cold-standby:end\r?\n?", '')
+    $hostnamePattern = [regex]::Escape([string]$Policy.operational_hostname)
+    $stablePattern = [regex]::Escape([string]$Policy.stable_hostname)
+    if ($without -match "(?m)^\s*-\s*hostname:\s*(?:$hostnamePattern|$stablePattern)\s*$") { throw 'Existing unmanaged ingress already claims a cold-standby hostname; reconcile it manually.' }
+    $catchall = [regex]::Match($without, '(?m)^\s*-\s*service:\s*http_status:404\s*$')
+    if (-not $catchall.Success) { throw 'cloudflared config requires a final http_status:404 catch-all.' }
+    $block = @"
+$begin
+  - hostname: $($Policy.stable_hostname)
+    service: $($Policy.origin_service_url)
+  - hostname: $($Policy.operational_hostname)
+    path: ^/health(?:/ready)?$
+    service: $($Policy.origin_service_url)
+  - hostname: $($Policy.operational_hostname)
+    service: http_status:404
+$end
+"@
+    return $without.Insert($catchall.Index, "$block`r`n")
+}
+
+function Assert-TunnelPolicyRouting {
+    param([string]$ConfigFile, [hashtable]$Policy)
+    $checks = @(
+        @{ url = "https://$($Policy.operational_hostname)/health"; expected = "service: $($Policy.origin_service_url)" },
+        @{ url = "https://$($Policy.operational_hostname)/health/ready"; expected = "service: $($Policy.origin_service_url)" },
+        @{ url = "https://$($Policy.operational_hostname)/mcp"; expected = 'service: http_status:404' },
+        @{ url = "https://$($Policy.operational_hostname)/.well-known/oauth-authorization-server"; expected = 'service: http_status:404' },
+        @{ url = "https://$($Policy.operational_hostname)/api/write"; expected = 'service: http_status:404' },
+        @{ url = "https://$($Policy.operational_hostname)/artifacts/item"; expected = 'service: http_status:404' },
+        @{ url = "https://$($Policy.stable_hostname)/mcp"; expected = "service: $($Policy.origin_service_url)" }
+    )
+    foreach ($check in $checks) {
+        $matched = (Invoke-NativeCommand 'cloudflared' @('tunnel', '--config', $ConfigFile, 'ingress', 'rule', $check.url)) -join "`n"
+        if ($matched -notmatch [regex]::Escape([string]$check.expected)) { throw "cloudflared ingress policy does not safely route $($check.url)." }
+    }
+    return $true
+}
+
+function Get-NativeMarkerVersion {
+    param([string]$IntentPath)
+    $bytes = [IO.File]::ReadAllBytes($IntentPath)
+    $intent = [Text.Encoding]::UTF8.GetString($bytes) | ConvertFrom-Json -AsHashtable
+    $file = Get-Item -LiteralPath $IntentPath -ErrorAction Stop
+    $unixTicks = $file.LastWriteTimeUtc.Ticks - [DateTime]::UnixEpoch.Ticks
+    $seconds = [int64][Math]::Floor($unixTicks / [TimeSpan]::TicksPerSecond)
+    $nanoseconds = [int64](($unixTicks % [TimeSpan]::TicksPerSecond) * 100)
+    $hash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+    @{ generation = [int64]$intent.generation; version = "$($intent.generation):$seconds`:$nanoseconds`:$($file.Length)`:$hash"; modified_s = $seconds; modified_ns = $nanoseconds; size = [int64]$file.Length }
+}
+
+function Get-NativeAdapter {
+    @{
+        Now = { [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() }
+        Sleep = { param($Seconds) if ([int]$Seconds -gt 0) { Start-Sleep -Seconds ([int]$Seconds) } }
+        GetService = { param($Name) try { $service = Get-Service -Name $Name -ErrorAction Stop; @{ state = $service.Status.ToString().ToLowerInvariant() } } catch { @{ state = 'unknown' } } }
+        GetServiceEnvironment = {
+            param($Name)
+            try {
+                $parameters = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$Name\Parameters" -ErrorAction Stop
+                if (-not ($parameters.PSObject.Properties.Name -contains 'AppEnvironmentExtra')) { return @{ state = 'unknown'; values = @{} } }
+                $values = @{}
+                foreach ($entry in @($parameters.AppEnvironmentExtra)) {
+                    $parts = ([string]$entry) -split '=', 2
+                    if ($parts.Count -eq 2 -and $parts[0]) { $values[$parts[0]] = $parts[1] }
+                }
+                @{ state = 'known'; values = $values }
+            } catch { @{ state = 'unknown'; values = @{} } }
+        }
+        StartService = { param($Name) Start-Service -Name $Name -ErrorAction Stop; $true }
+        StopService = { param($Name) Stop-Service -Name $Name -ErrorAction Stop; $true }
+        SetDemandStart = { param($Name) Set-Service -Name $Name -StartupType Manual -ErrorAction Stop; $true }
+        InspectDesktopTask = {
+            param($Command, $DelaySeconds)
+            try {
+                $task = Get-ScheduledTask -TaskName 'Exomem Cold Standby Recovery' -TaskPath '\Exomem\' -ErrorAction Stop
+                $principalName = if ($env:USERDOMAIN) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+                $taskAction = @($task.Actions)[0]
+                $trigger = @($task.Triggers)[0]
+                $triggerClass = [string]$trigger.CimClass.CimClassName
+                $correct = @($task.Actions).Count -eq 1 -and @($task.Triggers).Count -eq 1 -and
+                    ([IO.Path]::GetFileName([string]$taskAction.Execute) -in @('pwsh', 'pwsh.exe')) -and
+                    [string]$taskAction.Arguments -eq $Command -and
+                    $triggerClass -eq 'MSFT_TaskLogonTrigger' -and
+                    [string]$trigger.UserId -eq $principalName -and
+                    [string]$trigger.Delay -eq "PT$([int]$DelaySeconds)S" -and
+                    [string]$task.Principal.UserId -eq $principalName -and
+                    [string]$task.Principal.RunLevel -eq 'Limited' -and
+                    [bool]$task.Settings.RunOnlyIfNetworkAvailable
+                @{ state = if ($correct) { 'ready' } else { 'needs_update' } }
+            } catch { @{ state = 'needs_update' } }
+        }
+        RegisterDesktopTask = {
+            param($Command, $DelaySeconds)
+            $taskAction = New-ScheduledTaskAction -Execute 'pwsh.exe' -Argument $Command
+            $principalName = if ($env:USERDOMAIN) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+            $trigger = New-ScheduledTaskTrigger -AtLogOn -User $principalName
+            $trigger.Delay = "PT$([int]$DelaySeconds)S"
+            $settings = New-ScheduledTaskSettingsSet -RunOnlyIfNetworkAvailable -StartWhenAvailable
+            Register-ScheduledTask -TaskName 'Exomem Cold Standby Recovery' -TaskPath '\Exomem\' -Action $taskAction -Trigger $trigger -Settings $settings -User $principalName -RunLevel Limited -Force | Out-Null
+            $true
+        }
+        InspectTunnelConfig = {
+            param($Policy)
+            try {
+                if (-not (Test-Path -LiteralPath $Policy.config_path -PathType Leaf)) { return @{ state = 'unavailable' } }
+                $existing = Get-Content -Raw -LiteralPath $Policy.config_path
+                $expected = Get-ManagedTunnelText $existing $Policy
+                if ($expected -ceq $existing) { Assert-TunnelPolicyRouting $Policy.config_path $Policy | Out-Null; return @{ state = 'ready' } }
+                @{ state = 'needs_update' }
+            } catch { @{ state = 'invalid'; remediation = $_.Exception.Message } }
+        }
+        InspectTunnelServiceBinding = {
+            param($Name, $Policy)
+            try {
+                $service = Get-CimInstance -ClassName Win32_Service -Filter "Name='$($Name.Replace("'", "''"))'" -ErrorAction Stop
+                $commandLine = [string]$service.PathName
+                $tokens = @([regex]::Matches($commandLine, '"[^"]*"|\S+') | ForEach-Object { $_.Value.Trim('"') })
+                $configuredPath = $null
+                for ($index = 0; $index -lt $tokens.Count; $index++) {
+                    if ($tokens[$index] -eq '--config' -and ($index + 1) -lt $tokens.Count) { $configuredPath = $tokens[$index + 1]; break }
+                    if ($tokens[$index] -like '--config=*') { $configuredPath = $tokens[$index].Substring(9); break }
+                }
+                if ([string]::IsNullOrWhiteSpace($configuredPath)) { return @{ state = 'wrong_config'; command_fingerprint = Get-Sha256 $commandLine } }
+                $configuredPath = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($configuredPath))
+                if ($configuredPath -ne [IO.Path]::GetFullPath([string]$Policy.config_path)) { return @{ state = 'wrong_config'; command_fingerprint = Get-Sha256 $commandLine } }
+                $tunnelIndex = [Array]::IndexOf($tokens, 'tunnel')
+                $runIndex = [Array]::IndexOf($tokens, 'run')
+                if ($tunnelIndex -lt 0 -or $runIndex -lt 0 -or $runIndex -lt $tunnelIndex) { return @{ state = 'wrong_command'; command_fingerprint = Get-Sha256 $commandLine } }
+                $selectedByCommand = @($tokens | Where-Object { $_ -eq [string]$Policy.local_id -or $_ -eq [string]$Policy.local_name }).Count -gt 0
+                $configText = Get-Content -Raw -LiteralPath $Policy.config_path
+                $escapedId = [regex]::Escape([string]$Policy.local_id)
+                $tunnelPattern = '(?mi)^\s*tunnel\s*:\s*[''"]?' + $escapedId + '[''"]?\s*$'
+                $selectedByConfig = $configText -match $tunnelPattern
+                if (-not $selectedByCommand -and -not $selectedByConfig) { return @{ state = 'wrong_tunnel'; command_fingerprint = Get-Sha256 $commandLine } }
+                @{ state = 'ready'; command_fingerprint = Get-Sha256 $commandLine }
+            } catch { @{ state = 'unknown'; command_fingerprint = $null } }
+        }
+        PrepareTunnelConfig = {
+            param($Policy)
+            $path = [string]$Policy.config_path
+            $existing = Get-Content -Raw -LiteralPath $path
+            $updated = Get-ManagedTunnelText $existing $Policy
+            if ($updated -ceq $existing) { return $true }
+            $temporary = "$path.exomem-cold-standby.$([guid]::NewGuid().ToString('N')).tmp"
+            $backup = "$path.exomem-cold-standby.$([DateTime]::UtcNow.ToString('yyyyMMddHHmmss')).bak"
+            try {
+                $updated | Set-Content -LiteralPath $temporary -Encoding utf8
+                Invoke-NativeCommand 'cloudflared' @('--config', $temporary, 'tunnel', 'ingress', 'validate') | Out-Null
+                Assert-TunnelPolicyRouting $temporary $Policy | Out-Null
+                Copy-Item -LiteralPath $path -Destination $backup -ErrorAction Stop
+                Move-Item -LiteralPath $temporary -Destination $path -Force -ErrorAction Stop
+            } finally {
+                if (Test-Path -LiteralPath $temporary) { Remove-Item -LiteralPath $temporary -Force }
+            }
+            $true
+        }
+        ReloadTunnelService = {
+            param($Name)
+            Restart-Service -Name $Name -ErrorAction Stop
+            $service = Get-Service -Name $Name -ErrorAction Stop
+            $service.WaitForStatus([ServiceProcess.ServiceControllerStatus]::Running, [TimeSpan]::FromSeconds(15))
+            $true
+        }
+        Probe = {
+            param($Url)
+            try {
+                $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 10 -SkipHttpErrorCheck -ErrorAction Stop
+                if ($response.StatusCode -eq 503) { return @{ state = 'inactive'; status_code = 503 } }
+                if ($response.StatusCode -eq 502) { return @{ state = 'unserved'; status_code = 502 } }
+                if ($response.StatusCode -ne 200) { return @{ state = 'unknown'; status_code = $response.StatusCode } }
+                $payload = $response.Content | ConvertFrom-Json -AsHashtable
+                if ($payload.status -eq 'ready') { return @{ state = 'ready'; status_code = 200; instance_id = $payload.instance_id } }
+                if ($payload.status -eq 'not_ready') { return @{ state = 'inactive'; status_code = 200; instance_id = Get-OptionalValue $payload 'instance_id' } }
+                @{ state = 'unknown'; status_code = 200 }
+            } catch { @{ state = 'unreachable' } }
+        }
+        ProbeOAuth = {
+            param($Url)
+            try {
+                $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 10 -SkipHttpErrorCheck -ErrorAction Stop
+                if ($response.StatusCode -ne 200) { return @{ state = 'unknown' } }
+                $payload = $response.Content | ConvertFrom-Json -AsHashtable
+                if ([string]::IsNullOrWhiteSpace([string]$payload.issuer)) { return @{ state = 'unknown' } }
+                @{ state = 'ready'; issuer = [string]$payload.issuer }
+            } catch { @{ state = 'unreachable' } }
+        }
+        GetSyncthing = {
+            param($Syncthing)
+            try {
+                $apiKey = [Environment]::GetEnvironmentVariable([string]$Syncthing.api_key_environment)
+                if ([string]::IsNullOrWhiteSpace($apiKey)) { return @{ api = 'unavailable' } }
+                $headers = @{ 'X-API-Key' = $apiKey }
+                $folder = [Uri]::EscapeDataString([string]$Syncthing.folder_id)
+                $device = [Uri]::EscapeDataString([string]$Syncthing.peer_device_id)
+                $status = Invoke-RestMethod -Uri "$($Syncthing.api_url.TrimEnd('/'))/rest/db/status?folder=$folder" -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+                $completion = Invoke-RestMethod -Uri "$($Syncthing.api_url.TrimEnd('/'))/rest/db/completion?folder=$folder&device=$device" -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+                @{
+                    api = 'reachable'
+                    folder_state = [string]$status.state
+                    pending_items = [int64]$status.needItems
+                    pending_bytes = [int64]$status.needBytes
+                    peer_completion = [double]$completion.completion
+                    peer_complete = ([double]$completion.completion -ge 100 -and [int64]$completion.needItems -eq 0 -and [int64]$completion.needBytes -eq 0)
+                }
+            } catch { @{ api = 'unavailable'; folder_state = 'unknown'; pending_items = $null; pending_bytes = $null; peer_completion = $null; peer_complete = $null } }
+        }
+        GetMarkerVersion = {
+            param($IntentPath)
+            Get-NativeMarkerVersion $IntentPath
+        }
+        GetIntentDelivery = {
+            param($Syncthing, $Generation, $IntentPath)
+            try {
+                $markerVersion = Get-NativeMarkerVersion $IntentPath
+                if ([int64]$markerVersion.generation -ne [int64]$Generation) { return @{ state = 'unknown'; generation = $null; marker_version = $null } }
+                $apiKey = [Environment]::GetEnvironmentVariable([string]$Syncthing.api_key_environment)
+                if ([string]::IsNullOrWhiteSpace($apiKey)) { return @{ state = 'unknown'; generation = $null; marker_version = $null } }
+                $headers = @{ 'X-API-Key' = $apiKey }
+                $folder = [Uri]::EscapeDataString([string]$Syncthing.folder_id)
+                $device = [Uri]::EscapeDataString([string]$Syncthing.peer_device_id)
+                $markerPath = [Uri]::EscapeDataString([string]$Syncthing.intent_relative_path)
+                $file = Invoke-RestMethod -Uri "$($Syncthing.api_url.TrimEnd('/'))/rest/db/file?folder=$folder&file=$markerPath" -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+                if ($null -eq $file.local) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                $localProperties = @($file.local.PSObject.Properties.Name)
+                if ('deleted' -in $localProperties -and $file.local.deleted) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                if ('invalid' -in $localProperties -and $file.local.invalid) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                if ('modified' -notin $localProperties -or 'version' -notin $localProperties -or 'size' -notin $localProperties) { return @{ state = 'unknown'; generation = $null; marker_version = $null } }
+                $modifiedText = [string]$file.local.modified
+                try { $modifiedTime = [DateTimeOffset]::Parse($modifiedText, [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::RoundtripKind) } catch { return @{ state = 'unknown'; generation = $null; marker_version = $null } }
+                $fractionMatch = [regex]::Match($modifiedText, '\.(?<fraction>[0-9]+)(?:Z|[+-][0-9]{2}:[0-9]{2})$')
+                $modifiedNs = if ($fractionMatch.Success) { [int64]($fractionMatch.Groups['fraction'].Value.PadRight(9, '0').Substring(0, 9)) } else { 0 }
+                if ([int64]$modifiedTime.ToUnixTimeSeconds() -ne [int64]$markerVersion.modified_s -or $modifiedNs -ne [int64]$markerVersion.modified_ns -or [int64]$file.local.size -ne [int64]$markerVersion.size) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                $globalProperties = if ($null -ne $file.global) { @($file.global.PSObject.Properties.Name) } else { @() }
+                if ('version' -notin $globalProperties) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                $localVector = (@($file.local.version) | ForEach-Object { [string]$_ }) -join ','
+                $globalVector = (@($file.global.version) | ForEach-Object { [string]$_ }) -join ','
+                if ([string]::IsNullOrWhiteSpace($localVector) -or $localVector -ne $globalVector) { return @{ state = 'pending'; generation = $null; marker_version = $null } }
+                $completion = Invoke-RestMethod -Uri "$($Syncthing.api_url.TrimEnd('/'))/rest/db/completion?folder=$folder&device=$device" -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+                $remoteNeed = Invoke-RestMethod -Uri "$($Syncthing.api_url.TrimEnd('/'))/rest/db/remoteneed?folder=$folder&device=$device&page=1&perpage=100" -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+                $remoteProperties = @($remoteNeed.PSObject.Properties.Name)
+                $needed = @(if ('items' -in $remoteProperties) { @($remoteNeed.items) }) + @(if ('files' -in $remoteProperties) { @($remoteNeed.files) })
+                $markerNeeded = @($needed | Where-Object {
+                    $properties = @($_.PSObject.Properties.Name)
+                    $neededPath = if ('name' -in $properties) { [string]$_.name } elseif ('path' -in $properties) { [string]$_.path } else { '' }
+                    $neededPath -eq [string]$Syncthing.intent_relative_path
+                }).Count -gt 0
+                if ([double]$completion.completion -ge 100 -and [int64]$completion.needItems -eq 0 -and [int64]$completion.needBytes -eq 0 -and -not $markerNeeded) { @{ state = 'delivered'; generation = [int64]$Generation; marker_version = $markerVersion.version; syncthing_version = $localVector } } else { @{ state = 'pending'; generation = $null; marker_version = $null } }
+            } catch { @{ state = 'unknown'; generation = $null; marker_version = $null } }
+        }
+        GetTunnel = {
+            param($Name)
+            try {
+                $output = Invoke-NativeCommand 'cloudflared' @('tunnel', 'info', $Name, '--output', 'json')
+                $payload = ($output -join "`n") | ConvertFrom-Json -AsHashtable
+                $connections = if ($payload.ContainsKey('connections')) { @($payload.connections) } else { @() }
+                @{ state = if ($connections.Count) { 'connected' } else { 'disconnected' } }
+            } catch { @{ state = 'unknown' } }
+        }
+        GetRoute = {
+            param($Cloudflare, $Tunnels)
+            try {
+                $token = [Environment]::GetEnvironmentVariable([string]$Cloudflare.api_token_environment)
+                $zone = [Environment]::GetEnvironmentVariable([string]$Cloudflare.zone_id_environment)
+                if ([string]::IsNullOrWhiteSpace($token) -or [string]::IsNullOrWhiteSpace($zone)) { return @{ state = 'unknown'; tunnel_id = $null; target = $null } }
+                $name = [Uri]::EscapeDataString([string]$Tunnels.stable_hostname)
+                $response = Invoke-RestMethod -Uri "https://api.cloudflare.com/client/v4/zones/$zone/dns_records?type=CNAME&name=$name" -Headers @{ Authorization = "Bearer $token" } -TimeoutSec 10 -ErrorAction Stop
+                if (-not $response.success -or @($response.result).Count -ne 1) { return @{ state = 'unknown'; tunnel_id = $null; target = $null } }
+                $target = ([string]$response.result[0].content).TrimEnd('.').ToLowerInvariant()
+                $match = [regex]::Match($target, '^([0-9a-f-]{36})\.cfargotunnel\.com$')
+                if (-not $match.Success) { return @{ state = 'unknown'; tunnel_id = $null; target = $target } }
+                @{ state = 'known'; tunnel_id = $match.Groups[1].Value; target = $target }
+            } catch { @{ state = 'unknown'; tunnel_id = $null; target = $null } }
+        }
+        SetRoute = {
+            param($Tunnel, $Hostname)
+            Invoke-NativeCommand 'cloudflared' @('tunnel', 'route', 'dns', '--overwrite-dns', $Tunnel, $Hostname) | Out-Null
+            $true
+        }
+        WriteJson = {
+            param($Path, $Value)
+            $parent = Split-Path -Parent $Path
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+            $temporary = "$Path.$([guid]::NewGuid().ToString('N')).tmp"
+            try {
+                $Value | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $temporary -Encoding utf8
+                Move-Item -LiteralPath $temporary -Destination $Path -Force -ErrorAction Stop
+            } finally { if (Test-Path -LiteralPath $temporary) { Remove-Item -LiteralPath $temporary -Force } }
+            $true
+        }
+        ReadJson = { param($Path) if (Test-Path -LiteralPath $Path) { Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -AsHashtable } else { $null } }
+        GetTrace = { @() }
+    }
+}
+
+try {
+    $config = Get-Config $ConfigPath
+    $adapter = if ($AdapterPath) { . $AdapterPath } else { Get-NativeAdapter }
+    if ($adapter -isnot [hashtable]) { throw 'Adapter must return a hashtable.' }
+    $script:ActiveAdapter = $adapter
+
+    if ($Action -eq 'Configure') {
+        $identity = Get-IdentityContract $config $adapter
+        $policy = Get-TunnelPolicy $config
+        $tunnelInspection = Invoke-Adapter $adapter 'InspectTunnelConfig' @($policy)
+        if ($tunnelInspection.state -notin @('ready', 'needs_update')) { Write-Terminal @{ terminal = 'refused'; reasons = @('tunnel configuration is unavailable or unsafe to update'); next_action = 'restore a valid config with a final 404 catch-all' } 2 }
+        $serviceBinding = Invoke-Adapter $adapter 'InspectTunnelServiceBinding' @($config.services.cloudflared, $policy)
+        if ($serviceBinding.state -ne 'ready') { Write-Terminal @{ terminal = 'refused'; reasons = @('cloudflared Windows service is not bound to the configured file and local tunnel'); next_action = 'reinstall or correct the cloudflared service command, then rerun Configure' } 2 }
+        $taskCommand = "-NoProfile -NonInteractive -File `"$PSCommandPath`" Activate -IfUnserved -ConfigPath `"$ConfigPath`""
+        $taskInspection = if ($config.host.role -eq 'desktop') { Invoke-Adapter $adapter 'InspectDesktopTask' @($taskCommand, [int]$config.operations.desktop_logon_delay_seconds) } else { @{ state = 'not_applicable' } }
+        if ($config.host.role -eq 'desktop' -and $taskInspection.state -notin @('ready', 'needs_update')) { Write-Terminal @{ terminal = 'refused'; reasons = @('desktop scheduled-task state is unknown'); next_action = 'inspect the current-user scheduled task' } 2 }
+        $plan = @('set-exomem-demand-start', 'prepare-health-only-tunnel-ingress', 'reload-cloudflared-if-config-changed', 'publish-redacted-identity-manifest')
+        if ($config.host.role -eq 'desktop') { $plan += 'register-current-user-delayed-activate-if-unserved' }
+        if ($WhatIfPreference) { Write-Terminal @{ terminal = 'what_if'; plan = $plan; next_action = 'review the plan, then rerun without -WhatIf' } }
+        Invoke-Adapter $adapter 'SetDemandStart' @($config.services.exomem) | Out-Null
+        if ($tunnelInspection.state -eq 'needs_update') {
+            Invoke-Adapter $adapter 'PrepareTunnelConfig' @($policy) | Out-Null
+            Invoke-Adapter $adapter 'ReloadTunnelService' @($config.services.cloudflared) | Out-Null
+            $connected = $false
+            for ($index = 0; $index -lt [int]$config.operations.probe_attempts; $index++) {
+                $tunnel = Invoke-Adapter $adapter 'GetTunnel' @($config.tunnels.local_name)
+                if ($tunnel.state -eq 'connected') { $connected = $true; break }
+                if ($index -lt ([int]$config.operations.probe_attempts - 1) -and [int]$config.operations.probe_delay_seconds -gt 0) { Invoke-Adapter $adapter 'Sleep' @([int]$config.operations.probe_delay_seconds) | Out-Null }
+            }
+            if (-not $connected) { Write-Terminal @{ terminal = 'refused'; reasons = @('cloudflared did not reconnect to the configured local tunnel after reload'); next_action = 'inspect the Windows service command and tunnel logs; direct ingress may not be hardened live' } 2 }
+        }
+        Write-OperationJson $adapter $config.state.manifest_path $identity.manifest
+        if ($config.host.role -eq 'desktop' -and $taskInspection.state -eq 'needs_update') { Invoke-Adapter $adapter 'RegisterDesktopTask' @($taskCommand, [int]$config.operations.desktop_logon_delay_seconds) | Out-Null }
+        Write-Terminal @{
+            terminal = 'configured'
+            tunnel_policy = @{ stable = 'forward-all'; direct = @('/health', '/health/ready'); direct_fallback = 'http_status:404' }
+            next_action = 'configure the peer, converge Syncthing, then run Status and dry runs'
+        }
+    }
+
+    $evidence = Get-Evidence $config $adapter
+
+    if ($Action -eq 'Status') {
+        $reasons = @(Get-StatusReasons $evidence $config)
+        $localInactive = $evidence.local_health.state -eq 'inactive' -or ($evidence.local_health.state -eq 'unserved' -and $evidence.local_tunnel.state -eq 'connected')
+        $peerInactive = $evidence.peer_health.state -eq 'inactive' -or ($evidence.peer_health.state -eq 'unserved' -and $evidence.peer_tunnel.state -eq 'connected')
+        $active = if ($evidence.local_health.observed_ready -and $evidence.peer_health.observed_ready) {
+            'unsafe_ambiguous'
+        } elseif ($evidence.local_health.state -eq 'ready' -and $peerInactive -and $evidence.stable_health.state -eq 'ready' -and (Get-OptionalValue $evidence.stable_health 'instance_id') -eq $config.host.id -and (Test-ExpectedRoute $evidence.route $config.tunnels.local_id)) {
+            $config.host.id
+        } elseif ($evidence.peer_health.state -eq 'ready' -and $localInactive -and $evidence.stable_health.state -eq 'ready' -and (Get-OptionalValue $evidence.stable_health 'instance_id') -eq $config.host.peer_id -and (Test-ExpectedRoute $evidence.route $config.tunnels.peer_id)) {
+            $config.host.peer_id
+        } else { 'unknown' }
+        $next = if ($active -eq $config.host.id) { 'none: local host is serving' } elseif ($active -eq $config.host.peer_id) { 'none: peer is serving' } else { 'none: resolve unknown or unsafe evidence' }
+        $publicEvidence = @{
+            service = $evidence.service
+            local_health = $evidence.local_health
+            peer_health = $evidence.peer_health
+            stable_health = $evidence.stable_health
+            syncthing = $evidence.syncthing
+            local_tunnel = $evidence.local_tunnel
+            peer_tunnel = $evidence.peer_tunnel
+            route = $evidence.route
+            intent = @{ state = $evidence.intent.state; desired_host = if ($evidence.intent.state -eq 'present') { $evidence.intent.value.desired_host } else { $null }; generation = if ($evidence.intent.state -eq 'present') { $evidence.intent.value.generation } else { $null } }
+            journal = @{ state = $evidence.journal.state; phase = if ($evidence.journal.state -eq 'present') { Get-OptionalValue $evidence.journal.value 'phase' } else { $null }; terminal = if ($evidence.journal.state -eq 'present') { Get-OptionalValue $evidence.journal.value 'terminal' } else { $null } }
+            identity = @{ state = $evidence.identity.state; fingerprints = if ($evidence.identity.state -eq 'available') { $evidence.identity.manifest.fingerprints } else { $null } }
+        }
+        Write-Terminal @{ terminal = 'status'; active_host = $active; evidence = $publicEvidence; reasons = $reasons; next_action = $next }
+    }
+
+    if ($Action -eq 'Activate') {
+        if ($Force -and $Acknowledge -ne $ForceAcknowledgement) { Write-Terminal @{ terminal = 'refused'; reasons = @("-Force requires the exact acknowledgement: $ForceAcknowledgement"); next_action = 'supply both inputs only after accepting split-brain and data-loss risk' } 2 }
+        if (-not $Force -and -not [string]::IsNullOrWhiteSpace($Acknowledge)) { Write-Terminal @{ terminal = 'refused'; reasons = @('the risk acknowledgement has no effect without -Force'); next_action = 'remove -Acknowledge or use the complete disaster override' } 2 }
+        if (-not $WhatIfPreference) { Invoke-ActivationReplay $adapter $config $evidence }
+        $reasons = @(Get-ActivationReasons $evidence $config -GuardedBoot:$IfUnserved)
+        $bypassable = @('Syncthing is not converged', 'peer inactivity is unproven', 'desired-host intent names peer')
+        $bypassed = @()
+        if ($Force) {
+            $bypassed = @($reasons | Where-Object { $_ -in $bypassable })
+            $reasons = @($reasons | Where-Object { $_ -notin $bypassable })
+        }
+        if ($reasons.Count) { Write-Terminal @{ terminal = 'refused'; reasons = $reasons; bypassed_guards = $bypassed; next_action = 'resolve each named guard; peer unreachability is not proof of shutdown' } 2 }
+        $plan = @('write-desired-host-intent', 'start-local-service', 'verify-local-instance', 'route-stable-hostname', 'verify-cloudflare-target', 'verify-public-instance-and-oauth', 'commit-journal')
+        if ($WhatIfPreference) { Write-Terminal @{ terminal = 'what_if'; plan = $plan; bypassed_guards = $bypassed; next_action = 'review the plan, then rerun without -WhatIf' } }
+        $priorRoute = $evidence.route
+        $generation = Get-NextGeneration $adapter $evidence.intent
+        $intent = @{ schema_version = 1; desired_host = $config.host.id; generation = $generation; advisory = $true }
+        $journal = @{
+            action = 'Activate'; phase = 'intent_written'; generation = $generation; desired_host = $config.host.id
+            previous_route = if ($priorRoute.state -eq 'known') { $priorRoute.tunnel_id } else { $null }
+            started_service = $false; terminal = $null; bypassed_guards = @($bypassed)
+        }
+        Write-OperationJson $adapter $config.state.intent_path $intent
+        Save-Journal $adapter $config $journal
+        try {
+            $journal.started_service = $true
+            $journal.phase = 'starting_service'
+            Save-Journal $adapter $config $journal
+            Invoke-Adapter $adapter 'StartService' @($config.services.exomem) | Out-Null
+            $journal.phase = 'service_started'
+            Save-Journal $adapter $config $journal
+            $local = Invoke-BoundedProbe $adapter $config.health.local_url ([int]$config.operations.probe_attempts) ([int]$config.operations.probe_delay_seconds)
+            if ($local.state -ne 'ready' -or (Get-OptionalValue $local 'instance_id') -ne $config.host.id) { throw 'local runtime readiness did not report the configured instance_id' }
+            $journal.phase = 'routing'
+            Save-Journal $adapter $config $journal
+            Invoke-Adapter $adapter 'SetRoute' @($config.tunnels.local_name, $config.tunnels.stable_hostname) | Out-Null
+            $journal.phase = 'route_changed'
+            Save-Journal $adapter $config $journal
+            $route = Invoke-Adapter $adapter 'GetRoute' @($config.cloudflare, $config.tunnels)
+            if (-not (Test-ExpectedRoute $route $config.tunnels.local_id)) { throw 'Cloudflare DNS does not target the configured local tunnel ID' }
+            $public = Test-PublicHost $adapter $config $evidence.identity $config.host.id
+            if (-not $public.ready) { throw 'public readiness or OAuth discovery does not identify the configured local host and base URL' }
+            $journal.phase = 'public_verified'
+            Save-Journal $adapter $config $journal
+        } catch {
+            Invoke-ActivationCompensation $adapter $config $journal $_.Exception.Message
+        }
+        $journal.phase = 'terminal'
+        $journal.terminal = 'activated'
+        Save-Journal $adapter $config $journal
+        Write-Terminal @{
+            terminal = 'activated'
+            route_target = "$($config.tunnels.local_id).cfargotunnel.com"
+            bypassed_guards = $bypassed
+            next_action = 'keep the existing connector URL; reconnect or reauthorize only if its host-local OAuth session is absent'
+        }
+    }
+
+    if ($Action -eq 'Handoff') {
+        if ($Force -or $IfUnserved) { Write-Terminal @{ terminal = 'refused'; reasons = @('-Force and -IfUnserved apply only to Activate'); next_action = 'run Handoff without activation-only switches' } 2 }
+        if (-not $WhatIfPreference) { Invoke-HandoffReplay $adapter $config $evidence }
+        $reasons = @(Get-HandoffReasons $evidence $config)
+        if ($reasons.Count) { Write-Terminal @{ terminal = 'refused'; reasons = $reasons; next_action = 'restore source, target, replication, intent, identity, and route evidence before handoff' } 2 }
+        $plan = @('write-target-intent', 'confirm-exact-generation-delivery', 'stop-source-service', 'route-stable-hostname-to-target', 'verify-target-route', 'report-bounded-outage')
+        if ($WhatIfPreference) { Write-Terminal @{ terminal = 'what_if'; plan = $plan; next_action = 'review the outage and target-local activation steps before proceeding' } }
+        $generation = Get-NextGeneration $adapter $evidence.intent
+        $intent = @{ schema_version = 1; desired_host = $config.host.peer_id; generation = $generation; advisory = $true }
+        $journal = @{
+            action = 'Handoff'; phase = 'intent_writing'; generation = $generation; desired_host = $config.host.peer_id
+            previous_route = $config.tunnels.local_id; source_was_running = $true; terminal = $null
+            identity = @{ expected_base_url = $evidence.identity.expected_base_url }
+        }
+        Save-Journal $adapter $config $journal
+        Write-OperationJson $adapter $config.state.intent_path $intent
+        $markerVersion = Invoke-Adapter $adapter 'GetMarkerVersion' @($config.state.intent_path)
+        if ([int64]$markerVersion.generation -ne $generation -or [string]::IsNullOrWhiteSpace([string]$markerVersion.version)) { throw 'the newly written desired-host marker could not be versioned' }
+        $journal.marker_version = $markerVersion.version
+        $journal.phase = 'intent_written'
+        Save-Journal $adapter $config $journal
+        $delivery = Confirm-ExactIntentDelivery $adapter $config $journal
+        if (-not $delivery.delivered) {
+            $journal.phase = 'terminal'; $journal.terminal = 'intent_delivery_unproven'; Save-Journal $adapter $config $journal
+            Write-Terminal @{ terminal = 'intent_delivery_unproven'; reasons = @($delivery.reason); next_action = 'leave the source serving; restore replication, then rerun Handoff to retry this exact generation' } 2
+        }
+        $journal.phase = 'intent_delivered'
+        Save-Journal $adapter $config $journal
+        Invoke-HandoffTransition $adapter $config $journal
+    }
+} catch {
+    Write-Terminal @{ terminal = 'error'; reasons = @($_.Exception.Message); next_action = 'correct configuration or unavailable evidence before retrying' } 1
+}

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version
@@ -11,6 +12,13 @@ from typing import Any
 
 RUNTIME_CONTRACT = 1
 HTTP_TRANSPORT = "streamable-http-stateless"
+
+
+def _instance_id() -> str | None:
+    value = os.environ.get("EXOMEM_INSTANCE_ID", "").strip()
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", value):
+        return value
+    return None
 
 
 def _public_mutation_boundary(value: object) -> dict[str, Any]:
@@ -89,6 +97,7 @@ def build_runtime_readiness(
         "mcp_tool_surface_sha256": mcp_tool_surface_sha256,
         "runtime_contract": RUNTIME_CONTRACT,
         "transport": HTTP_TRANSPORT,
+        "instance_id": _instance_id(),
         "replica_id": replica_id,
         "coordination": {
             "enabled": enabled,

--- a/tests/test_cold_standby.py
+++ b/tests/test_cold_standby.py
@@ -1,0 +1,1211 @@
+"""End-to-end contract tests for the manual cold-standby entrypoint."""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+PWSH = shutil.which("pwsh")
+CLOUDFLARED = shutil.which("cloudflared")
+SCRIPT = Path(__file__).parents[1] / "scripts" / "cold-standby.ps1"
+ACK = "I ACKNOWLEDGE SPLIT-BRAIN AND DATA-LOSS RISK"
+DESKTOP_TUNNEL_ID = "11111111-1111-4111-8111-111111111111"
+LAPTOP_TUNNEL_ID = "22222222-2222-4222-8222-222222222222"
+
+pytestmark = pytest.mark.skipif(PWSH is None, reason="pwsh is not available")
+
+
+def _config(tmp_path: Path, *, role: str = "laptop") -> tuple[Path, dict[str, object]]:
+    peer = "desktop" if role == "laptop" else "laptop"
+    local_tunnel_id = LAPTOP_TUNNEL_ID if role == "laptop" else DESKTOP_TUNNEL_ID
+    peer_tunnel_id = DESKTOP_TUNNEL_ID if role == "laptop" else LAPTOP_TUNNEL_ID
+    config: dict[str, object] = {
+        "schema_version": 1,
+        "host": {"id": role, "role": role, "peer_id": peer},
+        "health": {
+            "local_url": f"https://{role}.ops.example.test/health/ready",
+            "peer_url": f"https://{peer}.ops.example.test/health/ready",
+            "stable_url": "https://exomem.example.test/health/ready",
+            "oauth_discovery_url": "https://exomem.example.test/.well-known/oauth-authorization-server",
+        },
+        "services": {"exomem": "Exomem", "cloudflared": "cloudflared"},
+        "tunnels": {
+            "local_name": f"{role}-tunnel",
+            "local_id": local_tunnel_id,
+            "peer_name": f"{peer}-tunnel",
+            "peer_id": peer_tunnel_id,
+            "stable_hostname": "exomem.example.test",
+            "local_operational_hostname": f"{role}.ops.example.test",
+            "peer_operational_hostname": f"{peer}.ops.example.test",
+            "config_path": str(tmp_path / f"cloudflared-{role}.yml"),
+            "origin_service_url": "http://127.0.0.1:8765",
+        },
+        "cloudflare": {
+            "api_token_environment": "TEST_CLOUDFLARE_API_TOKEN",
+            "zone_id_environment": "TEST_CLOUDFLARE_ZONE_ID",
+        },
+        "syncthing": {
+            "api_url": "http://127.0.0.1:8384",
+            "api_key_environment": "TEST_SYNCTHING_API_KEY",
+            "folder_id": "vault",
+            "folder_path": str(tmp_path / "syncthing-shared"),
+            "peer_device_id": "peer-device-id",
+            "intent_relative_path": ".exomem-state/desired-host.json",
+        },
+        "state": {
+            "journal_path": str(tmp_path / f"journal-{role}.json"),
+            "intent_path": str(tmp_path / "syncthing-shared" / ".exomem-state" / "desired-host.json"),
+            "manifest_path": str(tmp_path / "syncthing-shared" / ".exomem-state" / f"manifest-{role}.json"),
+            "peer_manifest_path": str(tmp_path / "syncthing-shared" / ".exomem-state" / f"manifest-{peer}.json"),
+        },
+        "identity_environment": {
+            "dotenv_path": str(tmp_path / f"service-{role}.env"),
+            "base_url": "TEST_BASE_URL",
+            "github_client_id": "TEST_GITHUB_CLIENT_ID",
+            "github_client_secret": "TEST_GITHUB_CLIENT_SECRET",
+            "github_username": "TEST_GITHUB_USERNAME",
+            "github_user_id": "TEST_GITHUB_USER_ID",
+            "jwt_signing_key": "TEST_JWT_SIGNING_KEY",
+            "instance_id": "TEST_INSTANCE_ID",
+        },
+        "operations": {
+            "probe_attempts": 3,
+            "probe_delay_seconds": 0,
+            "desktop_logon_delay_seconds": 30,
+        },
+    }
+    Path(str(config["identity_environment"]["dotenv_path"])).write_text(
+        "\n".join(
+            [
+                "TEST_BASE_URL=https://exomem.example.test/",
+                "TEST_GITHUB_CLIENT_ID=client-id",
+                "TEST_GITHUB_CLIENT_SECRET=client-secret",
+                "TEST_GITHUB_USERNAME=operator-login",
+                "TEST_GITHUB_USER_ID=123456",
+                "TEST_JWT_SIGNING_KEY=not-for-output",
+                f"TEST_INSTANCE_ID={role}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path = tmp_path / f"config-{role}.json"
+    path.write_text(json.dumps(config), encoding="utf-8")
+    return path, config
+
+
+def _default_state(config: dict[str, object]) -> dict[str, object]:
+    host = config["host"]
+    tunnels = config["tunnels"]
+    assert isinstance(host, dict) and isinstance(tunnels, dict)
+    role = str(host["id"])
+    peer = str(host["peer_id"])
+    return {
+        "services": {role: "stopped", peer: "stopped"},
+        "service_environments": {
+            role: {
+                "state": "known",
+                "values": {
+                    "TEST_BASE_URL": "https://exomem.example.test/",
+                    "TEST_GITHUB_CLIENT_ID": "client-id",
+                    "TEST_GITHUB_CLIENT_SECRET": "client-secret",
+                    "TEST_GITHUB_USERNAME": "operator-login",
+                    "TEST_GITHUB_USER_ID": "123456",
+                    "TEST_JWT_SIGNING_KEY": "not-for-output",
+                    "TEST_INSTANCE_ID": role,
+                },
+            },
+            peer: {
+                "state": "known",
+                "values": {
+                    "TEST_BASE_URL": "https://exomem.example.test/",
+                    "TEST_GITHUB_CLIENT_ID": "client-id",
+                    "TEST_GITHUB_CLIENT_SECRET": "client-secret",
+                    "TEST_GITHUB_USERNAME": "operator-login",
+                    "TEST_GITHUB_USER_ID": "123456",
+                    "TEST_JWT_SIGNING_KEY": "not-for-output",
+                    "TEST_INSTANCE_ID": peer,
+                },
+            },
+        },
+        "route": {
+            "state": "known",
+            "tunnel_id": str(tunnels["peer_id"]),
+            "target": f"{tunnels['peer_id']}.cfargotunnel.com",
+        },
+        "probe_override": {},
+        "probe_sequences": {},
+        "oauth_override": {},
+        "syncthing": {
+            "api": "reachable",
+            "folder_state": "idle",
+            "pending_items": 0,
+            "pending_bytes": 0,
+            "peer_completion": 100,
+            "peer_complete": True,
+        },
+        "tunnels": {
+            str(tunnels["local_name"]): "connected",
+            str(tunnels["peer_name"]): "connected",
+        },
+        "tunnel_config": "needs_update",
+        "tunnel_service_binding": "ready",
+        "intent_delivery": "delivered",
+        "set_route": "ok",
+        "start_result": "ok",
+        "stop_result": "ok",
+        "trace": [],
+    }
+
+
+def _write_matching_manifests(config: dict[str, object]) -> None:
+    state = config["state"]
+    assert isinstance(state, dict)
+    fingerprints = {
+        "stable_base_url": _sha256("https://exomem.example.test"),
+        "github_oauth_client_id": _sha256("client-id"),
+        "github_oauth_client_secret": _sha256("client-secret"),
+        "github_oauth_callback": _sha256("https://exomem.example.test/auth/callback"),
+        "allowed_github_username": _sha256("operator-login"),
+        "allowed_github_user_id": _sha256("123456"),
+        "jwt_signing_key": _sha256("not-for-output"),
+    }
+    for key in ("manifest_path", "peer_manifest_path"):
+        Path(str(state[key])).parent.mkdir(parents=True, exist_ok=True)
+        Path(str(state[key])).write_text(
+            json.dumps({"schema_version": 1, "host_id": Path(str(state[key])).stem.removeprefix("manifest-"), "fingerprints": fingerprints}),
+            encoding="utf-8",
+        )
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _write_intent(config: dict[str, object], host_id: str, generation: int = 7) -> None:
+    state = config["state"]
+    assert isinstance(state, dict)
+    Path(str(state["intent_path"])).parent.mkdir(parents=True, exist_ok=True)
+    Path(str(state["intent_path"])).write_text(
+        json.dumps({"schema_version": 1, "desired_host": host_id, "generation": generation, "advisory": True}),
+        encoding="utf-8",
+    )
+
+
+def _write_journal(config: dict[str, object], value: dict[str, object]) -> Path:
+    state = config["state"]
+    assert isinstance(state, dict)
+    path = Path(str(state["journal_path"]))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": 1, **value}), encoding="utf-8")
+    return path
+
+
+def _adapter(
+    tmp_path: Path,
+    config: dict[str, object],
+    state: dict[str, object] | None = None,
+    *,
+    shared_state_path: Path | None = None,
+) -> tuple[Path, Path]:
+    host = config["host"]
+    health = config["health"]
+    tunnels = config["tunnels"]
+    assert isinstance(host, dict) and isinstance(health, dict) and isinstance(tunnels, dict)
+    state_path = shared_state_path or (tmp_path / f"adapter-state-{host['id']}.json")
+    if state is not None or not state_path.exists():
+        state_path.write_text(json.dumps(state or _default_state(config)), encoding="utf-8")
+    adapter_path = tmp_path / f"adapter-{host['id']}.ps1"
+
+    def ps(value: object) -> str:
+        return str(value).replace("'", "''")
+
+    adapter_path.write_text(
+        f"""
+$global:ColdStandbyStatePath = '{ps(state_path)}'
+$global:ColdStandbyHostId = '{ps(host['id'])}'
+$global:ColdStandbyPeerId = '{ps(host['peer_id'])}'
+$global:ColdStandbyLocalUrl = '{ps(health['local_url'])}'
+$global:ColdStandbyPeerUrl = '{ps(health['peer_url'])}'
+$global:ColdStandbyStableUrl = '{ps(health['stable_url'])}'
+$global:ColdStandbyOAuthUrl = '{ps(health['oauth_discovery_url'])}'
+$global:ColdStandbyBaseUrl = 'https://exomem.example.test'
+$global:ColdStandbyLocalTunnelName = '{ps(tunnels['local_name'])}'
+$global:ColdStandbyLocalTunnelId = '{ps(tunnels['local_id'])}'
+$global:ColdStandbyPeerTunnelName = '{ps(tunnels['peer_name'])}'
+$global:ColdStandbyPeerTunnelId = '{ps(tunnels['peer_id'])}'
+$global:ColdStandbyProbeIndexes = @{{}}
+
+function Get-FakeState {{ Get-Content -Raw -LiteralPath $global:ColdStandbyStatePath | ConvertFrom-Json -AsHashtable }}
+function Save-FakeState($state) {{ $state | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $global:ColdStandbyStatePath -Encoding utf8 }}
+function Add-FakeTrace($name) {{ $state = Get-FakeState; $state.trace = @($state.trace) + $name; Save-FakeState $state }}
+function Get-FakeProbe($url) {{
+    $state = Get-FakeState
+    if ($state.probe_sequences.ContainsKey($url)) {{
+        $index = if ($global:ColdStandbyProbeIndexes.ContainsKey($url)) {{ [int]$global:ColdStandbyProbeIndexes[$url] }} else {{ 0 }}
+        $sequence = @($state.probe_sequences[$url])
+        $global:ColdStandbyProbeIndexes[$url] = $index + 1
+        return $sequence[[Math]::Min($index, $sequence.Count - 1)]
+    }}
+    if ($state.probe_override.ContainsKey($url)) {{ return $state.probe_override[$url] }}
+    if ($url -eq $global:ColdStandbyLocalUrl) {{
+        $service = $state.services[$global:ColdStandbyHostId]
+        return @{{ state = if ($service -eq 'running') {{ 'ready' }} else {{ 'inactive' }}; instance_id = $global:ColdStandbyHostId }}
+    }}
+    if ($url -eq $global:ColdStandbyPeerUrl) {{
+        if ($state.ContainsKey('pre_activation_peer') -and $state.services[$global:ColdStandbyHostId] -eq 'stopped') {{ return $state.pre_activation_peer }}
+        if ($state.ContainsKey('post_stop_peer') -and $state.services[$global:ColdStandbyHostId] -eq 'stopped') {{ return $state.post_stop_peer }}
+        $service = $state.services[$global:ColdStandbyPeerId]
+        return @{{ state = if ($service -eq 'running') {{ 'ready' }} else {{ 'inactive' }}; instance_id = $global:ColdStandbyPeerId }}
+    }}
+    if ($url -eq $global:ColdStandbyStableUrl) {{
+        if ($state.ContainsKey('pre_activation_stable') -and $state.services[$global:ColdStandbyHostId] -eq 'stopped') {{ return $state.pre_activation_stable }}
+        if ($state.ContainsKey('post_route_public') -and $state.route.tunnel_id -eq $global:ColdStandbyLocalTunnelId) {{ return $state.post_route_public }}
+        $active = if ($state.route.tunnel_id -eq $global:ColdStandbyLocalTunnelId) {{ $global:ColdStandbyHostId }} else {{ $global:ColdStandbyPeerId }}
+        $service = $state.services[$active]
+        return @{{ state = if ($service -eq 'running') {{ 'ready' }} else {{ 'inactive' }}; instance_id = $active }}
+    }}
+    return @{{ state = 'unknown' }}
+}}
+
+return @{{
+    Now = {{ [int64]1700000000000 }}
+    Sleep = {{ param($seconds) }}
+    GetService = {{ param($name) $state = Get-FakeState; @{{ state = $state.services[$global:ColdStandbyHostId] }} }}
+    GetServiceEnvironment = {{ param($name) $state = Get-FakeState; $state.service_environments[$global:ColdStandbyHostId] }}
+    StartService = {{ param($name) $state = Get-FakeState; Add-FakeTrace 'start-service'; if ($state.start_result -eq 'fail') {{ throw 'simulated start failure' }}; $state = Get-FakeState; $state.services[$global:ColdStandbyHostId] = 'running'; Save-FakeState $state; $true }}
+    StopService = {{ param($name) $state = Get-FakeState; Add-FakeTrace 'stop-service'; if ($state.stop_result -eq 'fail') {{ throw 'simulated stop failure' }}; $state = Get-FakeState; $state.services[$global:ColdStandbyHostId] = 'stopped'; Save-FakeState $state; $true }}
+    SetDemandStart = {{ param($name) Add-FakeTrace 'demand-start'; $true }}
+    InspectDesktopTask = {{ param($command, $delay) @{{ state = 'needs_update' }} }}
+    RegisterDesktopTask = {{ param($command, $delay) Add-FakeTrace 'register-task'; $true }}
+    InspectTunnelConfig = {{ param($policy) $state = Get-FakeState; @{{ state = $state.tunnel_config }} }}
+    InspectTunnelServiceBinding = {{ param($name, $policy) $state = Get-FakeState; @{{ state = $state.tunnel_service_binding }} }}
+    PrepareTunnelConfig = {{ param($policy) Add-FakeTrace 'backup-tunnel-config'; Add-FakeTrace 'write-temp-tunnel-config'; Add-FakeTrace 'validate-tunnel-config'; Add-FakeTrace 'replace-tunnel-config'; $true }}
+    ReloadTunnelService = {{ param($name) Add-FakeTrace 'reload-tunnel-service'; $true }}
+    Probe = {{ param($url) Get-FakeProbe $url }}
+    ProbeOAuth = {{ param($url) $state = Get-FakeState; if ($state.oauth_override.ContainsKey($url)) {{ return $state.oauth_override[$url] }}; @{{ state = 'ready'; issuer = $global:ColdStandbyBaseUrl }} }}
+    GetSyncthing = {{ param($syncthing) $state = Get-FakeState; $state.syncthing }}
+    GetMarkerVersion = {{ param($intentPath) $intent = Get-Content -Raw -LiteralPath $intentPath | ConvertFrom-Json -AsHashtable; @{{ generation = [int64]$intent.generation; version = "marker:$($intent.generation)" }} }}
+    GetIntentDelivery = {{ param($syncthing, $generation, $intentPath) $state = Get-FakeState; $intent = Get-Content -Raw -LiteralPath $intentPath | ConvertFrom-Json -AsHashtable; @{{ state = $state.intent_delivery; generation = if ($state.intent_delivery -eq 'delivered' -and [int64]$intent.generation -eq [int64]$generation) {{ $generation }} else {{ $null }}; marker_version = if ($state.intent_delivery -eq 'delivered') {{ "marker:$generation" }} elseif ($state.intent_delivery -eq 'stale') {{ 'marker:stale' }} else {{ $null }} }} }}
+    GetTunnel = {{ param($name) $state = Get-FakeState; @{{ state = $state.tunnels[$name] }} }}
+    GetRoute = {{ param($cloudflare, $tunnels) $state = Get-FakeState; $state.route }}
+    SetRoute = {{ param($tunnel, $hostname) Add-FakeTrace "set-route:$tunnel"; $state = Get-FakeState; if ($state.set_route -eq 'fail') {{ $state.set_route = 'ok'; Save-FakeState $state; throw 'simulated route failure' }}; if ($state.set_route -ne 'stale') {{ $id = if ($tunnel -eq $global:ColdStandbyLocalTunnelName -or $tunnel -eq $global:ColdStandbyLocalTunnelId) {{ $global:ColdStandbyLocalTunnelId }} else {{ $global:ColdStandbyPeerTunnelId }}; $state.route = @{{ state = 'known'; tunnel_id = $id; target = "$id.cfargotunnel.com" }}; Save-FakeState $state }}; $true }}
+    WriteJson = {{ param($path, $value) Add-FakeTrace "write-json:$([IO.Path]::GetFileName($path))"; $parent = Split-Path -Parent $path; New-Item -ItemType Directory -Force -Path $parent | Out-Null; $value | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $path -Encoding utf8; $true }}
+    ReadJson = {{ param($path) if (Test-Path -LiteralPath $path) {{ Get-Content -Raw -LiteralPath $path | ConvertFrom-Json -AsHashtable }} else {{ $null }} }}
+    GetTrace = {{ $state = Get-FakeState; @($state.trace) }}
+}}
+""",
+        encoding="utf-8",
+    )
+    return adapter_path, state_path
+
+
+def _run(config: Path, adapter: Path, *args: str, json_output: bool = True) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "TEST_BASE_URL": "https://exomem.example.test/",
+        "TEST_GITHUB_CLIENT_ID": "client-id",
+        "TEST_GITHUB_CLIENT_SECRET": "client-secret",
+        "TEST_GITHUB_USERNAME": "operator-login",
+        "TEST_GITHUB_USER_ID": "123456",
+        "TEST_JWT_SIGNING_KEY": "not-for-output",
+        "TEST_SYNCTHING_API_KEY": "not-for-output-either",
+        "TEST_CLOUDFLARE_API_TOKEN": "not-for-output-cloudflare",
+        "TEST_CLOUDFLARE_ZONE_ID": "test-zone-id",
+    }
+    command = [PWSH, "-NoProfile", "-NonInteractive", "-File", str(SCRIPT), *args, "-ConfigPath", str(config), "-AdapterPath", str(adapter)]
+    if json_output:
+        command.append("-Json")
+    return subprocess.run(command, text=True, capture_output=True, check=False, env=env)
+
+
+def _terminal(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:  # pragma: no cover - assertion context
+        raise AssertionError((result.returncode, result.stdout, result.stderr)) from error
+
+
+def _prepared(tmp_path: Path, *, role: str = "laptop", intent: str | None = None) -> tuple[Path, dict[str, object], Path, Path]:
+    path, config = _config(tmp_path, role=role)
+    _write_matching_manifests(config)
+    if intent is not None:
+        _write_intent(config, intent)
+    adapter, state_path = _adapter(tmp_path, config)
+    return path, config, adapter, state_path
+
+
+def test_status_is_bounded_read_only_and_names_unknown_evidence(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    state = _default_state(config)
+    health = config["health"]
+    assert isinstance(health, dict)
+    state["probe_override"] = {str(health["peer_url"]): {"state": "unreachable"}}
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Status")
+
+    assert result.returncode == 0, (result.stderr, result.stdout)
+    terminal = _terminal(result)
+    assert terminal["action"] == "Status"
+    assert terminal["active_host"] == "unknown"
+    assert "peer health is unknown" in terminal["reasons"]
+    assert terminal["next_action"] == "none: resolve unknown or unsafe evidence"
+    assert terminal["evidence"]["peer_health"]["samples"] == 3
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_status_human_terminal_is_useful_and_redacted(tmp_path: Path) -> None:
+    config_path, _, adapter, _ = _prepared(tmp_path)
+
+    result = _run(config_path, adapter, "Status", json_output=False)
+
+    assert result.returncode == 0
+    assert "Status" in result.stdout
+    assert "Next safe action" in result.stdout
+    assert "not-for-output" not in result.stdout
+    assert "operator-123" not in result.stdout
+
+
+def test_status_reports_both_ready_as_unsafe_without_mutation(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    host = config["host"]
+    assert isinstance(host, dict)
+    state["services"] = {str(host["id"]): "running", str(host["peer_id"]): "running"}
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Status")
+
+    terminal = _terminal(result)
+    assert terminal["active_host"] == "unsafe_ambiguous"
+    assert "both origins report ready" in terminal["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+@pytest.mark.parametrize(
+    "damage, expected",
+    [
+        (("host", "peer_id", "laptop"), "host and peer identities must be distinct"),
+        (("tunnels", "peer_name", "laptop-tunnel"), "local and peer tunnel names must be distinct"),
+        (("tunnels", "peer_id", LAPTOP_TUNNEL_ID), "local and peer tunnel IDs must be distinct"),
+        (("health", "peer_url", "https://laptop.ops.example.test/health/ready"), "local and peer health URLs must be distinct"),
+        (("health", "peer_url", "https://exomem.example.test/health/ready"), "peer readiness URL must use peer_operational_hostname"),
+    ],
+)
+def test_invalid_identity_configuration_refuses_before_mutation(tmp_path: Path, damage: tuple[str, str, str], expected: str) -> None:
+    config_path, config = _config(tmp_path)
+    section = config[damage[0]]
+    assert isinstance(section, dict)
+    section[damage[1]] = damage[2]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    adapter, state_path = _adapter(tmp_path, config)
+
+    result = _run(config_path, adapter, "Configure")
+
+    assert result.returncode != 0
+    assert any(expected in item for item in _terminal(result)["reasons"])
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_missing_required_configuration_refuses_before_adapter_load(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    del config["syncthing"]["folder_id"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    adapter, state_path = _adapter(tmp_path, config)
+
+    result = _run(config_path, adapter, "Configure")
+
+    assert result.returncode != 0
+    assert "Configuration requires 'syncthing.folder_id'." in _terminal(result)["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_status_bounds_malformed_replicated_generation(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path)
+    state_config = config["state"]
+    assert isinstance(state_config, dict)
+    intent_path = Path(str(state_config["intent_path"]))
+    intent_path.parent.mkdir(parents=True, exist_ok=True)
+    intent_path.write_text(json.dumps({"desired_host": "laptop", "generation": "bad"}), encoding="utf-8")
+
+    result = _run(config_path, adapter, "Status")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "status"
+    assert "desired-host intent is unknown" in terminal["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_safety_evidence_urls_require_https(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    config["health"]["peer_url"] = "http://desktop.ops.example.test/health/ready"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    adapter, state_path = _adapter(tmp_path, config)
+
+    result = _run(config_path, adapter, "Status")
+
+    assert result.returncode != 0
+    assert "must use HTTPS" in _terminal(result)["reasons"][0]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_configure_refuses_cloudflared_service_bound_to_another_config(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    state = _default_state(config)
+    state["tunnel_service_binding"] = "wrong_config"
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Configure")
+
+    assert result.returncode != 0
+    assert "not bound to the configured file" in _terminal(result)["reasons"][0]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+@pytest.mark.parametrize("action", ["Configure", "Activate", "Handoff"])
+def test_whatif_evaluates_preconditions_and_never_mutates(tmp_path: Path, action: str) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    if action == "Handoff":
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["services"] = {"laptop": "running", "desktop": "stopped"}
+        state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run(config_path, adapter, action, "-WhatIf")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "what_if"
+    assert terminal["plan"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+@pytest.mark.parametrize("action, phase", [("Activate", "routing"), ("Handoff", "stopping_source")])
+def test_whatif_never_replays_an_interrupted_operation(tmp_path: Path, action: str, phase: str) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    if action == "Handoff":
+        state["services"] = {"laptop": "running", "desktop": "stopped"}
+        state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+        desired_host = "desktop"
+    else:
+        desired_host = "laptop"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    journal_path = _write_journal(
+        config,
+        {
+            "action": action,
+            "phase": phase,
+            "generation": 8,
+            "desired_host": desired_host,
+            "previous_route": DESKTOP_TUNNEL_ID if action == "Activate" else LAPTOP_TUNNEL_ID,
+            "started_service": action == "Activate",
+            "source_was_running": action == "Handoff",
+            "marker_version": "marker:8",
+            "terminal": None,
+            "identity": {"expected_base_url": "https://exomem.example.test"},
+        },
+    )
+    before_journal = journal_path.read_text(encoding="utf-8")
+
+    _run(config_path, adapter, action, "-WhatIf")
+
+    assert journal_path.read_text(encoding="utf-8") == before_journal
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_configure_is_explicit_idempotent_and_role_scoped(tmp_path: Path) -> None:
+    desktop_path, desktop_config = _config(tmp_path, role="desktop")
+    desktop_adapter, desktop_state_path = _adapter(tmp_path, desktop_config)
+
+    result = _run(desktop_path, desktop_adapter, "Configure")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "configured"
+    assert terminal["tunnel_policy"] == {
+        "stable": "forward-all",
+        "direct": ["/health", "/health/ready"],
+        "direct_fallback": "http_status:404",
+    }
+    trace = json.loads(desktop_state_path.read_text(encoding="utf-8"))["trace"]
+    assert trace == [
+        "demand-start",
+        "backup-tunnel-config",
+        "write-temp-tunnel-config",
+        "validate-tunnel-config",
+        "replace-tunnel-config",
+        "reload-tunnel-service",
+        "write-json:manifest-desktop.json",
+        "register-task",
+    ]
+
+    laptop_dir = tmp_path / "laptop"
+    laptop_dir.mkdir()
+    laptop_path, laptop_config = _config(laptop_dir, role="laptop")
+    laptop_adapter, laptop_state_path = _adapter(laptop_dir, laptop_config)
+    result = _run(laptop_path, laptop_adapter, "Configure")
+    assert result.returncode == 0
+    assert "register-task" not in json.loads(laptop_state_path.read_text(encoding="utf-8"))["trace"]
+
+
+@pytest.mark.skipif(CLOUDFLARED is None, reason="cloudflared is not available")
+def test_native_tunnel_preparation_is_atomic_idempotent_and_health_only(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    tunnels = config["tunnels"]
+    assert isinstance(tunnels, dict)
+    tunnel_config = Path(str(tunnels["config_path"]))
+    tunnel_config.write_text(
+        "\n".join(
+            [
+                f"tunnel: {tunnels['local_id']}",
+                "credentials-file: operator-config/credentials.json",
+                "ingress:",
+                "  - hostname: unrelated.example.test",
+                "    service: http://127.0.0.1:9999",
+                "  - service: http_status:404",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    adapter = tmp_path / "native-tunnel-adapter.ps1"
+    dotenv_path = str(config["identity_environment"]["dotenv_path"]).replace("'", "''")
+    adapter.write_text(
+        """
+$native = Get-NativeAdapter
+return @{
+    SetDemandStart = { param($name) $true }
+    GetServiceEnvironment = { param($name) @{ state = 'known'; values = Read-DotenvMap '__DOTENV_PATH__' } }
+    InspectDesktopTask = { param($command, $delay) @{ state = 'not_applicable' } }
+    RegisterDesktopTask = { param($command, $delay) throw 'not expected' }
+    InspectTunnelConfig = $native.InspectTunnelConfig
+    InspectTunnelServiceBinding = { param($name, $policy) @{ state = 'ready' } }
+    PrepareTunnelConfig = $native.PrepareTunnelConfig
+    ReloadTunnelService = { param($name) $true }
+    GetTunnel = { param($name) @{ state = 'connected' } }
+    WriteJson = $native.WriteJson
+    GetTrace = { @() }
+}
+""".replace("__DOTENV_PATH__", dotenv_path),
+        encoding="utf-8",
+    )
+
+    first = _run(config_path, adapter, "Configure")
+
+    assert first.returncode == 0, (first.stdout, first.stderr)
+    rendered = tunnel_config.read_text(encoding="utf-8")
+    assert "hostname: unrelated.example.test" in rendered
+    assert "hostname: exomem.example.test" in rendered
+    assert "path: ^/health(?:/ready)?$" in rendered
+    direct_index = rendered.index("hostname: laptop.ops.example.test")
+    health_index = rendered.index("path: ^/health(?:/ready)?$", direct_index)
+    direct_404_index = rendered.index("service: http_status:404", health_index)
+    assert direct_index < health_index < direct_404_index
+    assert rendered.rstrip().endswith("- service: http_status:404")
+    backups = list(tmp_path.glob("cloudflared-laptop.yml.exomem-cold-standby.*.bak"))
+    assert len(backups) == 1
+    assert "hostname: unrelated.example.test" in backups[0].read_text(encoding="utf-8")
+
+    second = _run(config_path, adapter, "Configure")
+
+    assert second.returncode == 0, (second.stdout, second.stderr)
+    assert tunnel_config.read_text(encoding="utf-8") == rendered
+    assert len(list(tmp_path.glob("cloudflared-laptop.yml.exomem-cold-standby.*.bak"))) == 1
+
+    def matched_rule(url: str) -> str:
+        result = subprocess.run(
+            [CLOUDFLARED, "tunnel", "--config", str(tunnel_config), "ingress", "rule", url],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, (result.stdout, result.stderr)
+        return result.stdout
+
+    assert "service: http://127.0.0.1:8765" in matched_rule("https://laptop.ops.example.test/health")
+    assert "service: http://127.0.0.1:8765" in matched_rule("https://laptop.ops.example.test/health/ready")
+    for path in ("/mcp", "/.well-known/oauth-authorization-server", "/api/write", "/artifacts/item"):
+        assert "service: http_status:404" in matched_rule(f"https://laptop.ops.example.test{path}")
+    assert "service: http://127.0.0.1:8765" in matched_rule("https://exomem.example.test/mcp")
+
+
+def test_native_syncthing_delivery_accepts_documented_file_response(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    _write_intent(config, "laptop")
+    state_config = config["state"]
+    assert isinstance(state_config, dict)
+    intent_path = Path(str(state_config["intent_path"]))
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path == "/rest/db/file":
+                stat = intent_path.stat()
+                seconds, nanoseconds = divmod(stat.st_mtime_ns, 1_000_000_000)
+                modified = f"{time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(seconds))}.{nanoseconds:09d}Z"
+                entry = {
+                    "deleted": False,
+                    "ignored": False,
+                    "invalid": False,
+                    "modified": modified,
+                    "name": ".exomem-state/desired-host.json",
+                    "size": stat.st_size,
+                    "version": ["TESTDEVICE:1700000000000"],
+                }
+                payload = {"availability": [], "global": entry, "local": entry}
+            elif parsed.path == "/rest/db/completion":
+                payload = {"completion": 100, "needBytes": 0, "needItems": 0, "remoteState": "valid"}
+            elif parsed.path == "/rest/db/remoteneed":
+                payload = {"files": [], "page": 1, "perpage": 100}
+            else:
+                self.send_error(404)
+                return
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        config["syncthing"]["api_url"] = f"http://127.0.0.1:{server.server_port}"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        state = _default_state(config)
+        state["services"] = {"laptop": "running", "desktop": "stopped"}
+        state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+        fake_adapter, state_path = _adapter(tmp_path, config, state)
+        wrapper = tmp_path / "native-syncthing-adapter.ps1"
+        escaped_adapter = str(fake_adapter).replace("'", "''")
+        wrapper.write_text(
+            f"$fake = . '{escaped_adapter}'\n"
+            "$native = Get-NativeAdapter\n"
+            "$fake.GetMarkerVersion = $native.GetMarkerVersion\n"
+            "$fake.GetIntentDelivery = $native.GetIntentDelivery\n"
+            "return $fake\n",
+            encoding="utf-8",
+        )
+
+        result = _run(config_path, wrapper, "Handoff")
+
+        assert result.returncode == 0, (result.stdout, result.stderr)
+        assert _terminal(result)["terminal"] == "handoff_pending_activation"
+        journal = json.loads(Path(str(state_config["journal_path"])).read_text(encoding="utf-8"))
+        assert journal["syncthing_version"] == "TESTDEVICE:1700000000000"
+        assert json.loads(state_path.read_text(encoding="utf-8"))["services"]["laptop"] == "stopped"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize(
+    ("condition", "reason"),
+    [
+        ("peer_ready", "peer is ready"),
+        ("peer_unreachable", "peer inactivity is unproven"),
+        ("stable_ready", "stable endpoint is already ready"),
+        ("stable_unreachable", "stable endpoint state is ambiguous"),
+        ("sync_pending", "Syncthing is not converged"),
+        ("sync_unknown", "Syncthing API is unavailable"),
+        ("intent_conflict", "desired-host intent names peer"),
+        ("manifest_mismatch", "shared configuration fingerprint mismatch: jwt_signing_key"),
+    ],
+)
+def test_activate_refuses_unsafe_evidence_before_service_or_dns_mutation(tmp_path: Path, condition: str, reason: str) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    health = config["health"]
+    config_state = config["state"]
+    assert isinstance(health, dict) and isinstance(config_state, dict)
+    if condition == "peer_ready":
+        state["probe_override"] = {str(health["peer_url"]): {"state": "ready", "instance_id": "desktop"}}
+    elif condition == "peer_unreachable":
+        state["probe_override"] = {str(health["peer_url"]): {"state": "unreachable"}}
+    elif condition == "stable_ready":
+        state["probe_override"] = {str(health["stable_url"]): {"state": "ready", "instance_id": "desktop"}}
+    elif condition == "stable_unreachable":
+        state["probe_override"] = {str(health["stable_url"]): {"state": "unreachable"}}
+    elif condition == "sync_pending":
+        state["syncthing"]["pending_bytes"] = 4
+        state["syncthing"]["peer_complete"] = False
+    elif condition == "sync_unknown":
+        state["syncthing"]["api"] = "unreachable"
+    elif condition == "intent_conflict":
+        _write_intent(config, "desktop")
+    else:
+        peer_manifest = json.loads(Path(str(config_state["peer_manifest_path"])).read_text(encoding="utf-8"))
+        peer_manifest["fingerprints"]["jwt_signing_key"] = "f" * 64
+        Path(str(config_state["peer_manifest_path"])).write_text(json.dumps(peer_manifest), encoding="utf-8")
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    terminal = _terminal(result)
+    assert reason in terminal["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_activate_orders_transition_and_verifies_route_identity_and_oauth(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "activated"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    intent_index = trace.index("write-json:desired-host.json")
+    start_index = trace.index("start-service")
+    route_index = trace.index("set-route:laptop-tunnel")
+    assert intent_index < start_index < route_index
+    assert trace[-1] == "write-json:journal-laptop.json"
+    assert terminal["route_target"] == f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"
+    assert "not-for-output" not in result.stdout
+    assert "operator-123" not in result.stdout
+
+
+def test_planned_handoff_target_can_activate_from_connected_tunnel_502s(tmp_path: Path) -> None:
+    config_path, _, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state["pre_activation_peer"] = {"state": "unserved", "status_code": 502}
+    state["pre_activation_stable"] = {"state": "unserved", "status_code": 502}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert _terminal(result)["terminal"] == "activated"
+
+
+def test_activate_failure_before_routing_never_changes_dns(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    state["start_result"] = "fail"
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    assert _terminal(result)["terminal"] == "rolled_back"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert "start-service" in trace
+    assert not any(item.startswith("set-route:") for item in trace)
+
+
+def test_activate_compensates_wrong_public_origin_to_known_route(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    health = config["health"]
+    assert isinstance(health, dict)
+    state["probe_override"] = {str(health["stable_url"]): {"state": "ready", "instance_id": "desktop"}}
+    # The first stable checks must be inactive; the fake switches to this override only
+    # after routing by using the dedicated post-route override understood by the adapter.
+    state["probe_override"] = {}
+    state["post_route_public"] = {"state": "ready", "instance_id": "desktop"}
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "rolled_back"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert trace.index("set-route:laptop-tunnel") < trace.index(f"set-route:{DESKTOP_TUNNEL_ID}") < trace.index("stop-service")
+
+
+def test_activate_unknown_prior_route_requires_operator_recovery(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    state["route"] = {"state": "unknown", "tunnel_id": None, "target": None}
+    state["set_route"] = "stale"
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "operator_recovery_required"
+    assert "stop-service" in json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+
+
+def test_interrupted_route_replay_commits_only_when_route_and_origin_agree(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path)
+    config_state = config["state"]
+    assert isinstance(config_state, dict)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    Path(str(config_state["journal_path"])).write_text(
+        json.dumps({
+            "schema_version": 1,
+            "action": "Activate",
+            "phase": "route_changed",
+            "generation": 8,
+            "desired_host": "laptop",
+            "previous_route": DESKTOP_TUNNEL_ID,
+            "started_service": True,
+            "terminal": None,
+            "bypassed_guards": [],
+        }),
+        encoding="utf-8",
+    )
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert _terminal(result)["terminal"] == "recovered_activation"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert not any(item.startswith("set-route:") for item in trace)
+    assert "start-service" not in trace
+
+
+def test_completed_activation_replay_is_idempotent(tmp_path: Path) -> None:
+    config_path, _, adapter, state_path = _prepared(tmp_path)
+    first = _run(config_path, adapter, "Activate")
+    assert first.returncode == 0, (first.stdout, first.stderr)
+    first_trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+
+    second = _run(config_path, adapter, "Activate")
+
+    assert second.returncode == 0, (second.stdout, second.stderr)
+    assert _terminal(second)["terminal"] == "already_activated"
+    second_trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert second_trace == first_trace
+
+
+def test_force_is_two_part_narrow_and_audited(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    _write_intent(config, "desktop")
+    state = _default_state(config)
+    health = config["health"]
+    assert isinstance(health, dict)
+    state["probe_override"] = {str(health["peer_url"]): {"state": "unreachable"}}
+    state["syncthing"]["pending_bytes"] = 12
+    state["syncthing"]["peer_complete"] = False
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    missing_ack = _run(config_path, adapter, "Activate", "-Force")
+    assert missing_ack.returncode != 0
+    assert "exact acknowledgement" in _terminal(missing_ack)["reasons"][0]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+    result = _run(config_path, adapter, "Activate", "-Force", "-Acknowledge", ACK)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["bypassed_guards"] == [
+        "Syncthing is not converged",
+        "peer inactivity is unproven",
+        "desired-host intent names peer",
+    ]
+    journal = json.loads(Path(str(config["state"]["journal_path"])).read_text(encoding="utf-8"))
+    assert journal["bypassed_guards"] == terminal["bypassed_guards"]
+
+
+def test_force_cannot_bypass_unknown_stable_route_or_identity_drift(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    health = config["health"]
+    state_config = config["state"]
+    assert isinstance(health, dict) and isinstance(state_config, dict)
+    peer_manifest = json.loads(Path(str(state_config["peer_manifest_path"])).read_text(encoding="utf-8"))
+    peer_manifest["fingerprints"]["github_oauth_callback"] = "0" * 64
+    Path(str(state_config["peer_manifest_path"])).write_text(json.dumps(peer_manifest), encoding="utf-8")
+    state = _default_state(config)
+    state["probe_override"] = {str(health["stable_url"]): {"state": "unreachable"}}
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate", "-Force", "-Acknowledge", ACK)
+
+    assert result.returncode != 0
+    reasons = _terminal(result)["reasons"]
+    assert "stable endpoint state is ambiguous" in reasons
+    assert "shared configuration fingerprint mismatch: github_oauth_callback" in reasons
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_duplicate_local_manifest_cannot_stand_in_for_peer_parity(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state_config = config["state"]
+    assert isinstance(state_config, dict)
+    local_manifest = json.loads(Path(str(state_config["manifest_path"])).read_text(encoding="utf-8"))
+    Path(str(state_config["peer_manifest_path"])).write_text(json.dumps(local_manifest), encoding="utf-8")
+    adapter, state_path = _adapter(tmp_path, config)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    assert "shared configuration peer manifest identifies the wrong host" in _terminal(result)["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_status_bounds_malformed_manifest_shape(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state_config = config["state"]
+    assert isinstance(state_config, dict)
+    Path(str(state_config["peer_manifest_path"])).write_text(
+        json.dumps({"schema_version": 1, "host_id": "desktop", "fingerprints": "corrupt"}),
+        encoding="utf-8",
+    )
+    adapter, state_path = _adapter(tmp_path, config)
+
+    result = _run(config_path, adapter, "Status")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "shared configuration peer manifest is unavailable" in _terminal(result)["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_effective_service_secret_drift_refuses_activation(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    state = _default_state(config)
+    state["service_environments"]["laptop"]["values"]["TEST_GITHUB_CLIENT_SECRET"] = "different-secret"
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate")
+
+    assert result.returncode != 0
+    assert "effective shared configuration is unavailable" in _terminal(result)["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_force_cannot_bypass_any_positive_peer_ready_sample(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    _write_intent(config, "laptop")
+    health = config["health"]
+    assert isinstance(health, dict)
+    state = _default_state(config)
+    state["probe_sequences"] = {
+        str(health["peer_url"]): [
+            {"state": "ready", "instance_id": "desktop"},
+            {"state": "unserved", "status_code": 502},
+            {"state": "unserved", "status_code": 502},
+        ]
+    }
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Activate", "-Force", "-Acknowledge", ACK)
+
+    assert result.returncode != 0
+    terminal = _terminal(result)
+    assert "peer is ready" in terminal["reasons"]
+    assert "peer is ready" not in terminal["bypassed_guards"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_if_unserved_requires_desktop_intent_and_conclusive_inactivity(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, role="desktop", intent="laptop")
+
+    result = _run(config_path, adapter, "Activate", "-IfUnserved")
+
+    assert result.returncode != 0
+    assert "activate-if-unserved requires intent naming desktop" in _terminal(result)["reasons"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["trace"] == []
+
+
+def test_handoff_requires_exact_intent_delivery_before_stopping_source(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state["intent_delivery"] = "unknown"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run(config_path, adapter, "Handoff")
+
+    assert result.returncode != 0
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "intent_delivery_unproven"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert "stop-service" not in trace
+    assert not any(item.startswith("set-route:") for item in trace)
+
+
+def test_handoff_retries_the_same_timed_out_generation(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state["intent_delivery"] = "unknown"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    first = _run(config_path, adapter, "Handoff")
+    assert _terminal(first)["terminal"] == "intent_delivery_unproven"
+    journal = json.loads(Path(str(config["state"]["journal_path"])).read_text(encoding="utf-8"))
+    generation = journal["generation"]
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["intent_delivery"] = "delivered"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    second = _run(config_path, adapter, "Handoff")
+
+    assert second.returncode == 0, (second.stdout, second.stderr)
+    assert _terminal(second)["terminal"] == "handoff_pending_activation"
+    final_journal = json.loads(Path(str(config["state"]["journal_path"])).read_text(encoding="utf-8"))
+    assert final_journal["generation"] == generation
+
+
+@pytest.mark.parametrize("phase, route_at_target", [("stopping_source", False), ("routing", True)])
+def test_handoff_replays_power_loss_windows_without_split_brain(tmp_path: Path, phase: str, route_at_target: bool) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path)
+    _write_intent(config, "desktop", generation=8)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "stopped", "desktop": "stopped"}
+    route_id = DESKTOP_TUNNEL_ID if route_at_target else LAPTOP_TUNNEL_ID
+    state["route"] = {"state": "known", "tunnel_id": route_id, "target": f"{route_id}.cfargotunnel.com"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _write_journal(
+        config,
+        {
+            "action": "Handoff",
+            "phase": phase,
+            "generation": 8,
+            "desired_host": "desktop",
+            "previous_route": LAPTOP_TUNNEL_ID,
+            "source_was_running": True,
+            "marker_version": "marker:8",
+            "terminal": None,
+            "identity": {"expected_base_url": "https://exomem.example.test"},
+        },
+    )
+
+    result = _run(config_path, adapter, "Handoff")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert _terminal(result)["terminal"] == "handoff_pending_activation"
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert list(final_state["services"].values()).count("running") == 0
+    if route_at_target:
+        assert not any(item.startswith("set-route:") for item in final_state["trace"])
+    else:
+        assert "set-route:desktop-tunnel" in final_state["trace"]
+
+
+def test_handoff_stops_source_before_route_and_never_starts_remote(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run(config_path, adapter, "Handoff")
+
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    terminal = _terminal(result)
+    assert terminal["terminal"] == "handoff_pending_activation"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert trace.index("stop-service") < trace.index("set-route:desktop-tunnel")
+    assert "start-service" not in trace
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert list(final_state["services"].values()).count("running") == 0
+
+
+def test_handoff_failure_restarts_source_only_when_target_is_proven_inactive(tmp_path: Path) -> None:
+    config_path, config, adapter, state_path = _prepared(tmp_path, intent="laptop")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    state["set_route"] = "fail"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run(config_path, adapter, "Handoff")
+
+    assert result.returncode != 0
+    assert _terminal(result)["terminal"] == "rolled_back"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert trace.index("stop-service") < trace.index("start-service")
+    assert json.loads(state_path.read_text(encoding="utf-8"))["services"]["laptop"] == "running"
+
+
+def test_handoff_failure_keeps_source_stopped_when_target_state_is_unknown(tmp_path: Path) -> None:
+    config_path, config = _config(tmp_path)
+    _write_matching_manifests(config)
+    _write_intent(config, "laptop")
+    state = _default_state(config)
+    host = config["host"]
+    health = config["health"]
+    assert isinstance(host, dict) and isinstance(health, dict)
+    state["services"] = {"laptop": "running", "desktop": "stopped"}
+    state["route"] = {"state": "known", "tunnel_id": LAPTOP_TUNNEL_ID, "target": f"{LAPTOP_TUNNEL_ID}.cfargotunnel.com"}
+    # Peer is initially inactive, then compensation sees unknown through the post-stop override.
+    state["post_stop_peer"] = {"state": "unreachable"}
+    state["set_route"] = "fail"
+    adapter, state_path = _adapter(tmp_path, config, state)
+
+    result = _run(config_path, adapter, "Handoff")
+
+    assert result.returncode != 0
+    assert _terminal(result)["terminal"] == "operator_recovery_required"
+    trace = json.loads(state_path.read_text(encoding="utf-8"))["trace"]
+    assert "start-service" not in trace
+    assert json.loads(state_path.read_text(encoding="utf-8"))["services"]["laptop"] == "stopped"
+
+
+def test_desktop_laptop_round_trip_commits_with_at_most_one_active_service(tmp_path: Path) -> None:
+    desktop_path, desktop_config = _config(tmp_path, role="desktop")
+    laptop_path, laptop_config = _config(tmp_path, role="laptop")
+    _write_matching_manifests(desktop_config)
+    _write_matching_manifests(laptop_config)
+    _write_intent(desktop_config, "desktop")
+    shared_state_path = tmp_path / "two-host-world.json"
+    world = _default_state(desktop_config)
+    world["services"] = {"desktop": "running", "laptop": "stopped"}
+    world["route"] = {"state": "known", "tunnel_id": DESKTOP_TUNNEL_ID, "target": f"{DESKTOP_TUNNEL_ID}.cfargotunnel.com"}
+    desktop_adapter, _ = _adapter(tmp_path, desktop_config, world, shared_state_path=shared_state_path)
+    laptop_adapter, _ = _adapter(tmp_path, laptop_config, shared_state_path=shared_state_path)
+
+    def assert_active(expected: str | None) -> None:
+        shared = json.loads(shared_state_path.read_text(encoding="utf-8"))
+        active = [host for host, service in shared["services"].items() if service == "running"]
+        assert active == ([] if expected is None else [expected])
+
+    assert_active("desktop")
+    to_laptop = _run(desktop_path, desktop_adapter, "Handoff")
+    assert to_laptop.returncode == 0, (to_laptop.stdout, to_laptop.stderr)
+    assert _terminal(to_laptop)["terminal"] == "handoff_pending_activation"
+    assert_active(None)
+
+    laptop_activate = _run(laptop_path, laptop_adapter, "Activate")
+    assert laptop_activate.returncode == 0, (laptop_activate.stdout, laptop_activate.stderr)
+    assert_active("laptop")
+
+    to_desktop = _run(laptop_path, laptop_adapter, "Handoff")
+    assert to_desktop.returncode == 0, (to_desktop.stdout, to_desktop.stderr)
+    assert _terminal(to_desktop)["terminal"] == "handoff_pending_activation"
+    assert_active(None)
+
+    desktop_activate = _run(desktop_path, desktop_adapter, "Activate", "-IfUnserved")
+    assert desktop_activate.returncode == 0, (desktop_activate.stdout, desktop_activate.stderr)
+    assert_active("desktop")

--- a/tests/test_cold_standby.py
+++ b/tests/test_cold_standby.py
@@ -657,6 +657,7 @@ def test_native_syncthing_delivery_accepts_documented_file_response(tmp_path: Pa
             if parsed.path == "/rest/db/file":
                 stat = intent_path.stat()
                 seconds, nanoseconds = divmod(stat.st_mtime_ns, 1_000_000_000)
+                nanoseconds = (nanoseconds // 100) * 100 + 37
                 modified = f"{time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(seconds))}.{nanoseconds:09d}Z"
                 entry = {
                     "deleted": False,

--- a/tests/test_favicon_endpoint.py
+++ b/tests/test_favicon_endpoint.py
@@ -109,6 +109,7 @@ def test_readiness_endpoint_is_public_and_content_free(
             "release": "1.2.3",
             "runtime_contract": 1,
             "transport": "streamable-http-stateless",
+            "instance_id": "desktop-01",
             "replica_id": "desktop",
             "coordination": {
                 "enabled": True,
@@ -124,6 +125,7 @@ def test_readiness_endpoint_is_public_and_content_free(
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-store"
     assert response.json()["runtime_contract"] == 1
+    assert response.json()["instance_id"] == "desktop-01"
     rendered = response.text.lower()
     assert "vault" not in rendered
     assert "token" not in rendered
@@ -143,6 +145,7 @@ def test_readiness_endpoint_returns_503_without_changing_liveness(
             "release": "1.2.3",
             "runtime_contract": 1,
             "transport": "streamable-http-stateless",
+            "instance_id": None,
             "replica_id": "desktop",
             "coordination": {
                 "enabled": True,

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -33,6 +33,7 @@ def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
         "release": "1.2.3",
         "runtime_contract": RUNTIME_CONTRACT,
         "transport": HTTP_TRANSPORT,
+        "instance_id": None,
         "replica_id": None,
         "coordination": {
             "enabled": False,
@@ -49,6 +50,35 @@ def test_standalone_runtime_is_ready_without_multi_host_coordination() -> None:
         "takeover_eligible": True,
         "reasons": [],
     }
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (" laptop-01 ", "laptop-01"),
+        ("", None),
+        ("not public safe!", None),
+        ("x" * 65, None),
+    ],
+)
+def test_readiness_exposes_only_a_valid_trimmed_instance_id(
+    monkeypatch: pytest.MonkeyPatch, configured: str, expected: str | None
+) -> None:
+    from exomem import runtime_readiness as readiness_module
+
+    monkeypatch.setenv("EXOMEM_INSTANCE_ID", configured)
+    snapshot = readiness_module.build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="a" * 64,
+    )
+
+    assert snapshot["instance_id"] == expected
 
 
 def test_healthy_coordinated_follower_is_takeover_eligible() -> None:


### PR DESCRIPTION
## Summary

- add an opt-in, default-off Windows manual cold-standby operator with `Configure`, read-only `Status`, guarded `Activate`, `Activate -IfUnserved`, and planned `Handoff`
- keep one stable MCP/OAuth URL while using distinct named tunnels and health-only direct operational hostnames
- add fail-closed evidence, exact Syncthing intent delivery, identity-parity fingerprints, write-ahead journals, replay, compensation, and a narrow audited disaster override
- expose a public-safe `EXOMEM_INSTANCE_ID` on non-hosted readiness and document setup, cutover, rollback, and connector behavior

No live DNS, tunnel, service, OAuth, Syncthing, or vault mutation was performed. Existing automatic HA/lease/Worker source is unchanged.

## Safety evidence

- direct operational ingress forwards only `/health` and `/health/ready`; MCP, OAuth, REST, and transfer paths reach a final 404
- `-WhatIf` never replays an interrupted journal or mutates state
- peer, local, and stable readiness origins are explicit/distinct; safety evidence uses HTTPS
- service-effective OAuth/JWT values and per-host manifest identities must match before activation or handoff
- handoff stops the source before moving DNS, never starts a remote service, and replays power-loss windows without allowing two committed active services
- forced activation requires the literal acknowledgement and cannot bypass local readiness, route, identity, configuration, or public-origin verification

## Verification

- `61 passed` — `tests/test_runtime_readiness.py tests/test_cold_standby.py` after rebasing on current `origin/main`
- PowerShell AST parse: passed
- Ruff on changed Python: passed
- `openspec validate add-manual-cold-standby --strict`: passed
- `openspec validate --all --strict`: 105 passed, 0 failed
- public-artifact validation: 1696 files / 1695 text payloads clean
- `git diff --check`: passed
- independent safety review: no remaining actionable findings

The sanitized subprocess harness exercises desktop and laptop `Status`, `Configure -WhatIf`, `Activate -WhatIf`, `Handoff -WhatIf`, normal activation/handoff, disaster refusal, compensation, replay, native cloudflared ingress selection, and a Syncthing REST response shaped like the official API.

## Environment-only test blocks

- `tests/test_service_installers.py`: 7 failed, 1 passed because this managed Windows sandbox denies bash access to pytest-created paths (`E_ACCESSDENIED`)
- the two readiness endpoint integration cases are blocked by the same environment's SQLite temp-directory ACL (`unable to open database file`); readiness builder and end-to-end cold-standby coverage are green
