### PR TITLE
fix(hosted): mount the capacity contract as a regular file, not a symlink

### DIFF
--- a/infra/helm/platform/templates/durability-workloads.yaml
+++ b/infra/helm/platform/templates/durability-workloads.yaml
@@ -1026,7 +1026,8 @@ spec:
             capabilities: {drop: [ALL]}
           volumeMounts:
             - {name: temporary, mountPath: /tmp}
-            - {name: capacity-contract, mountPath: /etc/exomem/capacity, readOnly: true}
+            # subPath so the file is regular, not a ..data/ symlink; see provisioner.yaml.
+            - {name: capacity-contract, mountPath: /etc/exomem/capacity/private-alpha-capacity-v1.json, subPath: private-alpha-capacity-v1.json, readOnly: true}
       volumes:
         - name: temporary
           emptyDir: {sizeLimit: 64Mi}

--- a/infra/helm/platform/templates/provisioner.yaml
+++ b/infra/helm/platform/templates/provisioner.yaml
@@ -294,8 +294,16 @@ spec:
             - name: deployment-lock
               mountPath: /etc/exomem/deployment-lock
               readOnly: true
+            {{- /*
+              subPath, not a directory mount: ConfigMap projection publishes each key
+              as a symlink into ..data/, and load_capacity_contract() rejects a symlink
+              outright. subPath materializes a regular file, which satisfies that check
+              without weakening it. Safe here because the ConfigMap is immutable, so the
+              lost live-update behaviour is not behaviour we have.
+            */}}
             - name: capacity-contract
-              mountPath: /etc/exomem/capacity
+              mountPath: /etc/exomem/capacity/private-alpha-capacity-v1.json
+              subPath: private-alpha-capacity-v1.json
               readOnly: true
       volumes:
         - name: temporary

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -466,9 +466,11 @@ def test_platform_renders_live_capacity_receipt_collector_with_isolated_keys() -
             "exomem-capacity-receipt"
         )
         assert environment["EXOMEM_PROVISIONER_HCLOUD_SERVER_ID"]["value"] == "156895713"
+        # subPath, so the loader sees a regular file rather than a ..data/ symlink.
         assert any(
             mount["name"] == "capacity-contract"
-            and mount["mountPath"] == "/etc/exomem/capacity"
+            and mount["mountPath"] == "/etc/exomem/capacity/private-alpha-capacity-v1.json"
+            and mount["subPath"] == "private-alpha-capacity-v1.json"
             and mount["readOnly"] is True
             for mount in container["volumeMounts"]
         )
@@ -2206,3 +2208,41 @@ def test_provisioner_api_can_read_the_selected_deployment_lock() -> None:
     assert "EXOMEM_PROVISIONER_DEPLOYMENT_LOCK_SHA256" not in environment
     assert "EXOMEM_PROVISIONER_ADMISSION_MODE" not in environment
     assert "EXOMEM_PROVISIONER_RUNTIME_TARGET_JSON" not in environment
+
+
+def test_capacity_contract_is_mounted_as_a_regular_file() -> None:
+    """`load_capacity_contract` rejects a symlink, and ConfigMap keys are symlinks.
+
+    A ConfigMap volume publishes every key as a symlink into `..data/`, so a plain
+    directory mount made `contract_path.is_symlink()` true and both provider workers
+    died with "capacity contract is unavailable" on every start. `subPath`
+    materializes a regular file. Nothing about the manifests looked wrong -- the
+    volume, the key and the path env all matched -- so only asserting the mount
+    *shape* catches it.
+    """
+
+    documents = _render(PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform")
+    contract_file = "private-alpha-capacity-v1.json"
+    seen = 0
+    for document in documents:
+        if document.get("kind") not in {"Deployment", "CronJob"}:
+            continue
+        spec = document["spec"]
+        pod = (
+            spec["template"]["spec"]
+            if document["kind"] == "Deployment"
+            else spec["jobTemplate"]["spec"]["template"]["spec"]
+        )
+        if not any(v.get("name") == "capacity-contract" for v in pod.get("volumes", [])):
+            continue
+        for container in pod["containers"]:
+            for mount in container.get("volumeMounts", []):
+                if mount["name"] != "capacity-contract":
+                    continue
+                seen += 1
+                assert mount.get("subPath") == contract_file, (
+                    f"{document['metadata']['name']} mounts the capacity contract as a "
+                    "directory; the loader rejects the resulting ..data/ symlink"
+                )
+                assert mount["mountPath"] == f"/etc/exomem/capacity/{contract_file}"
+    assert seen >= 2, f"expected the provider workers to mount the contract, saw {seen}"


### PR DESCRIPTION
Both provider workers crashlooped on every start:

```
exomem_provisioner.capacity.CapacityReceiptError: capacity contract is unavailable
```

Nothing in the manifests looked wrong. The ConfigMap existed with the right key, the volume referenced it, and the mount path matched `EXOMEM_PROVISIONER_CAPACITY_CONTRACT_PATH` exactly. I verified all of that against the live objects before looking at the loader.

## Cause

`capacity.py:861` rejects a symlink outright:

```python
if contract_path.is_symlink() or not contract_path.is_file():
    raise CapacityReceiptError("capacity contract is unavailable")
```

A ConfigMap volume publishes every key as a **symlink into `..data/`** — that indirection is how Kubernetes makes projected updates atomic. So a directory mount could never satisfy this check, on any cluster, ever.

`subPath` materializes a regular file instead. That satisfies the invariant without weakening it, and the live-update behaviour we give up is behaviour this contract does not have — the ConfigMap is `immutable: true`.

## The asymmetry that hid it

The deployment lock is mounted from a ConfigMap the same way and loads fine, because `load_deployment_lock` has **no** symlink check. Only the capacity loader is strict, so only the capacity consumers broke — which is why this looked like a mount problem rather than a loader contract.

## Regression

`test_capacity_contract_is_mounted_as_a_regular_file` — every workload mounting the contract must use `subPath` at the exact file path. Red on the parent commit.

One existing collector assertion encoded the old directory mount and is updated.

## Verification

33 helm contract tests pass with pinned Helm 3.19.4.

Found by installing against the live node: the two provider workers were the last Deployments not reaching Ready after #393 and #394.
