### PR TITLE
fix(ci): authenticate hosted candidate verification

### DIFF
--- a/.github/workflows/publish-hosted-provisioner.yml
+++ b/.github/workflows/publish-hosted-provisioner.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Verify the provisioner image and signed candidate
         id: candidate-proof
         env:
+          GH_TOKEN: ${{ github.token }}
           CANDIDATE: ${{ steps.candidate.outputs.candidate }}
           IMAGE_BUNDLE: ${{ steps.candidate.outputs.bundle }}
           CANDIDATE_ATTESTATION_BUNDLE: ${{ steps.candidate-attestation.outputs.bundle-path }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -388,6 +388,7 @@ jobs:
       - name: Verify the hosted runtime image and signed candidate
         id: runtime-candidate-proof
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
           SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
           CANDIDATE: ${{ steps.runtime-candidate.outputs.candidate }}
@@ -604,6 +605,7 @@ jobs:
       - name: Verify the hosted runtime image and signed candidate
         id: runtime-candidate-proof
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
           SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
           CANDIDATE: ${{ steps.runtime-candidate.outputs.candidate }}

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -74,6 +74,9 @@ def test_release_workflow_publishes_digest_authoritative_hosted_candidates() -> 
     manual = _workflow_job(text, "publish-existing-image", "publish-existing-pypi")
 
     for job in (automatic, manual):
+        proof_step = job.split(
+            "\n      - name: Verify the hosted runtime image and signed candidate\n", 1
+        )[1].split("\n      - name:", 1)[0]
         assert "contents: write" in job
         assert "packages: write" in job
         assert "id-token: write" in job
@@ -93,6 +96,7 @@ def test_release_workflow_publishes_digest_authoritative_hosted_candidates() -> 
         assert job.count("create-storage-record: false") == 2
         assert "infra/scripts/hosted_image_candidate.py record" in job
         assert "infra/scripts/hosted_image_candidate.py verify" in job
+        assert "GH_TOKEN: ${{ github.token }}" in proof_step
         assert "--candidate-bundle" in job
         assert "candidate.sigstore.json" in job
         assert "--attestation-id" not in job

--- a/tests/test_hosted_provisioner_image_distribution.py
+++ b/tests/test_hosted_provisioner_image_distribution.py
@@ -97,6 +97,9 @@ def test_provisioner_workflow_is_an_independent_digest_bound_candidate_producer(
     text = (ROOT / ".github/workflows/publish-hosted-provisioner.yml").read_text(
         encoding="utf-8"
     )
+    proof_step = text.split(
+        "\n      - name: Verify the provisioner image and signed candidate\n", 1
+    )[1].split("\n      - name:", 1)[0]
 
     assert 'test "$GITHUB_REF" = "refs/heads/main"' in text
     assert "attestations: write" in text
@@ -108,6 +111,7 @@ def test_provisioner_workflow_is_an_independent_digest_bound_candidate_producer(
     assert text.count("create-storage-record: false") == 2
     assert "infra/scripts/hosted_image_candidate.py record" in text
     assert text.count("infra/scripts/hosted_image_candidate.py verify") >= 2
+    assert "GH_TOKEN: ${{ github.token }}" in proof_step
     assert text.count("--candidate-bundle") >= 2
     assert "--attestation-id" not in text
     assert "--attestation-url" not in text


### PR DESCRIPTION
## Why

The first canonical-main provisioner candidate run created both attestations but failed closed during verification because GitHub CLI had no GH_TOKEN. No candidate was promoted or attached.

This scopes the workflow token to each exact candidate-verification step (automatic runtime release, manual runtime republish, and provisioner) and adds step-scoped regression assertions.

Failure evidence: https://github.com/Artexis10/exomem/actions/runs/30511567499

## Verification

- 52 focused candidate/distribution tests passed
- Ruff passed
- Dockerized actionlint 1.7.9 passed on both workflows
- Independent reviewer: no findings
- Independent verifier: verified every invocation is covered