### PR TITLE
feat(memory): complete note-connectivity follow-ups

### DIFF
--- a/openspec/changes/classify-forward-references/.openspec.yaml
+++ b/openspec/changes/classify-forward-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/classify-forward-references/design.md
+++ b/openspec/changes/classify-forward-references/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`audit._check_broken_wikilinks` currently emits `broken_wikilink` for every body wikilink that fails Markdown-page or attachment resolution. A missing Markdown page and a definite attachment error therefore look identical, even though a missing page can be an intentional forward reference that self-resolves when the page is later created.
+
+This change affects audit classification only. Relation disposition independently resolves body wikilinks against connectable governed pages, so unresolved links remain unable to satisfy the connectivity lane.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Report unresolved Markdown-page targets as informational `forward_reference` findings.
+- Retain `broken_wikilink` for deterministic errors: missing explicit-extension attachments, ambiguous title resolution, and extensionless note links that collide with an existing non-Markdown file.
+- Reuse the existing resolver pass so creating the target clears the finding on the next audit.
+
+**Non-Goals:**
+
+- Inferring author intent or predicting whether a missing page will eventually be written.
+- Changing semantic relation disposition or allowing unresolved targets to satisfy connectivity.
+- Auto-creating pages or mutating links.
+
+## Decisions
+
+### Classify by what the resolver can prove
+
+A target that names a nonexistent Markdown page is a `forward_reference` at `info` severity. The audit cannot deterministically distinguish a deliberate future page from a typo or deleted page without adding authoring syntax or heuristic reasoning, so it does not claim to. Definite resolution conflicts remain `broken_wikilink`.
+
+### Keep forward references in the registered audit category set
+
+`forward_reference` is a normal audit category so default audit reporting remains complete after the split and callers can filter it explicitly. The existing broken-link category remains independently filterable.
+
+### Share one wikilink scan
+
+The existing checker receives the selected subset of the two categories and emits only requested classifications. This avoids parsing the corpus twice when both categories are selected.
+
+## Risks / Trade-offs
+
+- [A typo to a never-created Markdown page is initially reported as a forward reference] -> Keep the signal informational and let reviewers decide whether to create, correct, or remove it.
+- [Callers filtering only `broken_wikilink` no longer see missing Markdown pages] -> Expose `forward_reference` explicitly and include it in the default audit category set.
+- [Classification accidentally relaxes governance] -> Do not modify semantic-contract code; retain a regression assertion that disposition remains unsatisfied.
+- [A crafted relative target escapes the vault during collision probing] -> Resolve the candidate parent and refuse to enumerate it unless it remains under the vault root.

--- a/openspec/changes/classify-forward-references/proposal.md
+++ b/openspec/changes/classify-forward-references/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The audit currently reports every unresolved note wikilink as broken, even when the author deliberately references a page they intend to create. That turns a frictionless authoring pattern into an error without changing the harder rule that unresolved targets cannot satisfy governed relation connectivity.
+
+## What Changes
+
+- Classify unresolved Markdown-page wikilinks as informational forward references rather than broken links.
+- Keep definite attachment mistakes and ambiguous note targets classified as broken wikilinks.
+- Clear a forward-reference finding automatically when the referenced page becomes resolvable.
+- Leave semantic relation disposition unchanged: a forward reference does not satisfy connectivity.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `attention-queue`: Distinguish deliberate forward references from genuinely broken wikilinks in audit reporting.
+
+## Impact
+
+The audit category registry, wikilink audit classification, and focused audit tests change. The semantic write contract and relation-disposition implementation do not change.

--- a/openspec/changes/classify-forward-references/specs/attention-queue/spec.md
+++ b/openspec/changes/classify-forward-references/specs/attention-queue/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Forward references are distinct from broken wikilinks
+
+The audit surface SHALL classify an unresolved Markdown-page wikilink as an informational `forward_reference`, not as a `broken_wikilink`. It SHALL continue to classify definite resolution errors such as a missing explicit-extension attachment or an ambiguous note title as `broken_wikilink`. Both categories SHALL be independently filterable, and a default audit SHALL register the forward-reference category.
+
+This reporting distinction SHALL remain read-only and SHALL NOT make an unresolved or ambiguous target satisfy the semantic relation-disposition connectivity lane.
+
+#### Scenario: Missing note is a forward reference
+
+- **WHEN** a page links to a Markdown-page target that does not exist
+- **THEN** audit emits an informational `forward_reference` finding for the link
+- **AND** audit does not emit a `broken_wikilink` finding for that link
+- **AND** the page's semantic relation disposition remains unsatisfied by that link
+
+#### Scenario: Creating the target clears the finding
+
+- **WHEN** a page with a forward-reference finding is created at the referenced target
+- **THEN** the next audit resolves the wikilink and emits no finding for it
+
+#### Scenario: Definite resolution error stays broken
+
+- **WHEN** a wikilink names a missing explicit-extension attachment or resolves ambiguously
+- **THEN** audit emits `broken_wikilink` rather than `forward_reference`

--- a/openspec/changes/classify-forward-references/tasks.md
+++ b/openspec/changes/classify-forward-references/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract and regression tests
+
+- [x] 1.1 Add the attention-queue delta specification for forward-reference classification.
+- [x] 1.2 Add red-first tests for missing-page classification and automatic clearing after target creation.
+- [x] 1.3 Retain regression coverage that unresolved links do not satisfy semantic relation disposition.
+
+## 2. Audit classification
+
+- [x] 2.1 Register `forward_reference` as an audit category and share one scan across both link categories.
+- [x] 2.2 Emit informational forward-reference findings for unresolved Markdown-page targets.
+- [x] 2.3 Keep definite attachment, ambiguity, and note/attachment mismatch errors in `broken_wikilink`.
+
+## 3. Verification
+
+- [x] 3.1 Run focused audit and connectivity-lane tests.
+- [ ] 3.2 Run the full pytest suite and `ruff check . --select F` on Linux.
+- [x] 3.3 Validate the OpenSpec change in strict mode.

--- a/openspec/changes/connect-body-wikilinks/.openspec.yaml
+++ b/openspec/changes/connect-body-wikilinks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/connect-body-wikilinks/design.md
+++ b/openspec/changes/connect-body-wikilinks/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`SemanticPageState.body_wikilinks` already stores each deduplicated outbound body
+wikilink as `(target, line)` while the page body is in scope. The current disposition
+checks typed facts and then authored-relation connectivity facts, but it falls through to
+reviewed-none without consulting that page-state measurement. The earlier attempt to turn
+every body link into a `RelationFact` failed the 8k semantic write-latency gate.
+
+The same-session Windows comparator produced:
+
+| phase | pages | validate median | commit median | commit p95 |
+|---|---:|---:|---:|---:|
+| before | 2,000 | 34.3 ms | 133.0 ms | 138.3 ms |
+| before | 8,000 | 167.9 ms | 335.7 ms | 520.5 ms |
+| after | 2,000 | 32.5 ms | 140.3 ms | 153.2 ms |
+| after | 8,000 | 135.7 ms | 383.1 ms | 407.1 ms |
+
+Commit scaling was 2.52x before and 2.73x after. The after-run remains below the 750 ms
+8k ceiling and below the approximately 2.75x scaling limit. The benchmark's unchanged
+`measure()` and `check()` functions were invoked through a wrapper that pre-created the
+private lock directory because this managed Windows sandbox denies the directory produced
+by the benchmark's normal lock setup. Linux remains the authoritative acceptance gate and
+must be run outside this sandbox, where WSL process execution is denied.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recognize only resolved outbound body wikilinks to other existing connectable targets.
+- Reuse the existing `qualifying_relation` disposition kind and report
+  `qualifying_signal="connectivity"` with the existing warning.
+- Preserve the latency gate through normalized set membership only.
+
+**Non-Goals:**
+
+- No `RelationFact` construction, registry lookup, inbound-edge scan, new disposition
+  kind, or change to typed qualification.
+- No widening of `eligible_governed_paths`, provenance qualification, or unresolved-link
+  qualification.
+
+## Decisions
+
+### Resolve page-state targets directly against the connectable set
+
+After `qualify_connectivity` finds no fact, `_relation_disposition` will normalize each
+stored body-wikilink target into a canonical vault-relative path and test membership in
+`SemanticCorpusContext.connectable_target_paths`. The first match returns the existing
+`kind="qualifying_relation"` shape with `qualifying_signal="connectivity"`.
+
+This deliberately duplicates only the cheap final membership decision. Reintroducing
+wikilink facts would repeat fact construction, registry resolution, and target resolution
+for every body link across the corpus, which previously pushed the 8k commit median to
+1,259.3 ms.
+
+### Keep body-wikilink evidence separate from relation facts
+
+The disposition may name the matching target as its qualifying reference, but no fact is
+added to the corpus outbound map. This preserves the typed/connectivity fact semantics and
+keeps unregistered authored relation labels visible as relation debt rather than silently
+downgrading them.
+
+### Preserve existing boundary sets and fall-through order
+
+The check runs only in the outbound connectivity branch, after fact-based connectivity
+and before reviewed-none. `connectable_target_paths` remains distinct from
+`eligible_governed_paths`, so captured Sources do not consume the bootstrap exception.
+Frontmatter and inbound links never reach this check, while self, missing, ambiguous,
+and inactive targets fail qualification or membership.
+
+## Risks / Trade-offs
+
+- Path normalization could drift from corpus indexing. Mitigation: use the repository's
+  canonical wikilink/path normalization seam and test eligible, Source, inactive,
+  non-connectable, and unresolved targets.
+- A satisfied branch could accidentally introduce an unknown disposition kind.
+  Mitigation: reuse the existing kind and pin `qualifying_signal` plus commit behavior.
+- Corpus-scale iteration could regress latency. Mitigation: reuse the already bounded,
+  deduplicated page-state tuple and measure 2k/8k before and after without fact creation.
+- Linux verification is unavailable inside this managed Windows session. Mitigation:
+  record the same-session Windows comparator and leave the authoritative Linux command as
+  an explicit handoff gate rather than weakening or reinterpreting it.

--- a/openspec/changes/connect-body-wikilinks/proposal.md
+++ b/openspec/changes/connect-body-wikilinks/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The relation-debt audit and retrieval graph already treat resolved body wikilinks as
+real outbound connectivity, but the write-time relation disposition does not. The
+remaining mismatch forces an unnecessary reviewed-none round trip for pages that are
+already connected.
+
+## What Changes
+
+- Let a resolved outbound body wikilink to a connectable governed page satisfy the
+  existing connectivity lane without constructing a `RelationFact`.
+- Report the satisfaction as `qualifying_signal="connectivity"` and retain the
+  non-blocking `RELATION_TYPED_EDGE_ABSENT` warning.
+- Keep unresolved, ambiguous, inbound, inactive-target, and frontmatter-provenance links
+  non-qualifying, and preserve the separate empty-corpus bootstrap set.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `semantic-write-contract`: Resolved outbound body wikilinks become a disposition
+  signal through the existing connectivity lane.
+
+## Impact
+
+The change is confined to `src/exomem/semantic_contract.py`, focused connectivity-lane
+tests, and this OpenSpec change. It adds no relation kind, registry lookup, dependency,
+model, storage, graph edge, or tool-surface change. The write-latency and governance
+overhead gates measure the implementation before acceptance.

--- a/openspec/changes/connect-body-wikilinks/specs/semantic-write-contract/spec.md
+++ b/openspec/changes/connect-body-wikilinks/specs/semantic-write-contract/spec.md
@@ -1,0 +1,124 @@
+## MODIFIED Requirements
+
+### Requirement: Current Relation Review Disposition
+
+Every newly created active governed compiled page SHALL have a current relation-review
+disposition satisfied by a qualifying typed inbound/outbound relation, a qualifying
+outbound connectivity signal, an explicit reviewed-none decision bound to current page
+identity/content, or an automatic no-candidates bootstrap disposition only for a genuinely
+empty governed corpus.
+
+A relation qualifies as a **typed edge** only when it is authored or explicitly
+reviewer-accepted, its target resolves unambiguously to an eligible governed page at
+evaluation time, its canonical registry entry is active and scope-valid, its registry
+family is not `link`, `citation`, `derivation`, `evidence`, `mention`, `observation`, or
+`provenance`, and either (a) its origin is `markdown_relation`, `semantic_relation`, or
+`semantic_block`, or (b) its origin is `frontmatter` and its registered family is exactly
+`supersession`. The sole inactive-target exception is a canonical supersession edge to the
+exact governed predecessor now marked `superseded` whose `superseded_by` resolves back to
+the active successor.
+
+When no typed edge qualifies, the disposition MAY be satisfied by an **outbound
+connectivity signal**: an authored outbound connection whose target resolves unambiguously
+to a connectable governed page, whose canonical registry entry is active and scope-valid,
+and whose origin is `wikilink`, `markdown_relation`, `semantic_relation`, or
+`semantic_block`, irrespective of registry family. A resolved outbound body wikilink SHALL
+also satisfy this lane by normalized membership in the connectable target set without
+requiring a relation fact. The connectable set SHALL be the eligible governed set widened
+to admit append-only `Sources/` material, and SHALL be computed separately from the
+eligible governed set so that the empty-corpus bootstrap disposition is unaffected by
+captured sources.
+
+Frontmatter origin SHALL NOT satisfy connectivity. This keeps the disposition aligned with
+the relation-debt measurement, which clears a page on authored relation rows or body
+wikilinks and ignores `sources:`. Provenance is a vertical edge to raw material and carries
+no claim about how a conclusion relates to other conclusions; because every
+adoption-compiled note cites a source by construction, counting it would make the
+disposition a no-op for exactly the bulk-import case that most needs review.
+
+Inbound edges MUST NOT satisfy connectivity. Unresolved or ambiguous forward targets MUST
+NOT satisfy either lane. A disposition satisfied by connectivity SHALL report that signal
+distinctly from a typed edge and SHALL emit a non-blocking typed-edge-absent warning. The
+disposition SHALL carry any reviewed-none reason and reference it was satisfied by, so
+review decisions are observable rather than write-only. No minimum relation count SHALL be
+imposed in either lane.
+
+#### Scenario: Superseded predecessor remains a qualifying target
+- **WHEN** an active successor canonically supersedes a governed predecessor and the predecessor is marked `superseded` with an exact backlink to that successor
+- **THEN** the supersession edge remains qualifying after commit and during exact prepared recovery
+- **AND** no other inactive target receives this exception
+
+#### Scenario: Typed relation satisfies disposition
+- **WHEN** a new compiled page has a registered canonical relation to an existing page
+- **THEN** its relation disposition is satisfied and reports the typed edge
+- **AND** no typed-edge-absent warning is emitted
+
+#### Scenario: Reviewed none is fingerprint-bound
+- **WHEN** a reviewer records that a page has no qualifying relation candidates
+- **THEN** the disposition is satisfied only while the page identity and relevant content fingerprint remain current
+- **AND** a material change resurfaces relation review
+- **AND** the recorded reason is reported on the disposition rather than discarded
+
+#### Scenario: Empty vault bootstraps without fake edge
+- **WHEN** the first compiled page is created in a genuinely empty governed corpus and no target can exist
+- **THEN** the writer records an automatic bootstrap disposition without fabricating a relation or placeholder
+
+#### Scenario: Captured source does not consume the bootstrap exception
+- **WHEN** a vault contains only captured `Sources/` material and the first compiled page is created
+- **THEN** the page still receives the automatic bootstrap disposition
+- **AND** the connectable target set does not widen the eligible governed set used to detect an empty corpus
+
+#### Scenario: Bootstrap exception expires when a candidate can exist
+- **WHEN** a second eligible compiled page is added after the first page received an automatic bootstrap disposition
+- **THEN** the first page's bootstrap disposition becomes stale and enters ordinary relation review
+
+#### Scenario: Excluded-family relation satisfies connectivity without a typed edge
+- **WHEN** an active compiled page carries no qualifying typed relation but one or more authored relation rows of an excluded family resolving to connectable governed pages
+- **THEN** its relation disposition is satisfied and reports the connectivity signal rather than a typed edge
+- **AND** a typed-edge-absent warning is emitted at warning severity
+- **AND** the write is not blocked
+
+#### Scenario: Resolved body wikilink satisfies connectivity
+- **WHEN** an active compiled page carries only an outbound body wikilink that resolves unambiguously to a connectable governed page
+- **THEN** the disposition is satisfied and reports the connectivity signal rather than a typed edge
+- **AND** a typed-edge-absent warning is emitted at warning severity
+- **AND** the write is not blocked
+
+#### Scenario: Cited provenance alone does not satisfy the disposition
+- **WHEN** an active compiled page carries no typed relation and no body wikilink, but names existing `Sources/` pages in its `sources:` frontmatter
+- **THEN** the disposition remains unsatisfied and enters ordinary relation review
+- **AND** an adoption-compiled page, which always cites a source, still receives relation review
+
+#### Scenario: A body wikilink to a Source does satisfy connectivity
+- **WHEN** an active compiled page links a `Sources/` page from its body rather than only from frontmatter
+- **THEN** the disposition is satisfied by the connectivity signal
+- **AND** the target is not required to be an eligible governed page
+
+#### Scenario: Inbound links and provenance back-references never satisfy connectivity
+- **WHEN** a compiled page has no outbound connection of any kind, but a `Sources/` page links to it and its own `ingested_into:` back-reference names it
+- **THEN** the disposition remains unsatisfied and enters ordinary relation review
+- **AND** automatically written back-references cannot make the disposition vacuous
+
+#### Scenario: Excluded-family relation does not qualify as a typed edge but may connect
+- **WHEN** a page's only relation is in the `citation`, `evidence`, or `link` family and resolves to a connectable governed page
+- **THEN** it does not qualify as a typed edge
+- **AND** it satisfies the disposition as connectivity, reported distinctly, with a typed-edge-absent warning
+
+#### Scenario: Inactive relation does not qualify in either lane
+- **WHEN** a page has only a relation whose canonical registry entry is inactive or out of scope
+- **THEN** the edge remains visible in its own semantics and the disposition remains unsatisfied
+
+#### Scenario: Unresolved forward target does not qualify
+- **WHEN** a registered authored relation points to a missing or ambiguous target
+- **THEN** the relation remains visible with its resolution finding but does not satisfy relation review
+- **AND** it does not satisfy connectivity
+
+#### Scenario: Self wikilink does not qualify
+- **WHEN** a page's only outbound body wikilink resolves back to that same page
+- **THEN** the disposition remains unsatisfied and enters ordinary relation review
+- **AND** the self-link does not satisfy connectivity
+
+#### Scenario: Reviewed-none is not applicable to a connected page
+- **WHEN** a caller submits a reviewed-none decision for a page that satisfies the disposition through connectivity
+- **THEN** the write reports the decision as not applicable and names the connectivity satisfaction
+- **AND** the page commits without a review artifact

--- a/openspec/changes/connect-body-wikilinks/tasks.md
+++ b/openspec/changes/connect-body-wikilinks/tasks.md
@@ -1,0 +1,17 @@
+## 1. Red-first contract tests
+
+- [x] 1.1 Add focused tests for resolved eligible and Source body-wikilink connectivity, including signal, warning, and non-blocking behavior
+- [x] 1.2 Add focused tests proving self, inactive, non-connectable, unresolved, inbound, provenance-back-reference, and captured-Source bootstrap boundaries remain non-qualifying where required
+- [x] 1.3 Run the focused tests and record the expected pre-implementation failures
+
+## 2. Connectivity implementation
+
+- [x] 2.1 Normalize page-state body-wikilink targets and check direct membership in `connectable_target_paths` after fact-based connectivity
+- [x] 2.2 Reuse the existing qualifying disposition kind and connectivity warning without constructing relation facts or touching governed predicates
+- [x] 2.3 Run focused connectivity tests green
+
+## 3. Acceptance
+
+- [ ] 3.1 Run the governance-overhead test and full available test suite
+- [x] 3.2 Measure 2k/8k write latency after implementation in the same session and record the comparison in `design.md`
+- [x] 3.3 Run F-only Ruff and strict OpenSpec validation

--- a/openspec/changes/surface-relation-vocabulary-promotion/.openspec.yaml
+++ b/openspec/changes/surface-relation-vocabulary-promotion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/surface-relation-vocabulary-promotion/design.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/design.md
@@ -1,0 +1,51 @@
+## Context
+
+Compiled-note feedback already reports structural blocks, sources, links, relations, suggestions, and next actions. It counts relation rows but does not distinguish labels that the active relation registry cannot resolve. The semantic preflight currently treats that same observation as an error, so the public write never reaches feedback construction. Separately, `infer_relation_registry` already groups observations by raw label, counts them, and returns a copy of the active proposal, but it only inserts single-observation namespaced labels into that proposal.
+
+The governed save path is intentionally separate: callers review and complete a proposal, then explicitly request `save=true`; overwrite uses `expected_hash`, and observed labels cannot be silently deleted.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Surface exact unregistered relation labels inside existing write feedback, with the existing `schema_memory` promotion route and a next action.
+- Let a write with an independently qualifying connection commit while reporting the unregistered observation as advisory.
+- Insert recurring unregistered labels into the inferred extension proposal at a default threshold of three observations.
+- Leave the proposed parent and description unset so a human chooses the semantics.
+- Preserve read-only inference and all existing save guards.
+
+**Non-Goals:**
+
+- Blocking writes that contain unregistered relation rows.
+- Letting an unregistered row satisfy typed-edge or connectivity qualification.
+- Inferring a core parent, description, alias, namespace, or epistemic meaning.
+- Automatically saving a proposal or changing command/tool signatures.
+
+## Decisions
+
+### Separate advisory vocabulary feedback from relation qualification
+
+An authored fact whose relation is unregistered produces a warning-level `unregistered_relation` finding instead of an independent blocking error. The fact remains unresolved by the registry, so the existing typed-edge and connectivity predicates continue to reject it. A write therefore succeeds only when another governed connection, reviewed-none disposition, or bootstrap rule independently satisfies the relation gate. An unknown-only relation row still blocks on the missing relation disposition.
+
+Deprecated relations and scope violations remain errors. This change is limited to the unregistered observation that the feedback and proposal workflow can now surface for review.
+
+### Resolve feedback labels against the active registry
+
+After semantic preflight accepts a separately connected write, the feedback builder parses the normalized write body once, collects note-level and block-level relation labels, and calls `registry.resolve(kind)` for each distinct label. Only `status == "unregistered"` creates a signal; core, extension, alias, deprecated, and scoped resolutions are left to their existing governance paths.
+
+The signal lives under the existing `write_feedback.relations` block and names `schema_memory(operation='infer', subject='relations')`. The ordinary string `next_actions` list receives the same route. No new top-level result key or operation docstring is needed.
+
+### Threshold the existing grouped observations
+
+`infer_relation_registry` exposes a `recurrence_threshold` argument defaulting to three for direct deterministic use. After grouping, every unregistered label whose count meets the threshold is inserted into the copied proposal with `parent: null` and `description: null`. Labels below the threshold remain visible in the evidence list but are not proposed.
+
+### Keep proposal generation response-only
+
+Inference performs no writes. Existing extensions are copied unchanged, and `setdefault` prevents an observed label from overwriting a reviewed definition. The command layer's current explicit-save, expected-hash, and observed-deletion checks remain untouched.
+
+## Risks / Trade-offs
+
+- [A recurring plain label is not yet a valid namespaced extension] -> Preserve the raw evidence exactly and leave namespace, parent, and description for human review rather than inventing semantics.
+- [Loading the registry for feedback adds work] -> One small registry load is bounded and the body is already parsed for structural feedback.
+- [Making the observation advisory could look like qualification] -> Pin both predicates and an unknown-only write in regression tests; the warning changes severity, not eligibility.
+- [A low recurrence threshold creates noisy proposals] -> Default to three while retaining the direct function parameter for deterministic tests and specialist callers.

--- a/openspec/changes/surface-relation-vocabulary-promotion/proposal.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Authors can currently write an unregistered relation label without receiving an immediate route to govern it, while corpus inference exposes counts but proposes only a narrow subset of unknown labels. That leaves recurring vocabulary visible but unnecessarily hard to promote.
+
+## What Changes
+
+- Treat an unregistered relation observation as advisory at write time while keeping it ineligible for both typed-edge and connectivity qualification.
+- Add a non-blocking public write-feedback signal for unregistered relation rows, including the exact labels and the governed promotion route.
+- Add a matching next action without changing the top-level note response shape.
+- Populate the inferred relation-registry proposal for unregistered labels observed at least three times by default, leaving parent and description unset for human review.
+- Keep inference read-only and keep registry persistence behind the existing explicit `save=true` and expected-hash guards.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `command-surface`: Compiled-note writes report unregistered relation vocabulary inside existing write feedback and name the promotion command.
+- `attention-queue`: Recurring unregistered relation observations become proposal-ready review work without automatic registry mutation.
+- `semantic-write-contract`: Unregistered relation observations are warnings rather than independent blockers, but never satisfy relation disposition.
+
+## Impact
+
+The semantic relation-registry finding severity, compiled-note feedback builder, deterministic relation-registry inference, and their focused tests change. No operation docstring, command parameter, save guard, gate threshold, or external dependency changes.

--- a/openspec/changes/surface-relation-vocabulary-promotion/specs/attention-queue/spec.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/specs/attention-queue/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Recurring unregistered relations become proposal candidates
+
+Relation-registry inference SHALL populate its existing proposal scaffold with every unregistered raw relation label observed at or above a recurrence threshold that defaults to three. Each new candidate SHALL preserve the observed label and SHALL leave its core parent and description unset for human choice. An unregistered label below the threshold SHALL remain in the counted evidence but SHALL NOT appear in the proposal.
+
+Inference SHALL remain read-only. It MUST NOT persist a candidate unless the caller separately supplies a reviewed proposal through the existing explicit `save=true` path, and existing expected-hash and observed-relation-deletion guards SHALL remain authoritative.
+
+#### Scenario: Label at threshold is proposed
+
+- **WHEN** deterministic inference observes the same unregistered relation label three times under the default threshold
+- **THEN** the proposal scaffold contains that label with unset parent and description
+- **AND** no registry file is created or modified
+
+#### Scenario: Label below threshold stays observational
+
+- **WHEN** deterministic inference observes an unregistered relation label fewer than three times
+- **THEN** its count and examples remain in the inference response
+- **AND** it does not appear in the proposal scaffold
+
+#### Scenario: Proposal requires explicit guarded save
+
+- **WHEN** inference returns one or more recurring candidates without `save=true`
+- **THEN** it writes nothing
+- **AND** a later save remains subject to the existing reviewed-proposal, expected-hash, and observed-deletion guards

--- a/openspec/changes/surface-relation-vocabulary-promotion/specs/command-surface/spec.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/specs/command-surface/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Compiled writes surface unregistered relation vocabulary
+
+When a compiled write contains an explicit relation row whose label resolves with registry status `unregistered`, the write result SHALL include a non-blocking signal inside the existing `write_feedback.relations` structure. The signal SHALL name every distinct unregistered label and SHALL identify `schema_memory(operation="infer", subject="relations")` as the governed promotion route. The existing `write_feedback.next_actions` list SHALL include that route.
+
+The system SHALL NOT add a new top-level response key, and a registered relation row SHALL NOT produce the unregistered-vocabulary signal.
+
+#### Scenario: A separately connected write returns unregistered vocabulary feedback
+
+- **WHEN** a compiled write contains an unregistered relation row and a separate governed connection satisfies relation disposition
+- **THEN** the public write succeeds
+- **THEN** `write_feedback.relations` names the label and promotion route
+- **AND** `write_feedback.next_actions` names the same promotion route
+- **AND** the unregistered observation remains non-blocking and non-qualifying
+
+#### Scenario: Registered relation produces no promotion signal
+
+- **WHEN** every explicit relation row resolves through the active registry
+- **THEN** write feedback contains no unregistered-vocabulary signal

--- a/openspec/changes/surface-relation-vocabulary-promotion/specs/semantic-write-contract/spec.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/specs/semantic-write-contract/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Unregistered relation observations are advisory but non-qualifying
+
+When an authored relation row resolves with registry status `unregistered`, the semantic write evaluator SHALL emit an `unregistered_relation` warning rather than an independent blocking error. The unresolved relation fact SHALL remain ineligible for typed-edge and connectivity qualification and SHALL NOT satisfy relation disposition.
+
+Deprecated relations and registry scope violations SHALL remain blocking errors under their existing rules.
+
+#### Scenario: A separate governed connection permits advisory feedback
+
+- **WHEN** a compiled write contains an unregistered relation row and another outbound relation independently satisfies the connectivity lane
+- **THEN** the evaluator reports `unregistered_relation` with warning severity
+- **AND** relation disposition is satisfied only by the independently qualifying relation
+- **AND** the unregistered observation does not block the write
+
+#### Scenario: An unknown-only relation remains blocked by disposition
+
+- **WHEN** the only authored relation row uses an unregistered label
+- **THEN** the evaluator reports `unregistered_relation` with warning severity
+- **AND** neither typed-edge nor connectivity qualification accepts that fact
+- **AND** relation disposition remains unsatisfied and blocks the write
+
+#### Scenario: Governed registry violations remain errors
+
+- **WHEN** a relation resolves as deprecated or outside its permitted scope
+- **THEN** its existing registry finding remains an error

--- a/openspec/changes/surface-relation-vocabulary-promotion/tasks.md
+++ b/openspec/changes/surface-relation-vocabulary-promotion/tasks.md
@@ -1,0 +1,27 @@
+## 1. Contract and regression tests
+
+- [x] 1.1 Add command-surface and attention-queue delta specifications.
+- [x] 1.2 Add a semantic-write-contract delta specification for advisory but non-qualifying unregistered observations.
+- [x] 1.3 Replace the private feedback-builder regression with a red-first public compiled-write test.
+- [x] 1.4 Add red-first contract regressions proving an unknown-only relation remains non-qualifying.
+- [x] 1.5 Add red-first tests for at-threshold and below-threshold proposal inference.
+- [x] 1.6 Retain explicit-save, stale-hash, and observed-deletion regression coverage.
+
+## 2. Semantic disposition and write feedback
+
+- [x] 2.1 Resolve distinct authored relation labels through the active registry.
+- [x] 2.2 Make `unregistered_relation` advisory without allowing the fact to qualify.
+- [x] 2.3 Return the non-blocking signal and promotion next action from the public compiled-write result.
+- [x] 2.4 Keep registered relation feedback and the top-level note response shape unchanged.
+
+## 3. Recurrence proposals
+
+- [x] 3.1 Add a deterministic recurrence threshold defaulting to three.
+- [x] 3.2 Populate the copied proposal for recurring unregistered labels with unset parent and description.
+- [x] 3.3 Keep inference response-only and preserve reviewed extensions.
+
+## 4. Verification
+
+- [x] 4.1 Run focused note, memory-schema, and relation-registry tests.
+- [ ] 4.2 Run the full pytest suite and `ruff check . --select F` on Linux.
+- [x] 4.3 Validate the OpenSpec change in strict mode.

--- a/src/exomem/audit.py
+++ b/src/exomem/audit.py
@@ -1,7 +1,8 @@
 """Read-only audit of the Knowledge Base. Returns structured findings.
 
 Checks (all read-only; no writes ever):
-- `broken_wikilink`: `[[...]]` whose resolved target file doesn't exist.
+- `broken_wikilink`: `[[...]]` with a definite resolution error.
+- `forward_reference`: `[[...]]` to a Markdown page that does not exist yet.
   Skips wikilinks inside fenced code blocks and inline code spans (so
   `[[:space:]]` regex literals don't false-positive). Bare names resolve
   against filename stems AND frontmatter `title:` (so date-prefixed
@@ -73,7 +74,7 @@ from .vault import (
 log = logging.getLogger(__name__)
 
 ALL_CATEGORIES: tuple[str, ...] = (
-    "broken_wikilink", "orphan_entity", "unprocessed_source",
+    "broken_wikilink", "forward_reference", "orphan_entity", "unprocessed_source",
     "index_drift", "tag_inconsistency", "frontmatter_compliance",
     "unregistered_project_key", "embedding_drift", "graph_drift", "reference_identity",
     "relevance_pairs_pending", "stale_review", "corpus_contradictions",
@@ -358,8 +359,9 @@ def audit(
 
     findings: list[AuditFinding] = []
     metadata: dict = {}
-    if "broken_wikilink" in selected:
-        findings.extend(_check_broken_wikilinks(vault_root, pages))
+    link_categories = selected & {"broken_wikilink", "forward_reference"}
+    if link_categories:
+        findings.extend(_check_wikilinks(vault_root, pages, link_categories))
     if "orphan_entity" in selected:
         findings.extend(_check_orphan_entities(vault_root, pages))
     if "unprocessed_source" in selected:
@@ -1272,11 +1274,13 @@ def _page_signal_version(page: find_module.ParsedPage) -> str:
     return content_hash(frontmatter + "\n" + page.body)[:16]
 
 
-# ---------------- check: broken_wikilink ----------------
+# ---------------- checks: broken_wikilink / forward_reference ----------------
 
 
-def _check_broken_wikilinks(
-    vault_root: Path, pages: list[find_module.ParsedPage]
+def _check_wikilinks(
+    vault_root: Path,
+    pages: list[find_module.ParsedPage],
+    selected: set[str],
 ) -> list[AuditFinding]:
     findings: list[AuditFinding] = []
 
@@ -1286,7 +1290,7 @@ def _check_broken_wikilinks(
     # existence set from the full vault so those don't false-positive.
     full_paths: set[str] = set()          # vault-relative, no .md, e.g. "Reference/Strategy"
     kb_stripped_paths: set[str] = set()   # KB-relative, no .md
-    names_to_paths: dict[str, str] = {}   # bare filename (no ext) → first vault-rel path
+    names_to_paths: dict[str, list[str]] = {}  # bare filename (no ext) → vault-rel paths
     titles_to_paths: dict[str, list[str]] = {}  # lower(frontmatter title) → paths
     for md_path in _walk_vault_md(vault_root):
         try:
@@ -1296,7 +1300,7 @@ def _check_broken_wikilinks(
         no_ext = rel.removesuffix(".md")
         full_paths.add(no_ext)
         kb_stripped_paths.add(no_ext.removeprefix(kb_prefix()))
-        names_to_paths.setdefault(md_path.stem, no_ext)
+        names_to_paths.setdefault(md_path.stem, []).append(no_ext)
         # Title fallback: lets `[[North-Led Content Manual]]` resolve to a
         # date-prefixed source whose frontmatter `title:` matches.
         try:
@@ -1329,14 +1333,19 @@ def _check_broken_wikilinks(
                 continue
             # Bare-name lookup: Obsidian resolves [[name]] by filename anywhere
             # in the vault. Only attempt if no path separator.
+            ambiguous_stem = False
+            ambiguous_title = False
             if "/" not in target_for_resolve:
-                if target_for_resolve in names_to_paths:
+                stem_matches = names_to_paths.get(target_for_resolve)
+                if stem_matches and len(stem_matches) == 1:
                     continue
+                ambiguous_stem = bool(stem_matches)
                 # Title fallback. Only resolves when unambiguous; ambiguous
                 # title matches stay flagged so the user can disambiguate.
                 title_matches = titles_to_paths.get(target_for_resolve.lower())
-                if title_matches and len(title_matches) == 1:
+                if not ambiguous_stem and title_matches and len(title_matches) == 1:
                     continue
+                ambiguous_title = not ambiguous_stem and bool(title_matches)
             # Attachment links: Obsidian resolves a wikilink carrying an
             # explicit (non-.md) extension to the file on disk of any type
             # (e.g. [[.../scan.pdf]], [[Reference/diagram.png]]). The resolution
@@ -1351,12 +1360,46 @@ def _check_broken_wikilinks(
                     vault_root / kb_dirname() / normalized
                 ).exists():
                     continue
+
+            non_markdown_collision = (
+                not suffix
+                and _has_non_markdown_collision(
+                    vault_root, target_for_resolve.lstrip("/"), normalized
+                )
+            )
+            broken = bool(
+                (suffix and suffix != ".md")
+                or ambiguous_stem
+                or ambiguous_title
+                or non_markdown_collision
+            )
+            category = "broken_wikilink" if broken else "forward_reference"
+            if category not in selected:
+                continue
+
+            immutable = in_append_only_tree(str(page.rel_path)) is not None
+            if not broken:
+                meta = {"signal_version": _page_signal_version(page)}
+                if immutable:
+                    meta["immutable"] = True
+                findings.append(AuditFinding(
+                    category="forward_reference",
+                    severity="info",
+                    path=str(page.rel_path),
+                    detail=(
+                        f"Wikilink [[{target}]] is a forward reference to a page "
+                        "that does not exist yet"
+                    ),
+                    proposed_fix=(
+                        "Create the referenced page when ready. If the target is a "
+                        "typo or obsolete, correct or remove the link."
+                    ),
+                    meta=meta,
+                ))
+                continue
+
             # A broken link inside an append-only tree (Sources/, Evidence/)
             # can't be repaired in place — the containing file is immutable.
-            # Surface it at `info` + meta.immutable so it stays out of the
-            # actionable `warn` set (you'd fix it in the source body desk-side
-            # or accept it as a stray reference in captured material).
-            immutable = in_append_only_tree(str(page.rel_path)) is not None
             findings.append(AuditFinding(
                 category="broken_wikilink",
                 severity="info" if immutable else "warn",
@@ -1376,6 +1419,31 @@ def _check_broken_wikilinks(
                 meta={"immutable": True} if immutable else None,
             ))
     return findings
+
+
+def _has_non_markdown_collision(
+    vault_root: Path, vault_relative: str, kb_relative: str
+) -> bool:
+    """Whether an extensionless note link names an existing non-note file."""
+    resolved_root = vault_root.resolve()
+    for candidate in (
+        vault_root / vault_relative,
+        vault_root / kb_dirname() / kb_relative,
+    ):
+        try:
+            resolved_parent = candidate.parent.resolve()
+            resolved_parent.relative_to(resolved_root)
+            siblings = tuple(resolved_parent.iterdir())
+        except (OSError, ValueError):
+            continue
+        for sibling in siblings:
+            if (
+                sibling.is_file()
+                and sibling.stem == candidate.name
+                and sibling.suffix.lower() != ".md"
+            ):
+                return True
+    return False
 
 
 def _walk_vault_md(vault_root: Path):

--- a/src/exomem/memory_schema.py
+++ b/src/exomem/memory_schema.py
@@ -26,6 +26,7 @@ from .kbdir import kb_dirname
 
 SCHEMA_VERSION = 1
 MIN_REQUIRED_SAMPLE = 5
+DEFAULT_RELATION_PROMOTION_THRESHOLD = 3
 # Fixed generic description for reviewed-corpus category candidates. Inference
 # never infers semantics, so every proposed definition shares this public-safe
 # text; a human reviewer refines it before saving.
@@ -370,8 +371,11 @@ def infer_relation_registry(
     project: str | None = None,
     page_type: str | None = None,
     include_model_suggestions: bool = False,
+    recurrence_threshold: int = DEFAULT_RELATION_PROMOTION_THRESHOLD,
 ) -> dict[str, Any]:
     """Profile explicit relation observations without assigning new semantics."""
+    if recurrence_threshold < 1:
+        raise ValueError("recurrence_threshold must be at least 1")
     registry = relation_registry.load_registry(vault_root)
     pages, observations = _scan_relation_observations(
         vault_root, project=project, page_type=page_type, registry=registry
@@ -401,7 +405,10 @@ def infer_relation_registry(
     proposal = relation_registry_proposal(registry)
     for item in grouped.values():
         raw = item["raw_relation"]
-        if item["registry_status"] == "unregistered" and "." in raw:
+        if (
+            item["registry_status"] == "unregistered"
+            and item["count"] >= recurrence_threshold
+        ):
             proposal["extensions"].setdefault(raw, {"parent": None, "description": None})
     warnings: list[dict[str, str]] = []
     suggestions: list[dict[str, Any]] = []

--- a/src/exomem/note.py
+++ b/src/exomem/note.py
@@ -40,6 +40,7 @@ from . import (
     corpus_aware,
     indexes,
     memory_refs,
+    relation_registry,
     relation_review,
     semantic_units,
     semantic_writes,
@@ -263,6 +264,7 @@ class _PreparedNote:
 
 def _build_write_feedback(
     *,
+    vault_root: Path,
     note_type: str,
     sources_norm: list[str],
     body_clean: str,
@@ -271,12 +273,22 @@ def _build_write_feedback(
     backrefs_planned: int,
     suggestions_count: int,
 ) -> dict:
-    document = semantic_units.parse_semantic_units(body_clean)
+    registry = relation_registry.load_registry(vault_root)
+    document = semantic_units.parse_semantic_units(
+        body_clean,
+        relation_registry=registry,
+        retain_unknown_relations=True,
+    )
     by_kind: dict[str, int] = {}
     for unit in document.rich_units:
         by_kind[unit.kind] = by_kind.get(unit.kind, 0) + 1
 
-    note_relation_lines = {relation.line for relation in document.note_relations}
+    registered_note_relations = tuple(
+        relation
+        for relation in document.note_relations
+        if registry.resolve(relation.kind).status != "unregistered"
+    )
+    note_relation_lines = {relation.line for relation in registered_note_relations}
     block_relation_lines = {
         relation.line
         for unit in document.rich_units
@@ -298,8 +310,19 @@ def _build_write_feedback(
             seen_generic_targets.add(target)
             generic_targets.append(target)
 
-    typed_note_relations = len(document.note_relations)
+    typed_note_relations = len(registered_note_relations)
     typed_block_relations = sum(len(unit.relations) for unit in document.rich_units)
+    relation_kinds = {
+        relation.kind
+        for relation in document.note_relations
+    } | {
+        relation.kind
+        for unit in document.rich_units
+        for relation in unit.relations
+    }
+    unregistered_labels = sorted(
+        kind for kind in relation_kinds if registry.resolve(kind).status == "unregistered"
+    )
     relation_debt = not (
         typed_note_relations
         or typed_block_relations
@@ -314,6 +337,11 @@ def _build_write_feedback(
     if suggestions_count:
         next_actions.append(
             "review related-page suggestions and add accepted note edges under `## Relations`"
+        )
+    if unregistered_labels:
+        next_actions.append(
+            "review recurring relation vocabulary with "
+            "`schema_memory(operation='infer', subject='relations')`"
         )
     if not sources_norm:
         if not body_targets:
@@ -334,6 +362,22 @@ def _build_write_feedback(
         )
     if not next_actions:
         next_actions.append("no immediate structural follow-up")
+
+    relation_feedback: dict[str, object] = {
+        "typed_note": typed_note_relations,
+        "typed_block": typed_block_relations,
+        "errors": [error.as_dict() for error in document.note_relation_errors],
+        "relation_debt": relation_debt,
+    }
+    if unregistered_labels:
+        relation_feedback["unregistered"] = {
+            "count": len(unregistered_labels),
+            "labels": unregistered_labels,
+            "promotion_route": {
+                "tool": "schema_memory",
+                "args": {"operation": "infer", "subject": "relations"},
+            },
+        }
 
     return {
         "contract": "compiled-note",
@@ -359,12 +403,7 @@ def _build_write_feedback(
             "unresolved_count": len(unresolved),
             "unresolved": unresolved,
         },
-        "relations": {
-            "typed_note": typed_note_relations,
-            "typed_block": typed_block_relations,
-            "errors": [error.as_dict() for error in document.note_relation_errors],
-            "relation_debt": relation_debt,
-        },
+        "relations": relation_feedback,
         "suggestions": {
             "related_pages": suggestions_count,
         },
@@ -644,6 +683,7 @@ def _legacy_note(
 
     kb = kb_root(vault_root)
     write_feedback = _build_write_feedback(
+        vault_root=vault_root,
         note_type=note_type,
         sources_norm=sources_norm,
         body_clean=body_clean,
@@ -1867,6 +1907,7 @@ def note(
         suggestions,
     )
     feedback = _build_write_feedback(
+        vault_root=root,
         note_type=note_type,
         sources_norm=sources_norm,
         body_clean=body_clean,

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -3002,7 +3002,7 @@ def _registry_findings(
         findings.append(
             ContractFinding(
                 code=code,
-                severity="error",
+                severity="warning" if code == "unregistered_relation" else "error",
                 path=page.path,
                 span=None,
                 detail=detail,

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -2686,6 +2686,48 @@ def qualify_connectivity(
     return RelationQualification(not ordered, ordered)
 
 
+@dataclass(frozen=True, slots=True)
+class _WikilinkResolverView:
+    """Read-only resolver attributes already snapshotted on the corpus."""
+
+    full_paths: frozenset[str]
+    kb_stripped: frozenset[str]
+    stems: Mapping[str, tuple[str, ...]]
+    titles: Mapping[str, tuple[str, ...]]
+
+
+def _qualifying_body_wikilink_targets(
+    page: SemanticPageState,
+    corpus: SemanticCorpusContext,
+) -> tuple[str, ...]:
+    """Resolve body links by normalized set membership without relation facts."""
+    resolver = _WikilinkResolverView(
+        full_paths=corpus.resolver_full_paths,
+        kb_stripped=corpus.resolver_kb_stripped,
+        stems=corpus.resolver_stems,
+        titles=corpus.resolver_titles,
+    )
+    targets: list[str] = []
+    for raw_target, _line in page.body_wikilinks:
+        try:
+            normalized, _ = vault.normalize_wikilink(
+                raw_target,
+                corpus.vault_root,
+                resolver=resolver,  # type: ignore[arg-type]
+                strict=True,
+            )
+        except (vault.AmbiguousWikilinkError, vault.UnresolvedWikilinkError):
+            continue
+        path = normalized.split("#", 1)[0]
+        resolved_path = path if path.lower().endswith(".md") else f"{path}.md"
+        if (
+            resolved_path != page.path
+            and resolved_path in corpus.connectable_target_paths
+        ):
+            targets.append(resolved_path)
+    return tuple(targets)
+
+
 def is_relation_review_current(
     review: RelationReviewState,
     page: SemanticPageState,
@@ -2760,6 +2802,17 @@ def _relation_disposition(
             current=True,
             qualifying_directions=("outbound",) * len(connectivity),
             qualifying_facts=tuple(sorted(connectivity, key=lambda item: item.identity)),
+            rejected_facts=tuple(rejected),
+            actions=_satisfied_actions(),
+            qualifying_signal="connectivity",
+        )
+    body_wikilink_targets = _qualifying_body_wikilink_targets(page, corpus)
+    if body_wikilink_targets:
+        return RelationDisposition(
+            kind="qualifying_relation",
+            satisfied=True,
+            current=True,
+            qualifying_directions=("outbound",) * len(body_wikilink_targets),
             rejected_facts=tuple(rejected),
             actions=_satisfied_actions(),
             qualifying_signal="connectivity",

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -21,14 +21,14 @@ def test_audit_and_reconcile_import_in_fresh_process() -> None:
     assert imported.returncode == 0, imported.stderr
 
 
-def test_audit_findings_have_non_empty_path(vault: Path) -> None:
+def test_forward_reference_findings_have_non_empty_path(vault: Path) -> None:
     """Regression: every finding must carry the path of the file it concerns.
 
     Previously _parse_page set rel_path="" and relied on find() to fill it.
     audit called _parse_page directly, so every finding's `path` was empty —
     making the report un-triagable.
     """
-    # Plant a broken wikilink in an existing fixture file.
+    # Plant a forward reference in an existing fixture file.
     insight = (
         vault / "Knowledge Base" / "Notes" / "Insights"
         / "progressive-disclosure-without-mode-fragmentation.md"
@@ -39,11 +39,54 @@ def test_audit_findings_have_non_empty_path(vault: Path) -> None:
         encoding="utf-8",
     )
 
-    report = audit_module.audit(vault, categories=["broken_wikilink"])
-    assert report.findings, "expected at least one broken_wikilink finding"
+    report = audit_module.audit(vault, categories=["forward_reference"])
+    assert report.findings, "expected at least one forward_reference finding"
     for f in report.findings:
         assert f.path, f"finding has empty path: {f.as_dict()}"
         assert f.path.startswith("Knowledge Base/"), f.path
+
+
+def test_missing_note_is_forward_reference_not_broken(vault: Path) -> None:
+    insight = (
+        vault / "Knowledge Base" / "Notes" / "Insights"
+        / "progressive-disclosure-without-mode-fragmentation.md"
+    )
+    insight.write_text(
+        insight.read_text(encoding="utf-8")
+        + "\n\nPlanned: [[Knowledge Base/Notes/Patterns/future-pattern]]\n",
+        encoding="utf-8",
+    )
+
+    report = audit_module.audit(
+        vault, categories=["broken_wikilink", "forward_reference"]
+    )
+    hits = [f for f in report.findings if "future-pattern" in f.detail]
+
+    assert len(hits) == 1, [f.as_dict() for f in hits]
+    assert hits[0].category == "forward_reference"
+    assert hits[0].severity == "info"
+
+
+def test_forward_reference_clears_when_target_is_created(vault: Path) -> None:
+    insight = (
+        vault / "Knowledge Base" / "Notes" / "Insights"
+        / "progressive-disclosure-without-mode-fragmentation.md"
+    )
+    insight.write_text(
+        insight.read_text(encoding="utf-8")
+        + "\n\nPlanned: [[Knowledge Base/Notes/Patterns/future-pattern]]\n",
+        encoding="utf-8",
+    )
+
+    before = audit_module.audit(vault, categories=["forward_reference"])
+    assert any("future-pattern" in f.detail for f in before.findings)
+
+    target = vault / "Knowledge Base" / "Notes" / "Patterns" / "future-pattern.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Future pattern\n", encoding="utf-8")
+
+    after = audit_module.audit(vault, categories=["forward_reference"])
+    assert not any("future-pattern" in f.detail for f in after.findings)
 
 
 def test_audit_does_not_flag_parent_vault_wikilinks(vault: Path, tmp_path: Path) -> None:
@@ -143,10 +186,58 @@ def test_audit_flags_extensionless_link_even_if_nonmd_file_exists(vault: Path) -
     assert bad, "extension-less link to a .eml must stay flagged (Obsidian parity)"
 
 
-def test_broken_link_in_append_only_file_is_info_not_warn(vault: Path) -> None:
-    """Broken wikilinks inside append-only trees (Sources/, Evidence/) can't be
-    repaired in place, so audit surfaces them at `info` severity + meta.immutable
-    — keeping them out of the actionable (`warn`) set."""
+def test_audit_keeps_duplicate_stem_ambiguity_broken(vault: Path) -> None:
+    for folder in ("Patterns", "Research"):
+        target = vault / "Knowledge Base" / "Notes" / folder / "shared-name.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"# {folder} target\n", encoding="utf-8")
+    insight = (
+        vault / "Knowledge Base" / "Notes" / "Insights"
+        / "progressive-disclosure-without-mode-fragmentation.md"
+    )
+    insight.write_text(
+        insight.read_text(encoding="utf-8") + "\n\n[[shared-name]]\n",
+        encoding="utf-8",
+    )
+
+    report = audit_module.audit(
+        vault, categories=["broken_wikilink", "forward_reference"]
+    )
+    hits = [finding for finding in report.findings if "shared-name" in finding.detail]
+
+    assert len(hits) == 1, [finding.as_dict() for finding in hits]
+    assert hits[0].category == "broken_wikilink"
+
+
+def test_non_markdown_collision_probe_never_enumerates_outside_vault(
+    vault: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    outside = tmp_path / "outside-target.eml"
+    outside.write_text("not part of the vault", encoding="utf-8")
+    insight = (
+        vault / "Knowledge Base" / "Notes" / "Insights"
+        / "progressive-disclosure-without-mode-fragmentation.md"
+    )
+    insight.write_text(
+        insight.read_text(encoding="utf-8") + "\n\n[[../outside-target]]\n",
+        encoding="utf-8",
+    )
+    original_iterdir = Path.iterdir
+    vault_resolved = vault.resolve()
+
+    def contained_iterdir(path: Path):
+        path.resolve().relative_to(vault_resolved)
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", contained_iterdir)
+
+    audit_module.audit(vault, categories=["broken_wikilink", "forward_reference"])
+
+
+def test_forward_reference_in_append_only_file_is_info(vault: Path) -> None:
+    """Forward references remain informational in append-only captured material."""
     src = (
         vault / "Knowledge Base" / "Sources" / "Articles"
         / "2026-05-31-immutable-link-src.md"
@@ -159,16 +250,17 @@ def test_broken_link_in_append_only_file_is_info_not_warn(vault: Path) -> None:
         encoding="utf-8",
     )
 
-    report = audit_module.audit(vault, categories=["broken_wikilink"])
+    report = audit_module.audit(vault, categories=["forward_reference"])
     hits = [f for f in report.findings if "immutable-link-src" in f.path]
-    assert hits, "expected the source's broken link to be flagged"
+    assert hits, "expected the source's forward reference to be surfaced"
     f = hits[0]
+    assert f.category == "forward_reference", f.as_dict()
     assert f.severity == "info", f.as_dict()
     assert f.meta and f.meta.get("immutable") is True, f.as_dict()
 
 
-def test_broken_link_in_editable_file_stays_warn(vault: Path) -> None:
-    """Guard: broken links in editable compiled notes remain actionable `warn`."""
+def test_forward_reference_in_editable_file_is_info(vault: Path) -> None:
+    """A missing Markdown page is informational in editable notes too."""
     insight = (
         vault / "Knowledge Base" / "Notes" / "Insights"
         / "progressive-disclosure-without-mode-fragmentation.md"
@@ -179,10 +271,11 @@ def test_broken_link_in_editable_file_stays_warn(vault: Path) -> None:
         encoding="utf-8",
     )
 
-    report = audit_module.audit(vault, categories=["broken_wikilink"])
+    report = audit_module.audit(vault, categories=["forward_reference"])
     hits = [f for f in report.findings if "no-such-target-abc" in f.detail]
-    assert hits, "expected the broken link to be flagged"
-    assert hits[0].severity == "warn", hits[0].as_dict()
+    assert hits, "expected the forward reference to be surfaced"
+    assert hits[0].category == "forward_reference", hits[0].as_dict()
+    assert hits[0].severity == "info", hits[0].as_dict()
     assert not (hits[0].meta or {}).get("immutable"), hits[0].as_dict()
 
 

--- a/tests/test_memory_schema.py
+++ b/tests/test_memory_schema.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from exomem import audit, commands, memory_schema, semantic_language_registry
+from exomem import (
+    audit,
+    commands,
+    memory_schema,
+    relation_registry,
+    semantic_language_registry,
+)
 from exomem.__main__ import main
 
 
@@ -330,12 +336,20 @@ def test_schema_memory_registry_parity_and_strict_cli_exit(
 def test_relation_inference_is_evidence_backed_and_proposal_first(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     pages = _seed_pages(vault)
-    pages[0].write_text(
-        pages[0].read_text(encoding="utf-8")
-        + "\n- science.replicates: [[Knowledge Base/Notes/future]]\n",
-        encoding="utf-8",
-    )
-    before = pages[0].read_text(encoding="utf-8")
+    for page in pages[:3]:
+        page.write_text(
+            page.read_text(encoding="utf-8")
+            + "\n- science.replicates: [[Knowledge Base/Notes/future]]\n",
+            encoding="utf-8",
+        )
+    for page in pages[:2]:
+        page.write_text(
+            page.read_text(encoding="utf-8")
+            + "\n- science.sibling: [[Knowledge Base/Notes/future]]\n",
+            encoding="utf-8",
+        )
+    before = {page: page.read_bytes() for page in pages}
+    registry_path = relation_registry.extension_registry_path(vault)
 
     inferred = commands.op_schema_memory(
         vault,
@@ -349,14 +363,20 @@ def test_relation_inference_is_evidence_backed_and_proposal_first(tmp_path: Path
         item for item in inferred["relations"] if item["raw_relation"] == "science.replicates"
     )
     assert candidate["registry_status"] == "unregistered"
-    assert candidate["count"] == 1
+    assert candidate["count"] == 3
     assert candidate["examples"][0]["path"].endswith("page-0.md")
     assert inferred["proposal"]["extensions"]["science.replicates"] == {
         "parent": None,
         "description": None,
     }
+    sibling = next(
+        item for item in inferred["relations"] if item["raw_relation"] == "science.sibling"
+    )
+    assert sibling["count"] == 2
+    assert "science.sibling" not in inferred["proposal"]["extensions"]
     assert inferred["warnings"][0]["code"] == "model_suggestions_unavailable"
-    assert pages[0].read_text(encoding="utf-8") == before
+    assert {page: page.read_bytes() for page in pages} == before
+    assert not registry_path.exists()
 
     with pytest.raises(ValueError, match="INCOMPLETE_RELATION_PROPOSAL"):
         commands.op_schema_memory(vault, operation="infer", subject="relations", save=True)
@@ -468,11 +488,12 @@ def test_relation_registry_audit_is_explicit_and_not_default_attention_noise(
 def test_relation_diff_without_proposal_compares_corpus_reality(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     pages = _seed_pages(vault)
-    pages[0].write_text(
-        pages[0].read_text(encoding="utf-8")
-        + "\n- science.replicates: [[Knowledge Base/Notes/future]]\n",
-        encoding="utf-8",
-    )
+    for page in pages[:3]:
+        page.write_text(
+            page.read_text(encoding="utf-8")
+            + "\n- science.replicates: [[Knowledge Base/Notes/future]]\n",
+            encoding="utf-8",
+        )
     result = commands.op_schema_memory(vault, operation="diff", subject="relations")
     assert result["comparison"] == "corpus"
     assert result["changed"] is True

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -110,7 +110,46 @@ def test_note_returns_structural_write_feedback(vault: Path) -> None:
         "errors": [],
         "relation_debt": False,
     }
+    assert "unregistered" not in feedback["relations"]
     assert "write_feedback" in result.as_dict()
+
+
+def test_note_feedback_surfaces_unregistered_relation_promotion_route(
+    vault: Path,
+) -> None:
+    target = (
+        "Knowledge Base/Notes/Insights/"
+        "progressive-disclosure-without-mode-fragmentation"
+    )
+    result = note_module.note(
+        vault,
+        content=(
+            "# Vocabulary feedback\n\n"
+            "## Observations\n\n"
+            "- [constraint] Keep vocabulary promotion reviewed.\n\n"
+            "## Relations\n"
+            f"- relates_to [[{target}]]\n"
+            f"- parent [[{target}]]\n"
+        ),
+        note_type="insight",
+        title="Vocabulary feedback",
+        today=TODAY,
+    )
+
+    assert (vault / result.path).exists()
+    feedback = result.write_feedback
+    signal = feedback["relations"]["unregistered"]
+    assert feedback["relations"]["typed_note"] == 1
+    assert signal["labels"] == ["parent"]
+    assert signal["count"] == 1
+    assert signal["promotion_route"] == {
+        "tool": "schema_memory",
+        "args": {"operation": "infer", "subject": "relations"},
+    }
+    assert any(
+        "schema_memory" in action and "relations" in action
+        for action in feedback["next_actions"]
+    )
 
 
 def test_note_feedback_surfaces_relation_debt_without_blocking_write(vault: Path) -> None:

--- a/tests/test_semantic_connectivity_lane.py
+++ b/tests/test_semantic_connectivity_lane.py
@@ -184,6 +184,70 @@ def test_qualify_connectivity_accepts_what_the_typed_lane_excludes(
     ).qualifies
 
 
+def test_unregistered_relation_is_advisory_but_never_qualifies(
+    tmp_path: Path,
+) -> None:
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(
+            body=(
+                _OBS
+                + "## Relations\n"
+                + "- parent [[Knowledge Base/Notes/Patterns/target]]\n"
+            )
+        ),
+    )
+    target = _target(tmp_path)
+    corpus = _corpus(tmp_path, page, target)
+    fact = corpus.outbound[page.path][0]
+
+    assert not semantic_contract.qualify_relation(
+        fact, registry=relation_registry.core_registry(), corpus=corpus
+    ).qualifies
+    assert not semantic_contract.qualify_connectivity(
+        fact, registry=relation_registry.core_registry(), corpus=corpus
+    ).qualifies
+
+    result = _disposition(tmp_path, page, target)
+    finding = next(
+        finding
+        for finding in result.findings
+        if finding.code == "unregistered_relation"
+    )
+    assert finding.severity == "warning"
+    assert result.relation_disposition.satisfied is False
+    assert result.should_block is True
+
+
+def test_unregistered_warning_does_not_block_separately_connected_page(
+    tmp_path: Path,
+) -> None:
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(
+            body=(
+                _OBS
+                + "## Relations\n"
+                + "- cites [[Knowledge Base/Notes/Patterns/target]]\n"
+                + "- parent [[Knowledge Base/Notes/Patterns/target]]\n"
+            )
+        ),
+    )
+
+    result = _disposition(tmp_path, page, _target(tmp_path))
+    finding = next(
+        finding
+        for finding in result.findings
+        if finding.code == "unregistered_relation"
+    )
+    assert finding.severity == "warning"
+    assert result.relation_disposition.satisfied is True
+    assert result.relation_disposition.qualifying_signal == "connectivity"
+    assert result.should_block is False
+
+
 # --------------------------------------------------------------------------
 # What the weaker lane does and does not count.
 # --------------------------------------------------------------------------

--- a/tests/test_semantic_connectivity_lane.py
+++ b/tests/test_semantic_connectivity_lane.py
@@ -5,9 +5,9 @@ family connects a page instead of forcing a reviewed-none round trip.
 
 Two boundaries are deliberate. Frontmatter provenance does not count, mirroring
 the relation-debt audit, which also ignores `sources:` — otherwise every
-adoption-compiled note would satisfy the gate by construction. And body wikilinks
-are collected but not yet a signal: emitting them as relation facts blew the
-write-latency gate at 8k pages, so that half is withdrawn pending a cheaper check.
+adoption-compiled note would satisfy the gate by construction. Body wikilinks use
+the weaker lane only when their outbound target resolves to the existing
+connectable set; no per-link relation fact is constructed.
 
 These also pin the three things that must not break — the typed predicate's
 meaning, the empty-corpus bootstrap carve-out, and non-vacuity.
@@ -233,17 +233,10 @@ def test_cited_provenance_alone_does_not_satisfy_the_disposition(
     assert result.relation_disposition.kind == "missing"
 
 
-def test_body_wikilinks_are_collected_but_do_not_yet_satisfy(
+def test_resolved_body_wikilink_satisfies_connectivity_without_a_fact(
     tmp_path: Path,
 ) -> None:
-    """Body links are measured on page state, but are not yet a disposition signal.
-
-    Emitting them as relation facts blew the semantic write-latency gate at 8k
-    pages (commit median 1259ms against a 750ms threshold, scaling 4.7x where
-    ~2.75x is allowed), so the fact emission was withdrawn. The collected
-    `body_wikilinks` remain, ready for a cheaper set-membership check that does not
-    route every link through full fact construction and target resolution.
-    """
+    """Resolved page-state links qualify by set membership, never as facts."""
     page = _state(
         tmp_path,
         "Knowledge Base/Notes/Insights/page.md",
@@ -257,6 +250,102 @@ def test_body_wikilinks_are_collected_but_do_not_yet_satisfy(
     assert corpus.outbound.get(page.path, ()) == ()
 
     result = _disposition(tmp_path, page, _target(tmp_path))
+    disposition = result.relation_disposition
+    assert disposition.kind == "qualifying_relation"
+    assert disposition.satisfied is True
+    assert disposition.qualifying_signal == "connectivity"
+    assert disposition.qualifying_facts == ()
+    assert result.should_block is False
+
+    warning = next(
+        finding
+        for finding in result.findings
+        if finding.code == "RELATION_TYPED_EDGE_ABSENT"
+    )
+    assert warning.severity == "warning"
+
+
+def test_body_wikilink_to_captured_source_satisfies_connectivity(tmp_path: Path) -> None:
+    captured = _captured_source(tmp_path)
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(body=_OBS + f"Evidence lives in [[{_SOURCE_PAGE.removesuffix('.md')}]].\n"),
+    )
+
+    result = _disposition(tmp_path, page, captured)
+
+    assert result.relation_disposition.satisfied is True
+    assert result.relation_disposition.qualifying_signal == "connectivity"
+    assert result.relation_disposition.qualifying_facts == ()
+    assert result.should_block is False
+
+
+@pytest.mark.parametrize(
+    ("target_path", "target_source"),
+    (
+        (
+            "Knowledge Base/Notes/Other/plain.md",
+            _source(title="Plain", page_type=None, project=None),
+        ),
+        (
+            "Knowledge Base/Notes/Patterns/inactive.md",
+            _source(title="Inactive", page_type="pattern", status="draft"),
+        ),
+    ),
+)
+def test_body_wikilink_to_non_connectable_or_inactive_page_does_not_connect(
+    tmp_path: Path,
+    target_path: str,
+    target_source: str,
+) -> None:
+    target = _state(tmp_path, target_path, target_source)
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(body=_OBS + f"Points at [[{target_path.removesuffix('.md')}]].\n"),
+    )
+
+    result = _disposition(tmp_path, page, target)
+
+    assert target.path not in _corpus(tmp_path, page, target).connectable_target_paths
+    assert result.relation_disposition.satisfied is False
+
+
+def test_ambiguous_body_wikilink_does_not_connect(tmp_path: Path) -> None:
+    first = _target(tmp_path)
+    second = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Research/atlas/target.md",
+        _source(title="Other target", page_type="research-note"),
+    )
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(body=_OBS + "Points at [[target]].\n"),
+    )
+
+    result = _disposition(tmp_path, page, first, second)
+
+    assert result.relation_disposition.satisfied is False
+
+
+def test_self_body_wikilink_does_not_connect(tmp_path: Path) -> None:
+    page = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(
+            body=(
+                _OBS
+                + "Points back to [[Knowledge Base/Notes/Insights/page]].\n"
+            )
+        ),
+    )
+    target = _target(tmp_path)
+
+    result = _disposition(tmp_path, page, target)
+
+    assert page.path in _corpus(tmp_path, page, target).connectable_target_paths
     assert result.relation_disposition.satisfied is False
 
 

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -819,7 +819,7 @@ def test_evaluate_fails_closed_when_before_corpus_does_not_match_before_state(
         if finding.code == "unregistered_relation"
     ]
     assert len(unregistered) == 1
-    assert unregistered[0].severity == "error"
+    assert unregistered[0].severity == "warning"
 
 
 def test_outside_kb_pages_remain_resolvable_but_never_governed(
@@ -1066,6 +1066,99 @@ def test_project_scoped_relation_requires_an_attached_authored_project(
     assert authored.projects == ()
     assert not qualified.qualifies
     assert "scope_violation" in qualified.reasons
+
+
+@pytest.mark.parametrize(
+    ("extensions", "raw_relation", "finding_code"),
+    (
+        (
+            {
+                "science.current": {
+                    "parent": "supports",
+                    "description": "Current relation",
+                },
+                "science.old": {
+                    "parent": "supports",
+                    "description": "Deprecated relation",
+                    "status": "deprecated",
+                    "replaced_by": "science.current",
+                },
+            },
+            "science.old",
+            "inactive_relation",
+        ),
+        (
+            {
+                "science.scoped": {
+                    "parent": "supports",
+                    "description": "Project-scoped relation",
+                    "scope": {"projects": ["alpha"]},
+                }
+            },
+            "science.scoped",
+            "scope_violation",
+        ),
+    ),
+)
+def test_governed_relation_registry_violations_remain_blocking_errors(
+    tmp_path: Path,
+    extensions: dict,
+    raw_relation: str,
+    finding_code: str,
+) -> None:
+    registry = relation_registry.load_registry(
+        proposal={"schema_version": 1, "extensions": extensions}
+    )
+    target = _state(
+        tmp_path,
+        "Knowledge Base/Notes/Patterns/target.md",
+        _source(title="Target", page_type="pattern", project="alpha"),
+    )
+    page = semantic_contract.build_page_state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(
+            project="beta",
+            body=(
+                "## Observations\n\n"
+                "- [constraint] Keep the boundary explicit.\n\n"
+                "## Relations\n"
+                "- cites [[Knowledge Base/Notes/Patterns/target]]\n"
+                f"- {raw_relation} [[Knowledge Base/Notes/Patterns/target]]\n"
+            ),
+        ),
+        relation_registry=registry,
+        language_registry=semantic_language_registry.core_registry(),
+        review_fingerprint="review-v1",
+    )
+    before_corpus = semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        (target,),
+        registry=registry,
+        identity_census=_identity_census(target),
+    )
+    after_corpus = semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        (page, target),
+        registry=registry,
+        identity_census=_identity_census(page, target),
+    )
+
+    result = _evaluate(
+        before=None,
+        after=page,
+        before_corpus=before_corpus,
+        after_corpus=after_corpus,
+        operation="create",
+    )
+
+    finding = next(
+        finding for finding in result.findings if finding.code == finding_code
+    )
+    assert finding.severity == "error"
+    assert result.relation_disposition.satisfied is True
+    assert result.relation_disposition.qualifying_signal == "connectivity"
+    assert result.should_block is True
 
 
 def test_relation_scope_uses_graph_file_target_kind_and_preserves_raw_alias(


### PR DESCRIPTION
## Summary

Completes the three note-connectivity follow-ups left open by PR #369, each as its own OpenSpec change and branch commit.

- resolve outbound body wikilinks through the existing connectivity lane using normalized path membership, without constructing per-link relation facts
- distinguish deliberate forward references from definitely broken wikilinks while keeping unresolved targets non-qualifying
- surface unregistered relation vocabulary in public write feedback and propose recurring labels for reviewed promotion

## Why

PR #369 established the typed and connectivity relation-disposition lanes, but body links, forward-reference reporting, and vocabulary promotion still needed their specified follow-ups. The body-link implementation deliberately avoids the reverted per-link `RelationFact` design that breached the 8k semantic-write latency gate.

Unregistered relation observations are advisory at write time only when another governed connection independently satisfies disposition. They remain rejected by both qualification predicates, so an unknown-only relation still blocks.

## Validation

- `uv run python -m pytest -q tests/test_semantic_connectivity_lane.py tests/test_semantic_contract.py tests/test_audit.py tests/test_note.py tests/test_memory_schema.py tests/test_relation_registry.py::test_save_is_atomic_and_expected_hash_guarded tests/test_relation_registry.py::test_observed_relation_cannot_be_deleted` — 227 passed
- `uvx ruff check . --select F` — clean
- strict OpenSpec validation — all three changes valid
- same-session Task 1 comparator: 8k commit median 383.1 ms; 2k→8k scaling 2.73x
- independent reviewer and verifier passes, including public `note()` feedback, unknown-only blocking, self-link rejection, ambiguity, and path-containment regressions

Linux CI is the authority for the full suite, governance-overhead gate, and exact 2k/8k semantic-write latency job.
