### PR TITLE
fix(hosted): install release proof dependencies

### DIFF
--- a/.github/workflows/hosted-infrastructure.yml
+++ b/.github/workflows/hosted-infrastructure.yml
@@ -209,6 +209,8 @@ jobs:
       attestations: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           version: ${{ env.UV_VERSION }}

--- a/.github/workflows/hosted-infrastructure.yml
+++ b/.github/workflows/hosted-infrastructure.yml
@@ -209,6 +209,11 @@ jobs:
       attestations: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Install pinned ORAS for locked provisioner evidence discovery
         run: |
@@ -226,17 +231,17 @@ jobs:
           DEPLOYMENT_PHASE: ${{ inputs.deployment_phase }}
         run: |
           test -f "$DEPLOYMENT_LOCK_PAIR" || { echo "canonical deployment lock pair is not committed" >&2; exit 2; }
-          python3 infra/scripts/prepare_hosted_release.py \
+          uv run --frozen python infra/scripts/prepare_hosted_release.py \
             --lock-pair "$DEPLOYMENT_LOCK_PAIR" \
             --phase "$DEPLOYMENT_PHASE" \
             --control-hostname control.example.invalid \
             --transfer-hostname transfer.example.invalid \
             --values-output /tmp/exomem-hosted-release-values.json
           PROVISIONER_IMAGE="$(python3 -c 'import json; print(json.load(open("/tmp/exomem-hosted-release-values.json"))["provisioner"]["deploymentLockJson"] )' | python3 -c 'import json, sys; print(json.load(sys.stdin)["components"]["provisioner"]["image"])')"
-          python3 infra/scripts/verify_hosted_release.py \
+          uv run --frozen python infra/scripts/verify_hosted_release.py \
             --phase "$DEPLOYMENT_PHASE" \
             --repository .
-          python3 infra/scripts/verify_provisioner_image.py \
+          uv run --frozen python infra/scripts/verify_provisioner_image.py \
             --image "$PROVISIONER_IMAGE" \
             --require-published
 

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -213,6 +213,12 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
     release_job = parsed["jobs"]["release-proof"]
     assert release_job["needs"] == "static"
     assert "inputs.release_proof" in release_job["if"]
+    release_checkout = next(
+        step
+        for step in release_job["steps"]
+        if step.get("uses", "").startswith("actions/checkout@")
+    )
+    assert release_checkout.get("with") == {"fetch-depth": 0}
     release_uv_steps = [
         step
         for step in release_job["steps"]

--- a/tests/test_hosted_platform_operations.py
+++ b/tests/test_hosted_platform_operations.py
@@ -213,6 +213,32 @@ def test_hosted_ci_wires_every_static_security_gate() -> None:
     release_job = parsed["jobs"]["release-proof"]
     assert release_job["needs"] == "static"
     assert "inputs.release_proof" in release_job["if"]
+    release_uv_steps = [
+        step
+        for step in release_job["steps"]
+        if step.get("uses", "").startswith("astral-sh/setup-uv@")
+    ]
+    assert len(release_uv_steps) == 1
+    assert release_uv_steps[0] == {
+        "uses": "astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86",
+        "with": {
+            "version": "${{ env.UV_VERSION }}",
+            "python-version": "${{ env.PYTHON_VERSION }}",
+            "enable-cache": True,
+        },
+    }
+    release_proof_step = next(
+        step
+        for step in release_job["steps"]
+        if step.get("name")
+        == "Derive and prove both published images from the reviewed phase lock"
+    )
+    for script in (
+        "prepare_hosted_release.py",
+        "verify_hosted_release.py",
+        "verify_provisioner_image.py",
+    ):
+        assert f"uv run --frozen python infra/scripts/{script}" in release_proof_step["run"]
     blackbox_job = parsed["jobs"]["external-blackbox"]
     assert blackbox_job["if"] == (
         "github.event_name == 'schedule' || "


### PR DESCRIPTION
## What changed

- install the repository-pinned uv/Python toolchain in the published release-proof job
- check out full Git history for the source-closure proof
- execute the three proof scripts through `uv run --frozen`
- pin both dependency and Git-history boundaries with workflow contract regression tests

## Why

Run 31488192887 reached the reviewed v0.44 promotion proof but failed before artifact verification because bare `python3` could not import the provisioner wire models (`pydantic` was absent). GitHub jobs are isolated, and the same job also used a shallow checkout that the source-closure verifier intentionally rejects.

## Verification

- red: dependency test failed with zero setup-uv steps
- red: history test failed with no `fetch-depth: 0`
- green: 64 hosted operations/uv-lock tests passed
- exact online expand verifier: `hosted deployment lock verified`
- `git diff --check` passed