### PR TITLE
fix(hosted): read the server location HCloud actually returns

### DIFF
--- a/infra/helm/platform/files/operational_receipt_collector.py
+++ b/infra/helm/platform/files/operational_receipt_collector.py
@@ -220,8 +220,15 @@ def capacity_snapshot_from_documents(
     ):
         raise ReceiptCollectorError("configured HCloud server identity is invalid")
     server = hcloud_server.get("server") if isinstance(hcloud_server, dict) else None
-    datacenter = server.get("datacenter") if isinstance(server, dict) else None
-    location = datacenter.get("location") if isinstance(datacenter, dict) else None
+    # HCloud reports the location directly on the server and no longer returns a
+    # `datacenter` object from GET /v1/servers/{id}. Read the current shape first
+    # and keep the nested one as a fallback: taking only the nested path made the
+    # check fail closed on every run, because a missing `datacenter` reads as an
+    # identity mismatch rather than as the schema change it is.
+    location = server.get("location") if isinstance(server, dict) else None
+    if not isinstance(location, dict):
+        datacenter = server.get("datacenter") if isinstance(server, dict) else None
+        location = datacenter.get("location") if isinstance(datacenter, dict) else None
     if (
         not isinstance(server, dict)
         or not isinstance(server.get("id"), int)

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -2236,3 +2236,70 @@ def test_new_operator_scripts_are_executable() -> None:
     ):
         mode = (INFRA / "scripts" / name).stat().st_mode
         assert stat.S_IMODE(mode) & stat.S_IXUSR, name
+
+
+def test_capacity_snapshot_reads_the_location_hcloud_actually_returns() -> None:
+    """HCloud returns `location` on the server and no longer sends `datacenter`.
+
+    The collector read only `server.datacenter.location.name`, so every run
+    failed closed with "HCloud server identity differs" and no capacity receipt
+    was ever written — which left provisioning parked on
+    `capacity-live-observation-mismatch` indefinitely. The old fixture encoded
+    the obsolete shape, so the suite stayed green while production could not
+    work at all.
+    """
+
+    module = _load(
+        "infra/helm/platform/files/operational_receipt_collector.py",
+        "operational_receipt_collector_location_test",
+    )
+    tenant_id, cell_id, operation_id = "tenant-1", "cell-1", "operation-1"
+    resource_name = f"exo-{hashlib.sha256(cell_id.encode()).hexdigest()[:20]}"
+    namespaces = [
+        {
+            "metadata": {
+                "name": resource_name,
+                "labels": {
+                    "exomem.io/tenant-cell": "true",
+                    "exomem.io/cell-resource": resource_name,
+                },
+                "annotations": {
+                    "exomem.io/tenant-id": tenant_id,
+                    "exomem.io/cell-id": cell_id,
+                    "exomem.io/operation-id": operation_id,
+                    "exomem.io/tenant-digest": hashlib.sha256(tenant_id.encode()).hexdigest(),
+                    "exomem.io/subject-digest": hashlib.sha256(cell_id.encode()).hexdigest(),
+                    "exomem.io/operation-digest": hashlib.sha256(operation_id.encode()).hexdigest(),
+                    "exomem.io/fence": "1",
+                    "exomem.io/resource-name": resource_name,
+                    "exomem.io/provision-mode": "serve",
+                },
+            }
+        }
+    ]
+    pages = [{"volumes": [{"id": 11, "server": 101}], "meta": {"pagination": {"next_page": None}}}]
+
+    current_shape = {"server": {"id": 101, "location": {"name": "fsn1"}}}
+    legacy_shape = {"server": {"id": 101, "datacenter": {"location": {"name": "fsn1"}}}}
+
+    for label, document in (("current", current_shape), ("legacy", legacy_shape)):
+        snapshot = module.capacity_snapshot_from_documents(
+            tenant_namespaces={"kind": "NamespaceList", "items": namespaces},
+            cluster_namespace={"metadata": {"uid": "cluster-uid-1234"}},
+            hcloud_server=document,
+            hcloud_pages=pages,
+            expected_server_id=101,
+            expected_location="fsn1",
+        )
+        assert snapshot is not None, label
+
+    # A genuine location mismatch must still fail in the shape now returned.
+    with pytest.raises(module.ReceiptCollectorError, match="HCloud server"):
+        module.capacity_snapshot_from_documents(
+            tenant_namespaces={"kind": "NamespaceList", "items": namespaces},
+            cluster_namespace={"metadata": {"uid": "cluster-uid-1234"}},
+            hcloud_server={"server": {"id": 101, "location": {"name": "nbg1"}}},
+            hcloud_pages=pages,
+            expected_server_id=101,
+            expected_location="fsn1",
+        )


### PR DESCRIPTION
## The failure

Hosted provisioning parked with the provisioner's operation `PENDING` at checkpoint `capacity-live-observation-mismatch`, waiting on a live capacity receipt.

The `exomem-capacity-receipt-collector` CronJob failed **every run** with `HCloud server identity differs`, and its state ConfigMap read `last_sequence: 0` — **no receipt had ever been written, across 34 hours**. Provisioning could never have completed.

## Root cause

The collector validates the observed server via `server.datacenter.location.name`. HCloud no longer returns `datacenter` from `GET /v1/servers/{id}`; `location` is now directly on the server:

```
server.datacenter     → absent
server.location.name  → "fsn1"    (exactly the expected value)
```

`datacenter.get("location")` yields `None`, the `isinstance(location, dict)` guard fails, and the identity check raises.

## Not the credential

Verified by exercising the capacity read token directly: **HTTP 200**, server `156895713`, name `exomem-alpha-01`, location `fsn1`. The deployed token is also byte-identical to the one in BWS. Config and credential were both correct — only the response shape had moved.

## Why the suite stayed green

The existing fixture hardcodes `{"datacenter": {"location": {"name": "fsn1"}}}` — the obsolete shape. A fixture that encodes a stale upstream contract will pass forever while production fails on every call.

The new test pins **both** shapes and keeps a genuine location mismatch (`nbg1` vs `fsn1`) failing, so the check retains its teeth.

## Verification

- New test **proven red** against the unfixed collector, raising at the exact production line; green with the fix.
- `tests/test_hosted_platform_operations.py` + `tests/test_hosted_helm_contract.py` — **87 passed**.