### PR TITLE
feat(marketplace): add the missing directory evidence signer

### DIFF
--- a/scripts/sign-directory-evidence.py
+++ b/scripts/sign-directory-evidence.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Sign a directory evidence record for marketplace submission.
+
+The verifier for these records lives in ``hosted_plugins._load_signed_directory_evidence``
+but nothing shipped could produce one, so every submission attempt failed on
+``<name> is missing``. This closes that half.
+
+It deliberately does **not** gather the facts it signs. An evidence record
+asserts that probes were run against a real deployment; a tool that invented
+those results would turn the whole signed-evidence chain into decoration. You
+supply the payload, this binds it to a deployment and signs it.
+
+    export EXOMEM_HOSTED_PROMOTION_SECRET=...
+    python scripts/sign-directory-evidence.py production-evidence \
+        --payload probes.json --deployment-sha256 <64hex> --key-id <id>
+
+`--payload` holds only the evidence-type-specific fields (for
+production-evidence: surfaces, the four digests, origin_rejection,
+response_minimization, sampled_output_sale_free). The envelope --
+schema_version, evidence_type, deployment_sha256, checked_at, expires_at,
+operator_key_id -- is added here, and the signature covers all of it.
+
+Records expire in at most 24 hours by contract, so this is run immediately
+before a submission, not once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Mirrors the verifier's payload_fields table. Kept here rather than imported so
+# a mismatch shows up as a signing error rather than a silent agreement between
+# two copies of the same mistake.
+EVIDENCE_TYPES = {
+    "production-evidence": (
+        "directory-production-probes",
+        {
+            "surfaces",
+            "compatibility_sha256",
+            "command_surface_sha256",
+            "schema_contract_sha256",
+            "full_tool_contract_sha256",
+            "origin_rejection",
+            "response_minimization",
+            "sampled_output_sale_free",
+        },
+    ),
+    "prerequisite-evidence": ("directory-prerequisites", {"channels"}),
+    "public-admission-evidence": ("directory-public-admission", {"admission"}),
+    "reviewer-access-evidence": ("directory-reviewer-access", {"channels"}),
+}
+
+MAX_TTL = timedelta(hours=24)
+HEX64 = re.compile(r"[0-9a-f]{64}")
+
+
+def canonical_json(value: object) -> bytes:
+    """Byte-for-byte identical to the verifier's canonicalisation."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def stamp(moment: datetime) -> str:
+    return moment.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build(
+    *,
+    name: str,
+    payload: dict,
+    deployment_sha256: str,
+    key_id: str,
+    secret: str,
+    ttl: timedelta,
+) -> dict:
+    evidence_type, expected_fields = EVIDENCE_TYPES[name]
+    if set(payload) != expected_fields:
+        missing = sorted(expected_fields - set(payload))
+        extra = sorted(set(payload) - expected_fields)
+        raise SystemExit(
+            f"{name}: payload fields do not match the contract"
+            + (f"; missing {missing}" if missing else "")
+            + (f"; unexpected {extra}" if extra else "")
+        )
+    if not HEX64.fullmatch(deployment_sha256):
+        raise SystemExit("--deployment-sha256 must be 64 lowercase hex characters")
+    if ttl <= timedelta(0) or ttl > MAX_TTL:
+        raise SystemExit("--ttl-hours must be greater than 0 and at most 24")
+
+    checked_at = datetime.now(UTC)
+    record = {
+        "schema_version": 1,
+        "evidence_type": evidence_type,
+        "deployment_sha256": deployment_sha256,
+        "checked_at": stamp(checked_at),
+        "expires_at": stamp(checked_at + ttl),
+        "operator_key_id": key_id,
+        **payload,
+    }
+    # The signature covers the whole record except itself, exactly as the
+    # verifier recomputes it.
+    record["operator_signature"] = hmac.new(
+        secret.encode("utf-8"), canonical_json(record), hashlib.sha256
+    ).hexdigest()
+    return record
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("name", choices=sorted(EVIDENCE_TYPES))
+    parser.add_argument("--payload", required=True, type=Path)
+    parser.add_argument("--deployment-sha256", required=True)
+    parser.add_argument("--key-id", required=True)
+    parser.add_argument("--ttl-hours", type=float, default=24.0)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="defaults to plugins/hosted/directory/<name>.json",
+    )
+    args = parser.parse_args(argv)
+
+    secret = os.environ.get("EXOMEM_HOSTED_PROMOTION_SECRET", "").strip()
+    if not secret:
+        raise SystemExit("EXOMEM_HOSTED_PROMOTION_SECRET is not set")
+
+    try:
+        payload = json.loads(args.payload.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"cannot read payload: {error}") from error
+    if not isinstance(payload, dict):
+        raise SystemExit("payload must be a JSON object")
+
+    record = build(
+        name=args.name,
+        payload=payload,
+        deployment_sha256=args.deployment_sha256,
+        key_id=args.key_id,
+        secret=secret,
+        ttl=timedelta(hours=args.ttl_hours),
+    )
+    out = args.out or REPO_ROOT / "plugins/hosted/directory" / f"{args.name}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(record, indent=2, ensure_ascii=False) + "\n")
+    print(f"signed {args.name} -> {out} (expires {record['expires_at']})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_directory_evidence_signer.py
+++ b/tests/test_directory_evidence_signer.py
@@ -1,0 +1,160 @@
+"""The signer must produce records the real verifier accepts.
+
+A signer that agrees only with its own idea of the format is worthless -- the
+whole point is that ``hosted_plugins._load_signed_directory_evidence`` accepts
+the output. These tests therefore round-trip through the actual verifier rather
+than re-implementing its rules.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from exomem import hosted_plugins
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPLOYMENT = "a" * 64
+KEY_ID = "operator-key-1"
+SECRET = "an-operator-promotion-secret-value"
+
+PAYLOADS = {
+    "production-evidence": {
+        "surfaces": {"mcp": "ok"},
+        "compatibility_sha256": "b" * 64,
+        "command_surface_sha256": "c" * 64,
+        "schema_contract_sha256": "d" * 64,
+        "full_tool_contract_sha256": "e" * 64,
+        "origin_rejection": True,
+        "response_minimization": True,
+        "sampled_output_sale_free": True,
+    },
+    "prerequisite-evidence": {"channels": {"claude-connector": {}}},
+    "public-admission-evidence": {"admission": {"ordinary_acquisition": True}},
+    "reviewer-access-evidence": {"channels": {"claude-connector": {}}},
+}
+
+
+def signer() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "sign_directory_evidence", REPO_ROOT / "scripts" / "sign-directory-evidence.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_record(root: Path, name: str, record: dict) -> None:
+    target = root / "plugins" / "hosted" / "directory" / f"{name}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(record), encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_signed_record_is_accepted_by_the_real_verifier(tmp_path: Path, name: str) -> None:
+    module = signer()
+    record = module.build(
+        name=name,
+        payload=PAYLOADS[name],
+        deployment_sha256=DEPLOYMENT,
+        key_id=KEY_ID,
+        secret=SECRET,
+        ttl=timedelta(hours=1),
+    )
+    write_record(tmp_path, name, record)
+
+    evidence_type = module.EVIDENCE_TYPES[name][0]
+    loaded = hosted_plugins._load_signed_directory_evidence(
+        tmp_path,
+        name,
+        evidence_type,
+        trusted_key_id=KEY_ID,
+        trusted_secret=SECRET,
+        deployment_sha256=DEPLOYMENT,
+    )
+    assert loaded["evidence_type"] == evidence_type
+    assert loaded["deployment_sha256"] == DEPLOYMENT
+
+
+def test_tampering_with_a_signed_payload_is_rejected(tmp_path: Path) -> None:
+    module = signer()
+    record = module.build(
+        name="public-admission-evidence",
+        payload={"admission": {"ordinary_acquisition": True}},
+        deployment_sha256=DEPLOYMENT,
+        key_id=KEY_ID,
+        secret=SECRET,
+        ttl=timedelta(hours=1),
+    )
+    # Flip the asserted fact while keeping the signature: the signature must
+    # cover the payload, not just the envelope.
+    record["admission"] = {"ordinary_acquisition": False}
+    write_record(tmp_path, "public-admission-evidence", record)
+
+    with pytest.raises(ValueError, match="invalid operator signature"):
+        hosted_plugins._load_signed_directory_evidence(
+            tmp_path,
+            "public-admission-evidence",
+            "directory-public-admission",
+            trusted_key_id=KEY_ID,
+            trusted_secret=SECRET,
+            deployment_sha256=DEPLOYMENT,
+        )
+
+
+def test_a_record_signed_for_another_deployment_is_rejected(tmp_path: Path) -> None:
+    module = signer()
+    record = module.build(
+        name="public-admission-evidence",
+        payload={"admission": {"ordinary_acquisition": True}},
+        deployment_sha256="f" * 64,
+        key_id=KEY_ID,
+        secret=SECRET,
+        ttl=timedelta(hours=1),
+    )
+    write_record(tmp_path, "public-admission-evidence", record)
+
+    # Evidence proves something about one deployment. Reusing it for the next
+    # one would let a stale probe vouch for code that never ran.
+    with pytest.raises(ValueError, match="binds a different deployment"):
+        hosted_plugins._load_signed_directory_evidence(
+            tmp_path,
+            "public-admission-evidence",
+            "directory-public-admission",
+            trusted_key_id=KEY_ID,
+            trusted_secret=SECRET,
+            deployment_sha256=DEPLOYMENT,
+        )
+
+
+def test_payload_fields_must_match_the_contract() -> None:
+    module = signer()
+    with pytest.raises(SystemExit, match="missing"):
+        module.build(
+            name="production-evidence",
+            payload={"surfaces": {}},
+            deployment_sha256=DEPLOYMENT,
+            key_id=KEY_ID,
+            secret=SECRET,
+            ttl=timedelta(hours=1),
+        )
+
+
+def test_ttl_beyond_the_contract_ceiling_is_refused() -> None:
+    module = signer()
+    # The verifier caps evidence at 24h; signing a longer one would produce a
+    # record that is rejected later, at submission time, for no obvious reason.
+    with pytest.raises(SystemExit, match="at most 24"):
+        module.build(
+            name="public-admission-evidence",
+            payload={"admission": {"ordinary_acquisition": True}},
+            deployment_sha256=DEPLOYMENT,
+            key_id=KEY_ID,
+            secret=SECRET,
+            ttl=timedelta(hours=25),
+        )


### PR DESCRIPTION
## Why

Marketplace submission is gated on four signed evidence records. `hosted_plugins._load_signed_directory_evidence` verifies them — but **nothing shipped could produce one**, so every submission attempt died on `<name> is missing`. The verifier existed without its counterpart.

## What it deliberately does not do

It does not gather the facts it signs. An evidence record asserts that probes ran against a real deployment; a tool that invented those results would turn the whole signed-evidence chain into decoration. The operator supplies the payload; this binds it to a deployment and signs it.

```
export EXOMEM_HOSTED_PROMOTION_SECRET=...
python scripts/sign-directory-evidence.py public-admission-evidence \
    --payload admission.json --deployment-sha256 <64hex> --key-id <id>
```

## The 24-hour ceiling matters operationally

The contract caps evidence at a 24h TTL, so this runs **immediately before a submission, not once**. The signer refuses a longer TTL up front rather than emitting a record that gets rejected later, at submission time, for no obvious reason.

## Verification

8/8, and the tests round-trip through the **real verifier** rather than re-implementing its rules — a signer that agrees only with its own idea of the format is worthless. Covered:

- each of the four evidence types is accepted by `_load_signed_directory_evidence`
- tampering with a payload after signing is rejected (the signature covers the payload, not just the envelope)
- a record signed for another deployment is rejected — otherwise a stale probe could vouch for code that never ran
- wrong payload fields fail with the missing/unexpected keys named
- a TTL beyond 24h is refused at signing time

Also smoke-tested through the CLI end to end.

## What this unblocks

Four of the five remaining `directory-status` blockers. Still operator-only: running the actual probes to produce the payloads, `--openai-app-id` for the OpenAI packet, and `promotion is not live`.