### PR TITLE
fix(hosted): keep operator logging off read-only roots

### DIFF
--- a/infra/helm/cell/templates/init-job.yaml
+++ b/infra/helm/cell/templates/init-job.yaml
@@ -38,6 +38,9 @@ spec:
             - "1"
             - --request-file
             - /run/exomem/operator-requests/init.json
+          env:
+            - name: EXOMEM_LOG_DIR
+              value: /dev
           resources:
             requests:
               cpu: 100m

--- a/infra/helm/platform/templates/tenant-admission.yaml
+++ b/infra/helm/platform/templates/tenant-admission.yaml
@@ -126,7 +126,12 @@ spec:
         (
         !has(object.spec.containers[0].command) &&
         object.spec.containers[0].args == ['hosted', 'init', '--contract-version', '1', '--request-file', '/run/exomem/operator-requests/init.json'] &&
-        (!has(object.spec.containers[0].env) || size(object.spec.containers[0].env) == 0) &&
+        has(object.spec.containers[0].env) &&
+        size(object.spec.containers[0].env) == 1 &&
+        object.spec.containers[0].env[0].name == 'EXOMEM_LOG_DIR' &&
+        has(object.spec.containers[0].env[0].value) &&
+        object.spec.containers[0].env[0].value == '/dev' &&
+        !has(object.spec.containers[0].env[0].valueFrom) &&
         object.spec.containers[0].securityContext.runAsUser == 0 &&
         object.spec.containers[0].securityContext.runAsGroup == 0 &&
         size(object.spec.containers[0].securityContext.capabilities.add) == 3 &&

--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -79,10 +79,10 @@ def _configure_local_search_capabilities(action: str | None) -> tuple[str, ...]:
 # Subcommands `_dispatch_main` routes explicitly, before falling through to
 # `_serve_main`. Kept alongside `_is_cli_only_invocation` so a one-shot CLI
 # command gets its own log file; `serve` configures server-role logging
-# itself from `server.run()`, so it is deliberately excluded here.
+# itself from `server.run()`, and `hosted` emits a JSON-only operator protocol,
+# so they are deliberately excluded here.
 _CLI_ONLY_SUBCOMMANDS: frozenset[str] = frozenset(
     {
-        "hosted",
         "setup",
         "init",
         "install-skill",

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1846,6 +1846,7 @@ def test_cell_chart_renders_separate_privileged_init_and_restricted_serving_mode
             "--request-file",
             "/run/exomem/operator-requests/init.json",
         ]
+        assert container["env"] == [{"name": "EXOMEM_LOG_DIR", "value": "/dev"}]
     else:
         pod = workload["spec"]["template"]["spec"]
         assert pod["restartPolicy"] == "Always"

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -846,6 +846,34 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
     init_pod = _pod(init_job, name="cell-alpha-init-positive", namespace=namespace)
     assert _server_dry_run(k3s, init_pod).returncode == 0
 
+    init_env_variants = (
+        ("missing-env", [], "exact approved operator command"),
+        ("alternate-env", [{"name": "EXOMEM_LOG_DIR", "value": "/tmp"}], "exact approved operator command"),
+        (
+            "value-from-env",
+            [
+                {
+                    "name": "EXOMEM_LOG_DIR",
+                    "valueFrom": {"configMapKeyRef": {"name": "foreign-env", "key": "log-dir"}},
+                }
+            ],
+            "exact approved operator command",
+        ),
+        (
+            "additional-env",
+            [
+                {"name": "EXOMEM_LOG_DIR", "value": "/dev"},
+                {"name": "UNTRUSTED", "value": "1"},
+            ],
+            "exact approved operator command",
+        ),
+    )
+    for name, env, message in init_env_variants:
+        init_env_drift = copy.deepcopy(init_pod)
+        init_env_drift["metadata"]["name"] = f"cell-alpha-init-{name}"
+        init_env_drift["spec"]["containers"][0]["env"] = env
+        _assert_denied(k3s, init_env_drift, message=message)
+
     protected_update = _kubectl(
         k3s,
         [

--- a/tests/test_log_process_files.py
+++ b/tests/test_log_process_files.py
@@ -121,6 +121,37 @@ def test_bare_serve_is_not_a_cli_only_invocation() -> None:
     assert _is_cli_only_invocation(["--transport", "stdio"]) is False
 
 
+@pytest.mark.parametrize(
+    "operator_argv",
+    [
+        ["init", "--contract-version", "1", "--request-file", "/run/exomem/init.json"],
+        [
+            "restore-candidate",
+            "--contract-version",
+            "1",
+            "--request-file",
+            "/run/exomem/restore-candidate.json",
+        ],
+    ],
+)
+def test_main_dispatches_hosted_operators_without_cli_logging(
+    operator_argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import exomem.__main__ as main_module
+    from exomem import hosted_operator, logging_config
+
+    received: list[list[str]] = []
+
+    def cli_logging_must_not_run(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("hosted operators must not initialize CLI logging")
+
+    monkeypatch.setattr(logging_config, "configure_logging", cli_logging_must_not_run)
+    monkeypatch.setattr(hosted_operator, "main", lambda argv: received.append(argv) or 17)
+
+    assert main_module.main(["hosted", *operator_argv]) == 17
+    assert received == [operator_argv]
+
+
 def test_main_configures_cli_logging_for_doctor_but_not_for_serve(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Why

Hosted storage initialization on the immutable v0.39.2 runtime exits before operator dispatch because generic CLI logging tries to create a file under the read-only image filesystem.

## What

- route all `hosted` operator commands without generic rotating-file logging
- give legacy initialize-mode Jobs one exact ephemeral `EXOMEM_LOG_DIR=/dev` compatibility value
- enforce that exact value fail-closed in tenant admission
- cover init and restore dispatch plus positive/negative K3s admission shapes

The compatibility value is pod-local and does not write into the tenant PVC.

## Verification

- logging/operator/restore suite: 56 passed, 1 skipped
- hosted Helm contract: 36 passed
- exact K3s admission: rendered Job admitted; missing, alternate, valueFrom, and additional env denied
- cell and platform Helm lint: clean with validation values
- Ruff on touched files: clean
- independent reviews: no findings