### PR TITLE
chore(registry): enforce server description limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Artexis10/exomem",
   "title": "Exomem",
-  "description": "Local knowledge substrate for owned Markdown/Obsidian vaults, exposed through MCP, REST, and CLI with multimodal OCR/ASR/CLIP search.",
+  "description": "Local Markdown/Obsidian knowledge substrate for MCP agents with governed memory and hybrid search.",
   "version": "0.33.0",
   "websiteUrl": "https://substratesystems.io/exomem",
   "repository": {

--- a/tests/test_mcp_registry_artifact.py
+++ b/tests/test_mcp_registry_artifact.py
@@ -1,0 +1,14 @@
+"""Static checks for the published MCP Registry artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_server_description_obeys_registry_length_contract() -> None:
+    manifest = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+    assert 1 <= len(manifest["description"]) <= 100


### PR DESCRIPTION
## Why

The v0.33.0 MCP Registry publish failed because `server.json` used a 133-character description while the registry schema caps it at 100 characters.

## What changed

- shorten the public registry description to 98 characters
- add a regression test for the registry's 1–100 character contract

## Verification

- `uv run --frozen pytest tests/test_mcp_registry_artifact.py tests/test_uv_lock_policy.py tests/test_public_artifact_privacy.py -q` — 52 passed
- `uvx ruff check . --select F` — passed
- `uvx check-jsonschema --schemafile https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json server.json` — passed
- independent review — GO, no findings

After merge, rerun only the failed v0.33.0 registry-publisher job so the already-published package and image release remain unchanged.