### PR TITLE
fix(records): harden installed E2E and CI diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +31,19 @@ jobs:
           # conftest autouse defaults so a forgotten extra can't change behaviour.
           KB_MCP_DISABLE_EMBEDDINGS: "1"
           KB_MCP_DISABLE_MEDIA_EXTRACTION: "1"
-        run: uv run --frozen --python ${{ matrix.python-version }} python -m pytest -q
+        run: >-
+          uv run --frozen --python ${{ matrix.python-version }} python -m pytest -q
+          --session-timeout=1500
+          --durations=50
+          --durations-min=1
+          --junitxml=test-results/junit-${{ matrix.python-version }}.xml
+      - name: Upload lean test timing evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lean-py${{ matrix.python-version }}-junit
+          path: test-results/junit-${{ matrix.python-version }}.xml
+          if-no-files-found: warn
       - name: Sample vault smoke (the exact command users run)
         run: uv run --frozen --python ${{ matrix.python-version }} exomem demo --json
 

--- a/openspec/changes/harden-records-release-e2e-and-ci/.openspec.yaml
+++ b/openspec/changes/harden-records-release-e2e-and-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/harden-records-release-e2e-and-ci/design.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The Records implementation has exhaustive in-process coverage for the X3 chronological log, a file-per-item vehicle collection, dataset reads, governance-before-reduction, safe mutation, direct-edit visibility/audit-gap detection, and recall isolation. The repository's release-level product loop independently builds a wheel, installs it into a clean virtual environment, initializes a temporary vault, and drives real stdio MCP plus HTTP and restart paths. Those two proofs do not currently meet: `scripts/e2e_product_loop.py` does not discover or call `record_memory`. Designing that black-box journey exposed one accepted-contract gap: the internal governed manifest projector round-trips `links.plans`, while the public `record_memory(action="inspect")` response omits it despite the canonical Records requirement that inspection return the authorized descriptor unchanged.
+
+The accepted `close-technical-memory-gaps` change originally introduced that product loop but remained unarchived, so its `product-e2e`, stable-reference, schema-evolution, and related delta requirements had not reached canonical specs. This change first synchronizes that already-shipped contract into `openspec/specs/`; its own delta then has one unambiguous canonical capability to modify. Archiving the historical change remains mechanical follow-up and is not allowed to block this product correction.
+
+The lean matrix normally completes in about sixteen minutes per Python lane. A contended runner took thirty-nine minutes and exposed four tests whose correctness assertions used production time budgets or absolute wall-clock thresholds. The production boundaries behaved as designed; the test assumptions did not.
+
+The pre-change red evidence is retained in GitHub Actions rather than recreated after the fix. Run `31364355540`, job `93379461964`, recorded the 39-minute Python 3.11 lane with `MUTATION_BUSY` after the production five-second wait, a two-second Records future timeout, and a 3,020.2ms hold measurement against the 1,800ms host-speed threshold. Run `31363972628`, job `93378330587`, recorded the expired-checkpoint semantic test returning zero removals after its intentional 50ms production prune budget was exhausted. The replacement tests reproduce the relevant held-boundary, admission, boundary-state, and constrained-budget conditions while asserting semantic outcomes instead of replaying wall-clock failures.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one representative Records journey a release-blocking installed-wheel/real-MCP proof.
+- Exercise human file ownership and agent-safe mutation in the same canonical collection across a process restart.
+- Preserve the detailed lower-level Records matrices instead of reproducing every case in the product loop.
+- Replace runner-speed assertions with deterministic semantic assertions in the four observed flaky tests.
+- Bound a pathological lean lane and retain useful failure/timing evidence.
+- Correct the existing public Records inspection projection so the already-specified opaque Planning descriptor is actually reachable through the installed product surface.
+
+**Non-Goals:**
+
+- No new Records action/tool, storage format, governance policy, lock timeout, or prune budget change. The existing `inspect` response gains only the already-specified governed Planning descriptor.
+- No full Planning implementation; the fixture only proves the existing opaque Planning-reference contract.
+- No suite deletion, Python-version coverage reduction, `xdist`, broad sharding, coverage gate, or mutation-testing rollout.
+- No claim that every Records edge case is a black-box E2E scenario.
+
+## Decisions
+
+### Extend the existing product loop instead of creating another E2E harness
+
+The current script already proves wheel construction, clean installation, CLI initialization, real stdio MCP, restart persistence, HTTP lifecycle, and writer coordination. The Records phase will be added to its two stdio sessions and `record_memory` will become a required installed tool. A second harness would duplicate expensive setup and could drift from the release path.
+
+The script will create a small X3-compatible chronological-log collection inside its temporary vault using ordinary file writes. It will create an ordinary editable template and insert one completed block into the canonical log before the first MCP call. The fixture is self-contained in the product script rather than importing `tests/fixtures`, so success proves the installed product rather than a repository-only fixture dependency.
+
+During the first stdio session the product loop will:
+
+1. query the manually inserted session through `record_memory`;
+2. append an identified session using the returned container/source guard;
+3. query and target that item with its current item version;
+4. update one field with both drift guards;
+5. request a bounded derived Markdown or CSV view;
+6. inspect and round-trip the manifest's opaque Planning reference/query descriptor; and
+7. ask ordinary memory for a row-only sentinel and prove the canonical log is not returned as semantic recall.
+
+With the server stopped, the outer harness will directly edit the canonical log. The second stdio session will query the collection again and prove the human edit and prior guarded mutation both survive restart without a migration or derived source of truth. It will then inspect the collection and require a positive bounded audit gap for the unaudited human edit; visibility is not silently described as reconciliation or repair. The existing non-owner governance-before-reduction tests remain the exhaustive disclosure proof. The current no-auth HTTP E2E server deliberately represents local owner mode, so fabricated headers must not be used to pretend it is remote. Instead, the harness will launch the installed `python -m exomem --transport http` path, which enables auth, on a second temporary port. Its clean environment will explicitly override `EXOMEM_BASE_URL`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `EXOMEM_GITHUB_USERNAME`, a positive numeric `EXOMEM_GITHUB_USER_ID`, and `EXOMEM_JWT_SIGNING_KEY`; no inherited real credential may participate.
+
+The harness will send raw `POST /mcp` with a protocol-valid JSON-RPC `tools/call` body naming `record_memory`, `Accept: application/json, text/event-stream`, `Content-Type: application/json`, and no `Authorization` header. It must receive exactly `401` plus a Bearer `WWW-Authenticate` challenge naming the local protected-resource metadata URL. The assertion reads the raw response bytes—FastMCP's missing-auth response can be empty—and confirms they disclose no collection path, row, Planning reference, or aggregate value. A generic HTTP error, parse failure, or 404/405/406/415/500 does not pass. This certifies installed remote fail-closed routing, not execution of the command-level governance projector; stdio separately proves the owner product path.
+
+### Close the existing inspection-projection gap at the narrowest boundary
+
+`links.plans` is already parsed, validated, stored, and projected through the Records governance layer, and the canonical Records spec already requires inspection to return the authorized descriptor unchanged. The release journey must not call the unused internal `project_manifest()` helper or import product internals, because that would falsely certify an unavailable product path. Instead, `inspect_collection()` will include the same bounded `_project_plan_link` results in its public contract projection. The implementation will reuse the inspection's existing released manifest and `_LinkProjector`, preserve authorization of the containing manifest/source before projection, and perform no Planning lookup or comparison. Opaque `plan.reference` values are deliberately not resolved or target-authorized: missing and hidden targets must remain indistinguishable, while link-typed values inside the bounded Records query continue through `_LinkProjector` filtering.
+
+The nested egress boundary remains default-deny. `_validate_record_inspection` must explicitly accept, strictly reconstruct, and bound `contract.plans` rather than passing through arbitrary nested mappings. Collection inspection contracts always carry a list, including `plans: []`; the validator will require at most the manifest limit of 32 descriptors, exact `{reference, query}` descriptor keys, canonical bounded opaque references, exact query keys limited to `filters` and `limit`, bounded field names/plain-JSON filter values, and `1 <= limit <= HARD_ROW_CAP`. Hostile or extra nested data must still withhold the entire invalid inspection payload. Tests cover hidden/missing Planning-target parity, withheld nested query-link values, and denied collection/source non-disclosure as well as hostile validator input. This is an additive correction to the existing `inspect` result, not a new command or a general manifest API.
+
+### Assert concurrency state, not elapsed time
+
+The affected tests will preserve their original invariants while changing their observation mechanism:
+
+- The twenty-write test will deliberately produce pre-commit `MUTATION_BUSY`, prove every refused write is non-committed, then retry the refused writes in concurrent waves after release until all commit under one generous deadlock-only test deadline, retaining the original complete-vault/index/log/no-residue assertions. It will not widen the production five-second timeout or replace the successful-contention invariant with a backpressure-only test.
+- The Records mutation-matrix test will use positive attempt/admission/release events around the real mutation guard. Different vaults must both admit before release; a second same-vault attempt must not reach the guarded manifest loader until the first releases. Generous waits exist only as deadlock guards.
+- The critical-section test will record the active mutation state from the relation-review evaluation seam. Narrow mode must observe `free`; the wide-boundary kill switch must observe `held`. No sleep or millisecond threshold remains.
+- The continuation-prune semantic test will use a test-only generous prune budget, leaving the separate production-budget tests unchanged.
+
+Increasing production timeouts was rejected because it would hide correct backpressure and make slow CI define product behavior.
+
+### Use two nested CI ceilings and durable timing evidence
+
+The matrix pytest process will receive `--session-timeout=1500`, which pytest-timeout checks between test items rather than interrupting an already-running item. The existing sixty-second per-item timeout remains the item ceiling, and the GitHub job receives `timeout-minutes: 30` as the actual hard process bound. The requested inner stop should end normal collection/test execution cleanly enough to print the slowest tests and write JUnit; the outer ceiling catches collection, teardown, plugin, or runner hangs.
+
+Each Python lane will print its slowest fifty tests above a one-second floor and write a JUnit XML path containing `${{ matrix.python-version }}`. An `if: always()` artifact step will use an artifact name containing the same matrix version and `if-no-files-found: warn`, so immutable v4 uploads cannot collide and a missing file cannot mask the original test failure. The workflow remains serial within each lane and retains both supported Python versions in this change.
+
+### Keep performance restructuring separate
+
+The new evidence can support a later file-level shard layout and test consolidation. Doing that now would change coverage topology without reliable timings and would mix release correctness with a broader test-governance project. A pathological run becomes bounded now; reducing a normal sixteen-minute lane to the five-to-eight-minute target is a separate measured change.
+
+## Risks / Trade-offs
+
+- [Risk] The product E2E becomes a second exhaustive Records suite. → Keep one chronological-log happy path plus restart/refusal containment; leave vehicle, dataset, aggregate leak, ambiguity, crash-prefix, and scale cases in focused tests.
+- [Risk] A fixture embedded in the script drifts from the canonical X3 adapter. → Use the same manifest grammar and assert the manual/agent/restart behavior that defines compatibility; the full fixture fidelity test remains authoritative for the real files.
+- [Risk] The inner session timeout does not fire during collection or interpreter teardown. → Retain the independent thirty-minute GitHub job ceiling.
+- [Risk] JUnit is unavailable after a hard job kill. → Set the pytest ceiling five minutes earlier so normal failures upload evidence; the job cap is only the final hang guard.
+- [Risk] More generous deadlock guards are mistaken for performance budgets. → Tests assert state transitions immediately after positive synchronization; generous waits only fail a hang and never define acceptable speed.
+
+## Migration Plan
+
+No user data or runtime migration exists. Merge adds release proof, the additive governed `inspect.contract.plans` projection, and CI diagnostics. Rollback removes the added projection, product-loop phase, deterministic test rewrites, and workflow bounds without touching any vault or production configuration.
+
+## Open Questions
+
+None. Broader suite restructuring and multi-horizon Planning remain separately bounded follow-ups.

--- a/openspec/changes/harden-records-release-e2e-and-ci/proposal.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Records is shipped, but its release gate proves the product path only through in-process command calls: the installed-wheel stdio product loop never invokes `record_memory`. At the same time, one contended GitHub runner stretched the serial suite from its normal roughly sixteen minutes to thirty-nine minutes and exposed four tests whose assertions depended on host scheduling rather than product semantics.
+
+## What Changes
+
+- Extend the existing clean-wheel, real-stdio MCP product loop with one bounded Records journey covering manual file ownership, safe append, targeted update, structured query/derived view, opaque Planning evidence, restart persistence, direct-edit visibility plus audit-gap detection, governance, and ordinary-recall isolation.
+- Close the discovered public-surface gap where `record_memory(action="inspect")` omits the already-specified, governance-projected opaque Planning descriptors even though the internal manifest projection supports them.
+- Keep the detailed X3, vehicle, dataset, governance, mutation, and scale matrices at their current lower test layers; the installed-product journey is one representative release proof, not a duplicate exhaustive suite.
+- Rewrite three wall-clock-sensitive tests and isolate one cleanup test from the production prune budget so mutation admission, serialization, boundary placement, and cleanup semantics are observed independently of runner speed.
+- Bound the lean matrix with a pytest session deadline and a GitHub job deadline, and always publish slow-test/JUnit evidence for diagnosis.
+- Explicitly defer suite pruning, coverage-topology changes, Python-version coverage reduction, `xdist`, and broad sharding to a measured follow-up.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `records`: Require a real installed-wheel/stdio Records release journey in addition to in-process acceptance.
+- `install-readiness`: Require bounded, diagnosable lean-suite execution and semantic rather than runner-speed assertions in release-critical concurrency tests.
+- `product-e2e`: Extend the canonical installed-wheel product loop with Records discovery, mutation/restart proof, and unresolved-remote fail-closed coverage.
+
+## Impact
+
+- Canonical OpenSpec: sync the already-shipped `close-technical-memory-gaps` delta requirements before modifying its `product-e2e` capability.
+- Product proof: `scripts/e2e_product_loop.py` and focused test coverage around its Records phase.
+- Product correction: the bounded Records inspection projection and its command/governance tests; no new action or tool is added.
+- Deterministic tests: `tests/test_mutation_concurrency.py`, `tests/test_record_mutation_matrix.py`, `tests/test_shorten_critical_section.py`, and `tests/test_continuation_checkpoint.py`.
+- CI: `.github/workflows/ci.yml` gains a bounded matrix run and always-uploaded timing/JUnit evidence.
+- The existing `inspect` response is corrected additively to satisfy the accepted Records contract; there is no new action/tool, storage format, governance rule, dependency, migration, or runtime timeout change.

--- a/openspec/changes/harden-records-release-e2e-and-ci/specs/install-readiness/spec.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/specs/install-readiness/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Lean suite is time-bounded and diagnosable
+Each required lean Python matrix lane SHALL request pytest session termination between test items at 1,500 seconds through `--session-timeout=1500`, retain the repository's sixty-second per-item timeout, and run inside a GitHub job deadline no greater than thirty minutes. The lane SHALL report its slowest tests and write JUnit timing evidence whose path and immutable artifact name both include the matrix Python version. CI SHALL attempt to upload that evidence with `if: always()` and `if-no-files-found: warn` after ordinary success or test failure. The GitHub job deadline is the hard process bound for collection, a final in-flight item, teardown, plugin, or runner hangs and does not require an artifact from a forcibly terminated job.
+
+#### Scenario: Contended runner reaches the requested session stop
+- **WHEN** a contended runner reaches 1,500 seconds between test items
+- **THEN** pytest requests session termination, reports the available failure and duration evidence, and leaves the existing per-item timeout plus outer job ceiling to bound an item already in flight
+
+#### Scenario: Test process hangs outside its session lifecycle
+- **WHEN** collection, teardown, a plugin, or the runner prevents the pytest session deadline from completing cleanly
+- **THEN** the GitHub job terminates no later than thirty minutes rather than consuming the platform default timeout
+
+#### Scenario: Ordinary lane completion preserves timing evidence
+- **WHEN** a matrix lane passes or fails normally
+- **THEN** its log identifies the slowest bounded set of tests and its matrix-version-specific JUnit XML is uploaded under a matrix-version-specific artifact name for comparison
+
+### Requirement: Release-critical concurrency tests assert semantics
+Release-critical mutation, serialization, critical-section, and cleanup regression tests SHALL synchronize on explicit attempts, admissions, releases, states, or injected test budgets. They SHALL NOT treat completion within a quiet-runner wall-clock threshold as the product invariant. Any remaining timeout in such a semantic test SHALL be a generous deadlock/cleanup guard, while dedicated performance or budget tests MAY retain calibrated timing assertions with an appropriate control.
+
+#### Scenario: Same-vault contention returns retryable backpressure
+- **WHEN** a test deliberately holds the same-vault mutation boundary while other writes attempt entry
+- **THEN** it asserts that refused attempts are non-committed and safely retry to complete canonical state after release rather than requiring every write to fit the production acquisition timeout
+
+#### Scenario: Boundary placement is observed structurally
+- **WHEN** narrow and wide mutation modes evaluate the same validator
+- **THEN** the test distinguishes them by the observed mutation-boundary state at evaluation rather than elapsed milliseconds
+
+#### Scenario: Cleanup semantics are separated from production budget
+- **WHEN** a test proves that an expired checkpoint is tombstoned and pruned
+- **THEN** it uses a test-only budget sufficient for semantic completion while separate tests retain responsibility for the production prune budget

--- a/openspec/changes/harden-records-release-e2e-and-ci/specs/product-e2e/spec.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/specs/product-e2e/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Installed-wheel stdio product loop
+The system SHALL provide a black-box test that builds and installs the wheel, initializes a temporary vault through the installed CLI, connects through a real stdio MCP client, and completes source capture, source-backed memory, recall, read, graph context, evidence preservation, supersession, evolution review, reconcile, Records discovery/query/guarded mutation/direct-edit observation, restart, and persistence checks.
+
+#### Scenario: Governed lifecycle survives restart
+- **WHEN** the lean product E2E completes the governed lifecycle and restarts the stdio server
+- **THEN** the active conclusion, preserved source/evidence links, supersession history, and stable references remain resolvable
+
+#### Scenario: Human-owned Records lifecycle survives restart
+- **WHEN** the lean product E2E manually inserts a template block, performs guarded Records append/update calls, edits the canonical log while stopped, and restarts the stdio server
+- **THEN** the installed `record_memory` surface returns the manual and guarded state, observes the later edit, reports its audit gap, preserves the Planning descriptor, and does not expose raw rows through ordinary recall
+
+### Requirement: HTTP lifecycle and timeout safety
+The system SHALL exercise the actual HTTP application lifecycle, REST authentication, MCP initialization, a read, a write, auth-required remote Records refusal, and clean shutdown. Every transport test SHALL have a bounded timeout and MUST fail rather than hang. The existing no-auth local HTTP harness SHALL remain explicit owner mode and SHALL NOT be reclassified by fabricated authorization headers.
+
+#### Scenario: HTTP server starts and stops cleanly
+- **WHEN** the HTTP E2E starts the server, performs authenticated operations, and requests shutdown
+- **THEN** every request completes within its timeout and the server exits without a leaked lifespan task
+
+#### Scenario: Unauthenticated Records call is rejected at remote ingress
+- **WHEN** installed `python -m exomem --transport http` starts with isolated temporary OAuth anchors and receives a protocol-valid unauthenticated raw `POST /mcp` JSON-RPC `tools/call` payload naming `record_memory`
+- **THEN** it returns exactly 401 with a Bearer challenge naming the local protected-resource metadata URL, its raw response discloses no collection path, row, Planning reference, or aggregate value, and the E2E does not accept another HTTP error or claim command-level governance executed

--- a/openspec/changes/harden-records-release-e2e-and-ci/specs/records/spec.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/specs/records/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Installed-artifact Records release journey
+The release gate SHALL build and install the Exomem wheel in a clean environment, initialize a temporary human-owned vault, discover `record_memory` through a real MCP transport, and complete one bounded chronological-log Records journey without importing product code from the source checkout. The journey SHALL preserve ordinary template/manual entry, perform a guarded append and targeted guarded update, return a structured query and ephemeral derived view, round-trip an opaque Planning evidence descriptor, survive a server restart, observe a direct canonical-file edit, report its positive audit gap without silently repairing it, and keep row-only content out of ordinary semantic recall. Detailed domain, governance-reduction, mutation-crash, ambiguity, dataset, and scale cases MAY remain focused release-blocking tests rather than duplicate black-box scenarios.
+
+#### Scenario: Manual and guarded Records state survives restart
+- **WHEN** the installed product queries a manually inserted template block, appends and updates an identified item through `record_memory`, stops, receives a direct canonical-log edit, and restarts
+- **THEN** the next MCP query returns the manual entry, guarded mutation, and direct edit from the same canonical Markdown file, and inspection reports an audit gap without migration, silent repair, or a competing source of truth
+
+#### Scenario: Installed collection retains Planning and recall boundaries
+- **WHEN** the installed product inspects the collection and asks ordinary memory for content that exists only in a raw record row
+- **THEN** the opaque Planning reference/query descriptor round-trips unchanged and ordinary semantic recall does not return the raw canonical log
+
+#### Scenario: Public inspection exposes only governed opaque Planning descriptors
+- **WHEN** `record_memory(action="inspect")` reads a released collection containing a bounded Planning reference/query descriptor
+- **THEN** `inspect.contract.plans` strictly reconstructs and returns that descriptor through the existing governance projection, without invoking an internal-only API, resolving or target-authorizing the opaque Planning reference, or revealing a withheld link-typed query value
+
+#### Scenario: Inspection Planning projection remains default-deny
+- **WHEN** a projected inspection contains an extra, malformed, over-limit, noncanonical, or untyped nested Planning descriptor value
+- **THEN** the inspection egress validator refuses the invalid payload instead of passing the nested value through
+
+#### Scenario: Unresolved remote Records access fails closed
+- **WHEN** an auth-required installed HTTP MCP surface receives a protocol-valid unauthenticated raw `POST /mcp` JSON-RPC `tools/call` request naming `record_memory`
+- **THEN** authenticated ingress returns exactly 401 with a Bearer challenge naming the local protected-resource metadata URL, reveals no collection, rows, Planning references, paths, or aggregates in the raw response, and leaves the separate no-auth local HTTP harness in explicit owner mode

--- a/openspec/changes/harden-records-release-e2e-and-ci/tasks.md
+++ b/openspec/changes/harden-records-release-e2e-and-ci/tasks.md
@@ -1,0 +1,37 @@
+## 0. Canonical contract ownership
+
+- [x] 0.1 Sync the already-accepted `close-technical-memory-gaps` delta requirements into canonical specs so `product-e2e` has one main-spec owner before this change modifies it.
+
+## 1. Red-first release contracts
+
+- [x] 1.1 Add focused failing tests for the self-contained manual Records fixture and two-session Records phase in `scripts/e2e_product_loop.py`; record the failure before implementation.
+- [x] 1.2 Add a focused failing CI workflow contract for the pytest/job ceilings, duration reporting, lane-specific JUnit, and always-run artifact upload; record the failure before workflow changes.
+- [x] 1.3 Preserve the pre-change red evidence from Actions runs `31364355540`/`93379461964` and `31363972628`/`93378330587`, then exercise the same held-boundary, admission, boundary-state, and constrained-prune-budget conditions through semantic replacement tests.
+- [x] 1.4 Add failing public-command and egress-validator tests proving `record_memory(action="inspect")` currently omits the accepted opaque Planning descriptor. Require `contract.plans` as an always-present list (including `[]`), at most 32 exact `{reference, query}` entries, canonical opaque references, exact `filters`/`limit` query keys, bounded plain-JSON filters, `1 <= limit <= HARD_ROW_CAP`, hostile/extra-value refusal, hidden/missing target parity, withheld nested query-link filtering, and denied collection/source non-disclosure.
+
+## 2. Installed-product Records journey
+
+- [x] 2.1 Add a self-contained chronological-log manifest, canonical log, and ordinary template/manual insertion helper to the product E2E temporary vault without importing repository test fixtures.
+- [x] 2.2 Correct the existing governed inspection projection to include bounded opaque Planning descriptors; extend `_validate_record_inspection` to strictly reconstruct them while preserving missing/hidden target parity and link-typed query filtering; then require installed `record_memory` discovery and implement the first stdio session's manual query, guarded append, guarded targeted update, derived view, Planning descriptor, and recall-isolation assertions.
+- [x] 2.3 Directly edit the canonical log while the server is stopped and implement second-session assertions for the visible edit, prior mutations, and a positive audit gap without silent repair.
+- [x] 2.4 Preserve the existing no-auth HTTP harness as explicit local-owner mode. Launch installed `python -m exomem --transport http` on a second port with explicit temporary overrides for `EXOMEM_BASE_URL`, both GitHub client variables, username, positive numeric user ID, and JWT signing key. Raw-POST a protocol-valid JSON-RPC `tools/call` naming `record_memory` with MCP Accept/JSON content headers and no Authorization; require exactly 401, a Bearer challenge naming the local protected-resource metadata URL, and raw response bytes without disclosure. Do not accept a generic HTTP error, inherit real credentials, fabricate remote identity on the owner server, or claim ingress refusal executed command-level governance.
+
+## 3. Deterministic semantic regressions
+
+- [x] 3.1 Rewrite the twenty-write mutation test to prove non-committed `MUTATION_BUSY`, concurrent safe retry after release, complete canonical/index/log state, and no residue without changing the production timeout.
+- [x] 3.2 Rewrite the per-vault Records boundary test with positive attempt/admission/release events and generous deadlock-only guards.
+- [x] 3.3 Replace narrow/wide critical-section sleeps and millisecond thresholds with direct observation of mutation state at relation-review evaluation.
+- [x] 3.4 Give the expired-checkpoint cleanup semantic test a test-only completion budget while preserving dedicated production-budget coverage.
+
+## 4. Bounded CI evidence
+
+- [x] 4.1 Add `--session-timeout=1500` between-test termination, retain the sixty-second per-item timeout, and add a thirty-minute hard GitHub job deadline to each lean Python lane.
+- [x] 4.2 Print the slowest fifty tests above one second; include `${{ matrix.python-version }}` in both JUnit XML path and immutable artifact name; upload with `if: always()` and `if-no-files-found: warn` after ordinary pass/failure.
+- [x] 4.3 Keep both Python versions and the serial test topology unchanged; document broader sharding/pruning as deferred rather than expanding this change.
+
+## 5. Verification and review
+
+- [x] 5.1 Run the focused E2E-helper, CI-contract, concurrency, Records-matrix, critical-section, and continuation-checkpoint tests.
+- [x] 5.2 Run the installed-wheel product loop within its existing 240-second budget and verify both stdio sessions, HTTP refusal/lifecycle, and writer-lease phase.
+- [x] 5.3 Run Records product/governance/recall acceptance, Ruff on changed Python/tests, `git diff --check`, and strict OpenSpec change plus canonical-spec validation.
+- [x] 5.4 Run the full lean pytest suite once in a trusted writable test-state environment, then obtain an independent diff review and correct every attributable finding. The recorded run completed `8022 passed, 132 skipped` with one unrelated existing governance-overhead p95 failure; its isolated rerun passed (`mixed-search` p95 1.556ms, `structure-reduction` p95 3.027ms). The reviewer approved after all three attributable test-proof findings were corrected.

--- a/openspec/specs/command-surface/spec.md
+++ b/openspec/specs/command-surface/spec.md
@@ -201,3 +201,16 @@ Each action SHALL define required and forbidden arguments. `create` SHALL use cr
 - **WHEN** MCP exposes annotations for `record_memory`
 - **THEN** the command-level annotation remains write-capable even though selector dispatch keeps `inspect` and `query` lease-free
 
+### Requirement: Technical gap commands preserve registry parity
+The product registry SHALL expose `schema_memory`, stable-reference parameters and response fields, `connect_memory(operation="context")`, and `maintain_memory(mode="backfill-ids")` consistently across MCP, REST, CLI, OpenAPI, generated capability docs, and schema-fidelity tests.
+
+#### Scenario: One registry exposes every new route
+- **WHEN** generated surfaces are inspected
+- **THEN** the new command and modes are present with identical parameter semantics and no hand-maintained duplicate implementation
+
+### Requirement: Paths and references coexist
+Commands that accept governed page identifiers SHALL resolve paths and canonical references through one shared resolver and SHALL return both `path` and `ref` where they identify a durable governed artifact.
+
+#### Scenario: Surface responses carry durable identity
+- **WHEN** a source, note, entity, or evidence sidecar is created through MCP, REST, or CLI
+- **THEN** each surface reports the same vault-relative path and canonical reference

--- a/openspec/specs/context-packs/spec.md
+++ b/openspec/specs/context-packs/spec.md
@@ -156,3 +156,23 @@ fingerprint and any withheld notices) rather than sub-notice content.
 - **WHEN** a pack is assembled with no governed items
 - **THEN** the pack is identical to baseline
 
+### Requirement: Unified bounded memory context
+`connect_memory(operation="context")` SHALL accept a query, path, or stable reference and return seed nodes, semantic blocks, typed edges, source/evidence provenance, supersession history, warnings, and explicit truncation. `graph-context` SHALL remain a compatibility alias.
+
+#### Scenario: Context follows evidence and history
+- **WHEN** context is requested for a source-backed conclusion that supersedes an earlier version and cites evidence
+- **THEN** the response includes the active and prior conclusion, their supersession edge, the source/evidence nodes, and provenance paths within configured bounds
+
+### Requirement: Context assembly remains measurement-only
+Unified context SHALL use deterministic parsing, stored relations, retrieval, and precomputed model measurements only. It MUST NOT generate summaries, accept suggested relations, change retrieval ranking, or mutate the vault.
+
+#### Scenario: Context request is read-only
+- **WHEN** unified context is assembled with graph enrichment
+- **THEN** no vault file changes and returned excerpts are sourced from stored content with provenance
+
+### Requirement: Unresolved observed relations remain visible
+The graph SHALL represent an observed edge to a missing target with a typed placeholder node rather than silently dropping the edge during traversal.
+
+#### Scenario: Forward reference appears in context
+- **WHEN** a semantic relation points to a not-yet-created page
+- **THEN** context includes the observed edge and an unresolved placeholder carrying the original target

--- a/openspec/specs/live-index-freshness/spec.md
+++ b/openspec/specs/live-index-freshness/spec.md
@@ -196,3 +196,16 @@ not live, the system MUST fall back to the existing full-vault rebuild.
 - **THEN** the inbound-link index is computed by a full-vault rebuild, exactly as before this
   capability existed
 
+### Requirement: Stable-reference index follows every mutation path
+Writer hooks, moves, deletes, watcher events, and reconcile SHALL keep the reference index aligned with governed Markdown. Missed events SHALL be detectable as audit drift and repairable by reconcile or full rebuild.
+
+#### Scenario: External rename heals reference path
+- **WHEN** a governed page with an `exomem_id` is renamed outside Exomem and reconcile runs
+- **THEN** the canonical reference resolves to the renamed path and the stale mapping is removed
+
+### Requirement: Reference drift is explicit
+Audit SHALL report missing mappings, stale paths, duplicate IDs, malformed IDs, and sidecar rows for missing files without silently selecting a duplicate.
+
+#### Scenario: Duplicate IDs refuse ambiguous resolution
+- **WHEN** two governed pages contain the same `exomem_id`
+- **THEN** audit reports both paths and canonical resolution fails with a stable ambiguity error

--- a/openspec/specs/memory-schema-evolution/spec.md
+++ b/openspec/specs/memory-schema-evolution/spec.md
@@ -1,0 +1,34 @@
+# memory-schema-evolution Specification
+
+## Purpose
+Define optional, corpus-backed schema inference, persistence, validation, and drift comparison without blocking ordinary human-owned Markdown writes.
+
+## Requirements
+
+### Requirement: Infer a corpus-backed contract
+`schema_memory(operation="infer")` SHALL report frontmatter, semantic-block, and relation occurrence frequencies for a selected project/page-type corpus and return a proposed contract. It SHALL mark an element required only when present in every page of a sample of at least five pages.
+
+#### Scenario: Small corpus remains advisory
+- **WHEN** inference scans fewer than five matching pages
+- **THEN** it reports frequencies but proposes no required fields or blocks
+
+### Requirement: Persist optional contracts safely
+Contracts SHALL be optional YAML files under `Knowledge Base/_Schema/contracts/`. Inference SHALL write only with `save=true`, and overwriting an existing contract SHALL require its current content hash.
+
+#### Scenario: Drift guard prevents overwrite
+- **WHEN** save targets an existing contract with a missing or stale expected hash
+- **THEN** the write is refused and the existing contract remains unchanged
+
+### Requirement: Validate without blocking ordinary writes
+`schema_memory(operation="validate")` SHALL return path/span findings for contract violations. Validation SHALL never mutate pages or block ordinary writers; `strict=true` SHALL only provide a failing CLI/CI outcome.
+
+#### Scenario: Validation reports a missing required block
+- **WHEN** a page in contract scope lacks a required semantic block
+- **THEN** validation returns a finding naming the page, required block, severity, and remediation
+
+### Requirement: Diff contracts and corpus reality
+`schema_memory(operation="diff")` SHALL compare a saved contract with the current inferred corpus or another contract and report field, type, enum, block, and relation changes.
+
+#### Scenario: Corpus drift is explicit
+- **WHEN** current pages introduce a new relation type and stop using a previously required field
+- **THEN** diff reports both changes without modifying the contract

--- a/openspec/specs/product-e2e/spec.md
+++ b/openspec/specs/product-e2e/spec.md
@@ -1,0 +1,27 @@
+# product-e2e Specification
+
+## Purpose
+Require black-box release proof through the installed wheel and real product transports, with deterministic lean coverage and explicit heavy-capability tiers.
+
+## Requirements
+
+### Requirement: Installed-wheel stdio product loop
+The system SHALL provide a black-box test that builds and installs the wheel, initializes a temporary vault through the installed CLI, connects through a real stdio MCP client, and completes source capture, source-backed memory, recall, read, graph context, evidence preservation, supersession, evolution review, reconcile, restart, and persistence checks.
+
+#### Scenario: Governed lifecycle survives restart
+- **WHEN** the lean product E2E completes the governed lifecycle and restarts the stdio server
+- **THEN** the active conclusion, preserved source/evidence links, supersession history, and stable references remain resolvable
+
+### Requirement: HTTP lifecycle and timeout safety
+The system SHALL exercise the actual HTTP application lifecycle, REST authentication, MCP initialization, a read, a write, and clean shutdown. Every transport test SHALL have a bounded timeout and MUST fail rather than hang.
+
+#### Scenario: HTTP server starts and stops cleanly
+- **WHEN** the HTTP E2E starts the server, performs authenticated operations, and requests shutdown
+- **THEN** every request completes within its timeout and the server exits without a leaked lifespan task
+
+### Requirement: Tiered model and media gates
+Lean product E2E SHALL run without optional models on every pull request. Real embeddings/reranking SHALL run in the model job, and real OCR, PDF, ASR, CLIP, and video fixtures SHALL run scheduled or opt-in with explicit soft-fail reporting when their configured dependencies are unavailable.
+
+#### Scenario: Lean CI remains deterministic
+- **WHEN** optional model and media extras are absent in the pull-request job
+- **THEN** the lean E2E still proves the complete text/governance lifecycle and reports optional lanes as unavailable rather than failing implicitly

--- a/openspec/specs/stable-memory-references/spec.md
+++ b/openspec/specs/stable-memory-references/spec.md
@@ -1,0 +1,34 @@
+# stable-memory-references Specification
+
+## Purpose
+Give governed human-owned artifacts durable identities and canonical references while keeping paths compatible and all indexes rebuildable from Markdown.
+
+## Requirements
+
+### Requirement: Persistent governed identity
+Every newly created governed Source, Note, Entity, and evidence Markdown sidecar SHALL carry a unique `exomem_id` UUID in frontmatter. Identity SHALL survive content edits, moves, and renames.
+
+#### Scenario: Move preserves canonical identity
+- **WHEN** a governed page with an `exomem_id` is moved through Exomem
+- **THEN** its `exomem_id` is unchanged and its canonical reference resolves to the new path
+
+### Requirement: Canonical references and compatibility
+The system SHALL expose canonical references as `exomem://memory/<uuid>`, accept them anywhere a governed page path is accepted by read, edit, replace, connect, and review operations, and continue accepting existing paths plus `exomem://vault` and `exomem://source` aliases.
+
+#### Scenario: Read by canonical reference
+- **WHEN** `read_memory` receives a canonical reference returned by `remember`
+- **THEN** it reads the same page as the response's vault-relative path
+
+### Requirement: Rebuildable reference index
+The system SHALL maintain a rebuildable ID-to-path SQLite sidecar, detect duplicate or malformed IDs, and fall back to a bounded Markdown rebuild when the sidecar is absent or schema-mismatched.
+
+#### Scenario: Missing sidecar rebuilds from Markdown
+- **WHEN** the reference sidecar is removed and a canonical reference is resolved
+- **THEN** the system rebuilds the mapping from governed Markdown and resolves the reference without changing note bodies
+
+### Requirement: Explicit ID backfill
+`maintain_memory(mode="backfill-ids")` SHALL report proposed changes by default and SHALL write missing IDs only with `dry_run=false`. The write SHALL be atomic, preserve existing IDs, and refuse duplicate-ID ambiguity.
+
+#### Scenario: Dry-run does not mutate the vault
+- **WHEN** backfill runs with its default options over legacy pages
+- **THEN** it reports pages missing IDs and no vault file changes

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -51,6 +51,104 @@ def _clean_env(home: Path, vault: Path) -> dict[str, str]:
     return env
 
 
+def _write_records_fixture(vault: Path) -> dict[str, str]:
+    """Create the ordinary X3 files used only by the installed-product journey."""
+    collection = "Knowledge Base/Records/Health/X3/_collection.md"
+    log = "Knowledge Base/Records/Health/X3/Training Log.md"
+    template = "Knowledge Base/Templates/Records/Health/X3/X3 Push.md"
+    manifest_path = vault / collection
+    log_path = vault / log
+    template_path = vault / template
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        """---
+type: collection
+exomem_id: 9ba8d1cf-d1e7-4309-95ae-cb28d7a6eea8
+title: X3 training sessions
+semantic_profile: records
+collection_version: 1
+schema_version: 1
+lifecycle: active
+storage:
+  strategy: markdown-log
+  source: Training Log.md
+  format_version: 1
+  section:
+    level: 2
+    title: Sessions (newest first)
+  item_heading:
+    level: 3
+    fields:
+      - name: occurred_on
+        type: date
+        format: "%Y-%m-%d"
+      - name: title
+        type: string
+    separator: " · "
+    note:
+      field: note
+      open: " ("
+      close: ")"
+  defaults:
+    status: completed
+  insertion: newest-first
+  child_rows:
+    prefix: "- "
+    delimiter: "|"
+    fields: [movement, band, repetitions]
+    container_field: movements
+item_schema:
+  natural_key: [occurred_on, title]
+  fields:
+    occurred_on: {type: date, required: true}
+    title: {type: string, required: true}
+    status: {type: enum, enum: [completed, partial, aborted]}
+    movements: {type: array, items: {type: object}}
+templates:
+  - path: Knowledge Base/Templates/Records/Health/X3/X3 Push.md
+links:
+  plans:
+    - reference: exomem://memory/81947000-4c22-46e4-9874-23fed028314b
+      query: {filters: {status: completed}, limit: 24}
+---
+
+Human-owned X3 sessions remain ordinary Markdown.
+""",
+        encoding="utf-8",
+    )
+    log_path.write_text(
+        """---
+type: tracker
+---
+# X3 Training Log
+
+## Sessions (newest first)
+""",
+        encoding="utf-8",
+    )
+    template_path.write_text(
+        """### {{date}} · Push
+- Overhead Press | white short paraforce | 8
+- Deadlift | grey short paraforce | e2e record row-only sentinel
+""",
+        encoding="utf-8",
+    )
+    return {"collection": collection, "log": log, "template": template}
+
+
+def _insert_manual_x3_session(vault: Path, fixture: dict[str, str]) -> None:
+    log = vault / fixture["log"]
+    template = vault / fixture["template"]
+    entry = template.read_text(encoding="utf-8").replace("{{date}}", "2026-08-03")
+    log.write_text(
+        log.read_text(encoding="utf-8").replace(
+            "## Sessions (newest first)\n", f"## Sessions (newest first)\n\n{entry}\n", 1
+        ),
+        encoding="utf-8",
+    )
+
+
 def _run(
     command: list[str],
     *,
@@ -209,6 +307,164 @@ async def _assert_relation_contexts(
             raise RuntimeError(f"installed edge {canonical} lost raw observation identity")
 
 
+def _record_source_hash(result: dict[str, Any], suffix: str) -> str:
+    versions = result.get("source_versions")
+    if not isinstance(versions, list):
+        raise RuntimeError(f"record query omitted source versions: {result!r}")
+    for version in versions:
+        if isinstance(version, dict) and str(version.get("path", "")).endswith(suffix):
+            digest = version.get("hash")
+            if isinstance(digest, str):
+                return digest
+    raise RuntimeError(f"record query omitted source hash for {suffix!r}")
+
+
+async def _records_first_session(client, state: dict[str, Any], timeout: float) -> None:
+    fixture = state["records"]
+    collection = fixture["collection"]
+    before = await _call(
+        client,
+        "record_memory",
+        {
+            "action": "query",
+            "collection": collection,
+            "columns": ["occurred_on", "title", "status", "movements"],
+            "limit": 20,
+        },
+        timeout,
+    )
+    if not any(row.get("occurred_on") == "2026-08-03" for row in before.get("rows", [])):
+        raise RuntimeError("installed Records query did not return the manual template session")
+    item_key = "77777777-7777-4777-8777-777777777777"
+    appended = await _call_mutation(
+        client,
+        "record_memory",
+        {
+            "action": "append",
+            "collection": collection,
+            "item": {
+                "occurred_on": "2026-08-04",
+                "title": "Pull",
+                "status": "completed",
+                "movements": [{"movement": "Deadlift", "band": "grey", "repetitions": "22"}],
+            },
+            "item_key": item_key,
+            "expected_container_hash": _record_source_hash(before, "Training Log.md"),
+            "why": "record installed product session",
+        },
+        timeout,
+    )
+    if appended.get("operation") != "append":
+        raise RuntimeError(f"installed Records append returned unexpected data: {appended!r}")
+    after_append = await _call(
+        client,
+        "record_memory",
+        {
+            "action": "query",
+            "collection": collection,
+            "columns": ["occurred_on", "title", "movements"],
+            "limit": 20,
+        },
+        timeout,
+    )
+    item = next(
+        (row for row in after_append.get("rows", []) if row.get("record_id") == item_key),
+        None,
+    )
+    if not isinstance(item, dict) or not isinstance(item.get("item_version"), str):
+        raise RuntimeError("installed Records query did not return the appended item version")
+    updated = await _call_mutation(
+        client,
+        "record_memory",
+        {
+            "action": "update",
+            "collection": collection,
+            "item_key": item_key,
+            "changes": {"title": "Push corrected"},
+            "expected_container_hash": _record_source_hash(after_append, "Training Log.md"),
+            "expected_item_version": item["item_version"],
+            "why": "correct installed product session",
+        },
+        timeout,
+    )
+    if updated.get("operation") != "update":
+        raise RuntimeError(f"installed Records update returned unexpected data: {updated!r}")
+    derived = await _call(
+        client,
+        "record_memory",
+        {
+            "action": "query",
+            "collection": collection,
+            "columns": ["occurred_on", "title", "movements"],
+            "limit": 20,
+            "output_format": "markdown",
+        },
+        timeout,
+    )
+    if derived.get("derived") is not True or "| occurred_on" not in derived.get("rendered", ""):
+        raise RuntimeError("installed Records query did not return a bounded derived Markdown view")
+    inspection = await _call(
+        client, "record_memory", {"action": "inspect", "collection": collection}, timeout
+    )
+    expected_plan = {
+        "reference": "exomem://memory/81947000-4c22-46e4-9874-23fed028314b",
+        "query": {"filters": {"status": "completed"}, "limit": 24},
+    }
+    if inspection.get("contract", {}).get("plans") != [expected_plan]:
+        raise RuntimeError(
+            "installed Records inspection did not round-trip the Planning descriptor"
+        )
+    recalled = await _call(
+        client,
+        "ask_memory",
+        {"query": "e2e record row-only sentinel", "mode": "keyword"},
+        timeout,
+    )
+    hits = recalled.get("hits", []) if isinstance(recalled, dict) else recalled
+    if fixture["log"] in {hit.get("path") for hit in hits if isinstance(hit, dict)}:
+        raise RuntimeError("ordinary recall exposed the raw Records log")
+    state["records"].update({"item_key": item_key})
+
+
+async def _records_restart_session(client, state: dict[str, Any], timeout: float) -> None:
+    fixture = state["records"]
+    result = await _call(
+        client,
+        "record_memory",
+        {
+            "action": "query",
+            "collection": fixture["collection"],
+            "columns": ["occurred_on", "title", "movements"],
+            "limit": 30,
+        },
+        timeout,
+    )
+    rows = result.get("rows", [])
+    if not any(row.get("occurred_on") == "2026-08-03" for row in rows):
+        raise RuntimeError("manual Records state did not survive restart")
+    if not any(
+        row.get("record_id") == fixture["item_key"] and row.get("title") == "Push corrected"
+        for row in rows
+    ):
+        raise RuntimeError("guarded Records mutation did not survive restart")
+    if not any(
+        movement.get("repetitions") == "23"
+        for row in rows
+        for movement in row.get("movements", [])
+        if isinstance(movement, dict)
+    ):
+        raise RuntimeError("direct Records edit was not visible after restart")
+    inspection = await _call(
+        client,
+        "record_memory",
+        {"action": "inspect", "collection": fixture["collection"]},
+        timeout,
+    )
+    audit = inspection.get("audit", {})
+    if audit.get("status") != "gap" or not audit.get("gaps"):
+        raise RuntimeError("direct Records edit did not retain a positive audit gap")
+
+
 async def _stdio_session(
     executable: Path,
     env: dict[str, str],
@@ -246,6 +502,7 @@ async def _stdio_session(
                 "review_memory",
                 "maintain_memory",
                 "schema_memory",
+                "record_memory",
             }
             missing = required - tools
             if missing:
@@ -463,6 +720,7 @@ async def _stdio_session(
                         "registry_hash": registry_result["saved"]["content_hash"],
                     }
                 )
+                await _records_first_session(client, state, timeout)
             else:
                 reconcile = await _call_maintenance(
                     client,
@@ -501,6 +759,7 @@ async def _stdio_session(
                     relation_ref=state["relation_ref"],
                     timeout=timeout,
                 )
+                await _records_restart_session(client, state, timeout)
                 from exomem import epistemic_graph
 
                 graph_status = reconcile.get("graph_status")
@@ -522,6 +781,8 @@ def _installed_stdio(args: argparse.Namespace) -> int:
     home = Path(args.home)
     env = _clean_env(home, vault)
     state: dict[str, Any] = {}
+    state["records"] = _write_records_fixture(vault)
+    _insert_manual_x3_session(vault, state["records"])
     asyncio.run(
         _stdio_session(
             executable,
@@ -537,6 +798,13 @@ def _installed_stdio(args: argparse.Namespace) -> int:
     refs_sidecar.unlink(missing_ok=True)
     graph_sidecar = vault / "Knowledge Base" / ".graph.sqlite"
     graph_sidecar.unlink(missing_ok=True)
+    log = vault / state["records"]["log"]
+    log.write_text(
+        log.read_text(encoding="utf-8")
+        + "\n### 2026-08-06 · Pull (human restart edit)\n"
+        + "- Deadlift | grey | 23\n",
+        encoding="utf-8",
+    )
     asyncio.run(
         _stdio_session(
             executable,
@@ -603,6 +871,29 @@ def _http_get_raw(
     except urllib.error.HTTPError as exc:
         headers = {key.lower(): value for key, value in exc.headers.items()}
         return exc.code, headers, exc.read()
+
+
+def _http_post_raw(
+    url: str,
+    *,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    timeout: float,
+) -> tuple[int, dict[str, str], bytes]:
+    """POST a protocol payload and retain its unparsed response boundary."""
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            response_headers = {key.lower(): value for key, value in response.headers.items()}
+            return response.status, response_headers, response.read()
+    except urllib.error.HTTPError as exc:
+        response_headers = {key.lower(): value for key, value in exc.headers.items()}
+        return exc.code, response_headers, exc.read()
 
 
 def _first_review_item(base_url: str, token: str, timeout: float) -> dict[str, Any]:
@@ -753,10 +1044,137 @@ async def _initialize_http_mcp(base_url: str, timeout: float) -> None:
                 raise RuntimeError("HTTP MCP initialization omitted bootstrap")
 
 
+def _assert_unauthenticated_records_refusal(base_url: str, timeout: float) -> None:
+    """Prove the installed remote route refuses a real Records MCP request."""
+    metadata_url = f"{base_url}/.well-known/oauth-protected-resource/mcp"
+    status, headers, response = _http_post_raw(
+        f"{base_url}/mcp",
+        body={
+            "jsonrpc": "2.0",
+            "id": "records-auth-refusal",
+            "method": "tools/call",
+            "params": {
+                "name": "record_memory",
+                "arguments": {
+                    "action": "inspect",
+                    "collection": "Knowledge Base/Records/Health/X3/_collection.md",
+                },
+            },
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        },
+        timeout=timeout,
+    )
+    expected_challenge = f'Bearer resource_metadata="{metadata_url}"'
+    if status != 401 or headers.get("www-authenticate") != expected_challenge:
+        raise RuntimeError(
+            "unauthenticated installed HTTP Records request did not receive the expected "
+            f"401 Bearer challenge: {status} {headers.get('www-authenticate')!r}"
+        )
+    for forbidden in (b"Records/Health/X3", b"Planning", b"rows", b"aggregate"):
+        if forbidden in response:
+            raise RuntimeError("unauthenticated HTTP Records refusal disclosed collection content")
+
+
 def _reserve_port() -> int:
     with socket.socket() as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
+
+
+def _reserve_port_reservations(count: int) -> list[socket.socket]:
+    """Hold distinct local ports until their respective server launches."""
+    reservations: list[socket.socket] = []
+    try:
+        for _ in range(count):
+            reservation = socket.socket()
+            try:
+                reservation.bind(("127.0.0.1", 0))
+            except OSError:
+                reservation.close()
+                raise
+            reservations.append(reservation)
+    except OSError:
+        for reservation in reservations:
+            reservation.close()
+        raise
+    return reservations
+
+
+def _installed_auth_required_records_refusal(args: argparse.Namespace) -> None:
+    """Start the installed auth-required HTTP server and verify its ingress boundary."""
+    vault = Path(args.vault)
+    work = Path(args.work)
+    home = Path(args.home)
+    port = _reserve_port()
+    base_url = f"http://127.0.0.1:{port}"
+    env = _clean_env(home, vault)
+    env.update(
+        {
+            "EXOMEM_BASE_URL": base_url,
+            "GITHUB_CLIENT_ID": "e2e-github-client-id",
+            "GITHUB_CLIENT_SECRET": "e2e-github-client-secret",
+            "EXOMEM_GITHUB_USERNAME": "e2e-github-user",
+            "EXOMEM_GITHUB_USER_ID": "123456",
+            "EXOMEM_JWT_SIGNING_KEY": "e2e-jwt-signing-key",
+        }
+    )
+    server_log = work / "auth-required-http-server.log"
+    with server_log.open("w", encoding="utf-8") as log:
+        proc = subprocess.Popen(
+            [
+                args.python,
+                "-m",
+                "exomem",
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            cwd=work,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        clean_shutdown = False
+        try:
+            deadline = time.monotonic() + args.request_timeout
+            while True:
+                if proc.poll() is not None:
+                    raise RuntimeError(
+                        f"auth-required HTTP server exited during startup ({proc.returncode}):\n"
+                        + server_log.read_text(encoding="utf-8")[-4000:]
+                    )
+                try:
+                    _assert_unauthenticated_records_refusal(base_url, args.request_timeout)
+                    break
+                except urllib.error.URLError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            "auth-required HTTP server did not become ready before timeout"
+                        ) from None
+                    time.sleep(0.1)
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=args.request_timeout)
+                    clean_shutdown = True
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+            else:
+                clean_shutdown = proc.returncode == 0
+        if not clean_shutdown:
+            raise RuntimeError(
+                "auth-required HTTP server did not shut down cleanly:\n"
+                + server_log.read_text(encoding="utf-8")[-4000:]
+            )
 
 
 def _installed_http(args: argparse.Namespace) -> int:
@@ -863,6 +1281,7 @@ def _installed_http(args: argparse.Namespace) -> int:
                 "HTTP server did not shut down cleanly:\n"
                 + server_log.read_text(encoding="utf-8")[-4000:]
             )
+    _installed_auth_required_records_refusal(args)
     print(json.dumps({"success": True, "transport": "http", "clean_shutdown": True}))
     return 0
 
@@ -922,9 +1341,11 @@ def _installed_lease(args: argparse.Namespace) -> int:
     work = Path(args.work)
     home = Path(args.home)
     timeout = args.request_timeout
-    coord_port = _reserve_port()
-    port_a = _reserve_port()
-    port_b = _reserve_port()
+    reservations = _reserve_port_reservations(3)
+    coordinator_reservation, replica_a_reservation, replica_b_reservation = reservations
+    coord_port = int(coordinator_reservation.getsockname()[1])
+    port_a = int(replica_a_reservation.getsockname()[1])
+    port_b = int(replica_b_reservation.getsockname()[1])
     coord_url = f"http://127.0.0.1:{coord_port}"
     url_a = f"http://127.0.0.1:{port_a}"
     url_b = f"http://127.0.0.1:{port_b}"
@@ -947,6 +1368,7 @@ def _installed_lease(args: argparse.Namespace) -> int:
     try:
         coord_handle = coord_log.open("w", encoding="utf-8")
         handles.append(coord_handle)
+        coordinator_reservation.close()
         coordinator = subprocess.Popen(
             [
                 args.python,
@@ -975,12 +1397,13 @@ def _installed_lease(args: argparse.Namespace) -> int:
             label="lease coordinator",
         )
 
-        for url, env, log, handle_label in (
-            (url_a, env_a, log_a, port_a),
-            (url_b, env_b, log_b, port_b),
+        for url, env, log, handle_label, reservation in (
+            (url_a, env_a, log_a, port_a, replica_a_reservation),
+            (url_b, env_b, log_b, port_b, replica_b_reservation),
         ):
             handle = log.open("w", encoding="utf-8")
             handles.append(handle)
+            reservation.close()
             replica = subprocess.Popen(
                 [args.python, args.http_server, "--host", "127.0.0.1", "--port", str(handle_label)],
                 cwd=work,
@@ -1088,6 +1511,8 @@ def _installed_lease(args: argparse.Namespace) -> int:
             _terminate(proc, 5)
         for handle in handles:
             handle.close()
+        for reservation in reservations:
+            reservation.close()
     print(json.dumps({"success": True, "transport": "lease", "takeover": True}))
     return 0
 

--- a/src/exomem/record_governance.py
+++ b/src/exomem/record_governance.py
@@ -220,6 +220,32 @@ def _inspection_saved_view(value: Any) -> dict[str, Any] | None:
     return normalized
 
 
+def _inspection_plan_descriptor(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping) or set(value) != {"reference", "query"}:
+        return None
+    reference = _opaque_plan_reference(value.get("reference"))
+    query = value.get("query")
+    if reference is None or not isinstance(query, Mapping) or not query or set(query) - {"filters", "limit"}:
+        return None
+    limit = query.get("limit")
+    if type(limit) is not int or not 1 <= limit <= query_data.HARD_ROW_CAP:
+        return None
+    normalized_query: dict[str, Any] = {"limit": limit}
+    if "filters" in query:
+        filters = query["filters"]
+        if not isinstance(filters, Mapping) or len(filters) > 128:
+            return None
+        normalized_filters: dict[str, Any] = {}
+        for name, filter_value in filters.items():
+            field = _inspection_field_name(name)
+            projected = _inspection_json(filter_value)
+            if field is None or projected is _INSPECTION_INVALID:
+                return None
+            normalized_filters[field] = projected
+        normalized_query = {"filters": normalized_filters, "limit": limit}
+    return {"reference": reference, "query": normalized_query}
+
+
 def _validate_record_inspection(payload: Mapping[str, Any]) -> dict[str, Any] | None:
     """Reconstruct the report-only inspection union before it reaches egress."""
     kind = payload.get("kind")
@@ -275,7 +301,7 @@ def _validate_record_inspection(payload: Mapping[str, Any]) -> dict[str, Any] | 
     if kind == "collection":
         if legacy is not None or not isinstance(contract, Mapping):
             return None
-        if set(contract) != {"collection_id", "path", "title", "semantic_profile", "schema_version", "storage"}:
+        if set(contract) != {"collection_id", "path", "title", "semantic_profile", "schema_version", "storage", "plans"}:
             return None
         collection_id = _inspection_identifier(contract.get("collection_id"))
         path, title = _inspection_path(contract.get("path")), _inspection_string(contract.get("title"), maximum=512)
@@ -296,6 +322,12 @@ def _validate_record_inspection(payload: Mapping[str, Any]) -> dict[str, Any] | 
         strategy, source, format_version = storage.get("strategy"), _inspection_path(storage.get("source")), storage.get("format_version")
         if type(strategy) is not str or strategy not in {"markdown-log", "markdown-items", "dataset"} or source is None or format_version != 1:
             return None
+        plans = contract.get("plans")
+        if not isinstance(plans, list) or len(plans) > 32:
+            return None
+        normalized_plans = [_inspection_plan_descriptor(plan) for plan in plans]
+        if any(plan is None for plan in normalized_plans):
+            return None
         normalized_contract: dict[str, Any] | None = {
             "collection_id": collection_id,
             "path": path,
@@ -303,6 +335,7 @@ def _validate_record_inspection(payload: Mapping[str, Any]) -> dict[str, Any] | 
             "semantic_profile": profile,
             "schema_version": version,
             "storage": {"strategy": strategy, "source": source, "format_version": format_version},
+            "plans": [plan for plan in normalized_plans if plan is not None],
         }
         normalized_legacy: dict[str, Any] | None = None
         if status == "not_applicable":
@@ -765,7 +798,15 @@ def inspect_collection(
             {
                 "kind": "collection",
                 "report_only": True,
-                "contract": _inspection_contract(manifest),
+                "contract": {
+                    **_inspection_contract(manifest),
+                    "plans": [
+                        projected
+                        for plan in manifest.links.plans
+                        if (projected := _project_plan_link(root, manifest, plan, links=links))
+                        is not None
+                    ],
+                },
                 "legacy": None,
                 "snapshot": inspection.snapshot,
                 "source_versions": [
@@ -823,6 +864,7 @@ def _inspection_contract(manifest: collections.CollectionManifest) -> dict[str, 
             "source": manifest.storage.source,
             "format_version": manifest.storage.format_version,
         },
+        "plans": [],
     }
 
 

--- a/tests/test_ci_reliability_contract.py
+++ b/tests/test_ci_reliability_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_lean_python_lanes_have_time_bounds_and_versioned_timing_evidence() -> None:
+    workflow = yaml.safe_load(
+        (Path(__file__).parents[1] / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    job = workflow["jobs"]["test"]
+
+    assert job["timeout-minutes"] == 30
+    run_step = next(step for step in job["steps"] if step.get("name", "").startswith("Run tests"))
+    assert "--session-timeout=1500" in run_step["run"]
+    assert "--durations=50" in run_step["run"]
+    assert "--durations-min=1" in run_step["run"]
+    assert "--junitxml=test-results/junit-${{ matrix.python-version }}.xml" in run_step["run"]
+
+    artifact_step = next(step for step in job["steps"] if step.get("uses") == "actions/upload-artifact@v4")
+    assert artifact_step["if"] == "always()"
+    assert "${{ matrix.python-version }}" in artifact_step["with"]["name"]
+    assert artifact_step["with"]["path"] == "test-results/junit-${{ matrix.python-version }}.xml"
+    assert artifact_step["with"]["if-no-files-found"] == "warn"

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -1826,8 +1826,9 @@ def test_os_advisory_lock_times_out_and_releases_when_owner_is_killed(tmp_path: 
 
 @pytest.mark.parametrize("force_fallback", [False, True])
 def test_expired_state_is_tombstoned_and_pruned_with_both_lock_orders(
-    tmp_path: Path, force_fallback: bool
+    tmp_path: Path, force_fallback: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(checkpoint, "MAX_PRUNE_LOCK_SECONDS", 2.0)
     home = tmp_path / "home"
     old = _event(client="codex", session_id="old")
     current = _event(client="codex", session_id="current")

--- a/tests/test_mutation_concurrency.py
+++ b/tests/test_mutation_concurrency.py
@@ -4,10 +4,14 @@ import io
 import os
 import shutil
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
 from exomem import commands, preserve, schema
+from exomem.cli_ops import OpError
 from exomem.writer_lease import LeaseConfig, LeaseManager
 
 
@@ -19,28 +23,78 @@ def test_twenty_concurrent_real_captures_leave_complete_vault_state(
     vault: Path, source_schema
 ) -> None:
     assert os.environ["EXOMEM_DISABLE_EMBEDDINGS"] == "1"
-    manager = LeaseManager(LeaseConfig(state_dir=vault.parent / "mutation-state"))
+    state_dir = vault.parent / "mutation-state"
+    manager = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.05)
+    retry_manager = LeaseManager(LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.05)
+    assert retry_manager._mutation_timeout_seconds == 0.05
+    holder = LeaseManager(LeaseConfig(state_dir=state_dir))
     command = _add_command()
     start = threading.Barrier(20)
+    holding = threading.Event()
+    release = threading.Event()
 
-    def capture(number: int) -> dict:
-        start.wait(timeout=5.0)
+    def arguments(number: int) -> dict[str, str]:
         slug = f"concurrent-capture-{number:02d}"
-        return manager.invoke(
+        return {
+            "content": f"bounded concurrent payload {number}",
+            "source_type": "other",
+            "title": f"Concurrent Capture {number:02d}",
+            "slug": slug,
+        }
+
+    def capture(number: int, *, synchronize: bool, retry: bool = False) -> dict:
+        if synchronize:
+            start.wait(timeout=10.0)
+        return (retry_manager if retry else manager).invoke(
             command,
             (vault, source_schema),
-            {
-                "content": f"bounded concurrent payload {number}",
-                "source_type": "other",
-                "title": f"Concurrent Capture {number:02d}",
-                "slug": slug,
-            },
+            arguments(number),
         )
 
-    with ThreadPoolExecutor(max_workers=20) as pool:
-        results = list(pool.map(capture, range(20)))
+    def hold_boundary() -> None:
+        with holder.mutation_guard(vault, request_id="holder", operation="capture"):
+            holding.set()
+            assert release.wait(10.0)
 
-    paths = [result["path"] for result in results]
+    thread = threading.Thread(target=hold_boundary)
+    thread.start()
+    assert holding.wait(10.0)
+    with ThreadPoolExecutor(max_workers=20) as pool:
+        first_attempts = [pool.submit(capture, number, synchronize=True) for number in range(20)]
+        refused: list[OpError] = []
+        for future in first_attempts:
+            with pytest.raises(OpError) as raised:
+                future.result(timeout=10.0)
+            refused.append(raised.value)
+        assert len(refused) == 20
+        assert all(error.code == "MUTATION_BUSY" for error in refused)
+        assert all(error.details.get("committed") is False for error in refused)
+        assert not list((vault / "Knowledge Base/Sources/Other").glob("concurrent-capture-*.md"))
+
+        release.set()
+        thread.join(timeout=10.0)
+        assert not thread.is_alive()
+        pending = set(range(20))
+        results: dict[int, dict] = {}
+        deadline = time.monotonic() + 45.0
+        while pending:
+            assert time.monotonic() < deadline, "concurrent retry waves did not make progress"
+            with ThreadPoolExecutor(max_workers=20) as retry_pool:
+                futures = {
+                    number: retry_pool.submit(capture, number, synchronize=False, retry=True)
+                    for number in pending
+                }
+                for number, future in futures.items():
+                    try:
+                        remaining = deadline - time.monotonic()
+                        assert remaining > 0, "concurrent retry waves did not make progress"
+                        results[number] = future.result(timeout=remaining)
+                    except OpError as error:
+                        assert error.code == "MUTATION_BUSY"
+                        assert error.details.get("committed") is False
+            pending.difference_update(results)
+
+    paths = [result["path"] for result in results.values()]
     assert len(paths) == len(set(paths)) == 20
     sources_index = (vault / "Knowledge Base/Sources/index.md").read_text(encoding="utf-8")
     top_index = (vault / "Knowledge Base/index.md").read_text(encoding="utf-8")

--- a/tests/test_product_e2e_helpers.py
+++ b/tests/test_product_e2e_helpers.py
@@ -1,4 +1,6 @@
+import socket
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 from pydantic import RootModel
@@ -13,6 +15,153 @@ class _Hit(RootModel[dict[str, object]]):
 @dataclass
 class _SchemaHit:
     path: str
+
+
+def test_port_reservations_are_distinct_and_release_individually() -> None:
+    reservations = e2e_product_loop._reserve_port_reservations(3)
+    ports = [reservation.getsockname()[1] for reservation in reservations]
+
+    try:
+        assert len(set(ports)) == 3
+        for reservation, port in zip(reservations, ports, strict=True):
+            with socket.socket() as contender:
+                with pytest.raises(OSError):
+                    contender.bind(("127.0.0.1", port))
+            reservation.close()
+            with socket.socket() as contender:
+                contender.bind(("127.0.0.1", port))
+    finally:
+        for reservation in reservations:
+            reservation.close()
+
+
+def test_port_reservations_close_a_socket_that_fails_to_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingReservation:
+        closed = False
+
+        def bind(self, _address: tuple[str, int]) -> None:
+            raise OSError("port reservation failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    reservation = FailingReservation()
+    monkeypatch.setattr(e2e_product_loop.socket, "socket", lambda: reservation)
+
+    with pytest.raises(OSError, match="port reservation failed"):
+        e2e_product_loop._reserve_port_reservations(1)
+
+    assert reservation.closed
+
+
+def test_records_fixture_is_self_contained_and_preserves_manual_template_ownership(
+    tmp_path: Path,
+) -> None:
+    fixture = e2e_product_loop._write_records_fixture(tmp_path)
+
+    assert fixture["collection"] == "Knowledge Base/Records/Health/X3/_collection.md"
+    manifest = tmp_path / fixture["collection"]
+    log = tmp_path / fixture["log"]
+    template = tmp_path / fixture["template"]
+    assert manifest.is_file()
+    assert log.is_file()
+    assert template.is_file()
+    assert "semantic_profile: records" in manifest.read_text(encoding="utf-8")
+    assert "exomem://memory/81947000-4c22-46e4-9874-23fed028314b" in manifest.read_text(
+        encoding="utf-8"
+    )
+    assert "{{date}}" in template.read_text(encoding="utf-8")
+
+    e2e_product_loop._insert_manual_x3_session(tmp_path, fixture)
+
+    assert "2026-08-03 · Push" in log.read_text(encoding="utf-8")
+    assert "{{date}}" in template.read_text(encoding="utf-8")
+
+
+def test_unauthenticated_records_request_requires_exact_challenge_and_no_disclosure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "http://127.0.0.1:8765"
+    calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
+
+    def raw_post(
+        url: str, *, body: dict[str, object], headers: dict[str, str], timeout: float
+    ) -> tuple[int, dict[str, str], bytes]:
+        calls.append((url, body, headers))
+        assert timeout == 2.0
+        return (
+            401,
+            {
+                "www-authenticate": (
+                    'Bearer resource_metadata="http://127.0.0.1:8765/'
+                    '.well-known/oauth-protected-resource/mcp"'
+                )
+            },
+            b"",
+        )
+
+    monkeypatch.setattr(e2e_product_loop, "_http_post_raw", raw_post)
+
+    e2e_product_loop._assert_unauthenticated_records_refusal(base_url, timeout=2.0)
+
+    assert calls == [
+        (
+            f"{base_url}/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": "records-auth-refusal",
+                "method": "tools/call",
+                "params": {
+                    "name": "record_memory",
+                    "arguments": {
+                        "action": "inspect",
+                        "collection": "Knowledge Base/Records/Health/X3/_collection.md",
+                    },
+                },
+            },
+            {
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("status", "headers", "body"),
+    [
+        (500, {}, b""),
+        (401, {"www-authenticate": "Bearer"}, b""),
+        (
+            401,
+            {
+                "www-authenticate": (
+                    'Bearer resource_metadata="http://127.0.0.1:8765/'
+                    '.well-known/oauth-protected-resource/mcp"'
+                )
+            },
+            b"Knowledge Base/Records/Health/X3/Training Log.md",
+        ),
+    ],
+)
+def test_unauthenticated_records_request_rejects_generic_or_disclosing_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    headers: dict[str, str],
+    body: bytes,
+) -> None:
+    monkeypatch.setattr(
+        e2e_product_loop,
+        "_http_post_raw",
+        lambda _url, **_kwargs: (status, headers, body),
+    )
+
+    with pytest.raises(RuntimeError):
+        e2e_product_loop._assert_unauthenticated_records_refusal(
+            "http://127.0.0.1:8765", timeout=2.0
+        )
 
 
 def test_unwrap_result_normalizes_nested_typed_mcp_values() -> None:

--- a/tests/test_record_governance.py
+++ b/tests/test_record_governance.py
@@ -245,6 +245,7 @@ def test_record_inspection_egress_rejects_nested_untyped_payloads(section: str) 
                 "source": "Knowledge Base/Records/vehicle-maintenance/Events",
                 "format_version": 1,
             },
+            "plans": [],
         },
         "legacy": None,
         "snapshot": None,
@@ -302,6 +303,7 @@ def test_record_inspection_egress_fails_closed_on_unhashable_hostile_scalars(
                 "source": "Knowledge Base/Records/vehicle-maintenance/Events",
                 "format_version": 1,
             },
+            "plans": [],
         },
         "legacy": None,
         "snapshot": None,
@@ -387,6 +389,7 @@ def test_record_inspection_egress_keeps_a_valid_null_saved_view_filter_value() -
                 "source": "Knowledge Base/Records/vehicle-maintenance/Events",
                 "format_version": 1,
             },
+            "plans": [],
         },
         "legacy": None,
         "snapshot": None,
@@ -420,7 +423,12 @@ def test_record_inspection_egress_accepts_collection_field_names_with_spaces_and
             "title": "Vehicle maintenance",
             "semantic_profile": "records",
             "schema_version": 1,
-            "storage": {"strategy": "markdown-items", "source": "Knowledge Base/Records/events", "format_version": 1},
+            "storage": {
+                "strategy": "markdown-items",
+                "source": "Knowledge Base/Records/events",
+                "format_version": 1,
+            },
+            "plans": [],
         },
         "legacy": None,
         "snapshot": None,
@@ -787,6 +795,185 @@ One ordinary""",
         with pytest.raises(collections.CollectionError) as raised:
             record_governance.project_manifest(tmp_path, manifest)
     assert raised.value.code == "COLLECTION_NOT_FOUND"
+
+
+def test_governed_inspection_round_trips_opaque_plans_without_resolving_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest_path = fixture / "_collection.md"
+    reference = "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8").replace(
+            "\n---\n\nOne ordinary",
+            f"""
+links:
+  plans:
+    - reference: {reference}
+      query: {{filters: {{status: completed}}, limit: 12}}
+---
+
+One ordinary""",
+        ),
+        encoding="utf-8",
+    )
+    manifest = collections.load_manifest(tmp_path, manifest_path)
+
+    def unexpected_resolution(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("opaque planning references must not be resolved")
+
+    monkeypatch.setattr(memory_refs, "resolve_identifier_read_only", unexpected_resolution)
+    inspection = record_governance.inspect_collection(tmp_path, manifest)
+
+    assert inspection["contract"]["plans"] == [
+        {"reference": reference, "query": {"filters": {"status": "completed"}, "limit": 12}}
+    ]
+
+
+def test_governed_inspection_refuses_a_denied_source_before_plan_or_format_disclosure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest_path = fixture / "_collection.md"
+    reference = "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8").replace(
+            "\n---\n\nOne ordinary",
+            f"""
+links:
+  plans:
+    - reference: {reference}
+      query: {{limit: 12}}
+---
+
+One ordinary""",
+        ),
+        encoding="utf-8",
+    )
+    manifest = collections.load_manifest(tmp_path, manifest_path)
+    _write_l6_rule(tmp_path, ceiling=6, paths="Records/**")
+    _write_l0_rule(
+        tmp_path,
+        name="blocked",
+        paths="Records/vehicle-maintenance/Events",
+    )
+
+    def unexpected_format_read(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("a denied storage source must not be inspected")
+
+    monkeypatch.setattr(record_formats, "inspect_collection", unexpected_format_read)
+    with request_scope(RequestPrincipal(audience_id=EXTERNAL, surface="mcp")):
+        with pytest.raises(collections.CollectionError) as raised:
+            record_governance.inspect_collection(tmp_path, manifest)
+
+    assert raised.value.code == "COLLECTION_NOT_FOUND"
+    disclosed = str(raised.value)
+    assert reference not in disclosed
+    assert manifest.path not in disclosed
+    assert manifest.storage.source not in disclosed
+
+
+def test_record_inspection_validator_accepts_only_bounded_exact_plan_descriptors(tmp_path: Path) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest = collections.load_manifest(tmp_path, fixture / "_collection.md")
+    payload = record_governance.inspect_collection(tmp_path, manifest)
+    contract = dict(payload["contract"])
+    contract["plans"] = [
+        {
+            "reference": "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7",
+            "query": {"filters": {"status": "completed"}, "limit": 12},
+        }
+    ]
+    payload["contract"] = contract
+
+    accepted = record_governance._validate_record_inspection(payload)
+    assert accepted is not None
+    assert accepted["contract"]["plans"] == contract["plans"]
+
+    contract["plans"][0]["extra"] = "must-not-escape"
+    assert record_governance._validate_record_inspection(payload) is None
+
+
+def test_governed_inspection_plans_keep_hidden_targets_opaque_and_filter_query_links(
+    tmp_path: Path,
+) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest_path = fixture / "_collection.md"
+    reference = "exomem://vault/Planning/private.md"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8")
+        .replace("items:\n        type: string", "items:\n        type: link")
+        .replace(
+            "\n---\n\nOne ordinary",
+            f"""
+links:
+  plans:
+    - reference: {reference}
+      query: {{filters: {{asset: "[[Knowledge Base/Evidence/Secret.md]]", status: completed}}, limit: 12}}
+---
+
+One ordinary""",
+        ),
+        encoding="utf-8",
+    )
+    manifest = collections.load_manifest(tmp_path, manifest_path)
+    _write_l6_rule(tmp_path, ceiling=6, paths="Records/**")
+    _write_l0_rule(tmp_path, name="private", paths="Planning/**")
+    _write_l0_rule(tmp_path, name="secret", paths="Evidence/**")
+
+    with request_scope(RequestPrincipal(audience_id=EXTERNAL, surface="mcp")):
+        missing = record_governance.inspect_collection(tmp_path, manifest)
+    target = tmp_path / "Knowledge Base" / "Planning" / "private.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("private", encoding="utf-8")
+    with request_scope(RequestPrincipal(audience_id=EXTERNAL, surface="mcp")):
+        hidden = record_governance.inspect_collection(tmp_path, manifest)
+
+    assert hidden["contract"]["plans"] == missing["contract"]["plans"] == [
+        {"reference": reference, "query": {"filters": {"status": "completed"}, "limit": 12}}
+    ]
+
+
+def test_record_inspection_validator_refuses_more_than_thirty_two_plan_descriptors(
+    tmp_path: Path,
+) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest = collections.load_manifest(tmp_path, fixture / "_collection.md")
+    payload = record_governance.inspect_collection(tmp_path, manifest)
+    contract = dict(payload["contract"])
+    contract["plans"] = [
+        {"reference": "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7", "query": {"limit": 12}}
+    ] * 33
+    payload["contract"] = contract
+
+    assert record_governance._validate_record_inspection(payload) is None
+
+
+@pytest.mark.parametrize(
+    "plan",
+    (
+        {"reference": "exomem://vault/Planning/../private.md", "query": {"limit": 12}},
+        {
+            "reference": "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7",
+            "query": {"limit": 12, "extra": "must-not-escape"},
+        },
+        {
+            "reference": "exomem://memory/99f6fa8b-5d6e-43f8-8cdf-e30767e8f4d7",
+            "query": {"filters": {"status": object()}, "limit": 12},
+        },
+    ),
+)
+def test_record_inspection_validator_refuses_hostile_plan_values(
+    tmp_path: Path, plan: dict[str, object]
+) -> None:
+    fixture = copy_vehicle_maintenance_fixture(tmp_path)
+    manifest = collections.load_manifest(tmp_path, fixture / "_collection.md")
+    payload = record_governance.inspect_collection(tmp_path, manifest)
+    contract = dict(payload["contract"])
+    contract["plans"] = [plan]
+    payload["contract"] = contract
+
+    assert record_governance._validate_record_inspection(payload) is None
 
 
 def test_opaque_plan_reference_has_missing_and_hidden_target_parity(tmp_path: Path) -> None:

--- a/tests/test_record_mutation_matrix.py
+++ b/tests/test_record_mutation_matrix.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 from record_fixtures import copy_vehicle_maintenance_fixture, copy_x3_fixture
 
-from exomem import record_formats, vault, writer_lease
+from exomem import mutation_lock, record_formats, vault, writer_lease
 from exomem import structured_collections as collections
 
 
@@ -140,7 +141,7 @@ def test_bom_crlf_item_update_abrupt_prefixes_report_audit_gap(
 def test_record_boundaries_are_per_vault_but_serialize_same_vault(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Barriers prove independent vaults enter together and one vault enters in order."""
+    """Admission events prove per-vault independence and same-vault serialization."""
     from exomem import records
 
     first_root, second_root = tmp_path / "first", tmp_path / "second"
@@ -150,13 +151,13 @@ def test_record_boundaries_are_per_vault_but_serialize_same_vault(
     first_manifest = collections.load_manifest(first_root, first_fixture / "_collection.md")
     second_manifest = collections.load_manifest(second_root, second_fixture / "_collection.md")
     real_load = records._load_guarded_manifest
-    independent_entry = threading.Barrier(2)
-    independent_progress = threading.Barrier(3)
+    independent_admission = threading.Barrier(3)
+    independent_release = threading.Event()
 
     def together(root, collection):  # noqa: ANN001
         if root in {first_root, second_root}:
-            independent_entry.wait(timeout=2)
-            independent_progress.wait(timeout=2)
+            independent_admission.wait(timeout=10)
+            assert independent_release.wait(10.0)
         return real_load(root, collection)
 
     monkeypatch.setattr(records, "_load_guarded_manifest", together)
@@ -174,33 +175,48 @@ def test_record_boundaries_are_per_vault_but_serialize_same_vault(
                 ((first_root, first_manifest), (second_root, second_manifest))
             )
         ]
-        independent_progress.wait(timeout=2)
-        assert {future.result(timeout=2)["outcome"] for future in futures} == {"committed"}
+        independent_admission.wait(timeout=10)
+        independent_release.set()
+        assert {future.result(timeout=10)["outcome"] for future in futures} == {"committed"}
 
     same_root = tmp_path / "same"
     same_fixture = copy_x3_fixture(same_root)
     _activity_log(same_root)
     same_manifest = collections.load_manifest(same_root, same_fixture / "_collection.md")
-    first_entry = threading.Barrier(2)
+    first_admitted = threading.Event()
     release_first = threading.Event()
-    second_entry = threading.Event()
+    second_blocked = threading.Event()
+    second_admitted = threading.Event()
     calls = 0
     calls_lock = threading.Lock()
+    real_guard = writer_lease.LeaseManager.mutation_guard
 
-    def serialized(root, collection):  # noqa: ANN001
+    @contextmanager
+    def observed_guard(self, root, **metadata):  # noqa: ANN001
         nonlocal calls
-        if root == same_root:
-            with calls_lock:
-                calls += 1
-                ordinal = calls
+        if Path(root) != same_root:
+            with real_guard(self, root, **metadata):
+                yield
+            return
+        with calls_lock:
+            calls += 1
+            ordinal = calls
+        if ordinal == 2:
+            probe = mutation_lock.VaultMutationCoordinator(self.config.state_dir, root)
+            state = mutation_lock._state_for(probe.lock_path)
+            if state.guard.acquire(blocking=False):
+                state.guard.release()
+                raise AssertionError("same-vault second mutation guard was not blocked")
+            second_blocked.set()
+        with real_guard(self, root, **metadata):
             if ordinal == 1:
-                first_entry.wait(timeout=2)
-                assert release_first.wait(timeout=2)
+                first_admitted.set()
+                assert release_first.wait(10.0)
             else:
-                second_entry.set()
-        return real_load(root, collection)
+                second_admitted.set()
+            yield
 
-    monkeypatch.setattr(records, "_load_guarded_manifest", serialized)
+    monkeypatch.setattr(writer_lease.LeaseManager, "mutation_guard", observed_guard)
     with ThreadPoolExecutor(max_workers=2) as pool:
         first = pool.submit(
             records.append_record,
@@ -210,7 +226,8 @@ def test_record_boundaries_are_per_vault_but_serialize_same_vault(
             item_key="11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             why="hold the same vault boundary",
         )
-        first_entry.wait(timeout=2)
+        assert first_admitted.wait(10.0)
+
         second = pool.submit(
             records.append_record,
             same_root,
@@ -219,11 +236,12 @@ def test_record_boundaries_are_per_vault_but_serialize_same_vault(
             item_key="22222222-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             why="wait for the same vault boundary",
         )
-        assert not second_entry.wait(timeout=0.2)
+        assert second_blocked.wait(10.0)
+        assert not second_admitted.is_set()
         release_first.set()
-        assert first.result(timeout=2)["outcome"] == "committed"
-        assert second.result(timeout=2)["outcome"] == "committed"
-        assert second_entry.is_set()
+        assert first.result(timeout=10)["outcome"] == "committed"
+        assert second.result(timeout=10)["outcome"] == "committed"
+        assert second_admitted.is_set()
 
 
 @pytest.mark.parametrize("race", ["content", "duplicate"])

--- a/tests/test_shorten_critical_section.py
+++ b/tests/test_shorten_critical_section.py
@@ -6,7 +6,6 @@ loading — turn 3 (C3): guard narrowing + pre-warm + telemetry for `remember`.
 from __future__ import annotations
 
 import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -72,34 +71,26 @@ def _reset_metrics_and_managers():
     writer_lease.reset_managers_for_tests()
 
 
-def test_remember_boundary_hold_stays_bounded_under_a_slow_validator(
+def test_remember_validation_observes_a_free_boundary_in_narrow_mode(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     kwargs = _validated_kwargs(vault)
 
     real_evaluate = relation_review._evaluate
+    observed_states: list[str] = []
 
-    def slow_evaluate(*args, **kw):
-        time.sleep(2.0)
+    def observe_boundary(*args, **kw):
+        observed_states.append(str(mutation_lock.active_mutation_snapshot()["state"]))
         return real_evaluate(*args, **kw)
 
-    monkeypatch.setattr(relation_review, "_evaluate", slow_evaluate)
+    monkeypatch.setattr(relation_review, "_evaluate", observe_boundary)
 
     manager = _standalone_manager(vault.parent / "state")
 
     result = _invoke_remember(vault, manager, **kwargs)
 
     assert (vault / result["path"]).is_file()
-    timing = mutation_lock.last_mutation_timing()
-    assert timing is not None
-    # The floor here is real disk I/O for the commit itself (batch_atomic_write
-    # writing the primary page + log + index auxiliaries), which correctly
-    # stays inside the boundary by design: ~700-750ms measured quiet on this
-    # box, with spikes above 1s under load. 1800ms leaves headroom over that
-    # floor while staying well under the 2000ms validator sleep this asserts
-    # is excluded from the hold — a wide margin either side of the two costs
-    # it must tell apart.
-    assert timing["hold_ms"] < 1800
+    assert observed_states and set(observed_states) == {"free"}
 
 
 def test_pre_boundary_validation_failure_never_acquires_the_boundary(
@@ -376,27 +367,25 @@ def test_commit_existing_revalidates_on_census_mismatch_and_surfaces_stale_write
 
     assert exc.value.code == "STALE_SEMANTIC_WRITE"
 
-def test_wide_boundary_kill_switch_restores_validation_inside_the_hold(
+def test_wide_boundary_kill_switch_observes_validation_inside_the_hold(
     vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """EXOMEM_WIDE_MUTATION_BOUNDARY=1 must restore the wide boundary: the
-    full-leaf guard wraps validation again, so the slow validator's 2000ms
-    lands back INSIDE the measured hold."""
+    full-leaf guard wraps validation again."""
     monkeypatch.setenv("EXOMEM_WIDE_MUTATION_BOUNDARY", "1")
     kwargs = _validated_kwargs(vault)
 
     real_evaluate = relation_review._evaluate
+    observed_states: list[str] = []
 
-    def slow_evaluate(*args, **kw):
-        time.sleep(2.0)
+    def observe_boundary(*args, **kw):
+        observed_states.append(str(mutation_lock.active_mutation_snapshot()["state"]))
         return real_evaluate(*args, **kw)
 
-    monkeypatch.setattr(relation_review, "_evaluate", slow_evaluate)
+    monkeypatch.setattr(relation_review, "_evaluate", observe_boundary)
 
     manager = _standalone_manager(vault.parent / "state")
     result = _invoke_remember(vault, manager, **kwargs)
 
     assert (vault / result["path"]).is_file()
-    timing = mutation_lock.last_mutation_timing()
-    assert timing is not None
-    assert timing["hold_ms"] >= 2000
+    assert observed_states and set(observed_states) == {"held"}


### PR DESCRIPTION
## Summary

- add a real installed-wheel Records journey across manual entry, guarded mutation, restart/direct edit, Planning links, recall isolation, and authenticated HTTP refusal
- expose the already-specified governed inspect.contract.plans projection
- replace runner-speed test assumptions with deterministic semantic proofs and add bounded CI/JUnit timing evidence
- sync previously accepted product-E2E and stable-reference specs into canonical OpenSpec ownership
- prevent the existing lease E2E harness from allocating the same released ephemeral port to two child processes

## Verification

- definitive GitHub run 31385253888: all 12 checks passed
- Python 3.11 full suite passed in 16m27s; Python 3.13 passed in 17m55s
- installed product E2E passed in 40s on GitHub and 21.0s locally after final rebase
- retrieval evaluation passed in 5m03s
- 238 focused Records, governance, and recall tests passed before delivery
- Ruff, capability validation, demo, OpenSpec change, all 36 canonical specs, and diff checks passed
- independent reviews approved after all findings and the CI-discovered port race were corrected

An earlier local full run recorded 8022 passed, 132 skipped, and one pre-existing governance-overhead p95 flake. Its exact isolated rerun passed, and the definitive GitHub run is fully green.

## Scope

No production timeout, storage-format, Planning implementation, sharding, test deletion, or Python coverage reduction.