### PR TITLE
fix(hosted): admit legacy runtime images

### DIFF
--- a/infra/helm/platform/templates/_runtime-release.tpl
+++ b/infra/helm/platform/templates/_runtime-release.tpl
@@ -65,6 +65,15 @@
 {{- $lock.components.runtime.image -}}
 {{- end -}}
 
+{{- define "exomem.hostedRuntimeImages" -}}
+{{- $lock := include "exomem.hostedDeploymentLock" . | mustFromJson -}}
+{{- $images := list $lock.components.runtime.image -}}
+{{- range $legacy := $lock.composition.legacyCatalog -}}
+{{- $images = append $images $legacy.runtimeImage -}}
+{{- end -}}
+{{- $images | uniq | toJson -}}
+{{- end -}}
+
 {{- define "exomem.hostedProvisionerImage" -}}
 {{- $lock := include "exomem.hostedDeploymentLock" . | mustFromJson -}}
 {{- $lock.components.provisioner.image -}}

--- a/infra/helm/platform/templates/provisioner-scope-admission.yaml
+++ b/infra/helm/platform/templates/provisioner-scope-admission.yaml
@@ -1,5 +1,4 @@
-{{- $lock := include "exomem.hostedDeploymentLock" . | mustFromJson -}}
-{{- $runtimeImage := $lock.components.runtime.image -}}
+{{- $runtimeImages := include "exomem.hostedRuntimeImages" . | mustFromJson -}}
 {{- $provisionerImage := include "exomem.hostedProvisionerImage" . -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -177,7 +176,7 @@ spec:
             variables.target.spec.selector.matchLabels &&
           variables.target.spec.template.spec.serviceAccountName == request.namespace &&
           size(variables.target.spec.template.spec.containers) == 1 &&
-          variables.target.spec.template.spec.containers[0].image == '{{ $runtimeImage }}')
+          variables.target.spec.template.spec.containers[0].image in {{ $runtimeImages | toJson }})
       message: The hosted provisioner may manage only the exact pinned single-cell StatefulSet.
     - expression: >-
         request.resource.resource != 'networkpolicies' || request.operation != 'DELETE'
@@ -581,7 +580,7 @@ spec:
     - expression: >-
         request.resource.resource != 'jobs' || request.operation == 'DELETE' ||
         (variables.target.spec.template.spec.containers[0].name == 'restore-candidate' &&
-          variables.target.spec.template.spec.containers[0].image == '{{ $runtimeImage }}' &&
+          variables.target.spec.template.spec.containers[0].image in {{ $runtimeImages | toJson }} &&
           variables.target.spec.template.spec.containers[0].imagePullPolicy == 'IfNotPresent' &&
           variables.target.spec.template.spec.containers[0].command ==
             ['exomem', 'hosted', 'restore-candidate', '--contract-version', '1',
@@ -697,7 +696,7 @@ spec:
           variables.target.spec.template.spec.serviceAccountName == variables.resourceName &&
           variables.target.spec.template.spec.automountServiceAccountToken == false &&
           size(variables.target.spec.template.spec.containers) == 1 &&
-          variables.target.spec.template.spec.containers[0].image == '{{ $runtimeImage }}')
+          variables.target.spec.template.spec.containers[0].image in {{ $runtimeImages | toJson }})
       message: Durability actions may promote only the exact pinned candidate StatefulSet.
     - expression: >-
         request.resource.resource != 'services' ||

--- a/infra/helm/platform/templates/tenant-admission.yaml
+++ b/infra/helm/platform/templates/tenant-admission.yaml
@@ -1,4 +1,4 @@
-{{- $runtimeImage := include "exomem.hostedRuntimeImage" . -}}
+{{- $runtimeImages := include "exomem.hostedRuntimeImages" . | mustFromJson -}}
 {{- $provisionerImage := include "exomem.hostedProvisionerImage" . -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -104,7 +104,7 @@ spec:
         !variables.inScope ||
         (
         object.spec.containers[0].name == 'exomem' &&
-        object.spec.containers[0].image == {{ $runtimeImage | quote }} &&
+        object.spec.containers[0].image in {{ $runtimeImages | toJson }} &&
         object.spec.containers[0].imagePullPolicy == 'IfNotPresent' &&
         object.spec.containers[0].securityContext.allowPrivilegeEscalation == false &&
         object.spec.containers[0].securityContext.readOnlyRootFilesystem == true &&
@@ -457,7 +457,7 @@ spec:
       message: Restore candidate fetch must use the exact pinned provisioner command and bounded source.
     - expression: >-
         variables.restore.name == 'restore-candidate' &&
-        variables.restore.image == {{ $runtimeImage | quote }} &&
+        variables.restore.image in {{ $runtimeImages | toJson }} &&
         variables.restore.imagePullPolicy == 'IfNotPresent' &&
         variables.restore.command ==
           ['exomem', 'hosted', 'restore-candidate', '--contract-version', '1',

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -167,6 +167,78 @@ def test_platform_rejects_deployment_lock_hash_drift(
     assert "deployment lock SHA-256 mismatch" in result.stderr
 
 
+def test_platform_admission_policies_admit_each_governed_legacy_runtime_image(
+    tmp_path: Path,
+) -> None:
+    validation_values = yaml.safe_load(
+        (PLATFORM / "values.validation.yaml").read_text(encoding="utf-8")
+    )
+    lock = json.loads(validation_values["provisioner"]["deploymentLockJson"])
+    forward_image = lock["components"]["runtime"]["image"]
+    legacy_image = "ghcr.io/artexis10/exomem@sha256:" + "f" * 64
+    unrelated_image = "ghcr.io/artexis10/exomem@sha256:" + "9" * 64
+    legacy = lock["composition"]["legacyCatalog"][0]
+    legacy["runtimeImage"] = legacy_image
+    legacy["contract"]["runtimeImage"] = legacy_image
+    lock_json = json.dumps(lock, separators=(",", ":")) + "\n"
+    override = tmp_path / "legacy-runtime-lock.yaml"
+    override.write_text(
+        yaml.safe_dump(
+            {
+                "provisioner": {
+                    "deploymentLockJson": lock_json,
+                    "deploymentLockSha256": hashlib.sha256(lock_json.encode()).hexdigest(),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    documents = _render(
+        PLATFORM,
+        PLATFORM / "values.validation.yaml",
+        namespace="exomem-platform",
+        extra_args=("--values", str(override)),
+    )
+    policy_expressions = {
+        name: [
+            validation["expression"]
+            for validation in _find(documents, "ValidatingAdmissionPolicy", name)["spec"][
+                "validations"
+            ]
+        ]
+        for name in (
+            "exomem-tenant-boundary",
+            "exomem-tenant-restore-candidate",
+            "exomem-provisioner-scope",
+            "exomem-durability-actions-scope",
+        )
+    }
+    policies = {name: "\n".join(expressions) for name, expressions in policy_expressions.items()}
+    runtime_images = json.dumps([forward_image, legacy_image], separators=(",", ":"))
+    assert f"object.spec.containers[0].image in {runtime_images}" in policies[
+        "exomem-tenant-boundary"
+    ]
+    assert f"variables.restore.image in {runtime_images}" in policies[
+        "exomem-tenant-restore-candidate"
+    ]
+    provisioner_image_guard = (
+        f"variables.target.spec.template.spec.containers[0].image in {runtime_images}"
+    )
+    assert provisioner_image_guard in policies["exomem-provisioner-scope"]
+    durability_guards = (
+        "request.resource.resource != 'jobs'",
+        "request.resource.resource != 'statefulsets'",
+    )
+    assert all(
+        any(guard in expression and provisioner_image_guard in expression for expression in policy_expressions[
+            "exomem-durability-actions-scope"
+        ])
+        for guard in durability_guards
+    )
+    assert unrelated_image not in "\n".join(policies.values())
+
+
 def test_platform_rejects_wrong_provisioner_image_repository(tmp_path: Path) -> None:
     if HELM is None:
         pytest.skip("set HELM_BIN to run pinned Helm rendering")

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -175,11 +175,26 @@ def test_platform_admission_policies_admit_each_governed_legacy_runtime_image(
     )
     lock = json.loads(validation_values["provisioner"]["deploymentLockJson"])
     forward_image = lock["components"]["runtime"]["image"]
-    legacy_image = "ghcr.io/artexis10/exomem@sha256:" + "f" * 64
+    legacy_images = [
+        "ghcr.io/artexis10/exomem@sha256:" + "f" * 64,
+        "ghcr.io/artexis10/exomem@sha256:" + "e" * 64,
+    ]
     unrelated_image = "ghcr.io/artexis10/exomem@sha256:" + "9" * 64
-    legacy = lock["composition"]["legacyCatalog"][0]
-    legacy["runtimeImage"] = legacy_image
-    legacy["contract"]["runtimeImage"] = legacy_image
+    legacy_catalog = lock["composition"]["legacyCatalog"]
+    legacy = legacy_catalog[0]
+    for image in legacy_images:
+        unit = json.loads(json.dumps(legacy))
+        unit["runtimeImage"] = image
+        unit["contract"]["runtimeImage"] = image
+        unit["contractSha256"] = hashlib.sha256(
+            (json.dumps(unit["contract"], sort_keys=True, separators=(",", ":")) + "\n").encode()
+        ).hexdigest()
+        legacy_catalog.append(unit)
+    legacy["runtimeImage"] = forward_image
+    legacy["contract"]["runtimeImage"] = forward_image
+    legacy["contractSha256"] = hashlib.sha256(
+        (json.dumps(legacy["contract"], sort_keys=True, separators=(",", ":")) + "\n").encode()
+    ).hexdigest()
     lock_json = json.dumps(lock, separators=(",", ":")) + "\n"
     override = tmp_path / "legacy-runtime-lock.yaml"
     override.write_text(
@@ -215,7 +230,7 @@ def test_platform_admission_policies_admit_each_governed_legacy_runtime_image(
         )
     }
     policies = {name: "\n".join(expressions) for name, expressions in policy_expressions.items()}
-    runtime_images = json.dumps([forward_image, legacy_image], separators=(",", ":"))
+    runtime_images = json.dumps([forward_image, *legacy_images], separators=(",", ":"))
     assert f"object.spec.containers[0].image in {runtime_images}" in policies[
         "exomem-tenant-boundary"
     ]


### PR DESCRIPTION
## What changed

- derive the exact admitted runtime-image set from the selected deployment lock
  (forward image plus every legacy-catalog image)
- use that immutable set in all five tenant, provisioner, restore, and durability
  admission guards
- de-duplicate identical governed images
- add regression coverage with two distinct legacy images and one duplicate of
  the forward image

## Why

Hosted expand mode correctly admitted a fresh v1 request targeting the governed
0.39.2 legacy unit, and the provisioner correctly rendered its pinned runtime
image. The platform admission policies still allowed only the forward 0.40
image, so Kubernetes denied the cell's init Pod and provisioning could never
reach ready.

The allowlist remains fail closed: every admitted image must come from the exact
selected deployment lock, and unrelated digests remain denied.

## Verification

- `36 passed` — `tests/test_hosted_helm_contract.py`
- `17 passed` — `tests/test_hosted_deployment_lock_consumption.py`
- focused multiple-legacy/dedup regression: `1 passed`
- Ruff: clean
- Helm lint: clean
- `git diff --check`: clean
- canonical live expand lock render contains exactly the forward 0.40 and legacy
  0.39.2 runtime digests across all five guards
