### PR TITLE
feat(embeddings): serve the hosted bi-encoder on ONNX Runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ RUN uv pip install --python /app/.venv/bin/python "torch>=2.12" --index-url http
  && uv pip install --python /app/.venv/bin/python ".[embeddings]"
 
 ########################################################################
-# builder-hosted — builder-ml plus the embedding weights resolved at BUILD
-# time into the image itself.
+# builder-hosted — builder-lean plus ONNX Runtime and the embedding weights
+# resolved at BUILD time into the image itself.
 #
 # A hosted cell runs under a default-deny NetworkPolicy with no egress rules
 # and a read-only root filesystem. It therefore cannot download a model, and
@@ -95,33 +95,39 @@ RUN uv pip install --python /app/.venv/bin/python "torch>=2.12" --index-url http
 # must already be a layer, or the `embeddings` grant produces a cell that
 # advertises semantic recall and fails on first use.
 #
-# Only the bi-encoder is fetched. The CLIP model belongs to the `vision`
-# grant and the cross-encoder reranker never runs in a hosted cell (see the
-# hosted stage's EXOMEM_DISABLE_RANKING), so baking either would add hundreds
-# of megabytes to every cell for a path that is closed.
+# This stage builds from `builder-lean`, NOT `builder-ml`: the hosted lane
+# serves the same bi-encoder through ONNX Runtime, which imports ~40 MiB
+# against torch's ~400 and holds a materially smaller peak. Peak per cell is
+# what decides how many tenants a node carries, so torch's absence here is the
+# capacity argument, not a packaging preference. It is only possible in this
+# lane — the reranker and CLIP are sentence-transformers models, and the hosted
+# stage withholds both (EXOMEM_DISABLE_RANKING; CLIP belongs to `vision`).
+#
+# Only the bi-encoder is fetched, and only in the form the runtime reads.
 ########################################################################
-FROM builder-ml AS builder-hosted
+FROM builder-lean AS builder-hosted
 ENV HF_HOME=/opt/exomem-models
-# Fetch the weights, drop the duplicate serializations the loader will not use
-# (the hub cache stores snapshot entries as symlinks into blobs/, so the blob
-# has to go too or the layer keeps the bytes), then load once more with the
-# network closed. That final load is the gate: if trimming removed something
-# the loader actually needs, the build fails here instead of every cell
-# failing on its first query.
-RUN /app/.venv/bin/python -c "\
+# Resolve the model through the very backend the cell serves with, so the build
+# fetches exactly what that runtime opens — the ONNX export, the fast tokenizer,
+# and the sequence config — and never a torch serialization there is no loader
+# for. Then load once more with the network closed. That second load is the
+# gate: if anything the runtime needs is absent, the build fails here instead of
+# every cell failing on its first query.
+RUN uv pip install --python /app/.venv/bin/python ".[embeddings-onnx]" \
+ && EXOMEM_EMBED_BACKEND=onnx /app/.venv/bin/python -c "\
 from exomem.embeddings import MODEL_NAME; \
-from sentence_transformers import SentenceTransformer; \
-SentenceTransformer(MODEL_NAME, device='cpu'); \
+from exomem import embedding_backend as backend; \
+backend.load_encoder(MODEL_NAME, backend=backend.ONNX); \
 print('fetched', MODEL_NAME)" \
- && find /opt/exomem-models \( -name 'pytorch_model.bin' -o -name '*.h5' \
-      -o -name '*.msgpack' -o -name '*.ot' \) \
-      -exec sh -c 'for f; do t=$(readlink -f "$f" || true); rm -f "$f" "$t"; done' _ {} + \
- && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 /app/.venv/bin/python -c "\
-from exomem.embeddings import MODEL_NAME; \
-from sentence_transformers import SentenceTransformer; \
-m = SentenceTransformer(MODEL_NAME, device='cpu'); \
-v = m.encode(['offline load gate'], show_progress_bar=False); \
-assert v.shape[0] == 1 and v.shape[1] > 0, v.shape; \
+ && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 EXOMEM_EMBED_BACKEND=onnx \
+    /app/.venv/bin/python -c "\
+import importlib.util; \
+from exomem.embeddings import MODEL_NAME, VECTOR_DIM; \
+from exomem import embedding_backend as backend; \
+encoder = backend.load_encoder(MODEL_NAME, backend=backend.ONNX); \
+v = encoder.encode(['offline load gate'], batch_size=1); \
+assert v.shape == (1, VECTOR_DIM), v.shape; \
+assert importlib.util.find_spec('torch') is None, 'torch reached the hosted image'; \
 print('offline load verified', MODEL_NAME, v.shape)"
 
 ########################################################################
@@ -215,6 +221,7 @@ ENV PATH=/app/.venv/bin:$PATH \
     HF_HUB_OFFLINE=1 \
     TRANSFORMERS_OFFLINE=1 \
     EXOMEM_DISABLE_RANKING=1 \
+    EXOMEM_EMBED_BACKEND=onnx \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 

--- a/infra/ansible/roles/k3s/templates/config.yaml.j2
+++ b/infra/ansible/roles/k3s/templates/config.yaml.j2
@@ -31,9 +31,25 @@ etcd-s3: true
 etcd-s3-endpoint: {{ k3s_etcd_s3_endpoint | to_json }}
 etcd-s3-region: {{ k3s_etcd_s3_region | to_json }}
 etcd-s3-bucket: {{ k3s_etcd_s3_bucket | to_json }}
-etcd-s3-folder: exomem-private-alpha/etcd
+# Must match `name_prefix` on b2_application_key.etcd_snapshot_upload and
+# .etcd_snapshot_restore in infra/terraform/durability/storage.tf. It did not:
+# the keys permit `etcd-snapshot/` while this wrote to
+# `exomem-private-alpha/etcd`, so B2 rejected every upload AND every restore
+# listing with `not entitled`, silently, for the life of the cluster. The bucket
+# name already carries the deployment prefix, so repeating it here bought
+# nothing.
+etcd-s3-folder: etcd-snapshot
 etcd-s3-access-key: {{ k3s_etcd_s3_access_key | to_json }}
 etcd-s3-secret-key: {{ k3s_etcd_s3_secret_key | to_json }}
-etcd-s3-retention: 336
+# A COUNT of snapshots to keep on S3, not a duration — the previous 336 read as
+# "14 days of hours" but means 336 objects. Expiry is owned by the bucket's
+# lifecycle rule (hide at 30 days, delete one day later), so this is set above
+# anything that rule will ever allow to accumulate: 30-minute snapshots reach
+# ~1440 objects before lifecycle removes them. k3s therefore never prunes and
+# never issues a delete, which is what lets the upload identity stay
+# write-only. That matters because this credential lives on the node — if the
+# node is compromised it must not be able to erase its own etcd history.
+# k3s offers no way to disable S3 retention outright; it defaults to 5.
+etcd-s3-retention: 5000
 etcd-s3-timeout: 2m
 etcd-s3-skip-ssl-verify: false

--- a/infra/secrets/ansible/etcd-s3-access-key.v1.sops.json
+++ b/infra/secrets/ansible/etcd-s3-access-key.v1.sops.json
@@ -1,15 +1,15 @@
 {
-	"k3s_etcd_s3_access_key": "ENC[AES256_GCM,data:W7vkNpoEO9ea0kERuOr6Omw0OIvr0QR8+g==,iv:KgJf4qWttWsyowL/auhv1nXNi/g8ICDbRjJPn2byMUA=,tag:s44czLUs93ORWX0YRj+pmQ==,type:str]",
+	"k3s_etcd_s3_access_key": "ENC[AES256_GCM,data:Qy+el7eo2ilJdU/YOXe/knXlacpi7ppGdw==,iv:iw2d84ZoIzOojQd0k+dRyl8JZlr0tduEAUZC+NtWXnQ=,tag:72p36R1BTschSEneRfcgrg==,type:str]",
 	"sops": {
 		"age": [
 			{
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6TVBhYXpVYlk4ZklYZngv\nYm1OVmY0alpObWRpUzAwQVVjYUtGcWJOejBjCjZyMkNSSllaRlorN1p0V0ZWcHNz\nMFpBZXJCR1dtNWk4MmNKK0U5R3Rnc28KLS0tIGJJckkzMmVnRnpETWExakdGcnhP\nUHJ3aFFjZjVXK2ZRdHpXR2xrY0VMOWMKIIBZVPJ9255x6EHgFM8tJ3QWuisrCGED\nLy1c6njyr+U9A3sMl5XeRS8WB3hB+bvlRxRAckM7yjxLbkxrzKNocg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqbDRLY09qcW4rZ3FzN1pl\nNkxYUFU4bUZKemxnR2IyQy9BcEpnTHptaVFRClduODhCYTVRRnlzUUlsWHJaODE5\nWG4vVnZyQ1UwalByTVM2VEV1QVROMzgKLS0tIGlMaXhQajQxM1Q1dnNMSXh1NGZQ\nNjZ2WFQyNGJKbmdoRHJ4WWNrMWZDdlUKXC5xqbFlTHCYjSw/2V0whOXUfSItAKmr\ne05Xnr1UlRSodKntY9WbnzI5A6YFfQK8Rek3bF97E/nNFS9At2LIKA==\n-----END AGE ENCRYPTED FILE-----\n",
 				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
 			}
 		],
-		"lastmodified": "2026-07-26T10:43:45Z",
-		"mac": "ENC[AES256_GCM,data:DaJETUShLwCFz4zZGtLY8BNjDp9OqVxiJAg6cR8L4NMkwrruNJgqfRr4LztA+RaIKYU9r0Fq75XmPOk0XyBmV3sWscLALs9F2nNuD/Y41ymYDFRp1/nb4BOu6NV5A7q3cqd9U0ZwdDojIbcB5eOH0c956y6hQ9tsurB9JvHDq/Q=,iv:NgO8LeX8z8ppi0UEHMx4PnYG5e6b/V35kmiiRHoebjY=,tag:7QmhZtq7sDFqGqixh5G5tQ==,type:str]",
+		"lastmodified": "2026-08-05T07:14:15Z",
+		"mac": "ENC[AES256_GCM,data:AUcHutBj0j9VTyFIp0zKrjNm/LG4jX9uUGu56ftWwObsUgjJw34+Wi7fH62BKXp3RicYuhYQDj0QfCkblBT97EGWoxZvvz4C8OYRxXxpwymtxRky1ux7HOjP1epZJ7wdYcz7IrEBNdifFnO1tHlzR1BX2vEwe4ZXN+XISMIHiPE=,iv:K03H9ip3lnhnd+zAGlXZobE08e6nueDnrfUeF7SjgGk=,tag:fzkg87BJ5yxL/ICBQTOkUg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.13.2"
+		"version": "3.13.3"
 	}
 }

--- a/infra/secrets/ansible/etcd-s3-secret-key.v1.sops.json
+++ b/infra/secrets/ansible/etcd-s3-secret-key.v1.sops.json
@@ -1,15 +1,15 @@
 {
-	"k3s_etcd_s3_secret_key": "ENC[AES256_GCM,data:SeH0swlagSHmeajJLwfj9NDshPcV17YPQW52wHfjhA==,iv:5jke+FoSdHOrqtV3oq6y2oRyDzuyZubEB0Hqo7O0GUE=,tag:OzjdmYkCoV/3DiFJFog1yA==,type:str]",
+	"k3s_etcd_s3_secret_key": "ENC[AES256_GCM,data:yT2pDUallJg2SwYJBZLVljK2Cjx/M10cWkeTi17dhw==,iv:jfy1wFEUZRvG3d51TsH7AodLHLoztwJqv96E86L5rM0=,tag:1L2/0p6oyLOxOZK1ieTYeg==,type:str]",
 	"sops": {
 		"age": [
 			{
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZHErVjJ1VkNPWThKbkRv\nQ3RpeTMrRnpVcjB5aGpoK2NvdC9Va1d5OGhNCk9QcFUvdXI3RjVIb3diaW1yNklO\nd0RHN21uZGp2RHFhRCtIZytWQUhtMzQKLS0tIHRoSG5sNUxZaHNNNVhRRnFiejJh\nYnd4Q0oyUmNUWUZWQnVMY0pTcnNyQ0EKiXqh9on6yz1RbyEEx8wD5aKVg2EiK62p\nEt8vMaEuXNyXZjzNlCGZ2+8wrFERh2La5TvRcJ42o+XG4puwBD5Afg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRNmlhNCtDZ1hkQmxBS29E\ncGVhMzA2MHFXbXVsWHFCUzlSeWFma3ltLzE4ClFheXBhZ0NkZjcwRmhQbWQ1ek5Y\nSURSUTlwNlpZTWZmb2R1S0hlME90TVEKLS0tIC9oNy9TMkE3T3gxeWgzM0tkNHlT\nRDhzVVpsZTFJRHB0cTFQZk1YL3JrM28Knq0Ll6TKQbb1SnZAChgS/40VVfvWTyHR\nAsfTW1uUpSQUcyti47hHQGQfgvzSE6Ae5VlT6GOFOHedDiCuh7k+Jw==\n-----END AGE ENCRYPTED FILE-----\n",
 				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
 			}
 		],
-		"lastmodified": "2026-07-26T10:43:50Z",
-		"mac": "ENC[AES256_GCM,data:WQ+DFoVAZNn/UhcRxNHjqsARdjSNQMnBaA9f/m5MTYnYbLIYO/L801wJy726HV8ZYRF4AC2w0Bz0bOjYCLtJJf2xLo3Lzyw+rZyQ8F99AC20w9zvAwUAMCMhpJgLCQ3vJeudLgFnkUzhKedm/ghjCelwFl40VFC0ra5wr084y0I=,iv:eAarOPyHc+wSocHPKVs8+kvvAE4VIPWK2vFnP5DHV4A=,tag:Zacl171sbN4IXPA0EVmOdA==,type:str]",
+		"lastmodified": "2026-08-05T07:14:15Z",
+		"mac": "ENC[AES256_GCM,data:DW2uLZlrfUWw9qbVMCFW5zXBu+INSocjHD88quzkXvAx4EU0+bR4RHG4v2JfdtT1toQeDh27cAHDPoqQO7AfDBzTI/LekGHOCpmfGCLImmqrKtlrKSPMADT+hJlTctR74uu9wF1WfojhHQJ6I9nUpKn82eEQmi8RPbPK8hhBlfA=,iv:50QrAZ4AcLA5I6QsS44ccs4dxxnGnAMMteHXY8iyZo4=,tag:mz8wIk5yissdGozwWLR4qw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.13.2"
+		"version": "3.13.3"
 	}
 }

--- a/infra/terraform/durability/outputs.tf
+++ b/infra/terraform/durability/outputs.tf
@@ -10,6 +10,10 @@ output "database_backup_bucket_name" {
   value = b2_bucket.database_backup.bucket_name
 }
 
+output "etcd_snapshot_bucket_name" {
+  value = b2_bucket.etcd_snapshot.bucket_name
+}
+
 output "recovery_upload_application_key_id" {
   value     = b2_application_key.recovery_upload.application_key_id
   sensitive = true

--- a/infra/terraform/durability/storage.tf
+++ b/infra/terraform/durability/storage.tf
@@ -147,16 +147,59 @@ resource "b2_application_key" "database_backup_restore" {
   capabilities = ["listBuckets", "listFiles", "readFiles", "readFileRetentions"]
 }
 
+# etcd snapshots get their own bucket, and it deliberately has NO Object Lock.
+#
+# B2 requires a Content-MD5 or x-amz-checksum header on any PUT that carries
+# Object Lock parameters, and a bucket with a default retention applies those
+# parameters to every upload. k3s's uploader sends neither, so every snapshot
+# was rejected with "Content-MD5 OR x-amz-checksum- HTTP header is required".
+# Exomem's own durability workers are unaffected because boto3 sets Content-MD5
+# for locked PUTs; this is specific to k3s.
+#
+# Object Lock cannot be disabled once enabled on a B2 bucket, so sharing the
+# database-backup bucket would have meant dropping ITS default retention too —
+# stripping immutability from the provisioner's Postgres backups, which hold the
+# tenant-to-cell mapping and the capacity ledger. Splitting the bucket keeps that
+# protection where it matters most.
+#
+# The trade is explicit: etcd snapshots are no longer immutable. That is
+# acceptable because etcd holds cluster state, which is reconstructible from
+# Terraform and Ansible; tenant data lives in the recovery bucket and the
+# provisioner database, both of which stay locked.
+resource "b2_bucket" "etcd_snapshot" {
+  bucket_name = "${var.bucket_prefix}-etcd-${random_id.bucket_suffix.hex}"
+  bucket_type = "allPrivate"
+
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
+
+  lifecycle_rules {
+    file_name_prefix              = ""
+    days_from_uploading_to_hiding = 30
+    days_from_hiding_to_deleting  = 1
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Write-only by design: this credential lives on the node, so a compromised node
+# must not be able to erase its own etcd history. Expiry is owned by the bucket
+# lifecycle rule above rather than by k3s, which is why no delete capability is
+# granted here. See the matching comment in the k3s config template.
 resource "b2_application_key" "etcd_snapshot_upload" {
   key_name     = "exomem-etcd-snapshot-upload"
-  bucket_ids   = [b2_bucket.database_backup.bucket_id]
+  bucket_ids   = [b2_bucket.etcd_snapshot.bucket_id]
   name_prefix  = "etcd-snapshot/"
   capabilities = ["listBuckets", "listFiles", "writeFiles"]
 }
 
 resource "b2_application_key" "etcd_snapshot_restore" {
   key_name     = "exomem-etcd-snapshot-restore-jit"
-  bucket_ids   = [b2_bucket.database_backup.bucket_id]
+  bucket_ids   = [b2_bucket.etcd_snapshot.bucket_id]
   name_prefix  = "etcd-snapshot/"
   capabilities = ["listBuckets", "listFiles", "readFiles"]
 }

--- a/openspec/changes/swap-embedding-runtime-to-onnx/proposal.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+Tenant density on the alpha node is capped by the embedding runtime, not by the
+architecture. The node has 7751 MiB, of which 815 MiB is in use by K3s, containerd,
+metrics-server, and CoreDNS. Every remaining cell-shaped megabyte is a paying seat.
+
+The bi-encoder is loaded through `sentence-transformers`, which pulls the full PyTorch
+runtime into every cell. Measured on the identical model (`BAAI/bge-base-en-v1.5`):
+
+| | torch | ONNX Runtime |
+|---|---|---|
+| import cost | 431 MiB | 79 MiB |
+| warm resident | 854 MiB | 528 MiB |
+| encode throughput | baseline | 17% faster |
+
+The vectors are interchangeable: minimum cosine similarity 0.999977 across five texts
+including edge cases, same 768 dimensions. That is roughly forty times tighter than the
+fp16-versus-fp32 drift `_maybe_half` already documents as harmless for ranking, so this
+is a runtime substitution rather than a model change.
+
+326 MiB of warm resident per cell is the difference between four seats and six or more
+on hardware already paid for. Hetzner has retired the CX line, so the node cannot be
+resized and successors cost roughly four times as much for the same memory — density on
+the existing node is the only cheap capacity available.
+
+The alternative considered and rejected was a shared embedding service. It would collapse
+six model copies into one, but it cannot offer zero cross-tenant exposure: tenant text
+would cross a process boundary the isolation model currently forbids. ONNX reaches the
+same density with the isolation boundary untouched, so the trade is unnecessary.
+
+This change is deliberately sequenced before the first platform install. Composing the
+deployment lock pins an exact release; swapping the runtime afterwards would mean a
+second release, a second candidate, and recomposing the lock.
+
+## What Changes
+
+- Introduce an embedding-backend seam so the bi-encoder can be served by ONNX Runtime
+  without changing any calling code. All 32 call sites across 12 modules already route
+  through `get_model()` and `embed_texts()`.
+- Make device selection backend-aware. `accel.py` is torch-shaped end to end; ONNX
+  execution providers are not torch devices and need their own mapping.
+- Keep the measured batch-size policy (8 on CPU, 32 on accelerators) behind the seam,
+  because it currently reads `model.device`, which an ONNX session does not expose.
+- Build the hosted image from an ONNX-based stage and prove the offline load with an
+  `InferenceSession` rather than a `SentenceTransformer` construction. Retain the
+  model weights the grant promises; drop the torch weights the runtime no longer reads.
+- Make install readiness report the backend actually in use, so a torch-free hosted
+  image is not reported as unhealthy by a check that hardcodes torch.
+- Re-derive the cell memory envelope and the USER cell cap from the new measurement
+  rather than carrying the torch-sized values forward.
+
+Explicitly out of scope: the reranker and CLIP stay on `sentence-transformers`. The
+hosted image already disables ranking and does not carry CLIP, so the hosted lane can
+shed torch entirely while the `ml` and `cuda` images keep it.
+
+## Capabilities
+
+- `install-readiness` — the doctor's embeddings check becomes backend-aware.
+- `hosted-tenant-cell` — the cell's embedding runtime and memory envelope.
+
+## Impact
+
+No re-embedding and no migration. The model, its 768 dimensions, and the stored vector
+format are unchanged, and existing sidecars remain valid.
+
+That safety is currently incidental rather than enforced: the sidecar `meta` table stores
+only an instance identifier and generation tokens, and `SEMANTIC_UNIT_SCHEMA_VERSION`
+invalidates only on a parser change. Nothing records which model produced a vector, so a
+future model change would silently mix vector spaces. This change records an embedding
+runtime fingerprint so that hazard is closed while the code is open, without altering
+behaviour for the ONNX substitution itself.

--- a/openspec/changes/swap-embedding-runtime-to-onnx/proposal.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/proposal.md
@@ -5,23 +5,30 @@ architecture. The node has 7751 MiB, of which 815 MiB is in use by K3s, containe
 metrics-server, and CoreDNS. Every remaining cell-shaped megabyte is a paying seat.
 
 The bi-encoder is loaded through `sentence-transformers`, which pulls the full PyTorch
-runtime into every cell. Measured on the identical model (`BAAI/bge-base-en-v1.5`):
+runtime into every cell. Measured here on the identical model
+(`BAAI/bge-base-en-v1.5`), CPU, batch 8, same 15-text set through both runtimes:
 
 | | torch | ONNX Runtime |
 |---|---|---|
-| import cost | 431 MiB | 79 MiB |
-| warm resident | 854 MiB | 528 MiB |
-| encode throughput | baseline | 17% faster |
+| import cost | 399 MiB | 40 MiB |
+| peak resident | 905 MiB | 661 MiB |
+| load | 14.0 s | 1.1 s |
+| encode | 3.26 s | 0.91 s |
 
-The vectors are interchangeable: minimum cosine similarity 0.999977 across five texts
-including edge cases, same 768 dimensions. That is roughly forty times tighter than the
+The vectors are interchangeable: **minimum cosine similarity 0.99999994**, maximum
+absolute component difference 4.2e-07, identical 768 dimensions, and nearest-neighbour
+ordering identical on every input. That is four orders of magnitude tighter than the
 fp16-versus-fp32 drift `_maybe_half` already documents as harmless for ranking, so this
 is a runtime substitution rather than a model change.
 
-326 MiB of warm resident per cell is the difference between four seats and six or more
-on hardware already paid for. Hetzner has retired the CX line, so the node cannot be
-resized and successors cost roughly four times as much for the same memory — density on
-the existing node is the only cheap capacity available.
+Peak is the number that sizes a cell, and 244 MiB of it per cell is the difference
+between four seats and six or more on hardware already paid for. Hetzner has retired the
+CX line, so the node cannot be resized and successors cost roughly four times as much for
+the same memory — density on the existing node is the only cheap capacity available.
+
+These figures are a like-for-like comparison of the two runtimes on one workstation, not
+a cell envelope. The envelope that sets the cap is re-measured on the node itself, in the
+image, under realistic chunk load; see task 5.1.
 
 The alternative considered and rejected was a shared embedding service. It would collapse
 six model copies into one, but it cannot offer zero cross-tenant exposure: tenant text

--- a/openspec/changes/swap-embedding-runtime-to-onnx/specs/hosted-tenant-cell/spec.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/specs/hosted-tenant-cell/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: The embedding runtime is substitutable and provably equivalent
+
+The bi-encoder SHALL be reachable through a backend seam so the serving runtime can be
+substituted without changing retrieval behaviour or any calling code. A substituted
+backend SHALL produce vectors of the same dimensionality and SHALL be proven equivalent
+to the reference backend by cosine similarity on a fixed text set before it is shipped.
+
+A backend substitution SHALL NOT require re-embedding an existing vault, and SHALL NOT
+silently change which model produced stored vectors.
+
+#### Scenario: Backend is substituted
+
+- **WHEN** the embedding backend changes but the model identity and dimensionality do not
+- **THEN** stored vectors remain valid and no rebuild is triggered
+- **AND** an equivalence check on a fixed text set records the minimum cosine similarity
+
+#### Scenario: Model identity changes
+
+- **WHEN** a change would alter the model that produces vectors, not merely the runtime serving it
+- **THEN** the stored embedding runtime fingerprint no longer matches
+- **AND** the mismatch is surfaced rather than allowing two vector spaces to mix silently
+
+### Requirement: The hosted cell carries only the runtime it serves with
+
+The hosted image SHALL contain exactly one embedding runtime and the weights that runtime
+loads, and SHALL NOT carry weights or frameworks for a capability whose grant is withheld.
+The build SHALL prove the offline load with the runtime that actually serves requests.
+
+A cell runs with no egress and a read-only root filesystem, so an unproven load path is
+discovered by the first tenant to query by meaning rather than by the build.
+
+#### Scenario: Image is built for the hosted lane
+
+- **WHEN** the hosted image is built
+- **THEN** the build loads the model through the serving runtime with the hub pinned offline and asserts an encode succeeds
+- **AND** framework artifacts the serving runtime never reads are absent from the final image
+
+#### Scenario: Cell memory envelope is set
+
+- **WHEN** the embedding runtime changes the warm resident footprint of a cell
+- **THEN** the cell resource requests and limits are re-derived from a fresh measurement
+- **AND** the USER cell cap follows that measurement rather than the superseded envelope

--- a/openspec/changes/swap-embedding-runtime-to-onnx/specs/install-readiness/spec.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/specs/install-readiness/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Readiness reports the embedding backend actually in use
+
+The doctor's embeddings check SHALL determine health from the backend that is configured
+to serve, not from a fixed dependency list. An installation whose embedding backend loads
+and encodes SHALL be reported ready even when a framework used by a different backend is
+absent, and its remediation SHALL name the extra that installs the configured backend.
+
+Accelerator reporting SHALL be scoped to backends that can use one. A backend-specific
+accelerator probe SHALL NOT report a failure or a missing device for an installation that
+does not use that backend.
+
+#### Scenario: Hosted image is checked without torch present
+
+- **WHEN** `doctor --profile hybrid` runs on an image whose embedding backend is ONNX Runtime and which carries no torch
+- **THEN** the embeddings check passes on the strength of the configured backend loading and encoding
+- **AND** no failure is reported for the absent framework
+
+#### Scenario: Configured backend is missing
+
+- **WHEN** the configured embedding backend cannot be imported or cannot load the model
+- **THEN** the embeddings check fails
+- **AND** the remediation names the extra that installs that specific backend

--- a/openspec/changes/swap-embedding-runtime-to-onnx/tasks.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/tasks.md
@@ -1,0 +1,82 @@
+## 1. Prove equivalence before changing anything
+
+- [ ] 1.1 Add a committed equivalence check that encodes a fixed text set, including
+  empty, unicode, very long, and repeated-token edge cases, through both backends and
+  asserts minimum cosine similarity above 0.9999 at identical dimensionality. Record the
+  measured minimum rather than only asserting the bound.
+
+- [ ] 1.2 Capture the current torch baseline on the CPU profile the node runs — import
+  cost, warm resident, peak, and encode throughput — so the after-measurement is a
+  comparison rather than a claim.
+
+## 2. Introduce the backend seam
+
+- [ ] 2.1 Add a failing test asserting `embed_texts()` returns identical-shaped, unit-norm
+  vectors under either backend, selected by configuration, with no call-site change.
+
+- [ ] 2.2 Route `get_model()` through a backend seam. Keep the lazy singleton, the load
+  lock, and the local heavy import so `test_cli_lazy_imports` continues to prove the
+  framework stays off the hot path.
+
+- [ ] 2.3 Make `encode_batch_size()` take the batch policy from the backend rather than
+  reading `model.device`, preserving the measured policy: 8 on CPU, 32 on accelerators.
+
+- [ ] 2.4 Make device selection backend-aware in `accel.py` by mapping the selected device
+  onto execution providers for ONNX and leaving the torch path unchanged. Do not let a
+  torch-only concept such as fp16-on-MPS leak into the ONNX path.
+
+- [ ] 2.5 Keep idle reaping working under both backends. `unload_model()`, `_ModelGuard`,
+  and `BGE_GUARD` assume a torch object and a torch cache; give the seam an explicit
+  release hook instead.
+
+- [ ] 2.6 Record an embedding runtime fingerprint in the sidecar so a future model change
+  is detected rather than silently mixing vector spaces. Prove that substituting the
+  backend alone does not change the fingerprint and triggers no rebuild.
+
+## 3. Make readiness backend-aware
+
+- [ ] 3.1 Add a failing doctor test for an installation whose configured backend is ONNX
+  and where torch is absent, asserting the embeddings check passes and names the correct
+  remediation extra.
+
+- [ ] 3.2 Replace the hardcoded dependency triple with a check against the configured
+  backend, and scope the CUDA probe to backends that can use one.
+
+## 4. Build the hosted image on the new runtime
+
+- [ ] 4.1 Add the backend to the dependency set as its own extra, and stop pinning the
+  hosted lane to the CUDA torch index. Leave `ml` and `cuda` on torch — they still serve
+  the reranker and CLIP.
+
+- [ ] 4.2 Build the hosted stage against the new backend, exporting or fetching the model
+  in the ONNX form, and replace the offline load gate with one that constructs an
+  inference session and asserts an encode succeeds with the hub pinned offline.
+
+- [ ] 4.3 Trim the framework artifacts the serving runtime never reads, keeping the ONNX
+  weights, and assert the final hosted image contains no torch distribution.
+
+- [ ] 4.4 Prove the image embeds under the exact conditions a cell runs under —
+  `--network none --read-only --user 10001:10001 --cap-drop ALL`.
+
+## 5. Re-derive the envelope
+
+- [ ] 5.1 Measure warm resident and peak for one cell on the new runtime, on the node
+  profile in service, and record the numbers.
+
+- [ ] 5.2 Set the cell resource requests and limits and the namespace quota from that
+  measurement, keeping the declared and rendered worker policy in step.
+
+- [ ] 5.3 Raise the USER cell cap from the measurement, moving the operations contract and
+  its byte-identical chart copy together with the limits the provisioner hardcodes, and
+  correct the provisioner README, which still claims six cells against a contract of four.
+
+## 6. Verify
+
+- [ ] 6.1 Run the full repository suite plus the pinned validation gate and strict
+  OpenSpec validation.
+
+- [ ] 6.2 Confirm retrieval quality is unchanged on the golden retrieval set rather than
+  inferring it from cosine similarity alone.
+
+- [ ] 6.3 Independent review of the equivalence evidence, the measured envelope, and the
+  resulting cap.

--- a/openspec/changes/swap-embedding-runtime-to-onnx/tasks.md
+++ b/openspec/changes/swap-embedding-runtime-to-onnx/tasks.md
@@ -1,31 +1,31 @@
 ## 1. Prove equivalence before changing anything
 
-- [ ] 1.1 Add a committed equivalence check that encodes a fixed text set, including
+- [x] 1.1 Add a committed equivalence check that encodes a fixed text set, including
   empty, unicode, very long, and repeated-token edge cases, through both backends and
   asserts minimum cosine similarity above 0.9999 at identical dimensionality. Record the
   measured minimum rather than only asserting the bound.
 
-- [ ] 1.2 Capture the current torch baseline on the CPU profile the node runs — import
+- [x] 1.2 Capture the current torch baseline on the CPU profile the node runs — import
   cost, warm resident, peak, and encode throughput — so the after-measurement is a
   comparison rather than a claim.
 
 ## 2. Introduce the backend seam
 
-- [ ] 2.1 Add a failing test asserting `embed_texts()` returns identical-shaped, unit-norm
+- [x] 2.1 Add a failing test asserting `embed_texts()` returns identical-shaped, unit-norm
   vectors under either backend, selected by configuration, with no call-site change.
 
-- [ ] 2.2 Route `get_model()` through a backend seam. Keep the lazy singleton, the load
+- [x] 2.2 Route `get_model()` through a backend seam. Keep the lazy singleton, the load
   lock, and the local heavy import so `test_cli_lazy_imports` continues to prove the
   framework stays off the hot path.
 
-- [ ] 2.3 Make `encode_batch_size()` take the batch policy from the backend rather than
+- [x] 2.3 Make `encode_batch_size()` take the batch policy from the backend rather than
   reading `model.device`, preserving the measured policy: 8 on CPU, 32 on accelerators.
 
-- [ ] 2.4 Make device selection backend-aware in `accel.py` by mapping the selected device
+- [x] 2.4 Make device selection backend-aware in `accel.py` by mapping the selected device
   onto execution providers for ONNX and leaving the torch path unchanged. Do not let a
   torch-only concept such as fp16-on-MPS leak into the ONNX path.
 
-- [ ] 2.5 Keep idle reaping working under both backends. `unload_model()`, `_ModelGuard`,
+- [x] 2.5 Keep idle reaping working under both backends. `unload_model()`, `_ModelGuard`,
   and `BGE_GUARD` assume a torch object and a torch cache; give the seam an explicit
   release hook instead.
 
@@ -35,33 +35,39 @@
 
 ## 3. Make readiness backend-aware
 
-- [ ] 3.1 Add a failing doctor test for an installation whose configured backend is ONNX
+- [x] 3.1 Add a failing doctor test for an installation whose configured backend is ONNX
   and where torch is absent, asserting the embeddings check passes and names the correct
   remediation extra.
 
-- [ ] 3.2 Replace the hardcoded dependency triple with a check against the configured
+- [x] 3.2 Replace the hardcoded dependency triple with a check against the configured
   backend, and scope the CUDA probe to backends that can use one.
 
 ## 4. Build the hosted image on the new runtime
 
-- [ ] 4.1 Add the backend to the dependency set as its own extra, and stop pinning the
+- [x] 4.1 Add the backend to the dependency set as its own extra, and stop pinning the
   hosted lane to the CUDA torch index. Leave `ml` and `cuda` on torch — they still serve
   the reranker and CLIP.
 
-- [ ] 4.2 Build the hosted stage against the new backend, exporting or fetching the model
+- [x] 4.2 Build the hosted stage against the new backend, exporting or fetching the model
   in the ONNX form, and replace the offline load gate with one that constructs an
   inference session and asserts an encode succeeds with the hub pinned offline.
 
-- [ ] 4.3 Trim the framework artifacts the serving runtime never reads, keeping the ONNX
+- [x] 4.3 Trim the framework artifacts the serving runtime never reads, keeping the ONNX
   weights, and assert the final hosted image contains no torch distribution.
 
-- [ ] 4.4 Prove the image embeds under the exact conditions a cell runs under —
+- [x] 4.4 Prove the image embeds under the exact conditions a cell runs under —
   `--network none --read-only --user 10001:10001 --cap-drop ALL`.
 
 ## 5. Re-derive the envelope
 
 - [ ] 5.1 Measure warm resident and peak for one cell on the new runtime, on the node
   profile in service, and record the numbers.
+  - Measured in the hosted image under exact cell constraints (`--network none
+    --read-only --user 10001:10001 --cap-drop ALL --memory=1536m`), batch 8, 200
+    chunks: import 33 MiB, warm 548 MiB, **peak 604 MiB**, 22.7 chunks/s. The torch
+    envelope this replaces was 918 MiB peak at the same batch size.
+  - Still open because the cap also needs the platform's own memory delta, which
+    cannot be measured until the platform is installed on the node.
 
 - [ ] 5.2 Set the cell resource requests and limits and the namespace quota from that
   measurement, keeping the declared and rendered worker policy in step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,20 @@ embeddings = [
     # scan when absent or when this Python's sqlite3 can't load extensions.
     "sqlite-vec>=0.1.6",
 ]
+# Same bi-encoder, served by ONNX Runtime instead of PyTorch. Imports ~40 MiB against
+# torch's ~400 and holds a smaller peak, which is what decides how many hosted cells fit
+# a node. Vectors are interchangeable with the torch lane (see tests/test_embedding_backend.py),
+# so this is a runtime substitution and never a re-index.
+#
+# It cannot simply replace `embeddings`: the reranker and CLIP are sentence-transformers
+# models, so only a lane that withholds both — the hosted image does — can drop torch.
+# Select with EXOMEM_EMBED_BACKEND=onnx; `auto` picks torch whenever it is importable.
+embeddings-onnx = [
+    "onnxruntime>=1.20",
+    "tokenizers>=0.20",       # fast tokenizer, no torch and no transformers
+    "huggingface-hub>=0.24",  # resolves the published ONNX export from the hub cache
+    "sqlite-vec>=0.1.6",
+]
 # Server-side media extraction (transduction, not a brain): ASR for audio/video,
 # OCR for images, text for PDFs, MarkItDown for office/html docs. Optional so a lean box
 # runs without it — the code

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -134,9 +134,7 @@ def infer_profile() -> Profile:
         return raw  # type: ignore[return-value]
     if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
         return "lean"
-    embeddings_ready = all(
-        _module_available(name) for name in ("sentence_transformers", "torch", "PIL")
-    )
+    embeddings_ready = all(_module_available(name) for _, name in _embedding_requirements()[1])
     if not embeddings_ready:
         return "lean"
     media_ready = all(
@@ -381,6 +379,35 @@ def _check_schema_files(vault_root: Path | None) -> list[DoctorCheck]:
                 "restore the missing scaffold file from src/exomem/_scaffold/.",
             ))
     return checks
+
+
+def _embedding_requirements() -> tuple[str, list[tuple[str, str]]]:
+    """`(extra, [(distribution, import name)])` for the configured embedding backend.
+
+    Health belongs to the runtime that is actually configured to serve. A hosted
+    image built on ONNX Runtime carries no torch by design, and reporting that as
+    a missing dependency would mark a correct install unhealthy — and, through
+    `infer_profile`, silently demote it to `lean`, which is how a cell would come
+    to advertise keyword-only recall while holding a working embedder.
+    """
+    from . import embedding_backend
+
+    try:
+        backend = embedding_backend.resolve_backend(is_available=_module_available)
+    except ValueError:
+        # A misconfigured backend is reported by its own check; fall back to the
+        # default lane rather than raising out of a diagnostic command.
+        backend = embedding_backend.TORCH
+    if backend == embedding_backend.ONNX:
+        return "embeddings-onnx", [
+            ("onnxruntime", "onnxruntime"),
+            ("tokenizers", "tokenizers"),
+        ]
+    return "embeddings", [
+        ("sentence-transformers", "sentence_transformers"),
+        ("torch", "torch"),
+        ("pillow", "PIL"),
+    ]
 
 
 def _check_dependency(module: str, extra: str, *, import_name: str | None = None) -> DoctorCheck:
@@ -1903,16 +1930,18 @@ def doctor(
         checks.append(media_runtime)
 
     if profile in ("hybrid", "standard", "media"):
-        checks.extend([
-            _check_embeddings_disabled(),
-            _check_dependency("sentence-transformers", "embeddings", import_name="sentence_transformers"),
-            _check_dependency("torch", "embeddings"),
-            _check_dependency("pillow", "embeddings", import_name="PIL"),
-            _check_torch_cuda(),
-            _check_torch_device(),
-            _check_models_cache(),
-            _check_sqlite_vec(),
-        ])
+        extra, requirements = _embedding_requirements()
+        checks.append(_check_embeddings_disabled())
+        checks.extend(
+            _check_dependency(distribution, extra, import_name=import_name)
+            for distribution, import_name in requirements
+        )
+        # The torch accelerator probes describe a runtime this install may not
+        # have. Reporting "torch is not installed" on an ONNX image is noise
+        # about an absent framework, not a finding about the configured one.
+        if extra == "embeddings":
+            checks.extend([_check_torch_cuda(), _check_torch_device()])
+        checks.extend([_check_models_cache(), _check_sqlite_vec()])
         mps_headroom = _check_mps_headroom()
         if mps_headroom is not None:
             checks.append(mps_headroom)

--- a/src/exomem/embedding_backend.py
+++ b/src/exomem/embedding_backend.py
@@ -1,0 +1,296 @@
+"""Serving backend for the bi-encoder: torch/sentence-transformers or ONNX Runtime.
+
+The model is fixed; only the runtime that serves it is chosen here. That
+distinction is the whole point of the seam — a backend swap must not change
+which vectors a vault holds, so stored embeddings stay valid and nothing is
+re-indexed. `fingerprint()` records the model identity that *would* invalidate
+them, deliberately excluding the backend name.
+
+Why this exists: `sentence-transformers` pulls the full PyTorch runtime into
+every process that embeds. In a hosted cell that is the binding constraint on
+how many tenants a node carries — measured on the identical model, ONNX Runtime
+imports ~80 MiB against torch's ~400 and holds a smaller warm resident, with
+vectors interchangeable to a cosine similarity far tighter than the fp16 drift
+`embeddings._maybe_half` already accepts as harmless for ranking.
+
+Backends are equivalent in output, not in reach: torch also serves the reranker
+and CLIP, so only the hosted lane — which withholds both — can drop it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from typing import Protocol
+
+import numpy as np
+
+from . import accel
+
+log = logging.getLogger(__name__)
+
+#: Selects the serving runtime. ``auto`` prefers torch when it is importable so a
+#: developer box keeps its existing behaviour, and falls back to ONNX Runtime —
+#: which is what a torch-free hosted image lands on without configuration.
+BACKEND_ENV = "EXOMEM_EMBED_BACKEND"
+TORCH = "torch"
+ONNX = "onnx"
+_VALID = (TORCH, ONNX)
+
+#: BGE pools the CLS token rather than averaging; see the model's 1_Pooling
+#: config. Getting this wrong yields plausible-looking vectors that rank badly,
+#: which is exactly the failure a similarity gate is meant to catch.
+_POOLING_CLS = "cls"
+_DEFAULT_MAX_SEQ = 512
+
+
+class Encoder(Protocol):
+    """What `embeddings` needs from a serving runtime, and nothing more."""
+
+    #: Backend identifier, for logging and readiness reporting.
+    backend: str
+    #: Device the model actually landed on, in torch's vocabulary.
+    device: str
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        batch_size: int,
+        normalize_embeddings: bool = True,
+        convert_to_numpy: bool = True,
+        show_progress_bar: bool = False,
+    ) -> np.ndarray: ...
+
+    def release(self) -> None:
+        """Drop runtime-held memory. Called after the singleton is dropped."""
+
+
+def resolve_backend(*, is_available: Callable[[str], bool] | None = None) -> str:
+    """Which runtime should serve, honouring an explicit choice over detection.
+
+    `is_available` lets a caller supply its own import probe so detection agrees
+    with whatever that caller reports elsewhere — `doctor` passes its own, so a
+    single probe decides both the profile it infers and the dependencies it lists.
+    """
+    raw = (os.environ.get(BACKEND_ENV) or "").strip().lower()
+    if raw in _VALID:
+        return raw
+    if raw and raw != "auto":
+        raise ValueError(f"unknown {BACKEND_ENV}: {raw!r}. Valid: {list(_VALID)} or 'auto'")
+    probe = is_available or _importable
+    if probe("sentence_transformers"):
+        return TORCH
+    # ONNX only when it is genuinely the installed lane. With neither present the
+    # answer is torch, so an install that has no embedding backend at all is told
+    # to install the default one rather than the specialised hosted alternative.
+    return ONNX if probe("onnxruntime") else TORCH
+
+
+def _importable(module: str) -> bool:
+    """Whether `module` can be imported, without importing it.
+
+    An already-imported module counts even when it carries no import spec —
+    something injected into `sys.modules` is importable by definition, and
+    `find_spec` raises rather than answering for that case.
+    """
+    import importlib.util
+    import sys
+
+    if module in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):  # namespace oddities → treat as absent
+        return False
+
+
+def fingerprint(model_name: str) -> str:
+    """Identity of the vectors a vault holds — model and pooling, not backend.
+
+    Recorded alongside a sidecar so a future *model* change is detected instead
+    of silently mixing two vector spaces. A backend substitution must leave this
+    unchanged, which is what makes it a substitution rather than a migration.
+    """
+    return f"{model_name}|{_POOLING_CLS}|l2"
+
+
+class _TorchEncoder:
+    """sentence-transformers, unchanged in behaviour from the pre-seam path."""
+
+    backend = TORCH
+
+    def __init__(self, model_name: str, device: str, half: bool) -> None:
+        # Heavy import stays local — keyword-mode and a lean install must not pay it.
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer(model_name, device=device)
+        self._model = _maybe_half(model, device) if half else model
+        self.device = device
+
+    def encode(self, texts, **kwargs) -> np.ndarray:
+        kwargs.setdefault("convert_to_numpy", True)
+        kwargs.setdefault("normalize_embeddings", True)
+        kwargs.setdefault("show_progress_bar", False)
+        return self._model.encode(texts, **kwargs)
+
+    def release(self) -> None:
+        self._model = None
+        accel.empty_cache()
+
+
+class _OnnxEncoder:
+    """ONNX Runtime over the model's published ONNX export.
+
+    Reimplements only what sentence-transformers did for this model: tokenize,
+    run the encoder, take the CLS vector, L2-normalise. There is no torch here,
+    which is the entire reason the hosted image can shed ~300 MiB per cell.
+    """
+
+    backend = ONNX
+
+    def __init__(self, model_name: str, device: str) -> None:
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+
+        onnx_path = _resolve(model_name, "onnx/model.onnx")
+        tokenizer_path = _resolve(model_name, "tokenizer.json")
+
+        self._tokenizer = Tokenizer.from_file(tokenizer_path)
+        self._tokenizer.enable_truncation(max_length=_max_seq_length(model_name))
+        self._tokenizer.enable_padding(pad_id=0, pad_token="[PAD]")
+
+        options = ort.SessionOptions()
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        # One intra-op thread per cell core. Left at the runtime default here;
+        # the cell sets OMP_NUM_THREADS, which onnxruntime honours.
+        self._session = ort.InferenceSession(
+            onnx_path, sess_options=options, providers=_providers(device)
+        )
+        self._inputs = {spec.name for spec in self._session.get_inputs()}
+        self.device = device
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        batch_size: int = 8,
+        normalize_embeddings: bool = True,
+        convert_to_numpy: bool = True,  # noqa: ARG002 — always numpy; kept for parity
+        show_progress_bar: bool = False,  # noqa: ARG002 — no progress bar to suppress
+    ) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+        out: list[np.ndarray] = []
+        for start in range(0, len(texts), max(1, batch_size)):
+            out.append(self._encode_batch(texts[start : start + batch_size], normalize_embeddings))
+        return np.vstack(out)
+
+    def _encode_batch(self, batch: list[str], normalize: bool) -> np.ndarray:
+        encodings = self._tokenizer.encode_batch(batch)
+        feed = {
+            "input_ids": np.array([e.ids for e in encodings], dtype=np.int64),
+            "attention_mask": np.array([e.attention_mask for e in encodings], dtype=np.int64),
+            "token_type_ids": np.array([e.type_ids for e in encodings], dtype=np.int64),
+        }
+        hidden = self._session.run(None, {k: v for k, v in feed.items() if k in self._inputs})[0]
+        pooled = hidden[:, 0]  # CLS
+        if normalize:
+            norms = np.linalg.norm(pooled, axis=1, keepdims=True)
+            pooled = pooled / np.maximum(norms, 1e-12)
+        return pooled.astype(np.float32, copy=False)
+
+    def release(self) -> None:
+        self._session = None
+        self._tokenizer = None
+
+
+def _providers(device: str) -> list[str]:
+    """Map a torch-shaped device onto ONNX Runtime execution providers.
+
+    Providers are not torch devices: the list is an ordered preference and the
+    runtime silently uses the first one it can construct. CPU is always appended
+    so an unavailable accelerator degrades rather than raising — the same
+    politeness `accel.gpu_usable` applies on the torch side.
+    """
+    import onnxruntime as ort
+
+    available = set(ort.get_available_providers())
+    preferred: list[str] = []
+    if device.startswith("cuda") and "CUDAExecutionProvider" in available:
+        preferred.append("CUDAExecutionProvider")
+    elif device == "mps" and "CoreMLExecutionProvider" in available:
+        preferred.append("CoreMLExecutionProvider")
+    preferred.append("CPUExecutionProvider")
+    return preferred
+
+
+def _resolve(model_name: str, filename: str) -> str:
+    """Path to a model file, from the local hub cache when offline."""
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(model_name, filename)
+
+
+def _max_seq_length(model_name: str) -> int:
+    """The model's declared sequence limit, defaulting to BERT's 512."""
+    try:
+        with open(_resolve(model_name, "sentence_bert_config.json"), encoding="utf-8") as fh:
+            return int(json.load(fh).get("max_seq_length") or _DEFAULT_MAX_SEQ)
+    except Exception:  # noqa: BLE001 — a missing config must not block loading
+        log.debug("no sentence_bert_config for %s; using %d", model_name, _DEFAULT_MAX_SEQ)
+        return _DEFAULT_MAX_SEQ
+
+
+def _maybe_half(model, device: str):
+    """fp16 on Apple Silicon only. Imported by `embeddings` for backwards parity."""
+    if device != "mps" or os.environ.get("EXOMEM_MPS_FP16", "1") == "0":
+        return model
+    try:
+        return model.half()
+    except Exception:  # noqa: BLE001 — a precision tweak must never break model load
+        log.warning("fp16 (MPS) conversion failed; staying fp32", exc_info=True)
+        return model
+
+
+def load_encoder(model_name: str, *, backend: str | None = None) -> Encoder:
+    """Construct the configured backend for `model_name`.
+
+    Device selection stays with `accel`, which already returns ``cpu`` when torch
+    is absent — so a torch-free image resolves correctly without a special case.
+    """
+    chosen = backend or resolve_backend()
+    device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
+    log.info("loading embedding model %s on %s via %s", model_name, device, chosen)
+    if chosen == ONNX:
+        return _OnnxEncoder(model_name, device)
+    return _TorchEncoder(model_name, device, half=True)
+
+
+def batch_size_for(device: str) -> int:
+    """Encode batch size for a device, honouring an explicit override.
+
+    Batch size sets peak resident memory, because activations scale with it while
+    the weights do not. Measured on CPU with bge-base at ~280-token chunks: batch
+    32 peaks at 1332 MiB and yields 1.8 chunks/s, batch 8 peaks at 918 MiB and
+    yields 2.3 chunks/s. On CPU a large batch is strictly worse on both axes — it
+    buys no parallelism the cores were not already giving and just costs cache
+    locality. On an accelerator the opposite holds, so the choice follows the
+    device rather than being one global constant.
+
+    This matters most where memory is the binding constraint: a hosted cell's
+    limit is sized from this peak, and peak per cell decides how many tenants a
+    node carries.
+    """
+    override = os.environ.get("EXOMEM_EMBED_BATCH", "").strip()
+    if override:
+        try:
+            parsed = int(override)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    normalized = device.lower()
+    return 32 if (normalized.startswith("cuda") or normalized == "mps") else 8

--- a/src/exomem/embeddings.py
+++ b/src/exomem/embeddings.py
@@ -29,7 +29,7 @@ from typing import Any
 
 import numpy as np
 
-from . import accel, index_paths, vecstore
+from . import accel, embedding_backend, index_paths, vecstore
 from .clip_index import CLIP_DIM, ClipIndex
 from .embedding_index import VECTOR_DIM, EmbeddingIndex
 from .vector_index_common import vec_gate as _vec_gate
@@ -131,6 +131,13 @@ def unload_model() -> bool:
         if _MODEL is None or BGE_GUARD.inflight() > 0:
             return False
         m, _MODEL = _MODEL, None
+    # Backends hold runtime memory the reference drop alone will not return: an
+    # ONNX session owns arenas outside Python's heap, and torch owns a caching
+    # allocator. `release` is where each says how to give it back.
+    release = getattr(m, "release", None)
+    if release is not None:
+        with contextlib.suppress(Exception):  # unload must never raise
+            release()
     del m
     gc.collect()
     accel.empty_cache()
@@ -208,20 +215,20 @@ def _is_embeddable_path(path: Path) -> bool:
 
 
 def get_model():
-    """Lazy singleton selected by ``accel``, CPU-default unless explicitly set."""
+    """Lazy singleton served by the configured backend, CPU-default unless set.
+
+    The backend decides which runtime loads the model; the model itself, its
+    pooling, and its output are fixed, so a backend change never invalidates a
+    stored vector. `embedding_backend.load_encoder` keeps the heavy import local
+    for the same reason this function did — a lean install must not pay it.
+    """
     global _MODEL
     if _MODEL is not None:
         return _MODEL
     with _MODEL_LOCK:
         if _MODEL is not None:
             return _MODEL
-        # Heavy import stays local — keyword-mode and existing tests must not
-        # pay this cost.
-        from sentence_transformers import SentenceTransformer
-
-        device = accel.select_device(override_env="EXOMEM_EMBED_DEVICE")
-        log.info("loading embedding model %s on %s", MODEL_NAME, device)
-        _MODEL = _maybe_half(SentenceTransformer(MODEL_NAME, device=device), device)
+        _MODEL = embedding_backend.load_encoder(MODEL_NAME)
     BGE_GUARD.touch()  # start the idle clock at load, not epoch 0
     return _MODEL
 
@@ -243,24 +250,20 @@ def get_reranker():
     return _RERANKER
 
 
-def _maybe_half(model, device: str):
-    """Run bge/CLIP in fp16 on Apple Silicon (MPS): ~half the memory and faster encodes,
-    and these retrieval models tolerate half precision well. Gated to MPS only — CPU fp16
-    is emulated (slower) and the CUDA path stays fp32 for cross-run/voiceprint parity.
-    Disable with EXOMEM_MPS_FP16=0.
-
-    Storage is unaffected: every vector is upcast to float32 before it hits the sqlite blob
-    (the astype(np.float32) guards in embed_*/upsert_*), so the on-disk format is identical —
-    only the computed precision changes. Existing fp32 vectors differ from new fp16 ones by
-    ~1e-3 (harmless for ranking); `audit_fix(rebuild_embeddings=True)` re-embeds for exact
-    consistency if wanted."""
-    if device != "mps" or os.environ.get("EXOMEM_MPS_FP16", "1") == "0":
-        return model
-    try:
-        return model.half()
-    except Exception:  # noqa: BLE001 — a precision tweak must never break model load
-        log.warning("fp16 (MPS) conversion failed; staying fp32", exc_info=True)
-        return model
+# Run bge/CLIP in fp16 on Apple Silicon (MPS): ~half the memory and faster encodes, and
+# these retrieval models tolerate half precision well. Gated to MPS only — CPU fp16 is
+# emulated (slower) and the CUDA path stays fp32 for cross-run/voiceprint parity. Disable
+# with EXOMEM_MPS_FP16=0.
+#
+# Storage is unaffected: every vector is upcast to float32 before it hits the sqlite blob
+# (the astype(np.float32) guards in embed_*/upsert_*), so the on-disk format is identical —
+# only the computed precision changes. Existing fp32 vectors differ from new fp16 ones by
+# ~1e-3 (harmless for ranking); `audit_fix(rebuild_embeddings=True)` re-embeds for exact
+# consistency if wanted.
+#
+# It lives in `embedding_backend` because the torch encoder applies it at load; CLIP below
+# and `tests/test_accel.py` reach it through this name.
+_maybe_half = embedding_backend._maybe_half
 
 
 class ClipUnavailable(Exception):
@@ -899,28 +902,14 @@ def _chunks_for_page(vault_root: Path, page) -> list[str]:
 def encode_batch_size(model) -> int:
     """Encode batch size for the device the model actually landed on.
 
-    Batch size sets peak resident memory, because activations scale with it
-    while the weights do not. Measured on CPU with bge-base at ~280-token
-    chunks: batch 32 peaks at 1332 MiB and yields 1.8 chunks/s, batch 8 peaks
-    at 918 MiB and yields 2.3 chunks/s. On CPU a large batch is strictly worse
-    on both axes — it buys no parallelism the cores were not already giving and
-    just costs cache locality. On an accelerator the opposite holds, so the
-    choice follows the device rather than being one global constant.
-
-    This matters most where memory is the binding constraint: a hosted cell's
-    limit is sized from this peak, and peak per cell is what decides how many
-    tenants a node carries.
+    The policy lives in `embedding_backend.batch_size_for` so both backends share
+    one rule. An ONNX session exposes no `.device`, so the backend carries the
+    resolved device rather than the batch size being inferred from the model
+    object; `getattr` keeps a bare sentence-transformers model working for callers
+    and tests that construct one directly.
     """
-    override = os.environ.get("EXOMEM_EMBED_BATCH", "").strip()
-    if override:
-        try:
-            parsed = int(override)
-        except ValueError:
-            parsed = 0
-        if parsed > 0:
-            return parsed
-    device = str(getattr(model, "device", "cpu")).lower()
-    return 32 if (device.startswith("cuda") or device == "mps") else 8
+    device = str(getattr(model, "device", "cpu"))
+    return embedding_backend.batch_size_for(device)
 
 
 def embed_texts(texts: list[str], *, is_query: bool = False) -> np.ndarray:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -384,6 +384,59 @@ def test_doctor_infers_hybrid_from_installed_embeddings(monkeypatch: pytest.Monk
     assert doctor_module.infer_profile() == "hybrid"
 
 
+def test_doctor_infers_hybrid_from_onnx_backend_without_torch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A torch-free ONNX image holds a working embedder and must not be demoted.
+
+    Demotion to `lean` is not cosmetic: it is how a hosted cell would come to
+    advertise keyword-only recall while carrying the weights for semantic search.
+    """
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setattr(
+        doctor_module,
+        "_module_available",
+        lambda name: name in {"onnxruntime", "tokenizers"},
+    )
+    assert doctor_module.infer_profile() == "hybrid"
+
+
+def test_embedding_requirements_follow_the_configured_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "onnx")
+    extra, requirements = doctor_module._embedding_requirements()
+    assert extra == "embeddings-onnx"
+    assert [name for _, name in requirements] == ["onnxruntime", "tokenizers"]
+
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "torch")
+    extra, requirements = doctor_module._embedding_requirements()
+    assert extra == "embeddings"
+    assert "torch" in {name for _, name in requirements}
+
+
+def test_embedding_requirements_survive_an_invalid_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """doctor diagnoses configuration; it must not raise on the one it is diagnosing."""
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "tensorflow")
+    extra, _requirements = doctor_module._embedding_requirements()
+    assert extra == "embeddings"
+
+
+def test_doctor_omits_torch_probes_on_the_onnx_lane(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "onnx")
+    report = doctor_module.doctor(vault=str(tmp_path), profile="hybrid")
+    ids = {check.id for check in report.checks}
+
+    assert "dep.torch" not in ids
+    assert "torch.cuda" not in ids
+    assert "dep.onnxruntime" in ids
+    assert "dep.tokenizers" in ids
+
+
 def test_doctor_infers_media_when_full_stack_is_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -1,0 +1,167 @@
+"""Backend seam: selection policy, batch policy, and cross-backend equivalence.
+
+The equivalence case is opt-in because it loads the model twice under two
+runtimes and needs the weights present. Everything else runs everywhere and is
+what guards the policy a lean install actually exercises.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from exomem import embedding_backend
+
+RUN_EQUIVALENCE = os.environ.get("RUN_EMBED_EQUIVALENCE_TEST") == "1"
+
+#: Fixed text set for the equivalence gate. Deliberately includes the shapes a
+#: tokenizer is most likely to disagree on: empty, whitespace-only, non-ASCII,
+#: emoji, over-length (truncation), and code-shaped text.
+EQUIVALENCE_TEXTS = [
+    "",
+    " ",
+    "a",
+    "The mitochondrion is the powerhouse of the cell.",
+    "Exomem is a governed long-term memory store for durable conclusions.",
+    "  leading and trailing whitespace  ",
+    "Ünïcödé ñoñ-ÄSCII — em-dash, curly ’quotes‘, and 中文字符 mixed in.",
+    "🧠🔬 emoji only 🚀",
+    "repeat " * 300,
+    "\n\nnewlines\n\tand\ttabs\n\n",
+    "SELECT * FROM notes WHERE id = 42; -- code-shaped text",
+    "The quick brown fox jumps over the lazy dog. " * 20,
+]
+
+#: The measured floor. The observed minimum on this set is 0.99999994; the bound
+#: is set well below that so ordinary runtime jitter does not fail the gate,
+#: while a pooling or tokenizer mistake — which lands orders of magnitude lower —
+#: still does.
+MIN_COSINE = 0.9999
+
+
+def test_explicit_backend_wins_over_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(embedding_backend.BACKEND_ENV, "onnx")
+    assert embedding_backend.resolve_backend() == embedding_backend.ONNX
+    monkeypatch.setenv(embedding_backend.BACKEND_ENV, "torch")
+    assert embedding_backend.resolve_backend() == embedding_backend.TORCH
+
+
+def test_unknown_backend_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(embedding_backend.BACKEND_ENV, "tensorflow")
+    with pytest.raises(ValueError, match="unknown"):
+        embedding_backend.resolve_backend()
+
+
+def test_auto_prefers_torch_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(embedding_backend.BACKEND_ENV, "auto")
+    monkeypatch.setitem(sys.modules, "sentence_transformers", types.ModuleType("st"))
+    assert embedding_backend.resolve_backend() == embedding_backend.TORCH
+
+
+def test_auto_selects_onnx_when_it_is_the_installed_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A torch-free hosted image must land on ONNX without being configured."""
+    monkeypatch.delenv(embedding_backend.BACKEND_ENV, raising=False)
+    assert (
+        embedding_backend.resolve_backend(is_available=lambda name: name == "onnxruntime")
+        == embedding_backend.ONNX
+    )
+
+
+def test_auto_defaults_to_torch_when_no_backend_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With nothing installed, name the default lane — not the hosted alternative.
+
+    This is what decides which `uv sync --extra` a fresh box is told to run.
+    """
+    monkeypatch.delenv(embedding_backend.BACKEND_ENV, raising=False)
+    assert (
+        embedding_backend.resolve_backend(is_available=lambda _name: False)
+        == embedding_backend.TORCH
+    )
+
+
+def test_already_imported_module_counts_as_importable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A module injected into sys.modules has no spec but is importable."""
+    injected = types.ModuleType("exomem_fake_backend_probe")
+    assert injected.__spec__ is None
+    monkeypatch.setitem(sys.modules, "exomem_fake_backend_probe", injected)
+    assert embedding_backend._importable("exomem_fake_backend_probe") is True
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [("cpu", 8), ("CPU", 8), ("cuda", 32), ("cuda:1", 32), ("mps", 32), ("", 8)],
+)
+def test_batch_size_follows_device(
+    device: str, expected: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("EXOMEM_EMBED_BATCH", raising=False)
+    assert embedding_backend.batch_size_for(device) == expected
+
+
+def test_batch_size_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_EMBED_BATCH", "3")
+    assert embedding_backend.batch_size_for("cuda") == 3
+
+
+@pytest.mark.parametrize("bad", ["0", "-4", "not-a-number", "  "])
+def test_batch_size_ignores_unusable_override(bad: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXOMEM_EMBED_BATCH", bad)
+    assert embedding_backend.batch_size_for("cpu") == 8
+
+
+def test_fingerprint_excludes_the_backend() -> None:
+    """A backend swap must not look like a model change, or it would re-index."""
+    assert embedding_backend.ONNX not in embedding_backend.fingerprint("BAAI/bge-base-en-v1.5")
+    assert embedding_backend.TORCH not in embedding_backend.fingerprint("BAAI/bge-base-en-v1.5")
+    assert embedding_backend.fingerprint("model-a") != embedding_backend.fingerprint("model-b")
+
+
+def test_providers_always_end_in_cpu() -> None:
+    """An unavailable accelerator must degrade, never raise."""
+    pytest.importorskip("onnxruntime")
+    for device in ("cpu", "cuda", "cuda:1", "mps"):
+        assert embedding_backend._providers(device)[-1] == "CPUExecutionProvider"
+
+
+@pytest.mark.skipif(not RUN_EQUIVALENCE, reason="set RUN_EMBED_EQUIVALENCE_TEST=1")
+def test_onnx_and_torch_produce_interchangeable_vectors() -> None:
+    """Same model, two runtimes: vectors must be substitutable without re-indexing.
+
+    Asserts the property that actually matters — that an existing vault's vectors
+    stay comparable to newly encoded ones — rather than bitwise equality, which
+    no two runtimes give.
+    """
+    pytest.importorskip("sentence_transformers")
+    pytest.importorskip("onnxruntime")
+
+    from exomem.embeddings import MODEL_NAME
+
+    torch_encoder = embedding_backend.load_encoder(MODEL_NAME, backend=embedding_backend.TORCH)
+    onnx_encoder = embedding_backend.load_encoder(MODEL_NAME, backend=embedding_backend.ONNX)
+
+    left = torch_encoder.encode(EQUIVALENCE_TEXTS, batch_size=8)
+    right = onnx_encoder.encode(EQUIVALENCE_TEXTS, batch_size=8)
+
+    assert left.shape == right.shape
+    assert left.shape[1] == 768
+    assert right.dtype == np.float32
+    assert np.allclose(np.linalg.norm(right, axis=1), 1.0, atol=1e-5)
+
+    cosine = (left * right).sum(1) / (
+        np.linalg.norm(left, axis=1) * np.linalg.norm(right, axis=1)
+    )
+    assert cosine.min() >= MIN_COSINE, f"minimum cosine {cosine.min():.9f} below {MIN_COSINE}"
+
+    # Ranking is what retrieval actually consumes, so prove the ordering survives
+    # rather than inferring it from similarity.
+    left_rank = np.argsort(-(left @ left.T), axis=1)[:, 0]
+    right_rank = np.argsort(-(right @ right.T), axis=1)[:, 0]
+    assert (left_rank == right_rank).all()

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -2036,20 +2036,25 @@ def test_exact_k3s_runs_the_reviewed_hosted_runtime_release(k3s: str, tmp_path: 
     image = _build_reviewed_runtime_image(gate, tmp_path)
     try:
         runtime_image = _import_runtime_image(k3s, image)
-        release = json.loads(
-            (ROOT / "infra/contracts/exomem-hosted-release-v1.json").read_text(
-                encoding="utf-8"
-            )
+        # The tenant admission policy pins the exact runtime image, and that image
+        # is read from the deployment lock rather than a standalone release
+        # manifest. Rebind the reviewed lock to the digest we just imported so the
+        # policy admits the image this gate actually built.
+        validation_values = yaml.safe_load(
+            (PLATFORM / "values.validation.yaml").read_text(encoding="utf-8")
         )
-        release["runtimeImage"] = runtime_image
+        lock = json.loads(validation_values["provisioner"]["deploymentLockJson"])
+        lock["components"]["runtime"]["image"] = runtime_image
+        lock_json = json.dumps(lock, sort_keys=True, separators=(",", ":")) + "\n"
         platform_runtime_values = tmp_path / "platform-runtime-values.yaml"
         platform_runtime_values.write_text(
             yaml.safe_dump(
                 {
                     "provisioner": {
-                        "releaseManifestJson": json.dumps(
-                            release, sort_keys=True, separators=(",", ":")
-                        )
+                        "deploymentLockJson": lock_json,
+                        "deploymentLockSha256": hashlib.sha256(
+                            lock_json.encode("utf-8")
+                        ).hexdigest(),
                     }
                 }
             ),

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -226,8 +227,27 @@ def test_k3s_snapshot_and_break_glass_contract_is_off_host_and_versioned() -> No
 
     assert "etcd-s3: true" in config
     assert "etcd-s3-skip-ssl-verify: false" in config
-    assert "etcd-s3-folder: exomem-private-alpha/etcd" in config
     assert "secrets-encryption: true" in config
+
+    # The folder must match the prefix the B2 keys permit. It did not, and every
+    # upload AND every restore listing was rejected as `not entitled` for the
+    # life of the cluster — silently, because the only signal was a journal line.
+    # Pinning the folder as a literal string is what let the two drift apart, so
+    # cross-check them instead: this assertion fails on either side changing
+    # alone.
+    storage = (INFRA / "terraform/durability/storage.tf").read_text(encoding="utf-8")
+    folder = re.search(r"^etcd-s3-folder:\s*(\S+)\s*$", config, re.MULTILINE)
+    assert folder is not None, "etcd-s3-folder is not set"
+    for key in ("etcd_snapshot_upload", "etcd_snapshot_restore"):
+        block = storage.split(f'resource "b2_application_key" "{key}"', 1)[1].split(
+            "\nresource ", 1
+        )[0]
+        prefix = re.search(r'name_prefix\s*=\s*"([^"]+)"', block)
+        assert prefix is not None, key
+        assert prefix.group(1) == f"{folder.group(1)}/", (
+            f"{key} permits {prefix.group(1)!r} but k3s writes to "
+            f"{folder.group(1)!r}/ — B2 will reject every object as 'not entitled'"
+        )
     assert set(destinations) == {
         "ansible.hosted-node.k3s-server-token.active",
         "escrow.k3s-server-token.active",

--- a/tests/test_hosted_terraform_contract.py
+++ b/tests/test_hosted_terraform_contract.py
@@ -107,14 +107,14 @@ def test_cloudflare_tunnel_has_exact_control_and_transfer_ingress() -> None:
 
 def test_durability_has_object_lock_retention_and_split_credentials() -> None:
     storage = (DURABILITY / "storage.tf").read_text(encoding="utf-8")
-    outputs = (DURABILITY / "outputs.tf").read_text(encoding="utf-8")
 
     assert storage.count("file_lock_configuration") == 2
     assert storage.count("is_file_lock_enabled = true") == 2
     assert storage.count('mode = "governance"') == 2
     assert storage.count("duration = 7") == 2
     assert storage.count('unit     = "days"') == 2
-    assert storage.count("days_from_uploading_to_hiding = 30") == 2
+    # recovery, database_backup, and etcd_snapshot; user_export uses 31.
+    assert storage.count("days_from_uploading_to_hiding = 30") == 3
     assert 'resource "b2_bucket" "user_export"' in storage
     user_export = storage.split('resource "b2_bucket" "user_export"', 1)[1].split(
         'resource "b2_bucket" "database_backup"', 1
@@ -138,6 +138,47 @@ def test_durability_has_object_lock_retention_and_split_credentials() -> None:
     assert 'key_name     = "exomem-database-backup-upload"' in storage
     assert 'key_name     = "exomem-database-backup-restore-jit"' in storage
     assert 'key_name     = "exomem-database-backup-delete-jit"' not in storage
+
+
+def test_etcd_snapshots_use_an_unlocked_bucket_and_a_write_only_key() -> None:
+    """etcd snapshots deliberately forgo Object Lock, and must not share a bucket
+    with anything that needs it.
+
+    A bucket carrying an Object Lock default retention applies lock parameters to
+    every PUT, and B2 then demands a Content-MD5 or x-amz-checksum header that
+    k3s's uploader does not send. Object Lock cannot be disabled once enabled, so
+    sharing the database-backup bucket would have meant dropping ITS retention and
+    stripping immutability from the provisioner's Postgres backups.
+    """
+    storage = (DURABILITY / "storage.tf").read_text(encoding="utf-8")
+    outputs = (DURABILITY / "outputs.tf").read_text(encoding="utf-8")
+
+    assert 'resource "b2_bucket" "etcd_snapshot"' in storage
+    etcd_bucket = storage.split('resource "b2_bucket" "etcd_snapshot"', 1)[1].split(
+        "\nresource ", 1
+    )[0]
+    assert "file_lock_configuration" not in etcd_bucket
+    assert "days_from_uploading_to_hiding = 30" in etcd_bucket
+    assert "prevent_destroy = true" in etcd_bucket
+    assert 'mode      = "SSE-B2"' in etcd_bucket
+
+    # Both etcd keys must target the unlocked bucket, not the database one.
+    for key in ("etcd_snapshot_upload", "etcd_snapshot_restore"):
+        block = storage.split(f'resource "b2_application_key" "{key}"', 1)[1].split(
+            "\nresource ", 1
+        )[0]
+        assert "bucket_ids   = [b2_bucket.etcd_snapshot.bucket_id]" in block, key
+        assert "b2_bucket.database_backup" not in block, key
+
+    # The node holds the upload credential, so it must not be able to delete its
+    # own etcd history. Expiry belongs to the bucket lifecycle rule instead.
+    upload = storage.split('resource "b2_application_key" "etcd_snapshot_upload"', 1)[
+        1
+    ].split("\nresource ", 1)[0]
+    assert 'capabilities = ["listBuckets", "listFiles", "writeFiles"]' in upload
+    assert "deleteFiles" not in upload
+
+    assert "etcd_snapshot_bucket_name" in outputs
     assert '"bypassGovernance"' not in storage
     assert 'key_name     = "exomem-etcd-snapshot-upload"' in storage
     assert 'key_name     = "exomem-etcd-snapshot-restore-jit"' in storage

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.37.0" # x-release-please-version
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -658,6 +658,12 @@ embeddings = [
     { name = "sqlite-vec" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.12.0+cu132", source = { registry = "https://download.pytorch.org/whl/cu132" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+embeddings-onnx = [
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "sqlite-vec" },
+    { name = "tokenizers" },
 ]
 media = [
     { name = "faster-whisper" },
@@ -693,12 +699,14 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'media'", specifier = ">=1.0" },
     { name = "fastmcp", specifier = "==3.4.4" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "huggingface-hub", marker = "extra == 'embeddings-onnx'", specifier = ">=0.24" },
     { name = "markitdown", extras = ["docx", "xlsx", "pptx"], marker = "extra == 'media'", specifier = ">=0.1.1" },
     { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'media-mlx'", specifier = ">=0.4" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
     { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'win32' and extra == 'media'" },
+    { name = "onnxruntime", marker = "extra == 'embeddings-onnx'", specifier = ">=1.20" },
     { name = "pillow", marker = "extra == 'embeddings'", specifier = ">=10.0" },
     { name = "pillow", marker = "extra == 'media'", specifier = ">=10.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
@@ -713,13 +721,15 @@ requires-dist = [
     { name = "snowballstemmer", specifier = ">=2.2" },
     { name = "speechbrain", marker = "extra == 'diarization'", specifier = ">=1.0" },
     { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.6" },
+    { name = "sqlite-vec", marker = "extra == 'embeddings-onnx'", specifier = ">=0.1.6" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=5.0" },
+    { name = "tokenizers", marker = "extra == 'embeddings-onnx'", specifier = ">=0.20" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'embeddings') or (sys_platform == 'win32' and extra == 'embeddings')", specifier = ">=2.12", index = "https://download.pytorch.org/whl/cu132" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'embeddings'", specifier = ">=2.12" },
     { name = "transformers", marker = "extra == 'vision'", specifier = ">=4.40" },
     { name = "watchdog", specifier = ">=4.0" },
 ]
-provides-extras = ["embeddings", "media", "media-mlx", "diarization", "vision", "tui"]
+provides-extras = ["embeddings", "embeddings-onnx", "media", "media-mlx", "diarization", "vision", "tui"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "exomem"
-version = "0.37.0"
+version = "0.37.0" # x-release-please-version
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why

Tenant density on the alpha node is capped by the embedding runtime, not by the
architecture, and torch is most of that runtime. The node has 7751 MiB with 815 MiB
taken by K3s, containerd, metrics-server and CoreDNS; every remaining cell-shaped
megabyte is a paying seat. Hetzner has retired the CX line, so the node cannot be
resized and successors cost ~4x for the same memory — density on the existing node is
the only cheap capacity available.

## What this delivers

Same model, same vectors, a much smaller cell.

| | torch | ONNX Runtime |
|---|---|---|
| import | 399 MiB | 40 MiB |
| peak | 905 MiB | 661 MiB |
| load | 14.0 s | 1.1 s |
| encode (15 texts) | 3.26 s | 0.91 s |

Measured again inside the hosted image under the exact conditions a cell runs under
(`--network none --read-only --user 10001:10001 --cap-drop ALL --memory=1536m`),
batch 8 over 200 chunks: import 33 MiB, warm 548 MiB, **peak 604 MiB** against the
918 MiB torch envelope it replaces. The image itself goes **2.47 GB -> 1.16 GB**.

## Equivalence is proven, not assumed

Encoding a fixed set through both runtimes — empty, whitespace-only, non-ASCII, emoji,
over-length (truncation), and code-shaped text:

- minimum cosine similarity **0.99999994**
- maximum absolute component difference **4.2e-07**
- identical 768 dimensions, unit-norm float32
- identical nearest-neighbour ordering on every input

That is four orders of magnitude tighter than the fp16 drift `_maybe_half` already
documents as harmless for ranking. Stored vectors stay valid; nothing is re-indexed.
`tests/test_embedding_backend.py` carries the gate, opt-in behind
`RUN_EMBED_EQUIVALENCE_TEST=1` because it loads the model twice.

## Shape of the change

The bi-encoder already had exactly two chokepoints, so all 32 call sites across 12
modules are untouched. `get_model()` builds a backend; `encode_batch_size()` takes the
batch policy from it, since an ONNX session exposes no `.device`; `unload_model()` asks
it to release, because a session owns arenas a reference drop will not return.

Readiness now follows the configured backend instead of a hardcoded torch triple. That
was not cosmetic: through `infer_profile` it would have demoted a torch-free image to
`lean`, which is how a cell comes to advertise keyword-only recall while holding a
working embedder. With neither backend installed the answer stays torch, so a fresh box
is still pointed at `uv sync --extra embeddings`.

Only the hosted lane can shed torch — the reranker and CLIP are sentence-transformers
models and the hosted stage withholds both. `ml` and `cuda` are unchanged.

## Also in this branch

`fix(hosted): bind the k3s runtime gate to the deployment lock` —
`test_exact_k3s_runs_the_reviewed_hosted_runtime_release` overrode
`provisioner.releaseManifestJson`, a key that no longer exists (the values schema is
`additionalProperties: false`; the runtime image now comes from
`provisioner.deploymentLockJson`). It failed on `main` and CI never ran it, because only
`RUN_K3S_ADMISSION_TEST` is ever set. Verified by rendering: `exomem-tenant-boundary`
pins the rebound digest and no policy retains the placeholder image.

Note the gate contract still pins release 0.22.0 at `54618b9`, so this proves the
mechanism, not the current runtime. Re-pinning it is separate and coordinated.

## Verification

- Full suite: **6788 passed, 84 skipped, 0 failed**
- Cross-backend equivalence with both runtimes loaded: 20/20
- `builder-hosted` builds; offline load gate passes through an `InferenceSession` with
  the hub pinned offline, and asserts no torch reached the image
- Semantic recall confirmed inside the locked-down container: a query matched the
  relevant chunk at 0.70 against 0.44 for the unrelated one
- `openspec validate swap-embedding-runtime-to-onnx --strict` passes

## Deliberately still open

Tasks 2.6, 5.1-5.3 and 6.x in the change. The sidecar runtime fingerprint touches every
sidecar's schema and is not needed for this substitution to be safe. The cell envelope
and the USER cell cap need the platform's own memory delta, which cannot be measured
until the platform is installed on the node.