### PR TITLE
fix(auth): accept private_key_jwt client assertions at a domain root

### DIFF
--- a/src/exomem/session_oauth.py
+++ b/src/exomem/session_oauth.py
@@ -9,7 +9,11 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
-from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.auth import (
+    AccessToken,
+    PrivateKeyJWTClientAuthenticator,
+    TokenHandler,
+)
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import (
     DEFAULT_AUTH_CODE_EXPIRY_SECONDS,
@@ -18,7 +22,7 @@ from fastmcp.server.auth.oauth_proxy.models import (
 )
 from fastmcp.server.auth.oauth_proxy.ui import create_error_html
 from mcp.server.auth.provider import AuthorizationCode, RefreshToken, TokenError
-from mcp.server.auth.routes import create_protected_resource_routes
+from mcp.server.auth.routes import cors_middleware, create_protected_resource_routes
 from mcp.server.auth.settings import RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from starlette.middleware import Middleware
@@ -230,10 +234,54 @@ class ExomemSessionOAuthProxy(OAuthProxy):
             *super().get_middleware(),
         ]
 
+    def _rebind_cimd_assertion_audience(self, routes: list[Route]) -> list[Route]:
+        """Bind the CIMD assertion audience to the advertised token endpoint.
+
+        A `private_key_jwt` client assertion carries the token endpoint as its
+        `aud`, and that has to match what this server advertises byte for byte.
+        FastMCP 3.4.4 builds the advertised `token_endpoint` from
+        `base_url.rstrip("/")` but builds the *expected* audience from
+        `f"{self.base_url}/token"`. Pydantic renders a bare-authority
+        `AnyHttpUrl` with a trailing slash, so a deployment at a domain root
+        advertises `https://host/token` while demanding `https://host//token`,
+        and every assertion it ever receives is rejected on audience.
+
+        Only CIMD clients that pick `private_key_jwt` hit this. ChatGPT flipped
+        to it on 2026-08-07 and its connector broke; claude.ai authenticates as
+        a public client, so it never noticed. Rebuild that one route against the
+        advertised URL. Upstream fixed this after 3.4.6 by routing both sides
+        through one property, so drop this when the pin moves past it.
+        """
+        if self._cimd_manager is None:
+            return routes
+        authenticator = PrivateKeyJWTClientAuthenticator(
+            provider=self,
+            cimd_manager=self._cimd_manager,
+            token_endpoint_url=f"{str(self.base_url).rstrip('/')}/token",
+        )
+        handler = TokenHandler(provider=self, client_authenticator=authenticator)
+        return [
+            Route(
+                path=route.path,
+                endpoint=cors_middleware(handler.handle, ["POST", "OPTIONS"]),
+                methods=["POST", "OPTIONS"],
+                name=route.name,
+                include_in_schema=route.include_in_schema,
+            )
+            if (
+                isinstance(route, Route)
+                and route.path == "/token"
+                and route.methods is not None
+                and "POST" in route.methods
+            )
+            else route
+            for route in routes
+        ]
+
     @override
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         """Keep protocol-only scopes out of protected-resource metadata."""
-        routes = super().get_routes(mcp_path)
+        routes = self._rebind_cimd_assertion_audience(super().get_routes(mcp_path))
         if self._resource_url is None or self.issuer_url is None:
             return routes
         resource_routes = create_protected_resource_routes(

--- a/tests/test_session_oauth.py
+++ b/tests/test_session_oauth.py
@@ -13,7 +13,8 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import pytest
-from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.auth import AccessToken, PrivateKeyJWTClientAuthenticator
+from fastmcp.server.auth.auth import TokenHandler as FastMCPTokenHandler
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.oauth_proxy.models import (
     ClientCode,
@@ -24,6 +25,7 @@ from mcp.server.auth.provider import AuthorizationCode, TokenError
 from mcp.server.auth.routes import TokenHandler
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import AnyUrl
+from starlette.applications import Starlette
 from starlette.requests import Request
 
 from exomem.auth_sessions import (
@@ -59,6 +61,16 @@ def test_fastmcp_private_adapter_contract_is_pinned() -> None:
         "client",
         "refresh_token",
         "scopes",
+    ]
+    # The CIMD /token route is rebuilt in get_routes to correct the assertion
+    # audience, so both constructors it calls are part of the pinned surface.
+    assert list(
+        inspect.signature(PrivateKeyJWTClientAuthenticator.__init__).parameters
+    ) == ["self", "provider", "cimd_manager", "token_endpoint_url"]
+    assert list(inspect.signature(FastMCPTokenHandler.__init__).parameters) == [
+        "self",
+        "provider",
+        "client_authenticator",
     ]
     for seam in (
         "load_refresh_token",
@@ -987,3 +999,70 @@ async def test_rfc7009_revocation_tombstones_shared_session_and_unknown_is_succe
         ("session-token", "oauth-client-revocation"),
         ("unknown", "oauth-client-revocation"),
     ]
+
+
+class _RecordingCIMDManager:
+    """Capture the token endpoint a private_key_jwt assertion is checked against."""
+
+    def __init__(self) -> None:
+        self.token_endpoints: list[str] = []
+
+    async def validate_private_key_jwt(
+        self,
+        *,
+        assertion: str,
+        client: OAuthClientInformationFull,
+        token_endpoint: str,
+    ) -> None:
+        del assertion, client
+        self.token_endpoints.append(token_endpoint)
+        raise ValueError("signature is not exercised here")
+
+
+@pytest.mark.anyio
+async def test_cimd_assertion_audience_matches_advertised_token_endpoint() -> None:
+    """A private_key_jwt client is checked against the endpoint we advertise.
+
+    FastMCP 3.4.4 derives the expected audience from ``f"{base_url}/token"``.
+    Pydantic renders a bare-authority URL with a trailing slash, so the check
+    demanded ``https://memory.example//token`` while our own authorization
+    server metadata advertised ``https://memory.example/token``. ChatGPT signs
+    its assertion against the advertised value, so every exchange 401'd.
+    """
+    proxy = _proxy()
+    recorder = _RecordingCIMDManager()
+    proxy._cimd_manager = recorder
+    client_id = "https://chatgpt.example/oauth/abc/client.json"
+    cimd_client = OAuthClientInformationFull(
+        client_id=client_id,
+        redirect_uris=[AnyUrl("https://chatgpt.example/connector/oauth/abc")],
+        token_endpoint_auth_method="private_key_jwt",
+    )
+
+    # A CIMD client is resolved from its metadata document, not from DCR
+    # storage: register_client normalizes every client it stores to "none".
+    async def _get_client(requested: str) -> OAuthClientInformationFull | None:
+        return cimd_client if requested == client_id else None
+
+    proxy.get_client = _get_client  # type: ignore[method-assign]
+
+    transport = httpx.ASGITransport(app=Starlette(routes=proxy.get_routes("/mcp")))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://memory.example"
+    ) as client:
+        await client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "client_assertion_type": (
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                ),
+                "client_assertion": "signed-assertion",
+            },
+        )
+
+    assert recorder.token_endpoints == ["https://memory.example/token"]
+    # Tripwire: this is the upstream derivation the override exists to correct.
+    # When it stops producing a double slash, the override can go.
+    assert f"{proxy.base_url}/token" == "https://memory.example//token"


### PR DESCRIPTION
## Why

ChatGPT's connector stopped authenticating on 2026-08-07: the consent screen renders, you click Allow, and ChatGPT reports "Something went wrong with setting up the connection". The live service logged nine `POST /token` 401s, each one:

```
Bearer token rejected for client https://chatgpt.com/oauth/jKP_NLo_VszT/client.json:
audience mismatch (got 'https://exomem.substratesystems.io/token',
                expected 'https://exomem.substratesystems.io//token')
```

Note the double slash in *expected*. A `private_key_jwt` client assertion carries the token endpoint as its `aud`, and it has to match the advertised `token_endpoint` byte for byte. FastMCP 3.4.4 builds the advertised value from `base_url.rstrip("/")` (`proxy.py`, via `build_metadata`) but builds the expected audience from `f"{self.base_url}/token"` (`proxy.py:2061`). Pydantic renders a bare-authority `AnyHttpUrl` with a trailing slash, so any deployment at a domain root advertises `/token` and demands `//token`. Every assertion it ever receives is rejected.

What changed was on OpenAI's side, not ours. Their client ID metadata document now reads:

```json
"token_endpoint_auth_method": "private_key_jwt",
"token_endpoint_auth_methods_supported": ["none", "private_key_jwt"]
```

It used to authenticate as a public client. Same client id all week, five `POST /token → 200` before the flip and nine `401` after. claude.ai still authenticates with `none`, so it never touches this path — which is why Claude kept working (100/100 `200` on `/mcp`) and this looked like a ChatGPT or connectivity problem rather than a server bug.

## What

Rebuild the CIMD `/token` route in `ExomemSessionOAuthProxy.get_routes` with an authenticator bound to the advertised URL. The two FastMCP constructors this calls are added to the existing pinned-adapter contract test, matching how the rest of that private surface is guarded.

Scoped deliberately to the assertion audience: `base_url` is left alone because FastMCP's metadata `issuer` is `str(self.base_url)` *with* the trailing slash, and `server_assets.register_oauth_metadata_route` advertises the same. Stripping it globally would move the advertised issuer and risk breaking clients that currently work.

Upstream fixed this after 3.4.6 by routing both sides through a single `token_endpoint_url` property; 3.4.6 itself still has the bug verbatim. Drop this override when the pin moves past it — the new test's second assertion is the tripwire.

## Verified

- `tests/test_session_oauth.py` 21 passed.
- Red-first: the new test run against unpatched `main` fails with the production symptom, `'https://memory.example//token' != 'https://memory.example/token'`.
- `tests/test_session_oauth.py tests/test_server_auth.py tests/test_auth_http_boundary.py tests/test_auth_sessions.py` 63 passed.
- `uvx ruff check` clean on both files. `ruff format` deliberately not run: CI gates on `ruff check` only and `session_oauth.py` is not format-clean on `main`, so formatting it would bury the change in churn.

Full suite deferred to Linux CI (native Windows can't run it).
