### PR TITLE
docs(openspec): propose restoring hosted cell fidelity and daily durability

### DIFF
--- a/openspec/changes/fix-hosted-alpha-runtime-fidelity/proposal.md
+++ b/openspec/changes/fix-hosted-alpha-runtime-fidelity/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Two runtime settings chosen for capacity headroom would ship a hosted product that is
+materially worse than the local one, and a third would make storage cost scale with
+usage far faster than price.
+
+The cell chart ships `workerLimit: 0`. In `hosted_runtime.py` that resolves
+`workers_enabled = worker_count > 0` to false, which **sets** `EXOMEM_DISABLE_EMBEDDINGS`
+and `EXOMEM_DISABLE_MEDIA_EXTRACTION`; `server_runtime.py` then reports embeddings,
+file-watcher, and media as not-ready with `HOSTED_WORKER_LIMIT_ZERO`. A hosted cell
+therefore offers capture and keyword recall but **no semantic search** — the capability
+that distinguishes Exomem from a folder of markdown. Paying users would receive a
+strictly lesser product than the free local runtime.
+
+Separately, the durability worker takes a **complete portable archive every 30 minutes**
+while the recovery bucket retains every object for 30 days with no thinning rule. That
+is 1,440 full encrypted archives per cell coexisting — a 1,440× amplification with no
+deduplication, since each archive is separately encrypted. Storage cost then scales with
+vault size: break-even against the friends tier lands near a 150 MB average vault, and a
+single user filling the 5 GiB entitlement would cost several times what the whole cohort
+pays. The cadence also quiesces the cell each run against a two-minute objective, so it
+manufactures up to 96 minutes of unavailability per user per day.
+
+The 30-minute cadence was chosen for a one-hour RPO against volume loss. Hetzner Cloud
+Volumes are replicated network storage; volume loss is the least likely way this system
+loses data. Operator error, a bad migration, and account-level events are all more
+probable, and none are helped by frequency — they are helped by retention depth.
+
+## What Changes
+
+- Enable the `embeddings` feature grant and raise the cell worker limit above zero so
+  hosted cells run semantic recall, file watching, and media extraction.
+- Resize the alpha node from CX33 to CX43 to hold six embedding-capable cells, and update
+  the capacity contract's cost basis accordingly.
+- Change the vault durability cadence from 30-minute full archives to daily, restating
+  the recovery objective as 24 hours rather than one hour.
+- Record the resulting economics honestly, including that the EUR 5 friends tier is
+  approximately cost-neutral once the product is complete.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-alpha-operations`: cells must deliver the complete product surface, and the
+  capacity/cost basis moves to the resized node.
+- `hosted-durability`: the vault backup cadence and stated recovery objective change.
+
+## Impact
+
+- `infra/helm/cell/values.yaml` worker limit and feature grants; the rendered cell
+  environment stops setting `EXOMEM_DISABLE_EMBEDDINGS`.
+- `infra/terraform/foundation` server type, and the `server_type == "cx33"` validation.
+- `infra/operations/private-alpha-capacity-v1.json` and its byte-identical chart copy:
+  cost basis and the resource envelope behind the six-cell cap.
+- The durability worker's schedule and the declared RPO in runbooks and specs.
+- No change to tenant isolation, encryption, admission, or routing.

--- a/openspec/changes/fix-hosted-alpha-runtime-fidelity/specs/hosted-alpha-operations/spec.md
+++ b/openspec/changes/fix-hosted-alpha-runtime-fidelity/specs/hosted-alpha-operations/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Hosted cells deliver the complete product surface
+A hosted cell SHALL provide the same retrieval capability as the local runtime. The
+rendered cell environment MUST NOT disable embeddings or media extraction, and the cell
+worker limit SHALL be greater than zero with the `embeddings` feature granted. Readiness
+SHALL report the embeddings worker as ready rather than
+`HOSTED_WORKER_LIMIT_ZERO`. A cell that cannot run semantic recall SHALL NOT be presented
+as a paid or invited tenant.
+
+#### Scenario: Cell renders with workers disabled
+- **WHEN** the cell chart would render a worker limit of zero or omit the embeddings grant
+- **THEN** rendering fails rather than producing a cell that silently serves keyword-only recall
+
+#### Scenario: Tenant performs semantic recall
+- **WHEN** an invited tenant captures notes and then queries by meaning rather than exact wording
+- **THEN** the cell returns semantically ranked results, matching the local runtime's behaviour
+
+### Requirement: Capacity basis reflects the embedding-capable node
+The six-cell USER cap SHALL be justified against the resized node's CPU and memory with
+embeddings enabled, not against the smaller pre-embedding envelope. The capacity
+contract's monthly cost basis SHALL use the node actually in service, and raising the cap
+SHALL continue to require a fresh soak and reviewed cost sheet.
+
+#### Scenario: Cost basis names a node that is no longer in service
+- **WHEN** the capacity contract's server cost does not match the provisioned server type
+- **THEN** the cost evidence is rejected and provisioning admission fails closed

--- a/openspec/changes/fix-hosted-alpha-runtime-fidelity/specs/hosted-durability/spec.md
+++ b/openspec/changes/fix-hosted-alpha-runtime-fidelity/specs/hosted-durability/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Vault backup cadence is daily with a stated 24-hour objective
+The system durability worker SHALL create one complete encrypted vault archive per day
+rather than one every 30 minutes, and the declared vault recovery point objective SHALL
+be 24 hours. Retention SHALL remain 30 days with seven-day Object Lock. The cadence
+SHALL NOT be raised without either content-addressed incremental storage or an accepted
+cost and availability analysis, because each run quiesces the cell and each retained
+archive is a full independent copy.
+
+The stated objective SHALL match what tenants are told. A tighter objective SHALL NOT be
+advertised while the implementation stores full archives.
+
+#### Scenario: Volume is lost between daily archives
+- **WHEN** a cell's volume is lost and the most recent archive is up to 24 hours old
+- **THEN** restore proceeds from that archive and the loss window is within the declared objective
+
+#### Scenario: Someone proposes a shorter interval
+- **WHEN** a change would increase archive frequency while archives remain full copies
+- **THEN** it is rejected until incremental storage exists, because storage multiplies by run count and each run costs cell availability
+
+#### Scenario: Retention depth is what recovers from error
+- **WHEN** a tenant or operator discovers days later that data was damaged by a bad write or migration
+- **THEN** recovery uses the 30-day retention depth rather than cadence, which is the failure mode that actually occurs

--- a/openspec/changes/fix-hosted-alpha-runtime-fidelity/tasks.md
+++ b/openspec/changes/fix-hosted-alpha-runtime-fidelity/tasks.md
@@ -1,0 +1,29 @@
+## 1. Restore the complete product surface in hosted cells
+
+- [ ] 1.1 Add a failing rendered-manifest test asserting the cell environment does not contain `EXOMEM_DISABLE_EMBEDDINGS` or `EXOMEM_DISABLE_MEDIA_EXTRACTION`, and that the worker limit is greater than zero with the `embeddings` grant present.
+- [ ] 1.2 Set the cell chart's worker limit and feature grants accordingly, and make rendering fail closed when a zero worker limit would silently produce keyword-only recall.
+- [ ] 1.3 Update the platform admission policy's fixed environment set so the corrected variables are the admitted shape and the old disable-gated shape is rejected.
+- [ ] 1.4 Measure real embedding CPU and memory for one warm cell, and set the cell resource requests and limits from that measurement rather than the pre-embedding envelope.
+
+## 2. Resize the node to hold six embedding-capable cells
+
+- [ ] 2.1 Add a failing plan test for the resized server type, keeping the EU location validation and destroy protection intact.
+- [ ] 2.2 Change the foundation server type and its validation, then produce a reviewed saved plan and confirm it contains no destroy or replacement of the network, primary IP, firewall, SSH key, or tunnel.
+- [ ] 2.3 Apply the reviewed plan and retain redacted plan, locking, and cost evidence.
+
+## 3. Move vault durability to a daily cadence
+
+- [ ] 3.1 Add failing tests for the daily schedule and the 24-hour objective, including that a proposal to shorten the interval while archives remain full copies is rejected.
+- [ ] 3.2 Change the durability worker's schedule and every place the one-hour objective is stated, including runbooks and the observability contract's backup age thresholds.
+- [ ] 3.3 Prove one real archive, retention, and a clean restore at the new cadence.
+
+## 4. Record honest economics and close the capacity gate
+
+- [ ] 4.1 Fill the capacity contract's monthly cost basis from the resized node and the daily-cadence storage figure, keeping the chart copy byte-identical.
+- [ ] 4.2 Record the observed Paddle fee model and tax treatment, marking the net receipt for the friends price as derived from an observed model rather than an observed charge.
+- [ ] 4.3 Flip `live_costs_verified` only once both evidence digests and every cost field are present, and confirm provisioning admission passes.
+
+## 5. Verify
+
+- [ ] 5.1 Run the complete pinned validation gate and strict OpenSpec validation.
+- [ ] 5.2 Independent review of the rendered cell environment, the saved plan, and the economics evidence.


### PR DESCRIPTION
## Why

Spec-only. Two runtime settings chosen for capacity headroom would ship a **paid** hosted product materially worse than the **free** local one, and a third makes storage scale with usage far faster than price.

### Hosted cells currently have no semantic search

`infra/helm/cell/values.yaml` ships `workerLimit: 0`. In `hosted_runtime.py`:

```python
workers_enabled = self.resource_limits.worker_count > 0
_apply_disable_gate(target, workers_enabled and "embeddings" in self.feature_grants,
                    "EXOMEM_DISABLE_EMBEDDINGS")
```

`_apply_disable_gate` **sets** the variable when the condition is false. So the rendered cell gets `EXOMEM_DISABLE_EMBEDDINGS=1` and `EXOMEM_DISABLE_MEDIA_EXTRACTION=1`; `server_runtime.py` reports embeddings, file-watcher and media not-ready with `HOSTED_WORKER_LIMIT_ZERO`.

A hosted cell therefore offers capture and keyword recall but **no semantic search** — the capability that distinguishes Exomem from a folder of markdown.

### Backups amplify storage 1,440×

The durability worker takes a **complete portable archive every 30 minutes**, and the recovery bucket keeps every object 30 days (`days_from_uploading_to_hiding = 30`) with no thinning rule. That is **1,440 full encrypted archives per cell** coexisting, with no deduplication since each is separately encrypted.

Storage then scales with vault size rather than user count:

| avg vault | 6 cells | monthly |
|---|---|---|
| 50 MB | 432 GB | ~$2.60 |
| 150 MB | 1.3 TB | ~$7.80 (break-even) |
| 5 GiB entitlement | 43 TB | ~$259 |

One user filling their entitlement costs several times what the whole cohort pays. Each run also **quiesces the cell** against a two-minute objective — up to 96 minutes of manufactured unavailability per user per day.

### Why daily is the right cadence, not a compromise

The 30-minute interval existed for a one-hour RPO against volume loss. Hetzner Cloud Volumes are replicated network storage; volume loss is the *least* likely way this system loses data. Operator error, a bad migration, and account-level events are all likelier — and **none are helped by frequency**. They are helped by retention depth, which stays at 30 days.

Daily gives 30 archives per cell instead of 1,440. Even six users all filling 5 GiB lands near $5/month.

## What changes

- Enable the `embeddings` grant and a non-zero worker limit; rendering fails closed rather than silently serving keyword-only recall.
- Resize CX33 → CX43 to hold six embedding-capable cells; update the capacity cost basis.
- Vault cadence 30-minute → daily, with the objective restated as 24 hours and a requirement that it not be tightened again while archives remain full copies.

## Economics after the change

Using the Paddle model observed from a real completed transaction (24% inclusive VAT, 5% + €0.48 fee) against CX43 at €16.49 fixed:

| friends tier | 6 users net | profit/mo |
|---|---|---|
| €5 | €20.10 | ~break-even |
| €8 | €33.90 | +€13.5 |
| €10 | €43.08 | +€22.7 |
| €15 | €66.12 | +€46 |

## Scope

Spec only — no code, chart, or Terraform changes in this PR. Strict OpenSpec validation passes. Implementation follows in `tasks.md`, gated on measuring real embedding CPU/memory for a warm cell before setting the resource envelope.

No change to tenant isolation, encryption, admission, or routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
