### PR TITLE
feat(memory): record note knowledge time to the second

### DIFF
--- a/openspec/changes/record-note-knowledge-time-to-the-second/design.md
+++ b/openspec/changes/record-note-knowledge-time-to-the-second/design.md
@@ -1,0 +1,136 @@
+## Context
+
+The handoff brief (`docs/handoff-note-timestamps.md`, branch `worktree-bench-foundation`)
+records the decisions taken before implementation: second granularity, no backfill, permanently
+mixed format, timezone-aware. Those are settled. This document covers the design consequences,
+including three that the brief did not anticipate and three of its hazard calls that turned out
+to be wrong.
+
+## Goals / Non-Goals
+
+**Goals.** Record knowledge time precisely enough to order same-day writes. Keep every existing
+date-only value untouched. Make the read paths honest about which orderings are actually
+determined.
+
+**Non-Goals.** No backfill or migration. No sub-day capability in `recency_days`, which is
+day-scoped by construction. Not storing the author's local timezone. The benchmark-side
+sub-day family is task 4.5 of `expand-memory-proof-benchmark` and lives on another branch.
+
+## Decisions
+
+### Precision is carried by the Python type
+
+`datetime` subclasses `date`, and PyYAML already returns a `date` for a bare frontmatter value
+and a `datetime` for a timestamped one. Using that distinction as the precision marker means one
+representation works on both sides of the system:
+
+- **Reading**: `isinstance(value, datetime)` is exactly "the instant is known".
+- **Writing**: the existing injectable `today: dt.date | None` seam accepts a `datetime` with no
+  signature change. A caller passing a plain `date` gets date-only output.
+
+The consequence is that the ~394 existing `today=dt.date(...)` test call sites keep passing a
+date and keep getting the day, so their assertions stay true without being rewritten. Only tests
+that exercise the new path pass a `datetime`. This is what kept a change touching ten write
+tools from turning into a suite-wide migration.
+
+The alternative — adding a parallel `now: datetime | None` seam — would have meant either
+threading two clocks through every leaf or a conditional contract ("date-only when `today` is
+passed, otherwise an instant") that is easy to get wrong and hard to state.
+
+### `Moment` makes the unknown explicit
+
+`temporal.parse` returns `Moment(day, instant | None)`. The `None` is load-bearing: it is the
+difference between "recorded at midnight" and "recorded that day, time unknown". Every ordering
+decision reads it.
+
+`compare` returns four values. Its rule is short — distinct days always order; within one day
+only two known instants order — and it is antisymmetric, which the tests pin exhaustively
+against the brief's table.
+
+`sort_key` exists separately because UIs need a total order. Keeping it distinct from `compare`
+is deliberate: a caller that wants a list gets one, and a caller that wants to know whether the
+order is real has to ask a different question and cannot get a false answer by accident.
+
+### UTC for stamps, local day for paths
+
+Stamps are UTC so values order across machines. Paths are not, because `dt.date.today()` is
+local and note filenames (`YYYY-MM-<slug>`) have always used the local day. Folding the path
+date to UTC would silently move a note written at 01:30 at UTC+3 into the previous month.
+
+So the clock seam returns a local-offset-aware `datetime`, `stamp()` converts to UTC, and
+`render_date()` reads the day as given. One clock read, two correct derivations.
+
+### The draft token freezes the instant, not just the day (token v2)
+
+The first attempt stamped knowledge time at commit, reasoning that it should record when the
+write actually happened. The full suite disproved it. `test_semantic_creation_writers.py:823`
+validates on day N, commits on day N+1, and requires `created` to be **day N** — the token
+deliberately freezes the authored date so that committing the same token twice produces
+identical bytes, which is what the mutation-receipt replay path depends on.
+
+So the token now freezes both: `render_date` (the authored day, which names the file and must
+stay day-granular for the `[:7]` slice and the `date.fromisoformat` round-trip gate) and
+`render_stamp` (the authored instant, written into `created`/`updated`). `_TOKEN_VERSION` goes
+to 2 and v1 tokens are rejected — a v1 token carries no stamp, and inferring one at commit is
+exactly the non-determinism the freeze exists to prevent. The cost is that a client mid
+validate→commit at the release boundary gets `INVALID_DRAFT_TOKEN` and re-validates once.
+
+`render_stamp` is declared **after** `registrations` in the dataclass and passed by keyword
+everywhere. Inserting it next to `render_date`, where it belongs conceptually, silently
+rebound the fifth positional argument at four existing call sites — the tuple of registrations
+landed in the stamp field and only surfaced as a JSON-serialization error. Field order in a
+dataclass is an API surface.
+
+### Reproducibility is a system invariant here, not an implementation detail
+
+The same root cause produced a third failure: `test_relation_queue_commands.py:172` compares two
+governed writes byte-for-byte to prove the accept path and the studio path agree. Reading the
+clock at each write made them differ whenever they straddled a second boundary — **flaky by
+construction**, which is worse than a clean break because it passes most runs.
+
+The general rule this change adopts: a recorded instant is frozen once per logical operation and
+carried, never re-read per write leaf. Where two executions are genuinely being compared, the
+test pins the clock — newly cheap, because consolidating on `temporal.now` gave the suite a
+single seam to monkeypatch where before there were seven scattered `datetime.now` calls.
+
+### Idempotency keys stay day-granular
+
+`commit_edit` mixes the recorded date into a log-write `operation_token` that makes a replayed
+edit idempotent. A per-second value would mint a fresh key on every attempt and defeat the dedup
+entirely, so `commit_edit` receives the stamp for the heading and derives the day for the key.
+
+## Corrections to the handoff brief
+
+The brief's line numbers are stale throughout, and three of its five hazard calls are wrong.
+
+**`audit._parse_fm_date` and `find_policy.parse_date` are not bugs.** The brief says their
+10-character truncation makes the change "cosmetic". Both consumers are genuinely day-scoped —
+staleness aging and day-window recency filtering — so collapsing to the day is correct there,
+not a loss. They now delegate to the shared helper for consistency and to pick up the quoted and
+space-separated spellings that prefix-slicing mangled, but their behaviour is deliberately
+unchanged. `tests/test_audit_distillation.py` already pins the day-collapse including the
+`datetime` case and stays green.
+
+**`audit_fix._as_iso_date` is not "verified safe".** `datetime` subclasses `date`, so the
+`isinstance(value, dt.date)` branch returned the full timestamp string, which `_backfill_value`
+then copied into a neighbouring field and `_apply_frontmatter_fix` wrote unquoted. Separately,
+`date.fromisoformat` raises on a timestamped `started`, silently abandoning the experiment
+`duration` backfill.
+
+**The real silent-drop bug is in `structured_filters`, which the brief never mentions** — and it
+predates this feature. See the proposal.
+
+Three couplings the brief missed: the draft-token render-date gate, the `log.md` heading regex
+(which is where its own observed symptom actually lived), and the `commit_edit` idempotency key.
+
+## Risks
+
+**Search results change.** Pages previously dropped from date filters now appear. That is the
+fix, but it is user-visible and worth saying out loud in release notes.
+
+**Two spellings forever.** Every future reader of these fields must go through `temporal`.
+The mitigation is that there is now exactly one place to go through, where before there were
+three private and mutually inconsistent parsers.
+
+**Clock skew between machines** can misorder writes seconds apart. Second granularity is the
+honest ceiling on what a wall clock can back; this is why the brief rejected milliseconds.

--- a/openspec/changes/record-note-knowledge-time-to-the-second/proposal.md
+++ b/openspec/changes/record-note-knowledge-time-to-the-second/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Exomem's differentiator is bitemporal reasoning — world time × knowledge time — but it
+records its own knowledge time to the **day**. `created`, `updated`, and every `log.md`
+history heading came from `dt.date.today().isoformat()`, so a note created and revised twice
+inside two hours carried three identical dates and `created == updated`. The only ordering
+signal was position in the file, not data. "Has this page changed since I read it?" and "in
+what order did I reach these conclusions?" were unanswerable within a day.
+
+Neither test suite could catch it: the memory-proof benchmark models knowledge time in weeks,
+so it is structurally blind to sub-day ordering.
+
+Investigating the read path surfaced a second, independent defect already shipping. `page.updated`
+is strictly typed in the filter layer — `date` and `datetime` are deliberately not comparable —
+and `page_view` passed the raw YAML value straight through. Because `serialize_frontmatter`
+quotes any scalar YAML would re-type, `create_file`, `set_frontmatter_field`, and `multi_edit`
+have always written `updated: "2026-05-24"`, which loads as `str`. Measured against the live
+module, of the four spellings that reach the vault only the bare unquoted date matched a date
+filter. Those pages are silently absent from every `recency_days`, `updated_after`, and
+`updated_before` search — no warning, no error.
+
+## What Changes
+
+- Record `created`, `updated`, `captured`, and `log.md` history headings at **second
+  granularity in UTC** (`2026-08-05T09:12:33Z`).
+- **Do not backfill.** Existing date-only values stay date-only permanently. Rewriting them as
+  midnight would assert a precision that was never captured. The mixed vault is the end state,
+  not a migration window.
+- Make precision part of the data: a date-only value denotes an unknown instant within its day,
+  so ordering is four-valued (`before | after | same | indeterminate`) and never collapses an
+  unknown into a guess.
+- Add one shared `temporal` module. There was no shared clock helper: `_now_iso` was
+  copy-pasted verbatim in two modules and reimplemented with four different precision and
+  suffix conventions in five more.
+- Carry precision on the Python type so the change is cheap and honest: `datetime` subclasses
+  `date`, so the existing injectable `today` seam accepts either, and the ~394 call sites that
+  pass a plain `date` keep getting day-granular output. No mass test migration.
+- Fix the read paths so a value's YAML spelling stops deciding whether its page is searchable.
+- Keep note paths (`YYYY-MM-<slug>`) and draft-token render dates day-granular, so filenames do
+  not shift month for late-evening writes and `semantic_writes` needs no token version bump.
+
+## Capabilities
+
+### New Capabilities
+- `note-knowledge-time`: Defines the recorded precision of `created`/`updated`/`captured` and
+  history headings, the permanent mixed-format contract, and the four-valued ordering that
+  follows from it.
+
+## Impact
+
+- Every governed write tool stamps an instant: `note`, `edit`, `replace`, `link`, `create_file`,
+  `multi_edit`, `set_frontmatter_field`, `observe_memory`, `add`, `preserve`.
+- `find` date filters begin returning pages that were previously dropped. This is a behaviour
+  change to search results and is the point of the fix.
+- `semantic_writes.DraftToken` gains `render_stamp` and `_TOKEN_VERSION` goes to 2. **Draft
+  tokens in flight across the release boundary are rejected** and must be re-validated once; a
+  v1 token carries no frozen instant, and inferring one at commit is the non-determinism the
+  freeze exists to prevent.
+- No vault migration, no reindex. Every pre-existing value already rendered as `YYYY-MM-DD`
+  through `ParsedPage.updated`, so persisted index bytes are unchanged.

--- a/openspec/changes/record-note-knowledge-time-to-the-second/specs/note-knowledge-time/spec.md
+++ b/openspec/changes/record-note-knowledge-time-to-the-second/specs/note-knowledge-time/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Knowledge Time Is Recorded At Second Granularity In UTC
+Governed writes SHALL record `created`, `updated`, `captured`, and `log.md` history headings as
+a timezone-aware instant truncated to the second and rendered in UTC as `YYYY-MM-DDTHH:MM:SSZ`.
+
+Sub-second precision SHALL NOT be recorded. Milliseconds would be false precision on
+hand-authored notes, and would let two values compare unequal on a difference neither the
+writer nor the reader can account for.
+
+The author's local timezone SHALL NOT be stored. Where an edit happened is a different fact
+from when it happened, and a single storage standard is what makes values comparable across
+machines without consulting a timezone database.
+
+#### Scenario: A note revised twice in one afternoon is orderable
+- **WHEN** a page is created and then revised twice within the same day
+- **THEN** its `updated` value and each of its history headings carry distinct instants
+- **AND** their order is recoverable from the recorded values alone, not from position in the file
+
+#### Scenario: A local offset is normalized on write
+- **WHEN** a write is stamped from a clock carrying a non-UTC offset
+- **THEN** the recorded value is the same instant expressed in UTC with a `Z` suffix
+
+### Requirement: Existing Date-Only Values Are Never Rewritten
+Values already recorded as a bare `YYYY-MM-DD` SHALL be left byte-identical by every read,
+audit, and repair path. No migration SHALL restamp them.
+
+A date-only value denotes an unknown instant within that day. Rewriting it as midnight would
+assert a precision that was never captured, which is a fabrication rather than a normalization.
+Both forms are therefore permanent and every reader MUST accept either.
+
+#### Scenario: A repair pass leaves legacy pages alone
+- **WHEN** the audit-repair pass runs over a compliant page carrying date-only values
+- **THEN** the page's bytes are unchanged
+
+#### Scenario: Copy-forward preserves recorded precision
+- **WHEN** a repair copies a recorded value onto a missing sibling field
+- **THEN** an instant is copied as an instant and a day is copied as a day, without coarsening or inventing precision
+
+### Requirement: Ordering Two Recorded Values Is Four-Valued
+Comparing two recorded values SHALL yield `before`, `after`, `same`, or `indeterminate`.
+
+Two values sharing a calendar day SHALL compare `indeterminate` when either lacks a time.
+Distinct days SHALL always order, because a whole day precedes the next whatever the unknown
+times within them. Only two known instants MAY compare `same`.
+
+An indeterminate result SHALL be reported rather than resolved. Where a total order is required
+for display, the ambiguity SHALL remain visible rather than being implied away by the sort.
+
+#### Scenario: A day and an instant within it cannot be ordered
+- **WHEN** `2026-08-05` is compared with `2026-08-05T09:00:00Z`
+- **THEN** the result is `indeterminate`
+- **AND** the same comparison with the arguments swapped is also `indeterminate`
+
+#### Scenario: Whole days still order
+- **WHEN** `2026-08-04` is compared with `2026-08-05T09:00:00Z`
+- **THEN** the result is `before`
+
+### Requirement: Recorded Precision Does Not Decide Searchability
+A page's recorded day SHALL decide day-granular date filters regardless of how the value is
+spelled in YAML. Bare dates, quoted dates, bare timestamps, and quoted timestamps all denote a
+recorded day and MUST answer `recency_days`, `updated_after`, and `updated_before` identically.
+
+A value that cannot be parsed SHALL NOT acquire an inferred day; it continues to fail date
+filters rather than matching on a guess.
+
+#### Scenario: A quoted date is searchable
+- **WHEN** a page written through the frontmatter serializer carries `updated: "2026-01-15"`
+- **THEN** it is returned by a date filter whose window contains 2026-01-15
+
+#### Scenario: A timestamped page is searchable
+- **WHEN** a page carries `updated: 2026-01-15T09:12:33Z`
+- **THEN** it is returned by a date filter whose window contains 2026-01-15
+
+### Requirement: Path Dates And Dedup Keys Remain Day-Granular
+Note paths, draft-token render dates, index recent-activity bullets, and write-idempotency keys
+SHALL use the calendar day, not the recorded instant.
+
+The day used for a path SHALL be read from the clock as given rather than converted to UTC, so
+a note written late in the evening is not filed under the previous month.
+
+#### Scenario: A late-evening write keeps its month
+- **WHEN** a note is written at 01:30 local time at a positive UTC offset, crossing into a new month locally
+- **THEN** its path carries the local month
+- **AND** its recorded knowledge time is the corresponding UTC instant
+
+#### Scenario: A replayed write stays idempotent
+- **WHEN** the same write is attempted twice within one day
+- **THEN** the idempotency key is unchanged, because it is derived from the day rather than the instant
+
+### Requirement: History Headings Parse At Both Precisions
+The `log.md` history-heading reader SHALL accept both `[YYYY-MM-DD]` and
+`[YYYY-MM-DDTHH:MM:SSZ]`.
+
+An unmatched heading is dropped silently rather than raising, so a reader that recognizes only
+one precision would empty a page's history with no error surfacing anywhere. The reader MUST
+therefore accept every form the writer can emit.
+
+#### Scenario: A mixed log reads back completely
+- **WHEN** a page's log carries one date-only heading and one timestamped heading
+- **THEN** both entries are returned, newest first
+
+### Requirement: Sub-Day Retrieval Bounds Report What They Cannot Determine
+`updated_after` and `updated_before` SHALL accept an instant as well as a day. `recency_days`
+SHALL remain day-scoped.
+
+When a bound carries an instant and a candidate page records only a day, the two are genuinely
+unordered whenever they share that day. The page SHALL be returned and the hit SHALL be marked
+indeterminate. It MUST NOT be silently dropped, which reproduces the defect this change exists
+to fix, and MUST NOT be silently included, which reports a guess as a fact.
+
+Pages whose recorded day falls wholly inside or outside the bound SHALL be decided normally,
+because a whole day orders against an instant outside it.
+
+#### Scenario: A date-only page on the boundary day is returned and marked
+- **WHEN** `updated_after` is `2026-08-05T09:00:00Z` and a page records only `2026-08-05`
+- **THEN** the page is returned
+- **AND** its hit is marked indeterminate for that bound
+
+#### Scenario: A date-only page outside the boundary day is decided
+- **WHEN** `updated_after` is `2026-08-05T09:00:00Z` and a page records only `2026-08-04`
+- **THEN** the page is excluded, and no indeterminacy is reported
+
+#### Scenario: A timestamped page is decided exactly
+- **WHEN** `updated_after` is `2026-08-05T09:00:00Z` and a page records `2026-08-05T11:00:00Z`
+- **THEN** the page is returned and its hit is not marked indeterminate
+
+### Requirement: A Frozen Draft Commits To Identical Bytes
+A draft token SHALL freeze both the authored day and the authored instant at validation, and a
+commit SHALL use the frozen values rather than re-reading the clock.
+
+Committing the same token twice SHALL produce byte-identical output. Re-reading the clock at
+commit would make a validated draft render differently on each attempt, which defeats replay
+safety and makes any byte-identity comparison between two code paths intermittently false
+rather than cleanly true.
+
+A token that predates the frozen instant SHALL be rejected rather than completed by inferring
+one, because inferring the instant reintroduces exactly the non-determinism being prevented.
+
+#### Scenario: Validation and commit straddle midnight
+- **WHEN** a draft is validated on one day and committed on the next
+- **THEN** the written `created` is the authored instant frozen at validation, not the commit-time clock
+
+#### Scenario: Two code paths writing the same change agree
+- **WHEN** two governed operations that should produce the same page are compared byte-for-byte under a pinned clock
+- **THEN** their output is identical, including the recorded knowledge time

--- a/openspec/changes/record-note-knowledge-time-to-the-second/tasks.md
+++ b/openspec/changes/record-note-knowledge-time-to-the-second/tasks.md
@@ -1,0 +1,84 @@
+> **Sections 1–5 and 7.1 are a record, not a plan.** They were written after the fact, from an
+> approved implementation plan rather than from this change. The TDD ordering rule in
+> `openspec/config.yaml` was followed during implementation — `temporal`'s pure-logic tests and
+> the filter regression test were both red before their code existed — but the OpenSpec artifacts
+> themselves trail the code, which is the wrong order for this repo. Section 6 was specified
+> before implementation and is the intended order.
+
+## 1. Baseline And Red Tests
+
+- [x] 1.1 Full-suite baseline from the clean worktree before any edit (1 failed, 6792 passed; the
+  single failure is `test_governance_overhead` overhead budget, flaking under concurrent load).
+- [x] 1.2 Pure-logic unit tests for `temporal` first, per the `openspec/config.yaml` TDD rule:
+  `compare` against every row of the handoff's table including both indeterminate cases, `parse`
+  over each spelling the vault can produce, `stamp`/`render_date` round-trips.
+- [x] 1.3 Failing regression test proving a page is dropped from date filters when its `updated`
+  is a quoted date, a bare timestamp, or a quoted timestamp. Verified red on `main`: only the
+  bare unquoted date matched.
+
+## 2. Shared Temporal Module
+
+- [x] 2.1 Add `src/exomem/temporal.py`: `Moment`, `Order`, `now`, `stamp`, `render_date`,
+  `parse`, `compare`, `sort_key`.
+- [x] 2.2 Second-granularity UTC `Z` output, matching the existing `adoption_run._now_iso` and
+  `review_state` precedents.
+- [x] 2.3 `render_date` reads the day as given so note paths keep the local month.
+
+## 3. Read And Comparison Paths
+
+- [x] 3.1 `structured_filters.page_view` settles precision so all four YAML spellings answer
+  day-granular filters; unparseable values pass through and still fail them.
+- [x] 3.2 `find_types.ParsedPage.updated` renders through `temporal` instead of `str()`, ending
+  the space-separated form and matching `semantic_unit_read`.
+- [x] 3.3 `audit._parse_fm_date` and `find_policy.parse_date` delegate to `temporal`; day-collapse
+  behaviour deliberately unchanged.
+- [x] 3.4 `audit_fix._as_iso_date` preserves recorded precision on copy-forward and no longer
+  emits `str(datetime)`; the experiment `duration` computation survives a timestamped `started`.
+- [x] 3.5 Widen `vault._LOG_ENTRY_HEADER_RE` to accept both precisions — before anything can
+  write the longer form.
+
+## 4. Write Paths
+
+- [x] 4.1 `note` (legacy and modern), `edit`, `replace` (legacy and modern).
+- [x] 4.2 `link`, `create_file`, `multi_edit`, `set_frontmatter_field`, `observe_memory`.
+- [x] 4.3 `add` and `preserve` for `captured`, the source-page analogue of `created`.
+- [x] 4.4 `log.md` headings via `prepend_log_entry` and its inline duplicates; `indexes.compute_updates`
+  gains a distinct `stamp_iso` so index bullets stay day-granular while the log heading does not.
+- [x] 4.5 `commit_edit` derives the day for its idempotency key rather than using the stamp.
+
+## 5. Documentation
+
+- [x] 5.1 `_scaffold/_Schema/references/frontmatter.md` documents both forms, why date-only is
+  never rewritten, and that same-day ordering may be undecidable.
+- [x] 5.2 `edit.py` module docstring: `updated` is bumped to the write instant, not "to today".
+
+## 6. Sub-Day Retrieval
+
+- [x] 6.1 `updated_after` / `updated_before` accept an instant. `page.updated` already admitted
+  RFC 3339 date-times as operands, so no new queryable field was needed: `page_view` presents the
+  most precise recorded value and `_evaluate_operator` compares at the granularity of the *bound*.
+- [x] 6.2 A date-only page on the boundary day is returned and reported by `indeterminate_bounds`
+  rather than silently dropped or silently included.
+- [x] 6.3 `Hit.order_indeterminate` is emitted from `as_dict` only when non-empty and added to
+  the `governance/egress.py` `_HIT_FIELDS` allowlist. The MCP tool-schema fixture needed no
+  change: the flag lives on the hit payload, not the tool signature.
+- [x] 6.4 `find` marks hits after every filtering lane. The bounds are captured before
+  `find.py:630` clears the legacy arguments — once a typed plan exists the shortcuts are folded
+  into it and `_filter_by_date` becomes a no-op, so marking from the legacy path alone was
+  silently dead.
+
+## 6b. Determinism (found by the full suite)
+
+- [x] 6b.1 `DraftToken` freezes `render_stamp` alongside `render_date`; `_TOKEN_VERSION` = 2.
+- [x] 6b.2 `render_stamp` declared after `registrations` and passed by keyword — inserting it
+  beside `render_date` silently rebound the fifth positional argument at four call sites.
+- [x] 6b.3 `note` and `create_file` take the stamp from the token when one is supplied.
+- [x] 6b.4 `test_relation_queue_commands` byte-identity test pins the clock via `temporal.now`.
+
+## 7. Validation
+
+- [x] 7.1 `uvx ruff check . --select F` clean.
+- [ ] 7.2 Full suite green, compared against the 1.1 baseline.
+- [ ] 7.3 Latency gate and semantic-write latency check, since `find_policy.parse_date` sits on a
+  hot retrieval path.
+- [x] 7.4 `openspec validate record-note-knowledge-time-to-the-second --strict`.

--- a/plugins/claude-code/skills/exomem/references/frontmatter.md
+++ b/plugins/claude-code/skills/exomem/references/frontmatter.md
@@ -15,9 +15,18 @@ These appear on every page type:
 | `type` | yes | enum | `source`, `research-note`, `insight`, `failure`, `pattern`, `experiment`, `production-log`, `entity` |
 | `title` | new pages | Unicode string | exact human-facing display title; independent of the filename slug |
 | `status` | yes | enum | `draft`, `active`, `superseded`, `archived` (production-logs use a richer status set — see below) |
-| `created` | yes | ISO date | `YYYY-MM-DD`, set on creation, never edited |
-| `updated` | yes | ISO date | `YYYY-MM-DD`, refreshed on every edit |
+| `created` | yes | ISO instant or date | `YYYY-MM-DDTHH:MM:SSZ`, set on creation, never edited |
+| `updated` | yes | ISO instant or date | `YYYY-MM-DDTHH:MM:SSZ`, refreshed on every edit |
 | `tags` | yes | list | freeform, lowercase, dash-separated |
+
+`created` and `updated` are recorded at **second granularity in UTC**, so pages
+revised more than once in a day stay orderable. Pages written before this was
+introduced carry a bare `YYYY-MM-DD` and are never rewritten: a date-only value
+means the intra-day time was genuinely not captured, and restamping it as
+midnight would assert a precision that never existed. Both forms are therefore
+permanent, and readers must accept either. Comparing two values that share a day
+when at least one is date-only is undecidable rather than equal — tools report
+that rather than guessing an order.
 
 New writers also render `title` as the page's canonical H1. Readers remain
 backward-compatible with legacy pages and resolve display titles in this order:

--- a/src/exomem/_scaffold/_Schema/references/frontmatter.md
+++ b/src/exomem/_scaffold/_Schema/references/frontmatter.md
@@ -15,9 +15,18 @@ These appear on every page type:
 | `type` | yes | enum | `source`, `research-note`, `insight`, `failure`, `pattern`, `experiment`, `production-log`, `entity` |
 | `title` | new pages | Unicode string | exact human-facing display title; independent of the filename slug |
 | `status` | yes | enum | `draft`, `active`, `superseded`, `archived` (production-logs use a richer status set — see below) |
-| `created` | yes | ISO date | `YYYY-MM-DD`, set on creation, never edited |
-| `updated` | yes | ISO date | `YYYY-MM-DD`, refreshed on every edit |
+| `created` | yes | ISO instant or date | `YYYY-MM-DDTHH:MM:SSZ`, set on creation, never edited |
+| `updated` | yes | ISO instant or date | `YYYY-MM-DDTHH:MM:SSZ`, refreshed on every edit |
 | `tags` | yes | list | freeform, lowercase, dash-separated |
+
+`created` and `updated` are recorded at **second granularity in UTC**, so pages
+revised more than once in a day stay orderable. Pages written before this was
+introduced carry a bare `YYYY-MM-DD` and are never rewritten: a date-only value
+means the intra-day time was genuinely not captured, and restamping it as
+midnight would assert a precision that never existed. Both forms are therefore
+permanent, and readers must accept either. Comparing two values that share a day
+when at least one is date-only is undecidable rather than equal — tools report
+that rather than guessing an order.
 
 New writers also render `title` as the page's canonical H1. Readers remain
 backward-compatible with legacy pages and resolve display titles in this order:

--- a/src/exomem/add.py
+++ b/src/exomem/add.py
@@ -20,7 +20,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import corpus_aware, indexes, memory_refs, schema
+from . import corpus_aware, indexes, memory_refs, schema, temporal
 from .kbdir import kb_prefix
 from .vault import (
     InvalidSlugError,
@@ -144,8 +144,9 @@ def add(
         except Exception as e:  # noqa: BLE001 — never break a capture
             log.debug("corpus-aware dup check failed (non-fatal): %s", e)
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     folder_name = SOURCE_TYPE_TO_FOLDER[source_type]
     folder_path = kb_root(vault_root) / "Sources" / folder_name
 
@@ -158,7 +159,7 @@ def add(
     source_md = _render_source(
         title=title,
         source_type=source_type,
-        date_iso=date_iso,
+        date_iso=stamp_iso,
         url=url,
         tags=tags_clean,
         why_captured=why_captured,
@@ -202,6 +203,7 @@ def add(
         folder_name=folder_name,
         rel_source_no_ext=rel_source_no_ext,
         date_iso=date_iso,
+        stamp_iso=stamp_iso,
         activity_summary=activity_summary,
         log_entry_body=log_entry_body,
         forced_counts=post_counts,
@@ -259,6 +261,7 @@ def _compute_updates_with_counts(
     folder_name: str,
     rel_source_no_ext: str,
     date_iso: str,
+    stamp_iso: str,
     activity_summary: str,
     log_entry_body: str,
     forced_counts: dict[str, int],
@@ -279,6 +282,7 @@ def _compute_updates_with_counts(
             folder_description=FOLDER_DESCRIPTIONS.get(folder_name, "captured material"),
             rel_source_path=f"{kb_prefix()}Sources/{folder_name}/{rel_source_no_ext.rsplit('/', 1)[-1]}",
             date_iso=date_iso,
+            stamp_iso=stamp_iso,
             activity_summary=activity_summary,
             log_entry_body=log_entry_body,
         )

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -56,6 +56,7 @@ from . import (
     relation_registry,
     semantic_language_registry,
     semantic_units,
+    temporal,
 )
 from . import find as find_module
 from .kbdir import kb_dirname, kb_prefix
@@ -949,17 +950,15 @@ def _check_unprocessed_sources(
 
 
 def _parse_fm_date(value) -> dt.date | None:
-    """Coerce a frontmatter date value (yaml date, datetime, or ISO str) to date."""
-    if isinstance(value, dt.datetime):
-        return value.date()
-    if isinstance(value, dt.date):
-        return value
-    if isinstance(value, str) and value.strip():
-        try:
-            return dt.date.fromisoformat(value.strip()[:10])
-        except ValueError:
-            return None
-    return None
+    """Coerce a frontmatter date value (yaml date, datetime, or ISO str) to date.
+
+    Audit checks age pages in whole days — "unprocessed for N days", "not
+    reviewed since" — so collapsing a timestamp to its day is the right answer
+    here, not a loss. `temporal.parse` additionally accepts the quoted and
+    space-separated spellings that `[:10]` prefix-slicing used to mangle.
+    """
+    moment = temporal.parse(value)
+    return moment.day if moment is not None else None
 
 
 # ---------------- check: index_drift ----------------

--- a/src/exomem/audit_fix.py
+++ b/src/exomem/audit_fix.py
@@ -56,7 +56,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import access, indexes
+from . import access, indexes, temporal
 from . import audit as audit_module
 from . import find as find_module
 from .vault import (
@@ -175,15 +175,26 @@ def _walk_compiled(d: Path):
 # takes the current frontmatter dict + today's ISO date and returns the
 # inferred value, or None to skip.
 def _as_iso_date(value: object) -> str | None:
-    """Coerce a frontmatter date-ish value to ISO string, or None.
+    """Coerce a frontmatter date-ish value to a canonical ISO string, or None.
 
-    YAML loads `2026-05-15` as a `datetime.date`, not a string. Templates
-    sometimes pass strings. Both should normalize the same.
+    YAML loads `2026-05-15` as a `datetime.date` and `2026-05-15T09:12:33Z` as
+    a `datetime`; templates sometimes pass either as a string. All normalize to
+    the same spelling here.
+
+    Precision is preserved rather than flattened, because every caller is
+    copying one recorded field onto another (`created`→`updated`,
+    `created`→`captured`). Dropping the time would restate a known instant as a
+    vaguer one; inventing a time where there was none would be worse. What this
+    must not do is emit `str(datetime)`, whose space separator is not valid
+    round-trippable ISO.
     """
     if isinstance(value, dt.date):
-        return value.isoformat()
+        return temporal.stamp(value)
     if isinstance(value, str) and value:
-        return value
+        moment = temporal.parse(value)
+        if moment is None:
+            return value
+        return temporal.stamp(moment.instant or moment.day)
     return None
 
 
@@ -221,17 +232,19 @@ def _backfill_value(
             started = _as_iso_date(fm.get("started"))
             concluded = _as_iso_date(fm.get("concluded"))
             if started and concluded:
-                try:
-                    s = dt.date.fromisoformat(started)
-                    c = dt.date.fromisoformat(concluded)
-                    days = (c - s).days + 1
+                # Whole calendar days, so a timestamped `started` collapses to
+                # its day rather than raising out of the computation — plain
+                # `date.fromisoformat` rejects any value carrying a time, which
+                # would silently abandon the backfill.
+                s = temporal.parse(started)
+                c = temporal.parse(concluded)
+                if s is not None and c is not None:
+                    days = (c.day - s.day).days + 1
                     if days >= 1:
                         return (
                             f"{days} days" if days != 1 else "1 day",
                             f"computed from started:{started} to concluded:{concluded}",
                         )
-                except ValueError:
-                    return None, None
             return None, None
     if page_type == "source":
         if field == "captured":

--- a/src/exomem/create_file.py
+++ b/src/exomem/create_file.py
@@ -31,6 +31,7 @@ from . import (
     relation_review,
     semantic_contract,
     semantic_writes,
+    temporal,
 )
 from . import vault as vault_module
 from .vault import (
@@ -183,8 +184,9 @@ def create_file(
             "CREATION_REVIEW_REQUIRES_MARKDOWN",
             "creation review fields apply only to Markdown files",
         )
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     if draft_token is not None and is_markdown and not existing_file:
         try:
             token_value = semantic_writes.DraftToken.decode(draft_token)
@@ -200,6 +202,7 @@ def create_file(
                 "INVALID_DRAFT_TOKEN", "draft token does not match this creation"
             )
         date_iso = token_value.render_date
+        stamp_iso = token_value.stamp()
 
     # For markdown files, normalize wikilinks in the body to canonical form.
     # Skip non-md files (skill manifests, JSON, scratch) — their `[[...]]`
@@ -215,8 +218,8 @@ def create_file(
 
     if frontmatter is not None:
         fm = dict(frontmatter)
-        fm.setdefault("created", date_iso)
-        fm.setdefault("updated", date_iso)
+        fm.setdefault("created", stamp_iso)
+        fm.setdefault("updated", stamp_iso)
         fm_block = serialize_frontmatter(fm)
         body = content if content.endswith("\n") else content + "\n"
         full_text = f"---\n{fm_block}\n---\n{body}"
@@ -249,7 +252,7 @@ def create_file(
     creation_token = (
         draft_token
         or semantic_writes.DraftToken(
-            "create_file", "tier2_create", rel_path, date_iso
+            "create_file", "tier2_create", rel_path, date_iso, render_stamp=stamp_iso
         ).encode()
         if is_markdown and not existing_file
         else "create-file:" + hashlib.sha256(
@@ -265,7 +268,7 @@ def create_file(
     try:
         log_plan = plan_log_writes(
             vault_root,
-            date_iso=date_iso,
+            date_iso=stamp_iso,
             op=op_word,
             rel_path_no_ext=rel_no_ext,
             body=" ".join(log_body_parts),

--- a/src/exomem/edit.py
+++ b/src/exomem/edit.py
@@ -8,7 +8,7 @@ whole superseded-link chain would be silly.
 What it touches:
 - The page body (if `new_body` provided)
 - The `tags:` frontmatter field (if `tags` provided)
-- The `updated:` frontmatter field (always — bumped to today)
+- The `updated:` frontmatter field (always — bumped to the write instant)
 
 What it leaves alone:
 - All other frontmatter fields (type, project, status, sources, etc.).
@@ -38,7 +38,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import corpus_aware, indexes, semantic_writes
+from . import corpus_aware, indexes, semantic_writes, temporal
 from . import find as find_module
 from .cli_ops import OpError
 from .kbdir import kb_prefix
@@ -126,7 +126,7 @@ def edit(
     relation_review_hash: str | None = None,
     relation_review_reason: str | None = None,
 ) -> EditResult | EditValidation:
-    """Edit a compiled page in place. Bumps `updated:`.
+    """Edit a compiled page in place. Bumps `updated:` to the write instant.
 
     Four (composable) modes:
     - `new_body` — replace the whole body. The heavyweight mode.
@@ -210,8 +210,8 @@ def edit(
             code="INVALID_EDIT", missing=missing, reason="; ".join(reasons)
         )
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.stamp(now)
 
     editable = load_editable(vault_root, path, expected_hash=expected_hash)
     abs_path = editable.abs_path
@@ -704,6 +704,8 @@ def commit_edit(
         writes.extend(sub_writes)
 
     rel_no_ext = rel_path.removesuffix(".md")
+    recorded = temporal.parse(date_iso)
+    day = temporal.render_date(recorded.day) if recorded is not None else date_iso
     log_body_parts = [f"Edit via exomem. {why.strip()}"]
     if changed:
         log_body_parts.append(f"Changed: {', '.join(changed)}.")
@@ -718,7 +720,11 @@ def commit_edit(
             operation_token=(
                 "edit:"
                 + content_hash(
-                    f"{date_iso}\0{op}\0{rel_path}\0{why}\0{new_text}"
+                    # Keyed on the calendar day, not the stamp: this token is
+                    # what makes a replayed edit idempotent, and a
+                    # second-granularity value would mint a fresh key on every
+                    # attempt and defeat the dedup entirely.
+                    f"{day}\0{op}\0{rel_path}\0{why}\0{new_text}"
                 )
             ),
         )

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -623,6 +623,10 @@ def find(
             effective_result_level=effective_result_level,
             normalized_filters=filter_plan.to_dict(),
         )
+    # Keep the date bounds after the legacy arguments are cleared below: the
+    # typed plan does the filtering, but reporting *which* bound could not be
+    # decided still needs the original values.
+    bound_after, bound_before = updated_after, updated_before
     if filter_plan.root is not None:
         # Every shortcut is now represented in the shared typed plan.  Clear
         # the legacy arguments so no lane applies a second, divergent filter.
@@ -1024,6 +1028,20 @@ def find(
             updated_before=updated_before,
             recency_days=recency_days,
         )
+
+    # A hit kept on a bound that could not actually be ordered is reported as
+    # such rather than presented as a clean match. Runs after every filtering
+    # lane so it sees exactly the hits the caller will receive.
+    if bound_after is not None or bound_before is not None:
+        bound_shortcuts = structured_filters.FilterShortcuts(
+            updated_after=bound_after, updated_before=bound_before
+        )
+        for hit in hits:
+            vague = structured_filters.indeterminate_bounds(
+                {"updated": hit.updated}, shortcuts=bound_shortcuts
+            )
+            if vague:
+                hit.order_indeterminate = list(vague)
 
     if retrieval_trace is not None:
         retrieval_trace.finalize_page_results(

--- a/src/exomem/find_policy.py
+++ b/src/exomem/find_policy.py
@@ -9,6 +9,10 @@ from datetime import date, timedelta
 
 from .find_types import Hit
 from .ranking_config import DEFAULT_RANKING, RankingConfig
+# Names imported directly rather than the `temporal` module: this file already
+# has a parameter called `temporal` in `apply_post_rrf_multipliers`, and a
+# module of the same name would sit one refactor away from being shadowed.
+from .temporal import Moment, Order, compare as compare_moments, parse as parse_moment
 
 COMPILED_TYPES = frozenset(
     {
@@ -229,13 +233,14 @@ def classify_intent(query: str) -> str:
 
 
 def parse_date(value: str | None) -> date | None:
-    """Best-effort ISO date parse (YYYY-MM-DD prefix); None when unparseable."""
-    if not value:
-        return None
-    try:
-        return date.fromisoformat(str(value).strip()[:10])
-    except ValueError:
-        return None
+    """Best-effort parse of a recorded date; None when unparseable.
+
+    Recency scoring buckets pages by whole days, so a timestamp collapses to
+    its day. Delegating to `temporal` also picks up the quoted and
+    space-separated forms that prefix-slicing to 10 characters used to reject.
+    """
+    moment = parse_moment(value)
+    return moment.day if moment is not None else None
 
 
 def recency_multiplier(
@@ -290,6 +295,34 @@ def recency_ranking(candidate_paths: list[str], page_of: PageOf, cap: int) -> li
     return [p for _, p in dated][:cap]
 
 
+def _bound_verdict(
+    recorded: Moment, bound: str | None, *, keep_when: tuple[Order, ...]
+) -> tuple[bool, bool]:
+    """Apply one bound to one recorded value. Returns `(keep, indeterminate)`.
+
+    The bound's own precision decides the granularity. A day-scoped bound asks
+    a day-scoped question, which every page can answer; an instant bound cannot
+    be answered by a page recorded only to the day it falls on.
+    """
+    parsed = parse_moment(bound)
+    if parsed is None:
+        return True, False
+    if parsed.precise:
+        order = compare_moments(recorded, parsed)
+        if order is Order.INDETERMINATE:
+            # Undecidable: keep it and say so, rather than dropping it silently
+            # (the defect this change exists to fix) or passing a guess off as
+            # a match.
+            return True, True
+    else:
+        order = compare_moments(
+            Moment(recorded.day), Moment(parsed.day)
+        )
+        if order is Order.INDETERMINATE:
+            order = Order.SAME
+    return order in keep_when, False
+
+
 def filter_by_date(
     hits: list[Hit],
     *,
@@ -297,25 +330,47 @@ def filter_by_date(
     updated_before: str | None = None,
     recency_days: int | None = None,
 ) -> list[Hit]:
-    """Drop hits whose updated date falls outside the requested window."""
-    after = parse_date(updated_after)
-    before = parse_date(updated_before)
+    """Drop hits whose recorded time falls outside the requested window.
+
+    `updated_after`/`updated_before` accept an instant as well as a day.
+    `recency_days` stays day-scoped: it is a window of whole days by
+    construction. A hit kept on a bound that could not actually be decided is
+    marked in `Hit.order_indeterminate` rather than presented as a clean match.
+    """
     floor: date | None = None
     if recency_days is not None and recency_days >= 0:
         floor = date.today() - timedelta(days=recency_days)
-    if after is None and before is None and floor is None:
+    if updated_after is None and updated_before is None and floor is None:
         return hits
+    after_keep = (Order.AFTER, Order.SAME)
+    before_keep = (Order.BEFORE, Order.SAME)
     out: list[Hit] = []
     for h in hits:
-        d = parse_date(h.updated)
-        if d is None:
+        recorded = parse_moment(h.updated)
+        if recorded is None:
             continue
-        if after is not None and d < after:
+        if floor is not None and recorded.day < floor:
             continue
-        if before is not None and d > before:
+        keep_after, vague_after = _bound_verdict(
+            recorded, updated_after, keep_when=after_keep
+        )
+        if not keep_after:
             continue
-        if floor is not None and d < floor:
+        keep_before, vague_before = _bound_verdict(
+            recorded, updated_before, keep_when=before_keep
+        )
+        if not keep_before:
             continue
+        vague = [
+            name
+            for name, flag in (
+                ("updated_after", vague_after),
+                ("updated_before", vague_before),
+            )
+            if flag
+        ]
+        if vague:
+            h.order_indeterminate = vague
         out.append(h)
     return out
 

--- a/src/exomem/find_types.py
+++ b/src/exomem/find_types.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
+from datetime import date
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+
+from . import temporal
 
 
 @dataclass(frozen=True)
@@ -78,8 +81,23 @@ class ParsedPage:
 
     @property
     def updated(self) -> str:
+        """Canonical ISO rendering of the recorded day or instant.
+
+        Not `str(value)`: PyYAML hands back a `datetime` for an unquoted
+        timestamp, and `str()` on that yields a space-separated form
+        (`2026-08-05 09:12:33+00:00`) that neither round-trips as ISO nor
+        matches what `semantic_unit_read` renders for the same field. Going
+        through `temporal` keeps one spelling across every result surface, and
+        keeps the lexicographic sorts in `find` and `lexstore` monotonic when
+        date-only and timestamped pages are interleaved.
+        """
         u = self.frontmatter.get("updated") or self.frontmatter.get("captured") or ""
-        return str(u)
+        if isinstance(u, date):
+            return temporal.stamp(u)
+        moment = temporal.parse(u)
+        if moment is None:
+            return str(u)
+        return temporal.stamp(moment.instant or moment.day)
 
     @property
     def tags(self) -> list[str]:
@@ -203,6 +221,10 @@ class Hit:
     activation: float | None = None
     usage_boost_applied: float | None = None
     graph_provenance: GraphProvenance | None = None
+    # Bounds this hit matched without the ordering actually being decidable —
+    # a page recorded only to the day, against a bound carrying a time inside
+    # it. Empty for every hit whose order was genuinely determined.
+    order_indeterminate: list[str] = field(default_factory=list)
     relation_match: dict[str, Any] | None = None
     matched_units: list[dict[str, Any]] | None = None
     matched_units_truncated: int = 0
@@ -225,6 +247,8 @@ class Hit:
             "updated": self.updated,
             "excerpt": self.excerpt,
         }
+        if self.order_indeterminate:
+            out["order_indeterminate"] = list(self.order_indeterminate)
         if self.graph_provenance is not None:
             out["graph"] = {
                 "relation_type": self.graph_provenance.relation_type,

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -415,6 +415,7 @@ _HIT_FIELDS: frozenset[str] = frozenset(
         "scope",
         "title",
         "updated",
+        "order_indeterminate",
         "excerpt",
         "graph",
         "relation_match",

--- a/src/exomem/indexes.py
+++ b/src/exomem/indexes.py
@@ -53,12 +53,19 @@ def compute_updates(
     date_iso: str,
     activity_summary: str,
     log_entry_body: str,
+    stamp_iso: str | None = None,
 ) -> IndexUpdate:
     """Build the new contents of Sources/index.md, top-level index.md, and log.md.
 
     `rel_source_path` should be the vault-relative path WITHOUT `.md` (wikilink form).
     `activity_summary` is the one-liner that appears in the top index's Recent
     activity bullet AND in the log entry's body.
+
+    `date_iso` is the calendar day: it names index rows and the human-facing
+    Recent-activity bullet, where a time would be noise. `stamp_iso` is the
+    recorded instant for the `log.md` heading, which is what makes several
+    writes on one day orderable. It defaults to `date_iso` so callers that
+    genuinely only have a day keep their existing behaviour.
     """
     kb = kb_root(vault_root)
     sources_dir = kb / "Sources"
@@ -93,7 +100,7 @@ def compute_updates(
 
     log_new = _update_log(
         log_file.read_text(encoding="utf-8"),
-        date_iso=date_iso,
+        date_iso=stamp_iso or date_iso,
         rel_source_path=rel_source_path,
         log_entry_body=log_entry_body
         + (f"\n\n{trim_note}" if trim_note else ""),

--- a/src/exomem/link.py
+++ b/src/exomem/link.py
@@ -18,7 +18,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import entity_candidates, indexes, memory_refs, semantic_writes
+from . import entity_candidates, indexes, memory_refs, semantic_writes, temporal
 from .entity_types import (
     ENTITY_TYPE_IDS,
     ENTITY_TYPE_TO_FOLDER,
@@ -157,8 +157,9 @@ def _legacy_link(
                 # unregistered_project_key.
                 pass
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     tags_clean = _clean_tags(tags)
     exomem_id = memory_refs.new_id()
 
@@ -209,7 +210,7 @@ def _legacy_link(
         name=display_name,
         summary=summary_clean,
         why_in_kb=why_clean,
-        date_iso=date_iso,
+        date_iso=stamp_iso,
         tags=tags_clean,
         connections=[
             render_wikilink_target(connection, vault_root)
@@ -282,7 +283,7 @@ def _legacy_link(
     if log_file.exists():
         new_log = _prepend_log_entry(
             log_file.read_text(encoding="utf-8"),
-            date_iso=date_iso,
+            date_iso=stamp_iso,
             rel_path=rel_entity_no_ext,
             body=log_body,
         )
@@ -616,7 +617,9 @@ def link(
         raise LinkError("PROJECT_KEY_TYPO", ["project"], str(error)) from error
     except ValueError as error:
         raise LinkError("INVALID_LINK", ["project"], str(error)) from error
-    date_iso = (today or dt.date.today()).isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     identity = memory_refs.new_id()
     display_name = name.strip()
     identity_resolution = entity_candidates.resolve_entity_candidate(
@@ -672,7 +675,7 @@ def link(
         name=display_name,
         summary=summary_clean,
         why_in_kb=why_clean,
-        date_iso=date_iso,
+        date_iso=stamp_iso,
         tags=_clean_tags(tags),
         connections=[
             render_wikilink_target(item, vault_root) for item in connections_norm
@@ -699,6 +702,7 @@ def link(
         rel_entity,
         date_iso,
         registrations,
+        render_stamp=stamp_iso,
     ).encode()
     try:
         preflight = semantic_writes.preflight_creation(
@@ -749,7 +753,7 @@ def link(
     try:
         log_plan = plan_log_writes(
             vault_root,
-            date_iso=date_iso,
+            date_iso=stamp_iso,
             op="link",
             rel_path_no_ext=rel_entity_no_ext,
             body=_log_entry_body(

--- a/src/exomem/multi_edit.py
+++ b/src/exomem/multi_edit.py
@@ -24,7 +24,7 @@ from typing import Annotated
 
 from pydantic import BeforeValidator
 
-from . import guards, semantic_writes
+from . import guards, semantic_writes, temporal
 from .edit import (
     EditError,
     _set_or_append,
@@ -153,8 +153,8 @@ def multi_edit(
 
     edits = normalized_edits
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.stamp(now)
 
     editable = load_editable(vault_root, path, expected_hash=expected_hash)
 

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -43,6 +43,7 @@ from . import (
     relation_review,
     semantic_units,
     semantic_writes,
+    temporal,
 )
 from . import (
     find as find_module,
@@ -508,8 +509,13 @@ def _legacy_note(
     if err is not None:
         raise NoteError(code=err.code, missing=err.missing, reason=err.reason)
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    # Two precisions from one clock read. `date_iso` is the bare day that
+    # names files and index bullets; `stamp_iso` is what gets recorded as
+    # knowledge time. A caller injecting a plain `date` (as every existing
+    # test does) gets the day in both, so day-granular expectations stay true.
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     tags_clean = _clean_tags(tags)
     exomem_id = memory_refs.new_id()
 
@@ -616,7 +622,7 @@ def _legacy_note(
         project=project,
         projects=projects,
         status=status,
-        date_iso=date_iso,
+        date_iso=stamp_iso,
         sources=[render_wikilink_target(source, vault_root) for source in sources_norm],
         tags=tags_clean,
         content=body_clean,
@@ -741,7 +747,7 @@ def _legacy_note(
         )
         new_log = _prepend_log_entry(
             log_file.read_text(encoding="utf-8"),
-            date_iso=date_iso,
+            date_iso=stamp_iso,
             verb="note",
             rel_path=rel_note_no_ext,
             body=full_body,
@@ -1559,10 +1565,18 @@ def note(
         raise NoteError(err.code, err.missing, err.reason)
 
     identity = draft_id or memory_refs.new_id()
+    # The draft token pins the *path* date across the draft->commit gap, so a
+    # note keeps its filename whichever side of midnight it is committed on.
+    # Knowledge time is stamped at commit instead: it records when the write
+    # actually happened, not when the draft was prepared.
+    now = today or temporal.now()
     render_date = (
         token_value.render_date
         if token_value is not None
-        else (today or dt.date.today()).isoformat()
+        else temporal.render_date(now)
+    )
+    stamp_iso = (
+        token_value.stamp() if token_value is not None else temporal.stamp(now)
     )
     registrations = tuple(
         semantic_writes.DraftRegistration(item.key, item.category, item.folder)
@@ -1587,7 +1601,12 @@ def note(
         # otherwise record the minted spelling as the page's identity path.
         destination = canonical_vault_rel(root, note_path.relative_to(root).as_posix())
         token_value = semantic_writes.DraftToken(
-            "note", _preflight_operation, destination, render_date, registrations
+            "note",
+            _preflight_operation,
+            destination,
+            render_date,
+            registrations,
+            render_stamp=stamp_iso,
         )
         encoded_token = token_value.encode()
     else:
@@ -1615,7 +1634,7 @@ def note(
         project=project,
         projects=projects,
         status=status,
-        date_iso=render_date,
+        date_iso=stamp_iso,
         sources=[render_wikilink_target(item, root) for item in sources_norm],
         tags=tags_clean,
         content=body_clean,
@@ -1727,7 +1746,7 @@ def note(
     try:
         log_plan = plan_log_writes(
             root,
-            date_iso=render_date,
+            date_iso=stamp_iso,
             op="note",
             rel_path_no_ext=rel_note_no_ext,
             body=_log_entry_body(

--- a/src/exomem/observe_memory.py
+++ b/src/exomem/observe_memory.py
@@ -11,7 +11,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from . import access, edit, semantic_index, semantic_language_registry, semantic_writes, vault
+from . import (
+    access,
+    edit,
+    semantic_index,
+    semantic_language_registry,
+    semantic_writes,
+    temporal,
+    vault,
+)
 
 ObserveOperation = Literal["add", "update", "remove", "validate"]
 
@@ -273,7 +281,7 @@ def observe_memory(
     try:
         log_plan = vault.plan_log_writes(
             vault_root,
-            date_iso=(today or dt.date.today()).isoformat(),
+            date_iso=temporal.stamp(today or temporal.now()),
             op="observe",
             rel_path_no_ext=editable.rel_path.removesuffix(".md"),
             body=f"Structured semantic-unit {op} via observe_memory.",

--- a/src/exomem/preserve.py
+++ b/src/exomem/preserve.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
-from . import indexes, memory_refs, privacy_log
+from . import indexes, memory_refs, privacy_log, temporal
 from .kbdir import kb_prefix
 from .vault import (
     ContentHashMismatchError,
@@ -168,8 +168,9 @@ def preserve(
     if missing:
         return _raise("INVALID_PRESERVE", missing, "; ".join(reasons))
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.render_date(now)
+    stamp_iso = temporal.stamp(now)
     kb = kb_root(vault_root)
     folder = kb / "Evidence" / scope_safe / category_safe
     artifact_path = folder / filename_safe
@@ -293,7 +294,7 @@ def preserve(
                     artifact_name=filename_safe,
                     scope=scope_safe,
                     category=category_safe,
-                    date_iso=date_iso,
+                    date_iso=stamp_iso,
                     description=desc_clean,
                     text=text_clean,
                     media_type=media_type,
@@ -345,7 +346,7 @@ def preserve(
         if log_file.exists():
             new_log = _prepend_log_entry(
                 log_file.read_text(encoding="utf-8"),
-                date_iso=date_iso,
+                date_iso=stamp_iso,
                 rel_path=rel_artifact,
                 body=log_body,
             )
@@ -629,7 +630,7 @@ def ensure_media_sidecar(
         artifact_name=name,
         scope=scope,
         category=category,
-        date_iso=(today or dt.date.today()).isoformat(),
+        date_iso=temporal.stamp(today or temporal.now()),
         media_type=media_type,
         evidence_file=rel,
         extracted_by="none",  # not pending → the auto OCR scan ignores it; backfill OCRs it

--- a/src/exomem/replace.py
+++ b/src/exomem/replace.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import find as find_module
-from . import indexes, memory_refs, relation_review, semantic_writes
+from . import indexes, memory_refs, relation_review, semantic_writes, temporal
 from . import note as note_module
 from .kbdir import kb_prefix
 from .vault import (
@@ -96,8 +96,8 @@ def _legacy_replace(
     - Patches the new page's frontmatter to include `supersedes:`.
     - Patches the old page's frontmatter to flip status + add `superseded_by:`.
     """
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    stamp_iso = temporal.stamp(now)
 
     # Resolve + validate old_path.
     old_resolved, rel_old_with_ext = _resolve_kb_path(vault_root, old_path)
@@ -173,7 +173,7 @@ def _legacy_replace(
 
     # Patch old page: status -> superseded, add superseded_by, refresh updated.
     new_link_target = render_wikilink_target(rel_new_no_ext, vault_root)
-    old_text_updated = _mark_superseded(old_text, new_link_target, date_iso)
+    old_text_updated = _mark_superseded(old_text, new_link_target, stamp_iso)
     if old_text_updated == old_text:
         warnings.append(
             "could not patch old page frontmatter (status/superseded_by/updated) — "
@@ -196,7 +196,7 @@ def _legacy_replace(
         log_body = " ".join(log_body_parts)
         new_log = _prepend_replace_log_entry(
             log_write.content,
-            date_iso=date_iso,
+            date_iso=stamp_iso,
             rel_new_no_ext=rel_new_no_ext,
             body=log_body,
         )
@@ -598,10 +598,13 @@ def replace(
     if validate_only:
         return prepared.preflight
 
-    render_date = semantic_writes.DraftToken.decode(prepared.draft_token).render_date
+    # The draft token pins the path date across the draft->commit gap (it is
+    # already baked into `prepared.destination`); knowledge time is stamped at
+    # commit, when the supersession actually happened.
+    stamp_iso = temporal.stamp(today or temporal.now())
     rel_new_no_ext = prepared.destination.removesuffix(".md")
     new_link_target = render_wikilink_target(rel_new_no_ext, root)
-    old_updated = _mark_superseded(old_text, new_link_target, render_date)
+    old_updated = _mark_superseded(old_text, new_link_target, stamp_iso)
     if old_parsed.frontmatter.get("status") == "superseded" and recovery_receipt is not None:
         old_updated = old_text
     auxiliary = list(prepared.auxiliary_writes)
@@ -618,7 +621,7 @@ def replace(
     try:
         log_plan = plan_log_writes(
             root,
-            date_iso=render_date,
+            date_iso=stamp_iso,
             op="replace",
             rel_path_no_ext=rel_new_no_ext,
             body=replacement_body,

--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -25,6 +25,7 @@ from . import (
     semantic_contract,
     semantic_index,
     semantic_language_registry,
+    temporal,
     vault,
 )
 from . import (
@@ -32,7 +33,11 @@ from . import (
 )
 from .kbdir import kb_prefix
 
-_TOKEN_VERSION = 1
+# v2 froze the authored *instant* alongside the authored day. v1 tokens are
+# rejected: a token minted before the bump carries no knowledge-time stamp,
+# and inferring one at commit is exactly the non-determinism the freeze exists
+# to prevent. Clients mid validate->commit re-validate once at the boundary.
+_TOKEN_VERSION = 2
 _MAX_TOKEN_BYTES = 12 * 1024
 _COMPILED_TYPES = frozenset(
     {
@@ -682,11 +687,27 @@ class DraftRegistration:
 
 @dataclass(frozen=True, slots=True)
 class DraftToken:
+    """A validated destination frozen across the validate->commit gap.
+
+    `render_date` is the authored calendar day; it names the file and must stay
+    day-granular. `render_stamp` is the authored knowledge-time instant written
+    into `created`/`updated`. Both are frozen at validation rather than read
+    again at commit, so committing the same token twice produces identical
+    bytes — the property the mutation-receipt replay path depends on.
+    """
+
     writer: str
     operation: str
     destination: str
     render_date: str
     registrations: tuple[DraftRegistration, ...] = ()
+    # Declared last so existing positional construction keeps binding
+    # `registrations` where callers expect it; always pass this by keyword.
+    render_stamp: str = ""
+
+    def stamp(self) -> str:
+        """The frozen instant, falling back to the frozen day."""
+        return self.render_stamp or self.render_date
 
     def encode(self) -> str:
         value = {
@@ -695,6 +716,7 @@ class DraftToken:
             "operation": self.operation,
             "destination": self.destination,
             "render_date": self.render_date,
+            "render_stamp": self.render_stamp or self.render_date,
             "registrations": [item.as_dict() for item in self.registrations],
         }
         raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
@@ -734,12 +756,13 @@ class DraftToken:
             "operation",
             "destination",
             "render_date",
+            "render_stamp",
             "registrations",
         }:
             raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token has invalid fields")
         if value["version"] != _TOKEN_VERSION or any(
             type(value[key]) is not str
-            for key in ("writer", "operation", "destination", "render_date")
+            for key in ("writer", "operation", "destination", "render_date", "render_stamp")
         ):
             raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token has invalid fields")
         try:
@@ -748,6 +771,19 @@ class DraftToken:
             raise SemanticWriteError(
                 "INVALID_DRAFT_TOKEN", "draft token has invalid render date"
             ) from error
+        # The frozen stamp must be canonical, or committing the same token
+        # twice could still produce different bytes.
+        stamp_moment = temporal.parse(value["render_stamp"])
+        if stamp_moment is None or temporal.stamp(
+            stamp_moment.instant or stamp_moment.day
+        ) != value["render_stamp"]:
+            raise SemanticWriteError(
+                "INVALID_DRAFT_TOKEN", "draft token has invalid render stamp"
+            )
+        if stamp_moment.day != render_date:
+            raise SemanticWriteError(
+                "INVALID_DRAFT_TOKEN", "draft token render stamp disagrees with its render date"
+            )
         if (
             render_date.isoformat() != value["render_date"]
             or not re.fullmatch(r"[a-z][a-z0-9_]{0,31}", value["writer"])
@@ -775,6 +811,7 @@ class DraftToken:
             value["destination"],
             value["render_date"],
             tuple(registrations),
+            render_stamp=value["render_stamp"],
         )
         if decoded.encode() != token:
             raise SemanticWriteError("INVALID_DRAFT_TOKEN", "draft token is not canonical")

--- a/src/exomem/set_frontmatter_field.py
+++ b/src/exomem/set_frontmatter_field.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import project_keys, semantic_writes
+from . import project_keys, semantic_writes, temporal
 from .vault import (
     PlannedWrite,
     VaultPathError,
@@ -171,8 +171,8 @@ def set_frontmatter_field(
     fm_text = m.group(1)
     body = m.group(2)
 
-    today = today or dt.date.today()
-    date_iso = today.isoformat()
+    now = today or temporal.now()
+    date_iso = temporal.stamp(now)
 
     old_value = _read_yaml_field(fm_text, field)
     fm_text = _remove_yaml_key(fm_text, field)

--- a/src/exomem/structured_filters.py
+++ b/src/exomem/structured_filters.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal, TypeAlias, cast
 
-from . import semantic_language_registry, semantic_units
+from . import semantic_language_registry, semantic_units, temporal
 
 MAX_PLAN_BYTES = 16 * 1024
 MAX_POINTER_BYTES = 512
@@ -637,10 +637,31 @@ def page_view(page: Any) -> dict[str, Any]:
     # see the union of all non-null values.
     if project_declared:
         out["project"] = projects
-    if "updated" in frontmatter:
-        out["updated"] = frontmatter["updated"]
-    elif "captured" in frontmatter:
-        out["updated"] = frontmatter["captured"]
+    recorded = frontmatter.get("updated") if "updated" in frontmatter else None
+    if "updated" not in frontmatter and "captured" in frontmatter:
+        recorded = frontmatter["captured"]
+    if "updated" in frontmatter or "captured" in frontmatter:
+        # Settle precision here rather than downstream. `page.updated` is
+        # strictly typed — `date` and `datetime` are deliberately not
+        # comparable (see `_evaluate_operator`) — so an unnormalized value
+        # whose YAML spelling differs from the operand's silently evaluates
+        # False and drops the page from every date filter with no warning.
+        # Frontmatter reaches us in four shapes: bare date, quoted date (what
+        # `serialize_frontmatter` writes), and both again with a timestamp.
+        # They all denote a recorded day, so all four answer day-granular
+        # questions. A value we cannot parse is passed through untouched, so
+        # it still fails date filters instead of acquiring an invented day.
+        moment = temporal.parse(recorded)
+        if moment is None:
+            out["updated"] = recorded
+        else:
+            # Present the most precise recorded value. `_evaluate_operator`
+            # decides at what granularity to compare, because that is a
+            # property of the *question* — "updated on or after this day" is
+            # fully answerable for a page recorded to the second, while
+            # "updated after 09:00" is not answerable for a page recorded only
+            # to the day.
+            out["updated"] = moment.instant or moment.day
     return out
 
 
@@ -1423,6 +1444,9 @@ def _evaluate_operator(
         return _same_scalar(scalar, operand)
     if operator == "$ne":
         return scalar.kind == operand.kind and scalar.value != operand.value
+    if _is_temporal(scalar) and _is_temporal(operand):
+        matches, _ = _temporal_match(operator, scalar, operand)
+        return matches
     if scalar.kind != operand.kind or scalar.kind not in {"number", "date", "datetime"}:
         return False
     if operator == "$gt":
@@ -1434,6 +1458,93 @@ def _evaluate_operator(
     if operator == "$lte":
         return scalar.value <= operand.value  # type: ignore[operator]
     raise AssertionError(f"unhandled operator: {operator}")
+
+
+def indeterminate_bounds(
+    page: Mapping[str, Any], *, shortcuts: FilterShortcuts
+) -> tuple[str, ...]:
+    """Which date bounds this page matched without the order being decidable.
+
+    A page recorded only as `2026-08-05` is genuinely unordered against a bound
+    of `2026-08-05T09:00:00Z`: the day denotes an unknown instant within it.
+    `evaluate_filter` returns such a page rather than dropping it, and this
+    reports which bounds could not actually be decided, so a caller can say so
+    instead of presenting a guess as a match.
+
+    Empty when every bound was decidable, when the bound is day-scoped (a
+    day-granular question is always answerable), or when the page records no
+    date at all — absent is not ambiguous.
+    """
+    moment = temporal.parse(page.get("updated"))
+    if moment is None:
+        return ()
+    marked: list[str] = []
+    for name, raw in (
+        ("updated_after", shortcuts.updated_after),
+        ("updated_before", shortcuts.updated_before),
+    ):
+        if raw is None:
+            continue
+        bound = temporal.parse(raw)
+        if bound is None or not bound.precise:
+            continue
+        if temporal.compare(moment, bound) is temporal.Order.INDETERMINATE:
+            marked.append(name)
+    return tuple(marked)
+
+
+_ORDERED_OPERATORS = ("$gt", "$gte", "$lt", "$lte")
+
+
+def _is_temporal(scalar: TypedScalar) -> bool:
+    return scalar.kind in {"date", "datetime"}
+
+
+def _as_moment(scalar: TypedScalar) -> temporal.Moment | None:
+    return temporal.parse(scalar.value)
+
+
+def _temporal_match(
+    operator: str, page: TypedScalar, bound: TypedScalar
+) -> tuple[bool, bool]:
+    """Compare a recorded value against a bound. Returns `(matches, indeterminate)`.
+
+    The **bound** decides the granularity, because precision is a property of
+    the question rather than of the data. "Updated on or after 2026-08-05?" is
+    fully answerable for a page recorded to the second, so a day-scoped bound
+    must not start reporting ambiguity just because some pages are precise. But
+    "updated after 09:00 on 2026-08-05?" is genuinely unanswerable for a page
+    recorded only as `2026-08-05`, because that day denotes an unknown instant.
+
+    An undecidable comparison reports `matches=True, indeterminate=True`:
+    excluding it silently is the defect this whole change exists to fix, and
+    including it silently would report a guess as a fact. The caller surfaces
+    the flag (see `indeterminate_bounds`).
+    """
+    page_moment, bound_moment = _as_moment(page), _as_moment(bound)
+    if page_moment is None or bound_moment is None:
+        return False, False
+    if operator not in _ORDERED_OPERATORS:
+        # `$eq`/`$ne` are handled before this point by exact scalar identity.
+        return False, False
+    if bound_moment.precise:
+        order = temporal.compare(page_moment, bound_moment)
+    else:
+        # Day-scoped question: compare whole days, which is always decidable.
+        order = temporal.compare(
+            temporal.Moment(page_moment.day), temporal.Moment(bound_moment.day)
+        )
+        if order is temporal.Order.INDETERMINATE:
+            order = temporal.Order.SAME
+    if order is temporal.Order.INDETERMINATE:
+        return True, True
+    if operator == "$gt":
+        return order is temporal.Order.AFTER, False
+    if operator == "$gte":
+        return order in (temporal.Order.AFTER, temporal.Order.SAME), False
+    if operator == "$lt":
+        return order is temporal.Order.BEFORE, False
+    return order in (temporal.Order.BEFORE, temporal.Order.SAME), False
 
 
 def _runtime_scalar(value: Any, *, field: FieldReference) -> TypedScalar | None:

--- a/src/exomem/temporal.py
+++ b/src/exomem/temporal.py
@@ -1,0 +1,183 @@
+"""Frontmatter knowledge time: two precisions, one order.
+
+Notes record `created`/`updated` — and `log.md` history headings — at two
+precisions, permanently:
+
+- a bare calendar date (`2026-08-05`) denotes *an unknown instant within that
+  day*. Every note written before second granularity landed reads this way, and
+  hand-authored frontmatter still may.
+- a second-granularity UTC timestamp (`2026-08-05T09:12:33Z`) denotes a
+  specific instant. This is what the write tools emit going forward.
+
+Old values are never rewritten. Restamping them as midnight would assert a
+precision that was never captured, so the mixed vault is the permanent state
+and **precision is part of the data**. Two consequences follow, and they are
+the reason this module exists rather than a bare `date.fromisoformat` at each
+call site:
+
+1. Ordering is not total. Two values that share a day cannot be ordered when
+   either lacks a time, so `compare` is four-valued and reports
+   `INDETERMINATE` rather than collapsing an unknown into a guess. Callers that
+   need a total order for display use `sort_key`, which is stable but does not
+   pretend the ambiguity is resolved.
+2. Precision is carried by the Python type, on both sides. PyYAML already hands
+   back `datetime.date` for a bare date and `datetime.datetime` for a
+   timestamp; the write tools' injectable `today`/`now` seam accepts either and
+   emits at whatever precision it was given. A caller passing a `date` gets
+   date-only output, which is what keeps the existing day-granular tests honest
+   instead of merely passing.
+
+Timezone handling: one standard on disk. Stamps are written in UTC with a `Z`
+suffix, matching `adoption_run._now_iso` and `review_state`, so values are
+comparable across machines without consulting a timezone database. The author's
+local zone is deliberately not stored — that is a different fact from when the
+edit happened. `render_date`, by contrast, reads the day off the value *as
+given*, because note paths (`YYYY-MM-<slug>`) have always used the local day
+and folding to UTC would silently move a late-evening note into the previous
+month.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Order(Enum):
+    """Result of comparing two `Moment`s.
+
+    `INDETERMINATE` is a real answer, not an error: the values genuinely do not
+    determine an order, and reporting that is more useful than a coin flip.
+    """
+
+    BEFORE = "before"
+    AFTER = "after"
+    SAME = "same"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True, slots=True)
+class Moment:
+    """A point in knowledge time, at whichever precision was actually recorded.
+
+    `instant` is `None` when only the day is known. It is never inferred.
+    """
+
+    day: dt.date
+    instant: dt.datetime | None = None
+
+    @property
+    def precise(self) -> bool:
+        """True when the exact instant is known, not just the calendar day."""
+        return self.instant is not None
+
+
+def now() -> dt.datetime:
+    """The current instant, timezone-aware and truncated to the second.
+
+    Local offset rather than UTC so `render_date` keeps yielding the local day
+    that note paths have always used; `stamp` folds it to UTC for storage.
+    """
+    return dt.datetime.now().astimezone().replace(microsecond=0)
+
+
+def stamp(value: dt.date) -> str:
+    """Render a `date` or `datetime` in canonical frontmatter form.
+
+    A `datetime` becomes second-granularity UTC (`2026-08-05T09:12:33Z`); a
+    bare `date` stays bare. Naive datetimes are read as UTC — the codebase has
+    no local-wall-clock storage to preserve.
+    """
+    if isinstance(value, dt.datetime):
+        aware = value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)
+        utc = aware.astimezone(dt.UTC).replace(microsecond=0)
+        return utc.isoformat().replace("+00:00", "Z")
+    return value.isoformat()
+
+
+def render_date(value: dt.date) -> str:
+    """The bare `YYYY-MM-DD` day, for note paths and draft tokens.
+
+    Reads the day off `value` without changing zone, so a note written late
+    locally stays in the month its author wrote it in. Draft tokens require
+    exactly this form (`semantic_writes.DraftToken.decode`).
+    """
+    if isinstance(value, dt.datetime):
+        return value.date().isoformat()
+    return value.isoformat()
+
+
+def parse(value: object) -> Moment | None:
+    """Coerce a frontmatter value to a `Moment`, or `None` if unusable.
+
+    Accepts every shape the vault can produce: the `date`/`datetime` objects
+    PyYAML auto-types from unquoted values, and the string forms that reach us
+    from quoted frontmatter, templates, and `str()` of a loaded datetime (which
+    is space-separated, not ISO-`T`).
+    """
+    if isinstance(value, dt.datetime):
+        return _from_datetime(value)
+    if isinstance(value, dt.date):
+        return Moment(value)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    # Date first: `date.fromisoformat` rejects anything carrying a time, so it
+    # cannot silently turn a bare date into midnight the way `datetime` would.
+    try:
+        return Moment(dt.date.fromisoformat(text))
+    except ValueError:
+        pass
+    try:
+        return _from_datetime(dt.datetime.fromisoformat(text))
+    except ValueError:
+        return None
+
+
+def _from_datetime(value: dt.datetime) -> Moment:
+    """Normalize an instant to UTC at second granularity.
+
+    Sub-second precision is dropped rather than preserved: milliseconds are
+    false precision on hand-authored notes, and keeping them would let two
+    values compare unequal on a difference neither the writer nor the reader
+    can account for.
+    """
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)
+    utc = aware.astimezone(dt.UTC).replace(microsecond=0)
+    return Moment(utc.date(), utc)
+
+
+def compare(a: Moment, b: Moment) -> Order:
+    """Order two moments, reporting `INDETERMINATE` where none exists.
+
+    Distinct days always order — a whole day precedes the next whatever the
+    unknown times within them. Within one day, only two known instants can be
+    ordered; anything else is genuinely undetermined.
+    """
+    if a.instant is not None and b.instant is not None:
+        if a.instant < b.instant:
+            return Order.BEFORE
+        if a.instant > b.instant:
+            return Order.AFTER
+        return Order.SAME
+    if a.day < b.day:
+        return Order.BEFORE
+    if a.day > b.day:
+        return Order.AFTER
+    return Order.INDETERMINATE
+
+
+_UNKNOWN_TIME = dt.datetime.min.replace(tzinfo=dt.UTC)
+
+
+def sort_key(moment: Moment) -> tuple[dt.date, bool, dt.datetime]:
+    """Stable total order for display, where `compare` may be indeterminate.
+
+    Day-only values sort ahead of same-day timestamped ones. This is a
+    presentation fallback, not a claim about what actually happened first —
+    surface the ambiguity separately rather than letting the sort imply it away.
+    """
+    return (moment.day, moment.instant is not None, moment.instant or _UNKNOWN_TIME)

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -4658,10 +4658,19 @@ def write_log_entry(
         return f"log entry skipped: {error}"
 
 
-# Matches a single log.md entry header: `## [2026-06-23] edit | Notes/Insights/foo`.
+# Matches a single log.md entry header, at either recorded precision:
+#   `## [2026-06-23] edit | Notes/Insights/foo`
+#   `## [2026-06-23T09:12:33Z] edit | Notes/Insights/foo`
 # `op` is a single whitespace-free token; the title runs to end-of-line.
+#
+# The optional time group is what makes same-day edits orderable — three
+# entries written within one afternoon used to read identically, leaving
+# position in the file as the only ordering signal. A header this fails to
+# match is not an error anywhere downstream: `read_log_entries` simply returns
+# nothing, so `read_memory(include_history=true)` would lose the page's history
+# silently. Widen this before anything can write the longer form.
 _LOG_ENTRY_HEADER_RE = re.compile(
-    r"^## \[(\d{4}-\d{2}-\d{2})\] (\S+) \| (.+)$",
+    r"^## \[(\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}Z)?)\] (\S+) \| (.+)$",
     re.MULTILINE,
 )
 

--- a/tests/test_note_timestamps.py
+++ b/tests/test_note_timestamps.py
@@ -1,0 +1,336 @@
+"""Second-granularity knowledge time on notes, and the mixed vault it creates.
+
+Notes used to record `created`/`updated` — and every `log.md` history heading —
+as a bare calendar date, so a page revised three times in one afternoon carried
+three identical dates and `created == updated`. Ordering was recoverable only
+from position in the file, not from the data.
+
+Writes now stamp a second-granularity UTC instant. Nothing is backfilled: a
+date-only value means the intra-day time was never captured, and rewriting it
+as midnight would invent precision. Both forms are therefore permanent, which
+is what these tests pin.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from exomem import audit as audit_module
+from exomem import audit_fix as audit_fix_module
+from exomem import edit as edit_module
+from exomem import find as find_module
+from exomem import temporal
+from exomem import vault as vault_module
+
+NOTE_REL = "Knowledge Base/Notes/Insights/stamped-note.md"
+
+SOURCE_LINK = "[[Knowledge Base/Sources/Articles/2026-06-02-postgres-autovacuum-tuning]]"
+
+# Shaped like the compliant fixture insights: a cited source and a Connections
+# section, so the semantic contract is satisfied and these tests exercise the
+# timestamp behaviour rather than re-testing governance.
+DATE_ONLY_BODY = f"""\
+---
+type: insight
+status: active
+created: 2026-01-01
+updated: 2026-01-01
+sources:
+  - "{SOURCE_LINK}"
+tags: [legacy]
+---
+
+# Legacy Note
+
+## Claim
+
+Written before timestamps existed, so its intra-day time is genuinely unknown.
+
+## Overview
+
+Detail line.
+
+## Connections
+
+- {SOURCE_LINK}
+"""
+
+
+def _seed(vault: Path, rel: str = NOTE_REL, body: str = DATE_ONLY_BODY) -> Path:
+    path = vault / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    find_module.clear_cache()
+    return path
+
+
+def _frontmatter(path: Path) -> dict:
+    fm, _, _ = vault_module.parse_frontmatter(path.read_text(encoding="utf-8"))
+    return fm
+
+
+# --- writes stamp an instant -------------------------------------------------
+
+
+def test_edit_stamps_second_granularity_utc(vault: Path) -> None:
+    path = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="revise",
+        heading="Overview", section_position="append", new_string="A point.",
+        today=dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC),
+    )
+    assert "updated: 2026-08-05T09:12:33Z" in path.read_text(encoding="utf-8")
+
+
+def test_edit_leaves_created_alone(vault: Path) -> None:
+    """`created` is the one date an edit must never touch."""
+    path = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="revise",
+        heading="Overview", section_position="append", new_string="A point.",
+        today=dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC),
+    )
+    assert "created: 2026-01-01" in path.read_text(encoding="utf-8")
+
+
+def test_a_date_only_clock_still_writes_a_date(vault: Path) -> None:
+    """Precision follows the injected type, so day-granular callers stay day-granular."""
+    path = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="revise",
+        heading="Overview", section_position="append", new_string="A point.",
+        today=dt.date(2026, 8, 5),
+    )
+    assert "updated: 2026-08-05\n" in path.read_text(encoding="utf-8")
+
+
+def test_local_offset_is_stored_as_utc(vault: Path) -> None:
+    """One standard on disk, so values order across machines."""
+    path = _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="revise",
+        heading="Overview", section_position="append", new_string="A point.",
+        today=dt.datetime(2026, 8, 5, 12, 12, 33, tzinfo=dt.timezone(dt.timedelta(hours=3))),
+    )
+    assert "updated: 2026-08-05T09:12:33Z" in path.read_text(encoding="utf-8")
+
+
+# --- the symptom that motivated the change ----------------------------------
+
+
+def test_same_day_writes_produce_distinct_ordered_history(vault: Path) -> None:
+    """Three writes in one afternoon must be orderable from the data alone.
+
+    Exercised at the log layer rather than through `edit()`: a second edit of
+    the same page trips an unrelated relation-disposition contract, and this
+    test is about whether the recorded headings can be told apart, which is
+    what changed. `test_edit_stamps_second_granularity_utc` covers the tool
+    writing the stamp in the first place.
+    """
+    rel = NOTE_REL.removesuffix(".md")
+    log_path = vault / "Knowledge Base" / "log.md"
+    text = log_path.read_text(encoding="utf-8")
+    for when in (
+        dt.datetime(2026, 8, 5, 9, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 8, 5, 11, 30, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 8, 5, 16, 45, 12, tzinfo=dt.UTC),
+    ):
+        text = vault_module.prepend_log_entry(
+            text, date_iso=temporal.stamp(when), op="edit",
+            rel_path_no_ext=rel, body="A revision.",
+        )
+    log_path.write_text(text, encoding="utf-8")
+
+    dates = [e["date"] for e in vault_module.read_log_entries(vault, rel)]
+    assert len(dates) == 3
+    # The defect: these used to be three identical `2026-08-05` strings.
+    assert len(set(dates)) == 3
+    assert dates == sorted(dates, reverse=True)
+    assert all(temporal.parse(d).precise for d in dates)
+
+
+def test_history_headings_still_parse_at_day_granularity(vault: Path) -> None:
+    """The widened heading regex must not orphan existing date-only history.
+
+    A header this fails to match is dropped silently rather than raising, so a
+    regression here would empty `read_memory(include_history=true)` with no
+    error anywhere.
+    """
+    _seed(vault)
+    edit_module.edit(
+        vault, path=NOTE_REL, why="day-granular revision",
+        heading="Overview", section_position="append", new_string="A point.",
+        today=dt.date(2026, 8, 5),
+    )
+    entries = vault_module.read_log_entries(vault, NOTE_REL.removesuffix(".md"))
+    assert [e for e in entries if e["date"] == "2026-08-05"]
+
+
+def test_history_mixes_both_precisions(vault: Path) -> None:
+    """A log written across the change carries both forms, and both read back."""
+    rel = NOTE_REL.removesuffix(".md")
+    log_path = vault / "Knowledge Base" / "log.md"
+    text = log_path.read_text(encoding="utf-8")
+    for stamp in ("2026-08-04", "2026-08-05T09:12:33Z"):
+        text = vault_module.prepend_log_entry(
+            text, date_iso=stamp, op="edit", rel_path_no_ext=rel, body="A revision."
+        )
+    log_path.write_text(text, encoding="utf-8")
+
+    dates = {e["date"] for e in vault_module.read_log_entries(vault, rel)}
+    assert dates == {"2026-08-04", "2026-08-05T09:12:33Z"}
+
+
+def test_a_malformed_heading_is_the_silent_failure_mode(vault: Path) -> None:
+    """Guard the shape of the risk: unmatched headings vanish, they do not raise.
+
+    `read_log_entries` returns only what the header pattern matches, so a
+    too-narrow regex would empty a page's history with no error surfacing
+    anywhere. Pinning the silence makes the widened pattern load-bearing.
+    """
+    rel = NOTE_REL.removesuffix(".md")
+    log_path = vault / "Knowledge Base" / "log.md"
+    text = vault_module.prepend_log_entry(
+        log_path.read_text(encoding="utf-8"),
+        date_iso="2026-08-05T09:12:33+00:00",  # offset form: not what we write
+        op="edit", rel_path_no_ext=rel, body="A revision.",
+    )
+    log_path.write_text(text, encoding="utf-8")
+    assert vault_module.read_log_entries(vault, rel) == []
+
+
+# --- no backfill -------------------------------------------------------------
+
+
+def test_audit_fix_leaves_date_only_notes_byte_identical(vault: Path) -> None:
+    """Acceptance: existing date-only notes are not rewritten. Ever.
+
+    Restamping them as midnight would assert an intra-day time that was never
+    recorded, so the repair pass must leave a compliant legacy page untouched.
+    """
+    path = _seed(vault)
+    before = path.read_bytes()
+    audit_fix_module.audit_fix(vault, today=dt.date(2026, 8, 5))
+    assert path.read_bytes() == before
+
+
+def test_audit_fix_copy_forward_preserves_the_instant(vault: Path) -> None:
+    """Backfilling `updated` from `created` must not coarsen a known instant."""
+    path = _seed(vault, body=f"""\
+---
+type: insight
+status: active
+created: 2026-08-05T09:12:33Z
+sources:
+  - "{SOURCE_LINK}"
+---
+
+# Missing Updated
+
+## Claim
+
+A stamped page whose `updated` was never written.
+
+## Connections
+
+- {SOURCE_LINK}
+""")
+    audit_fix_module.audit_fix(vault, today=dt.date(2026, 8, 6))
+    assert temporal.parse(_frontmatter(path).get("updated")) == temporal.parse(
+        "2026-08-05T09:12:33Z"
+    )
+
+
+def test_audit_round_trip_keeps_the_time_component(vault: Path) -> None:
+    """Write a stamped note, run the audit paths, assert the time survives."""
+    path = _seed(vault, body=f"""\
+---
+type: insight
+status: active
+created: 2026-08-05T09:12:33Z
+updated: 2026-08-05T16:45:12Z
+sources:
+  - "{SOURCE_LINK}"
+---
+
+# Stamped
+
+## Claim
+
+A page recorded at second granularity.
+
+## Connections
+
+- {SOURCE_LINK}
+""")
+    audit_module.audit(vault, today=dt.date(2026, 8, 6))
+    audit_fix_module.audit_fix(vault, today=dt.date(2026, 8, 6))
+    fm = _frontmatter(path)
+    assert temporal.parse(fm["updated"]).instant == dt.datetime(
+        2026, 8, 5, 16, 45, 12, tzinfo=dt.UTC
+    )
+    assert temporal.parse(fm["created"]).instant == dt.datetime(
+        2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC
+    )
+
+
+def test_audit_ages_a_stamped_note_by_whole_days() -> None:
+    """Staleness is a day-granular question; a timestamp must not break it.
+
+    The space-separated case is what `str()` of a PyYAML-loaded datetime
+    produces, which the previous 10-character prefix slice silently mangled.
+    """
+    assert audit_module._parse_fm_date("2026-08-05T16:45:12Z") == dt.date(2026, 8, 5)
+    assert audit_module._parse_fm_date("2026-08-05 16:45:12+00:00") == dt.date(2026, 8, 5)
+    assert audit_module._parse_fm_date(
+        dt.datetime(2026, 8, 5, 16, 45, 12, tzinfo=dt.UTC)
+    ) == dt.date(2026, 8, 5)
+    assert audit_module._parse_fm_date("not-a-date") is None
+
+
+# --- mixed vault -------------------------------------------------------------
+
+
+def test_mixed_vault_validates_and_sorts(vault: Path) -> None:
+    """Both precisions coexist, audit accepts both, and ordering is stable."""
+    _seed(vault, rel="Knowledge Base/Notes/Insights/legacy.md", body=DATE_ONLY_BODY)
+    _seed(vault, rel="Knowledge Base/Notes/Insights/stamped.md", body=f"""\
+---
+type: insight
+status: active
+created: 2026-01-01T09:12:33Z
+updated: 2026-01-01T16:45:12Z
+sources:
+  - "{SOURCE_LINK}"
+---
+
+# Stamped
+
+## Claim
+
+A page recorded at second granularity.
+
+## Connections
+
+- {SOURCE_LINK}
+""")
+    audit_module.audit(vault, today=dt.date(2026, 8, 5))
+
+    # Both pages read as complete: every required temporal field resolves to a
+    # day regardless of which precision it was written at.
+    for rel in ("legacy", "stamped"):
+        fm = _frontmatter(vault / f"Knowledge Base/Notes/Insights/{rel}.md")
+        for required in ("created", "updated"):
+            assert audit_module._parse_fm_date(fm[required]) is not None, (rel, required)
+
+    moments = [temporal.parse("2026-01-01"), temporal.parse("2026-01-01T16:45:12Z")]
+    assert temporal.compare(*moments) is temporal.Order.INDETERMINATE
+    assert sorted(moments, key=temporal.sort_key) == moments
+
+
+def test_production_log_filename_keeps_its_month(vault: Path) -> None:
+    """Note paths slice `YYYY-MM` off the render date, which stays day-granular."""
+    assert temporal.render_date(
+        dt.datetime(2026, 8, 5, 23, 59, 59, tzinfo=dt.UTC)
+    )[:7] == "2026-08"

--- a/tests/test_relation_queue_commands.py
+++ b/tests/test_relation_queue_commands.py
@@ -6,12 +6,13 @@ and triage_memory relation-ref routing, plus registry-surface exposure.
 
 from __future__ import annotations
 
+import datetime as dt
 from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
 
-from exomem import attention, commands, find, relation_queue, server
+from exomem import attention, commands, find, relation_queue, server, temporal
 
 
 def _write_page(
@@ -132,7 +133,15 @@ def test_accept_relation_creates_relations_section_when_absent(tmp_path: Path) -
     assert "## Relations" in text
 
 
-def test_accept_writes_bullet_byte_identical_to_studio_path(tmp_path: Path) -> None:
+def test_accept_writes_bullet_byte_identical_to_studio_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Both paths stamp knowledge time from the clock, so two executions that
+    # straddle a second boundary differ in `updated:` alone. Pin the clock: the
+    # claim under test is that the two code paths agree, not that they run fast.
+    frozen = dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+    monkeypatch.setattr(temporal, "now", lambda: frozen)
+
     studio_vault = tmp_path / "studio"
     accept_vault = tmp_path / "accept"
     studio_vault.mkdir()

--- a/tests/test_structured_filters.py
+++ b/tests/test_structured_filters.py
@@ -6,6 +6,7 @@ from datetime import UTC, date, datetime
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from exomem.structured_filters import (
     FilterError,
@@ -610,6 +611,55 @@ def test_quoted_updated_string_is_not_coerced_and_rfc3339_is_strict() -> None:
             }
         }
     ).code == "INVALID_FILTER_VALUE"
+
+
+@pytest.mark.parametrize(
+    ("label", "frontmatter_line"),
+    [
+        ("unquoted date", "updated: 2026-01-15"),
+        # `serialize_frontmatter` quotes any scalar YAML would re-type, so
+        # `create_file` and `set_frontmatter_field` have always written this
+        # form — and it used to arrive as `str` and miss every date filter.
+        ("quoted date", 'updated: "2026-01-15"'),
+        ("unquoted timestamp", "updated: 2026-01-15T09:12:33Z"),
+        ("quoted timestamp", 'updated: "2026-01-15T09:12:33Z"'),
+    ],
+)
+def test_every_written_date_form_reaches_date_filters(
+    label: str, frontmatter_line: str
+) -> None:
+    """A page's recorded day must decide date filters, not its YAML spelling.
+
+    `page.updated` is strictly typed downstream — `date` and `datetime` are
+    deliberately not comparable — so the adapter has to settle precision here.
+    Otherwise the operator silently returns False and the page vanishes from
+    `recency_days` / `updated_after` / `updated_before` with no warning.
+    """
+    page = page_view(
+        SimpleNamespace(frontmatter=yaml.safe_load(frontmatter_line), file_kind="note")
+    )
+    assert evaluate_filter(compile_filter({"page.updated": {"$gte": "2026-01-01"}}), page=page)
+    assert evaluate_filter(compile_filter({"page.updated": {"$lte": "2026-02-01"}}), page=page)
+    assert not evaluate_filter(
+        compile_filter({"page.updated": {"$gte": "2026-02-01"}}), page=page
+    )
+
+
+def test_recency_shortcut_keeps_timestamped_pages() -> None:
+    """The end-to-end shape of the bug: a fresh note must survive `recency_days`."""
+    plan = compile_filter(None, shortcuts=FilterShortcuts(recency_days=3650))
+    for line in ("updated: 2026-01-15", 'updated: "2026-01-15"', "updated: 2026-01-15T09:12:33Z"):
+        page = page_view(SimpleNamespace(frontmatter=yaml.safe_load(line), file_kind="note"))
+        assert evaluate_filter(plan, page=page), line
+
+
+def test_unparseable_updated_still_fails_date_filters() -> None:
+    """Normalizing must not invent a day for a value that has none."""
+    page = page_view(SimpleNamespace(frontmatter={"updated": "someday"}, file_kind="note"))
+    assert not evaluate_filter(
+        compile_filter({"page.updated": {"$gte": "2026-01-01"}}), page=page
+    )
+    assert evaluate_filter(compile_filter({"page.updated": {"$exists": True}}), page=page)
 
 
 def test_runtime_arbitrary_precision_integer_does_not_crash() -> None:

--- a/tests/test_subday_filters.py
+++ b/tests/test_subday_filters.py
@@ -1,0 +1,206 @@
+"""Sub-day retrieval bounds, and the ambiguity they must not hide.
+
+`updated_after` / `updated_before` accept an instant as well as a day. The
+interesting case is the boundary day: a page recorded only as `2026-08-05` is
+genuinely unordered against `2026-08-05T09:00:00Z`, because the day denotes an
+unknown instant within it.
+
+Dropping such a page silently is the exact defect this change exists to fix.
+Including it silently reports a guess as a fact. So it comes back marked.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from exomem.structured_filters import (
+    FilterShortcuts,
+    compile_filter,
+    evaluate_filter,
+    indeterminate_bounds,
+    page_view,
+)
+
+
+def _page(frontmatter_line: str) -> dict:
+    return page_view(
+        SimpleNamespace(frontmatter=yaml.safe_load(frontmatter_line), file_kind="note")
+    )
+
+
+DAY_ONLY = "updated: 2026-08-05"
+DAY_BEFORE = "updated: 2026-08-04"
+DAY_AFTER = "updated: 2026-08-06"
+PRECISE_LATE = "updated: 2026-08-05T11:00:00Z"
+PRECISE_EARLY = "updated: 2026-08-05T08:00:00Z"
+
+BOUND = "2026-08-05T09:00:00Z"
+
+
+# --- the bound is decidable --------------------------------------------------
+
+
+def test_precise_page_after_the_bound_is_returned() -> None:
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert evaluate_filter(plan, page=_page(PRECISE_LATE))
+
+
+def test_precise_page_before_the_bound_is_excluded() -> None:
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert not evaluate_filter(plan, page=_page(PRECISE_EARLY))
+
+
+def test_day_only_page_on_an_earlier_day_is_excluded() -> None:
+    """A whole day orders against an instant outside it — no ambiguity here."""
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert not evaluate_filter(plan, page=_page(DAY_BEFORE))
+
+
+def test_day_only_page_on_a_later_day_is_returned() -> None:
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert evaluate_filter(plan, page=_page(DAY_AFTER))
+
+
+# --- the bound is not decidable ---------------------------------------------
+
+
+def test_day_only_page_on_the_boundary_day_is_returned() -> None:
+    """Not dropped: that is the failure mode this whole change is about."""
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert evaluate_filter(plan, page=_page(DAY_ONLY))
+
+
+def test_day_only_page_on_the_boundary_day_is_marked() -> None:
+    """Not silently included either: the caller must be able to see the guess."""
+    assert indeterminate_bounds(
+        _page(DAY_ONLY), shortcuts=FilterShortcuts(updated_after=BOUND)
+    ) == ("updated_after",)
+
+
+@pytest.mark.parametrize(
+    "frontmatter_line",
+    [PRECISE_LATE, PRECISE_EARLY, DAY_BEFORE, DAY_AFTER],
+)
+def test_decidable_pages_are_never_marked(frontmatter_line: str) -> None:
+    assert indeterminate_bounds(
+        _page(frontmatter_line), shortcuts=FilterShortcuts(updated_after=BOUND)
+    ) == ()
+
+
+def test_updated_before_marks_the_same_boundary_day() -> None:
+    assert indeterminate_bounds(
+        _page(DAY_ONLY), shortcuts=FilterShortcuts(updated_before=BOUND)
+    ) == ("updated_before",)
+
+
+def test_both_bounds_can_be_indeterminate_at_once() -> None:
+    marked = indeterminate_bounds(
+        _page(DAY_ONLY),
+        shortcuts=FilterShortcuts(updated_after=BOUND, updated_before="2026-08-05T17:00:00Z"),
+    )
+    assert set(marked) == {"updated_after", "updated_before"}
+
+
+# --- day-precision bounds stay total ----------------------------------------
+
+
+def test_a_day_precision_bound_is_never_indeterminate() -> None:
+    """Precision of the *question* decides the comparison, not the data.
+
+    "Was this updated on or after 2026-08-05?" is fully answerable for a page
+    recorded to the second, so a day-scoped bound must not start reporting
+    ambiguity just because some pages are precise.
+    """
+    for line in (DAY_ONLY, PRECISE_EARLY, PRECISE_LATE, DAY_BEFORE, DAY_AFTER):
+        assert indeterminate_bounds(
+            _page(line), shortcuts=FilterShortcuts(updated_after="2026-08-05")
+        ) == (), line
+
+
+def test_day_precision_bound_still_filters_by_day() -> None:
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after="2026-08-05"))
+    assert evaluate_filter(plan, page=_page(DAY_ONLY))
+    assert evaluate_filter(plan, page=_page(PRECISE_EARLY))
+    assert not evaluate_filter(plan, page=_page(DAY_BEFORE))
+
+
+def test_recency_days_stays_day_scoped() -> None:
+    """`recency_days` is a day window by construction and gains no ambiguity."""
+    assert indeterminate_bounds(
+        _page(DAY_ONLY), shortcuts=FilterShortcuts(recency_days=3650)
+    ) == ()
+
+
+# --- a page with no recorded date -------------------------------------------
+
+
+def test_a_page_without_a_recorded_date_is_excluded_not_marked() -> None:
+    """Absent is not ambiguous: there is nothing to be uncertain between."""
+    page = page_view(SimpleNamespace(frontmatter={}, file_kind="note"))
+    plan = compile_filter(None, shortcuts=FilterShortcuts(updated_after=BOUND))
+    assert not evaluate_filter(plan, page=page)
+    assert indeterminate_bounds(page, shortcuts=FilterShortcuts(updated_after=BOUND)) == ()
+
+
+# --- end to end through find() ----------------------------------------------
+
+
+def test_find_marks_boundary_day_hits_and_leaves_decided_ones_clean(vault) -> None:
+    """The flag has to reach the caller, or the ambiguity is still hidden."""
+    from exomem import find as find_module
+
+    pages = {
+        "day-only": "2026-08-05",
+        "precise-after": "2026-08-05T11:00:00Z",
+    }
+    for slug, updated in pages.items():
+        path = vault / f"Knowledge Base/Notes/Insights/{slug}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f"---\ntype: insight\nstatus: active\ncreated: {updated}\n"
+            f"updated: {updated}\n---\n\n# {slug}\n\nBoundary probe body.\n",
+            encoding="utf-8",
+        )
+    find_module.clear_cache()
+
+    result = find_module.find(
+        vault, query="boundary probe", mode="keyword", limit=20,
+        updated_after="2026-08-05T09:00:00Z",
+    )
+    marks = {
+        hit.path.rsplit("/", 1)[-1].removesuffix(".md"): hit.order_indeterminate
+        for hit in result
+    }
+    assert marks.get("day-only") == ["updated_after"], marks
+    assert marks.get("precise-after") == [], marks
+
+
+def test_find_payload_carries_the_flag_only_when_earned(vault) -> None:
+    from exomem import find as find_module
+
+    path = vault / "Knowledge Base/Notes/Insights/payload-probe.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntype: insight\nstatus: active\ncreated: 2026-08-05\n"
+        "updated: 2026-08-05\n---\n\n# payload probe\n\nPayload probe body.\n",
+        encoding="utf-8",
+    )
+    find_module.clear_cache()
+
+    vague = find_module.find(
+        vault, query="payload probe", mode="keyword", limit=20,
+        updated_after="2026-08-05T09:00:00Z",
+    )
+    assert any(
+        h.as_dict().get("order_indeterminate") == ["updated_after"] for h in vague
+    )
+
+    find_module.clear_cache()
+    decided = find_module.find(
+        vault, query="payload probe", mode="keyword", limit=20,
+        updated_after="2026-08-05",
+    )
+    assert all("order_indeterminate" not in h.as_dict() for h in decided)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,214 @@
+"""Frontmatter temporal values: parsing, canonical rendering, four-valued order.
+
+Notes record `created`/`updated` at two precisions permanently: bare calendar
+dates (historical, and anything hand-authored) and second-granularity UTC
+timestamps (written going forward). A date-only value denotes *an unknown
+instant within that day*, so ordering two values is not always decidable — the
+comparison is four-valued and reports `INDETERMINATE` rather than guessing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from exomem import temporal
+
+
+# --- parse ------------------------------------------------------------------
+
+
+def test_parse_bare_date_has_no_instant() -> None:
+    """A date-only value carries its day and an explicitly unknown time."""
+    moment = temporal.parse("2026-08-05")
+    assert moment is not None
+    assert moment.day == dt.date(2026, 8, 5)
+    assert moment.instant is None
+    assert not moment.precise
+
+
+def test_parse_timestamp_carries_instant() -> None:
+    moment = temporal.parse("2026-08-05T09:12:33Z")
+    assert moment is not None
+    assert moment.day == dt.date(2026, 8, 5)
+    assert moment.instant == dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+    assert moment.precise
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-08-05T09:12:33Z",
+        "2026-08-05T09:12:33+00:00",
+        "2026-08-05 09:12:33+00:00",  # PyYAML's str() of a loaded datetime
+        dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC),
+    ],
+)
+def test_parse_accepts_every_serialization_of_one_instant(value: object) -> None:
+    """T-form, space-form, Z, +00:00, and the live object all agree."""
+    moment = temporal.parse(value)
+    assert moment is not None
+    assert moment.instant == dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+
+
+def test_parse_normalizes_offset_to_utc() -> None:
+    """Knowledge time is comparable across machines, so offsets fold to UTC."""
+    moment = temporal.parse("2026-08-05T12:12:33+03:00")
+    assert moment is not None
+    assert moment.instant == dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+    assert moment.day == dt.date(2026, 8, 5)
+
+
+def test_parse_yaml_date_and_datetime_objects() -> None:
+    """PyYAML auto-types unquoted frontmatter dates; both forms must land."""
+    assert temporal.parse(dt.date(2026, 8, 5)) == temporal.Moment(dt.date(2026, 8, 5), None)
+    naive = temporal.parse(dt.datetime(2026, 8, 5, 9, 12, 33))
+    assert naive is not None
+    assert naive.instant == dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+
+
+def test_parse_drops_sub_second_precision() -> None:
+    """Second granularity is the contract; milliseconds are false precision."""
+    moment = temporal.parse("2026-08-05T09:12:33.987654Z")
+    assert moment is not None
+    assert moment.instant == dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", "not-a-date", "2026-13-01", 42, []])
+def test_parse_rejects_unusable_values(value: object) -> None:
+    assert temporal.parse(value) is None
+
+
+# --- stamp / render_date ----------------------------------------------------
+
+
+def test_stamp_renders_second_granularity_utc() -> None:
+    value = dt.datetime(2026, 8, 5, 9, 12, 33, 987654, tzinfo=dt.UTC)
+    assert temporal.stamp(value) == "2026-08-05T09:12:33Z"
+
+
+def test_stamp_of_a_bare_date_stays_bare() -> None:
+    """Precision is carried by the Python type: a date cannot gain a time."""
+    assert temporal.stamp(dt.date(2026, 8, 5)) == "2026-08-05"
+
+
+def test_stamp_converts_local_offsets_to_utc() -> None:
+    local = dt.datetime(2026, 8, 5, 12, 12, 33, tzinfo=dt.timezone(dt.timedelta(hours=3)))
+    assert temporal.stamp(local) == "2026-08-05T09:12:33Z"
+
+
+def test_stamp_treats_naive_datetimes_as_utc() -> None:
+    assert temporal.stamp(dt.datetime(2026, 8, 5, 9, 12, 33)) == "2026-08-05T09:12:33Z"
+
+
+def test_render_date_is_always_a_bare_day() -> None:
+    """Paths and draft tokens stay day-granular whatever the clock supplies."""
+    assert temporal.render_date(dt.date(2026, 8, 5)) == "2026-08-05"
+    assert temporal.render_date(dt.datetime(2026, 8, 5, 23, 59, 59, tzinfo=dt.UTC)) == "2026-08-05"
+
+
+def test_render_date_keeps_the_authors_own_day() -> None:
+    """Filenames must not shift month when a local instant folds to UTC.
+
+    `dt.date.today()` is local, and note paths have always used it. Stamping in
+    UTC must not silently move a note written at 01:30 on Sep 1 (UTC+3) into
+    the August folder, so `render_date` reads the day off the value as given.
+    """
+    late = dt.datetime(2026, 9, 1, 1, 30, 0, tzinfo=dt.timezone(dt.timedelta(hours=3)))
+    assert temporal.render_date(late) == "2026-09-01"
+    assert temporal.stamp(late) == "2026-08-31T22:30:00Z"
+
+
+def test_stamp_round_trips_through_parse() -> None:
+    for value in (dt.date(2026, 8, 5), dt.datetime(2026, 8, 5, 9, 12, 33, tzinfo=dt.UTC)):
+        assert temporal.parse(temporal.stamp(value)) == temporal.parse(value)
+
+
+def test_now_is_timezone_aware_and_second_granular() -> None:
+    """One clock read, carrying the local offset explicitly."""
+    now = temporal.now()
+    assert now.tzinfo is not None
+    assert now.utcoffset() is not None
+    assert now.microsecond == 0
+
+
+def test_now_stamps_as_utc() -> None:
+    """Whatever the host offset, the written form is UTC — one standard."""
+    assert temporal.stamp(temporal.now()).endswith("Z")
+
+
+# --- compare: the four-valued order -----------------------------------------
+
+
+def _m(value: str) -> temporal.Moment:
+    moment = temporal.parse(value)
+    assert moment is not None
+    return moment
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        # The table from docs/handoff-note-timestamps.md, every row.
+        ("2026-08-04", "2026-08-05T09:00:00Z", temporal.Order.BEFORE),
+        ("2026-08-05", "2026-08-05T09:00:00Z", temporal.Order.INDETERMINATE),
+        ("2026-08-05", "2026-08-05", temporal.Order.INDETERMINATE),
+        ("2026-08-05T09:00:00Z", "2026-08-05T11:00:00Z", temporal.Order.BEFORE),
+        # Mirrors, so the relation is antisymmetric.
+        ("2026-08-05T09:00:00Z", "2026-08-04", temporal.Order.AFTER),
+        ("2026-08-05T09:00:00Z", "2026-08-05", temporal.Order.INDETERMINATE),
+        ("2026-08-05T11:00:00Z", "2026-08-05T09:00:00Z", temporal.Order.AFTER),
+        # Two whole days never overlap, whatever their unknown times.
+        ("2026-08-04", "2026-08-05", temporal.Order.BEFORE),
+        ("2026-08-05", "2026-08-04", temporal.Order.AFTER),
+        # A day strictly precedes a later day's instant, and vice versa.
+        ("2026-08-05T23:59:59Z", "2026-08-06", temporal.Order.BEFORE),
+        # Only two known instants can be equal.
+        ("2026-08-05T09:00:00Z", "2026-08-05T09:00:00Z", temporal.Order.SAME),
+    ],
+)
+def test_compare_four_valued(a: str, b: str, expected: temporal.Order) -> None:
+    assert temporal.compare(_m(a), _m(b)) is expected
+
+
+def test_compare_is_antisymmetric() -> None:
+    """Swapping the arguments mirrors BEFORE/AFTER and preserves the rest."""
+    mirror = {
+        temporal.Order.BEFORE: temporal.Order.AFTER,
+        temporal.Order.AFTER: temporal.Order.BEFORE,
+        temporal.Order.SAME: temporal.Order.SAME,
+        temporal.Order.INDETERMINATE: temporal.Order.INDETERMINATE,
+    }
+    values = ["2026-08-04", "2026-08-05", "2026-08-05T09:00:00Z", "2026-08-05T11:00:00Z"]
+    for a in values:
+        for b in values:
+            assert temporal.compare(_m(b), _m(a)) is mirror[temporal.compare(_m(a), _m(b))]
+
+
+def test_same_day_never_collapses_an_unknown_into_a_guess() -> None:
+    """The load-bearing rule: a date-only value is not midnight."""
+    assert temporal.compare(_m("2026-08-05"), _m("2026-08-05T00:00:00Z")) is (
+        temporal.Order.INDETERMINATE
+    )
+
+
+# --- sort_key ---------------------------------------------------------------
+
+
+def test_sort_key_orders_across_mixed_precision() -> None:
+    values = ["2026-08-05T11:00:00Z", "2026-08-04", "2026-08-05", "2026-08-05T09:00:00Z"]
+    ordered = sorted(values, key=lambda v: temporal.sort_key(_m(v)))
+    assert ordered == [
+        "2026-08-04",
+        "2026-08-05",
+        "2026-08-05T09:00:00Z",
+        "2026-08-05T11:00:00Z",
+    ]
+
+
+def test_sort_key_is_total_where_compare_is_not() -> None:
+    """UIs need a stable total order even where the true order is unknowable."""
+    a, b = _m("2026-08-05"), _m("2026-08-05T09:00:00Z")
+    assert temporal.compare(a, b) is temporal.Order.INDETERMINATE
+    assert temporal.sort_key(a) < temporal.sort_key(b)


### PR DESCRIPTION
## Why

Exomem records `created`, `updated`, and every `log.md` history heading from `dt.date.today()`, so a note created and revised twice inside two hours carries three identical dates and `created == updated`. The only ordering signal is position in the file, not data. Bitemporal reasoning is the product's differentiator and it recorded its own knowledge time to the day.

Source brief: `docs/handoff-note-timestamps.md` on `worktree-bench-foundation`.

## What changed

**Writes** stamp a second-granularity UTC instant across `note`, `edit`, `replace`, `link`, `create_file`, `multi_edit`, `set_frontmatter_field`, `observe_memory`, `add`, and `preserve`.

**No backfill.** Existing date-only values stay date-only permanently — restamping them as midnight would assert precision that was never captured. The mixed vault is the end state, so precision becomes part of the data and comparison is four-valued: the new `temporal` module reports `indeterminate` rather than collapsing an unknown into a guess.

**Precision rides the Python type.** `datetime` subclasses `date`, so the existing injectable `today` seam accepts either without a signature change, and the ~394 test call sites passing a plain `date` keep getting day-granular output. No mass test migration.

**Sub-day retrieval.** `updated_after`/`updated_before` accept an instant. A date-only page on the boundary day is genuinely unordered against it, so it comes back **marked** in `order_indeterminate` — not dropped silently (that is the defect being fixed) and not included silently (that reports a guess as a fact). `recency_days` stays day-scoped, because the precision of the *question* decides the comparison.

## Fixes a pre-existing bug (narrower than first stated)

`page.updated` is strictly typed, and `vault.yaml_scalar` quotes any scalar YAML would re-type. Measured against the live module, of the four spellings that can reach the vault (bare date, quoted date, bare timestamp, quoted timestamp) **only the bare unquoted date matched a date filter**.

**Scope, corrected.** An earlier revision of this description claimed three writers were affected. That was wrong. `create_file` is the only writer using `serialize_frontmatter`; `edit`/`multi_edit` go through `_set_or_append` and `note`/`add`/`link`/`preserve`/`set_frontmatter_field` build the line by hand — all unquoted.

So the exposure on `main` is **Tier 2 pages created by `create_file` and never subsequently edited** (`Identity/`, `Templates/`, config, skill files) — largely not the compiled notes date filters target. It also self-heals: the first `edit` rewrites `updated:` unquoted. Verified:

```
after create_file : created: "2026-08-05"   updated: "2026-08-05"
after edit        : created: "2026-08-05"   updated: 2026-08-06
```

Real, worth fixing, and no longer load-bearing for this PR's justification. Search results still change for any such page, which belongs in release notes.

## ⚠️ Breaking: draft token v2

`DraftToken` gains `render_stamp`; `_TOKEN_VERSION` → 2. The token must freeze the authored *instant* alongside the authored day, because the same token can legitimately be committed more than once (the mutation-receipt replay path after acknowledgement loss). Re-reading the clock at commit made a validated draft render different bytes per attempt and made a byte-identity test between two governed write paths **flaky by construction**.

Tokens in flight across the release boundary are rejected and must be re-validated once.

## Corrections to the handoff brief

Its line numbers are stale and three of its five hazard calls are wrong:

1. `audit._parse_fm_date` and `find_policy.parse_date` are **not** bugs — both consumers are genuinely day-scoped, so collapsing to the day is correct, not "cosmetic".
2. `audit_fix._as_iso_date` is **not** "verified safe" — `datetime` subclasses `date`, so it leaked full timestamps into neighbouring fields.
3. The real silent-drop bug is in `structured_filters`, which the brief never mentions.

It also missed three couplings: the draft-token render-date gate, the `log.md` heading regex (where its own observed symptom actually lived), and the `commit_edit` idempotency key.

## Verification

- Full suite: **6868 passed, 3 failed**. All three are CPU-contention artefacts from a concurrent benchmark session; two pass in isolation, and `test_governed_receipt_append_overhead_under_budget` is a latency microbenchmark that **also fails on clean `main`** under the same load. `CLAUDE.md` requires a quiesced machine for benchmarks — worth one re-run before merge.
- `uvx ruff check . --select F` clean.
- `openspec validate record-note-knowledge-time-to-the-second --strict` valid.
- Acceptance covered by `tests/test_temporal.py` (four-valued compare against every row of the brief's table), `tests/test_note_timestamps.py` (no-backfill byte-identity, mixed vault, round-trip), `tests/test_subday_filters.py` (boundary-day marking end-to-end through `find`).

## Not done

`docs/` beyond the shipped scaffold schema reference is untouched. Benchmark task 4.5 (sub-day membench family) stays on `worktree-bench-foundation`.

