### PR TITLE
fix(hosted): label credential Secret for admission

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -447,7 +447,10 @@ class KubernetesCellAdapter:
                 "name": "exomem-cell-credentials",
                 "namespace": metadata.resource_name,
                 "annotations": annotations,
-                "labels": {"exomem.io/resource-name": metadata.resource_name},
+                "labels": {
+                    "exomem.io/cell": metadata.resource_name,
+                    "exomem.io/resource-name": metadata.resource_name,
+                },
             },
             "type": "Opaque",
             "immutable": False,

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -211,6 +211,10 @@ async def test_cell_adapter_creates_external_secret_then_reads_the_exact_bundle(
         def create_namespaced_secret(self, namespace, body):
             assert namespace == metadata.resource_name
             assert body["metadata"]["name"] == "exomem-cell-credentials"
+            assert body["metadata"]["labels"] == {
+                "exomem.io/cell": metadata.resource_name,
+                "exomem.io/resource-name": metadata.resource_name,
+            }
             self.patch_namespaced_secret = lambda name, namespace, update: setattr(
                 self,
                 "secret",


### PR DESCRIPTION
## Why

A live fresh-tenant provision reached capacity admission, then the provisioner worker crashed because Kubernetes rejected `exomem-cell-credentials`. The existing fail-closed `exomem-provisioner-scope` policy requires child resources to carry `exomem.io/cell == request.namespace`; the adapter did not put that label on the credential Secret.

## What changed

- add the namespace-bound `exomem.io/cell` label to the credential Secret
- preserve the existing resource label and provider identity/recovery annotations
- add a regression assertion over the external Secret CREATE path

## Verification

- red first: focused regression failed on the missing label
- `15 passed` in `test_provider_adapters.py`
- Ruff clean on both changed files
- `git diff --check` clean
- independent review: APPROVE, no findings

## Live follow-up

After merge and the governed provisioner candidate/lock refresh, resume the existing nonterminal fresh-tenant operation; do not mutate its persisted request.