### PR TITLE
docs(maintain-memory): surface the duplicated_sidecar repair to callers

### DIFF
--- a/deploy/chatgpt/personal-plugin-contract.json
+++ b/deploy/chatgpt/personal-plugin-contract.json
@@ -9,7 +9,7 @@
     "offline_access"
   ],
   "registered_tool_surface_sha256": "3fb189ee7d9e48183c404d5b5d36df3c36d5e8df995b7e4cd78ad8c763672ae6",
-  "pending_tool_surface_sha256": "1faf13c145d4dc66b77b15dc7281fd4cce504b784e57ba2c280e0e17d22b5aeb",
+  "pending_tool_surface_sha256": "9807777ec4a332441dc87a493ebdf7f98da6214ed7d3e5521752bac500a100ab",
   "refresh_required": true,
   "rollout_state": "awaiting-post-deploy-refresh",
   "last_verified_release": "0.25.5",

--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -5209,6 +5209,15 @@ def op_maintain_memory(
     `op_reconcile` itself (idempotent, non-destructive) — so it defaults to
     writing; pass `dry_run=true` to preview instead.
 
+    `mode="fix"` also collapses media sidecars that accumulated nested copies of
+    themselves (audit category `duplicated_sidecar`, reportable on its own via
+    `mode="audit", categories=["duplicated_sidecar"]`). It keeps the longest
+    surviving `## Extracted text` — for a sidecar whose top-level block was
+    blanked by a re-render, that is the one buried in a nested copy — and refuses
+    any rewrite that would leave less transcript than it found. Frontmatter is
+    untouched, so a still-`pending` sidecar is re-extracted normally and the
+    recovered text is only the fallback.
+
     Args:
         mode: audit, fix, reconcile, or backfill-ids.
         categories: Optional audit category filter.

--- a/src/exomem/tool_surface_contract.json
+++ b/src/exomem/tool_surface_contract.json
@@ -12,5 +12,5 @@
     "execution"
   ],
   "tool_count": 26,
-  "sha256": "1faf13c145d4dc66b77b15dc7281fd4cce504b784e57ba2c280e0e17d22b5aeb"
+  "sha256": "9807777ec4a332441dc87a493ebdf7f98da6214ed7d3e5521752bac500a100ab"
 }

--- a/tests/fixtures/mcp_tool_schemas.json
+++ b/tests/fixtures/mcp_tool_schemas.json
@@ -2155,7 +2155,7 @@
     }
   },
   "maintain_memory": {
-    "description": "Maintain vault health with explicit write-capable modes.\n\nDefault mode is read-only audit. `mode=\"fix\"` and `mode=\"backfill-ids\"`\nrewrite content (wikilinks, frontmatter, stable IDs) and default to\ndry-run here as a safety net. `mode=\"reconcile\"` only heals index-count\nand sidecar drift from out-of-band edits — the same canonical default as\n`op_reconcile` itself (idempotent, non-destructive) — so it defaults to\nwriting; pass `dry_run=true` to preview instead.",
+    "description": "Maintain vault health with explicit write-capable modes.\n\nDefault mode is read-only audit. `mode=\"fix\"` and `mode=\"backfill-ids\"`\nrewrite content (wikilinks, frontmatter, stable IDs) and default to\ndry-run here as a safety net. `mode=\"reconcile\"` only heals index-count\nand sidecar drift from out-of-band edits — the same canonical default as\n`op_reconcile` itself (idempotent, non-destructive) — so it defaults to\nwriting; pass `dry_run=true` to preview instead.\n\n`mode=\"fix\"` also collapses media sidecars that accumulated nested copies of\nthemselves (audit category `duplicated_sidecar`, reportable on its own via\n`mode=\"audit\", categories=[\"duplicated_sidecar\"]`). It keeps the longest\nsurviving `## Extracted text` — for a sidecar whose top-level block was\nblanked by a re-render, that is the one buried in a nested copy — and refuses\nany rewrite that would leave less transcript than it found. Frontmatter is\nuntouched, so a still-`pending` sidecar is re-extracted normally and the\nrecovered text is only the fallback.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {


### PR DESCRIPTION
Follow-up to #363, which shipped the `duplicated_sidecar` repair but deliberately left it undocumented at the call site to avoid moving the pinned MCP surface. Taking that on now.

## What changes

`maintain_memory`'s docstring — which **is** the MCP tool description Claude and ChatGPT see — now says that `mode="fix"` collapses self-nesting media sidecars, that `mode="audit", categories=["duplicated_sidecar"]` reports it on its own, and the two properties a caller needs in order to trust it:

- the **longest surviving** `## Extracted text` wins — for a sidecar whose top-level block a re-render blanked, that is the copy buried in a nested section, so the obvious "truncate at the first heading" repair would destroy it;
- a rewrite that would leave **less transcript than it found is refused**, not applied.

Frontmatter stays untouched, so a still-`pending` sidecar is re-extracted normally and the recovered text is only the fallback.

## Why the baseline moves

`tests/test_mcp_schema_fidelity.py` pins every tool's description byte-for-byte, plus a SHA in `src/exomem/tool_surface_contract.json`. Regenerated with `scripts/dump-tool-schemas.py`; the diff is only this description. Four lines of substance in total.

## Connector attestation — pending only

`deploy/chatgpt/personal-plugin-contract.json` advances `pending_tool_surface_sha256` to the new digest and **nothing else**.

Worth being explicit: the connector was *already* `awaiting-post-deploy-refresh` before this. `registered_tool_surface_sha256` is still the **0.25.5** digest from **2026-07-20**, so the rollout debt predates this change by ~10 releases. This does not create a rollout; it updates which digest is waiting on one.

`registered_tool_surface_sha256`, `last_verified_*`, and `verification` are deliberately unchanged. They stay as they are until the plugin is actually recreated and **content-bearing** reads are re-verified — the attestation's own text records that bootstrap and frontmatter-only reads can succeed while content reads stay blocked, so connectivity alone is not evidence.

## Verification

`tests/test_mcp_schema_fidelity.py` + `tests/test_connector_guardrails.py` — 10 passed. `ruff check` clean.