### PR TITLE
docs(hosted): specify runtime identity deployment

### DIFF
--- a/openspec/changes/add-hosted-private-alpha-infrastructure/specs/hosted-cell-orchestration/spec.md
+++ b/openspec/changes/add-hosted-private-alpha-infrastructure/specs/hosted-cell-orchestration/spec.md
@@ -1,11 +1,19 @@
 ## ADDED Requirements
 
-### Requirement: Provisioner v1 authenticates and bounds every call
-The provisioner SHALL expose the 14 `exomem-cell-provisioner.v1` actions expected by Substrate at `/cells/<action>`. Every request MUST use HTTPS, the independent provisioner bearer, exact protocol header, JSON content type, and an idempotency key. It SHALL reject redirects, oversized request/response bodies, unsupported fields, invalid identifiers, and unauthenticated calls without provider side effects.
+### Requirement: Provisioner wire protocols authenticate and bound every call
+The provisioner SHALL expose the 14 actions expected by Substrate at `/cells/<action>` and SHALL select the closed v1 or v2 request and response contract from the exact provisioner protocol header. Every request MUST use HTTPS, the independent provisioner bearer, JSON content type, and an idempotency key. It SHALL reject redirects, oversized request/response bodies, unsupported or mixed-version fields, invalid identifiers, unsupported protocol headers, and unauthenticated calls without operation or provider side effects. During expansion it SHALL dual-serve fresh v1 only for exact verified entries in the bounded authoritative legacy runtime catalog and fresh v2 for the locked forward target. After contraction it SHALL accept fresh v2 operations, exact non-final v1 replay only against a retained verified catalog entry, and exact already-final v1 replay without a catalog entry after current-fence and v1-model validation because that replay performs no runtime or provider effect.
 
 #### Scenario: Invalid protocol is rejected before mutation
 - **WHEN** a provision request has valid JSON and bearer credentials but the wrong provisioner protocol header
 - **THEN** the request receives a terminal contract error and no namespace, operation, or provider resource is created
+
+#### Scenario: Persisted v1 survives contraction
+- **WHEN** an exact v1 action, idempotency key, canonical body, stored wire discriminator, current fence, and retained runtime catalog entry match a non-final persisted operation after contraction
+- **THEN** the provisioner resumes that operation under the unchanged v1 schema without admitting a fresh v1 operation
+
+#### Scenario: Final v1 replay outlives its catalog entry
+- **WHEN** an exact current-fence replay matches an already-final v1 operation whose runtime unit is no longer cataloged
+- **THEN** the provisioner validates and returns the persisted v1 result without runtime or provider effects
 
 ### Requirement: Operations are durably idempotent and tenant-fenced
 Before performing side effects, the provisioner SHALL persist the action, canonical request hash, idempotency key, tenant ID, operation/checkpoint, monotonic fence generation, and progress. Every durable Kubernetes namespace/release/PVC/PV/route, HCloud volume, and B2 export/backup side effect SHALL also carry or authenticate immutable opaque tenant ID, cell/candidate ID, operation ID, and fence generation outside PostgreSQL. Replaying the same key and body SHALL resume or return the same result. Reusing a key with changed input SHALL conflict. A lower fence MUST NOT mutate, recreate, or destroy resources after a higher fence is observed. These guarantees SHALL survive provisioner and database-client restarts.
@@ -75,11 +83,15 @@ Before either the routine lifecycle driver or the dedicated volume-registration 
 - **THEN** destructive completion rolls back rather than releasing or fencing the equal-or-newer reservation
 
 ### Requirement: Provisioner health proves the exact runtime admission contract
-Health SHALL call the authenticated private cell live, ready, and contract routes and SHALL return the exact flattened identity, protocol, release, service-authentication, mutation-authority, read/write admission, worker-policy, and reason fields parsed by Substrate. It MUST NOT substitute TCP success, OAuth metadata, or Helm status for runtime readiness.
+V1 health SHALL preserve the existing authenticated live, ready, and gateway-contract probes and flattened response. V2 health SHALL additionally call the selected authenticated agent-contract route and SHALL return a nested `runtimeIdentity` containing only the observed release, Hosted protocol, agent profile, gateway digest, command fingerprint, and schema digest after all six match the stored target. Compatibility and client-package lineage SHALL remain Substrate-owned and MUST NOT be reported as cell observations. Neither version may substitute TCP success, OAuth metadata, Helm status, a partial contract, or locally assumed values for runtime readiness.
 
 #### Scenario: Contract drift blocks binding
-- **WHEN** the cell image reports a release, protocol, command semantics, or digest different from the frozen Substrate fixture
+- **WHEN** the cell image reports a release, Hosted protocol, profile, gateway digest, command fingerprint, or schema digest different from the stored lifecycle target
 - **THEN** health/binding fails closed and the cell is not routed
+
+#### Scenario: Broken runtime is destroyed
+- **WHEN** a fenced discard or destroy targets a cell whose live contract cannot be observed
+- **THEN** static target fencing remains enforced but the destructive recovery path does not require successful runtime health
 
 ### Requirement: Lifecycle actions preserve runtime ordering
 Quiesce SHALL reject new mutations and drain active work. Stop SHALL quiesce before scaling compute to zero without deleting storage. Resume SHALL start compute if needed, resume the runtime, and require later health admission. Rotate-credential SHALL stage active/pending overlap, prove pending-token health, promote, finalize, and prove the former token rejects. Seal SHALL be terminal and SHALL run only after routing stop and drain.

--- a/openspec/changes/add-hosted-private-alpha-infrastructure/specs/hosted-private-routing/spec.md
+++ b/openspec/changes/add-hosted-private-alpha-infrastructure/specs/hosted-private-routing/spec.md
@@ -1,11 +1,15 @@
 ## ADDED Requirements
 
 ### Requirement: Control routes require two independent credentials
-Cloudflare Tunnel SHALL be the only public ingress to the cluster. The control hostname SHALL require a Cloudflare Access service token held by Vercel/operators and Traefik SHALL expose only provisioner `/cells/*` and versioned private cell-control paths. Provisioner calls SHALL additionally require the provisioner bearer; cell calls SHALL additionally require the per-cell service bearer and exact hosted identity headers. The personal OAuth/public Exomem surface MUST NOT be routed.
+Cloudflare Tunnel SHALL be the only public ingress to the cluster. The control hostname SHALL require a Cloudflare Access service token held by Vercel/operators and Traefik SHALL expose only provisioner `/cells/*` and versioned private cell-control paths. The `/cells/*` routes SHALL multiplex provisioner wire v1 and v2 through the exact provisioner protocol header without creating a second route family. Provisioner calls SHALL additionally require the provisioner bearer; cell calls SHALL additionally require the per-cell service bearer and exact Hosted runtime identity headers. The provisioner wire protocol and the private-cell Hosted runtime protocol SHALL remain independent version axes. Routing MUST NOT supply candidate, compatibility, or client-package authority. The personal OAuth/public Exomem surface MUST NOT be routed.
 
 #### Scenario: Access credential is missing
 - **WHEN** a caller presents a valid cell bearer and headers but no valid Cloudflare Access service token on the control hostname
 - **THEN** the request is rejected at the edge and never reaches the cell
+
+#### Scenario: Provisioner v2 uses the existing route
+- **WHEN** an authenticated caller invokes `/cells/health` with the exact v2 provisioner protocol header
+- **THEN** routing forwards the request to the provisioner without changing the independent `/private/exomem/v1/...` runtime route contract
 
 #### Scenario: Personal route is requested through control ingress
 - **WHEN** an Access-authenticated caller requests a non-private Exomem route

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/.openspec.yaml
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/README.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/README.md
@@ -1,0 +1,3 @@
+# bind-hosted-candidate-runtime-identity
+
+Bind independently verified hosted runtime and provisioner candidates to one fail-closed deployment lock and provisioner v2 runtime identity contract.

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/design.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/design.md
@@ -1,0 +1,165 @@
+## Context
+
+The runtime and provisioner producers now publish strict, independently attested image-candidate records. The v0.35.1 runtime candidate is fixed at source `f1472c297d9256a28c9706bb666e249b64cfd804` and image `ghcr.io/artexis10/exomem@sha256:3264271d7292c713e1f6ba6ae4a11a4b8e8c52a58a1a06e1d13726a515175ca3`. The existing provisioner candidate is fixed at source `6cc0718fc6baf294ed313662a889462aad56f164` and image `ghcr.io/artexis10/exomem-provisioner@sha256:b3f2f12691207200a57dd193f3669a8f2cd2f7c058105b0d4af691f3057097df`.
+
+Those records prove what was built, by which reviewed workflow, from which source. They do not choose one deployable pair, prove that later source still represents each image, or bind a Substrate lifecycle target to the runtime contract observed inside a cell. The committed schema-v1 Hosted release manifest is also stale: it describes release 0.22.0 and a 21-command surface, while v0.35.1 exposes 25 REST commands. It cannot be silently reused as v0.35.1 contract evidence.
+
+Three version axes must remain independent:
+
+- Provisioner wire protocol: `exomem-cell-provisioner.v1` or `exomem-cell-provisioner.v2`.
+- Hosted runtime protocol: the value `"1"` in the runtime contract and lifecycle target.
+- Private runtime routes: `/private/exomem/v1/...`.
+
+Substrate already owns the candidate catalog, compatibility digest, package/archive locks, canary assignment, and immutable lifecycle target columns. Exomem deployment infrastructure owns runtime/provisioner image selection and authenticated observation of the running runtime. The design must not create a second authority for either side.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Compose one independently verified runtime candidate, one independently verified provisioner candidate, matching runtime-contract evidence, and the exact bounded legacy-v1 runtime catalog into strict expand and contract deployment locks.
+- Add a dual-serving provisioner whose v2 request names the exact runtime target and whose v2 health response reports the exact observed runtime identity.
+- Preserve v1 schemas and replay while making protocol selection durable and safe across retries, restarts, feature-gate changes, and rolling deployments.
+- Gate readiness, routing, binding, activation, and promotion on the complete observed identity without blocking offline restore, salvage, discard, or destruction when a cell is unhealthy.
+- Keep compatibility and client-package lineage in Substrate and outside the provisioner wire contract and deployment lock.
+- Deploy through an explicit expand/contract sequence with an exact, hash-pinned rollback tuple.
+
+**Non-Goals:**
+
+- Changing the Hosted runtime protocol, private route versions, MCP protocol, or user-facing Exomem behavior.
+- Rebuilding the runtime image unless the source-closure guard proves that v0.35.1 no longer represents the composition source.
+- Copying candidate IDs, source commits, image references, compatibility digests, package locks, plugin provenance, or OAuth metadata into `runtimeTarget` or `runtimeIdentity`.
+- Adding a second Substrate target/observation JSON blob or duplicating migration 0036 identity columns.
+- Treating a repository merge, image publication, or rendered Helm chart as proof of a live deployment.
+- Requiring a running cell contract for offline recovery or destructive cleanup.
+
+## Decisions
+
+### Provisioner v2 uses the existing routes and an exact header
+
+All 14 actions stay at `/cells/<action>`. The exact `X-Exomem-Provisioner-Protocol` header selects a closed v1 or v2 schema and response model. Unsupported or mixed-version requests fail before operation creation or provider effects. Adding `/v2/cells/*` would duplicate routing and still require an independent replay discriminator.
+
+V1 request bodies, pending responses, final responses, canonical hashing, and failure envelopes remain unchanged. Internal code reads the legacy top-level release/protocol fields through a pure accessor; it never rewrites persisted v1 dictionaries into v2-shaped data.
+
+For every cell-scoped v2 action, the runtime identity is exactly:
+
+```json
+{
+  "runtimeTarget": {
+    "releaseVersion": "0.35.1",
+    "protocolVersion": "1",
+    "agentProfile": "hosted-alpha-agent-v1",
+    "gatewayContractDigest": "<64 lowercase hex>",
+    "commandFingerprint": "<64 lowercase hex>",
+    "schemaDigest": "<64 lowercase hex>"
+  }
+}
+```
+
+Successful v2 health returns the same six fields under `runtimeIdentity`. The v2 model forbids candidate IDs, source commits, image references, compatibility fields, package/archive locks, plugin/OAuth provenance, and generic `contractIdentity` objects.
+
+V2 does not discard the established action contract around that identity. Every cell-scoped request retains the existing action-specific context, credentials, worker policy, provider references, and bounded specialized fields, replacing only the legacy top-level release/protocol identity with `runtimeTarget`. The context-only `export-delete`, `export-download`, and tenant `destroy` actions have explicit target-free v2 models whose bodies remain otherwise unchanged. V2 health retains `live`, `ready`, `cellId`, service-authentication, mutation-authority, read/write-admission, worker-policy, and reason fields, replacing only the flattened release/protocol identity with `runtimeIdentity`. Other final and pending response shapes remain unchanged.
+
+### Runtime identity is measurement; compatibility remains catalog authority
+
+The provisioner observes the existing authenticated live, ready, and full gateway contract routes plus `/private/exomem/v1/agent/hosted-alpha-agent-v1/contract`. It derives release and Hosted protocol from the runtime responses, the gateway digest from the full gateway contract, and the profile, command fingerprint, and schema digest from the selected agent contract. It returns `runtimeIdentity` only after all six values match the requested target.
+
+Substrate snapshots and builds `runtimeTarget` for every cell-scoped lifecycle operation from the authoritative selected candidate and cell binding, not only provision and restore. It compares the returned runtime identity to that target. Candidate compatibility and Claude/OpenAI package/archive lineage remain resolved locally through the immutable candidate ID. If the existing all-or-none observation constraint requires an observed compatibility value, Substrate derives it from the selected local candidate and documents it as catalog binding, never as cell evidence.
+
+### Wire protocol is persisted on both sides
+
+The provisioner adds an additive `wire_protocol` column to durable operations. Existing rows are backfilled as v1 and the database keeps a permanent v1 server default so the pinned D0 binary can still insert rows after migration. Operation submission includes wire protocol in the transactional exactness check.
+
+Substrate adds only an immutable provisioner-wire-protocol discriminator to lifecycle operations, also backfilled/defaulted to v1. A missing or malformed issuance flag is off; only normalized `"true"` creates new v2 operations. The selected discriminator and, for every cell-scoped action, the complete runtime target are stored before the first request. Every retry uses stored state rather than re-evaluating the feature flag or process release configuration.
+
+Migration 0036 remains authoritative for target and observed runtime identity. No second identity JSON or duplicate target columns are added.
+
+### Expansion and contraction have different v1 admission rules
+
+The forward provisioner has two explicit admission modes and one bounded legacy-v1 runtime catalog. The catalog contains the exact hash-pinned runtime manifest and digest for every release/protocol pair that is routable, assigned, or referenced by an unfinished v1 operation at expansion preflight. D1 selects fresh v1 and non-final v1 replay behavior only from that catalog; an exact already-final v1 replay may return its persisted, v1-model-validated final result without a runtime catalog entry because it performs no runtime or provider effect. The forward six-field v2 target remains bound to R. An absent, duplicate, unverified, or unreferenced legacy entry fails preflight rather than being guessed from request text.
+
+The modes are:
+
+- `expand`: fresh v1 operations are accepted only for exact cataloged legacy runtime units and fresh v2 operations are accepted for the locked target, allowing D1 to deploy before Substrate changes issuance without breaking current v1 releases.
+- `contract`: fresh v2 operations are accepted; an exact already-final v1 operation may return its persisted final result, while non-final v1 succeeds only when action, idempotency key, stored wire protocol, canonical request hash, existing fence semantics, and a retained legacy catalog unit match.
+
+The replay-only decision is atomic inside repository submission. A separate read followed by create/reject would race. Replays continue to obey the existing monotonic tenant-fence rules; this change does not make stale operations replayable after a newer destructive fence.
+
+Cross-version reuse of an action/idempotency key conflicts. Admission errors use the existing bounded content-free envelope and create no operation or provider resource.
+
+### Static target validation and live probing are separate gates
+
+Before installing or changing runtime bytes, the requested v2 target must match the immutable deployment lock. That static validation happens before provider effects.
+
+Live authenticated observation is required before declaring a cell ready, binding routing, activating an assignment, or promoting a candidate. Restore-candidate, backup recovery, salvage, discard, delete, and destruction carry and fence the stored target for audit but do not require a working runtime probe. This preserves recovery precisely when runtime identity is broken.
+
+### Composition verifies candidates, contract evidence, and source closure
+
+A dedicated composer verifies both candidate records through the existing cryptographic candidate verifier; parsing candidate JSON is insufficient. It accepts the forward and every legacy v1 runtime-contract artifact only with exact caller-supplied SHA-256 values, bounded regular-file checks, duplicate-key rejection, immutable image cross-checks, and agreement with the authoritative preflight release set. The stale committed 0.22.0 manifest must fail unless it is independently proven to be an actually referenced legacy unit. A current v0.35.1 compatibility manifest/receipt is generated and independently verified from the immutable runtime image before final composition.
+
+The composer then enforces Git ancestry and fixed no-shell source closures:
+
+- Runtime: `Dockerfile`, `.dockerignore`, `pyproject.toml`, `uv.lock`, `README.md`, `LICENSE`, and `src/**` from runtime candidate source to the composition source.
+- Provisioner: `infra/provisioner/Dockerfile`, `infra/provisioner/pyproject.toml`, `infra/provisioner/uv.lock`, `infra/provisioner/README.md`, `infra/provisioner/alembic.ini`, `infra/provisioner/src/**`, `infra/provisioner/alembic/**`, `infra/helm/cell/**`, and `.dockerignore` from provisioner candidate source to the composition source.
+
+Missing/shallow commits, non-ancestry, additions, deletions, renames, or diffs inside a closure fail closed. A valid signature never waives source drift. An unrelated documentation or deployment-only diff does not force an image rebuild.
+
+The composer emits a strict canonical lock pair with identical component/catalog lineage and different immutable admission modes: one expand lock and one contract lock. Each lock contains:
+
+- Runtime candidate image, source, canonical candidate-byte hash, and verified contract identity.
+- Forward provisioner candidate image, source, and canonical candidate-byte hash.
+- The exact six-field runtime target.
+- Provisioner wire protocol v2 and the lock's exact admission mode.
+- Composition evidence, including guarded commits/path sets, the forward contract hash, the complete bounded legacy-v1 runtime catalog, and the canonical authoritative legacy release-set digest it was built from.
+- An exact rollback block containing D0 image/source, canonical v1 corpus hash, the actual pre-D1 legacy manifest hash, and the pinned last-known-good v1 Substrate consumer commit.
+
+Neither lock contains a compatibility digest or client-package lineage. Helm derives both image digests and runtime configuration from exactly one selected lock; the provisioner image and admission mode are not free overrides. Moving from expand to contract deploys the reviewed contract-lock bytes after drain evidence instead of mutating or overriding the expand lock.
+
+### Candidate producers remain independent
+
+Runtime and provisioner workflows continue producing independent candidates. Composition is a consumer workflow and does not make one producer read the other's candidate. Because v2 changes provisioner build inputs, the current provisioner candidate D0 is rollback-only and implementation must produce a new independently attested D1 before a final lock can be committed.
+
+The runtime candidate R may be reused only if its source closure remains clean. If root runtime inputs change, work stops for a new runtime release/candidate instead of composing stale bytes.
+
+### The cross-language corpus freezes both protocols
+
+V1 fixture bytes and behavior stay frozen at the independently recomputed SHA-256 `ced714a5aa204a837e22cab831262cc0ae4766e44720b2896e61b8c157ddd3b5`. A separate v2 corpus covers every request, pending/final response, protocol header, mismatch, and replay failure. Python validates the corpus against strict Pydantic models; TypeScript consumes the same canonical bytes or an exact hash-pinned copy and proves header/body agreement. The canonical v1 corpus SHA-256 becomes part of rollback authority.
+
+### Rollback is one exact rehearsed tuple
+
+“Roll back to v1” is not an allowed instruction. Rollback requires the exact D0 image and source, the canonical v1 corpus hash, the actual pre-D1 legacy runtime-manifest hash, the exact last-known-good Substrate v1 consumer commit, admission stopped, proof that neither database contains a non-final v2 operation, and proof that every remaining cell/operation is compatible with that one legacy unit. Before the tuple is accepted, an executable rehearsal SHALL run the exact D0 image, manifest, and historical consumer against both upgraded database schemas and the frozen replay corpus. If any precondition or rehearsal fails, D1 stays running while the system rolls forward or resolves operations.
+
+## Risks / Trade-offs
+
+- [Runtime candidate R becomes stale while implementation lands] -> Run the source-closure guard before accepting composition; publish a new runtime release if any guarded path changed.
+- [V1 replay behavior drifts through internal normalization] -> Keep v1 classes and fixtures exact, use a read-only accessor, and regression-test pending and final replay across upgrade.
+- [A feature flag changes an in-flight request] -> Persist the selected wire protocol before issuance and retry only from stored state.
+- [Compatibility is mistaken for observed runtime evidence] -> Remove it from the wire and derive it only from the Substrate candidate catalog.
+- [Live identity gates make broken cells impossible to recover] -> Require probes only for readiness/binding/activation/promotion; use static target fencing for offline recovery/destruction.
+- [Two signed candidates are composed even though contract metadata is stale] -> Require hash-pinned, candidate-matching runtime-contract evidence and reject the existing stale manifest.
+- [D0 is deployed against unfinished v2 operations] -> Make the no-non-final-v2 preflight mandatory and fail closed.
+- [D1 expansion rejects the currently live v1 release] -> Generate the bounded legacy catalog from authoritative routable/assigned/in-flight state and prove each exact runtime unit before deployment.
+- [The authoritative legacy set changes after lock review] -> Recompute and compare its canonical digest under the cohort/admission lock immediately before D1 takes traffic, freeze assignment/promotion changes through cutover, and regenerate/review the pair on mismatch.
+- [A cell-scoped maintenance action lacks a target] -> Snapshot the selected candidate/runtime target for every cell-scoped operation; use explicit target-free v2 only for export-reference and tenant-destroy actions.
+- [Mixed deployments create fresh v1 work after contraction] -> Deploy the expand lock, switch new issuance to stored v2, prove the drain, then deploy the immutable contract lock.
+- [D0 metadata exists but rollback is not executable] -> Rehearse the exact old binaries and manifest against upgraded schemas and corpus before accepting the tuple.
+- [A generated lock contains a placeholder or mutable tag] -> The composer accepts only verified digest-authoritative candidates and writes atomically after every check; no placeholder lock is committed.
+
+## Migration Plan
+
+1. Land and validate this OpenSpec plus the paired Substrate delta before implementation.
+2. Implement Exomem dual protocol, durable protocol storage, legacy runtime catalog, runtime observation, cross-language corpus, composition tooling, and Helm exact-lock consumption without changing guarded runtime inputs.
+3. Implement the Substrate dual-protocol client, operation discriminator, and complete per-cell-action target snapshotting with v2 issuance default-off.
+4. Merge Exomem implementation and let the reviewed producer create D1. Verify D1 image and candidate attestations independently.
+5. Generate and verify current v0.35.1 runtime-contract evidence from R plus every authoritative legacy v1 unit. Compose R + D1 only after both source-closure checks pass, then commit the exact expand/contract lock pair.
+6. Rehearse the exact D0 rollback unit against both upgraded schemas and the frozen v1 corpus. Immediately before cutover, acquire the cohort/admission lock, freeze assignment and promotion changes, recompute the authoritative legacy release-set digest, and compare it to the expand lock. On mismatch, stop and regenerate/review the lock pair; on match, move traffic to D1, then release the freeze. Prove every cataloged v1 unit plus synthetic v2 behavior and full runtime identity.
+7. Deploy the Substrate consumer, enable v2 for new operations, and prove retries preserve stored v1/v2 selection.
+8. Prove no new v1 operations are created, drain or finish legacy operations, and deploy the reviewed contract lock.
+9. Canary a fresh v2 lifecycle through provision, health identity, binding, routing, and promotion. Record live deployment evidence separately from merge and artifact evidence.
+10. Archive the change only after repository verification, D1/lock proof, and the explicitly scoped deployment gates are complete.
+
+Rollback stops admission, checks both databases for unfinished v2 operations and one-unit compatibility, and applies only the rehearsed exact rollback tuple. If the preflight fails, keep D1 and roll forward.
+
+## Open Questions
+
+- The final D1 image digest, source commit, candidate-byte hash, authoritative legacy-v1 catalog, actual pre-D1 manifest hash, and rollback Substrate commit are intentionally unknown until their reviewed implementations and live-state preflight exist. They MUST NOT be represented by placeholders.
+- Live K3s apply and canary require operator credentials and cost/capacity authority. Repository delivery can prepare and verify the rollout, but cannot turn missing external authority into deployment evidence.

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/proposal.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Exomem now publishes independently attested runtime and provisioner image candidates, but nothing yet composes those candidates into immutable phase-specific deployment units or proves that a provisioned cell is running the selected runtime contract. A merge can therefore produce trustworthy artifacts without making the Hosted control plane safe to deploy, retry, contract, or roll back.
+
+## What Changes
+
+- Add provisioner wire protocol v2 on the existing `/cells/<action>` routes. V2 requests carry one strict `runtimeTarget`; health returns the matching observed `runtimeIdentity`.
+- Preserve provisioner v1 request and response behavior exactly for expansion and persisted-operation replay, then reject fresh v1 operations after contraction.
+- Persist the outer provisioner wire protocol independently from the Hosted runtime protocol so retries remain byte- and version-stable across restarts and deployments.
+- Compose separately verified runtime and provisioner candidates with verified runtime-contract evidence into deterministic expand and contract locks, with one bounded legacy-v1 runtime catalog, component-specific source-closure checks, and exact rollback pins.
+- Keep candidate, compatibility, and client-package lineage in Substrate; none of those fields cross the provisioner API or become cell-reported identity.
+- Add the paired Substrate v2 consumer and an expand/contract rollout in which issuance and every cell-scoped runtime target are stored per operation before the v2 feature gate is enabled; context-only export-reference and tenant-destroy actions use explicit target-free v2 schemas.
+- Correct the active private-alpha specifications that currently describe provisioner v1 and flattened or compatibility-bearing health as the final contract.
+- Produce and attest a new provisioner candidate after implementation. The existing signed provisioner is rollback-only because it cannot serve v2.
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-candidate-runtime-binding`: Candidate composition, provisioner v2 runtime targeting and observation, durable versioned replay, expand/contract rollout, and exact rollback authority.
+
+### Modified Capabilities
+
+- `hosted-image-candidate-publication`: Candidate consumption additionally requires ancestry and component-specific source-closure proof; signatures cannot waive source drift.
+
+## Impact
+
+- Exomem provisioner schemas, admission, durable operation storage, lifecycle targeting, authenticated runtime probes, release composition, Helm inputs, deployment verification, fixtures, tests, and hosted runbooks.
+- A paired Substrate change to its provisioner client, lifecycle-operation schema, reconciler, candidate catalog binding, tests, and active Hosted OAuth OpenSpec.
+- Provisioner wire v2 is additive during expansion but becomes the only protocol for fresh operations after contraction. The Hosted runtime protocol remains `1`, private runtime paths remain `/private/exomem/v1/...`, and recovery/destruction paths remain operable when live runtime probes fail.
+- Runtime candidate `ghcr.io/artexis10/exomem@sha256:3264271d7292c713e1f6ba6ae4a11a4b8e8c52a58a1a06e1d13726a515175ca3` may be reused only if the source-closure guard from `f1472c297d9256a28c9706bb666e249b64cfd804` passes. The v1 provisioner candidate at `sha256:b3f2f12691207200a57dd193f3669a8f2cd2f7c058105b0d4af691f3057097df` is retained only in the exact rollback tuple.

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/specs/hosted-candidate-runtime-binding/spec.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/specs/hosted-candidate-runtime-binding/spec.md
@@ -1,0 +1,220 @@
+## ADDED Requirements
+
+### Requirement: Provisioner v2 binds every cell operation to one runtime target
+
+The provisioner SHALL dual-serve the existing `/cells/<action>` routes under exact `exomem-cell-provisioner.v1` and `exomem-cell-provisioner.v2` headers. Every cell-scoped v2 request MUST contain exactly one strict `runtimeTarget` with `releaseVersion`, Hosted `protocolVersion`, `agentProfile`, `gatewayContractDigest`, `commandFingerprint`, and `schemaDigest`. Digests MUST be lowercase 64-character hexadecimal values. The v2 target MUST NOT contain candidate IDs, source commits, image references, compatibility digests, client package/archive locks, plugin or OAuth provenance, or a generic contract-identity object. The context-only `export-delete`, `export-download`, and tenant `destroy` actions SHALL use explicit target-free v2 models and MUST NOT invent a runtime target.
+
+#### Scenario: Complete v2 target is admitted
+
+- **WHEN** an authenticated bounded v2 request carries the six-field target matching the deployment lock
+- **THEN** the request is validated under the v2 action schema before operation or provider mutation
+
+#### Scenario: Cross-authority field is supplied
+
+- **WHEN** a v2 request adds a candidate ID, image reference, compatibility value, package lock, or unknown field
+- **THEN** admission fails closed before an operation or provider resource is created
+
+#### Scenario: Runtime protocol is confused with wire protocol
+
+- **WHEN** the outer protocol header is v2 and the runtime target names the supported Hosted runtime protocol `1`
+- **THEN** the provisioner treats those as independent version axes and does not rewrite private `/private/exomem/v1/...` routes or Helm runtime protocol values
+
+#### Scenario: Context-only action uses v2
+
+- **WHEN** an export-reference or tenant-destroy operation uses the v2 header
+- **THEN** its closed action body remains target-free while its stored wire discriminator still prevents cross-version replay
+
+### Requirement: Health reports a fully observed matching runtime identity
+
+V2 health SHALL authenticate and inspect the cell live, ready, full gateway-contract, and selected agent-contract routes. It SHALL preserve the existing `live`, `ready`, `cellId`, service-authentication, mutation-authority, read/write-admission, worker-policy, and reason fields while replacing the flattened release/protocol identity with `runtimeIdentity`. It SHALL derive that object with exactly the same six fields as `runtimeTarget` only after every observed value matches. TCP reachability, Helm status, OAuth metadata, a partial contract, or a locally assumed value MUST NOT substitute for runtime observation. V1 health responses SHALL retain their existing flat schema, and non-health pending/final response shapes SHALL remain unchanged.
+
+#### Scenario: All six observations match
+
+- **WHEN** live and ready admission succeeds and the observed release, Hosted protocol, profile, gateway digest, command fingerprint, and schema digest match the stored target
+- **THEN** v2 health returns that exact six-field `runtimeIdentity`
+
+#### Scenario: One identity field drifts
+
+- **WHEN** any one observed gateway, release, protocol, profile, command, or schema value differs from the target
+- **THEN** health fails closed and the cell cannot become ready, routed, bound, active, or promoted
+
+#### Scenario: Agent contract cannot be observed
+
+- **WHEN** the generic gateway contract succeeds but the selected agent-contract route is absent, unauthenticated, malformed, or incomplete
+- **THEN** v2 health fails rather than inferring profile, command, or schema identity
+
+### Requirement: Provisioner wire selection is durable and replay-safe
+
+The provisioner and Substrate SHALL persist the outer wire protocol independently from the Hosted runtime protocol. Existing rows SHALL be backfilled as v1, and the provisioner database SHALL retain a server-side v1 default compatible with the pinned legacy provisioner. Substrate SHALL persist the selected wire protocol before first issuance and SHALL reuse it for every retry regardless of feature-gate or deployment changes. Cross-version reuse of the same action and idempotency key MUST conflict.
+
+#### Scenario: Process restarts during a legacy operation
+
+- **WHEN** a persisted v1 operation is retried after either service restarts or v2 issuance is enabled
+- **THEN** the retry uses the exact v1 header and body and converges on the existing operation
+
+#### Scenario: Feature gate changes during a v2 operation
+
+- **WHEN** a v2 lifecycle operation is persisted and the issuance flag later becomes false
+- **THEN** every retry remains v2 because stored operation state outranks the current flag
+
+#### Scenario: Same idempotency key crosses protocols
+
+- **WHEN** a caller reuses an existing action and idempotency key under a different wire protocol
+- **THEN** the request receives a terminal conflict and the original operation is unchanged
+
+### Requirement: Contract mode permits only exact persisted v1 replay
+
+The forward provisioner SHALL support explicit `expand` and `contract` admission modes plus one bounded legacy-v1 runtime catalog containing every exact release/protocol unit that authoritative preflight finds routable, assigned, or referenced by unfinished v1 work. Expand SHALL admit fresh strict v1 only when its release/protocol selects one unique verified catalog unit and SHALL admit fresh v2 for the locked forward target. Contract SHALL admit fresh v2 operations and SHALL process v1 through one atomic repository decision: an exact already-final v1 operation MAY return its persisted v1-model-validated final result without a runtime catalog entry, while a non-final v1 replay MUST additionally match a retained catalog unit and existing monotonic-fence rules. Missing, duplicate, unverified, or unreferenced legacy units and fresh v1 rejection MUST create no operation and perform no provider effect.
+
+#### Scenario: Fresh v1 is used during expansion
+
+- **WHEN** D1 runs in expand mode before Substrate v2 issuance is enabled and a fresh v1 request names one exact cataloged legacy release
+- **THEN** the operation retains the exact legacy behavior for that runtime unit
+
+#### Scenario: Fresh v1 is used after contraction
+
+- **WHEN** contract mode receives a well-formed v1 request without an exact persisted operation
+- **THEN** it returns a bounded terminal error before operation creation or provider mutation
+
+#### Scenario: Exact legacy replay occurs after contraction
+
+- **WHEN** contract mode receives a v1 action/key/body matching a persisted v1 operation and current fence semantics
+- **THEN** the operation resumes or returns its existing final result under the unchanged v1 response schema
+
+#### Scenario: Final legacy unit is no longer cataloged
+
+- **WHEN** an exact v1 replay matches an already-final stored operation whose old runtime release is no longer routable or retained in the runtime catalog
+- **THEN** the provisioner returns the persisted result after v1 model validation without contacting a runtime or provider
+
+#### Scenario: Stale legacy replay follows existing fencing
+
+- **WHEN** a body-exact legacy request is older than the tenant's already-observed destructive fence
+- **THEN** replay remains rejected under the existing monotonic-fence contract
+
+### Requirement: Runtime target and package lineage have separate authorities
+
+The deployment lock and provisioner wire SHALL contain runtime-observable release, Hosted protocol, profile, gateway, command, and schema identity only. Substrate SHALL remain authoritative for candidate identity, compatibility, Claude/OpenAI packages and archives, plugin artifacts, OAuth bindings, and staged-client evidence through its immutable candidate catalog and lifecycle snapshot. A cell response MUST NOT be accepted as package or compatibility evidence.
+
+#### Scenario: Client package changes without runtime changes
+
+- **WHEN** a Claude or OpenAI package/archive lock changes while the runtime six-field identity is unchanged
+- **THEN** Substrate updates its candidate or staged-client lineage without changing a provisioner request hash or forcing a cell rollout
+
+#### Scenario: Observation storage requires compatibility
+
+- **WHEN** an existing all-or-none database constraint requires an observed compatibility value
+- **THEN** Substrate derives it from the immutable local candidate and does not claim it was observed from health
+
+### Requirement: Static target validation and live admission gates remain distinct
+
+Before installing or changing runtime bytes, the provisioner SHALL validate the requested runtime target against the immutable deployment lock before provider effects. It SHALL require matching live runtime identity before readiness, route binding, assignment activation, or candidate promotion. Offline restore, backup recovery, salvage, discard, delete, and destruction SHALL retain target fencing and audit identity but MUST remain possible without a successful live runtime probe.
+
+#### Scenario: Target does not match the deployment lock
+
+- **WHEN** a v2 provision or runtime-changing resume names an untrusted release or contract target
+- **THEN** the operation fails before namespace, image, Helm, compute, storage, or routing effects that would install or change that runtime
+
+#### Scenario: Restore candidate is offline
+
+- **WHEN** a valid restore-candidate operation reconstructs stopped storage while the runtime cannot answer health probes
+- **THEN** static target and durability fencing are enforced but the restore is not blocked by missing live identity
+
+#### Scenario: Broken cell must be destroyed
+
+- **WHEN** a fenced discard or destroy request targets a cell whose runtime contract is unavailable or mismatched
+- **THEN** the authenticated destructive workflow can complete without first making that runtime healthy
+
+### Requirement: Immutable phase locks compose verified component lineage
+
+Production preparation SHALL consume exactly one member of a deterministic strict expand/contract lock pair produced only after cryptographically verifying the exact runtime and provisioner candidate bytes and their image attestations, verifying the forward and every authoritative legacy runtime-contract artifact by caller-supplied SHA-256, and passing source-closure checks. Both locks SHALL carry identical component/catalog lineage and the canonical digest of the authoritative routable, assigned, and unfinished-v1 release set, and SHALL differ only in their immutable provisioner admission mode. Each SHALL derive both digest-authoritative images and runtime configuration for Helm, record component sources and candidate-byte hashes, include the six-field forward runtime target, the bounded legacy-v1 runtime catalog, and exact composition and rollback evidence. Neither a provisioner image nor admission mode MAY be supplied as a free override, and a lock MUST NOT contain mutable image tags as authority, placeholders, compatibility values, or client-package lineage.
+
+#### Scenario: Two candidates and contract evidence verify
+
+- **WHEN** exact signed runtime and provisioner candidates, matching hash-pinned forward and legacy runtime-contract evidence, and both source closures pass
+- **THEN** the composer atomically writes deterministic expand and contract locks from which Helm derives both images and runtime settings
+
+#### Scenario: Existing stale v1 manifest is supplied
+
+- **WHEN** the committed 0.22.0/21-command v1 manifest is supplied for the v0.35.1 runtime candidate
+- **THEN** composition fails on release, source, image, or contract mismatch rather than carrying stale metadata forward
+
+#### Scenario: Free provisioner image is supplied at preparation time
+
+- **WHEN** an operator attempts to override the provisioner digest separately from the reviewed lock
+- **THEN** production preparation fails instead of composing an unreviewed image pair
+
+#### Scenario: Admission mode is overridden
+
+- **WHEN** an operator tries to mutate the expand lock into contract mode through a Helm value or environment override
+- **THEN** preparation fails and requires the exact reviewed contract-lock bytes
+
+### Requirement: Rollout follows an explicit expand and contract sequence
+
+Immediately before D1 takes traffic, deployment SHALL hold the cohort/admission lock, freeze assignment and promotion changes, recompute the canonical authoritative legacy release-set digest, and require it to match the reviewed expand lock. A mismatch SHALL stop cutover and require regenerated/reviewed phase locks. With the freeze held, deployment SHALL move traffic to D1 and the reviewed expand lock, then release the freeze, prove every cataloged v1 unit and synthetic v2 behavior, and deploy the Substrate v2-capable consumer with v2 issuance initially disabled. Enabling v2 SHALL affect only newly persisted operations, and every cell-scoped operation SHALL already snapshot a complete runtime target. Contraction SHALL deploy the reviewed contract lock only after no new v1 operations are observed and existing v1 operations are drained or proven replayable. Live canary evidence SHALL be recorded separately from code merge and artifact publication.
+
+#### Scenario: D1 is deployed before Substrate v2 issuance
+
+- **WHEN** the dual-serving provisioner is rolled out in expand mode
+- **THEN** the existing Substrate consumer continues operating under v1 while a synthetic v2 target/identity round trip is verified
+
+#### Scenario: Legacy set changes after lock review
+
+- **WHEN** the under-lock pre-cutover release-set digest differs from the digest in the reviewed expand lock
+- **THEN** traffic remains on the old provisioner and the lock pair is regenerated and reviewed before another attempt
+
+#### Scenario: Issuance is enabled
+
+- **WHEN** the v2 feature gate is enabled after the consumer deployment
+- **THEN** new operations persist v2 while already persisted operations retain their stored protocol
+
+#### Scenario: Contraction preconditions are incomplete
+
+- **WHEN** fresh v1 operations are still being created or legacy operations have not been drained or audited
+- **THEN** the provisioner remains in expand mode and the rollout cannot claim contraction complete
+
+### Requirement: Rollback is exact, rehearsed, and rejects unfinished v2 work
+
+Rollback SHALL name the exact D0 provisioner image digest and source, canonical v1 corpus SHA-256, actual pre-D1 runtime-manifest SHA-256, and last-known-good Substrate v1 consumer commit. Before the tuple is accepted, an executable rehearsal MUST run those exact binaries and manifest against both upgraded database schemas and the frozen replay corpus. Before rollback, admission SHALL stop, both databases SHALL prove that no v2 operation remains non-final, and all remaining cells/operations SHALL match the one legacy runtime unit. Generic schema-v1 or tag-based downgrade authority MUST NOT be accepted.
+
+#### Scenario: Exact rollback tuple is clean
+
+- **WHEN** admission is stopped, all v2 operations are final, and every retained rollback pin matches
+- **THEN** the reviewed rollback procedure may deploy the exact legacy unit
+
+#### Scenario: Exact rollback unit is not rehearsed
+
+- **WHEN** the pinned D0 image, manifest, historical consumer, upgraded schemas, or replay corpus has not passed the executable rehearsal
+- **THEN** the tuple is not accepted as rollback authority
+
+#### Scenario: An unfinished v2 operation exists
+
+- **WHEN** either database contains a non-final v2 operation
+- **THEN** D0 rollback is forbidden and D1 remains running while the operation is resolved or rolled forward
+
+#### Scenario: Generic v1 image is proposed
+
+- **WHEN** an operator supplies a v1 tag, schema version, or image other than the exact retained tuple
+- **THEN** rollback validation fails closed
+
+### Requirement: Both language implementations share canonical protocol corpora
+
+The repository SHALL retain canonical v1 and v2 corpora covering all 14 request, pending, final, and failure shapes plus their exact protocol headers. Python SHALL validate them against the provisioner models and TypeScript SHALL consume the same bytes or an exact hash-pinned copy. Unknown fields, mixed envelopes, header/body disagreement, and unbounded responses MUST be rejected consistently. The v1 corpus hash SHALL be retained as rollback evidence.
+
+#### Scenario: V1 corpus is replayed after implementation
+
+- **WHEN** the post-v2 Python and TypeScript implementations load the canonical v1 corpus
+- **THEN** every header, request, pending response, final proof, and error remains compatible with the frozen v1 hash
+
+#### Scenario: V2 response uses a v1 envelope
+
+- **WHEN** the client issued a v2 header but receives a flat v1 health response or another mixed-version envelope
+- **THEN** parsing fails closed rather than auto-detecting or downgrading
+
+### Requirement: Admission failures remain bounded and content-free
+
+Unknown protocol headers, invalid runtime targets, cross-version replay, fresh v1 in contract mode, identity mismatch, and composition validation failures SHALL expose only bounded reason codes and retryability appropriate to the existing contract. They MUST NOT echo credentials, tenant data, request bodies, contract payloads, image metadata, or provider details, and MUST NOT create partial side effects.
+
+#### Scenario: Runtime target contains a secret and is rejected
+
+- **WHEN** a malformed request supplies a forbidden or invalid field containing sensitive text
+- **THEN** the response and logs use a content-free code without reflecting that value

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/specs/hosted-image-candidate-publication/spec.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/specs/hosted-image-candidate-publication/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Candidate composition proves component source closure
+
+A consumer SHALL compose an image candidate only when the candidate source commit is equal to or an ancestor of the composition commit and a fixed no-shell Git diff proves no relevant build input changed. The runtime closure SHALL include `Dockerfile`, `.dockerignore`, `pyproject.toml`, `uv.lock`, `README.md`, `LICENSE`, and `src/**`. The provisioner closure SHALL include `infra/provisioner/Dockerfile`, `infra/provisioner/pyproject.toml`, `infra/provisioner/uv.lock`, `infra/provisioner/README.md`, `infra/provisioner/alembic.ini`, `infra/provisioner/src/**`, `infra/provisioner/alembic/**`, `infra/helm/cell/**`, and `.dockerignore`. Missing or shallow commits, non-ancestry, Git errors, additions, deletions, renames, or content changes within the closure MUST fail closed. A valid candidate or image attestation MUST NOT waive source drift.
+
+#### Scenario: Only unrelated composition files changed
+
+- **WHEN** a candidate source is an ancestor and every change since that source is outside its component closure
+- **THEN** the candidate remains eligible for composition after its signatures and exact bytes verify
+
+#### Scenario: Runtime input changed after candidate publication
+
+- **WHEN** any file under the runtime closure changes between the runtime candidate source and composition commit
+- **THEN** composition rejects the candidate and requires a newly published runtime candidate
+
+#### Scenario: Provisioner migration changed after candidate publication
+
+- **WHEN** a provisioner Alembic migration/configuration, README, cell Helm input, provisioner source, package lock, Dockerfile, or `.dockerignore` changes after the provisioner candidate source
+- **THEN** composition rejects that provisioner candidate and requires a new independently attested candidate
+
+#### Scenario: Candidate commit is unavailable or unrelated
+
+- **WHEN** the candidate source is missing from the repository, cannot be proven as an ancestor, or the checkout is too shallow to perform the proof
+- **THEN** the guard fails closed instead of assuming source closure

--- a/openspec/changes/bind-hosted-candidate-runtime-identity/tasks.md
+++ b/openspec/changes/bind-hosted-candidate-runtime-identity/tasks.md
@@ -1,0 +1,81 @@
+## 1. Freeze And Review The Contract
+
+- [x] 1.1 Validate this change and the corrected private-alpha specifications with strict OpenSpec checks
+- [x] 1.2 Add the paired Substrate OpenSpec delta for v2 issuance, migration 0037, runtime-only observation, and expand/contract deployment
+- [x] 1.3 Obtain an adversarial architecture/security review of both repository artifacts and address every actionable finding
+- [x] 1.4 Record the exact v1 wire corpus hash and the current runtime/provisioner candidate evidence used as implementation baselines
+
+## 2. Add Strict Dual-Protocol Models
+
+- [ ] 2.1 Add failing tests for exact v1 regression, strict six-field v2 targets, v2 health identity, mixed envelopes, unknown fields, and bounded content-free failures
+- [ ] 2.2 Freeze the current v1 request/final maps and add separate header-selected v2 models for all 14 actions, including explicit target-free export-reference and tenant-destroy requests
+- [ ] 2.3 Add one pure runtime-target accessor that reads untouched v1 top-level identity or required v2 `runtimeTarget` without rewriting persisted request bodies
+- [ ] 2.4 Route API validation, pending/final replay, outer health metadata, and worker response validation through the selected exact wire protocol
+
+## 3. Persist Protocol And Enforce Replay Admission
+
+- [ ] 3.1 Add failing repository and PostgreSQL-upgrade tests for v1 backfill/default, protocol immutability, cross-version conflict, atomic replay-only admission, and D0-compatible inserts
+- [ ] 3.2 Add the additive provisioner operation wire-protocol migration with permanent server-side v1 default
+- [ ] 3.3 Include stored wire protocol in operation snapshots and transactional idempotency comparison without changing the canonical v1 request body hash
+- [ ] 3.4 Implement explicit expand and contract modes plus the verified legacy-v1 runtime catalog so current cataloged v1 releases survive expansion and contract mode accepts exact persisted v1 replay only
+- [ ] 3.5 Prove existing monotonic-fence behavior still rejects otherwise exact stale v1 replay
+
+## 4. Validate And Observe Runtime Identity
+
+- [ ] 4.1 Add failing lifecycle tests proving runtime-changing effects require static lock/target match while restore-candidate, salvage, discard, and destroy do not require a live probe
+- [ ] 4.2 Replace direct legacy release/protocol field reads with the pure target accessor across lifecycle, live, durability, and provider paths
+- [ ] 4.3 Extend authenticated private-cell probing to the selected agent-contract route and derive the six observed identity fields without conflating gateway, capability, command, or schema claims
+- [ ] 4.4 Fail readiness, routing, binding, activation, and promotion on every one-field mismatch while preserving the exact flat v1 health response
+- [ ] 4.5 Run focused API, repository, lifecycle, durability, live-provider, and PostgreSQL 17 suites
+
+## 5. Freeze The Cross-Language Contract
+
+- [ ] 5.1 Preserve the canonical v1 corpus bytes and add a separate canonical v2 corpus covering all requests, headers, pending/final responses, mismatches, replay failures, and error envelopes
+- [ ] 5.2 Validate both corpora against the Python Pydantic models and assert the canonical v1 SHA-256
+- [ ] 5.3 Make the paired TypeScript tests consume the exact corpus bytes or a hash-pinned copy and assert header/body agreement plus strict response parsing
+
+## 6. Compose Verified Deployment Lineage
+
+- [ ] 6.1 Add failing composition tests for candidate attestation verification, exact candidate-byte hashing, unsafe/stale/duplicate legacy runtime evidence, deterministic expand/contract locks, and atomic private writes
+- [ ] 6.2 Implement fixed no-shell ancestry and source-closure guards for the runtime and provisioner path sets, including add/delete/rename, missing, shallow, and non-ancestor failures
+- [ ] 6.3 Add a strict composer that verifies both candidate records, exact hash-pinned v0.35.1 runtime evidence, and the authoritative bounded legacy-v1 runtime catalog plus canonical release-set digest before producing phase locks
+- [ ] 6.4 Add v2 expand/contract lock verification containing identical component/catalog lineage, the six-field target, immutable admission mode, composition proof, and exact rollback tuple without package or compatibility data
+- [ ] 6.5 Update release preparation and verification so production accepts one exact member of the v2 lock pair, derives both immutable images and admission mode from it, and has no free overrides
+- [ ] 6.6 Update platform Helm templates, values, admission expressions, ConfigMap/path, and tests to consume both images and runtime settings from the selected exact phase lock
+- [ ] 6.7 Rewire hosted-infrastructure release proof to reverify candidate attestations, forward and legacy runtime identity, provisioner smoke, source closure, and the exact phase lock
+
+## 7. Implement The Paired Substrate Consumer
+
+- [ ] 7.1 Add failing TypeScript tests for default-off v1 issuance, explicit v2 issuance, stored retry selection, cross-version idempotency, strict health parsing, and runtime-only identity comparison
+- [ ] 7.2 Add migration 0037 with only the immutable provisioner-wire-protocol discriminator, v1 backfill/default, allowed-value constraint, and no duplicate identity columns
+- [ ] 7.3 Add strict v1/v2 serializers and response parsers while preserving exact v1 bodies and keeping runtime Hosted protocol separate
+- [ ] 7.4 Persist the selected protocol before first issuance; make retries use stored state and let only normalized `true` enable v2 for new operations
+- [ ] 7.5 Snapshot and build v2 `runtimeTarget` for every cell-scoped action from authoritative candidate/cell state, use explicit target-free v2 for export-reference and tenant-destroy actions, and compare only returned `runtimeIdentity`
+- [ ] 7.6 Keep compatibility and Claude/OpenAI package/archive lineage candidate-owned; derive any constraint-required compatibility observation locally rather than from health
+- [ ] 7.7 Run focused Node tests, migration/integration tests, lint, TypeScript checking, and strict Substrate OpenSpec validation
+
+## 8. Publish D1 And Finalize The Lock
+
+- [ ] 8.1 Integrate and independently review the Exomem implementation without changing guarded root runtime inputs
+- [ ] 8.2 Merge the Exomem implementation and verify the resulting provisioner producer publishes a new D1 candidate with valid image and candidate attestations
+- [ ] 8.3 Generate and independently verify current v0.35.1 runtime evidence plus every authoritative legacy-v1 runtime unit; reject stale or unreferenced manifests
+- [ ] 8.4 Prove R and D1 source closure, prove D0 fails as the forward candidate, and compose the exact expand/contract lock pair without placeholders
+- [ ] 8.5 Rehearse the exact D0 image, actual pre-D1 manifest, frozen corpus, and historical Substrate consumer against both upgraded schemas before accepting rollback authority
+- [ ] 8.6 Commit, review, merge, and reverify the final deployment lock pair at its exact default-branch commit
+- [ ] 8.7 Merge the paired Substrate consumer with v2 issuance still disabled and record its exact rollback/forward commits
+
+## 9. Deploy Through Expand And Contract
+
+- [ ] 9.1 Run deployment preflight for credentials, capacity, cost alarms, database backups, additive migrations, authoritative legacy release-set digest, and rehearsed exact rollback tuple without claiming success from repository evidence
+- [ ] 9.2 Under the cohort/admission lock freeze assignment/promotion changes, compare the live legacy-set digest to the reviewed expand lock, abort/regenerate on mismatch, or move traffic to D1 before releasing the freeze; then verify every cataloged v1 unit and synthetic v2 target/identity behavior
+- [ ] 9.3 Deploy the paired Substrate consumer, enable v2 only for new operations, and prove restart/retry preserves stored protocol selection
+- [ ] 9.4 Prove no new v1 operations are created, drain or audit persisted v1 work, and deploy the exact reviewed contract lock
+- [ ] 9.5 Canary a fresh v2 cell through provisioning, complete identity observation, binding, routing, activation, and promotion
+- [ ] 9.6 Verify fresh v1 rejection, exact persisted v1 replay, offline recovery/destruction, tenant isolation, one-unit rollback compatibility, and the no-unfinished-v2 preflight
+- [ ] 9.7 Record exact live deployment, canary, and rollback evidence separately from merge, release, and marketplace status
+
+## 10. Close The Change
+
+- [ ] 10.1 Run all focused and full repository verification, strict OpenSpec validation, source-closure checks, Helm rendering, and immutable image smokes at exact delivered commits
+- [ ] 10.2 Obtain independent code/security review and an exact-HEAD verifier pass across Exomem, Substrate, D1, the lock, and rollout evidence
+- [ ] 10.3 Sync the completed delta specs, archive the change only after its scoped gates are genuinely complete, and retain unresolved external marketplace approval as a separate launch gate


### PR DESCRIPTION
## Why
Signed runtime and provisioner candidates still need one reviewed deployment contract that preserves legacy traffic, binds v2 runtime identity, and makes contraction/rollback executable.

## What
- freezes the outer provisioner v2 contract while keeping Hosted runtime protocol 1
- defines bounded legacy-v1 catalog and exact final/non-final replay behavior
- defines complete cell-scoped targets, target-free context actions, phase locks, source closure, and rehearsed rollback
- corrects the older active infrastructure requirements

## Verification
- openspec validate --all --strict --no-interactive (113/113)
- git diff --check
- adversarial architecture review with all findings resolved
- independent verifier: clean