### PR TITLE
fix(hosted): allow provisioner cell health ingress

### DIFF
--- a/infra/helm/cell/templates/network-policy.yaml
+++ b/infra/helm/cell/templates/network-policy.yaml
@@ -49,4 +49,14 @@ spec:
       ports:
         - protocol: TCP
           port: 8765
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: exomem-platform
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: exomem-provisioner-worker
+      ports:
+        - protocol: TCP
+          port: 8765
 {{- end }}

--- a/infra/helm/platform/templates/provisioner-scope-admission.yaml
+++ b/infra/helm/platform/templates/provisioner-scope-admission.yaml
@@ -192,7 +192,7 @@ spec:
                 'exomem.io/cell': request.namespace
               } &&
               variables.target.spec.policyTypes == ['Ingress'] &&
-              size(variables.target.spec.ingress) == 2 &&
+              size(variables.target.spec.ingress) == 3 &&
               size(variables.target.spec.ingress[0].from) == 1 &&
               variables.target.spec.ingress[0].from[0].namespaceSelector.matchLabels == {
                 'kubernetes.io/metadata.name': '{{ .Release.Namespace }}'
@@ -214,6 +214,16 @@ spec:
               size(variables.target.spec.ingress[1].ports) == 1 &&
               variables.target.spec.ingress[1].ports[0].protocol == 'TCP' &&
               variables.target.spec.ingress[1].ports[0].port == 8765 &&
+              size(variables.target.spec.ingress[2].from) == 1 &&
+              variables.target.spec.ingress[2].from[0].namespaceSelector.matchLabels == {
+                'kubernetes.io/metadata.name': '{{ .Release.Namespace }}'
+              } &&
+              variables.target.spec.ingress[2].from[0].podSelector.matchLabels == {
+                'app.kubernetes.io/name': 'exomem-provisioner-worker'
+              } &&
+              size(variables.target.spec.ingress[2].ports) == 1 &&
+              variables.target.spec.ingress[2].ports[0].protocol == 'TCP' &&
+              variables.target.spec.ingress[2].ports[0].port == 8765 &&
               !has(variables.target.spec.egress)))
       message: The hosted provisioner may manage only the exact default-deny and platform ingress policies.
     - expression: >-
@@ -501,7 +511,8 @@ spec:
                 'exomem.io/cell': variables.resourceName
               } &&
               variables.target.spec.policyTypes == ['Ingress'] &&
-              size(variables.target.spec.ingress) == 2 &&
+              size(variables.target.spec.ingress) == 3 &&
+              size(variables.target.spec.ingress[0].from) == 1 &&
               variables.target.spec.ingress[0].from[0].namespaceSelector.matchLabels ==
                 {'kubernetes.io/metadata.name': '{{ .Release.Namespace }}'} &&
               variables.target.spec.ingress[0].from[0].podSelector.matchLabels == {
@@ -510,6 +521,7 @@ spec:
               size(variables.target.spec.ingress[0].ports) == 1 &&
               variables.target.spec.ingress[0].ports[0].protocol == 'TCP' &&
               variables.target.spec.ingress[0].ports[0].port == 8765 &&
+              size(variables.target.spec.ingress[1].from) == 1 &&
               variables.target.spec.ingress[1].from[0].namespaceSelector.matchLabels ==
                 {'kubernetes.io/metadata.name': '{{ .Release.Namespace }}'} &&
               variables.target.spec.ingress[1].from[0].podSelector.matchLabels ==
@@ -517,6 +529,14 @@ spec:
               size(variables.target.spec.ingress[1].ports) == 1 &&
               variables.target.spec.ingress[1].ports[0].protocol == 'TCP' &&
               variables.target.spec.ingress[1].ports[0].port == 8765 &&
+              size(variables.target.spec.ingress[2].from) == 1 &&
+              variables.target.spec.ingress[2].from[0].namespaceSelector.matchLabels ==
+                {'kubernetes.io/metadata.name': '{{ .Release.Namespace }}'} &&
+              variables.target.spec.ingress[2].from[0].podSelector.matchLabels ==
+                {'app.kubernetes.io/name': 'exomem-provisioner-worker'} &&
+              size(variables.target.spec.ingress[2].ports) == 1 &&
+              variables.target.spec.ingress[2].ports[0].protocol == 'TCP' &&
+              variables.target.spec.ingress[2].ports[0].port == 8765 &&
               !has(variables.target.spec.egress))
           : (variables.target.spec.podSelector.matchLabels == variables.labels &&
           variables.target.spec.policyTypes == ['Egress'] &&

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1666,6 +1666,18 @@ def test_platform_renders_luks_retain_storage_and_exact_schedule_contract() -> N
         not in provisioner_scope_text
     )
     assert "NetworkPolicy deletion is reserved for namespace destruction" in provisioner_scope_text
+    action_scope = _find(documents, "ValidatingAdmissionPolicy", "exomem-durability-actions-scope")
+    for scope in (provisioner_scope, action_scope):
+        scope_text = json.dumps(scope)
+        assert "size(variables.target.spec.ingress) == 3" in scope_text
+        for index in range(3):
+            assert f"size(variables.target.spec.ingress[{index}].from) == 1" in scope_text
+        assert "variables.target.spec.ingress[2].from[0].namespaceSelector.matchLabels" in scope_text
+        assert "variables.target.spec.ingress[2].from[0].podSelector.matchLabels" in scope_text
+        assert "'app.kubernetes.io/name': 'exomem-provisioner-worker'" in scope_text
+        assert "size(variables.target.spec.ingress[2].ports) == 1" in scope_text
+        assert "variables.target.spec.ingress[2].ports[0].protocol == 'TCP'" in scope_text
+        assert "variables.target.spec.ingress[2].ports[0].port == 8765" in scope_text
 
     contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
     cronjobs = {
@@ -2048,6 +2060,19 @@ def test_cell_chart_renders_separate_privileged_init_and_restricted_serving_mode
                         },
                         "podSelector": {
                             "matchLabels": {"app.kubernetes.io/name": "exomem-durability-actions"}
+                        },
+                    }
+                ],
+                "ports": [{"protocol": "TCP", "port": 8765}],
+            },
+            {
+                "from": [
+                    {
+                        "namespaceSelector": {
+                            "matchLabels": {"kubernetes.io/metadata.name": "exomem-platform"}
+                        },
+                        "podSelector": {
+                            "matchLabels": {"app.kubernetes.io/name": "exomem-provisioner-worker"}
                         },
                     }
                 ],

--- a/tests/test_hosted_k3s_admission.py
+++ b/tests/test_hosted_k3s_admission.py
@@ -947,6 +947,61 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
         },
         "spec": {"podSelector": {}, "policyTypes": ["Ingress", "Egress"]},
     }
+    ingress_policy = {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": namespace + "-traefik-ingress",
+            "namespace": namespace,
+            "annotations": identity,
+            "labels": labels,
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {
+                    "app.kubernetes.io/name": "exomem-cell",
+                    "exomem.io/cell": namespace,
+                }
+            },
+            "policyTypes": ["Ingress"],
+            "ingress": [
+                {
+                    "from": [{
+                        "namespaceSelector": {"matchLabels": {
+                            "kubernetes.io/metadata.name": "exomem-platform"
+                        }},
+                        "podSelector": {"matchLabels": {
+                            "app.kubernetes.io/name": "traefik",
+                            "exomem.io/ingress": "traefik",
+                        }},
+                    }],
+                    "ports": [{"protocol": "TCP", "port": 8765}],
+                },
+                {
+                    "from": [{
+                        "namespaceSelector": {"matchLabels": {
+                            "kubernetes.io/metadata.name": "exomem-platform"
+                        }},
+                        "podSelector": {"matchLabels": {
+                            "app.kubernetes.io/name": "exomem-durability-actions"
+                        }},
+                    }],
+                    "ports": [{"protocol": "TCP", "port": 8765}],
+                },
+                {
+                    "from": [{
+                        "namespaceSelector": {"matchLabels": {
+                            "kubernetes.io/metadata.name": "exomem-platform"
+                        }},
+                        "podSelector": {"matchLabels": {
+                            "app.kubernetes.io/name": "exomem-provisioner-worker"
+                        }},
+                    }],
+                    "ports": [{"protocol": "TCP", "port": 8765}],
+                },
+            ],
+        },
+    }
     route = {
         "apiVersion": "traefik.io/v1alpha1",
         "kind": "IngressRoute",
@@ -971,6 +1026,27 @@ def test_exact_k3s_api_admits_only_the_rendered_tenant_shapes(k3s: str) -> None:
         },
     }
     _kubectl(k3s, ["apply", "--filename=-"], documents=[service, network_policy, route])
+
+    admitted_ingress = _kubectl(
+        k3s,
+        ["apply", "--dry-run=server", "--filename=-", f"--as={routine_username}"],
+        documents=[ingress_policy],
+        check=False,
+    )
+    assert admitted_ingress.returncode == 0, admitted_ingress.stderr
+
+    forged_ingress = copy.deepcopy(ingress_policy)
+    forged_ingress["spec"]["ingress"][2]["from"][0]["podSelector"]["matchLabels"] = {
+        "app.kubernetes.io/name": "foreign-worker"
+    }
+    forged_admission = _kubectl(
+        k3s,
+        ["apply", "--dry-run=server", "--filename=-", f"--as={routine_username}"],
+        documents=[forged_ingress],
+        check=False,
+    )
+    assert forged_admission.returncode != 0
+    assert "exact default-deny and platform ingress policies" in forged_admission.stderr
 
     retargeted_service = copy.deepcopy(service)
     retargeted_service["spec"]["selector"]["exomem.io/cell"] = "exo-foreign-cell"


### PR DESCRIPTION
## What changed

- allow the provisioner worker to reach the private cell health endpoint through the tenant default-deny policy
- update both fail-closed platform admission contracts to require the exact third ingress peer
- add Helm and real-K3s regressions for the exact policy and forged-peer rejection

## Why

The first Hosted tenant reached an initialized, Ready StatefulSet, but the provisioner worker could not call the private health endpoint. The cell NetworkPolicy admitted Traefik and durability actions only, while the provisioner uses the direct service path. This caused the worker to crash-loop and left the provider operation parked at initialized.

## Verification

- focused Helm contracts: 3 passed
- full Hosted Helm contracts: 37 passed
- exact K3s provisioner admission test: passed
- Ruff: passed
- strict Helm lint for platform and both cell values: passed
- git diff --check: passed
- independent review: APPROVE, no findings