### PR TITLE
fix(release): regenerate hosted plugin artifacts on the release branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      release_branch: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).headBranchName }}
     steps:
       - name: Mint GitHub App installation token
         if: env.HAS_RELEASE_APP == 'true'
@@ -43,6 +44,66 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Release Please bumps the package version but cannot carry the hosted plugin
+  # artifacts with it. `plugins/hosted/definition.json` pins `source_release`,
+  # `hosted_plugins` hard-fails when that diverges from the package release, and
+  # the generated descriptors carry sha256 locks over the definition and the
+  # compatibility manifest that no `extra-files` updater can recompute. So the
+  # release branch runs the real generator and amends its own PR.
+  #
+  # Without the GitHub App token this push uses GITHUB_TOKEN, which does not
+  # retrigger the PR's checks -- the amended branch is correct but shows the
+  # pre-amendment run, so re-run checks before merging.
+  sync-hosted-artifacts:
+    needs: release-please
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_branch != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      HAS_RELEASE_APP: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID != '' && secrets.RELEASE_PLEASE_APP_PRIVATE_KEY != '' }}
+    steps:
+      - name: Mint GitHub App installation token
+        if: env.HAS_RELEASE_APP == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.release_branch }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # Order matters: regenerate refuses to run while the definition is stale,
+      # so the release guard blocks its own remedy until this resync lands.
+      - name: Sync hosted source_release with the release version
+        run: python scripts/sync_hosted_release.py
+
+      - name: Regenerate hosted plugin artifacts
+        run: uv run --frozen python scripts/hosted-plugin.py regenerate --platform claude
+
+      - name: Verify the regenerated artifacts are current
+        run: uv run --frozen python scripts/hosted-plugin.py check --platform claude
+
+      - name: Commit the resync onto the release PR
+        run: |
+          if git diff --quiet; then
+            echo "hosted artifacts already current for this release"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugins/hosted
+          git commit -m "chore(hosted): regenerate plugin artifacts for the release"
+          git push
 
   build-artifacts:
     needs: release-please

--- a/scripts/sync_hosted_release.py
+++ b/scripts/sync_hosted_release.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Point the hosted plugin definition's `source_release` at the package version.
+
+Release Please bumps `pyproject.toml`, but the hosted plugin definition pins
+`source_release` separately and `hosted_plugins.compatibility_manifest` hard
+-fails when the two diverge. That alone would be a job for a Release Please
+`extra-files` updater; it is not, because the generated descriptors under
+`plugins/hosted/generated/` carry sha256 locks over the definition and the
+compatibility manifest. No config-file updater can recompute those, so the
+release branch has to run the real generator.
+
+This script does the version half. `hosted-plugin.py regenerate` does the rest,
+and refuses to run until this has happened -- the release guard also blocks its
+own remedy, so the order matters.
+
+Idempotent: writes nothing and reports no change when already in sync. The
+replacement is textual and anchored to the key so the file's formatting (and
+therefore its sha256, once regenerated) stays under the generator's control
+rather than json.dumps'.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import NamedTuple
+
+DEFINITION_PATH = Path("plugins/hosted/definition.json")
+PYPROJECT_PATH = Path("pyproject.toml")
+_SOURCE_RELEASE = re.compile(r'("source_release"\s*:\s*")([^"]*)(")')
+
+
+class SyncResult(NamedTuple):
+    version: str
+    previous: str
+    changed: bool
+
+
+def package_version(repo_root: Path) -> str:
+    with (repo_root / PYPROJECT_PATH).open("rb") as handle:
+        return tomllib.load(handle)["project"]["version"]
+
+
+def sync(repo_root: Path) -> SyncResult:
+    """Rewrite `source_release` to the package version. Returns what happened."""
+
+    version = package_version(repo_root)
+    definition = repo_root / DEFINITION_PATH
+    text = definition.read_text(encoding="utf-8")
+
+    match = _SOURCE_RELEASE.search(text)
+    if match is None:
+        raise SystemExit(f"no source_release key in {DEFINITION_PATH}")
+    previous = match.group(2)
+    if previous == version:
+        return SyncResult(version, previous, False)
+
+    # count=1: the key appears once, and a stray match elsewhere should not be
+    # silently rewritten too.
+    updated = _SOURCE_RELEASE.sub(rf"\g<1>{version}\g<3>", text, count=1)
+    definition.write_text(updated, encoding="utf-8")
+    return SyncResult(version, previous, True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (defaults to this script's repository)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report drift without writing; exit 1 when out of sync",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        version = package_version(args.repo_root)
+        text = (args.repo_root / DEFINITION_PATH).read_text(encoding="utf-8")
+        match = _SOURCE_RELEASE.search(text)
+        if match is None:
+            raise SystemExit(f"no source_release key in {DEFINITION_PATH}")
+        if match.group(2) != version:
+            print(
+                f"source_release is {match.group(2)}, package version is {version}; "
+                "run scripts/sync_hosted_release.py then "
+                "scripts/hosted-plugin.py regenerate --platform claude",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"source_release is in sync at {version}")
+        return 0
+
+    result = sync(args.repo_root)
+    if result.changed:
+        print(f"source_release {result.previous} -> {result.version}")
+    else:
+        print(f"source_release already at {result.version}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_sync_hosted_release.py
+++ b/tests/test_sync_hosted_release.py
@@ -1,0 +1,105 @@
+"""The release branch must be able to resync the hosted definition's version."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "sync_hosted_release.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-please.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("sync_hosted_release_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_repo(tmp_path: Path, *, package: str, source: str) -> Path:
+    (tmp_path / "plugins" / "hosted").mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "exomem"\nversion = "{package}"\n', encoding="utf-8"
+    )
+    (tmp_path / "plugins" / "hosted" / "definition.json").write_text(
+        '{\n  "plugin_id": "exomem-hosted",\n'
+        f'  "source_release": "{source}",\n'
+        '  "version": "0.1.0"\n}\n',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_sync_rewrites_a_stale_source_release(tmp_path: Path) -> None:
+    root = make_repo(tmp_path, package="0.34.0", source="0.33.0")
+    result = load_module().sync(root)
+
+    assert (result.previous, result.version, result.changed) == ("0.33.0", "0.34.0", True)
+    text = (root / "plugins/hosted/definition.json").read_text(encoding="utf-8")
+    assert '"source_release": "0.34.0"' in text
+    # Formatting survives, so the generator still owns the file's sha256.
+    assert text.startswith('{\n  "plugin_id"')
+    assert '"version": "0.1.0"' in text
+
+
+def test_sync_is_idempotent(tmp_path: Path) -> None:
+    root = make_repo(tmp_path, package="0.34.0", source="0.34.0")
+    definition = root / "plugins/hosted/definition.json"
+    before = definition.read_text(encoding="utf-8")
+
+    result = load_module().sync(root)
+
+    assert result.changed is False
+    assert definition.read_text(encoding="utf-8") == before
+
+
+def test_sync_leaves_the_plugin_version_alone(tmp_path: Path) -> None:
+    """`version` is the plugin's own version and must not track the release."""
+
+    root = make_repo(tmp_path, package="0.34.0", source="0.33.0")
+    load_module().sync(root)
+
+    text = (root / "plugins/hosted/definition.json").read_text(encoding="utf-8")
+    assert '"version": "0.1.0"' in text
+
+
+def test_check_mode_reports_drift_without_writing(tmp_path: Path) -> None:
+    root = make_repo(tmp_path, package="0.34.0", source="0.33.0")
+    definition = root / "plugins/hosted/definition.json"
+    before = definition.read_text(encoding="utf-8")
+    module = load_module()
+
+    assert module.main(["--repo-root", str(root), "--check"]) == 1
+    assert definition.read_text(encoding="utf-8") == before
+
+    assert module.main(["--repo-root", str(root)]) == 0
+    assert module.main(["--repo-root", str(root), "--check"]) == 0
+
+
+def test_missing_key_is_an_explicit_failure(tmp_path: Path) -> None:
+    root = make_repo(tmp_path, package="0.34.0", source="0.33.0")
+    (root / "plugins/hosted/definition.json").write_text('{"plugin_id": "x"}\n', encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="no source_release key"):
+        load_module().sync(root)
+
+
+def test_the_checked_in_repo_is_in_sync() -> None:
+    """A release that forgets the resync must not reach main silently."""
+
+    assert load_module().main(["--repo-root", str(REPO_ROOT), "--check"]) == 0
+
+
+def test_the_release_workflow_runs_the_resync_before_regenerating() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    sync_at = text.find("scripts/sync_hosted_release.py")
+    regenerate_at = text.find("hosted-plugin.py regenerate")
+
+    assert sync_at != -1, "the release workflow must resync source_release"
+    assert regenerate_at != -1, "the release workflow must regenerate hosted artifacts"
+    # regenerate refuses to run while the definition is stale, so order matters.
+    assert sync_at < regenerate_at


### PR DESCRIPTION
Every release since the hosted client packages landed (#337) would have failed CI on the release PR. 0.34.0 (#340) is the first one to hit it.

## What breaks

Release Please bumps `pyproject.toml`. `plugins/hosted/definition.json` pins `source_release` separately, and `hosted_plugins.compatibility_manifest` raises when the two diverge:

```
ValueError: Hosted definition source release must match the agent contract release
```

`check_compatibility_descriptor` then separately verifies the committed generated artifacts match freshly-generated output, so the bump invalidates those too.

This only fires on the release branch, which is why #337's own CI was green and main is green today.

## Why not `extra-files`

That was my first attempt — `server.json` is already handled that way. It cannot work here: `plugins/hosted/generated/claude.lock.json` carries `definition_sha256` and `compatibility_sha256` over the very files that would be edited. No config-file updater can recompute a hash. The release branch has to run the real generator.

## What this does

A `sync-hosted-artifacts` job on the release branch: resync `source_release`, regenerate, verify, and amend the release PR.

Ordering is load-bearing and non-obvious — `hosted-plugin.py regenerate` is itself behind the same guard, so it refuses to run while the definition is stale. The release guard blocks its own remedy. `scripts/sync_hosted_release.py` has to run first, and `test_the_release_workflow_runs_the_resync_before_regenerating` pins that ordering so a future reorder fails loudly rather than at the next release.

The sync is a textual, key-anchored replacement rather than a `json.dumps` round-trip, so the file's formatting stays under the generator's control — it's an input to a sha256 lock.

`--check` mode reports drift without writing, and `test_the_checked_in_repo_is_in_sync` runs it against the repo so a forgotten resync can't reach main quietly.

## Caveat

Without the GitHub App token the amend push uses `GITHUB_TOKEN`, which doesn't retrigger the PR's checks. The branch is correct but the PR shows the pre-amendment run, so re-run checks before merging. Noted in the workflow comment.

## Verification

- `pytest tests/test_sync_hosted_release.py` — 7 passed
- `uvx ruff check` on both new files — clean
- Workflow YAML parses; job graph confirmed
- The same steps run by hand on the 0.34.0 release branch produced exactly the three-file diff this job automates, and `hosted-plugin.py check` reported "Hosted generated artifacts are current"

Full suite deferred to CI — native Windows can't run it.
