### PR TITLE
fix(hosted): let the provisioner API and the capacity workers actually start

### DIFF
--- a/docs/runbooks/hosted/deploy.md
+++ b/docs/runbooks/hosted/deploy.md
@@ -108,6 +108,9 @@ capacity_values="${deploy_work_dir}/capacity-values.json"
 jq -n --argjson server_id "$hcloud_server_id" \
   '{capacityCollector: {hcloudServerId: $server_id}}' > "$capacity_values"
 chmod 0600 "$capacity_values"
+# The chart pipes this through `int64` before use. Helm parses values as float64
+# and Go prints a large one as 1.56895713e+08, which every worker rejects at
+# startup with "unable to parse string as an integer".
 helm template exomem-platform infra/helm/platform --namespace exomem-platform \
   --values infra/helm/platform/values.yaml \
   --values "${deploy_work_dir}/release-values.json" \

--- a/infra/helm/platform/templates/capacity-collector.yaml
+++ b/infra/helm/platform/templates/capacity-collector.yaml
@@ -152,7 +152,7 @@ spec:
                 - --state-configmap
                 - {{ $stateName }}
                 - --hcloud-server-id
-                - {{ .Values.capacityCollector.hcloudServerId | quote }}
+                - {{ .Values.capacityCollector.hcloudServerId | int64 | quote }}
                 - --hcloud-location
                 - {{ .Values.provisioner.location | quote }}
               env:

--- a/infra/helm/platform/templates/durability-workloads.yaml
+++ b/infra/helm/platform/templates/durability-workloads.yaml
@@ -1006,7 +1006,7 @@ spec:
             - name: EXOMEM_PROVISIONER_CAPACITY_RECEIPT_CONFIG_MAP
               value: {{ .Values.capacityCollector.stateConfigMap | quote }}
             - name: EXOMEM_PROVISIONER_HCLOUD_SERVER_ID
-              value: {{ .Values.capacityCollector.hcloudServerId | quote }}
+              value: {{ .Values.capacityCollector.hcloudServerId | int64 | quote }}
             - name: EXOMEM_PROVISIONER_VOLUME_ENCRYPTION_SECRET_NAME
               value: {{ .Values.storage.encryptionSecretName | quote }}
             - name: EXOMEM_PROVISIONER_VOLUME_ENCRYPTION_SECRET_NAMESPACE

--- a/infra/helm/platform/templates/provisioner.yaml
+++ b/infra/helm/platform/templates/provisioner.yaml
@@ -103,6 +103,15 @@ spec:
               value: {{ .Values.provisioner.trustedProxyIps | quote }}
             - name: HOME
               value: /tmp
+            {{- /*
+              create_app() refuses to serve admission without the selected lock, and
+              reads admission mode, legacy catalog and forward target out of the file
+              itself -- so the API needs the path and the mount, and must NOT receive
+              the worker's extra EXOMEM_PROVISIONER_* vars: ProvisionerSettings sets
+              extra="forbid", so an unmodelled prefixed variable fails validation.
+            */}}
+            - name: EXOMEM_PROVISIONER_DEPLOYMENT_LOCK_PATH
+              value: /etc/exomem/deployment-lock/exomem-hosted-deployment-lock-v2.json
           ports:
             - name: http
               containerPort: 8080
@@ -135,10 +144,19 @@ spec:
           volumeMounts:
             - name: temporary
               mountPath: /tmp
+            - name: deployment-lock
+              mountPath: /etc/exomem/deployment-lock
+              readOnly: true
       volumes:
         - name: temporary
           emptyDir:
             sizeLimit: 16Mi
+        - name: deployment-lock
+          configMap:
+            name: {{ $lockName }}
+            items:
+              - key: exomem-hosted-deployment-lock-v2.json
+                path: exomem-hosted-deployment-lock-v2.json
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -236,7 +254,7 @@ spec:
             - name: EXOMEM_PROVISIONER_CAPACITY_RECEIPT_CONFIG_MAP
               value: {{ .Values.capacityCollector.stateConfigMap | quote }}
             - name: EXOMEM_PROVISIONER_HCLOUD_SERVER_ID
-              value: {{ .Values.capacityCollector.hcloudServerId | quote }}
+              value: {{ .Values.capacityCollector.hcloudServerId | int64 | quote }}
             - name: EXOMEM_PROVISIONER_INTERNAL_ORIGIN
               value: {{ .Values.provisioner.internalOrigin | quote }}
             - name: EXOMEM_PROVISIONER_VOLUME_ENCRYPTION_SECRET_NAME

--- a/infra/helm/platform/values.validation.yaml
+++ b/infra/helm/platform/values.validation.yaml
@@ -9,7 +9,9 @@ provisioner:
 scheduler:
   contractVersion: 1
 capacityCollector:
-  hcloudServerId: 101
+  # Nine digits on purpose: Helm parses values as float64, and Go renders a
+  # large float64 in scientific notation. A small fixture cannot catch that.
+  hcloudServerId: 156895713
 durability:
   b2Endpoint: https://s3.eu-central-003.backblazeb2.com
   b2Region: eu-central-003

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -391,7 +392,7 @@ def test_platform_renders_live_capacity_receipt_collector_with_isolated_keys() -
         "--state-configmap",
         "exomem-capacity-receipt",
         "--hcloud-server-id",
-        "101",
+        "156895713",
         "--hcloud-location",
         "fsn1",
     ]
@@ -464,7 +465,7 @@ def test_platform_renders_live_capacity_receipt_collector_with_isolated_keys() -
         assert environment["EXOMEM_PROVISIONER_CAPACITY_RECEIPT_CONFIG_MAP"]["value"] == (
             "exomem-capacity-receipt"
         )
-        assert environment["EXOMEM_PROVISIONER_HCLOUD_SERVER_ID"]["value"] == "101"
+        assert environment["EXOMEM_PROVISIONER_HCLOUD_SERVER_ID"]["value"] == "156895713"
         assert any(
             mount["name"] == "capacity-contract"
             and mount["mountPath"] == "/etc/exomem/capacity"
@@ -639,7 +640,7 @@ def test_platform_renders_disjoint_durability_workloads() -> None:
     assert volume_env["EXOMEM_PROVISIONER_CAPACITY_RECEIPT_CONFIG_MAP"] == (
         "exomem-capacity-receipt"
     )
-    assert volume_env["EXOMEM_PROVISIONER_HCLOUD_SERVER_ID"] == "101"
+    assert volume_env["EXOMEM_PROVISIONER_HCLOUD_SERVER_ID"] == "156895713"
 
     deletion_job = json.loads(
         _find(documents, "ConfigMap", "exomem-deletion-job-template")["data"][
@@ -2135,3 +2136,73 @@ def test_scheduler_cronjobs_are_namespaced_away_from_workload_cronjobs() -> None
         == "exomem-hosted-scheduler"
     }
     assert rendered == expected
+
+
+def test_no_rendered_value_uses_scientific_notation() -> None:
+    """Helm parses values as float64, and Go prints a large float64 as 1.5e+08.
+
+    `hcloudServerId` reached the provisioner as the string '1.56895713e+08' and
+    every worker died in pydantic with `unable to parse string as an integer`.
+    The deploy runbook hands that value in as a JSON number (`jq --argjson`), so
+    the chart has to survive a float64; the templates pipe through `int64`. The
+    validation fixture used to be `101`, which is small enough that Go prints it
+    plainly -- the fixture, not the template, was why this rendered clean in CI.
+    """
+
+    if HELM is None:
+        pytest.skip("set HELM_BIN to run pinned Helm rendering")
+    rendered = subprocess.run(
+        [
+            str(HELM),
+            "template",
+            "contract-test",
+            str(PLATFORM),
+            "--namespace",
+            "exomem-platform",
+            "--values",
+            str(PLATFORM / "values.validation.yaml"),
+            "--include-crds",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    offenders = re.findall(r"\d+\.\d+e[+-]\d+", rendered)
+    assert not offenders, f"rendered manifests contain float-formatted numbers: {sorted(set(offenders))}"
+
+
+def test_provisioner_api_can_read_the_selected_deployment_lock() -> None:
+    """Without the lock the API cannot start at all.
+
+    `create_app` raises "selected deployment lock is required for serving
+    admission" when the path is unset, and the chart mounted the lock on the
+    worker container only. Nothing rendered wrong -- the Deployment was valid,
+    it just could never boot -- so only a test that looks for the mount catches
+    it. The API must not inherit the worker's other EXOMEM_PROVISIONER_* vars:
+    ProvisionerSettings forbids extras, so an unmodelled one fails validation.
+    """
+
+    documents = _render(PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform")
+    api = next(
+        document
+        for document in documents
+        if document.get("kind") == "Deployment"
+        and document["metadata"]["name"] == "exomem-provisioner-api"
+    )
+    pod = api["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+    environment = {item["name"]: item.get("value") for item in container["env"]}
+
+    lock_path = "/etc/exomem/deployment-lock/exomem-hosted-deployment-lock-v2.json"
+    assert environment["EXOMEM_PROVISIONER_DEPLOYMENT_LOCK_PATH"] == lock_path
+    assert {"name": "deployment-lock", "mountPath": "/etc/exomem/deployment-lock", "readOnly": True} in container["volumeMounts"]
+    lock_volume = next(volume for volume in pod["volumes"] if volume["name"] == "deployment-lock")
+    assert lock_volume["configMap"]["items"] == [
+        {
+            "key": "exomem-hosted-deployment-lock-v2.json",
+            "path": "exomem-hosted-deployment-lock-v2.json",
+        }
+    ]
+    assert "EXOMEM_PROVISIONER_DEPLOYMENT_LOCK_SHA256" not in environment
+    assert "EXOMEM_PROVISIONER_ADMISSION_MODE" not in environment
+    assert "EXOMEM_PROVISIONER_RUNTIME_TARGET_JSON" not in environment


### PR DESCRIPTION
Two defects that both render valid YAML and both fail only at container start. Found by installing the platform, not by rendering it.

## 1. The provisioner API never got its deployment lock

`app.py:124` raises `ValueError: selected deployment lock is required for serving admission` when the path is unset. `provisioner.yaml:208-210` mounted the lock on the **worker** container only, unconditionally — there is no value that enables it for the API. So `exomem-provisioner-api` could not boot with the shipped chart at all.

Confirmed against the live object rather than the template: the running container had 8 env vars, no `EXOMEM_PROVISIONER_DEPLOYMENT_LOCK_PATH`, and only the `temporary` volume.

The API now gets the path plus a read-only mount — and **deliberately not** the worker's `_DEPLOYMENT_LOCK_SHA256`, `_ADMISSION_MODE`, `_RUNTIME_TARGET_JSON`. `ProvisionerSettings` sets `extra="forbid"` under the `EXOMEM_PROVISIONER_` prefix, so an unmodelled prefixed variable fails validation; and `create_app` reads admission mode, legacy catalog and forward target out of the lock file itself.

## 2. `hcloudServerId` arrived as `'1.56895713e+08'`

Every capacity consumer died in pydantic with `unable to parse string as an integer`. Helm parses values as float64 and Go prints a large float64 in scientific notation:

```
$ helm template ... --values '{"id":156895713}'
raw:   "1.56895713e+08"
int64: "156895713"
```

The deploy runbook hands this in as a JSON number (`jq --argjson`), so following the runbook as written produces the bug. The chart must tolerate a float64 — all three call sites now pipe through `int64`, and the runbook gains a note.

**Why CI never saw it:** `values.validation.yaml` used `hcloudServerId: 101`. Go prints a *small* float64 plainly, so the fixture — not the template — is why this rendered clean. It is now a realistic nine-digit id, which is what makes the assertion meaningful. Three dependent assertions updated.

## Regressions

Both fail on the parent commit (verified by swapping the templates back and re-running):

- **`test_no_rendered_value_uses_scientific_notation`** — the general form. No rendered value may match `\d+\.\d+e[+-]\d+`. This catches the whole class, not just this field.
- **`test_provisioner_api_can_read_the_selected_deployment_lock`** — pins the path, the mount, the volume items, and the *absence* of the three forbidden extras.

## Verification

- 32 helm contract tests pass with pinned Helm 3.19.4.
- Full render against the real release values: **zero** scientific-notation values, and the API container carries the lock path, mount and volume.

## Not fixed here

`exomem-hosted-scheduler-alerts` still crashloops until `EXOMEM_HOSTED_ALERT_TOKEN_SHA256` exists on Vercel — the receiver 404s to everything while it is unset, and the evaluator treats a failed delivery as fatal. That is a sequencing fact, not a chart bug: the control-plane env has to be configured before the first install.
