### PR TITLE
fix(memory): accept draft tokens minted across the UTC day boundary

### DIFF
--- a/src/exomem/semantic_writes.py
+++ b/src/exomem/semantic_writes.py
@@ -780,7 +780,13 @@ class DraftToken:
             raise SemanticWriteError(
                 "INVALID_DRAFT_TOKEN", "draft token has invalid render stamp"
             )
-        if stamp_moment.day != render_date:
+        # `render_date` is the author's local day while `render_stamp` folds to
+        # UTC (see `temporal`), so on any host with a non-zero offset the two
+        # legitimately land on different days -- demanding equality rejected
+        # every write made between local midnight and the UTC day boundary.
+        # Bound the gap instead: real offsets span -12:00..+14:00, so one
+        # calendar day is the ceiling a correctly-minted pair can differ by.
+        if abs((stamp_moment.day - render_date).days) > 1:
             raise SemanticWriteError(
                 "INVALID_DRAFT_TOKEN", "draft token render stamp disagrees with its render date"
             )

--- a/tests/test_semantic_creation_writers.py
+++ b/tests/test_semantic_creation_writers.py
@@ -21,6 +21,7 @@ from exomem import (
     relation_review,
     replace,
     semantic_writes,
+    temporal,
 )
 from exomem import (
     vault as vault_module,
@@ -1438,6 +1439,94 @@ def test_draft_token_rejects_cross_writer_and_duplicate_json_keys(vault: Path) -
     with pytest.raises(semantic_writes.SemanticWriteError) as duplicate_exc:
         semantic_writes.DraftToken.decode(encoded)
     assert duplicate_exc.value.code == "INVALID_DRAFT_TOKEN"
+
+
+# The offsets are carried on the values themselves rather than taken from the
+# host clock: these must fail on a UTC machine too, or CI -- which runs in UTC,
+# where the local and UTC day never diverge -- would go on missing the bug.
+@pytest.mark.parametrize(
+    ("offset_hours", "hour", "minute", "expected_date", "expected_stamp"),
+    (
+        pytest.param(3, 0, 40, "2026-09-01", "2026-08-31T21:40:00Z", id="local-day-ahead"),
+        pytest.param(-5, 19, 30, "2026-09-01", "2026-09-02T00:30:00Z", id="local-day-behind"),
+    ),
+)
+def test_draft_token_survives_the_local_utc_day_boundary(
+    offset_hours: int, hour: int, minute: int, expected_date: str, expected_stamp: str
+) -> None:
+    """A token minted either side of the UTC day boundary must still decode.
+
+    `render_date` is the author's local day while `render_stamp` folds to UTC,
+    so on a UTC+3 host a note written at 00:40 carries a stamp on the *previous*
+    UTC day, and a UTC-5 evening write carries one on the *next*. Requiring the
+    two to agree rejected every governed write inside those windows.
+    """
+    minted = dt.datetime(
+        2026, 9, 1, hour, minute, tzinfo=dt.timezone(dt.timedelta(hours=offset_hours))
+    )
+    render_date = temporal.render_date(minted)
+    render_stamp = temporal.stamp(minted)
+    assert (render_date, render_stamp) == (expected_date, expected_stamp)
+
+    decoded = semantic_writes.DraftToken.decode(
+        semantic_writes.DraftToken(
+            "note",
+            "create",
+            "Knowledge Base/Notes/Insights/day-boundary.md",
+            render_date,
+            render_stamp=render_stamp,
+        ).encode()
+    )
+    assert decoded.render_date == render_date
+    assert decoded.stamp() == render_stamp
+
+
+def test_note_commits_when_authored_after_local_midnight(vault: Path) -> None:
+    """The reported outage, end to end: a governed note authored at 00:40 UTC+3.
+
+    `today` carries the offset, so the note's path date is the author's local
+    day while its knowledge stamp lands on the previous UTC day -- the pairing
+    `decode` used to reject at commit, after validation had already handed the
+    caller the very token it then refused.
+    """
+    after_midnight = dt.datetime(2026, 9, 1, 0, 40, tzinfo=dt.timezone(dt.timedelta(hours=3)))
+    kwargs = {
+        "content": _compact_content("After local midnight"),
+        "note_type": "insight",
+        "title": "After local midnight",
+        "today": after_midnight,
+    }
+    validation = note.note(vault, validate_only=True, **kwargs)
+    assert semantic_writes.DraftToken.decode(validation.draft_token).render_date == "2026-09-01"
+
+    note.note(
+        vault,
+        draft_id=validation.draft_id,
+        draft_hash=validation.draft_hash,
+        draft_token=validation.draft_token,
+        relation_disposition="reviewed_none",
+        relation_review_hash=validation.draft_hash,
+        relation_review_reason="No honest relation exists in the fixture corpus.",
+        **kwargs,
+    )
+
+    written = (vault / validation.destination).read_text(encoding="utf-8")
+    assert "2026-08-31T21:40:00Z" in written
+
+
+def test_draft_token_rejects_a_render_stamp_from_an_unrelated_day() -> None:
+    """One day is the whole allowance -- the widest a real UTC offset can skew."""
+    token = semantic_writes.DraftToken(
+        "note",
+        "create",
+        "Knowledge Base/Notes/Insights/day-boundary.md",
+        "2026-09-01",
+        render_stamp="2026-08-29T12:00:00Z",
+    ).encode()
+    with pytest.raises(semantic_writes.SemanticWriteError) as exc:
+        semantic_writes.DraftToken.decode(token)
+    assert exc.value.code == "INVALID_DRAFT_TOKEN"
+    assert "disagrees with its render date" in exc.value.reason
 
 
 @pytest.mark.parametrize("writer", ("note", "replace", "link", "create_file"))


### PR DESCRIPTION
## What broke

Governed Exomem writes fail with:

```
INVALID_DRAFT_TOKEN: draft token render stamp disagrees with its render date
```

`DraftToken.decode` required a token's `render_stamp` day to equal its `render_date`. Those two fields are recorded in **different frames, by design**:

| Field | Built by | Frame |
|---|---|---|
| `render_date` | `temporal.render_date(now)` | **local** day — so a note keeps the month its author wrote it in |
| `render_stamp` | `temporal.stamp(now)` | **UTC** instant — one comparable storage standard |

`temporal.parse` normalizes to UTC, so `Moment.day` is the UTC day. Comparing it to a local day asserts an invariant `temporal` explicitly guarantees is false — `tests/test_temporal.py::test_render_date_keeps_the_authors_own_day` asserts the divergence is intended.

The token mints fine (`encode` does not validate); it is rejected at commit, *after* validation already handed the caller that exact token.

## Blast radius

Every writer that mints a `DraftToken` — `note.py`, `create_file.py`, `link.py`. `edit.py` mints none, so `edit_memory` kept working, which is why the outage looked intermittent rather than total.

The window is a pure function of host UTC offset:

| Offset | Local window that fails |
|---|---|
| UTC+3 (Tallinn summer) | 00:00 – 02:59 |
| UTC+2 (Tallinn winter) | 00:00 – 01:59 |
| **UTC+0 (CI)** | **never** |
| UTC-5 | 19:00 – 23:59 |
| UTC+14 | 00:00 – 13:59 |

**CI runs in UTC, where the local and UTC day never diverge — which is why this shipped green in #375.**

## The fix

Bound the divergence to one calendar day instead of demanding equality. Real UTC offsets span -12:00 to +14:00, so one day is the widest a correctly-minted pair can differ by.

Keeping a bounded check rather than deleting it: the token is unsigned base64 JSON, so this guard never provided tamper resistance (a forger sets both fields consistently). Its real value is catching an internal mint regression — which `> 1` still does, at zero false-positive cost.

Rejected: deriving `render_date` from UTC. That would file a note written at 00:40 on Sep 1 under August — the exact regression `test_render_date_keeps_the_authors_own_day` exists to prevent.

## Verification

Red-first, by temporarily restoring the old guard — the end-to-end test reproduces the reported symptom through the real writer path:

```
E  exomem.note.NoteError: ('INVALID_DRAFT_TOKEN', [], 'draft token render stamp disagrees with its render date')
FAILED test_draft_token_survives_the_local_utc_day_boundary[local-day-ahead]
FAILED test_draft_token_survives_the_local_utc_day_boundary[local-day-behind]
FAILED test_note_commits_when_authored_after_local_midnight
3 failed, 1 passed
```

Green with the fix:

```
uvx ruff check src/exomem/semantic_writes.py tests/test_semantic_creation_writers.py   # All checks passed
uv run pytest tests/test_semantic_creation_writers.py tests/test_temporal.py \
              tests/test_note_timestamps.py tests/test_relation_review.py -q           # 156 passed
```

Live-clock check on a UTC+3 host, taken inside the failing window:

```
local now: 2026-08-08T01:03:06+03:00
decode OK -> 2026-08-08 2026-08-07T22:03:06Z
```

New tests carry their offsets on the values rather than reading the host clock, so they fail on a UTC machine too — otherwise CI would go on missing this whole class.

## Follow-up (not in this PR)

CI is UTC-only, so every local-day-vs-UTC-day bug is structurally untestable there. A TZ matrix on the temporal/token suites would close that gap.
