### PR TITLE
fix(hosted): accept successful init job retries

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -196,10 +196,14 @@ class KubernetesProviderRegistry:
             getattr(item, "type", None) == "Complete" and getattr(item, "status", None) == "True"
             for item in conditions
         )
-        init_failed = any(
-            getattr(item, "type", None) == "Failed" and getattr(item, "status", None) == "True"
-            for item in conditions
-        ) or bool(getattr(getattr(init_job, "status", None), "failed", 0))
+        init_failed = not init_complete and (
+            any(
+                getattr(item, "type", None) == "Failed"
+                and getattr(item, "status", None) == "True"
+                for item in conditions
+            )
+            or bool(getattr(getattr(init_job, "status", None), "failed", 0))
+        )
         stateful_set = await exists(
             self._apps.read_namespaced_stateful_set,
             current.resource_name,

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -741,6 +741,16 @@ async def test_registry_requires_deployed_helm_record_in_addition_to_pvc() -> No
         (
             SimpleNamespace(
                 status=SimpleNamespace(
+                    conditions=(SimpleNamespace(type="Complete", status="True"),), failed=1
+                )
+            ),
+            True,
+            True,
+            False,
+        ),
+        (
+            SimpleNamespace(
+                status=SimpleNamespace(
                     conditions=(SimpleNamespace(type="Failed", status="True"),), failed=1
                 )
             ),


### PR DESCRIPTION
## What changed

- Treat a Kubernetes init Job with terminal `Complete=True` as successful even when `status.failed` records an earlier retry.
- Preserve terminal failure behavior for non-complete Jobs with either `Failed=True` or a positive failed count.
- Add a production-shaped regression for one failed Pod attempt followed by a successful attempt.

## Why

The first fresh Hosted tenant completed its init Job after one retry, but the provisioner classified the historical failed attempt as a terminal metadata conflict. That prevented the existing operation from advancing to serving despite Kubernetes reporting the Job complete.

## Verification

- `uv run --project infra/provisioner pytest -q infra/provisioner/tests` — 429 passed, 15 skipped
- `uv run --project infra/provisioner ruff check infra/provisioner/src infra/provisioner/tests`
- `git diff --check`
- Independent review: approved with no findings
