### PR TITLE
test: stabilize file watcher drift resolver assertion

### DIFF
--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1432,7 +1432,9 @@ def test_reconcile_drift_evicts_resolver_without_checkpoint_leapfrog(
     # Prime the process-shared resolver at the current freshness triple.
     r1 = find_module._get_query_resolver(vault)
 
-    target = next(find_module._walk_md(vault / "Knowledge Base"))
+    # `index` is duplicated below Knowledge Base/; bare-link normalization
+    # deterministically promotes the KB-root path before stem matching.
+    target = vault / "Knowledge Base" / "index.md"
     future = time.time() + 10_000
     os.utime(target, (future, future))
 


### PR DESCRIPTION
## Why

The release PR CI twice exposed a deterministic test bug: the fixture contains both Knowledge Base/index.md and Knowledge Base/Sources/index.md, while the test selected an arbitrary first filesystem entry but expected bare-link resolution to return that entry. The resolver correctly gives the KB-root index precedence.

## Change

Select the canonical KB-root index explicitly in the drift/rebuild assertion. Product behavior is unchanged.

## Verification

- Focused test: 20/20 passes
- Full test_file_watcher.py file: 58 passed
- Ruff: clean
- git diff --check: clean
- Independent review: APPROVE, no findings