### PR TITLE
fix(hosted): let traefik carry the tunnel's forwarded scheme

### DIFF
--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -130,6 +130,15 @@ traefik:
     web:
       port: 8000
       exposedPort: 80
+      # The tunnel terminates TLS at Cloudflare and dials this entrypoint over
+      # plain HTTP, so traefik must be told the hop in front of it is trusted or
+      # it rewrites X-Forwarded-Proto to http. The provisioner refuses any
+      # /cells/* request whose scheme is not https, so without this every
+      # control-plane call fails closed. Narrower than the 10.0.0.0/8 the
+      # provisioner already trusts for the same header.
+      forwardedHeaders:
+        trustedIPs:
+          - 10.42.0.0/16
     websecure:
       expose:
         default: false

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -2247,6 +2248,42 @@ def test_capacity_contract_is_mounted_as_a_regular_file() -> None:
                 )
                 assert mount["mountPath"] == f"/etc/exomem/capacity/{contract_file}"
     assert seen >= 2, f"expected the provider workers to mount the contract, saw {seen}"
+
+
+def test_traefik_preserves_the_tunnel_forwarded_scheme() -> None:
+    """The provisioner fails closed on any /cells/* request that did not arrive over TLS.
+
+    Cloudflare terminates TLS and cloudflared dials traefik's web entrypoint over
+    plain HTTP from inside the cluster, so `X-Forwarded-Proto: https` is the only
+    evidence the provisioner has. Traefik rewrites that header to the scheme it
+    received unless the client is a trusted proxy, and uvicorn then reports
+    `request.url.scheme == "http"`, which the contract middleware answers with
+    PROVISIONER_REJECTED 400. Every provision, health and deletion call fails, and
+    the rejection is content-free at both ends, so nothing names the cause.
+    """
+
+    documents = _render(PLATFORM, PLATFORM / "values.validation.yaml", namespace="exomem-platform")
+    traefik = _find(documents, "Deployment", "contract-test-traefik")
+    arguments = traefik["spec"]["template"]["spec"]["containers"][0]["args"]
+    trusted = [
+        argument
+        for argument in arguments
+        if argument.startswith("--entryPoints.web.forwardedHeaders.trustedIPs=")
+    ]
+    assert trusted, (
+        "traefik's web entrypoint trusts no proxy, so it overwrites the tunnel's "
+        f"X-Forwarded-Proto and the provisioner rejects every call; args were {arguments}"
+    )
+    networks = [
+        ipaddress.ip_network(value)
+        for value in trusted[0].split("=", 1)[1].split(",")
+        if value
+    ]
+    cloudflared = ipaddress.ip_address("10.42.0.1")
+    assert any(cloudflared in network for network in networks), (
+        f"the trusted set {trusted[0]} does not cover the cluster pod network that "
+        "cloudflared dials from"
+    )
 
 
 def test_no_service_requires_an_external_load_balancer() -> None:


### PR DESCRIPTION
## The failure

A real tenant provisioned against the installed platform reached checkpoint `candidate-created` and then failed every attempt with `PROVISIONER_REJECTED`. The credential was correct, Cloudflare Access was correct, and the provisioner was healthy — 1/1 Ready, zero restarts, live readiness probe.

## Root cause

`infra/provisioner/src/exomem_provisioner/app.py:155` fails closed on any `/cells/*` request whose scheme is not `https`:

```python
if request.url.scheme != "https":
    return _failure("PROVISIONER_REJECTED", 400)
```

Cloudflare terminates TLS, and `cloudflared` (in-cluster) dials traefik's web entrypoint over plain HTTP. So `X-Forwarded-Proto: https` is the only evidence the provisioner has. Traefik rewrites that header to the scheme *it* received unless the client is a trusted proxy — and the chart set no `forwardedHeaders.trustedIPs`. uvicorn runs with `proxy_headers=True` and `forwarded_allow_ips=10.0.0.0/8`, so it was ready to honour the header; it just never arrived intact.

The chart was internally inconsistent: it configured the provisioner to *expect* a truthful proxy header and configured the proxy to discard it.

## How it was isolated

Bisected the middleware gates from outside, through the real ingress, with a temporary Cloudflare Access service token (since removed, policy restored to its single original include):

| Request | Result |
|---|---|
| no bearer | `401` — auth gate, as designed |
| cluster bearer | `400` — auth passes |
| bearer + protocol + `Content-Type` + valid `Idempotency-Key` + body | still `400` |

With every other pre-body gate satisfied, the scheme check is the only remaining `400`. Confirmed the tunnel config from the Cloudflare API (`service: http://exomem-platform-traefik…:80`) and that traefik's rendered args carry no `forwardedHeaders` entry.

This was invisible from logs by design: the provisioner's rejection is content-free, traefik's access log is disabled, and Substrate records only the error code.

## Verification

- New test `test_traefik_preserves_the_tunnel_forwarded_scheme` renders the chart and asserts the web entrypoint trusts the pod network cloudflared dials from. **Proven red against the unfixed values** (`assert []`) and green with the fix.
- `tests/test_hosted_helm_contract.py` + `tests/test_hosted_platform_operations.py` — 86 passed.

Trusts `10.42.0.0/16`, narrower than the `10.0.0.0/8` uvicorn already accepts for the same header.