### PR TITLE
fix(release): publish from the created tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Install mcp-publisher
         run: |

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -139,6 +139,19 @@ def test_release_workflow_binds_automatic_and_manual_builds_to_the_tag_commit() 
     assert 'gh release view "$TAG" --json tagName --jq .tagName' in manual
 
 
+def test_release_publication_jobs_checkout_the_created_tag() -> None:
+    text = _read(".github/workflows/release-please.yml")
+    jobs = (
+        _workflow_job(text, "build-artifacts", "sync-hosted-artifacts"),
+        _workflow_job(text, "publish-pypi", "publish-mcp-registry"),
+        _workflow_job(text, "publish-mcp-registry", "publish-image"),
+    )
+
+    for job in jobs:
+        assert "ref: ${{ needs.release-please.outputs.tag_name }}" in job
+        assert "ref: main" not in job
+
+
 def test_compose_overrides_select_cpu_ml_and_cuda() -> None:
     ml = _read("compose.ml.yaml")
     cuda = _read("compose.cuda.yaml")


### PR DESCRIPTION
## Why

Release artifacts, PyPI, and the MCP Registry must publish the immutable commit named by the release tag. Checking out mutable main allowed a concurrent merge to change what was published under an already-created version.

## What changed

- bind all three publication jobs to the release-please tag output
- add a regression test preventing those jobs from returning to main

## Verification

- focused container distribution tests: 19 passed
- Ruff: passed
- git diff check: passed