### PR TITLE
fix(hosted): recover init retry operation

### DIFF
--- a/docs/runbooks/hosted/cell.md
+++ b/docs/runbooks/hosted/cell.md
@@ -90,6 +90,58 @@ the signing seed.
 Retry through the same Substrate endpoint and idempotency key. A pending result
 is healthy progress; never invent a new key to bypass it.
 
+## Init-retry false-negative recovery
+
+This is the only manual provider-operation recovery. Use it only for the
+recorded `PROVISION / ERROR / failed /
+PROVISIONER_PROVIDER_METADATA_CONFLICT` init-retry false-negative, after the
+selected signed provisioner image contains the recovery command. It is not an
+API action, SQL procedure, or a way to edit any other operation state.
+
+Keep Substrate reconciliation suspended. Capture the current controller state,
+suspend every database-mutating reconcile CronJob, drain its child Jobs, and
+scale the API, routine worker, and volume worker to zero. Leave the receipt
+collector running. Stop if any migration/bootstrap process or other database
+consumer remains, or if the collector cannot provide a fresh signed receipt.
+
+Supply the confidential internal operation ID only through a current-user-owned
+regular mode-`0600` file. Do not put it in a shell history, command argument,
+manifest, log, receipt, or ticket.
+
+```bash
+umask 077
+recovery_identity=/secure/operator/recovery-operation-id
+test -f "$recovery_identity" && test ! -L "$recovery_identity"
+test "$(stat -c %u "$recovery_identity")" = "$(id -u)"
+test "$(stat -c %a "$recovery_identity")" = 600
+```
+
+In an explicitly launched, non-network-published operator container using the
+selected provisioner image and its existing provisioner configuration, run the
+fixed sequence below. Preserve only the content-free JSON output and receipt
+digest as operator evidence.
+
+```bash
+exomem-provisioner-recover-init-retry preflight --identity-file "$recovery_identity"
+exomem-provisioner-recover-init-retry reopen --identity-file "$recovery_identity"
+exomem-provisioner-recover-init-retry verify-receipt --identity-file "$recovery_identity"
+```
+
+Any refusal, conflict, resource drift, receipt-verification failure, or timeout
+is a stop condition. Do not retry `reopen` after a refusal and never reverse the
+checkpoint manually.
+
+After a committed receipt, restore only the routine worker and bounded-poll the
+content-free `inspect` result for at most ten minutes until `FINAL / complete`.
+Stop on terminal error or unexpected resource mutation. Restore the API only
+after provider finalization, run one manual Substrate reconcile Job at a time
+until the original control operation succeeds and the cell is ready, then
+restore the volume worker/durability state and scheduled reconciliation last.
+
+```bash
+exomem-provisioner-recover-init-retry inspect --identity-file "$recovery_identity"
+```
+
 For direct operator diagnosis, use the authenticated internal API and the exact
 mode-`0600` health request captured by the control plane. It contains the full
 target identity and no human identifier:

--- a/docs/superpowers/plans/2026-08-11-hosted-init-retry-operation-recovery-plan.md
+++ b/docs/superpowers/plans/2026-08-11-hosted-init-retry-operation-recovery-plan.md
@@ -4,11 +4,14 @@ Source of truth: `docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-
 
 ## Scope
 
-Implement one operator-only provisioner command that can recover only the proven init-retry false-negative. Do not add an HTTP endpoint, migration, generic operation mutation API, caller-selected state/checkpoint/error, or raw-SQL runbook. Preserve normal submit/claim/fail behavior.
+Implement one operator-only provisioner command that can recover only the proven init-retry false-negative. Add only the migration/model needed for an immutable transactional receipt. Do not add an HTTP endpoint, generic operation mutation API, caller-selected state/checkpoint/error, filesystem receipt, or raw-SQL runbook. Preserve normal submit/claim/fail behavior.
 
 Expected production files:
 
 - new `infra/provisioner/src/exomem_provisioner/operation_recovery.py`;
+- `infra/provisioner/src/exomem_provisioner/models.py` and `database.py` for the immutable receipt model/revision;
+- one new Alembic `0007` recovery-receipt migration;
+- shared live provider/adapter modules needed for one typed authenticated recovery observation;
 - `infra/provisioner/pyproject.toml` for one console entrypoint;
 - `infra/provisioner/Dockerfile` for build-time command smoke;
 - `infra/scripts/verify_provisioner_image.py` for immutable-image entrypoint proof;
@@ -27,7 +30,7 @@ Stop before expanding this allowlist.
 
 Add tests that import the recovery module before it exists and require:
 
-- modes exactly `preflight`, `reopen`, `inspect`, and `finalize-receipt`;
+- modes exactly `preflight`, `reopen`, `inspect`, and `verify-receipt`;
 - operation identity from stdin or a regular current-user-owned mode-`0600` file only;
 - refusal of identity in argv, symlinks, non-regular files, wrong ownership, broad permissions, empty input, multiple lines, and invalid UUIDs;
 - no environment, database URL, identifier, ciphertext, resource reference, envelope, DSN, or secret in stdout/stderr/errors;
@@ -45,7 +48,7 @@ Reuse `canonical_request_sha256`, the existing envelope purposes/codecs, model e
 - sorted resources and resource-reference digests;
 - capacity reservation;
 - live Kubernetes observation;
-- prepared/committed receipt payloads.
+- transactional receipt and live-observation payloads.
 
 Canonical hashing must use sorted compact JSON with explicit conversion for UUIDs, enums, datetimes, and nulls. Tests must prove field ordering cannot change hashes and secret-bearing fields are hashed rather than serialized into receipts or output.
 
@@ -54,7 +57,7 @@ Canonical hashing must use sorted compact JSON with explicit conversion for UUID
 Red-first PostgreSQL tests seed the exact historical operation shape, then independently mutate every predicate. The recovery service must:
 
 1. refuse SQLite;
-2. require the configured PostgreSQL role, schema, and sole Alembic head `0006_operation_wire_protocol`;
+2. require the configured PostgreSQL role, schema, and sole Alembic head `0007_operation_recovery_receipt`;
 3. acquire the database advisory transaction lock used by bootstrap/migration;
 4. resolve the confidential operation row without output;
 5. lock in repository order: tenant fence, operation, cell lock domain, capacity ledger/destructive fences/reservation, then resources;
@@ -71,39 +74,42 @@ The negative matrix must cover:
 - another pending/claimed tenant or cell operation;
 - cell lock or equal/newer destructive fence;
 - request decryption/hash/tenant/cell/operation/fence/caller-checkpoint/protocol/serve-mode mismatch;
+- failure of the same runtime-target compatibility check the normal worker applies to the deployed lock;
 - missing/duplicate/extra/wrong-kind resources, a route already present, cross-boundary metadata, reference-decryption failure, or digest mismatch;
 - missing/duplicate/released/mismatched reservation or non-null release fields.
 
 Every refusal asserts byte-for-byte database nonmutation.
 
-## Step 4: add exact live-observation validation
+## Step 4: add one shared exact live-observation boundary
 
-Reuse the production Kubernetes/provider observation boundary rather than adding a second metadata parser. Given only identities derived from the validated database snapshot, require:
+Extend the shared production Kubernetes/provider observation boundary with one typed, read-only recovery snapshot rather than adding a second metadata parser in the command. Reuse existing adapter identity/envelope checks. Given only identities derived from the validated database snapshot, require:
 
-- namespace, Helm release, PVC, and provider volume present and authenticated;
+- namespace, Helm release, PVC, bound PV, and provider volume present and authenticated;
 - live identities/fence match durable resource metadata;
 - PVC bound;
-- init Job present with `Complete=True` (historical failed count/condition allowed);
+- no Kubernetes object has `deletionTimestamp`, no provider volume is deleting, and no relevant finalizer transition is active;
+- init Job absent or authenticated/non-terminating; if present, running or `Complete=True` is allowed and Failed-only is refused;
 - runtime admission marker and routes absent.
 
-Tests cover absent/running/Failed-only Job, completed-after-retry Job, live identity/fence mismatch, unbound PVC, pre-existing runtime admission, and route presence. No Kubernetes object or identifier may enter public output/receipt.
+Query the same full same-tenant/cell resource scope and ordering used by `LiveLifecyclePlane.observe_operation()`. Require the target namespace is the sole namespace worker adoption can select and no older or foreign same-cell resource can redirect replay. Take two observations around the transaction boundary and require stable UID/resourceVersion plus non-terminating state.
 
-## Step 5: implement atomic prepared/final receipt handling
+Tests cover absent/running/Failed-only/completed-after-retry/terminating Job; terminating or replaced namespace/PVC/PV/release/provider volume; live identity/fence mismatch; unbound PVC; worker-adoption ambiguity; pre-existing runtime admission; and route presence. No Kubernetes object or identifier may enter public output or the receipt.
 
-Create a private receipt directory/file boundary that:
+## Step 5: add the immutable transactional receipt
 
-- rejects symlinked/non-owned/broad-permission directories and files;
-- uses exclusive creation for the prepared receipt;
-- writes canonical JSON, fsyncs file and parent directory;
-- contains only approved fixed fields/hashes/counts/booleans and a random nonce;
-- finalizes through a same-directory temporary file plus atomic rename and parent fsync;
-- never overwrites an unrelated or finalized receipt.
+Add migration `0007_operation_recovery_receipt` and its ORM model. The table is one-to-one with the operation and contains only:
 
-Tests inject failures at create/write/fsync/rename/parent-fsync boundaries. Before database commit, failures roll back. After a committed transition, finalization failure produces a fixed `receipt-finalization-required` result, and only `finalize-receipt` may finish the matching prepared receipt.
+- fixed schema/helper source identities and database timestamps;
+- old/new fixed state and checkpoint;
+- approved counts and booleans;
+- hashes of the old row, preserved fields, request/ciphertext, resources, reservation, tenant fence, both live observations, and committed row;
+- no tenant/cell/provider identifiers except the private operation foreign key needed for the one-to-one relationship, which is never emitted.
+
+Add database constraints and update/delete guards so committed receipts are append-only. Upgrade/downgrade tests prove exact schema. Insert the receipt in the same transaction as the operation CAS so commit, rollback, process death, pod loss, and lost acknowledgement can never split receipt from transition. A repeated command verifies and returns the existing content-free receipt digest.
 
 ## Step 6: implement the single CAS transition
 
-`reopen` repeats the full preflight under the same transaction, writes/fsyncs the prepared receipt, and runs one named-bind update. The WHERE clause includes the confidential row identity plus exact action/state/checkpoint/error, empty claim/result, provider/external identity and fence equality, prior request hash, claim generation, and prior update timestamp.
+`reopen` repeats the database preflight under locks, requires the second stable live observation, runs one named-bind operation update, and inserts the immutable receipt before commit. The WHERE clause includes the confidential row identity plus exact action/state/checkpoint/error, empty claim/result, provider/external identity and fence equality, prior request hash, claim generation, and prior update timestamp.
 
 Changed columns are exactly state, checkpoint, error, claim fields, finalized timestamp, available timestamp, and updated timestamp. The new values are fixed at `PENDING`, `volume-owned`, null terminal/claim fields, and database-clock timestamps.
 
@@ -114,7 +120,7 @@ Before commit, re-read and assert:
 - active reservation still exists;
 - result remains absent.
 
-Then commit and finalize the receipt. Tests cover CAS loss, concurrent second invocation, already-progressed operation, commit failure, receipt-finalization recovery, and exact changed-column/preserved-field sets.
+Then commit both changes. Tests cover CAS loss, concurrent second invocation, already-progressed operation, rollback, process termination or lost acknowledgement, existing receipt replay, and exact changed-column/preserved-field sets.
 
 ## Step 7: implement read-only inspect
 
@@ -124,7 +130,7 @@ Tests assert its output allowlist over every state and that terminal/final inspe
 
 ## Step 8: wire and prove the signed image
 
-Add `exomem-provisioner-recover-init-retry = "exomem_provisioner.operation_recovery:main"` to project scripts. Add a Docker build-time `--help` smoke. Add the command to `_ENTRYPOINTS` in `verify_provisioner_image.py`, then update image-distribution tests to require it and prove the entrypoint loads as callable from the immutable image.
+Add `exomem-provisioner-recover-init-retry = "exomem_provisioner.operation_recovery:main"` to project scripts. Add a Docker build-time `--help` smoke. Change the image verifier from a set of command names to an exact command-name → `module:function` mapping, assert each installed entrypoint value before loading it, and add a negative misrouting test.
 
 Do not add Kubernetes RBAC or a standing controller. Production invokes the command only in an explicitly launched, non-network-published operator context using the existing provisioner database/envelope/Kubernetes configuration.
 
@@ -135,8 +141,8 @@ Document content-free operator steps and stop conditions:
 1. keep Substrate reconcile suspended;
 2. capture exact controller state, suspend five DB-mutating CronJobs, drain their Jobs, and scale API/routine/volume deployments to zero while leaving the collector healthy;
 3. prove no migration/bootstrap/other DB consumer exists;
-4. run `preflight`, then `reopen`, with the identity supplied through protected stdin/file and receipt in a private directory;
-5. verify committed receipt;
+4. run `preflight`, then `reopen`, with the identity supplied through protected stdin/file;
+5. capture the content-free output digest and run `verify-receipt` against the committed database receipt;
 6. restore routine worker alone and bounded-poll `inspect` to `FINAL/complete`;
 7. restore API and run one manual Substrate reconcile Job at a time to original control success and cell `ready`;
 8. restore volume worker/durability state and scheduled reconcile last;
@@ -150,7 +156,7 @@ Run at minimum:
 
 ```bash
 cd infra/provisioner
-uv run pytest -p no:cacheprovider -q tests/test_operation_recovery.py tests/test_postgresql17.py
+RUN_POSTGRESQL17_TEST=1 uv run pytest -p no:cacheprovider -q tests/test_operation_recovery.py tests/test_postgresql17.py
 uv run pytest -p no:cacheprovider -q
 uv run ruff check src/exomem_provisioner tests
 cd ../..
@@ -158,13 +164,13 @@ uv run pytest -q tests/test_hosted_provisioner_image_distribution.py tests/test_
 git diff --check
 ```
 
-Also build the provisioner wheel/image and run `infra/scripts/verify_provisioner_image.py` against the local immutable test digest using the repository's existing image-test path. Run the full hosted validator if any root-level hosted contract/runbook test changes.
+The PostgreSQL command must fail rather than skip if the PostgreSQL 17 container fixture cannot start. Also build the provisioner wheel/image and run `infra/scripts/verify_provisioner_image.py` against the local immutable test digest using the repository's existing image-test path. Run the full hosted validator if any root-level hosted contract/runbook test changes.
 
 Before delivery:
 
 - inspect diff against this allowlist;
 - scan diff/output for secret-bearing values and identifiers;
-- independent reviewer must approve transaction locking/CAS, receipt crash boundaries, output redaction, entrypoint/image proof, and test matrix;
+- independent reviewer must approve transaction locking/CAS, migration/receipt immutability, live-observation parity, output redaction, exact entrypoint/image proof, and test matrix;
 - commit, integrate current `origin/main`, rerun acceptance, push, open a ready Conventional-Commit PR, wait green, and merge only under the existing launch authorization.
 
 After merge, wait for the exact-source signed provisioner candidate. Only then refresh/merge Release Please v0.46, wait for the signed runtime candidate, compose/review/merge the v0.46 deployment lock, pass expand release proof, deploy, and execute the documented recovery.

--- a/docs/superpowers/plans/2026-08-11-hosted-init-retry-operation-recovery-plan.md
+++ b/docs/superpowers/plans/2026-08-11-hosted-init-retry-operation-recovery-plan.md
@@ -1,0 +1,170 @@
+# Hosted init-retry operation recovery implementation plan
+
+Source of truth: `docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-recovery-design.md`.
+
+## Scope
+
+Implement one operator-only provisioner command that can recover only the proven init-retry false-negative. Do not add an HTTP endpoint, migration, generic operation mutation API, caller-selected state/checkpoint/error, or raw-SQL runbook. Preserve normal submit/claim/fail behavior.
+
+Expected production files:
+
+- new `infra/provisioner/src/exomem_provisioner/operation_recovery.py`;
+- `infra/provisioner/pyproject.toml` for one console entrypoint;
+- `infra/provisioner/Dockerfile` for build-time command smoke;
+- `infra/scripts/verify_provisioner_image.py` for immutable-image entrypoint proof;
+- a short recovery section in `docs/runbooks/hosted/cell.md` or a focused hosted recovery runbook only if the existing cell runbook cannot hold the operational sequence.
+
+Expected tests:
+
+- new `infra/provisioner/tests/test_operation_recovery.py`;
+- PostgreSQL-backed cases in `infra/provisioner/tests/test_postgresql17.py` or a focused PostgreSQL recovery test file using its existing fixture;
+- `tests/test_hosted_provisioner_image_distribution.py` and the existing image-verifier tests for the new command;
+- runbook contract assertions only if a runbook changes.
+
+Stop before expanding this allowlist.
+
+## Step 1: lock the command and output contract red-first
+
+Add tests that import the recovery module before it exists and require:
+
+- modes exactly `preflight`, `reopen`, `inspect`, and `finalize-receipt`;
+- operation identity from stdin or a regular current-user-owned mode-`0600` file only;
+- refusal of identity in argv, symlinks, non-regular files, wrong ownership, broad permissions, empty input, multiple lines, and invalid UUIDs;
+- no environment, database URL, identifier, ciphertext, resource reference, envelope, DSN, or secret in stdout/stderr/errors;
+- fixed JSON output keys containing only status/refusal, states, checkpoints, error code, counts, booleans, hashes, timestamps, and receipt digest;
+- `--help` works without loading database/Kubernetes secrets.
+
+Implement the smallest parser/input/output boundary. Keep the module directly executable only through the console entrypoint.
+
+## Step 2: build a typed, hashable recovery snapshot
+
+Reuse `canonical_request_sha256`, the existing envelope purposes/codecs, model enums, configuration validation, and repository session factory. Add private immutable snapshot types for:
+
+- operation pre-state and preserved fields;
+- tenant fence and conflict counts;
+- sorted resources and resource-reference digests;
+- capacity reservation;
+- live Kubernetes observation;
+- prepared/committed receipt payloads.
+
+Canonical hashing must use sorted compact JSON with explicit conversion for UUIDs, enums, datetimes, and nulls. Tests must prove field ordering cannot change hashes and secret-bearing fields are hashed rather than serialized into receipts or output.
+
+## Step 3: implement database preflight under canonical locks
+
+Red-first PostgreSQL tests seed the exact historical operation shape, then independently mutate every predicate. The recovery service must:
+
+1. refuse SQLite;
+2. require the configured PostgreSQL role, schema, and sole Alembic head `0006_operation_wire_protocol`;
+3. acquire the database advisory transaction lock used by bootstrap/migration;
+4. resolve the confidential operation row without output;
+5. lock in repository order: tenant fence, operation, cell lock domain, capacity ledger/destructive fences/reservation, then resources;
+6. decrypt and canonical-hash the request;
+7. authenticate each resource reference and its stored digest;
+8. return a private validated snapshot or one fixed refusal code.
+
+The negative matrix must cover:
+
+- missing/duplicate target resolution;
+- wrong action/state/checkpoint/error;
+- null cell, live claim, missing finalization, any result, provider/external identity or fence mismatch;
+- tenant-fence mismatch;
+- another pending/claimed tenant or cell operation;
+- cell lock or equal/newer destructive fence;
+- request decryption/hash/tenant/cell/operation/fence/caller-checkpoint/protocol/serve-mode mismatch;
+- missing/duplicate/extra/wrong-kind resources, a route already present, cross-boundary metadata, reference-decryption failure, or digest mismatch;
+- missing/duplicate/released/mismatched reservation or non-null release fields.
+
+Every refusal asserts byte-for-byte database nonmutation.
+
+## Step 4: add exact live-observation validation
+
+Reuse the production Kubernetes/provider observation boundary rather than adding a second metadata parser. Given only identities derived from the validated database snapshot, require:
+
+- namespace, Helm release, PVC, and provider volume present and authenticated;
+- live identities/fence match durable resource metadata;
+- PVC bound;
+- init Job present with `Complete=True` (historical failed count/condition allowed);
+- runtime admission marker and routes absent.
+
+Tests cover absent/running/Failed-only Job, completed-after-retry Job, live identity/fence mismatch, unbound PVC, pre-existing runtime admission, and route presence. No Kubernetes object or identifier may enter public output/receipt.
+
+## Step 5: implement atomic prepared/final receipt handling
+
+Create a private receipt directory/file boundary that:
+
+- rejects symlinked/non-owned/broad-permission directories and files;
+- uses exclusive creation for the prepared receipt;
+- writes canonical JSON, fsyncs file and parent directory;
+- contains only approved fixed fields/hashes/counts/booleans and a random nonce;
+- finalizes through a same-directory temporary file plus atomic rename and parent fsync;
+- never overwrites an unrelated or finalized receipt.
+
+Tests inject failures at create/write/fsync/rename/parent-fsync boundaries. Before database commit, failures roll back. After a committed transition, finalization failure produces a fixed `receipt-finalization-required` result, and only `finalize-receipt` may finish the matching prepared receipt.
+
+## Step 6: implement the single CAS transition
+
+`reopen` repeats the full preflight under the same transaction, writes/fsyncs the prepared receipt, and runs one named-bind update. The WHERE clause includes the confidential row identity plus exact action/state/checkpoint/error, empty claim/result, provider/external identity and fence equality, prior request hash, claim generation, and prior update timestamp.
+
+Changed columns are exactly state, checkpoint, error, claim fields, finalized timestamp, available timestamp, and updated timestamp. The new values are fixed at `PENDING`, `volume-owned`, null terminal/claim fields, and database-clock timestamps.
+
+Before commit, re-read and assert:
+
+- exactly one row changed;
+- preserved-field hash, request/ciphertext hash, resources hash, reservation hash, tenant fence, and claim generation are unchanged;
+- active reservation still exists;
+- result remains absent.
+
+Then commit and finalize the receipt. Tests cover CAS loss, concurrent second invocation, already-progressed operation, commit failure, receipt-finalization recovery, and exact changed-column/preserved-field sets.
+
+## Step 7: implement read-only inspect
+
+`inspect` authenticates the same confidential row input but emits only bounded content-free lifecycle facts needed for polling. It must distinguish refusal, pending/claimed/final/error, checkpoint, approved error code, resource-kind counts, active-reservation boolean, and final-proof boolean without logging identifiers.
+
+Tests assert its output allowlist over every state and that terminal/final inspection does not mutate or decrypt result payload into output.
+
+## Step 8: wire and prove the signed image
+
+Add `exomem-provisioner-recover-init-retry = "exomem_provisioner.operation_recovery:main"` to project scripts. Add a Docker build-time `--help` smoke. Add the command to `_ENTRYPOINTS` in `verify_provisioner_image.py`, then update image-distribution tests to require it and prove the entrypoint loads as callable from the immutable image.
+
+Do not add Kubernetes RBAC or a standing controller. Production invokes the command only in an explicitly launched, non-network-published operator context using the existing provisioner database/envelope/Kubernetes configuration.
+
+## Step 9: document the exact production procedure
+
+Document content-free operator steps and stop conditions:
+
+1. keep Substrate reconcile suspended;
+2. capture exact controller state, suspend five DB-mutating CronJobs, drain their Jobs, and scale API/routine/volume deployments to zero while leaving the collector healthy;
+3. prove no migration/bootstrap/other DB consumer exists;
+4. run `preflight`, then `reopen`, with the identity supplied through protected stdin/file and receipt in a private directory;
+5. verify committed receipt;
+6. restore routine worker alone and bounded-poll `inspect` to `FINAL/complete`;
+7. restore API and run one manual Substrate reconcile Job at a time to original control success and cell `ready`;
+8. restore volume worker/durability state and scheduled reconcile last;
+9. stop on any refusal, error, conflict, resource drift, or timeout; never reverse the checkpoint manually.
+
+The runbook must never contain a real identifier, DSN, secret, envelope, or pasteable raw SQL.
+
+## Step 10: verification and delivery
+
+Run at minimum:
+
+```bash
+cd infra/provisioner
+uv run pytest -p no:cacheprovider -q tests/test_operation_recovery.py tests/test_postgresql17.py
+uv run pytest -p no:cacheprovider -q
+uv run ruff check src/exomem_provisioner tests
+cd ../..
+uv run pytest -q tests/test_hosted_provisioner_image_distribution.py tests/test_hosted_platform_operations.py
+git diff --check
+```
+
+Also build the provisioner wheel/image and run `infra/scripts/verify_provisioner_image.py` against the local immutable test digest using the repository's existing image-test path. Run the full hosted validator if any root-level hosted contract/runbook test changes.
+
+Before delivery:
+
+- inspect diff against this allowlist;
+- scan diff/output for secret-bearing values and identifiers;
+- independent reviewer must approve transaction locking/CAS, receipt crash boundaries, output redaction, entrypoint/image proof, and test matrix;
+- commit, integrate current `origin/main`, rerun acceptance, push, open a ready Conventional-Commit PR, wait green, and merge only under the existing launch authorization.
+
+After merge, wait for the exact-source signed provisioner candidate. Only then refresh/merge Release Please v0.46, wait for the signed runtime candidate, compose/review/merge the v0.46 deployment lock, pass expand release proof, deploy, and execute the documented recovery.

--- a/docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-recovery-design.md
@@ -8,7 +8,7 @@ The tenant must be recovered in place. Creating another operation would conflict
 
 ## Decision
 
-Ship a one-purpose, operator-only recovery helper in the signed provisioner image. It can reopen only the exact init-retry false-negative shape:
+Ship a one-purpose, operator-only recovery helper in the signed provisioner image. Migration `0007` adds an immutable, content-free operation-recovery receipt table so the receipt insert and operation transition commit in one PostgreSQL transaction. The helper can reopen only the exact init-retry false-negative shape:
 
 `PROVISION / ERROR / failed / PROVISIONER_PROVIDER_METADATA_CONFLICT`
 
@@ -29,7 +29,7 @@ The provisioner package exposes a console command with four fixed modes:
 - `preflight`: validates every invariant without mutation;
 - `reopen`: repeats preflight under locks, performs the single compare-and-swap transition, and commits a receipt;
 - `inspect`: returns content-free state for bounded polling;
-- `finalize-receipt`: repairs receipt finalization after a committed transition without reopening again.
+- `verify-receipt`: reads and verifies the immutable transactional receipt without reopening again.
 
 Modes do not accept caller-selected checkpoints, actions, states, error codes, tenants, cells, fences, resource identities, or SQL fragments.
 
@@ -37,30 +37,35 @@ Modes do not accept caller-selected checkpoints, actions, states, error codes, t
 
 A dedicated service owns validation and mutation. It uses the existing database/envelope configuration and follows the repository's fence-first lock order. The transition is isolated from normal submission and claim APIs so it cannot weaken their terminal-state behavior.
 
-### Receipt writer
+### Transactional receipt
 
-Before mutation, the helper creates and fsyncs an exclusive prepared receipt in a private, non-repository directory. The receipt contains hashes, booleans, counts, fixed state names, helper/image identity, and timestamps only. It never contains identifiers, ciphertext, resource references, credentials, DSNs, decrypted payloads, or recovery envelopes.
+Migration `0007` creates one append-only receipt table keyed one-to-one to the recovered operation. The receipt contains hashes, booleans, counts, fixed state names, helper source identity, schema version, and database timestamps only. It never contains tenant/cell/provider identifiers, ciphertext, resource references, credentials, DSNs, decrypted payloads, or recovery envelopes. Database constraints and update/delete guards make a committed receipt immutable.
 
-After commit, the helper atomically finalizes the receipt with the committed-row hash. If finalization fails, workers stay stopped and `finalize-receipt` completes the existing receipt; `reopen` cannot run again.
+`reopen` inserts the receipt and performs the operation compare-and-swap in the same transaction. Both commit or neither commits, eliminating prepared-file, lost-commit-acknowledgement, pod filesystem, and node-loss windows. `verify-receipt` recomputes the content-free evidence digest from the committed row. Operator evidence binds that digest to the independently observed deployed image digest and pod image ID; the database row is a durable transaction audit, not a self-signed trust root.
+
+### Shared recovery observation
+
+The helper uses a new typed, read-only recovery observation on the shared live provider boundary. It reuses the existing Kubernetes, Helm, PVC/PV, and HCloud identity/envelope parsers rather than duplicating metadata rules in the command. The snapshot authenticates the namespace, Helm release, PVC, bound PV/provider volume, optional init Job, runtime-admission state, and routes; exposes only booleans/counts internally; and rejects any object already terminating.
 
 ## Preflight contract
 
 The helper refuses unless all of these facts hold under the same transaction and live-observation boundary:
 
-1. PostgreSQL is in use, the current role/schema are exact, and the database is at the one expected Alembic revision.
+1. PostgreSQL is in use, the current role/schema are exact, and the database is at the one expected Alembic revision containing the recovery receipt table.
 2. Exactly one target operation exists with action `PROVISION`, state `ERROR`, checkpoint `failed`, error `PROVISIONER_PROVIDER_METADATA_CONFLICT`, no claim, no result, a finalization timestamp, and matching external/provider operation and fence fields.
 3. The tenant fence equals the operation fence. No other pending or claimed operation, cell-operation lock, or equal/newer destructive capacity fence exists for the tenant or cell.
 4. The stored request decrypts, canonicalizes to its stored hash, and matches the operation's tenant, cell, operation, fence, caller checkpoint, protocol, and serve-mode intent.
-5. Durable resources are exactly one each of `HELM_RELEASE`, `KUBERNETES_NAMESPACE`, `PVC`, and `VOLUME`; their encrypted references authenticate, their digests match, and their stored identity matches the operation. No route exists.
+5. Durable resources for the target are exactly one each of `HELM_RELEASE`, `KUBERNETES_NAMESPACE`, `PVC`, and `VOLUME`; their encrypted references authenticate, their digests match, and their stored identity matches the operation. The target namespace must also be the sole namespace the normal worker would adopt in its full same-tenant/cell resource-selection scope; no foreign same-cell resource or route ambiguity may exist.
 6. Exactly one matching active user capacity reservation exists and every release field is null.
-7. Live namespace, release, PVC, and volume identity match the durable registry; the PVC is bound; the exact init Job has `Complete=True`; runtime admission and routes do not yet exist.
-8. The operation still matches the preflight row hash, request hash, claim generation, and update timestamp at compare-and-swap time.
+7. The stored request passes the same `runtime_target_matches` rule that the restored worker will apply against the deployed lock. For v1 its exact release/protocol unit remains in the legacy catalog; for v2 its runtime target equals the forward target.
+8. Live namespace, Helm release, PVC, bound PV/provider volume identity match the durable registry; none has a deletion timestamp or provider deleting state. Runtime admission and routes do not exist. The init Job may be absent because its five-minute TTL is expected; if present it must be authenticated, non-terminating, and either still running or `Complete=True`. A Failed-only Job is refused. The normal worker's existing idempotent initialize replay is the recovery path when the Job is absent.
+9. The operation still matches the preflight row hash, request hash, claim generation, and update timestamp at compare-and-swap time. A second stable live observation immediately before the CAS must match the first objects' UIDs/resource versions and non-terminating state.
 
 Any mismatch is a hard no-op with a fixed refusal code.
 
 ## Mutation contract
 
-The transaction changes only:
+The transaction inserts exactly one immutable recovery receipt and changes only these operation columns:
 
 - state to `PENDING`;
 - checkpoint to `volume-owned`;
@@ -69,13 +74,13 @@ The transaction changes only:
 
 It preserves the encrypted request, canonical request hash, all identities and fences, caller checkpoint, progress, retry interval, claim generation, result fields, resources, tenant fence, capacity ledger, reservation, and creation timestamp.
 
-The compare-and-swap includes the exact old action/state/checkpoint/error, empty claim/result fields, canonical request hash, claim generation, and prior update timestamp. Exactly one updated row is required. A later invocation returns `already-progressed` or `refused` without mutation.
+The compare-and-swap includes the exact old action/state/checkpoint/error, empty claim/result fields, canonical request hash, claim generation, and prior update timestamp. The receipt row includes the pre-state, preserved-field, request, resource, reservation, tenant-fence, live-observation, and post-state hashes. Exactly one updated operation and one inserted receipt are required in the same transaction. A later invocation returns `already-progressed` or the existing verified receipt without mutation.
 
 ## Deployment and recovery flow
 
 The helper and observer fix must be present in the same signed provisioner candidate selected by the deployment lock. Before reopening, Substrate reconciliation and all database-mutating provisioner workloads are quiesced; the three direct provisioner deployments are stopped; transient migration/bootstrap/database consumers are absent; and a fresh collector receipt remains available.
 
-After a committed receipt:
+After the transactional receipt and operation transition commit:
 
 1. restore only the routine provisioner worker;
 2. use content-free `inspect` polling for at most ten minutes;
@@ -93,6 +98,7 @@ There is no reverse checkpoint mutation after the helper commits. If the worker 
 - No public or admin HTTP recovery endpoint.
 - No identifiers or secret-bearing values in argv, stdout, logs, receipts, tests, or operator evidence.
 - The command refuses SQLite and noncanonical database role/schema/revision.
+- The immutable image verifier binds every required command name to its exact `module:function`, not merely to any callable entrypoint.
 - The image verification gate proves the console command is present and routes only to the recovery module.
 - Normal repository terminal-state and idempotency behavior remains unchanged.
 - Production evidence records only fixed states, booleans, counts, hashes, timestamps, and receipt digests.
@@ -107,12 +113,15 @@ Tests must prove red-first behavior for the historical retry-success shape and c
 - request decryption, canonical-hash, identity, checkpoint, protocol, and fence mismatches;
 - missing, duplicate, extra, unauthenticated, or mismatched resources;
 - missing/released/mismatched reservation and destructive-fence conflicts;
-- absent/running/failed init Job, with only `Complete=True` accepted even when historical failures exist;
+- absent/running/completed/failed/terminating init Job, with absence accepted for the existing idempotent re-init path and Failed-only refused;
+- terminating namespace/PVC/PV/release/provider-volume objects and changed UID/resourceVersion between observations;
+- same-cell older namespace/foreign resource rows that would change normal worker adoption;
+- v1 legacy-catalog and v2 exact-forward runtime-target compatibility;
 - compare-and-swap lost races and second-invocation no-op behavior;
-- prepared/finalized receipt permissions, fsync/atomicity, redaction, and crash recovery;
+- migration upgrade, one-to-one transactional receipt insertion, immutability, rollback, redaction, and lost-acknowledgement replay;
 - exact changed-column and preserved-field hash assertions;
 - console entrypoint and built-image smoke verification;
-- PostgreSQL integration at the canonical schema revision.
+- non-skipped PostgreSQL integration at the canonical schema revision with `RUN_POSTGRESQL17_TEST=1`.
 
 The focused recovery suite, full provisioner suite, Ruff, image verification, deployment-lock composition gates, and independent security/code review must pass before production use.
 

--- a/docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-11-hosted-init-retry-operation-recovery-design.md
@@ -1,0 +1,121 @@
+# Hosted init-retry operation recovery
+
+## Context
+
+The first capacity-managed Hosted reviewer tenant reached a terminal provider error after all durable infrastructure had been created. Its Kubernetes init Job eventually completed successfully, but an earlier failed Pod left `status.failed > 0`. The old provisioner observer treated the Job as both complete and failed and terminalized the provider operation with `PROVISIONER_PROVIDER_METADATA_CONFLICT`. The observer fix is merged, tested, and published, but replaying the same API operation only returns the stored terminal result.
+
+The tenant must be recovered in place. Creating another operation would conflict with its identity-bound resources and active capacity reservation. Deleting resources or rewriting the request would discard proof and risk duplication.
+
+## Decision
+
+Ship a one-purpose, operator-only recovery helper in the signed provisioner image. It can reopen only the exact init-retry false-negative shape:
+
+`PROVISION / ERROR / failed / PROVISIONER_PROVIDER_METADATA_CONFLICT`
+
+to:
+
+`PROVISION / PENDING / volume-owned`
+
+The helper is not a general operation editor and is not exposed through the provisioner API. It accepts the confidential internal operation identifier only through standard input or a current-user-owned mode-`0600` file, never through command-line arguments.
+
+Raw SQL is rejected because it cannot safely authenticate the encrypted request and resource references and would not create a trustworthy receipt. Abandoning the tenant is rejected because the existing resources and reservation are deliberately retained after terminal provision failure.
+
+## Components
+
+### Recovery command
+
+The provisioner package exposes a console command with four fixed modes:
+
+- `preflight`: validates every invariant without mutation;
+- `reopen`: repeats preflight under locks, performs the single compare-and-swap transition, and commits a receipt;
+- `inspect`: returns content-free state for bounded polling;
+- `finalize-receipt`: repairs receipt finalization after a committed transition without reopening again.
+
+Modes do not accept caller-selected checkpoints, actions, states, error codes, tenants, cells, fences, resource identities, or SQL fragments.
+
+### Repository recovery service
+
+A dedicated service owns validation and mutation. It uses the existing database/envelope configuration and follows the repository's fence-first lock order. The transition is isolated from normal submission and claim APIs so it cannot weaken their terminal-state behavior.
+
+### Receipt writer
+
+Before mutation, the helper creates and fsyncs an exclusive prepared receipt in a private, non-repository directory. The receipt contains hashes, booleans, counts, fixed state names, helper/image identity, and timestamps only. It never contains identifiers, ciphertext, resource references, credentials, DSNs, decrypted payloads, or recovery envelopes.
+
+After commit, the helper atomically finalizes the receipt with the committed-row hash. If finalization fails, workers stay stopped and `finalize-receipt` completes the existing receipt; `reopen` cannot run again.
+
+## Preflight contract
+
+The helper refuses unless all of these facts hold under the same transaction and live-observation boundary:
+
+1. PostgreSQL is in use, the current role/schema are exact, and the database is at the one expected Alembic revision.
+2. Exactly one target operation exists with action `PROVISION`, state `ERROR`, checkpoint `failed`, error `PROVISIONER_PROVIDER_METADATA_CONFLICT`, no claim, no result, a finalization timestamp, and matching external/provider operation and fence fields.
+3. The tenant fence equals the operation fence. No other pending or claimed operation, cell-operation lock, or equal/newer destructive capacity fence exists for the tenant or cell.
+4. The stored request decrypts, canonicalizes to its stored hash, and matches the operation's tenant, cell, operation, fence, caller checkpoint, protocol, and serve-mode intent.
+5. Durable resources are exactly one each of `HELM_RELEASE`, `KUBERNETES_NAMESPACE`, `PVC`, and `VOLUME`; their encrypted references authenticate, their digests match, and their stored identity matches the operation. No route exists.
+6. Exactly one matching active user capacity reservation exists and every release field is null.
+7. Live namespace, release, PVC, and volume identity match the durable registry; the PVC is bound; the exact init Job has `Complete=True`; runtime admission and routes do not yet exist.
+8. The operation still matches the preflight row hash, request hash, claim generation, and update timestamp at compare-and-swap time.
+
+Any mismatch is a hard no-op with a fixed refusal code.
+
+## Mutation contract
+
+The transaction changes only:
+
+- state to `PENDING`;
+- checkpoint to `volume-owned`;
+- error, claim, and finalization fields to null;
+- availability and update timestamps to the current database clock.
+
+It preserves the encrypted request, canonical request hash, all identities and fences, caller checkpoint, progress, retry interval, claim generation, result fields, resources, tenant fence, capacity ledger, reservation, and creation timestamp.
+
+The compare-and-swap includes the exact old action/state/checkpoint/error, empty claim/result fields, canonical request hash, claim generation, and prior update timestamp. Exactly one updated row is required. A later invocation returns `already-progressed` or `refused` without mutation.
+
+## Deployment and recovery flow
+
+The helper and observer fix must be present in the same signed provisioner candidate selected by the deployment lock. Before reopening, Substrate reconciliation and all database-mutating provisioner workloads are quiesced; the three direct provisioner deployments are stopped; transient migration/bootstrap/database consumers are absent; and a fresh collector receipt remains available.
+
+After a committed receipt:
+
+1. restore only the routine provisioner worker;
+2. use content-free `inspect` polling for at most ten minutes;
+3. require progression from `volume-owned` through initialization, runtime admission, route opening, and `FINAL/complete`;
+4. stop on any terminal error, fence/capacity conflict, unexpected resource mutation, or timeout;
+5. restore the API only after provider finalization;
+6. run one bounded manual Substrate reconcile Job at a time while the scheduled CronJob remains suspended;
+7. accept only when the original control operation succeeds and the tenant/cell is bound and ready with authenticated health;
+8. restore the remaining controllers to their exact captured states and unsuspend scheduled reconciliation last.
+
+There is no reverse checkpoint mutation after the helper commits. If the worker fails, stop it and diagnose the preserved pending operation. If provider finalizes but control reconciliation fails, preserve provider final state and replay only the control operation.
+
+## Security and observability
+
+- No public or admin HTTP recovery endpoint.
+- No identifiers or secret-bearing values in argv, stdout, logs, receipts, tests, or operator evidence.
+- The command refuses SQLite and noncanonical database role/schema/revision.
+- The image verification gate proves the console command is present and routes only to the recovery module.
+- Normal repository terminal-state and idempotency behavior remains unchanged.
+- Production evidence records only fixed states, booleans, counts, hashes, timestamps, and receipt digests.
+
+## Testing
+
+Tests must prove red-first behavior for the historical retry-success shape and cover:
+
+- exact happy-path preflight and reopen;
+- every old-state/action/checkpoint/error mismatch;
+- claim/result/finalization mismatches;
+- request decryption, canonical-hash, identity, checkpoint, protocol, and fence mismatches;
+- missing, duplicate, extra, unauthenticated, or mismatched resources;
+- missing/released/mismatched reservation and destructive-fence conflicts;
+- absent/running/failed init Job, with only `Complete=True` accepted even when historical failures exist;
+- compare-and-swap lost races and second-invocation no-op behavior;
+- prepared/finalized receipt permissions, fsync/atomicity, redaction, and crash recovery;
+- exact changed-column and preserved-field hash assertions;
+- console entrypoint and built-image smoke verification;
+- PostgreSQL integration at the canonical schema revision.
+
+The focused recovery suite, full provisioner suite, Ruff, image verification, deployment-lock composition gates, and independent security/code review must pass before production use.
+
+## Success criteria
+
+The signed deployment contains the observer fix and recovery helper; the helper reopens only the proven operation and emits a content-free committed receipt; the provider operation reaches `FINAL/complete` without duplicate resources or reservations; the original control operation reaches successful terminal state; and the fresh reviewer tenant reaches authenticated `ready` before database credential rotation begins.

--- a/infra/provisioner/Dockerfile
+++ b/infra/provisioner/Dockerfile
@@ -61,6 +61,7 @@ RUN case "$(pg_dump --version)" in "pg_dump (PostgreSQL) 17."*) ;; *) exit 1;; e
     && exomem-provisioner-worker --help >/dev/null \
     && exomem-volume-worker --help >/dev/null \
     && exomem-provisioner-volume-rebind --help >/dev/null \
+    && exomem-provisioner-recover-init-retry --help >/dev/null \
     && exomem-durability-actions --help >/dev/null \
     && exomem-restore-fetch --help >/dev/null \
     && for command in exomem-provisioner-database-bootstrap \

--- a/infra/provisioner/alembic/versions/0007_operation_recovery_receipt.py
+++ b/infra/provisioner/alembic/versions/0007_operation_recovery_receipt.py
@@ -1,0 +1,113 @@
+"""Add immutable transactional receipts for init-retry operation recovery.
+
+Revision ID: 0007_operation_recovery_receipt
+Revises: 0006_operation_wire_protocol
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+revision: str = "0007_operation_recovery_receipt"
+down_revision: str | Sequence[str] | None = "0006_operation_wire_protocol"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_HASHES = (
+    "helper_source_sha256",
+    "operation_sha256",
+    "preserved_sha256",
+    "request_sha256",
+    "request_ciphertext_sha256",
+    "resources_sha256",
+    "reservation_sha256",
+    "tenant_fence_sha256",
+    "first_observation_sha256",
+    "second_observation_sha256",
+    "committed_operation_sha256",
+)
+
+
+def _schema() -> str | None:
+    return context.config.attributes.get("provisioner_schema")
+
+
+def _qualified(name: str) -> str:
+    schema = _schema()
+    return f'"{schema}"."{name}"' if schema else f'"{name}"'
+
+
+def _foreign_key(table: str, column: str) -> str:
+    schema = _schema()
+    return f"{schema}.{table}.{column}" if schema else f"{table}.{column}"
+
+
+def upgrade() -> None:
+    schema = _schema()
+    op.create_table(
+        "operation_recovery_receipts",
+        sa.Column(
+            "operation_id",
+            sa.String(36),
+            sa.ForeignKey(_foreign_key("operations", "id"), ondelete="RESTRICT"),
+            primary_key=True,
+        ),
+        sa.Column("schema_version", sa.Integer(), nullable=False),
+        sa.Column("helper_source_sha256", sa.String(64), nullable=False),
+        sa.Column("old_state", sa.String(16), nullable=False),
+        sa.Column("old_checkpoint", sa.String(256), nullable=False),
+        sa.Column("new_state", sa.String(16), nullable=False),
+        sa.Column("new_checkpoint", sa.String(256), nullable=False),
+        sa.Column("resource_count", sa.Integer(), nullable=False),
+        sa.Column("route_count", sa.Integer(), nullable=False),
+        sa.Column("init_job_present", sa.Boolean(), nullable=False),
+        sa.Column("init_job_complete", sa.Boolean(), nullable=False),
+        *(sa.Column(name, sa.String(64), nullable=False) for name in _HASHES[1:]),
+        sa.Column("committed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("schema_version = 1", name="ck_recovery_receipt_schema_version"),
+        sa.CheckConstraint("old_state = 'error'", name="ck_recovery_receipt_old_state"),
+        sa.CheckConstraint("old_checkpoint = 'failed'", name="ck_recovery_receipt_old_checkpoint"),
+        sa.CheckConstraint("new_state = 'pending'", name="ck_recovery_receipt_new_state"),
+        sa.CheckConstraint(
+            "new_checkpoint = 'volume-owned'", name="ck_recovery_receipt_new_checkpoint"
+        ),
+        sa.CheckConstraint("resource_count = 4", name="ck_recovery_receipt_resource_count"),
+        sa.CheckConstraint("route_count = 0", name="ck_recovery_receipt_route_count"),
+        *(sa.CheckConstraint(f"length({name}) = 64", name=f"ck_recovery_receipt_{name}_hash") for name in _HASHES),
+        schema=schema,
+    )
+    if op.get_bind().dialect.name == "postgresql":
+        table = _qualified("operation_recovery_receipts")
+        function = _qualified("prevent_operation_recovery_receipt_mutation")
+        op.execute(
+            sa.text(
+                f"CREATE FUNCTION {function}() RETURNS trigger LANGUAGE plpgsql AS $$ "
+                "BEGIN RAISE EXCEPTION 'operation recovery receipts are immutable'; END; $$"
+            )
+        )
+        for event in ("UPDATE", "DELETE"):
+            op.execute(
+                sa.text(
+                    f"CREATE TRIGGER operation_recovery_receipts_no_{event.lower()} "
+                    f"BEFORE {event} ON {table} FOR EACH ROW EXECUTE FUNCTION {function}()"
+                )
+            )
+
+
+def downgrade() -> None:
+    schema = _schema()
+    if op.get_bind().dialect.name == "postgresql":
+        table = _qualified("operation_recovery_receipts")
+        function = _qualified("prevent_operation_recovery_receipt_mutation")
+        for event in ("UPDATE", "DELETE"):
+            op.execute(
+                sa.text(
+                    f"DROP TRIGGER IF EXISTS operation_recovery_receipts_no_{event.lower()} ON {table}"
+                )
+            )
+        op.execute(sa.text(f"DROP FUNCTION IF EXISTS {function}()"))
+    op.drop_table("operation_recovery_receipts", schema=schema)

--- a/infra/provisioner/pyproject.toml
+++ b/infra/provisioner/pyproject.toml
@@ -33,6 +33,7 @@ exomem-restore-fetch = "exomem_provisioner.restore_fetch:run_restore_fetch"
 exomem-provisioner-database-bootstrap = "exomem_provisioner.database_bootstrap:run_bootstrap"
 exomem-provisioner-database-migrate = "exomem_provisioner.database_bootstrap:run_migrate"
 exomem-provisioner-database-validate = "exomem_provisioner.database_bootstrap:run_validate"
+exomem-provisioner-recover-init-retry = "exomem_provisioner.operation_recovery:main"
 
 [dependency-groups]
 dev = [

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -1169,6 +1169,29 @@ class HCloudVolumeAdapter:
                 ) from error
         return True
 
+    async def verify_recovery_volume(
+        self,
+        handle: str,
+        metadata: OpaqueProviderMetadata,
+        location: str,
+        recovery_envelope: str,
+    ) -> bool:
+        """Authenticate the durable HCloud envelope before reading live state."""
+        if self._identity_verifier is not None:
+            try:
+                self._identity_verifier.authenticate(
+                    recovery_envelope,
+                    provider="hcloud",
+                    provider_reference=ProviderReference.hcloud(kind="volume", resource_id=handle),
+                    tenant_id=metadata.tenant_id,
+                    cell_id=metadata.subject_id,
+                    operation_id=metadata.operation_id,
+                    fence_generation=metadata.fence_generation,
+                )
+            except ProviderIdentityConflict as error:
+                raise MetadataConflict("HCloud provider recovery identity did not authenticate") from error
+        return await self.verify_volume(handle, metadata, location)
+
     async def delete_volume(self, handle: str) -> None:
         volume = await self._get(handle)
         if volume is not None:

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -12,6 +12,7 @@ import re
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,14 @@ from .provider_identity import (
     chunk_hcloud_identity_envelope,
     decode_hcloud_identity_envelope,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class BoundVolumeRecoveryObservation:
+    """Authenticated bound-volume identity with no raw Kubernetes identifiers."""
+
+    recorded: RecordedVolume
+    stability_digest: str
 
 
 def _api_status(error: Exception) -> int | None:
@@ -185,6 +194,54 @@ class KubernetesVolumeAdapter:
             metadata,
             pv_recovery_envelope=pv_envelope,
             pvc_recovery_envelope=pvc_envelope,
+        )
+
+    async def observe_recovery_bound_volume(
+        self, metadata: OpaqueProviderMetadata
+    ) -> BoundVolumeRecoveryObservation | None:
+        """Bind recovery to the exact authenticated PV object and its version."""
+        recorded = await self.discover_bound_volume(metadata)
+        if recorded is None:
+            return None
+        pv = await asyncio.to_thread(self._core.read_persistent_volume, recorded.pv_name)
+        if getattr(pv.metadata, "deletion_timestamp", None) is not None:
+            raise MetadataConflict("PV is terminating")
+        annotations = dict(getattr(pv.metadata, "annotations", None) or {})
+        _require_annotations(annotations, metadata)
+        if not recorded.pv_recovery_envelope:
+            raise MetadataConflict("PV provider recovery identity is absent")
+        if self._identity_verifier is not None:
+            try:
+                self._identity_verifier.authenticate(
+                    recorded.pv_recovery_envelope,
+                    provider="kubernetes",
+                    provider_reference=ProviderReference.kubernetes(
+                        provider="kubernetes",
+                        api_version="v1",
+                        kind="PersistentVolume",
+                        namespace="",
+                        name=recorded.pv_name,
+                    ),
+                    tenant_id=metadata.tenant_id,
+                    cell_id=metadata.subject_id,
+                    operation_id=metadata.operation_id,
+                    fence_generation=metadata.fence_generation,
+                )
+            except ProviderIdentityConflict as error:
+                raise MetadataConflict("PV provider recovery identity did not authenticate") from error
+        return BoundVolumeRecoveryObservation(
+            recorded=recorded,
+            stability_digest=hashlib.sha256(
+                json.dumps(
+                    {
+                        "name": recorded.pv_name,
+                        "uid": str(getattr(pv.metadata, "uid", "")),
+                        "resourceVersion": str(getattr(pv.metadata, "resource_version", "")),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest(),
         )
 
     async def label_bound_volume(self, recorded: RecordedVolume, recovery_envelope: str) -> None:

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -116,6 +116,8 @@ class KubernetesVolumeAdapter:
                 return None
             raise
         pvc_annotations = dict(getattr(pvc.metadata, "annotations", None) or {})
+        if getattr(pvc.metadata, "deletion_timestamp", None) is not None:
+            raise MetadataConflict("PVC is terminating")
         _require_annotations(pvc_annotations, metadata)
         pvc_envelope = str(pvc_annotations.get("exomem.io/recovery-envelope", ""))
         if self._identity_verifier is not None:
@@ -143,6 +145,8 @@ class KubernetesVolumeAdapter:
         if not isinstance(pv_name, str) or not pv_name:
             return None
         pv = await asyncio.to_thread(self._core.read_persistent_volume, pv_name)
+        if getattr(pv.metadata, "deletion_timestamp", None) is not None:
+            raise MetadataConflict("PV is terminating")
         csi = getattr(pv.spec, "csi", None)
         handle = getattr(csi, "volume_handle", None)
         if not isinstance(handle, str) or not handle:
@@ -1083,6 +1087,8 @@ class HCloudVolumeAdapter:
     ) -> bool:
         volume = await self._get(handle)
         if volume is None:
+            return False
+        if getattr(volume, "status", None) == "deleting":
             return False
         labels = dict(getattr(volume, "labels", {}) or {})
         actual_location = getattr(getattr(volume, "location", None), "name", None)

--- a/infra/provisioner/src/exomem_provisioner/database.py
+++ b/infra/provisioner/src/exomem_provisioner/database.py
@@ -14,7 +14,7 @@ from sqlalchemy.pool import StaticPool
 from .config import ProvisionerSettings
 from .models import Base, CapacityLedger
 
-DATABASE_REVISION = "0006_operation_wire_protocol"
+DATABASE_REVISION = "0007_operation_recovery_receipt"
 
 
 class ProvisionerDatabase:

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -108,6 +108,11 @@ class KubernetesProviderRegistry:
             ) from error
 
     @staticmethod
+    def _require_not_terminating(resource: Any) -> None:
+        if getattr(getattr(resource, "metadata", None), "deletion_timestamp", None) is not None:
+            raise MetadataConflict("Kubernetes provider object is terminating")
+
+    @staticmethod
     def _cell_identity(
         annotations: dict[str, str] | None,
         metadata: OpaqueProviderMetadata,
@@ -138,6 +143,7 @@ class KubernetesProviderRegistry:
             return KubernetesProviderSnapshot(
                 False, False, False, False, False, False, False, (False, False)
             )
+        self._require_not_terminating(namespace)
         self._cell_identity(getattr(namespace.metadata, "annotations", None), current)
         _require_annotations(getattr(namespace.metadata, "annotations", None), owned)
         self._authenticate_annotations(
@@ -167,6 +173,7 @@ class KubernetesProviderRegistry:
             current.resource_name,
         )
         if pvc is not None:
+            self._require_not_terminating(pvc)
             _require_annotations(getattr(pvc.metadata, "annotations", None), owned)
             self._authenticate_annotations(
                 getattr(pvc.metadata, "annotations", None),
@@ -185,12 +192,16 @@ class KubernetesProviderRegistry:
             current.resource_name,
             label_selector=(f"owner=helm,name={current.resource_name},status=deployed"),
         )
+        for release in getattr(helm_releases, "items", ()) or ():
+            self._require_not_terminating(release)
         release_deployed = bool(getattr(helm_releases, "items", ()) or ())
         init_job = await exists(
             self._batch.read_namespaced_job,
             current.resource_name + "-init",
             current.resource_name,
         )
+        if init_job is not None:
+            self._require_not_terminating(init_job)
         conditions = getattr(getattr(init_job, "status", None), "conditions", ()) or ()
         init_complete = any(
             getattr(item, "type", None) == "Complete" and getattr(item, "status", None) == "True"
@@ -209,6 +220,8 @@ class KubernetesProviderRegistry:
             current.resource_name,
             current.resource_name,
         )
+        if stateful_set is not None:
+            self._require_not_terminating(stateful_set)
         routes: list[bool] = []
         for suffix in ("control", "transfer"):
             route = await exists(
@@ -223,6 +236,9 @@ class KubernetesProviderRegistry:
                 current.resource_name,
             )
             if route is not None:
+                metadata = route.get("metadata", {})
+                if metadata.get("deletionTimestamp") is not None:
+                    raise MetadataConflict("Kubernetes provider object is terminating")
                 _require_annotations(route.get("metadata", {}).get("annotations"), owned)
                 self._authenticate_annotations(
                     route.get("metadata", {}).get("annotations"),

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -128,6 +128,114 @@ class KubernetesProviderRegistry:
             if values.get(key) != expected[key]:
                 raise MetadataConflict("Kubernetes cell identity annotations differ")
 
+    @staticmethod
+    def _recovery_digest(*resources: Any) -> str:
+        """Expose only a stability digest for exact Kubernetes object versions."""
+        values: list[dict[str, str]] = []
+        for resource in resources:
+            metadata = getattr(resource, "metadata", None)
+            values.append(
+                {
+                    "name": str(getattr(metadata, "name", "")),
+                    "namespace": str(getattr(metadata, "namespace", "")),
+                    "uid": str(getattr(metadata, "uid", "")),
+                    "resourceVersion": str(getattr(metadata, "resource_version", "")),
+                }
+            )
+        return hashlib.sha256(
+            json.dumps(values, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+    async def authenticate_recovery_record(self, metadata: OpaqueProviderMetadata) -> str:
+        """Read and authenticate the durable Kubernetes recovery identities once."""
+        namespace = await asyncio.to_thread(self._core.read_namespace, metadata.resource_name)
+        pvc = await asyncio.to_thread(
+            self._core.read_namespaced_persistent_volume_claim,
+            metadata.resource_name + "-data",
+            metadata.resource_name,
+        )
+        operation_record = await asyncio.to_thread(
+            self._core.read_namespaced_config_map,
+            provider_operation_resource_name(metadata.operation_id),
+            metadata.resource_name,
+        )
+        helm_records = tuple(
+            getattr(
+                await asyncio.to_thread(
+                    self._core.list_namespaced_config_map,
+                    metadata.resource_name,
+                    label_selector=(
+                        f"owner=helm,name={metadata.resource_name},status=deployed"
+                    ),
+                ),
+                "items",
+                (),
+            )
+            or ()
+        )
+        if len(helm_records) != 1:
+            raise MetadataConflict("deployed Helm release record is not exact")
+        helm_record = helm_records[0]
+        self._require_not_terminating(helm_record)
+        helm_labels = dict(getattr(helm_record.metadata, "labels", None) or {})
+        if (
+            getattr(helm_record.metadata, "namespace", None) != metadata.resource_name
+            or helm_labels.get("owner") != "helm"
+            or helm_labels.get("name") != metadata.resource_name
+            or helm_labels.get("status") != "deployed"
+        ):
+            raise MetadataConflict("deployed Helm release record identity differs")
+        for resource in (namespace, pvc, operation_record):
+            self._require_not_terminating(resource)
+            _require_annotations(getattr(resource.metadata, "annotations", None), metadata)
+        self._authenticate_annotations(
+            getattr(namespace.metadata, "annotations", None),
+            metadata,
+            provider="kubernetes",
+            provider_reference=ProviderReference.kubernetes(
+                provider="kubernetes", api_version="v1", kind="Namespace", namespace="", name=metadata.resource_name
+            ),
+        )
+        self._authenticate_annotations(
+            getattr(pvc.metadata, "annotations", None),
+            metadata,
+            provider="kubernetes",
+            provider_reference=ProviderReference.kubernetes(
+                provider="kubernetes", api_version="v1", kind="PersistentVolumeClaim", namespace=metadata.resource_name, name=metadata.resource_name + "-data"
+            ),
+        )
+        self._authenticate_annotations(
+            getattr(operation_record.metadata, "annotations", None),
+            metadata,
+            provider="kubernetes",
+            provider_reference=ProviderReference.kubernetes(
+                provider="kubernetes", api_version="v1", kind="ConfigMap", namespace=metadata.resource_name, name=provider_operation_resource_name(metadata.operation_id)
+            ),
+        )
+        try:
+            init_job = await asyncio.to_thread(
+                self._batch.read_namespaced_job,
+                metadata.resource_name + "-init",
+                metadata.resource_name,
+            )
+        except Exception as error:
+            if _api_status(error) != 404:
+                raise
+            init_job = None
+        if init_job is not None:
+            self._require_not_terminating(init_job)
+            self._authenticate_annotations(
+                getattr(init_job.metadata, "annotations", None),
+                metadata,
+                provider="kubernetes",
+                provider_reference=ProviderReference.kubernetes(
+                    provider="kubernetes", api_version="batch/v1", kind="Job", namespace=metadata.resource_name, name=metadata.resource_name + "-init"
+                ),
+            )
+        return self._recovery_digest(
+            namespace, pvc, operation_record, helm_record, init_job
+        )
+
     async def inspect(
         self,
         current: OpaqueProviderMetadata,

--- a/infra/provisioner/src/exomem_provisioner/models.py
+++ b/infra/provisioner/src/exomem_provisioner/models.py
@@ -137,6 +137,68 @@ class Operation(Base):
     finalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
+class OperationRecoveryReceipt(Base):
+    """One immutable, content-free transaction receipt for a reopened operation."""
+
+    __tablename__ = "operation_recovery_receipts"
+    __table_args__ = (
+        CheckConstraint("schema_version = 1", name="ck_recovery_receipt_schema_version"),
+        CheckConstraint("old_state = 'error'", name="ck_recovery_receipt_old_state"),
+        CheckConstraint("old_checkpoint = 'failed'", name="ck_recovery_receipt_old_checkpoint"),
+        CheckConstraint("new_state = 'pending'", name="ck_recovery_receipt_new_state"),
+        CheckConstraint(
+            "new_checkpoint = 'volume-owned'", name="ck_recovery_receipt_new_checkpoint"
+        ),
+        CheckConstraint("resource_count = 4", name="ck_recovery_receipt_resource_count"),
+        CheckConstraint("route_count = 0", name="ck_recovery_receipt_route_count"),
+        *(
+            CheckConstraint(
+                f"length({column}) = 64", name=f"ck_recovery_receipt_{column}_hash"
+            )
+            for column in (
+                "helper_source_sha256",
+                "operation_sha256",
+                "preserved_sha256",
+                "request_sha256",
+                "request_ciphertext_sha256",
+                "resources_sha256",
+                "reservation_sha256",
+                "tenant_fence_sha256",
+                "first_observation_sha256",
+                "second_observation_sha256",
+                "committed_operation_sha256",
+            )
+        ),
+    )
+
+    operation_id: Mapped[str] = mapped_column(
+        ForeignKey("operations.id", ondelete="RESTRICT"), primary_key=True
+    )
+    schema_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    helper_source_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    old_state: Mapped[str] = mapped_column(String(16), nullable=False, default="error")
+    old_checkpoint: Mapped[str] = mapped_column(String(256), nullable=False, default="failed")
+    new_state: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    new_checkpoint: Mapped[str] = mapped_column(String(256), nullable=False, default="volume-owned")
+    resource_count: Mapped[int] = mapped_column(Integer, nullable=False, default=4)
+    route_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    init_job_present: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    init_job_complete: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    operation_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    preserved_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    request_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    request_ciphertext_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    resources_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    reservation_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    tenant_fence_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    first_observation_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    second_observation_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    committed_operation_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    committed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+
+
 class TenantFence(Base):
     __tablename__ = "tenant_fences"
     __table_args__ = (CheckConstraint("fence_generation >= 1", name="ck_tenant_fence"),)

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -17,7 +17,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Protocol
 
-from sqlalchemy import func, select, text, update
+from sqlalchemy import cast, func, select, text, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .config import DeploymentLock
@@ -37,20 +38,33 @@ from .models import (
     ResourceKind,
     TenantFence,
 )
+from .provider_identity import cell_resource_name
 from .repository import canonical_request_sha256
 
 _FIXED_MODES = ("preflight", "reopen", "inspect", "verify-receipt")
 _RECEIPT_PAYLOAD_KEYS = frozenset(
     {
+        "schema_version",
         "helper_source_sha256",
+        "old_state",
+        "old_checkpoint",
+        "new_state",
+        "new_checkpoint",
+        "resource_count",
+        "route_count",
+        "init_job_present",
+        "init_job_complete",
         "operation_sha256",
+        "preserved_sha256",
         "request_sha256",
+        "request_ciphertext_sha256",
         "resources_sha256",
         "reservation_sha256",
         "tenant_fence_sha256",
         "first_observation_sha256",
         "second_observation_sha256",
         "committed_operation_sha256",
+        "committed_at",
     }
 )
 _OUTPUT_KEYS = frozenset(
@@ -70,6 +84,12 @@ _OUTPUT_KEYS = frozenset(
 
 class RecoveryRefusal(RuntimeError):
     """A content-free no-op refusal."""
+
+
+class _RecoveryArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        raise RecoveryRefusal("command arguments are invalid")
 
 
 def _json_value(value: object) -> object:
@@ -102,27 +122,51 @@ def canonical_sha256(value: object) -> str:
 
 @dataclass(frozen=True, slots=True)
 class RecoveryReceiptPayload:
+    schema_version: int
     helper_source_sha256: str
+    old_state: str
+    old_checkpoint: str
+    new_state: str
+    new_checkpoint: str
+    resource_count: int
+    route_count: int
+    init_job_present: bool
+    init_job_complete: bool
     operation_sha256: str
+    preserved_sha256: str
     request_sha256: str
+    request_ciphertext_sha256: str
     resources_sha256: str
     reservation_sha256: str
     tenant_fence_sha256: str
     first_observation_sha256: str
     second_observation_sha256: str
     committed_operation_sha256: str
+    committed_at: datetime
 
     def to_payload(self) -> dict[str, object]:
         return {
+            "schema_version": self.schema_version,
             "helper_source_sha256": self.helper_source_sha256,
+            "old_state": self.old_state,
+            "old_checkpoint": self.old_checkpoint,
+            "new_state": self.new_state,
+            "new_checkpoint": self.new_checkpoint,
+            "resource_count": self.resource_count,
+            "route_count": self.route_count,
+            "init_job_present": self.init_job_present,
+            "init_job_complete": self.init_job_complete,
             "operation_sha256": self.operation_sha256,
+            "preserved_sha256": self.preserved_sha256,
             "request_sha256": self.request_sha256,
+            "request_ciphertext_sha256": self.request_ciphertext_sha256,
             "resources_sha256": self.resources_sha256,
             "reservation_sha256": self.reservation_sha256,
             "tenant_fence_sha256": self.tenant_fence_sha256,
             "first_observation_sha256": self.first_observation_sha256,
             "second_observation_sha256": self.second_observation_sha256,
             "committed_operation_sha256": self.committed_operation_sha256,
+            "committed_at": self.committed_at,
         }
 
 
@@ -138,6 +182,7 @@ class LiveObservation:
     terminating: bool
     runtime_admitted: bool
     routes_present: int
+    identity_digest: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -226,6 +271,7 @@ def validate_live_observation(observation: LiveObservation) -> None:
         or observation.terminating
         or observation.runtime_admitted
         or observation.routes_present != 0
+        or (observation.identity_digest and len(observation.identity_digest) != 64)
     ):
         raise RecoveryRefusal("live recovery preflight failed")
 
@@ -267,15 +313,27 @@ def _hash_model(model: object, *, excluded: frozenset[str] = frozenset()) -> str
 
 def _receipt_payload(receipt: OperationRecoveryReceipt) -> RecoveryReceiptPayload:
     return RecoveryReceiptPayload(
+        schema_version=receipt.schema_version,
         helper_source_sha256=receipt.helper_source_sha256,
+        old_state=receipt.old_state,
+        old_checkpoint=receipt.old_checkpoint,
+        new_state=receipt.new_state,
+        new_checkpoint=receipt.new_checkpoint,
+        resource_count=receipt.resource_count,
+        route_count=receipt.route_count,
+        init_job_present=receipt.init_job_present,
+        init_job_complete=receipt.init_job_complete,
         operation_sha256=receipt.operation_sha256,
+        preserved_sha256=receipt.preserved_sha256,
         request_sha256=receipt.request_sha256,
+        request_ciphertext_sha256=receipt.request_ciphertext_sha256,
         resources_sha256=receipt.resources_sha256,
         reservation_sha256=receipt.reservation_sha256,
         tenant_fence_sha256=receipt.tenant_fence_sha256,
         first_observation_sha256=receipt.first_observation_sha256,
         second_observation_sha256=receipt.second_observation_sha256,
         committed_operation_sha256=receipt.committed_operation_sha256,
+        committed_at=receipt.committed_at,
     )
 
 
@@ -324,7 +382,19 @@ class RecoveryService:
                     "status": "ready",
                     "state": snapshot.operation.state.value,
                     "checkpoint": snapshot.operation.checkpoint,
-                    "resource_kind_counts": {kind.value: 1 for kind in ResourceKind if kind is not ResourceKind.ROUTE},
+                    "resource_kind_counts": {
+                        **{
+                            kind.value: 1
+                            for kind in (
+                                ResourceKind.HELM_RELEASE,
+                                ResourceKind.KUBERNETES_NAMESPACE,
+                                ResourceKind.PVC,
+                                ResourceKind.VOLUME,
+                            )
+                        },
+                        ResourceKind.ROUTE.value: 0,
+                        "provider-object": 0,
+                    },
                     "active_reservation": True,
                 }
         except RecoveryRefusal:
@@ -335,6 +405,7 @@ class RecoveryService:
     async def reopen(self, operation_id: str) -> dict[str, object]:
         try:
             async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
                 existing = await session.get(OperationRecoveryReceipt, operation_id, with_for_update=True)
                 if existing is not None:
                     return self._receipt_result(existing, "already-recovered")
@@ -361,6 +432,8 @@ class RecoveryService:
                         Operation.claim_token.is_(None),
                         Operation.claim_expires_at.is_(None),
                         Operation.result_ciphertext.is_(None),
+                        cast(Operation.result_redacted, JSONB) == cast({}, JSONB),
+                        Operation.finalized_at.is_not(None),
                         Operation.external_operation_id == Operation.provider_operation_id,
                         Operation.fence_generation == Operation.provider_fence_generation,
                         Operation.canonical_request_sha256 == before.canonical_request_sha256,
@@ -410,7 +483,8 @@ class RecoveryService:
 
     async def inspect(self, operation_id: str) -> dict[str, object]:
         try:
-            async with self._sessions() as session:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
                 operation = await session.get(Operation, operation_id)
                 if operation is None:
                     raise RecoveryRefusal("operation is unavailable")
@@ -425,7 +499,6 @@ class RecoveryService:
                         CapacityReservation.released_at.is_(None),
                     )
                 )
-                receipt = await session.get(OperationRecoveryReceipt, operation.id)
                 return {
                     "status": "inspected",
                     "state": operation.state.value,
@@ -436,7 +509,7 @@ class RecoveryService:
                         for kind in ResourceKind
                     },
                     "active_reservation": reservation is not None,
-                    "final_proof": receipt is not None,
+                    "final_proof": self._final_proof(operation),
                 }
         except RecoveryRefusal:
             raise
@@ -445,7 +518,8 @@ class RecoveryService:
 
     async def verify_receipt(self, operation_id: str) -> dict[str, object]:
         try:
-            async with self._sessions() as session:
+            async with self._sessions.begin() as session:
+                await self._require_database_identity(session)
                 receipt = await session.get(OperationRecoveryReceipt, operation_id)
                 if receipt is None:
                     raise RecoveryRefusal("receipt is unavailable")
@@ -456,17 +530,7 @@ class RecoveryService:
             raise RecoveryRefusal("receipt-verification-failed") from error
 
     async def _preflight(self, session: AsyncSession, operation_id: str) -> _RecoverySnapshot:
-        require_postgresql(session.get_bind().dialect.name)
-        await session.scalar(
-            select(func.pg_advisory_xact_lock(database_lock_key(self._database_schema, self._database_role)))
-        )
-        revision_rows = list(await session.scalars(text("SELECT version_num FROM alembic_version")))
-        if revision_rows != [DATABASE_REVISION]:
-            raise RecoveryRefusal("database revision is invalid")
-        role = await session.scalar(select(func.current_user()))
-        schema = await session.scalar(select(func.current_schema()))
-        if role != self._database_role or schema != self._database_schema:
-            raise RecoveryRefusal("database identity is invalid")
+        await self._require_database_identity(session)
         initial = await session.get(Operation, operation_id)
         if initial is None:
             raise RecoveryRefusal("operation is unavailable")
@@ -479,6 +543,24 @@ class RecoveryService:
             or fence.fence_generation != operation.fence_generation
         ):
             raise RecoveryRefusal("recovery preflight failed")
+        return await self._preflight_locked(session, operation, fence)
+
+    async def _require_database_identity(self, session: AsyncSession) -> None:
+        require_postgresql(session.get_bind().dialect.name)
+        await session.scalar(
+            select(func.pg_advisory_xact_lock(database_lock_key(self._database_schema, self._database_role)))
+        )
+        revision_rows = list(await session.scalars(text("SELECT version_num FROM alembic_version")))
+        if revision_rows != [DATABASE_REVISION]:
+            raise RecoveryRefusal("database revision is invalid")
+        role = await session.scalar(select(func.current_user()))
+        schema = await session.scalar(select(func.current_schema()))
+        if role != self._database_role or schema != self._database_schema:
+            raise RecoveryRefusal("database identity is invalid")
+
+    async def _preflight_locked(
+        self, session: AsyncSession, operation: Operation, fence: TenantFence
+    ) -> _RecoverySnapshot:
         transition = recovery_transition_values(
             OperationPreState(
                 action=operation.action.value,
@@ -489,7 +571,7 @@ class RecoveryService:
                     value is not None
                     for value in (operation.claim_owner, operation.claim_token, operation.claim_expires_at)
                 ),
-                has_result=operation.result_ciphertext is not None,
+                has_result=(operation.result_ciphertext is not None or operation.result_redacted != {}),
                 finalized=operation.finalized_at is not None,
             )
         )
@@ -535,7 +617,8 @@ class RecoveryService:
         lock = await session.get(CellOperationLock, operation.cell_id, with_for_update=True)
         if lock is not None:
             raise RecoveryRefusal("recovery preflight failed")
-        await session.get(CapacityLedger, 1, with_for_update=True)
+        if await session.get(CapacityLedger, 1, with_for_update=True) is None:
+            raise RecoveryRefusal("recovery preflight failed")
         destructive = tuple(
             await session.scalars(
                 select(CapacityDestructiveFence)
@@ -582,11 +665,7 @@ class RecoveryService:
         if (
             {item.kind for item in resources} != expected
             or len(resources) != len(expected)
-            or any(item.kind is ResourceKind.ROUTE for item in scoped)
-            or any(
-                item.kind is ResourceKind.KUBERNETES_NAMESPACE and item.operation_id != operation.id
-                for item in scoped
-            )
+            or any(item.operation_id != operation.id for item in scoped)
         ):
             raise RecoveryRefusal("recovery preflight failed")
         for resource in resources:
@@ -622,6 +701,7 @@ class RecoveryService:
         reservation = reservations[0]
         if (
             reservation.reservation_class.value != "USER"
+            or reservation.resource_name != cell_resource_name(operation.cell_id)
             or reservation.reserving_provider_operation_id != operation.external_operation_id
             or reservation.reserving_fence_generation != operation.fence_generation
             or reservation.released_at is not None
@@ -637,6 +717,20 @@ class RecoveryService:
         ):
             raise RecoveryRefusal("recovery preflight failed")
         return reservation
+
+    @staticmethod
+    def _final_proof(operation: Operation) -> bool:
+        result = operation.result_redacted
+        return (
+            operation.state is OperationState.FINAL
+            and operation.checkpoint == "complete"
+            and operation.result_ciphertext is not None
+            and result == {
+                "completed": True,
+                "fields": ["privateEndpoint", "providerRef"],
+            }
+            and operation.finalized_at is not None
+        )
 
     @staticmethod
     def _receipt_result(receipt: OperationRecoveryReceipt, status: str) -> dict[str, object]:
@@ -655,6 +749,7 @@ class _ProductionRecoveryObserver:
     volumes: object
     hcloud: object
     location: str
+    codec: EnvelopeCodec
 
     async def observe(
         self,
@@ -663,7 +758,6 @@ class _ProductionRecoveryObserver:
     ) -> LiveObservation:
         from .lifecycle import OpaqueProviderMetadata
 
-        del resources
         if operation.cell_id is None:
             raise RecoveryRefusal("live recovery preflight failed")
         metadata = OpaqueProviderMetadata(
@@ -672,10 +766,36 @@ class _ProductionRecoveryObserver:
             operation_id=operation.external_operation_id,
             fence_generation=operation.fence_generation,
         )
+        references: dict[ResourceKind, str] = {}
+        for resource in resources:
+            value = self.codec.decrypt_json(
+                resource.reference_ciphertext,
+                purpose=f"resource-reference:{resource.operation_id}:{resource.kind.value}",
+            ).get("reference")
+            if not isinstance(value, str):
+                raise RecoveryRefusal("live recovery preflight failed")
+            references[resource.kind] = value
+        if references != {
+            ResourceKind.KUBERNETES_NAMESPACE: metadata.resource_name,
+            ResourceKind.HELM_RELEASE: metadata.resource_name,
+            ResourceKind.PVC: metadata.resource_name + "-data",
+            ResourceKind.VOLUME: references.get(ResourceKind.VOLUME, ""),
+        }:
+            raise RecoveryRefusal("live recovery preflight failed")
+        from .lifecycle import RecordedVolume
+
+        expected_volume = RecordedVolume.from_recoverable_reference(
+            references[ResourceKind.VOLUME], metadata
+        )
         snapshot = await self.registry.inspect(metadata, metadata)  # type: ignore[attr-defined]
-        recorded = await self.volumes.discover_bound_volume(metadata)  # type: ignore[attr-defined]
-        volume_present = recorded is not None and await self.hcloud.verify_volume(  # type: ignore[attr-defined]
-            recorded.volume_handle, metadata, self.location
+        registry_digest = await self.registry.authenticate_recovery_record(metadata)  # type: ignore[attr-defined]
+        volume_observation = await self.volumes.observe_recovery_bound_volume(metadata)  # type: ignore[attr-defined]
+        volume_present = (
+            volume_observation is not None
+            and volume_observation.recorded == expected_volume
+            and await self.hcloud.verify_volume(  # type: ignore[attr-defined]
+            expected_volume.volume_handle, metadata, self.location
+            )
         )
         return LiveObservation(
             namespace_present=snapshot.namespace,
@@ -688,6 +808,16 @@ class _ProductionRecoveryObserver:
             terminating=False,
             runtime_admitted=snapshot.runtime_admitted,
             routes_present=sum(snapshot.routes),
+            identity_digest=canonical_sha256(
+                {
+                    "kubernetes": registry_digest,
+                    "pv": (
+                        volume_observation.stability_digest
+                        if volume_observation is not None
+                        else ""
+                    ),
+                }
+            ),
         )
 
 
@@ -699,7 +829,7 @@ def emit_result(payload: dict[str, object]) -> int:
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = _RecoveryArgumentParser(add_help=False)
     parser.add_argument("mode", choices=_FIXED_MODES)
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--stdin", action="store_true")
@@ -758,6 +888,7 @@ async def _run(args: argparse.Namespace) -> dict[str, object]:
                 identity_verifier=identity,
             ),
             location=volume.location,
+            codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
         )
         service = RecoveryService(
             sessions=database.session_factory,

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -1,0 +1,812 @@
+"""Fail-closed operator recovery for one hosted init-retry false negative."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import sys
+import uuid
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+from sqlalchemy import func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .config import DeploymentLock
+from .crypto import EnvelopeCodec
+from .database import DATABASE_REVISION
+from .database_bootstrap import database_lock_key
+from .models import (
+    CapacityDestructiveFence,
+    CapacityLedger,
+    CapacityReservation,
+    CellOperationLock,
+    Operation,
+    OperationAction,
+    OperationRecoveryReceipt,
+    OperationState,
+    Resource,
+    ResourceKind,
+    TenantFence,
+)
+from .repository import canonical_request_sha256
+
+_FIXED_MODES = ("preflight", "reopen", "inspect", "verify-receipt")
+_RECEIPT_PAYLOAD_KEYS = frozenset(
+    {
+        "helper_source_sha256",
+        "operation_sha256",
+        "request_sha256",
+        "resources_sha256",
+        "reservation_sha256",
+        "tenant_fence_sha256",
+        "first_observation_sha256",
+        "second_observation_sha256",
+        "committed_operation_sha256",
+    }
+)
+_OUTPUT_KEYS = frozenset(
+    {
+        "status",
+        "refusal",
+        "state",
+        "checkpoint",
+        "error_code",
+        "resource_kind_counts",
+        "active_reservation",
+        "final_proof",
+        "receipt_digest",
+    }
+)
+
+
+class RecoveryRefusal(RuntimeError):
+    """A content-free no-op refusal."""
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    raise TypeError("recovery value is not canonical JSON")
+
+
+def canonical_receipt_bytes(value: dict[str, object]) -> bytes:
+    return json.dumps(
+        _json_value(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: object) -> str:
+    if not isinstance(value, dict):
+        raise TypeError("recovery hashes require object values")
+    return hashlib.sha256(canonical_receipt_bytes(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryReceiptPayload:
+    helper_source_sha256: str
+    operation_sha256: str
+    request_sha256: str
+    resources_sha256: str
+    reservation_sha256: str
+    tenant_fence_sha256: str
+    first_observation_sha256: str
+    second_observation_sha256: str
+    committed_operation_sha256: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "helper_source_sha256": self.helper_source_sha256,
+            "operation_sha256": self.operation_sha256,
+            "request_sha256": self.request_sha256,
+            "resources_sha256": self.resources_sha256,
+            "reservation_sha256": self.reservation_sha256,
+            "tenant_fence_sha256": self.tenant_fence_sha256,
+            "first_observation_sha256": self.first_observation_sha256,
+            "second_observation_sha256": self.second_observation_sha256,
+            "committed_operation_sha256": self.committed_operation_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LiveObservation:
+    namespace_present: bool
+    release_present: bool
+    pvc_bound: bool
+    volume_present: bool
+    init_job_present: bool
+    init_complete: bool
+    init_failed_only: bool
+    terminating: bool
+    runtime_admitted: bool
+    routes_present: int
+
+
+@dataclass(frozen=True, slots=True)
+class OperationPreState:
+    action: str
+    state: str
+    checkpoint: str
+    error_code: str | None
+    has_claim: bool
+    has_result: bool
+    finalized: bool
+
+
+class RecoveryLiveObserver(Protocol):
+    async def observe(
+        self,
+        operation: Operation,
+        resources: tuple[Resource, ...],
+    ) -> LiveObservation: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _RecoverySnapshot:
+    operation: Operation
+    resources: tuple[Resource, ...]
+    reservation: CapacityReservation
+    operation_sha256: str
+    preserved_sha256: str
+    request_sha256: str
+    request_ciphertext_sha256: str
+    resources_sha256: str
+    reservation_sha256: str
+    tenant_fence_sha256: str
+
+
+def read_operation_identity(
+    *, stdin: str | None = None, identity_file: Path | None = None
+) -> str:
+    if (stdin is None) == (identity_file is None):
+        raise RecoveryRefusal("operation identity source is invalid")
+    if identity_file is not None:
+        try:
+            metadata = identity_file.stat(follow_symlinks=False)
+            if (
+                identity_file.is_symlink()
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.getuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                raise RecoveryRefusal("operation identity file is unsafe")
+            descriptor = os.open(identity_file, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as error:
+            raise RecoveryRefusal("operation identity file is unsafe") from error
+        try:
+            raw = os.read(descriptor, 128).decode("ascii")
+        except (OSError, UnicodeDecodeError) as error:
+            raise RecoveryRefusal("operation identity file is unsafe") from error
+        finally:
+            os.close(descriptor)
+    else:
+        raw = stdin or ""
+    if raw.count("\n") != 1 or not raw.endswith("\n"):
+        raise RecoveryRefusal("operation identity is invalid")
+    value = raw[:-1]
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError as error:
+        raise RecoveryRefusal("operation identity is invalid") from error
+    if str(parsed) != value:
+        raise RecoveryRefusal("operation identity is invalid")
+    return value
+
+
+def require_postgresql(dialect: str) -> None:
+    if dialect != "postgresql":
+        raise RecoveryRefusal("PostgreSQL is required")
+
+
+def validate_live_observation(observation: LiveObservation) -> None:
+    if (
+        not observation.namespace_present
+        or not observation.release_present
+        or not observation.pvc_bound
+        or not observation.volume_present
+        or observation.init_failed_only
+        or observation.terminating
+        or observation.runtime_admitted
+        or observation.routes_present != 0
+    ):
+        raise RecoveryRefusal("live recovery preflight failed")
+
+
+def recovery_transition_values(before: OperationPreState) -> dict[str, object]:
+    if (
+        before.action != "provision"
+        or before.state != "error"
+        or before.checkpoint != "failed"
+        or before.error_code != "PROVISIONER_PROVIDER_METADATA_CONFLICT"
+        or before.has_claim
+        or before.has_result
+        or not before.finalized
+    ):
+        if before.state in {"pending", "claimed", "final"}:
+            raise RecoveryRefusal("already progressed")
+        raise RecoveryRefusal("recovery preflight failed")
+    return {
+        "state": OperationState.PENDING,
+        "checkpoint": "volume-owned",
+        "error_code": None,
+        "claim_owner": None,
+        "claim_token": None,
+        "claim_expires_at": None,
+        "finalized_at": None,
+    }
+
+
+def _hash_model(model: object, *, excluded: frozenset[str] = frozenset()) -> str:
+    table = model.__table__  # type: ignore[attr-defined]
+    return canonical_sha256(
+        {
+            column.name: getattr(model, column.name)
+            for column in table.columns
+            if column.name not in excluded
+        }
+    )
+
+
+def _receipt_payload(receipt: OperationRecoveryReceipt) -> RecoveryReceiptPayload:
+    return RecoveryReceiptPayload(
+        helper_source_sha256=receipt.helper_source_sha256,
+        operation_sha256=receipt.operation_sha256,
+        request_sha256=receipt.request_sha256,
+        resources_sha256=receipt.resources_sha256,
+        reservation_sha256=receipt.reservation_sha256,
+        tenant_fence_sha256=receipt.tenant_fence_sha256,
+        first_observation_sha256=receipt.first_observation_sha256,
+        second_observation_sha256=receipt.second_observation_sha256,
+        committed_operation_sha256=receipt.committed_operation_sha256,
+    )
+
+
+class RecoveryService:
+    """The only recovery mutation, bound to one immutable receipt row."""
+
+    _CHANGED_COLUMNS = frozenset(
+        {
+            "state",
+            "checkpoint",
+            "error_code",
+            "claim_owner",
+            "claim_token",
+            "claim_expires_at",
+            "finalized_at",
+            "available_at",
+            "updated_at",
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        sessions: async_sessionmaker[AsyncSession],
+        codec: EnvelopeCodec,
+        database_role: str,
+        database_schema: str,
+        deployment_lock: DeploymentLock,
+        observer: RecoveryLiveObserver,
+    ) -> None:
+        self._sessions = sessions
+        self._codec = codec
+        self._database_role = database_role
+        self._database_schema = database_schema
+        self._deployment_lock = deployment_lock
+        self._observer = observer
+        self._helper_source_sha256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+    async def preflight(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                snapshot = await self._preflight(session, operation_id)
+                observation = await self._observer.observe(snapshot.operation, snapshot.resources)
+                validate_live_observation(observation)
+                return {
+                    "status": "ready",
+                    "state": snapshot.operation.state.value,
+                    "checkpoint": snapshot.operation.checkpoint,
+                    "resource_kind_counts": {kind.value: 1 for kind in ResourceKind if kind is not ResourceKind.ROUTE},
+                    "active_reservation": True,
+                }
+        except RecoveryRefusal:
+            raise
+        except Exception as error:  # content-free boundary for database/provider failures
+            raise RecoveryRefusal("preflight-failed") from error
+
+    async def reopen(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions.begin() as session:
+                existing = await session.get(OperationRecoveryReceipt, operation_id, with_for_update=True)
+                if existing is not None:
+                    return self._receipt_result(existing, "already-recovered")
+                snapshot = await self._preflight(session, operation_id)
+                first = await self._observer.observe(snapshot.operation, snapshot.resources)
+                validate_live_observation(first)
+                second = await self._observer.observe(snapshot.operation, snapshot.resources)
+                validate_live_observation(second)
+                if first != second:
+                    raise RecoveryRefusal("live recovery preflight failed")
+                now = await session.scalar(select(func.clock_timestamp()))
+                if not isinstance(now, datetime):
+                    raise RecoveryRefusal("database clock is unavailable")
+                before = snapshot.operation
+                updated = await session.scalar(
+                    update(Operation)
+                    .where(
+                        Operation.id == before.id,
+                        Operation.action == OperationAction.PROVISION,
+                        Operation.state == OperationState.ERROR,
+                        Operation.checkpoint == "failed",
+                        Operation.error_code == "PROVISIONER_PROVIDER_METADATA_CONFLICT",
+                        Operation.claim_owner.is_(None),
+                        Operation.claim_token.is_(None),
+                        Operation.claim_expires_at.is_(None),
+                        Operation.result_ciphertext.is_(None),
+                        Operation.external_operation_id == Operation.provider_operation_id,
+                        Operation.fence_generation == Operation.provider_fence_generation,
+                        Operation.canonical_request_sha256 == before.canonical_request_sha256,
+                        Operation.claim_generation == before.claim_generation,
+                        Operation.updated_at == before.updated_at,
+                    )
+                    .values(
+                        state=OperationState.PENDING,
+                        checkpoint="volume-owned",
+                        error_code=None,
+                        claim_owner=None,
+                        claim_token=None,
+                        claim_expires_at=None,
+                        finalized_at=None,
+                        available_at=now,
+                        updated_at=now,
+                    )
+                    .returning(Operation)
+                )
+                if updated is None:
+                    raise RecoveryRefusal("already progressed")
+                await session.flush()
+                receipt = OperationRecoveryReceipt(
+                    operation_id=before.id,
+                    helper_source_sha256=self._helper_source_sha256,
+                    init_job_present=first.init_job_present,
+                    init_job_complete=first.init_complete,
+                    operation_sha256=snapshot.operation_sha256,
+                    preserved_sha256=snapshot.preserved_sha256,
+                    request_sha256=snapshot.request_sha256,
+                    request_ciphertext_sha256=snapshot.request_ciphertext_sha256,
+                    resources_sha256=snapshot.resources_sha256,
+                    reservation_sha256=snapshot.reservation_sha256,
+                    tenant_fence_sha256=snapshot.tenant_fence_sha256,
+                    first_observation_sha256=canonical_sha256(asdict(first)),
+                    second_observation_sha256=canonical_sha256(asdict(second)),
+                    committed_operation_sha256=_hash_model(updated),
+                    committed_at=now,
+                )
+                session.add(receipt)
+                await session.flush()
+                return self._receipt_result(receipt, "reopened")
+        except RecoveryRefusal:
+            raise
+        except Exception as error:  # receipt and transition roll back together
+            raise RecoveryRefusal("recovery-failed") from error
+
+    async def inspect(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions() as session:
+                operation = await session.get(Operation, operation_id)
+                if operation is None:
+                    raise RecoveryRefusal("operation is unavailable")
+                resources = tuple(
+                    await session.scalars(
+                        select(Resource).where(Resource.operation_id == operation.id)
+                    )
+                )
+                reservation = await session.scalar(
+                    select(CapacityReservation).where(
+                        CapacityReservation.reserving_operation_id == operation.id,
+                        CapacityReservation.released_at.is_(None),
+                    )
+                )
+                receipt = await session.get(OperationRecoveryReceipt, operation.id)
+                return {
+                    "status": "inspected",
+                    "state": operation.state.value,
+                    "checkpoint": operation.checkpoint,
+                    "error_code": operation.error_code,
+                    "resource_kind_counts": {
+                        kind.value: sum(item.kind is kind for item in resources)
+                        for kind in ResourceKind
+                    },
+                    "active_reservation": reservation is not None,
+                    "final_proof": receipt is not None,
+                }
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("inspect-failed") from error
+
+    async def verify_receipt(self, operation_id: str) -> dict[str, object]:
+        try:
+            async with self._sessions() as session:
+                receipt = await session.get(OperationRecoveryReceipt, operation_id)
+                if receipt is None:
+                    raise RecoveryRefusal("receipt is unavailable")
+                return self._receipt_result(receipt, "verified")
+        except RecoveryRefusal:
+            raise
+        except Exception as error:
+            raise RecoveryRefusal("receipt-verification-failed") from error
+
+    async def _preflight(self, session: AsyncSession, operation_id: str) -> _RecoverySnapshot:
+        require_postgresql(session.get_bind().dialect.name)
+        await session.scalar(
+            select(func.pg_advisory_xact_lock(database_lock_key(self._database_schema, self._database_role)))
+        )
+        revision_rows = list(await session.scalars(text("SELECT version_num FROM alembic_version")))
+        if revision_rows != [DATABASE_REVISION]:
+            raise RecoveryRefusal("database revision is invalid")
+        role = await session.scalar(select(func.current_user()))
+        schema = await session.scalar(select(func.current_schema()))
+        if role != self._database_role or schema != self._database_schema:
+            raise RecoveryRefusal("database identity is invalid")
+        initial = await session.get(Operation, operation_id)
+        if initial is None:
+            raise RecoveryRefusal("operation is unavailable")
+        fence = await session.get(TenantFence, initial.tenant_id, with_for_update=True)
+        operation = await session.get(Operation, operation_id, with_for_update=True)
+        if (
+            operation is None
+            or fence is None
+            or fence.tenant_id != operation.tenant_id
+            or fence.fence_generation != operation.fence_generation
+        ):
+            raise RecoveryRefusal("recovery preflight failed")
+        transition = recovery_transition_values(
+            OperationPreState(
+                action=operation.action.value,
+                state=operation.state.value,
+                checkpoint=operation.checkpoint,
+                error_code=operation.error_code,
+                has_claim=any(
+                    value is not None
+                    for value in (operation.claim_owner, operation.claim_token, operation.claim_expires_at)
+                ),
+                has_result=operation.result_ciphertext is not None,
+                finalized=operation.finalized_at is not None,
+            )
+        )
+        if operation.cell_id is None or operation.external_operation_id != operation.provider_operation_id or operation.fence_generation != operation.provider_fence_generation:
+            raise RecoveryRefusal("recovery preflight failed")
+        del transition
+        await self._lock_conflicts(session, operation)
+        request = self._codec.decrypt_json(
+            operation.request_ciphertext,
+            purpose=f"operation-request:{operation.action.value}:{operation.idempotency_key}",
+        )
+        if (
+            canonical_request_sha256(request) != operation.canonical_request_sha256
+            or request.get("tenantId") != operation.tenant_id
+            or request.get("cellId") != operation.cell_id
+            or request.get("operationId") != operation.external_operation_id
+            or request.get("fenceGeneration") != operation.fence_generation
+            or request.get("checkpoint") != operation.caller_checkpoint
+            or request.get("provisionMode") != "serve"
+            or not self._deployment_lock.matches_runtime_request(
+                request, wire_protocol=operation.wire_protocol.value
+            )
+        ):
+            raise RecoveryRefusal("recovery preflight failed")
+        resources = await self._resources(session, operation)
+        reservation = await self._reservation(session, operation)
+        return _RecoverySnapshot(
+            operation=operation,
+            resources=resources,
+            reservation=reservation,
+            operation_sha256=_hash_model(operation),
+            preserved_sha256=_hash_model(operation, excluded=self._CHANGED_COLUMNS),
+            request_sha256=operation.canonical_request_sha256,
+            request_ciphertext_sha256=hashlib.sha256(operation.request_ciphertext.encode()).hexdigest(),
+            resources_sha256=canonical_sha256(
+                {item.id: _hash_model(item) for item in sorted(resources, key=lambda item: item.id)}
+            ),
+            reservation_sha256=_hash_model(reservation),
+            tenant_fence_sha256=_hash_model(fence),
+        )
+
+    async def _lock_conflicts(self, session: AsyncSession, operation: Operation) -> None:
+        lock = await session.get(CellOperationLock, operation.cell_id, with_for_update=True)
+        if lock is not None:
+            raise RecoveryRefusal("recovery preflight failed")
+        await session.get(CapacityLedger, 1, with_for_update=True)
+        destructive = tuple(
+            await session.scalars(
+                select(CapacityDestructiveFence)
+                .where(
+                    CapacityDestructiveFence.tenant_id == operation.tenant_id,
+                    CapacityDestructiveFence.fence_generation >= operation.fence_generation,
+                )
+                .with_for_update()
+            )
+        )
+        if destructive:
+            raise RecoveryRefusal("recovery preflight failed")
+        conflicts = tuple(
+            await session.scalars(
+                select(Operation)
+                .where(
+                    Operation.id != operation.id,
+                    Operation.state.in_((OperationState.PENDING, OperationState.CLAIMED)),
+                    (Operation.tenant_id == operation.tenant_id)
+                    | (Operation.cell_id == operation.cell_id),
+                )
+                .with_for_update()
+            )
+        )
+        if conflicts:
+            raise RecoveryRefusal("recovery preflight failed")
+
+    async def _resources(self, session: AsyncSession, operation: Operation) -> tuple[Resource, ...]:
+        scoped = tuple(
+            await session.scalars(
+                select(Resource)
+                .where(Resource.tenant_id == operation.tenant_id, Resource.cell_id == operation.cell_id)
+                .order_by(Resource.created_at, Resource.id)
+                .with_for_update()
+            )
+        )
+        resources = tuple(item for item in scoped if item.operation_id == operation.id)
+        expected = {
+            ResourceKind.HELM_RELEASE,
+            ResourceKind.KUBERNETES_NAMESPACE,
+            ResourceKind.PVC,
+            ResourceKind.VOLUME,
+        }
+        if (
+            {item.kind for item in resources} != expected
+            or len(resources) != len(expected)
+            or any(item.kind is ResourceKind.ROUTE for item in scoped)
+            or any(
+                item.kind is ResourceKind.KUBERNETES_NAMESPACE and item.operation_id != operation.id
+                for item in scoped
+            )
+        ):
+            raise RecoveryRefusal("recovery preflight failed")
+        for resource in resources:
+            if (
+                resource.provider_operation_id != operation.external_operation_id
+                or resource.provider_fence_generation != operation.fence_generation
+            ):
+                raise RecoveryRefusal("recovery preflight failed")
+            reference = self._codec.decrypt_json(
+                resource.reference_ciphertext,
+                purpose=f"resource-reference:{resource.operation_id}:{resource.kind.value}",
+            ).get("reference")
+            if not isinstance(reference, str) or hashlib.sha256(reference.encode()).hexdigest() != resource.reference_digest:
+                raise RecoveryRefusal("recovery preflight failed")
+        return resources
+
+    async def _reservation(
+        self, session: AsyncSession, operation: Operation
+    ) -> CapacityReservation:
+        reservations = tuple(
+            await session.scalars(
+                select(CapacityReservation)
+                .where(
+                    CapacityReservation.reserving_operation_id == operation.id,
+                    CapacityReservation.tenant_id == operation.tenant_id,
+                    CapacityReservation.cell_id == operation.cell_id,
+                )
+                .with_for_update()
+            )
+        )
+        if len(reservations) != 1:
+            raise RecoveryRefusal("recovery preflight failed")
+        reservation = reservations[0]
+        if (
+            reservation.reservation_class.value != "USER"
+            or reservation.reserving_provider_operation_id != operation.external_operation_id
+            or reservation.reserving_fence_generation != operation.fence_generation
+            or reservation.released_at is not None
+            or any(
+                value is not None
+                for value in (
+                    reservation.releasing_operation_id,
+                    reservation.releasing_provider_operation_id,
+                    reservation.releasing_fence_generation,
+                    reservation.release_reason,
+                )
+            )
+        ):
+            raise RecoveryRefusal("recovery preflight failed")
+        return reservation
+
+    @staticmethod
+    def _receipt_result(receipt: OperationRecoveryReceipt, status: str) -> dict[str, object]:
+        return {
+            "status": status,
+            "receipt_digest": canonical_sha256(_receipt_payload(receipt).to_payload()),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _ProductionRecoveryObserver:
+    """Compose existing authenticated Kubernetes/PV/HCloud readers without mutations."""
+
+    registry: object
+    cell: object
+    volumes: object
+    hcloud: object
+    location: str
+
+    async def observe(
+        self,
+        operation: Operation,
+        resources: tuple[Resource, ...],
+    ) -> LiveObservation:
+        from .lifecycle import OpaqueProviderMetadata
+
+        del resources
+        if operation.cell_id is None:
+            raise RecoveryRefusal("live recovery preflight failed")
+        metadata = OpaqueProviderMetadata(
+            tenant_id=operation.tenant_id,
+            subject_id=operation.cell_id,
+            operation_id=operation.external_operation_id,
+            fence_generation=operation.fence_generation,
+        )
+        snapshot = await self.registry.inspect(metadata, metadata)  # type: ignore[attr-defined]
+        recorded = await self.volumes.discover_bound_volume(metadata)  # type: ignore[attr-defined]
+        volume_present = recorded is not None and await self.hcloud.verify_volume(  # type: ignore[attr-defined]
+            recorded.volume_handle, metadata, self.location
+        )
+        return LiveObservation(
+            namespace_present=snapshot.namespace,
+            release_present=snapshot.release,
+            pvc_bound=await self.cell.volume_claim_bound(metadata),  # type: ignore[attr-defined]
+            volume_present=volume_present,
+            init_job_present=snapshot.init_job_present,
+            init_complete=snapshot.init_complete,
+            init_failed_only=snapshot.init_failed,
+            terminating=False,
+            runtime_admitted=snapshot.runtime_admitted,
+            routes_present=sum(snapshot.routes),
+        )
+
+
+def emit_result(payload: dict[str, object]) -> int:
+    if set(payload) - _OUTPUT_KEYS or not isinstance(payload.get("status"), str):
+        raise RecoveryRefusal("recovery output is invalid")
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("mode", choices=_FIXED_MODES)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--stdin", action="store_true")
+    source.add_argument("--identity-file", type=Path)
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> dict[str, object]:
+    from hcloud import Client as HCloudClient
+    from kubernetes import client, config
+
+    from .adapters import HCloudVolumeAdapter, KubernetesCellAdapter, KubernetesVolumeAdapter
+    from .config import ProviderWorkerSettings, ProvisionerSettings, VolumeWorkerSettings
+    from .crypto import AesGcmEnvelopeCodec
+    from .database import ProvisionerDatabase
+    from .live import KubernetesProviderRegistry
+    from .main import _require_production_database
+    from .provider_identity import ProviderRecoveryIdentityVerifier
+
+    database: ProvisionerDatabase | None = None
+    api_client: object | None = None
+    try:
+        settings = ProvisionerSettings()  # type: ignore[call-arg]
+        provider = ProviderWorkerSettings()  # type: ignore[call-arg]
+        volume = VolumeWorkerSettings()  # type: ignore[call-arg]
+        _require_production_database(settings)
+        database = ProvisionerDatabase(settings)
+        config.load_incluster_config()
+        api_client = client.ApiClient()
+        identity = ProviderRecoveryIdentityVerifier.from_public_key(
+            provider.provider_recovery_public_key
+        )
+        core = client.CoreV1Api(api_client)
+        observer = _ProductionRecoveryObserver(
+            registry=KubernetesProviderRegistry(
+                core_v1=core,
+                apps_v1=client.AppsV1Api(api_client),
+                batch_v1=client.BatchV1Api(api_client),
+                custom_objects=client.CustomObjectsApi(api_client),
+                identity_verifier=identity,
+            ),
+            cell=KubernetesCellAdapter(
+                core_v1=core,
+                apps_v1=client.AppsV1Api(api_client),
+                identity_verifier=identity,
+            ),
+            volumes=KubernetesVolumeAdapter(
+                core_v1=core,
+                storage_class_name="exomem-hcloud-encrypted-retain",
+                encryption_secret_name=volume.volume_encryption_secret_name,
+                encryption_secret_namespace=volume.volume_encryption_secret_namespace,
+                identity_verifier=identity,
+            ),
+            hcloud=HCloudVolumeAdapter(
+                client=HCloudClient(token=volume.hcloud_token.get_secret_value()),
+                identity_verifier=identity,
+            ),
+            location=volume.location,
+        )
+        service = RecoveryService(
+            sessions=database.session_factory,
+            codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+            database_role=settings.database_role,
+            database_schema=settings.database_schema,
+            deployment_lock=provider.deployment_lock,
+            observer=observer,
+        )
+        operation_id = read_operation_identity(
+            stdin=sys.stdin.read() if args.stdin else None,
+            identity_file=args.identity_file,
+        )
+        match args.mode:
+            case "preflight":
+                return await service.preflight(operation_id)
+            case "reopen":
+                return await service.reopen(operation_id)
+            case "inspect":
+                return await service.inspect(operation_id)
+            case "verify-receipt":
+                return await service.verify_receipt(operation_id)
+        raise RecoveryRefusal("recovery mode is invalid")
+    except RecoveryRefusal:
+        raise
+    except Exception as error:
+        raise RecoveryRefusal("recovery command failed") from error
+    finally:
+        if database is not None:
+            await database.dispose()
+        if api_client is not None:
+            await asyncio.to_thread(api_client.close)  # type: ignore[attr-defined]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    values = list(sys.argv[1:] if argv is None else argv)
+    if values == ["--help"]:
+        print(
+            "exomem-provisioner-recover-init-retry - recover one proven hosted init retry "
+            "false-negative; configuration is supplied through environment variables"
+        )
+        return 0
+    try:
+        arguments = _parser().parse_args(values)
+        return emit_result(asyncio.run(_run(arguments)))
+    except RecoveryRefusal as error:
+        emit_result({"status": "refused", "refusal": str(error)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/provisioner/src/exomem_provisioner/operation_recovery.py
+++ b/infra/provisioner/src/exomem_provisioner/operation_recovery.py
@@ -792,9 +792,19 @@ class _ProductionRecoveryObserver:
         volume_observation = await self.volumes.observe_recovery_bound_volume(metadata)  # type: ignore[attr-defined]
         volume_present = (
             volume_observation is not None
-            and volume_observation.recorded == expected_volume
-            and await self.hcloud.verify_volume(  # type: ignore[attr-defined]
+            and (
+                volume_observation.recorded.volume_handle == expected_volume.volume_handle
+                and volume_observation.recorded.pv_name == expected_volume.pv_name
+                and volume_observation.recorded.location == expected_volume.location
+                and volume_observation.recorded.metadata == expected_volume.metadata
+                and volume_observation.recorded.pv_recovery_envelope
+                == expected_volume.pv_recovery_envelope
+                and volume_observation.recorded.pvc_recovery_envelope
+                == expected_volume.pvc_recovery_envelope
+            )
+            and await self.hcloud.verify_recovery_volume(  # type: ignore[attr-defined]
             expected_volume.volume_handle, metadata, self.location
+            , expected_volume.hcloud_recovery_envelope
             )
         )
         return LiveObservation(

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from exomem_provisioner.capacity import CapacityConflict
 from exomem_provisioner.config import (
     ProviderWorkerSettings,
+    load_deployment_lock,
     load_hosted_release_manifest,
 )
 from exomem_provisioner.driver import DriverPending, EffectContext
@@ -178,6 +179,41 @@ def test_live_worker_loads_the_selected_lock_and_rejects_an_unavailable_lock(tmp
     )
     with pytest.raises(ValueError, match="deployment lock is unavailable"):
         _ = missing.deployment_lock
+
+
+def test_deployment_lock_requires_exact_legacy_v1_or_exact_forward_v2_target(tmp_path: Path) -> None:
+    path = _deployment_lock(tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["runtimeTarget"]["releaseVersion"] = "0.39.2"
+    payload["composition"]["legacyCatalog"][0]["releaseVersion"] = "0.39.2"
+    payload["composition"]["legacyCatalog"][0]["protocolVersion"] = "1"
+    payload["composition"]["legacyCatalog"][0]["contract"]["releaseVersion"] = "0.39.2"
+    payload["composition"]["legacyCatalog"][0]["contract"]["protocolVersion"] = "1"
+    payload["composition"]["legacyCatalog"][0]["contractSha256"] = _canonical_sha256(
+        payload["composition"]["legacyCatalog"][0]["contract"]
+    )
+    payload["composition"]["legacyReleaseSetSha256"] = _canonical_sha256(
+        [{"releaseVersion": "0.39.2", "protocolVersion": "1"}]
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    lock = load_deployment_lock(path)
+    target = lock.runtime_target.model_dump(mode="json")
+
+    assert lock.matches_runtime_request(
+        {"releaseVersion": "0.39.2", "protocolVersion": "1"},
+        wire_protocol="exomem-cell-provisioner.v1",
+    )
+    assert not lock.matches_runtime_request(
+        {"releaseVersion": "0.39.1", "protocolVersion": "1"},
+        wire_protocol="exomem-cell-provisioner.v1",
+    )
+    assert lock.matches_runtime_request(
+        {"runtimeTarget": target}, wire_protocol="exomem-cell-provisioner.v2"
+    )
+    assert not lock.matches_runtime_request(
+        {"runtimeTarget": {**target, "releaseVersion": "0.39.1"}},
+        wire_protocol="exomem-cell-provisioner.v2",
+    )
 
 
 def test_release_manifest_is_complete_strict_and_immutable(tmp_path: Path) -> None:
@@ -824,6 +860,109 @@ async def test_registry_distinguishes_absent_running_complete_and_failed_init_jo
     assert snapshot.init_job_present is present
     assert snapshot.init_complete is complete
     assert snapshot.init_failed is failed
+
+
+@pytest.mark.asyncio
+async def test_recovery_reader_authenticates_init_job_and_stabilizes_helm_record() -> None:
+    metadata = _metadata()
+    envelopes = cell_provider_recovery_envelopes(
+        IDENTITY_CODEC,
+        tenant_id=metadata.tenant_id,
+        cell_id=metadata.subject_id,
+        operation_id=metadata.operation_id,
+        fence_generation=metadata.fence_generation,
+        resource_name=metadata.resource_name,
+        operation_resource_name=provider_operation_resource_name(metadata.operation_id),
+    )
+
+    def resource(*, name: str, annotations: dict[str, str], uid: str, version: str, labels=None):
+        return SimpleNamespace(
+            metadata=SimpleNamespace(
+                name=name,
+                namespace=metadata.resource_name,
+                annotations=annotations,
+                labels=labels or {},
+                uid=uid,
+                resource_version=version,
+                deletion_timestamp=None,
+            )
+        )
+
+    class Core:
+        helm = resource(
+            name="helm-release",
+            annotations={},
+            uid="helm-one",
+            version="1",
+            labels={"owner": "helm", "name": metadata.resource_name, "status": "deployed"},
+        )
+
+        def read_namespace(self, name):
+            return resource(
+                name=name,
+                annotations={
+                    **metadata.kubernetes_annotations,
+                    "exomem.io/recovery-envelope": envelopes["namespace"],
+                },
+                uid="namespace-one",
+                version="1",
+            )
+
+        def read_namespaced_persistent_volume_claim(self, name, namespace):
+            return resource(
+                name=name,
+                annotations={
+                    **metadata.kubernetes_annotations,
+                    "exomem.io/recovery-envelope": envelopes["vaultPvc"],
+                },
+                uid="pvc-one",
+                version="1",
+            )
+
+        def read_namespaced_config_map(self, name, namespace):
+            return resource(
+                name=name,
+                annotations={
+                    **metadata.kubernetes_annotations,
+                    "exomem.io/recovery-envelope": envelopes["providerOperationConfigMap"],
+                },
+                uid="operation-one",
+                version="1",
+            )
+
+        def list_namespaced_config_map(self, namespace, *, label_selector):
+            return SimpleNamespace(items=[self.helm])
+
+    class Batch:
+        job = resource(
+            name=metadata.resource_name + "-init",
+            annotations={
+                **metadata.kubernetes_annotations,
+                "exomem.io/recovery-envelope": envelopes["initJob"],
+            },
+            uid="job-one",
+            version="1",
+        )
+
+        def read_namespaced_job(self, name, namespace):
+            return self.job
+
+    core = Core()
+    batch = Batch()
+    registry = KubernetesProviderRegistry(
+        core_v1=core,
+        apps_v1=SimpleNamespace(),
+        batch_v1=batch,
+        custom_objects=SimpleNamespace(),
+        identity_verifier=IDENTITY_CODEC.verifier(),
+    )
+
+    first = await registry.authenticate_recovery_record(metadata)
+    core.helm.metadata.uid = "helm-two"
+    assert first != await registry.authenticate_recovery_record(metadata)
+    batch.job.metadata.annotations["exomem.io/recovery-envelope"] = "forged"
+    with pytest.raises(MetadataConflict):
+        await registry.authenticate_recovery_record(metadata)
 
 
 def _init_snapshot(*, present: bool, complete: bool = False, failed: bool = False, serving: bool = False):

--- a/infra/provisioner/tests/test_migrations.py
+++ b/infra/provisioner/tests/test_migrations.py
@@ -40,6 +40,9 @@ def test_alembic_upgrades_empty_sqlite_database_to_head(tmp_path: Path) -> None:
         }
         revision = connection.execute("SELECT version_num FROM alembic_version").fetchone()
         operation_columns = {row[1] for row in connection.execute("PRAGMA table_info(operations)")}
+        receipt_columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(operation_recovery_receipts)")
+        }
         ledger = connection.execute("SELECT id, revision FROM capacity_ledger").fetchall()
     assert {
         "alembic_version",
@@ -57,8 +60,9 @@ def test_alembic_upgrades_empty_sqlite_database_to_head(tmp_path: Path) -> None:
         "capacity_ledger",
         "capacity_reservations",
         "capacity_destructive_fences",
+        "operation_recovery_receipts",
     } <= tables
-    assert revision == ("0006_operation_wire_protocol",)
+    assert revision == ("0007_operation_recovery_receipt",)
     assert ledger == [(1, 0)]
     assert {
         "caller_checkpoint",
@@ -69,6 +73,13 @@ def test_alembic_upgrades_empty_sqlite_database_to_head(tmp_path: Path) -> None:
         "claim_expires_at",
         "wire_protocol",
     } <= operation_columns
+    assert {
+        "operation_id",
+        "helper_source_sha256",
+        "request_ciphertext_sha256",
+        "committed_operation_sha256",
+        "committed_at",
+    } <= receipt_columns
 
 
 def test_capacity_migration_downgrade_upgrade_round_trip(tmp_path: Path) -> None:
@@ -113,8 +124,9 @@ def test_capacity_migration_downgrade_upgrade_round_trip(tmp_path: Path) -> None
                 "capacity_ledger",
                 "capacity_reservations",
                 "capacity_destructive_fences",
+                "operation_recovery_receipts",
             } <= tables
-            assert revision == ("0006_operation_wire_protocol",)
+            assert revision == ("0007_operation_recovery_receipt",)
 
 
 def test_wire_protocol_sqlite_backfill_default_constraint_and_round_trip(tmp_path: Path) -> None:

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -29,10 +29,27 @@ def test_recovery_command_has_only_fixed_modes_and_environment_free_help(
     assert parser.parse_args(["preflight", "--stdin"]).mode == "preflight"
     for mode in ("reopen", "inspect", "verify-receipt"):
         assert parser.parse_args([mode, "--stdin"]).mode == mode
-    with pytest.raises(SystemExit):
+    with pytest.raises(recovery.RecoveryRefusal):
         parser.parse_args(["anything-else", "--stdin"])
-    with pytest.raises(SystemExit):
+    with pytest.raises(recovery.RecoveryRefusal):
         parser.parse_args(["preflight", "--operation-id", str(uuid.uuid4())])
+
+
+def test_recovery_command_never_echoes_rejected_arguments(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    recovery = _module()
+    forbidden = str(uuid.uuid4())
+
+    assert recovery.main(["preflight", "--operation-id", forbidden]) == 2
+
+    captured = capsys.readouterr()
+    assert forbidden not in captured.out
+    assert forbidden not in captured.err
+    assert json.loads(captured.out) == {
+        "refusal": "command arguments are invalid",
+        "status": "refused",
+    }
 
 
 @pytest.mark.parametrize(
@@ -95,39 +112,95 @@ def test_canonical_hash_is_order_stable_and_never_serializes_secret_fields() -> 
 
     assert recovery.canonical_sha256(first) == recovery.canonical_sha256(second)
     receipt = recovery.RecoveryReceiptPayload(
+        schema_version=1,
         helper_source_sha256="9" * 64,
+        old_state="error",
+        old_checkpoint="failed",
+        new_state="pending",
+        new_checkpoint="volume-owned",
+        resource_count=4,
+        route_count=0,
+        init_job_present=False,
+        init_job_complete=False,
         operation_sha256="a" * 64,
+        preserved_sha256="a" * 64,
         request_sha256="b" * 64,
+        request_ciphertext_sha256="b" * 64,
         resources_sha256="c" * 64,
         reservation_sha256="d" * 64,
         tenant_fence_sha256="e" * 64,
         first_observation_sha256="f" * 64,
         second_observation_sha256="0" * 64,
         committed_operation_sha256="1" * 64,
+        committed_at=datetime(2030, 1, 2, 3, 4, 5, tzinfo=UTC),
     )
     encoded = recovery.canonical_receipt_bytes(receipt.to_payload())
     assert b"operation_sha256" in encoded
-    assert b"ciphertext" not in encoded
+    assert b"request_ciphertext_sha256" in encoded
     assert b"reference" not in encoded
 
 
 def test_transactional_receipt_payload_is_content_free_and_hashable() -> None:
     recovery = _module()
     receipt = recovery.RecoveryReceiptPayload(
+        schema_version=1,
         helper_source_sha256="9" * 64,
+        old_state="error",
+        old_checkpoint="failed",
+        new_state="pending",
+        new_checkpoint="volume-owned",
+        resource_count=4,
+        route_count=0,
+        init_job_present=False,
+        init_job_complete=False,
         operation_sha256="a" * 64,
+        preserved_sha256="a" * 64,
         request_sha256="b" * 64,
+        request_ciphertext_sha256="b" * 64,
         resources_sha256="c" * 64,
         reservation_sha256="d" * 64,
         tenant_fence_sha256="e" * 64,
         first_observation_sha256="f" * 64,
         second_observation_sha256="0" * 64,
         committed_operation_sha256="1" * 64,
+        committed_at=datetime(2030, 1, 2, 3, 4, 5, tzinfo=UTC),
     )
 
     encoded = recovery.canonical_receipt_bytes(receipt.to_payload())
     assert set(json.loads(encoded)) == recovery._RECEIPT_PAYLOAD_KEYS
-    assert b"ciphertext" not in encoded and b"reference" not in encoded
+    assert b"request_ciphertext_sha256" in encoded and b"reference" not in encoded
+
+
+def test_receipt_digest_binds_every_content_free_receipt_field() -> None:
+    recovery = _module()
+    receipt = recovery.RecoveryReceiptPayload(
+        schema_version=1,
+        helper_source_sha256="9" * 64,
+        old_state="error",
+        old_checkpoint="failed",
+        new_state="pending",
+        new_checkpoint="volume-owned",
+        resource_count=4,
+        route_count=0,
+        init_job_present=False,
+        init_job_complete=False,
+        operation_sha256="a" * 64,
+        preserved_sha256="b" * 64,
+        request_sha256="c" * 64,
+        request_ciphertext_sha256="d" * 64,
+        resources_sha256="e" * 64,
+        reservation_sha256="f" * 64,
+        tenant_fence_sha256="0" * 64,
+        first_observation_sha256="1" * 64,
+        second_observation_sha256="2" * 64,
+        committed_operation_sha256="3" * 64,
+        committed_at=datetime(2030, 1, 2, 3, 4, 5, tzinfo=UTC),
+    )
+
+    assert set(receipt.to_payload()) == recovery._RECEIPT_PAYLOAD_KEYS
+    assert recovery.canonical_sha256(receipt.to_payload()) != recovery.canonical_sha256(
+        replace(receipt, init_job_complete=True).to_payload()
+    )
 
 
 def test_recovery_receipt_model_is_one_to_one_content_free_and_immutable() -> None:
@@ -243,6 +316,28 @@ def test_reopen_is_single_exact_cas_and_a_second_invocation_is_noop() -> None:
         recovery.recovery_transition_values(
             replace(before, state="pending", checkpoint="volume-owned")
         )
+
+
+def test_final_proof_requires_the_exact_normal_provision_completion_shape() -> None:
+    recovery = _module()
+    operation = type(
+        "OperationProof",
+        (),
+        {
+            "state": recovery.OperationState.FINAL,
+            "checkpoint": "complete",
+            "result_ciphertext": "encrypted-result",
+            "result_redacted": {
+                "completed": True,
+                "fields": ["privateEndpoint", "providerRef"],
+            },
+            "finalized_at": datetime(2030, 1, 2, 3, 4, 5, tzinfo=UTC),
+        },
+    )()
+
+    assert recovery.RecoveryService._final_proof(operation) is True
+    operation.result_redacted = {"completed": True, "fields": []}
+    assert recovery.RecoveryService._final_proof(operation) is False
 
 
 def test_main_converts_refusals_to_content_free_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+
+def _module():
+    import exomem_provisioner.operation_recovery as recovery
+
+    return recovery
+
+
+def test_recovery_command_has_only_fixed_modes_and_environment_free_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    recovery = _module()
+
+    assert recovery.main(["--help"]) == 0
+    assert capsys.readouterr().out == (
+        "exomem-provisioner-recover-init-retry - recover one proven hosted init retry "
+        "false-negative; configuration is supplied through environment variables\n"
+    )
+    parser = recovery._parser()
+    assert parser.parse_args(["preflight", "--stdin"]).mode == "preflight"
+    for mode in ("reopen", "inspect", "verify-receipt"):
+        assert parser.parse_args([mode, "--stdin"]).mode == mode
+    with pytest.raises(SystemExit):
+        parser.parse_args(["anything-else", "--stdin"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["preflight", "--operation-id", str(uuid.uuid4())])
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "\n", "not-a-uuid\n", f"{uuid.uuid4()}\n{uuid.uuid4()}\n"],
+)
+def test_operation_identity_stdin_is_exactly_one_uuid(raw: str) -> None:
+    recovery = _module()
+
+    with pytest.raises(recovery.RecoveryRefusal, match="operation identity is invalid"):
+        recovery.read_operation_identity(stdin=raw)
+
+
+def test_operation_identity_stdin_never_leaks_confidential_value() -> None:
+    recovery = _module()
+    identity = str(uuid.uuid4())
+
+    assert recovery.read_operation_identity(stdin=identity + "\n") == identity
+
+
+def test_operation_identity_file_requires_owned_regular_mode_0600(tmp_path: Path) -> None:
+    recovery = _module()
+    identity = str(uuid.uuid4())
+    path = tmp_path / "identity"
+    path.write_text(identity + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+    assert recovery.read_operation_identity(identity_file=path) == identity
+
+    path.chmod(0o640)
+    with pytest.raises(recovery.RecoveryRefusal, match="operation identity file is unsafe"):
+        recovery.read_operation_identity(identity_file=path)
+
+    path.chmod(0o600)
+    linked = tmp_path / "linked"
+    linked.symlink_to(path)
+    with pytest.raises(recovery.RecoveryRefusal, match="operation identity file is unsafe"):
+        recovery.read_operation_identity(identity_file=linked)
+
+
+def test_operation_identity_rejects_both_or_neither_source() -> None:
+    recovery = _module()
+    identity = str(uuid.uuid4())
+
+    with pytest.raises(recovery.RecoveryRefusal, match="operation identity source is invalid"):
+        recovery.read_operation_identity()
+    with pytest.raises(recovery.RecoveryRefusal, match="operation identity source is invalid"):
+        recovery.read_operation_identity(stdin=identity + "\n", identity_file=Path("/tmp/identity"))
+
+
+def test_canonical_hash_is_order_stable_and_never_serializes_secret_fields() -> None:
+    recovery = _module()
+    first = {
+        "operation": uuid.UUID("123e4567-e89b-42d3-a456-426614174000"),
+        "state": recovery.OperationState.ERROR,
+        "observed_at": datetime(2030, 1, 2, 3, 4, 5, tzinfo=UTC),
+        "empty": None,
+    }
+    second = dict(reversed(tuple(first.items())))
+
+    assert recovery.canonical_sha256(first) == recovery.canonical_sha256(second)
+    receipt = recovery.RecoveryReceiptPayload(
+        helper_source_sha256="9" * 64,
+        operation_sha256="a" * 64,
+        request_sha256="b" * 64,
+        resources_sha256="c" * 64,
+        reservation_sha256="d" * 64,
+        tenant_fence_sha256="e" * 64,
+        first_observation_sha256="f" * 64,
+        second_observation_sha256="0" * 64,
+        committed_operation_sha256="1" * 64,
+    )
+    encoded = recovery.canonical_receipt_bytes(receipt.to_payload())
+    assert b"operation_sha256" in encoded
+    assert b"ciphertext" not in encoded
+    assert b"reference" not in encoded
+
+
+def test_transactional_receipt_payload_is_content_free_and_hashable() -> None:
+    recovery = _module()
+    receipt = recovery.RecoveryReceiptPayload(
+        helper_source_sha256="9" * 64,
+        operation_sha256="a" * 64,
+        request_sha256="b" * 64,
+        resources_sha256="c" * 64,
+        reservation_sha256="d" * 64,
+        tenant_fence_sha256="e" * 64,
+        first_observation_sha256="f" * 64,
+        second_observation_sha256="0" * 64,
+        committed_operation_sha256="1" * 64,
+    )
+
+    encoded = recovery.canonical_receipt_bytes(receipt.to_payload())
+    assert set(json.loads(encoded)) == recovery._RECEIPT_PAYLOAD_KEYS
+    assert b"ciphertext" not in encoded and b"reference" not in encoded
+
+
+def test_recovery_receipt_model_is_one_to_one_content_free_and_immutable() -> None:
+    from exomem_provisioner.database import DATABASE_REVISION
+    from exomem_provisioner.models import OperationRecoveryReceipt
+
+    assert DATABASE_REVISION == "0007_operation_recovery_receipt"
+    table = OperationRecoveryReceipt.__table__
+    assert set(table.c.keys()) == {
+        "operation_id",
+        "schema_version",
+        "helper_source_sha256",
+        "old_state",
+        "old_checkpoint",
+        "new_state",
+        "new_checkpoint",
+        "resource_count",
+        "route_count",
+        "init_job_present",
+        "init_job_complete",
+        "operation_sha256",
+        "preserved_sha256",
+        "request_sha256",
+        "request_ciphertext_sha256",
+        "resources_sha256",
+        "reservation_sha256",
+        "tenant_fence_sha256",
+        "first_observation_sha256",
+        "second_observation_sha256",
+        "committed_operation_sha256",
+        "committed_at",
+    }
+    assert table.c.operation_id.primary_key is True
+    assert table.c.operation_id.foreign_keys
+    assert {"tenant_id", "cell_id", "provider_operation_id"}.isdisjoint(table.c.keys())
+
+
+def test_recovery_refusal_output_is_fixed_and_content_free(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    recovery = _module()
+    secret = "secret-operation-and-dsn-value"
+
+    assert recovery.emit_result({"status": "refused", "refusal": "preflight-failed"}) == 0
+    output = capsys.readouterr().out
+    assert json.loads(output) == {"refusal": "preflight-failed", "status": "refused"}
+    assert secret not in output
+    with pytest.raises(recovery.RecoveryRefusal):
+        recovery.emit_result({"status": "refused", "operation_id": secret})
+
+
+def test_sqlite_is_refused_before_any_recovery_work() -> None:
+    recovery = _module()
+
+    with pytest.raises(recovery.RecoveryRefusal, match="PostgreSQL is required"):
+        recovery.require_postgresql("sqlite")
+
+
+def test_live_init_observation_allows_absent_or_complete_job_but_refuses_failed_or_terminating() -> None:
+    recovery = _module()
+
+    absent = recovery.LiveObservation(
+        namespace_present=True,
+        release_present=True,
+        pvc_bound=True,
+        volume_present=True,
+        init_job_present=False,
+        init_complete=False,
+        init_failed_only=False,
+        terminating=False,
+        runtime_admitted=False,
+        routes_present=0,
+    )
+    assert recovery.validate_live_observation(absent) is None
+    assert recovery.validate_live_observation(
+        replace(absent, init_job_present=True, init_complete=True)
+    ) is None
+    for changed in (
+        {"init_job_present": True, "init_failed_only": True},
+        {"pvc_bound": False},
+        {"terminating": True},
+        {"runtime_admitted": True},
+        {"routes_present": 1},
+    ):
+        with pytest.raises(recovery.RecoveryRefusal, match="live recovery preflight failed"):
+            recovery.validate_live_observation(
+                replace(absent, **changed)
+            )
+
+
+def test_reopen_is_single_exact_cas_and_a_second_invocation_is_noop() -> None:
+    recovery = _module()
+    before = recovery.OperationPreState(
+        action="provision",
+        state="error",
+        checkpoint="failed",
+        error_code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+        has_claim=False,
+        has_result=False,
+        finalized=True,
+    )
+
+    assert recovery.recovery_transition_values(before) == {
+        "state": recovery.OperationState.PENDING,
+        "checkpoint": "volume-owned",
+        "error_code": None,
+        "claim_owner": None,
+        "claim_token": None,
+        "claim_expires_at": None,
+        "finalized_at": None,
+    }
+    with pytest.raises(recovery.RecoveryRefusal, match="already progressed"):
+        recovery.recovery_transition_values(
+            replace(before, state="pending", checkpoint="volume-owned")
+        )
+
+
+def test_main_converts_refusals_to_content_free_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    recovery = _module()
+
+    async def refuse(_: object) -> dict[str, object]:
+        raise recovery.RecoveryRefusal("preflight-failed")
+
+    monkeypatch.setattr(recovery, "_run", refuse)
+
+    assert recovery.main(["preflight", "--stdin"]) == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "refusal": "preflight-failed",
+        "status": "refused",
+    }

--- a/infra/provisioner/tests/test_operation_recovery.py
+++ b/infra/provisioner/tests/test_operation_recovery.py
@@ -340,6 +340,58 @@ def test_final_proof_requires_the_exact_normal_provision_completion_shape() -> N
     assert recovery.RecoveryService._final_proof(operation) is False
 
 
+@pytest.mark.asyncio
+async def test_production_observer_compares_live_volume_fields_not_absent_hcloud_copy() -> None:
+    recovery = _module()
+    from exomem_provisioner.lifecycle import OpaqueProviderMetadata, RecordedVolume
+    from exomem_provisioner.models import ResourceKind
+
+    metadata = OpaqueProviderMetadata("tenant-alpha", "cell-alpha", "provider-alpha", 7)
+    expected = RecordedVolume(
+        "42", "pv-alpha", "fsn1", metadata, "hcloud-envelope", "pv-envelope", "pvc-envelope"
+    )
+    live = RecordedVolume("42", "pv-alpha", "fsn1", metadata, "", "pv-envelope", "pvc-envelope")
+    references = {
+        ResourceKind.KUBERNETES_NAMESPACE: metadata.resource_name,
+        ResourceKind.HELM_RELEASE: metadata.resource_name,
+        ResourceKind.PVC: metadata.resource_name + "-data",
+        ResourceKind.VOLUME: expected.recoverable_reference(),
+    }
+
+    class Codec:
+        def decrypt_json(self, ciphertext, *, purpose):
+            return {"reference": references[ResourceKind(ciphertext)]}
+
+    class Registry:
+        async def inspect(self, current, owned):
+            return type("Snapshot", (), {"namespace": True, "release": True, "init_job_present": False, "init_complete": False, "init_failed": False, "serving": False, "runtime_admitted": False, "routes": (False, False)})()
+
+        async def authenticate_recovery_record(self, current):
+            return "a" * 64
+
+    class Volumes:
+        async def observe_recovery_bound_volume(self, current):
+            return type("Bound", (), {"recorded": live, "stability_digest": "b" * 64})()
+
+    class HCloud:
+        async def verify_recovery_volume(self, handle, current, location, envelope):
+            return (handle, current, location, envelope) == ("42", metadata, "fsn1", "hcloud-envelope")
+
+    class Cell:
+        async def volume_claim_bound(self, current):
+            return current == metadata
+
+    observer = recovery._ProductionRecoveryObserver(Registry(), Cell(), Volumes(), HCloud(), "fsn1", Codec())
+    operation = type("Operation", (), {"cell_id": "cell-alpha", "tenant_id": "tenant-alpha", "external_operation_id": "provider-alpha", "fence_generation": 7})()
+    resources = tuple(
+        type("Resource", (), {"kind": kind, "reference_ciphertext": kind.value, "operation_id": "internal"})()
+        for kind in references
+    )
+
+    observed = await observer.observe(operation, resources)
+    assert observed.volume_present is True
+
+
 def test_main_converts_refusals_to_content_free_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     recovery = _module()
 

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -23,6 +23,7 @@ PROVISIONER_ROOT = Path(__file__).resolve().parents[1]
 PROVISIONER_TEST_IMAGE = os.environ.get("PROVISIONER_TEST_IMAGE")
 if PROVISIONER_TEST_IMAGE is None:
     from sqlalchemy import func, select, text, update
+    from sqlalchemy.exc import DBAPIError
 
     import exomem_provisioner.repository as repository_module
     from exomem_provisioner.capacity import (
@@ -39,9 +40,19 @@ if PROVISIONER_TEST_IMAGE is None:
         CapacityDestructiveFence,
         CapacityLedger,
         CapacityReservation,
+        CapacityReservationClass,
         Operation,
         OperationAction,
+        OperationRecoveryReceipt,
+        OperationState,
+        Resource,
+        ResourceKind,
         TenantFence,
+    )
+    from exomem_provisioner.operation_recovery import (
+        LiveObservation,
+        RecoveryRefusal,
+        RecoveryService,
     )
     from exomem_provisioner.repository import OperationRepository, StaleFence
 else:
@@ -374,6 +385,149 @@ def _repository(
         codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
         claim_seconds=settings.claim_seconds,
     )
+
+
+@ASYNCIO_POSTGRESQL17
+async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
+    postgresql17: PostgreSQL17,
+) -> None:
+    target = _new_database(postgresql17, "recovery")
+    migrated = _migrate(postgresql17, target)
+    assert migrated.returncode == 0, migrated.stdout + migrated.stderr
+    assert target.settings is not None
+    database = ProvisionerDatabase(target.settings)
+
+    class Lock:
+        def matches_runtime_request(self, request: dict[str, object], *, wire_protocol: str) -> bool:
+            return (
+                wire_protocol == "exomem-cell-provisioner.v1"
+                and request["provisionMode"] == "serve"
+                and request["releaseVersion"] == "0.39.2"
+                and request["protocolVersion"] == "1"
+            )
+
+    class Observer:
+        async def observe(
+            self, operation: Operation, resources: tuple[Resource, ...]
+        ) -> LiveObservation:
+            assert len(resources) == 4
+            return LiveObservation(
+                namespace_present=True,
+                release_present=True,
+                pvc_bound=True,
+                volume_present=True,
+                init_job_present=False,
+                init_complete=False,
+                init_failed_only=False,
+                terminating=False,
+                runtime_admitted=False,
+                routes_present=0,
+            )
+
+    request: dict[str, object] = {
+        "operationId": "provider-recovery-postgresql",
+        "checkpoint": "requested",
+        "fenceGeneration": 7,
+        "tenantId": "tenant-recovery-postgresql",
+        "cellId": "cell-recovery-postgresql",
+        "protocolVersion": "1",
+        "releaseVersion": "0.39.2",
+        "provisionMode": "serve",
+    }
+    codec = AesGcmEnvelopeCodec.from_secret(target.settings.envelope_key.get_secret_value())
+    operation_id = str(uuid.uuid4())
+    try:
+        async with database.session_factory.begin() as session:
+            operation = Operation(
+                id=operation_id,
+                action=OperationAction.PROVISION,
+                idempotency_key="recovery-postgresql-key",
+                canonical_request_sha256=repository_module.canonical_request_sha256(request),
+                tenant_id="tenant-recovery-postgresql",
+                cell_id="cell-recovery-postgresql",
+                external_operation_id="provider-recovery-postgresql",
+                provider_operation_id="provider-recovery-postgresql",
+                fence_generation=7,
+                provider_fence_generation=7,
+                state=OperationState.ERROR,
+                caller_checkpoint="requested",
+                checkpoint="failed",
+                request_ciphertext=codec.encrypt_json(
+                    request, purpose="operation-request:provision:recovery-postgresql-key"
+                ),
+                error_code="PROVISIONER_PROVIDER_METADATA_CONFLICT",
+                finalized_at=datetime.now(UTC),
+            )
+            session.add(operation)
+            session.add(TenantFence(tenant_id=operation.tenant_id, fence_generation=7))
+            await session.flush()
+            for kind in (
+                ResourceKind.HELM_RELEASE,
+                ResourceKind.KUBERNETES_NAMESPACE,
+                ResourceKind.PVC,
+                ResourceKind.VOLUME,
+            ):
+                reference = f"recovery-reference-{kind.value}"
+                session.add(
+                    Resource(
+                        operation_id=operation_id,
+                        tenant_id=operation.tenant_id,
+                        cell_id=operation.cell_id,
+                        kind=kind,
+                        reference_digest=hashlib.sha256(reference.encode()).hexdigest(),
+                        reference_ciphertext=codec.encrypt_json(
+                            {"reference": reference},
+                            purpose=f"resource-reference:{operation_id}:{kind.value}",
+                        ),
+                        provider_operation_id=operation.external_operation_id,
+                        provider_fence_generation=operation.fence_generation,
+                    )
+                )
+            session.add(
+                CapacityReservation(
+                    tenant_id=operation.tenant_id,
+                    cell_id=operation.cell_id,
+                    resource_name="exo-recovery-postgresql",
+                    reservation_class=CapacityReservationClass.USER,
+                    reserving_operation_id=operation_id,
+                    reserving_provider_operation_id=operation.external_operation_id,
+                    reserving_fence_generation=operation.fence_generation,
+                )
+            )
+        denied = RecoveryService(
+            sessions=database.session_factory,
+            codec=codec,
+            database_role=target.role,
+            database_schema=target.schema,
+            deployment_lock=object(),  # type: ignore[arg-type]
+            observer=Observer(),
+        )
+        with pytest.raises(RecoveryRefusal, match="preflight-failed"):
+            await denied.preflight(operation_id)
+        service = RecoveryService(
+            sessions=database.session_factory,
+            codec=codec,
+            database_role=target.role,
+            database_schema=target.schema,
+            deployment_lock=Lock(),  # type: ignore[arg-type]
+            observer=Observer(),
+        )
+        result = await service.reopen(operation_id)
+        assert result["status"] == "reopened"
+        assert isinstance(result["receipt_digest"], str) and len(result["receipt_digest"]) == 64
+        assert (await service.reopen(operation_id))["status"] == "already-recovered"
+        async with database.session_factory() as session:
+            operation = await session.get(Operation, operation_id)
+            receipt = await session.get(OperationRecoveryReceipt, operation_id)
+            assert operation is not None and operation.state is OperationState.PENDING
+            assert operation.checkpoint == "volume-owned"
+            assert operation.error_code is None and operation.finalized_at is None
+            assert receipt is not None
+            with pytest.raises(DBAPIError):
+                receipt.resource_count = 5
+                await session.commit()
+    finally:
+        await database.dispose()
 
 
 @ASYNCIO_POSTGRESQL17

--- a/infra/provisioner/tests/test_postgresql17.py
+++ b/infra/provisioner/tests/test_postgresql17.py
@@ -54,6 +54,7 @@ if PROVISIONER_TEST_IMAGE is None:
         RecoveryRefusal,
         RecoveryService,
     )
+    from exomem_provisioner.provider_identity import cell_resource_name
     from exomem_provisioner.repository import OperationRepository, StaleFence
 else:
     database_source = (
@@ -110,7 +111,7 @@ def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProce
 @pytest.fixture(scope="module")
 def postgresql17() -> Iterator[PostgreSQL17]:
     if shutil.which("docker") is None:
-        pytest.skip("Docker is required for the PostgreSQL 17 integration gates")
+        pytest.fail("Docker is required when RUN_POSTGRESQL17_TEST=1")
     container = f"exomem-provisioner-pg17-{uuid.uuid4().hex[:12]}"
     network = f"exomem-provisioner-pg17-{uuid.uuid4().hex[:12]}"
     admin_password = f"admin-{uuid.uuid4().hex}"
@@ -487,7 +488,7 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
                 CapacityReservation(
                     tenant_id=operation.tenant_id,
                     cell_id=operation.cell_id,
-                    resource_name="exo-recovery-postgresql",
+                    resource_name=cell_resource_name(operation.cell_id),
                     reservation_class=CapacityReservationClass.USER,
                     reserving_operation_id=operation_id,
                     reserving_provider_operation_id=operation.external_operation_id,
@@ -512,10 +513,185 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
             deployment_lock=Lock(),  # type: ignore[arg-type]
             observer=Observer(),
         )
-        result = await service.reopen(operation_id)
-        assert result["status"] == "reopened"
+        async def refuse_after(
+            model: type[Operation] | type[Resource] | type[CapacityReservation],
+            identity: object,
+            field: str,
+            value: object,
+        ) -> None:
+            async with database.session_factory.begin() as session:
+                row = await session.get(model, identity)
+                assert row is not None
+                original = getattr(row, field)
+                setattr(row, field, value)
+            with pytest.raises(RecoveryRefusal):
+                await service.preflight(operation_id)
+            async with database.session_factory.begin() as session:
+                row = await session.get(model, identity)
+                assert row is not None
+                setattr(row, field, original)
+
+        # These are all independent real-PostgreSQL refusal cases; restoring each
+        # row proves a rejected preflight has not progressed the operation.
+        await refuse_after(Operation, operation_id, "action", OperationAction.HEALTH)
+        await refuse_after(Operation, operation_id, "state", OperationState.PENDING)
+        await refuse_after(Operation, operation_id, "checkpoint", "volume-owned")
+        await refuse_after(Operation, operation_id, "error_code", "OTHER")
+        await refuse_after(Operation, operation_id, "claim_owner", "other-worker")
+        await refuse_after(Operation, operation_id, "result_redacted", {"completed": True})
+        await refuse_after(Operation, operation_id, "finalized_at", None)
+        await refuse_after(Operation, operation_id, "provider_operation_id", "other-provider")
+        await refuse_after(Operation, operation_id, "provider_fence_generation", 8)
+        await refuse_after(Operation, operation_id, "canonical_request_sha256", "0" * 64)
+        async with database.session_factory() as session:
+            resource = await session.scalar(select(Resource).where(Resource.operation_id == operation_id))
+            reservation = await session.scalar(
+                select(CapacityReservation).where(
+                    CapacityReservation.reserving_operation_id == operation_id
+                )
+            )
+            assert resource is not None and reservation is not None
+            resource_id = resource.id
+            reservation_id = reservation.id
+        await refuse_after(Resource, resource_id, "reference_digest", "0" * 64)
+        await refuse_after(Resource, resource_id, "provider_operation_id", "other-provider")
+        await refuse_after(CapacityReservation, reservation_id, "resource_name", "wrong-name")
+
+        async def delete_then_refuse(model, identity: object) -> None:
+            async with database.session_factory.begin() as session:
+                row = await session.get(model, identity)
+                assert row is not None
+                values = {column.name: getattr(row, column.name) for column in row.__table__.columns}
+                await session.delete(row)
+            with pytest.raises(RecoveryRefusal):
+                await service.preflight(operation_id)
+            async with database.session_factory.begin() as session:
+                session.add(model(**values))
+
+        await delete_then_refuse(Resource, resource_id)
+        await delete_then_refuse(CapacityReservation, reservation_id)
+        async with database.session_factory.begin() as session:
+            ledger = await session.get(CapacityLedger, 1)
+            assert ledger is not None
+            ledger_values = {column.name: getattr(ledger, column.name) for column in ledger.__table__.columns}
+            await session.delete(ledger)
+        with pytest.raises(RecoveryRefusal):
+            await service.preflight(operation_id)
+        async with database.session_factory.begin() as session:
+            session.add(CapacityLedger(**ledger_values))
+        async with database.session_factory.begin() as session:
+            session.add(
+                CapacityDestructiveFence(
+                    tenant_id=operation.tenant_id,
+                    cell_id=operation.cell_id,
+                    release_reason="DISCARD",
+                    destructive_operation_id=operation_id,
+                    provider_operation_id=operation.external_operation_id,
+                    fence_generation=operation.fence_generation,
+                    completed_at=datetime.now(UTC),
+                )
+            )
+        with pytest.raises(RecoveryRefusal):
+            await service.preflight(operation_id)
+        async with database.session_factory.begin() as session:
+            fence = await session.scalar(
+                select(CapacityDestructiveFence).where(
+                    CapacityDestructiveFence.destructive_operation_id == operation_id
+                )
+            )
+            assert fence is not None
+            await session.delete(fence)
+        foreign_operation_id = str(uuid.uuid4())
+        async with database.session_factory.begin() as session:
+            current = await session.get(Operation, operation_id)
+            assert current is not None
+            values = {
+                column.name: getattr(current, column.name)
+                for column in current.__table__.columns
+            }
+            values.update(
+                id=foreign_operation_id,
+                idempotency_key="recovery-postgresql-conflict-key",
+                state=OperationState.PENDING,
+                checkpoint="requested",
+                error_code=None,
+                finalized_at=None,
+                available_at=datetime.now(UTC),
+            )
+            session.add(Operation(**values))
+        with pytest.raises(RecoveryRefusal):
+            await service.preflight(operation_id)
+        async with database.session_factory.begin() as session:
+            foreign = await session.get(Operation, foreign_operation_id)
+            assert foreign is not None
+            await session.delete(foreign)
+        async with database.session_factory.begin() as session:
+            current = await session.get(Operation, operation_id)
+            resource = await session.get(Resource, resource_id)
+            assert current is not None and resource is not None
+            session.add(
+                Resource(
+                    id=str(uuid.uuid4()),
+                    operation_id=foreign_operation_id,
+                    tenant_id=current.tenant_id,
+                    cell_id=current.cell_id,
+                    kind=ResourceKind.ROUTE,
+                    reference_digest=resource.reference_digest,
+                    reference_ciphertext=resource.reference_ciphertext,
+                    provider_operation_id=current.external_operation_id,
+                    provider_fence_generation=current.fence_generation,
+                )
+            )
+            values = {
+                column.name: getattr(current, column.name)
+                for column in current.__table__.columns
+            }
+            values.update(
+                id=foreign_operation_id,
+                idempotency_key="recovery-postgresql-foreign-key",
+                state=OperationState.ERROR,
+            )
+            session.add(Operation(**values))
+        with pytest.raises(RecoveryRefusal):
+            await service.preflight(operation_id)
+        async with database.session_factory.begin() as session:
+            foreign_resource = await session.scalar(
+                select(Resource).where(Resource.operation_id == foreign_operation_id)
+            )
+            foreign = await session.get(Operation, foreign_operation_id)
+            assert foreign_resource is not None and foreign is not None
+            await session.delete(foreign_resource)
+            await session.flush()
+            await session.delete(foreign)
+        async with database.session_factory.begin() as session:
+            await session.execute(
+                text(
+                    "CREATE FUNCTION recovery_receipt_test_refusal() RETURNS trigger "
+                    "LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'forced receipt rollback'; END $$"
+                )
+            )
+            await session.execute(
+                text(
+                    "CREATE TRIGGER recovery_receipt_test_refusal BEFORE INSERT "
+                    "ON operation_recovery_receipts FOR EACH ROW "
+                    "EXECUTE FUNCTION recovery_receipt_test_refusal()"
+                )
+            )
+        with pytest.raises(RecoveryRefusal, match="recovery-failed"):
+            await service.reopen(operation_id)
+        async with database.session_factory() as session:
+            rolled_back = await session.get(Operation, operation_id)
+            assert rolled_back is not None and rolled_back.state is OperationState.ERROR
+            assert await session.get(OperationRecoveryReceipt, operation_id) is None
+        async with database.session_factory.begin() as session:
+            await session.execute(text("DROP TRIGGER recovery_receipt_test_refusal ON operation_recovery_receipts"))
+            await session.execute(text("DROP FUNCTION recovery_receipt_test_refusal()"))
+        first, second = await asyncio.gather(
+            service.reopen(operation_id), service.reopen(operation_id)
+        )
+        assert {first["status"], second["status"]} == {"reopened", "already-recovered"}
+        result = first if first["status"] == "reopened" else second
         assert isinstance(result["receipt_digest"], str) and len(result["receipt_digest"]) == 64
-        assert (await service.reopen(operation_id))["status"] == "already-recovered"
         async with database.session_factory() as session:
             operation = await session.get(Operation, operation_id)
             receipt = await session.get(OperationRecoveryReceipt, operation_id)
@@ -526,6 +702,31 @@ async def test_postgresql17_recovery_cas_inserts_one_immutable_receipt(
             with pytest.raises(DBAPIError):
                 receipt.resource_count = 5
                 await session.commit()
+        for role, schema in (("wrong-role", target.schema), (target.role, "wrong_schema")):
+            wrong_identity = RecoveryService(
+                sessions=database.session_factory,
+                codec=codec,
+                database_role=role,
+                database_schema=schema,
+                deployment_lock=Lock(),  # type: ignore[arg-type]
+                observer=Observer(),
+            )
+            for method in (
+                wrong_identity.inspect,
+                wrong_identity.verify_receipt,
+                wrong_identity.reopen,
+            ):
+                with pytest.raises(RecoveryRefusal, match="database identity is invalid"):
+                    await method(operation_id)
+        async with database.session_factory.begin() as session:
+            await session.execute(text("UPDATE alembic_version SET version_num='wrong_revision'"))
+        with pytest.raises(RecoveryRefusal, match="database revision is invalid"):
+            await service.verify_receipt(operation_id)
+        async with database.session_factory.begin() as session:
+            await session.execute(
+                text("UPDATE alembic_version SET version_num=:revision"),
+                {"revision": DATABASE_REVISION},
+            )
     finally:
         await database.dispose()
 

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -196,6 +196,33 @@ async def test_kubernetes_adapter_rejects_pvc_identity_or_location_without_mutat
 
 
 @pytest.mark.asyncio
+async def test_recovery_bound_volume_digest_changes_for_pv_replacement() -> None:
+    metadata = _metadata()
+    core = _KubernetesCore(metadata)
+    core.pv.metadata.annotations = {
+        **metadata.kubernetes_annotations,
+        "exomem.io/recovery-envelope": "sealed-pv-envelope",
+    }
+    core.pv.metadata.uid = "pv-uid-one"
+    core.pv.metadata.resource_version = "11"
+    adapter = KubernetesVolumeAdapter(
+        core_v1=core,
+        storage_class_name="encrypted-retain",
+        encryption_secret_name="volume-encryption",
+        encryption_secret_namespace="exomem-platform",
+    )
+
+    first = await adapter.observe_recovery_bound_volume(metadata)
+    assert first is not None
+    core.pv.metadata.uid = "pv-uid-two"
+    core.pv.metadata.resource_version = "12"
+    second = await adapter.observe_recovery_bound_volume(metadata)
+
+    assert second is not None
+    assert first.stability_digest != second.stability_digest
+
+
+@pytest.mark.asyncio
 async def test_cell_adapter_creates_external_secret_then_reads_the_exact_bundle() -> None:
     metadata = _metadata()
     identity = ProviderRecoveryIdentityCodec.from_secret("credential-secret-recovery")

--- a/infra/scripts/verify_provisioner_image.py
+++ b/infra/scripts/verify_provisioner_image.py
@@ -12,21 +12,22 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 _IMAGE_PATTERN = re.compile(r"^ghcr\.io/artexis10/exomem-provisioner@sha256:[0-9a-f]{64}$")
-_ENTRYPOINTS = (
-    "exomem-provisioner-database-bootstrap",
-    "exomem-provisioner-database-migrate",
-    "exomem-provisioner-database-validate",
-    "exomem-provisioner-api",
-    "exomem-provisioner-worker",
-    "exomem-provisioner-volume-rebind",
-    "exomem-durability-actions",
-    "exomem-restore-fetch",
-    "exomem-export-gc",
-    "exomem-durability-backup-worker",
-    "exomem-database-backup-worker",
-    "exomem-deletion-worker",
-    "exomem-volume-worker",
-)
+_ENTRYPOINTS = {
+    "exomem-provisioner-database-bootstrap": "exomem_provisioner.database_bootstrap:run_bootstrap",
+    "exomem-provisioner-database-migrate": "exomem_provisioner.database_bootstrap:run_migrate",
+    "exomem-provisioner-database-validate": "exomem_provisioner.database_bootstrap:run_validate",
+    "exomem-provisioner-api": "exomem_provisioner.main:run_api",
+    "exomem-provisioner-worker": "exomem_provisioner.production:run_worker",
+    "exomem-provisioner-volume-rebind": "exomem_provisioner.volume:run_volume_rebind",
+    "exomem-durability-actions": "exomem_provisioner.durability_actions:run_durability_actions",
+    "exomem-restore-fetch": "exomem_provisioner.restore_fetch:run_restore_fetch",
+    "exomem-export-gc": "exomem_provisioner.durability_jobs:run_export_gc",
+    "exomem-durability-backup-worker": "exomem_provisioner.durability_jobs:run_durability_backup",
+    "exomem-database-backup-worker": "exomem_provisioner.durability_jobs:run_database_backup",
+    "exomem-deletion-worker": "exomem_provisioner.durability_jobs:run_deletion_worker",
+    "exomem-volume-worker": "exomem_provisioner.volume:run_volume_worker",
+    "exomem-provisioner-recover-init-retry": "exomem_provisioner.operation_recovery:main",
+}
 _MIGRATION_ROOT = "/opt/exomem/provisioner-migrations"
 _PROVISIONER_ROOT = Path(__file__).resolve().parents[1] / "provisioner"
 _EXPECTED_MIGRATION_FILES = {
@@ -64,12 +65,14 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 from exomem_provisioner.database import DATABASE_REVISION
 
-required = {set(_ENTRYPOINTS)!r}
+required = {_ENTRYPOINTS!r}
 installed = {{entry.name: entry for entry in metadata.distribution('exomem-provisioner').entry_points}}
-if not required.issubset(installed):
+if set(required).difference(installed):
     raise SystemExit(11)
-for name in required:
+for name, expected_value in required.items():
     entry = installed[name]
+    if entry.value != expected_value:
+        raise SystemExit(18)
     if not callable(entry.load()):
         raise SystemExit(13)
 for path in {_POSTGRES_BINARIES!r}:

--- a/tests/test_hosted_provisioner_image_distribution.py
+++ b/tests/test_hosted_provisioner_image_distribution.py
@@ -33,6 +33,10 @@ def test_provisioner_distribution_exposes_three_database_commands() -> None:
             "exomem_provisioner.database_bootstrap:run_validate"
         ),
     } == project["project"]["scripts"]
+    assert (
+        project["project"]["scripts"]["exomem-provisioner-recover-init-retry"]
+        == "exomem_provisioner.operation_recovery:main"
+    )
 
 
 def test_provisioner_image_packages_migrations_at_fixed_read_only_path() -> None:
@@ -75,6 +79,9 @@ def test_image_verifier_requires_packaged_migrations_and_database_commands() -> 
         "exomem-provisioner-database-migrate",
         "exomem-provisioner-database-validate",
     } <= set(module._ENTRYPOINTS)
+    assert module._ENTRYPOINTS["exomem-provisioner-recover-init-retry"] == (
+        "exomem_provisioner.operation_recovery:main"
+    )
     assert module._MIGRATION_ROOT == MIGRATION_ROOT
     assert "DATABASE_REVISION" in module._PROBE
     assert "is_symlink" in module._PROBE
@@ -91,6 +98,7 @@ def test_image_verifier_requires_packaged_migrations_and_database_commands() -> 
         ]
         if path.is_file() and "__pycache__" not in path.parts
     }
+    assert "entry.value" in module._PROBE
 
 
 def test_provisioner_workflow_is_an_independent_digest_bound_candidate_producer() -> None:


### PR DESCRIPTION
## What changed

- add a one-purpose operator command that can reopen only the proven Hosted init-retry false-negative from `ERROR/failed` to `PENDING/volume-owned`
- add an immutable PostgreSQL recovery receipt in the same transaction as the exact CAS
- authenticate and stabilize the durable Kubernetes, Helm, PVC/PV, HCloud, request, reservation, fence, and runtime-target evidence before mutation
- make the signed provisioner image verifier bind every command to its exact `module:function`
- document the quiesced, content-free production recovery procedure

## Why

The first capacity-managed Hosted reviewer cell completed its init Job after one failed Pod attempt, but the old observer treated the historical failed count as a terminal provider metadata conflict. Normal API replay correctly preserves terminal results, while creating another operation would collide with the existing identity-bound resources and active capacity reservation.

This helper is deliberately not an API or generic operation editor. It accepts the confidential internal operation identity only via stdin or a protected mode-0600 file, emits only bounded content-free evidence, and refuses every state or identity outside the exact incident shape.

## Verification

- full provisioner suite: 452 passed, 16 skipped
- real PostgreSQL 17 recovery suite: 29 passed, 7 built-image-only skips
- hosted image/platform contracts: 68 passed
- Ruff clean
- wheel and provisioner Docker image build passed
- in-image recovery command smoke passed
- independent security/correctness review: approved after two correction rounds

## Operational impact

After merge, the exact-source signed provisioner candidate will be composed with the v0.46 runtime while retaining legacy 0.39.2/protocol 1. The recovery remains inert unless an operator deliberately launches the command in a quiesced private context.
