### PR TITLE
fix(hosted): admit exact tenant PVC quantities

### DIFF
--- a/infra/helm/platform/templates/provisioner-scope-admission.yaml
+++ b/infra/helm/platform/templates/provisioner-scope-admission.yaml
@@ -149,7 +149,7 @@ spec:
         (variables.target.spec.accessModes == ['ReadWriteOnce'] &&
           variables.target.spec.volumeMode == 'Filesystem' &&
           variables.target.spec.storageClassName == 'exomem-hcloud-encrypted-retain' &&
-          variables.target.spec.resources.requests.storage == quantity('10Gi'))
+          quantity(dyn(variables.target.spec).resources.requests['storage']).compareTo(quantity('10Gi')) == 0)
       message: The hosted provisioner may manage only the exact encrypted 10 GiB tenant PVC.
     - expression: >-
         request.resource.resource != 'services' || request.operation == 'DELETE' ||
@@ -632,7 +632,7 @@ spec:
           variables.target.spec.accessModes == ['ReadWriteOnce'] &&
           variables.target.spec.volumeMode == 'Filesystem' &&
           variables.target.spec.storageClassName == 'exomem-hcloud-encrypted-retain' &&
-          variables.target.spec.resources.requests.storage == quantity('10Gi'))
+          quantity(dyn(variables.target.spec).resources.requests['storage']).compareTo(quantity('10Gi')) == 0)
       message: Durability actions may reconcile only the exact retained encrypted tenant PVC.
     - expression: >-
         request.resource.resource != 'serviceaccounts' ||

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1258,6 +1258,12 @@ def test_platform_renders_one_shot_durability_actions_and_exact_restore_scope() 
 
     action_scope = _find(documents, "ValidatingAdmissionPolicy", "exomem-durability-actions-scope")
     action_scope_text = json.dumps(action_scope)
+    exact_tenant_pvc_quantity = (
+        "quantity(dyn(variables.target.spec).resources.requests['storage'])"
+        ".compareTo(quantity('10Gi')) == 0"
+    )
+    assert exact_tenant_pvc_quantity in action_scope_text
+    assert "variables.target.spec.resources.requests.storage == quantity('10Gi')" not in action_scope_text
     for exact_guard in (
         "system:serviceaccount:exomem-platform:exomem-durability-actions",
         "^restore-[a-f0-9]{20}$",
@@ -1537,6 +1543,11 @@ def test_platform_renders_luks_retain_storage_and_exact_schedule_contract() -> N
         "transfer",
     ):
         assert exact_guard in provisioner_scope_text
+    assert (
+        "quantity(dyn(variables.target.spec).resources.requests['storage'])"
+        ".compareTo(quantity('10Gi')) == 0"
+    ) in provisioner_scope_text
+    assert "variables.target.spec.resources.requests.storage == quantity('10Gi')" not in provisioner_scope_text
     assert "NetworkPolicy deletion is reserved for namespace destruction" in provisioner_scope_text
 
     contract = json.loads(CONTRACT.read_text(encoding="utf-8"))

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -638,6 +638,11 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
                     },
                     {
                         "apiGroups": [""],
+                        "resources": ["persistentvolumeclaims"],
+                        "verbs": ["create", "get"],
+                    },
+                    {
+                        "apiGroups": [""],
                         "resources": ["services"],
                         "verbs": ["create", "delete", "get", "patch", "update"],
                     },
@@ -719,6 +724,31 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
         check=False,
     )
     assert routine_create.returncode == 0, routine_create.stderr
+
+    pvc_namespace = "exo-pvc-admission-test"
+    pvc_initialize = _render(
+        CELL,
+        CELL / "values.initialize.yaml",
+        pvc_namespace,
+        extra_args=("--set", f"resourceName={pvc_namespace}"),
+    )
+    pvc_namespace_document = next(item for item in pvc_initialize if item.get("kind") == "Namespace")
+    _kubectl(k3s, ["apply", "--filename=-"], documents=[pvc_namespace_document])
+    rendered_pvc = next(item for item in pvc_initialize if item.get("kind") == "PersistentVolumeClaim")
+    admitted_pvc = _kubectl(
+        k3s,
+        [
+            "apply",
+            "--namespace",
+            pvc_namespace,
+            "--dry-run=server",
+            "--filename=-",
+            f"--as={routine_username}",
+        ],
+        documents=[rendered_pvc],
+        check=False,
+    )
+    assert admitted_pvc.returncode == 0, admitted_pvc.stderr
 
     cleanup_namespace = "exo-restore-cleanup-test"
     _kubectl(k3s, ["create", "namespace", cleanup_namespace])


### PR DESCRIPTION
## What changed

- parse dynamic PVC storage requests with CEL `quantity(...)`
- compare against the exact `10Gi` invariant with `compareTo(...) == 0`
- apply the fix to both routine provisioner and durability-actions policies
- add rendered-policy assertions and an exact K3s server-side admission regression using the real provisioner service-account identity

## Root cause

Kubernetes exposes the PVC request through the dynamic CEL object. Direct equality between that serialized value and CEL's `Quantity` object evaluated false, so the platform rejected the correctly rendered 10 GiB tenant PVC.

All storage class, access mode, volume mode, identity, image, and NetworkPolicy deletion restrictions remain unchanged.

## Verification

- `36 passed` — hosted Helm contract suite
- `1 passed` — exact K3s tenant-shapes admission test
- Helm lint: `1 chart(s) linted, 0 chart(s) failed`
- Ruff: clean
- `git diff --check`: clean
- independent review: APPROVE, no findings