### PR TITLE
fix: diagnose service label mismatches and clarify disposition wording

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -13,6 +13,7 @@
 #   bash scripts/upgrade.sh --package-version 0.25.4   # pin instead of latest
 #   bash scripts/upgrade.sh --cli-sync always          # install CLI if absent
 #   bash scripts/upgrade.sh --skip-restart             # stage it, restart later
+#   bash scripts/upgrade.sh --unit-file ~/Library/LaunchAgents/com.exomem.http.plist
 
 set -euo pipefail
 
@@ -28,6 +29,7 @@ PACKAGE_VERSION=""
 VAULT=""
 SKIP_RESTART=0
 CLI_SYNC="auto"
+UNIT_FILE=""
 
 die() { echo "upgrade: $*" >&2; exit 1; }
 
@@ -37,8 +39,9 @@ while [[ $# -gt 0 ]]; do
         --package-version) PACKAGE_VERSION="${2:?}"; shift 2 ;;
         --vault)           VAULT="${2:?}"; shift 2 ;;
         --cli-sync)        CLI_SYNC="${2:?}"; shift 2 ;;
+        --unit-file)       UNIT_FILE="${2:?}"; shift 2 ;;
         --skip-restart)    SKIP_RESTART=1; shift ;;
-        -h|--help)         sed -n '2,14p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,15p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -54,12 +57,43 @@ esac
 
 OS="$(uname -s)"
 case "$OS" in
-    Darwin) UNIT_FILE="$HOME/Library/LaunchAgents/$LABEL.plist" ;;
-    Linux)  UNIT_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$SERVICE_NAME.service" ;;
-    *)      die "unsupported platform $OS; on Windows use scripts/upgrade.ps1" ;;
+    Darwin)
+        UNIT_DIR="$HOME/Library/LaunchAgents"
+        UNIT_GLOB="$LABEL*.plist"
+        DEFAULT_UNIT="$UNIT_DIR/$LABEL.plist"
+        ;;
+    Linux)
+        UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+        UNIT_GLOB="$SERVICE_NAME*.service"
+        DEFAULT_UNIT="$UNIT_DIR/$SERVICE_NAME.service"
+        ;;
+    *)  die "unsupported platform $OS; on Windows use scripts/upgrade.ps1" ;;
 esac
 
-[[ -f "$UNIT_FILE" ]] || die "no installed service found at $UNIT_FILE. Install one first: bash scripts/install-service.sh --release"
+if [[ -n "$UNIT_FILE" ]]; then
+    [[ -f "$UNIT_FILE" ]] || die "--unit-file not found: $UNIT_FILE"
+elif [[ -f "$DEFAULT_UNIT" ]]; then
+    UNIT_FILE="$DEFAULT_UNIT"
+else
+    # A hand-rolled install may register a suffixed label (com.exomem.http), so
+    # say what was searched and what turned up rather than implying nothing is
+    # installed. Suffixed units are reported, never auto-selected: the upgrade
+    # reads the service venv out of the rendered unit, so guessing wrong fails
+    # later and far less legibly than refusing here.
+    shopt -s nullglob
+    CANDIDATES=("$UNIT_DIR"/$UNIT_GLOB)
+    shopt -u nullglob
+    MSG="no installed service found at $DEFAULT_UNIT (searched $UNIT_DIR for $UNIT_GLOB)."
+    if (( ${#CANDIDATES[@]} )); then
+        MSG="$MSG Found ${#CANDIDATES[@]} similarly-named unit(s): ${CANDIDATES[*]}."
+        MSG="$MSG That is a label mismatch, not a missing install."
+        MSG="$MSG Re-run with --unit-file <path> if the unit launches the exomem entry point;"
+        MSG="$MSG a unit that invokes a custom wrapper cannot be upgraded by this script."
+    else
+        MSG="$MSG Install one first: bash scripts/install-service.sh --release"
+    fi
+    die "$MSG"
+fi
 
 # --- Locate the venv the service ACTUALLY runs ----------------------------------
 # The rendered unit is the source of truth here, the same role the NSSM registry

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -2975,7 +2975,7 @@ def _disposition_detail(page: SemanticPageState, disposition: RelationDispositio
     if page.document.canonical_section_present and page.document.canonical_bullet_count == 0:
         return (
             "the empty canonical Relations section requires a current "
-            "reviewed-none or bootstrap disposition"
+            "reviewed or bootstrap disposition"
         )
     return "the compiled page needs a qualifying relation or explicit current review"
 


### PR DESCRIPTION
Two small follow-ups from Yusuke's 0.33.0 re-test. Both are cosmetic-to-diagnostic, no behaviour change to the write path.

## `upgrade.sh` refused a hand-rolled install with a misleading message

He registered the shared HTTP server by hand as `com.exomem.http`, invoking his own wrapper. `scripts/upgrade.sh` hardcoded `LABEL="com.exomem"` and died with `no installed service found at ~/Library/LaunchAgents/com.exomem.plist` — which reads as "nothing is installed" when the truth is "the label doesn't match".

The script was behaving correctly by refusing; only the message was wrong. It now reports what it searched and what it found, and adds `--unit-file` for units it can still drive.

Deliberately **not** doing prefix auto-selection, which was the obvious fix: the upgrade resolves the service venv by reading the rendered unit (`exomem_service_python`). A wrapper-invoking unit fails that step regardless, so auto-selecting would just move the failure from line 62 to line 69 with a worse message.

## `RELATION_DISPOSITION_MISSING` advertised a hyphen it doesn't accept

The finding's `detail` said `reviewed-none or bootstrap disposition` one line above a `remediation` correctly naming `relation_disposition="reviewed_none"`. The hyphenated prose reads as a field literal. Reworded to `reviewed or bootstrap disposition`.

Note the boundary already accepts both spellings — `relation_review.normalize_relation_disposition()` maps `reviewed-none` → `reviewed_none` (shipped in #335). So this was never a functional break, just a confusing error payload.

## Verification

- `uvx ruff check src/exomem/semantic_contract.py` — clean
- `pytest tests/test_semantic_contract.py tests/test_relation_review.py` — 167 passed
- No test asserted the old detail string
- `bash -n scripts/upgrade.sh` — clean
- All three `upgrade.sh` paths exercised against a `uname` shim + fake `HOME`: no units found; a suffixed `exomem-http.service` present (Yusuke's case, produces the label-mismatch message); and a bad `--unit-file`

Full suite deferred to CI — native Windows can't run it.
