### PR TITLE
fix(diagnostics): confirm latency-gate failures and attribute graph holds

### DIFF
--- a/scripts/semantic_write_latency.py
+++ b/scripts/semantic_write_latency.py
@@ -153,13 +153,44 @@ def check(results: list[dict[str, float | int]]) -> None:
         raise SystemExit("semantic write latency gate failed: " + "; ".join(failures))
 
 
-def main() -> int:
+def measure_all(
+    sizes: list[int], samples: int, root: Path | None
+) -> list[dict[str, float | int]]:
+    if root is not None:
+        root.mkdir(parents=True, exist_ok=False)
+        runtime_temp = root / "runtime-temp"
+        runtime_temp.mkdir()
+        tempfile.tempdir = str(runtime_temp)
+        roots = [root / f"vault-{size}" for size in sizes]
+        for vault_root in roots:
+            vault_root.mkdir(parents=True)
+        return [
+            measure(vault_root, size, samples)
+            for vault_root, size in zip(roots, sizes, strict=True)
+        ]
+    with tempfile.TemporaryDirectory(prefix="exomem-write-latency-") as temp:
+        base = Path(temp)
+        results: list[dict[str, float | int]] = []
+        for size in sizes:
+            vault_root = base / f"vault-{size}"
+            vault_root.mkdir()
+            results.append(measure(vault_root, size, samples))
+        return results
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--sizes", nargs="+", type=int, default=list(DEFAULT_SIZES))
     parser.add_argument("--samples", type=int, default=5)
     parser.add_argument("--root", type=Path)
     parser.add_argument("--check", action="store_true")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=2,
+        help="measurement attempts before --check fails the build (default 2)",
+    )
+    args = parser.parse_args(argv)
     for name in (
         "EXOMEM_DISABLE_EMBEDDINGS",
         "EXOMEM_DISABLE_CLIP",
@@ -168,28 +199,33 @@ def main() -> int:
     ):
         os.environ[name] = "1"
 
-    if args.root is not None:
-        args.root.mkdir(parents=True, exist_ok=False)
-        runtime_temp = args.root / "runtime-temp"
-        runtime_temp.mkdir()
-        tempfile.tempdir = str(runtime_temp)
-        roots = [args.root / f"vault-{size}" for size in args.sizes]
-        for root in roots:
-            root.mkdir(parents=True)
-        results = [
-            measure(root, size, args.samples) for root, size in zip(roots, args.sizes, strict=True)
-        ]
-    else:
-        with tempfile.TemporaryDirectory(prefix="exomem-write-latency-") as temp:
-            base = Path(temp)
-            results = []
-            for size in args.sizes:
-                root = base / f"vault-{size}"
-                root.mkdir()
-                results.append(measure(root, size, args.samples))
+    results = measure_all(args.sizes, args.samples, args.root)
     print(json.dumps({"results": results}, sort_keys=True))
-    if args.check:
-        check(results)
+    if not args.check:
+        return 0
+
+    # One sample set on a shared runner is not evidence. The scaling bound is
+    # anchored to the same run's small-corpus median, so a contended runner can
+    # breach it from both ends at once: the baseline comes in unusually fast,
+    # which *tightens* the bound, while the large measurement inflates. That is
+    # a measured failure, not a flaky assertion, so it cannot be papered over by
+    # loosening the threshold -- doing that would blunt the regression signal
+    # the gate exists for. Re-measure and require the failure to reproduce.
+    #
+    # `--root` keeps its artifacts for inspection and refuses a pre-existing
+    # directory, so a retry there would fail on mkdir; those runs get one shot.
+    for attempt in range(2, args.attempts + 1):
+        try:
+            check(results)
+        except SystemExit as failure:
+            if args.root is not None:
+                raise
+            print(f"attempt {attempt - 1}: {failure}; re-measuring", file=sys.stderr)
+            results = measure_all(args.sizes, args.samples, None)
+            print(json.dumps({"attempt": attempt, "results": results}, sort_keys=True))
+        else:
+            return 0
+    check(results)
     return 0
 
 

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -311,7 +311,12 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        with self._mutation_coordinator.hold():
+        # Attributed: a full rebuild is the longest holder of the vault mutation
+        # boundary at scale, and an unattributed "held too long" warning names
+        # neither the operation nor the holder -- which reads as a stalled write.
+        with self._mutation_coordinator.hold(
+            operation="epistemic_graph_rebuild_all", holder_kind="graph"
+        ):
             return self._rebuild_all_locked()
 
     def _rebuild_all_locked(self) -> dict[str, int]:
@@ -411,7 +416,9 @@ class EpistemicGraphIndex:
     def refresh_paths(self, paths: list[Path]) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        with self._mutation_coordinator.hold():
+        with self._mutation_coordinator.hold(
+            operation="epistemic_graph_refresh_paths", holder_kind="graph"
+        ):
             return self._refresh_paths_locked(paths)
 
     def _refresh_paths_locked(self, paths: list[Path]) -> dict[str, int]:
@@ -432,7 +439,9 @@ class EpistemicGraphIndex:
             conn.close()
 
     def delete_paths(self, rel_paths: list[str]) -> int:
-        with self._mutation_coordinator.hold():
+        with self._mutation_coordinator.hold(
+            operation="epistemic_graph_delete_paths", holder_kind="graph"
+        ):
             return self._delete_paths_locked(rel_paths)
 
     def _delete_paths_locked(self, rel_paths: list[str]) -> int:

--- a/tests/test_semantic_write_latency_gate.py
+++ b/tests/test_semantic_write_latency_gate.py
@@ -1,0 +1,124 @@
+"""The write-latency gate must not fail the build on one noisy sample set.
+
+Real incident, 2026-07-27: a contended CI runner produced a 2k baseline that was
+*faster* than normal and an 8k measurement that was roughly double normal. The
+scaling bound is anchored to the same run's small-corpus median, so both ends
+moved the wrong way at once and the gate failed a release PR that had touched
+nothing but a version string. A re-run passed with ordinary numbers.
+
+These tests pin that arithmetic (so the sensitivity stays visible rather than
+being rediscovered under time pressure) and pin the confirmation behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "semantic_write_latency.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("semantic_write_latency_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def result(pages: int, *, commit: float, validate: float = 30.0) -> dict[str, float | int]:
+    return {
+        "pages": pages,
+        "samples": 5,
+        "cold_ms": 1000.0,
+        "validate_median_ms": validate,
+        "validate_p95_ms": validate * 1.4,
+        "commit_median_ms": commit,
+        "commit_p95_ms": commit * 1.15,
+    }
+
+
+HEALTHY = [result(2_000, commit=51.5), result(8_000, commit=191.7)]
+# The numbers from the 2026-07-27 false failure.
+NOISY = [result(2_000, commit=42.3), result(8_000, commit=365.6)]
+
+
+def test_healthy_scaling_passes() -> None:
+    load_module().check(HEALTHY)
+
+
+def test_absolute_ceiling_breach_fails() -> None:
+    module = load_module()
+    with pytest.raises(SystemExit, match="commit_median_ms"):
+        module.check([result(8_000, commit=module.COMMIT_MEDIAN_MS + 1)])
+
+
+def test_superlinear_scaling_fails() -> None:
+    with pytest.raises(SystemExit, match="commit scaling"):
+        load_module().check(NOISY)
+
+
+def test_a_faster_baseline_tightens_the_bound() -> None:
+    """The documented sensitivity: a quick 2k run makes the gate stricter."""
+
+    module = load_module()
+    bound = lambda small: small * module.SCALING_RATIO + module.SCALING_SLACK_MS  # noqa: E731
+
+    # The real incident: baseline 42.3ms yielded a 284.6ms bound, while the
+    # ordinary 51.5ms baseline would have allowed 303.0ms.
+    assert bound(42.3) == pytest.approx(284.6)
+    assert bound(51.5) == pytest.approx(303.0)
+    assert bound(42.3) < bound(51.5)
+
+
+def test_check_failure_is_confirmed_by_a_second_measurement(monkeypatch) -> None:
+    """A first-attempt failure re-measures; a clean second attempt passes."""
+
+    module = load_module()
+    attempts: list[int] = []
+
+    def fake_measure_all(sizes, samples, root):
+        attempts.append(len(attempts) + 1)
+        return NOISY if len(attempts) == 1 else HEALTHY
+
+    monkeypatch.setattr(module, "measure_all", fake_measure_all)
+    assert module.main(["--check"]) == 0
+    assert attempts == [1, 2], "a failing first attempt must be re-measured once"
+
+
+def test_a_reproducible_failure_still_fails(monkeypatch) -> None:
+    """Confirmation must not turn a real regression into a pass."""
+
+    module = load_module()
+    attempts: list[int] = []
+
+    def fake_measure_all(sizes, samples, root):
+        attempts.append(len(attempts) + 1)
+        return NOISY
+
+    monkeypatch.setattr(module, "measure_all", fake_measure_all)
+    with pytest.raises(SystemExit, match="commit scaling"):
+        module.main(["--check"])
+    assert attempts == [1, 2], "exactly two attempts before failing the build"
+
+
+def test_attempts_one_disables_confirmation(monkeypatch) -> None:
+    module = load_module()
+    attempts: list[int] = []
+
+    def fake_measure_all(sizes, samples, root):
+        attempts.append(len(attempts) + 1)
+        return NOISY
+
+    monkeypatch.setattr(module, "measure_all", fake_measure_all)
+    with pytest.raises(SystemExit, match="commit scaling"):
+        module.main(["--check", "--attempts", "1"])
+    assert attempts == [1]
+
+
+def test_no_check_flag_never_fails(monkeypatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "measure_all", lambda sizes, samples, root: NOISY)
+    assert module.main([]) == 0


### PR DESCRIPTION
Two diagnostics defects that cost real time today, both surfaced by the same false alarm on the 0.34.1 release PR.

## The write-latency gate failed on a version bump

`scripts/semantic_write_latency.py --check` failed #343, which changed nothing but a version string and three regenerated artifact files.

The scaling bound is `small_median × 2.0 + 200ms`, anchored to the *same run's* small-corpus median. A contended runner breached it from both ends at once:

| | 2k commit | 8k commit | bound | cold 8k |
|---|---|---|---|---|
| passing runs | 51–54 ms | 192–209 ms | ~303 ms | ~9000 ms |
| the failure | **42.3 ms** | **365.6 ms** | **284.6 ms** | **4817 ms** |
| re-run | 55.9 ms | 244.1 ms | 311.8 ms | 8907 ms |

The baseline came in *faster* than normal, which tightened the bound, while the large measurement roughly doubled. `cold_ms` at half its usual value shows the machine was running ~2× fast at job start and then degraded — a stall, not a regression.

**Fix: require the failure to reproduce on a second measurement.** Deliberately *not* loosening the threshold — a wider bound would blunt exactly the regression signal the gate exists for, and this was a measured failure rather than a flaky assertion. Retry costs nothing on green runs. `--attempts 1` restores single-shot behaviour, and `--root` runs still get one shot since that mode refuses a pre-existing directory.

`test_a_faster_baseline_tightens_the_bound` pins the arithmetic with the real incident numbers so the sensitivity stays visible instead of being rediscovered under release pressure.

## `epistemic_graph` held the mutation boundary anonymously

The same job logged:

```
vault mutation boundary held too long request_id=untracked operation=unknown holder_kind=unknown hold_ms=172205.67
```

Three `hold()` calls in `epistemic_graph.py` passed no attribution, so a graph rebuild — legitimately the longest holder at 8k pages — reported as an unnamed 172-second hold. That reads as a stalled production write, and it briefly sent me chasing a non-existent regression in the write path.

Now named `epistemic_graph_rebuild_all`, `epistemic_graph_refresh_paths`, `epistemic_graph_delete_paths`, all `holder_kind="graph"`.

Only the acquisition sites changed. The `"unknown"` fallback in `mutation_lock` is untouched, because it also feeds the snapshot dict that health and doctor consume and renaming it there would desync the two.

## Not addressed here

A graph rebuild holding the vault mutation boundary for ~172 s at 8k pages may itself be worth moving outside the boundary, the way #327 moved validation and model loading out. That's a separate change; this PR only makes it legible.

## Verification

- `pytest tests/test_semantic_write_latency_gate.py tests/test_epistemic_graph.py tests/test_mutation_lock.py` — 57 passed
- `uvx ruff check` on all three changed files — clean
- 8 new tests cover the bound arithmetic, confirmation-on-failure, that a reproducible failure still fails, and that `--attempts 1` disables confirmation

Full suite deferred to CI — native Windows can't run it.
