### PR TITLE
fix(hosted): stop the scheduler CronJob colliding with the durability one

### DIFF
--- a/infra/helm/platform/templates/scheduler.yaml
+++ b/infra/helm/platform/templates/scheduler.yaml
@@ -74,8 +74,17 @@ data:
 ---
 apiVersion: batch/v1
 kind: CronJob
+{{- /*
+  Prefixed like every other scheduler-owned object. The bare contract name
+  collides: the schedules contract carries a job called `exomem-export-gc`, and
+  durability-workloads.yaml independently renders a CronJob of that exact name
+  in the same namespace, so the chart emitted two objects with one identity and
+  `helm install --wait` failed with "no CronJob with the name exomem-export-gc
+  found". The job's logical name stays $job.name everywhere it is data -- the
+  state ConfigMap key, the runtime's JOB_NAME, the labels.
+*/}}
 metadata:
-  name: {{ $job.name }}
+  name: exomem-hosted-scheduler-{{ $job.name }}
   labels:
     app.kubernetes.io/name: {{ $job.name }}
     app.kubernetes.io/part-of: exomem-hosted-scheduler

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1455,9 +1455,11 @@ def test_platform_renders_luks_retain_storage_and_exact_schedule_contract() -> N
         and document.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/part-of")
         == "exomem-hosted-scheduler"
     }
-    assert set(cronjobs) == {job["name"] for job in contract["jobs"]}
+    # Scheduler CronJobs are prefixed; the bare contract name collided with the
+    # durability `exomem-export-gc` CronJob in the same namespace.
+    assert set(cronjobs) == {f"exomem-hosted-scheduler-{job['name']}" for job in contract["jobs"]}
     for job in contract["jobs"]:
-        rendered = cronjobs[job["name"]]
+        rendered = cronjobs[f"exomem-hosted-scheduler-{job['name']}"]
         spec = rendered["spec"]
         job_spec = spec["jobTemplate"]["spec"]
         pod = job_spec["template"]["spec"]
@@ -2084,3 +2086,52 @@ def test_cloudflare_tunnel_targets_the_rendered_production_traefik_service() -> 
     target = "http://exomem-platform-traefik.exomem-platform.svc.cluster.local:80"
     cloudflare = (ROOT / "infra/terraform/foundation/cloudflare.tf").read_text(encoding="utf-8")
     assert cloudflare.count(target) == 2
+
+
+def test_no_two_rendered_objects_share_one_kubernetes_identity() -> None:
+    """Two manifests with the same identity silently collapse into one object.
+
+    The schedules contract carries a job named `exomem-export-gc`, and
+    durability-workloads.yaml independently renders a CronJob of that exact name
+    in the same namespace. Kubernetes accepted the second as an update of the
+    first, so the chart shipped eight CronJobs and the cluster held seven, and
+    `helm install --wait` failed with "no CronJob with the name exomem-export-gc
+    found" only at install time. Every other assertion in this file inspects a
+    document it looked up by name, which cannot notice a second document
+    answering to the same name.
+    """
+
+    documents = _render(PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform")
+    identities: dict[tuple[str, str, str, str], int] = {}
+    for document in documents:
+        metadata = document.get("metadata")
+        if not isinstance(metadata, dict) or not metadata.get("name"):
+            continue
+        identity = (
+            str(document.get("apiVersion", "")),
+            str(document.get("kind", "")),
+            str(metadata.get("namespace", "exomem-platform")),
+            str(metadata["name"]),
+        )
+        identities[identity] = identities.get(identity, 0) + 1
+
+    duplicates = sorted(identity for identity, count in identities.items() if count > 1)
+    assert not duplicates, f"rendered manifests collide on one identity: {duplicates}"
+
+
+def test_scheduler_cronjobs_are_namespaced_away_from_workload_cronjobs() -> None:
+    """The scheduler owns its object names; the contract only supplies the job name."""
+
+    documents = _render(PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform")
+    schedules = json.loads(
+        (PLATFORM / "files/exomem-hosted-schedules-v1.json").read_text(encoding="utf-8")
+    )
+    expected = {f"exomem-hosted-scheduler-{job['name']}" for job in schedules["jobs"]}
+    rendered = {
+        document["metadata"]["name"]
+        for document in documents
+        if document.get("kind") == "CronJob"
+        and document.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/part-of")
+        == "exomem-hosted-scheduler"
+    }
+    assert rendered == expected


### PR DESCRIPTION
The first real `helm upgrade --install` failed and `--atomic` rolled it back:

```
Error: release exomem-platform failed, and has been uninstalled due to atomic
being set: no CronJob with the name "exomem-export-gc" found
```

## Cause

The chart renders that name **twice**:

| source | object |
|---|---|
| `scheduler.yaml:78` | `name: {{ $job.name }}` — the schedules contract has a job `exomem-export-gc` |
| `durability-workloads.yaml:442` | `name: exomem-export-gc` — the in-cluster export GC |

Same name, same namespace. Kubernetes took the second manifest as an update of the first, so the chart shipped 9 CronJobs and the cluster held 8, and Helm's `--wait` could not find the resource it was tracking.

They are unrelated jobs that happened to collide: the scheduler one GETs `https://substratesystems.io/api/cron/exomem-export-gc` hourly; the durability one runs the `exomem-export-gc` command in-cluster every 5 minutes.

## Fix

Every *other* scheduler-owned object was already prefixed — `exomem-hosted-scheduler-state-<job>`, `-runtime`, `-contract`, `-state-writer`. The CronJob was the single place a contract-supplied name became an object identity verbatim. It now carries the same prefix.

The job's **logical** name is unchanged everywhere it is data: labels, the state ConfigMap key, RBAC `resourceNames`, and the runtime's `JOB_NAME`. Only the CronJob's own `metadata.name` moves.

## Why no test caught it

Every assertion in `test_hosted_helm_contract.py` looks a document up **by name**, and a lookup by name cannot notice a second document answering to the same name. One existing test even asserted the colliding scheme (`set(cronjobs) == {job["name"] ...}`) — it encoded the bug, and is updated here.

Two regressions added:

- **`test_no_two_rendered_objects_share_one_kubernetes_identity`** — the general form. No two rendered manifests may share `(apiVersion, kind, namespace, name)`. This is the assertion that was missing.
- **`test_scheduler_cronjobs_are_namespaced_away_from_workload_cronjobs`** — pins the naming scheme against the contract file.

Both fail on the parent commit; I checked by reverting the template and re-running.

## Verification

- 30 helm contract tests pass with pinned Helm 3.19.4 (`HELM_BIN` set).
- Full render: **105 objects, zero duplicate identities**. Previously 105 manifests collapsing to 104 objects.
- The rendered scheduler CronJobs are now `exomem-hosted-scheduler-exomem-{access-delivery,reconcile,export-gc}`.

Found by running the install against the live node, not by reading the chart — the manifests are individually valid and only conflict in aggregate.
