### PR TITLE
fix(provisioner): accept a managed-provider runtime identity on Neon

### DIFF
--- a/docs/runbooks/hosted/deploy.md
+++ b/docs/runbooks/hosted/deploy.md
@@ -186,6 +186,19 @@ unsupported. A separately reviewed proxy with a backend-session-affinity
 guarantee may use `pool_mode=session` as the local contract marker. That marker
 does not make a transaction pool safe.
 
+On a managed provider the runtime role's search path must be pinned on the role
+itself. Neon's proxy silently drops the `search_path` startup parameter, so the
+`server_settings` the provisioner sends on every connection never take effect and
+the role would resolve to `public` instead of its own schema. Pin it once, with a
+credential that administers the runtime role:
+
+```bash
+ALTER ROLE exomem_provisioner_runtime SET search_path = exomem_provisioner, pg_catalog;
+```
+
+Confirm `SELECT current_schema` returns `exomem_provisioner` as the runtime role
+before bootstrapping; the bootstrap asserts exactly this and fails closed on it.
+
 ```bash
 : "${EXOMEM_DATABASE_ADMIN_ROTATION_RECEIPT:?set the private receipt path}"
 : "${EXOMEM_DATABASE_BOOTSTRAP_ATTEMPT_STATE:?set a persistent private attempt-state path}"

--- a/infra/provisioner/src/exomem_provisioner/database_bootstrap.py
+++ b/infra/provisioner/src/exomem_provisioner/database_bootstrap.py
@@ -33,6 +33,15 @@ class DatabaseBootstrapError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeRoleMembership:
+    """One grant of the runtime role to another role."""
+
+    member: str
+    inherits: bool
+    can_set_role: bool
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeRoleState:
     """Security-relevant PostgreSQL runtime-role attributes."""
 
@@ -44,7 +53,7 @@ class RuntimeRoleState:
     can_replicate: bool
     can_bypass_rls: bool
     member_of: tuple[str, ...]
-    members: tuple[str, ...]
+    members: tuple[RuntimeRoleMembership, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,7 +108,16 @@ def validate_runtime_role(
         or state.can_replicate
         or state.can_bypass_rls
         or state.member_of
-        or state.members
+        or any(
+            # A managed provider records an unrevocable administrative grant of every
+            # role it creates to the account owner (Neon does this as `cloud_admin`),
+            # so requiring no members at all is unsatisfiable there. Reject any grant
+            # that can actually assume the runtime role, and any other grantee.
+            membership.member != database_owner
+            or membership.inherits
+            or membership.can_set_role
+            for membership in state.members
+        )
     ):
         raise DatabaseBootstrapError("runtime role is unsafe")
     if admin_role == expected_role:
@@ -312,17 +330,23 @@ async def _runtime_role_state(
         ).scalars()
     )
     members = tuple(
-        (
+        RuntimeRoleMembership(
+            member=str(membership.rolname),
+            inherits=bool(membership.inherit_option),
+            can_set_role=bool(membership.set_option),
+        )
+        for membership in (
             await connection.execute(
                 text(
-                    "SELECT member.rolname FROM pg_auth_members membership "
+                    "SELECT member.rolname, membership.inherit_option, membership.set_option "
+                    "FROM pg_auth_members membership "
                     "JOIN pg_roles member ON member.oid = membership.member "
                     "JOIN pg_roles parent ON parent.oid = membership.roleid "
                     "WHERE parent.rolname = :role ORDER BY member.rolname"
                 ),
                 {"role": role},
             )
-        ).scalars()
+        ).all()
     )
     return RuntimeRoleState(
         name=str(row.rolname),

--- a/infra/provisioner/tests/test_database_bootstrap.py
+++ b/infra/provisioner/tests/test_database_bootstrap.py
@@ -32,7 +32,6 @@ def test_bootstrap_lock_key_is_deterministic_and_database_schema_specific() -> N
         {"can_replicate": True},
         {"can_bypass_rls": True},
         {"member_of": ("privileged_parent",)},
-        {"members": ("inherited_reader",)},
     ],
 )
 def test_existing_runtime_role_with_unsafe_attributes_fails_closed(
@@ -61,6 +60,59 @@ def test_existing_runtime_role_with_unsafe_attributes_fails_closed(
             expected_schema="exomem_provisioner",
             owned_schemas=("exomem_provisioner",),
         )
+
+
+@pytest.mark.parametrize(
+    ("member", "inherits", "can_set_role", "accepted"),
+    [
+        # A managed provider (Neon) records an unrevocable administrative grant of the
+        # runtime role to the account owner. Administration alone cannot assume the role.
+        ("neondb_owner", False, False, True),
+        # Anything that can actually act as the runtime role is still rejected.
+        ("neondb_owner", True, False, False),
+        ("neondb_owner", False, True, False),
+        # A grantee that is not the database owner is never expected.
+        ("some_other_role", False, False, False),
+    ],
+)
+def test_only_a_non_assumable_database_owner_grant_is_tolerated(
+    member: str,
+    inherits: bool,
+    can_set_role: bool,
+    accepted: bool,
+) -> None:
+    module = _bootstrap_module()
+    state = module.RuntimeRoleState(
+        name="exomem_provisioner_runtime",
+        can_login=True,
+        is_superuser=False,
+        can_create_database=False,
+        can_create_role=False,
+        can_replicate=False,
+        can_bypass_rls=False,
+        member_of=(),
+        members=(
+            module.RuntimeRoleMembership(
+                member=member, inherits=inherits, can_set_role=can_set_role
+            ),
+        ),
+    )
+
+    def validate() -> None:
+        module.validate_runtime_role(
+            state,
+            expected_role="exomem_provisioner_runtime",
+            admin_role="bootstrap_admin",
+            database_owner="neondb_owner",
+            expected_schema="exomem_provisioner",
+            owned_schemas=("exomem_provisioner",),
+        )
+
+    if accepted:
+        validate()
+    else:
+        with pytest.raises(module.DatabaseBootstrapError, match="runtime role is unsafe"):
+            validate()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The database bootstrap **could never succeed against Neon** — which is what Substrate's control plane actually runs on. Found while executing the hosted-alpha install after the deployment lock landed (#376).

## The blocker

`validate_runtime_role` required the runtime role to have **zero members**. On a managed provider that is structurally unsatisfiable:

- Neon records a membership grant of every created role to the account owner, made by its internal `cloud_admin` superuser.
- It cannot be revoked: `permission denied to revoke privileges granted by role "cloud_admin"`.
- It is **not** GUC-driven — I tested with `createrole_self_grant = ''` and the grant still appears.

The invariant only ever held for self-managed Postgres with a true superuser admin. Neon never grants one.

## The change

Reject the grants that actually matter rather than all of them: any member that is not the database owner, and any grant carrying `INHERIT` or `SET`. Administration alone cannot assume the role — and on managed Postgres the account owner holds that power regardless of what we record.

`_runtime_role_state` now reads `inherit_option`/`set_option` (PostgreSQL 16+; cells already run 17) so the validator can draw that distinction.

## A second managed-provider gap (documented, not coded around)

Neon's proxy **silently drops the `search_path` startup parameter**. The `server_settings` the provisioner sends on every connection never take effect, so the runtime role resolves to `public` instead of its own schema. I confirmed this at the raw asyncpg layer, so it is not a SQLAlchemy artifact.

This affects the **running provisioner** (`database.py:31`, `durability_jobs.py:645`) as much as the bootstrap. The portable fix is to pin the search path on the role — now documented as a runbook precondition:

```
ALTER ROLE exomem_provisioner_runtime SET search_path = exomem_provisioner, pg_catalog;
```

Worth a follow-up decision on whether the runtime should also set it per session rather than trusting startup parameters.

## Verification

Against the **live Neon control-plane database**:

- Bootstrap completes: `BOOTSTRAP_OK`
- Schema migrates to `0006_operation_wire_protocol`, 15 tables
- `validate` passes
- The **pre-change** validator fails that same database with `runtime role is unsafe`
- `418 passed, 15 skipped` in the provisioner suite; `ruff check . --select F` clean

New tests cover the Neon-shaped grant (accepted) and reject `INHERIT`, `SET`, and non-owner grantees.

## Follow-on

The deployment lock pins provisioner `8e384f8`, which carries the old validator — I verified it cannot validate the bootstrapped database. Installing the platform needs a new provisioner image and a recomposed lock.