### PR TITLE
chore(hosted): encrypt the three hcloud tokens for the platform install

### DIFF
--- a/infra/secrets/platform/hcloud-capacity-reader.v1.sops.json
+++ b/infra/secrets/platform/hcloud-capacity-reader.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:Op4=,iv:XrLONfp/2jqQ2uHJFCmyPsNMDOs22jn7oEwJo9h1ZIc=,tag:5rRVNpZrNwR4z9Gve7PmBg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:jrQs/o+T,iv:4iZqVDr6VlUkJZUrtXa1mJ0zIVnOflzZZWSWtYxOwX8=,tag:dEDgWNrjBzPFEMYxflQfRg==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:O0FGxIRfDcoAYgiTW9CK/7+SYF7a,iv:s0Mw5op3mK59HuEbITu/hk634USL7NHMJiSnM873nds=,tag:qOEPyC2kD7XdHXpbCwl9Xw==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:iLM=,iv:cwfsRj3zZrSMoX2LpMANI9R5cNqM14SBvi9EP3qfWmo=,tag:o1cWhJBfv9S7+5r5ZvSypA==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:ap49GJfbCth6F+ComeXPsGSAt90NJWD4SiRjJ+U=,iv:onb3EkFGKSCtEeOcKymuQOJVA6vPyrQD0olNJTyf4yM=,tag:iSxmy2ZpCTzzE5YxZV3lAw==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:WtBEkRYeBjj3DR3R2CGd,iv:zelHokAc1/W3KJvdw9ZZGnrK6dA4IO/1hJS0YfS3YC8=,tag:/8Pd6G1+dLv87syvz45IQQ==,type:str]"
+	},
+	"stringData": {
+		"token": "ENC[AES256_GCM,data:VUaw6kGEtErwBcEimYWFzHU60NQ4LpP4onuP1CuClIO9bMXysjCJXBOONCxLBc+fuo0pgzota8nGx3+xJ6FqXg==,iv:PMOOpE1qZcUrFwU2v8OLLVMPfv12BpIorh+soyW+8/4=,tag:MmvPKAo6ttyVbqO5Z1UsXA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:jnfqSs8D,iv:+zjYrvoWR+w4UEeo9fSCXvKE9A0Z9lh+Bp+JUo0scLI=,tag:m9jLikOpe4BliSTEM2xmxA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2ZDV2MitWVFd2cGRSQVpX\nelBjdW9Ka2pLa29OdEJ2RkN2dzlqZmpYNkRzCmFYbEJQOCtZMnFBUW15aDdxOXJr\nU3RxWGw5OWd1eWhYZmlySnZIMXFtMVEKLS0tIHZSZ25ZRm10TnNmcDErWThZdmFX\nNWkzTDdFR0dhNUJpa0pCSlhpZDJOdlUKEjsvcwT/2psZWRiKl9iDyIPqkXqX0JVN\nFGr2/yHnjGFGSZccE0Lu/aMvNnaQgdkNLJC2dtI3QEBM6RPqZkE3kw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-08T03:45:41Z",
+		"mac": "ENC[AES256_GCM,data:AcEdhuuYBcW6sPjnzoyI+9D0y7q5f0k3Ac5VEWwNoEcPkadf6xgnIVyNB+YezLmkz/pS8/1KmMkziZjiZiG62VcZ45m4qUQnFxEEOqoDG0LIv+TFjZiluXxAot7cfxWZH518E/yKDtA9x2o2UhClTokighoHOPOvs5qkWnPuooM=,iv:N8J/a/6KGswdbC1VClkMN4pdVtnZ0hUUEkYiZRgEadU=,tag:rL/jMidooKqK+5MvvYXouQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}

--- a/infra/secrets/platform/hcloud-csi-token.v1.sops.json
+++ b/infra/secrets/platform/hcloud-csi-token.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:NFg=,iv:2RoxJQJ16uD0f1FdjNp60VJUmsubhaZ3r5eU2+un17Q=,tag:Kuuaho60OSuPGw5kdeeJYw==,type:str]",
+	"kind": "ENC[AES256_GCM,data:cTp6LiKJ,iv:7iXvBx6ZL+MGt8oOMpLN9uKRHo2KJySKmHW4z4HdX8Q=,tag:CYrjUJ+KTkFXoW01bOTeRQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:Gn2gfRhXAvWqSPHPwuM5PF0P6Lzb,iv:pjyyMTPup8vVU4UX1AJiT9e9hZWawYtJZ1XMEiMMcFA=,tag:oy2ewpCMgMgKpTBe3/bVDQ==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:aeE=,iv:5dtzy2lm2XoExrL6vha1Ogit3L5hUdGT/Mper0teaWU=,tag:LsqhH6GJdqNhey+jR7HSuQ==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:VozbZKjE8//cL7/KYMwcd4R37a01o1o=,iv:01hTfGelBe+PuIsaz9/gWYTGd+pRhe5lUbTZZdxdfMQ=,tag:gPFf+GljAxvaSHxh5cbkWw==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:+gV1EgQo50tkkdatuZKt,iv:th16MU4r7aSS2HXuch1bND2u/eTIDgothE/w0CmGwPE=,tag:EVHnBX5V1enGV4eJpI22ww==,type:str]"
+	},
+	"stringData": {
+		"token": "ENC[AES256_GCM,data:TLQWO/16a2aJgAUromgJVSjIrM1ceq4RFgtqhUWpzmBi2r7ZwUpo+uPdz019iwQk78FpgTFcXXWvza2GyCjfbw==,iv:FmRRJeZqONQdDjoaY4dAJtl+HBfEibgaJ/7vqfYHrw0=,tag:bgr+f8w5x1U1NnyJSmaJrw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:Jy1Aei6G,iv:lO+ZTGWKQ0QiP7ogiuxYWksO3e9a52pwAvjAzcVkZf8=,tag:z9vS6GJ9z2Iys9aKz5qb7Q==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUFlGTW1ia0pSMnFPbng1\nSnl4STdQYlJmdVRRQnhRcFJoUWxRcWtHaFU4CmlweTZxZDRMUC9qNGRGM0NCa0tG\nQldtU1ppSklPYlR4aTIyVGsySmk0V2sKLS0tIDBNc2RBTzNmMnczaXkvdEJiNHlP\nUDVsUkVTSEpXdEc3S2d5UkRhb0Z1bnMK4TBsuHtKfS1F1Wuz2MRosaEY9tKd8/P+\n84e76EXp1Maa9A8ApwXlwnXhOqgIqpEkUvKpw5tUowYjE0ySSXgs7g==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-08T03:45:39Z",
+		"mac": "ENC[AES256_GCM,data:bauFZnb2l6j2CVo8YaihOq6aSnXSDh3iPYvHFOS2sxY3BZuNji15N8Dg51OtgBo4LDQtP6LTr1Di4B0fn2bRaQBXmaXq6UNoc03N5u8OeZkNL75ELarEPYa1W+QCBjW4Bh8RNwX8njmYWnx037zUsnHWTjj9RGR18OggUWhMfa8=,iv:w4TORh2P/eS0BDvq98NgZ5OeSHF7Tj/SC3a5Ae5iqFc=,tag:hmO0trNSXVuyu7t4cUirhw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}

--- a/infra/secrets/provisioner/database-url.v1.sops.json
+++ b/infra/secrets/provisioner/database-url.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:vR8=,iv:k65Y5qseZol3VMgRFVq1SGvNTF0V0vTotqbbMzhnzf0=,tag:lznDw7tGm6LNMdKZoD8+Vg==,type:str]",
+	"kind": "ENC[AES256_GCM,data:aYNUslXE,iv:ptxT3u5EkMlUpwfa8IwLv8gtzhFOvGnWjhKRWR0Eo3w=,tag:JNB5GqVxmaquzpEXgAVfdQ==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:C/4LQSIYTsbjgGPRBAkqDbRyexza,iv:/Ao81eQe25AxP+Myixihlua87wznPyLkw5pnH13sSq8=,tag:pUGK091147ANyokexZkxpA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:gTA=,iv:4tdpjMD+1hOocvLbu47H4X+OZXcwxL7KGvo8UDFrALE=,tag:PYhXKIYCKSUkd9VZLxubHg==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:kgB/zIGs17mbNQVz5fK/KO1VO5Ibk0bQdxVa,iv:iTk9BESzq2Pnlw7FvBUy5i++ngBddXeIsr55pLVCQ2g=,tag:nExFQJT4LpAUbgMrt8ymvQ==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:lLz3Mhs15yguKAmv/sh+,iv:j9P9xXMoDS1RvTTsY7bf216I54BeVQa7EGDqKa+3BOY=,tag:Yd1uv7Swx6VdQujoQ6QzzA==,type:str]"
+	},
+	"stringData": {
+		"url": "ENC[AES256_GCM,data:cZOIF0YHFca4XLXY40/53LSIZhm1NWhETRX4Jf4KRdN5qY2EBR2La/kxy03ryl/WHAn6JxqWerQgOfLFOWu4GgGabHrdbVSgn2AwhykS7vVuirctnAOZPO/LXQqeeeidPaNTA/U+YWvfe+4KDdatgASTf0DvqU/+cq2sIMN03iQ68LZjOS37lQrkepeK4VI5p/8WLZ1i5uCvhGc=,iv:TNhqfpAB45cuhaDmypODMRml58pNEZI7nwkzr4jMw4I=,tag:jNtTB/VRGgzJsupb6QzjOA==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:t4k9mhtF,iv:TpZDayBW9nj05+yMr2Cu0vW9W7jds6XFu1uwLQb1kjU=,tag:Mrop1FiDDVVBrc3v8dG1FQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNclpWUEI2ZGgvcThmWHZ4\nb0U5OXdOdkRqK3FsdTk2QnVFR0pkMkxHdGtNCkZ1Qy9HWXJ3ZFlKeDg1R2hrQ1dY\nNlJxYy9sNnd0eWVBSEFCV3ErWEZwWlEKLS0tIFo1T25SQmt6OE5USWhmT3p2UkJy\nK28va0JqZERzeFl2b1dZQ3pJdExxaG8KUjeH2Ku9532T+WAvU9m42QbbR1M3ht8q\nxfyAncmMl4Na/VkK43MOYTIp0xtakgRz8s99OZUNkvDQYCe+U5GDGg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-08T04:21:01Z",
+		"mac": "ENC[AES256_GCM,data:gt5wZb/SPEhk2T3P/wU6uJZ74T0n189dDyt5qx9f87/+bg++sChrS6r7nDUTqzpUU6F7H+ErdQ1VDaa4aURZv7LUTnEDfWKJBg6f+GC/4oG++qOH1PXqxamvNbXf0zbfyjKw/+QXaw+YgZiXN99pVsi6jCQqVqgwpxeLTAr49Xs=,iv:5XE0hrVzY+C5JM3xHEXvhlSs666ip30N1IGJ6ZwY3s0=,tag:LqGWbQSHGEoF8/A/BLRJHw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}

--- a/infra/secrets/provisioner/hcloud-token.v1.sops.json
+++ b/infra/secrets/provisioner/hcloud-token.v1.sops.json
@@ -1,0 +1,28 @@
+{
+	"apiVersion": "ENC[AES256_GCM,data:PXg=,iv:ILvE4LgriIa0HzVIbGofPmk5+3GpxQR5rWGQFkWmtBU=,tag:PXWbW5t8C/2fvg2UsgHzGA==,type:str]",
+	"kind": "ENC[AES256_GCM,data:hb4j00M3,iv:82jB0NeZM4uJJRZMVZ3x5UP2QQsdEfDb0aExyI6RPS8=,tag:+Zlfqo2DKd8quulnOVE97Q==,type:str]",
+	"metadata": {
+		"labels": {
+			"app.kubernetes.io/managed-by": "ENC[AES256_GCM,data:5B9dRpbb1QrGqyMDKofLd0fECvql,iv:Rr0odPG0Lx9AqNtJ51eX4O2YVWxQ+nw//M4BoItg1Tg=,tag:X4U4dAHDCKfv3+Du8t0oNA==,type:str]",
+			"exomem.io/secret-version": "ENC[AES256_GCM,data:gug=,iv:+M0w73q4hSu7U2Fj8BeO9Aqjq92RKtO0miB6Pfh3n1I=,tag:X4GKMLv3McNjD1T7TTOx3Q==,type:str]"
+		},
+		"name": "ENC[AES256_GCM,data:4MNWcViwm2dt2LhEPqap48wQHMClbXGKFDlG2qpJzA==,iv:2fj0CnW9LKPft8mmVDoP7JnMPFDGDBEUFYclU/OuqBU=,tag:IyUUcVWsZ+ajvC+veADMww==,type:str]",
+		"namespace": "ENC[AES256_GCM,data:0BYBSNHrmVXrRK2UEN7k,iv:oA+TWe9JVOabnkPDFHeOU42nXHloIExVmI6Vgcf4JJk=,tag:Foe67drjAv7URvtTMnjvCA==,type:str]"
+	},
+	"stringData": {
+		"token": "ENC[AES256_GCM,data:9p5B9ANeA4BN9b98/sMW3c4dZb1hfzH0/iSJxCBhTnpNF3D/cLnUsTY6Be7r5t5Mh8O8pfWjraUsi2wnpdk8UQ==,iv:9doEPc1RUf4Qd3/zoPMRs5yKTNETkYNMrO7l4yofNPg=,tag:NXWC7Ef/Sf3a2WmE5CZ7kw==,type:str]"
+	},
+	"type": "ENC[AES256_GCM,data:5sH40+hf,iv:qYG/mEhmgchk9yhroSSKG/h9c7rQxl8KEy8HlTFgFRg=,tag:FRbrNripPjs/28egKJ56EQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6eHpyVXVzR21YY3lmd0Jo\nN2VTa0FDV3F0dysyMDN0TXNwenV1U3o0Nmc0CjRNbi9tWENYMEwrN0ttU1FVQ0NL\nNnNLQnBZR0t4N0k2d210Qmx4TG1OT2cKLS0tIFpHMEk0TGRwTjdGR3hHdlgyL2Ru\ndWUwbGY5djEva25IK2RLWXRDRW9neTAKfWjxzg+m7dhIgCOHmaUO/vw9CpKCz7GI\nRmiuk9V0CgBGa9iIYsRKI960627O+RPO/6tEQsQ5TVPLrQuvBHbIxw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1jvd2ukkeuehcck6wewpeaqujzcelmy9fl5yqm5ttddt9s0v66gkq3dh75p"
+			}
+		],
+		"lastmodified": "2026-08-08T03:45:40Z",
+		"mac": "ENC[AES256_GCM,data:Fpp/YJqGHskQH1RAHA6ZjdmrUXZGkyETPE1CW57H6A4JSb75NsxnR1/9FE3S9f+YgYv32SZKV5IaXxXpY1vl0Mid+cJKzN+NcMyCKZFT4TPdXmVUToNjyX1gAJRYOd0p196Sp674RvOakhIz6YlDN9nhTLhUF3H25zwfVZKiDHU=,iv:Y4tqhUVpriX6DS9vJ2NQUwPU5XLxrzgwgq6LwF7lBgU=,tag:CAfjqAEPiY7k+8aqiVSvKw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.3"
+	}
+}


### PR DESCRIPTION
Moves the CSI, provisioner, and capacity-reader Hetzner tokens from Bitwarden into SOPS/age ciphertext through the reviewed destination matrix in `secret-destinations-v1.json`, via `secret_handoff.py` — no hand-written Secret manifest, no value printed.

These are three of the nine secrets outstanding before the first `helm install`. The rest either need minting (`provisioner-credential`, `hosted-scheduler`, `alert-delivery`) or derive from the provisioner database, which is now bootstrapped.

Verified: all three decrypt with the local age key.