### PR TITLE
fix(hosted): atomically label bound volumes

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -152,12 +152,6 @@ class KubernetesVolumeAdapter:
         identity_keys = set(metadata.kubernetes_annotations)
         if identity_keys.intersection(annotations):
             _require_annotations(annotations, metadata)
-        else:
-            await asyncio.to_thread(
-                self._core.patch_persistent_volume,
-                pv_name,
-                {"metadata": {"annotations": metadata.kubernetes_annotations}},
-            )
         pv_envelope = str(annotations.get("exomem.io/recovery-envelope", ""))
         if self._identity_verifier is not None and pv_envelope:
             try:

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -79,6 +79,7 @@ class _KubernetesCore:
         self.created_pvcs: list[tuple[str, dict[str, object]]] = []
         self.deleted_pvcs: list[tuple[str, str]] = []
         self.deleted_pvs: list[str] = []
+        self.persistent_volume_patches: list[tuple[str, dict[str, object]]] = []
 
     def read_namespaced_persistent_volume_claim(self, name: str, namespace: str):
         assert name.endswith("-data")
@@ -95,6 +96,7 @@ class _KubernetesCore:
 
     def patch_persistent_volume(self, name: str, body: dict[str, object]):
         assert name == "pv-alpha"
+        self.persistent_volume_patches.append((name, body))
         self.pv.metadata.annotations.update(body["metadata"]["annotations"])
 
     def create_persistent_volume(self, body: dict[str, object]):
@@ -123,7 +125,7 @@ class _ApiConflict(Exception):
 
 
 @pytest.mark.asyncio
-async def test_kubernetes_adapter_discovers_csi_handle_tags_pv_and_rebinds_original() -> None:
+async def test_kubernetes_adapter_discovers_csi_handle_then_labels_with_full_identity() -> None:
     metadata = _metadata()
     core = _KubernetesCore(metadata)
     adapter = KubernetesVolumeAdapter(
@@ -136,7 +138,23 @@ async def test_kubernetes_adapter_discovers_csi_handle_tags_pv_and_rebinds_origi
     recorded = await adapter.discover_bound_volume(metadata)
 
     assert recorded == RecordedVolume("42", "pv-alpha", "fsn1", metadata)
-    assert core.pv.metadata.annotations == metadata.kubernetes_annotations
+    assert core.pv.metadata.annotations == {}
+    assert core.persistent_volume_patches == []
+
+    await adapter.label_bound_volume(recorded, "sealed-pv-envelope")
+    assert core.persistent_volume_patches == [
+        (
+            "pv-alpha",
+            {
+                "metadata": {
+                    "annotations": {
+                        **metadata.kubernetes_annotations,
+                        "exomem.io/recovery-envelope": "sealed-pv-envelope",
+                    }
+                }
+            },
+        )
+    ]
 
     await adapter.create_static_binding(recorded)
     assert core.created_pvs[0]["spec"]["csi"]["volumeHandle"] == "42"

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -1691,6 +1691,58 @@ def test_exact_k3s_scopes_privileged_volume_and_deletion_mutations(k3s: str) -> 
         check=False,
     )
     assert valid_pv.returncode == 0, valid_pv.stderr
+
+    identityless_pv = copy.deepcopy(pv)
+    identityless_pv["metadata"] = {
+        "name": "pvc-identityless-transition",
+        "labels": {"exomem.io/resource-name": namespace},
+    }
+    identityless_pv["spec"]["csi"]["volumeHandle"] = "5678"
+    _kubectl(k3s, ["apply", "--filename=-"], documents=[identityless_pv])
+
+    partial_identity_patch = _kubectl(
+        k3s,
+        [
+            "patch",
+            "persistentvolume",
+            "pvc-identityless-transition",
+            "--type=merge",
+            "--patch",
+            json.dumps(
+                {
+                    "metadata": {
+                        "annotations": {
+                            key: value
+                            for key, value in identity.items()
+                            if key != "exomem.io/recovery-envelope"
+                        }
+                    }
+                }
+            ),
+            "--dry-run=server",
+            f"--as={volume_user}",
+        ],
+        check=False,
+    )
+    assert partial_identity_patch.returncode != 0
+    assert "immutable authenticated hosted PV identity" in partial_identity_patch.stderr
+
+    full_identity_patch = _kubectl(
+        k3s,
+        [
+            "patch",
+            "persistentvolume",
+            "pvc-identityless-transition",
+            "--type=merge",
+            "--patch",
+            json.dumps({"metadata": {"annotations": identity}}),
+            "--dry-run=server",
+            f"--as={volume_user}",
+        ],
+        check=False,
+    )
+    assert full_identity_patch.returncode == 0, full_identity_patch.stderr
+
     wrong_secret_pv = copy.deepcopy(pv)
     wrong_secret_pv["spec"]["csi"]["nodePublishSecretRef"]["name"] = "foreign-key"
     denied_pv = _kubectl(


### PR DESCRIPTION
## What changed

- make discovery of an identity-less CSI-created PV read-only
- let the existing volume-label operation perform the first atomic base-identity plus authenticated recovery-envelope patch
- add unit and exact-K3s admission regressions for the real transition

## Why

The live volume worker attempted a base-identity-only PV update before the recovery envelope existed. The fail-closed admission policy correctly rejected that partial identity with Kubernetes 422, so provisioning could never advance past volume registration.

This keeps the policy strict and fixes the mutation order instead.

## Verification

- `uv run --project infra/provisioner pytest infra/provisioner/tests/test_provider_adapters.py -q` — 15 passed
- exact K3s admission transition — 1 passed
- provisioner and root Ruff checks — clean
- `git diff --check` — clean
- independent review — APPROVE, no findings
