### PR TITLE
feat(governance): let a scope deny audiences it does not name

### DIFF
--- a/openspec/changes/add-default-deny-scope-cap/design.md
+++ b/openspec/changes/add-default-deny-scope-cap/design.md
@@ -49,18 +49,42 @@ closed unless opened.
 The obvious implementation — inject a ceiling-0 standing rule for declared scopes — is
 wrong, and the reason is worth recording. `standing_min` is a `min` over matched rules, so
 a synthetic 0 would combine with an explicit `ceiling: 3` as `min(3, 0) = 0` and silently
-override the authored allowance. The declaration must apply only when the standing set is
-EMPTY:
+override the authored allowance. Emptiness is resolved PER DECLARING SCOPE: a standing
+rule names only the scopes in that rule, and every declared member it does not name keeps
+its restrictive default:
 
 ```python
-if standing:
-    standing_min = min(r.ceiling for r in standing)
-else:
-    standing_min = DISCLOSURE_MIN if _denied_by_default(...) else DISCLOSURE_MAX
+named_scope_ids = {
+    scope_id for rule in standing for scope_id in rule.scope_ids
+} & item_scope_ids
+default_deny_scope_ids = {
+    scope_id for scope_id in item_scope_ids
+    if policy.scopes[scope_id].default_deny and scope_id not in named_scope_ids
+}
+ceilings = [rule.ceiling for rule in standing]
+if default_deny_scope_ids:
+    ceilings.append(DISCLOSURE_MIN)
+standing_min = min(ceilings, default=DISCLOSURE_MAX)
 ```
 
 Everything downstream then works untouched: `grant_max` still raises off the floor, so
 "unless a grant names them" needs no special case.
+
+### Reserved audience ids stay outside the authored grammar
+
+The evaluator uses a NUL-prefixed audience namespace for the unresolved fail-closed
+identity and the unnamed-audience transition probe. YAML can decode an escaped `\0` into
+that namespace, so every authored audience-bearing field (`audience` and `to_audience`)
+rejects any NUL as an error finding. A rule or grant therefore cannot capture either
+reserved identity or mint a lookalike inside the reserved prefix.
+
+### Transition previews expose the unnamed default separately
+
+`target_ceiling` remains the maximum post-change ceiling among authored audiences for
+compatibility. Proposal consequences also always carry `unnamed_audience_ceiling` (nullable
+when the concrete membership is empty), computed from the post-change unnamed-audience
+probe. Removing `default_deny` can therefore report authored `target_ceiling: 1` and
+`unnamed_audience_ceiling: 6` without hiding the credential-rotation consequence.
 
 ### Owner exemption is by audience identity, at the default site
 

--- a/openspec/changes/add-default-deny-scope-cap/design.md
+++ b/openspec/changes/add-default-deny-scope-cap/design.md
@@ -1,0 +1,98 @@
+## Context
+
+`_decide_at` (`governance/decisions.py`) evaluates a pure, order-free lattice:
+
+```python
+standing_min = min((r.ceiling for r in standing), default=DISCLOSURE_MAX)
+grant_max    = max([g.ceiling for g in matched_grants] + [standing_min])
+org_cap_min  = min((r.ceiling for r in org_caps), default=DISCLOSURE_MAX)
+level        = min(org_cap_min, grant_max)
+```
+
+The `default=DISCLOSURE_MAX` on `standing_min` is the entire default-open behaviour. Every
+other part of the lattice is already correct for this change: grants raise, org caps lower,
+purpose narrows. So the change is one default, conditioned on the scope and the audience.
+
+Wave 0 established that this matters in practice: audiences are exact-id matched
+(`principal.normalize_audience`), and for non-OAuth MCP clients the subject derives from
+the bearer credential, so a credential rotation produces an audience no rule names.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make "nobody but me unless I name them" expressible for a scope.
+- Compose with the existing lattice rather than sitting beside it.
+- Keep the owner's access unconditional.
+- Leave undeclared scopes and ungoverned vaults byte-identical.
+
+**Non-Goals**
+
+- Not a new document kind. The declaration belongs to the scope it describes.
+- Not a global default. Flipping the whole vault to default-deny is a different, larger
+  decision with a migration; this is per scope and opt-in.
+- Not a replacement for org caps. An org cap bounds an authored allowance from above; this
+  supplies a floor where nothing was authored at all.
+
+## Decisions
+
+### A scope field, not a rule kind
+
+Adding a third `_RULE_KINDS` value would mean a rule that matches no audience — a rule
+whose entire purpose is to describe the absence of other rules. That inverts what a rule
+is and would have to be excluded from `matched_rules`, `options` merging, and the
+`rule_ids` a decision reports. A boolean on `Scope` says what it means: this scope is
+closed unless opened.
+
+### Change the default, do not add a synthetic rule
+
+The obvious implementation — inject a ceiling-0 standing rule for declared scopes — is
+wrong, and the reason is worth recording. `standing_min` is a `min` over matched rules, so
+a synthetic 0 would combine with an explicit `ceiling: 3` as `min(3, 0) = 0` and silently
+override the authored allowance. The declaration must apply only when the standing set is
+EMPTY:
+
+```python
+if standing:
+    standing_min = min(r.ceiling for r in standing)
+else:
+    standing_min = DISCLOSURE_MIN if _denied_by_default(...) else DISCLOSURE_MAX
+```
+
+Everything downstream then works untouched: `grant_max` still raises off the floor, so
+"unless a grant names them" needs no special case.
+
+### Owner exemption is by audience identity, at the default site
+
+`OWNER_AUDIENCE` is a reserved id that `normalize_audience` cannot produce, so testing it
+is not a string-comparison hazard. The exemption applies where the default is chosen, not
+as a post-hoc override, so an authored rule that deliberately restricts the owner still
+takes effect.
+
+### Any declared scope wins
+
+Membership is a set, and a scope cannot be widened by adding another scope alongside it —
+that would make the declaration defeatable by authoring a broad undeclared scope, which is
+exactly the mistake this change exists to prevent.
+
+## Risks / Trade-offs
+
+- **A declared scope with no rules is invisible until someone is denied.** Mitigated by
+  `explain` naming the declaring scope rather than reporting "no rule matched", so the
+  owner can tell a default denial from a missing item.
+- **Latency.** The default path needs the scope objects for an item's already-resolved
+  scope ids — a dict lookup per scope, only on the branch where no rule matched, and only
+  for governed vaults. The overhead gate covers the empty-policy budget.
+- **It is opt-in, so it does not fix existing scopes.** Deliberate: silently inverting the
+  default for policies already authored would change live disclosure outcomes on upgrade.
+  The consolidation work is expected to author declared scopes from the start.
+
+## Migration Plan
+
+None. Documents omitting the field compile and decide exactly as today; no stored format,
+schema version, or sidecar changes.
+
+## Open Questions
+
+None blocking. Whether the vault-wide default should eventually invert is deliberately out
+of scope and would need its own change with a migration path.

--- a/openspec/changes/add-default-deny-scope-cap/proposal.md
+++ b/openspec/changes/add-default-deny-scope-cap/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The policy grammar has no way to say "nobody but me, unless I name them". Two facts
+combine into a hole that no amount of careful authoring closes:
+
+1. **No matching rule means full release.** `_decide_at` computes
+   `standing_min = min(ceilings, default=DISCLOSURE_MAX)`, so a scope with no rule for a
+   given audience resolves to L6. Confidentiality is opt-in per (scope, audience) pair.
+2. **Audiences are matched by exact id.** `normalize_audience` derives an id from the
+   issuer and subject, and for non-OAuth MCP clients the subject derives from the bearer
+   credential itself. So **rotating a credential mints an audience id that no rule names**,
+   and the vault falls open to it.
+
+The consequence is that "this assistant may never receive my private material" is not
+currently expressible. The true statement is "…so long as its audience id matches an
+authored rule", which is a precondition the owner cannot enforce and will not remember.
+Every scope added later inherits the same default, so the hole widens as the vault grows.
+
+This blocks the governed-consolidation work: the whole point of consolidating two Exomems
+into one is that a deterministic release plane replaces physical isolation. Trading a
+boundary with no attack surface for one that a credential rotation reopens is not a trade
+worth making, and no orchestration above the kernel can fix a default in the lattice.
+
+## What Changes
+
+- A scope MAY declare that an audience no rule names receives nothing. For such a scope,
+  the standing default for a non-owner audience becomes the most restrictive level instead
+  of the most permissive one.
+- The owner is never subject to it. A scope the owner cannot read is a scope that has
+  removed the owner's own access to their own vault, which is not what this expresses.
+- Existing composition is unchanged: an explicit rule still sets the ceiling for the
+  audience it names, a grant still only raises, an org cap still only lowers, and a
+  declared purpose still only narrows. The declaration changes exactly one thing — the
+  default that applies when nothing matched.
+- The policy compiler validates and reports the declaration so `explain`/`simulate` can
+  show that an item is withheld by default rather than by an authored rule.
+- Ungoverned vaults are untouched: no governance tree still means the empty fast path.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `governance-kernel`: a scope may invert the standing default for unnamed audiences, and
+  the evaluator resolves that default before grants, org caps and purpose conditions apply.
+
+## Impact
+
+- Affected code: `governance/policy.py` (scope field, compile, validation),
+  `governance/decisions.py` (the standing default), `governance/inspection.py` (explain),
+  and focused governance tests.
+- APIs: no request or response shape changes. Policy documents gain one optional scope
+  field; documents that omit it behave exactly as today.
+- Dependencies and runtime: no new dependency, model, background task, or sidecar
+  migration. The empty-policy fast path and its latency budget are unchanged, and the
+  declaration costs one lookup per already-resolved scope on the decision path.

--- a/openspec/changes/add-default-deny-scope-cap/proposal.md
+++ b/openspec/changes/add-default-deny-scope-cap/proposal.md
@@ -66,8 +66,11 @@ None.
 - Affected code: `governance/policy.py` (scope field, compile, validation),
   `governance/decisions.py` (the standing default), `governance/inspection.py` (explain),
   and focused governance tests.
-- APIs: no request or response shape changes. Policy documents gain one optional scope
-  field; documents that omit it behave exactly as today.
+- APIs: no request-schema changes. Policy documents gain one optional scope field;
+  documents that omit it behave exactly as today. Proposal consequences gain the
+  additive `unnamed_audience_ceiling` field so the default is visible separately from
+  authored-audience `target_ceiling`. Non-owner inspection of a default-denied path now
+  uses the same invalid-path refusal as a missing path.
 - Dependencies and runtime: no new dependency, model, background task, or sidecar
   migration. The empty-policy fast path and its latency budget are unchanged, and the
   declaration costs one lookup per already-resolved scope on the decision path.

--- a/openspec/changes/add-default-deny-scope-cap/proposal.md
+++ b/openspec/changes/add-default-deny-scope-cap/proposal.md
@@ -16,6 +16,10 @@ currently expressible. The true statement is "…so long as its audience id matc
 authored rule", which is a precondition the owner cannot enforce and will not remember.
 Every scope added later inherits the same default, so the hole widens as the vault grows.
 
+This change makes the statement hold against an audience no document names — including one
+minted by a credential rotation. It does not make it hold against an audience holding a
+grant on an overlapping scope; see the scope note below.
+
 This blocks the governed-consolidation work: the whole point of consolidating two Exomems
 into one is that a deterministic release plane replaces physical isolation. Trading a
 boundary with no attack surface for one that a credential rotation reopens is not a trade
@@ -32,6 +36,16 @@ worth making, and no orchestration above the kernel can fix a default in the lat
   audience it names, a grant still only raises, an org cap still only lowers, and a
   declared purpose still only narrows. The declaration changes exactly one thing — the
   default that applies when nothing matched.
+- **Scope of the guarantee.** The declaration closes the RULE lane: a rule naming an
+  audience for one scope no longer suppresses a different scope's default. It does NOT
+  close the GRANT lane. A grant matches on scope intersection and raises the whole item,
+  so a grant naming an audience for a sibling scope still lifts an item that is also in a
+  declared scope naming nobody. That is a pre-existing property of the lattice — an
+  authored `ceiling: 0` rule behaves identically, verified by an equivalence test — and
+  scoping a grant's raise to the scopes it names is a separate change with its own
+  compatibility surface. Until then, "an audience no document names receives nothing"
+  holds; "an audience named anywhere receives nothing outside what it was named for"
+  does not.
 - The policy compiler validates and reports the declaration so `explain`/`simulate` can
   show that an item is withheld by default rather than by an authored rule.
 - Ungoverned vaults are untouched: no governance tree still means the empty fast path.

--- a/openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md
+++ b/openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md
@@ -22,12 +22,47 @@ alongside it.
 
 A vault with no governance tree SHALL remain on the empty fast path, unaffected.
 
+Authored audience-bearing fields SHALL NOT enter the evaluator's reserved NUL-prefixed
+namespace. A NUL in `audience` or `to_audience` SHALL produce an ERROR finding and refuse
+the compile, including the values reserved for unresolved principals and the unnamed-
+audience transition probe.
+
+Policy transition previews SHALL expose the post-change ceiling for the unnamed-audience
+default as `unnamed_audience_ceiling`, separately from the authored-audience
+`target_ceiling`. The field SHALL be present and nullable when no concrete membership can
+be evaluated.
+
 #### Scenario: an audience no rule names receives nothing
 
 - **WHEN** an item belongs to a scope carrying the declaration and a request arrives from
-  an audience for which no standing rule matches that scope
+  an audience for which no standing rule matches that scope and no matching grant applies
 - **THEN** the decision is no disclosure
-- **AND** the item is indistinguishable from one that does not exist
+- **AND** outside the relevance-ranking signals `bm25_rank`, `keyword_rank`, `vector_rank`,
+  and `graph_in_degree`, its projected representation is indistinguishable from one that
+  does not exist
+- **AND** those signals reflect corpus position and are a known pre-existing channel
+  tracked separately from this change
+
+#### Scenario: non-owner inspection does not reveal a default-denied path
+
+- **WHEN** a non-owner uses `explain` or `simulate` for one path, first while it exists and
+  is denied at no disclosure and again after the same path is deleted
+- **THEN** both requests receive the same error class and text
+- **AND** owner inspection behaviour is unchanged
+- **AND** an established terminal `release_reason` remains inspectable
+
+#### Scenario: reserved audience ids refuse compilation
+
+- **WHEN** a rule or grant authors an `audience` or `to_audience` containing a NUL
+- **THEN** the compiler emits an ERROR finding
+- **AND** the policy compile is refused
+
+#### Scenario: a transition preview exposes the unnamed default
+
+- **WHEN** a declared scope has an L1 rule for `external` and a proposal removes the
+  declaration
+- **THEN** `target_ceiling` remains 1 for the authored audience
+- **AND** `unnamed_audience_ceiling` is 6 for the post-change default
 
 #### Scenario: a newly minted audience id is denied by default
 

--- a/openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md
+++ b/openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: A Scope May Deny Audiences It Does Not Name
+
+A scope MAY declare that the standing default for an audience is the most restrictive
+level rather than the most permissive one. Where a scope carries that declaration and an
+item is a member of it, an audience for which no standing rule matches SHALL resolve to no
+disclosure, instead of to full release.
+
+The declaration changes the DEFAULT only. It SHALL NOT override an authored rule: where a
+standing rule names the audience for that scope, that rule's ceiling applies exactly as it
+does today. Grants SHALL continue to only raise, organisation caps SHALL continue to only
+lower, and a declared purpose SHALL continue to only narrow.
+
+The owner SHALL never be subject to the declaration. An owner locked out of their own
+scope is a vault that has lost its own contents, which is not the confidentiality this
+expresses.
+
+Where an item is a member of several scopes and any one of them carries the declaration,
+the restrictive default applies — a scope cannot be widened by adding an undeclared scope
+alongside it.
+
+A vault with no governance tree SHALL remain on the empty fast path, unaffected.
+
+#### Scenario: an audience no rule names receives nothing
+
+- **WHEN** an item belongs to a scope carrying the declaration and a request arrives from
+  an audience for which no standing rule matches that scope
+- **THEN** the decision is no disclosure
+- **AND** the item is indistinguishable from one that does not exist
+
+#### Scenario: a newly minted audience id is denied by default
+
+- **WHEN** a principal's credential is rotated so it resolves to an audience id that
+  appears in no policy document, and it requests an item in a declared scope
+- **THEN** the decision is no disclosure
+- **AND** the outcome is identical to the pre-rotation audience having been unnamed
+
+#### Scenario: an authored rule still governs the audience it names
+
+- **WHEN** a standing rule names an audience for a declared scope with a ceiling above no
+  disclosure
+- **THEN** that audience receives the rule's ceiling
+- **AND** the declaration does not lower it
+
+#### Scenario: a grant still raises above the default
+
+- **WHEN** an audience unnamed by any standing rule holds a grant for a declared scope
+- **THEN** the grant's ceiling applies
+- **AND** the declaration does not suppress it
+
+#### Scenario: an organisation cap still lowers
+
+- **WHEN** an organisation cap applies to a declared scope alongside a rule permitting a
+  higher level
+- **THEN** the lower of the two applies, unchanged by the declaration
+
+#### Scenario: the owner reads a declared scope
+
+- **WHEN** the owner requests an item in a declared scope for which no rule names the owner
+- **THEN** the owner receives full release
+
+#### Scenario: one declared scope denies across an overlapping undeclared scope
+
+- **WHEN** an item belongs to both a declared scope and an undeclared scope, and the
+  audience is named by no standing rule
+- **THEN** the decision is no disclosure
+
+#### Scenario: an undeclared scope keeps today's default
+
+- **WHEN** an item belongs only to scopes carrying no declaration and no standing rule
+  matches the audience
+- **THEN** the decision is full release, exactly as before this change
+
+#### Scenario: inspection explains a default denial
+
+- **WHEN** the owner explains the decision for an item withheld by the declaration
+- **THEN** the explanation identifies the declaring scope
+- **AND** it does not attribute the outcome to a standing rule that does not exist

--- a/openspec/changes/add-default-deny-scope-cap/tasks.md
+++ b/openspec/changes/add-default-deny-scope-cap/tasks.md
@@ -27,4 +27,4 @@
 - [x] 4.3 Run `ruff check`, `git diff --check`, and the scaffold leak gate.
 - [x] 4.4 Run `openspec validate add-default-deny-scope-cap --strict`.
 - [x] 4.5 Run the lean suite, then the full suite.
-- [ ] 4.6 Independent adversarial review of the exact diff, with the reviewer rechecking its own findings after fixes.
+- [x] 4.6 Independent adversarial review of the exact diff, with the reviewer rechecking its own findings after fixes.

--- a/openspec/changes/add-default-deny-scope-cap/tasks.md
+++ b/openspec/changes/add-default-deny-scope-cap/tasks.md
@@ -1,0 +1,30 @@
+## 1. Scope Declaration
+
+- [x] 1.1 Add failing coverage: a scope document carrying the declaration compiles, and one omitting it is unchanged.
+- [x] 1.2 Add failing coverage: a malformed declaration value is an error finding, not a silent default.
+- [x] 1.3 Add the field to `Scope`, the compiler's recognised scope fields, and validation.
+
+## 2. Evaluator Default
+
+- [x] 2.1 Add failing coverage: an audience no standing rule names resolves to no disclosure for a declared scope, and to full release for an undeclared one.
+- [x] 2.2 Add failing coverage: a rotated credential minting an unnamed audience id is denied identically.
+- [x] 2.3 Add failing coverage: an authored rule still governs the audience it names, and the declaration does not lower it.
+- [x] 2.4 Add failing coverage: a grant still raises above the default; an org cap still lowers; a declared purpose still only narrows.
+- [x] 2.5 Add failing coverage: the owner reads a declared scope at full release.
+- [x] 2.6 Add failing coverage: an item in both a declared and an undeclared scope is denied.
+- [x] 2.7 Change the standing default in `_decide_at` to depend on the declaration and the audience, applying it only when the standing set is empty.
+
+## 3. Surfaces And Indistinguishability
+
+- [x] 3.1 Add failing coverage: an item denied by default is byte-identical to a missing one across `get`, `fetch`, recall, graph and media — reusing the same-input/varied-condition shape, not two different paths.
+- [x] 3.2 Add failing coverage: `explain` names the declaring scope and does not attribute the outcome to a nonexistent rule.
+- [x] 3.3 Wire the explanation through `inspection`.
+
+## 4. Verification
+
+- [x] 4.1 Run the governance, decision, membership and postfilter suites with embeddings disabled.
+- [x] 4.2 Run the governance overhead and latency gates; confirm the empty-policy budget is unchanged.
+- [x] 4.3 Run `ruff check`, `git diff --check`, and the scaffold leak gate.
+- [x] 4.4 Run `openspec validate add-default-deny-scope-cap --strict`.
+- [x] 4.5 Run the lean suite, then the full suite.
+- [ ] 4.6 Independent adversarial review of the exact diff, with the reviewer rechecking its own findings after fixes.

--- a/src/exomem/governance/bridges.py
+++ b/src/exomem/governance/bridges.py
@@ -708,16 +708,24 @@ def restriction_signature(
         for grant in policy.grants
         if grant.audience == audience and bool(scopes & set(grant.scope_ids))
     ]
+
+    def scope_row(scope_id: str) -> dict[str, Any]:
+        scope = policy.scopes.get(scope_id)
+        return {
+            "id": scope_id,
+            "constraint": None if scope is None else scope.constraint,
+            # A `default_deny` declaration restricts as much as an authored
+            # `ceiling: 0` does, and it names no rule — so without it here,
+            # locking the source scope leaves a previously approved
+            # abstraction of a private source flowing on a fresh-looking
+            # signature.
+            "default_deny": False if scope is None else bool(scope.default_deny),
+        }
+
     payload = {
         "audience": audience,
         "scope_ids": sorted(scopes),
-        "scopes": [
-            {
-                "id": scope_id,
-                "constraint": policy.scopes[scope_id].constraint if scope_id in policy.scopes else None,
-            }
-            for scope_id in sorted(scopes)
-        ],
+        "scopes": [scope_row(scope_id) for scope_id in sorted(scopes)],
         "rules": sorted(rules, key=lambda row: (row["id"], row["kind"], row["ceiling"])),
         "grants": sorted(grants, key=lambda row: (row["id"], row["ceiling"])),
     }

--- a/src/exomem/governance/decisions.py
+++ b/src/exomem/governance/decisions.py
@@ -8,6 +8,12 @@ rule participates, and min/max are commutative so the result never depends on
 authoring order (design decision D5). Purpose-absence is deterministic: a
 purpose-conditioned allowance does not fire when purpose is undeclared, while
 an "outside purpose" restriction does.
+
+The standing default is OPEN — an audience no rule names receives full
+disclosure — unless a scope the item belongs to sets `default_deny`, which
+inverts that default for every audience but the owner. It is a default and
+nothing more: it applies only when NO standing rule matched, so it never
+lowers an authored ceiling.
 """
 
 from __future__ import annotations
@@ -16,7 +22,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
-from .policy import DISCLOSURE_MAX, Policy, Rule, StandingGrant
+from .policy import DISCLOSURE_MAX, DISCLOSURE_MIN, Policy, Rule, StandingGrant
+from .principal import OWNER_AUDIENCE
 
 
 @dataclass(frozen=True)
@@ -24,6 +31,11 @@ class Decision:
     level: int
     scope_ids: tuple[str, ...] = ()
     rule_ids: tuple[str, ...] = ()
+    #: The scopes whose `default_deny` supplied the standing floor because NO
+    #: standing rule matched. Non-empty only when the outcome was decided by
+    #: the default rather than by an authored rule, so `explain` can name the
+    #: declaring scope without inventing a rule id.
+    default_deny_scope_ids: tuple[str, ...] = ()
     options: dict[str, Any] = field(default_factory=dict)
     notice: str | None = None
     bridge: str | None = None
@@ -127,7 +139,33 @@ def _decide_at(
     standing = [r for r in matched_rules if r.kind != "org_cap"]
     org_caps = [r for r in matched_rules if r.kind == "org_cap"]
 
-    standing_min = min((r.ceiling for r in standing), default=DISCLOSURE_MAX)
+    # The one default this change inverts. It applies ONLY when the standing
+    # set is empty. `standing_min` is a `min`, so injecting a synthetic
+    # ceiling-0 rule for a declared scope instead would combine with an
+    # authored `ceiling: 3` as `min(3, 0) = 0` and silently override the
+    # allowance the owner wrote — a declaration must change the default, never
+    # a rule's outcome.
+    default_deny_scope_ids: tuple[str, ...] = ()
+    if standing:
+        standing_min = min(r.ceiling for r in standing)
+    else:
+        # The owner is exempt where the default is CHOSEN, not by a post-hoc
+        # override, so a rule that deliberately restricts the owner still
+        # takes effect through the branch above.
+        if audience != OWNER_AUDIENCE:
+            # ANY declared member closes the item: membership is a set, and a
+            # declaration that could be defeated by authoring a broad
+            # undeclared scope alongside it would be no control at all.
+            default_deny_scope_ids = tuple(
+                sorted(
+                    scope_id
+                    for scope_id in scope_id_set
+                    if (scope := policy.scopes.get(scope_id)) is not None and scope.default_deny
+                )
+            )
+        standing_min = DISCLOSURE_MIN if default_deny_scope_ids else DISCLOSURE_MAX
+    # Unchanged: a grant still raises off the floor, so "unless a grant names
+    # them" needs no special case.
     grant_max = max([g.ceiling for g in matched_grants] + [standing_min])
     org_cap_min = min((r.ceiling for r in org_caps), default=DISCLOSURE_MAX)
     level = min(org_cap_min, grant_max)
@@ -158,6 +196,7 @@ def _decide_at(
         level=level,
         scope_ids=tuple(sorted(scope_id_set)),
         rule_ids=tuple(sorted(r.id for r in matched_rules)),
+        default_deny_scope_ids=default_deny_scope_ids,
         options=options,
         notice=options.get("notice"),
         bridge=options.get("bridge"),

--- a/src/exomem/governance/decisions.py
+++ b/src/exomem/governance/decisions.py
@@ -12,8 +12,9 @@ an "outside purpose" restriction does.
 The standing default is OPEN — an audience no rule names receives full
 disclosure — unless a scope the item belongs to sets `default_deny`, which
 inverts that default for every audience but the owner. It is a default and
-nothing more: it applies only when NO standing rule matched, so it never
-lowers an authored ceiling.
+nothing more: it applies only where no standing rule named the audience FOR
+THAT SCOPE, so it never lowers a ceiling authored on the scope it governs, and
+a rule authored on one declared scope never suppresses another's declaration.
 """
 
 from __future__ import annotations
@@ -31,10 +32,10 @@ class Decision:
     level: int
     scope_ids: tuple[str, ...] = ()
     rule_ids: tuple[str, ...] = ()
-    #: The scopes whose `default_deny` supplied the standing floor because NO
-    #: standing rule matched. Non-empty only when the outcome was decided by
-    #: the default rather than by an authored rule, so `explain` can name the
-    #: declaring scope without inventing a rule id.
+    #: The scopes whose `default_deny` supplied the standing floor because no
+    #: standing rule named this audience for them. Non-empty only where the
+    #: default rather than an authored rule set the floor, so `explain` can
+    #: name the declaring scope without inventing a rule id.
     default_deny_scope_ids: tuple[str, ...] = ()
     options: dict[str, Any] = field(default_factory=dict)
     notice: str | None = None
@@ -139,31 +140,41 @@ def _decide_at(
     standing = [r for r in matched_rules if r.kind != "org_cap"]
     org_caps = [r for r in matched_rules if r.kind == "org_cap"]
 
-    # The one default this change inverts. It applies ONLY when the standing
-    # set is empty. `standing_min` is a `min`, so injecting a synthetic
-    # ceiling-0 rule for a declared scope instead would combine with an
-    # authored `ceiling: 3` as `min(3, 0) = 0` and silently override the
-    # allowance the owner wrote — a declaration must change the default, never
-    # a rule's outcome.
+    # The one default this change inverts, resolved PER DECLARING SCOPE. A
+    # declared scope keeps its default until a standing rule names this
+    # audience *for that scope* — resolving it against the item's global
+    # matched-rule set instead would let a rule authored on one compartment
+    # suppress a different compartment's declaration, so authorising a partner
+    # on S1 would hand them an item that is also in an untouched S2.
+    #
+    # It stays a default and not a synthetic ceiling-0 rule: the floor is
+    # folded into `standing_min` only for scopes NO rule named, so an authored
+    # `ceiling: 3` on a declared scope still reads 3 rather than
+    # `min(3, 0) = 0`.
     default_deny_scope_ids: tuple[str, ...] = ()
-    if standing:
-        standing_min = min(r.ceiling for r in standing)
-    else:
+    if audience != OWNER_AUDIENCE:
         # The owner is exempt where the default is CHOSEN, not by a post-hoc
         # override, so a rule that deliberately restricts the owner still
-        # takes effect through the branch above.
-        if audience != OWNER_AUDIENCE:
-            # ANY declared member closes the item: membership is a set, and a
-            # declaration that could be defeated by authoring a broad
-            # undeclared scope alongside it would be no control at all.
-            default_deny_scope_ids = tuple(
-                sorted(
-                    scope_id
-                    for scope_id in scope_id_set
-                    if (scope := policy.scopes.get(scope_id)) is not None and scope.default_deny
-                )
+        # takes effect through the ceilings below.
+        named_scope_ids = {
+            scope_id for rule in standing for scope_id in rule.scope_ids
+        } & scope_id_set
+        # ANY declared member that named nobody closes the item: membership is
+        # a set, and a declaration that could be defeated by authoring a broad
+        # undeclared scope alongside it would be no control at all.
+        default_deny_scope_ids = tuple(
+            sorted(
+                scope_id
+                for scope_id in scope_id_set
+                if scope_id not in named_scope_ids
+                and (scope := policy.scopes.get(scope_id)) is not None
+                and scope.default_deny
             )
-        standing_min = DISCLOSURE_MIN if default_deny_scope_ids else DISCLOSURE_MAX
+        )
+    ceilings = [rule.ceiling for rule in standing]
+    if default_deny_scope_ids:
+        ceilings.append(DISCLOSURE_MIN)
+    standing_min = min(ceilings, default=DISCLOSURE_MAX)
     # Unchanged: a grant still raises off the floor, so "unless a grant names
     # them" needs no special case.
     grant_max = max([g.ceiling for g in matched_grants] + [standing_min])

--- a/src/exomem/governance/inspection.py
+++ b/src/exomem/governance/inspection.py
@@ -99,11 +99,24 @@ def inspect_operation(
         decision = projected(rel_path)
         level = policy_module.DISCLOSURE_MIN if decision is None else decision.level
         rule_ids = [] if decision is None else list(decision.rule_ids)
+        # A scope carrying `default_deny` is invisible until someone is denied:
+        # no rule matched, so `rule_ids` is legitimately empty and a bare
+        # "nothing matched" would read as a missing item. Name the declaring
+        # scope instead of attributing the outcome to a rule that does not
+        # exist. Owner-only, matching `list`, which already withholds scope ids
+        # from a non-owner while disclosing rule ids — a default denial must
+        # not become the one place a third party learns the scope structure.
+        declaring_scopes = [] if decision is None else list(decision.default_deny_scope_ids)
         return {
             "enabled": True,
             "effective_ceiling": level,
             "rule_ids": rule_ids,
             "participating_chain": rule_ids,
+            **(
+                {"default_deny_scope_ids": declaring_scopes}
+                if owner and declaring_scopes
+                else {}
+            ),
             **(
                 {"release_reason": decision.release_reason}
                 if decision is not None and decision.release_reason

--- a/src/exomem/governance/inspection.py
+++ b/src/exomem/governance/inspection.py
@@ -97,6 +97,19 @@ def inspect_operation(
     if operation == "explain":
         rel_path = _canonical_vault_path(vault_root, kwargs.get("path"))
         decision = projected(rel_path)
+        if (
+            not owner
+            and decision is not None
+            and decision.level <= policy_module.DISCLOSURE_MIN
+            and decision.default_deny_scope_ids
+            and decision.release_reason is None
+        ):
+            # Match the exact refusal for a path that does not exist. Returning
+            # a successful default-denial explanation here would disclose that
+            # the caller named an existing item even though it is withheld.
+            raise InspectionError(
+                "INVALID_INSPECTION_PATH", "path must be canonical"
+            )
         level = policy_module.DISCLOSURE_MIN if decision is None else decision.level
         rule_ids = [] if decision is None else list(decision.rule_ids)
         # A scope carrying `default_deny` is invisible until someone is denied:
@@ -131,6 +144,16 @@ def inspect_operation(
         raise InspectionError("INVALID_INSPECTION", "paths must be a list of strings")
     canonical_paths = [_canonical_vault_path(vault_root, path) for path in raw_paths]
     decisions = [projected(path) for path in canonical_paths]
+    if not owner and any(
+        decision is not None
+        and decision.level <= policy_module.DISCLOSURE_MIN
+        and decision.default_deny_scope_ids
+        and decision.release_reason is None
+        for decision in decisions
+    ):
+        # Keep the batch surface on the same success-vs-error boundary as
+        # `explain`; otherwise a valid default-denied path remains an oracle.
+        raise InspectionError("INVALID_INSPECTION_PATH", "path must be canonical")
     withheld = sum(
         decision is None or decision.level < policy_module.DISCLOSURE_MAX
         for decision in decisions

--- a/src/exomem/governance/lifecycle.py
+++ b/src/exomem/governance/lifecycle.py
@@ -269,18 +269,34 @@ def _scope_ids(vault_root: Path, item: ManifestItem, policy: policy_module.Polic
     return membership.evaluate_snapshot(page, policy, content_hash=item.content_hash)
 
 
+def _restricting_scope_ids(policy: policy_module.Policy) -> set[str]:
+    """Every scope whose membership makes an item governed material.
+
+    A scope restricts either because a rule lowers its ceiling for someone, or
+    because it DECLARES that audiences it does not name receive nothing — the
+    declaration names no rule, so enumerating rules alone leaves a
+    declaration-only item looking ungoverned. That misclassification is a
+    disclosure bug, not a bookkeeping one: an ungoverned deletion writes no
+    tombstone, so `is_tombstoned` stays False and the path can no longer be
+    withheld once the item itself is gone.
+    """
+    return {
+        scope_id
+        for rule in policy.rules
+        if rule.ceiling < policy_module.DISCLOSURE_MAX
+        for scope_id in rule.scope_ids
+    } | {
+        scope_id for scope_id, scope in policy.scopes.items() if scope.default_deny
+    }
+
+
 def _is_governed(vault_root: Path, manifest: tuple[ManifestItem, ...]) -> bool:
     policy = policy_module.load(vault_root)
     if policy.blocked:
         return True
     if policy.empty:
         return False
-    restricting_scope_ids = {
-        scope_id
-        for rule in policy.rules
-        if rule.ceiling < policy_module.DISCLOSURE_MAX
-        for scope_id in rule.scope_ids
-    }
+    restricting_scope_ids = _restricting_scope_ids(policy)
     for item in manifest:
         try:
             scope_ids = _scope_ids(vault_root, item, policy)
@@ -1080,9 +1096,7 @@ def _is_governed_for_restore(vault_root: Path, manifest: tuple[ManifestItem, ...
         return True
     if policy.empty:
         return False
-    restricting = {
-        sid for rule in policy.rules if rule.ceiling < policy_module.DISCLOSURE_MAX for sid in rule.scope_ids
-    }
+    restricting = _restricting_scope_ids(policy)
     for item in manifest:
         if not item.source_path.lower().endswith(".md"):
             if restricting.intersection(

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -771,6 +771,25 @@ def _valid_release_time(value: object) -> bool:
     return True
 
 
+def _reject_reserved_audience(
+    value: str | None,
+    rel: str,
+    field_name: str,
+    findings: list[dict[str, str]],
+) -> str | None:
+    """Keep authored policy out of the process-reserved NUL namespace."""
+    if value is not None and "\x00" in value:
+        findings.append(
+            _finding(
+                "invalid_field",
+                f"{rel}:{field_name}",
+                f"{field_name} must not contain NUL; the NUL prefix is reserved",
+            )
+        )
+        return None
+    return value
+
+
 def _parse_scope(data: dict[str, Any], rel: str) -> tuple[Scope | None, list[dict[str, str]]]:
     findings, doc_id = _check_common(data, rel, _SCOPE_ALLOWED_FIELDS)
 
@@ -880,6 +899,7 @@ def _parse_rule(data: dict[str, Any], rel: str) -> tuple[Rule | None, list[dict[
     if not isinstance(audience, str) or not audience.strip():
         findings.append(_finding("missing_field", f"{rel}:audience", "audience is required"))
         audience = None
+    audience = _reject_reserved_audience(audience, rel, "audience", findings)
 
     ceiling = data.get("ceiling")
     if (
@@ -966,6 +986,7 @@ def _parse_grant(
     if not isinstance(audience, str) or not audience.strip():
         findings.append(_finding("missing_field", f"{rel}:audience", "audience is required"))
         audience = None
+    audience = _reject_reserved_audience(audience, rel, "audience", findings)
 
     ceiling = data.get("ceiling")
     if (
@@ -1018,7 +1039,9 @@ def _parse_release_grant(
         findings.append(_finding("invalid_field", f"{rel}:content_hash", "content_hash must be lowercase SHA-256"))
         content_hash = None
 
-    to_audience = required_text("to_audience")
+    to_audience = _reject_reserved_audience(
+        required_text("to_audience"), rel, "to_audience", findings
+    )
     released_at = required_text("released_at")
     if released_at is not None and not _valid_release_time(released_at):
         findings.append(_finding("invalid_field", f"{rel}:released_at", "released_at must be an ISO-8601 timestamp"))

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -108,6 +108,7 @@ _SCOPE_ALLOWED_FIELDS = frozenset(
         "name",
         "exclude",
         "constraint",
+        "default_deny",
         *_SCOPE_SELECTOR_FIELDS,
     }
 )
@@ -162,6 +163,11 @@ class Scope:
     source: str
     name: str | None = None
     constraint: str | None = None
+    #: When true, an audience that no standing rule names receives NOTHING for
+    #: an item in this scope, instead of full release. It inverts one default;
+    #: it is not a rule and never lowers an authored ceiling (see
+    #: `decisions._decide_at`). The owner is never subject to it.
+    default_deny: bool = False
     paths: tuple[str, ...] = ()
     projects: tuple[str, ...] = ()
     tags: tuple[str, ...] = ()
@@ -794,6 +800,25 @@ def _parse_scope(data: dict[str, Any], rel: str) -> tuple[Scope | None, list[dic
         )
         constraint = None
 
+    # Presence-checked rather than `.get() is not None`: `default_deny:` with
+    # the value forgotten parses as YAML null, and for a confidentiality
+    # control the permissive reading of a typo is the whole failure mode this
+    # field exists to close. Any non-boolean is an ERROR, which refuses the
+    # compile — the scope is never quietly left open.
+    default_deny = False
+    if "default_deny" in data:
+        raw_default_deny = data["default_deny"]
+        if isinstance(raw_default_deny, bool):
+            default_deny = raw_default_deny
+        else:
+            findings.append(
+                _finding(
+                    "invalid_field",
+                    f"{rel}:default_deny",
+                    "default_deny must be a boolean",
+                )
+            )
+
     if doc_id is None:
         return None, findings
 
@@ -802,6 +827,7 @@ def _parse_scope(data: dict[str, Any], rel: str) -> tuple[Scope | None, list[dic
         source=rel,
         name=name,
         constraint=constraint,
+        default_deny=default_deny,
         paths=_as_str_tuple(data.get("paths"), rel, "paths", findings),
         projects=_as_str_tuple(data.get("projects"), rel, "projects", findings),
         tags=_as_str_tuple(data.get("tags"), rel, "tags", findings),

--- a/src/exomem/governance/principal.py
+++ b/src/exomem/governance/principal.py
@@ -46,6 +46,15 @@ OWNER_AUDIENCE = "owner"
 # be produced by `normalize_audience`), so "deny" cannot be widened by policy.
 MOST_RESTRICTIVE_AUDIENCE = "\x00unresolved"
 
+# A stand-in for "whoever the policy does not name" — never bound to a request
+# and never resolvable, on the same reserved `\x00` prefix so no document and
+# no credential can mint it. Policy review enumerates audiences from the rules
+# and grants a proposal touches, which by construction cannot see a change to
+# the DEFAULT that applies where no rule matches; this id puts that default in
+# the compared lattice so removing a `default_deny` declaration reports as the
+# widening it is.
+UNNAMED_AUDIENCE_PROBE = "\x00unnamed"
+
 # Surface-scope prefixes whose payload is ALREADY a sha256 over `iss\0sub` —
 # the same formula `normalize_audience` uses, so they fold into the shared id
 # space by relabelling rather than by re-hashing. `cf-access:` is minted in

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -33,7 +33,12 @@ from .operations import (
     operation_variant,
     select_operation,
 )
-from .principal import OWNER_AUDIENCE, RequestPrincipal, effective_principal
+from .principal import (
+    OWNER_AUDIENCE,
+    UNNAMED_AUDIENCE_PROBE,
+    RequestPrincipal,
+    effective_principal,
+)
 from .transaction import GovernanceCrash, GovernanceError, authorization_row, policy_target
 
 PENDING_MARKER = ".policy-mutation.pending.json"
@@ -246,6 +251,32 @@ def _resolved_membership_manifest(
     ]
 
 
+def _compared_audiences(
+    current: policy_module.Policy, prospective: policy_module.Policy
+) -> list[str]:
+    """Every audience a transition can move, including the unnamed default.
+
+    Enumerating rules and grants alone compares only audiences some document
+    names — which is exactly the set a change to the DEFAULT cannot appear in.
+    Removing a scope's `default_deny` then moves an unnamed audience from 0 to
+    6 while every named audience sits still, and the review reports a
+    narrowing. `UNNAMED_AUDIENCE_PROBE` stands in for that audience; no
+    document can name it and no credential can mint it, so it always resolves
+    through the default and never matches a rule or grant.
+
+    It also guarantees a non-empty audience set, so an empty lattice can no
+    longer be mistaken for "nothing to compare".
+    """
+    return sorted(
+        {
+            document.audience
+            for policy in (current, prospective)
+            for document in (*policy.rules, *policy.grants)
+        }
+        | {UNNAMED_AUDIENCE_PROBE}
+    )
+
+
 def _proposal_analysis(
     vault_root: Path,
     current: policy_module.Policy,
@@ -253,22 +284,18 @@ def _proposal_analysis(
     manifest: list[dict[str, str]],
 ) -> tuple[dict[str, int], list[str], str, list[str], bool, int | None]:
     """Evaluate the concrete affected membership, never caller hint paths."""
-    audiences = sorted(
-        {
-            rule.audience
-            for policy in (current, prospective)
-            for rule in (*policy.rules, *policy.grants)
-        }
-    )
+    audiences = _compared_audiences(current, prospective)
     purposes = sorted(
         {rule.purpose for policy in (current, prospective) for rule in policy.rules if rule.purpose}
     )
     purposes = [None, *purposes]
-    if not audiences:
-        return ({"narrowed": 0, "widened": 0, "unchanged": 0}, [], "widening", [], False, None)
     before: dict[str, int] = {}
     after: dict[str, int] = {}
     rule_ids: set[str] = set()
+    # `target_ceiling` echoes back the highest level the proposal leaves an
+    # AUTHORED audience at, so the probe — which by construction always sits on
+    # the default — must not raise it to 6 for every open policy.
+    named_after: list[int] = []
     all_open = True
     for row in manifest:
         rel = str(row["path"])
@@ -284,6 +311,8 @@ def _proposal_analysis(
                 new = decisions.decide(prospective_scopes, audience=audience, purpose=purpose, policy=prospective)
                 before[key] = old.level
                 after[key] = new.level
+                if audience != UNNAMED_AUDIENCE_PROBE:
+                    named_after.append(new.level)
                 rule_ids.update(old.rule_ids)
                 rule_ids.update(new.rule_ids)
                 rule_ids.update(
@@ -298,7 +327,7 @@ def _proposal_analysis(
     }
     direction = classify_transition_direction(before, after)
     samples = [str(row["path"]) for row in manifest[:5]] if all_open else []
-    return consequences, samples, direction, sorted(rule_ids), all_open, max(after.values(), default=None)
+    return consequences, samples, direction, sorted(rule_ids), all_open, max(named_after, default=None)
 
 
 def _purpose_direction(
@@ -1398,13 +1427,7 @@ def _effective_transition_direction(
         return "widening"
     try:
         manifest = _membership_manifest(vault_root, current, prospective, set(documents))
-        audiences = sorted(
-            {
-                document.audience
-                for policy in (current, prospective)
-                for document in (*policy.rules, *policy.grants)
-            }
-        )
+        audiences = _compared_audiences(current, prospective)
         purposes = [
             None,
             *sorted(

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -282,7 +282,9 @@ def _proposal_analysis(
     current: policy_module.Policy,
     prospective: policy_module.Policy,
     manifest: list[dict[str, str]],
-) -> tuple[dict[str, int], list[str], str, list[str], bool, int | None]:
+) -> tuple[
+    dict[str, int], list[str], str, list[str], bool, int | None, int | None
+]:
     """Evaluate the concrete affected membership, never caller hint paths."""
     audiences = _compared_audiences(current, prospective)
     purposes = sorted(
@@ -292,10 +294,11 @@ def _proposal_analysis(
     before: dict[str, int] = {}
     after: dict[str, int] = {}
     rule_ids: set[str] = set()
-    # `target_ceiling` echoes back the highest level the proposal leaves an
-    # AUTHORED audience at, so the probe — which by construction always sits on
-    # the default — must not raise it to 6 for every open policy.
+    # `target_ceiling` remains the highest level the proposal leaves an
+    # AUTHORED audience at. The default has its own owner-visible ceiling so the
+    # rotation path is explicit without changing that compatibility field.
     named_after: list[int] = []
+    unnamed_after: list[int] = []
     all_open = True
     for row in manifest:
         rel = str(row["path"])
@@ -303,7 +306,15 @@ def _proposal_analysis(
             current_scopes = _memberships_for_path(vault_root, vault_root / rel, current)
             prospective_scopes = _memberships_for_path(vault_root, vault_root / rel, prospective)
         except GovernanceError:
-            return ({"narrowed": 0, "widened": 0, "unchanged": 0}, [], "widening", [], False, None)
+            return (
+                {"narrowed": 0, "widened": 0, "unchanged": 0},
+                [],
+                "widening",
+                [],
+                False,
+                None,
+                None,
+            )
         for audience in audiences:
             for purpose in purposes:
                 key = f"{audience}:{purpose or '-'}:{rel}"
@@ -313,6 +324,8 @@ def _proposal_analysis(
                 after[key] = new.level
                 if audience != UNNAMED_AUDIENCE_PROBE:
                     named_after.append(new.level)
+                else:
+                    unnamed_after.append(new.level)
                 rule_ids.update(old.rule_ids)
                 rule_ids.update(new.rule_ids)
                 rule_ids.update(
@@ -327,7 +340,15 @@ def _proposal_analysis(
     }
     direction = classify_transition_direction(before, after)
     samples = [str(row["path"]) for row in manifest[:5]] if all_open else []
-    return consequences, samples, direction, sorted(rule_ids), all_open, max(named_after, default=None)
+    return (
+        consequences,
+        samples,
+        direction,
+        sorted(rule_ids),
+        all_open,
+        max(named_after, default=None),
+        max(unnamed_after, default=None),
+    )
 
 
 def _purpose_direction(
@@ -399,9 +420,15 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
     target_ceiling = int(kwargs.get("target_ceiling", policy_module.DISCLOSURE_MAX))
     if not policy_module.DISCLOSURE_MIN <= target_ceiling <= policy_module.DISCLOSURE_MAX:
         raise GovernanceError("INVALID_GOVERNANCE_PROPOSAL", "target ceiling is invalid")
-    consequences, samples, direction, overlaps, all_open, derived_ceiling = _proposal_analysis(
-        vault_root, current_policy, prospective, manifest
-    )
+    (
+        consequences,
+        samples,
+        direction,
+        overlaps,
+        all_open,
+        derived_ceiling,
+        unnamed_audience_ceiling,
+    ) = _proposal_analysis(vault_root, current_policy, prospective, manifest)
     hint_diagnostics: list[str] = []
     if patterns:
         hint_diagnostics.append("selector_paths are compatibility hints; concrete membership is authoritative")
@@ -435,7 +462,12 @@ def _proposal(vault_root: Path, **kwargs: Any) -> dict[str, Any]:
         "interpretation": intent,
         "canonical_yaml": documents,
         "membership_preview": {"count": len(manifest), "samples": samples},
-        "consequences": {**consequences, "target_ceiling": derived_ceiling, "direction": direction},
+        "consequences": {
+            **consequences,
+            "target_ceiling": derived_ceiling,
+            "unnamed_audience_ceiling": unnamed_audience_ceiling,
+            "direction": direction,
+        },
         "overlaps": overlaps,
         "hint_diagnostics": hint_diagnostics,
         "duration": kwargs.get("duration"),

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -3734,6 +3734,8 @@ def test_a_proposal_removing_default_deny_counts_the_widened_audience(
 
     assert proposal["consequences"]["direction"] == "widening"
     assert proposal["consequences"]["widened"] > 0
+    assert proposal["consequences"]["target_ceiling"] == 1
+    assert proposal["consequences"]["unnamed_audience_ceiling"] == 6
 
 
 def test_a_proposal_adding_default_deny_counts_the_narrowed_audience(
@@ -3758,13 +3760,60 @@ def test_a_proposal_adding_default_deny_counts_the_narrowed_audience(
     assert proposal["consequences"]["widened"] == 0
 
 
-def test_explain_does_not_hand_a_non_owner_the_declaring_scope_id(vault: Path) -> None:
-    """`list` already withholds scope ids from non-owners while disclosing rule
-    ids. A default denial must not become the one place a third party learns
-    the vault's scope structure."""
+@pytest.mark.parametrize(
+    ("operation", "argument"),
+    [("explain", "path"), ("simulate", "paths")],
+)
+def test_non_owner_inspection_cannot_distinguish_default_denied_from_missing(
+    vault: Path, operation: str, argument: str
+) -> None:
+    """Same input, varied condition: the caller asks about one path while it
+    exists behind a declared default, then asks again after it is deleted."""
+    from exomem.governance.tool import GovernanceError, op_govern_memory
+
+    _write_declared_scope(vault)
+    value: object = DECLARED_RESTRICTED if argument == "path" else [DECLARED_RESTRICTED]
+
+    def outcome() -> tuple[str, str, str]:
+        try:
+            result = op_govern_memory(
+                vault,
+                operation=operation,
+                principal=_external(),
+                audience="external",
+                **{argument: value},
+            )
+        except GovernanceError as error:
+            return type(error).__name__, error.code, str(error)
+        return "ok", "", repr(result)
+
+    present = outcome()
+    (vault / DECLARED_RESTRICTED).unlink()
+    missing = outcome()
+
+    assert present == missing
+    assert present == (
+        "GovernanceError",
+        "INVALID_INSPECTION_PATH",
+        "INVALID_INSPECTION_PATH: path must be canonical",
+    )
+
+
+def test_non_owner_inspection_remains_available_when_a_grant_raises_the_default(
+    vault: Path,
+) -> None:
+    """The oracle guard applies only while the declared floor remains L0."""
     from exomem.governance.tool import op_govern_memory
 
     _write_declared_scope(vault)
+    grants = vault / "Knowledge Base" / "_Governance" / "grants"
+    grants.mkdir(parents=True, exist_ok=True)
+    (grants / "external.yaml").write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB1\nkind: standing\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: external\nceiling: 4\n',
+        encoding="utf-8",
+    )
+
     explained = op_govern_memory(
         vault,
         operation="explain",
@@ -3772,5 +3821,13 @@ def test_explain_does_not_hand_a_non_owner_the_declaring_scope_id(vault: Path) -
         audience="external",
         path=DECLARED_RESTRICTED,
     )
-    assert explained["effective_ceiling"] == 0
-    assert "default_deny_scope_ids" not in explained
+    simulated = op_govern_memory(
+        vault,
+        operation="simulate",
+        principal=_external(),
+        audience="external",
+        paths=[DECLARED_RESTRICTED],
+    )
+
+    assert explained["effective_ceiling"] == 4
+    assert simulated["evaluated_count"] == 1

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -3589,3 +3589,81 @@ def test_multi_grant_revoke_receipt_uses_sorted_component_identity_hashes(
         if record.get("event_id") == revoked["event_id"]
     )
     assert intent["affected_ids"] == expected == sorted(set(expected))
+
+
+# ---------------------------------------------------------------------------
+# `explain` for a default denial (add-default-deny-scope-cap, task 3)
+# ---------------------------------------------------------------------------
+
+DECLARED_RESTRICTED = "Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md"
+
+
+def _write_declared_scope(vault: Path, *, default_deny: bool = True) -> None:
+    """A scope carrying the declaration and NO rule naming `external`."""
+    scopes = vault / "Knowledge Base" / "_Governance" / "scopes"
+    scopes.mkdir(parents=True, exist_ok=True)
+    (scopes / "patterns.yaml").write_text(
+        f"governance_version: 1\nid: {SCOPE_ID}\nname: Confidential patterns\n"
+        f'paths: ["{PATTERN_GLOB}"]\n'
+        + ("default_deny: true\n" if default_deny else ""),
+        encoding="utf-8",
+    )
+
+
+def test_explain_names_the_declaring_scope_for_a_default_denial(vault: Path) -> None:
+    """Spec: the explanation identifies the declaring scope, and does NOT
+    attribute the outcome to a standing rule that does not exist.
+
+    A declared scope with no rules is invisible until someone is denied, so
+    `explain` reporting a bare "nothing matched" would leave the owner unable
+    to tell a default denial from a missing item."""
+    from exomem.governance.tool import op_govern_memory
+
+    _write_declared_scope(vault)
+    explained = op_govern_memory(
+        vault,
+        operation="explain",
+        principal=owner_principal(),
+        audience="external",
+        path=DECLARED_RESTRICTED,
+    )
+    assert explained["effective_ceiling"] == 0
+    # No rule was invented to carry the outcome.
+    assert explained["rule_ids"] == []
+    assert explained["participating_chain"] == []
+    assert explained["default_deny_scope_ids"] == [SCOPE_ID]
+
+
+def test_explain_reports_no_declaring_scope_when_a_rule_decided(vault: Path) -> None:
+    """The distinguishing half: an authored denial must not be dressed up as a
+    default one, or the field means nothing."""
+    from exomem.governance.tool import op_govern_memory
+
+    _committed_policy(vault)
+    explained = op_govern_memory(
+        vault,
+        operation="explain",
+        principal=owner_principal(),
+        audience="external",
+        path=DECLARED_RESTRICTED,
+    )
+    assert explained["rule_ids"] == [RULE_ID]
+    assert "default_deny_scope_ids" not in explained
+
+
+def test_explain_does_not_hand_a_non_owner_the_declaring_scope_id(vault: Path) -> None:
+    """`list` already withholds scope ids from non-owners while disclosing rule
+    ids. A default denial must not become the one place a third party learns
+    the vault's scope structure."""
+    from exomem.governance.tool import op_govern_memory
+
+    _write_declared_scope(vault)
+    explained = op_govern_memory(
+        vault,
+        operation="explain",
+        principal=_external(),
+        audience="external",
+        path=DECLARED_RESTRICTED,
+    )
+    assert explained["effective_ceiling"] == 0
+    assert "default_deny_scope_ids" not in explained

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -3651,6 +3651,113 @@ def test_explain_reports_no_declaring_scope_when_a_rule_decided(vault: Path) -> 
     assert "default_deny_scope_ids" not in explained
 
 
+def _scope_document(*, default_deny: bool) -> str:
+    return (
+        f"governance_version: 1\nid: {SCOPE_ID}\nname: Confidential patterns\n"
+        f'paths: ["{PATTERN_GLOB}"]\n'
+        + ("default_deny: true\n" if default_deny else "")
+    )
+
+
+def _write_declared_scope_with_a_rule(vault: Path, *, default_deny: bool) -> None:
+    """A declared scope PLUS an unrelated authored audience.
+
+    The rule is what makes the failure visible rather than vacuous: with a
+    named audience in the policy the lattice is non-empty, so a direction is
+    computed from it — and the audience whose ceiling actually moved is the one
+    no document names.
+    """
+    governance = vault / "Knowledge Base" / "_Governance"
+    (governance / "scopes").mkdir(parents=True, exist_ok=True)
+    (governance / "rules").mkdir(parents=True, exist_ok=True)
+    (governance / "scopes" / "patterns.yaml").write_text(
+        _scope_document(default_deny=default_deny), encoding="utf-8"
+    )
+    (governance / "rules" / "patterns.yaml").write_text(
+        f"governance_version: 1\nid: {RULE_ID}\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: external\nceiling: 1\n',
+        encoding="utf-8",
+    )
+
+
+def test_removing_default_deny_is_classified_as_a_widening(vault: Path) -> None:
+    """The owner's only review signal before committing must not misreport the
+    exact edit that undoes this feature.
+
+    The declaration names no audience, so enumerating audiences from rules and
+    grants alone never evaluates the one whose ceiling moves 0 -> 6. The
+    default itself has to be in the compared lattice.
+    """
+    from exomem.governance.tool import _effective_transition_direction
+
+    _write_declared_scope_with_a_rule(vault, default_deny=True)
+
+    direction = _effective_transition_direction(
+        vault, {"scopes/patterns.yaml": _scope_document(default_deny=False)}
+    )
+
+    assert direction == "widening"
+
+
+def test_adding_default_deny_is_classified_as_a_narrowing(vault: Path) -> None:
+    """The other half of the pair: the declaration is a restriction, and the
+    lattice it is measured in must be able to see that."""
+    from exomem.governance.tool import _effective_transition_direction
+
+    _write_declared_scope_with_a_rule(vault, default_deny=False)
+
+    direction = _effective_transition_direction(
+        vault, {"scopes/patterns.yaml": _scope_document(default_deny=True)}
+    )
+
+    assert direction == "narrowing"
+
+
+def test_a_proposal_removing_default_deny_counts_the_widened_audience(
+    vault: Path,
+) -> None:
+    """`propose` reports the consequences the owner reviews. A removal that
+    reopens every unnamed audience must not read as `widened: 0`."""
+    from exomem.governance.tool import op_govern_memory
+
+    _write_declared_scope_with_a_rule(vault, default_deny=True)
+
+    proposal = op_govern_memory(
+        vault,
+        operation="propose",
+        principal=owner_principal(),
+        intent="Stop denying audiences the policy does not name",
+        documents={"scopes/patterns.yaml": _scope_document(default_deny=False)},
+        selector_paths=[],
+        target_ceiling=6,
+    )
+
+    assert proposal["consequences"]["direction"] == "widening"
+    assert proposal["consequences"]["widened"] > 0
+
+
+def test_a_proposal_adding_default_deny_counts_the_narrowed_audience(
+    vault: Path,
+) -> None:
+    from exomem.governance.tool import op_govern_memory
+
+    _write_declared_scope_with_a_rule(vault, default_deny=False)
+
+    proposal = op_govern_memory(
+        vault,
+        operation="propose",
+        principal=owner_principal(),
+        intent="Deny audiences the policy does not name",
+        documents={"scopes/patterns.yaml": _scope_document(default_deny=True)},
+        selector_paths=[],
+        target_ceiling=0,
+    )
+
+    assert proposal["consequences"]["direction"] == "narrowing"
+    assert proposal["consequences"]["narrowed"] > 0
+    assert proposal["consequences"]["widened"] == 0
+
+
 def test_explain_does_not_hand_a_non_owner_the_declaring_scope_id(vault: Path) -> None:
     """`list` already withholds scope ids from non-owners while disclosing rule
     ids. A default denial must not become the one place a third party learns

--- a/tests/test_governance_bridges.py
+++ b/tests/test_governance_bridges.py
@@ -470,6 +470,39 @@ def test_complete_bridge_without_release_approval_is_withheld_everywhere(
     assert simulated["release_reasons"] == ["RELEASE_UNAPPROVED"]
 
 
+def test_default_deny_does_not_hide_a_bridge_release_reason_from_inspection(
+    vault: Path,
+) -> None:
+    """The existence-oracle guard owns pure default denials, not the bridge
+    state's established content-free explanation contract."""
+    _write_bridge_fixture(vault, approval=False)
+    _write_policy(
+        vault,
+        "scopes",
+        "closed-bridge",
+        _scope_document(SCOPE_B, path=BRIDGE_PATH) + "default_deny: true\n",
+    )
+
+    with request_scope(_external()):
+        explained = commands.op_govern_memory(
+            vault,
+            operation="explain",
+            path=BRIDGE_PATH,
+            audience="external",
+        )
+        simulated = commands.op_govern_memory(
+            vault,
+            operation="simulate",
+            paths=[BRIDGE_PATH],
+            audience="external",
+        )
+
+    assert explained["effective_ceiling"] == 0
+    assert explained["release_reason"] == "RELEASE_UNAPPROVED"
+    assert simulated["withheld_count"] == 1
+    assert simulated["release_reasons"] == ["RELEASE_UNAPPROVED"]
+
+
 def test_exact_approved_unchanged_bridge_releases_but_source_stays_withheld(
     vault: Path,
 ) -> None:

--- a/tests/test_governance_bridges.py
+++ b/tests/test_governance_bridges.py
@@ -1043,6 +1043,71 @@ def test_restriction_signature_preserves_typed_nested_option_keys() -> None:
     )
 
 
+def test_restriction_signature_moves_when_a_scope_declares_default_deny() -> None:
+    """An approved bridge stales when the restriction behind its source moves.
+
+    Differential against the equivalent authored `ceiling: 0`: declaring
+    `default_deny` on the source scope closes it to every audience no rule
+    names, so it must stale the approved abstraction exactly as writing the
+    ceiling-0 rule does. Blind to the declaration, a previously approved
+    abstraction of a private source keeps flowing after the owner locks the
+    scope.
+    """
+
+    def signature(*, default_deny: bool = False, ceiling: int | None = None) -> str:
+        compiled = policy.Policy(
+            fingerprint="test",
+            scopes={
+                SCOPE_A: policy.Scope(
+                    id=SCOPE_A, source="scopes/private.yaml", default_deny=default_deny
+                )
+            },
+            rules=()
+            if ceiling is None
+            else (
+                policy.Rule(
+                    id=RULE_ID,
+                    source="rules/private.yaml",
+                    scope_ids=(SCOPE_A,),
+                    audience="external",
+                    ceiling=ceiling,
+                ),
+            ),
+        )
+        return bridges.restriction_signature(
+            {SCOPE_A}, policy=compiled, audience="external"
+        )
+
+    open_scope = signature()
+    # The control: authoring the equivalent restriction as a rule moves it.
+    assert signature(ceiling=0) != open_scope
+    # The declaration owes the same.
+    assert signature(default_deny=True) != open_scope
+    # ...and REMOVING it moves the signature back, so an owner who unlocks the
+    # scope cannot leave a stale approval looking fresh either.
+    assert signature(default_deny=False) == open_scope
+
+
+def test_restriction_signature_ignores_a_declaration_on_an_unrelated_scope() -> None:
+    """Only the source's own scopes bind the signature; a declaration on a
+    scope the source is not a member of must not churn every approval."""
+    def signature(*, default_deny: bool) -> str:
+        compiled = policy.Policy(
+            fingerprint="test",
+            scopes={
+                SCOPE_A: policy.Scope(id=SCOPE_A, source="scopes/private.yaml"),
+                SCOPE_B: policy.Scope(
+                    id=SCOPE_B, source="scopes/other.yaml", default_deny=default_deny
+                ),
+            },
+        )
+        return bridges.restriction_signature(
+            {SCOPE_A}, policy=compiled, audience="external"
+        )
+
+    assert signature(default_deny=True) == signature(default_deny=False)
+
+
 def test_restriction_signature_preserves_container_types() -> None:
     def signature(options: dict) -> str:
         compiled = policy.Policy(

--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -8,6 +8,7 @@ authoring/insertion order.
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import random
 
@@ -526,3 +527,65 @@ def test_no_declaring_scope_is_recorded_when_a_rule_decided_the_outcome() -> Non
 def test_no_declaring_scope_is_recorded_for_the_owner() -> None:
     pol = _policy(scopes=[_scope(default_deny=True)])
     assert decide([SCOPE], audience=OWNER_AUDIENCE, policy=pol).default_deny_scope_ids == ()
+
+
+def test_a_grant_on_a_sibling_scope_still_raises_a_declared_scope_as_it_does_a_ceiling_0_rule() -> None:
+    """The declaration does NOT close the grant lane, and must not pretend to.
+
+    `grant_max = max(grant_ceilings + [standing_min])` and `_grant_matches` tests
+    scope INTERSECTION, so a grant naming an audience for S2 raises an item that
+    is also in a closed S1 — the compartment crossover, via grants rather than
+    rules. Measured L0 -> L6.
+
+    This is pinned as an EQUIVALENCE, not as an approval. The authored
+    `ceiling: 0` spelling behaves identically, so the behaviour is a pre-existing
+    property of the lattice and not something the declaration introduced. The
+    test exists so the two spellings cannot silently diverge while the real fix
+    (scoping a grant's raise to the scopes it names) is out of scope here.
+    """
+    s1 = "01ARZ3NDEKTSV4RRFFQ69G5FA1"
+    s2 = "01ARZ3NDEKTSV4RRFFQ69G5FA2"
+    both = [s1, s2]
+    grant = StandingGrant(
+        id="01ARZ3NDEKTSV4RRFFQ69G5FB1",
+        source="grants/g.yaml",
+        scope_ids=(s2,),
+        audience="partner-x",
+        ceiling=6,
+    )
+
+    declared = Policy(
+        fingerprint="p",
+        scopes={
+            s1: Scope(id=s1, source="scopes/s1.yaml", default_deny=True),
+            s2: Scope(id=s2, source="scopes/s2.yaml"),
+        },
+    )
+    authored = Policy(
+        fingerprint="p",
+        scopes={
+            s1: Scope(id=s1, source="scopes/s1.yaml"),
+            s2: Scope(id=s2, source="scopes/s2.yaml"),
+        },
+        rules=(
+            Rule(
+                id="01ARZ3NDEKTSV4RRFFQ69G5FB0",
+                source="rules/r.yaml",
+                scope_ids=(s1,),
+                audience="partner-x",
+                ceiling=0,
+            ),
+        ),
+    )
+
+    # Closed identically without a grant.
+    assert decide(both, audience="partner-x", policy=declared).level == DISCLOSURE_MIN
+    assert decide(both, audience="partner-x", policy=authored).level == DISCLOSURE_MIN
+
+    # And raised identically by a grant that names only the sibling scope.
+    declared_granted = dataclasses.replace(declared, grants=(grant,))
+    authored_granted = dataclasses.replace(authored, grants=(grant,))
+    assert (
+        decide(both, audience="partner-x", policy=declared_granted).level
+        == decide(both, audience="partner-x", policy=authored_granted).level
+    ), "the declaration must not be weaker OR stronger than an authored ceiling-0 here"

--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 import itertools
 import random
+from pathlib import Path
 
 from exomem.governance.decisions import decide
 from exomem.governance.policy import (
@@ -65,6 +66,31 @@ def _policy(rules=(), grants=(), scopes=()):
         rules=tuple(rules),
         grants=tuple(grants),
     )
+
+
+def _change_contract(name: str) -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "openspec/changes/add-default-deny-scope-cap"
+        / name
+    ).read_text(encoding="utf-8")
+
+
+def test_design_resolves_default_emptiness_per_declaring_scope() -> None:
+    design = _change_contract("design.md")
+
+    assert "if standing:" not in design
+    assert "named_scope_ids" in design
+    assert "default_deny_scope_ids" in design
+
+
+def test_no_disclosure_scenario_excludes_a_matching_grant() -> None:
+    spec = _change_contract("specs/governance-kernel/spec.md")
+    scenario = spec.split(
+        "#### Scenario: an audience no rule names receives nothing", 1
+    )[1].split("#### Scenario:", 1)[0]
+
+    assert "no matching grant applies" in scenario
 
 
 def test_default_is_full_disclosure_when_nothing_matches() -> None:

--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -1,8 +1,9 @@
 """Pure order-free disclosure evaluator: truth table, purity, purpose semantics.
 
 `decide()` computes `min(org_cap, max(grants, min(standing_rules)))`, default
-OPEN (L6) — see design decision D5. min/max are commutative, so the result
-must never depend on authoring/insertion order.
+OPEN (L6) unless a scope declares `default_deny` — see design decision D5.
+min/max are commutative, so the result must never depend on
+authoring/insertion order.
 """
 
 from __future__ import annotations
@@ -13,12 +14,16 @@ import random
 from exomem.governance.decisions import decide
 from exomem.governance.policy import (
     DISCLOSURE_MAX,
+    DISCLOSURE_MIN,
     Policy,
     Rule,
+    Scope,
     StandingGrant,
 )
+from exomem.governance.principal import OWNER_AUDIENCE
 
 SCOPE = "scope-1"
+OTHER_SCOPE = "scope-2"
 
 
 def _rule(
@@ -48,8 +53,17 @@ def _grant(id_, ceiling, *, audience="ext"):
     return StandingGrant(id=id_, source="grants/x.yaml", scope_ids=(SCOPE,), audience=audience, ceiling=ceiling)
 
 
-def _policy(rules=(), grants=()):
-    return Policy(fingerprint="test", scopes={}, rules=tuple(rules), grants=tuple(grants))
+def _scope(id_=SCOPE, *, default_deny=False):
+    return Scope(id=id_, source="scopes/x.yaml", default_deny=default_deny)
+
+
+def _policy(rules=(), grants=(), scopes=()):
+    return Policy(
+        fingerprint="test",
+        scopes={scope.id: scope for scope in scopes},
+        rules=tuple(rules),
+        grants=tuple(grants),
+    )
 
 
 def test_default_is_full_disclosure_when_nothing_matches() -> None:
@@ -269,3 +283,152 @@ def test_options_merge_pins_lexical_rule_id_order() -> None:
     }
     assert decision.notice == "from-bbb"
     assert decision.bridge == "bridge-a"
+
+
+# ---------------------------------------------------------------------------
+# A scope may deny audiences it does not name (add-default-deny-scope-cap)
+#
+# The change is ONE default: `standing_min`'s fallback when the standing set is
+# empty. Everything below pins that it is a DEFAULT and not a synthetic
+# ceiling-0 rule — a synthetic rule would enter the `min` and silently override
+# an authored allowance, which is the failure mode design.md records.
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_scope_denies_an_audience_no_standing_rule_names() -> None:
+    """Spec: an audience no rule names receives nothing."""
+    pol = _policy(scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_an_undeclared_scope_keeps_todays_open_default() -> None:
+    """Spec: an undeclared scope keeps today's default — the change is opt-in."""
+    pol = _policy(scopes=[_scope(default_deny=False)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MAX
+
+
+def test_a_scope_absent_from_the_policy_table_keeps_the_open_default() -> None:
+    """A scope id with no compiled record cannot carry a declaration, so the
+    lookup must not be a fail-closed guess about scopes the evaluator was
+    handed but the policy never defined."""
+    assert decide([SCOPE], audience="ext", policy=_policy()).level == DISCLOSURE_MAX
+
+
+def test_a_declared_scope_does_not_lower_an_authored_rule() -> None:
+    """THE constraint that rules out the synthetic-rule implementation.
+
+    Inject a ceiling-0 standing rule for a declared scope and this reads
+    `min(3, 0) == 0` — the declaration silently overriding the allowance the
+    owner authored. It must apply only when the standing set is EMPTY."""
+    pol = _policy(rules=[_rule("r1", 3)], scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == 3
+
+
+def test_a_declared_scope_does_not_lower_an_authored_full_release_rule() -> None:
+    """The same constraint at the top of the lattice: an owner who deliberately
+    opens a declared scope to one named audience gets exactly that."""
+    pol = _policy(rules=[_rule("r1", DISCLOSURE_MAX)], scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MAX
+
+
+def test_a_grant_still_raises_above_the_declared_default() -> None:
+    """Spec: "unless a grant names them" needs no special case — `grant_max`
+    is `max(grants + [standing_min])`, so a grant raises off the floor."""
+    pol = _policy(grants=[_grant("g1", 4)], scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == 4
+
+
+def test_a_grant_for_another_audience_does_not_lift_the_declared_default() -> None:
+    pol = _policy(grants=[_grant("g1", 4, audience="someone-else")],
+                  scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_an_org_cap_still_lowers_on_a_declared_scope() -> None:
+    """Spec: an organisation cap still lowers, unchanged by the declaration."""
+    pol = _policy(
+        rules=[_rule("r1", 5), _rule("cap", 2, kind="org_cap")],
+        scopes=[_scope(default_deny=True)],
+    )
+    assert decide([SCOPE], audience="ext", policy=pol).level == 2
+
+
+def test_an_org_cap_alone_leaves_the_standing_set_empty_and_the_default_applies() -> None:
+    """An org cap is not a standing rule, so a matching cap must not be read as
+    "something matched" and re-open the scope."""
+    pol = _policy(rules=[_rule("cap", 5, kind="org_cap")], scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_the_owner_is_never_subject_to_the_declaration() -> None:
+    """Spec: the owner reads a declared scope at full release."""
+    pol = _policy(scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience=OWNER_AUDIENCE, policy=pol).level == DISCLOSURE_MAX
+
+
+def test_an_authored_rule_still_restricts_the_owner_on_a_declared_scope() -> None:
+    """The exemption is chosen at the DEFAULT site, not applied as a post-hoc
+    override, so a rule that deliberately restricts the owner still holds."""
+    pol = _policy(rules=[_rule("r1", 1, audience=OWNER_AUDIENCE)],
+                  scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience=OWNER_AUDIENCE, policy=pol).level == 1
+
+
+def test_one_declared_scope_denies_across_an_overlapping_undeclared_scope() -> None:
+    """Spec: a scope cannot be widened by authoring a broad undeclared scope
+    alongside it. Membership is a set; ANY declared member closes the item."""
+    pol = _policy(scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=False)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+    # Order-free, like the rest of the lattice.
+    assert decide([OTHER_SCOPE, SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_a_rule_on_the_undeclared_sibling_still_governs_both() -> None:
+    """A standing rule matching via the undeclared scope is still a match, so
+    the standing set is not empty and the default never fires."""
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(OTHER_SCOPE,),
+        audience="ext", ceiling=3,
+    )
+    pol = _policy(rules=[rule],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=False)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == 3
+
+
+def test_a_declared_purpose_still_only_narrows_on_a_declared_scope() -> None:
+    """Spec: a declared purpose continues to only narrow. Declaring the purpose
+    of a purpose-conditioned allowance must not lift a default denial, because
+    purpose is a self-assertion by the party the rules constrain."""
+    pol = _policy(rules=[_rule("r1", 5, purpose="research")],
+                  scopes=[_scope(default_deny=True)])
+    undeclared = decide([SCOPE], audience="ext", policy=pol).level
+    declared = decide([SCOPE], audience="ext", purpose="research", policy=pol).level
+    assert undeclared == DISCLOSURE_MIN
+    assert declared <= undeclared
+
+
+def test_a_suspended_rule_falls_back_to_the_declared_default() -> None:
+    """Suspending the one rule that named an audience must close the scope for
+    that audience, not re-open it."""
+    pol = _policy(rules=[_rule("r1", 5, options={"suspended": True})],
+                  scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_the_decision_names_the_declaring_scope_for_a_default_denial() -> None:
+    """`explain` must be able to say WHICH scope closed the item without
+    inventing a rule id, so the evaluator records it where it made the choice."""
+    pol = _policy(scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=False)])
+    decision = decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol)
+    assert decision.default_deny_scope_ids == (SCOPE,)
+    assert decision.rule_ids == ()
+
+
+def test_no_declaring_scope_is_recorded_when_a_rule_decided_the_outcome() -> None:
+    pol = _policy(rules=[_rule("r1", 3)], scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience="ext", policy=pol).default_deny_scope_ids == ()
+
+
+def test_no_declaring_scope_is_recorded_for_the_owner() -> None:
+    pol = _policy(scopes=[_scope(default_deny=True)])
+    assert decide([SCOPE], audience=OWNER_AUDIENCE, policy=pol).default_deny_scope_ids == ()

--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -383,16 +383,110 @@ def test_one_declared_scope_denies_across_an_overlapping_undeclared_scope() -> N
     assert decide([OTHER_SCOPE, SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
 
 
-def test_a_rule_on_the_undeclared_sibling_still_governs_both() -> None:
-    """A standing rule matching via the undeclared scope is still a match, so
-    the standing set is not empty and the default never fires."""
+def test_a_rule_on_the_undeclared_sibling_does_not_unlock_the_declared_scope() -> None:
+    """A rule authorising an audience on the UNDECLARED sibling says nothing
+    about the declared scope, which still names nobody — so the item stays
+    closed. The floor is resolved per declaring scope, not against the item's
+    global matched-rule set."""
     rule = Rule(
         id="r1", source="rules/x.yaml", scope_ids=(OTHER_SCOPE,),
         audience="ext", ceiling=3,
     )
     pol = _policy(rules=[rule],
                   scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=False)])
-    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == 3
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+    assert decide([OTHER_SCOPE, SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_a_rule_on_one_declared_scope_does_not_unlock_another_declared_scope() -> None:
+    """Compartment crossover. `S1{default_deny}` with a rule opening it to an
+    audience, alongside `S2{default_deny}` naming nobody: an item in BOTH is a
+    member of a compartment that audience was never authorised for, so it is
+    closed. Authorising someone on one compartment must not unlock another."""
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,),
+        audience="ext", ceiling=DISCLOSURE_MAX,
+    )
+    pol = _policy(rules=[rule],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+    # Commutative: the module promises order-independence.
+    assert decide([OTHER_SCOPE, SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+    # ...and the item stays fully open on the compartment that DID name them.
+    assert decide([SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MAX
+
+
+def test_the_unnamed_declared_scope_is_the_one_named_in_the_explanation() -> None:
+    """The explanation must point at the compartment that closed the item, not
+    at the one whose rule was overridden."""
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,),
+        audience="ext", ceiling=DISCLOSURE_MAX,
+    )
+    pol = _policy(rules=[rule],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    decision = decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol)
+    assert decision.default_deny_scope_ids == (OTHER_SCOPE,)
+
+
+def test_a_suspended_rule_on_a_second_declared_scope_recloses_it() -> None:
+    """Suspending the rule that named the audience for one compartment returns
+    that compartment to its declared default, even though another compartment's
+    rule still matches the item."""
+    live = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,), audience="ext", ceiling=4,
+    )
+    suspended = Rule(
+        id="r2", source="rules/x.yaml", scope_ids=(OTHER_SCOPE,), audience="ext",
+        ceiling=4, options={"suspended": True},
+    )
+    pol = _policy(rules=[live, suspended],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_an_org_cap_on_a_declared_scope_does_not_count_as_naming_the_audience() -> None:
+    """An org cap only lowers; it never authorises. A cap naming the audience
+    for a declared scope must not be read as the rule that opens it."""
+    cap = Rule(
+        id="cap", source="rules/x.yaml", scope_ids=(OTHER_SCOPE,), audience="ext",
+        ceiling=5, kind="org_cap",
+    )
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,), audience="ext", ceiling=4,
+    )
+    pol = _policy(rules=[cap, rule],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == DISCLOSURE_MIN
+
+
+def test_a_grant_still_raises_off_a_per_scope_declared_floor() -> None:
+    """The floor is still only a floor: a grant naming the audience raises off
+    it exactly as it does when the whole standing set was empty."""
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,), audience="ext", ceiling=4,
+    )
+    grant = StandingGrant(
+        id="g1", source="grants/x.yaml", scope_ids=(OTHER_SCOPE,),
+        audience="ext", ceiling=2,
+    )
+    pol = _policy(rules=[rule], grants=[grant],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    assert decide([SCOPE, OTHER_SCOPE], audience="ext", policy=pol).level == 2
+
+
+def test_the_owner_is_exempt_from_a_per_scope_declared_floor() -> None:
+    """The owner exemption is chosen where the default is chosen, so a second
+    declared compartment naming nobody never locks the owner out."""
+    rule = Rule(
+        id="r1", source="rules/x.yaml", scope_ids=(SCOPE,),
+        audience=OWNER_AUDIENCE, ceiling=4,
+    )
+    pol = _policy(rules=[rule],
+                  scopes=[_scope(default_deny=True), _scope(OTHER_SCOPE, default_deny=True)])
+    decision = decide([SCOPE, OTHER_SCOPE], audience=OWNER_AUDIENCE, policy=pol)
+    assert decision.level == 4
+    assert decision.default_deny_scope_ids == ()
 
 
 def test_a_declared_purpose_still_only_narrows_on_a_declared_scope() -> None:

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -42,11 +42,18 @@ def _gov_dir(vault: Path) -> Path:
     return vault / "Knowledge Base" / "_Governance"
 
 
-def write_scope(vault: Path, *, paths: str = PATTERNS_GLOB, name: str = "Patterns") -> None:
+def write_scope(
+    vault: Path,
+    *,
+    paths: str = PATTERNS_GLOB,
+    name: str = "Patterns",
+    default_deny: bool = False,
+) -> None:
     target = _gov_dir(vault) / "scopes" / "patterns.yaml"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(
-        f"governance_version: 1\nid: {SCOPE_ID}\nname: {name}\npaths: [\"{paths}\"]\n",
+        f"governance_version: 1\nid: {SCOPE_ID}\nname: {name}\npaths: [\"{paths}\"]\n"
+        + ("default_deny: true\n" if default_deny else ""),
         encoding="utf-8",
     )
 
@@ -3472,3 +3479,317 @@ def test_a_percent_literal_filename_resolves_to_itself(vault: Path) -> None:
         vault, {"entries": [{"path": "Knowledge Base/Notes/Patterns/a%20b.md"}]}
     )
     assert out["entries"] == [], "the percent-literal file resolved to its decoded twin"
+
+
+# --------------------------------------------------------------------------
+# A scope may deny audiences it does not name (add-default-deny-scope-cap)
+#
+# Wave 0's finding, at the surfaces: audiences are matched by EXACT id, and
+# for a non-OAuth MCP client the subject derives from the bearer credential —
+# so rotating a credential mints an audience id no rule names, and the vault
+# falls open to it. These pin the closed default end to end.
+# --------------------------------------------------------------------------
+
+DECLARED_VIDEO = "Knowledge Base/Notes/Patterns/board-briefing.mp4"
+
+
+def _audience_for(credential: str) -> str:
+    """The audience id a bearer credential resolves to, as the MCP surface
+    mints it — the thing a rotation changes."""
+    from exomem.governance.principal import normalize_audience
+
+    return normalize_audience(subject=credential, issuer="mcp-bearer")
+
+
+def _as(audience: str) -> RequestPrincipal:
+    return RequestPrincipal(audience_id=audience, surface="mcp")
+
+
+def test_a_declared_scope_denies_an_unnamed_audience_end_to_end(vault: Path) -> None:
+    """No rule document at all: the scope alone closes the item."""
+    write_scope(vault, default_deny=True)
+    _reset_caches()
+    with request_scope(_external()):
+        with pytest.raises(ValueError, match="NOT_FOUND"):
+            commands.op_get(vault, path=RESTRICTED_PATH)
+
+
+def test_the_same_scope_without_the_declaration_still_releases(vault: Path) -> None:
+    """The control for the test above — the change is opt-in, so an identical
+    scope carrying no declaration keeps today's full release."""
+    write_scope(vault)
+    _reset_caches()
+    with request_scope(_external()):
+        page = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert "Kill switch" in page["body"]
+
+
+def test_a_rotated_credential_minting_an_unnamed_audience_id_is_denied(
+    vault: Path,
+) -> None:
+    """Spec: a newly minted audience id is denied by default.
+
+    The rule names the audience the ORIGINAL credential resolves to. Rotating
+    the credential produces a different id that appears in no document — the
+    precondition the owner cannot enforce and will not remember."""
+    before = _audience_for("bearer-token-v1")
+    after = _audience_for("bearer-token-v2")
+    never_named = _audience_for("some-assistant-that-was-never-authored")
+    assert len({before, after, never_named}) == 3
+
+    write_scope(vault, default_deny=True)
+    write_rule(vault, ceiling=egress.LEVEL_FULL, audience=before)
+    _reset_caches()
+
+    with request_scope(_as(before)):
+        page = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert "Kill switch" in page["body"]
+
+    def _denied(audience: str) -> str:
+        _reset_caches()
+        with request_scope(_as(audience)):
+            with pytest.raises(ValueError) as excinfo:
+                commands.op_get(vault, path=RESTRICTED_PATH)
+        return str(excinfo.value)
+
+    # …and the rotated id is denied identically to one that was never authored.
+    assert _denied(after) == _denied(never_named)
+    assert _denied(after) == f"NOT_FOUND: file does not exist: {RESTRICTED_PATH}"
+
+
+def test_a_rotated_credential_falls_open_without_the_declaration(vault: Path) -> None:
+    """The defect the declaration exists to close, pinned as the control: the
+    same policy WITHOUT the declaration serves the rotated credential in full."""
+    before = _audience_for("bearer-token-v1")
+    after = _audience_for("bearer-token-v2")
+    write_scope(vault)
+    write_rule(vault, ceiling=egress.LEVEL_NONE, audience=before)
+    _reset_caches()
+    with request_scope(_as(after)):
+        page = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert "Kill switch" in page["body"]
+
+
+def test_a_grant_still_reaches_an_unnamed_audience_in_a_declared_scope(
+    vault: Path,
+) -> None:
+    """Spec: a grant still raises above the default, with no special case."""
+    audience = _audience_for("bearer-token-v2")
+    write_scope(vault, default_deny=True)
+    grant = _gov_dir(vault) / "grants" / "rotated.yaml"
+    grant.parent.mkdir(parents=True, exist_ok=True)
+    grant.write_text(
+        f"governance_version: 1\nid: {GRANT_ID}\nkind: standing\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: {audience}\n'
+        f"ceiling: {egress.LEVEL_FULL}\n",
+        encoding="utf-8",
+    )
+    _reset_caches()
+    with request_scope(_as(audience)):
+        page = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert "Kill switch" in page["body"]
+
+
+def test_the_owner_still_reads_a_declared_scope(vault: Path) -> None:
+    """Spec: the owner reads a declared scope at full release. A scope the
+    owner cannot read is a vault that has lost its own contents."""
+    write_scope(vault, default_deny=True)
+    _reset_caches()
+    with request_scope(RequestPrincipal(audience_id="owner", surface="cli")):
+        page = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert "Kill switch" in page["body"]
+
+
+def test_an_ungoverned_vault_is_untouched_by_the_declaration(vault: Path) -> None:
+    """No governance tree still means the empty fast path."""
+    baseline = commands.op_get(vault, path=RESTRICTED_PATH)
+    _reset_caches()
+    with request_scope(_external()):
+        governed = commands.op_get(vault, path=RESTRICTED_PATH)
+    assert governed == baseline
+
+
+#: Deterministic stand-in for the fixture note, so the two probes below differ
+#: only in whether the item exists.
+_DECLARED_NOTE = (
+    "---\ntype: pattern\ntitle: Kill switch for risky releases\n---\n"
+    "A kill switch limits the blast radius of a risky release.\n"
+)
+
+#: Corpus-statistics fields a withheld item still moves on the items that
+#: SURVIVE it: it displaces their ranks and counts toward their in-degree.
+#: This channel predates the change and is identical for an authored
+#: `ceiling: 0` rule — pinned by the differential test below rather than
+#: assumed here, so excluding it is a proven property and not hand-waving.
+_RANK_DERIVED_SIGNALS = ("bm25_rank", "keyword_rank", "vector_rank", "graph_in_degree")
+
+
+def _strip_rank_signals(payload):
+    hits = payload["hits"] if isinstance(payload, dict) else payload
+    for hit in hits if isinstance(hits, list) else []:
+        signals = hit.get("signals") if isinstance(hit, dict) else None
+        if isinstance(signals, dict):
+            for key in _RANK_DERIVED_SIGNALS:
+                signals.pop(key, None)
+    return payload
+
+
+def _probe_surfaces_present_then_absent(
+    vault: Path, *, keep_rank_signals: bool = False
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Ask every surface for the same two paths twice: present, then deleted.
+
+    Returns `(present, absent)` keyed by surface. The caller supplies the
+    policy, so the only thing that varies between the two dicts is whether the
+    items exist on disk.
+    """
+    md = vault / RESTRICTED_PATH
+    video = vault / DECLARED_VIDEO
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text(_DECLARED_NOTE, encoding="utf-8")
+    # The bytes are never reached: the release gate refuses before extraction.
+    video.write_bytes(PNG_1X1)
+
+    surfaces = {
+        "get": lambda: commands.op_get(vault, path=RESTRICTED_PATH),
+        "fetch": lambda: commands.op_fetch(vault, id=RESTRICTED_PATH),
+        "read_media": lambda: commands.op_get_video_frames(vault, path=DECLARED_VIDEO),
+        "recall": lambda: commands.op_find(
+            vault, query="kill switch risky releases", limit=10
+        ),
+        "graph": lambda: commands.op_graph_context(vault, path=RESTRICTED_PATH),
+    }
+
+    def _probe(name: str, call) -> str:
+        _reset_caches()
+        with request_scope(_external()):
+            try:
+                payload = call()
+            except ValueError as error:
+                return f"raised:{error}"
+        if name == "recall" and not keep_rank_signals:
+            payload = _strip_rank_signals(payload)
+        return f"ok:{json.dumps(payload, default=str, sort_keys=True)}"
+
+    present = {name: _probe(name, call) for name, call in surfaces.items()}
+    md.unlink()
+    video.unlink()
+    absent = {name: _probe(name, call) for name, call in surfaces.items()}
+    return present, absent
+
+
+def test_a_default_denied_item_is_indistinguishable_from_a_missing_one(
+    vault: Path,
+) -> None:
+    """Spec: the item is indistinguishable from one that does not exist.
+
+    Same-input/varied-condition: each surface is asked for ONE path twice —
+    once while it exists and is denied by the declaration, once after deleting
+    it. The caller controls the input, so the only bit that can differ is
+    whether the item exists, and that bit must not be observable.
+
+    Comparing two DIFFERENT withheld paths cannot isolate that bit: a response
+    legitimately echoes whichever path the caller named, so differing inputs
+    are expected to differ. A prior round of this work shipped an existence
+    oracle for exactly that reason.
+    """
+    write_scope(vault, default_deny=True)
+    present, absent = _probe_surfaces_present_then_absent(vault)
+
+    divergent = {
+        name: (present[name], absent[name])
+        for name in present
+        if present[name] != absent[name]
+    }
+    assert not divergent, (
+        "EXISTENCE ORACLE: a default-denied item answers differently from a "
+        f"missing one on surface(s): {sorted(divergent)}"
+    )
+    # `recall` is the one surface the caller did not name the item on, so the
+    # item must not come back as a hit there.
+    #
+    # Deliberately NOT "the stem appears nowhere in the payload": a PERMITTED
+    # note's own prose may link to the closed one, and that excerpt reads the
+    # same whether the target exists or not — the assertion above already
+    # proved it byte-identical, so it carries no existence bit. Reference
+    # FIELDS (provenance, relations, graph seeds) are stripped, which
+    # `test_a_withheld_path_is_recognised_in_every_reference_form` covers.
+    # The probe deletes the item on its way out, so restore it before asking.
+    (vault / RESTRICTED_PATH).write_text(_DECLARED_NOTE, encoding="utf-8")
+    _reset_caches()
+    with request_scope(_external()):
+        hits = commands.op_find(vault, query="kill switch risky releases", limit=10)
+    returned = [hit.get("path") for hit in (hits["hits"] if isinstance(hits, dict) else hits)]
+    assert (vault / RESTRICTED_PATH).is_file()
+    assert RESTRICTED_PATH not in returned
+
+
+def test_the_declaration_adds_no_observable_an_explicit_ceiling_0_rule_lacks(
+    vault: Path,
+) -> None:
+    """The assertion this change actually owns, stated as a differential.
+
+    `_RANK_DERIVED_SIGNALS` is excluded from the test above because a withheld
+    item still displaces the ranks of the items that survive it, and still
+    counts toward their `graph_in_degree` — a corpus-statistics channel that
+    predates this change and is identical for an explicit `ceiling: 0` rule
+    (verified against pristine `main`). Excluding it would be hand-waving if
+    nothing pinned it, so this pins it: every surface, INCLUDING the excluded
+    signals, answers byte-identically whether the item is closed by the
+    declaration or by an authored ceiling-0 rule. The declaration therefore
+    introduces no new observable — it only supplies the default.
+    """
+    write_scope(vault, default_deny=True)
+    declared_present, declared_absent = _probe_surfaces_present_then_absent(
+        vault, keep_rank_signals=True
+    )
+
+    # Same vault, same items, closed the already-supported way instead.
+    write_scope(vault)
+    write_rule(vault, ceiling=egress.LEVEL_NONE)
+    authored_present, authored_absent = _probe_surfaces_present_then_absent(
+        vault, keep_rank_signals=True
+    )
+
+    assert declared_present == authored_present
+    assert declared_absent == authored_absent
+
+
+def test_a_broad_undeclared_scope_cannot_reopen_a_declared_one(vault: Path) -> None:
+    """Spec: one declared scope denies across an overlapping undeclared scope.
+
+    The attack this closes: if membership in ANY undeclared scope re-opened the
+    item, the declaration would be defeatable by authoring a broad scope
+    alongside it — and authoring a broad scope is the ordinary thing an owner
+    does next. Proven through real membership resolution, not just the lattice.
+    """
+    write_scope(vault, default_deny=True)  # Notes/Patterns/** , declared
+    broad = _gov_dir(vault) / "scopes" / "everything.yaml"
+    broad.write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB2\nname: Everything\n"
+        'paths: ["Notes/**"]\n',
+        encoding="utf-8",
+    )
+    _reset_caches()
+
+    from exomem.governance import policy as policy_module
+
+    pol = policy_module.load(vault)
+    decision = egress._decide_path(
+        vault,
+        RESTRICTED_PATH,
+        policy=pol,
+        audience=EXTERNAL,
+        purpose=None,
+        grants_hash=egress._grants_hash(pol),
+    )
+    assert decision is not None
+    # Both scopes really do contain the item — otherwise the test proves nothing.
+    assert len(decision.scope_ids) == 2
+    assert decision.level == 0
+    assert decision.default_deny_scope_ids == (SCOPE_ID,)
+
+    _reset_caches()
+    with request_scope(_external()):
+        with pytest.raises(ValueError, match="NOT_FOUND"):
+            commands.op_get(vault, path=RESTRICTED_PATH)

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -3624,6 +3624,20 @@ _DECLARED_NOTE = (
 _RANK_DERIVED_SIGNALS = ("bm25_rank", "keyword_rank", "vector_rank", "graph_in_degree")
 
 
+def test_spec_names_the_known_preexisting_relevance_ranking_channel() -> None:
+    spec = (
+        Path(__file__).resolve().parents[1]
+        / "openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md"
+    ).read_text(encoding="utf-8")
+    scenario = spec.split(
+        "#### Scenario: an audience no rule names receives nothing", 1
+    )[1].split("#### Scenario:", 1)[0]
+
+    assert all(signal in scenario for signal in _RANK_DERIVED_SIGNALS)
+    assert "known pre-existing channel" in scenario
+    assert "tracked separately" in scenario
+
+
 def _strip_rank_signals(payload):
     hits = payload["hits"] if isinstance(payload, dict) else payload
     for hit in hits if isinstance(hits, list) else []:
@@ -3678,15 +3692,15 @@ def _probe_surfaces_present_then_absent(
     return present, absent
 
 
-def test_a_default_denied_item_is_indistinguishable_from_a_missing_one(
+def test_a_default_denied_item_matches_missing_except_known_ranking_signals(
     vault: Path,
 ) -> None:
-    """Spec: the item is indistinguishable from one that does not exist.
+    """Spec: the item matches a missing one outside the named ranking channel.
 
     Same-input/varied-condition: each surface is asked for ONE path twice —
     once while it exists and is denied by the declaration, once after deleting
-    it. The caller controls the input, so the only bit that can differ is
-    whether the item exists, and that bit must not be observable.
+    it. The caller controls the input, so any non-ranking difference would be
+    a new existence oracle introduced by the declaration.
 
     Comparing two DIFFERENT withheld paths cannot isolate that bit: a response
     legitimately echoes whichever path the caller named, so differing inputs
@@ -3724,20 +3738,19 @@ def test_a_default_denied_item_is_indistinguishable_from_a_missing_one(
     assert RESTRICTED_PATH not in returned
 
 
-def test_the_declaration_adds_no_observable_an_explicit_ceiling_0_rule_lacks(
+def test_the_declaration_is_no_worse_than_the_existing_ceiling_0_primitive(
     vault: Path,
 ) -> None:
-    """The assertion this change actually owns, stated as a differential.
+    """The assertion this change owns: it is no worse than the old primitive.
 
     `_RANK_DERIVED_SIGNALS` is excluded from the test above because a withheld
     item still displaces the ranks of the items that survive it, and still
     counts toward their `graph_in_degree` — a corpus-statistics channel that
     predates this change and is identical for an explicit `ceiling: 0` rule
-    (verified against pristine `main`). Excluding it would be hand-waving if
-    nothing pinned it, so this pins it: every surface, INCLUDING the excluded
+    (verified against pristine `main`). This differential keeps the declaration
+    no worse than that existing primitive: every surface, INCLUDING the named
     signals, answers byte-identically whether the item is closed by the
-    declaration or by an authored ceiling-0 rule. The declaration therefore
-    introduces no new observable — it only supplies the default.
+    declaration or by an authored ceiling-0 rule.
     """
     write_scope(vault, default_deny=True)
     declared_present, declared_absent = _probe_surfaces_present_then_absent(

--- a/tests/test_governance_policy.py
+++ b/tests/test_governance_policy.py
@@ -800,3 +800,87 @@ def test_the_authoring_gate_creates_no_state_when_it_refuses(vault: Path) -> Non
             duration="standing",
         )
     assert _snapshot() == before, "the refused authoring gate mutated the vault"
+
+
+# ---------------------------------------------------------------------------
+# A scope may declare that unnamed audiences get nothing
+# (add-default-deny-scope-cap, task 1)
+# ---------------------------------------------------------------------------
+
+_SCOPE_A_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+
+def test_a_scope_may_declare_a_default_deny(vault: Path) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A + "default_deny: true\n")
+    _write(vault, "rules", "acmeco-external", _RULE_A)
+    pol = policy.load(vault)
+    assert pol.blocked is False
+    assert [f for f in pol.findings if f["severity"] == "error"] == []
+    assert pol.scopes[_SCOPE_A_ID].default_deny is True
+
+
+def test_a_scope_declaring_false_is_the_same_as_omitting_it(vault: Path) -> None:
+    """Not just "is False" — the two documents must compile to the same scope,
+    so `default_deny: false` is a no-op an author can write to be explicit."""
+    _write(vault, "scopes", "acmeco", _SCOPE_A + "default_deny: false\n")
+    _write(vault, "rules", "acmeco-external", _RULE_A)
+    explicit = policy.load(vault).scopes[_SCOPE_A_ID]
+
+    policy._CACHE.clear()
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    omitted = policy.load(vault).scopes[_SCOPE_A_ID]
+
+    assert explicit == omitted
+    assert explicit.default_deny is False
+
+
+def test_a_scope_omitting_the_declaration_compiles_exactly_as_before(vault: Path) -> None:
+    """The change is opt-in: an untouched document must compile clean, keep its
+    content fingerprint, and carry the permissive value."""
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(vault, "rules", "acmeco-external", _RULE_A)
+    pol = policy.load(vault)
+    assert pol.blocked is False
+    assert pol.findings == ()
+    assert pol.scopes[_SCOPE_A_ID].default_deny is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        '"true"',      # a quoted string is not a boolean
+        "1",           # an int is not a boolean
+        "[true]",      # a list is not a boolean
+        "{}",          # a mapping is not a boolean
+        "",            # `default_deny:` with the value forgotten -> YAML null
+        "deny",        # a bare word that is not a YAML boolean
+    ],
+)
+def test_a_malformed_declaration_is_an_error_finding_not_a_silent_default(
+    vault: Path, value: str
+) -> None:
+    """A confidentiality control must never fall back to permissive because the
+    author mistyped it. The finding is an ERROR, so the compile is refused.
+
+    The code has to be `invalid_field`, not `unknown_field`: before the field
+    existed every one of these values was rejected merely because the compiler
+    had never heard of the key. That accident would keep this test green while
+    the recognised field silently accepted a non-boolean."""
+    _write(vault, "scopes", "acmeco", _SCOPE_A + f"default_deny:{f' {value}' if value else ''}\n")
+    _write(vault, "rules", "acmeco-external", _RULE_A)
+    pol = policy.load(vault)
+    findings = [f for f in pol.findings if f["path"].endswith(":default_deny")]
+    assert findings, f"no finding for default_deny: {value!r}"
+    assert [f["code"] for f in findings] == ["invalid_field"]
+    assert all(f["severity"] == "error" for f in findings)
+    # Cold start with no prior good compile -> the fail-closed floor, not open.
+    assert pol.blocked is True
+
+
+def test_a_yaml_boolean_spelling_is_accepted(vault: Path) -> None:
+    """`yes` is a YAML 1.1 boolean, so it must not be reported as malformed."""
+    _write(vault, "scopes", "acmeco", _SCOPE_A + "default_deny: yes\n")
+    _write(vault, "rules", "acmeco-external", _RULE_A)
+    pol = policy.load(vault)
+    assert pol.blocked is False
+    assert pol.scopes[_SCOPE_A_ID].default_deny is True

--- a/tests/test_governance_policy.py
+++ b/tests/test_governance_policy.py
@@ -770,7 +770,7 @@ def test_the_authoring_gate_creates_no_state_when_it_refuses(vault: Path) -> Non
     policy directory, receipt or marker. The conflict probe therefore reads the
     directory listing rather than going through `load()`, which opens the
     governance sidecar via the guard probe."""
-    from exomem.governance.tool import op_govern_memory
+    from exomem.governance.tool import GovernanceError, op_govern_memory
 
     _write(vault, "scopes", "client", _SCOPE_A)
     conflict = (
@@ -788,7 +788,7 @@ def test_the_authoring_gate_creates_no_state_when_it_refuses(vault: Path) -> Non
         }
 
     before = _snapshot()
-    with pytest.raises(Exception):
+    with pytest.raises(GovernanceError):
         op_govern_memory(
             vault,
             operation="propose",
@@ -884,3 +884,73 @@ def test_a_yaml_boolean_spelling_is_accepted(vault: Path) -> None:
     pol = policy.load(vault)
     assert pol.blocked is False
     assert pol.scopes[_SCOPE_A_ID].default_deny is True
+
+
+@pytest.mark.parametrize(
+    "audience_yaml",
+    [r'"\0unnamed"', r'"\0unresolved"', r'"external\0suffix"'],
+)
+@pytest.mark.parametrize(
+    ("kind", "field", "document"),
+    [
+        (
+            "rules",
+            "audience",
+            "governance_version: 1\n"
+            "id: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n"
+            'scope_ids: ["01ARZ3NDEKTSV4RRFFQ69G5FAV"]\n'
+            "audience: {audience}\n"
+            "ceiling: 2\n",
+        ),
+        (
+            "grants",
+            "audience",
+            "governance_version: 1\n"
+            "id: 01ARZ3NDEKTSV4RRFFQ69G5FB1\n"
+            "kind: standing\n"
+            'scope_ids: ["01ARZ3NDEKTSV4RRFFQ69G5FAV"]\n'
+            "audience: {audience}\n"
+            "ceiling: 6\n",
+        ),
+        (
+            "grants",
+            "to_audience",
+            "governance_version: 1\n"
+            "id: 01ARZ3NDEKTSV4RRFFQ69G5FB2\n"
+            "kind: release\n"
+            "path: Knowledge Base/Notes/Patterns/released.md\n"
+            "ref: exomem://memory/00000000-0000-0000-0000-000000000001\n"
+            f"content_hash: {'a' * 64}\n"
+            "to_audience: {audience}\n"
+            "released_at: '2026-07-28T12:00:00Z'\n"
+            "why: Owner reviewed the exact release\n"
+            "bridge_scope: review\n"
+            "bridge_of:\n"
+            "  - ref: exomem://memory/00000000-0000-0000-0000-000000000002\n"
+            "    path: Knowledge Base/Sources/Other/source.md\n"
+            f"    content_hash: {'b' * 64}\n"
+            f"    restriction_signature: {'c' * 64}\n"
+            "options:\n"
+            "  strip_provenance:\n"
+            "    - exomem://memory/00000000-0000-0000-0000-000000000002\n",
+        ),
+    ],
+)
+def test_authored_audiences_cannot_enter_the_reserved_nul_namespace(
+    vault: Path, audience_yaml: str, kind: str, field: str, document: str
+) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(vault, kind, "reserved-audience", document.format(audience=audience_yaml))
+
+    compiled = policy.load(vault)
+    audience_findings = [
+        finding for finding in compiled.findings
+        if finding["path"].endswith(f":{field}")
+    ]
+
+    assert [finding["code"] for finding in audience_findings] == ["invalid_field"]
+    assert all(finding["severity"] == "error" for finding in audience_findings)
+    assert compiled.blocked is True
+    assert compiled.rules == ()
+    assert compiled.grants == ()
+    assert compiled.release_grants == ()

--- a/tests/test_governance_receipts.py
+++ b/tests/test_governance_receipts.py
@@ -1576,6 +1576,121 @@ def test_governed_file_delete_records_lifecycle_before_terminal_and_keeps_lineag
     assert json.loads(tombstones[0].read_text(encoding="utf-8"))["state"] == "committed"
 
 
+def _write_restriction_shape(vault: Path, pattern: str, *, shape: str) -> None:
+    """Write the SAME restriction two ways, so lifecycle can be diffed on them.
+
+    `ceiling_zero` authors a rule that closes the scope to the one audience it
+    names. `default_deny` declares the scope closed to every audience no rule
+    names — and names no rule at all. A declaration restricts at least as much
+    as the rule does, so every subsystem that asks "is this item restricted?"
+    owes the same answer to both.
+    """
+    governance = vault / "Knowledge Base" / "_Governance"
+    scope = governance / "scopes" / "lifecycle.yaml"
+    rule = governance / "rules" / "lifecycle.yaml"
+    scope.parent.mkdir(parents=True, exist_ok=True)
+    rule.parent.mkdir(parents=True, exist_ok=True)
+    scope.write_text(
+        f'governance_version: 1\nid: {_LIFECYCLE_SCOPE}\npaths: ["{pattern}"]\n'
+        + ("default_deny: true\n" if shape == "default_deny" else ""),
+        encoding="utf-8",
+    )
+    if shape == "ceiling_zero":
+        rule.write_text(
+            f"governance_version: 1\nid: {_LIFECYCLE_RULE}\n"
+            f'scope_ids: ["{_LIFECYCLE_SCOPE}"]\naudience: external\nceiling: 0\n',
+            encoding="utf-8",
+        )
+    elif rule.exists():
+        rule.unlink()
+    from exomem.governance import membership, policy
+
+    policy._CACHE.clear()
+    membership.clear_memo()
+    egress.clear_decision_memo()
+
+
+_RESTRICTION_SHAPES = pytest.mark.parametrize(
+    "shape", ["ceiling_zero", "default_deny"]
+)
+
+
+@_RESTRICTION_SHAPES
+def test_deleting_a_restricted_item_tombstones_it_however_the_restriction_is_written(
+    vault: Path, shape: str
+) -> None:
+    """A governed delete leaves a tombstone; an ungoverned one does not.
+
+    Classify a `default_deny`-only item as ungoverned and `begin_deletion`
+    takes the ungoverned branch: no tombstone, so `is_tombstoned` is False
+    forever and the reference gate (`egress._ArtifactReferenceGate._permits`)
+    can no longer withhold a path that no longer exists — a permitted note's
+    wikilink to it renders in the clear. It also removes governed material with
+    no `governed_delete` audit record.
+    """
+    from exomem.governance import lifecycle
+
+    rel = "Knowledge Base/Notes/Insights/restricted-delete.md"
+    (vault / rel).write_text(
+        "---\ntype: insight\n---\n# Restricted\nprivate body\n", encoding="utf-8"
+    )
+    _write_restriction_shape(vault, "Notes/Insights/restricted-delete.md", shape=shape)
+
+    delete_file.delete_file(vault, path=rel, confirm=True)
+
+    tombstones = list(
+        (vault / "Knowledge Base" / "_Governance" / "deletion-tombstones").glob("*.json")
+    )
+    assert len(tombstones) == 1
+    assert lifecycle.is_tombstoned(vault, rel) is True
+    assert any(item["event_type"] == "deletion" for item in _receipt_records(vault))
+
+
+@_RESTRICTION_SHAPES
+def test_a_tombstoned_path_stays_withheld_after_the_policy_is_removed(
+    vault: Path, shape: str
+) -> None:
+    """The tombstone is what survives the item. Without it the path is
+    published the moment the governance tree stops matching it."""
+    rel = "Knowledge Base/Notes/Insights/restricted-stale.md"
+    body = "---\ntype: insight\n---\n# Restricted stale\n"
+    (vault / rel).write_text(body, encoding="utf-8")
+    _write_restriction_shape(vault, "Notes/Insights/restricted-stale.md", shape=shape)
+    delete_file.delete_file(vault, path=rel, confirm=True)
+    governance = vault / "Knowledge Base" / "_Governance"
+    shutil.rmtree(governance / "scopes")
+    if (governance / "rules").exists():
+        shutil.rmtree(governance / "rules")
+    from exomem.governance import membership, policy
+
+    policy._CACHE.clear()
+    membership.clear_memo()
+    egress.clear_decision_memo()
+
+    assert egress.annotate_page(vault, {"path": rel, "body": body}) is None
+    assert egress.release_level_for(vault, rel) is None
+
+
+@_RESTRICTION_SHAPES
+def test_restoring_a_restricted_item_is_governed_however_the_restriction_is_written(
+    vault: Path, shape: str
+) -> None:
+    """`_is_governed_for_restore` decides on its own whenever the deletion left
+    no committed lineage — here the item was deleted before the policy existed,
+    so the restore is the first governed step and must be receipted."""
+    rel = "Knowledge Base/Notes/Insights/restricted-restore.md"
+    (vault / rel).write_text(
+        "---\ntype: insight\nstatus: draft\n---\n# Restore me\n", encoding="utf-8"
+    )
+    deleted = delete_file.delete_file(vault, path=rel, confirm=True)
+    assert not any(item["event_type"] == "deletion" for item in _receipt_records(vault))
+    _write_restriction_shape(vault, "Notes/Insights/restricted-restore.md", shape=shape)
+
+    recover_from_trash.recover_from_trash(vault, trash_path=deleted.trash_path)
+
+    assert any(item["event_type"] == "recovery" for item in _receipt_records(vault))
+
+
 def test_tombstone_suppresses_stale_page_before_empty_policy_and_not_same_hash_sibling(
     vault: Path,
 ) -> None:


### PR DESCRIPTION
## Why

The policy grammar had no way to say **"nobody but me, unless I name them."** Two facts combined into a hole no careful authoring could close:

1. **No matching rule meant full release.** `_decide_at` computed `standing_min = min(ceilings, default=DISCLOSURE_MAX)`, so a scope with no rule for an audience resolved to L6. Confidentiality was opt-in per (scope, audience) pair.
2. **Audiences are matched by exact id**, and for non-OAuth MCP clients the subject derives from the bearer credential — so **rotating a credential minted an audience id no rule named**, and the vault fell open to it.

"This assistant may never receive my private material" was not expressible. The true statement was *"…so long as its audience id matches an authored rule"* — a precondition the owner cannot enforce and will not remember.

This blocks the governed-consolidation work: consolidating two Exomems means a deterministic release plane replaces physical isolation. Trading a boundary with **no** attack surface for one a credential rotation reopens is not a trade worth making, and no orchestration above the kernel can fix a default in the lattice.

## What changes

A scope may declare that an audience no standing rule names **for that scope** receives nothing. It changes exactly one default and composes with everything else unchanged — grants still raise, org caps still lower, purpose still only narrows.

**Deliberately not a synthetic ceiling-0 rule.** `standing_min` is a `min`, so a synthetic zero combines with an authored `ceiling: 3` as `min(3,0) = 0` and silently overrides the allowance. That implementation was built on purpose during development to confirm the guards catch it — four tests failed, including one proving an org cap alone leaves the standing set empty.

## Review history — two adversarial rounds, and what each caught

Both rounds found real defects a green suite did not.

**Round 1 (4 findings, HOLD).** One cause: `default_deny` is a *new way to restrict*, and three subsystems answer "is this restricted?" by enumerating **rules** with a ceiling below max. A declaration names no rule, so it was invisible to all of them.

- **HIGH** — deleting a `default_deny`-only item **published its full path**. It was classified ungoverned, so no tombstone was written, and a permitted note's wikilink to it then rendered the exact path once the file was gone. No `governed_delete` receipt either. The equivalent `ceiling: 0` policy tombstones correctly — a strict regression against the existing primitive.
- **HIGH** — removing the declaration was reported to the owner as a **narrowing** with `widened: 0`, while actually opening every item L0 → L6. That is the owner's only review signal before committing.
- **MEDIUM** — a rule on one declared scope suppressed a *different* declared scope's default (compartment crossover). Fixed per declaring scope, not by amending the spec: authorising a partner on one compartment must not unlock another.
- **MEDIUM** — `restriction_signature` omitted the declaration, so locking a scope did not stale an approved bridge while `ceiling: 0` did.

**Round 2 (6 findings, HOLD)** — including a criticism of the author's own reasoning:

- **P1** — `explain`/`simulate` leaked existence to non-owners: an existing denied path returned L0 success, a missing path raised `INVALID_INSPECTION_PATH`. **Success-vs-error is itself the bit.**
- **P1** — the "unmintable" probe audience was authorable. PyYAML parses `audience: "\0unnamed"` to exactly the reserved value. Now an ERROR that refuses the compile, covering the unresolved-principal sentinel too.
- **P1** — **the guard test stripped the evidence the spec claimed.** It removed `bm25_rank`/`keyword_rank` before comparing, so it passed while the requirement claimed byte-indistinguishability. Measured: a present denied note displaces a visible hit to `bm25_rank: 2`; delete it and you get `1`.
- **P2** — `target_ceiling` reported `1` while the unnamed audience actually moved to `6`, precisely on the rotation path this feature exists for.
- **P2 ×2** — `design.md` described the pre-fix algorithm, and a spec scenario admitted two outcomes for one input.

## Scope of the guarantee — stated honestly

Two known channels are **not** closed here, both verified pre-existing and identical under an authored `ceiling: 0`:

- **Relevance-ranking signals.** A withheld item still displaces `bm25_rank`/`keyword_rank` and counts toward `graph_in_degree`. Rather than let the test strip the fields, the **spec now names them** as a carved-out, separately-tracked channel, and the equivalence assertion is redocumented as *"no worse than the existing primitive"* — never *"indistinguishable"*. Equivalence to an older primitive establishes non-regression, never compliance.
- **The grant lane.** A grant matches on scope intersection and raises the whole item, so a grant naming a sibling scope lifts an item also in a declared scope naming nobody (measured L0 → L6). Pinned by an equivalence test, called out in the proposal.

So: *"an audience no document names receives nothing"* holds. *"An audience named anywhere receives nothing outside what it was named for"* does not.

## Verification

| | |
|---|---|
| Governance suites | **787 passed** |
| Overhead gate | 14/14, empty-policy budget 5.0 ms unchanged — `decide_paths` short-circuits before `decide()` is reached (measured 0.29 ms base vs 0.18 ms branch) |
| Full suite | 6670 passed / 33 failed vs pristine baseline 6609 / 35 — branch failures a **strict subset**, zero introduced |
| Lint | zero findings added vs `main` |
| OpenSpec | `validate --strict` valid |

Every fix landed red-first. Two existing assertions were replaced rather than adjusted, each quoted and justified — one of them (`effective_ceiling == 0` plus a stripped scope id) had itself encoded the oracle.

Implementation and both review rounds ran on Codex under the repo's Codex worker protocol; commits and merge stay with Claude per that protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bpb3EM192K3zXChJMzEfh
