### PR TITLE
fix(hosted): label recovered PV atomically

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -191,7 +191,12 @@ class KubernetesVolumeAdapter:
         await asyncio.to_thread(
             self._core.patch_persistent_volume,
             recorded.pv_name,
-            {"metadata": {"annotations": annotations}},
+            {
+                "metadata": {
+                    "labels": {"exomem.io/resource-name": recorded.metadata.resource_name},
+                    "annotations": annotations,
+                }
+            },
         )
 
     @staticmethod

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -147,6 +147,9 @@ async def test_kubernetes_adapter_discovers_csi_handle_then_labels_with_full_ide
             "pv-alpha",
             {
                 "metadata": {
+                    "labels": {
+                        "exomem.io/resource-name": metadata.resource_name,
+                    },
                     "annotations": {
                         **metadata.kubernetes_annotations,
                         "exomem.io/recovery-envelope": "sealed-pv-envelope",

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -1695,7 +1695,6 @@ def test_exact_k3s_scopes_privileged_volume_and_deletion_mutations(k3s: str) -> 
     identityless_pv = copy.deepcopy(pv)
     identityless_pv["metadata"] = {
         "name": "pvc-identityless-transition",
-        "labels": {"exomem.io/resource-name": namespace},
     }
     identityless_pv["spec"]["csi"]["volumeHandle"] = "5678"
     _kubectl(k3s, ["apply", "--filename=-"], documents=[identityless_pv])
@@ -1727,7 +1726,7 @@ def test_exact_k3s_scopes_privileged_volume_and_deletion_mutations(k3s: str) -> 
     assert partial_identity_patch.returncode != 0
     assert "immutable authenticated hosted PV identity" in partial_identity_patch.stderr
 
-    full_identity_patch = _kubectl(
+    full_identity_without_label_patch = _kubectl(
         k3s,
         [
             "patch",
@@ -1736,6 +1735,30 @@ def test_exact_k3s_scopes_privileged_volume_and_deletion_mutations(k3s: str) -> 
             "--type=merge",
             "--patch",
             json.dumps({"metadata": {"annotations": identity}}),
+            "--dry-run=server",
+            f"--as={volume_user}",
+        ],
+        check=False,
+    )
+    assert full_identity_without_label_patch.returncode != 0
+    assert "exact encrypted 10 GiB Retain HCloud PV specification" in full_identity_without_label_patch.stderr
+
+    full_identity_patch = _kubectl(
+        k3s,
+        [
+            "patch",
+            "persistentvolume",
+            "pvc-identityless-transition",
+            "--type=merge",
+            "--patch",
+            json.dumps(
+                {
+                    "metadata": {
+                        "labels": {"exomem.io/resource-name": namespace},
+                        "annotations": identity,
+                    }
+                }
+            ),
             "--dry-run=server",
             f"--as={volume_user}",
         ],


### PR DESCRIPTION
## Why

A real CSI-created hosted PV has no labels. The volume worker now makes its first and only PV mutation atomically add the required `exomem.io/resource-name` label together with the full authenticated recovery identity; this closes the live Kubernetes 422 without relaxing admission.

## Safety

- discovery remains read-only
- partial identity remains denied
- full identity without the resource label remains denied
- only the exact label plus all eight annotations is admitted

## Verification

- provider adapter suite: 15 passed
- exact K3s admission transition: 1 passed, 4 deselected
- provisioner Ruff: passed
- root test Ruff: passed
- provisioner package build: passed
- `git diff --check`: passed
- independent review: APPROVE, no findings