### PR TITLE
fix(memory): make guarded writes and the compact bootstrap readable to clients

### DIFF
--- a/src/exomem/commands.py
+++ b/src/exomem/commands.py
@@ -333,7 +333,16 @@ def op_bootstrap(
             ),
         },
         "knowledge_packs": {
-            "available": knowledge_packs_module.list_builtin_packs(),
+            # A compact bootstrap advertises which packs EXIST, not what each of them
+            # would instruct. Only the selected pack's guidance can apply, so shipping
+            # every pack's `agent_instructions` on every session start spent ~13 KB of
+            # the caller's context on packs it will never act on. `full` keeps the
+            # catalogue for callers that genuinely browse it.
+            "available": (
+                knowledge_packs_module.list_builtin_packs()
+                if profile != "compact"
+                else _pack_index(knowledge_packs_module.list_builtin_packs())
+            ),
             "selected": selected_packs,
             "selection_rule": (
                 "Packs are product guidance only. They help route simple user intent "
@@ -6786,6 +6795,29 @@ def _mentions_unavailable_callable(
         elif re.search(rf"(?<!\w){escaped}\s*\(", value):
             return True
     return False
+
+
+#: Enough to name a pack and decide whether to look it up; never its guidance body.
+#: `beginner_description` earns its bytes — without a human-readable line the catalogue
+#: is a list of slugs and nobody can choose from it.
+_PACK_INDEX_FIELDS = ("id", "name", "audience", "beginner_description")
+
+
+def _pack_index(packs: object) -> list[dict]:
+    """Identity-only view of the built-in pack catalogue.
+
+    Only the *selected* pack's `agent_instructions` can ever apply, so a compact
+    bootstrap that ships all six packs' instruction bodies spends the caller's context
+    on guidance it must ignore. Callers that genuinely browse the catalogue ask for
+    `profile="full"`.
+    """
+    if not isinstance(packs, list):
+        return []
+    return [
+        {field: pack[field] for field in _PACK_INDEX_FIELDS if field in pack}
+        for pack in packs
+        if isinstance(pack, dict)
+    ]
 
 
 def _filter_bootstrap_payload(

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -11,6 +11,50 @@ _TERMINAL_MARKER = "exomem.mutation-terminal"
 _TERMINAL_VERSION = 1
 _RESPONSE_DETAILS = frozenset({"compact", "full", "legacy"})
 
+#: The closed mutation state machine. A client may branch on exactly these values and
+#: MUST NOT infer any other. `needs_review` is explicitly NONTERMINAL: it means the
+#: guarded write is mid-flight and the caller should complete the review step, not that
+#: anything failed. Conflating it with failure is the 2026-08-06 misclassification.
+STATES = ("needs_review", "committed", "rejected", "retryable", "indeterminate")
+TERMINAL_STATES = frozenset({"committed", "rejected"})
+
+#: Keys a client may branch on. Everything else in a response is advisory.
+_ENVELOPE_KEYS = (
+    "ok",
+    "state",
+    "terminal",
+    "status",
+    "mutated",
+    "path",
+    "paths",
+    "operation_id",
+    "error_code",
+    "next_action",
+    "request_id",
+    "receipt_id",
+)
+
+
+def _operation_id(result: Any) -> str | None:
+    """Correlate a validate call with its later commit.
+
+    Both halves of a guarded write already carry the same `draft_id` — it is minted at
+    validation and handed back on commit — so the correlation identity exists and only
+    needs naming. Nothing has to be threaded through the writer lease.
+    """
+    if not isinstance(result, Mapping):
+        return None
+    draft_id = result.get("draft_id")
+    if isinstance(draft_id, str) and draft_id:
+        return draft_id
+    for nested_key in ("creation_commit", "creation_validation", "source"):
+        nested = result.get(nested_key)
+        if isinstance(nested, Mapping):
+            nested_id = nested.get("draft_id")
+            if isinstance(nested_id, str) and nested_id:
+                return nested_id
+    return None
+
 
 def _warning_count(result: Any) -> int:
     if not isinstance(result, Mapping):
@@ -91,10 +135,17 @@ def committed_terminal(
         "_terminal": _TERMINAL_MARKER,
         "version": _TERMINAL_VERSION,
         "ok": True,
+        # `state` is the closed machine; `status` is retained verbatim for existing
+        # consumers and always agrees with it.
+        "state": "committed",
         "status": "committed",
+        "terminal": True,
         "mutated": True,
     }
     terminal.update(_path_projection(leaf_result))
+    operation_id = _operation_id(leaf_result)
+    if operation_id is not None:
+        terminal["operation_id"] = operation_id
     terminal.update(
         request_id=request_id,
         receipt_id=receipt_id,
@@ -103,6 +154,62 @@ def committed_terminal(
     )
     if idempotency_key is not None:
         terminal["idempotency_key"] = idempotency_key
+    return terminal
+
+
+def _is_guarded_precommit(result: Any) -> bool:
+    """Whether a non-committing leaf result is a guarded write awaiting review.
+
+    Deliberately narrow. Most non-committing leaves are ordinary reads or unrelated
+    shapes and MUST pass through untouched; only a validated draft that explicitly
+    reports it did not mutate earns the nonterminal envelope.
+    """
+    if not isinstance(result, Mapping):
+        return False
+    if result.get("mutated") is not False:
+        return False
+    if _operation_id(result) is None:
+        return False
+    return any(
+        key in result
+        for key in ("committable_after_review", "draft_hash", "draft_token")
+    )
+
+
+def needs_review_terminal(leaf_result: Any) -> Any:
+    """Own the NONTERMINAL half of a guarded write; pass anything else through.
+
+    A precommit refusal is not a failure: the operation is mid-flight and the caller
+    should complete the review step. Before this, validation returned a shape with no
+    relationship to the eventual success envelope, so a client had nothing tying the
+    two calls together and could reasonably read the first response as the outcome —
+    which is exactly the misclassification observed on 2026-08-06.
+    """
+    if not _is_guarded_precommit(leaf_result):
+        return leaf_result
+    committable = bool(leaf_result.get("committable_after_review"))
+    terminal: dict[str, Any] = {
+        "_terminal": _TERMINAL_MARKER,
+        "version": _TERMINAL_VERSION,
+        "ok": True,
+        "state": "needs_review",
+        "terminal": False,
+        "mutated": False,
+        "next_action": (
+            "Re-issue the same call with the returned draft identity and an explicit "
+            "relation disposition to commit it. This response is not a failure."
+            if committable
+            else "Resolve the reported blocking findings, then re-validate. This "
+            "response is not a failure."
+        ),
+    }
+    operation_id = _operation_id(leaf_result)
+    if operation_id is not None:
+        terminal["operation_id"] = operation_id
+    terminal.update(
+        warnings_count=_warning_count(leaf_result),
+        leaf_result=leaf_result,
+    )
     return terminal
 
 
@@ -134,11 +241,7 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         return result
     if detail == "legacy":
         return result["leaf_result"]
-    compact = {
-        key: result[key]
-        for key in ("ok", "status", "mutated", "path", "paths", "request_id", "receipt_id")
-        if key in result
-    }
+    compact = {key: result[key] for key in _ENVELOPE_KEYS if key in result}
     if "idempotency_key" in result:
         compact["idempotency_key"] = result["idempotency_key"]
     compact["warnings_count"] = result["warnings_count"]

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -3121,10 +3121,18 @@ def _disposition_finding(
         path=page.path,
         span=None,
         detail=_disposition_detail(page, disposition),
+        # Route-neutral by necessity. This finding fires on creation writers AND on
+        # ordinary edits, but `validate_only` and the draft trio exist only on the
+        # creation path — naming them unconditionally sent edit callers hunting for
+        # fields their operation does not have, and pushed them onto an unnatural
+        # operation to find one. Name only what every route accepts, then qualify.
+        # Length matters: this repeats per finding and competes for the audit
+        # truncation budget, so keep it at or under the previous wording.
         remediation=(
-            "Add a qualifying typed relation, or validate_only=true then commit unchanged "
-            "draft_id, draft_hash, draft_token, relation_disposition=\"reviewed_none\", "
-            "relation_review_hash=<returned>, and relation_review_reason."
+            "Add a qualifying typed relation, or re-issue the same call with "
+            "relation_disposition=\"reviewed_none\", relation_review_hash=<returned>, "
+            "relation_review_reason. Creation writers also return "
+            "draft_id/draft_hash/draft_token."
         ),
         governed_element_identity=("relations", "disposition"),
         resolved_rule=("relations", "*", "disposition"),

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -40,6 +40,7 @@ from .mutation_lock import _release_os_lock as _release_owner_lock
 from .mutation_lock import _try_os_lock as _try_owner_lock
 from .mutation_terminal import (
     committed_terminal,
+    needs_review_terminal,
     project_terminal,
     split_response_detail,
 )
@@ -1369,7 +1370,11 @@ class LeaseManager:
                         receipt_id=receipt,
                         idempotency_key=effective_public_idempotency_key,
                     )
-                return leaf_result
+                # A guarded write that validated but did not commit is mid-flight, not
+                # failed. Give it the same envelope shape as its eventual success so a
+                # client can correlate the pair on `operation_id` and see `terminal`
+                # is false, instead of reading the first response as the outcome.
+                return needs_review_terminal(leaf_result)
             except Exception as error:
                 if (
                     _ACTIVE_MUTATION_COMMITTED.get()

--- a/tests/test_bootstrap_compact_budget.py
+++ b/tests/test_bootstrap_compact_budget.py
@@ -1,0 +1,121 @@
+"""`bootstrap(profile="compact")` must actually be compact.
+
+The profile existed but did almost nothing: compact was 64,070 bytes and full was
+65,039 — a 1.5% saving — so every generic-MCP session start spent roughly 16,000
+tokens of the caller's context before any work happened. The largest single cause was
+shipping all six built-in packs' `agent_instructions` when only the *selected* pack's
+guidance can ever apply.
+
+These tests pin the saving so the profile cannot quietly collapse back into full.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+import pytest
+
+from exomem import commands
+
+#: Ceiling for the compact payload. Chosen above the measured 52 KB so ordinary growth
+#: is fine, and far below the 64 KB regression point. Lower it when compact shrinks
+#: further; never raise it without deciding the extra bytes earn a caller's context.
+COMPACT_BYTE_CEILING = 56_000
+
+#: The defect was compact and full being near-identical. A profile that does not
+#: measurably differ from full is not a profile.
+MINIMUM_SAVING_RATIO = 0.15
+
+
+@pytest.fixture(scope="module")
+def payloads() -> dict[str, dict]:
+    root = pathlib.Path(tempfile.mkdtemp())
+    (root / "Knowledge Base").mkdir()
+    return {
+        profile: commands.op_bootstrap(root, profile=profile)
+        for profile in ("compact", "full", "diagnostics")
+    }
+
+
+def _size(payload: dict) -> int:
+    return len(json.dumps(payload))
+
+
+def test_compact_stays_under_its_byte_ceiling(payloads):
+    size = _size(payloads["compact"])
+    assert size <= COMPACT_BYTE_CEILING, (
+        f"compact bootstrap is {size:,} bytes (~{size // 4:,} tokens), over the "
+        f"{COMPACT_BYTE_CEILING:,} ceiling"
+    )
+
+
+def test_compact_is_materially_smaller_than_full(payloads):
+    compact, full = _size(payloads["compact"]), _size(payloads["full"])
+    saving = (full - compact) / full
+    assert saving >= MINIMUM_SAVING_RATIO, (
+        f"compact saves only {saving:.1%} over full ({compact:,} vs {full:,}); the "
+        "profile has collapsed back into full"
+    )
+
+
+def test_profiles_are_ordered_by_size(payloads):
+    assert _size(payloads["compact"]) < _size(payloads["full"]) <= _size(
+        payloads["diagnostics"]
+    )
+
+
+# ------------------------------------------------------------------ what was trimmed
+
+
+def test_compact_omits_unselected_pack_guidance(payloads):
+    """Only the selected pack's instructions can apply; the rest are dead weight."""
+    available = payloads["compact"]["knowledge_packs"]["available"]
+    assert available, "the catalogue must still be discoverable"
+    for pack in available:
+        assert "agent_instructions" not in pack
+        assert "examples" not in pack
+
+
+def test_compact_still_names_every_pack(payloads):
+    """Trimming bodies must not hide which packs exist."""
+    compact_ids = {p["id"] for p in payloads["compact"]["knowledge_packs"]["available"]}
+    full_ids = {p["id"] for p in payloads["full"]["knowledge_packs"]["available"]}
+    assert compact_ids == full_ids
+    for pack in payloads["compact"]["knowledge_packs"]["available"]:
+        assert pack["name"]
+
+
+def test_full_retains_the_complete_catalogue(payloads):
+    assert any(
+        "agent_instructions" in pack
+        for pack in payloads["full"]["knowledge_packs"]["available"]
+    )
+
+
+# --------------------------------------------------------------- what must survive
+
+
+def test_selected_pack_guidance_survives_in_compact(payloads):
+    """The one pack whose instructions actually apply must keep them."""
+    selected = json.dumps(payloads["compact"]["knowledge_packs"]["selected"])
+    assert "agent_instructions" in selected
+
+
+def test_compact_still_teaches_the_core_loop(payloads):
+    """A smaller contract is only a win if it is still a contract."""
+    compact = payloads["compact"]
+    workflow = compact["workflow"]
+    assert workflow["save_rule"]
+    assert workflow["miss_rule"]
+    for section in ("server", "active_capabilities", "governance", "search_guidance"):
+        assert section in compact, section
+
+
+def test_compact_and_full_agree_on_everything_but_detail(payloads):
+    """The trim is a presentation choice; it must not change what is advertised."""
+    compact, full = payloads["compact"], payloads["full"]
+    assert set(compact) <= set(full)
+    assert compact["server"] == full["server"]
+    assert compact["active_capabilities"] == full["active_capabilities"]

--- a/tests/test_disposition_remediation_is_route_neutral.py
+++ b/tests/test_disposition_remediation_is_route_neutral.py
@@ -1,0 +1,105 @@
+"""Relation-disposition remediation must be followable from every route.
+
+Regression cover for the 2026-08-06 friction: an ordinary `edit_section` was blocked by
+a relation-disposition finding whose remediation named `validate_only=true` and a draft
+trio. None of those are `edit_memory` parameters — they belong to the creation writers —
+so the caller went hunting for a field their operation did not have and switched to
+`replace_string`, an unnatural operation for the edit they wanted, purely to reach it.
+
+The fields the remediation names must exist on the operation that provoked it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exomem import edit_operations
+from exomem.edit_operations import EDIT_OPERATION_ADAPTER
+
+# Every guarded edit kind that can provoke a relation-disposition finding.
+GUARDED_KINDS = [
+    {"kind": "replace_body", "new_body": "body"},
+    {"kind": "replace_tags", "tags": ["a"]},
+    {"kind": "replace_string", "old_string": "a", "new_string": "b"},
+    {"kind": "batch_replace", "edits": [{"old_string": "a", "new_string": "b"}]},
+    {"kind": "edit_section", "heading": "## Notes", "new_string": "text"},
+]
+
+DISPOSITION_FIELDS = (
+    "relation_disposition",
+    "relation_review_hash",
+    "relation_review_reason",
+)
+
+
+def _remediation() -> str:
+    from exomem import semantic_contract
+
+    source = semantic_contract._disposition_finding.__code__.co_consts
+    text = " ".join(c for c in source if isinstance(c, str))
+    assert "qualifying typed relation" in text, "remediation text moved"
+    return text
+
+
+@pytest.mark.parametrize("payload", GUARDED_KINDS, ids=lambda p: p["kind"])
+def test_every_guarded_kind_accepts_the_disposition_recovery_fields(payload):
+    """The recovery the remediation names must be expressible on the blocked call."""
+    operation = EDIT_OPERATION_ADAPTER.validate_python(
+        {
+            **payload,
+            "relation_disposition": "reviewed_none",
+            "relation_review_hash": "a" * 64,
+            "relation_review_reason": "no qualifying relation applies",
+        }
+    )
+    for field in DISPOSITION_FIELDS:
+        assert hasattr(operation, field), f"{payload['kind']} cannot carry {field}"
+
+
+@pytest.mark.parametrize("field", DISPOSITION_FIELDS)
+def test_recovery_fields_live_on_the_shared_semantic_base(field):
+    """Shared base, so a new edit kind inherits the recovery instead of forgetting it."""
+    assert field in edit_operations._SemanticEditOperation.model_fields
+
+
+def test_remediation_does_not_name_validate_only():
+    """`validate_only` previews a surgical match; three of five guarded kinds lack it."""
+    assert "validate_only" not in _remediation()
+
+
+def test_remediation_qualifies_the_creation_only_draft_trio():
+    """Naming the trio unconditionally is what sent an edit caller off-route."""
+    text = _remediation()
+    for token in ("draft_id", "draft_hash", "draft_token"):
+        assert token in text, "the creation path still needs these"
+    assert "Creation writers" in text, "the trio must be marked creation-only"
+
+
+def test_remediation_names_only_universally_available_fields_unqualified():
+    """Everything before the creation-writer caveat must exist on every guarded kind."""
+    unqualified = _remediation().split("Creation writers")[0]
+    for field in DISPOSITION_FIELDS:
+        assert field in unqualified
+
+    edit_section = EDIT_OPERATION_ADAPTER.validate_python(
+        {"kind": "edit_section", "heading": "## Notes", "new_string": "text"}
+    )
+    named = {
+        token.strip('",=')
+        for token in unqualified.replace("(", " ").replace(")", " ").split()
+        if token.strip('",=').isidentifier()
+    }
+    creation_only = {"draft_id", "draft_hash", "draft_token", "validate_only"}
+    assert not (named & creation_only), (
+        "the unqualified half names a field the edit route does not have"
+    )
+    assert edit_section.relation_disposition is None
+
+
+def test_validate_only_remains_surgical_only():
+    """Guard the boundary: it must not quietly acquire a second meaning."""
+    surgical = {"replace_string", "batch_replace"}
+    for payload in GUARDED_KINDS:
+        operation = EDIT_OPERATION_ADAPTER.validate_python(payload)
+        has_field = "validate_only" in type(operation).model_fields
+        assert has_field == (payload["kind"] in surgical), payload["kind"]

--- a/tests/test_mutation_state_machine.py
+++ b/tests/test_mutation_state_machine.py
@@ -1,0 +1,159 @@
+"""The mutation state machine — correlating a guarded write's two halves.
+
+Regression cover for the 2026-08-06 misclassification: a governed `remember` returned
+a precommit refusal, then committed on the follow-up call, and the client reported the
+whole write as failed. Both responses were individually correct; the *sequence* was
+unreadable because the refusal had no relationship to the success envelope.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exomem import mutation_terminal as mt
+
+DRAFT = "01JAAAAAAAAAAAAAAAAAAAAAAA"
+
+
+def _precommit(**overrides):
+    payload = {
+        "mutated": False,
+        "draft_id": DRAFT,
+        "draft_hash": "a" * 64,
+        "draft_token": "opaque",
+        "committable_after_review": True,
+        "contract_result": {"blocking_findings": [{"code": "RELATION_DISPOSITION_MISSING"}]},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _committed(**overrides):
+    payload = {"mutated": True, "draft_id": DRAFT, "path": "Knowledge Base/Notes/x.md"}
+    payload.update(overrides)
+    return mt.committed_terminal(
+        payload, request_id="r-1", receipt_id="rc-1", idempotency_key=None
+    )
+
+
+# ------------------------------------------------------------------ the state machine
+
+
+def test_states_are_closed_and_terminality_is_explicit():
+    assert set(mt.STATES) == {
+        "needs_review",
+        "committed",
+        "rejected",
+        "retryable",
+        "indeterminate",
+    }
+    assert mt.TERMINAL_STATES == {"committed", "rejected"}
+    assert "needs_review" not in mt.TERMINAL_STATES
+
+
+def test_needs_review_is_not_a_failure():
+    """The decisive property. `ok` stays true and `terminal` is explicitly false."""
+    env = mt.project_terminal(mt.needs_review_terminal(_precommit()))
+    assert env["ok"] is True
+    assert env["state"] == "needs_review"
+    assert env["terminal"] is False
+    assert env["mutated"] is False
+    assert "error_code" not in env
+
+
+def test_needs_review_names_the_next_action_and_denies_failure():
+    env = mt.project_terminal(mt.needs_review_terminal(_precommit()))
+    assert "not a failure" in env["next_action"]
+    assert "draft identity" in env["next_action"]
+
+
+def test_uncommittable_draft_points_at_the_blockers_instead():
+    env = mt.project_terminal(
+        mt.needs_review_terminal(_precommit(committable_after_review=False))
+    )
+    assert env["state"] == "needs_review"
+    assert "blocking findings" in env["next_action"]
+
+
+# ------------------------------------------------------------------- the correlation
+
+
+def test_both_halves_share_one_operation_id():
+    """Without this, a client has nothing tying the refusal to the later success."""
+    first = mt.project_terminal(mt.needs_review_terminal(_precommit()))
+    second = mt.project_terminal(_committed())
+    assert first["operation_id"] == second["operation_id"] == DRAFT
+
+
+def test_the_terminal_result_supersedes_the_nonterminal_one():
+    first = mt.project_terminal(mt.needs_review_terminal(_precommit()))
+    second = mt.project_terminal(_committed())
+    assert first["terminal"] is False and second["terminal"] is True
+    assert second["state"] == "committed" and second["mutated"] is True
+
+
+def test_operation_id_is_found_through_a_nested_commit_record():
+    terminal = mt.committed_terminal(
+        {"mutated": True, "creation_commit": {"draft_id": DRAFT}, "path": "a.md"},
+        request_id="r-1",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+    assert mt.project_terminal(terminal)["operation_id"] == DRAFT
+
+
+# ------------------------------------------------------------------------ narrowness
+
+
+@pytest.mark.parametrize(
+    "leaf",
+    [
+        {"hits": [1, 2, 3]},
+        {"mutated": False},
+        {"mutated": False, "note": "no draft identity"},
+        {"draft_id": DRAFT},
+        "not a mapping",
+        None,
+    ],
+)
+def test_non_guarded_results_pass_through_untouched(leaf):
+    """Most non-committing leaves are ordinary reads and must not be re-shaped."""
+    assert mt.needs_review_terminal(leaf) is leaf
+
+
+def test_a_committed_result_is_never_treated_as_precommit():
+    assert mt.needs_review_terminal({"mutated": True, "draft_id": DRAFT}) == {
+        "mutated": True,
+        "draft_id": DRAFT,
+    }
+
+
+# -------------------------------------------------------------------- back-compat
+
+
+def test_status_still_agrees_with_state_for_existing_consumers():
+    env = mt.project_terminal(_committed())
+    assert env["status"] == env["state"] == "committed"
+
+
+def test_diagnostics_stay_behind_full_detail_on_both_states():
+    """Success burial is a presentation bug: noise must never lead the response."""
+    pre = mt.needs_review_terminal(_precommit())
+    assert "contract_result" not in mt.project_terminal(pre, "compact")
+    assert mt.project_terminal(pre, "full")["diagnostics"]["contract_result"]
+
+    com = _committed()
+    assert "draft_id" not in mt.project_terminal(com, "compact")
+    assert mt.project_terminal(com, "full")["diagnostics"]["draft_id"] == DRAFT
+
+
+def test_legacy_detail_returns_the_untouched_leaf_for_both_states():
+    raw = _precommit()
+    assert mt.project_terminal(mt.needs_review_terminal(raw), "legacy") is raw
+
+
+def test_envelope_keys_lead_the_compact_projection():
+    """A client scanning the first keys must reach the decisive ones immediately."""
+    env = mt.project_terminal(_committed())
+    leading = list(env)[:4]
+    assert leading == ["ok", "state", "terminal", "status"]

--- a/tests/test_mutation_terminal.py
+++ b/tests/test_mutation_terminal.py
@@ -32,6 +32,8 @@ def test_compact_projection_leads_with_decisive_commit_fields() -> None:
 
     assert mutation_terminal.project_terminal(terminal, "compact") == {
         "ok": True,
+        "state": "committed",
+        "terminal": True,
         "status": "committed",
         "mutated": True,
         "path": "Knowledge Base/Notes/Insights/decisive.md",
@@ -60,6 +62,8 @@ def test_full_projection_adds_the_complete_leaf_result_only_under_diagnostics() 
 
     assert projected == {
         "ok": True,
+        "state": "committed",
+        "terminal": True,
         "status": "committed",
         "mutated": True,
         "paths": ["Knowledge Base/one.md", "Knowledge Base/two.md"],

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -466,11 +466,16 @@ def test_valid_unit_does_not_satisfy_missing_relation_review(tmp_path: Path) -> 
     assert "RELATION_DISPOSITION_MISSING" in codes
     assert "missing_semantic_unit" not in codes
     finding = next(item for item in result.blocking_findings if item.code == "RELATION_DISPOSITION_MISSING")
-    assert "validate_only=true" in finding.remediation
+    # Route-neutral: this finding also fires on ordinary edits, where `validate_only`
+    # and the draft trio do not exist as parameters. Naming them unconditionally sent
+    # edit callers onto an unnatural operation to find a field they could reach.
+    assert "validate_only" not in finding.remediation
     assert "draft_id" in finding.remediation
     assert "draft_hash" in finding.remediation
     assert "draft_token" in finding.remediation
+    assert "Creation writers" in finding.remediation
     assert 'relation_disposition="reviewed_none"' in finding.remediation
+    assert "re-issue the same call" in finding.remediation
     assert "relation_review_hash" in finding.remediation
     assert "relation_review_reason" in finding.remediation
 


### PR DESCRIPTION
Closes the three verified ergonomics defects from the ChatGPT friction profile. Two of the six documented defects turned out to be **already fixed** (`edit_memory`'s discriminated `operation.kind`, `response_detail`) and a third (`MUTATION_BUSY` retry/holder metadata) was fully implemented — those are untouched here.

## 1. The guarded-write state machine (`0705713`)

A validate→commit pair returned two responses with no relationship to each other: a precommit refusal carrying draft identity, then a committed terminal envelope. Both individually correct; the *sequence* was unreadable. On 2026-08-06 a ChatGPT session took the first as the outcome and reported the write as failed, naming an error code the server never returned. The note existed and read fine.

The nonterminal half now gets the same envelope shape as its eventual success — `ok` stays true, `state: needs_review`, `terminal: false`, and a `next_action` that says what to call next and that this is not a failure.

**`operation_id` needed no plumbing.** Both halves already carried the same `draft_id` — minted at validation, handed back on commit — so the correlation identity existed and only needed naming.

The wrapper is deliberately narrow: only a validated draft that explicitly reports it did not mutate earns the envelope, asserted over a table of near-miss shapes. `status` is retained beside `state` and always agrees, so existing consumers are unaffected.

## 2. Route-neutral disposition remediation (`fb68635`)

This is the *actual* `edit_section` defect, and it isn't the one the plan predicted.

The relation-disposition finding fires on creation writers and ordinary edits alike, but its remediation named `validate_only=true` plus `draft_id`/`draft_hash`/`draft_token`. **None of those are `edit_memory` parameters** — `validate_only` previews a surgical text match and exists on only two of five guarded edit kinds; the draft trio belongs to the creation path. So an edit caller followed the instruction, found the field only on `replace_string`, and switched to an unnatural operation to reach it.

Same defect class as advertising a tool the active surface cannot call: instructing a client to take a route that doesn't exist for it. Fixed by naming only what every guarded route accepts, then qualifying the creation-only fields.

`validate_only` deliberately keeps its precise surgical meaning rather than acquiring a second one; a test pins that boundary.

**Note the length constraint** — the remediation repeats per finding and competes for the audit truncation budget. My first rewrite was 14 characters longer and pushed omitted contract results from 1 to 17. The final wording is shorter than the original.

## 3. A compact profile that is actually compact (`bd37302`)

`compact` was 64,070 bytes against `full`'s 65,039 — a **1.5%** saving. ~16,000 tokens of the caller's context at every generic-MCP session start.

Largest cause: `knowledge_packs.available` at 13,006 bytes carried all six packs' `agent_instructions` and `examples`, when only the *selected* pack's guidance can ever apply. Compact now carries an identity-only index (id, name, audience, beginner_description — enough to choose one); `full` keeps the catalogue; the selected pack keeps its instructions in both.

**52,928 bytes, an 18.6% saving.** Tests pin an absolute ceiling *and* a minimum ratio against full, because the defect wasn't size alone — it was the two profiles being indistinguishable.

Deliberately not addressed: `authoring_contract` (12.9 KB) and `semantic_authoring` (9.0 KB) share no keys and are genuine distinct contract content; `simple_actions` and `front_door_actions` are the vocabulary a generic client needs. Trimming those is a contract-design decision, not a presentation one, and wants its own pass.

## Verification

- New: `test_mutation_state_machine.py`, `test_disposition_remediation_is_route_neutral.py`, `test_bootstrap_compact_budget.py`
- Affected suites: 1445 passed on the semantic/mutation/edit/contract selection; 394 passed on bootstrap/pack/hosted/surface
- Two pre-existing failures confirmed unrelated by stashing: `test_setup_wizard.py::test_interactive_setup_can_select_multiple_packs` and `test_demo.py::test_happy_path_human_output`
- CI ruff gate (`ruff check . --select F`): clean

Independent review not yet done.