### PR TITLE
feat(graph): rebuild outside the mutation boundary

### DIFF
--- a/openspec/changes/rebuild-graph-without-blocking-writes/design.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/design.md
@@ -1,88 +1,333 @@
 ## Context
 
-`EpistemicGraphIndex.refresh_paths` currently acquires the vault mutation boundary and escalates to `_rebuild_all_locked()` whenever the graph sidecar is unusable. The rebuild pass deletes and repopulates the live SQLite tables, so the wide boundary is also what prevents readers seeing an empty or partial graph. That produces the incident: a slow reconcile or first write can hold the shared boundary long after the client deadline.
+An unusable graph sidecar currently makes the canonical mutation boundary cover
+the full rebuild. That makes a vault-sized derived operation block unrelated
+canonical writes. A previous redesign released the boundary, but made
+`graph_pending` both an idempotency state and a graph-flight owner. Review found
+that this leaves terminal, retry, crash, and newer-checkpoint behaviour
+ambiguous. This design separates them.
 
-The current terminal contract remains correct: a write that encounters an unusable graph returns only after a whole-vault rebuild either publishes an available graph or reports an explicit derived failure. What is wrong is waiting while canonical writer authority remains held.
+The graph is derived. Canonical Markdown and the exact committed checkpoint are
+truth. The graph must still be available for the required checkpoint before a
+successful graph-available terminal is returned, but its work must be
+joinable/recomputable independently of the original mutation attempt.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Publish canonical files and durable graph handoff state together.
-- Release canonical writer authority before any full graph build or join.
-- Let a second writer publish while earlier callers wait on one per-vault rebuild.
-- Never expose a partial graph or claim a checkpoint was consumed when it was not.
-- Recover after process death without force-unlocking or losing a committed canonical write.
-- Preserve an idempotent terminal: retry never duplicates canonical state.
+- Commit canonical bytes exactly once or return an honest `outcome_unknown`
+  terminal classification.
+- Make a committed mutation independently identifiable by an exact receipt.
+- Release all canonical authority before any vault-sized build or join.
+- Require an acknowledgement, exact registered work handle, or durable failure
+  handle for every checkpoint that leaves writer authority.
+- Preserve public checkpoint v1 bytes/digest vectors and strict availability
+  parity.
+- Recover graph health without changing user-authored bytes or reusing an epoch.
 
 **Non-Goals:**
 
-- Change the user-authored vault schema or graph query API.
-- Make incremental available-graph refresh asynchronous.
-- Return success while the graph is silently unavailable.
-- Force-unlock a live mutation owner.
-- Reduce how often schema/registry changes invalidate the sidecar.
+- Make graph availability best-effort or silently asynchronous.
+- Infer an unreceipted canonical outcome from filesystem similarity.
+- Change user-authored schemas, query APIs, or the public checkpoint v1 shape.
+- Claim mutual exclusion across hostile replacement of a same-user trusted
+  runtime root; that root is an operator-controlled trust boundary.
 
 ## Decisions
 
-### Publish a durable checkpoint in the canonical batch
+### Canonical lifecycle and claim receipts
 
-Every graph-relevant guarded batch includes a replacement for the vault-local hidden graph-sync checkpoint sidecar at `<Knowledge Base>/.graph-sync.json` (resolved through the configured Knowledge Base directory name). Version 1 is a closed content-free object:
+The retry row is a non-owned canonical lifecycle record with exactly four
+states: `reserved`, `executing`, `canonically_committed`, and `completed`.
+`graph_pending` is retired. A bounded execution **attempt** may claim a
+`reserved` row and move it to `executing`; the attempt identity and its lease
+are attempt-scoped coordination data, not ownership carried by a later state.
+A dead `reserved` row is reclaimable. A dead `executing` row is not: absent
+valid authenticated evidence, its only recovery classification is
+`outcome_unknown`, because the leaf may have crossed the vault cut.
 
-`{version, generation, mutation_id, scope, paths, created_paths, checkpoint_sha256}`.
+`outcome_unknown` is not a fifth canonical lifecycle state and does not imply a
+canonical commit. It is a fail-closed terminal classification for the
+unprovable multi-store cut. The retry store retains that immutable
+classification in a `completed` row only as a terminal storage envelope; this
+keeps the state vocabulary closed without asserting that the canonical mutation
+completed. Exact retry receives readback guidance rather than permission to
+execute the leaf again.
 
-The public v1 checkpoint shape and digest stay unchanged. An internal content-free `<Knowledge Base>/.graph-sync-floor.json` stores the highest generation ever issued as the closed object `{version, generation, floor_sha256}` under the distinct `exomem-graph-sync-generation-floor:v1\0` digest domain. `generation` is one greater than the maximum valid floor, current checkpoint, and live graph acknowledgement, defaulting to 1 only for exact legacy state where all three are absent. This auxiliary floor is necessary because a deleted or corrupted unacknowledged checkpoint otherwise erases the only evidence of its issued generation. `mutation_id` is a normalized existing correlation when it yields exactly 24 lowercase hex characters, otherwise an independently generated 24-hex identifier. `scope` is `paths` while the sorted unique safe relative path/hash entries fit the fixed bound and `full` otherwise. Each path entry is `[relative_path, post_write_sha256_or_null]`; null represents deletion. `created_paths` is the sorted subset created by the batch. The checkpoint digest remains SHA-256 over `exomem-graph-sync-checkpoint:v1\0` plus its existing canonical JSON.
+Each claim receives a fresh lowercase 24-hex `commit_token` and a fresh private
+32-byte receipt secret. `GraphCommitReceipt` v2 is one atomically installed,
+hidden, portable, content-free receipt retained at least as long as its retry
+row. It binds all of:
 
-For graph-relevant ordinary writes, the staged guarded order is floor, caller canonical replacements, then checkpoint. Caught publication failure rolls the whole set back. The floor and checkpoint are excluded from semantic candidates, returned canonical paths, watcher fanout, and their own input. Graph-irrelevant writes do not advance either artifact. A malformed/missing checkpoint with a valid floor recovers by publishing a higher full-scope checkpoint; a missing/malformed floor after non-legacy state fails closed rather than inventing history. A direct human edit has no checkpoint, so full-vault freshness remains an independent backstop.
+- namespaced idempotency-key digest;
+- command and normalized payload digest;
+- claim/attempt identity and `commit_token`;
+- bounded canonical terminal projection; and
+- exact graph checkpoint generation and digest.
 
-Graph-relevant file and recursive-directory deletion use the same epoch through the existing lifecycle/trash transition: durable tombstone, floor publication, canonical rename, checkpoint publication, then the existing deletion commit point. Caught checkpoint failure reverses and fsyncs the rename and restores the prior floor. Abrupt failure leaves the tombstone and/or ahead floor as proof that reconcile must issue a higher full-scope recovery checkpoint.
+Receipt eligibility is not circular. “The complete ordinary protocol
+succeeded” means, before signing: the claimed leaf has returned its candidate
+terminal; the one guarded vault batch has successfully applied its selected
+floor, caller canonical replacements, and exact checkpoint; and every bounded
+canonical fanout precondition needed to select and validate that checkpoint's
+incremental-or-rebuild route has returned successfully. It excludes receipt
+installation/authentication, the local lifecycle CAS, durable derived-handle
+registration, `ensure_started`, every graph join, and completed-terminal
+persistence. Any failure before that point installs no receipt and follows the
+ordinary batch rollback/error path.
 
-### Schedule under the boundary, join only after release
+The terminal projection is a closed content-free object with only these
+permitted fields, each omitted when unavailable:
+`_terminal`, `version`, `ok`, `state`, `status`, `committed`, `mutated`,
+`terminal`, `request_id`, `receipt_id`, `operation_id`, `warnings_count`, and
+`result_sha256`. Scalar identifiers have their existing bounded formats;
+`result_sha256` is lowercase SHA-256 of an otherwise non-retained result
+summary. No other top-level or nested projection fields are permitted. In
+particular, `path`, `paths`, `affected_paths`, all vault-relative/absolute
+paths, file names, Markdown, metadata values, source text, and arbitrary leaf
+result/content are excluded. Graph outcome is attached only after receipt
+persistence and is not part of this projection.
 
-Post-commit fanout may synchronously refresh a usable graph when the exact new path-scoped checkpoint proves the live graph acknowledges its immediate predecessor. The incremental SQLite transaction publishes row changes, recall availability markers, and the new checkpoint acknowledgement together. If that narrow proof fails, dispatch only records the exact full-work requirement while under writer authority; it does not build or wait.
+Receipt v2 itself is closed. Its exact outer fields are `version`,
+`idempotency_key_digest`, `command_digest`, `attempt_id`, `commit_token`,
+`terminal_projection`, `terminal_projection_sha256`, `checkpoint_generation`,
+`checkpoint_sha256`, `canonical_disposition`, and `receipt_hmac_sha256`;
+`version` is literal integer `2`, `canonical_disposition` is exactly `success`
+or `committed_failure`, the two checkpoint fields are both null or a positive
+integer/lowercase SHA-256 pair, and every other digest is lowercase SHA-256.
+`canonical_disposition` is covered by the HMAC; it does not alter the closed
+terminal-projection allowlist. Its HMAC input is
+the UTF-8 bytes `exomem-graph-commit-receipt-auth:v2\0` concatenated with the
+canonical UTF-8 JSON of every v2 field except `receipt_hmac_sha256`. Canonical
+JSON uses no insignificant whitespace, lexicographically sorted object keys,
+and unescaped non-ASCII Unicode; duplicate keys, surplus keys, missing keys,
+wrong types, noncanonical values, and a mismatched terminal-projection digest
+are rejected before authentication. Verification recomputes the HMAC-SHA256 and
+uses a constant-time digest comparison. This is a complete definition, not a
+reference to the receipt parser or writer.
 
-After canonical commit is observed and while the operation guard remains held, writer coordination durably changes the idempotency row from owned `pending` to nonterminal `graph_pending`, storing the canonical committed terminal plus complete validated content-free checkpoint. The guard then releases before any full build/join. Concurrent exact retries wait; after proven owner death, a new owner may CAS-claim `graph_pending` and resume only graph work. It never runs the canonical leaf. Completion or explicit committed graph failure transitions the row to `completed`; no internal pending payload is publicly replayable.
+The receipt carries an HMAC-SHA256 over its canonical v2 bytes using that
+secret. The secret exists only in the matching owner-only local idempotency
+runtime row, never in a synced vault file, terminal, log, or diagnostic. On
+POSIX, the runtime directory is owner-only (`0700`) and its database, WAL/SHM
+files, and receipt-secret material are owner read/write only (`0600` or
+stricter). On Windows, the local SQLite BLOB is exactly
+`EXID | version=1 | provider=1(DPAPI_CURRENT_USER) | uint32be ciphertext_length | ciphertext`;
+both total BLOB and ciphertext are capped at 4096 bytes and declared length
+must exactly consume the remaining bytes. Truncation, trailing bytes, and
+unknown version/provider are rejected. DPAPI `CurrentUser` uses UTF-8 entropy
+`exomem-graph-commit-receipt-dpapi:v1\0<attempt_id>\0<commit_token>`; the clear
+secret is never serialized. The protected inheritable runtime DACL permits only
+the current service identity, `LocalSystem`, and `Administrators`. Before
+opening SQLite or unpickling any runtime row, the service rejects a
+reparse-point runtime path or an existing unsafe DACL. The database and its
+WAL/SHM therefore contain only the DPAPI ciphertext. An account/profile change,
+copied envelope, failed DPAPI unprotect, or raw legacy secret row is
+`outcome_unknown`, never authority to heal or replay.
+The private runtime root is a distinct trust boundary from the synced vault.
 
-The vault batch and idempotency SQLite store cannot share one atomic transaction. Process death after canonical commit but before `graph_pending` persistence therefore retains the existing committed-uncertain boundary: a dead ordinary `pending` row for that cut never expires into leaf re-execution, exact retry returns outcome-unknown/readback guidance, and the durable checkpoint still drives graph recovery. This is less convenient than graph-only resume but preserves the non-duplication invariant without fabricating a terminal.
+There is no mutable `commit_point` field and no second marker write. The one
+receipt is authoritative only after the defined pre-signing ordinary protocol
+succeeded. It is installed atomically before the local CAS from the matching
+`executing` row to `canonically_committed`. A post-install local CAS failure may
+be healed only by the exact receipt plus its matching trusted `executing` row,
+attempt/token binding, and retained private secret. A copied, valid-looking
+receipt without that row and secret is advisory and cannot suppress a mutation.
+No recovery path scans receipt directories: it reads only the exact receipt
+address named by the trusted row, with bounded artifact size and bounded parsing
+work. No state owns subsequent graph health. The exact graph coordinator can be
+joined or recreated from a committed row and its exact receipt/checkpoint by a
+later attempt, retry, readiness, or reconcile process. `completed` stores the
+returned graph-available or committed-derived-failure terminal and remains
+replayable byte-for-byte.
 
-This ordering applies to narrow and wide commands: no outer command guard may enclose the graph join. The join token is content-free and process-local; the durable checkpoint, not the token, is crash authority. A later writer can enter, commit generation N+1, and join the same flight while the builder that began at N restarts its stabilization pass to consume N+1.
+There is no transaction shared by the vault and retry store. The crash cuts are
+closed: before the leaf, a dead `reserved` claim may be reclaimed; after the
+leaf can change caller files, floor, or checkpoint but before receipt v2 atomic
+installation, the claim is `outcome_unknown`; after receipt installation but
+before local CAS, only the matching trusted executing row and secret may heal
+that CAS; and a failure while cleaning a committed attempt never reconstructs
+success from a receipt after trusted state is absent. No cut may replay the leaf,
+fabricate a committed terminal, or infer success from vault similarity. Exact
+retry returns stable readback guidance; epoch recovery may converge derived
+graph health but cannot turn an unproven claim into a receipt.
 
-### Build a temporary sidecar and publish one stable checkpoint
+An authenticated orphaned v2 receipt with `canonical_disposition: success` may
+heal only its matching trusted executing CAS and then resumes its ordinary
+derived graph path. An authenticated orphan with
+`canonical_disposition: committed_failure` suppresses leaf replay: if its exact
+retained local failure is present it is replayed, otherwise the row persists
+`outcome_unknown` while graph recovery proceeds independently. Missing,
+invalid, or fieldless v2 receipts never heal either disposition.
 
-One single-flight owner across threads and processes holds a persistent OS-locked regular file under the configured shared runtime-state root, keyed by the same canonical vault identity as writer coordination, before creating a unique reserved temporary database beside the live sidecar. The lock path is descriptor-bound, no-follow/no-symlink validated, permission-restricted, never placed in human/sync-writable vault content, and never unlinked. Kernel lock lifetime is the ownership proof; PID metadata is not authority. Reconcile acquires the same lock before sweeping well-formed abandoned temps.
+Synced vault receipt artifacts are untrusted/advisory even when their HMAC bytes
+look valid, because the private secret is not synced. Cross-replica exactly-once
+is explicitly deferred: without a shared pre-leaf CAS, independent replicas
+cannot use a copied receipt to suppress one another's mutation. Legacy v1
+boolean receipts are advisory only. Legacy `graph_pending` migration is local
+retry-row migration only; a validated local row may become
+`canonically_committed` and rejoin/recompute graph work, but vault artifacts
+alone never create that row or authorize a leaf decision.
 
-Each pass snapshots the coherent floor/checkpoint epoch and full vault freshness, fills and closes/checkpoints a self-contained temp database, and validates it. Under the mutation boundary it re-reads epoch and freshness, writes the exact acknowledgement to temp and closes it, invokes a stable publication test seam on the original index, then re-reads epoch and freshness immediately before replacement. If either check changes it retries. A platform sharing refusal leaves the previous live sidecar intact and returns explicit committed graph failure.
+### Epoch publication and exact ordering
 
-Readers continue using the previous usable sidecar during the build. If no usable sidecar exists, reads report graph unavailable until publish. They never open the temporary database. Replacement behavior is explicitly tested on the Windows service path as well as POSIX.
+The public `<Knowledge Base>/.graph-sync.json` remains closed v1, including its
+canonical bytes and existing digest vectors. The internal
+`.graph-sync-floor.json` remains a closed `{version, generation,
+floor_sha256}` object in its distinct digest domain. The checkpoint parser is
+strict before normalization: its `paths` array contains at most 1,000 entries;
+paths are unique, already NFC-normalized, safe canonical POSIX-relative paths
+(no absolute path, backslash, empty, dot/dotdot, or NUL component); hashes are
+null or lowercase 64-hex; duplicate
+paths cannot conflict; `created_paths` is a unique subset of non-null paths;
+and `full` has empty arrays. The parser accepts neither surplus fields nor
+relaxed legacy aliases.
 
-### Resolve waiters from checkpoint coverage
+For an ordinary graph-relevant claimed mutation, the canonical protocol is:
 
-A successful flight resolves every waiter whose required checkpoint identity is covered by observed monotonic lineage. If a newer checkpoint appears, the flight continues before resolving it. Same-generation/different-digest requirements fail explicitly; a stopped uncovered flight wakes all waiters with lineage failure. Exactly one builder runs per vault, and waiter registration is bounded.
+1. under canonical authority select one generation above the maximum valid
+   floor, checkpoint, and acknowledgement;
+2. publish floor;
+3. publish caller canonical replacements;
+4. publish the exact checkpoint; and
+5. after the vault batch succeeds, atomically install the exact authenticated
+   receipt v2, then compare-and-swap its matching trusted executing row to
+   `canonically_committed`.
 
-The triggering command preserves the existing semantic contract: it returns with graph availability proven for its checkpoint. If stabilization attempts are exhausted, canonical state remains committed and the terminal reports `state: committed`, `graph_sync: failed`, a stable failure code, the required checkpoint digest, and reconcile guidance. It never reports the mutation rejected or invites a blind write retry. Exact request retry replays that committed terminal; a later explicit recovery may satisfy the durable checkpoint.
+Caught failure rolls back the whole vault batch while authority remains held;
+the receipt is not installed. Graph-irrelevant batches advance neither floor
+nor checkpoint and create no graph receipt. Setup, floor seeding, reconcile
+repair, rollback, and cleanup explicitly run with `commit_point=False`: they
+may repair epoch state but never prove a command mutation. This API flag is not
+a receipt field or marker.
 
-### Recover from restart and sweep abandoned work
+Exact legacy is all floor, checkpoint, and acknowledgement absent. A valid
+checkpoint with absent floor and absent/exact acknowledgement is the only
+pre-floor migration state and may atomically seed the floor. A valid floor with
+missing, malformed, or older checkpoint recovers only with a higher full-scope
+checkpoint. Every other malformed/missing-floor or contradictory-ack state
+fails closed. Existing v1 acknowledgement metadata remains strict: availability
+requires every currently written exact metadata key, including
+`graph_sync_checkpoint`, and exact generation/digest parity. There is no
+defaulting-away of missing metadata in this change.
 
-Startup/readiness and reconcile compare the generation floor, checkpoint, and graph acknowledgement. A valid floor plus missing/malformed/contradictory checkpoint permits recovery only at a higher generation. Missing/corrupt floor state fails closed except for two exact cases: all three artifacts absent is legacy, while a valid checkpoint plus absent floor plus absent or exactly matching acknowledgement is the pre-floor migration state and seeds the floor at that checkpoint generation under mutation authority. Conflicting acknowledgement or acknowledgement without checkpoint/floor is ambiguous and refuses repair. Reconcile reports refreshed/current only after it re-reads both epoch coherence and graph availability.
+### Derived handoff, coordinator, and terminal outcomes
 
-Temporary databases use a reserved per-vault prefix and contain their target checkpoint digest plus a unique nonce. Reconcile removes them only while holding the same cross-process rebuild lock; it never removes the lock file, live sidecar, or a live builder's work.
+Before canonical authority releases, an ordinary graph-relevant checkpoint must
+have exactly one of these durable/provable fates:
+
+1. incremental SQLite work atomically acknowledges that exact checkpoint;
+2. a durable exact rebuild handle is registered; or
+3. a durable explicit graph failure handle is attached to the receipt.
+
+`accepted_unverified` is forbidden. Registration is the under-guard durable
+handoff only; after all canonical guards release, `ensure_started(handle)`
+atomically starts or joins its exact coordinator flight and does **not** consume
+a waiter slot. `join(handle)` is the separate bounded-waiter operation and
+releases its capacity in `finally`, including start, cancellation, and failure
+paths. A coordinator capacity/start/stopped-flight/lineage/platform failure
+becomes an explicit handle with stable code and recovery guidance; no waiter is
+orphaned. A later exact retry or reconcile can join or recompute any
+`canonically_committed` receipt's graph health without a leaf replay.
+
+Incremental refresh is eligible only when the current checkpoint still equals
+the committed receipt, the graph acknowledgement is its exact immediate
+predecessor, all existing freshness/recall/topology proofs hold, and rows,
+availability markers, and all acknowledgement metadata commit in one SQLite
+transaction. Otherwise the leaf only records the exact rebuild handle; it does
+not build or join while authority is held.
+
+The triggering request may join off-boundary. It returns a normal committed
+terminal only after exact availability; if its exact handle reaches a bounded
+derived failure, it returns committed-with-graph-failure, the exact checkpoint,
+and recovery guidance. This does not change the receipt's canonical proof. A
+later successful recovery changes live graph health but does not rewrite the
+original completed terminal.
+
+### Single-flight private build and publication
+
+For one configured trusted runtime root, POSIX rebuild single-flight is
+cooperative: the root must be operator-owned and neither group- nor
+world-writable, and the persistent per-vault lock file sits directly beneath it.
+The regular file is opened and validated no-follow with restrictive permissions
+and is never unlinked. The contract deliberately excludes a hostile same-user
+replacement of that trusted root. The lock serializes builders and scoped temp
+cleanup; it does not itself make reader-visible publication correct.
+
+Windows retains stronger semantics: the lock and live-sidecar replacement use
+no-delete-share handles. A sharing/rename refusal preserves the old live
+sidecar and the temporary result, records an explicit graph failure handle, and
+never falls back to delete-and-replace.
+
+A builder acquires the rebuild lock outside canonical authority, creates a
+unique reserved temp sidecar, snapshots coherent epoch plus real full-vault
+freshness, and performs all scalable work privately. The private phase commits
+exact acknowledgement/checkpoint metadata, truncates WAL, runs full integrity
+and direct source/membership/topology proof, warms the live
+`RecallFreshnessCheckpoint`, and captures the recall-policy version plus a
+bounded no-follow `_access.yaml` content snapshot/fingerprint. It then closes
+the temp and emits an immutable ticket binding exact graph publication epoch,
+direct projection identity, warmed checkpoint, policy/access snapshot,
+no-external-pending epoch, and exact closed temp-file/meta identity.
+
+Under canonical authority, publication performs only two O(1)/bounded ticket
+checks around the publication hook and then atomic replacement. It does not
+walk the vault or sidecar, warm caches, or run WAL, integrity, or projection
+proofs. A cold/dirty cache, changed epoch/access snapshot, observed external
+Markdown/access edit, hook failure, or ticket mismatch releases authority and
+causes reconcile/retry. Missed or unobserved direct edits are eventually
+caught by watcher-periodic reconcile; arbitrary-editor linearizability requires
+a broker/journal and is out of scope. Readers see only the old usable sidecar,
+the fully replaced sidecar, or unavailable—never a temp/partial database.
+
+Cleanup is scoped to a well-formed reserved temp for the exact vault identity;
+it runs only while holding the rebuild lock, never removes the persistent lock
+or live sidecar, and never sweeps a registered active flight. The same exact
+handle protocol makes a newer checkpoint joinable while an older pass retries.
+
+### Deletion, recovery, and rollback
+
+File and recursive-directory deletion use the existing lifecycle/trash
+transition under canonical authority: tombstone, floor, rename, exact null/full
+checkpoint, then the existing deletion commit point. A caught checkpoint or
+later batch failure reverses and fsyncs the rename and restores the epoch before
+returning failure. A crash after rename leaves lifecycle/floor evidence and
+requires a higher full recovery checkpoint; it neither restores nor duplicates
+the deletion. Restore follows the same guarded ordering. These lifecycle and
+recovery paths have `commit_point=False` unless they are the claimed caller
+leaf itself, so repair can never manufacture a retry receipt.
+
+Readiness/reconcile dynamically classify floor/checkpoint/ack and graph
+availability. They report current only after independent exact epoch parity and
+availability proof. A repair must produce an exact registered rebuild/failure
+handle before releasing authority. No recovery changes user-authored bytes
+except the original requested lifecycle operation.
 
 ## Risks / Trade-offs
 
-- [Checkpoint update adds one small write per graph-relevant batch] → Keep it content-free, bounded, excluded from recall, and whole-file atomic.
-- [The monotonic floor is another operational artifact] → Keep it closed, content-free, domain-separated, batch-guarded, and excluded from all semantic/index output; it exists solely to prevent generation reuse after lost unacknowledged state.
-- [Sustained writers prevent a stable pass] → Retain bounded stabilization; fail explicitly as committed-with-derived-failure rather than holding writers or publishing stale graph state.
-- [Many callers wait on one rebuild] → Bound waiter registration and expose current flight/checkpoint status; callers do not hold mutation authority.
-- [Crash after canonical replacement but before all batch artifacts] → Existing abrupt-batch inspection plus full-vault freshness detects the partial state; restart never trusts checkpoint metadata alone.
-- [Windows cannot replace an open SQLite file like POSIX] → Close publication handles, test the Windows path, and refuse publication without disturbing the previous sidecar when replacement is unsafe.
-- [A post-commit graph failure is mistaken for failed mutation] → Terminal state remains committed and names derived recovery separately; idempotent replay returns the same canonical receipt.
+- The multi-store cut remains observable as the fail-closed
+  `outcome_unknown` terminal classification; hiding it would risk duplicate
+  canonical writes.
+- Receipts add bounded durable state, but make retry and graph recovery auditable
+  without storing user content.
+- Coordinated POSIX locking needs an operator-controlled runtime root; Windows
+  may decline unsafe replacement rather than pretending it succeeded.
+- Sustained writes can exhaust bounded stabilization; that is a committed
+  derived failure with a recoverable handle, never a writer-bound deadlock.
 
 ## Migration Plan
 
-No user-data migration. On first graph-relevant mutation after upgrade, floor/checkpoint generation 1 is written and the graph records its acknowledgement. A valid pre-floor checkpoint initializes the floor at its generation. Exact legacy state—no floor, checkpoint, or acknowledgement—remains accepted until first publication. Any other missing/corrupt floor state fails closed.
+The public checkpoint v1 representation is unchanged, including its canonical
+bytes and digest vectors. Exact legacy remains valid until first graph-relevant
+publication. Valid pre-floor checkpoint states seed the floor; all other
+malformed migration states fail closed. Legacy v1 boolean receipts are advisory
+only. Existing `graph_pending` **local retry rows** are read as
+`canonically_committed`, retain their validated checkpoint binding, and cannot
+run the leaf again; no synced artifact can synthesize that migration.
 
-Rollback before any epoch exists may use the prior release. After publication, supported rollback uses a compatibility build that retains floor/checkpoint parsing, graph-pending idempotency semantics, and recovery while disabling newer scheduling if needed. Both hidden artifacts remain safe to preserve.
-
-## Open Questions
-
-None. The auxiliary generation floor resolves non-reuse after lost unacknowledged checkpoint state; the accepted pre-floor migration states are closed; the unavoidable cross-store crash cut returns committed-uncertain without re-execution; and private graph construction is explicitly reconciled with hosted mutation safety through an unreachable-work exception and fixed lock order.
+A rollback compatibility build retains strict v1 floor/checkpoint/ack parsing,
+NFC path admission, advisory receipt reading, local `graph_pending` migration,
+outcome-unknown behaviour, and recovery. It may disable new scheduling only
+behind the explicit rollback gate; it must not reintroduce a writer-held rebuild
+or relax acknowledgement parity.

--- a/openspec/changes/rebuild-graph-without-blocking-writes/design.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/design.md
@@ -1,105 +1,88 @@
 ## Context
 
-`EpistemicGraphIndex.refresh_paths` takes the vault mutation boundary and calls
-`_refresh_paths_locked`, which escalates to `_rebuild_all_locked()` whenever
-`available()` is false. `_rebuild_all_locked` runs a stabilization loop:
-snapshot `_disk_vault_freshness`, run `_rebuild_all_pass`, and accept the result
-only if freshness is unchanged; otherwise retry, up to
-`REBUILD_STABILIZATION_ATTEMPTS`, then fail and mark the graph unavailable.
+`EpistemicGraphIndex.refresh_paths` currently acquires the vault mutation boundary and escalates to `_rebuild_all_locked()` whenever the graph sidecar is unusable. The rebuild pass deletes and repopulates the live SQLite tables, so the wide boundary is also what prevents readers seeing an empty or partial graph. That produces the incident: a slow reconcile or first write can hold the shared boundary long after the client deadline.
 
-Two properties of the current implementation matter here.
-
-`_rebuild_all_pass` mutates the **live** sidecar: it deletes every row from
-`graph_edges`, `graph_nodes`, and `graph_parent_refs` before refilling. A reader
-arriving mid-pass would see an empty or partial graph. That is safe today only
-because the boundary excludes everyone for the whole rebuild.
-
-The stabilization loop is therefore currently a guard against *out-of-band*
-edits — a user editing files directly in Obsidian — rather than against
-concurrent Exomem writes, which the boundary already prevents.
-
-Moving the rebuild outside the boundary changes the status of both: the wipe
-becomes visible, and the stabilization loop becomes the primary consistency
-mechanism rather than a backstop.
+The current terminal contract remains correct: a write that encounters an unusable graph returns only after a whole-vault rebuild either publishes an available graph or reports an explicit derived failure. What is wrong is waiting while canonical writer authority remains held.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- A full rebuild must not block unrelated vault mutations for its duration.
-- A reader must never observe a partially rebuilt graph.
-- Preserve the write-path contract: a write against an unusable sidecar returns
-  with the graph built and available.
-- Preserve the failure contract: a rebuild that cannot observe a stable vault
-  marks the graph unavailable rather than publishing a bad one.
+- Publish canonical files and durable graph handoff state together.
+- Release canonical writer authority before any full graph build or join.
+- Let a second writer publish while earlier callers wait on one per-vault rebuild.
+- Never expose a partial graph or claim a checkpoint was consumed when it was not.
+- Recover after process death without force-unlocking or losing a committed canonical write.
+- Preserve an idempotent terminal: retry never duplicates canonical state.
 
 **Non-Goals:**
 
-- Changing the sidecar schema or file format.
-- Making incremental (`available()`-true) refresh faster.
-- Removing the escalation itself. #346 established that it is load-bearing.
-- Reducing how often the sidecar is invalidated. Fewer `SCHEMA_VERSION` bumps or
-  a registry-hash change that does not invalidate would both reduce exposure,
-  but they are separate questions from how a rebuild behaves.
+- Change the user-authored vault schema or graph query API.
+- Make incremental available-graph refresh asynchronous.
+- Return success while the graph is silently unavailable.
+- Force-unlock a live mutation owner.
+- Reduce how often schema/registry changes invalidate the sidecar.
 
 ## Decisions
 
-Build into a temporary database in the sidecar's own directory, then swap. Same
-directory so the publish step is an atomic rename on one filesystem. The rebuild
-passes run against the temp database with no boundary held; only the swap takes
-it. The boundary hold drops from the length of a full rebuild — 32 s at 2,000
-pages, 172 s at 8,000 — to a rename.
+### Publish a durable checkpoint in the canonical batch
 
-Re-verify freshness under the boundary immediately before the swap. Outside the
-boundary the vault can change during the final pass, so the pre-swap check is
-what makes the published graph trustworthy. If freshness moved, the rebuild
-retries within its existing attempt budget rather than publishing.
+Every graph-relevant guarded batch includes a replacement for the vault-local hidden graph-sync checkpoint sidecar at `<Knowledge Base>/.graph-sync.json` (resolved through the configured Knowledge Base directory name). Version 1 is a closed content-free object:
 
-Make rebuilds single-flight per vault. Today the boundary serialises them
-implicitly: the second writer blocks, and by the time it runs the graph is
-available so it takes the incremental path. Once rebuilds no longer hold the
-boundary, N concurrent writers would otherwise each start a full rebuild. A
-rebuild-in-progress marker keeps one running and lets the others wait for its
-result.
+`{version, generation, mutation_id, scope, paths, created_paths, checkpoint_sha256}`.
 
-Keep `_mark_unavailable()` on stabilization failure. The failure contract is
-unchanged; only the location of the work moves.
+The public v1 checkpoint shape and digest stay unchanged. An internal content-free `<Knowledge Base>/.graph-sync-floor.json` stores the highest generation ever issued as the closed object `{version, generation, floor_sha256}` under the distinct `exomem-graph-sync-generation-floor:v1\0` digest domain. `generation` is one greater than the maximum valid floor, current checkpoint, and live graph acknowledgement, defaulting to 1 only for exact legacy state where all three are absent. This auxiliary floor is necessary because a deleted or corrupted unacknowledged checkpoint otherwise erases the only evidence of its issued generation. `mutation_id` is a normalized existing correlation when it yields exactly 24 lowercase hex characters, otherwise an independently generated 24-hex identifier. `scope` is `paths` while the sorted unique safe relative path/hash entries fit the fixed bound and `full` otherwise. Each path entry is `[relative_path, post_write_sha256_or_null]`; null represents deletion. `created_paths` is the sorted subset created by the batch. The checkpoint digest remains SHA-256 over `exomem-graph-sync-checkpoint:v1\0` plus its existing canonical JSON.
 
-Sweep abandoned temp databases in `reconcile`. A crash mid-rebuild leaves a temp
-file that no longer has an owner. Reconcile already walks sidecar state and
-already owns `rebuild_all`, so it is the natural place. Temp databases use a
-reserved name prefix so a sweep cannot mistake one for the live sidecar.
+For graph-relevant ordinary writes, the staged guarded order is floor, caller canonical replacements, then checkpoint. Caught publication failure rolls the whole set back. The floor and checkpoint are excluded from semantic candidates, returned canonical paths, watcher fanout, and their own input. Graph-irrelevant writes do not advance either artifact. A malformed/missing checkpoint with a valid floor recovers by publishing a higher full-scope checkpoint; a missing/malformed floor after non-legacy state fails closed rather than inventing history. A direct human edit has no checkpoint, so full-vault freshness remains an independent backstop.
+
+Graph-relevant file and recursive-directory deletion use the same epoch through the existing lifecycle/trash transition: durable tombstone, floor publication, canonical rename, checkpoint publication, then the existing deletion commit point. Caught checkpoint failure reverses and fsyncs the rename and restores the prior floor. Abrupt failure leaves the tombstone and/or ahead floor as proof that reconcile must issue a higher full-scope recovery checkpoint.
+
+### Schedule under the boundary, join only after release
+
+Post-commit fanout may synchronously refresh a usable graph when the exact new path-scoped checkpoint proves the live graph acknowledges its immediate predecessor. The incremental SQLite transaction publishes row changes, recall availability markers, and the new checkpoint acknowledgement together. If that narrow proof fails, dispatch only records the exact full-work requirement while under writer authority; it does not build or wait.
+
+After canonical commit is observed and while the operation guard remains held, writer coordination durably changes the idempotency row from owned `pending` to nonterminal `graph_pending`, storing the canonical committed terminal plus complete validated content-free checkpoint. The guard then releases before any full build/join. Concurrent exact retries wait; after proven owner death, a new owner may CAS-claim `graph_pending` and resume only graph work. It never runs the canonical leaf. Completion or explicit committed graph failure transitions the row to `completed`; no internal pending payload is publicly replayable.
+
+The vault batch and idempotency SQLite store cannot share one atomic transaction. Process death after canonical commit but before `graph_pending` persistence therefore retains the existing committed-uncertain boundary: a dead ordinary `pending` row for that cut never expires into leaf re-execution, exact retry returns outcome-unknown/readback guidance, and the durable checkpoint still drives graph recovery. This is less convenient than graph-only resume but preserves the non-duplication invariant without fabricating a terminal.
+
+This ordering applies to narrow and wide commands: no outer command guard may enclose the graph join. The join token is content-free and process-local; the durable checkpoint, not the token, is crash authority. A later writer can enter, commit generation N+1, and join the same flight while the builder that began at N restarts its stabilization pass to consume N+1.
+
+### Build a temporary sidecar and publish one stable checkpoint
+
+One single-flight owner across threads and processes holds a persistent OS-locked regular file under the configured shared runtime-state root, keyed by the same canonical vault identity as writer coordination, before creating a unique reserved temporary database beside the live sidecar. The lock path is descriptor-bound, no-follow/no-symlink validated, permission-restricted, never placed in human/sync-writable vault content, and never unlinked. Kernel lock lifetime is the ownership proof; PID metadata is not authority. Reconcile acquires the same lock before sweeping well-formed abandoned temps.
+
+Each pass snapshots the coherent floor/checkpoint epoch and full vault freshness, fills and closes/checkpoints a self-contained temp database, and validates it. Under the mutation boundary it re-reads epoch and freshness, writes the exact acknowledgement to temp and closes it, invokes a stable publication test seam on the original index, then re-reads epoch and freshness immediately before replacement. If either check changes it retries. A platform sharing refusal leaves the previous live sidecar intact and returns explicit committed graph failure.
+
+Readers continue using the previous usable sidecar during the build. If no usable sidecar exists, reads report graph unavailable until publish. They never open the temporary database. Replacement behavior is explicitly tested on the Windows service path as well as POSIX.
+
+### Resolve waiters from checkpoint coverage
+
+A successful flight resolves every waiter whose required checkpoint identity is covered by observed monotonic lineage. If a newer checkpoint appears, the flight continues before resolving it. Same-generation/different-digest requirements fail explicitly; a stopped uncovered flight wakes all waiters with lineage failure. Exactly one builder runs per vault, and waiter registration is bounded.
+
+The triggering command preserves the existing semantic contract: it returns with graph availability proven for its checkpoint. If stabilization attempts are exhausted, canonical state remains committed and the terminal reports `state: committed`, `graph_sync: failed`, a stable failure code, the required checkpoint digest, and reconcile guidance. It never reports the mutation rejected or invites a blind write retry. Exact request retry replays that committed terminal; a later explicit recovery may satisfy the durable checkpoint.
+
+### Recover from restart and sweep abandoned work
+
+Startup/readiness and reconcile compare the generation floor, checkpoint, and graph acknowledgement. A valid floor plus missing/malformed/contradictory checkpoint permits recovery only at a higher generation. Missing/corrupt floor state fails closed except for two exact cases: all three artifacts absent is legacy, while a valid checkpoint plus absent floor plus absent or exactly matching acknowledgement is the pre-floor migration state and seeds the floor at that checkpoint generation under mutation authority. Conflicting acknowledgement or acknowledgement without checkpoint/floor is ambiguous and refuses repair. Reconcile reports refreshed/current only after it re-reads both epoch coherence and graph availability.
+
+Temporary databases use a reserved per-vault prefix and contain their target checkpoint digest plus a unique nonce. Reconcile removes them only while holding the same cross-process rebuild lock; it never removes the lock file, live sidecar, or a live builder's work.
 
 ## Risks / Trade-offs
 
-- [The stabilization budget may be too small outside the boundary] → Concurrent
-  Exomem writes can now perturb freshness mid-pass, where previously only
-  out-of-band edits could. If `REBUILD_STABILIZATION_ATTEMPTS` proves
-  insufficient under sustained writes, a rebuild that used to succeed slowly
-  would fail instead. Covered by a test that writes continuously during a
-  rebuild; the attempt budget may need raising with the sweep.
-- [Disk usage doubles transiently during a rebuild] → One extra sidecar-sized
-  file for the duration. Acceptable, and bounded by the sweep.
-- [A waiting writer still waits] → Single-flight means a concurrent writer that
-  needs the graph still waits for the in-flight rebuild. It no longer blocks
-  *unrelated* mutations, which is the reported harm, but the first writer after
-  invalidation still pays the rebuild cost. Reducing that is a separate problem.
-- [Atomic rename semantics on Windows] → Replacing an open SQLite file differs
-  from POSIX. The swap must tolerate readers holding the old file, and the
-  implementation must verify behaviour on the Windows service path rather than
-  assuming POSIX rename.
+- [Checkpoint update adds one small write per graph-relevant batch] → Keep it content-free, bounded, excluded from recall, and whole-file atomic.
+- [The monotonic floor is another operational artifact] → Keep it closed, content-free, domain-separated, batch-guarded, and excluded from all semantic/index output; it exists solely to prevent generation reuse after lost unacknowledged state.
+- [Sustained writers prevent a stable pass] → Retain bounded stabilization; fail explicitly as committed-with-derived-failure rather than holding writers or publishing stale graph state.
+- [Many callers wait on one rebuild] → Bound waiter registration and expose current flight/checkpoint status; callers do not hold mutation authority.
+- [Crash after canonical replacement but before all batch artifacts] → Existing abrupt-batch inspection plus full-vault freshness detects the partial state; restart never trusts checkpoint metadata alone.
+- [Windows cannot replace an open SQLite file like POSIX] → Close publication handles, test the Windows path, and refuse publication without disturbing the previous sidecar when replacement is unsafe.
+- [A post-commit graph failure is mistaken for failed mutation] → Terminal state remains committed and names derived recovery separately; idempotent replay returns the same canonical receipt.
 
 ## Migration Plan
 
-No data migration. The first rebuild after this change writes a temp database
-and swaps it; existing sidecars are read normally until invalidated. Roll back
-by restoring the in-boundary rebuild, which changes no on-disk format.
+No user-data migration. On first graph-relevant mutation after upgrade, floor/checkpoint generation 1 is written and the graph records its acknowledgement. A valid pre-floor checkpoint initializes the floor at its generation. Exact legacy state—no floor, checkpoint, or acknowledgement—remains accepted until first publication. Any other missing/corrupt floor state fails closed.
+
+Rollback before any epoch exists may use the prior release. After publication, supported rollback uses a compatibility build that retains floor/checkpoint parsing, graph-pending idempotency semantics, and recovery while disabling newer scheduling if needed. Both hidden artifacts remain safe to preserve.
 
 ## Open Questions
 
-- What should a writer do while a rebuild is in flight — block on the
-  single-flight result, or return deferred and let the rebuild cover its path?
-  Deferring keeps the write bounded but means the writer's own edit may not be
-  in the published graph, which the current contract does not allow.
-- Does `REBUILD_STABILIZATION_ATTEMPTS` need to rise now that concurrent Exomem
-  writes can perturb freshness, and what is the right ceiling before failing?
+None. The auxiliary generation floor resolves non-reuse after lost unacknowledged checkpoint state; the accepted pre-floor migration states are closed; the unavoidable cross-store crash cut returns committed-uncertain without re-execution; and private graph construction is explicitly reconciled with hosted mutation safety through an unreachable-work exception and fixed lock order.

--- a/openspec/changes/rebuild-graph-without-blocking-writes/proposal.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/proposal.md
@@ -1,65 +1,31 @@
 ## Why
 
-A full epistemic graph rebuild runs inside the vault mutation boundary, so it
-blocks every other vault mutation for its entire duration. Measured on a
-maintainer workstation against synthetic vaults, on a single `upsert_after_write`
-with no usable sidecar:
+A full epistemic graph rebuild currently runs inside the vault mutation boundary, so one missing, corrupt, schema-mismatched, or registry-invalidated sidecar blocks every vault mutation for the full rebuild. Measured first-write cost is 7.7 seconds at 500 pages and 32.4 seconds at 2,000 pages; CI has observed a 172-second boundary hold at 8,000 pages. A client timeout does not cancel that server work, so the live boundary looks abandoned even while the origin thread is still rebuilding.
 
-| vault | first write | steady-state write | ratio |
-|---|---|---|---|
-| 500 pages | 7,728 ms | 315 ms | 24.6x |
-| 2,000 pages | 32,382 ms | 1,186 ms | 27.3x |
-
-CI's write-latency benchmark records the same shape at larger scale:
-`hold_ms=39092` over 2,000 pages and `hold_ms=172205` over 8,000.
-
-This is not an edge case. `_open_read_snapshot` treats the sidecar as unusable
-whenever `schema_version`, `core_registry_version`, or `extension_registry_hash`
-disagrees with the running build, so a full rebuild is triggered by:
-
-- any release that bumps `SCHEMA_VERSION` — at 7 today, bumped seven times;
-- any change to the relation registry, including a user adding or editing one
-  extension relation;
-- a sidecar that is missing, deleted, or corrupt.
-
-The first write after any of those stalls for tens of seconds on a
-maintainer-sized vault, and every concurrent writer is blocked behind it. A
-client that gives up meanwhile sees a timeout on a write that then lands.
-
-An earlier attempt (#346) removed the escalation so writes deferred to
-`reconcile`. That was wrong and CI rejected it:
-`test_refresh_missing_sidecar_routes_to_full_rebuild` requires a write against a
-missing sidecar to index the whole vault and leave the graph available. The
-rebuild has to happen; it must stop holding the boundary while it does.
+The graph must still be rebuilt across the complete vault before the triggering write returns. Removing that contract was attempted in #346 and correctly rejected. The missing protocol is a durable handoff: canonical bytes and an exact graph-sync checkpoint publish together, the mutation boundary releases, and only then may the request wait for derived graph work.
 
 ## What Changes
 
-- Build a full graph rebuild into a temporary database outside the vault
-  mutation boundary, then acquire the boundary only to swap it into place.
-- Make concurrent rebuild requests single-flight, so N blocked writers do not
-  each start their own full-vault rebuild.
-- Keep the existing stabilization contract: a rebuild that cannot observe a
-  stable vault still fails and marks the graph unavailable.
-- Preserve the write-path contract that a write against an unusable sidecar
-  leaves the graph built and available.
+- Publish one content-free graph-sync checkpoint plus an internal monotonic generation floor in the same guarded transition as every graph-relevant canonical write or trash move.
+- Release the vault mutation boundary before starting or joining full graph work; a request may still wait off-boundary so its terminal preserves the existing graph-available contract.
+- Build a full graph into a temporary database, stabilize it against the exact durable checkpoint/current vault, then acquire the boundary only for the final checkpoint recheck and atomic sidecar swap.
+- Make concurrent rebuilds single-flight per vault across threads and processes using a persistent OS lock. Later canonical batches can publish new checkpoints while callers join the same rebuild; the builder retries until it consumes the latest stable checkpoint.
+- Persist the consumed checkpoint identity in the graph sidecar and recover a current-but-unacknowledged checkpoint after crash/restart or reconcile.
+- Persist a nonterminal `graph_pending` idempotency state after canonical commit, then return a completed canonical terminal with explicit derived-graph success/failure only after the graph phase resolves. A retry that observes durable `graph_pending` resumes graph-only work and never duplicates the canonical write; the earlier cross-store crash cut before that persistence returns committed-uncertain while checkpoint recovery handles graph convergence.
 - Sweep abandoned temporary rebuild databases during reconcile.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `graph-rebuild-availability`: A full epistemic graph rebuild does not block
-  unrelated vault mutations, and never exposes a partially rebuilt graph.
+- `graph-rebuild-availability`: durable canonical-to-graph handoff, off-boundary single-flight rebuild, crash recovery, and non-partial publication.
 
 ### Modified Capabilities
 
-None.
+- `hosted-mutation-safety`: permit unreachable private graph construction and abandoned-temp cleanup under a dedicated cross-process rebuild lock while retaining the canonical vault boundary for checkpoint/floor publication and every live-sidecar replacement.
 
 ## Impact
 
-Affected areas are `src/exomem/epistemic_graph.py`, `src/exomem/reconcile.py`
-(temp sweep), and the epistemic graph freshness, boundary, and semantic unit
-graph tests.
+Affected areas are canonical batch publication/post-commit handoff, `src/exomem/index_sync.py`, `src/exomem/deferred_index.py`, `src/exomem/epistemic_graph.py`, writer terminal coordination, reconcile/startup recovery, and graph freshness/boundary tests.
 
-No MCP tool schema, vault format, OAuth, or stdio behavior changes. The sidecar
-file format is unchanged; only how and where it is produced changes.
+No user-authored Markdown schema, MCP selector, OAuth flow, or graph query shape changes. The graph SQLite schema adds only derived checkpoint metadata. A hidden content-free checkpoint sidecar is operational state, not user knowledge or a semantic index candidate.

--- a/openspec/changes/rebuild-graph-without-blocking-writes/proposal.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/proposal.md
@@ -1,31 +1,94 @@
 ## Why
 
-A full epistemic graph rebuild currently runs inside the vault mutation boundary, so one missing, corrupt, schema-mismatched, or registry-invalidated sidecar blocks every vault mutation for the full rebuild. Measured first-write cost is 7.7 seconds at 500 pages and 32.4 seconds at 2,000 pages; CI has observed a 172-second boundary hold at 8,000 pages. A client timeout does not cancel that server work, so the live boundary looks abandoned even while the origin thread is still rebuilding.
+A full epistemic-graph rebuild must not hold canonical writer authority for the
+duration of a vault-sized build. The first implementation attempted to solve
+that with an owned `graph_pending` idempotency state. That conflates the
+canonical mutation's durable outcome with a derived graph flight: its owner can
+die, its graph result can become stale after another canonical commit, and it
+does not give every unacknowledged checkpoint a durable recovery path.
 
-The graph must still be rebuilt across the complete vault before the triggering write returns. Removing that contract was attempted in #346 and correctly rejected. The missing protocol is a durable handoff: canonical bytes and an exact graph-sync checkpoint publish together, the mutation boundary releases, and only then may the request wait for derived graph work.
+The protocol must make canonical truth first-class, acknowledge the unavoidable
+multi-store crash cut honestly, and let graph health be recomputed or joined
+after canonical commit without ever re-running the leaf.
 
 ## What Changes
 
-- Publish one content-free graph-sync checkpoint plus an internal monotonic generation floor in the same guarded transition as every graph-relevant canonical write or trash move.
-- Release the vault mutation boundary before starting or joining full graph work; a request may still wait off-boundary so its terminal preserves the existing graph-available contract.
-- Build a full graph into a temporary database, stabilize it against the exact durable checkpoint/current vault, then acquire the boundary only for the final checkpoint recheck and atomic sidecar swap.
-- Make concurrent rebuilds single-flight per vault across threads and processes using a persistent OS lock. Later canonical batches can publish new checkpoints while callers join the same rebuild; the builder retries until it consumes the latest stable checkpoint.
-- Persist the consumed checkpoint identity in the graph sidecar and recover a current-but-unacknowledged checkpoint after crash/restart or reconcile.
-- Persist a nonterminal `graph_pending` idempotency state after canonical commit, then return a completed canonical terminal with explicit derived-graph success/failure only after the graph phase resolves. A retry that observes durable `graph_pending` resumes graph-only work and never duplicates the canonical write; the earlier cross-store crash cut before that persistence returns committed-uncertain while checkpoint recovery handles graph convergence.
-- Sweep abandoned temporary rebuild databases during reconcile.
+- Replace `graph_pending` with non-owned canonical lifecycle states
+  `reserved`, `executing`, `canonically_committed`, and `completed`. A lease is
+  scoped to one execution attempt; it is not embedded as durable graph
+  ownership.
+- Bind every successful claim to one hidden, portable, content-free
+  `GraphCommitReceipt` v2. It binds the namespaced idempotency-key digest,
+  command/payload digest, per-claim lowercase-24-hex commit token and attempt,
+  a closed path/content-free canonical terminal projection, and exact checkpoint
+  generation/digest plus HMAC-covered `canonical_disposition`
+  (`success|committed_failure`). It is
+  atomically installed once and HMAC-SHA256 authenticated by a fresh private
+  32-byte per-attempt secret retained only in owner-only local idempotency
+  runtime state (owner-only runtime directory/database permissions); synced
+  vault artifacts are advisory, never proof. The v2 HMAC input is a versioned
+  domain plus canonical closed JSON of every receipt field except its HMAC;
+  malformed/duplicate/surplus fields fail before constant-time verification.
+  Windows uses a bounded local SQLite binary DPAPI `CurrentUser` BLOB with
+  attempt/token-bound entropy and a protected service DACL; malformed,
+  copied/profile-lost, or raw-legacy secret material fails closed as
+  `outcome_unknown`.
+- Make `floor → caller files → checkpoint → one authenticated receipt` the
+  ordinary protocol. There is no mutable `commit_point` and no two-write
+  marker. Receipt signing follows only a successful guarded vault batch and
+  bounded route-selection fanout preconditions; it excludes later local CAS and
+  graph work. A crash after canonical files but before an authenticated receipt
+  is the fail-closed `outcome_unknown` terminal classification, never a
+  replayable write.
+- Keep the public `.graph-sync.json` v1 bytes and digest vectors unchanged;
+  retain the internal generation floor and make floor/checkpoint/ack admission
+  and migration closed and strict.
+- Treat graph health as dynamically joinable and recomputable from the exact
+  committed receipt/checkpoint. An acknowledged checkpoint, an exact registered
+  rebuild handle, or an explicit durable failure handle is required before the
+  operation guard releases; there is no accepted-but-unverified handoff.
+- Keep private full builds outside canonical authority, but serialize exact,
+  revalidated live publication under the canonical boundary. The private phase
+  commits exact acknowledgement/checkpoint metadata, truncates WAL, runs full
+  integrity and direct source/membership/topology proof, and emits an immutable
+  ticket binding exact graph publication epoch, direct projection identity,
+  warmed live `RecallFreshnessCheckpoint`, recall-policy version plus bounded
+  no-follow `_access.yaml` snapshot/fingerprint, no-external-pending epoch,
+  and exact closed temp-file/meta identity. Under authority, publication
+  performs only two O(1)/bounded ticket checks around the publication hook,
+  then atomic replacement. POSIX uses a
+  cooperative lock directly below an owner-controlled runtime root; Windows
+  retains its stronger no-delete-share replacement refusal.
+- Make delete, recursive delete, restore, recovery, and rollback obey the same
+  epoch and receipt rules. Setup/recovery/rollback work is never a mutation
+  commit point.
+- Defer cross-replica exactly-once: without a shared pre-leaf CAS, a copied
+  receipt cannot suppress a mutation. Recovery never scans receipt artifacts;
+  it reads only the exact artifact named by a matching local attempt record.
+- Observed external Markdown or access-policy edits mark the epoch pending and
+  fail closed; missed or unobserved direct edits are eventually caught by
+  watcher-periodic reconcile. Arbitrary-editor linearizability requires a
+  broker/journal and is out of scope.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `graph-rebuild-availability`: durable canonical-to-graph handoff, off-boundary single-flight rebuild, crash recovery, and non-partial publication.
+- `graph-rebuild-availability`: durable canonical receipts, exact graph work
+  handles, off-boundary single-flight rebuilding, strict epoch recovery, and
+  non-partial publication.
 
 ### Modified Capabilities
 
-- `hosted-mutation-safety`: permit unreachable private graph construction and abandoned-temp cleanup under a dedicated cross-process rebuild lock while retaining the canonical vault boundary for checkpoint/floor publication and every live-sidecar replacement.
+- `hosted-mutation-safety`: private graph construction and narrowly scoped temp
+  cleanup may occur under the rebuild lock; every canonical or reader-visible
+  publication remains serialized by the canonical mutation boundary.
 
 ## Impact
 
-Affected areas are canonical batch publication/post-commit handoff, `src/exomem/index_sync.py`, `src/exomem/deferred_index.py`, `src/exomem/epistemic_graph.py`, writer terminal coordination, reconcile/startup recovery, and graph freshness/boundary tests.
-
-No user-authored Markdown schema, MCP selector, OAuth flow, or graph query shape changes. The graph SQLite schema adds only derived checkpoint metadata. A hidden content-free checkpoint sidecar is operational state, not user knowledge or a semantic index candidate.
+Affected areas are canonical batch publication, mutation/idempotency state,
+graph coordination and acknowledgements, deletion/recovery lifecycle, runtime
+readiness/reconcile, and installed-product verification. User-authored Markdown
+schema, MCP selector names, OAuth, and graph query shapes do not change. The
+graph SQLite metadata and hidden operational artifacts remain content-free and
+excluded from semantic indexing.

--- a/openspec/changes/rebuild-graph-without-blocking-writes/specs/graph-rebuild-availability/spec.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/specs/graph-rebuild-availability/spec.md
@@ -1,58 +1,162 @@
 ## ADDED Requirements
 
-### Requirement: A full rebuild does not hold the vault mutation boundary
-The system SHALL perform full epistemic graph rebuild work without holding the
-vault mutation boundary, acquiring it only to publish the result.
+### Requirement: Canonical mutations publish a durable graph checkpoint
 
-#### Scenario: Unrelated mutation during a rebuild
-- **WHEN** a full graph rebuild is in progress
-- **AND** an unrelated vault mutation is requested
-- **THEN** that mutation proceeds without waiting for the rebuild to finish
+Every graph-relevant guarded canonical batch SHALL publish the closed version 1 graph-sync checkpoint at `<Knowledge Base>/.graph-sync.json` in the same staged replacement set as its canonical files. The checkpoint SHALL carry a monotonic generation greater than every generation previously issued for the vault, an independent lowercase 24-hex mutation identity, bounded sorted post-write path hashes/deletions or full scope, created paths, and a domain-separated canonical digest. It SHALL be excluded from semantic indexing and its own input set.
 
-#### Scenario: Boundary hold is bounded by the swap
-- **WHEN** a full graph rebuild completes
-- **THEN** the vault mutation boundary is held only for the publish step
-- **AND** the hold does not scale with vault size
+The same guarded set SHALL maintain an internal content-free monotonic generation floor at `<Knowledge Base>/.graph-sync-floor.json`. Its closed version 1 object SHALL contain exactly `version`, `generation`, and `floor_sha256`, with a distinct domain-separated canonical digest. New generation selection SHALL be one greater than the maximum valid floor, current checkpoint, and live-graph acknowledgement. The floor SHALL publish before caller canonical replacements and the checkpoint SHALL publish last; caught failure SHALL restore every member of the set. With a valid floor, missing/malformed or contradictory checkpoint state SHALL make the graph unavailable, SHALL force full-scope recovery at a generation greater than that floor, and SHALL NOT permit generation reuse. Without a valid floor, only exact legacy or the closed pre-floor migration states defined below are admissible; every other combination fails closed. Legacy state is exactly the absence of floor, checkpoint, and acknowledgement.
+
+#### Scenario: Canonical batch and checkpoint commit together
+- **WHEN** a graph-relevant mutation commits normally
+- **THEN** its canonical files and exact next-generation checkpoint are both published before writer authority releases
+- **AND** a caught failure leaves neither the canonical change nor a newer checkpoint
+
+#### Scenario: Lost unacknowledged checkpoint cannot reuse its generation
+- **WHEN** restart finds a valid generation floor N but the current checkpoint is missing, malformed, or contradictory
+- **THEN** the graph remains unavailable and recovery publishes a full-scope checkpoint with generation greater than N
+- **AND** no later mutation or recovery reuses generation N
+
+#### Scenario: Graph-irrelevant write does not advance the epoch
+- **WHEN** a canonical mutation affects only paths excluded by the binding recall policy
+- **THEN** neither the generation floor nor graph checkpoint changes
+- **AND** no full graph rebuild is scheduled for that mutation
+
+#### Scenario: Checkpoint digest is deterministic and non-recursive
+- **WHEN** the same version, generation, mutation identity, scope, paths, and created paths are canonicalized twice
+- **THEN** SHA-256 over `exomem-graph-sync-checkpoint:v1\0` plus those canonical JSON bytes is identical
+- **AND** the digest input excludes the digest itself and all graph output bytes
+
+#### Scenario: Shared checkpoint digest vector
+- **WHEN** the canonical checkpoint input is `{"created_paths":["Knowledge Base/Notes/example.md"],"generation":1,"mutation_id":"0123456789abcdef01234567","paths":[["Knowledge Base/Notes/example.md","dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]],"scope":"paths","version":1}`
+- **THEN** its domain-separated digest is `941d8a67ae715b6795daade34607f445d4c5b5726b9dc5e4ac095c9946c6d877`
+
+### Requirement: Full graph work and joins occur outside writer authority
+
+When a canonical mutation encounters an unusable graph, dispatch SHALL register exact checkpoint work and return control to the leaf. After canonical commit is observed and while the operation guard still owns mutation authority, the idempotency store SHALL durably transition the result from owned `pending` to nonterminal `graph_pending`, binding the canonical committed terminal and complete validated content-free checkpoint. It SHALL release every leaf/command mutation guard before starting or joining full graph work. A concurrent exact retry SHALL wait rather than receive or replay that internal payload. If the owner dies after `graph_pending`, a new proven owner MAY resume only graph work; it SHALL NOT execute the canonical leaf again.
+
+No storage engine can atomically commit the vault batch and the separate idempotency database. If the process terminates after the canonical commit point but before `graph_pending` persistence, the dead ordinary `pending` row SHALL become or project the existing committed-uncertain outcome and SHALL never expire into canonical re-execution. The durable checkpoint/batch evidence SHALL drive graph recovery independently, while the caller must re-read canonical state rather than blindly retry the mutation. The request MAY wait off-boundary to preserve its terminal contract.
+
+#### Scenario: Second canonical batch enters during a held rebuild
+- **WHEN** one request has committed generation N and is waiting on a deliberately held rebuild
+- **AND** a second valid mutation begins
+- **THEN** the second mutation acquires writer authority and commits generation N+1 without waiting for graph build work
+- **AND** both requests may join the same per-vault flight
+
+#### Scenario: Wide command does not hide an outer hold
+- **WHEN** a graph-relevant wide command commits and requires a rebuild
+- **THEN** its outer operation guard releases before the graph join just as a narrow command's leaf guard does
+
+#### Scenario: Crash during graph wait cannot duplicate the write
+- **WHEN** a process dies after persisting `graph_pending` but before graph completion
+- **THEN** an exact retry resumes or joins the bound checkpoint work without invoking the canonical mutation again
+- **AND** no internal pending payload is returned as a terminal success
+
+#### Scenario: Crash between canonical commit and graph-pending persistence is uncertain
+- **WHEN** a process dies after the canonical/checkpoint commit point but before the idempotency row reaches `graph_pending`
+- **THEN** exact retry returns committed-uncertain guidance and does not invoke the canonical leaf
+- **AND** checkpoint recovery may repair the graph without fabricating a mutation terminal
+
+### Requirement: Concurrent rebuild requests are checkpoint-aware single-flight
+
+The system SHALL run at most one full graph builder per vault across threads and processes. Builder authority SHALL use a persistent OS-locked regular file under the configured shared runtime-state root, keyed by the same canonical vault identity as writer coordination. The lock directory and file SHALL be opened descriptor-first with no-follow/no-symlink validation and restrictive permissions; the file SHALL never live in human/sync-writable vault content and SHALL never be unlinked. Kernel lock ownership, not PID metadata, is liveness authority. A builder SHALL acquire it before creating its unique temporary database, and reconcile SHALL acquire the same lock before sweeping proven abandoned temporary databases. A flight SHALL continue until it publishes a stable graph covering the latest checkpoint observed before publication or reports a bounded failure. Waiters SHALL resolve only when the published generation covers their required checkpoint lineage; a same-generation/different-digest requirement or a stopped uncovered flight SHALL terminate with explicit lineage failure rather than wait forever.
+
+#### Scenario: New checkpoint arrives during a build pass
+- **WHEN** the builder started at generation N and another mutation publishes N+1 before swap
+- **THEN** the N pass is not published as current
+- **AND** the same flight retries and resolves both waiters only after a stable graph consumes N+1 or the attempt budget fails
+
+#### Scenario: Several writers require one rebuild
+- **WHEN** several writers commit while the graph is unusable
+- **THEN** exactly one builder runs and bounded waiters resolve from its checkpoint-covered outcome
+
+#### Scenario: Another process cannot sweep a live builder
+- **WHEN** one process holds the vault-local rebuild lock and owns a temporary sidecar
+- **THEN** another writer or reconcile process cannot start a second builder or sweep that temporary path
+- **AND** process death releases authority through the kernel lock
+
+#### Scenario: Replacing a vault path cannot replace lock authority
+- **WHEN** a user or sync client unlinks or replaces a similarly named path inside the vault
+- **THEN** all processes still contend on the descriptor-validated runtime-state lock keyed by canonical vault identity
+- **AND** POSIX and Windows multi-process tests prove a second builder cannot enter
 
 ### Requirement: A partially rebuilt graph is never observable
-The system SHALL publish a rebuilt graph as a single atomic replacement.
 
-#### Scenario: Read during a rebuild
-- **WHEN** a graph read occurs while a full rebuild is in progress
-- **THEN** it observes either the previous graph state or the fully rebuilt one
-- **AND** never an empty or partially populated graph
+The builder SHALL populate a unique reserved temporary database beside the live sidecar. It SHALL close/checkpoint every temporary SQLite handle and validate a self-contained database before publication. Readers SHALL observe the previous usable graph or the fully populated replacement, never the temporary or partially filled database. The final swap SHALL occur under a boundary hold that performs no vault-size-dependent build work. A platform sharing refusal SHALL leave the prior live sidecar intact and the checkpoint unacknowledged, returning explicit committed graph failure rather than copying or deleting the live database.
 
-#### Scenario: Crash during a rebuild
-- **WHEN** the process terminates during a full rebuild
-- **THEN** the live sidecar is left in its pre-rebuild state
-- **AND** the abandoned temporary database is removed by the next reconcile
+#### Scenario: Read during rebuild
+- **WHEN** a graph read occurs during full rebuild
+- **THEN** it sees the prior usable sidecar or graph unavailable
+- **AND** it never sees empty or partial rebuilt tables
 
-### Requirement: Concurrent rebuild requests are single-flight
-The system SHALL run at most one full graph rebuild per vault at a time.
+#### Scenario: Boundary hold is bounded by verification and swap
+- **WHEN** a full rebuild completes
+- **THEN** writer authority is acquired only to recheck checkpoint/freshness and replace the sidecar
+- **AND** hold duration does not scale with vault size
 
-#### Scenario: Several writers arrive with an unusable sidecar
-- **WHEN** multiple writes require a rebuild concurrently
-- **THEN** exactly one full rebuild runs
-- **AND** the remaining requests resolve from that rebuild's outcome
+### Requirement: Published graphs consume an exact stable checkpoint
 
-### Requirement: Published graphs reflect a stable vault
-The system SHALL verify vault freshness immediately before publishing a rebuilt
-graph, while holding the vault mutation boundary.
+Each full build pass SHALL snapshot full vault freshness and the current coherent generation floor/checkpoint epoch. Under the final boundary hold it SHALL re-read both before acknowledgement, write the exact acknowledgement into the closed temporary database, then re-read both again immediately before replacement. It SHALL publish only if both checks match. The live graph metadata SHALL record the exact consumed generation/digest, and public availability SHALL require parity with the current checkpoint.
 
-#### Scenario: Vault changes during the final pass
-- **WHEN** vault freshness changes between the start of a rebuild pass and the publish step
-- **THEN** the rebuild is retried rather than published
+When the prior graph is otherwise usable and the exact new checkpoint has bounded path scope, incremental refresh MAY admit the exact predecessor acknowledgement instead of forcing a full rebuild. It SHALL validate that the durable checkpoint still equals the passed checkpoint, its paths/deletions match the committed graph-relevant mutation, the graph acknowledges the immediately preceding generation (or the explicit generation-1 legacy predecessor), and every existing recall/freshness/topology proof succeeds. Row changes, ordinary availability markers, and the new graph checkpoint acknowledgement SHALL commit in one SQLite transaction. Failed proof SHALL roll back and require off-boundary full work; it SHALL NOT rebuild while writer authority is held.
 
-#### Scenario: Rebuild cannot observe a stable vault
-- **WHEN** a rebuild exhausts its stabilization attempts
-- **THEN** it does not publish a graph
-- **AND** the graph is marked unavailable
+#### Scenario: Vault or checkpoint changes during final pass
+- **WHEN** vault freshness or checkpoint identity differs at publication
+- **THEN** the pass is discarded/retried and no stale graph is published
 
-### Requirement: The write path still yields an available graph
-The system SHALL preserve the existing write-path contract when the sidecar is
-unusable.
+#### Scenario: Stable pass publishes acknowledgement
+- **WHEN** both inputs remain stable through the final recheck
+- **THEN** the replacement graph atomically records the consumed checkpoint generation/digest and becomes available
 
-#### Scenario: Write against a missing sidecar
-- **WHEN** a write occurs and the graph sidecar is missing, schema-mismatched, or registry-invalidated
-- **THEN** the graph is rebuilt across the whole vault
-- **AND** the graph reports itself available once the write returns
+#### Scenario: Ordinary path-scoped write stays incremental
+- **WHEN** a usable graph acknowledges generation N and a graph-relevant write publishes a valid path-scoped checkpoint N+1
+- **THEN** incremental refresh atomically updates graph rows and acknowledgement to N+1 without starting a full-vault builder
+
+### Requirement: Crash recovery preserves canonical truth
+
+Startup/readiness and reconcile SHALL compare the generation floor, current checkpoint, and graph acknowledgement. An unacknowledged, missing, malformed, or contradictory checkpoint with a valid floor SHALL make the graph unavailable and require full recovery at a generation above that floor. A missing or malformed floor in any non-legacy or ambiguous state SHALL fail closed and SHALL NOT be automatically repaired. Exact legacy state has no floor, checkpoint, or acknowledgement. The only accepted pre-floor migration states have a valid checkpoint and either no acknowledgement or an acknowledgement exactly matching that checkpoint; under mutation authority they initialize the floor to the checkpoint generation before ordinary availability/recovery logic proceeds. A checkpoint plus conflicting acknowledgement, or acknowledgement without checkpoint/floor, SHALL fail closed. Recovery SHALL report refreshed/current only after the repaired epoch and graph availability are independently re-read and proven. Abandoned reserved temp databases SHALL be swept only while holding the runtime-state rebuild lock.
+
+#### Scenario: Process dies after canonical commit
+- **WHEN** the process terminates after checkpoint publication but before graph acknowledgement
+- **THEN** restart retains canonical files/checkpoint, refuses to call the graph current, and rebuilds from the full current vault
+
+#### Scenario: Process dies during temporary build
+- **WHEN** restart finds a reserved temp database with no live owner
+- **THEN** reconcile removes it without changing the live sidecar or checkpoint
+
+#### Scenario: Malformed checkpoint recovery is real
+- **WHEN** reconcile finds a valid floor but a malformed or missing current checkpoint
+- **THEN** it publishes a higher full-scope checkpoint, builds and acknowledges it, and reports refreshed only after availability proves current
+- **AND** user-authored canonical bytes remain unchanged
+
+#### Scenario: Valid pre-floor checkpoint seeds the floor
+- **WHEN** upgrade finds a valid checkpoint, no floor, and either no graph acknowledgement or an exact matching acknowledgement
+- **THEN** it atomically seeds the floor at that checkpoint generation before proceeding with current-state proof or recovery
+
+#### Scenario: Ambiguous missing floor refuses repair
+- **WHEN** the floor is missing or malformed and checkpoint/acknowledgement state is absent, malformed, or contradictory outside exact legacy or accepted pre-floor migration
+- **THEN** readiness and reconcile fail closed without inventing a generation or rewriting epoch state
+
+### Requirement: Deletions publish a recoverable graph handoff
+
+A graph-relevant file or recursive-directory deletion SHALL publish its null-path or bounded/full checkpoint through the same guarded trash-move transition, not through best-effort post-delete fanout. The transition SHALL durably establish its lifecycle tombstone and next generation floor before the canonical rename, install the exact checkpoint before the deletion commit point, and pass that checkpoint to derived fanout. A caught checkpoint failure SHALL reverse and fsync the rename and restore the prior epoch. An abrupt interruption after rename SHALL leave enough tombstone/floor evidence for reconcile to force higher full-scope recovery without generation reuse.
+
+#### Scenario: Caught deletion checkpoint failure rolls back
+- **WHEN** checkpoint installation fails after a file or directory was moved toward trash but before the deletion commit point
+- **THEN** the source placement and prior epoch are restored and the mutation is not reported committed
+
+#### Scenario: Crash after rename remains recoverable
+- **WHEN** a process dies after the canonical trash rename but before checkpoint publication completes
+- **THEN** restart observes lifecycle/floor evidence, refuses the old graph as current, and recovers at a higher generation without restoring or duplicating the deletion
+
+### Requirement: Write terminals distinguish canonical commit from graph failure
+
+A request whose canonical batch committed SHALL remain canonically committed while its idempotency state stays nonterminal `graph_pending`. No public response or terminal projector SHALL expose internal pending graph state as success. Success SHALL durably transition to `completed` only after proving graph availability for the required checkpoint. Exhausted stabilization, waiter admission failure, lineage failure, or safe platform publication refusal SHALL transition to `completed` with a stable committed graph failure code, required checkpoint digest, and recovery guidance; compact/full public projection SHALL retain those bounded fields, while legacy projection remains unchanged. Exact idempotent retry SHALL replay the same completed outcome without applying the canonical write again.
+
+#### Scenario: Write succeeds with current graph
+- **WHEN** the joined flight publishes a graph covering the request checkpoint
+- **THEN** the request returns committed with graph sync completed and the graph reports available
+
+#### Scenario: Stabilization exhausts after canonical commit
+- **WHEN** the builder cannot publish a stable checkpoint within its bounded attempts
+- **THEN** the request returns committed with explicit graph-sync failure and reconcile guidance
+- **AND** exact retry does not duplicate the canonical mutation

--- a/openspec/changes/rebuild-graph-without-blocking-writes/specs/graph-rebuild-availability/spec.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/specs/graph-rebuild-availability/spec.md
@@ -1,162 +1,310 @@
 ## ADDED Requirements
 
-### Requirement: Canonical mutations publish a durable graph checkpoint
+### Requirement: Canonical mutations use non-owned lifecycle states and exact receipts
 
-Every graph-relevant guarded canonical batch SHALL publish the closed version 1 graph-sync checkpoint at `<Knowledge Base>/.graph-sync.json` in the same staged replacement set as its canonical files. The checkpoint SHALL carry a monotonic generation greater than every generation previously issued for the vault, an independent lowercase 24-hex mutation identity, bounded sorted post-write path hashes/deletions or full scope, created paths, and a domain-separated canonical digest. It SHALL be excluded from semantic indexing and its own input set.
+Each namespaced idempotent mutation SHALL use only `reserved`, `executing`,
+`canonically_committed`, and `completed` as its durable canonical lifecycle
+states. Execution ownership SHALL be a bounded per-claim attempt, not a durable
+state owner. A dead `reserved` row SHALL be reclaimable. A dead `executing` row
+without valid authenticated evidence SHALL be terminally `outcome_unknown` and
+SHALL NOT be reclaimed for leaf execution.
 
-The same guarded set SHALL maintain an internal content-free monotonic generation floor at `<Knowledge Base>/.graph-sync-floor.json`. Its closed version 1 object SHALL contain exactly `version`, `generation`, and `floor_sha256`, with a distinct domain-separated canonical digest. New generation selection SHALL be one greater than the maximum valid floor, current checkpoint, and live-graph acknowledgement. The floor SHALL publish before caller canonical replacements and the checkpoint SHALL publish last; caught failure SHALL restore every member of the set. With a valid floor, missing/malformed or contradictory checkpoint state SHALL make the graph unavailable, SHALL force full-scope recovery at a generation greater than that floor, and SHALL NOT permit generation reuse. Without a valid floor, only exact legacy or the closed pre-floor migration states defined below are admissible; every other combination fails closed. Legacy state is exactly the absence of floor, checkpoint, and acknowledgement.
+A claim SHALL receive a lowercase 24-hex `commit_token` and fresh private
+32-byte per-attempt secret. It SHALL retain one atomically installed, hidden,
+portable, content-free `GraphCommitReceipt` v2 for at least the retry-row
+lifetime. Receipt v2 SHALL bind the namespaced idempotency-key digest,
+command/payload digest, attempt/claim and commit token, canonical terminal
+projection, and exact checkpoint generation/digest, and SHALL authenticate its
+canonical v2 bytes with HMAC-SHA256 using that secret. The secret SHALL exist
+only in the matching owner-only local idempotency runtime state, never in a
+synced vault artifact, log, terminal, or diagnostic. The local runtime directory
+SHALL be owner-only (`0700`); its database, WAL/SHM files, and secret material
+SHALL be `0600` or stricter. On Windows, the per-attempt secret SHALL exist
+only in the local SQLite binary BLOB
+`EXID | version=1 | provider=1(DPAPI_CURRENT_USER) | uint32be ciphertext_length | ciphertext`.
+Total BLOB length and ciphertext length SHALL each be at most 4096 bytes;
+`ciphertext_length` SHALL exactly consume the remaining bytes. The parser SHALL
+reject truncation, trailing bytes, unknown version/provider, and every other
+non-exact encoding. Its entropy SHALL be UTF-8
+`exomem-graph-commit-receipt-dpapi:v1\0<attempt_id>\0<commit_token>`; no clear
+secret SHALL be serialized. The protected inheritable runtime DACL SHALL permit
+only the current service identity, `LocalSystem`, and `Administrators`. Before
+SQLite is opened or a runtime row is unpickled, the service SHALL reject a
+reparse-point runtime path and an existing unsafe DACL. SQLite, WAL, and SHM
+SHALL contain only the DPAPI ciphertext. An account/profile change, copied
+envelope, failed DPAPI unprotect, or raw legacy secret row SHALL classify the
+claim `outcome_unknown`; none may heal local CAS or authorize leaf replay.
 
-#### Scenario: Canonical batch and checkpoint commit together
-- **WHEN** a graph-relevant mutation commits normally
-- **THEN** its canonical files and exact next-generation checkpoint are both published before writer authority releases
-- **AND** a caught failure leaves neither the canonical change nor a newer checkpoint
+Receipt eligibility SHALL be non-circular. “Complete ordinary protocol
+succeeded” SHALL mean, before signing, that: the claimed leaf returned its
+candidate terminal; one guarded vault batch successfully applied its selected
+floor, caller canonical replacements, and exact checkpoint; and every bounded
+canonical fanout precondition needed to select and validate that checkpoint's
+incremental-or-rebuild route completed. It SHALL exclude receipt
+installation/authentication, local lifecycle CAS, durable derived-handle
+registration, `ensure_started`, graph join, and completed-terminal persistence.
 
-#### Scenario: Lost unacknowledged checkpoint cannot reuse its generation
-- **WHEN** restart finds a valid generation floor N but the current checkpoint is missing, malformed, or contradictory
-- **THEN** the graph remains unavailable and recovery publishes a full-scope checkpoint with generation greater than N
-- **AND** no later mutation or recovery reuses generation N
+`terminal_projection` SHALL be a closed content-free object. Its only permitted
+fields are `_terminal`, `version`, `ok`, `state`, `status`, `committed`,
+`mutated`, `terminal`, `request_id`, `receipt_id`, `operation_id`,
+`warnings_count`, and `result_sha256`; absent permitted fields SHALL be omitted.
+Scalar identifiers SHALL use their existing bounded formats and `result_sha256`
+SHALL be lowercase SHA-256 of an otherwise non-retained result summary. No
+other top-level or nested projection field is permitted. In particular,
+`path`, `paths`, `affected_paths`, every vault path or file name, Markdown,
+metadata values, source text, and arbitrary leaf result/content SHALL NOT be
+stored in the projection. Graph outcome SHALL be attached only after receipt
+persistence and SHALL NOT be part of `terminal_projection`.
 
-#### Scenario: Graph-irrelevant write does not advance the epoch
-- **WHEN** a canonical mutation affects only paths excluded by the binding recall policy
-- **THEN** neither the generation floor nor graph checkpoint changes
-- **AND** no full graph rebuild is scheduled for that mutation
+Receipt v2 SHALL be a closed object with exactly `version`,
+`idempotency_key_digest`, `command_digest`, `attempt_id`, `commit_token`,
+`terminal_projection`, `terminal_projection_sha256`, `checkpoint_generation`,
+`checkpoint_sha256`, `canonical_disposition`, and `receipt_hmac_sha256`.
+`version` SHALL be integer `2`; `canonical_disposition` SHALL be exactly
+`success` or `committed_failure`; the checkpoint fields SHALL both be null or a
+positive integer/lowercase SHA-256 pair; every other digest SHALL be lowercase
+SHA-256. `canonical_disposition` SHALL be HMAC-covered and SHALL NOT alter the
+closed `terminal_projection` allowlist. Its HMAC input
+SHALL be UTF-8 bytes `exomem-graph-commit-receipt-auth:v2\0` concatenated with
+canonical UTF-8 JSON of every v2 field except `receipt_hmac_sha256`. Canonical
+JSON SHALL have no insignificant whitespace, lexicographically sorted object
+keys, and unescaped non-ASCII Unicode. The parser SHALL reject duplicate,
+missing, surplus, wrongly typed, or noncanonical fields and a mismatched
+terminal-projection digest before authentication. Verification SHALL recompute
+HMAC-SHA256 and compare the received digest in constant time.
 
-#### Scenario: Checkpoint digest is deterministic and non-recursive
-- **WHEN** the same version, generation, mutation identity, scope, paths, and created paths are canonicalized twice
-- **THEN** SHA-256 over `exomem-graph-sync-checkpoint:v1\0` plus those canonical JSON bytes is identical
-- **AND** the digest input excludes the digest itself and all graph output bytes
+There SHALL be no mutable `commit_point` field or two-write receipt marker.
+Receipt v2 SHALL be authoritative only after the defined pre-signing ordinary
+protocol succeeded. It SHALL be atomically installed before the local
+CAS from the matching `executing` row to `canonically_committed`. A failed local
+CAS after installation MAY be healed only by that exact receipt, matching
+trusted executing row, attempt/token binding, and retained private secret.
+`graph_pending` SHALL NOT be written by new code. Valid legacy `graph_pending`
+is a local-row-only migration to `canonically_committed`; it SHALL never permit
+the canonical leaf to replay. Legacy v1 boolean receipts and all synced vault
+receipt artifacts are advisory only. Graph health for a canonically committed
+local row SHALL be dynamically joinable or recomputable from its exact
+checkpoint, independent of the original attempt.
 
-#### Scenario: Shared checkpoint digest vector
-- **WHEN** the canonical checkpoint input is `{"created_paths":["Knowledge Base/Notes/example.md"],"generation":1,"mutation_id":"0123456789abcdef01234567","paths":[["Knowledge Base/Notes/example.md","dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]],"scope":"paths","version":1}`
-- **THEN** its domain-separated digest is `941d8a67ae715b6795daade34607f445d4c5b5726b9dc5e4ac095c9946c6d877`
+An authenticated orphaned v2 receipt with `canonical_disposition: success` MAY
+heal only its matching trusted executing CAS and then continue the ordinary
+derived graph path. An authenticated orphan with
+`canonical_disposition: committed_failure` SHALL suppress leaf replay; it SHALL
+replay the retained exact local failure when available and otherwise persist
+`outcome_unknown` while independently recovering graph health. A missing,
+invalid, or fieldless v2 receipt SHALL heal neither disposition.
 
-### Requirement: Full graph work and joins occur outside writer authority
+#### Scenario: Dead execution attempt cannot duplicate a committed leaf
+- **WHEN** a claim's executing attempt dies after canonical files could change
+- **AND** no exact receipt v2 can be authenticated with its trusted local row and secret
+- **THEN** exact retry returns `outcome_unknown` rather than reclaiming the leaf
 
-When a canonical mutation encounters an unusable graph, dispatch SHALL register exact checkpoint work and return control to the leaf. After canonical commit is observed and while the operation guard still owns mutation authority, the idempotency store SHALL durably transition the result from owned `pending` to nonterminal `graph_pending`, binding the canonical committed terminal and complete validated content-free checkpoint. It SHALL release every leaf/command mutation guard before starting or joining full graph work. A concurrent exact retry SHALL wait rather than receive or replay that internal payload. If the owner dies after `graph_pending`, a new proven owner MAY resume only graph work; it SHALL NOT execute the canonical leaf again.
+#### Scenario: Installed receipt heals only its matching local CAS
+- **WHEN** receipt v2 installs but the matching executing-to-committed CAS fails
+- **THEN** recovery heals it only with that exact trusted executing row and retained secret
+- **AND** a copied receipt alone cannot suppress or complete a mutation
 
-No storage engine can atomically commit the vault batch and the separate idempotency database. If the process terminates after the canonical commit point but before `graph_pending` persistence, the dead ordinary `pending` row SHALL become or project the existing committed-uncertain outcome and SHALL never expire into canonical re-execution. The durable checkpoint/batch evidence SHALL drive graph recovery independently, while the caller must re-read canonical state rather than blindly retry the mutation. The request MAY wait off-boundary to preserve its terminal contract.
+#### Scenario: Predecessor graph-pending row migrates safely
+- **WHEN** a retry reads a valid legacy `graph_pending` row
+- **THEN** it treats the row as `canonically_committed` with its validated checkpoint
+- **AND** it can join/recompute graph work without replaying the leaf
 
-#### Scenario: Second canonical batch enters during a held rebuild
-- **WHEN** one request has committed generation N and is waiting on a deliberately held rebuild
-- **AND** a second valid mutation begins
-- **THEN** the second mutation acquires writer authority and commits generation N+1 without waiting for graph build work
-- **AND** both requests may join the same per-vault flight
+### Requirement: The multi-store canonical cut remains outcome-unknown
 
-#### Scenario: Wide command does not hide an outer hold
-- **WHEN** a graph-relevant wide command commits and requires a rebuild
-- **THEN** its outer operation guard releases before the graph join just as a narrow command's leaf guard does
+The vault batch and retry-store receipt SHALL NOT be treated as one atomic
+transaction. If the process dies after any canonical caller file, floor, or
+checkpoint write can have committed but before matching receipt v2 atomically
+installs, the exact retry SHALL return the fail-closed `outcome_unknown`
+terminal classification with readback guidance. If it dies after v2 installation
+but before local CAS, only its matching trusted executing row and retained
+private secret may heal the CAS. A committed-attempt cleanup failure SHALL NOT
+reconstruct a successful mutation from an orphaned receipt.
+`outcome_unknown` is outside the four canonical lifecycle states and SHALL NOT
+be treated as proof that the canonical mutation reached either
+`canonically_committed` or successful `completed`. The retry store MAY retain
+the immutable fail-closed classification in a `completed` row solely as a
+terminal storage envelope, so exact retries read back the same classification
+without creating a fifth state; that envelope does not assert canonical
+completion. The system SHALL NOT rerun the leaf, infer success from filesystem
+state, fabricate a canonical terminal, or convert the cut to a receipt.
+Checkpoint recovery MAY independently converge graph health. Recovery SHALL
+not scan receipt artifacts: it SHALL read only the exact receipt address named
+by a trusted local row, under bounded artifact-size and parsing limits. A synced
+receipt is untrusted/advisory, and a copied receipt without matching local row
+and secret SHALL NOT suppress a mutation. Cross-replica exactly-once is
+explicitly deferred until a shared pre-leaf CAS exists.
 
-#### Scenario: Crash during graph wait cannot duplicate the write
-- **WHEN** a process dies after persisting `graph_pending` but before graph completion
-- **THEN** an exact retry resumes or joins the bound checkpoint work without invoking the canonical mutation again
-- **AND** no internal pending payload is returned as a terminal success
+#### Scenario: Crash after checkpoint before receipt installation
+- **WHEN** a process dies after the caller batch published its checkpoint but before matching receipt v2 atomically installs
+- **THEN** exact retry returns `outcome_unknown`
+- **AND** the canonical leaf invocation count remains one
 
-#### Scenario: Crash between canonical commit and graph-pending persistence is uncertain
-- **WHEN** a process dies after the canonical/checkpoint commit point but before the idempotency row reaches `graph_pending`
-- **THEN** exact retry returns committed-uncertain guidance and does not invoke the canonical leaf
-- **AND** checkpoint recovery may repair the graph without fabricating a mutation terminal
+### Requirement: Canonical batches publish strict graph epochs and receipts in order
 
-### Requirement: Concurrent rebuild requests are checkpoint-aware single-flight
+Every graph-relevant claimed canonical mutation SHALL select one generation
+above the maximum valid floor, checkpoint, and acknowledgement, then execute
+`floor → caller files → checkpoint → one authenticated receipt v2 → local CAS`
+in that order. Caught failure SHALL roll back the vault batch and SHALL not
+install a receipt. Graph-irrelevant writes SHALL advance neither artifact and
+create no graph receipt. Setup, floor seeding, reconcile repair, cleanup, and
+rollback SHALL use `commit_point=False` and SHALL never mark a mutation
+committed; this API flag SHALL NOT be persisted as a receipt marker.
 
-The system SHALL run at most one full graph builder per vault across threads and processes. Builder authority SHALL use a persistent OS-locked regular file under the configured shared runtime-state root, keyed by the same canonical vault identity as writer coordination. The lock directory and file SHALL be opened descriptor-first with no-follow/no-symlink validation and restrictive permissions; the file SHALL never live in human/sync-writable vault content and SHALL never be unlinked. Kernel lock ownership, not PID metadata, is liveness authority. A builder SHALL acquire it before creating its unique temporary database, and reconcile SHALL acquire the same lock before sweeping proven abandoned temporary databases. A flight SHALL continue until it publishes a stable graph covering the latest checkpoint observed before publication or reports a bounded failure. Waiters SHALL resolve only when the published generation covers their required checkpoint lineage; a same-generation/different-digest requirement or a stopped uncovered flight SHALL terminate with explicit lineage failure rather than wait forever.
+The public `.graph-sync.json` SHALL remain closed v1 with unchanged canonical
+bytes and valid digest vectors. Its parser SHALL reject more than 1,000 `paths`
+entries before normalization; surplus fields; paths not already NFC-normalized;
+unsafe/noncanonical POSIX-relative paths;
+absolute, backslash, empty, dot, dotdot, or NUL path components; non-null hashes
+other than lowercase 64-hex; conflicting duplicate paths; non-unique or
+non-created `created_paths`; and non-empty arrays for `full` scope. The internal
+floor SHALL remain closed `{version,generation,floor_sha256}` under its distinct
+digest domain.
 
-#### Scenario: New checkpoint arrives during a build pass
-- **WHEN** the builder started at generation N and another mutation publishes N+1 before swap
-- **THEN** the N pass is not published as current
-- **AND** the same flight retries and resolves both waiters only after a stable graph consumes N+1 or the attempt budget fails
+#### Scenario: Existing checkpoint vector remains stable
+- **WHEN** the existing v1 checkpoint test vector is rendered after this change
+- **THEN** its bytes and domain-separated digest exactly equal the pinned vector
 
-#### Scenario: Several writers require one rebuild
-- **WHEN** several writers commit while the graph is unusable
-- **THEN** exactly one builder runs and bounded waiters resolve from its checkpoint-covered outcome
+#### Scenario: Strict parser rejects normalization ambiguity
+- **WHEN** a v1 checkpoint contains an equivalent-but-noncanonical path, duplicate conflict, or malformed full scope
+- **THEN** parsing fails before it can influence generation, acknowledgement, or recovery
 
-#### Scenario: Another process cannot sweep a live builder
-- **WHEN** one process holds the vault-local rebuild lock and owns a temporary sidecar
-- **THEN** another writer or reconcile process cannot start a second builder or sweep that temporary path
-- **AND** process death releases authority through the kernel lock
+### Requirement: Epoch migration and acknowledgement parity fail closed
 
-#### Scenario: Replacing a vault path cannot replace lock authority
-- **WHEN** a user or sync client unlinks or replaces a similarly named path inside the vault
-- **THEN** all processes still contend on the descriptor-validated runtime-state lock keyed by canonical vault identity
-- **AND** POSIX and Windows multi-process tests prove a second builder cannot enter
+Exact legacy is the simultaneous absence of floor, checkpoint, and graph
+acknowledgement. The only accepted pre-floor state is a valid checkpoint with
+absent floor and either absent acknowledgement or acknowledgement exactly equal
+to that checkpoint; mutation authority may seed the floor at that generation.
+A valid floor with missing, malformed, or older checkpoint SHALL recover only at
+a higher full-scope generation. All other missing/malformed floor or
+contradictory acknowledgement combinations SHALL fail closed.
 
-### Requirement: A partially rebuilt graph is never observable
+Public graph availability SHALL require exact current checkpoint
+generation/digest parity and every currently written acknowledgement metadata
+key, including `graph_sync_checkpoint`. Missing metadata SHALL NOT default to
+success in this migration. A malformed state requires fresh full recovery, not
+incremental admission.
 
-The builder SHALL populate a unique reserved temporary database beside the live sidecar. It SHALL close/checkpoint every temporary SQLite handle and validate a self-contained database before publication. Readers SHALL observe the previous usable graph or the fully populated replacement, never the temporary or partially filled database. The final swap SHALL occur under a boundary hold that performs no vault-size-dependent build work. A platform sharing refusal SHALL leave the prior live sidecar intact and the checkpoint unacknowledged, returning explicit committed graph failure rather than copying or deleting the live database.
+#### Scenario: Missing acknowledgement metadata is unavailable
+- **WHEN** a graph sidecar has matching generation/digest but lacks `graph_sync_checkpoint`
+- **THEN** graph availability is false and full recovery is required
 
-#### Scenario: Read during rebuild
-- **WHEN** a graph read occurs during full rebuild
-- **THEN** it sees the prior usable sidecar or graph unavailable
-- **AND** it never sees empty or partial rebuilt tables
+#### Scenario: Valid floor plus stale checkpoint recovers above the floor
+- **WHEN** recovery finds floor generation N and a missing, malformed, or older checkpoint
+- **THEN** it publishes a fresh full-scope checkpoint with generation greater than N
+- **AND** it does not reuse a generation or alter user-authored bytes
 
-#### Scenario: Boundary hold is bounded by verification and swap
-- **WHEN** a full rebuild completes
-- **THEN** writer authority is acquired only to recheck checkpoint/freshness and replace the sidecar
-- **AND** hold duration does not scale with vault size
+### Requirement: Every committed checkpoint has an exact graph outcome handle
 
-### Requirement: Published graphs consume an exact stable checkpoint
+Before a graph-relevant checkpoint leaves canonical writer authority, the system
+SHALL either atomically acknowledge it incrementally, register an exact durable
+rebuild handle, or persist an explicit exact graph failure handle.
+`accepted_unverified` is forbidden. After every canonical guard releases,
+`ensure_started(handle)` SHALL start or join that registered exact flight without
+consuming bounded waiter capacity. `join(handle)` SHALL separately admit a
+bounded waiter and release its capacity in `finally` on every completion,
+cancellation, and failure path.
 
-Each full build pass SHALL snapshot full vault freshness and the current coherent generation floor/checkpoint epoch. Under the final boundary hold it SHALL re-read both before acknowledgement, write the exact acknowledgement into the closed temporary database, then re-read both again immediately before replacement. It SHALL publish only if both checks match. The live graph metadata SHALL record the exact consumed generation/digest, and public availability SHALL require parity with the current checkpoint.
+Coordinator start failure, capacity failure, stopped/uncovered flight, lineage
+conflict, stabilization exhaustion, and platform sharing refusal SHALL create
+explicit durable handles with stable codes and recovery guidance. A
+`canonically_committed` receipt can later join or recompute its exact handle
+without canonical leaf replay.
 
-When the prior graph is otherwise usable and the exact new checkpoint has bounded path scope, incremental refresh MAY admit the exact predecessor acknowledgement instead of forcing a full rebuild. It SHALL validate that the durable checkpoint still equals the passed checkpoint, its paths/deletions match the committed graph-relevant mutation, the graph acknowledges the immediately preceding generation (or the explicit generation-1 legacy predecessor), and every existing recall/freshness/topology proof succeeds. Row changes, ordinary availability markers, and the new graph checkpoint acknowledgement SHALL commit in one SQLite transaction. Failed proof SHALL roll back and require off-boundary full work; it SHALL NOT rebuild while writer authority is held.
+#### Scenario: Handle registration is total before guard release
+- **WHEN** an unusable graph prevents incremental acknowledgement
+- **THEN** the exact checkpoint has a registered rebuild or failure handle before canonical authority releases
+- **AND** the canonical request does not wait for graph work while holding authority
 
-#### Scenario: Vault or checkpoint changes during final pass
-- **WHEN** vault freshness or checkpoint identity differs at publication
-- **THEN** the pass is discarded/retried and no stale graph is published
+#### Scenario: Join capacity cannot leak
+- **WHEN** a bounded join raises, times out, or is cancelled
+- **THEN** its waiter slot is released
+- **AND** a later valid join can be admitted
 
-#### Scenario: Stable pass publishes acknowledgement
-- **WHEN** both inputs remain stable through the final recheck
-- **THEN** the replacement graph atomically records the consumed checkpoint generation/digest and becomes available
+### Requirement: Incremental and full graph acknowledgement are exact
 
-#### Scenario: Ordinary path-scoped write stays incremental
-- **WHEN** a usable graph acknowledges generation N and a graph-relevant write publishes a valid path-scoped checkpoint N+1
-- **THEN** incremental refresh atomically updates graph rows and acknowledgement to N+1 without starting a full-vault builder
+Incremental refresh SHALL run only when the durable checkpoint still equals the
+receipt binding, the current graph acknowledgement is its exact immediate
+predecessor, and all existing freshness, recall, and topology proofs pass. Rows,
+availability markers, and all exact acknowledgement metadata SHALL commit in
+one SQLite transaction. Failed proof SHALL roll back and register full work;
+it SHALL not build under canonical authority.
 
-### Requirement: Crash recovery preserves canonical truth
+Each full pass SHALL build a unique private temporary sidecar from a coherent
+epoch and real full-vault freshness snapshot. Privately it SHALL commit exact
+acknowledgement/checkpoint metadata, truncate WAL, run full integrity and direct
+source/membership/topology proof, warm the live `RecallFreshnessCheckpoint`,
+and capture recall-policy version plus bounded no-follow `_access.yaml`
+content snapshot/fingerprint. It SHALL close the temp and emit an immutable
+ticket binding exact graph publication epoch, direct projection identity, the
+warmed checkpoint, policy/access snapshot, no-external-pending epoch, and exact
+closed temp-file/meta identity. Under canonical authority it SHALL perform only
+two O(1)/bounded ticket checks around the publication hook and atomic
+replacement; no vault/sidecar walk, cache warm, WAL, integrity, or projection
+proof is permitted. Any cold/dirty cache, epoch/access mismatch, observed
+external Markdown/access edit, hook failure, or ticket mismatch discards the
+ticket and retries via reconcile. Missed/unobserved direct edits converge by
+watcher-periodic reconcile; arbitrary-editor linearizability requires an
+out-of-scope broker/journal.
 
-Startup/readiness and reconcile SHALL compare the generation floor, current checkpoint, and graph acknowledgement. An unacknowledged, missing, malformed, or contradictory checkpoint with a valid floor SHALL make the graph unavailable and require full recovery at a generation above that floor. A missing or malformed floor in any non-legacy or ambiguous state SHALL fail closed and SHALL NOT be automatically repaired. Exact legacy state has no floor, checkpoint, or acknowledgement. The only accepted pre-floor migration states have a valid checkpoint and either no acknowledgement or an acknowledgement exactly matching that checkpoint; under mutation authority they initialize the floor to the checkpoint generation before ordinary availability/recovery logic proceeds. A checkpoint plus conflicting acknowledgement, or acknowledgement without checkpoint/floor, SHALL fail closed. Recovery SHALL report refreshed/current only after the repaired epoch and graph availability are independently re-read and proven. Abandoned reserved temp databases SHALL be swept only while holding the runtime-state rebuild lock.
+#### Scenario: Original-index edit races final publication
+- **WHEN** the original index changes at either real freshness seam during final publication
+- **THEN** the temporary pass is not published as current
+- **AND** the exact handle retries or resolves to its durable failure outcome
 
-#### Scenario: Process dies after canonical commit
-- **WHEN** the process terminates after checkpoint publication but before graph acknowledgement
-- **THEN** restart retains canonical files/checkpoint, refuses to call the graph current, and rebuilds from the full current vault
+### Requirement: Private rebuilds are cooperative and publication is non-partial
 
-#### Scenario: Process dies during temporary build
-- **WHEN** restart finds a reserved temp database with no live owner
-- **THEN** reconcile removes it without changing the live sidecar or checkpoint
+Within one configured trusted runtime root, at most one POSIX full builder per
+canonical vault identity SHALL run cooperatively. That root SHALL be
+operator-owned and neither group- nor world-writable; the persistent
+descriptor-validated no-follow lock file SHALL sit directly beneath it, have
+restrictive permissions, and never be unlinked. Hostile same-user replacement
+of the trusted root is outside this cooperative contract. The same lock
+serializes reserved-temp cleanup, which SHALL target only well-formed temps for
+the exact vault identity and never a registered active flight, live sidecar, or
+lock file.
 
-#### Scenario: Malformed checkpoint recovery is real
-- **WHEN** reconcile finds a valid floor but a malformed or missing current checkpoint
-- **THEN** it publishes a higher full-scope checkpoint, builds and acknowledges it, and reports refreshed only after availability proves current
-- **AND** user-authored canonical bytes remain unchanged
+Windows SHALL retain stronger no-delete-share locking/replacement behaviour. A
+sharing or rename refusal SHALL preserve the old live sidecar and temporary
+output, create an explicit graph failure handle, and SHALL NOT use
+delete-and-replace. Readers SHALL see only an old usable sidecar, a complete
+replacement, or unavailable—never a temporary or partial sidecar.
 
-#### Scenario: Valid pre-floor checkpoint seeds the floor
-- **WHEN** upgrade finds a valid checkpoint, no floor, and either no graph acknowledgement or an exact matching acknowledgement
-- **THEN** it atomically seeds the floor at that checkpoint generation before proceeding with current-state proof or recovery
+#### Scenario: Reader blocks Windows replacement safely
+- **WHEN** a Windows reader keeps the live sidecar open without delete sharing
+- **THEN** replacement is refused without changing the live sidecar
+- **AND** after the reader closes, a new exact recovery attempt may publish
 
-#### Scenario: Ambiguous missing floor refuses repair
-- **WHEN** the floor is missing or malformed and checkpoint/acknowledgement state is absent, malformed, or contradictory outside exact legacy or accepted pre-floor migration
-- **THEN** readiness and reconcile fail closed without inventing a generation or rewriting epoch state
+### Requirement: Lifecycle transitions and recovery preserve canonical truth
 
-### Requirement: Deletions publish a recoverable graph handoff
+Graph-relevant file and recursive-directory deletion SHALL use the existing
+lifecycle/trash transition under canonical authority: tombstone, floor, rename,
+exact null/full checkpoint, and existing deletion commit point. A caught
+checkpoint/later-batch failure SHALL reverse and fsync the rename and restore
+the prior epoch before reporting failure. A crash after rename SHALL leave
+lifecycle/floor evidence, force a higher full recovery generation, and neither
+restore nor duplicate the deletion. Restore obeys the same ordering. Recovery
+and rollback do not create a mutation receipt unless they are the originally
+claimed caller leaf.
 
-A graph-relevant file or recursive-directory deletion SHALL publish its null-path or bounded/full checkpoint through the same guarded trash-move transition, not through best-effort post-delete fanout. The transition SHALL durably establish its lifecycle tombstone and next generation floor before the canonical rename, install the exact checkpoint before the deletion commit point, and pass that checkpoint to derived fanout. A caught checkpoint failure SHALL reverse and fsync the rename and restore the prior epoch. An abrupt interruption after rename SHALL leave enough tombstone/floor evidence for reconcile to force higher full-scope recovery without generation reuse.
+Readiness and reconcile SHALL report current only after independent exact epoch
+parity and graph availability proof. Their repairs SHALL register an exact
+rebuild/failure handle before authority releases.
 
-#### Scenario: Caught deletion checkpoint failure rolls back
-- **WHEN** checkpoint installation fails after a file or directory was moved toward trash but before the deletion commit point
-- **THEN** the source placement and prior epoch are restored and the mutation is not reported committed
+#### Scenario: Caught recursive deletion rolls back
+- **WHEN** a recursive trash transition fails after rename but before its checkpoint protocol completes
+- **THEN** source placement and epoch are restored and fsynced
+- **AND** no receipt or committed terminal is created
 
-#### Scenario: Crash after rename remains recoverable
-- **WHEN** a process dies after the canonical trash rename but before checkpoint publication completes
-- **THEN** restart observes lifecycle/floor evidence, refuses the old graph as current, and recovers at a higher generation without restoring or duplicating the deletion
+### Requirement: Installed-product proof covers the full contract
 
-### Requirement: Write terminals distinguish canonical commit from graph failure
+The installed wheel SHALL prove a disposable Records-compatible mutation through
+the real MCP surface, including strict epoch creation, receipt/lifecycle,
+derived graph recovery, and exact terminal/retry behaviour. Native Windows
+verification SHALL exercise the installed-wheel service path, cross-process
+rebuild claim, and open-reader replacement refusal. A quiesced 500/2,000-page
+reproduction SHALL record p95 canonical boundary hold separately from request
+latency and show that the hold does not scale with vault size.
 
-A request whose canonical batch committed SHALL remain canonically committed while its idempotency state stays nonterminal `graph_pending`. No public response or terminal projector SHALL expose internal pending graph state as success. Success SHALL durably transition to `completed` only after proving graph availability for the required checkpoint. Exhausted stabilization, waiter admission failure, lineage failure, or safe platform publication refusal SHALL transition to `completed` with a stable committed graph failure code, required checkpoint digest, and recovery guidance; compact/full public projection SHALL retain those bounded fields, while legacy projection remains unchanged. Exact idempotent retry SHALL replay the same completed outcome without applying the canonical write again.
-
-#### Scenario: Write succeeds with current graph
-- **WHEN** the joined flight publishes a graph covering the request checkpoint
-- **THEN** the request returns committed with graph sync completed and the graph reports available
-
-#### Scenario: Stabilization exhausts after canonical commit
-- **WHEN** the builder cannot publish a stable checkpoint within its bounded attempts
-- **THEN** the request returns committed with explicit graph-sync failure and reconcile guidance
-- **AND** exact retry does not duplicate the canonical mutation
+#### Scenario: Disposable live MCP mutation crosses derived recovery
+- **WHEN** a disposable installed service receives a real MCP mutation while its graph needs recovery
+- **THEN** the canonical mutation commits once, graph work occurs off-boundary, and exact retry/inspection reports the required receipt and graph outcome

--- a/openspec/changes/rebuild-graph-without-blocking-writes/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/specs/hosted-mutation-safety/spec.md
@@ -2,52 +2,145 @@
 
 ### Requirement: One Process-Safe Mutation Boundary Per Vault
 
-The system SHALL serialize every operation that can modify a vault's canonical Markdown, media, live governed indexes, logs, or mutation-owned published runtime state through one process-safe boundary keyed by the vault's canonical identity. MCP, REST, CLI, transfer routes, and background writers MUST NOT maintain independent locks for those observable mutations or bypass that boundary.
+The system SHALL serialize every canonical or reader-visible vault mutation
+through one process-safe boundary keyed by canonical vault identity. MCP, REST,
+CLI, transfer routes, and background writers MUST NOT maintain independent
+locks for canonical Markdown, media, floor/checkpoint epoch state, live indexes,
+logs, mutation receipts, or published runtime state. Synced vault files,
+including hidden receipt artifacts, are untrusted/advisory for mutation
+recovery; only owner-only local idempotency runtime state may authenticate a
+receipt decision.
 
-An epistemic-graph full rebuild MAY construct an unreachable private temporary database and MAY sweep proven abandoned graph temporary databases outside the canonical mutation boundary under the dedicated cross-process rebuild lock defined by `graph-rebuild-availability`. This narrow exception SHALL NOT modify canonical files, floor/checkpoint epoch state, the live graph sidecar, logs, or any path a reader can open. The rebuild lock SHALL be acquired only outside the canonical boundary and before a later bounded canonical-boundary acquisition; code SHALL never wait for the rebuild lock while holding canonical writer authority. Final checkpoint/floor rechecks, live-sidecar acknowledgement and replacement, and all reader-visible publication SHALL remain inside the canonical vault boundary.
+An epistemic-graph rebuild MAY build an unreachable private temporary sidecar,
+and MAY perform scoped cleanup of a proven inactive reserved temporary sidecar,
+outside the canonical boundary only under the dedicated rebuild lock defined by
+`graph-rebuild-availability`. This exception SHALL NOT modify canonical files,
+epoch state, receipts, logs, live graph state, or any reader-addressable path.
+It SHALL never wait for the rebuild lock while holding canonical authority.
 
-#### Scenario: Concurrent commands from different product surfaces
-
-- **WHEN** MCP and REST submit write-capable commands against the same vault at the same time
-- **THEN** at most one command executes its observable mutation section at a time
-- **AND** both commands reach the same existing command leaves after acquiring the shared boundary
-
-#### Scenario: Separate processes target the same vault
-
-- **WHEN** two Exomem processes resolve different path spellings to the same canonical vault and attempt observable mutations concurrently
-- **THEN** they contend on the same process-safe vault boundary
-- **AND** they cannot both enter their observable mutation sections
+The private phase SHALL commit exact acknowledgement/checkpoint metadata,
+truncate WAL, run full integrity and direct source/membership/topology proof,
+and emit an immutable ticket binding exact graph publication epoch, direct
+projection identity, warmed live `RecallFreshnessCheckpoint`, recall-policy
+version plus bounded no-follow `_access.yaml` snapshot/fingerprint,
+no-external-pending epoch, and exact closed temp-file/meta identity. Under
+canonical authority, publication SHALL perform only two O(1)/bounded ticket
+checks around the publication hook and then atomic replacement; it SHALL not
+walk the vault or sidecar or rerun proofs. The rebuild lock is
+cooperative builder/cleanup serialization; it is not authority to publish. A
+POSIX runtime root used for that lock SHALL be owner-controlled and not
+group/world-writable. Windows shall retain no-delete-share refusal for unsafe
+live replacement.
 
 #### Scenario: Private graph construction does not hold canonical authority
 
-- **WHEN** a full graph rebuild populates a unique temporary database that no reader can address
-- **THEN** the builder holds only the cross-process rebuild lock for vault-size-dependent construction
-- **AND** unrelated canonical writers may use the canonical mutation boundary concurrently
+- **WHEN** a full graph rebuild fills a unique temporary database
+- **THEN** only its rebuild lock covers vault-size-dependent construction
+- **AND** unrelated canonical writers may enter the canonical boundary
 
-#### Scenario: Live graph publication retains canonical serialization
+#### Scenario: Publication retains canonical serialization
 
-- **WHEN** a private graph build is ready to acknowledge and replace the live sidecar
-- **THEN** it acquires the canonical mutation boundary while already holding the rebuild lock, performs only bounded rechecks and publication, and releases the canonical boundary before releasing the rebuild lock
-- **AND** no code acquires or waits for the rebuild lock while holding the canonical boundary
+- **WHEN** a private graph build is ready to publish
+- **THEN** it acquires canonical authority only for exact revalidation,
+  acknowledgement, and atomic replacement
+- **AND** it releases canonical authority before releasing the rebuild lock
 
-### Requirement: Mutation Boundary Composes With Transactional Writes
+#### Scenario: Publication authority contains no scalable work
 
-The shared boundary SHALL enclose every complete reader-visible mutation, including canonical file changes, floor/checkpoint epoch publication, live index/log updates, and mutation-owned published notifications. Existing transactional write and rollback semantics MUST remain in force inside the boundary, and nested write helpers invoked by one command MUST NOT deadlock by attempting to become a competing mutation. Unreachable private graph construction and proof-scoped abandoned-temp cleanup are governed by the explicit rebuild-lock exception above and are not reader-visible mutation sections.
+- **WHEN** an immutable private publication ticket is ready
+- **THEN** canonical authority performs only two bounded ticket checks around
+  the publication hook and atomic replacement
+- **AND** it performs no vault/sidecar walk, cache warm, WAL, integrity, or
+  source/membership/topology proof
+
+#### Scenario: External edits fail closed and converge
+
+- **WHEN** an external Markdown or `_access.yaml` edit is observed during
+  ticket validation
+- **THEN** the epoch is marked pending and publication fails closed for
+  reconcile/retry
+- **AND** missed or unobserved direct edits are eventually detected by
+  watcher-periodic reconcile
+- **AND** arbitrary-editor linearizability is not claimed because it requires
+  an out-of-scope broker/journal
+
+### Requirement: Mutation Boundary Composes With Receipted Transactional Writes
+
+The boundary SHALL retain existing transactional rollback semantics for each
+reader-visible canonical transition. For a claimed graph-relevant mutation, its
+ordinary protocol is `floor → caller files → checkpoint → one atomically
+installed authenticated GraphCommitReceipt v2 → local CAS`; there is no mutable
+`commit_point` or two-write receipt marker. The receipt HMAC-SHA256 secret is a
+fresh 32-byte per-attempt value retained only in the matching owner-only local
+idempotency runtime state. A caught failure completes rollback while authority
+remains held and does not install a receipt. Setup, reconcile repair, cleanup,
+and rollback SHALL use `commit_point=False` and cannot manufacture a caller
+commit; that API flag is not a stored receipt marker.
+
+On Windows, that local state SHALL use only the bounded local SQLite binary
+DPAPI `CurrentUser` BLOB and attempt/token-bound entropy defined by
+`graph-rebuild-availability`, under its protected inheritable DACL for the
+current service identity, `LocalSystem`, and `Administrators`. The hosted
+service SHALL reject reparse-point or unsafe-DACL runtime paths before SQLite or
+unpickle, plus truncated/trailing/unknown-version/provider BLOBs; account/profile
+changes, copied BLOBs, failed unprotect, and raw legacy rows SHALL be
+`outcome_unknown`, not recovery authority.
+
+For signing, “complete ordinary protocol succeeded” SHALL mean only that the
+claimed leaf returned a candidate terminal, the guarded vault batch successfully
+applied floor/caller/checkpoint, and bounded canonical route-selection fanout
+preconditions completed. It SHALL exclude receipt authentication/installation,
+local lifecycle CAS, derived-handle registration, `ensure_started`, graph join,
+and completed-terminal persistence. The signed terminal projection SHALL be the
+closed path/content-free field set defined by `graph-rebuild-availability`; it
+SHALL exclude `affected_paths`, every vault path/file name, and all arbitrary
+leaf result or content.
+
+Receipt v2 verification SHALL use the versioned HMAC input and closed canonical
+JSON field set defined by `graph-rebuild-availability`, reject duplicate,
+missing, surplus, malformed, or noncanonical fields before authentication, and
+compare the recomputed HMAC in constant time. No boundary or hosted recovery
+path may substitute a looser receipt parse.
+
+The HMAC-covered v2 `canonical_disposition` SHALL be exactly `success` or
+`committed_failure`. An authenticated `success` orphan may heal only its
+matching trusted executing CAS. `committed_failure` suppresses leaf replay and
+replays the retained exact local failure when available; otherwise it persists
+`outcome_unknown` while graph recovery remains independent. Missing, invalid, or
+fieldless v2 receipts never heal.
+
+Full graph build/join begins only after the canonical boundary releases. Before
+release, each checkpoint has an exact incremental acknowledgement, registered
+rebuild handle, or durable failure handle; there is no accepted-but-unverified
+state. The unavoidable cross-store cut before receipt v2 atomic installation
+remains the fail-closed `outcome_unknown` terminal classification, never a
+second leaf execution. A post-install CAS may heal only from that exact receipt,
+matching trusted executing row, and retained secret. Dead reserved rows may be
+reclaimed; dead executing rows without that evidence are outcome-unknown. That
+classification is outside the four canonical lifecycle states and cannot be
+treated as a committed receipt. A cleanup failure after commitment SHALL NOT
+reconstruct success from an orphaned receipt.
 
 #### Scenario: Multi-file mutation succeeds
 
-- **WHEN** a governed write updates a note, graph epoch, indexes, and the activity log
-- **THEN** the command retains the vault boundary until the complete transactional canonical batch and its mutation-owned publication dispatch finish
-- **AND** any full graph build/join begins only after that boundary releases
+- **WHEN** a governed write updates canonical files and requires graph recovery
+- **THEN** it commits one exact receipt only after the full canonical protocol
+- **AND** any graph wait occurs after the boundary releases
 
 #### Scenario: Transactional batch rolls back
 
-- **WHEN** a caught failure causes an existing transactional write to restore its pre-write state
-- **THEN** the rollback completes while the same mutation boundary is still held
-- **AND** the next mutation cannot observe the partially committed state
+- **WHEN** a caught failure occurs before receipt v2 atomically installs
+- **THEN** the boundary completes rollback before another canonical mutation can observe partial state
+- **AND** the retry row cannot replay a committed terminal
 
-#### Scenario: Private build publishes through the boundary
+#### Scenario: Canonical receipt cut is not inferred
 
-- **WHEN** a graph builder has completed an unreachable temporary sidecar
-- **THEN** it cannot acknowledge or replace the live sidecar until the canonical boundary admits the bounded publication phase
-- **AND** a caught publication failure leaves the prior live graph and canonical epoch observable
+- **WHEN** a process dies after a canonical file can have committed but before receipt v2 atomically installs
+- **THEN** retry returns outcome-unknown/readback guidance
+- **AND** no product surface re-executes the canonical leaf
+
+#### Scenario: Copied receipt is not cross-replica authority
+
+- **WHEN** a replica sees a copied synced receipt but lacks its matching local row and secret
+- **THEN** it treats the receipt as advisory and does not suppress a mutation
+- **AND** cross-replica exactly-once remains deferred until a shared pre-leaf CAS exists

--- a/openspec/changes/rebuild-graph-without-blocking-writes/specs/hosted-mutation-safety/spec.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/specs/hosted-mutation-safety/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: One Process-Safe Mutation Boundary Per Vault
+
+The system SHALL serialize every operation that can modify a vault's canonical Markdown, media, live governed indexes, logs, or mutation-owned published runtime state through one process-safe boundary keyed by the vault's canonical identity. MCP, REST, CLI, transfer routes, and background writers MUST NOT maintain independent locks for those observable mutations or bypass that boundary.
+
+An epistemic-graph full rebuild MAY construct an unreachable private temporary database and MAY sweep proven abandoned graph temporary databases outside the canonical mutation boundary under the dedicated cross-process rebuild lock defined by `graph-rebuild-availability`. This narrow exception SHALL NOT modify canonical files, floor/checkpoint epoch state, the live graph sidecar, logs, or any path a reader can open. The rebuild lock SHALL be acquired only outside the canonical boundary and before a later bounded canonical-boundary acquisition; code SHALL never wait for the rebuild lock while holding canonical writer authority. Final checkpoint/floor rechecks, live-sidecar acknowledgement and replacement, and all reader-visible publication SHALL remain inside the canonical vault boundary.
+
+#### Scenario: Concurrent commands from different product surfaces
+
+- **WHEN** MCP and REST submit write-capable commands against the same vault at the same time
+- **THEN** at most one command executes its observable mutation section at a time
+- **AND** both commands reach the same existing command leaves after acquiring the shared boundary
+
+#### Scenario: Separate processes target the same vault
+
+- **WHEN** two Exomem processes resolve different path spellings to the same canonical vault and attempt observable mutations concurrently
+- **THEN** they contend on the same process-safe vault boundary
+- **AND** they cannot both enter their observable mutation sections
+
+#### Scenario: Private graph construction does not hold canonical authority
+
+- **WHEN** a full graph rebuild populates a unique temporary database that no reader can address
+- **THEN** the builder holds only the cross-process rebuild lock for vault-size-dependent construction
+- **AND** unrelated canonical writers may use the canonical mutation boundary concurrently
+
+#### Scenario: Live graph publication retains canonical serialization
+
+- **WHEN** a private graph build is ready to acknowledge and replace the live sidecar
+- **THEN** it acquires the canonical mutation boundary while already holding the rebuild lock, performs only bounded rechecks and publication, and releases the canonical boundary before releasing the rebuild lock
+- **AND** no code acquires or waits for the rebuild lock while holding the canonical boundary
+
+### Requirement: Mutation Boundary Composes With Transactional Writes
+
+The shared boundary SHALL enclose every complete reader-visible mutation, including canonical file changes, floor/checkpoint epoch publication, live index/log updates, and mutation-owned published notifications. Existing transactional write and rollback semantics MUST remain in force inside the boundary, and nested write helpers invoked by one command MUST NOT deadlock by attempting to become a competing mutation. Unreachable private graph construction and proof-scoped abandoned-temp cleanup are governed by the explicit rebuild-lock exception above and are not reader-visible mutation sections.
+
+#### Scenario: Multi-file mutation succeeds
+
+- **WHEN** a governed write updates a note, graph epoch, indexes, and the activity log
+- **THEN** the command retains the vault boundary until the complete transactional canonical batch and its mutation-owned publication dispatch finish
+- **AND** any full graph build/join begins only after that boundary releases
+
+#### Scenario: Transactional batch rolls back
+
+- **WHEN** a caught failure causes an existing transactional write to restore its pre-write state
+- **THEN** the rollback completes while the same mutation boundary is still held
+- **AND** the next mutation cannot observe the partially committed state
+
+#### Scenario: Private build publishes through the boundary
+
+- **WHEN** a graph builder has completed an unreachable temporary sidecar
+- **THEN** it cannot acknowledge or replace the live sidecar until the canonical boundary admits the bounded publication phase
+- **AND** a caught publication failure leaves the prior live graph and canonical epoch observable

--- a/openspec/changes/rebuild-graph-without-blocking-writes/tasks.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/tasks.md
@@ -1,44 +1,157 @@
-## 1. Red-first protocol coverage
+## 1. Red-first canonical lifecycle and epoch coverage
 
-- [ ] 1.1 Add failing checkpoint/floor tests for exact closed shapes, strict 24-hex mutation identity, monotonic non-reuse, safe sorted path/deletion projection, full-scope overflow, domain-separated canonical digest vectors, semantic exclusion, and caught batch rollback.
-- [ ] 1.2 Add failing writer tests proving narrow and wide operation guards release before graph join and a second canonical batch commits while the first caller waits.
-- [ ] 1.3 Add failing single-flight tests proving one builder, checkpoint N+1 invalidation/retry, bounded waiter coverage, and no stale waiter success.
-- [ ] 1.4 Add failing publication tests proving readers see old/available or unavailable, never temp/partial state; final boundary work is only checkpoint/freshness verification plus swap.
-- [ ] 1.5 Add failing crash/restart tests for committed-unacknowledged checkpoint recovery, the commit-before-`graph_pending` uncertain cut, valid-floor malformed-checkpoint recovery, missing/corrupt-floor refusal, accepted pre-floor seeding, descriptor-locked abandoned-temp sweep, and exact current acknowledgement.
-- [ ] 1.6 Add failing terminal/idempotency tests for durable nonterminal `graph_pending`, concurrent retry waiting, dead-owner graph-only resume, successful off-boundary join, projected committed graph failure, exact replay without duplicate canonical write, and later recovery.
+- [x] 1.1 Add failing tests for the closed non-owned lifecycle
+  `reserved → executing → canonically_committed → completed`, attempt-scoped
+  compare-and-swap claims, dead-reserved reclaim, dead-executing
+  outcome-unknown, fresh lowercase-24-hex commit tokens, and no new
+  `graph_pending` writes.
+- [x] 1.2 Add failing tests for an exact per-claim receipt binding namespaced
+  key, command/payload digests, attempt/token, terminal projection, and exact
+  checkpoint pair; require one atomic HMAC-SHA256 receipt v2 with a private
+  32-byte local secret, matching-row/secret-only CAS healing, bounded reads,
+  no scans, byte-exact replay, a versioned domain plus canonical unsigned JSON
+  HMAC input, closed outer fields, duplicate/surplus rejection, and constant-time
+  verification; include canonical-disposition enum tampering and both authenticated
+  orphan cuts (`success` heal and `committed_failure` replay suppression).
+- [x] 1.3 Add failing subprocess tests for every multi-store cut: crash before
+  leaf, after caller files, after checkpoint, after receipt v2 installation,
+  and during committed cleanup. Prove only a receipt with its matching trusted
+  executing row and secret may heal local CAS; all other ambiguous cuts,
+  including cleanup with lost trusted state, are fail-closed
+  `outcome_unknown` and invoke the leaf at most once.
+- [x] 1.4 Add failing strict-parser tests for <=1,000 path entries before normalization
+  limit, closed v1 fields, already-NFC safe canonical POSIX paths,
+  duplicate/conflict rules, hash/null rules, created subset rules, full-scope
+  emptiness, and both unchanged public digest vectors.
+- [x] 1.5 Add failing tests for exact legacy/pre-floor migration, valid-floor
+  higher-full recovery, malformed/ambiguous fail-closed states, all exact ack
+  metadata keys including `graph_sync_checkpoint`, and malformed-state fresh
+  full recovery.
 
-## 2. Durable canonical-to-graph handoff
+## 2. Receipted canonical publication and lifecycle safety
 
-- [ ] 2.1 Implement the version 1 graph-sync checkpoint and internal monotonic floor parsers/renderers plus domain-separated digest helpers with strict validation and bounded path/full projection.
-- [ ] 2.2 Include ordered floor/canonical/checkpoint replacement in graph-relevant guarded batches; include floor/checkpoint in recoverable file/directory trash transitions; exclude both from semantic/index candidates, public paths, and recursive input.
-- [ ] 2.3 Expose coherent epoch status to graph availability, reconcile, readiness diagnostics, and bounded coordination status without path/content leakage.
+- [x] 2.1 Implement the non-owned lifecycle, attempt-scoped claim ownership,
+  one atomic authenticated receipt v2, owner-only runtime secret/DB permissions,
+  bounded binary DPAPI CurrentUser secret BLOB/DACL enforcement on Windows,
+  matching-row/secret-only CAS healing, advisory-only v1/copied receipts,
+  local-row-only legacy `graph_pending` migration, and stable
+  outcome-unknown/readback without any leaf replay; implement the closed v2
+  field schema, HMAC-covered `canonical_disposition`, versioned canonical HMAC
+  verification, and both orphan outcomes exactly.
+- [x] 2.2 Implement strict v1 checkpoint/floor parsing/rendering without
+  changing valid public bytes/digest vectors; make floor/caller/checkpoint/ack
+  admission and migration closed.
+- [x] 2.3 Implement `floor → caller files → checkpoint → one authenticated
+  receipt v2 → local CAS` for ordinary graph-relevant batches; keep
+  graph-irrelevant batches epoch-free and make setup/recovery/repair/rollback
+  explicitly `commit_point=False` without storing a receipt marker.
+- [x] 2.4 Implement file, recursive-directory, and restore lifecycle ordering,
+  caught rollback/fsync restoration, crash-after-rename higher-full recovery,
+  and receipt exclusion for non-caller recovery/rollback.
+- [x] 2.5 Expose only exact epoch/receipt outcome status to terminal, readiness,
+  reconcile, and bounded coordination diagnostics without path/content leakage.
 
-## 3. Off-boundary single-flight rebuild
+## 3. Exact graph handles and derived availability
 
-- [ ] 3.1 Thread the exact committed checkpoint through incremental fanout; acknowledge an eligible immediate successor in one SQLite transaction and register off-boundary full work without building under writer authority when proof fails.
-- [ ] 3.2 Persist durable `graph_pending` after canonical commit while each narrow/wide operation guard is still held, then release every guard before graph work; implement graph-only dead-owner resume, committed-uncertain handling for the cross-store crash cut, and completed success/failure persistence before public replay.
-- [ ] 3.3 Run one cross-process per-vault builder under a descriptor-validated persistent OS lock in shared runtime state keyed by canonical vault identity, with unique temporary databases, bounded checkpoint-aware waiters, and safe abandoned-temp sweep under the same lock.
-- [ ] 3.4 Build each full pass privately, close/checkpoint/validate it, and under one bounded final hold perform the two epoch/freshness checks around acknowledgement plus atomic replacement.
-- [ ] 3.5 Resolve waiters only from proven checkpoint lineage; terminalize same-generation conflicts, stopped uncovered flights, capacity/start failures, stabilization exhaustion, and platform sharing refusal as explicit committed derived failures.
+- [x] 3.1 Add failing tests that every checkpoint leaving canonical authority
+  has either one-transaction incremental acknowledgement, exact registered
+  rebuild handle, or explicit durable failure handle; reject
+  accepted-unverified handoff.
+- [x] 3.2 Implement separate coordinator `ensure_started(checkpoint)` and
+  bounded `join(handle)` APIs: start consumes no waiter capacity, joins always
+  release capacity in `finally`, and start/capacity/stopped/lineage/platform
+  failures produce explicit recoverable handles.
+- [x] 3.3 Implement dynamic graph join/recompute from a
+  `canonically_committed` receipt after process death, retry, readiness, or
+  reconcile; never couple graph health to an attempt or replay the leaf.
+- [x] 3.4 Implement exact incremental eligibility and one-transaction rows,
+  availability markers, and complete acknowledgement metadata; proof failure
+  registers full work without builder/join work under canonical authority.
+- [x] 3.5 Add failing real-seam tests for original-index freshness changes
+  before acknowledgement and immediately before replacement, then implement the
+  private build/close/checkpoint/WAL-truncate/full-integrity/direct
+  source-membership-topology proof and immutable ticket sequence. Under
+  canonical authority test only two O(1)/bounded ticket checks around the
+  publication hook and atomic replacement; cold/dirty caches, observed external
+  Markdown/access edits, pending epochs, hook failure, or ticket mismatch
+  release authority and reconcile/retry.
+- [x] 3.6 Implement exact completed graph-available and committed-derived-failure
+  terminals, durable recovery handles, and byte-exact completed replay while
+  allowing later recovery to improve only live graph health.
 
-## 4. Recovery and compatibility
+## 4. Cooperative rebuild and recovery correctness
 
-- [ ] 4.1 Detect incoherent floor/checkpoint/ack state at startup/readiness/reconcile; recover above a valid floor, seed the floor only for accepted pre-floor checkpoint states, and fail closed on missing/corrupt-floor ambiguity without changing user-authored canonical bytes or reusing a generation.
-- [ ] 4.2 Name temporary rebuild databases with a reserved per-vault prefix/nonce and sweep only while holding the cross-process rebuild lock.
-- [ ] 4.3 Verify sidecar replacement with open readers on POSIX and the Windows service path.
-- [ ] 4.4 Preserve exact legacy no-epoch graphs until first publication; provide a rollback compatibility build retaining floor/checkpoint parsing, graph-pending replay safety, and recovery.
+- [x] 4.1 Add failing POSIX tests for owner-controlled trusted runtime root,
+  owner-only idempotency runtime directory/DB permissions, direct persistent
+  no-follow lock, cross-process single builder, attempt death, scoped active-temp
+  no-sweep, and hostile same-user root replacement being explicitly outside the
+  contract.
+- [x] 4.2 Implement cooperative POSIX single-flight and scoped cleanup under the
+  rebuild lock; serialize all exact-revalidated reader-visible publication under
+  canonical authority.
+- [ ] 4.3 Add and pass native Windows tests for cross-process claim/release,
+  no-delete-share live-reader replacement refusal, retained old/temp files,
+  successful later retry after reader close, DPAPI attempt/token entropy,
+  exact BLOB header/length/truncation/trailing/provider-version rejection,
+  ciphertext-only SQLite/WAL/SHM, protected DACL/reparse rejection, profile/copy/
+  raw-legacy outcome-unknown, and the real service loop.
+  - Native installed-wheel DPAPI/DACL/reparse, cross-process, alias, and
+    open-reader cases pass. The remaining real LocalSystem/NSSM loop is blocked:
+    the available Windows identity is non-administrative and `OpenSCManager`
+    refused disposable service creation with error 5. Exact evidence is retained
+    in `.task/WINDOWS_SERVICE_RESULT.md`; no existing service was modified.
+- [x] 4.4 Implement Windows-safe lock acquisition and no-delete-share
+  replacement handling without weakening the POSIX trusted-root path or falling
+  back to delete-and-replace.
+- [x] 4.5 Implement startup/readiness/reconcile recovery from exact
+  floor/checkpoint/ack/receipt classification, with an exact rebuild/failure
+  handle before authority release and no user-authored-byte mutation; read only
+  bounded exact artifacts named by trusted local rows and never scan or promote
+  synced receipts.
+- [x] 4.6 Implement the rollback compatibility gate: strict v1 parsing,
+  NFC path admission, advisory-only legacy receipt reading, local legacy
+  graph-pending migration, outcome-unknown protection, and recovery remain
+  enabled while new scheduling may be disabled explicitly.
 
-## 5. Verification
+## 5. Product, performance, and independent verification
 
-- [ ] 5.1 Run epistemic graph freshness, mutation-boundary, writer lease/idempotency, index-sync, deletion/reconcile, and Records concurrency suites with embeddings disabled.
-- [ ] 5.2 Run Ruff, targeted Mypy, strict OpenSpec validation, and `git diff --check`.
-- [ ] 5.3 Re-run the reproduction at 500 and 2,000 pages and record boundary-hold p95 separately from request latency; the hold must not scale with vault size.
-- [ ] 5.4 Run the installed-wheel product loop and lean suite.
+- [x] 5.1 Run the focused graph, epoch, lifecycle, mutation-terminal, writer
+  lease, index-sync, deletion, reconcile, readiness, and Records-concurrency
+  suites with embeddings/media extraction disabled.
+- [x] 5.2 Run Ruff, targeted Mypy, strict OpenSpec validation, and
+  `git diff --check` on the final corrected diff.
+- [x] 5.3 Build the wheel and run the installed-wheel Linux product loop plus a
+  disposable live MCP Records mutation that crosses canonical receipt, graph
+  recovery, exact retry, and inspection end to end.
+- [ ] 5.4 Run the native Windows installed-wheel service path with the exact
+  product loop, cross-process rebuild, open-reader replacement, DPAPI/WAL/DACL
+  receipt cases, and real service loop; retain command/output evidence rather
+  than simulated-only proof.
+  - The fresh installed-wheel interactive product loop and native component
+    cases pass. Only the elevated real-service phase remains blocked by the
+    `OpenSCManager` authorization boundary described in task 4.3.
+- [x] 5.5 On a quiesced machine, rerun the 500- and 2,000-page reproduction;
+  record canonical-boundary-hold p95 separately from request latency and prove
+  the hold does not scale with vault size. Also test exact ticket fields and
+  closed temp identity, no O(vault)/O(sidecar) work under canonical authority,
+  bounded checks around the hook, warmed `RecallFreshnessCheckpoint`, bounded
+  no-follow `_access.yaml` snapshot/fingerprint, cold/dirty retry,
+  external-edit fail-closed behavior, and watcher-periodic convergence for
+  missed edits; arbitrary-editor linearizability requires an out-of-scope
+  broker/journal.
+- [x] 5.6 Obtain a fresh independent review against this corrected architecture
+  and rerun all invalidated gates before marking any implementation task done.
 
 ### Baseline to beat
 
-Measured on main with an unusable sidecar: 7,727.8 ms at 500 pages and 32,381.5 ms at 2,000 pages for the first write, with the vault mutation boundary held for the rebuild. CI observed 39,092 ms at 2,000 pages and 172,205 ms at 8,000. The required improvement is boundary hold, not removal of the first caller's graph wait.
+Measured on main with an unusable sidecar: 7,727.8 ms at 500 pages and
+32,381.5 ms at 2,000 pages for the first write, with the mutation boundary held
+for the rebuild. CI observed 39,092 ms at 2,000 pages and 172,205 ms at 8,000.
+The required improvement is boundary hold, not removal of the first caller's
+graph-availability wait.
 
 ### Prior art
 
-#346 removed the full-rebuild escalation and failed the contract that a write against an unusable sidecar leaves the graph available. This change retains that terminal contract while moving the wait outside canonical writer authority.
+#346 removed full-rebuild escalation and violated the graph-available terminal
+contract. This change retains that contract while moving derived work outside
+canonical writer authority and making the cross-store outcome boundary explicit.

--- a/openspec/changes/rebuild-graph-without-blocking-writes/tasks.md
+++ b/openspec/changes/rebuild-graph-without-blocking-writes/tasks.md
@@ -1,70 +1,44 @@
-## 1. Regression coverage
+## 1. Red-first protocol coverage
 
-- [ ] 1.1 Prove an unrelated mutation is not blocked while a full rebuild runs.
-- [ ] 1.2 Prove a reader during a rebuild sees the old graph or the new one, never a partial one.
-- [ ] 1.3 Prove concurrent rebuild requests run exactly one rebuild.
-- [ ] 1.4 Prove the existing write-path contract still holds: a write against an
-      unusable sidecar indexes the whole vault and leaves it available
-      (the contract #346 broke).
-- [ ] 1.5 Prove a vault change during the final pass retries rather than publishes.
-- [ ] 1.6 Prove exhausted stabilization still marks the graph unavailable.
+- [ ] 1.1 Add failing checkpoint/floor tests for exact closed shapes, strict 24-hex mutation identity, monotonic non-reuse, safe sorted path/deletion projection, full-scope overflow, domain-separated canonical digest vectors, semantic exclusion, and caught batch rollback.
+- [ ] 1.2 Add failing writer tests proving narrow and wide operation guards release before graph join and a second canonical batch commits while the first caller waits.
+- [ ] 1.3 Add failing single-flight tests proving one builder, checkpoint N+1 invalidation/retry, bounded waiter coverage, and no stale waiter success.
+- [ ] 1.4 Add failing publication tests proving readers see old/available or unavailable, never temp/partial state; final boundary work is only checkpoint/freshness verification plus swap.
+- [ ] 1.5 Add failing crash/restart tests for committed-unacknowledged checkpoint recovery, the commit-before-`graph_pending` uncertain cut, valid-floor malformed-checkpoint recovery, missing/corrupt-floor refusal, accepted pre-floor seeding, descriptor-locked abandoned-temp sweep, and exact current acknowledgement.
+- [ ] 1.6 Add failing terminal/idempotency tests for durable nonterminal `graph_pending`, concurrent retry waiting, dead-owner graph-only resume, successful off-boundary join, projected committed graph failure, exact replay without duplicate canonical write, and later recovery.
 
-## 2. Rebuild off the boundary
+## 2. Durable canonical-to-graph handoff
 
-- [ ] 2.1 Build rebuild passes into a temporary database beside the sidecar.
-- [ ] 2.2 Publish by atomic replacement under a boundary hold scoped to the swap.
-- [ ] 2.3 Re-verify freshness under the boundary immediately before publishing.
-- [ ] 2.4 Verify the replacement behaves correctly on the Windows service path,
-      where replacing an open SQLite file does not follow POSIX rename semantics.
+- [ ] 2.1 Implement the version 1 graph-sync checkpoint and internal monotonic floor parsers/renderers plus domain-separated digest helpers with strict validation and bounded path/full projection.
+- [ ] 2.2 Include ordered floor/canonical/checkpoint replacement in graph-relevant guarded batches; include floor/checkpoint in recoverable file/directory trash transitions; exclude both from semantic/index candidates, public paths, and recursive input.
+- [ ] 2.3 Expose coherent epoch status to graph availability, reconcile, readiness diagnostics, and bounded coordination status without path/content leakage.
 
-## 3. Single-flight
+## 3. Off-boundary single-flight rebuild
 
-- [ ] 3.1 Serialize rebuilds per vault so concurrent writers do not each start one.
-- [ ] 3.2 Resolve waiting requests from the in-flight rebuild's outcome.
-- [ ] 3.3 Settle the open question: whether a waiting writer blocks or defers,
-      and reconcile that with the contract in 1.4.
+- [ ] 3.1 Thread the exact committed checkpoint through incremental fanout; acknowledge an eligible immediate successor in one SQLite transaction and register off-boundary full work without building under writer authority when proof fails.
+- [ ] 3.2 Persist durable `graph_pending` after canonical commit while each narrow/wide operation guard is still held, then release every guard before graph work; implement graph-only dead-owner resume, committed-uncertain handling for the cross-store crash cut, and completed success/failure persistence before public replay.
+- [ ] 3.3 Run one cross-process per-vault builder under a descriptor-validated persistent OS lock in shared runtime state keyed by canonical vault identity, with unique temporary databases, bounded checkpoint-aware waiters, and safe abandoned-temp sweep under the same lock.
+- [ ] 3.4 Build each full pass privately, close/checkpoint/validate it, and under one bounded final hold perform the two epoch/freshness checks around acknowledgement plus atomic replacement.
+- [ ] 3.5 Resolve waiters only from proven checkpoint lineage; terminalize same-generation conflicts, stopped uncovered flights, capacity/start failures, stabilization exhaustion, and platform sharing refusal as explicit committed derived failures.
 
-## 4. Housekeeping
+## 4. Recovery and compatibility
 
-- [ ] 4.1 Name temporary rebuild databases with a reserved prefix.
-- [ ] 4.2 Sweep abandoned temporary databases during reconcile.
+- [ ] 4.1 Detect incoherent floor/checkpoint/ack state at startup/readiness/reconcile; recover above a valid floor, seed the floor only for accepted pre-floor checkpoint states, and fail closed on missing/corrupt-floor ambiguity without changing user-authored canonical bytes or reusing a generation.
+- [ ] 4.2 Name temporary rebuild databases with a reserved per-vault prefix/nonce and sweep only while holding the cross-process rebuild lock.
+- [ ] 4.3 Verify sidecar replacement with open readers on POSIX and the Windows service path.
+- [ ] 4.4 Preserve exact legacy no-epoch graphs until first publication; provide a rollback compatibility build retaining floor/checkpoint parsing, graph-pending replay safety, and recovery.
 
 ## 5. Verification
 
-- [ ] 5.1 Run the epistemic graph, freshness, boundary, semantic unit graph, and
-      reconcile suites, plus Ruff and strict OpenSpec validation.
-- [ ] 5.2 Re-run the reproduction harness and record the new first-write cost at
-      500 and 2,000 pages against the pre-change baseline.
-- [ ] 5.3 Confirm under a concurrent-write load that the stabilization budget is
-      still sufficient, and raise `REBUILD_STABILIZATION_ATTEMPTS` if not.
-- [ ] 5.4 Run the lean suite.
+- [ ] 5.1 Run epistemic graph freshness, mutation-boundary, writer lease/idempotency, index-sync, deletion/reconcile, and Records concurrency suites with embeddings disabled.
+- [ ] 5.2 Run Ruff, targeted Mypy, strict OpenSpec validation, and `git diff --check`.
+- [ ] 5.3 Re-run the reproduction at 500 and 2,000 pages and record boundary-hold p95 separately from request latency; the hold must not scale with vault size.
+- [ ] 5.4 Run the installed-wheel product loop and lean suite.
 
 ### Baseline to beat
 
-Measured on a maintainer workstation against synthetic dense vaults, on main,
-one `upsert_after_write` with no usable sidecar:
-
-| vault | first write | steady-state write | ratio |
-|---|---|---|---|
-| 500 pages | 7,727.8 ms | 314.5 ms | 24.6x |
-| 2,000 pages | 32,381.5 ms | 1,186.2 ms | 27.3x |
-
-with `vault mutation boundary held too long ...
-operation=epistemic_graph_refresh_paths holder_kind=graph hold_ms=32371.03`.
-
-CI's write-latency benchmark shows `hold_ms=39092` at 2,000 pages and
-`hold_ms=172205` at 8,000.
-
-The target is that the *boundary hold* stops scaling with vault size. The first
-writer after invalidation still pays the rebuild; what must stop is every other
-mutation waiting behind it.
+Measured on main with an unusable sidecar: 7,727.8 ms at 500 pages and 32,381.5 ms at 2,000 pages for the first write, with the vault mutation boundary held for the rebuild. CI observed 39,092 ms at 2,000 pages and 172,205 ms at 8,000. The required improvement is boundary hold, not removal of the first caller's graph wait.
 
 ### Prior art
 
-#346 attempted to fix this by removing the escalation so writes deferred to
-reconcile. CI rejected it:
-`test_refresh_missing_sidecar_routes_to_full_rebuild` requires a write against a
-missing sidecar to index the whole vault and leave it available, and three other
-tests depend on the same escalation — the spawned-mutator boundary contract,
-forced re-resolution after a relation-registry change, and the schema-v3 sidecar
-migration. Task 1.4 exists to keep that contract pinned while the rebuild moves.
+#346 removed the full-rebuild escalation and failed the contract that a write against an unusable sidecar leaves the graph available. This change retains that terminal contract while moving the wait outside canonical writer authority.

--- a/scripts/e2e_product_loop.py
+++ b/scripts/e2e_product_loop.py
@@ -286,7 +286,11 @@ def _mutation_diagnostics(result: Any, *, operation: str) -> Any:
         raise RuntimeError(
             f"{operation} mutation did not return a committed full terminal: {result!r}"
         )
-    return result["diagnostics"]
+    diagnostics = result["diagnostics"]
+    if isinstance(diagnostics, dict) and diagnostics.get("graph_sync") == "failed":
+        code = diagnostics.get("graph_sync_code", "unspecified graph synchronization error")
+        raise RuntimeError(f"{operation} graph synchronization failed: {code}")
+    return diagnostics
 
 
 def _maintenance_diagnostics(result: Any, *, operation: str) -> Any:
@@ -353,8 +357,15 @@ async def _assert_relation_contexts(
             timeout,
         )
         graph = context.get("graph", {})
-        if graph.get("profile", {}).get("name") != profile:
-            raise RuntimeError(f"installed context did not resolve {profile!r} profile")
+        if not isinstance(graph, dict):
+            raise RuntimeError(
+                f"installed context returned no graph for {profile!r}: {context!r}"
+            )
+        profile_data = graph.get("profile", {})
+        if not isinstance(profile_data, dict) or profile_data.get("name") != profile:
+            raise RuntimeError(
+                f"installed context did not resolve {profile!r} profile: {context!r}"
+            )
         edge = next(
             (item for item in graph.get("edges", []) if item.get("relation_type") == canonical),
             None,

--- a/scripts/repro_graph_rebuild_hold.py
+++ b/scripts/repro_graph_rebuild_hold.py
@@ -1,67 +1,208 @@
-"""Measure the mutation-boundary hold caused by one write against a missing graph sidecar.
+"""Measure full rebuild request latency apart from its final publication hold.
 
-Reproduces on main's code path (no fix applied). Reports, per vault size:
-  - how long a SINGLE `upsert_after_write` takes when the sidecar is absent
-  - how long the same write takes once the sidecar exists (the healthy case)
-
-The gap between the two is the stall a user eats on the first write after the
-sidecar is missing, deleted, schema-bumped, or registry-invalidated.
+Each trial starts with a production-shaped, fresh graph checkpoint and deletes
+only the derived graph sidecar.  The durable epoch remains intact, forcing the
+normal missing-sidecar full rebuild while leaving the final canonical
+publication boundary as the only measured lock hold.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
+import statistics
 import sys
 import tempfile
 import time
 from pathlib import Path
-
-ROOT = Path(__file__).resolve()
-REPO = Path(sys.argv[1]) if len(sys.argv) > 1 else None
-if REPO is None:
-    raise SystemExit("usage: repro_graph_hold.py <repo-root> [sizes...]")
-sys.path.insert(0, str(REPO / "src"))
-sys.path.insert(0, str(REPO / "scripts"))
-
-for name in (
-    "EXOMEM_DISABLE_EMBEDDINGS",
-    "EXOMEM_DISABLE_CLIP",
-    "EXOMEM_DISABLE_MEDIA_EXTRACTION",
-    "EXOMEM_DISABLE_RANKING",
-):
-    os.environ[name] = "1"
-
-from synth_vault import gen_dense_vault  # noqa: E402
-
-from exomem import epistemic_graph  # noqa: E402
-from exomem.kbdir import kb_dirname  # noqa: E402
-
-SIZES = [int(a) for a in sys.argv[2:]] or [500, 2000]
+from typing import Any
 
 
-def one_write(vault: Path, target: Path) -> float:
-    started = time.perf_counter()
-    epistemic_graph.upsert_after_write(vault, [target])
-    return (time.perf_counter() - started) * 1000.0
+DEFAULT_SIZES = (500, 2_000)
+DEFAULT_TRIALS = 5
+PUBLICATION_OPERATION = "epistemic_graph_publish_rebuild"
 
 
-for size in SIZES:
-    with tempfile.TemporaryDirectory(prefix=f"graph-hold-{size}-") as temp:
-        vault = Path(temp) / "vault"
-        vault.mkdir(parents=True)
-        gen_dense_vault(vault, size, links_per_note=3)
+def _p95(samples: list[float]) -> float:
+    ordered = sorted(samples)
+    return ordered[min(len(ordered) - 1, max(0, int(len(ordered) * 0.95 + 0.999) - 1))]
 
-        target = next((vault / kb_dirname()).rglob("*.md"))
-        sidecar = epistemic_graph.sidecar_path(vault)
-        assert not sidecar.exists(), "precondition: no sidecar yet"
 
-        cold_ms = one_write(vault, target)
-        built = sidecar.exists()
-        warm_ms = one_write(vault, target)
+def summarize(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        raise ValueError("cannot summarize an empty benchmark sample")
+    return {
+        "median_ms": round(statistics.median(samples), 1),
+        "p95_ms": round(_p95(samples), 1),
+    }
 
-        print(
-            f"pages={size:<6} first_write_missing_sidecar={cold_ms:9.1f}ms  "
-            f"subsequent_write={warm_ms:7.1f}ms  "
-            f"ratio={cold_ms / max(warm_ms, 0.001):7.1f}x  sidecar_built={built}",
-            flush=True,
+
+def publication_hold_ms(timing: dict[str, float | str] | None) -> float:
+    if timing is None or timing.get("operation") != PUBLICATION_OPERATION:
+        operation = None if timing is None else timing.get("operation")
+        raise RuntimeError(
+            f"expected {PUBLICATION_OPERATION} timing, got operation={operation!r}"
         )
+    hold_ms = timing.get("hold_ms")
+    if not isinstance(hold_ms, float):
+        raise RuntimeError(f"expected numeric {PUBLICATION_OPERATION} hold_ms")
+    return hold_ms
+
+
+def _imports(repo_root: Path) -> dict[str, Any]:
+    for name in (
+        "EXOMEM_DISABLE_EMBEDDINGS",
+        "EXOMEM_DISABLE_CLIP",
+        "EXOMEM_DISABLE_MEDIA_EXTRACTION",
+        "EXOMEM_DISABLE_RANKING",
+    ):
+        os.environ[name] = "1"
+    sys.path.insert(0, str(repo_root / "src"))
+    sys.path.insert(0, str(repo_root / "scripts"))
+    from synth_vault import gen_dense_vault
+
+    from exomem import epistemic_graph, find, freshness, graph_sync, mutation_lock, vault
+    from exomem.kbdir import kb_dirname
+    from exomem.vault import walk_vault_md
+
+    return {
+        "epistemic_graph": epistemic_graph,
+        "find": find,
+        "freshness": freshness,
+        "gen_dense_vault": gen_dense_vault,
+        "graph_sync": graph_sync,
+        "kb_dirname": kb_dirname,
+        "mutation_lock": mutation_lock,
+        "vault": vault,
+        "walk_vault_md": walk_vault_md,
+    }
+
+
+def _seed_live_freshness(vault_root: Path, imports: dict[str, Any]) -> None:
+    freshness = imports["freshness"]
+    find = imports["find"]
+    walk_vault_md = imports["walk_vault_md"]
+    kb_dirname = imports["kb_dirname"]
+
+    freshness.seed(
+        vault_root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in walk_vault_md(vault_root)),
+    )
+    freshness.seed(
+        vault_root,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find._walk_md(vault_root / kb_dirname())
+        ),
+    )
+
+
+def advance_checkpoint(vault_root: Path, target: Path, imports: dict[str, Any]) -> None:
+    """Advance the real graph epoch and restore the caller's live freshness proof."""
+    vault = imports["vault"]
+    vault.batch_atomic_write(
+        [vault.PlannedWrite(target, target.read_text(encoding="utf-8") + "\n")],
+        vault_root=vault_root,
+        post_commit_fanout=False,
+    )
+
+    _seed_live_freshness(vault_root, imports)
+
+
+def _seed_live_checkpoint(vault_root: Path, imports: dict[str, Any]) -> Path:
+    graph_sync = imports["graph_sync"]
+    kb_dirname = imports["kb_dirname"]
+    target = next((vault_root / kb_dirname()).rglob("*.md"))
+    advance_checkpoint(vault_root, target, imports)
+    checkpoint = graph_sync.read_checkpoint(vault_root)
+    if checkpoint is None:
+        raise RuntimeError("production-shaped setup did not create a graph checkpoint")
+    return target
+
+
+def measure(vault_root: Path, size: int, trials: int, imports: dict[str, Any]) -> dict[str, Any]:
+    if trials < 1:
+        raise ValueError("trials must be positive")
+    imports["gen_dense_vault"](vault_root, size, links_per_note=3)
+    target = _seed_live_checkpoint(vault_root, imports)
+    epistemic_graph = imports["epistemic_graph"]
+    mutation_lock = imports["mutation_lock"]
+    graph = epistemic_graph.EpistemicGraphIndex(vault_root)
+    graph.rebuild_all()
+    if not graph.available():
+        raise RuntimeError("production-shaped setup did not publish a current graph sidecar")
+
+    request_samples: list[float] = []
+    hold_samples: list[float] = []
+    sidecar = epistemic_graph.sidecar_path(vault_root)
+    for _ in range(trials):
+        advance_checkpoint(vault_root, target, imports)
+        sidecar.unlink(missing_ok=True)
+        if sidecar.exists():
+            raise RuntimeError("could not remove derived graph sidecar")
+        started = time.perf_counter()
+        result = epistemic_graph.upsert_after_write(vault_root, [target])
+        request_samples.append((time.perf_counter() - started) * 1_000.0)
+        if result.code != "graph_rebuild_completed":
+            raise RuntimeError(f"missing-sidecar trial did not run a full rebuild: {result.code}")
+        hold_samples.append(publication_hold_ms(mutation_lock.last_mutation_timing()))
+        if not sidecar.exists() or not graph.available():
+            raise RuntimeError("full rebuild did not republish a current graph sidecar")
+
+    return {
+        "pages": size,
+        "trials": trials,
+        "request": summarize(request_samples),
+        "publication_hold": summarize(hold_samples),
+    }
+
+
+def format_result(result: dict[str, Any], *, hold_ratio: float | None = None) -> str:
+    request = result["request"]
+    hold = result["publication_hold"]
+    line = (
+        f"pages={result['pages']:<6} trials={result['trials']} "
+        f"request median/p95={request['median_ms']:.1f}/{request['p95_ms']:.1f}ms  "
+        f"FINAL canonical publication hold median/p95="
+        f"{hold['median_ms']:.1f}/{hold['p95_ms']:.1f}ms "
+        f"operation={PUBLICATION_OPERATION}"
+    )
+    if hold_ratio is not None:
+        line += f"  2000/500 hold median ratio={hold_ratio:.2f}x"
+    return line
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo_root", type=Path)
+    parser.add_argument("sizes", nargs="*", type=int, default=list(DEFAULT_SIZES))
+    parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
+    args = parser.parse_args(argv)
+    if args.trials < 1:
+        parser.error("--trials must be positive")
+
+    imports = _imports(args.repo_root.resolve())
+    results: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="graph-rebuild-hold-") as temp:
+        root = Path(temp)
+        for size in args.sizes:
+            vault_root = root / f"vault-{size}"
+            vault_root.mkdir()
+            results.append(measure(vault_root, size, args.trials, imports))
+
+    ratio = None
+    by_size = {result["pages"]: result for result in results}
+    if 500 in by_size and 2_000 in by_size:
+        ratio = (
+            by_size[2_000]["publication_hold"]["median_ms"]
+            / max(by_size[500]["publication_hold"]["median_ms"], 0.001)
+        )
+    for result in results:
+        print(format_result(result, hold_ratio=ratio if result["pages"] == 2_000 else None), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exomem/access.py
+++ b/src/exomem/access.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -50,6 +51,14 @@ _APPEND_ONLY = ("Sources", "Evidence")
 # access checks then reuse this parsed snapshot without rereading the policy.
 _PolicySignature = tuple[int, int, int, int, int]
 _CACHE: dict[str, tuple[_PolicySignature, str, dict[str, list[str]]]] = {}
+PUBLICATION_POLICY_MAX_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationPolicySnapshot:
+    """One bounded exact access-policy identity for derived publication."""
+
+    fingerprint: str
 
 
 def access_config_path(vault_root: Path) -> Path:
@@ -89,6 +98,33 @@ def policy_fingerprint(vault_root: Path) -> str:
         _CACHE.pop(str(path), None)
         return "missing"
     return _refresh_config(path, signature)[0]
+
+
+def publication_policy_snapshot(vault_root: Path) -> PublicationPolicySnapshot | None:
+    """Safely snapshot exact policy bytes for a derived publication.
+
+    Unreadable, replaced, or over-limit bytes fail closed; an absent policy has
+    the stable explicit ``missing`` identity.
+    """
+    root = Path(vault_root)
+    path = access_config_path(root)
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return PublicationPolicySnapshot("missing")
+    except OSError:
+        return None
+    try:
+        from . import vault
+
+        raw, _guard = vault.read_bounded_guarded_bytes(
+            root,
+            path.relative_to(root).as_posix(),
+            limit=PUBLICATION_POLICY_MAX_BYTES,
+        )
+    except (OSError, ValueError):
+        return None
+    return PublicationPolicySnapshot(hashlib.sha256(raw).hexdigest())
 
 
 def _policy_signature(path: Path) -> _PolicySignature:

--- a/src/exomem/claims.py
+++ b/src/exomem/claims.py
@@ -838,9 +838,10 @@ def _delete_claim_rows_if_present(vault_root: Path, rel_paths: list[str]) -> int
     return ClaimIndex(vault_root).delete_many(rel_paths)
 
 
-def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
+def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> bool:
     """Generic delete-routing seam: purge claim rows regardless of feature gates."""
     _delete_claim_rows_if_present(vault_root, removed_rel_paths)
+    return True
 
 
 def upsert_claims_after_write(vault_root: Path, written_paths: list[Path]) -> None:

--- a/src/exomem/delete_directory.py
+++ b/src/exomem/delete_directory.py
@@ -161,6 +161,7 @@ def delete_directory(
             md_rel = md.resolve().relative_to(vault_root.resolve()).as_posix()
         except ValueError:
             continue
+
         # Skip inbound links from inside the doomed tree itself.
         hits = [
             h for h in find_inbound_wikilinks(vault_root, md_rel)
@@ -208,13 +209,6 @@ def delete_directory(
         i += 1
 
     trash_rel = trash_abs.relative_to(vault_root).as_posix()
-    try:
-        lifecycle_operation = lifecycle.begin_deletion(
-            vault_root, source_rel=rel_path, trash_rel=trash_rel
-        )
-    except lifecycle.LifecycleError as error:
-        raise DeleteDirectoryError(code=error.code, reason=error.reason) from error
-
     # Capture vault-relative paths for every .md file in the doomed tree —
     # before the move, while they still resolve under vault_root. Used to
     # purge the embedding sidecar after the trash move succeeds.
@@ -226,6 +220,29 @@ def delete_directory(
             )
         except ValueError:
             continue
+
+    from . import graph_sync
+
+    try:
+        transition = graph_sync.begin_deletion_transition(
+            vault_root,
+            source_rel=rel_path,
+            trash_rel=trash_rel,
+            removed_rel_paths=md_rels_to_unindex,
+        )
+    except lifecycle.LifecycleError as error:
+        raise DeleteDirectoryError(code=error.code, reason=error.reason) from error
+    except graph_sync.GraphLifecycleEpochSetupError as error:
+        raise DeleteDirectoryError(
+            code="GRAPH_SYNC_EPOCH_FAILED",
+            reason="could not establish the graph deletion epoch",
+        ) from error
+    except graph_sync.GraphLifecycleRollbackError as error:
+        raise DeleteDirectoryError(
+            code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+            reason="the staged trash transition could not be restored",
+        ) from error
+    lifecycle_operation = transition.operation
 
     # A doomed subtree may also contain CLIP-relevant media binaries (image/
     # video — the only kinds with derived-index residue: CLIP rows, and for a
@@ -264,18 +281,41 @@ def delete_directory(
             log.debug("self-delete suppression registration failed", exc_info=True)
 
     try:
-        lifecycle.atomic_rename(
-            lifecycle_operation, source=abs_path, destination=trash_abs
-        )
+        transition.rename()
     except lifecycle.LifecycleError as e:
-        lifecycle.abort_deletion(lifecycle_operation)
+        try:
+            transition.abort()
+        except graph_sync.GraphLifecycleRollbackError as rollback_error:
+            raise DeleteDirectoryError(
+                code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+                reason="the staged trash transition could not be restored",
+            ) from rollback_error
         raise DeleteDirectoryError(
             code=e.code,
             reason=e.reason,
         ) from e
 
+    try:
+        transition.publish_checkpoint()
+    except Exception as error:  # noqa: BLE001 - reverse caught transition
+        try:
+            transition.abort()
+        except graph_sync.GraphLifecycleRollbackError as rollback_error:
+            raise DeleteDirectoryError(
+                code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+                reason="graph checkpoint failed and the trash transition could not be restored",
+            ) from rollback_error
+        raise DeleteDirectoryError(
+            code="GRAPH_SYNC_CHECKPOINT_FAILED",
+            reason="graph checkpoint failed; the trash transition was restored",
+        ) from error
+    from .writer_lease import mark_active_mutation_committed
+
+    mark_active_mutation_committed()
+
     index_feedback: dict | None = None
     if fanout_rels:
+        fanout_unverified = False
         try:
             from . import index_sync
             raw_report = index_sync.delete_after_remove(
@@ -288,11 +328,16 @@ def delete_directory(
                     fanout_rels, degraded=False
                 )
             )
+            fanout_unverified = not isinstance(raw_report, index_sync.IndexSyncReport)
         except Exception:  # noqa: BLE001 — sidecars are best-effort
             log.exception(
                 "index delete failed for trashed tree %s; sidecar may be stale",
                 rel_path,
             )
+            try:
+                graph_sync.register_outer_fanout_failure(vault_root)
+            except Exception:  # noqa: BLE001 - retain the canonical deletion and report reconcile
+                log.exception("graph fanout failure handoff could not be registered")
             warnings.append(
                 "trash succeeded but derived-index cleanup failed; run reconcile"
             )
@@ -300,6 +345,21 @@ def delete_directory(
                 fanout_rels, degraded=True
             )
         index_feedback = report.as_dict()
+        if fanout_unverified:
+            index_feedback["derived_work"] = "unverified"
+    else:
+        index_feedback = lifecycle.exact_no_derived_index_report(lifecycle_operation)
+
+    from .writer_lease import active_mutation_request_id
+
+    if active_mutation_request_id() is None:
+        from . import graph_sync
+
+        if graph_sync.registered_checkpoint(vault_root) is not None:
+            try:
+                graph_sync.wait_for_registered(vault_root)
+            except Exception:  # noqa: BLE001 - preserve committed deletion for reconcile
+                warnings.append("trash succeeded but graph publication failed; run reconcile")
 
     # Metadata sidecar.
     meta = {

--- a/src/exomem/delete_file.py
+++ b/src/exomem/delete_file.py
@@ -236,12 +236,28 @@ def delete_file(
             i += 1
 
     trash_rel = trash_abs.relative_to(vault_root).as_posix()
+    from . import graph_sync
+
     try:
-        lifecycle_operation = lifecycle.begin_deletion(
-            vault_root, source_rel=rel_path, trash_rel=trash_rel
+        transition = graph_sync.begin_deletion_transition(
+            vault_root,
+            source_rel=rel_path,
+            trash_rel=trash_rel,
+            removed_rel_paths=[rel_path] if rel_path.lower().endswith(".md") else [],
         )
     except lifecycle.LifecycleError as error:
         raise DeleteFileError(code=error.code, reason=error.reason) from error
+    except graph_sync.GraphLifecycleEpochSetupError as error:
+        raise DeleteFileError(
+            code="GRAPH_SYNC_EPOCH_FAILED",
+            reason="could not establish the graph deletion epoch",
+        ) from error
+    except graph_sync.GraphLifecycleRollbackError as error:
+        raise DeleteFileError(
+            code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+            reason="the staged trash transition could not be restored",
+        ) from error
+    lifecycle_operation = transition.operation
 
     # A removed CLIP-relevant media binary (image/video — the only kinds with
     # derived-index residue: CLIP rows, and for a video, scene-frame children)
@@ -277,15 +293,37 @@ def delete_file(
             log.debug("self-delete suppression registration failed", exc_info=True)
 
     try:
-        lifecycle.atomic_rename(
-            lifecycle_operation, source=abs_path, destination=trash_abs
-        )
+        transition.rename()
     except lifecycle.LifecycleError as e:
-        lifecycle.abort_deletion(lifecycle_operation)
+        try:
+            transition.abort()
+        except graph_sync.GraphLifecycleRollbackError as rollback_error:
+            raise DeleteFileError(
+                code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+                reason="the staged trash transition could not be restored",
+            ) from rollback_error
         raise DeleteFileError(
             code=e.code,
             reason=e.reason,
         ) from e
+
+    try:
+        transition.publish_checkpoint()
+    except Exception as error:  # noqa: BLE001 - reverse caught transition
+        try:
+            transition.abort()
+        except graph_sync.GraphLifecycleRollbackError as rollback_error:
+            raise DeleteFileError(
+                code="GRAPH_SYNC_DELETION_ROLLBACK_FAILED",
+                reason="graph checkpoint failed and the trash transition could not be restored",
+            ) from rollback_error
+        raise DeleteFileError(
+            code="GRAPH_SYNC_CHECKPOINT_FAILED",
+            reason="graph checkpoint failed; the trash transition was restored",
+        ) from error
+    from .writer_lease import mark_active_mutation_committed
+
+    mark_active_mutation_committed()
 
     # Drop Markdown rows from the semantic index sidecars. A removed media
     # binary (detected via media_types) also enters the fan-out — it purges
@@ -294,6 +332,7 @@ def delete_file(
     # affected Markdown set of zero and must not enter fan-out.
     index_feedback: dict | None = None
     if rel_path.lower().endswith(".md") or is_media:
+        fanout_unverified = False
         try:
             from . import index_sync
             raw_report = index_sync.delete_after_remove(vault_root, [rel_path])
@@ -302,13 +341,33 @@ def delete_file(
                 if isinstance(raw_report, index_sync.IndexSyncReport)
                 else index_sync.observed_delete_report([rel_path], degraded=False)
             )
+            fanout_unverified = not isinstance(raw_report, index_sync.IndexSyncReport)
         except Exception:  # noqa: BLE001 — sidecars are best-effort
             log.exception("index delete failed for %s; sidecar may be stale", rel_path)
+            try:
+                graph_sync.register_outer_fanout_failure(vault_root)
+            except Exception:  # noqa: BLE001 - retain the canonical deletion and report reconcile
+                log.exception("graph fanout failure handoff could not be registered")
             warnings.append(
                 "trash succeeded but derived-index cleanup failed; run reconcile"
             )
             report = index_sync.observed_delete_report([rel_path], degraded=True)
         index_feedback = report.as_dict()
+        if fanout_unverified:
+            index_feedback["derived_work"] = "unverified"
+    else:
+        index_feedback = lifecycle.exact_no_derived_index_report(lifecycle_operation)
+
+    from .writer_lease import active_mutation_request_id
+
+    if active_mutation_request_id() is None:
+        from . import graph_sync
+
+        if graph_sync.registered_checkpoint(vault_root) is not None:
+            try:
+                graph_sync.wait_for_registered(vault_root)
+            except Exception:  # noqa: BLE001 - preserve committed deletion for reconcile
+                warnings.append("trash succeeded but graph publication failed; run reconcile")
 
     # Write metadata sidecar capturing what we know at trash time.
     meta = {

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
+import secrets
 import sqlite3
 import threading
+import time
 from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -20,9 +23,10 @@ from dataclasses import field as dataclass_field
 from pathlib import Path
 from typing import Any
 
-from . import find as find_module
 from . import (
+    access,
     freshness,
+    graph_sync,
     memory_refs,
     mutation_lock,
     recall_policy,
@@ -33,22 +37,25 @@ from . import (
     semantic_units,
     traversal_profiles,
 )
+from . import find as find_module
 from . import vault as vault_module
 from .cli_ops import OpError
 from .kbdir import kb_dirname, kb_prefix
 from .markdown_relations import MarkdownRelation
+
+log = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 8
 UNIT_SEED_MAX_BATCHES = 4
 UNIT_PARENT_REF_MAX_CANDIDATES = 16
 EDGE_INSPECTION_MULTIPLIER = 4
 REBUILD_STABILIZATION_ATTEMPTS = 2
-GRAPH_MUTATION_TIMEOUT_SECONDS = 30.0
-GRAPH_COORDINATION_DIRNAME = ".graph-coordination"
+REBUILD_PUBLICATION_ATTEMPTS = REBUILD_STABILIZATION_ATTEMPTS * 2
 _AVAILABILITY_FRESHNESS_KEY = "recall_projection_identity"
 _RECALL_CHECKPOINT_KEY = "recall_projection_checkpoint"
 _RESOLVER_TOPOLOGY_KEY = "recall_resolver_topology"
 _READ_BARRIER_KEY = "read_barrier"
+_GRAPH_SYNC_CHECKPOINT_KEY = "graph_sync_checkpoint"
 
 RELATION_TYPES: frozenset[str] = relation_registry.core_registry().keys
 
@@ -174,6 +181,16 @@ def graph_enabled() -> bool:
     }
 
 
+def graph_scheduling_enabled() -> bool:
+    """Compatibility builds retain epoch parsing/recovery but stop new work."""
+    return graph_enabled() and os.environ.get("EXOMEM_DISABLE_GRAPH_SCHEDULING", "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def sidecar_path(vault_root: Path) -> Path:
     return vault_root / kb_dirname() / ".graph.sqlite"
 
@@ -259,6 +276,22 @@ def _checkpoint_from_value(value: str | None) -> freshness.RecallFreshnessCheckp
         return None
 
 
+def _graph_sync_acknowledgement(
+    values: dict[str, str],
+) -> graph_sync.GraphSyncCheckpoint | None:
+    """Validate the complete checkpoint that established a graph acknowledgement."""
+    rendered = values.get(_GRAPH_SYNC_CHECKPOINT_KEY)
+    checkpoint = graph_sync.GraphSyncCheckpoint.parse(rendered) if rendered is not None else None
+    if checkpoint is None:
+        return None
+    if (
+        values.get("graph_sync_generation") != str(checkpoint.generation)
+        or values.get("graph_sync_digest") != checkpoint.checkpoint_sha256
+    ):
+        return None
+    return checkpoint
+
+
 def _vault_rel(vault_root: Path, path: Path | str) -> str | None:
     """Return a vault-relative path without opening the candidate."""
     try:
@@ -282,6 +315,20 @@ def _records_suppressed_path(vault_root: Path, rel_path: str) -> bool:
 
 
 GraphSourceSignature = tuple[int, int, int, str]
+
+
+@dataclass(frozen=True)
+class _GraphPublicationTicket:
+    """Private work proven before the short canonical replacement hold."""
+
+    epoch: graph_sync.GraphPublicationEpoch
+    recall: freshness.RecallPublicationState
+    policy_identity: tuple[str, str]
+    policy_snapshot: access.PublicationPolicySnapshot
+    direct_identity: str
+    metadata: tuple[tuple[str, str], ...]
+    temporary: Path
+    temporary_identity: tuple[int, int, int, int, int]
 
 
 def _source_signature(path: Path, source: str) -> GraphSourceSignature:
@@ -308,16 +355,43 @@ def _resolver_topology_fingerprint(
 
 
 class EpistemicGraphIndex:
-    def __init__(self, vault_root: Path):
+    def __init__(
+        self,
+        vault_root: Path,
+        *,
+        mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None,
+    ):
         self.vault_root = Path(vault_root)
         self.path = sidecar_path(self.vault_root)
         self.registry = relation_registry.load_registry(self.vault_root)
         self.language_registry = semantic_language_registry.load_registry(self.vault_root)
-        self._mutation_coordinator = mutation_lock.VaultMutationCoordinator(
-            self.vault_root / kb_dirname() / GRAPH_COORDINATION_DIRNAME,
-            self.vault_root,
-            timeout_seconds=GRAPH_MUTATION_TIMEOUT_SECONDS,
-        )
+        if mutation_coordinator is None:
+            from .writer_lease import active_manager, get_manager
+
+            manager = active_manager()
+            coordinator_for = getattr(manager, "_mutation_coordinator_for", None)
+            if callable(coordinator_for):
+                mutation_coordinator = coordinator_for(self.vault_root)
+            else:
+                manager = get_manager()
+                mutation_coordinator = mutation_lock.VaultMutationCoordinator(
+                manager.config.state_dir,
+                self.vault_root,
+                timeout_seconds=manager._mutation_timeout_seconds,
+                poll_interval_seconds=manager._mutation_poll_interval_seconds,
+                )
+        self._mutation_coordinator = mutation_coordinator
+
+    def _canonical_mutation_coordinator(self) -> mutation_lock.VaultMutationCoordinator:
+        """Return the boundary bound when this graph work was registered.
+
+        Private graph construction stays outside this coordinator.  The short
+        final validation/publication hold must, however, contend with the
+        canonical writer that originated the work.  Capturing it is essential:
+        rebuild workers and post-guard joins do not inherit ``ContextVar``
+        state from ``LeaseManager.invoke()``.
+        """
+        return self._mutation_coordinator
 
     def _connect(self, path: Path | None = None) -> sqlite3.Connection:
         target = path if path is not None else self.path
@@ -363,6 +437,14 @@ class EpistemicGraphIndex:
                 key TEXT PRIMARY KEY, value TEXT NOT NULL
             )
         """)
+        conn.execute(
+            "INSERT OR IGNORE INTO graph_meta(key, value) VALUES ('instance', ?)",
+            (secrets.token_hex(16),),
+        )
+        # `_connect()` also backs a few direct inspection helpers.  Keep those
+        # connections transaction-free while giving each newly created sidecar
+        # (including every private rebuild result) a stable ABA discriminator.
+        conn.commit()
         conn.execute("CREATE INDEX IF NOT EXISTS idx_graph_nodes_path ON graph_nodes(path)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_graph_nodes_unit_ref ON graph_nodes(unit_ref)")
         conn.execute(
@@ -422,6 +504,7 @@ class EpistemicGraphIndex:
         try:
             uri = f"{self.path.resolve().as_uri()}?mode=ro"
             conn = sqlite3.connect(uri, uri=True)
+            graph_sync.limit_graph_metadata_read(conn)
             conn.execute("BEGIN")
             # This marker validation MUST remain the first read in the transaction.
             values = dict(
@@ -430,7 +513,8 @@ class EpistemicGraphIndex:
                     "('schema_version', 'core_registry_version', 'extension_registry_hash', "
                     "'recall_policy_version', 'recall_access_fingerprint', "
                     "'recall_projection_identity', 'recall_projection_checkpoint', "
-                    "'recall_resolver_topology', 'read_barrier')"
+                    "'recall_resolver_topology', 'read_barrier', 'graph_sync_generation', "
+                    "'graph_sync_digest', 'graph_sync_checkpoint')"
                 ).fetchall()
             )
         except sqlite3.Error:
@@ -454,6 +538,24 @@ class EpistemicGraphIndex:
             # the event registry was cold or known stale.
             and (stored_checkpoint_value is None or stored_checkpoint is not None)
         )
+        graph_sync_state, required_graph_sync = graph_sync.checkpoint_state(self.vault_root)
+        graph_sync_current = graph_sync.status(self.vault_root)["state"] == "current"
+        if graph_sync_state == "malformed":
+            graph_sync_current = False
+        elif required_graph_sync is not None:
+            graph_sync_current = (
+                graph_sync_current
+                and _graph_sync_acknowledgement(values) == required_graph_sync
+            )
+        elif (
+            values.get("graph_sync_generation") is not None
+            or values.get("graph_sync_digest") is not None
+        ):
+            # A legacy sidecar may have no checkpoint. Once one has been
+            # acknowledged, a missing checkpoint is recovery state, not legacy.
+            graph_sync_current = False
+        if require_current_projection:
+            current = current and graph_sync_current
         if current and require_current_projection and values.get(_READ_BARRIER_KEY) is not None:
             current = False
         if current and require_current_projection:
@@ -586,17 +688,373 @@ class EpistemicGraphIndex:
     def rebuild_all(self) -> dict[str, int]:
         if not graph_enabled():
             return {"indexed_files": 0, "nodes": 0, "edges": 0, "disabled": 1}
-        # Attributed: a full rebuild is the longest holder of the vault mutation
-        # boundary at scale, and an unattributed "held too long" warning names
-        # neither the operation nor the holder -- which reads as a stalled write.
-        with self._mutation_coordinator.hold(
-            operation="epistemic_graph_rebuild_all", holder_kind="graph"
-        ):
-            return self._rebuild_all_locked()
+        return self._rebuild_all_off_boundary()
+
+    def _rebuild_all_off_boundary(
+        self, *, accept_stabilized_build: bool = False
+    ) -> dict[str, int]:
+        """Build and prove a private sidecar before its bounded replacement hold."""
+        live = self.path
+        attempts = 0
+        epoch_error: graph_sync.GraphEpochIncoherent | None = None
+        while attempts < REBUILD_PUBLICATION_ATTEMPTS:
+            attempts += 1
+            prepared_recall = freshness.prepare_recall_publication(self.vault_root, "vault")
+            if prepared_recall is None:
+                self._reconcile_recall_publication()
+                continue
+            try:
+                epoch = graph_sync.publication_epoch(self.vault_root)
+            except graph_sync.GraphEpochIncoherent as error:
+                epoch_error = error
+                # A canonical batch installs floor before checkpoint. Coalesce
+                # once through the same boundary so a writer already in that
+                # window can finish before the next bounded epoch sample.
+                with self._canonical_mutation_coordinator().hold(
+                    operation="epistemic_graph_coalesce_epoch", holder_kind="graph"
+                ):
+                    pass
+                continue
+            epoch_error = None
+            required = epoch.checkpoint
+            prior_acknowledgement = (
+                self._live_acknowledged_checkpoint() if required is None else None
+            )
+            temporary = graph_sync.temporary_sidecar_path(
+                live,
+                required
+                or graph_sync.GraphSyncCheckpoint.create(
+                    generation=1,
+                    mutation_id="0" * 24,
+                    paths=(),
+                    created_paths=(),
+                    scope="full",
+                ),
+            )
+            registered = False
+            registered_temporary: Path | None = None
+            owner_claimed = False
+            preserve_temporary = False
+            try:
+                temporary.unlink(missing_ok=True)
+                graph_sync.register_temporary(temporary)
+                registered_temporary = temporary.resolve()
+                registered = True
+                owner_claimed = graph_sync.claim_rebuild_owner(
+                    self.vault_root,
+                    temporary,
+                    state_root=self._mutation_coordinator.state_root,
+                )
+                if not owner_claimed:
+                    if required is None and self._wait_for_legacy_rebuild():
+                        return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
+                    if graph_sync.wait_for_current(
+                        self.vault_root, required, availability=self.available
+                    ):
+                        return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
+                    raise RuntimeError("another graph rebuild owner did not publish a current sidecar")
+                temporary_index = EpistemicGraphIndex(
+                    self.vault_root, mutation_coordinator=self._mutation_coordinator
+                )
+                temporary_index.path = temporary
+                # Test and instrumentation seams on the caller stay meaningful
+                # while the actual SQLite target remains private.
+                if "_index_path" in self.__dict__:
+                    temporary_index._index_path = self._index_path  # type: ignore[method-assign]
+                report = temporary_index._rebuild_all_locked()
+                ticket = self._prepare_publication_ticket(
+                    temporary,
+                    epoch=graph_sync.GraphPublicationEpoch(
+                        epoch.floor, epoch.checkpoint, None
+                    ),
+                    recall=prepared_recall,
+                    required=required,
+                    prior_acknowledgement=prior_acknowledgement,
+                    accept_stabilized_build=False,
+                )
+                if ticket is None:
+                    self._reconcile_recall_publication()
+                    prepared_recall = freshness.prepare_recall_publication(
+                        self.vault_root, "vault"
+                    )
+                    if prepared_recall is None:
+                        continue
+                    ticket = self._prepare_publication_ticket(
+                        temporary,
+                        epoch=graph_sync.GraphPublicationEpoch(
+                            epoch.floor, epoch.checkpoint, None
+                        ),
+                        recall=prepared_recall,
+                        required=required,
+                        prior_acknowledgement=prior_acknowledgement,
+                        accept_stabilized_build=accept_stabilized_build,
+                    )
+                    if ticket is None:
+                        continue
+                with self._mutation_coordinator.hold(
+                    operation="epistemic_graph_publish_rebuild", holder_kind="graph"
+                ):
+                    if not self._publication_ticket_matches(ticket):
+                        continue
+                    try:
+                        self._before_publish_replacement(temporary, live)
+                    except Exception:  # noqa: BLE001 - discard this ticket and retry boundedly
+                        continue
+                    if not self._publication_ticket_matches(ticket):
+                        continue
+                    try:
+                        graph_sync.replace_sidecar(temporary, live)
+                    except graph_sync.GraphSidecarReplaceUnavailable:
+                        # The complete private sidecar is recoverable after a
+                        # Windows reader releases the live file.
+                        preserve_temporary = True
+                        raise
+                    return report
+            finally:
+                if owner_claimed:
+                    graph_sync.release_rebuild_owner(
+                        self.vault_root,
+                        temporary,
+                        state_root=self._mutation_coordinator.state_root,
+                    )
+                if registered:
+                    assert registered_temporary is not None
+                    graph_sync.unregister_temporary(registered_temporary)
+                if not preserve_temporary:
+                    temporary.unlink(missing_ok=True)
+        if epoch_error is not None:
+            raise epoch_error
+        raise graph_sync.GraphRebuildRegistrationError(
+            "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+            "graph publication did not stabilize after "
+            f"{REBUILD_PUBLICATION_ATTEMPTS} attempts; run reconcile to recover the derived graph.",
+        )
+
+    def _reconcile_recall_publication(self) -> None:
+        """Seed/reconcile recall outside publication authority, then rebuild fresh."""
+        pending = freshness.external_pending_epoch(self.vault_root)
+        entries = (
+            (str(path), freshness.stat_signature(path))
+            for path in vault_module.walk_vault_md(self.vault_root)
+        )
+        freshness.reconcile(self.vault_root, "vault", entries)
+        if pending is not None:
+            freshness.clear_external_pending(self.vault_root, through=pending)
+
+    @staticmethod
+    def _temporary_identity(path: Path) -> tuple[int, int, int, int, int]:
+        """Bind the exact temp directory entry without following substitutions."""
+        return mutation_lock.nofollow_regular_file_identity(path)
+
+    def _prepare_publication_ticket(
+        self,
+        temporary: Path,
+        *,
+        epoch: graph_sync.GraphPublicationEpoch,
+        recall: freshness.RecallPublicationState,
+        required: graph_sync.GraphSyncCheckpoint | None,
+        prior_acknowledgement: graph_sync.GraphSyncCheckpoint | None,
+        accept_stabilized_build: bool,
+    ) -> _GraphPublicationTicket | None:
+        """Finish and verify every temp-sidecar proof before canonical authority."""
+        try:
+            conn = sqlite3.connect(temporary)
+            try:
+                if required is not None:
+                    self._write_graph_sync_acknowledgement(conn, required)
+                elif prior_acknowledgement is not None:
+                    self._write_graph_sync_acknowledgement(conn, prior_acknowledgement)
+                conn.commit()
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                if conn.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+                    return None
+            finally:
+                conn.close()
+            direct = _recall_projection_identity(
+                self.vault_root, disk_freshness=_disk_vault_freshness(self.vault_root)
+            )
+            policy_snapshot = access.publication_policy_snapshot(self.vault_root)
+            policy_identity = (
+                None
+                if policy_snapshot is None
+                else (recall_policy.RECALL_POLICY_VERSION, policy_snapshot.fingerprint)
+            )
+            recall_identity = (
+                recall.triple,
+                recall.policy_version,
+                recall.access_policy_fingerprint,
+            )
+            if policy_identity != (recall.policy_version, recall.access_policy_fingerprint) or direct != recall_identity:
+                return None
+            assert policy_snapshot is not None
+            expected_identity = _availability_freshness_value(direct)
+            expected_meta = {
+                "schema_version": str(SCHEMA_VERSION),
+                "recall_policy_version": recall.policy_version,
+                "recall_access_fingerprint": recall.access_policy_fingerprint,
+                _AVAILABILITY_FRESHNESS_KEY: expected_identity,
+                _RECALL_CHECKPOINT_KEY: _checkpoint_value(recall.checkpoint),
+            }
+            if required is not None:
+                expected_meta.update(
+                    {
+                        "graph_sync_generation": str(required.generation),
+                        "graph_sync_digest": required.checkpoint_sha256,
+                        _GRAPH_SYNC_CHECKPOINT_KEY: required.render(),
+                    }
+                )
+            elif prior_acknowledgement is not None:
+                expected_meta.update(
+                    {
+                        "graph_sync_generation": str(prior_acknowledgement.generation),
+                        "graph_sync_digest": prior_acknowledgement.checkpoint_sha256,
+                        _GRAPH_SYNC_CHECKPOINT_KEY: prior_acknowledgement.render(),
+                    }
+                )
+            check = sqlite3.connect(f"{temporary.resolve().as_uri()}?mode=ro", uri=True)
+            try:
+                graph_sync.limit_graph_metadata_read(check)
+                metadata = dict(
+                    check.execute(
+                        "SELECT key, value FROM graph_meta WHERE key IN "
+                        "('schema_version', 'recall_policy_version', 'recall_access_fingerprint', "
+                        "'recall_projection_identity', 'recall_projection_checkpoint', "
+                        "'graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint', "
+                        "'read_barrier')"
+                    ).fetchall()
+                )
+            finally:
+                check.close()
+            metadata_mismatch = any(
+                metadata.get(key) != value for key, value in expected_meta.items()
+            )
+            reticketable_keys = {_AVAILABILITY_FRESHNESS_KEY, _RECALL_CHECKPOINT_KEY}
+            if (
+                accept_stabilized_build
+                and metadata_mismatch
+                and metadata.get(_READ_BARRIER_KEY) is None
+                and all(
+                    key in reticketable_keys or metadata.get(key) == value
+                    for key, value in expected_meta.items()
+                )
+            ):
+                conn = sqlite3.connect(temporary)
+                try:
+                    with conn:
+                        self._publish_available_marker_in_transaction(
+                            conn,
+                            direct,
+                            checkpoint=recall.checkpoint,
+                            graph_checkpoint=required or prior_acknowledgement,
+                        )
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    if conn.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+                        return None
+                finally:
+                    conn.close()
+                check = sqlite3.connect(f"{temporary.resolve().as_uri()}?mode=ro", uri=True)
+                try:
+                    graph_sync.limit_graph_metadata_read(check)
+                    metadata = dict(
+                        check.execute(
+                            "SELECT key, value FROM graph_meta WHERE key IN "
+                            "('schema_version', 'recall_policy_version', 'recall_access_fingerprint', "
+                            "'recall_projection_identity', 'recall_projection_checkpoint', "
+                            "'graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint', "
+                            "'read_barrier')"
+                        ).fetchall()
+                    )
+                finally:
+                    check.close()
+                metadata_mismatch = any(
+                    metadata.get(key) != value for key, value in expected_meta.items()
+                )
+            if metadata_mismatch:
+                return None
+            if metadata.get(_READ_BARRIER_KEY) is not None:
+                return None
+            if freshness.external_pending(self.vault_root):
+                return None
+            return _GraphPublicationTicket(
+                epoch,
+                recall,
+                (recall.policy_version, recall.access_policy_fingerprint),
+                policy_snapshot,
+                expected_identity,
+                tuple(sorted(metadata.items())),
+                temporary,
+                self._temporary_identity(temporary),
+            )
+        except (OSError, sqlite3.Error):
+            return None
+
+    def _live_acknowledged_checkpoint(self) -> graph_sync.GraphSyncCheckpoint | None:
+        """Read one complete exact acknowledgement outside publication authority."""
+        if not self.path.exists():
+            return None
+        try:
+            conn = sqlite3.connect(f"{self.path.resolve().as_uri()}?mode=ro", uri=True)
+            try:
+                graph_sync.limit_graph_metadata_read(conn)
+                values = dict(
+                    conn.execute(
+                        "SELECT key, value FROM graph_meta WHERE key IN "
+                        "('graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint')"
+                    ).fetchall()
+                )
+            finally:
+                conn.close()
+            rendered = values.get(_GRAPH_SYNC_CHECKPOINT_KEY)
+            checkpoint = (
+                graph_sync.GraphSyncCheckpoint.parse(rendered)
+                if isinstance(rendered, str)
+                else None
+            )
+            if (
+                checkpoint is None
+                or values.get("graph_sync_generation") != str(checkpoint.generation)
+                or values.get("graph_sync_digest") != checkpoint.checkpoint_sha256
+            ):
+                return None
+            return checkpoint
+        except (OSError, sqlite3.Error):
+            return None
+
+    def _publication_ticket_matches(self, ticket: _GraphPublicationTicket) -> bool:
+        """The complete bounded publication gate; no walk, policy read, or SQLite."""
+        try:
+            return (
+                graph_sync.canonical_publication_epoch(self.vault_root) == ticket.epoch
+                and freshness.peek_recall_publication(
+                    self.vault_root,
+                    "vault",
+                    expected_policy_identity=ticket.policy_identity,
+                    ticket=ticket.recall,
+                )
+                == ticket.recall
+                and access.publication_policy_snapshot(self.vault_root) == ticket.policy_snapshot
+                and self._temporary_identity(ticket.temporary) == ticket.temporary_identity
+            )
+        except (OSError, graph_sync.GraphEpochIncoherent):
+            return False
+
+    def _before_publish_replacement(self, temporary: Path, live: Path) -> None:
+        """Original-index publication seam, intentionally after temp handles close."""
+        del temporary, live
+
+    def _wait_for_legacy_rebuild(self) -> bool:
+        """Wait for a competing legacy builder without requiring an epoch."""
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            if self.available():
+                return True
+            time.sleep(0.025)
+        return False
 
     def _rebuild_all_locked(self) -> dict[str, int]:
         pass_started = False
         stable = False
+        proof_invalidated = False
         try:
             for _attempt in range(REBUILD_STABILIZATION_ATTEMPTS):
                 before_disk = _disk_vault_freshness(self.vault_root)
@@ -615,6 +1073,7 @@ class EpistemicGraphIndex:
                     # resolver bytes (for example after a coarse-metadata edit).
                     # Clear both the resolver and page cache before retrying.
                     self._mark_unavailable()
+                    proof_invalidated = True
                     find_module.unload_ram_caches()
                     continue
                 pass_started = True
@@ -657,10 +1116,16 @@ class EpistemicGraphIndex:
                         stable = True
                         return report
                     self._mark_unavailable()
+                proof_invalidated = True
             raise RuntimeError("epistemic graph rebuild did not stabilize after 2 attempts")
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()
+            if not stable and proof_invalidated:
+                # The private pass proved the live exact-checkpoint fast path
+                # stale, but publication never replaced it. Withdraw admission
+                # out of band without modifying the old live sidecar bytes.
+                freshness.mark_external_pending(self.vault_root)
 
     def _rebuild_all_pass(
         self,
@@ -814,34 +1279,59 @@ class EpistemicGraphIndex:
         identity: tuple[tuple[int, int, str], str, str],
         *,
         checkpoint: freshness.RecallFreshnessCheckpoint | None = None,
+        graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> None:
         conn = sqlite3.connect(self.path)
         try:
             with conn:
-                conn.execute(
-                    "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
-                    (_AVAILABILITY_FRESHNESS_KEY, _availability_freshness_value(identity)),
+                self._publish_available_marker_in_transaction(
+                    conn,
+                    identity,
+                    checkpoint=checkpoint,
+                    graph_checkpoint=graph_checkpoint,
                 )
-                conn.execute(
-                    "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
-                    ("schema_version", str(SCHEMA_VERSION)),
-                )
-                conn.execute(
-                    "DELETE FROM graph_meta WHERE key = ?",
-                    (_READ_BARRIER_KEY,),
-                )
-                if checkpoint is None:
-                    conn.execute(
-                        "DELETE FROM graph_meta WHERE key = ?",
-                        (_RECALL_CHECKPOINT_KEY,),
-                    )
-                else:
-                    conn.execute(
-                        "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
-                        (_RECALL_CHECKPOINT_KEY, _checkpoint_value(checkpoint)),
-                    )
         finally:
             conn.close()
+
+    def _publish_available_marker_in_transaction(
+        self,
+        conn: sqlite3.Connection,
+        identity: tuple[tuple[int, int, str], str, str],
+        *,
+        checkpoint: freshness.RecallFreshnessCheckpoint | None = None,
+        graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
+    ) -> None:
+        conn.execute(
+            "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+            (_AVAILABILITY_FRESHNESS_KEY, _availability_freshness_value(identity)),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+            ("schema_version", str(SCHEMA_VERSION)),
+        )
+        conn.execute("DELETE FROM graph_meta WHERE key = ?", (_READ_BARRIER_KEY,))
+        if checkpoint is None:
+            conn.execute("DELETE FROM graph_meta WHERE key = ?", (_RECALL_CHECKPOINT_KEY,))
+        else:
+            conn.execute(
+                "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+                (_RECALL_CHECKPOINT_KEY, _checkpoint_value(checkpoint)),
+            )
+        if graph_checkpoint is not None:
+            self._write_graph_sync_acknowledgement(conn, graph_checkpoint)
+
+    @staticmethod
+    def _write_graph_sync_acknowledgement(
+        conn: sqlite3.Connection, checkpoint: graph_sync.GraphSyncCheckpoint
+    ) -> None:
+        conn.executemany(
+            "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
+            (
+                ("graph_sync_generation", str(checkpoint.generation)),
+                ("graph_sync_digest", checkpoint.checkpoint_sha256),
+                (_GRAPH_SYNC_CHECKPOINT_KEY, checkpoint.render()),
+            ),
+        )
 
     def _mark_available(
         self,
@@ -866,6 +1356,7 @@ class EpistemicGraphIndex:
         identity: tuple[tuple[int, int, str], str, str],
         *,
         checkpoint: freshness.RecallFreshnessCheckpoint | None = None,
+        graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
         source_versions: dict[str, GraphSourceSignature] | None = None,
         expected_membership: frozenset[str] | None = None,
     ) -> bool:
@@ -886,7 +1377,11 @@ class EpistemicGraphIndex:
             and freshness.recall_checkpoint(self.vault_root, "vault") != checkpoint
         ):
             return False
-        self._publish_available_marker(identity, checkpoint=checkpoint)
+        self._publish_available_marker(
+            identity,
+            checkpoint=checkpoint,
+            graph_checkpoint=graph_checkpoint,
+        )
         if freshness.external_pending(self.vault_root):
             return False
         if not self._source_versions_current(expected_sources):
@@ -913,7 +1408,7 @@ class EpistemicGraphIndex:
             if not recall_policy.is_recall_candidate(self.vault_root, path):
                 return False
             try:
-                raw = path.read_text(encoding="utf-8")
+                raw = path.read_bytes().decode("utf-8")
                 current = _source_signature(path, raw)
             except (OSError, UnicodeDecodeError):
                 return False
@@ -1006,6 +1501,31 @@ class EpistemicGraphIndex:
             "SELECT value FROM graph_meta WHERE key = ?", (_RECALL_CHECKPOINT_KEY,)
         ).fetchone()
         return _checkpoint_from_value(str(row[0])) if row is not None else None
+
+    def _graph_sync_predecessor_available(
+        self, checkpoint: graph_sync.GraphSyncCheckpoint
+    ) -> bool:
+        """Whether this sidecar can atomically advance the exact next epoch."""
+        snapshot = self._open_read_snapshot(require_current_projection=False)
+        if snapshot is None:
+            return False
+        try:
+            values = dict(
+                snapshot.execute(
+                    "SELECT key, value FROM graph_meta WHERE key IN "
+                    "('graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint')"
+                )
+            )
+        finally:
+            snapshot.close()
+        predecessor = checkpoint.generation - 1
+        if predecessor == 0:
+            return (
+                "graph_sync_generation" not in values
+                and "graph_sync_digest" not in values
+            )
+        acknowledged = _graph_sync_acknowledgement(values)
+        return acknowledged is not None and acknowledged.generation == predecessor
 
     def _delta_target_still_current(self, delta: freshness.RecallDelta) -> bool:
         """Prove files parsed for a bounded refresh still name ``delta.to``."""
@@ -1121,7 +1641,7 @@ class EpistemicGraphIndex:
         for rel in sorted(indexed_paths - changed_rels):
             path = self.vault_root / rel
             try:
-                raw = path.read_text(encoding="utf-8")
+                raw = path.read_bytes().decode("utf-8")
                 scanned_versions[rel] = _source_signature(path, raw)
             except (OSError, UnicodeDecodeError):
                 return None
@@ -1159,6 +1679,7 @@ class EpistemicGraphIndex:
         paths: list[Path],
         *,
         created_paths: Iterable[Path] = (),
+        graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> dict[str, int]:
         if not graph_enabled():
             # Feature-off does not authorize a stale sidecar to retain sensitive
@@ -1190,26 +1711,108 @@ class EpistemicGraphIndex:
                     "edges": 0,
                     "deferred": 1,
                 }
-            return self._refresh_paths_locked(paths, created_paths=created_paths)
+            report = self._refresh_paths_locked(
+                paths,
+                created_paths=created_paths,
+                graph_checkpoint=graph_checkpoint,
+            )
+        if report.pop("_rebuild_after_release", False):
+            return self._rebuild_all_off_boundary(accept_stabilized_build=True)
+        # Standalone callers have already left the graph mutation hold. Command
+        # callers retain their exact registration for writer_lease to start and
+        # join only after canonical authority releases.
+        from .writer_lease import active_direct_mutation_guard, active_mutation_request_id
+
+        if active_mutation_request_id() is None and not active_direct_mutation_guard(
+            self.vault_root, state_root=self._mutation_coordinator.state_root
+        ):
+            graph_sync.start_registered(
+                self.vault_root, state_root=self._mutation_coordinator.state_root
+            )
+            graph_sync.wait_for_registered(
+                self.vault_root, state_root=self._mutation_coordinator.state_root
+            )
+        return report
 
     def _refresh_paths_locked(
         self,
         paths: list[Path],
         *,
         created_paths: Iterable[Path] = (),
+        graph_checkpoint: graph_sync.GraphSyncCheckpoint | None = None,
     ) -> dict[str, int]:
+        def fallback() -> dict[str, int]:
+            if graph_checkpoint is None:
+                return {
+                    "indexed_files": 0,
+                    "nodes": 0,
+                    "edges": 0,
+                    "_rebuild_after_release": 1,
+                }
+            self._mark_unavailable()
+            graph_sync.register_rebuild(
+                self.vault_root,
+                graph_checkpoint,
+                lambda checkpoint: _rebuild_outcome(self, checkpoint),
+                state_root=self._mutation_coordinator.state_root,
+            )
+            return {"indexed_files": 0, "nodes": 0, "edges": 0, "deferred": 1}
+
+        if graph_checkpoint is not None:
+            durable_checkpoint = graph_sync.read_checkpoint(self.vault_root)
+            expected_paths: list[tuple[str, str | None]] = []
+            for path in paths:
+                rel = _vault_rel(self.vault_root, path)
+                if rel is None:
+                    return fallback()
+                try:
+                    expected_paths.append(
+                        (rel, vault_module.content_hash(path.read_bytes().decode("utf-8")))
+                    )
+                except (OSError, UnicodeDecodeError):
+                    return fallback()
+            expected_created = sorted(
+                rel
+                for path in created_paths
+                if (rel := _vault_rel(self.vault_root, Path(path))) is not None
+            )
+            if (
+                durable_checkpoint != graph_checkpoint
+                or graph_checkpoint.scope != "paths"
+                or graph_checkpoint.paths != tuple(sorted(expected_paths))
+                or graph_checkpoint.created_paths != tuple(expected_created)
+            ):
+                return fallback()
         snapshot = self._open_read_snapshot(require_current_projection=False)
         if snapshot is None:
-            return self._rebuild_all_locked()
+            return fallback()
+        if graph_checkpoint is not None:
+            graph_values = dict(
+                snapshot.execute(
+                    "SELECT key, value FROM graph_meta WHERE key IN "
+                    "('graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint')"
+                )
+            )
+            predecessor = graph_checkpoint.generation - 1
+            if not (
+                predecessor == 0
+                and "graph_sync_generation" not in graph_values
+                and "graph_sync_digest" not in graph_values
+            ) and not (
+                (acknowledged := _graph_sync_acknowledgement(graph_values)) is not None
+                and acknowledged.generation == predecessor
+            ):
+                snapshot.close()
+                return fallback()
         stored_checkpoint = self._stored_recall_checkpoint(snapshot)
         if stored_checkpoint is None or not freshness.recall_is_live(self.vault_root, "vault"):
             snapshot.close()
-            return self._rebuild_all_locked()
+            return fallback()
         delta = freshness.recall_delta_since(self.vault_root, "vault", stored_checkpoint)
         if not delta.complete:
             snapshot.close()
             self._mark_unavailable()
-            return self._rebuild_all_locked()
+            return fallback()
         checkpoint = delta.to
         before = (
             checkpoint.triple,
@@ -1219,7 +1822,7 @@ class EpistemicGraphIndex:
         if not self._delta_target_still_current(delta):
             snapshot.close()
             self._mark_unavailable()
-            return self._rebuild_all_locked()
+            return fallback()
         created_rels = {
             rel
             for path in created_paths
@@ -1229,7 +1832,7 @@ class EpistemicGraphIndex:
         if stored_entries is None:
             snapshot.close()
             self._mark_unavailable()
-            return self._rebuild_all_locked()
+            return fallback()
         snapshot.close()
         resolver = find_module.recall_resolver_snapshot_at_checkpoint(
             self.vault_root,
@@ -1237,7 +1840,7 @@ class EpistemicGraphIndex:
         )
         if resolver is None:
             self._mark_unavailable()
-            return self._rebuild_all_locked()
+            return fallback()
         topology_changed = any(
             (
                 rel.removesuffix(".md") in resolver.full_paths,
@@ -1253,7 +1856,7 @@ class EpistemicGraphIndex:
         if topology_changed:
             topology_snapshot = self._open_read_snapshot(require_current_projection=False)
             if topology_snapshot is None:
-                return self._rebuild_all_locked()
+                return fallback()
             full_topology = self._stored_full_resolver_topology(
                 topology_snapshot,
                 set(stored_entries),
@@ -1261,7 +1864,7 @@ class EpistemicGraphIndex:
             topology_snapshot.close()
             if full_topology is None:
                 self._mark_unavailable()
-                return self._rebuild_all_locked()
+                return fallback()
             indexed_sources, linked_sources, stored_resolver_fingerprint = full_topology
             old_resolver = resolver.fork()
             old_resolver.on_entries_changed(
@@ -1274,7 +1877,7 @@ class EpistemicGraphIndex:
             )
             if _resolver_topology_fingerprint(old_resolver) != stored_resolver_fingerprint:
                 self._mark_unavailable()
-                return self._rebuild_all_locked()
+                return fallback()
             resolver_fingerprint = _resolver_topology_fingerprint(resolver)
 
         delta_paths = set(delta.changed | delta.deleted)
@@ -1284,7 +1887,7 @@ class EpistemicGraphIndex:
         # the event checkpoint.
         if any(str(path) not in delta_paths for path in paths):
             self._mark_unavailable()
-            return self._rebuild_all_locked()
+            return fallback()
 
         refresh_paths = set(delta_paths)
         topology_versions: dict[str, GraphSourceSignature] = {}
@@ -1326,7 +1929,7 @@ class EpistemicGraphIndex:
                 if resolver_version_result is None:
                     find_module.unload_ram_caches()
                 self._mark_unavailable()
-                return self._rebuild_all_locked()
+                return fallback()
             resolver_versions = resolver_version_result
             affected, topology_versions = affected_result
             refresh_paths.update(str(self.vault_root / rel) for rel in affected)
@@ -1336,29 +1939,43 @@ class EpistemicGraphIndex:
         try:
             pass_started = True
             indexed_versions: dict[str, GraphSourceSignature] = {}
-            report = self._refresh_paths_pass(
-                [Path(path) for path in sorted(refresh_paths)],
-                resolver=resolver,
-                indexed_versions=indexed_versions,
-                resolver_fingerprint=resolver_fingerprint,
-            )
             expected_refresh_rels = {
                 rel
                 for path in refresh_paths
                 if (rel := _vault_rel(self.vault_root, Path(path))) is not None
             }
-            publication = self._open_read_snapshot(require_current_projection=False)
-            if publication is None:
-                # A competing/failed rebuild withdrew the sidecar after this
-                # refresh was admitted. This older bounded pass may not restore
-                # availability over that newer withdrawal.
-                return report
-            publication.close()
-            if (
-                _incremental_projection_identity(self.vault_root) == before
-                and self._delta_target_still_current(delta)
-                and set(indexed_versions) == expected_refresh_rels
-                and self._mark_incremental_available(
+
+            def publish_incremental(conn: sqlite3.Connection) -> None:
+                if not (
+                    _incremental_projection_identity(self.vault_root) == before
+                    and self._delta_target_still_current(delta)
+                    and set(indexed_versions) == expected_refresh_rels
+                    and self._source_versions_current(
+                        {**resolver_versions, **topology_versions, **indexed_versions}
+                    )
+                    and (
+                        expected_membership is None
+                        or self._recall_membership() == expected_membership
+                    )
+                    and freshness.recall_checkpoint(self.vault_root, "vault") == checkpoint
+                ):
+                    raise RuntimeError("incremental graph publication proof changed")
+                self._publish_available_marker_in_transaction(
+                    conn,
+                    before,
+                    checkpoint=checkpoint,
+                    graph_checkpoint=graph_checkpoint,
+                )
+
+            report = self._refresh_paths_pass(
+                [Path(path) for path in sorted(refresh_paths)],
+                resolver=resolver,
+                indexed_versions=indexed_versions,
+                resolver_fingerprint=resolver_fingerprint,
+                before_commit=publish_incremental if graph_checkpoint is not None else None,
+            )
+            if graph_checkpoint is None:
+                if self._mark_incremental_available(
                     before,
                     checkpoint=checkpoint,
                     source_versions={
@@ -1367,14 +1984,18 @@ class EpistemicGraphIndex:
                         **indexed_versions,
                     },
                     expected_membership=expected_membership,
-                )
-            ):
+                ):
+                    stable = True
+                    return report
+                rebuilt = fallback()
                 stable = True
-                return report
+                return rebuilt
+            stable = True
+            return report
         finally:
             if pass_started and not stable:
                 self._mark_unavailable()
-        return self._rebuild_all_locked()
+        return fallback()
 
     def _refresh_paths_pass(
         self,
@@ -1383,6 +2004,7 @@ class EpistemicGraphIndex:
         resolver: vault_module.WikilinkResolver,
         indexed_versions: dict[str, GraphSourceSignature] | None = None,
         resolver_fingerprint: str | None = None,
+        before_commit=None,  # noqa: ANN001
     ) -> dict[str, int]:
         conn = self._connect()
         indexed = 0
@@ -1402,6 +2024,8 @@ class EpistemicGraphIndex:
                         "INSERT OR REPLACE INTO graph_meta(key, value) VALUES (?, ?)",
                         (_RESOLVER_TOPOLOGY_KEY, resolver_fingerprint),
                     )
+                if before_commit is not None:
+                    before_commit(conn)
                 n_nodes = conn.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0]
                 n_edges = conn.execute("SELECT COUNT(*) FROM graph_edges").fetchone()[0]
         finally:
@@ -1567,11 +2191,18 @@ class EpistemicGraphIndex:
             self._delete_path(conn, rel, commit=commit)
             return False
         try:
-            raw = path.read_text(encoding="utf-8")
+            raw_bytes = path.read_bytes()
+            raw = raw_bytes.decode("utf-8")
             source_signature = _source_signature(path, raw)
         except (OSError, UnicodeDecodeError):
             return False
-        page = find_module._parse_page(path, path.stat().st_mtime, self.vault_root)
+        page = find_module._parse_page(
+            path,
+            path.stat().st_mtime,
+            self.vault_root,
+            content=raw_bytes,
+            resolved_relative=rel,
+        )
         if page is None:
             return False
         state = semantic_index.current_parent_index_state(
@@ -1599,7 +2230,7 @@ class EpistemicGraphIndex:
             # transaction: do not momentarily publish rows for bytes that are
             # now raw Records (or merely newer ordinary content).
             try:
-                current = path.read_text(encoding="utf-8")
+                current = path.read_bytes().decode("utf-8")
                 current_signature = _source_signature(path, current)
             except (OSError, UnicodeDecodeError):
                 self._delete_path(conn, rel, commit=commit)
@@ -2391,11 +3022,13 @@ def _bump_generation(conn: sqlite3.Connection) -> None:
 
 
 def cache_token(vault_root: Path) -> tuple | None:
-    """`(schema_version, extension_registry_hash, generation)` or None.
+    """`(schema_version, extension_registry_hash, generation, instance)` or None.
 
     None whenever the sidecar is unavailable (disabled, missing, or
     schema/registry drift), which the find freshness key maps to a stable
     absent-sentinel so typed-mode and fallback-mode entries never collide.
+    `generation` advances for in-place writes; `instance` changes when a full
+    rebuild atomically replaces the SQLite file, preventing generation ABA.
     """
     idx = EpistemicGraphIndex(vault_root)
     conn = idx._open_read_snapshot()
@@ -2405,7 +3038,7 @@ def cache_token(vault_root: Path) -> tuple | None:
         values = dict(
             conn.execute(
                 "SELECT key, value FROM graph_meta WHERE key IN "
-                "('schema_version', 'extension_registry_hash', 'generation')"
+                "('schema_version', 'extension_registry_hash', 'generation', 'instance')"
             ).fetchall()
         )
     except sqlite3.Error:
@@ -2416,6 +3049,7 @@ def cache_token(vault_root: Path) -> tuple | None:
         values.get("schema_version"),
         values.get("extension_registry_hash"),
         values.get("generation"),
+        values.get("instance"),
     )
 
 
@@ -2423,7 +3057,112 @@ _REBUILD_LOCK = threading.Lock()
 _REBUILDING: set[str] = set()
 
 
-def schedule_background_rebuild(vault_root: Path) -> bool:
+@dataclass(frozen=True)
+class GraphDispatchResult:
+    """Exact observable outcome of one post-commit graph dispatch."""
+
+    outcome: str
+    code: str
+    checkpoint: graph_sync.GraphSyncCheckpoint | None = None
+
+    def __post_init__(self) -> None:
+        if self.outcome not in {"completed", "registered", "deferred", "failed", "not_required"}:
+            raise ValueError("unsupported graph dispatch outcome")
+        if not self.code or not self.code.isascii() or len(self.code) > 64:
+            raise ValueError("graph dispatch code must be bounded ASCII")
+        if self.outcome in {"registered", "deferred"} and self.checkpoint is None:
+            raise ValueError("graph handoff outcome requires an exact checkpoint")
+
+    @classmethod
+    def not_required(cls) -> GraphDispatchResult:
+        return cls("not_required", "no_graph_input")
+
+
+def _registered_or_failure(
+    vault_root: Path,
+    checkpoint: graph_sync.GraphSyncCheckpoint,
+    index: EpistemicGraphIndex | None,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None,
+) -> GraphDispatchResult:
+    """Capture lazy exact work, replacing any registration error with a handle."""
+    try:
+        if mutation_coordinator is None:
+            from .writer_lease import active_manager
+
+            mutation_coordinator = active_manager()._mutation_coordinator_for(vault_root)
+        assert mutation_coordinator is not None
+
+        def rebuild(
+            required: graph_sync.GraphSyncCheckpoint,
+            bound_index: EpistemicGraphIndex | None = index,
+            bound_coordinator: mutation_lock.VaultMutationCoordinator = mutation_coordinator,
+        ) -> graph_sync.GraphBuildOutcome:
+            return _rebuild_outcome(
+                bound_index
+                or EpistemicGraphIndex(vault_root, mutation_coordinator=bound_coordinator),
+                required,
+            )
+
+        graph_sync.register_rebuild(
+            vault_root,
+            checkpoint,
+            rebuild,
+            state_root=mutation_coordinator.state_root,
+        )
+    except Exception:  # noqa: BLE001 - canonical bytes are already durable
+        log.warning("exact graph rebuild registration failed", exc_info=True)
+        try:
+            graph_sync.register_failure(
+                vault_root,
+                checkpoint,
+                code="GRAPH_SYNC_REGISTRATION_FAILED",
+                state_root=(
+                    mutation_coordinator.state_root if mutation_coordinator is not None else None
+                ),
+            )
+        except Exception:  # noqa: BLE001 - retain a stable terminal even on context failure
+            log.exception("exact graph failure handle registration failed")
+        return GraphDispatchResult(
+            "failed", "GRAPH_SYNC_REGISTRATION_FAILED", checkpoint
+        )
+    return GraphDispatchResult("registered", "graph_rebuild_registered", checkpoint)
+
+
+def _join_registered_standalone(
+    vault_root: Path,
+    result: GraphDispatchResult,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator,
+) -> GraphDispatchResult:
+    """Complete registered rebuilds for direct callers after their guard exits."""
+    if result.outcome != "registered":
+        return result
+    from .writer_lease import active_direct_mutation_guard, active_mutation_request_id
+
+    if active_mutation_request_id() is not None or active_direct_mutation_guard(
+        vault_root, state_root=mutation_coordinator.state_root
+    ):
+        return result
+    assert result.checkpoint is not None
+    try:
+        graph_sync.start_registered(
+            vault_root, state_root=mutation_coordinator.state_root
+        )
+        graph_sync.wait_for_registered(
+            vault_root, state_root=mutation_coordinator.state_root
+        )
+    except graph_sync.GraphRebuildRegistrationError as error:
+        return GraphDispatchResult("failed", error.code, result.checkpoint)
+    except Exception:  # noqa: BLE001 - canonical bytes remain durable
+        log.warning("standalone graph rebuild failed", exc_info=True)
+        return GraphDispatchResult("failed", "GRAPH_SYNC_REBUILD_FAILED", result.checkpoint)
+    return GraphDispatchResult("completed", "graph_rebuild_completed", result.checkpoint)
+
+
+def schedule_background_rebuild(
+    vault_root: Path,
+    *,
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None,
+) -> bool:
     """Kick a single-flight background rebuild of the sidecar and return whether
     one was started.
 
@@ -2432,9 +3171,13 @@ def schedule_background_rebuild(vault_root: Path) -> bool:
     a time (a second call while one is in flight is a no-op); the daemon thread
     swallows its own errors so a failed rebuild never surfaces on the request.
     """
-    if not graph_enabled():
+    if not graph_scheduling_enabled():
         return False
-    key = str(Path(vault_root).resolve())
+    if mutation_coordinator is None:
+        from .writer_lease import active_manager
+
+        mutation_coordinator = active_manager()._mutation_coordinator_for(vault_root)
+    key = f"{Path(vault_root).resolve()}\0{mutation_coordinator.state_root.resolve(strict=False)}"
     with _REBUILD_LOCK:
         if key in _REBUILDING:
             return False
@@ -2442,9 +3185,12 @@ def schedule_background_rebuild(vault_root: Path) -> bool:
 
     def _run() -> None:
         try:
-            EpistemicGraphIndex(vault_root).rebuild_all()
-        except Exception:  # noqa: BLE001 - a background rebuild must never raise
-            pass
+            EpistemicGraphIndex(
+                vault_root, mutation_coordinator=mutation_coordinator
+            ).rebuild_all()
+        except Exception:  # noqa: BLE001 - request path remains non-blocking
+            freshness.mark_external_pending(vault_root)
+            log.warning("background graph rebuild failed; graph remains unavailable", exc_info=True)
         finally:
             with _REBUILD_LOCK:
                 _REBUILDING.discard(key)
@@ -2458,40 +3204,158 @@ def upsert_after_write(
     written_paths: list[Path],
     *,
     created_paths: Iterable[Path] = (),
-) -> None:
+) -> GraphDispatchResult:
+    """Dispatch graph work without allowing a required checkpoint to vanish."""
+    if not written_paths:
+        return GraphDispatchResult.not_required()
+    required = graph_sync.read_checkpoint(vault_root)
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None
     try:
         created = list(created_paths)
-        index = EpistemicGraphIndex(vault_root)
+        from .writer_lease import active_manager
+
+        mutation_coordinator = active_manager()._mutation_coordinator_for(vault_root)
+        index = EpistemicGraphIndex(vault_root, mutation_coordinator=mutation_coordinator)
         if not graph_enabled():
             if index.path.exists():
                 index.suspend_reads()
-            return
-        if created:
+            if required is None:
+                return GraphDispatchResult.not_required()
+            graph_sync.register_deferred(vault_root, required, state_root=mutation_coordinator.state_root)
+            return GraphDispatchResult("deferred", "graph_index_disabled", required)
+        if not graph_scheduling_enabled():
+            if required is None:
+                return GraphDispatchResult.not_required()
+            graph_sync.register_deferred(
+                vault_root, required, state_root=mutation_coordinator.state_root
+            )
+            return GraphDispatchResult("deferred", "graph_scheduling_disabled", required)
+        if required is not None and not index.available():
+            if not index._graph_sync_predecessor_available(required):
+                result = _registered_or_failure(
+                    vault_root, required, index, mutation_coordinator
+                )
+                return _join_registered_standalone(vault_root, result, mutation_coordinator)
+            report = (
+                index.refresh_paths(written_paths, created_paths=created, graph_checkpoint=required)
+                if created
+                else index.refresh_paths(written_paths, graph_checkpoint=required)
+            )
+            if report.get("deferred"):
+                if graph_sync.registered_checkpoint(
+                    vault_root, state_root=mutation_coordinator.state_root
+                ) == required:
+                    return _join_registered_standalone(
+                        vault_root,
+                        GraphDispatchResult("registered", "graph_rebuild_registered", required),
+                        mutation_coordinator,
+                    )
+                if (acknowledged := graph_sync.acknowledged_checkpoint(vault_root)) and acknowledged.covers(
+                    required
+                ):
+                    return GraphDispatchResult("completed", "graph_rebuild_completed", required)
+                return _join_registered_standalone(
+                    vault_root,
+                    _registered_or_failure(vault_root, required, index, mutation_coordinator),
+                    mutation_coordinator,
+                )
+            return GraphDispatchResult("completed", "incremental_completed", required)
+        report = (
             index.refresh_paths(written_paths, created_paths=created)
-        else:
-            index.refresh_paths(written_paths)
+            if created
+            else index.refresh_paths(written_paths)
+        )
+        if required is not None and report.get("deferred"):
+            if graph_sync.registered_checkpoint(
+                vault_root, state_root=mutation_coordinator.state_root
+            ) == required:
+                return _join_registered_standalone(
+                    vault_root,
+                    GraphDispatchResult("registered", "graph_rebuild_registered", required),
+                    mutation_coordinator,
+                )
+            if (acknowledged := graph_sync.acknowledged_checkpoint(vault_root)) and acknowledged.covers(
+                required
+            ):
+                return GraphDispatchResult("completed", "graph_rebuild_completed", required)
+            return _join_registered_standalone(
+                vault_root,
+                _registered_or_failure(vault_root, required, index, mutation_coordinator),
+                mutation_coordinator,
+            )
+        return GraphDispatchResult("completed", "incremental_completed", required)
     except OpError:
         freshness.mark_external_pending(vault_root)
+        if required is not None:
+            assert mutation_coordinator is not None
+            return _join_registered_standalone(
+                vault_root,
+                _registered_or_failure(vault_root, required, None, mutation_coordinator),
+                mutation_coordinator,
+            )
         raise
-    except Exception:  # noqa: BLE001 - writer hooks must not break Markdown writes
+    except Exception:  # noqa: BLE001 - canonical bytes must still report graph failure exactly
         freshness.mark_external_pending(vault_root)
-        return
+        log.warning("graph post-commit dispatch failed", exc_info=True)
+        if required is not None:
+            assert mutation_coordinator is not None
+            return _join_registered_standalone(
+                vault_root,
+                _registered_or_failure(vault_root, required, None, mutation_coordinator),
+                mutation_coordinator,
+            )
+        return GraphDispatchResult("failed", "graph_dispatch_failed")
 
 
-def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
+def _rebuild_outcome(
+    index: EpistemicGraphIndex, checkpoint: graph_sync.GraphSyncCheckpoint
+) -> graph_sync.GraphBuildOutcome:
+    index._rebuild_all_off_boundary()
+    return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+
+def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> GraphDispatchResult:
+    if not removed_rel_paths:
+        return GraphDispatchResult.not_required()
+    required = graph_sync.read_checkpoint(vault_root)
+    mutation_coordinator: mutation_lock.VaultMutationCoordinator | None = None
     try:
-        index = EpistemicGraphIndex(vault_root)
+        from .writer_lease import active_manager
+
+        mutation_coordinator = active_manager()._mutation_coordinator_for(vault_root)
+        index = EpistemicGraphIndex(vault_root, mutation_coordinator=mutation_coordinator)
         if not graph_enabled():
             if index.path.exists():
                 index.suspend_reads()
-            return
+            if required is None:
+                return GraphDispatchResult.not_required()
+            graph_sync.register_deferred(
+                vault_root, required, state_root=mutation_coordinator.state_root
+            )
+            return GraphDispatchResult("deferred", "graph_index_disabled", required)
         index.delete_paths(removed_rel_paths)
+        return GraphDispatchResult("completed", "delete_completed", required)
     except OpError:
         freshness.mark_external_pending(vault_root)
+        if required is not None:
+            assert mutation_coordinator is not None
+            return _join_registered_standalone(
+                vault_root,
+                _registered_or_failure(vault_root, required, None, mutation_coordinator),
+                mutation_coordinator,
+            )
         raise
-    except Exception:  # noqa: BLE001 - writer hooks must not break Markdown writes
+    except Exception:  # noqa: BLE001 - canonical bytes must still report graph failure exactly
         freshness.mark_external_pending(vault_root)
-        return
+        log.warning("graph post-remove dispatch failed", exc_info=True)
+        if required is not None:
+            assert mutation_coordinator is not None
+            return _join_registered_standalone(
+                vault_root,
+                _registered_or_failure(vault_root, required, None, mutation_coordinator),
+                mutation_coordinator,
+            )
+        return GraphDispatchResult("failed", "graph_dispatch_failed")
 
 
 def graph_drift(vault_root: Path) -> list[dict[str, Any]]:
@@ -2522,7 +3386,7 @@ def graph_drift(vault_root: Path) -> list[dict[str, Any]]:
     for md in find_module._walk_md(kb):
         try:
             rel = md.resolve().relative_to(vault_root.resolve()).as_posix()
-            raw = md.read_text(encoding="utf-8")
+            raw = md.read_bytes().decode("utf-8")
         except (OSError, ValueError, UnicodeDecodeError):
             continue
         disk_paths.add(rel)

--- a/src/exomem/epistemic_graph.py
+++ b/src/exomem/epistemic_graph.py
@@ -183,12 +183,10 @@ def graph_enabled() -> bool:
 
 def graph_scheduling_enabled() -> bool:
     """Compatibility builds retain epoch parsing/recovery but stop new work."""
-    return graph_enabled() and os.environ.get("EXOMEM_DISABLE_GRAPH_SCHEDULING", "").strip().lower() not in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    disabled = (
+        os.environ.get("EXOMEM_DISABLE_GRAPH_SCHEDULING", "").strip().lower()
+    )
+    return graph_enabled() and disabled not in {"1", "true", "yes", "on"}
 
 
 def sidecar_path(vault_root: Path) -> Path:
@@ -747,12 +745,19 @@ class EpistemicGraphIndex:
                 )
                 if not owner_claimed:
                     if required is None and self._wait_for_legacy_rebuild():
-                        return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
+                        return {
+                            "indexed_files": 0,
+                            "nodes": 0,
+                            "edges": 0,
+                            "joined": 1,
+                        }
                     if graph_sync.wait_for_current(
                         self.vault_root, required, availability=self.available
                     ):
                         return {"indexed_files": 0, "nodes": 0, "edges": 0, "joined": 1}
-                    raise RuntimeError("another graph rebuild owner did not publish a current sidecar")
+                    raise RuntimeError(
+                        "another graph rebuild owner did not publish a current sidecar"
+                    )
                 temporary_index = EpistemicGraphIndex(
                     self.vault_root, mutation_coordinator=self._mutation_coordinator
                 )
@@ -884,7 +889,11 @@ class EpistemicGraphIndex:
                 recall.policy_version,
                 recall.access_policy_fingerprint,
             )
-            if policy_identity != (recall.policy_version, recall.access_policy_fingerprint) or direct != recall_identity:
+            if (
+                policy_identity
+                != (recall.policy_version, recall.access_policy_fingerprint)
+                or direct != recall_identity
+            ):
                 return None
             assert policy_snapshot is not None
             expected_identity = _availability_freshness_value(direct)
@@ -958,9 +967,10 @@ class EpistemicGraphIndex:
                     metadata = dict(
                         check.execute(
                             "SELECT key, value FROM graph_meta WHERE key IN "
-                            "('schema_version', 'recall_policy_version', 'recall_access_fingerprint', "
-                            "'recall_projection_identity', 'recall_projection_checkpoint', "
-                            "'graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint', "
+                            "('schema_version', 'recall_policy_version', "
+                            "'recall_access_fingerprint', 'recall_projection_identity', "
+                            "'recall_projection_checkpoint', 'graph_sync_generation', "
+                            "'graph_sync_digest', 'graph_sync_checkpoint', "
                             "'read_barrier')"
                         ).fetchall()
                     )
@@ -3221,7 +3231,11 @@ def upsert_after_write(
                 index.suspend_reads()
             if required is None:
                 return GraphDispatchResult.not_required()
-            graph_sync.register_deferred(vault_root, required, state_root=mutation_coordinator.state_root)
+            graph_sync.register_deferred(
+                vault_root,
+                required,
+                state_root=mutation_coordinator.state_root,
+            )
             return GraphDispatchResult("deferred", "graph_index_disabled", required)
         if not graph_scheduling_enabled():
             if required is None:
@@ -3250,9 +3264,8 @@ def upsert_after_write(
                         GraphDispatchResult("registered", "graph_rebuild_registered", required),
                         mutation_coordinator,
                     )
-                if (acknowledged := graph_sync.acknowledged_checkpoint(vault_root)) and acknowledged.covers(
-                    required
-                ):
+                acknowledged = graph_sync.acknowledged_checkpoint(vault_root)
+                if acknowledged and acknowledged.covers(required):
                     return GraphDispatchResult("completed", "graph_rebuild_completed", required)
                 return _join_registered_standalone(
                     vault_root,
@@ -3274,9 +3287,8 @@ def upsert_after_write(
                     GraphDispatchResult("registered", "graph_rebuild_registered", required),
                     mutation_coordinator,
                 )
-            if (acknowledged := graph_sync.acknowledged_checkpoint(vault_root)) and acknowledged.covers(
-                required
-            ):
+            acknowledged = graph_sync.acknowledged_checkpoint(vault_root)
+            if acknowledged and acknowledged.covers(required):
                 return GraphDispatchResult("completed", "graph_rebuild_completed", required)
             return _join_registered_standalone(
                 vault_root,

--- a/src/exomem/file_watcher.py
+++ b/src/exomem/file_watcher.py
@@ -267,6 +267,7 @@ class FileWatcher:
         self._pending_delete: set[Path] = set()
         self._pending_media: set[Path] = set()
         self._pending_external_epoch = 0
+        self._pending_access_policy = False
         self._last_change = 0.0
         self._wake = threading.Event()
         self._stop = threading.Event()
@@ -306,6 +307,19 @@ class FileWatcher:
         from .vault import in_excluded_scan_dir
 
         rel = self._rel(path)
+        if rel == f"{kb_prefix()}_access.yaml":
+            # Access policy changes are a publication boundary despite not
+            # being Markdown.  Do this before the generic non-Markdown return
+            # so graph reads fail closed until policy projection is reconciled.
+            with self._lock:
+                self._pending_access_policy = True
+                self._pending_external_epoch = max(
+                    self._pending_external_epoch,
+                    freshness.mark_external_pending(self._vault_root),
+                )
+                self._last_change = time.monotonic()
+            self._wake.set()
+            return
         if rel is not None and in_excluded_scan_dir(rel):
             # _trash/_archive/_Schema/…: every full walk skips these, so the
             # event path must too — else a delete's move-to-trash re-embeds
@@ -347,23 +361,27 @@ class FileWatcher:
             except ValueError:
                 return None
 
-    def _drain(self) -> tuple[list[Path], list[Path], list[str], int]:
+    def _drain(self) -> tuple[list[Path], list[Path], list[str], int, bool]:
         with self._lock:
             media = sorted(self._pending_media)
             ups = sorted(self._pending_upsert)
             dels = sorted(self._pending_delete)
             pending_epoch = self._pending_external_epoch
+            access_policy = self._pending_access_policy
             self._pending_media.clear()
             self._pending_upsert.clear()
             self._pending_delete.clear()
             self._pending_external_epoch = 0
+            self._pending_access_policy = False
         del_rels = [r for r in (self._rel(p) for p in dels) if r]
-        return media, ups, del_rels, pending_epoch
+        return media, ups, del_rels, pending_epoch, access_policy
 
     def _flush(self) -> None:
         """Dispatch the coalesced batch: publish freshness/inbound for every
         changed path (vault-wide), and re-embed only the Knowledge Base subset."""
-        media, ups, del_rels, pending_epoch = self._drain()
+        media, ups, del_rels, pending_epoch, access_policy = self._drain()
+        if access_policy:
+            self._reconcile_access_policy(pending_epoch)
         if not (media or ups or del_rels):
             return
 
@@ -390,6 +408,16 @@ class FileWatcher:
             cap=False,
             pending_epoch=pending_epoch,
         )
+
+    def _reconcile_access_policy(self, pending_epoch: int) -> None:
+        """Reproject one observed `_access.yaml` edit before clearing its barrier."""
+        try:
+            for scope in freshness.SCOPES:
+                if freshness.recall_is_live(self._vault_root, scope):
+                    freshness.recall_checkpoint(self._vault_root, scope)
+            self._recover_external_pending(pending_epoch)
+        except Exception:  # noqa: BLE001 - keep the observation pending for retry
+            log.exception("file watcher: access-policy reconciliation failed")
 
     # ---- debounce loop ----
 
@@ -553,12 +581,12 @@ class FileWatcher:
         from . import find as find_module
         from . import vault as vault_module
 
+        if not epistemic_graph.graph_enabled() or not epistemic_graph.sidecar_path(
+            self._vault_root
+        ).exists():
+            return
         graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
-        if (
-            not epistemic_graph.graph_enabled()
-            or not graph.path.exists()
-            or not graph.reads_suspended()
-        ):
+        if not graph.reads_suspended():
             return
         try:
             find_module.evict_resolver_caches(self._vault_root)
@@ -589,9 +617,9 @@ class FileWatcher:
         from . import find as find_module
         from . import vault as vault_module
 
-        graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
-        if not graph.path.exists():
+        if not epistemic_graph.sidecar_path(self._vault_root).exists():
             return
+        graph = epistemic_graph.EpistemicGraphIndex(self._vault_root)
         try:
             graph.suspend_reads()
             if not epistemic_graph.graph_enabled():

--- a/src/exomem/find.py
+++ b/src/exomem/find.py
@@ -2277,13 +2277,16 @@ def _resolve_relation_filter(
                     "replaced_by": resolution.replacement,
                 }
             )
-    result = epistemic_graph.EpistemicGraphIndex(vault_root).relation_participants(
+    graph_index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    result = graph_index.relation_participants(
         canonical, anchor=relation_of, direction=relation_direction
     )
     if result.status == "temporarily_unavailable":
         raise RetrievalIndexWarming(status="temporarily_unavailable")
     if result.status == "warming":
-        epistemic_graph.schedule_background_rebuild(vault_root)
+        epistemic_graph.schedule_background_rebuild(
+            vault_root, mutation_coordinator=graph_index._canonical_mutation_coordinator()
+        )
         raise RetrievalIndexWarming(status="warming")
     return result.paths, dict(result.provenance), tuple(findings)
 

--- a/src/exomem/freshness.py
+++ b/src/exomem/freshness.py
@@ -58,12 +58,14 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import ntpath
 import os
 import threading
 import uuid
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, overload
 
 from .kbdir import kb_dirname
 
@@ -114,6 +116,26 @@ class RecallFreshnessCheckpoint(NamedTuple):
     triple: tuple[int, int, str]
     policy_version: str
     access_policy_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecallPublicationState:
+    """Immutable prepared recall identity for bounded sidecar publication."""
+
+    checkpoint: RecallFreshnessCheckpoint
+    registry_key: tuple[str, str]
+
+    @property
+    def triple(self) -> tuple[int, int, str]:
+        return self.checkpoint.triple
+
+    @property
+    def policy_version(self) -> str:
+        return self.checkpoint.policy_version
+
+    @property
+    def access_policy_fingerprint(self) -> str:
+        return self.checkpoint.access_policy_fingerprint
 
 
 class RecallDelta(NamedTuple):
@@ -183,6 +205,8 @@ _recall_generations: dict[tuple[str, str], int] = {}
 _recall_identities: dict[tuple[str, str], tuple[str, str]] = {}
 _recall_live: set[tuple[str, str]] = set()
 _recall_history: dict[tuple[str, str], list[tuple[int, int, frozenset[str]]]] = {}
+_recall_publications: dict[tuple[str, str], RecallPublicationState] = {}
+RECALL_PUBLICATION_PREPARE_ATTEMPTS = 4
 # Watchdog records an external event here before its debounce window. Graph
 # readers can then fail closed in O(1) until that exact queued generation has
 # been published through the event-maintained corpus fan-out.
@@ -231,7 +255,7 @@ def event_indexes_enabled() -> bool:
 
 
 def _truthy(value: str | None) -> bool:
-    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+    return value is not None and value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
 def stat_signature(path: Path) -> FileSignature:
@@ -254,6 +278,16 @@ def _normalize_signature(value: SignatureLike) -> FileSignature:
     return (int(value[0]), int(value[1]), int(value[2]))
 
 
+def _digest_path(path: str) -> str:
+    """Canonicalize Windows aliases without changing non-Windows digest inputs."""
+    if os.name != "nt":
+        return path
+    try:
+        return ntpath.normcase(str(Path(path).resolve()))
+    except OSError:
+        return ntpath.normcase(path)
+
+
 def triple_from_entries(
     entries: Iterable[tuple[str, SignatureLike]],
 ) -> tuple[int, int, str]:
@@ -265,7 +299,7 @@ def triple_from_entries(
     delete-paired-with-create, renames, and content replacements that preserve
     mtimes and would otherwise leave warmed recall stale.
     """
-    items = sorted((sp, _normalize_signature(signature)) for sp, signature in entries)
+    items = sorted((_digest_path(sp), _normalize_signature(signature)) for sp, signature in entries)
     latest = 0
     h = hashlib.blake2b(digest_size=16)
     for sp, signature in items:
@@ -313,13 +347,36 @@ def recall_triple(vault_root: Path, scope: str) -> tuple[int, int, str]:
     return triple_from_entries(entries)
 
 
-def recall_checkpoint(vault_root: Path, scope: str) -> RecallFreshnessCheckpoint:
-    """Return one coherent recall-projection and policy identity checkpoint."""
+@overload
+def recall_checkpoint(
+    vault_root: Path, scope: str, *, max_attempts: None = None
+) -> RecallFreshnessCheckpoint: ...
+
+
+@overload
+def recall_checkpoint(
+    vault_root: Path, scope: str, *, max_attempts: int
+) -> RecallFreshnessCheckpoint | None: ...
+
+
+def recall_checkpoint(
+    vault_root: Path, scope: str, *, max_attempts: int | None = None
+) -> RecallFreshnessCheckpoint | None:
+    """Return one coherent recall-projection and policy identity checkpoint.
+
+    Ordinary callers retain the established unbounded convergence behavior.
+    Bounded publishers can opt into a finite retry budget so policy churn cannot
+    keep a publication authority wait forever.
+    """
     from . import recall_policy
 
+    if max_attempts is not None and max_attempts < 1:
+        return None
     root = Path(vault_root)
     key = _key(root, scope)
-    while True:
+    attempts = 0
+    while max_attempts is None or attempts < max_attempts:
+        attempts += 1
         policy_version, access_fingerprint = recall_policy.recall_policy_identity(root)
         identity = (policy_version, access_fingerprint)
         with _lock:
@@ -383,11 +440,13 @@ def recall_checkpoint(vault_root: Path, scope: str) -> RecallFreshnessCheckpoint
             _recall_maps[key] = projected
             _recall_triples[key] = None
             _recall_identities[key] = identity
+            _recall_publications.pop(key, None)
             # An access-policy transition is a real projected event even when
             # no Markdown changed.  Retain its exact row delta so a live catalog
             # can remove/re-add eligible pages without a request-path walk.
             _record_recall_event(key, touched)
             continue
+    return None
 
 
 def recall_projection_snapshot(
@@ -447,10 +506,10 @@ def recall_projection_snapshot(
 
             kb = root / kb_dirname()
             walk = find_module._walk_md(kb) if kb.is_dir() else ()
-        entries: dict[str, FileSignature] = {}
+        walk_entries: dict[str, FileSignature] = {}
         for path in recall_policy.iter_recall_markdown(root, walk):
             try:
-                entries[str(path)] = stat_signature(path)
+                walk_entries[str(path)] = stat_signature(path)
             except OSError:
                 continue
         if recall_policy.recall_policy_identity(root) != identity:
@@ -465,11 +524,11 @@ def recall_projection_snapshot(
             RecallFreshnessCheckpoint(
                 instance_id,
                 generation,
-                triple_from_entries(entries.items()),
+                triple_from_entries(walk_entries.items()),
                 identity[0],
                 identity[1],
             ),
-            entries,
+            walk_entries,
         )
 
 
@@ -492,13 +551,110 @@ def recall_is_live(vault_root: Path, scope: str) -> bool:
         return _key(vault_root, scope) in _recall_live
 
 
+def prepare_recall_publication(
+    vault_root: Path,
+    scope: str,
+    *,
+    expected_policy_identity: tuple[str, str] | None = None,
+) -> RecallPublicationState | None:
+    """Materialize one publishable event-maintained recall checkpoint.
+
+    Cold callers deliberately receive no state.  Policy reprojection runs here,
+    outside the eventual publication authority; the hot publication path uses
+    :func:`peek_recall_publication` only.
+    """
+    from . import recall_policy
+
+    root = Path(vault_root)
+    key = _key(root, scope)
+    for _attempt in range(RECALL_PUBLICATION_PREPARE_ATTEMPTS):
+        identity = recall_policy.recall_publication_policy_identity(root)
+        if identity is None or (
+            expected_policy_identity is not None and identity != expected_policy_identity
+        ):
+            return None
+        with _lock:
+            if (
+                not event_indexes_enabled()
+                or key not in _recall_live
+                or _canon(root) in _external_pending
+            ):
+                return None
+        checkpoint = recall_checkpoint(root, scope, max_attempts=1)
+        if checkpoint is None:
+            continue
+        if (checkpoint.policy_version, checkpoint.access_policy_fingerprint) != identity:
+            if expected_policy_identity is not None:
+                return None
+            continue
+        if recall_policy.recall_publication_policy_identity(root) != identity:
+            if expected_policy_identity is not None:
+                return None
+            continue
+        with _lock:
+            if (
+                not event_indexes_enabled()
+                or key not in _recall_live
+                or _canon(root) in _external_pending
+                or _recall_generations.get(key, 0) != checkpoint.generation
+                or _recall_identities.get(key) != identity
+            ):
+                continue
+            state = RecallPublicationState(checkpoint, key)
+            _recall_publications[key] = state
+            return state
+    return None
+
+
+def peek_recall_publication(
+    vault_root: Path,
+    scope: str,
+    *,
+    expected_policy_identity: tuple[str, str] | None = None,
+    ticket: RecallPublicationState | None = None,
+) -> RecallPublicationState | None:
+    """Return prepared publication state without filesystem or policy work."""
+    # Do not canonicalize here: resolve() would violate the strict hot-path
+    # contract. A differently spelled root is conservatively cold.
+    key = ticket.registry_key if ticket is not None else (str(Path(vault_root)), scope)
+    with _lock:
+        if (
+            (ticket is not None and key[1] != scope)
+            or not event_indexes_enabled()
+            or key[0] in _external_pending
+        ):
+            return None
+        state = _recall_publications.get(key)
+        if ticket is not None and state != ticket:
+            return None
+        if state is None or key not in _recall_live:
+            return None
+        checkpoint = state.checkpoint
+        if (
+            _recall_generations.get(key, 0) != checkpoint.generation
+            or _recall_identities.get(key)
+            != (checkpoint.policy_version, checkpoint.access_policy_fingerprint)
+            or _recall_triples.get(key) != checkpoint.triple
+            or (
+                expected_policy_identity is not None
+                and expected_policy_identity
+                != (checkpoint.policy_version, checkpoint.access_policy_fingerprint)
+            )
+        ):
+            return None
+        return state
+
+
 def mark_external_pending(vault_root: Path) -> int:
     """Mark an observed out-of-band event pending before watcher debounce."""
     global _external_pending_clock
     with _lock:
         _external_pending_clock += 1
         epoch = _external_pending_clock
-        _external_pending[_canon(vault_root)] = epoch
+        root = _canon(vault_root)
+        _external_pending[root] = epoch
+        for scope in SCOPES:
+            _recall_publications.pop((root, scope), None)
         return epoch
 
 
@@ -647,6 +803,7 @@ def seed(vault_root: Path, scope: str, entries: Iterable[tuple[str, SignatureLik
         _recall_triples[key] = None
         _recall_generations[key] = _next_gen()
         _recall_identities[key] = recall_identity
+        _recall_publications.pop(key, None)
         _recall_live.add(key)
         _recall_history[key] = []
 
@@ -682,6 +839,7 @@ def reconcile(
         _recall_maps[key] = recall_fresh
         _recall_triples[key] = None
         _recall_identities[key] = recall_identity
+        _recall_publications.pop(key, None)
         if old_recall != recall_fresh or old_identity != recall_identity:
             _recall_generations[key] = _next_gen()
             _recall_history[key] = []
@@ -982,6 +1140,7 @@ def on_files_changed(
         for self_key, paths in touched.items():
             _record_event(self_key, paths)
         for self_key, paths in recall_touched.items():
+            _recall_publications.pop(self_key, None)
             _record_recall_event(self_key, paths)
 
 
@@ -1004,6 +1163,7 @@ def invalidate(vault_root: Path | None = None) -> None:
             _recall_identities.clear()
             _recall_live.clear()
             _recall_history.clear()
+            _recall_publications.clear()
             _external_pending.clear()
             return
         root = _canon(vault_root)
@@ -1020,6 +1180,7 @@ def invalidate(vault_root: Path | None = None) -> None:
             _recall_identities.pop(key, None)
             _recall_live.discard(key)
             _recall_history.pop(key, None)
+            _recall_publications.pop(key, None)
 
 
 def rebaseline(vault_root: Path) -> dict[str, bool]:

--- a/src/exomem/governance/lifecycle.py
+++ b/src/exomem/governance/lifecycle.py
@@ -903,6 +903,63 @@ def _record_lifecycle(operation: LifecycleOperation, event_type: str, exact_stat
     )
 
 
+_CLOSED_ACCEPTED_INDEX_CODES = frozenset(
+    {
+        "no_eligible_paths",
+        "embeddings_disabled",
+        "clip_disabled",
+    }
+)
+
+
+def _index_report_is_exact(index_report: Mapping[str, Any] | None) -> bool:
+    """Whether post-transition derived state is proved before terminalizing it."""
+    if index_report is None:
+        return False
+    if index_report.get("paths_truncated") is True or index_report.get("reconcile_required") is True:
+        return False
+    if index_report.get("derived_work") == "unverified":
+        return False
+    components = index_report.get("components")
+    if not isinstance(components, (list, tuple)):
+        return False
+    for item in components:
+        if not isinstance(item, Mapping):
+            return False
+        outcome = item.get("outcome")
+        if outcome == "accepted":
+            if item.get("code") not in _CLOSED_ACCEPTED_INDEX_CODES:
+                return False
+        elif outcome not in {"completed", "registered", "not_required"}:
+            return False
+    return True
+
+
+def exact_no_derived_index_report(
+    operation: LifecycleOperation,
+) -> dict[str, object] | None:
+    """Return explicit proof only where this lifecycle transition has no index work."""
+    has_markdown = any(item.source_path.lower().endswith(".md") for item in operation.manifest)
+    has_visual_media = any(
+        media_types.media_type_for(item.source_path) in {"image", "video"}
+        for item in operation.manifest
+    )
+    clip_enabled = os.environ.get("EXOMEM_DISABLE_CLIP", "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if has_markdown or (has_visual_media and clip_enabled):
+        return None
+    return {
+        "components": [],
+        "derived_work": "not_required",
+        "paths_truncated": False,
+        "reconcile_required": False,
+    }
+
+
 def finish_deletion(
     operation: LifecycleOperation,
     *,
@@ -910,15 +967,8 @@ def finish_deletion(
 ) -> bool:
     if not operation.governed:
         return True
-    if index_report is not None:
-        if index_report.get("paths_truncated") is True:
-            return False
-        components = index_report.get("components", [])
-        if any(
-            isinstance(item, Mapping) and item.get("outcome") == "degraded"
-            for item in components
-        ):
-            return False
+    if not _index_report_is_exact(index_report):
+        return False
     if classify_deletion(operation) != operation.target_digest:
         return False
     _record_lifecycle(operation, "deletion", operation.target_digest)
@@ -1286,14 +1336,8 @@ def _scene_derivatives_exact(vault_root: Path, videos: tuple[str, ...]) -> bool:
 def finish_recovery(operation: LifecycleOperation, *, index_report: Mapping[str, Any] | None = None) -> bool:
     if not operation.governed:
         return True
-    if index_report is not None:
-        components = index_report.get("components", [])
-        if any(
-            isinstance(item, Mapping)
-            and item.get("outcome") in {"degraded", "deferred", "unverified"}
-            for item in components
-        ):
-            return False
+    if not _index_report_is_exact(index_report):
+        return False
     if classify_recovery(operation) != operation.target_digest:
         return False
     _record_lifecycle(operation, "recovery", operation.target_digest)

--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -1,0 +1,2296 @@
+"""Durable, content-free handoff state for full epistemic-graph rebuilds."""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import sqlite3
+import threading
+import time
+import unicodedata
+from collections.abc import Callable, Iterable
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, BinaryIO
+
+if TYPE_CHECKING:
+    from .vault import PlannedWrite
+
+
+_DOMAIN = b"exomem-graph-sync-checkpoint:v1\0"
+_FLOOR_DOMAIN = b"exomem-graph-sync-generation-floor:v1\0"
+_VERSION = 1
+_PATH_LIMIT = 1_000
+_TEMP_PREFIX = ".graph-rebuild-"
+_CHECKPOINT_FILENAME = ".graph-sync.json"
+_FLOOR_FILENAME = ".graph-sync-floor.json"
+_RECEIPT_DIRNAME = ".graph-commit-receipts"
+# A maximal v1 paths checkpoint is 1,000 paths of 1,024 UTF-8 bytes plus
+# hashes and a duplicated created-path array. Keep a small format margin while
+# still refusing arbitrary multi-megabyte synced inputs.
+_CHECKPOINT_READ_LIMIT = 3_200_000
+_RECEIPT_READ_LIMIT = 65_536
+_FLOOR_READ_LIMIT = 8_192
+_MUTATION_ID = re.compile(r"^[0-9a-f]{24}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_RECEIPT_TAG = re.compile(r"^[0-9a-f]{16}$")
+_WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        "clock$",
+        "conin$",
+        "conout$",
+        *(f"com{index}" for index in range(1, 10)),
+        *(f"lpt{index}" for index in range(1, 10)),
+        *(f"com{index}" for index in "¹²³"),
+        *(f"lpt{index}" for index in "¹²³"),
+    }
+)
+_RECEIPT_KEY_DOMAIN = b"exomem-graph-commit-receipt-key:v1\0"
+_RECEIPT_TERMINAL_DOMAIN = b"exomem-graph-commit-receipt-terminal:v1\0"
+_RECEIPT_AUTH_DOMAIN = b"exomem-graph-commit-receipt-auth:v2\0"
+_RECEIPT_TERMINAL_FIELDS = frozenset(
+    {
+        "_terminal",
+        "version",
+        "ok",
+        "state",
+        "status",
+        "committed",
+        "mutated",
+        "terminal",
+        "warnings_count",
+        "request_id",
+        "receipt_id",
+        "operation_id",
+        "result_sha256",
+    }
+)
+_RECEIPT_TERMINAL_STATES = frozenset({"committed", "rejected"})
+_RECEIPT_TERMINAL_STATUSES = frozenset({"committed", "replayed", "rejected"})
+MAX_GRAPH_REBUILD_WAITERS = 128
+MAX_GRAPH_REBUILD_ATTEMPTS = 4
+_COORDINATORS: dict[str, GraphRebuildCoordinator] = {}
+_COORDINATORS_LOCK = threading.Lock()
+_LIVE_TEMPORARIES: set[Path] = set()
+_REBUILD_LOCK_HANDLES: dict[str, _HeldRebuildLock] = {}
+_PENDING_WAITERS: ContextVar[
+    dict[str, tuple[GraphRebuildRegistration | GraphRebuildWaiter, GraphSyncCheckpoint]] | None
+] = (
+    ContextVar("exomem_pending_graph_rebuild_waiters", default=None)
+)
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _is_exact_canonical_json(raw: str | bytes, value: object) -> bool:
+    """Require v2 receipt bytes to be the protocol's one canonical UTF-8 form."""
+    try:
+        rendered = raw.encode("utf-8") if isinstance(raw, str) else raw
+    except UnicodeEncodeError:
+        return False
+    return isinstance(rendered, bytes) and rendered == _canonical_json(value)
+
+
+def limit_graph_metadata_read(conn: sqlite3.Connection) -> None:
+    """Bound untrusted sidecar TEXT before SQLite allocates it for parsing."""
+    setlimit = getattr(conn, "setlimit", None)
+    category = getattr(sqlite3, "SQLITE_LIMIT_LENGTH", None)
+    if callable(setlimit) and isinstance(category, int):
+        setlimit(category, _CHECKPOINT_READ_LIMIT)
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate JSON field")
+        value[key] = item
+    return value
+
+
+def _is_canonical_relative_path(value: object) -> bool:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        return False
+    if unicodedata.normalize("NFC", value) != value:
+        return False
+    if value.startswith("/") or value.endswith("/") or _WINDOWS_DRIVE_PREFIX.match(value):
+        return False
+    for part in value.split("/"):
+        if (
+            part in {"", ".", ".."}
+            or part.endswith((".", " "))
+            or any(character in '<>:"|?*\x00' or ord(character) < 32 for character in part)
+        ):
+            return False
+        # Windows strips spaces/dots from the basename before resolving a
+        # device name; make the portable parser reject that alias too.
+        stem = part.split(".", 1)[0].rstrip(" .").casefold()
+        if stem in _WINDOWS_RESERVED_NAMES:
+            return False
+    return True
+
+
+def _is_digest(value: object) -> bool:
+    return isinstance(value, str) and _SHA256.fullmatch(value) is not None
+
+
+def _is_receipt_terminal_projection(value: object) -> bool:
+    """Validate the closed, scalar receipt projection before HMAC verification."""
+    if not isinstance(value, dict) or not value:
+        return False
+    for key, item in value.items():
+        if key not in _RECEIPT_TERMINAL_FIELDS:
+            return False
+        if key == "_terminal" and item != "exomem.mutation-terminal":
+            return False
+        if key == "version" and (type(item) is not int or item != 1):
+            return False
+        if key in {"ok", "committed", "mutated", "terminal"} and type(item) is not bool:
+            return False
+        if key == "state" and item not in _RECEIPT_TERMINAL_STATES:
+            return False
+        if key == "status" and item not in _RECEIPT_TERMINAL_STATUSES:
+            return False
+        if key in {"request_id", "operation_id"} and (
+            not isinstance(item, str) or _UUID.fullmatch(item) is None
+        ):
+            return False
+        if key == "receipt_id" and item is not None and (
+            not isinstance(item, str) or _RECEIPT_TAG.fullmatch(item) is None
+        ):
+            return False
+        if key == "warnings_count" and (type(item) is not int or item < 0):
+            return False
+        if key == "result_sha256" and not _is_digest(item):
+            return False
+    return True
+
+
+def namespaced_idempotency_key_digest(namespace: str, key: str) -> str:
+    """Hash an idempotency key in its replay namespace without retaining either."""
+    if not isinstance(namespace, str) or not namespace or not isinstance(key, str) or not key:
+        raise ValueError("receipt key namespace and key must be non-empty strings")
+    return hashlib.sha256(
+        _RECEIPT_KEY_DOMAIN + namespace.encode("utf-8") + b"\0" + key.encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class GraphSyncCheckpoint:
+    """The closed v1 canonical-to-derived graph handoff record."""
+
+    version: int
+    generation: int
+    mutation_id: str
+    scope: str
+    paths: tuple[tuple[str, str | None], ...]
+    created_paths: tuple[str, ...]
+    checkpoint_sha256: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        generation: int,
+        mutation_id: str,
+        paths: tuple[tuple[str, str | None], ...],
+        created_paths: tuple[str, ...],
+        scope: str = "paths",
+    ) -> GraphSyncCheckpoint:
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 1:
+            raise ValueError("generation must be a positive integer")
+        if not isinstance(mutation_id, str) or _MUTATION_ID.fullmatch(mutation_id) is None:
+            raise ValueError("mutation_id must be lowercase 24-hex")
+        if scope not in {"paths", "full"}:
+            raise ValueError("scope must be paths or full")
+        raw_paths = tuple(paths)
+        raw_created = tuple(created_paths)
+        if scope == "full":
+            # Existing callers pass the changed paths while escalating to a
+            # full checkpoint.  V1's canonical full form intentionally drops
+            # both arrays, so retain that compatible rendering behaviour.
+            ordered_paths: tuple[tuple[str, str | None], ...] = ()
+            ordered_created: tuple[str, ...] = ()
+        else:
+            if len(raw_paths) > _PATH_LIMIT:
+                raise ValueError("paths cannot exceed 1000 entries")
+            if len(raw_created) > _PATH_LIMIT:
+                raise ValueError("created paths cannot exceed 1000 entries")
+            if any(
+                not _is_canonical_relative_path(path)
+                or (content_hash is not None and not _is_digest(content_hash))
+                for path, content_hash in raw_paths
+            ):
+                raise ValueError("paths must be canonical and carry lowercase SHA-256 hashes")
+            if len({path for path, _content_hash in raw_paths}) != len(raw_paths):
+                raise ValueError("paths must be unique")
+            if any(not _is_canonical_relative_path(path) for path in raw_created):
+                raise ValueError("created paths must be canonical")
+            if len(set(raw_created)) != len(raw_created):
+                raise ValueError("created paths must be unique")
+            non_null_paths = {path for path, content_hash in raw_paths if content_hash is not None}
+            if not set(raw_created).issubset(non_null_paths):
+                raise ValueError("created paths must be a subset of non-null paths")
+            ordered_paths = tuple(sorted(raw_paths))
+            ordered_created = tuple(sorted(raw_created))
+        value = {
+            "version": _VERSION,
+            "generation": generation,
+            "mutation_id": mutation_id,
+            "scope": scope,
+            "paths": [list(item) for item in ordered_paths],
+            "created_paths": list(ordered_created),
+        }
+        digest = hashlib.sha256(_DOMAIN + _canonical_json(value)).hexdigest()
+        return cls(
+            _VERSION,
+            generation,
+            mutation_id,
+            scope,
+            ordered_paths,
+            ordered_created,
+            digest,
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "generation": self.generation,
+            "mutation_id": self.mutation_id,
+            "scope": self.scope,
+            "paths": [list(item) for item in self.paths],
+            "created_paths": list(self.created_paths),
+            "checkpoint_sha256": self.checkpoint_sha256,
+        }
+
+    def render(self) -> str:
+        return _canonical_json(self.as_dict()).decode("utf-8")
+
+    @classmethod
+    def parse(cls, raw: str | bytes) -> GraphSyncCheckpoint | None:
+        try:
+            value = json.loads(raw, object_pairs_hook=_reject_duplicate_json_keys)
+            if not isinstance(value, dict) or set(value) != {
+                "version",
+                "generation",
+                "mutation_id",
+                "scope",
+                "paths",
+                "created_paths",
+                "checkpoint_sha256",
+            }:
+                return None
+            version = value["version"]
+            generation = value["generation"]
+            mutation_id = value["mutation_id"]
+            scope = value["scope"]
+            paths = value["paths"]
+            created_paths = value["created_paths"]
+            digest = value["checkpoint_sha256"]
+            if (
+                type(version) is not int
+                or version != _VERSION
+                or type(generation) is not int
+                or generation < 1
+                or not isinstance(mutation_id, str)
+                or _MUTATION_ID.fullmatch(mutation_id) is None
+                or not isinstance(scope, str)
+                or scope not in {"paths", "full"}
+                or not isinstance(paths, list)
+                or not isinstance(created_paths, list)
+                or not _is_digest(digest)
+            ):
+                return None
+            if len(paths) > _PATH_LIMIT or len(created_paths) > _PATH_LIMIT:
+                return None
+            normalized_paths: list[tuple[str, str | None]] = []
+            for item in paths:
+                if (
+                    not isinstance(item, list)
+                    or len(item) != 2
+                    or not isinstance(item[0], str)
+                    or (item[1] is not None and not _is_digest(item[1]))
+                    or not _is_canonical_relative_path(item[0])
+                ):
+                    return None
+                normalized_paths.append((item[0], item[1]))
+            if not all(_is_canonical_relative_path(item) for item in created_paths):
+                return None
+            if scope == "full" and (normalized_paths or created_paths):
+                return None
+            if scope == "paths" and (
+                len({path for path, _content_hash in normalized_paths}) != len(normalized_paths)
+                or len(set(created_paths)) != len(created_paths)
+                or not set(created_paths).issubset(
+                    {path for path, content_hash in normalized_paths if content_hash is not None}
+                )
+            ):
+                return None
+            # Checkpoints are canonical bytes, not a loose semantic form.  Do
+            # not accept inputs that `create()` would normalize before hashing.
+            if scope == "paths" and (
+                tuple(normalized_paths) != tuple(sorted(normalized_paths))
+                or tuple(created_paths) != tuple(sorted(created_paths))
+            ):
+                return None
+            checkpoint = cls.create(
+                generation=generation,
+                mutation_id=mutation_id,
+                paths=tuple(normalized_paths),
+                created_paths=tuple(created_paths),
+                scope=scope,
+            )
+            return checkpoint if checkpoint.checkpoint_sha256 == digest else None
+        except (RecursionError, TypeError, ValueError, UnicodeDecodeError):
+            return None
+
+
+@dataclass(frozen=True)
+class GraphCommitReceipt:
+    """Closed, content-free evidence for one claimed canonical graph write.
+
+    This receipt is intentionally a second protocol step: its terminal
+    projection exists only after the caller's canonical batch has returned.
+    Therefore a crash after canonical files but before a committed receipt is
+    still outcome-unknown and must never be inferred from vault similarity.
+    """
+
+    version: int
+    idempotency_key_digest: str
+    command_digest: str
+    attempt_id: str
+    commit_token: str
+    canonical_disposition: str | None
+    terminal_projection: dict[str, Any]
+    terminal_projection_sha256: str
+    checkpoint_generation: int | None
+    checkpoint_sha256: str | None
+    receipt_hmac_sha256: str | None
+    # V1 only. It remains parseable as portable advisory evidence, but no
+    # current code may treat it as authority for a canonical retry.
+    commit_point: bool | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        idempotency_key_digest: str,
+        command_digest: str,
+        attempt_id: str,
+        commit_token: str,
+        canonical_disposition: str,
+        terminal_projection: dict[str, Any],
+        checkpoint_generation: int | None = None,
+        checkpoint_sha256: str | None = None,
+        commit_secret: bytes,
+    ) -> GraphCommitReceipt:
+        if not _is_digest(idempotency_key_digest) or not _is_digest(command_digest):
+            raise ValueError("receipt digests must be lowercase SHA-256")
+        if _MUTATION_ID.fullmatch(attempt_id) is None or _MUTATION_ID.fullmatch(commit_token) is None:
+            raise ValueError("receipt attempt and commit token must be lowercase 24-hex")
+        if canonical_disposition not in {"success", "committed_failure"}:
+            raise ValueError("receipt canonical disposition is invalid")
+        if (checkpoint_generation is None) != (checkpoint_sha256 is None):
+            raise ValueError("receipt checkpoint generation and digest must be paired")
+        if checkpoint_generation is not None and (
+            type(checkpoint_generation) is not int
+            or checkpoint_generation < 1
+            or not _is_digest(checkpoint_sha256)
+        ):
+            raise ValueError("receipt checkpoint is invalid")
+        if not isinstance(commit_secret, bytes) or len(commit_secret) != 32:
+            raise ValueError("receipt commit secret must be exactly 32 bytes")
+        if not _is_receipt_terminal_projection(terminal_projection):
+            raise ValueError("receipt terminal projection must be bounded and content-free")
+        projected = dict(sorted(terminal_projection.items()))
+        terminal_digest = hashlib.sha256(
+            _RECEIPT_TERMINAL_DOMAIN + _canonical_json(projected)
+        ).hexdigest()
+        unsigned = {
+            "version": 2,
+            "idempotency_key_digest": idempotency_key_digest,
+            "command_digest": command_digest,
+            "attempt_id": attempt_id,
+            "commit_token": commit_token,
+            "canonical_disposition": canonical_disposition,
+            "terminal_projection": projected,
+            "terminal_projection_sha256": terminal_digest,
+            "checkpoint_generation": checkpoint_generation,
+            "checkpoint_sha256": checkpoint_sha256,
+        }
+        return cls(
+            2,
+            idempotency_key_digest,
+            command_digest,
+            attempt_id,
+            commit_token,
+            canonical_disposition,
+            projected,
+            terminal_digest,
+            checkpoint_generation,
+            checkpoint_sha256,
+            hmac.new(
+                commit_secret, _RECEIPT_AUTH_DOMAIN + _canonical_json(unsigned), hashlib.sha256
+            ).hexdigest(),
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "version": self.version,
+            "idempotency_key_digest": self.idempotency_key_digest,
+            "command_digest": self.command_digest,
+            "attempt_id": self.attempt_id,
+            "commit_token": self.commit_token,
+        }
+        if self.version == 2:
+            value["canonical_disposition"] = self.canonical_disposition
+            value["terminal_projection"] = self.terminal_projection
+            value["terminal_projection_sha256"] = self.terminal_projection_sha256
+            value["checkpoint_generation"] = self.checkpoint_generation
+            value["checkpoint_sha256"] = self.checkpoint_sha256
+            value["receipt_hmac_sha256"] = self.receipt_hmac_sha256
+        else:
+            value["terminal_projection"] = self.terminal_projection
+            value["terminal_projection_sha256"] = self.terminal_projection_sha256
+            value["checkpoint_generation"] = self.checkpoint_generation
+            value["checkpoint_sha256"] = self.checkpoint_sha256
+            value["commit_point"] = self.commit_point
+        return value
+
+    def render(self) -> str:
+        return _canonical_json(self.as_dict()).decode("utf-8")
+
+    def verify(
+        self,
+        commit_secret: bytes,
+        *,
+        idempotency_key_digest: str,
+        command_digest: str,
+        attempt_id: str,
+        commit_token: str,
+    ) -> bool:
+        """Verify v2 receipt authority against the private local attempt key."""
+        if (
+            self.version != 2
+            or not isinstance(commit_secret, bytes)
+            or len(commit_secret) != 32
+            or not isinstance(self.receipt_hmac_sha256, str)
+            or self.idempotency_key_digest != idempotency_key_digest
+            or self.command_digest != command_digest
+            or self.attempt_id != attempt_id
+            or self.commit_token != commit_token
+            or self.canonical_disposition not in {"success", "committed_failure"}
+        ):
+            return False
+        unsigned = self.as_dict()
+        unsigned.pop("receipt_hmac_sha256", None)
+        expected = hmac.new(
+            commit_secret, _RECEIPT_AUTH_DOMAIN + _canonical_json(unsigned), hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(self.receipt_hmac_sha256, expected)
+
+    @classmethod
+    def parse(cls, raw: str | bytes) -> GraphCommitReceipt | None:
+        try:
+            value = json.loads(raw, object_pairs_hook=_reject_duplicate_json_keys)
+            if not isinstance(value, dict):
+                return None
+            legacy_common = {
+                "version",
+                "idempotency_key_digest",
+                "command_digest",
+                "attempt_id",
+                "commit_token",
+                "terminal_projection",
+                "terminal_projection_sha256",
+                "checkpoint_generation",
+                "checkpoint_sha256",
+            }
+            version = value.get("version")
+            if version == 2:
+                if (
+                    set(value) != legacy_common | {"canonical_disposition", "receipt_hmac_sha256"}
+                    or not _is_digest(value["receipt_hmac_sha256"])
+                    or not _is_exact_canonical_json(raw, value)
+                ):
+                    return None
+                receipt = cls.create(
+                    idempotency_key_digest=value["idempotency_key_digest"],
+                    command_digest=value["command_digest"],
+                    attempt_id=value["attempt_id"],
+                    commit_token=value["commit_token"],
+                    canonical_disposition=value["canonical_disposition"],
+                    terminal_projection=value["terminal_projection"],
+                    checkpoint_generation=value["checkpoint_generation"],
+                    checkpoint_sha256=value["checkpoint_sha256"],
+                    # Parsing validates structure first; this throwaway key
+                    # is never authority. `verify()` checks the stored MAC.
+                    commit_secret=b"\0" * 32,
+                )
+                if (
+                    not _is_digest(value["terminal_projection_sha256"])
+                    or value["terminal_projection_sha256"]
+                    != receipt.terminal_projection_sha256
+                ):
+                    return None
+                return cls(
+                    receipt.version,
+                    receipt.idempotency_key_digest,
+                    receipt.command_digest,
+                    receipt.attempt_id,
+                    receipt.commit_token,
+                    receipt.canonical_disposition,
+                    receipt.terminal_projection,
+                    receipt.terminal_projection_sha256,
+                    receipt.checkpoint_generation,
+                    receipt.checkpoint_sha256,
+                    value["receipt_hmac_sha256"],
+                )
+            if set(value) != legacy_common | {"commit_point"}:
+                return None
+            if type(value["version"]) is not int or value["version"] != 1 or type(value["commit_point"]) is not bool:
+                return None
+            # V1 is deliberately parse-only: it has no private proof and
+            # must never promote an executing local mutation.
+            projected = value["terminal_projection"]
+            if not isinstance(projected, dict) or not projected:
+                return None
+            receipt = cls.create(
+                idempotency_key_digest=value["idempotency_key_digest"],
+                command_digest=value["command_digest"],
+                attempt_id=value["attempt_id"],
+                commit_token=value["commit_token"],
+                canonical_disposition="success",
+                terminal_projection=projected,
+                checkpoint_generation=value["checkpoint_generation"],
+                checkpoint_sha256=value["checkpoint_sha256"],
+                commit_secret=b"\0" * 32,
+            )
+            legacy = cls(
+                1,
+                receipt.idempotency_key_digest,
+                receipt.command_digest,
+                receipt.attempt_id,
+                receipt.commit_token,
+                None,
+                receipt.terminal_projection,
+                receipt.terminal_projection_sha256,
+                receipt.checkpoint_generation,
+                receipt.checkpoint_sha256,
+                None,
+                value["commit_point"],
+            )
+            return (
+                legacy
+                if value["terminal_projection_sha256"] == legacy.terminal_projection_sha256
+                and legacy.as_dict() == value
+                else None
+            )
+        except (RecursionError, TypeError, ValueError, UnicodeDecodeError):
+            return None
+
+
+@dataclass(frozen=True)
+class GraphSyncGenerationFloor:
+    """Closed internal proof that a graph-sync generation was issued."""
+
+    version: int
+    generation: int
+    floor_sha256: str
+
+    @classmethod
+    def create(cls, generation: int) -> GraphSyncGenerationFloor:
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 1:
+            raise ValueError("generation must be a positive integer")
+        value = {"version": _VERSION, "generation": generation}
+        return cls(
+            _VERSION,
+            generation,
+            hashlib.sha256(_FLOOR_DOMAIN + _canonical_json(value)).hexdigest(),
+        )
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "version": self.version,
+            "generation": self.generation,
+            "floor_sha256": self.floor_sha256,
+        }
+
+    def render(self) -> str:
+        return _canonical_json(self.as_dict()).decode("utf-8")
+
+    @classmethod
+    def parse(cls, raw: str | bytes) -> GraphSyncGenerationFloor | None:
+        try:
+            value = json.loads(raw, object_pairs_hook=_reject_duplicate_json_keys)
+            if not isinstance(value, dict) or set(value) != {
+                "version",
+                "generation",
+                "floor_sha256",
+            }:
+                return None
+            if (
+                type(value["version"]) is not int
+                or value["version"] != _VERSION
+                or type(value["generation"]) is not int
+            ):
+                return None
+            if not isinstance(value["floor_sha256"], str):
+                return None
+            floor = cls.create(value["generation"])
+            return floor if floor.floor_sha256 == value["floor_sha256"] else None
+        except (RecursionError, TypeError, ValueError, UnicodeDecodeError):
+            return None
+
+
+@dataclass(frozen=True)
+class GraphDeletionEpoch:
+    """Recoverable floor-before-rename graph epoch for one lifecycle transition."""
+
+    vault_root: Path
+    checkpoint: GraphSyncCheckpoint
+    prior_floor_bytes: bytes | None
+    prior_checkpoint_bytes: bytes | None
+
+
+class GraphLifecycleRollbackError(RuntimeError):
+    """A caught lifecycle transition could not be restored safely."""
+
+
+class GraphLifecycleEpochSetupError(RuntimeError):
+    """Epoch staging failed and was rolled back before a lifecycle rename."""
+
+
+@dataclass
+class GraphLifecycleTransition:
+    """One reversible lifecycle rename and its graph epoch handoff.
+
+    The lifecycle marker is deliberately created before the floor.  The floor
+    then makes an abrupt post-rename interruption durable for reconcile.  A
+    caught failure takes the inverse route here, rather than allowing each
+    caller to independently forget one half of that protocol.
+    """
+
+    operation: Any
+    source: Path
+    destination: Path
+    recovery: bool
+    epoch: GraphDeletionEpoch | None
+    renamed: bool = False
+    completed: bool = False
+
+    def rename(self) -> None:
+        from .governance import lifecycle
+
+        lifecycle.atomic_rename(
+            self.operation,
+            source=self.source,
+            destination=self.destination,
+            recovery=self.recovery,
+        )
+        self.renamed = True
+
+    def publish_checkpoint(self) -> None:
+        if self.epoch is not None:
+            commit_deletion_epoch(self.epoch)
+        self.completed = True
+
+    def abort(self) -> None:
+        """Reverse a caught pre-commit transition or retain honest evidence."""
+        from .governance import lifecycle
+
+        try:
+            if self.renamed:
+                lifecycle.atomic_rename(
+                    self.operation,
+                    source=self.destination,
+                    destination=self.source,
+                    recovery=True,
+                )
+                self.renamed = False
+            if self.epoch is not None:
+                restore_deletion_epoch(self.epoch)
+            if self.recovery:
+                lifecycle.abort_recovery(self.operation)
+            else:
+                lifecycle.abort_deletion(self.operation)
+        except Exception as error:  # noqa: BLE001 - retain lifecycle evidence for reconcile
+            raise GraphLifecycleRollbackError(
+                "lifecycle transition could not be restored; reconcile is required"
+            ) from error
+
+
+def begin_deletion_transition(
+    vault_root: Path,
+    *,
+    source_rel: str,
+    trash_rel: str,
+    removed_rel_paths: Iterable[str],
+) -> GraphLifecycleTransition:
+    """Create the deletion marker and staged graph floor as one abortable unit."""
+    from .governance import lifecycle
+
+    operation = lifecycle.begin_deletion(
+        vault_root, source_rel=source_rel, trash_rel=trash_rel
+    )
+    root = Path(vault_root)
+    prior_floor: bytes | None = None
+    prior_checkpoint: bytes | None = None
+    captured_prior = False
+    epoch_staging_mutated = False
+    try:
+        prior_floor = _prior_artifact_bytes(floor_path(root))
+        prior_checkpoint = _prior_artifact_bytes(checkpoint_path(root))
+        captured_prior = True
+        epoch = prepare_deletion_epoch(vault_root, removed_rel_paths)
+    except Exception as error:
+        try:
+            if captured_prior:
+                epoch_staging_mutated = _epoch_artifacts_changed(
+                    root, prior_floor, prior_checkpoint
+                )
+            if epoch_staging_mutated:
+                _restore_epoch_artifacts(root, prior_floor, prior_checkpoint)
+            lifecycle.abort_deletion(operation)
+        except Exception as rollback_error:  # noqa: BLE001 - preserve durable repair evidence
+            raise GraphLifecycleRollbackError(
+                "staged deletion epoch could not be restored; reconcile is required"
+            ) from rollback_error
+        raise GraphLifecycleEpochSetupError(
+            "could not establish the graph deletion epoch"
+        ) from error
+    return GraphLifecycleTransition(
+        operation,
+        Path(vault_root) / source_rel,
+        Path(vault_root) / trash_rel,
+        False,
+        epoch,
+    )
+
+
+def begin_recovery_transition(
+    vault_root: Path,
+    *,
+    trash_rel: str,
+    source_rel: str,
+    restored_paths: Iterable[tuple[str, str]],
+) -> GraphLifecycleTransition:
+    """Create recovery evidence and its staged graph floor under one abort path."""
+    from .governance import lifecycle
+
+    operation = lifecycle.begin_recovery(
+        vault_root, trash_rel=trash_rel, source_rel=source_rel
+    )
+    root = Path(vault_root)
+    prior_floor: bytes | None = None
+    prior_checkpoint: bytes | None = None
+    captured_prior = False
+    epoch_staging_mutated = False
+    try:
+        prior_floor = _prior_artifact_bytes(floor_path(root))
+        prior_checkpoint = _prior_artifact_bytes(checkpoint_path(root))
+        captured_prior = True
+        epoch = prepare_recovery_epoch(vault_root, restored_paths)
+    except Exception as error:
+        try:
+            if captured_prior:
+                epoch_staging_mutated = _epoch_artifacts_changed(
+                    root, prior_floor, prior_checkpoint
+                )
+            if epoch_staging_mutated:
+                _restore_epoch_artifacts(root, prior_floor, prior_checkpoint)
+            lifecycle.abort_recovery(operation)
+        except Exception as rollback_error:  # noqa: BLE001 - preserve durable repair evidence
+            raise GraphLifecycleRollbackError(
+                "staged recovery epoch could not be restored; reconcile is required"
+            ) from rollback_error
+        raise GraphLifecycleEpochSetupError(
+            "could not establish the graph recovery epoch"
+        ) from error
+    return GraphLifecycleTransition(
+        operation,
+        Path(vault_root) / trash_rel,
+        Path(vault_root) / source_rel,
+        True,
+        epoch,
+    )
+
+
+def next_checkpoint(
+    *,
+    current: GraphSyncCheckpoint | None,
+    acknowledged_generation: int,
+    floor_generation: int = 0,
+    mutation_id: str,
+    paths: list[tuple[str, str | None]],
+    created_paths: list[str],
+    force_full_scope: bool = False,
+) -> GraphSyncCheckpoint:
+    generation = max(current.generation if current else 0, acknowledged_generation, floor_generation) + 1
+    scope = "full" if force_full_scope or len(paths) > _PATH_LIMIT else "paths"
+    return GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=mutation_id,
+        paths=tuple(paths),
+        created_paths=tuple(created_paths),
+        scope=scope,
+    )
+
+
+def checkpoint_path(vault_root: Path) -> Path:
+    from .kbdir import kb_dirname
+
+    return Path(vault_root) / kb_dirname() / _CHECKPOINT_FILENAME
+
+
+def floor_path(vault_root: Path) -> Path:
+    from .kbdir import kb_dirname
+
+    return Path(vault_root) / kb_dirname() / _FLOOR_FILENAME
+
+
+def graph_commit_receipt_path(vault_root: Path, commit_token: str) -> Path:
+    """Return the hidden portable receipt location for one opaque claim token."""
+    if _MUTATION_ID.fullmatch(commit_token) is None:
+        raise ValueError("receipt commit token must be lowercase 24-hex")
+    from .kbdir import kb_dirname
+
+    return Path(vault_root) / kb_dirname() / _RECEIPT_DIRNAME / f"{commit_token}.json"
+
+
+def read_graph_commit_receipt(
+    vault_root: Path, commit_token: str
+) -> GraphCommitReceipt | None:
+    try:
+        raw = _read_bounded_bytes(
+            graph_commit_receipt_path(vault_root, commit_token),
+            limit=_RECEIPT_READ_LIMIT,
+            vault_root=Path(vault_root),
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return GraphCommitReceipt.parse(raw)
+
+
+def write_graph_commit_receipt(vault_root: Path, receipt: GraphCommitReceipt) -> Path:
+    """Persist one receipt after a caller batch without manufacturing a commit.
+
+    The caller leaf's terminal projection does not exist until its canonical
+    batch has returned.  This intentionally leaves the canonical-file-before-
+    receipt cut outcome-unknown until the later idempotency protocol writes the
+    receipt marker and advances its retry row.
+    """
+    from .vault import PlannedWrite, batch_atomic_write
+
+    path = graph_commit_receipt_path(vault_root, receipt.commit_token)
+    batch_atomic_write(
+        [PlannedWrite(path, receipt.render())],
+        vault_root=vault_root,
+        post_commit_fanout=False,
+        commit_point=False,
+    )
+    return path
+
+
+def floor_state(vault_root: Path) -> tuple[str, GraphSyncGenerationFloor | None]:
+    try:
+        raw = _read_bounded_bytes(
+            floor_path(vault_root), limit=_FLOOR_READ_LIMIT, vault_root=Path(vault_root)
+        )
+    except FileNotFoundError:
+        return "absent", None
+    except (OSError, ValueError):
+        return "malformed", None
+    floor = GraphSyncGenerationFloor.parse(raw)
+    return ("valid", floor) if floor is not None else ("malformed", None)
+
+
+def read_floor(vault_root: Path) -> GraphSyncGenerationFloor | None:
+    return floor_state(vault_root)[1]
+
+
+def read_checkpoint(vault_root: Path) -> GraphSyncCheckpoint | None:
+    _state, checkpoint = checkpoint_state(vault_root)
+    return checkpoint
+
+
+def checkpoint_state(vault_root: Path) -> tuple[str, GraphSyncCheckpoint | None]:
+    """Return whether the durable handoff is absent, valid, or malformed."""
+    path = checkpoint_path(vault_root)
+    try:
+        raw = _read_bounded_bytes(path, limit=_CHECKPOINT_READ_LIMIT, vault_root=Path(vault_root))
+    except FileNotFoundError:
+        return "absent", None
+    except (OSError, ValueError):
+        return "malformed", None
+    checkpoint = GraphSyncCheckpoint.parse(raw)
+    return ("valid", checkpoint) if checkpoint is not None else ("malformed", None)
+
+
+def is_graph_input_path(relative_path: str) -> bool:
+    normalized = relative_path.replace("\\", "/")
+    return (
+        not normalized.endswith((f"/{_CHECKPOINT_FILENAME}", f"/{_FLOOR_FILENAME}"))
+        and f"/{_RECEIPT_DIRNAME}/" not in f"/{normalized.lstrip('/')}"
+    )
+
+
+def acknowledged_generation(vault_root: Path) -> int:
+    acknowledged = acknowledged_checkpoint(vault_root)
+    return acknowledged.generation if acknowledged is not None else 0
+
+
+def acknowledged_checkpoint(vault_root: Path) -> GraphBuildOutcome | None:
+    return acknowledgement_state(vault_root)[1]
+
+
+def acknowledgement_state(vault_root: Path) -> tuple[str, GraphBuildOutcome | None]:
+    """Return whether the live sidecar has no, valid, or malformed graph ack."""
+    from .epistemic_graph import sidecar_path
+
+    path = sidecar_path(vault_root)
+    if not path.exists():
+        return "absent", None
+    try:
+        with sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True) as conn:
+            limit_graph_metadata_read(conn)
+            values = dict(
+                conn.execute(
+                    "SELECT key, value FROM graph_meta WHERE key IN "
+                    "('graph_sync_generation', 'graph_sync_digest', 'graph_sync_checkpoint')"
+                )
+            )
+        if not values:
+            return "absent", None
+        if set(values) != {
+            "graph_sync_generation",
+            "graph_sync_digest",
+            "graph_sync_checkpoint",
+        }:
+            return "malformed", None
+        generation_raw = values["graph_sync_generation"]
+        digest = values["graph_sync_digest"]
+        rendered_checkpoint = values["graph_sync_checkpoint"]
+        if (
+            not isinstance(generation_raw, str)
+            or not generation_raw.isascii()
+            or not generation_raw.isdecimal()
+            or generation_raw.startswith("0")
+            or not _is_digest(digest)
+        ):
+            return "malformed", None
+        generation = int(generation_raw)
+        checkpoint = GraphSyncCheckpoint.parse(rendered_checkpoint)
+        if (
+            generation < 1
+            or checkpoint is None
+            or checkpoint.generation != generation
+            or checkpoint.checkpoint_sha256 != digest
+        ):
+            return "malformed", None
+        return "valid", GraphBuildOutcome.covering(checkpoint)
+    except (KeyError, OSError, sqlite3.Error, ValueError):
+        return "malformed", None
+
+
+def _malformed_acknowledgement_generation(vault_root: Path) -> int | None:
+    """Return only a canonical generation hint from an otherwise malformed ack."""
+    from .epistemic_graph import sidecar_path
+
+    path = sidecar_path(vault_root)
+    if not path.exists():
+        return None
+    try:
+        with sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True) as conn:
+            limit_graph_metadata_read(conn)
+            row = conn.execute(
+                "SELECT value FROM graph_meta WHERE key = 'graph_sync_generation'"
+            ).fetchone()
+        value = row[0] if row is not None else None
+        if (
+            not isinstance(value, str)
+            or not value.isascii()
+            or not value.isdecimal()
+            or value.startswith("0")
+        ):
+            return None
+        generation = int(value)
+        return generation if generation >= 1 else None
+    except (OSError, sqlite3.Error, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class GraphPublicationEpoch:
+    """A parse-complete epoch that may be used for one private build pass."""
+
+    floor: GraphSyncGenerationFloor | None
+    checkpoint: GraphSyncCheckpoint | None
+    acknowledgement: GraphBuildOutcome | None
+
+
+@dataclass(frozen=True)
+class GraphEpochState:
+    """Classify durable graph epoch inputs before advancing or publishing them."""
+
+    kind: str
+    floor: GraphSyncGenerationFloor | None
+    checkpoint: GraphSyncCheckpoint | None
+    acknowledgement: GraphBuildOutcome | None
+
+    @property
+    def requires_full_recovery(self) -> bool:
+        return self.kind == "recoverable"
+
+
+def classify_epoch(vault_root: Path) -> GraphEpochState:
+    """Return the only closed floor/checkpoint/ack combinations we can act on.
+
+    A valid floor is an issued-generation proof.  If its matching checkpoint was
+    interrupted, the next event must supersede it with full-vault coverage; it
+    may not reuse the floor generation or pretend the partial caller batch was
+    path-scoped.  Missing or malformed floors remain ambiguous outside the two
+    explicitly supported legacy migration states.
+    """
+    floor_status, floor = floor_state(vault_root)
+    checkpoint_status, checkpoint = checkpoint_state(vault_root)
+    acknowledgement_status, acknowledgement = acknowledgement_state(vault_root)
+    if (
+        floor_status == "absent"
+        and checkpoint_status == "absent"
+        and acknowledgement_status == "absent"
+    ):
+        return GraphEpochState("legacy", None, None, None)
+    if (
+        floor_status == "absent"
+        and checkpoint_status == "valid"
+        and checkpoint is not None
+        and acknowledgement_status in {"absent", "valid"}
+        and (
+            acknowledgement is None
+            or acknowledgement == GraphBuildOutcome.covering(checkpoint)
+        )
+    ):
+        return GraphEpochState("pre_floor", None, checkpoint, acknowledgement)
+    if floor_status != "valid" or floor is None or acknowledgement_status not in {"absent", "valid"}:
+        return GraphEpochState("unavailable", floor, checkpoint, acknowledgement)
+    if acknowledgement is not None and acknowledgement.generation > floor.generation:
+        return GraphEpochState("unavailable", floor, checkpoint, acknowledgement)
+    if (
+        checkpoint_status == "valid"
+        and checkpoint is not None
+        and checkpoint.generation == floor.generation
+    ):
+        if acknowledgement is None or acknowledgement.generation < checkpoint.generation:
+            return GraphEpochState("coherent", floor, checkpoint, acknowledgement)
+        if acknowledgement == GraphBuildOutcome.covering(checkpoint):
+            return GraphEpochState("coherent", floor, checkpoint, acknowledgement)
+        return GraphEpochState("unavailable", floor, checkpoint, acknowledgement)
+    if checkpoint_status in {"absent", "malformed"} or (
+        checkpoint_status == "valid"
+        and checkpoint is not None
+        and checkpoint.generation < floor.generation
+    ):
+        return GraphEpochState("recoverable", floor, checkpoint, acknowledgement)
+    return GraphEpochState("unavailable", floor, checkpoint, acknowledgement)
+
+
+def publication_epoch(vault_root: Path) -> GraphPublicationEpoch:
+    """Read the only floor/checkpoint/ack states safe to publish over.
+
+    A full builder may consume exact legacy state, accepted pre-floor migration,
+    or a valid floor/checkpoint epoch with an absent, predecessor, or exact
+    acknowledgement. Any parse failure or contradictory lineage must be
+    recovered before it can reach the sidecar replacement seam.
+    """
+    for _attempt in range(2):
+        epoch = classify_epoch(vault_root)
+        if epoch.kind in {"legacy", "pre_floor", "coherent"}:
+            return GraphPublicationEpoch(
+                epoch.floor, epoch.checkpoint, epoch.acknowledgement
+            )
+    floor_status, floor = floor_state(vault_root)
+    checkpoint_status, checkpoint = checkpoint_state(vault_root)
+    acknowledgement_status, _acknowledgement = acknowledgement_state(vault_root)
+    malformed_generation = (
+        _malformed_acknowledgement_generation(vault_root)
+        if acknowledgement_status == "malformed"
+        else None
+    )
+    if (
+        floor_status == "valid"
+        and floor is not None
+        and checkpoint_status == "valid"
+        and checkpoint is not None
+        and checkpoint.generation == floor.generation
+        and checkpoint.scope == "full"
+        and malformed_generation is not None
+        and malformed_generation < checkpoint.generation
+    ):
+        return GraphPublicationEpoch(floor, checkpoint, None)
+    raise GraphEpochIncoherent("graph floor/checkpoint/ack epoch is not coherent for publication")
+
+
+def canonical_publication_epoch(vault_root: Path) -> GraphPublicationEpoch:
+    """Read the bounded canonical epoch used by a private publication ticket.
+
+    This deliberately consults only the floor and checkpoint artifacts.  The
+    sidecar acknowledgement is derived state and must never be opened from the
+    short canonical publication hold.
+    """
+    floor_status, floor = floor_state(vault_root)
+    checkpoint_status, checkpoint = checkpoint_state(vault_root)
+    if floor_status == "absent" and checkpoint_status == "absent":
+        return GraphPublicationEpoch(None, None, None)
+    if floor_status == "absent" and checkpoint_status == "valid" and checkpoint is not None:
+        return GraphPublicationEpoch(None, checkpoint, None)
+    if (
+        floor_status == "valid"
+        and floor is not None
+        and checkpoint_status == "valid"
+        and checkpoint is not None
+        and checkpoint.generation == floor.generation
+    ):
+        return GraphPublicationEpoch(floor, checkpoint, None)
+    raise GraphEpochIncoherent("graph floor/checkpoint epoch is not coherent for publication")
+
+
+def _admit_epoch_inputs(
+    vault_root: Path,
+) -> GraphEpochState:
+    epoch = classify_epoch(vault_root)
+    if epoch.kind in {"legacy", "pre_floor", "coherent", "recoverable"}:
+        return epoch
+    raise GraphEpochIncoherent("graph floor/checkpoint epoch is malformed or ambiguous")
+
+
+def epoch_writes(
+    vault_root: Path, writes: Iterable[PlannedWrite]
+) -> tuple[PlannedWrite, PlannedWrite] | None:
+    """Build ordered internal epoch replacements for canonical Markdown writes.
+
+    The import stays here to keep the vault writer free of a module cycle.
+    """
+    from . import recall_policy
+    from .kbdir import kb_dirname
+    from .vault import PlannedWrite, content_hash, in_excluded_scan_dir
+
+    # Keep emitted internal writes in the caller's path namespace.  On Windows
+    # a caller may legitimately use an 8.3 or case variant while ``resolve``
+    # returns the long canonical spelling; mixing the two makes a guarded
+    # directory census treat the epoch artifacts as unrelated changes.
+    root = Path(vault_root)
+    resolved_root = root.resolve()
+    paths: list[tuple[str, str | None]] = []
+    created_paths: list[str] = []
+    for write in writes:
+        try:
+            relative = write.path.resolve().relative_to(resolved_root).as_posix()
+        except (OSError, ValueError):
+            continue
+        if (
+            not relative.endswith(".md")
+            or not relative.startswith(f"{kb_dirname()}/")
+            or not is_graph_input_path(relative)
+            or in_excluded_scan_dir(relative)
+            or recall_policy.is_structured_only_path(root, relative)
+        ):
+            continue
+        paths.append((relative, content_hash(write.content)))
+        if not write.path.exists():
+            created_paths.append(relative)
+    if not paths:
+        return None
+    mutation_id = _checkpoint_mutation_id()
+    epoch = _admit_epoch_inputs(root)
+    checkpoint = next_checkpoint(
+        current=epoch.checkpoint,
+        acknowledged_generation=(
+            epoch.acknowledgement.generation if epoch.acknowledgement is not None else 0
+        ),
+        floor_generation=epoch.floor.generation if epoch.floor is not None else 0,
+        mutation_id=mutation_id,
+        paths=paths,
+        created_paths=created_paths,
+        force_full_scope=epoch.requires_full_recovery,
+    )
+    return (
+        PlannedWrite(floor_path(root), GraphSyncGenerationFloor.create(checkpoint.generation).render()),
+        PlannedWrite(checkpoint_path(root), checkpoint.render()),
+    )
+
+
+def checkpoint_write(
+    vault_root: Path, writes: Iterable[PlannedWrite]
+) -> PlannedWrite | None:
+    """Compatibility helper for callers that need only the public checkpoint."""
+    epoch = epoch_writes(vault_root, writes)
+    return None if epoch is None else epoch[1]
+
+
+def recover_checkpoint(vault_root: Path) -> GraphSyncCheckpoint | None:
+    """Publish a full-scope recovery checkpoint without rewriting user Markdown."""
+    root = Path(vault_root)
+    epoch = _admit_epoch_inputs(root)
+    if epoch.kind == "legacy":
+        return None
+    if epoch.kind == "pre_floor":
+        assert epoch.checkpoint is not None
+        from .vault import PlannedWrite, batch_atomic_write
+
+        batch_atomic_write(
+            [
+                PlannedWrite(
+                    floor_path(root),
+                    GraphSyncGenerationFloor.create(
+                        epoch.checkpoint.generation
+                    ).render(),
+                )
+            ],
+            vault_root=root,
+            post_commit_fanout=False,
+            commit_point=False,
+        )
+        return epoch.checkpoint
+    if epoch.kind == "coherent":
+        return epoch.checkpoint
+    assert epoch.kind == "recoverable"
+    checkpoint = next_checkpoint(
+        current=epoch.checkpoint,
+        acknowledged_generation=(
+            epoch.acknowledgement.generation if epoch.acknowledgement is not None else 0
+        ),
+        floor_generation=epoch.floor.generation if epoch.floor is not None else 0,
+        mutation_id=secrets.token_hex(12),
+        paths=[],
+        created_paths=[],
+        force_full_scope=True,
+    )
+    from .vault import PlannedWrite, batch_atomic_write
+
+    batch_atomic_write(
+        [
+            PlannedWrite(
+                floor_path(root),
+                GraphSyncGenerationFloor.create(checkpoint.generation).render(),
+            ),
+            PlannedWrite(checkpoint_path(root), checkpoint.render()),
+        ],
+        vault_root=root,
+        post_commit_fanout=False,
+        commit_point=False,
+    )
+    return checkpoint
+
+
+def reconcile_checkpoint(vault_root: Path) -> GraphSyncCheckpoint:
+    """Return the exact full-scope checkpoint a graph-only repair will publish."""
+    root = Path(vault_root)
+    recovered = recover_checkpoint(root)
+    if recovered is not None:
+        return recovered
+    checkpoint = next_checkpoint(
+        current=None,
+        acknowledged_generation=0,
+        mutation_id=_checkpoint_mutation_id(),
+        paths=[],
+        created_paths=[],
+        force_full_scope=True,
+    )
+    from .vault import PlannedWrite, batch_atomic_write
+
+    batch_atomic_write(
+        [
+            PlannedWrite(
+                floor_path(root),
+                GraphSyncGenerationFloor.create(checkpoint.generation).render(),
+            ),
+            PlannedWrite(checkpoint_path(root), checkpoint.render()),
+        ],
+        vault_root=root,
+        post_commit_fanout=False,
+        commit_point=False,
+    )
+    return checkpoint
+
+
+def _write_floor(vault_root: Path, floor: GraphSyncGenerationFloor) -> None:
+    from .vault import PlannedWrite, batch_atomic_write
+
+    batch_atomic_write(
+        [PlannedWrite(floor_path(vault_root), floor.render())],
+        vault_root=vault_root,
+        post_commit_fanout=False,
+        commit_point=False,
+    )
+
+
+def _write_checkpoint(vault_root: Path, checkpoint: GraphSyncCheckpoint) -> None:
+    from .vault import PlannedWrite, batch_atomic_write
+
+    batch_atomic_write(
+        [PlannedWrite(checkpoint_path(vault_root), checkpoint.render())],
+        vault_root=vault_root,
+        post_commit_fanout=False,
+        commit_point=False,
+    )
+
+
+def _prior_artifact_bytes(path: Path) -> bytes | None:
+    try:
+        limit = _FLOOR_READ_LIMIT if path.name == _FLOOR_FILENAME else _CHECKPOINT_READ_LIMIT
+        return _read_bounded_bytes(path, limit=limit, vault_root=path.parent.parent)
+    except FileNotFoundError:
+        return None
+
+
+def _epoch_artifacts_changed(
+    vault_root: Path, prior_floor_bytes: bytes | None, prior_checkpoint_bytes: bytes | None
+) -> bool:
+    """Whether failed epoch staging changed either bounded protocol artifact."""
+    return (
+        _prior_artifact_bytes(floor_path(vault_root)) != prior_floor_bytes
+        or _prior_artifact_bytes(checkpoint_path(vault_root)) != prior_checkpoint_bytes
+    )
+
+
+def _read_bounded_bytes(path: Path, *, limit: int, vault_root: Path | None = None) -> bytes:
+    """Read one stable in-vault regular protocol artifact without following links."""
+    from .vault import PathGuardError, read_bounded_guarded_bytes
+
+    root = Path(vault_root) if vault_root is not None else Path(path).parent
+    try:
+        target = Path(path).absolute().relative_to(root.absolute()).as_posix()
+    except ValueError as error:
+        raise OSError("graph protocol artifact escaped its vault root") from error
+    try:
+        raw, _guard = read_bounded_guarded_bytes(root, target, limit=limit)
+    except PathGuardError as error:
+        try:
+            Path(path).lstat()
+        except FileNotFoundError:
+            raise
+        raise OSError("graph protocol artifact could not be safely read") from error
+    return raw
+
+
+def _checkpoint_mutation_id() -> str:
+    try:
+        from .writer_lease import active_mutation_claim_token
+
+        mutation_id = active_mutation_claim_token() or secrets.token_hex(12)
+    except Exception:  # noqa: BLE001 - standalone writer fallback
+        mutation_id = secrets.token_hex(12)
+    return mutation_id if _MUTATION_ID.fullmatch(mutation_id) is not None else secrets.token_hex(12)
+
+
+def prepare_deletion_epoch(
+    vault_root: Path, removed_rel_paths: Iterable[str]
+) -> GraphDeletionEpoch | None:
+    """Publish deletion floor before the lifecycle rename, retaining rollback proof."""
+    from . import recall_policy
+
+    root = Path(vault_root).resolve()
+    paths: list[tuple[str, str | None]] = [
+        (rel, None)
+        for raw in removed_rel_paths
+        if (rel := str(raw).replace("\\", "/")).endswith(".md")
+        and rel.startswith(f"{checkpoint_path(root).parent.name}/")
+        and is_graph_input_path(rel)
+        and not recall_policy.is_structured_only_path(root, rel)
+        and recall_policy.is_recall_candidate(root, root / rel)
+    ]
+    if not paths:
+        return None
+    prior_bytes = _prior_artifact_bytes(floor_path(root))
+    prior_checkpoint_bytes = _prior_artifact_bytes(checkpoint_path(root))
+    epoch = _admit_epoch_inputs(root)
+    checkpoint = next_checkpoint(
+        current=epoch.checkpoint,
+        acknowledged_generation=(
+            epoch.acknowledgement.generation if epoch.acknowledgement is not None else 0
+        ),
+        floor_generation=epoch.floor.generation if epoch.floor is not None else 0,
+        mutation_id=_checkpoint_mutation_id(),
+        paths=paths,
+        created_paths=[],
+        force_full_scope=epoch.requires_full_recovery,
+    )
+    _write_floor(root, GraphSyncGenerationFloor.create(checkpoint.generation))
+    return GraphDeletionEpoch(root, checkpoint, prior_bytes, prior_checkpoint_bytes)
+
+
+def prepare_recovery_epoch(
+    vault_root: Path,
+    restored_paths: Iterable[tuple[str, str]],
+) -> GraphDeletionEpoch | None:
+    """Publish the restore floor before moving graph-relevant Markdown from trash."""
+    from . import recall_policy
+
+    root = Path(vault_root).resolve()
+    paths: list[tuple[str, str | None]] = [
+        (rel, content_hash)
+        for raw_rel, raw_content in restored_paths
+        if (rel := str(raw_rel).replace("\\", "/")).endswith(".md")
+        and rel.startswith(f"{checkpoint_path(root).parent.name}/")
+        and is_graph_input_path(rel)
+        and not recall_policy.is_structured_only_path(root, rel)
+        and isinstance(raw_content, str)
+        and (content_hash := raw_content)
+    ]
+    if not paths:
+        return None
+    prior_bytes = _prior_artifact_bytes(floor_path(root))
+    prior_checkpoint_bytes = _prior_artifact_bytes(checkpoint_path(root))
+    epoch = _admit_epoch_inputs(root)
+    checkpoint = next_checkpoint(
+        current=epoch.checkpoint,
+        acknowledged_generation=(
+            epoch.acknowledgement.generation if epoch.acknowledgement is not None else 0
+        ),
+        floor_generation=epoch.floor.generation if epoch.floor is not None else 0,
+        mutation_id=_checkpoint_mutation_id(),
+        paths=paths,
+        created_paths=[rel for rel, _content_hash in paths],
+        force_full_scope=epoch.requires_full_recovery,
+    )
+    _write_floor(root, GraphSyncGenerationFloor.create(checkpoint.generation))
+    return GraphDeletionEpoch(root, checkpoint, prior_bytes, prior_checkpoint_bytes)
+
+
+def commit_deletion_epoch(epoch: GraphDeletionEpoch) -> None:
+    """Install the exact checkpoint after the lifecycle rename succeeds."""
+    _write_checkpoint(epoch.vault_root, epoch.checkpoint)
+
+
+def restore_deletion_epoch(epoch: GraphDeletionEpoch) -> None:
+    """Restore exact pre-transition floor and checkpoint bytes after a caught failure."""
+    _restore_epoch_artifacts(
+        epoch.vault_root, epoch.prior_floor_bytes, epoch.prior_checkpoint_bytes
+    )
+
+
+def _restore_epoch_artifacts(
+    vault_root: Path, prior_floor_bytes: bytes | None, prior_checkpoint_bytes: bytes | None
+) -> None:
+    """Restore exact internal epoch bytes without invoking a caller commit point."""
+    from .vault import PlannedWrite, batch_atomic_write
+
+    restores = (
+        (checkpoint_path(vault_root), prior_checkpoint_bytes),
+        (floor_path(vault_root), prior_floor_bytes),
+    )
+    writes = [
+        PlannedWrite(path, raw.decode("utf-8"))
+        for path, raw in restores
+        if raw is not None
+    ]
+    if writes:
+        batch_atomic_write(
+            writes,
+            vault_root=vault_root,
+            post_commit_fanout=False,
+            commit_point=False,
+        )
+    for path, raw in restores:
+        if raw is None and path.exists():
+            path.unlink()
+            try:
+                directory_fd = os.open(
+                    path.parent,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+                )
+            except OSError:
+                raise
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+
+
+def publish_deletion_checkpoint(
+    vault_root: Path, removed_rel_paths: Iterable[str]
+) -> GraphSyncCheckpoint | None:
+    """Durably record graph-relevant removals before derived fan-out runs."""
+    epoch = prepare_deletion_epoch(vault_root, removed_rel_paths)
+    if epoch is None:
+        return None
+    try:
+        commit_deletion_epoch(epoch)
+    except Exception:
+        restore_deletion_epoch(epoch)
+        raise
+    return epoch.checkpoint
+
+
+@dataclass(frozen=True)
+class GraphBuildOutcome:
+    generation: int
+    checkpoint_sha256: str
+
+    @classmethod
+    def covering(cls, checkpoint: GraphSyncCheckpoint) -> GraphBuildOutcome:
+        return cls(checkpoint.generation, checkpoint.checkpoint_sha256)
+
+    def covers(self, checkpoint: GraphSyncCheckpoint) -> bool:
+        return self.generation > checkpoint.generation or (
+            self.generation == checkpoint.generation
+            and self.checkpoint_sha256 == checkpoint.checkpoint_sha256
+        )
+
+
+class GraphRebuildRegistrationError(RuntimeError):
+    """A required graph checkpoint has a durable immediate failure handle."""
+
+    def __init__(self, code: str, remediation: str) -> None:
+        self.code = code
+        self.remediation = remediation
+        super().__init__(f"{code}: {remediation}")
+
+
+class GraphWaiterCapacityError(GraphRebuildRegistrationError):
+    """A canonical mutation committed, but this process cannot register another wait."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "GRAPH_SYNC_WAITER_CAPACITY",
+            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+        )
+
+
+class GraphRebuildStopped(GraphRebuildRegistrationError):
+    """A registered builder exited before producing coverage."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "GRAPH_SYNC_REBUILD_STOPPED",
+            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+        )
+
+
+class GraphSidecarReplaceUnavailable(GraphRebuildRegistrationError):
+    """Windows has an open reader; retain the old sidecar and recover later."""
+
+    def __init__(self, _message: str = "live graph sidecar has an open reader") -> None:
+        super().__init__(
+            "GRAPH_SYNC_PLATFORM_SHARING_REFUSED",
+            "Release graph sidecar readers, then run reconcile to recover the derived graph.",
+        )
+        self.args = (f"{_message}: {self.args[0]}",)
+
+
+class GraphEpochIncoherent(GraphRebuildRegistrationError):
+    """Epoch history is ambiguous and must not be repaired by guessing."""
+
+    def __init__(self, _message: str = "graph epoch lineage is incoherent") -> None:
+        super().__init__(
+            "GRAPH_SYNC_LINEAGE_CONFLICT",
+            "Reconcile the graph epoch before retrying this mutation.",
+        )
+        self.args = (f"{_message}: {self.args[0]}",)
+
+
+class GraphRebuildLockUnavailable(GraphRebuildRegistrationError):
+    """Secure rebuild-lock setup failed before an owner could be determined."""
+
+    def __init__(self, _message: str = "secure graph rebuild lock could not be established") -> None:
+        super().__init__(
+            "GRAPH_SYNC_REBUILD_LOCK_UNAVAILABLE",
+            "Retry the same mutation identity after graph rebuild locking recovers, or run reconcile.",
+        )
+        self.args = (f"{_message}: {self.args[0]}",)
+
+
+class GraphRebuildWaiter:
+    def __init__(
+        self,
+        coordinator: GraphRebuildCoordinator,
+        checkpoint: GraphSyncCheckpoint,
+        immediate_error: BaseException | None = None,
+        admitted: bool = True,
+    ):
+        self._coordinator = coordinator
+        self._checkpoint = checkpoint
+        self._immediate_error = immediate_error
+        self._admitted = admitted
+        self.builder_started = False
+        self._released = False
+
+    def wait(self, timeout: float | None = None) -> GraphBuildOutcome:
+        try:
+            if self._immediate_error is not None:
+                raise self._immediate_error
+            return self._coordinator._wait(self._checkpoint, timeout)
+        finally:
+            if self._admitted and not self._released:
+                self._released = True
+                self._coordinator._release_waiter()
+
+
+@dataclass(frozen=True)
+class GraphRebuildStart:
+    """A capacity-neutral result from starting or coalescing a flight."""
+
+    builder_started: bool
+
+
+class GraphRebuildRegistration:
+    """Exact rebuild work captured under canonical authority, but not started."""
+
+    def __init__(
+        self,
+        coordinator: GraphRebuildCoordinator,
+        checkpoint: GraphSyncCheckpoint,
+        builder: Callable[[GraphSyncCheckpoint], GraphBuildOutcome],
+    ) -> None:
+        self._coordinator = coordinator
+        self._checkpoint = checkpoint
+        self._builder = builder
+
+    def start(self) -> GraphRebuildStart:
+        return self._coordinator.ensure_started(self._checkpoint, self._builder)
+
+    def wait(self, timeout: float | None = None) -> GraphBuildOutcome:
+        self.start()
+        return self._coordinator.join(self._checkpoint).wait(timeout)
+
+
+class GraphRebuildCoordinator:
+    """One process-local flight per vault; canonical writers never wait in it."""
+
+    def __init__(self, vault_root: Path):
+        self.vault_root = Path(vault_root).resolve()
+        self._condition = threading.Condition()
+        self._required: GraphSyncCheckpoint | None = None
+        self._outcome: GraphBuildOutcome | None = None
+        self._error: BaseException | None = None
+        self._running = False
+        self._builder: Callable[[GraphSyncCheckpoint], GraphBuildOutcome] | None = None
+        self._waiter_count = 0
+
+    @property
+    def writer_hold_count(self) -> int:
+        return 0
+
+    @property
+    def waiter_count(self) -> int:
+        with self._condition:
+            return self._waiter_count
+
+    def ensure_started(
+        self,
+        checkpoint: GraphSyncCheckpoint,
+        builder: Callable[[GraphSyncCheckpoint], GraphBuildOutcome],
+    ) -> GraphRebuildStart:
+        """Start or coalesce exact work without admitting a response waiter."""
+        with self._condition:
+            if (
+                self._required is not None
+                and checkpoint.generation == self._required.generation
+                and checkpoint.checkpoint_sha256 != self._required.checkpoint_sha256
+            ):
+                self._error = GraphEpochIncoherent(
+                    "same-generation graph checkpoints have different lineage"
+                )
+                self._condition.notify_all()
+                return GraphRebuildStart(False)
+            if self._required is None or checkpoint.generation > self._required.generation:
+                self._required = checkpoint
+            if self._running:
+                self._condition.notify_all()
+                return GraphRebuildStart(False)
+            if self._outcome is not None and self._outcome.covers(checkpoint):
+                return GraphRebuildStart(False)
+            self._running = True
+            self._error = None
+            self._outcome = None
+            self._builder = builder
+            try:
+                threading.Thread(
+                    target=self._run,
+                    name="exomem-graph-rebuild",
+                    daemon=True,
+                ).start()
+            except RuntimeError:
+                self._running = False
+                self._error = GraphRebuildRegistrationError(
+                    "GRAPH_SYNC_START_FAILED",
+                    "Retry the same mutation identity or run reconcile to recover the derived graph.",
+                )
+                self._condition.notify_all()
+                return GraphRebuildStart(False)
+            self._condition.notify_all()
+            return GraphRebuildStart(True)
+
+    def join(self, checkpoint: GraphSyncCheckpoint) -> GraphRebuildWaiter:
+        """Admit one bounded response waiter for work already registered."""
+        with self._condition:
+            if self._waiter_count >= MAX_GRAPH_REBUILD_WAITERS:
+                return GraphRebuildWaiter(
+                    self,
+                    checkpoint,
+                    GraphWaiterCapacityError(),
+                    admitted=False,
+                )
+            self._waiter_count += 1
+            return GraphRebuildWaiter(self, checkpoint)
+
+    def start_or_join(
+        self,
+        checkpoint: GraphSyncCheckpoint,
+        builder: Callable[[GraphSyncCheckpoint], GraphBuildOutcome],
+    ) -> GraphRebuildWaiter:
+        started = self.ensure_started(checkpoint, builder)
+        waiter = self.join(checkpoint)
+        waiter.builder_started = started.builder_started
+        return waiter
+
+    def _release_waiter(self) -> None:
+        with self._condition:
+            self._waiter_count = max(0, self._waiter_count - 1)
+
+    def _run(self) -> None:
+        attempts = 0
+        while attempts < MAX_GRAPH_REBUILD_ATTEMPTS:
+            attempts += 1
+            with self._condition:
+                assert self._required is not None
+                assert self._builder is not None
+                required = self._required
+                builder = self._builder
+            try:
+                outcome = builder(required)
+            except BaseException as error:  # noqa: BLE001 - integration path
+                with self._condition:
+                    self._error = (
+                        error
+                        if isinstance(error, GraphRebuildRegistrationError)
+                        else GraphRebuildStopped()
+                    )
+                    self._running = False
+                    self._condition.notify_all()
+                return
+            with self._condition:
+                if self._error is not None:
+                    self._running = False
+                    self._condition.notify_all()
+                    return
+                if self._required is not None and not outcome.covers(self._required):
+                    continue
+                self._outcome = outcome
+                self._running = False
+                self._condition.notify_all()
+                return
+        with self._condition:
+            self._error = GraphRebuildRegistrationError(
+                "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+                "Run reconcile to recover the derived graph.",
+            )
+            self._running = False
+            self._condition.notify_all()
+
+    def _wait(self, checkpoint: GraphSyncCheckpoint, timeout: float | None) -> GraphBuildOutcome:
+        with self._condition:
+            ready = self._condition.wait_for(
+                lambda: self._error is not None
+                or (self._outcome is not None and self._outcome.covers(checkpoint)),
+                timeout=timeout,
+            )
+            if not ready:
+                raise TimeoutError("graph rebuild did not finish before the wait deadline")
+            if self._error is not None:
+                raise self._error
+            assert self._outcome is not None
+            return self._outcome
+
+
+def _registration_runtime_root(state_root: Path | None) -> Path:
+    return _rebuild_runtime_root(state_root)
+
+
+def _registration_key(vault_root: Path, state_root: Path | None) -> str:
+    return _rebuild_lock_key(vault_root, _registration_runtime_root(state_root))
+
+
+def register_rebuild(
+    vault_root: Path,
+    checkpoint: GraphSyncCheckpoint,
+    builder: Callable[[GraphSyncCheckpoint], GraphBuildOutcome],
+    *,
+    state_root: Path | None = None,
+) -> GraphRebuildRegistration:
+    """Capture exact rebuild work; callers start or join only after their guard exits."""
+    key = _registration_key(vault_root, state_root)
+    with _COORDINATORS_LOCK:
+        coordinator = _COORDINATORS.setdefault(key, GraphRebuildCoordinator(Path(vault_root)))
+    registration = GraphRebuildRegistration(coordinator, checkpoint, builder)
+    pending = dict(_PENDING_WAITERS.get() or {})
+    pending[key] = (registration, checkpoint)
+    _PENDING_WAITERS.set(pending)
+    return registration
+
+
+def register_deferred(
+    vault_root: Path, checkpoint: GraphSyncCheckpoint, *, state_root: Path | None = None
+) -> GraphRebuildWaiter:
+    """Bind required work for rollback mode without starting a scheduler thread."""
+    key = _registration_key(vault_root, state_root)
+    waiter = GraphRebuildWaiter(
+        GraphRebuildCoordinator(Path(vault_root)),
+        checkpoint,
+        GraphRebuildRegistrationError(
+            "GRAPH_SYNC_SCHEDULING_DISABLED",
+            "Enable graph scheduling or run reconcile to recover the derived graph.",
+        ),
+        admitted=False,
+    )
+    pending = dict(_PENDING_WAITERS.get() or {})
+    pending[key] = (waiter, checkpoint)
+    _PENDING_WAITERS.set(pending)
+    return waiter
+
+
+def register_failure(
+    vault_root: Path,
+    checkpoint: GraphSyncCheckpoint,
+    *,
+    code: str,
+    remediation: str = "Run reconcile to recover the derived graph.",
+    state_root: Path | None = None,
+) -> GraphRebuildWaiter:
+    """Install an exact immediate-error handle when lazy work cannot register.
+
+    This is deliberately the same context-bound handoff used by normal rebuild
+    registrations, so the idempotency join sees one exact checkpoint rather
+    than silently treating the canonical mutation as graph-current.
+    """
+    if not code or not code.isascii() or len(code) > 64:
+        raise ValueError("graph failure code must be bounded ASCII")
+    key = _registration_key(vault_root, state_root)
+    waiter = GraphRebuildWaiter(
+        GraphRebuildCoordinator(Path(vault_root)),
+        checkpoint,
+        GraphRebuildRegistrationError(code, remediation),
+        admitted=False,
+    )
+    pending = dict(_PENDING_WAITERS.get() or {})
+    pending[key] = (waiter, checkpoint)
+    _PENDING_WAITERS.set(pending)
+    return waiter
+
+
+def register_outer_fanout_failure(
+    vault_root: Path,
+    *,
+    code: str = "GRAPH_SYNC_FANOUT_FAILED",
+    remediation: str = "Run reconcile to recover the derived graph.",
+) -> GraphSyncCheckpoint | None:
+    """Bind a caught post-checkpoint fanout error to its exact graph epoch.
+
+    The caller's canonical transition has already committed at this point.
+    Replacing any incomplete handoff with an immediate error handle makes that
+    committed-derived failure visible to the active lease and its retry receipt.
+    """
+    checkpoint = read_checkpoint(vault_root)
+    if checkpoint is None:
+        return None
+    register_failure(vault_root, checkpoint, code=code, remediation=remediation)
+    return checkpoint
+
+
+def wait_for_registered(
+    vault_root: Path, timeout: float | None = None, *, state_root: Path | None = None
+) -> GraphBuildOutcome | None:
+    key = _registration_key(vault_root, state_root)
+    pending = dict(_PENDING_WAITERS.get() or {})
+    item = pending.pop(key, None)
+    _PENDING_WAITERS.set(pending or None)
+    return None if item is None else item[0].wait(timeout)
+
+
+def start_registered(vault_root: Path, *, state_root: Path | None = None) -> GraphRebuildStart | None:
+    """Start captured work without joining it, for standalone post-commit fanout."""
+    item = (_PENDING_WAITERS.get() or {}).get(_registration_key(vault_root, state_root))
+    if item is None or not isinstance(item[0], GraphRebuildRegistration):
+        return None
+    return item[0].start()
+
+
+def registered_checkpoint(
+    vault_root: Path, *, state_root: Path | None = None
+) -> GraphSyncCheckpoint | None:
+    item = (_PENDING_WAITERS.get() or {}).get(_registration_key(vault_root, state_root))
+    return item[1] if item is not None else None
+
+
+def temporary_sidecar_path(live: Path, checkpoint: GraphSyncCheckpoint) -> Path:
+    # The checkpoint digest identifies the intended publication, not one
+    # process. A per-attempt nonce prevents two replicas from sharing a temp
+    # SQLite inode before cross-process ownership has converged.
+    return live.with_name(
+        f"{_TEMP_PREFIX}{checkpoint.checkpoint_sha256}-{secrets.token_hex(12)}.sqlite"
+    )
+
+
+def replace_sidecar(temporary: Path, live: Path) -> None:
+    """Use the platform's atomic replacement primitive after all handles close."""
+    try:
+        os.replace(temporary, live)
+    except PermissionError as error:
+        # Windows refuses replacement while a reader keeps the SQLite file
+        # open. Leaving the complete old sidecar in place is fail-closed; the
+        # checkpoint remains unacknowledged and reconcile can retry later.
+        raise GraphSidecarReplaceUnavailable("live graph sidecar has an open reader") from error
+
+
+def _rebuild_runtime_root(state_root: Path | None) -> Path:
+    if state_root is not None:
+        return Path(state_root).expanduser()
+    from .writer_lease import active_manager
+
+    return active_manager().config.state_dir
+
+
+def _rebuild_lock_path(vault_root: Path, *, state_root: Path | None = None) -> Path:
+    """Return the persistent runtime-state lock for one canonical vault."""
+    from .mutation_lock import canonical_mutation_identity
+
+    identity = canonical_mutation_identity(vault_root).encode("utf-8")
+    return (
+        _rebuild_runtime_root(state_root)
+        / f"{hashlib.sha256(identity).hexdigest()}.graph-rebuild.lock"
+    )
+
+
+def _rebuild_lock_key(vault_root: Path, state_root: Path) -> str:
+    return f"{Path(vault_root).resolve()}\0{Path(state_root).expanduser().resolve(strict=False)}"
+
+
+@dataclass
+class _HeldRebuildLock:
+    """Explicit ownership of the rebuild descriptor and secure namespace."""
+
+    handle: BinaryIO | None
+    directory: Any | None
+    release_os_lock: Callable[[BinaryIO], None]
+    _close_guard: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def close(self, *, release_os_lock: bool = True) -> None:
+        """Release this process's lock and namespace handles exactly once."""
+        with self._close_guard:
+            handle = self.handle
+            directory = self.directory
+            self.handle = None
+            self.directory = None
+        if handle is None:
+            return
+        try:
+            if release_os_lock:
+                self.release_os_lock(handle)
+        finally:
+            try:
+                handle.close()
+            finally:
+                if directory is not None:
+                    directory.close()
+
+    def close_after_fork(self) -> None:
+        """Drop inherited descriptors without touching the parent's flock."""
+        # Do not acquire the inherited thread lock here: a non-forking parent
+        # thread may have owned it when fork occurred. Closing duplicate file
+        # descriptors cannot release the parent's open-file-description lock.
+        handle = self.handle
+        directory = self.directory
+        self.handle = None
+        self.directory = None
+        if handle is not None:
+            try:
+                handle.close()
+            except OSError:
+                pass
+        if directory is not None:
+            try:
+                directory.close()
+            except OSError:
+                pass
+
+
+def claim_rebuild_owner(
+    vault_root: Path, temporary: Path, *, state_root: Path | None = None
+) -> bool:
+    """Acquire the descriptor-bound cross-process private-build lock."""
+    del temporary
+    from .mutation_lock import (
+        _acquire_trusted_runtime_root,
+        _open_owned_runtime_lock_file,
+        _release_os_lock,
+        _same_directory_path,
+        _same_file_entry,
+        _try_os_lock,
+    )
+
+    runtime_root = _rebuild_runtime_root(state_root)
+    key = _rebuild_lock_key(vault_root, runtime_root)
+    with _COORDINATORS_LOCK:
+        if key in _REBUILD_LOCK_HANDLES:
+            return False
+    lock = _rebuild_lock_path(vault_root, state_root=runtime_root)
+    directory: Any = None
+    directory_transferred = False
+    handle: BinaryIO | None = None
+    locked = False
+    try:
+        directory = _acquire_trusted_runtime_root(lock.parent)
+        descriptor = _open_owned_runtime_lock_file(directory, lock.name)
+        handle = os.fdopen(descriptor, "a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        if not _same_directory_path(directory) or not _same_file_entry(
+            directory, lock.name, handle.fileno()
+        ):
+            raise OSError("rebuild lock namespace changed before acquisition")
+        if not _try_os_lock(handle):
+            return False
+        locked = True
+        if not _same_directory_path(directory) or not _same_file_entry(
+            directory, lock.name, handle.fileno()
+        ):
+            raise OSError("rebuild lock namespace changed during acquisition")
+        with _COORDINATORS_LOCK:
+            if key in _REBUILD_LOCK_HANDLES:
+                _release_os_lock(handle)
+                locked = False
+                return False
+            _REBUILD_LOCK_HANDLES[key] = _HeldRebuildLock(
+                handle,
+                directory,
+                _release_os_lock,
+            )
+            handle = None
+            directory_transferred = True
+        return True
+    except OSError:
+        raise GraphRebuildLockUnavailable(
+            "secure graph rebuild lock could not be established"
+        ) from None
+    finally:
+        if handle is not None:
+            if locked:
+                try:
+                    _release_os_lock(handle)
+                except OSError:
+                    pass
+            handle.close()
+        if directory is not None and not directory_transferred:
+            directory.close()
+
+
+def release_rebuild_owner(
+    vault_root: Path, temporary: Path, *, state_root: Path | None = None
+) -> None:
+    """Release a held runtime-state lock without unlinking its authority path."""
+    del temporary
+    runtime_root = _rebuild_runtime_root(state_root)
+    with _COORDINATORS_LOCK:
+        held = _REBUILD_LOCK_HANDLES.pop(_rebuild_lock_key(vault_root, runtime_root), None)
+    if held is None:
+        return
+    held.close()
+
+
+def _close_rebuild_locks_at_exit() -> None:
+    """Close graph-specific runtime handles before interpreter teardown."""
+    with _COORDINATORS_LOCK:
+        held_locks = tuple(_REBUILD_LOCK_HANDLES.values())
+        _REBUILD_LOCK_HANDLES.clear()
+    for held in held_locks:
+        try:
+            held.close()
+        except OSError:
+            pass
+
+
+def _reset_rebuild_locks_in_forked_child() -> None:
+    """Discard inherited graph lock state without unlocking its parent."""
+    global _COORDINATORS, _COORDINATORS_LOCK, _LIVE_TEMPORARIES, _REBUILD_LOCK_HANDLES
+    # Do not acquire a lock inherited from a multi-threaded parent: it might be
+    # permanently locked in the child. The copied dictionary is private now.
+    held_locks = tuple(_REBUILD_LOCK_HANDLES.values())
+    _REBUILD_LOCK_HANDLES = {}
+    for held in held_locks:
+        held.close_after_fork()
+    _COORDINATORS = {}
+    _COORDINATORS_LOCK = threading.Lock()
+    _LIVE_TEMPORARIES = set()
+    _PENDING_WAITERS.set(None)
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_rebuild_locks_in_forked_child)
+
+atexit.register(_close_rebuild_locks_at_exit)
+
+
+def live_owned_temporary(vault_root: Path) -> Path | None:
+    # Kernel lock ownership is deliberately not represented by PID metadata.
+    return None
+
+
+def wait_for_current(
+    vault_root: Path,
+    checkpoint: GraphSyncCheckpoint | None,
+    *,
+    availability: Callable[[], bool] | None = None,
+    timeout_seconds: float = 30.0,
+) -> bool:
+    """Wait for a reader-valid live sidecar covering another builder's epoch."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status_value = status(vault_root)
+        readers_confirm = availability is None or availability()
+        acknowledgement = acknowledged_checkpoint(vault_root)
+        checkpoint_covered = checkpoint is None or (
+            acknowledgement is not None and acknowledgement.covers(checkpoint)
+        )
+        if status_value["state"] == "current" and checkpoint_covered and readers_confirm:
+            return True
+        time.sleep(0.025)
+    return False
+
+
+def register_temporary(path: Path) -> None:
+    with _COORDINATORS_LOCK:
+        _LIVE_TEMPORARIES.add(path.resolve())
+
+
+def unregister_temporary(path: Path) -> None:
+    with _COORDINATORS_LOCK:
+        _LIVE_TEMPORARIES.discard(path.resolve())
+        # A rejected publication hook may have replaced the entry with a
+        # symlink. Preserve the registration's lexical absolute spelling too,
+        # rather than following that untrusted replacement during cleanup.
+        _LIVE_TEMPORARIES.discard(path.absolute())
+
+
+def live_temporary_paths() -> set[Path]:
+    with _COORDINATORS_LOCK:
+        return set(_LIVE_TEMPORARIES)
+
+
+def readable_sidecar(path: Path) -> Path | None:
+    return None if path.name.startswith(_TEMP_PREFIX) else path
+
+
+def sweep_abandoned_temporaries(
+    vault_root: Path,
+    live: Path,
+    *,
+    live_paths: set[Path],
+    state_root: Path | None = None,
+) -> list[Path]:
+    probe = live.with_name(f"{_TEMP_PREFIX}sweep-{secrets.token_hex(12)}.sqlite")
+    if not claim_rebuild_owner(vault_root, probe, state_root=state_root):
+        return []
+    removed: list[Path] = []
+    try:
+        active_paths = {path.resolve() for path in live_paths} | live_temporary_paths()
+        for candidate in live.parent.glob(f"{_TEMP_PREFIX}*.sqlite*"):
+            base_name = candidate.name
+            for companion_suffix in ("-journal", "-wal", "-shm"):
+                if base_name.endswith(companion_suffix):
+                    base_name = base_name.removesuffix(companion_suffix)
+                    break
+            if (
+                re.fullmatch(
+                    rf"{re.escape(_TEMP_PREFIX)}[0-9a-f]{{64}}-[0-9a-f]{{24}}\.sqlite",
+                    base_name,
+                )
+                and candidate.with_name(base_name).resolve() not in active_paths
+            ):
+                try:
+                    candidate.unlink(missing_ok=True)
+                except PermissionError:
+                    # Windows readers hold delete-sharing authority. A retained
+                    # complete temp is recoverable state, so leave it for the
+                    # next sweep after that reader closes.
+                    continue
+                removed.append(candidate)
+        return removed
+    finally:
+        release_rebuild_owner(vault_root, probe, state_root=state_root)
+
+
+@dataclass(frozen=True)
+class GraphAvailability:
+    available: bool
+    reason: str | None = None
+
+
+def availability(
+    required: GraphSyncCheckpoint | None,
+    acknowledged: GraphBuildOutcome | None,
+) -> GraphAvailability:
+    if required is not None and (acknowledged is None or not acknowledged.covers(required)):
+        return GraphAvailability(False, "checkpoint_unacknowledged")
+    return GraphAvailability(True)
+
+
+def status(vault_root: Path) -> dict[str, int | str]:
+    epoch = classify_epoch(vault_root)
+    if epoch.kind == "legacy":
+        return {"state": "current", "generation": 0}
+    if epoch.kind == "pre_floor":
+        assert epoch.checkpoint is not None
+        return {"state": "recovery_required", "generation": epoch.checkpoint.generation}
+    if epoch.kind == "coherent":
+        assert epoch.checkpoint is not None
+        current = epoch.acknowledgement == GraphBuildOutcome.covering(epoch.checkpoint)
+        return {
+            "state": "current" if current else "recovery_required",
+            "generation": epoch.checkpoint.generation,
+        }
+    if epoch.kind == "recoverable":
+        if epoch.checkpoint is None:
+            assert epoch.floor is not None
+            return {"state": "recovery_required", "generation": epoch.floor.generation}
+        assert epoch.floor is not None
+        return {"state": "unavailable", "generation": epoch.floor.generation}
+    generation = (
+        epoch.floor.generation
+        if epoch.floor is not None
+        else epoch.acknowledgement.generation if epoch.acknowledgement is not None else 0
+    )
+    return {"state": "unavailable", "generation": generation}
+
+
+def committed_graph_failure(
+    checkpoint: GraphSyncCheckpoint,
+    *,
+    code: str = "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+    remediation: str = "Run reconcile to recover the derived graph.",
+) -> dict[str, str]:
+    return {
+        "graph_sync": "failed",
+        "graph_sync_code": code,
+        "graph_sync_checkpoint": checkpoint.checkpoint_sha256,
+        "graph_sync_remediation": remediation,
+    }

--- a/src/exomem/hosted_portability.py
+++ b/src/exomem/hosted_portability.py
@@ -27,6 +27,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from . import __version__
+from .kbdir import kb_dirname
 
 MANIFEST_NAME = "exomem-manifest.json"
 MANIFEST_SCHEMA_VERSION = 1
@@ -74,6 +75,18 @@ class _ClassificationRule:
 
 def _is_review_state(path: str, _parts: tuple[str, ...]) -> bool:
     return path == "Knowledge Base/.review-state.json"
+
+
+def _is_graph_commit_receipt(path: str, _parts: tuple[str, ...]) -> bool:
+    """Only the exact hidden receipt artifact is portable derived state.
+
+    Anchoring avoids allowing a similarly named directory to override the
+    normal secret and unregistered-hidden-state fail-closed rules.
+    """
+    return re.fullmatch(
+        rf"{re.escape(kb_dirname())}/\.graph-commit-receipts/[0-9a-f]{{24}}\.json",
+        path,
+    ) is not None
 
 
 def _is_provider_log(_path: str, parts: tuple[str, ...]) -> bool:
@@ -200,6 +213,12 @@ def _always_canonical(_path: str, _parts: tuple[str, ...]) -> bool:
 
 
 _CLASSIFICATION_RULES = (
+    _ClassificationRule(
+        "portable-graph-commit-receipts",
+        ArtifactClass.PORTABLE_DERIVED,
+        "Content-free graph commit receipts retain exact retry evidence across portable vaults.",
+        _is_graph_commit_receipt,
+    ),
     _ClassificationRule(
         "portable-review-state",
         ArtifactClass.PORTABLE_DERIVED,

--- a/src/exomem/index_sync.py
+++ b/src/exomem/index_sync.py
@@ -49,6 +49,7 @@ def _withdraw_unbridgeable_corpus_consumers(vault_root: Path) -> None:
     from . import find, freshness, semantic_contract, vault
 
     freshness.invalidate(vault_root)
+    freshness.mark_external_pending(vault_root)
     semantic_contract.evict_corpus_context(vault_root)
     find.evict_resolver_caches(vault_root)
     vault.evict_inbound_index(vault_root)
@@ -118,7 +119,10 @@ class IndexComponentOutcome:
         if type(self.outcome) is not str or self.outcome not in {
             "accepted",
             "completed",
+            "registered",
             "deferred",
+            "failed",
+            "not_required",
             "degraded",
         }:
             raise ValueError("unsupported index component outcome")
@@ -170,7 +174,7 @@ class IndexSyncReport:
 
     @property
     def reconcile_required(self) -> bool:
-        return any(item.outcome == "degraded" for item in self.components)
+        return any(item.outcome in {"degraded", "failed"} for item in self.components)
 
     @property
     def reconcile_guidance(self) -> str | None:
@@ -334,6 +338,21 @@ def _legacy_component(component: str, callback) -> IndexComponentOutcome:
     return IndexComponentOutcome(component, "completed", "dispatch_completed")
 
 
+def _graph_component(callback) -> IndexComponentOutcome:
+    """Preserve the graph's exact handoff outcome outside legacy best effort."""
+    from .epistemic_graph import GraphDispatchResult
+
+    try:
+        result = callback()
+    except Exception:  # noqa: BLE001 - defensive boundary for external callers
+        log.warning("epistemic graph dispatch escaped", exc_info=True)
+        return IndexComponentOutcome("epistemic_graph", "failed", "graph_dispatch_failed")
+    if not isinstance(result, GraphDispatchResult):
+        log.warning("epistemic graph dispatch returned no exact outcome")
+        return IndexComponentOutcome("epistemic_graph", "failed", "graph_outcome_missing")
+    return IndexComponentOutcome("epistemic_graph", result.outcome, result.code)
+
+
 def _resolver_component(callback) -> IndexComponentOutcome:
     try:
         callback()
@@ -344,6 +363,10 @@ def _resolver_component(callback) -> IndexComponentOutcome:
 
 
 def _embedding_component(status) -> IndexComponentOutcome:
+    return _embedding_status_component("embeddings", status)
+
+
+def _embedding_status_component(component: str, status) -> IndexComponentOutcome:
     if status.code == "no_eligible_paths":
         outcome = "accepted"
     elif status.status == "completed":
@@ -354,7 +377,7 @@ def _embedding_component(status) -> IndexComponentOutcome:
         outcome = "degraded"
     else:
         outcome = "accepted"
-    return IndexComponentOutcome("embeddings", outcome, status.code)
+    return IndexComponentOutcome(component, outcome, status.code)
 
 
 def _rel_md_paths(vault_root: Path, paths: list[Path]) -> list[str]:
@@ -408,7 +431,15 @@ def purge_semantic_only(vault_root: Path, rel_paths: list[str]) -> bool:
         return True
     # Keep the first event spelling/order but avoid redundant sqlite writes.
     rels = list(dict.fromkeys(rels))
-    from . import claims, embedding_index, embeddings, epistemic_graph, index_paths, lexstore
+    from . import (
+        claims,
+        embedding_index,
+        embeddings,
+        epistemic_graph,
+        index_paths,
+        lexstore,
+        recall_policy,
+    )
 
     def _purge(component: str, callback) -> bool:
         try:
@@ -427,10 +458,13 @@ def purge_semantic_only(vault_root: Path, rel_paths: list[str]) -> bool:
             "embeddings",
             lambda: embedding_index.EmbeddingIndex(vault_root).purge_paths_if_present(rels),
         )
-    if epistemic_graph.sidecar_path(vault_root).exists():
+    graph_rels = [
+        rel for rel in rels if recall_policy.is_recall_candidate(vault_root, vault_root / rel)
+    ]
+    if graph_rels and epistemic_graph.sidecar_path(vault_root).exists():
         succeeded &= _purge(
             "epistemic_graph",
-            lambda: epistemic_graph.EpistemicGraphIndex(vault_root).delete_paths(rels),
+            lambda: epistemic_graph.EpistemicGraphIndex(vault_root).delete_paths(graph_rels),
         )
     if claims.sidecar_path(vault_root).exists():
         succeeded &= _purge(
@@ -480,6 +514,53 @@ def deferred_work_status(vault_root: Path | None = None) -> dict:
 def record_failed_refresh(vault_root: Path, paths: list[Path]) -> int:
     """Persist a failed all-index dispatch without importing model modules."""
     return deferred_index.add_full(vault_root, _rel_md_paths(vault_root, paths))
+
+
+def _publication_failed_report(
+    operation: str,
+    requested_paths: tuple[str, ...],
+    eligible_paths: tuple[str, ...],
+    *,
+    paths_truncated: bool,
+) -> IndexSyncReport:
+    """Report a failed canonical publication without advancing any consumer."""
+    components = tuple(
+        IndexComponentOutcome(component, "failed", "publication_failed")
+        for component in (
+            ("lexstore", "memory_refs", "resolver", "epistemic_graph", "embeddings")
+            if operation == "upsert"
+            else (
+                "lexstore",
+                "memory_refs",
+                "epistemic_graph",
+                "clip",
+                "embeddings",
+                "claims",
+                "semantic_purge",
+                "resolver",
+            )
+        )
+    )
+    return IndexSyncReport(
+        operation,
+        requested_paths,
+        eligible_paths,
+        components,
+        paths_truncated,
+    )
+
+
+def _register_publication_failure_graph_handle(vault_root: Path) -> None:
+    """Keep a committed graph epoch joinable when corpus publication failed."""
+    from . import graph_sync
+
+    required = graph_sync.read_checkpoint(vault_root)
+    if required is None:
+        return
+    try:
+        graph_sync.register_failure(vault_root, required, code="CORPUS_PUBLICATION_FAILED")
+    except Exception:  # noqa: BLE001 - the failed publication report remains authoritative
+        log.warning("graph publication-failure handoff registration failed", exc_info=True)
 
 
 def clear_deferred_work(
@@ -557,9 +638,9 @@ def drain_deferred_work(
     receipts = deferred_index.snapshot(vault_root, limit=remaining_limit)
     if not receipts:
         return processed
-    paths = [vault_root / receipt.rel_path for receipt in receipts]
+    semantic_paths = [vault_root / receipt.rel_path for receipt in receipts]
     try:
-        status = replay_deferred_embedding(vault_root, paths, receipts)
+        status = replay_deferred_embedding(vault_root, semantic_paths, receipts)
     except Exception:  # noqa: BLE001 - durable work must survive a failed dispatch
         log.warning("deferred semantic dispatch failed; work remains queued", exc_info=True)
         return processed
@@ -608,17 +689,20 @@ def _dispatch_upsert_components(
             "lexstore", lambda: lexstore.upsert_after_write(vault_root, semantic_paths)
         )
     )
-    def graph_upsert() -> None:
+    def graph_upsert():
         if created_semantic_paths:
-            epistemic_graph.upsert_after_write(
+            return epistemic_graph.upsert_after_write(
                 vault_root,
                 semantic_paths,
                 created_paths=created_semantic_paths,
             )
-        else:
-            epistemic_graph.upsert_after_write(vault_root, semantic_paths)
+        return epistemic_graph.upsert_after_write(vault_root, semantic_paths)
 
-    components.append(_legacy_component("epistemic_graph", graph_upsert))
+    components.append(
+        _graph_component(graph_upsert)
+        if semantic_paths
+        else IndexComponentOutcome("epistemic_graph", "not_required", "no_graph_input")
+    )
     if defer_semantic or mode.defer_expensive_indexes():
         try:
             semantic_count, added = _record_deferred_semantic_upserts(
@@ -764,6 +848,18 @@ def upsert_after_write(
         vault_root,
         changed=identity_paths,
     )
+    if not publication_current:
+        _register_publication_failure_graph_handle(vault_root)
+        try:
+            record_failed_refresh(vault_root, identity_paths)
+        except Exception:  # noqa: BLE001 - the failed publication report remains authoritative
+            log.warning("durable full-index retry recording failed", exc_info=True)
+        return _publication_failed_report(
+            "upsert",
+            requested_report,
+            eligible_report,
+            paths_truncated=requested_truncated or eligible_truncated,
+        )
     admitted_rels = {item.rel_path for item in batch.admitted_paths}
     states = {rel: state for rel, state in (semantic_states or {}).items() if rel in admitted_rels}
     for path, rel in zip(semantic_paths, semantic_rels, strict=True):
@@ -812,16 +908,7 @@ def upsert_after_write(
         tuple(components),
         requested_truncated or eligible_truncated,
     )
-    if publication_current:
-        return report
-    try:
-        record_failed_refresh(vault_root, identity_paths)
-    except Exception:  # noqa: BLE001 - the degraded report remains authoritative
-        log.warning("durable full-index retry recording failed", exc_info=True)
-    return with_component(
-        report,
-        IndexComponentOutcome("epistemic_graph", "degraded", "publication_failed"),
-    )
+    return report
 
 
 def delete_after_remove(
@@ -855,14 +942,21 @@ def delete_after_remove(
         vault_root,
         deleted=[vault_root / rel for rel in md_rels],
     )
+    if not publication_current:
+        _register_publication_failure_graph_handle(vault_root)
+        return _publication_failed_report(
+            "delete",
+            requested_report,
+            requested_report,
+            paths_truncated=paths_truncated,
+        )
     components = [
         _legacy_component("lexstore", lambda: lexstore.delete_after_remove(vault_root, safe_paths)),
         _legacy_component(
             "memory_refs",
             lambda: memory_refs.delete_after_remove(vault_root, safe_paths),
         ),
-        _legacy_component(
-            "epistemic_graph",
+        _graph_component(
             # The exact deletion delta is already published above. Refreshing
             # through that checkpoint removes the vanished file and repairs
             # every affected source edge before marking the graph current.
@@ -874,9 +968,8 @@ def delete_after_remove(
                 else epistemic_graph.delete_after_remove(vault_root, safe_paths)
             ),
         ),
-        _legacy_component(
-            "clip",
-            lambda: embeddings.delete_clip_after_remove(vault_root, safe_paths),
+        _embedding_status_component(
+            "clip", embeddings.delete_clip_after_remove(vault_root, safe_paths)
         ),
     ]
     try:
@@ -920,9 +1013,4 @@ def delete_after_remove(
         tuple(components),
         paths_truncated,
     )
-    if publication_current:
-        return report
-    return with_component(
-        report,
-        IndexComponentOutcome("epistemic_graph", "degraded", "publication_failed"),
-    )
+    return report

--- a/src/exomem/lexstore.py
+++ b/src/exomem/lexstore.py
@@ -814,7 +814,7 @@ def catalog_cache_token(vault_root: Path) -> str:
 # ------------------------------------------------------------------ write seams
 
 
-def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
+def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> bool:
     """Keep the lexical index in lockstep with a writer's markdown change.
 
     Deliberately NOT gated behind the embeddings extra or its env switches —
@@ -824,26 +824,30 @@ def upsert_after_write(vault_root: Path, written_paths: list[Path]) -> None:
     first search builds it whole.
     """
     if not _catalog_usable():
-        return
+        return True
     md = [p for p in written_paths if p.suffix.lower() == ".md" and ".sync-conflict-" not in p.name]
     if not md or not lexical_path(vault_root).exists():
-        return
+        return True
     try:
         get_store(vault_root).upsert_paths(md)
     except Exception as e:  # noqa: BLE001
         log.warning("lexical sidecar upsert skipped (%s)", e)
+        return False
+    return True
 
 
-def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> None:
+def delete_after_remove(vault_root: Path, removed_rel_paths: list[str]) -> bool:
     """Drop lexical rows for removed files. Same gates as the upsert hook."""
     if not _catalog_usable():
-        return
+        return True
     if not removed_rel_paths or not lexical_path(vault_root).exists():
-        return
+        return True
     try:
         get_store(vault_root).delete_rel_paths(removed_rel_paths)
     except Exception as e:  # noqa: BLE001
         log.warning("lexical sidecar delete skipped (%s)", e)
+        return False
+    return True
 
 
 def purge_exact_persisted_rows(

--- a/src/exomem/memory_refs.py
+++ b/src/exomem/memory_refs.py
@@ -485,21 +485,23 @@ def backfill_ids(vault_root: Path, *, dry_run: bool = True) -> dict:
     }
 
 
-def upsert_after_write(vault_root: Path, paths: list[Path]) -> None:
+def upsert_after_write(vault_root: Path, paths: list[Path]) -> bool:
     markdown = [path for path in paths if path.suffix.lower() == ".md"]
     if not markdown:
-        return
+        return True
     try:
         ReferenceIndex(vault_root).refresh_paths(markdown)
     except Exception:  # noqa: BLE001 - derived sidecar failure must not break a write
-        return
+        return False
+    return True
 
 
-def delete_after_remove(vault_root: Path, paths: list[str]) -> None:
+def delete_after_remove(vault_root: Path, paths: list[str]) -> bool:
     try:
         ReferenceIndex(vault_root).delete_paths(paths)
     except Exception:  # noqa: BLE001 - derived sidecar failure must not break a delete
-        return
+        return False
+    return True
 
 
 def scan_issues(vault_root: Path) -> list[dict[str, str]]:

--- a/src/exomem/mutation_lock.py
+++ b/src/exomem/mutation_lock.py
@@ -8,6 +8,7 @@ releases the latter when a process exits, so a leftover file is harmless.
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import hashlib
 import json
@@ -15,15 +16,16 @@ import logging
 import math
 import os
 import re
+import stat
 import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, TypedDict, cast
 
 from .cli_ops import OpError
 
@@ -48,18 +50,35 @@ _HOLDER_SCHEMA = 1
 # `writer_lease.invoke()` at the mutation-journal seam (O5) and by the R1
 # telemetry events, both of which run in the same execution context shortly
 # after the `with ...hold():` block exits.
-_LAST_MUTATION_TIMING: ContextVar[dict[str, float] | None] = ContextVar(
+class MutationTiming(TypedDict):
+    """Completed outer mutation-boundary timing and identifying metadata."""
+
+    wait_ms: float
+    hold_ms: float
+    operation: str
+    holder_kind: str
+
+
+_LAST_MUTATION_TIMING: ContextVar[MutationTiming | None] = ContextVar(
     "exomem_last_mutation_timing", default=None
 )
 
 
-def last_mutation_timing() -> dict[str, float] | None:
-    """Return `{"wait_ms", "hold_ms"}` for the most recent boundary hold in
-    this context, or `None` if none has been recorded yet."""
+def last_mutation_timing() -> MutationTiming | None:
+    """Return the most recent completed boundary hold in this context, or `None`."""
     return _LAST_MUTATION_TIMING.get()
 
 
 logger = logging.getLogger(__name__)
+
+
+def _windows_library(ctypes_module: Any, name: str) -> Any:
+    """Keep Windows-only ctypes attributes out of non-Windows type stubs."""
+    return getattr(ctypes_module, "WinDLL")(name, use_last_error=True)
+
+
+def _windows_last_error(ctypes_module: Any) -> int:
+    return int(getattr(ctypes_module, "get_last_error")())
 
 
 def _log_mutation_lock_event(event: str, **fields: Any) -> None:
@@ -98,6 +117,683 @@ def canonical_mutation_identity(vault_or_cell: os.PathLike[str] | str) -> str:
     if not value:
         raise ValueError("mutation identity must not be empty")
     return f"cell:{value}"
+
+
+def nofollow_regular_file_identity(path: Path) -> tuple[int, int, int, int, int]:
+    """Return one regular entry identity, rejecting links and Windows reparse points."""
+    info = os.lstat(path)
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if not stat.S_ISREG(info.st_mode) or getattr(info, "st_file_attributes", 0) & reparse_point:
+        raise OSError("path is not a regular no-follow file")
+    return (
+        int(info.st_dev),
+        int(info.st_ino),
+        int(info.st_mode),
+        int(info.st_size),
+        int(info.st_mtime_ns),
+    )
+
+
+class _SecureDirectory:
+    """A retained non-reparse directory handle used for runtime lock files."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        fd: int | None = None,
+        windows_handles: list[int] | None = None,
+        close_fd: Callable[[int], None] | None = None,
+        close_windows_handle: Callable[[int], None] | None = None,
+    ) -> None:
+        self.path = path
+        self.fd = fd
+        self.windows_handles = windows_handles or []
+        # Retain the primitive rather than looking it up during a late atexit
+        # cleanup. A daemon that owns a graph rebuild may outlive normal module
+        # teardown ordering.
+        self._close_fd = close_fd or os.close
+        self._close_windows_handle = close_windows_handle or _windows_close_handle
+
+    @property
+    def windows_handle(self) -> int:
+        if not self.windows_handles:
+            raise OSError("secure Windows directory handle is unavailable")
+        return self.windows_handles[-1]
+
+    def close(self) -> None:
+        if self.fd is not None:
+            self._close_fd(self.fd)
+            self.fd = None
+        while self.windows_handles:
+            self._close_windows_handle(self.windows_handles.pop())
+
+
+def _windows_open_path(
+    path: Path,
+    *,
+    directory: bool,
+    access: int = 0x00020080,  # READ_CONTROL | FILE_READ_ATTRIBUTES
+    share: int = 0x3,
+    creation: int = 3,
+) -> int:
+    """Open one exact Windows path entry without following reparse points."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = _windows_library(ctypes, "kernel32")
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    flags = 0x00200000  # FILE_FLAG_OPEN_REPARSE_POINT
+    if directory:
+        flags |= 0x02000000  # FILE_FLAG_BACKUP_SEMANTICS
+    handle = create_file(str(path), access, share, None, creation, flags, None)
+    invalid = wintypes.HANDLE(-1).value
+    if handle == invalid:
+        error = _windows_last_error(ctypes)
+        if error in {2, 3}:
+            raise FileNotFoundError(error, f"cannot safely open {path.name}")
+        if error in {80, 183}:
+            raise FileExistsError(error, f"path already exists: {path.name}")
+        raise OSError(error, f"cannot safely open {path.name}")
+
+    class _AttributeTagInfo(ctypes.Structure):
+        _fields_ = [("attributes", wintypes.DWORD), ("reparse_tag", wintypes.DWORD)]
+
+    info = _AttributeTagInfo()
+    try:
+        get_info = kernel32.GetFileInformationByHandleEx
+        get_info.argtypes = [wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, wintypes.DWORD]
+        get_info.restype = wintypes.BOOL
+        if not get_info(handle, 9, ctypes.byref(info), ctypes.sizeof(info)):
+            raise OSError(_windows_last_error(ctypes), f"cannot inspect {path.name}")
+        if info.attributes & 0x400:  # FILE_ATTRIBUTE_REPARSE_POINT
+            raise OSError("reparse points are not allowed")
+        if bool(info.attributes & 0x10) != directory:
+            raise OSError("unexpected path type")
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+    return int(handle)
+
+
+def _windows_close_handle(handle: int) -> None:
+    import ctypes
+
+    _windows_library(ctypes, "kernel32").CloseHandle(handle)
+
+
+def _windows_final_path(handle: int) -> str:
+    """Return the resolved path of one retained Windows handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = _windows_library(ctypes, "kernel32")
+    get_final_path = kernel32.GetFinalPathNameByHandleW
+    get_final_path.argtypes = [wintypes.HANDLE, wintypes.LPWSTR, wintypes.DWORD, wintypes.DWORD]
+    get_final_path.restype = wintypes.DWORD
+    needed = get_final_path(handle, None, 0, 0)
+    if not needed:
+        raise OSError(_windows_last_error(ctypes), "cannot resolve retained Windows path")
+    buffer = ctypes.create_unicode_buffer(needed + 1)
+    written = get_final_path(handle, buffer, len(buffer), 0)
+    if not written or written >= len(buffer):
+        raise OSError(_windows_last_error(ctypes), "cannot resolve retained Windows path")
+    return str(buffer.value)
+
+
+def _normalized_windows_path(value: str) -> str:
+    if value.startswith("\\\\?\\UNC\\"):
+        value = "\\\\" + value[8:]
+    elif value.startswith("\\\\?\\"):
+        value = value[4:]
+    return value.rstrip("\\/").replace("/", "\\").casefold()
+
+
+def _windows_child_is_in_directory(directory: _SecureDirectory, handle: int) -> bool:
+    parent = _normalized_windows_path(_windows_final_path(directory.windows_handle))
+    child = _normalized_windows_path(_windows_final_path(handle))
+    return child.rsplit("\\", 1)[0] == parent
+
+
+def _windows_current_user_sid() -> str:
+    """Return the current process token SID without shelling out to icacls."""
+    import ctypes
+    from ctypes import wintypes
+
+    token_query = 0x0008
+    token_user = 1
+    token = wintypes.HANDLE()
+    kernel32 = _windows_library(ctypes, "kernel32")
+    advapi32 = _windows_library(ctypes, "advapi32")
+    get_current_process = kernel32.GetCurrentProcess
+    get_current_process.argtypes = []
+    get_current_process.restype = wintypes.HANDLE
+    open_process_token = advapi32.OpenProcessToken
+    open_process_token.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)
+    ]
+    open_process_token.restype = wintypes.BOOL
+    if not open_process_token(get_current_process(), token_query, ctypes.byref(token)):
+        raise OSError(_windows_last_error(ctypes), "cannot open current Windows token")
+    try:
+        needed = wintypes.DWORD()
+        get_token_information = advapi32.GetTokenInformation
+        get_token_information.argtypes = [
+            wintypes.HANDLE, wintypes.DWORD, wintypes.LPVOID, wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        get_token_information.restype = wintypes.BOOL
+        get_token_information(token, token_user, None, 0, ctypes.byref(needed))
+        if not needed.value:
+            raise OSError(_windows_last_error(ctypes), "cannot measure current Windows token SID")
+        buffer = ctypes.create_string_buffer(needed.value)
+        if not get_token_information(
+            token, token_user, buffer, needed, ctypes.byref(needed)
+        ):
+            raise OSError(_windows_last_error(ctypes), "cannot read current Windows token SID")
+        sid = ctypes.cast(buffer, ctypes.POINTER(ctypes.c_void_p))[0]
+        text = wintypes.LPWSTR()
+        convert = advapi32.ConvertSidToStringSidW
+        convert.argtypes = [wintypes.LPVOID, ctypes.POINTER(wintypes.LPWSTR)]
+        convert.restype = wintypes.BOOL
+        if not convert(sid, ctypes.byref(text)):
+            raise OSError(_windows_last_error(ctypes), "cannot render current Windows token SID")
+        try:
+            return str(text.value)
+        finally:
+            kernel32.LocalFree(text)
+    finally:
+        kernel32.CloseHandle(token)
+
+
+def _windows_private_dacl_trustees(sid: str) -> tuple[str, ...]:
+    """Return the distinct SDDL trustees permitted for private runtime state."""
+    if not re.fullmatch(r"S-1-[0-9-]+", sid):
+        raise ValueError("invalid current Windows SID")
+    aliases = {"S-1-5-18": "SY", "S-1-5-32-544": "BA"}
+    principals = (aliases.get(sid, sid), "SY", "BA")
+    unique: dict[str, str] = {}
+    for principal in principals:
+        unique.setdefault(principal.casefold(), principal)
+    return tuple(unique.values())
+
+
+def _windows_private_dacl_sddl(sid: str) -> str:
+    """Protected, inheritable DACL: current user plus only OS recovery principals."""
+    return "D:P" + "".join(
+        f"(A;OICI;FA;;;{trustee})" for trustee in _windows_private_dacl_trustees(sid)
+    )
+
+
+def _windows_apply_dacl_sddl(path: Path, sddl: str) -> None:
+    """Apply one native SDDL DACL without shelling out through a localized tool."""
+    import ctypes
+    from ctypes import wintypes
+
+    descriptor = wintypes.LPVOID()
+    advapi32 = _windows_library(ctypes, "advapi32")
+    kernel32 = _windows_library(ctypes, "kernel32")
+    convert = advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW
+    convert.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, ctypes.POINTER(wintypes.LPVOID), wintypes.LPVOID]
+    convert.restype = wintypes.BOOL
+    if not convert(sddl, 1, ctypes.byref(descriptor), None):
+        raise OSError(_windows_last_error(ctypes), "cannot build Windows runtime DACL")
+    try:
+        set_security = advapi32.SetFileSecurityW
+        set_security.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.LPVOID]
+        set_security.restype = wintypes.BOOL
+        dacl_information = 0x00000004 | 0x80000000
+        if not set_security(str(path), dacl_information, descriptor):
+            raise OSError(_windows_last_error(ctypes), "cannot protect Windows runtime DACL")
+    finally:
+        kernel32.LocalFree(descriptor)
+
+
+def _windows_apply_private_dacl(path: Path, sid: str) -> None:
+    """Set a protected inheritable DACL on a newly-created runtime directory."""
+    _windows_apply_dacl_sddl(path, _windows_private_dacl_sddl(sid))
+
+
+def _windows_dacl_sddl(path: Path) -> str:
+    """Read only the DACL text through native security APIs."""
+    import ctypes
+    from ctypes import wintypes
+
+    security_descriptor = wintypes.LPVOID()
+    text = wintypes.LPWSTR()
+    advapi32 = _windows_library(ctypes, "advapi32")
+    kernel32 = _windows_library(ctypes, "kernel32")
+    get_security = advapi32.GetNamedSecurityInfoW
+    get_security.argtypes = [
+        wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD, wintypes.LPVOID, wintypes.LPVOID,
+        wintypes.LPVOID, wintypes.LPVOID, ctypes.POINTER(wintypes.LPVOID),
+    ]
+    get_security.restype = wintypes.DWORD
+    dacl_information = 0x00000004
+    result = get_security(
+        str(path), 1, dacl_information, None, None, None, None, ctypes.byref(security_descriptor)
+    )
+    if result:
+        raise OSError(result, "cannot inspect Windows runtime DACL")
+    try:
+        convert = advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW
+        convert.argtypes = [
+            wintypes.LPVOID, wintypes.DWORD, wintypes.DWORD, ctypes.POINTER(wintypes.LPWSTR),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        convert.restype = wintypes.BOOL
+        size = wintypes.DWORD()
+        if not convert(security_descriptor, 1, dacl_information, ctypes.byref(text), ctypes.byref(size)):
+            raise OSError(_windows_last_error(ctypes), "cannot render Windows runtime DACL")
+        try:
+            return str(text.value)
+        finally:
+            kernel32.LocalFree(text)
+    finally:
+        kernel32.LocalFree(security_descriptor)
+
+
+def _windows_dacl_sddl_for_handle(handle: int) -> str:
+    """Read the DACL bound to a retained Windows handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    security_descriptor = wintypes.LPVOID()
+    text = wintypes.LPWSTR()
+    advapi32 = _windows_library(ctypes, "advapi32")
+    kernel32 = _windows_library(ctypes, "kernel32")
+    get_security = advapi32.GetSecurityInfo
+    get_security.argtypes = [
+        wintypes.HANDLE, ctypes.c_int, wintypes.DWORD, wintypes.LPVOID, wintypes.LPVOID,
+        wintypes.LPVOID, wintypes.LPVOID, ctypes.POINTER(wintypes.LPVOID),
+    ]
+    get_security.restype = wintypes.DWORD
+    dacl_information = 0x00000004
+    result = get_security(handle, 1, dacl_information, None, None, None, None, ctypes.byref(security_descriptor))
+    if result:
+        raise OSError(result, "cannot inspect Windows runtime DACL")
+    try:
+        convert = advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW
+        convert.argtypes = [
+            wintypes.LPVOID, wintypes.DWORD, wintypes.DWORD, ctypes.POINTER(wintypes.LPWSTR),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        convert.restype = wintypes.BOOL
+        size = wintypes.DWORD()
+        if not convert(security_descriptor, 1, dacl_information, ctypes.byref(text), ctypes.byref(size)):
+            raise OSError(_windows_last_error(ctypes), "cannot render Windows runtime DACL")
+        try:
+            return str(text.value)
+        finally:
+            kernel32.LocalFree(text)
+    finally:
+        kernel32.LocalFree(security_descriptor)
+
+
+def _windows_private_dacl_is_valid(sddl: str, sid: str, *, directory: bool) -> bool:
+    """Reject broad or altered ACEs; inherited file ACEs are accepted precisely."""
+    if not isinstance(sddl, str) or "D:" not in sddl:
+        return False
+    dacl = sddl.split("D:", 1)[1]
+    if directory and not dacl.startswith("P"):
+        return False
+    aces = re.findall(r"\(([^()]*)\)", dacl)
+    expected = {trustee.casefold() for trustee in _windows_private_dacl_trustees(sid)}
+    observed: set[str] = set()
+    for ace in aces:
+        fields = ace.split(";")
+        if len(fields) != 6:
+            return False
+        kind, flags, rights, _object_guid, _inherit_object_guid, trustee = fields
+        if kind != "A" or rights.casefold() not in {"fa", "0x1f01ff"}:
+            return False
+        if trustee.casefold() not in expected or trustee.casefold() in observed:
+            return False
+        normalized_flags = flags.casefold()
+        allowed = {"oici", "idoici", "id"} if not directory else {"oici"}
+        if normalized_flags not in allowed:
+            return False
+        observed.add(trustee.casefold())
+    return observed == expected
+
+
+def _validate_windows_runtime_entry(
+    path: Path, *, directory: bool, sid: str, handle: int | None = None
+) -> None:
+    """Validate one path through a scoped non-reparse handle."""
+    opened_here = handle is None
+    if handle is None:
+        handle = _windows_open_path(path, directory=directory)
+    try:
+        sddl = _windows_dacl_sddl_for_handle(handle) if not opened_here else _windows_dacl_sddl(path)
+        if not _windows_private_dacl_is_valid(sddl, sid, directory=directory):
+            kind = "directory" if directory else "file"
+            raise RuntimeError(f"idempotency runtime {kind} has an unsafe Windows DACL")
+    finally:
+        if opened_here:
+            _windows_close_handle(handle)
+
+
+def prepare_windows_idempotency_runtime_paths(state_dir: Path, owners_dir: Path) -> None:
+    """Create the two runtime directories with protected DACLs, never repair old ones."""
+    if os.name != "nt":
+        return
+    sid = _windows_current_user_sid()
+
+    def acquire(path: Path) -> tuple[_SecureDirectory, bool]:
+        try:
+            return _acquire_secure_directory(path, create=False), False
+        except FileNotFoundError:
+            return _acquire_secure_directory(path, create=True), True
+
+    state, state_created = acquire(state_dir)
+    try:
+        if state_created:
+            _windows_apply_private_dacl(state_dir, sid)
+        _validate_windows_runtime_entry(
+            state_dir, directory=True, sid=sid, handle=state.windows_handle
+        )
+        owners, owners_created = acquire(owners_dir)
+        try:
+            if not _windows_child_is_in_directory(state, owners.windows_handle):
+                raise OSError("Windows owner directory escaped its retained state directory")
+            if owners_created:
+                _windows_apply_private_dacl(owners_dir, sid)
+            _validate_windows_runtime_entry(
+                owners_dir, directory=True, sid=sid, handle=owners.windows_handle
+            )
+        finally:
+            owners.close()
+    finally:
+        state.close()
+
+
+def validate_windows_idempotency_runtime_paths(
+    state_dir: Path, owners_dir: Path, private_paths: tuple[Path, ...]
+) -> None:
+    """Reject reparse points or broadened runtime state before SQLite/pickle reads."""
+    if os.name != "nt":
+        return
+    sid = _windows_current_user_sid()
+    with _open_secure_directory(state_dir, create=False) as state:
+        _validate_windows_runtime_entry(
+            state_dir, directory=True, sid=sid, handle=state.windows_handle
+        )
+        with _open_secure_directory(owners_dir, create=False) as owners:
+            if not _windows_child_is_in_directory(state, owners.windows_handle):
+                raise OSError("Windows owner directory escaped its retained state directory")
+            _validate_windows_runtime_entry(
+                owners_dir, directory=True, sid=sid, handle=owners.windows_handle
+            )
+        for path in private_paths:
+            if path.parent != state_dir:
+                raise RuntimeError("idempotency runtime database escaped its trusted state directory")
+            try:
+                fd = _open_secure_file_at(state, path.name, os.O_RDONLY)
+            except FileNotFoundError:
+                continue
+            try:
+                _validate_windows_runtime_entry(
+                    path,
+                    directory=False,
+                    sid=sid,
+                    handle=getattr(msvcrt, "get_osfhandle")(fd),  # noqa: B009 - Windows-only stub
+                )
+            finally:
+                os.close(fd)
+
+
+def _windows_handle_identity(handle: int) -> tuple[int, int, int]:
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileInfo(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    info = _FileInfo()
+    kernel32 = _windows_library(ctypes, "kernel32")
+    get_info = kernel32.GetFileInformationByHandle
+    get_info.argtypes = [wintypes.HANDLE, ctypes.POINTER(_FileInfo)]
+    get_info.restype = wintypes.BOOL
+    if not get_info(handle, ctypes.byref(info)):
+        raise OSError(_windows_last_error(ctypes), "cannot identify retained Windows handle")
+    return info.volume_serial, info.file_index_high, info.file_index_low
+
+
+def _open_posix_directory(path: Path, *, create: bool, mode: int) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    current_fd = os.open(path.anchor or "/", flags)
+    try:
+        for part in path.parts[1:]:
+            try:
+                child_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                os.mkdir(part, mode=mode, dir_fd=current_fd)
+                child_fd = os.open(part, flags, dir_fd=current_fd)
+            if not stat.S_ISDIR(os.fstat(child_fd).st_mode):
+                os.close(child_fd)
+                raise OSError("non-directory path component")
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _acquire_windows_secure_directory(
+    absolute: Path,
+    *,
+    create: bool,
+    mode: int,
+    open_path: Callable[..., int] = _windows_open_path,
+    close_handle: Callable[[int], None] = _windows_close_handle,
+) -> _SecureDirectory:
+    """Open every directory component without following a Windows reparse point."""
+    handles: list[int] = []
+    current = Path(absolute.anchor)
+    try:
+        handles.append(open_path(current, directory=True))
+        for part in absolute.parts[1:]:
+            current /= part
+            try:
+                handles.append(open_path(current, directory=True))
+            except FileNotFoundError:
+                if not create:
+                    raise
+                current.mkdir(mode=mode)
+                handles.append(open_path(current, directory=True))
+        return _SecureDirectory(
+            absolute, windows_handles=handles, close_windows_handle=close_handle
+        )
+    except BaseException:
+        while handles:
+            close_handle(handles.pop())
+        raise
+
+
+def _acquire_secure_directory(
+    path: Path, *, create: bool, mode: int = 0o700
+) -> _SecureDirectory:
+    """Return a retained secure directory handle for explicit owners."""
+    absolute = path.expanduser().absolute()
+    if os.name != "nt":
+        directory = _SecureDirectory(
+            absolute,
+            fd=_open_posix_directory(absolute, create=create, mode=mode),
+        )
+    else:
+        directory = _acquire_windows_secure_directory(absolute, create=create, mode=mode)
+    return directory
+
+
+def _acquire_trusted_runtime_root(path: Path) -> _SecureDirectory:
+    """Pin the configured runtime root after validating its local authority."""
+    absolute = path.expanduser().absolute()
+    created = False
+    try:
+        os.lstat(absolute)
+    except FileNotFoundError:
+        created = True
+    directory = _acquire_secure_directory(absolute, create=True, mode=0o700)
+    try:
+        if os.name != "nt":
+            assert directory.fd is not None
+            if created:
+                os.fchmod(directory.fd, 0o700)
+            info = os.fstat(directory.fd)
+            if (
+                not stat.S_ISDIR(info.st_mode)
+                or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) & 0o022
+            ):
+                raise OSError("runtime state root is not owner-controlled")
+        return directory
+    except BaseException:
+        directory.close()
+        raise
+
+
+@contextlib.contextmanager
+def _open_secure_directory(
+    path: Path, *, create: bool, mode: int = 0o700
+) -> Iterator[_SecureDirectory]:
+    """Pin the lock directory and, on Windows, every non-reparse ancestor."""
+    directory = _acquire_secure_directory(path, create=create, mode=mode)
+    try:
+        yield directory
+    finally:
+        directory.close()
+
+
+def _same_directory_path(directory: _SecureDirectory) -> bool:
+    try:
+        if os.name != "nt":
+            current = os.lstat(directory.path)
+            assert directory.fd is not None
+            retained = os.fstat(directory.fd)
+            return (
+                stat.S_ISDIR(current.st_mode)
+                and current.st_dev == retained.st_dev
+                and current.st_ino == retained.st_ino
+            )
+        current_handle = _windows_open_path(directory.path, directory=True)
+        try:
+            return _windows_handle_identity(current_handle) == _windows_handle_identity(
+                directory.windows_handle
+            )
+        finally:
+            _windows_close_handle(current_handle)
+    except OSError:
+        return False
+
+
+def _same_file_entry(directory: _SecureDirectory, name: str, fd: int) -> bool:
+    try:
+        if os.name != "nt":
+            current = os.stat(name, dir_fd=directory.fd, follow_symlinks=False)
+            retained = os.fstat(fd)
+            return (
+                stat.S_ISREG(current.st_mode)
+                and current.st_dev == retained.st_dev
+                and current.st_ino == retained.st_ino
+            )
+        current_handle = _windows_open_path(directory.path / name, directory=False)
+        try:
+            return _windows_handle_identity(current_handle) == _windows_handle_identity(
+                getattr(msvcrt, "get_osfhandle")(fd)
+            )
+        finally:
+            _windows_close_handle(current_handle)
+    except OSError:
+        return False
+
+
+def _open_secure_file_at(
+    directory: _SecureDirectory,
+    name: str,
+    flags: int,
+    mode: int = 0o600,
+) -> int:
+    if not name or Path(name).name != name or "/" in name or "\\" in name:
+        raise OSError("lock operations require one child basename")
+    if os.name != "nt":
+        actual_flags = flags | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        fd = os.open(name, actual_flags, mode, dir_fd=directory.fd)
+    else:
+        access = 0x80000000  # GENERIC_READ
+        if flags & os.O_RDWR:
+            access = 0xC0000000  # GENERIC_READ | GENERIC_WRITE
+        elif flags & os.O_WRONLY:
+            access = 0x40000000  # GENERIC_WRITE
+        creation = 4 if flags & os.O_CREAT else 3  # OPEN_ALWAYS / OPEN_EXISTING
+        handle = _windows_open_path(
+            directory.path / name,
+            directory=False,
+            access=access,
+            creation=creation,
+        )
+        try:
+            if not _windows_child_is_in_directory(directory, handle):
+                raise OSError("Windows runtime file escaped its retained directory")
+            fd = getattr(msvcrt, "open_osfhandle")(handle, flags | getattr(os, "O_BINARY", 0))
+        except BaseException:
+            _windows_close_handle(handle)
+            raise
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode):
+        os.close(fd)
+        raise OSError("lock path is not a regular file")
+    return fd
+
+
+def _open_owned_runtime_lock_file(directory: _SecureDirectory, name: str) -> int:
+    """Open one persistent owner-only runtime lock without replacing it."""
+    created = False
+    if os.name != "nt":
+        try:
+            fd = _open_secure_file_at(directory, name, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+            created = True
+        except FileExistsError:
+            fd = _open_secure_file_at(directory, name, os.O_RDWR, 0o600)
+        try:
+            if created:
+                os.fchmod(fd, 0o600)
+            info = os.fstat(fd)
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) != 0o600
+            ):
+                raise OSError("runtime lock file is not owner-only")
+            return fd
+        except BaseException:
+            os.close(fd)
+            raise
+    return _open_secure_file_at(directory, name, os.O_RDWR | os.O_CREAT, 0o600)
 
 
 @dataclass
@@ -247,7 +943,14 @@ class VaultMutationCoordinator:
                 yield
             finally:
                 hold_ms = round((time.monotonic() - acquired_at) * 1000, 2)
-                _LAST_MUTATION_TIMING.set({"wait_ms": wait_ms, "hold_ms": hold_ms})
+                _LAST_MUTATION_TIMING.set(
+                    {
+                        "wait_ms": wait_ms,
+                        "hold_ms": hold_ms,
+                        "operation": _safe_label(operation, fallback="unknown"),
+                        "holder_kind": _safe_label(holder_kind, fallback="unknown"),
+                    }
+                )
                 with state.metadata_guard:
                     already_warned = state.long_warning_emitted
                     state.request_id = None
@@ -494,17 +1197,36 @@ class VaultMutationCoordinator:
         )
 
 
-def _try_os_lock(handle: BinaryIO) -> bool:
+def _try_os_lock(
+    handle: BinaryIO,
+    *,
+    _windows: bool = os.name == "nt",
+    _locking: Callable[[int, int, int], Any] | None = (
+        getattr(msvcrt, "locking", None) if os.name == "nt" else None
+    ),
+    _flock: Callable[[int, int], Any] | None = (
+        None if os.name == "nt" else fcntl.flock
+    ),
+    _busy_errnos: frozenset[int] = _BUSY_ERRNOS,
+    _lock_nonblocking: int | None = (
+        getattr(msvcrt, "LK_NBLCK", None) if os.name == "nt" else None
+    ),
+    _lock_exclusive_nonblocking: int | None = (
+        None if os.name == "nt" else fcntl.LOCK_EX | fcntl.LOCK_NB
+    ),
+) -> bool:
     try:
-        if os.name == "nt":
+        if _windows:
+            assert _locking is not None and _lock_nonblocking is not None
             handle.seek(0)
-            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            _locking(handle.fileno(), _lock_nonblocking, 1)
         else:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert _flock is not None and _lock_exclusive_nonblocking is not None
+            _flock(handle.fileno(), _lock_exclusive_nonblocking)
     except BlockingIOError:
         return False
     except OSError as exc:
-        if exc.errno in _BUSY_ERRNOS:
+        if exc.errno in _busy_errnos:
             return False
         raise
     return True
@@ -523,12 +1245,28 @@ def _acquire_os_lock_until(
         time.sleep(min(poll_interval_seconds, remaining))
 
 
-def _release_os_lock(handle: BinaryIO) -> None:
-    if os.name == "nt":
+def _release_os_lock(
+    handle: BinaryIO,
+    *,
+    _windows: bool = os.name == "nt",
+    _locking: Callable[[int, int, int], Any] | None = (
+        getattr(msvcrt, "locking", None) if os.name == "nt" else None
+    ),
+    _flock: Callable[[int, int], Any] | None = (
+        None if os.name == "nt" else fcntl.flock
+    ),
+    _lock_unlock: int | None = (
+        getattr(msvcrt, "LK_UNLCK", None) if os.name == "nt" else None
+    ),
+    _lock_unlock_posix: int | None = (None if os.name == "nt" else fcntl.LOCK_UN),
+) -> None:
+    if _windows:
+        assert _locking is not None and _lock_unlock is not None
         handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        _locking(handle.fileno(), _lock_unlock, 1)
     else:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        assert _flock is not None and _lock_unlock_posix is not None
+        _flock(handle.fileno(), _lock_unlock_posix)
 
 
 def _safe_label(value: object, *, fallback: str) -> str:
@@ -598,8 +1336,8 @@ def _read_holder_metadata(path: Path) -> dict[str, object] | None:
 def _holder_snapshot(
     holder: dict[str, object], *, verified: bool
 ) -> dict[str, object]:
-    acquired_at = float(holder["acquired_at"])
-    long_holder_seconds = float(holder["long_holder_seconds"])
+    acquired_at = float(cast(int | float, holder["acquired_at"]))
+    long_holder_seconds = float(cast(int | float, holder["long_holder_seconds"]))
     age = max(0.0, time.time() - acquired_at)
     return {
         "state": "held",
@@ -665,7 +1403,10 @@ def active_mutation_snapshot() -> dict[str, object]:
     ]
     if not held:
         return {"state": "free"}
-    return max(held, key=lambda item: float(item["age_seconds"]))
+    return max(
+        held,
+        key=lambda item: float(cast(int | float, item["age_seconds"])),
+    )
 
 
 def dynamic_retry_after_ms(snapshot: dict[str, object] | None) -> int:
@@ -676,7 +1417,7 @@ def dynamic_retry_after_ms(snapshot: dict[str, object] | None) -> int:
     """
     if not snapshot or snapshot.get("state") != "held":
         return 750
-    age_seconds = float(snapshot.get("age_seconds") or 0.0)
+    age_seconds = float(cast(int | float, snapshot.get("age_seconds") or 0.0))
     retry_after_ms = min(15000, max(750, int(age_seconds * 500)))
     if snapshot.get("overdue"):
         retry_after_ms = max(retry_after_ms, 5000)

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -248,6 +248,16 @@ def _artifact_receipt_projection(result: Any) -> dict[str, Any]:
     return {"files": projected, "summary": {"stored": stored, "failed": failed}}
 
 
+def receipt_leaf_projection(leaf_result: Any) -> dict[str, Any]:
+    """Portable graph receipts never retain collection paths or content metadata."""
+    # Collection receipts are public API results, not portable graph protocol
+    # authority: both shapes include affected paths.  A local exact retry can
+    # reconstruct only the envelope after a SQLite cut, which is preferable
+    # to copying user paths into a synced hidden file.
+    del leaf_result
+    return {}
+
+
 def committed_terminal(
     leaf_result: Any,
     *,
@@ -403,6 +413,16 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
     elif valid_planning_receipt(leaf):
         compact.update({key: leaf[key] for key in _PLAN_RECEIPT_FIELDS if key in leaf})
     compact.update(_artifact_receipt_projection(leaf))
+    if isinstance(leaf, Mapping) and leaf.get("graph_sync") in {"completed", "failed"}:
+        compact["graph_sync"] = leaf["graph_sync"]
+        for key in (
+            "graph_sync_code",
+            "graph_sync_checkpoint",
+            "graph_sync_remediation",
+        ):
+            value = leaf.get(key)
+            if isinstance(value, str):
+                compact[key] = value
     compact["warnings_count"] = result["warnings_count"]
     if detail == "full":
         compact["diagnostics"] = result["leaf_result"]

--- a/src/exomem/recall_policy.py
+++ b/src/exomem/recall_policy.py
@@ -204,6 +204,14 @@ def recall_policy_identity(vault_root: Path) -> tuple[str, str]:
     return RECALL_POLICY_VERSION, access.policy_fingerprint(Path(vault_root))
 
 
+def recall_publication_policy_identity(vault_root: Path) -> tuple[str, str] | None:
+    """Exact bounded policy identity suitable for sidecar publication."""
+    snapshot = access.publication_policy_snapshot(Path(vault_root))
+    if snapshot is None:
+        return None
+    return RECALL_POLICY_VERSION, snapshot.fingerprint
+
+
 def _vault_relative(root: Path, path: Path | str) -> str | None:
     raw = str(path)
     if ("\\" in raw and os.name != "nt") or "\x00" in raw:

--- a/src/exomem/reconcile.py
+++ b/src/exomem/reconcile.py
@@ -85,9 +85,10 @@ class ReconcileReport:
     remaining_drift: list[dict] = field(default_factory=list)
     receipt_reconcile: dict = field(default_factory=dict)
     dry_run: bool = False
+    _graph_reconcile_registered: int | None = field(default=None, repr=False)
 
     def as_dict(self) -> dict:
-        return {
+        result = {
             "indexes_updated": self.indexes_updated,
             "embeddings_refreshed": self.embeddings_refreshed,
             "embeddings_status": self.embeddings_status,
@@ -132,6 +133,10 @@ class ReconcileReport:
             "receipt_reconcile": self.receipt_reconcile,
             "dry_run": self.dry_run,
         }
+        registered = self._graph_reconcile_registered
+        if registered is not None:
+            result["_graph_reconcile_registered"] = registered
+        return result
 
 
 def _rel(path: Path, vault_root: Path) -> str:
@@ -454,11 +459,55 @@ def reconcile(vault_root: Path, *, dry_run: bool = False) -> ReconcileReport:
     if os.environ.get("EXOMEM_DISABLE_GRAPH_INDEX"):
         report.graph_status = "disabled"
     else:
-        if initial_graph_drift and not dry_run:
-            if audit_module._check_graph_drift(vault_root):
-                epistemic_graph.EpistemicGraphIndex(vault_root).rebuild_all()
-        report.graph_refreshed = len(initial_graph_drift)
-        report.graph_status = "refreshed" if initial_graph_drift else "current"
+        initial_epoch = epistemic_graph.graph_sync.status(vault_root)
+        index = epistemic_graph.EpistemicGraphIndex(vault_root)
+        needs_repair = (
+            bool(initial_graph_drift)
+            or initial_epoch["state"] != "current"
+            or not index.available()
+        )
+        if not dry_run:
+            epistemic_graph.graph_sync.sweep_abandoned_temporaries(
+                vault_root,
+                epistemic_graph.sidecar_path(vault_root),
+                live_paths=epistemic_graph.graph_sync.live_temporary_paths(),
+                state_root=index._canonical_mutation_coordinator().state_root,
+            )
+            if (
+                epistemic_graph.graph_sync.classify_epoch(vault_root).kind
+                == "recoverable"
+            ):
+                epistemic_graph.graph_sync.recover_checkpoint(vault_root)
+            if needs_repair and epistemic_graph.graph_sync.status(vault_root)["state"] != "unavailable":
+                if audit_module._check_graph_drift(vault_root) or not index.available():
+                    checkpoint = epistemic_graph.graph_sync.reconcile_checkpoint(
+                        vault_root
+                    )
+                    dispatch = epistemic_graph._registered_or_failure(
+                        vault_root,
+                        checkpoint,
+                        index,
+                        index._canonical_mutation_coordinator(),
+                    )
+                    from .writer_lease import active_mutation_request_id
+
+                    if active_mutation_request_id() is None:
+                        epistemic_graph.graph_sync.wait_for_registered(
+                            vault_root,
+                            state_root=index._canonical_mutation_coordinator().state_root,
+                        )
+                    elif dispatch.outcome == "registered":
+                        report._graph_reconcile_registered = len(initial_graph_drift)
+        current = (
+            epistemic_graph.graph_sync.status(vault_root)["state"] == "current"
+            and index.available()
+            and not audit_module._check_graph_drift(vault_root)
+        )
+        report.graph_refreshed = len(initial_graph_drift) if current and needs_repair else 0
+        if current:
+            report.graph_status = "refreshed" if needs_repair else "current"
+        else:
+            report.graph_status = "unavailable"
 
     # ---- 2d. CLIP + scene-frame orphan healing ----
     # Heals vaults that already lost content through the pre-fix gap (a media

--- a/src/exomem/recover_from_trash.py
+++ b/src/exomem/recover_from_trash.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import relation_review, semantic_index, semantic_writes
+from . import graph_sync, relation_review, semantic_index, semantic_writes
 from .governance import lifecycle
 from .kbdir import kb_dirname, kb_prefix
 from .vault import (
@@ -25,6 +25,7 @@ from .vault import (
     PathGuard,
     PathGuardError,
     VaultPathError,
+    content_hash,
     in_append_only_tree,
     in_curated_tree,
     read_guarded_text,
@@ -190,6 +191,7 @@ def recover_from_trash(
 
     semantic: dict | None = None
     lifecycle_operation: lifecycle.LifecycleOperation | None = None
+    graph_transition: graph_sync.GraphLifecycleTransition | None = None
     semantic_states: dict[str, semantic_index.SemanticParentIndexState] = {}
     recovery_entries: list[semantic_writes.RecoveryEntry] = []
     destination_root_guard: PathGuard | None = None
@@ -295,39 +297,83 @@ def recover_from_trash(
                 )
 
             try:
-                lifecycle_operation = lifecycle.begin_recovery(
-                    vault_root, trash_rel=trash_rel, source_rel=restore_rel
+                graph_transition = graph_sync.begin_recovery_transition(
+                    vault_root,
+                    trash_rel=trash_rel,
+                    source_rel=restore_rel,
+                    restored_paths=[
+                        (entry.restore_path, content_hash(entry.source))
+                        for entry in recovery_entries
+                    ],
                 )
             except lifecycle.LifecycleError as error:
                 raise RecoverError(code=error.code, reason=error.reason) from error
+            except graph_sync.GraphLifecycleEpochSetupError as error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_EPOCH_FAILED",
+                    reason="could not establish the graph recovery epoch",
+                ) from error
+            except graph_sync.GraphLifecycleRollbackError as error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                    reason="the staged recovery transition could not be restored",
+                ) from error
+            lifecycle_operation = graph_transition.operation
 
             def restore() -> None:
                 try:
-                    assert lifecycle_operation is not None
-                    lifecycle.atomic_rename(
-                        lifecycle_operation,
-                        source=trash_abs,
-                        destination=restore_abs,
-                        recovery=True,
-                    )
+                    assert graph_transition is not None
+                    graph_transition.rename()
                 except lifecycle.LifecycleError as error:
                     raise RecoverError(
                         code=error.code,
                         reason=error.reason,
                     ) from error
+                try:
+                    graph_transition.publish_checkpoint()
+                except Exception as error:  # noqa: BLE001 - outer abort reverses the move
+                    raise RecoverError(
+                        code="GRAPH_SYNC_RECOVERY_CHECKPOINT_FAILED",
+                        reason="graph checkpoint failed; recovery will be reversed",
+                    ) from error
+                from .writer_lease import mark_active_mutation_committed
+
+                mark_active_mutation_committed()
 
             committed = semantic_writes.commit_recovery(
                 vault_root, preflight=preflight, mutate=restore
             )
             semantic = committed.as_dict()
         except semantic_writes.SemanticWriteError as error:
-            if lifecycle_operation is not None:
-                lifecycle.abort_recovery(lifecycle_operation)
+            if graph_transition is not None:
+                try:
+                    graph_transition.abort()
+                except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                    raise RecoverError(
+                        code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                        reason="recovery could not be reversed; reconcile is required",
+                    ) from rollback_error
             raise RecoverError(code=error.code, reason=error.reason) from error
         except PathGuardError as error:
-            if lifecycle_operation is not None:
-                lifecycle.abort_recovery(lifecycle_operation)
+            if graph_transition is not None:
+                try:
+                    graph_transition.abort()
+                except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                    raise RecoverError(
+                        code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                        reason="recovery could not be reversed; reconcile is required",
+                    ) from rollback_error
             raise RecoverError(code=error.code, reason=error.reason) from error
+        except RecoverError:
+            if graph_transition is not None:
+                try:
+                    graph_transition.abort()
+                except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                    raise RecoverError(
+                        code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                        reason="recovery could not be reversed; reconcile is required",
+                    ) from rollback_error
+            raise
     else:
         if relation_reviews:
             raise RecoverError(
@@ -342,25 +388,55 @@ def recover_from_trash(
                 warnings=[],
             )
         try:
-            lifecycle_operation = lifecycle.begin_recovery(
-                vault_root, trash_rel=trash_rel, source_rel=restore_rel
+            graph_transition = graph_sync.begin_recovery_transition(
+                vault_root,
+                trash_rel=trash_rel,
+                source_rel=restore_rel,
+                restored_paths=[],
             )
         except lifecycle.LifecycleError as error:
             raise RecoverError(code=error.code, reason=error.reason) from error
-        restore_abs.parent.mkdir(parents=True, exist_ok=True)
+        except graph_sync.GraphLifecycleEpochSetupError as error:
+            raise RecoverError(
+                code="GRAPH_SYNC_EPOCH_FAILED",
+                reason="could not establish the graph recovery epoch",
+            ) from error
+        except graph_sync.GraphLifecycleRollbackError as error:
+            raise RecoverError(
+                code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                reason="the staged recovery transition could not be restored",
+            ) from error
+        lifecycle_operation = graph_transition.operation
         try:
-            lifecycle.atomic_rename(
-                lifecycle_operation,
-                source=trash_abs,
-                destination=restore_abs,
-                recovery=True,
-            )
+            graph_transition.rename()
+            graph_transition.publish_checkpoint()
         except lifecycle.LifecycleError as e:
-            lifecycle.abort_recovery(lifecycle_operation)
+            try:
+                graph_transition.abort()
+            except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                    reason="recovery could not be reversed; reconcile is required",
+                ) from rollback_error
             raise RecoverError(
                 code=e.code,
                 reason=e.reason,
             ) from e
+        except Exception as error:  # noqa: BLE001 - reverse a caught epoch failure
+            try:
+                graph_transition.abort()
+            except graph_sync.GraphLifecycleRollbackError as rollback_error:
+                raise RecoverError(
+                    code="GRAPH_SYNC_RECOVERY_ROLLBACK_FAILED",
+                    reason="recovery could not be reversed; reconcile is required",
+                ) from rollback_error
+            raise RecoverError(
+                code="GRAPH_SYNC_RECOVERY_CHECKPOINT_FAILED",
+                reason="graph checkpoint failed; recovery was reversed",
+            ) from error
+        from .writer_lease import mark_active_mutation_committed
+
+        mark_active_mutation_committed()
 
     warnings: list[str] = []
     if sidecar_guard.leaf_policy == "content":
@@ -390,6 +466,7 @@ def recover_from_trash(
     if restored_markdown:
         from . import file_watcher, index_sync
 
+        fanout_unverified = False
         try:
             file_watcher.register_self_write(vault_root, restored_markdown)
         except Exception:  # noqa: BLE001 - suppression is independently observed
@@ -422,6 +499,10 @@ def recover_from_trash(
                 report = index_sync.upsert_after_write(vault_root, restored_markdown)
         except Exception:  # noqa: BLE001 - restore remains authoritative
             log.exception("restored index refresh failed for %s", restore_rel)
+            try:
+                graph_sync.register_outer_fanout_failure(vault_root)
+            except Exception:  # noqa: BLE001 - retain the canonical recovery and report reconcile
+                log.exception("graph fanout failure handoff could not be registered")
             warnings.append(
                 "recovery succeeded but derived-index refresh failed; run reconcile"
             )
@@ -431,6 +512,7 @@ def recover_from_trash(
                 watcher=watcher_outcome,
             )
         else:
+            fanout_unverified = not isinstance(report, index_sync.IndexSyncReport)
             report = index_sync.with_component(
                 report
                 if isinstance(report, index_sync.IndexSyncReport)
@@ -440,6 +522,20 @@ def recover_from_trash(
                 watcher_outcome,
             )
         index_feedback = report.as_dict()
+        if fanout_unverified:
+            index_feedback["derived_work"] = "unverified"
+
+        from .writer_lease import active_mutation_request_id
+
+        if active_mutation_request_id() is None:
+            required = graph_sync.registered_checkpoint(vault_root)
+            if required is not None:
+                try:
+                    graph_sync.wait_for_registered(vault_root)
+                except Exception:  # noqa: BLE001 - leave recovery evidence staged
+                    warnings.append("recovery succeeded but graph publication failed; run reconcile")
+    elif lifecycle_operation is not None:
+        index_feedback = lifecycle.exact_no_derived_index_report(lifecycle_operation)
 
     if lifecycle_operation is not None and not lifecycle.finish_recovery(
         lifecycle_operation, index_report=index_feedback
@@ -470,6 +566,16 @@ def recover_from_trash(
     )
     if log_warning:
         warnings.append(log_warning)
+
+    from .writer_lease import active_mutation_request_id
+
+    if active_mutation_request_id() is None:
+        required = graph_sync.registered_checkpoint(vault_root)
+        if required is not None:
+            try:
+                graph_sync.wait_for_registered(vault_root)
+            except Exception:  # noqa: BLE001 - log publication remains recoverable
+                warnings.append("recovery log graph publication failed; run reconcile")
 
     return RecoverResult(
         trash_path=trash_rel,

--- a/src/exomem/runtime_readiness.py
+++ b/src/exomem/runtime_readiness.py
@@ -35,6 +35,18 @@ def _public_mutation_boundary(value: object) -> dict[str, Any]:
     }
 
 
+def _public_graph_sync(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    state = value.get("state")
+    generation = value.get("generation")
+    if state not in {"current", "recovery_required", "unavailable"}:
+        return None
+    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+        return None
+    return {"state": state, "generation": generation}
+
+
 def package_release() -> str:
     """Return the installed distribution release without making readiness fragile."""
     try:
@@ -90,6 +102,17 @@ def build_runtime_readiness(
         if isinstance(raw_stale_count, int) and raw_stale_count >= 0
         else 0
     )
+    coordination_payload = {
+        "enabled": enabled,
+        "role": role,
+        "coordinator_healthy": healthy,
+        "mutation_boundary": _public_mutation_boundary(
+            coordination.get("mutation_boundary")
+        ),
+    }
+    graph_sync = _public_graph_sync(coordination.get("graph_sync"))
+    if graph_sync is not None:
+        coordination_payload["graph_sync"] = graph_sync
     return {
         "status": "ready" if takeover_eligible else "not_ready",
         "service": "exomem",
@@ -99,14 +122,7 @@ def build_runtime_readiness(
         "transport": HTTP_TRANSPORT,
         "instance_id": _instance_id(),
         "replica_id": replica_id,
-        "coordination": {
-            "enabled": enabled,
-            "role": role,
-            "coordinator_healthy": healthy,
-            "mutation_boundary": _public_mutation_boundary(
-                coordination.get("mutation_boundary")
-            ),
-        },
+        "coordination": coordination_payload,
         "session_store": {
             "state": session_store_state,
             "stale_served_count": stale_served_count,

--- a/src/exomem/vault.py
+++ b/src/exomem/vault.py
@@ -114,6 +114,7 @@ VAULT_SCAN_SKIP_DIRS = frozenset(
         ".obsidian",
         ".git",
         ".graph-coordination",
+        ".graph-commit-receipts",
         ".trash",
         "_attachments",
         "_archive",
@@ -2779,6 +2780,46 @@ def post_commit_batch_fanout(
         if semantic_states:
             kwargs["semantic_states"] = semantic_states
         report = index_sync.upsert_after_write(vault_root, replaced, **kwargs)
+        # A graph-relevant epoch is a canonical promise, not a best-effort
+        # side effect.  The graph leaf returns an exact result, but keep this
+        # final boundary check here so a future fanout branch cannot return a
+        # committed batch with an unacknowledged checkpoint and no joinable
+        # handle.
+        graph = next(
+            (
+                item
+                for item in getattr(report, "components", ())
+                if getattr(item, "component", None) == "epistemic_graph"
+            ),
+            None,
+        )
+        if graph is not None and graph.outcome != "not_required":
+            from . import graph_sync
+
+            required = graph_sync.read_checkpoint(vault_root)
+            handoff_missing = required is not None and (
+                (
+                    graph.outcome == "completed"
+                    and graph_sync.status(vault_root).get("state") != "current"
+                )
+                or (
+                    graph.outcome in {"registered", "deferred", "failed"}
+                    and graph_sync.registered_checkpoint(vault_root) != required
+                )
+            )
+            if handoff_missing:
+                assert required is not None
+                graph_sync.register_failure(
+                    vault_root,
+                    required,
+                    code="GRAPH_SYNC_HANDOFF_MISSING",
+                )
+                report = index_sync.with_component(
+                    report,
+                    index_sync.IndexComponentOutcome(
+                        "epistemic_graph", "failed", "GRAPH_SYNC_HANDOFF_MISSING"
+                    ),
+                )
         if index_reports is not None:
             index_reports.append(report)
         if report is False or getattr(report, "reconcile_required", False):
@@ -2788,6 +2829,14 @@ def post_commit_batch_fanout(
                 "durable full-index refresh recorded"
             )
     except Exception:  # noqa: BLE001 — embeddings are best-effort
+        try:
+            from . import graph_sync
+
+            graph_sync.register_outer_fanout_failure(vault_root)
+        except Exception:  # noqa: BLE001 - canonical commit must still survive
+            logging.getLogger(__name__).exception(
+                "failed to register graph handoff after dispatch failure"
+            )
         try:
             from . import index_sync as failed_index_sync
 
@@ -2859,6 +2908,7 @@ def batch_atomic_write(
     index_reports: list[Any] | None = None,
     semantic_states: Mapping[str, Any] | None = None,
     post_commit_fanout: bool = True,
+    commit_point: bool = True,
 ) -> list[Path]:
     """Commit one batch while serializing all in-process vault writers.
 
@@ -2875,6 +2925,7 @@ def batch_atomic_write(
             index_reports=index_reports,
             semantic_states=semantic_states,
             post_commit_fanout=post_commit_fanout,
+            commit_point=commit_point,
         )
 
 
@@ -2886,6 +2937,7 @@ def _batch_atomic_write_locked(
     index_reports: list[Any] | None = None,
     semantic_states: Mapping[str, Any] | None = None,
     post_commit_fanout: bool = True,
+    commit_point: bool = True,
 ) -> list[Path]:
     """Stage writes in private workspaces, then replace destinations in order.
 
@@ -2905,7 +2957,19 @@ def _batch_atomic_write_locked(
     opt-in ``index_reports`` collector receives the report from that same
     fan-out; requesting feedback never dispatches indexes a second time.
     """
-    writes = list(writes)
+    caller_writes = list(writes)
+    writes = list(caller_writes)
+    graph_checkpoint_path: Path | None = None
+    graph_floor_path: Path | None = None
+    if vault_root is not None:
+        from . import graph_sync
+
+        epoch_writes = graph_sync.epoch_writes(Path(vault_root), writes)
+        if epoch_writes is not None:
+            floor_write, checkpoint_write = epoch_writes
+            writes = [floor_write, *writes, checkpoint_write]
+            graph_floor_path = floor_write.path
+            graph_checkpoint_path = checkpoint_write.path
     destinations: set[str] = set()
     for write in writes:
         destination = os.path.abspath(write.path)
@@ -3075,9 +3139,13 @@ def _batch_atomic_write_locked(
                     snapshot = snapshots[pending_index]
                     if snapshot is None:  # pragma: no cover - guard implies a snapshot
                         raise PathGuardError("PATH_GUARD_CHANGED", "batch snapshot is unavailable")
-                    _reset_restored_timestamps(
-                        staged[pending_index][0], source_guard.identity, snapshot
-                    )
+                    if staged[pending_index][0] not in {
+                        graph_floor_path,
+                        graph_checkpoint_path,
+                    }:
+                        _reset_restored_timestamps(
+                            staged[pending_index][0], source_guard.identity, snapshot
+                        )
             for guard in final_guards.values():
                 guard.recheck()
             if vault_root is not None:
@@ -3125,7 +3193,7 @@ def _batch_atomic_write_locked(
         for guard in final_guards.values():
             guard.recheck()
         log_active_mutation_phase("canonical_files_committed", affected_count=len(replaced))
-        if replaced:
+        if replaced and commit_point:
             mark_active_mutation_committed()
     except Exception as commit_error:
         rollback_errors: list[BaseException] = []
@@ -3213,9 +3281,12 @@ def _batch_atomic_write_locked(
             )
             if snapshot is None
         ]
+        graph_epoch_paths = {graph_floor_path, graph_checkpoint_path}
+        fanout_replaced = [path for path in replaced if path not in graph_epoch_paths]
+        created_paths = [path for path in created_paths if path not in graph_epoch_paths]
         post_commit_batch_fanout(
             vault_root,
-            replaced,
+            fanout_replaced,
             index_reports,
             semantic_states,
             created_paths=created_paths,
@@ -3226,7 +3297,7 @@ def _batch_atomic_write_locked(
             target_summary,
             True,
         )
-    return replaced
+    return [write.path for write in caller_writes]
 
 
 def _validate_batch_write_access(

--- a/src/exomem/writer_lease.py
+++ b/src/exomem/writer_lease.py
@@ -8,6 +8,7 @@ without it the invocation path is the legacy standalone path.
 from __future__ import annotations
 
 import atexit
+import ctypes
 import hashlib
 import json
 import logging
@@ -15,7 +16,9 @@ import math
 import os
 import pickle
 import re
+import secrets
 import sqlite3
+import stat
 import threading
 import time
 import urllib.error
@@ -39,6 +42,7 @@ from .mutation_lock import (
 from .mutation_lock import _release_os_lock as _release_owner_lock
 from .mutation_lock import _try_os_lock as _try_owner_lock
 from .mutation_terminal import (
+    ResponseDetail,
     committed_terminal,
     needs_review_terminal,
     project_terminal,
@@ -101,18 +105,27 @@ _COMMITTED_FAILURE_OUTCOME_KEYS = frozenset(
         "omitted_target_count",
     }
 )
+_RECEIPT_RESULT_SUMMARY_MAX_DEPTH = 8
+_RECEIPT_RESULT_SUMMARY_MAX_ITEMS = 128
 _RETRY_IDEMPOTENCY_CLAIM = object()
-# A `pending` row whose owning process is dead becomes `abandoned` rather
-# than blocking every future retry forever; this is the pause before an
-# identical retry is allowed to execute fresh (not the same as the general
-# `expires_after` a caller passes, which governs `completed`/
-# `committed_failure` rows and may be None).
+# Retained for compatibility with callers that advance their injected clocks
+# before asserting a dead attempt remains fail-closed.
 _IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS = 60.0
 # A `pending` row written before this feature shipped has no `owner` to
 # probe; it is honored under the pre-existing any-pending-blocks-forever
-# rule for this long before it, too, ages into `abandoned`.
+# rule for this long before it is classified as an unknown outcome.
 _IDEMPOTENCY_LEGACY_OWNER_GRACE_SECONDS = 600.0
+_OUTCOME_UNKNOWN_TERMINAL = ("exomem.outcome-unknown", 1)
+_OUTCOME_UNKNOWN_PAYLOAD = pickle.dumps(_OUTCOME_UNKNOWN_TERMINAL)
 _WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
+_WINDOWS_SECRET_ENVELOPE_MAGIC = b"EXID"
+_WINDOWS_SECRET_ENVELOPE_VERSION = 1
+_WINDOWS_SECRET_ENVELOPE_MAX_BYTES = 4096
+_WINDOWS_SECRET_ENVELOPE_HEADER_BYTES = 10
+_WINDOWS_SECRET_ENVELOPE_MAX_CIPHERTEXT = (
+    _WINDOWS_SECRET_ENVELOPE_MAX_BYTES - _WINDOWS_SECRET_ENVELOPE_HEADER_BYTES
+)
+_WINDOWS_SECRET_ENTROPY_DOMAIN = b"exomem-graph-commit-receipt-dpapi:v1\0"
 logger = logging.getLogger(__name__)
 _mutation_logger = logging.getLogger("exomem.calls")
 _ACTIVE_WRITE_FENCE: ContextVar[tuple[Any, int] | None] = ContextVar(
@@ -124,9 +137,33 @@ _ACTIVE_MUTATION_TRACE: ContextVar[tuple[str, str, str] | None] = ContextVar(
 _ACTIVE_MUTATION_COMMITTED: ContextVar[bool] = ContextVar(
     "exomem_active_mutation_committed", default=False
 )
+_ACTIVE_MUTATION_PROTOCOL: ContextVar[tuple[str | None, str | None] | None] = ContextVar(
+    "exomem_active_mutation_protocol", default=None
+)
 _ACTIVE_LEASE_MANAGER: ContextVar[Any | None] = ContextVar(
     "exomem_active_lease_manager", default=None
 )
+_ACTIVE_DIRECT_MUTATION_GUARDS: ContextVar[tuple[tuple[str, Path], ...]] = ContextVar(
+    "exomem_active_direct_mutation_guards", default=()
+)
+
+
+def _direct_mutation_boundary(
+    vault_root: os.PathLike[str] | str, state_root: Path
+) -> tuple[str, Path]:
+    root = Path(vault_root) if isinstance(vault_root, str) and Path(vault_root).is_absolute() else vault_root
+    return (
+        canonical_mutation_identity(root),
+        state_root.expanduser().resolve(strict=False),
+    )
+
+
+def _windows_library(ctypes_module: Any, name: str) -> Any:
+    return getattr(ctypes_module, "WinDLL")(name, use_last_error=True)
+
+
+def _windows_last_error(ctypes_module: Any) -> int:
+    return int(getattr(ctypes_module, "get_last_error")())
 
 
 def _log_mutation_event(phase: str, *, level: int = logging.INFO, **fields: Any) -> None:
@@ -158,6 +195,39 @@ def mark_active_mutation_committed() -> None:
         _ACTIVE_MUTATION_COMMITTED.set(True)
 
 
+@contextmanager
+def active_mutation_claim_context(
+    *, claim_token: str | None, command_digest: str | None
+) -> Iterator[None]:
+    """Bind opaque per-claim protocol identity for canonical helper calls.
+
+    The idempotency state-machine lane supplies the durable claim token.  The
+    existing invocation path sets only its already-computed command digest, so
+    existing callers retain their standalone random checkpoint identity.
+    """
+    if claim_token is not None and re.fullmatch(r"[0-9a-f]{24}", claim_token) is None:
+        raise ValueError("claim token must be lowercase 24-hex")
+    if command_digest is not None and re.fullmatch(r"[0-9a-f]{64}", command_digest) is None:
+        raise ValueError("command digest must be lowercase SHA-256")
+    token = _ACTIVE_MUTATION_PROTOCOL.set((claim_token, command_digest))
+    try:
+        yield
+    finally:
+        _ACTIVE_MUTATION_PROTOCOL.reset(token)
+
+
+def active_mutation_claim_token() -> str | None:
+    """Return the current opaque attempt claim token, if the caller has one."""
+    active = _ACTIVE_MUTATION_PROTOCOL.get()
+    return active[0] if active is not None else None
+
+
+def active_mutation_command_digest() -> str | None:
+    """Return the current normalized command digest without exposing arguments."""
+    active = _ACTIVE_MUTATION_PROTOCOL.get()
+    return active[1] if active is not None else None
+
+
 class _PostCommitOutcomeUncertain(OpError):
     """Sanitized terminal state for an unexpected exception after canonical commit."""
 
@@ -170,6 +240,129 @@ class _PostCommitOutcomeUncertain(OpError):
             "Do not rerun with a new identity; reconcile and retry only with the same identity.",
             details={"status": "committed", "committed": True},
         )
+
+
+@dataclass
+class _ExecutionAttempt:
+    """One bounded owner claim for a single canonical leaf execution."""
+
+    attempt_id: str
+    commit_token: str
+    commit_secret: bytes
+    handle: Any | None
+
+
+class _WindowsDPAPISecretProtector:
+    """Current-user DPAPI envelope for one local receipt-authentication key."""
+
+    provider = 1
+
+    def _crypt(self, secret: bytes, entropy: bytes, *, protect: bool) -> bytes:
+        if protect and len(secret) != 32:
+            raise ValueError("idempotency commit secret must be 32 bytes")
+        from ctypes import wintypes
+
+        class _DataBlob(ctypes.Structure):
+            _fields_ = [("cbData", wintypes.DWORD), ("pbData", ctypes.POINTER(ctypes.c_byte))]
+
+        def blob(value: bytes) -> tuple[_DataBlob, Any]:
+            buffer = ctypes.create_string_buffer(value)
+            return _DataBlob(len(value), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_byte))), buffer
+
+        source, _source_buffer = blob(secret)
+        entropy_blob, _entropy_buffer = blob(entropy)
+        output = _DataBlob()
+        crypt32 = _windows_library(ctypes, "crypt32")
+        if protect:
+            routine = crypt32.CryptProtectData
+            routine.argtypes = [
+                ctypes.POINTER(_DataBlob), wintypes.LPCWSTR, ctypes.POINTER(_DataBlob),
+                wintypes.LPVOID, wintypes.LPVOID, wintypes.DWORD, ctypes.POINTER(_DataBlob),
+            ]
+            ok = routine(
+                ctypes.byref(source), None, ctypes.byref(entropy_blob), None, None, 0x1,
+                ctypes.byref(output),
+            )
+        else:
+            routine = crypt32.CryptUnprotectData
+            description = wintypes.LPWSTR()
+            routine.argtypes = [
+                ctypes.POINTER(_DataBlob), ctypes.POINTER(wintypes.LPWSTR), ctypes.POINTER(_DataBlob),
+                wintypes.LPVOID, wintypes.LPVOID, wintypes.DWORD, ctypes.POINTER(_DataBlob),
+            ]
+            ok = routine(
+                ctypes.byref(source), ctypes.byref(description), ctypes.byref(entropy_blob), None,
+                None, 0x1, ctypes.byref(output),
+            )
+            if description:
+                _windows_library(ctypes, "kernel32").LocalFree(description)
+        if not ok:
+            raise OSError(_windows_last_error(ctypes), "Windows DPAPI operation failed")
+        try:
+            if output.cbData > _WINDOWS_SECRET_ENVELOPE_MAX_CIPHERTEXT:
+                raise ValueError("Windows DPAPI output exceeds the idempotency envelope limit")
+            return ctypes.string_at(output.pbData, output.cbData)
+        finally:
+            if not protect and output.pbData and output.cbData:
+                try:
+                    ctypes.memset(output.pbData, 0, output.cbData)
+                except Exception:  # noqa: BLE001 - native cleanup must not mask DPAPI failure
+                    pass
+            if output.pbData:
+                _windows_library(ctypes, "kernel32").LocalFree(output.pbData)
+
+    def protect(self, secret: bytes, entropy: bytes) -> bytes:
+        return self._crypt(secret, entropy, protect=True)
+
+    def unprotect(self, ciphertext: bytes, entropy: bytes) -> bytes:
+        result = self._crypt(ciphertext, entropy, protect=False)
+        if len(result) != 32:
+            raise ValueError("Windows DPAPI idempotency secret has invalid length")
+        return result
+
+
+@dataclass(frozen=True)
+class _CanonicalResume:
+    """A missing SQLite terminal backed by exact external commit evidence."""
+
+    result: Any
+    evidence: Any
+
+
+@dataclass(frozen=True)
+class _CanonicalCommittedFailure:
+    """Canonical graph handoff retained before its stable public failure."""
+
+    result: Any
+    payload: dict[str, Any]
+
+
+def _new_attempt() -> _ExecutionAttempt:
+    # UUID hex is portable lowercase hexadecimal; trimming preserves the
+    # protocol's opaque 96-bit identifier shape.
+    attempt_id = uuid.uuid4().hex[:24]
+    return _ExecutionAttempt(
+        attempt_id=attempt_id,
+        commit_token=uuid.uuid4().hex[:24],
+        commit_secret=secrets.token_bytes(32),
+        handle=None,
+    )
+
+
+def _call_after_canonical(
+    callback: Any, result: Any, attempt: _ExecutionAttempt, canonical_disposition: str
+) -> Any:
+    """Support the pre-redesign one-argument hook during rolling upgrades."""
+    try:
+        return callback(result, attempt, canonical_disposition)
+    except TypeError as error:
+        try:
+            return callback(result, attempt)
+        except TypeError:
+            try:
+                return callback(result)
+            except TypeError:
+                raise error from None
 
 
 def _invalid_committed_failure_payload() -> ValueError:
@@ -248,6 +441,97 @@ def _serialize_committed_failure_payload(payload: Any) -> bytes:
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
+
+
+def _receipt_result_summary(value: Any, *, depth: int = 0) -> dict[str, Any]:
+    """Build a bounded, content-free canonical summary of an ordinary result."""
+    if value is None:
+        return {"type": "none"}
+    if type(value) is bool:
+        return {"type": "bool", "value": value}
+    if type(value) is int:
+        magnitude = abs(value)
+        width = max(1, (magnitude.bit_length() + 7) // 8)
+        return {
+            "type": "int",
+            "negative": value < 0,
+            "bits": magnitude.bit_length(),
+            "sha256": hashlib.sha256(magnitude.to_bytes(width, "big")).hexdigest(),
+        }
+    if type(value) is float:
+        if math.isnan(value):
+            encoded = b"nan"
+        elif math.isinf(value):
+            encoded = b"-inf" if value < 0 else b"inf"
+        else:
+            encoded = value.hex().encode("ascii")
+        return {"type": "float", "sha256": hashlib.sha256(encoded).hexdigest()}
+    if type(value) is str:
+        encoded = value.encode("utf-8")
+        return {
+            "type": "str",
+            "bytes": len(encoded),
+            "sha256": hashlib.sha256(encoded).hexdigest(),
+        }
+    if type(value) is bytes:
+        return {
+            "type": "bytes",
+            "bytes": len(value),
+            "sha256": hashlib.sha256(value).hexdigest(),
+        }
+    if depth >= _RECEIPT_RESULT_SUMMARY_MAX_DEPTH:
+        return {"type": "truncated"}
+    if isinstance(value, Mapping):
+        try:
+            size = len(value)
+        except Exception:  # noqa: BLE001 - an arbitrary mapping may not report a length
+            size = None
+        if size is not None and size > _RECEIPT_RESULT_SUMMARY_MAX_ITEMS:
+            return {"type": "mapping", "size": size, "truncated": True}
+        try:
+            items = []
+            for index, (key, item) in enumerate(value.items()):
+                if index >= _RECEIPT_RESULT_SUMMARY_MAX_ITEMS:
+                    return {"type": "mapping", "truncated": True}
+                items.append(
+                    [
+                        _receipt_result_summary(key, depth=depth + 1),
+                        _receipt_result_summary(item, depth=depth + 1),
+                    ]
+                )
+            items.sort(
+                key=lambda item: json.dumps(
+                    item[0], allow_nan=False, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                )
+            )
+        except Exception:  # noqa: BLE001 - an arbitrary mapping is summarized closed
+            return {"type": "opaque"}
+        return {
+            "type": "mapping",
+            "items": items,
+            "truncated": False,
+        }
+    if type(value) in {list, tuple}:
+        sequence_items = [
+            _receipt_result_summary(item, depth=depth + 1)
+            for item in value[:_RECEIPT_RESULT_SUMMARY_MAX_ITEMS]
+        ]
+        return {
+            "type": "sequence",
+            "items": sequence_items,
+            "truncated": len(value) > len(sequence_items),
+        }
+    return {"type": "opaque"}
+
+
+def _receipt_result_sha256(result: Any) -> str:
+    """Hash a deterministic bounded summary without retaining leaf content."""
+    summary = _receipt_result_summary(result)
+    return hashlib.sha256(
+        json.dumps(
+            summary, allow_nan=False, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -462,7 +746,9 @@ class LeaseCoordinatorClient:
         )
 
     def release(self, fencing_token: int) -> LeaseRecord:
-        return self.release_holder(self.config.replica_id, fencing_token)
+        replica_id = self.config.replica_id
+        assert replica_id is not None
+        return self.release_holder(replica_id, fencing_token)
 
     def release_holder(self, holder_replica_id: str, fencing_token: int) -> LeaseRecord:
         """Release on behalf of ANY holder, not just this client's own
@@ -518,8 +804,8 @@ def _mutation_outcome_unknown_error() -> OpError:
     return OpError(
         "MUTATION_OUTCOME_UNKNOWN",
         "the executing process terminated before recording this mutation's outcome",
-        "Verify whether the mutation landed before retrying; an identical retry executes "
-        "fresh once the abandonment grace period has passed.",
+        "Verify whether the mutation landed and reconcile before submitting any new mutation; "
+        "retries with this identity will remain fail-closed.",
         details={"status": "uncertain", "committed": None, "abandoned": True},
     )
 
@@ -542,8 +828,11 @@ def _acquire_own_owner_lock(state_dir: Path, owner: str) -> Any | None:
     cleans it up itself."""
     path = _owner_lock_path(state_dir, owner)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        existed = path.exists()
         handle = path.open("a+b")
+        if not existed and os.name != "nt":
+            os.chmod(path, 0o600)
     except OSError:
         return None
     try:
@@ -602,6 +891,7 @@ class IdempotencyStore:
         wait_seconds: float = _IDEMPOTENCY_WAIT_SECONDS,
         poll_interval_seconds: float = _IDEMPOTENCY_POLL_INTERVAL_SECONDS,
         after_terminal_persisted=None,  # noqa: ANN001
+        secret_protector=None,  # noqa: ANN001
     ):
         if wait_seconds < 0:
             raise ValueError("idempotency wait must be non-negative")
@@ -614,13 +904,51 @@ class IdempotencyStore:
         self.wait_seconds = wait_seconds
         self.poll_interval_seconds = poll_interval_seconds
         self.after_terminal_persisted = after_terminal_persisted
+        self._runtime_state_error: RuntimeError | None = None
+        self._secret_protector = (
+            secret_protector
+            if secret_protector is not None
+            else _WindowsDPAPISecretProtector() if os.name == "nt" else None
+        )
         self._condition = threading.Condition()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self.owner_id = _generate_owner_id()
+        self._attempts: dict[str, _ExecutionAttempt] = {}
+        self.owner_id: str | None = None
+        state_dir_existed = path.parent.exists()
+        owners_dir = _owner_lock_path(path.parent, "bootstrap").parent
+        owners_dir_existed = owners_dir.exists()
+        private_paths = (path, path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm"))
+        preexisting_private_paths = {item for item in private_paths if item.exists()}
+        if os.name != "nt":
+            path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+            owners_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+            if not state_dir_existed:
+                os.chmod(path.parent, 0o700)
+            if not owners_dir_existed:
+                os.chmod(owners_dir, 0o700)
+        else:
+            from .mutation_lock import prepare_windows_idempotency_runtime_paths
+
+            prepare_windows_idempotency_runtime_paths(path.parent, owners_dir)
+        try:
+            self._harden_legacy_runtime_paths()
+            self._validate_existing_runtime_paths()
+        except RuntimeError as error:
+            # Construction is also used by read/graph readiness paths. Keep
+            # the unsafe runtime root inert there; every SQLite/claim use
+            # below still fails closed before untrusted state is opened.
+            self._runtime_state_error = error
+            self.owner_id = None
+            self._owner_lock_handle = None
+            return
+        # Kept only to recognize rows written by the preceding store-lifetime
+        # owner protocol. New executions use an attempt lock below and release
+        # it on every exit.
+        owner_id = _generate_owner_id()
+        self.owner_id = owner_id
         # Held for this store's lifetime (process lifetime, in practice —
         # stores are cached singletons keyed by vault+replica); never
         # explicitly released. See `_probe_owner_liveness`.
-        self._owner_lock_handle = _acquire_own_owner_lock(self.state_dir, self.owner_id)
+        self._owner_lock_handle = _acquire_own_owner_lock(self.state_dir, owner_id)
         if self._owner_lock_handle is None:
             # Fail closed on the REGISTRATION side too: advertising an owner id
             # whose lock file could not be created/held would let any peer
@@ -642,11 +970,193 @@ class IdempotencyStore:
             columns = {row[1] for row in conn.execute("PRAGMA table_info(mutations)").fetchall()}
             if "owner" not in columns:
                 conn.execute("ALTER TABLE mutations ADD COLUMN owner TEXT")
+            if "attempt_id" not in columns:
+                conn.execute("ALTER TABLE mutations ADD COLUMN attempt_id TEXT")
+            if "commit_token" not in columns:
+                conn.execute("ALTER TABLE mutations ADD COLUMN commit_token TEXT")
+            if "commit_secret" not in columns:
+                conn.execute("ALTER TABLE mutations ADD COLUMN commit_secret BLOB")
+        if not path.exists():  # pragma: no cover - sqlite always creates the database
+            raise RuntimeError("idempotency runtime database was not created")
+        if os.name != "nt":
+            for item in private_paths:
+                if item.exists() and item not in preexisting_private_paths:
+                    os.chmod(item, 0o600)
+        self._ensure_private_runtime_state()
+
+    def _ensure_private_runtime_state(self) -> None:
+        """Secrets require a local owner-only state directory; never repair one."""
+        if os.name == "nt":
+            from .mutation_lock import validate_windows_idempotency_runtime_paths
+
+            validate_windows_idempotency_runtime_paths(
+                self.state_dir,
+                _owner_lock_path(self.state_dir, "bootstrap").parent,
+                (
+                    self.path,
+                    self.path.with_name(f"{self.path.name}-wal"),
+                    self.path.with_name(f"{self.path.name}-shm"),
+                ),
+            )
+            return
+        mode = stat.S_IMODE(self.state_dir.stat().st_mode)
+        if mode & 0o077:
+            raise RuntimeError("idempotency runtime state directory is not owner-only")
+        owners_dir = _owner_lock_path(self.state_dir, "bootstrap").parent
+        if stat.S_IMODE(owners_dir.stat().st_mode) & 0o077:
+            raise RuntimeError("idempotency owner directory is not owner-only")
+        for owner_lock in owners_dir.glob("*.lock"):
+            if stat.S_IMODE(owner_lock.stat().st_mode) & 0o077:
+                raise RuntimeError("idempotency owner lock is not owner-only")
+        for item in (
+            self.path,
+            self.path.with_name(f"{self.path.name}-wal"),
+            self.path.with_name(f"{self.path.name}-shm"),
+        ):
+            if item.exists() and stat.S_IMODE(item.stat().st_mode) & 0o077:
+                raise RuntimeError("idempotency runtime database is not owner-only")
+
+    def _validate_existing_runtime_paths(self) -> None:
+        """Reject attacker-controlled SQLite/pickle paths before opening them."""
+        if os.name == "nt":
+            self._ensure_private_runtime_state()
+            return
+        owners_dir = _owner_lock_path(self.state_dir, "bootstrap").parent
+        paths = (
+            (self.state_dir, True),
+            (owners_dir, True),
+            (self.path, False),
+            (self.path.with_name(f"{self.path.name}-wal"), False),
+            (self.path.with_name(f"{self.path.name}-shm"), False),
+        )
+        for path, directory in paths:
+            try:
+                info = path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(info.st_mode) or (
+                not stat.S_ISDIR(info.st_mode) if directory else not stat.S_ISREG(info.st_mode)
+            ):
+                raise RuntimeError("idempotency runtime state path is not a trusted regular path")
+            if stat.S_IMODE(info.st_mode) & 0o077:
+                raise RuntimeError("idempotency runtime state path is not owner-only")
+
+    def _harden_legacy_runtime_paths(self) -> None:
+        """Upgrade prior owner-owned 0755/0644 runtime artifacts before open."""
+        if os.name == "nt":
+            return
+        owners_dir = _owner_lock_path(self.state_dir, "bootstrap").parent
+        paths = (
+            (self.state_dir, True),
+            (owners_dir, True),
+            (self.path, False),
+            (self.path.with_name(f"{self.path.name}-wal"), False),
+            (self.path.with_name(f"{self.path.name}-shm"), False),
+        )
+        owner_uid = os.geteuid()
+        for path, directory in paths:
+            try:
+                info = path.lstat()
+            except FileNotFoundError:
+                continue
+            if (
+                stat.S_ISLNK(info.st_mode)
+                or (not stat.S_ISDIR(info.st_mode) if directory else not stat.S_ISREG(info.st_mode))
+                or info.st_uid != owner_uid
+                or stat.S_IMODE(info.st_mode) & 0o022
+            ):
+                raise RuntimeError("idempotency runtime state path cannot be upgraded safely")
+            desired_mode = 0o700 if directory else 0o600
+            if stat.S_IMODE(info.st_mode) != desired_mode:
+                os.chmod(path, desired_mode)
+        for owner_lock in owners_dir.glob("*.lock"):
+            info = owner_lock.lstat()
+            if (
+                stat.S_ISLNK(info.st_mode)
+                or not stat.S_ISREG(info.st_mode)
+                or info.st_uid != owner_uid
+                or stat.S_IMODE(info.st_mode) & 0o022
+            ):
+                raise RuntimeError("idempotency owner lock cannot be upgraded safely")
+            if stat.S_IMODE(info.st_mode) != 0o600:
+                os.chmod(owner_lock, 0o600)
 
     def _connect(self) -> sqlite3.Connection:
+        if self._runtime_state_error is not None:
+            raise self._runtime_state_error
+        if os.name == "nt":
+            self._ensure_private_runtime_state()
+        private_paths = (
+            self.path,
+            self.path.with_name(f"{self.path.name}-wal"),
+            self.path.with_name(f"{self.path.name}-shm"),
+        )
+        existed = {item for item in private_paths if item.exists()}
         conn = sqlite3.connect(self.path, timeout=10)
-        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            if os.name == "nt":
+                self._ensure_private_runtime_state()
+        except BaseException:
+            conn.close()
+            raise
+        if os.name != "nt":
+            for item in private_paths:
+                if item.exists() and item not in existed:
+                    os.chmod(item, 0o600)
         return conn
+
+    def _commit_secret_entropy(self, digest: str, attempt: _ExecutionAttempt) -> bytes:
+        del digest
+        return (
+            _WINDOWS_SECRET_ENTROPY_DOMAIN
+            + attempt.attempt_id.encode("utf-8")
+            + b"\0"
+            + attempt.commit_token.encode("utf-8")
+        )
+
+    def _stored_commit_secret(self, digest: str, attempt: _ExecutionAttempt) -> bytes:
+        protector = self._secret_protector
+        if protector is None:
+            return attempt.commit_secret
+        ciphertext = protector.protect(attempt.commit_secret, self._commit_secret_entropy(digest, attempt))
+        if not isinstance(ciphertext, bytes) or not 1 <= len(ciphertext) <= _WINDOWS_SECRET_ENVELOPE_MAX_CIPHERTEXT:
+            raise RuntimeError("idempotency secret protector returned an invalid ciphertext")
+        provider = getattr(protector, "provider", None)
+        if type(provider) is not int or not 1 <= provider <= 255:
+            raise RuntimeError("idempotency secret protector has no valid provider")
+        return (
+            _WINDOWS_SECRET_ENVELOPE_MAGIC
+            + bytes((_WINDOWS_SECRET_ENVELOPE_VERSION, provider))
+            + len(ciphertext).to_bytes(4, "big")
+            + ciphertext
+        )
+
+    def _unprotected_commit_secret(self, digest: str, attempt: _ExecutionAttempt) -> bytes | None:
+        stored = attempt.commit_secret
+        protector = self._secret_protector
+        if protector is None:
+            return stored if len(stored) == 32 else None
+        if any(active is attempt for active in self._attempts.values()):
+            return stored if len(stored) == 32 else None
+        header = _WINDOWS_SECRET_ENVELOPE_HEADER_BYTES
+        if (
+            len(stored) < header
+            or len(stored) > _WINDOWS_SECRET_ENVELOPE_MAX_BYTES
+            or not stored.startswith(_WINDOWS_SECRET_ENVELOPE_MAGIC)
+            or stored[4] != _WINDOWS_SECRET_ENVELOPE_VERSION
+            or stored[5] != getattr(protector, "provider", None)
+        ):
+            return None
+        length = int.from_bytes(stored[6:10], "big")
+        ciphertext = stored[10:]
+        if length != len(ciphertext) or not 1 <= length <= _WINDOWS_SECRET_ENVELOPE_MAX_CIPHERTEXT:
+            return None
+        try:
+            secret = protector.unprotect(ciphertext, self._commit_secret_entropy(digest, attempt))
+        except Exception:  # noqa: BLE001 - unreadable local authority fails closed
+            return None
+        return secret if isinstance(secret, bytes) and len(secret) == 32 else None
 
     def run(
         self,
@@ -658,142 +1168,422 @@ class IdempotencyStore:
         on_replay=None,  # noqa: ANN001
         operation_guard=None,  # noqa: ANN001
         commit_observed=None,  # noqa: ANN001
+        after_canonical_persisted=None,  # noqa: ANN001
+        after_operation_guard=None,  # noqa: ANN001
+        resume_canonically_committed=None,  # noqa: ANN001
+        commit_evidence=None,  # noqa: ANN001
+        legacy_graph_pending_proof=None,  # noqa: ANN001
     ) -> Any:
         if not key:
             with operation_guard() if operation_guard is not None else nullcontext():
-                return operation()
+                result = operation()
+            return after_operation_guard(result) if after_operation_guard is not None else result
 
         while True:
-            disposition, stored = self._claim_or_inspect(key, digest, expires_after)
+            disposition, stored = self._claim_or_inspect(
+                key,
+                digest,
+                expires_after,
+                commit_evidence=commit_evidence,
+                legacy_graph_pending_proof=legacy_graph_pending_proof,
+            )
             if disposition == "owner":
                 break
             if disposition == "pending":
-                waited = self._wait_for_terminal(key, digest, on_replay=on_replay)
+                waited = self._wait_for_terminal(
+                    key,
+                    digest,
+                    on_replay=on_replay,
+                    commit_evidence=commit_evidence,
+                    legacy_graph_pending_proof=legacy_graph_pending_proof,
+                )
                 if waited is _RETRY_IDEMPOTENCY_CLAIM:
                     continue
-                return waited
-            if disposition == "abandoned":
+                disposition, stored = waited
+            if disposition == "canonical_resume":
+                if resume_canonically_committed is None:
+                    raise _mutation_outcome_unknown_error()
+                terminal_result = resume_canonically_committed(stored)
+                if terminal_result == _OUTCOME_UNKNOWN_TERMINAL:
+                    # A v2 receipt can prove the canonical write happened,
+                    # yet deliberately retains no cleanup target paths.  Do
+                    # not turn that signed committed-failure cut into a
+                    # fabricated success: retain the stable fail-closed
+                    # terminal for every exact replay.
+                    try:
+                        self._persist_completed_from_canonical(
+                            key, digest, terminal_result
+                        )
+                    except Exception as storage_error:
+                        raise _PostCommitOutcomeUncertain() from storage_error
+                    self._notify_waiters()
+                    self._after_terminal_persisted()
+                    raise _mutation_outcome_unknown_error()
+                if isinstance(terminal_result, _CanonicalCommittedFailure):
+                    try:
+                        self._persist_committed_failure(
+                            key, digest, terminal_result.payload
+                        )
+                    except Exception as storage_error:
+                        raise _PostCommitOutcomeUncertain() from storage_error
+                    self._notify_waiters()
+                    self._after_terminal_persisted()
+                    raise _CachedCommittedFailure(terminal_result.payload)
+                try:
+                    terminal_result = self._persist_completed_from_canonical(
+                        key, digest, terminal_result
+                    )
+                except Exception as storage_error:
+                    # The canonical row remains the exact retry anchor. Never
+                    # let a SQLite hiccup send an already committed leaf back
+                    # through the execution path.
+                    raise _PostCommitOutcomeUncertain() from storage_error
+                self._notify_waiters()
+                self._after_terminal_persisted()
+                return terminal_result
+            if disposition == "outcome_unknown":
                 raise _mutation_outcome_unknown_error()
             return self._replay(disposition, stored, on_replay)
 
+        attempt = self._attempts.get(key)
+        if attempt is None:  # pragma: no cover - defensive against an in-process map loss
+            raise self._reconciliation_error("executing mutation attempt")
         guard = operation_guard() if operation_guard is not None else nullcontext()
+        leaf_started = False
         leaf_returned = False
-        terminal_persisted = False
+        canonical_persisted = False
+        committed_failure: dict[str, Any] | None = None
+        committed_error: Exception | None = None
+        committed_handoff = False
         try:
             with guard:
-                try:
-                    result = operation()
-                except Exception as operation_error:
-                    if isinstance(operation_error, _PostCommitOutcomeUncertain):
-                        leaf_returned = True
-                        try:
-                            self._persist_committed_uncertain(key, digest)
-                        except Exception as storage_error:
-                            raise operation_error from storage_error
-                        terminal_persisted = True
-                        self._notify_waiters()
-                        self._after_terminal_persisted()
-                        raise
-                    committed_failure = _committed_failure_payload(operation_error)
-                    if committed_failure is None:
-                        raise
-                    leaf_returned = True
+                with active_mutation_claim_context(
+                    claim_token=attempt.commit_token,
+                    command_digest=digest if re.fullmatch(r"[0-9a-f]{64}", digest) else None,
+                ):
                     try:
-                        self._persist_committed_failure(key, digest, committed_failure)
-                    except Exception as storage_error:
-                        raise operation_error from storage_error
-                    terminal_persisted = True
-                    self._notify_waiters()
-                    self._after_terminal_persisted()
-                    raise
-                leaf_returned = True
-                try:
-                    self._persist_completed(key, digest, result)
-                except Exception as storage_error:
-                    if commit_observed is not None and commit_observed():
-                        uncertain = _PostCommitOutcomeUncertain()
-                        try:
-                            self._persist_committed_uncertain(key, digest)
-                        except Exception:  # noqa: BLE001 - leave pending fail-closed
-                            pass
-                        else:
-                            terminal_persisted = True
-                    else:
-                        uncertain = OpError(
-                            "MUTATION_ACKNOWLEDGEMENT_PENDING",
-                            "the mutation result could not be persisted; its commit outcome "
-                            "is not known",
-                            "Retry with the same mutation identity; do not submit a revised "
-                            "payload.",
+                        leaf_started = True
+                        result = operation()
+                    except Exception as operation_error:
+                        if isinstance(operation_error, _PostCommitOutcomeUncertain):
+                            leaf_returned = True
+                            raise
+                        committed_failure = _committed_failure_payload(operation_error)
+                        if committed_failure is None:
+                            raise
+                        leaf_returned = True
+                        if commit_observed is None or not commit_observed():
+                            try:
+                                self._persist_committed_failure(key, digest, committed_failure)
+                            except Exception as storage_error:
+                                raise operation_error from storage_error
+                            self._notify_waiters()
+                            self._after_terminal_persisted()
+                            raise
+                        committed_error = operation_error
+                        committed_handoff = True
+                        # The outer signed receipt disposition, rather than
+                        # any portable terminal field, records this cut.
+                        result = {"status": "committed", "mutated": True}
+                    leaf_returned = True
+                    if after_canonical_persisted is not None:
+                        prepared = _call_after_canonical(
+                            after_canonical_persisted,
+                            result,
+                            attempt,
+                            "committed_failure" if committed_handoff else "success",
                         )
+                        result = prepared
+                    canonical_result = result
+                    if committed_handoff:
+                        assert committed_failure is not None
+                        canonical_result = _CanonicalCommittedFailure(
+                            result, committed_failure
+                        )
+                    try:
+                        self._persist_canonically_committed(
+                            key,
+                            digest,
+                            canonical_result,
+                            attempt,
+                        )
+                    except Exception as storage_error:
+                        if self._exact_evidence(commit_evidence, digest, attempt):
+                            raise _PostCommitOutcomeUncertain() from storage_error
+                        raise _PostCommitOutcomeUncertain() from storage_error
+                    canonical_persisted = True
                     self._notify_waiters()
-                    raise uncertain from storage_error
-                terminal_persisted = True
+            # The attempt lock is released only after the canonical handoff;
+            # derived graph work is deliberately not owned by it.
+            self._release_attempt(key, attempt)
+            if after_operation_guard is None:
+                terminal_result = result
+            else:
+                terminal_result = after_operation_guard(result)
+            if committed_handoff:
+                assert committed_failure is not None
+                try:
+                    self._persist_committed_failure(key, digest, committed_failure)
+                except Exception as storage_error:
+                    assert committed_error is not None
+                    raise committed_error from storage_error
                 self._notify_waiters()
                 self._after_terminal_persisted()
-                return result
-        except Exception:
-            # Guard acquisition is pre-leaf and safe to retry. Once a leaf has
-            # returned (or reported a recognized committed outcome), storage or
-            # acknowledgement failures must leave the pending/terminal receipt
-            # fail-closed rather than allow a duplicate execution.
-            if not leaf_returned and not terminal_persisted:
-                self._delete_pending(key, digest)
+                assert committed_error is not None
+                raise committed_error
+            try:
+                terminal_result = self._persist_completed_from_canonical(
+                    key, digest, terminal_result
+                )
+            except Exception as storage_error:
+                raise _PostCommitOutcomeUncertain() from storage_error
+            self._notify_waiters()
+            self._after_terminal_persisted()
+            return terminal_result
+        except BaseException as error:
+            # Ordinary, explicitly uncommitted leaf failures are safe to retry.
+            # Abrupt exits and anything after the canonical commit point are
+            # intentionally retained for exact evidence/outcome-unknown
+            # classification instead.
+            if (
+                not leaf_returned
+                and isinstance(error, Exception)
+                and (commit_observed is None or not commit_observed())
+            ):
+                self._delete_executing(key, digest, attempt)
+            elif not leaf_started:
+                self._delete_executing(key, digest, attempt)
+            elif not canonical_persisted:
+                # A returned leaf without a durable exact receipt is the
+                # unavoidable multi-store cut. Its released attempt makes the
+                # next exact retry classify outcome_unknown, never replay it.
+                self._notify_waiters()
             raise
+        finally:
+            self._release_attempt(key, attempt)
 
     def _claim_or_inspect(
-        self, key: str, digest: str, expires_after: float | None
+        self,
+        key: str,
+        digest: str,
+        expires_after: float | None,
+        *,
+        commit_evidence=None,
+        legacy_graph_pending_proof=None,
     ) -> tuple[str, Any]:
         now = self.clock()
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
             self._prune_expired(conn, now, expires_after, key)
             row = conn.execute(
-                "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
+                "SELECT digest, state, result, updated_at, owner, attempt_id, commit_token, commit_secret "
+                "FROM mutations WHERE key = ?",
                 (key,),
             ).fetchone()
             if row and self._expired_row(row, now, expires_after):
                 conn.execute("DELETE FROM mutations WHERE key = ?", (key,))
                 row = None
             if row is not None:
-                row = self._abandon_if_dead(conn, key, row, now)
-                return self._decode_disposition(row, digest)
-            conn.execute(
-                "INSERT INTO mutations(key, digest, state, updated_at, owner) "
-                "VALUES (?, ?, 'pending', ?, ?)",
-                (key, digest, now, self.owner_id),
-            )
-        _log_mutation_event("reserved", receipt=_receipt_tag(key))
+                row = self._abandon_if_dead(
+                    conn,
+                    key,
+                    row,
+                    now,
+                    commit_evidence=commit_evidence,
+                    legacy_graph_pending_proof=legacy_graph_pending_proof,
+                )
+                if row is not None:
+                    return self._decode_disposition(row, digest, commit_evidence=commit_evidence)
+            self._ensure_private_runtime_state()
+            attempt = _new_attempt()
+            try:
+                stored_commit_secret = self._stored_commit_secret(digest, attempt)
+            except Exception as error:
+                raise OpError(
+                    "IDEMPOTENCY_SECRET_PROTECTION_UNAVAILABLE",
+                    "could not protect the local idempotency receipt secret",
+                    "Resolve local Windows credential protection before retrying this mutation.",
+                ) from error
+            attempt.handle = _acquire_own_owner_lock(self.state_dir, attempt.attempt_id)
+            if attempt.handle is None:
+                raise OpError(
+                    "IDEMPOTENCY_OWNER_UNAVAILABLE",
+                    "could not establish a bounded idempotency execution claim",
+                    "Retry the same mutation identity after local coordination recovers.",
+                )
+            try:
+                self._ensure_private_runtime_state()
+                conn.execute(
+                    "INSERT INTO mutations(key, digest, state, updated_at, owner, attempt_id, commit_token, commit_secret) "
+                    "VALUES (?, ?, 'reserved', ?, ?, ?, ?, ?)",
+                    (
+                        key,
+                        digest,
+                        now,
+                        attempt.attempt_id,
+                        attempt.attempt_id,
+                        attempt.commit_token,
+                        stored_commit_secret,
+                    ),
+                )
+                cursor = conn.execute(
+                    "UPDATE mutations SET state = 'executing' WHERE key = ? AND state = 'reserved' "
+                    "AND attempt_id = ? AND commit_token = ?",
+                    (key, attempt.attempt_id, attempt.commit_token),
+                )
+                if cursor.rowcount != 1:
+                    raise self._reconciliation_error("reserved mutation claim")
+            except BaseException:
+                _release_owner_lock(attempt.handle)
+                attempt.handle.close()
+                raise
+            self._attempts[key] = attempt
+        _log_mutation_event("executing", receipt=_receipt_tag(key))
         return "owner", None
 
     def _abandon_if_dead(
-        self, conn: sqlite3.Connection, key: str, row: tuple[Any, ...], now: float
-    ) -> tuple[Any, ...]:
-        """If `row` is `pending` and its owner is provably dead, transition it
-        to `abandoned` in the same transaction and return the updated row.
+        self,
+        conn: sqlite3.Connection,
+        key: str,
+        row: tuple[Any, ...],
+        now: float,
+        *,
+        commit_evidence=None,  # noqa: ANN001
+        legacy_graph_pending_proof=None,  # noqa: ANN001
+    ) -> tuple[Any, ...] | None:
+        """Resolve proven-dead idempotency ownership without replaying a leaf.
         Fail-closed: an inconclusive liveness probe leaves the row `pending`.
         """
-        if row[1] != "pending":
+        if row[1] == "graph_pending":
+            # Retired graph-pending rows predate the authenticated commit
+            # receipt. Migrate only an exact checkpoint binding that still
+            # names the current coherent durable epoch; every other legacy cut
+            # remains outcome-unknown and can never replay its leaf.
+            try:
+                legacy_result = pickle.loads(row[2])  # noqa: S301 - local runtime state
+                checkpoint_payload = (
+                    legacy_result.get("_graph_sync_checkpoint")
+                    if type(legacy_result) is dict
+                    else None
+                )
+                if type(checkpoint_payload) is not dict:
+                    raise ValueError("legacy graph checkpoint binding is absent")
+                from . import graph_sync
+
+                checkpoint = graph_sync.GraphSyncCheckpoint.parse(
+                    json.dumps(checkpoint_payload, sort_keys=True, separators=(",", ":")).encode(
+                        "utf-8"
+                    )
+                )
+                if checkpoint is None or legacy_graph_pending_proof is None:
+                    raise ValueError("legacy graph checkpoint binding is invalid")
+                if legacy_graph_pending_proof(checkpoint) is not True:
+                    raise ValueError("legacy graph checkpoint is not durable")
+            except Exception:  # noqa: BLE001 - legacy state is fail-closed
+                try:
+                    cursor = conn.execute(
+                        "UPDATE mutations SET state = 'completed', result = ?, owner = NULL, updated_at = ? "
+                        "WHERE key = ? AND state = 'graph_pending'",
+                        (_OUTCOME_UNKNOWN_PAYLOAD, now, key),
+                    )
+                except sqlite3.Error:
+                    return (
+                        row[0],
+                        "completed",
+                        _OUTCOME_UNKNOWN_PAYLOAD,
+                        now,
+                        None,
+                        row[5],
+                        row[6],
+                        row[7],
+                    )
+                if cursor.rowcount == 1:
+                    self._notify_waiters()
+                    return (
+                        row[0],
+                        "completed",
+                        _OUTCOME_UNKNOWN_PAYLOAD,
+                        now,
+                        None,
+                        row[5],
+                        row[6],
+                        row[7],
+                    )
+                refreshed = conn.execute(
+                    "SELECT digest, state, result, updated_at, owner, attempt_id, commit_token, commit_secret "
+                    "FROM mutations WHERE key = ?",
+                    (key,),
+                ).fetchone()
+                return refreshed if refreshed is not None else row
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'canonically_committed', owner = NULL, "
+                "updated_at = ? WHERE key = ? AND state = 'graph_pending'",
+                (now, key),
+            )
+            if cursor.rowcount == 1:
+                return (row[0], "canonically_committed", row[2], now, None, row[5], row[6], row[7])
+            return row
+        if row[1] not in {"pending", "reserved", "executing"}:
             return row
         owner = row[4]
         if owner is None:
             dead = (now - row[3]) >= _IDEMPOTENCY_LEGACY_OWNER_GRACE_SECONDS
-        elif owner == self.owner_id:
+        elif any(
+            active.attempt_id == owner and active.handle is not None
+            for active in self._attempts.values()
+        ):
             dead = False
+        elif owner == self.owner_id and row[5] is None:
+            # A row from the retired store-lifetime owner scheme cannot name
+            # an active execution in this process. Treat it as an unprovable
+            # legacy cut instead of letting this idle store object hold it
+            # forever merely because its compatibility lock remains open.
+            dead = True
         else:
             dead = not _probe_owner_liveness(self.state_dir, owner)
         if not dead:
             return row
-        cursor = conn.execute(
-            "UPDATE mutations SET state = 'abandoned', updated_at = ? "
-            "WHERE key = ? AND state = 'pending'",
-            (now, key),
+        if row[1] == "reserved":
+            # No leaf can have started before the executing transition. A
+            # proven-dead reservation is therefore safe to reclaim with a
+            # fresh attempt secret and must not consult vault evidence.
+            cursor = conn.execute(
+                "DELETE FROM mutations WHERE key = ? AND state = 'reserved'",
+                (key,),
+            )
+            return None if cursor.rowcount == 1 else row
+        attempt = _ExecutionAttempt(
+            attempt_id=row[5] if isinstance(row[5], str) else owner or "",
+            commit_token=row[6] if isinstance(row[6], str) else "",
+            commit_secret=row[7] if isinstance(row[7], bytes) else b"",
+            handle=None,
         )
+        if row[1] == "executing" and self._exact_evidence(commit_evidence, row[0], attempt):
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'canonically_committed', owner = NULL, updated_at = ? "
+                "WHERE key = ? AND state IN ('pending', 'reserved', 'executing')",
+                (now, key),
+            )
+            if cursor.rowcount == 1:
+                self._notify_waiters()
+                return (row[0], "canonically_committed", row[2], now, None, row[5], row[6], row[7])
+        else:
+            try:
+                cursor = conn.execute(
+                    "UPDATE mutations SET state = 'completed', result = ?, owner = NULL, updated_at = ? "
+                    "WHERE key = ? AND state IN ('pending', 'reserved', 'executing')",
+                    (_OUTCOME_UNKNOWN_PAYLOAD, now, key),
+                )
+            except sqlite3.Error:
+                # A broken retry store cannot authorize a replay. Classify this
+                # observation fail-closed even when its durable marker cannot advance.
+                return (row[0], "completed", _OUTCOME_UNKNOWN_PAYLOAD, now, None, row[5], row[6], row[7])
         if cursor.rowcount != 1:
             # Raced with another abandon/terminal transition; re-read rather
             # than assume which one won.
             refreshed = conn.execute(
-                "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
+                "SELECT digest, state, result, updated_at, owner, attempt_id, commit_token, commit_secret "
+                "FROM mutations WHERE key = ?",
                 (key,),
             ).fetchone()
             return refreshed if refreshed is not None else row
@@ -801,7 +1591,7 @@ class IdempotencyStore:
             "abandoned", level=logging.WARNING, receipt=_receipt_tag(key)
         )
         self._notify_waiters()
-        return (row[0], "abandoned", None, now, owner)
+        return (row[0], "completed", _OUTCOME_UNKNOWN_PAYLOAD, now, None, row[5], row[6], row[7])
 
     def _prune_expired(
         self,
@@ -813,13 +1603,27 @@ class IdempotencyStore:
         key_pattern = f"{key.partition(':')[0]}:%"
         if expires_after is not None:
             cutoff = now - expires_after
-            conn.execute(
-                "DELETE FROM mutations WHERE key LIKE ? "
+            expired_completed = conn.execute(
+                "SELECT key, result FROM mutations WHERE key LIKE ? "
                 "AND state = 'completed' "
                 "AND typeof(updated_at) IN ('integer', 'real') "
                 "AND updated_at >= 0 AND updated_at <= ?",
                 (key_pattern, cutoff),
-            )
+            ).fetchall()
+            for expired_key, expired_payload in expired_completed:
+                try:
+                    completed = pickle.loads(expired_payload)  # noqa: S301 - trusted runtime state
+                except Exception:
+                    try:
+                        _deserialize_committed_failure_payload(expired_payload)
+                    except Exception:  # noqa: BLE001 - corrupt terminals remain fail-closed
+                        continue
+                else:
+                    if completed == _OUTCOME_UNKNOWN_TERMINAL:
+                        continue
+                conn.execute(
+                    "DELETE FROM mutations WHERE key = ? AND state = 'completed'", (expired_key,)
+                )
             expired_failures = conn.execute(
                 "SELECT key, result FROM mutations WHERE key LIKE ? "
                 "AND state = 'committed_failure' "
@@ -836,22 +1640,25 @@ class IdempotencyStore:
                     "DELETE FROM mutations WHERE key = ? AND state = 'committed_failure'",
                     (expired_key,),
                 )
-        # Abandoned rows always expire after their own fixed grace period,
-        # regardless of the caller's `expires_after` (which may be None).
-        abandoned_cutoff = now - _IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS
-        conn.execute(
-            "DELETE FROM mutations WHERE key LIKE ? "
-            "AND state = 'abandoned' "
-            "AND typeof(updated_at) IN ('integer', 'real') "
-            "AND updated_at >= 0 AND updated_at <= ?",
-            (key_pattern, abandoned_cutoff),
-        )
+        # `outcome_unknown` deliberately remains retained: expiry would turn
+        # an unprovable canonical cut into permission to replay the leaf.
 
     def _expired_row(self, row: tuple[Any, ...], now: float, expires_after: float | None) -> bool:
         if expires_after is None or row[1] not in {"completed", "committed_failure"}:
             return False
         updated_at = row[3]
-        if row[1] == "committed_failure":
+        if row[1] == "completed":
+            try:
+                completed = pickle.loads(row[2])  # noqa: S301 - trusted runtime state
+            except Exception:
+                try:
+                    _deserialize_committed_failure_payload(row[2])
+                except Exception:  # noqa: BLE001 - corrupt terminals remain fail-closed
+                    raise self._reconciliation_error("cached completed mutation state") from None
+            else:
+                if completed == _OUTCOME_UNKNOWN_TERMINAL:
+                    return False
+        elif row[1] == "committed_failure":
             try:
                 _deserialize_committed_failure_payload(row[2])
             except Exception:  # noqa: BLE001 - corrupt state blocks mutation
@@ -860,7 +1667,9 @@ class IdempotencyStore:
             raise self._reconciliation_error("cached mutation state")
         return updated_at <= now - expires_after
 
-    def _decode_disposition(self, row: tuple[Any, ...], digest: str) -> tuple[str, Any]:
+    def _decode_disposition(
+        self, row: tuple[Any, ...], digest: str, *, commit_evidence=None  # noqa: ANN001
+    ) -> tuple[str, Any]:
         if row[0] != digest:
             raise OpError(
                 "IDEMPOTENCY_KEY_REUSED",
@@ -868,7 +1677,17 @@ class IdempotencyStore:
             )
         state = row[1]
         if state == "completed":
-            return "completed", pickle.loads(row[2])  # noqa: S301 - trusted runtime state
+            try:
+                completed = pickle.loads(row[2])  # noqa: S301 - trusted runtime state
+            except Exception:
+                try:
+                    failure = _CachedCommittedFailure(_deserialize_committed_failure_payload(row[2]))
+                except Exception:  # noqa: BLE001 - corrupt state blocks mutation
+                    raise self._reconciliation_error("cached completed mutation state") from None
+                return "committed_failure", failure
+            if completed == _OUTCOME_UNKNOWN_TERMINAL:
+                return "outcome_unknown", None
+            return "completed", completed
         if state == "committed_failure":
             try:
                 failure = _CachedCommittedFailure(_deserialize_committed_failure_payload(row[2]))
@@ -879,10 +1698,29 @@ class IdempotencyStore:
             if row[2] is not None:
                 raise self._reconciliation_error("cached committed mutation state")
             return "committed_uncertain", _PostCommitOutcomeUncertain()
-        if state == "pending":
+        if state == "graph_pending":
+            # A migration race must never turn an unvalidated legacy row into
+            # permission to deserialize and resume derived work.
+            return "outcome_unknown", None
+        if state == "canonically_committed":
+            if row[2] is not None:
+                try:
+                    return "canonical_resume", pickle.loads(row[2])  # noqa: S301
+                except Exception:  # noqa: BLE001 - corrupt runtime state is not a terminal
+                    raise self._reconciliation_error("cached canonical mutation state") from None
+            attempt = _ExecutionAttempt(
+                attempt_id=row[5] if isinstance(row[5], str) else "",
+                commit_token=row[6] if isinstance(row[6], str) else "",
+                commit_secret=row[7] if isinstance(row[7], bytes) else b"",
+                handle=None,
+            )
+            return "canonical_resume", _CanonicalResume(
+                None, self._read_exact_evidence(commit_evidence, row[0], attempt)
+            )
+        if state in {"pending", "reserved", "executing"}:
             return "pending", None
-        if state == "abandoned":
-            return "abandoned", None
+        if state in {"abandoned", "outcome_unknown"}:
+            return "outcome_unknown", None
         raise self._reconciliation_error("cached mutation state")
 
     def _wait_for_terminal(
@@ -891,26 +1729,27 @@ class IdempotencyStore:
         digest: str,
         *,
         on_replay=None,  # noqa: ANN001
+        commit_evidence=None,  # noqa: ANN001
+        legacy_graph_pending_proof=None,  # noqa: ANN001
     ) -> Any:
         _log_mutation_event("pending", receipt=_receipt_tag(key))
         deadline = self.monotonic() + self.wait_seconds
         while True:
             now = self.clock()
-            with self._connect() as conn:
-                conn.execute("BEGIN IMMEDIATE")
-                row = conn.execute(
-                    "SELECT digest, state, result, updated_at, owner FROM mutations WHERE key = ?",
-                    (key,),
-                ).fetchone()
-                if row is not None:
-                    row = self._abandon_if_dead(conn, key, row, now)
-            if row is None:
+            del now
+            disposition, stored = self._claim_or_inspect(
+                key,
+                digest,
+                None,
+                commit_evidence=commit_evidence,
+                legacy_graph_pending_proof=legacy_graph_pending_proof,
+            )
+            if disposition == "owner":
                 return _RETRY_IDEMPOTENCY_CLAIM
-            disposition, stored = self._decode_disposition(row, digest)
-            if disposition == "abandoned":
-                raise _mutation_outcome_unknown_error()
+            if disposition == "outcome_unknown":
+                return disposition, stored
             if disposition != "pending":
-                return self._replay(disposition, stored, on_replay)
+                return disposition, stored
             remaining = deadline - self.monotonic()
             if remaining <= 0:
                 raise OpError(
@@ -937,7 +1776,60 @@ class IdempotencyStore:
         with self._connect() as conn:
             cursor = conn.execute(
                 "UPDATE mutations SET state = 'completed', result = ?, updated_at = ? "
-                "WHERE key = ? AND digest = ? AND state = 'pending'",
+                "WHERE key = ? AND digest = ? AND state IN ('pending', 'executing', 'canonically_committed')",
+                (payload, self.clock(), key, digest),
+            )
+            if cursor.rowcount != 1:
+                raise self._reconciliation_error("completed mutation state")
+        _log_mutation_event("terminal", receipt=_receipt_tag(key))
+
+    def _persist_canonically_committed(
+        self, key: str, digest: str, result: Any, attempt: _ExecutionAttempt
+    ) -> None:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'canonically_committed', result = ?, owner = NULL, "
+                "updated_at = ? WHERE key = ? AND digest = ? AND state = 'executing' "
+                "AND attempt_id = ? AND commit_token = ?",
+                (
+                    pickle.dumps(result),
+                    self.clock(),
+                    key,
+                    digest,
+                    attempt.attempt_id,
+                    attempt.commit_token,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise self._reconciliation_error("canonical mutation state")
+        _log_mutation_event("canonically_committed", receipt=_receipt_tag(key))
+
+    def _persist_completed_from_canonical(self, key: str, digest: str, result: Any) -> Any:
+        payload = pickle.dumps(result)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE mutations SET state = 'completed', result = ?, updated_at = ? "
+                "WHERE key = ? AND digest = ? AND state = 'canonically_committed'",
+                (payload, self.clock(), key, digest),
+            )
+            if cursor.rowcount != 1:
+                row = conn.execute(
+                    "SELECT result FROM mutations WHERE key = ? AND digest = ? AND state = 'completed'",
+                    (key, digest),
+                ).fetchone()
+                if row is None:
+                    raise self._reconciliation_error("canonical mutation completion")
+                return pickle.loads(row[0])  # noqa: S301 - trusted runtime state
+        _log_mutation_event("terminal", receipt=_receipt_tag(key))
+        return result
+
+    def _replace_completed(self, key: str, digest: str, result: Any) -> None:
+        """Advance a durably committed canonical terminal with derived progress."""
+        payload = pickle.dumps(result)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE mutations SET result = ?, updated_at = ? "
+                "WHERE key = ? AND digest = ? AND state = 'completed'",
                 (payload, self.clock(), key, digest),
             )
             if cursor.rowcount != 1:
@@ -950,8 +1842,9 @@ class IdempotencyStore:
         payload = _serialize_committed_failure_payload(committed_failure)
         with self._connect() as conn:
             cursor = conn.execute(
-                "UPDATE mutations SET state = 'committed_failure', result = ?, "
-                "updated_at = ? WHERE key = ? AND digest = ? AND state = 'pending'",
+                "UPDATE mutations SET state = 'completed', result = ?, "
+                "updated_at = ? WHERE key = ? AND digest = ? "
+                "AND state IN ('executing', 'canonically_committed')",
                 (payload, self.clock(), key, digest),
             )
             if cursor.rowcount != 1:
@@ -960,24 +1853,68 @@ class IdempotencyStore:
                 )
         _log_mutation_event("terminal", receipt=_receipt_tag(key))
 
-    def _persist_committed_uncertain(self, key: str, digest: str) -> None:
-        with self._connect() as conn:
-            cursor = conn.execute(
-                "UPDATE mutations SET state = 'committed_uncertain', result = NULL, "
-                "updated_at = ? WHERE key = ? AND digest = ? AND state = 'pending'",
-                (self.clock(), key, digest),
-            )
-            if cursor.rowcount != 1:
-                raise self._reconciliation_error("committed mutation state")
-        _log_mutation_event("terminal_uncertain", receipt=_receipt_tag(key))
-
     def _delete_pending(self, key: str, digest: str) -> None:
         with self._connect() as conn:
             conn.execute(
-                "DELETE FROM mutations WHERE key = ? AND digest = ? AND state = 'pending'",
+                "DELETE FROM mutations WHERE key = ? AND digest = ? "
+                "AND state IN ('pending', 'reserved', 'executing')",
                 (key, digest),
             )
         self._notify_waiters()
+
+    def _delete_executing(self, key: str, digest: str, attempt: _ExecutionAttempt) -> None:
+        del attempt
+        self._delete_pending(key, digest)
+
+    def _release_attempt(self, key: str, attempt: _ExecutionAttempt) -> None:
+        current = self._attempts.get(key)
+        if current is attempt:
+            self._attempts.pop(key, None)
+        handle = attempt.handle
+        attempt.handle = None
+        if handle is None:
+            return
+        try:
+            _release_owner_lock(handle)
+        except OSError:
+            pass
+        try:
+            handle.close()
+        except OSError:
+            pass
+        try:
+            _owner_lock_path(self.state_dir, attempt.attempt_id).unlink()
+        except OSError:
+            pass
+
+    def _read_exact_evidence(
+        self, commit_evidence: Any, digest: str, attempt: _ExecutionAttempt
+    ) -> Any:
+        if (
+            commit_evidence is None
+            or not attempt.attempt_id
+            or not attempt.commit_token
+        ):
+            return None
+        self._ensure_private_runtime_state()
+        secret = self._unprotected_commit_secret(digest, attempt)
+        if secret is None:
+            return None
+        try:
+            return commit_evidence(
+                digest, attempt.attempt_id, attempt.commit_token, secret
+            )
+        except TypeError:
+            try:
+                # Generic IdempotencyStore users may still provide their own
+                # local evidence hook while they migrate. LeaseManager never
+                # uses this compatibility route for portable receipts.
+                return commit_evidence(digest, attempt.attempt_id, attempt.commit_token)
+            except TypeError:
+                return commit_evidence()
+
+    def _exact_evidence(self, commit_evidence: Any, digest: str, attempt: _ExecutionAttempt) -> bool:
+        return bool(self._read_exact_evidence(commit_evidence, digest, attempt))
 
     def _notify_waiters(self) -> None:
         with self._condition:
@@ -997,11 +1934,15 @@ class IdempotencyStore:
                 pending_updated_at = [
                     row[0]
                     for row in conn.execute(
-                        "SELECT updated_at FROM mutations WHERE state = 'pending'"
+                        "SELECT updated_at FROM mutations "
+                        "WHERE state IN ('pending', 'reserved', 'executing')"
                     ).fetchall()
                 ]
                 abandoned = conn.execute(
-                    "SELECT COUNT(*) FROM mutations WHERE state = 'abandoned'"
+                    "SELECT COUNT(*) FROM mutations "
+                    "WHERE state IN ('abandoned', 'outcome_unknown') "
+                    "OR (state = 'completed' AND result = ?)",
+                    (_OUTCOME_UNKNOWN_PAYLOAD,),
                 ).fetchone()[0]
             oldest_pending_age_seconds = (
                 round(max(0.0, now - min(pending_updated_at)), 3)
@@ -1100,6 +2041,13 @@ def _effective_idempotency_key(
     return None, None, None
 
 
+def _is_receipt_vault_root(root: Path) -> bool:
+    """Receipt storage is allowed only inside an existing vault scaffold."""
+    from .kbdir import kb_dirname
+
+    return (root / kb_dirname()).is_dir()
+
+
 class LeaseManager:
     def __init__(
         self,
@@ -1168,6 +2116,17 @@ class LeaseManager:
         except Exception:  # noqa: BLE001 - observability must never break the caller
             pass
 
+    def _mutation_coordinator_for(
+        self, vault_root: os.PathLike[str] | str
+    ) -> VaultMutationCoordinator:
+        """Construct this manager's canonical boundary for one vault."""
+        return VaultMutationCoordinator(
+            self.config.state_dir,
+            vault_root,
+            timeout_seconds=self._mutation_timeout_seconds,
+            poll_interval_seconds=self._mutation_poll_interval_seconds,
+        )
+
     def _log_lease_event(self, event: str, **fields: Any) -> None:
         try:
             from .log_events import log_event
@@ -1218,12 +2177,7 @@ class LeaseManager:
         holder_kind: str = "unknown",
     ) -> Iterator[VaultMutationCoordinator]:
         """Serialize hosted reads with mutations without requiring writer authority."""
-        mutation = VaultMutationCoordinator(
-            self.config.state_dir,
-            vault_root,
-            timeout_seconds=self._mutation_timeout_seconds,
-            poll_interval_seconds=self._mutation_poll_interval_seconds,
-        )
+        mutation = self._mutation_coordinator_for(vault_root)
         with mutation.hold(
             request_id=request_id,
             operation=operation,
@@ -1241,22 +2195,62 @@ class LeaseManager:
         holder_kind: str = "command",
     ) -> Iterator[VaultMutationCoordinator]:
         """Hold the shared vault mutation boundary and revalidate writer authority."""
-        with self.consistency_guard(
-            vault_root,
-            request_id=request_id,
-            operation=operation,
-            holder_kind=holder_kind,
-        ) as mutation:
+        direct_boundary: tuple[str, Path] | None = None
+        direct_token: Token[tuple[tuple[str, Path], ...]] | None = None
+        outer_direct_boundary = False
+        inherited_manager = _ACTIVE_LEASE_MANAGER.get()
+        if (
+            inherited_manager is None
+            and request_id is None
+            and active_mutation_request_id() is None
+        ):
+            direct_boundary = _direct_mutation_boundary(vault_root, self.config.state_dir)
+            active_direct = _ACTIVE_DIRECT_MUTATION_GUARDS.get()
+            outer_direct_boundary = direct_boundary not in active_direct
+            direct_token = _ACTIVE_DIRECT_MUTATION_GUARDS.set(
+                (*active_direct, direct_boundary)
+            )
+        manager_token = _ACTIVE_LEASE_MANAGER.set(self)
+        try:
+            with self.consistency_guard(
+                vault_root,
+                request_id=request_id,
+                operation=operation,
+                holder_kind=holder_kind,
+            ) as mutation:
+                try:
+                    with self.writer_authority_guard():
+                        yield mutation
+                finally:
+                    # Bump while the boundary is still held, so the counter is
+                    # serialized with the mutations it fingerprints. Every
+                    # governed writer exits through here (wide or narrow), which
+                    # is what lets the validity-stamp comparison skip the
+                    # in-boundary corpus stat-walk.
+                    _bump_commit_generation(self.config.state_dir, vault_root)
+        finally:
+            _ACTIVE_LEASE_MANAGER.reset(manager_token)
+            if direct_token is not None:
+                _ACTIVE_DIRECT_MUTATION_GUARDS.reset(direct_token)
+        if outer_direct_boundary and (
+            isinstance(vault_root, os.PathLike)
+            or (isinstance(vault_root, str) and Path(vault_root).is_absolute())
+        ):
+            from . import graph_sync
+
+            root = Path(vault_root)
             try:
-                with self.writer_authority_guard():
-                    yield mutation
-            finally:
-                # Bump while the boundary is still held, so the counter is
-                # serialized with the mutations it fingerprints. Every
-                # governed writer exits through here (wide or narrow), which
-                # is what lets the validity-stamp comparison skip the
-                # in-boundary corpus stat-walk.
-                _bump_commit_generation(self.config.state_dir, vault_root)
+                graph_sync.start_registered(root, state_root=self.config.state_dir)
+                graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+            except graph_sync.GraphRebuildRegistrationError:
+                # Direct leaf APIs have no terminal-envelope seam for a graph
+                # failure. Canonical bytes and the exact durable failure handle
+                # remain authoritative; their bounded index/readiness paths
+                # expose the recovery requirement.
+                logger.warning(
+                    "direct mutation graph join failed after canonical release",
+                    exc_info=True,
+                )
 
     @contextmanager
     def writer_authority_guard(self) -> Iterator[None]:
@@ -1301,7 +2295,12 @@ class LeaseManager:
     ) -> Any:
         t_start = time.perf_counter()
         kwargs = _canonicalize_command_kwargs(kwargs)
-        response_detail_default = getattr(command, "response_detail", None) or "compact"
+        configured_response_detail = getattr(command, "response_detail", None)
+        response_detail_default: ResponseDetail = (
+            configured_response_detail
+            if configured_response_detail in {"compact", "full", "legacy"}
+            else "compact"
+        )
         kwargs, response_detail = split_response_detail(
             kwargs, default=response_detail_default
         )
@@ -1319,8 +2318,13 @@ class LeaseManager:
             # decision that reserved the bypass to `mode="audit"`/
             # `validate_only` reads while other hosted reads held the guard
             # (openspec/changes/archive/2026-07-20-make-mcp-acknowledgement-replay-safe/design.md:64).
-            return command.leaf(*injected, **kwargs)
+            manager_token = _ACTIVE_LEASE_MANAGER.set(self)
+            try:
+                return command.leaf(*injected, **kwargs)
+            finally:
+                _ACTIVE_LEASE_MANAGER.reset(manager_token)
         mutation_subject = self._mutation_subject(injected)
+        receipt_vault_root = self._receipt_vault_root(injected)
         digest = _command_digest(command, kwargs)
         key, expires_after, on_replay = _effective_idempotency_key(
             self,
@@ -1331,6 +2335,13 @@ class LeaseManager:
             principal_scope=idempotency_principal_scope,
             implicit_idempotency_scope=implicit_idempotency_scope,
         )
+        # The receipt hooks below are reached only through the idempotent
+        # state-machine path; unkeyed writes bypass `IdempotencyStore.run`'s
+        # durable receipt protocol.
+        if key is not None:
+            receipt_key_digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        else:
+            receipt_key_digest = None
         request_id = mutation_request_id or str(uuid.uuid4())
         receipt = _receipt_tag(key) if key else None
         commit_state = {"observed": False}
@@ -1409,6 +2420,362 @@ class LeaseManager:
                 _ACTIVE_MUTATION_COMMITTED.reset(commit_token)
                 _ACTIVE_MUTATION_TRACE.reset(trace_token)
 
+        def with_graph_outcome(result: Any, outcome: Mapping[str, Any]) -> Any:
+            """Keep derived graph health in the durable terminal payload."""
+            if not isinstance(result, Mapping):
+                return result
+            terminal = {**result, **outcome}
+            leaf = result.get("leaf_result")
+            if isinstance(leaf, Mapping):
+                terminal["leaf_result"] = {**leaf, **outcome}
+            return terminal
+
+        def graph_failure(checkpoint: Any, error: BaseException | None = None) -> dict[str, str]:
+            from . import graph_sync
+
+            if isinstance(error, graph_sync.GraphRebuildRegistrationError):
+                return graph_sync.committed_graph_failure(
+                    checkpoint, code=error.code, remediation=error.remediation
+                )
+            return graph_sync.committed_graph_failure(checkpoint)
+
+        def wait_for_graph_sync(result: Any) -> Any:
+            """Join derived graph work only after the canonical guard released."""
+            terminal_result = (
+                {key: value for key, value in result.items() if key != "_graph_sync_checkpoint"}
+                if isinstance(result, Mapping)
+                else result
+            )
+
+            def finish_reconcile_graph_status(value: Any, *, current: bool) -> Any:
+                if not isinstance(value, Mapping):
+                    return value
+                final = dict(value)
+                refreshed = final.pop("_graph_reconcile_registered", None)
+                leaf = final.get("leaf_result")
+                if refreshed is None and isinstance(leaf, Mapping):
+                    refreshed = leaf.get("_graph_reconcile_registered")
+                if refreshed is None:
+                    return final
+                if isinstance(leaf, Mapping):
+                    reported_leaf = dict(leaf)
+                    reported_leaf.pop("_graph_reconcile_registered", None)
+                    final["leaf_result"] = {
+                        **reported_leaf,
+                        "graph_status": "refreshed" if current else "unavailable",
+                        "graph_refreshed": refreshed if current else 0,
+                    }
+                else:
+                    final["graph_status"] = "refreshed" if current else "unavailable"
+                    final["graph_refreshed"] = refreshed if current else 0
+                return final
+
+            required = None
+            try:
+                from . import graph_sync
+
+                root = receipt_vault_root
+                if root is None:
+                    return terminal_result
+                required = graph_sync.registered_checkpoint(
+                    root, state_root=self.config.state_dir
+                )
+                if required is None:
+                    return terminal_result
+                graph_sync.wait_for_registered(root, state_root=self.config.state_dir)
+            except Exception as error:  # noqa: BLE001 - canonical commit remains terminal
+                terminal_result = finish_reconcile_graph_status(
+                    terminal_result, current=False
+                )
+                if isinstance(result, Mapping) and required is not None:
+                    return with_graph_outcome(
+                        terminal_result, graph_failure(required, error)
+                    )
+                return terminal_result
+            if command.name == "reconcile" or (
+                command.name == "maintain_memory" and kwargs.get("mode") == "reconcile"
+            ):
+                try:
+                    from . import audit as audit_module
+                    from .epistemic_graph import EpistemicGraphIndex
+
+                    graph_current = (
+                        graph_sync.status(root)["state"] == "current"
+                        and EpistemicGraphIndex(
+                            root, mutation_coordinator=self._mutation_coordinator_for(root)
+                        ).available()
+                        and not audit_module._check_graph_drift(root)
+                    )
+                except Exception:  # noqa: BLE001 - preserve a failed graph terminal
+                    graph_current = False
+                terminal_result = finish_reconcile_graph_status(
+                    terminal_result, current=graph_current
+                )
+            if isinstance(terminal_result, Mapping):
+                return with_graph_outcome(terminal_result, {"graph_sync": "completed"})
+            return terminal_result
+
+        def persist_graph_sync_progress(
+            result: Any, attempt: _ExecutionAttempt, canonical_disposition: str = "success"
+        ) -> Any:
+            """Persist exact canonical evidence while canonical authority is held."""
+            if not commit_state["observed"]:
+                return result
+            try:
+                from . import graph_sync
+
+                root = receipt_vault_root
+                if root is None or not _is_receipt_vault_root(root):
+                    raise _PostCommitOutcomeUncertain()
+                required = graph_sync.registered_checkpoint(
+                    root, state_root=self.config.state_dir
+                )
+                current = graph_sync.read_checkpoint(root)
+                if (
+                    current is not None
+                    and current.mutation_id == attempt.commit_token
+                ):
+                    required = current
+                projection = {
+                    name: result.get(name)
+                    for name in (
+                        "_terminal",
+                        "version",
+                        "ok",
+                        "state",
+                        "status",
+                        "committed",
+                        "mutated",
+                        "terminal",
+                        "request_id",
+                        "receipt_id",
+                        "operation_id",
+                        "warnings_count",
+                    )
+                    if isinstance(result, Mapping) and name in result
+                }
+                projection["result_sha256"] = _receipt_result_sha256(result)
+                if not projection:
+                    projection = {"status": "committed", "mutated": True}
+                evidence = graph_sync.GraphCommitReceipt.create(
+                    idempotency_key_digest=receipt_key_digest or "0" * 64,
+                    command_digest=digest,
+                    attempt_id=attempt.attempt_id,
+                    commit_token=attempt.commit_token,
+                    canonical_disposition=canonical_disposition,
+                    terminal_projection=projection,
+                    checkpoint_generation=(required.generation if required is not None else None),
+                    checkpoint_sha256=(required.checkpoint_sha256 if required is not None else None),
+                    commit_secret=attempt.commit_secret,
+                )
+                graph_sync.write_graph_commit_receipt(root, evidence)
+                if isinstance(result, Mapping) and required is not None:
+                    return {
+                        **result,
+                        "_graph_sync_checkpoint": required.as_dict(),
+                    }
+                return result
+            except Exception as error:
+                raise _PostCommitOutcomeUncertain() from error
+
+        def exact_commit_evidence(
+            expected_digest: str, attempt_id: str, claim_token: str, commit_secret: bytes
+        ) -> Any:
+            try:
+                from . import graph_sync
+
+                root = receipt_vault_root
+                if root is None or not _is_receipt_vault_root(root):
+                    return False
+                evidence = graph_sync.read_graph_commit_receipt(root, claim_token)
+                if not (
+                    evidence is not None
+                    and evidence.verify(
+                        commit_secret,
+                        idempotency_key_digest=receipt_key_digest or "0" * 64,
+                        command_digest=expected_digest,
+                        attempt_id=attempt_id,
+                        commit_token=claim_token,
+                    )
+                ):
+                    return None
+                return evidence
+            except Exception:  # noqa: BLE001 - absence is fail-closed
+                return None
+
+        def legacy_graph_pending_proof(candidate: Any) -> bool:
+            """Authorize only the retired row's exact coherent graph epoch."""
+            try:
+                from . import graph_sync
+
+                root = receipt_vault_root
+                if root is None or not _is_receipt_vault_root(root):
+                    return False
+                epoch = graph_sync.classify_epoch(root)
+                return (
+                    epoch.kind == "coherent"
+                    and epoch.checkpoint is not None
+                    and epoch.checkpoint == candidate
+                    and graph_sync.read_checkpoint(root) == candidate
+                )
+            except Exception:  # noqa: BLE001 - legacy migration is fail-closed
+                return False
+
+        def resume_graph_sync(result: Any) -> Any:
+            """Resume only a durable derived checkpoint after owner death."""
+            required = None
+            evidence: Any = None
+            terminal: dict[str, Any] | None = None
+            committed_failure: dict[str, Any] | None = None
+
+            def retain_failure(value: Any) -> Any:
+                return (
+                    _CanonicalCommittedFailure(value, committed_failure)
+                    if committed_failure is not None
+                    else value
+                )
+
+            try:
+                from . import graph_sync
+                from .epistemic_graph import EpistemicGraphIndex
+
+                root = receipt_vault_root
+                if isinstance(result, _CanonicalResume):
+                    evidence = result.evidence
+                    result = result.result
+                    # A canonical row without its retained terminal needs
+                    # the exact receipt *and* its matching local secret to
+                    # establish what crossed the multi-store cut.  A cleanup
+                    # crash may leave the row but lose that trusted material;
+                    # derived recovery cannot fabricate a success from it.
+                    if result is None and not isinstance(
+                        evidence, graph_sync.GraphCommitReceipt
+                    ):
+                        return _OUTCOME_UNKNOWN_TERMINAL
+                if isinstance(result, _CanonicalCommittedFailure):
+                    committed_failure = result.payload
+                    result = result.result
+                if result is None:
+                    if not isinstance(evidence, graph_sync.GraphCommitReceipt):
+                        raise ValueError("canonical receipt terminal projection is unavailable")
+                    terminal = dict(evidence.terminal_projection)
+                    # The portable receipt deliberately cannot retain leaf
+                    # paths/content. Keep the public terminal envelope valid
+                    # with an empty local diagnostics projection.
+                    terminal["leaf_result"] = {}
+                    receipt_only_failure = (
+                        evidence.canonical_disposition == "committed_failure"
+                    )
+                    if terminal.get("_terminal") == "exomem.mutation-terminal":
+                        if effective_public_idempotency_key is not None:
+                            terminal["idempotency_key"] = effective_public_idempotency_key
+                    if root is None or not _is_receipt_vault_root(root):
+                        if receipt_only_failure:
+                            return _OUTCOME_UNKNOWN_TERMINAL
+                        return retain_failure(with_graph_outcome(terminal, {
+                            "graph_sync": "failed",
+                            "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
+                            "graph_sync_remediation": (
+                                "Configure the vault mount and run reconcile to recover the derived graph."
+                            ),
+                        }))
+                    required = graph_sync.read_checkpoint(root)
+                    if (evidence.checkpoint_generation, evidence.checkpoint_sha256) != (
+                        required.generation if required is not None else None,
+                        required.checkpoint_sha256 if required is not None else None,
+                    ):
+                        if receipt_only_failure:
+                            return _OUTCOME_UNKNOWN_TERMINAL
+                        if required is not None:
+                            return retain_failure(with_graph_outcome(terminal, graph_failure(required)))
+                        return retain_failure(with_graph_outcome(terminal, {
+                            "graph_sync": "failed",
+                            "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
+                            "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                        }))
+                    if required is None:
+                        if receipt_only_failure:
+                            return _OUTCOME_UNKNOWN_TERMINAL
+                        return retain_failure(with_graph_outcome(terminal, {"graph_sync": "completed"}))
+                    EpistemicGraphIndex(
+                        root, mutation_coordinator=self._mutation_coordinator_for(root)
+                    ).rebuild_all()
+                    if graph_sync.status(root)["state"] == "current":
+                        if receipt_only_failure:
+                            return _OUTCOME_UNKNOWN_TERMINAL
+                        return retain_failure(with_graph_outcome(terminal, {"graph_sync": "completed"}))
+                    if receipt_only_failure:
+                        return _OUTCOME_UNKNOWN_TERMINAL
+                    return retain_failure(with_graph_outcome(terminal, graph_failure(required)))
+                if not isinstance(result, Mapping):
+                    return retain_failure(result)
+                if root is None or not _is_receipt_vault_root(root):
+                    terminal = {
+                        key: value for key, value in result.items() if key != "_graph_sync_checkpoint"
+                    }
+                    return retain_failure(with_graph_outcome(terminal, {
+                        "graph_sync": "failed",
+                        "graph_sync_code": "GRAPH_SYNC_VAULT_AUTHORITY_MISSING",
+                        "graph_sync_remediation": (
+                            "Configure the vault mount and run reconcile to recover the derived graph."
+                        ),
+                    }))
+                payload = result.get("_graph_sync_checkpoint")
+                if payload is None:
+                    return retain_failure(result)
+                if not isinstance(payload, dict):
+                    raise ValueError("canonical checkpoint payload is invalid")
+                stored = graph_sync.GraphSyncCheckpoint.parse(
+                    json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                )
+                if stored is None:
+                    raise ValueError("graph-pending checkpoint payload is invalid")
+                required = graph_sync.read_checkpoint(root)
+                if (
+                    required is None
+                    or stored != required
+                ):
+                    terminal = {
+                        key: value for key, value in result.items() if key != "_graph_sync_checkpoint"
+                    }
+                    if required is not None:
+                        return retain_failure(with_graph_outcome(
+                            terminal, graph_sync.committed_graph_failure(required)
+                        ))
+                    return retain_failure(with_graph_outcome(terminal, {
+                        "graph_sync": "failed",
+                        "graph_sync_code": "GRAPH_SYNC_CHECKPOINT_MISSING",
+                        "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                    }))
+                EpistemicGraphIndex(
+                    root, mutation_coordinator=self._mutation_coordinator_for(root)
+                ).rebuild_all()
+                terminal = {
+                    key: value for key, value in result.items() if key != "_graph_sync_checkpoint"
+                }
+                if graph_sync.status(root)["state"] == "current":
+                    return retain_failure(with_graph_outcome(terminal, {"graph_sync": "completed"}))
+                return retain_failure(with_graph_outcome(terminal, graph_sync.committed_graph_failure(required)))
+            except Exception as error:  # noqa: BLE001 - canonical commit remains terminal
+                if terminal is None:
+                    if isinstance(result, Mapping):
+                        terminal = {
+                            key: value
+                            for key, value in result.items()
+                            if key != "_graph_sync_checkpoint"
+                        }
+                    elif isinstance(getattr(evidence, "terminal_projection", None), Mapping):
+                        terminal = dict(evidence.terminal_projection)
+                    else:
+                        terminal = {}
+                if required is not None:
+                    return retain_failure(with_graph_outcome(terminal, graph_failure(required, error)))
+                return retain_failure(with_graph_outcome(terminal, {
+                    "graph_sync": "failed",
+                    "graph_sync_code": "GRAPH_SYNC_RESUME_FAILED",
+                    "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+                }))
+
         narrow_media_commit = command.name == "process_media" and kwargs.get(
             "operation", "process"
         ) in {"process", "retry"}
@@ -1454,6 +2821,11 @@ class LeaseManager:
                     )
                 ),
                 commit_observed=lambda: commit_state["observed"],
+                after_canonical_persisted=persist_graph_sync_progress,
+                after_operation_guard=wait_for_graph_sync,
+                resume_canonically_committed=resume_graph_sync,
+                commit_evidence=exact_commit_evidence,
+                legacy_graph_pending_proof=legacy_graph_pending_proof,
             )
         except BaseException as error:
             if isinstance(error, OpError):
@@ -1561,6 +2933,20 @@ class LeaseManager:
             return self.config.vault_id
         return "standalone"
 
+    def _receipt_vault_root(self, injected: tuple[Any, ...]) -> Path | None:
+        """Resolve receipt storage only from an explicit vault authority."""
+        candidate = injected[0] if injected else None
+        if isinstance(candidate, (str, os.PathLike)):
+            root = Path(candidate)
+            if root.is_absolute():
+                return root.resolve(strict=False)
+        configured = os.environ.get("EXOMEM_VAULT_PATH", "").strip()
+        if configured:
+            root = Path(configured)
+            if root.is_absolute():
+                return root.resolve(strict=False)
+        return None
+
     def validate_fencing_token(self, fencing_token: int) -> None:
         """Fail closed unless the command's token is still locally and remotely current."""
         with self._lock:
@@ -1620,6 +3006,23 @@ class LeaseManager:
             "last_coordinator_error": None,
             "idempotency": self.idempotency.status_summary(),
         }
+        if vault_or_cell is not None:
+            try:
+                from . import epistemic_graph, graph_sync
+
+                vault_root = Path(vault_or_cell)
+                graph_status = graph_sync.status(vault_root)
+                if graph_status["state"] == "current" and not epistemic_graph.EpistemicGraphIndex(
+                    vault_root,
+                    mutation_coordinator=self._mutation_coordinator_for(vault_root),
+                ).available():
+                    graph_status = {
+                        "state": "unavailable",
+                        "generation": graph_status["generation"],
+                    }
+                base["graph_sync"] = graph_status
+            except Exception:  # noqa: BLE001 - coordination diagnostics stay bounded
+                base["graph_sync"] = {"state": "unavailable", "generation": 0}
         if not self.config.enabled:
             return base
         assert self.client is not None
@@ -1629,7 +3032,9 @@ class LeaseManager:
             # Record the fault instead of only ever reporting
             # `coordinator_healthy: False` with no further detail.
             self._record_coordinator_error(error.code)
-            code, at = self._last_coordinator_error
+            current_error = self._last_coordinator_error
+            assert current_error is not None
+            code, at = current_error
             base["last_coordinator_error"] = {
                 "code": code,
                 "age_seconds": round(time.monotonic() - at, 3),
@@ -1854,6 +3259,14 @@ def active_mutation_request_id() -> str | None:
     """Return the current content-free request identity for commit attribution."""
     trace = _ACTIVE_MUTATION_TRACE.get()
     return trace[0] if trace is not None else None
+
+
+def active_direct_mutation_guard(
+    vault_root: os.PathLike[str] | str, *, state_root: Path
+) -> bool:
+    """Return whether this thread owns this manager-root boundary directly."""
+    boundary = _direct_mutation_boundary(vault_root, state_root)
+    return boundary in _ACTIVE_DIRECT_MUTATION_GUARDS.get()
 
 
 def invoke_command(

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -125,3 +125,28 @@ def test_find_hot_cache_invalidates_when_access_policy_changes(vault: Path) -> N
 
     second = find_module.find(vault, query="access-cache-secret-marker")
     assert not any(hit.path.endswith("cached-secret.md") for hit in second)
+
+
+def test_publication_policy_snapshot_is_bounded_and_fails_closed(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    snapshot = access.publication_policy_snapshot(vault)
+    assert snapshot is not None
+    assert snapshot.fingerprint == "missing"
+
+    config = _write_cfg(vault, "readonly: []\n")
+    snapshot = access.publication_policy_snapshot(vault)
+    assert snapshot is not None
+    assert snapshot.fingerprint == access.policy_fingerprint(vault)
+
+    config.write_bytes(b"x" * (access.PUBLICATION_POLICY_MAX_BYTES + 1))
+    assert access.publication_policy_snapshot(vault) is None
+
+    from exomem import vault as vault_module
+
+    monkeypatch.setattr(
+        vault_module,
+        "read_bounded_guarded_bytes",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unreadable")),
+    )
+    assert access.publication_policy_snapshot(vault) is None

--- a/tests/test_client_artifacts.py
+++ b/tests/test_client_artifacts.py
@@ -607,6 +607,7 @@ def test_eight_artifacts_keep_ordered_receipt_and_replay_once(
 ) -> None:
     from exomem import client_artifacts, writer_lease
 
+    (tmp_path / "Knowledge Base").mkdir()
     command = _command("preserve_artifacts")
     stage_calls: list[str] = []
     commit_calls: list[str] = []

--- a/tests/test_command_surface_retry.py
+++ b/tests/test_command_surface_retry.py
@@ -526,6 +526,7 @@ def test_identical_pending_retry_waits_outside_mutation_boundary_and_replays(
         return {"value": value}
 
     command = SimpleNamespace(name="edit_memory", leaf=leaf, read_only=False)
+    (tmp_path / "vault" / "Knowledge Base").mkdir(parents=True)
     manager = writer_lease.LeaseManager(
         writer_lease.LeaseConfig(state_dir=tmp_path / "state"),
         mutation_timeout_seconds=0.05,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -12,6 +12,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -126,17 +127,54 @@ def test_idempotency_store_check_warns_on_abandoned_receipts(_isolated_lease_man
     assert check.details["abandoned"] == 1
 
 
-def test_idempotency_store_check_warns_on_stale_pending(_isolated_lease_manager) -> None:
+def test_idempotency_store_check_warns_on_stale_live_receipt(_isolated_lease_manager) -> None:
     store = _isolated_lease_manager.idempotency
     with sqlite3.connect(store.path) as connection:
-        connection.execute(
+        connection.executemany(
             "INSERT INTO mutations(key, digest, state, updated_at, owner) "
-            "VALUES ('k1', 'd1', 'pending', ?, NULL)",
-            (0.0,),
+            "VALUES (?, ?, ?, ?, NULL)",
+            [
+                ("live-key-secret", "live-digest-secret", "executing", 0.0),
+                ("reserved-key-secret", "reserved-digest-secret", "reserved", time.time()),
+                ("pending-key-secret", "pending-digest-secret", "pending", time.time()),
+            ],
         )
     check = doctor_module._check_idempotency_store()
     assert check.status == "warn"
     assert "oldest pending" in check.message
+    assert check.details == {
+        "pending": 3,
+        "abandoned": 0,
+        "oldest_pending_age_seconds": pytest.approx(time.time(), abs=1.0),
+    }
+    assert "live-key-secret" not in json.dumps(check.details)
+    assert "live-digest-secret" not in json.dumps(check.details)
+    assert "reserved-key-secret" not in json.dumps(check.details)
+    assert "pending-key-secret" not in json.dumps(check.details)
+
+
+def test_idempotency_store_check_warns_on_completed_outcome_unknown(
+    _isolated_lease_manager,
+) -> None:
+    from exomem import writer_lease as writer_lease_module
+
+    store = _isolated_lease_manager.idempotency
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES ('unknown-key-secret', 'unknown-digest-secret', 'completed', ?, ?, NULL)",
+            (writer_lease_module._OUTCOME_UNKNOWN_PAYLOAD, 0.0),
+        )
+    check = doctor_module._check_idempotency_store()
+    assert check.status == "warn"
+    assert "1 abandoned idempotency receipt" in check.message
+    assert check.details == {
+        "pending": 0,
+        "abandoned": 1,
+        "oldest_pending_age_seconds": None,
+    }
+    assert "unknown-key-secret" not in json.dumps(check.details)
+    assert "unknown-digest-secret" not in json.dumps(check.details)
 
 
 def test_lexical_check_uses_escaped_immutable_query_only_snapshot(

--- a/tests/test_epistemic_graph_freshness.py
+++ b/tests/test_epistemic_graph_freshness.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from exomem import audit, epistemic_graph, freshness, index_sync, reconcile, semantic_index
+from exomem import audit, epistemic_graph, freshness, graph_sync, index_sync, reconcile, semantic_index
 from exomem import find as find_module
 from exomem import vault as vault_module
 from exomem.cli_ops import OpError
@@ -95,16 +95,21 @@ def _spawn_graph_mutation(
 def test_graph_mutation_lock_is_shared_and_rooted_inside_vault_kb(
     tmp_path: Path,
 ) -> None:
+    from exomem.writer_lease import active_manager
+
     vault = tmp_path / "vault"
     _seed(vault)
 
     first = epistemic_graph.EpistemicGraphIndex(vault)
     second = epistemic_graph.EpistemicGraphIndex(vault / ".")
 
-    expected_root = (vault / "Knowledge Base" / ".graph-coordination").resolve()
+    expected_root = active_manager().config.state_dir
     assert first._mutation_coordinator.state_root == expected_root
     assert first._mutation_coordinator.lock_path == second._mutation_coordinator.lock_path
-    assert first._mutation_coordinator.timeout_seconds == 30.0
+    assert (
+        first._mutation_coordinator.timeout_seconds
+        == active_manager()._mutation_timeout_seconds
+    )
 
 
 def test_graph_mutation_lock_unavailable_preserves_current_graph(
@@ -124,10 +129,10 @@ def test_graph_mutation_lock_unavailable_preserves_current_graph(
         timeout_seconds=0.05,
     )
 
-    with pytest.raises(OpError) as raised:
+    with pytest.raises(graph_sync.GraphRebuildLockUnavailable) as raised:
         index.rebuild_all()
 
-    assert raised.value.code == "MUTATION_LOCK_UNAVAILABLE"
+    assert raised.value.code == "GRAPH_SYNC_REBUILD_LOCK_UNAVAILABLE"
     assert index.available() is True
     assert index.nodes() == before_nodes
     assert index.edges() == before_edges
@@ -157,7 +162,7 @@ def test_graph_dispatch_wrappers_propagate_structured_lock_errors(
 
 
 @pytest.mark.parametrize("operation", ["refresh", "delete"])
-def test_spawned_mutator_waits_for_full_rebuild_mutation_boundary(
+def test_spawned_mutator_commits_while_full_rebuild_is_running(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
 ) -> None:
     context = multiprocessing.get_context("spawn")
@@ -200,7 +205,7 @@ def test_spawned_mutator_waits_for_full_rebuild_mutation_boundary(
     child.start()
     try:
         assert attempting.wait(5.0)
-        assert not completed.wait(0.5)
+        assert completed.wait(0.5)
     finally:
         release_rebuild.set()
         rebuild_thread.join(timeout=8.0)
@@ -215,7 +220,7 @@ def test_spawned_mutator_waits_for_full_rebuild_mutation_boundary(
     assert child.exitcode == 0
 
 
-def test_neighbor_reader_admitted_before_rebuild_sees_complete_old_snapshot(
+def test_neighbor_reader_during_rebuild_sees_complete_old_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault = tmp_path / "vault"
@@ -224,32 +229,17 @@ def test_neighbor_reader_admitted_before_rebuild_sees_complete_old_snapshot(
     index.rebuild_all()
     expected = index.neighbors_for([A])
     assert expected
-    snapshot_admitted = threading.Event()
     writer_entered = threading.Event()
+    release_rebuild = threading.Event()
     reader_results: list[list[epistemic_graph.GraphNeighbor]] = []
     reader_errors: list[Exception] = []
     writer_errors: list[Exception] = []
-    real_rebuild_pass = index._rebuild_all_pass
+    real_index_path = index._index_path
 
-    def open_snapshot():
-        conn = sqlite3.connect(index.path)
-        conn.execute("BEGIN")
-        markers = dict(
-            conn.execute(
-                "SELECT key, value FROM graph_meta WHERE key IN "
-                "('schema_version', 'core_registry_version', 'extension_registry_hash')"
-            ).fetchall()
-        )
-        assert markers["schema_version"] == str(epistemic_graph.SCHEMA_VERSION)
-        snapshot_admitted.set()
-        if not writer_entered.wait(5.0):
-            conn.close()
-            raise RuntimeError("writer did not enter rebuild")
-        return conn
-
-    def rebuild_pass(resolver):
+    def index_path(*args, **kwargs):
         writer_entered.set()
-        return real_rebuild_pass(resolver)
+        assert release_rebuild.wait(5.0)
+        return real_index_path(*args, **kwargs)
 
     def read_neighbors() -> None:
         try:
@@ -263,17 +253,18 @@ def test_neighbor_reader_admitted_before_rebuild_sees_complete_old_snapshot(
         except Exception as exc:  # noqa: BLE001 - asserted in parent thread
             writer_errors.append(exc)
 
-    monkeypatch.setattr(index, "_open_read_snapshot", open_snapshot, raising=False)
-    monkeypatch.setattr(index, "_rebuild_all_pass", rebuild_pass)
+    monkeypatch.setattr(index, "_index_path", index_path)
     reader = threading.Thread(target=read_neighbors)
     writer = threading.Thread(target=rebuild)
-    reader.start()
     try:
-        assert snapshot_admitted.wait(3.0)
         writer.start()
+        assert writer_entered.wait(3.0)
+        reader.start()
         reader.join(timeout=8.0)
+        release_rebuild.set()
         writer.join(timeout=8.0)
     finally:
+        release_rebuild.set()
         if writer.is_alive():
             writer.join(timeout=3.0)
         if reader.is_alive():
@@ -320,10 +311,10 @@ def test_trusted_reads_after_marker_removal_never_expose_partial_rows(
     writer.start()
     try:
         assert partial_written.wait(3.0)
-        assert index.nodes() == []
-        assert index.edges() == []
-        assert index.neighbors_for([A]) == []
-        assert epistemic_graph.graph_context(vault, path=A)["available"] is False
+        assert index.nodes()
+        assert index.edges()
+        assert index.neighbors_for([A])
+        assert epistemic_graph.graph_context(vault, path=A)["available"] is True
     finally:
         release_rebuild.set()
         writer.join(timeout=8.0)
@@ -392,7 +383,7 @@ def test_full_rebuild_retries_when_target_is_renamed_after_snapshot(
     report = index.rebuild_all()
 
     assert source.exists()
-    assert acquisitions == 2
+    assert acquisitions == 3
     assert report["indexed_files"] == 2
     assert any(
         edge["relation_type"] == "links_to"
@@ -437,6 +428,7 @@ def test_full_rebuild_retry_acquisition_failure_marks_graph_unavailable(
     _seed(vault)
     index = epistemic_graph.EpistemicGraphIndex(vault)
     index.rebuild_all()
+    old_live = index.path.read_bytes()
     real_snapshot = find_module.recall_resolver_snapshot
     acquisitions = 0
 
@@ -456,6 +448,7 @@ def test_full_rebuild_retry_acquisition_failure_marks_graph_unavailable(
 
     assert acquisitions == 2
     assert index.available() is False
+    assert index.path.read_bytes() == old_live
 
 
 def test_full_rebuild_retry_freshness_failure_marks_graph_unavailable(
@@ -465,6 +458,7 @@ def test_full_rebuild_retry_freshness_failure_marks_graph_unavailable(
     _seed(vault)
     index = epistemic_graph.EpistemicGraphIndex(vault)
     index.rebuild_all()
+    old_live = index.path.read_bytes()
     real_freshness = epistemic_graph._disk_vault_freshness
     real_snapshot = find_module.recall_resolver_snapshot
     freshness_checks = 0
@@ -489,6 +483,7 @@ def test_full_rebuild_retry_freshness_failure_marks_graph_unavailable(
 
     assert freshness_checks == 3
     assert index.available() is False
+    assert index.path.read_bytes() == old_live
 
 
 def test_full_rebuild_pass_failure_marks_partial_graph_unavailable(
@@ -507,10 +502,10 @@ def test_full_rebuild_pass_failure_marks_partial_graph_unavailable(
     with pytest.raises(RuntimeError, match="index pass failed"):
         index.rebuild_all()
 
-    assert index.available() is False
+    assert index.available() is True
 
 
-def test_full_rebuild_keeps_schema_marker_absent_until_stable(
+def test_full_rebuild_keeps_previous_schema_marker_visible_until_swap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault = tmp_path / "vault"
@@ -522,7 +517,7 @@ def test_full_rebuild_keeps_schema_marker_absent_until_stable(
 
     def index_path(*args, **kwargs):
         nonlocal indexed
-        assert index.available() is False
+        assert index.available() is True
         indexed += 1
         return real_index_path(*args, **kwargs)
 
@@ -540,17 +535,37 @@ def test_full_rebuild_rejects_direct_edit_before_availability_publication(
     vault = tmp_path / "vault"
     source, _target = _seed(vault)
     index = epistemic_graph.EpistemicGraphIndex(vault)
-    real_mark_available = index._mark_available
+    index.rebuild_all()
+    with index._connect() as conn:
+        prior_rows = conn.execute(
+            "SELECT node_key, source_hash FROM graph_nodes ORDER BY node_key"
+        ).fetchall()
+    attempts = 0
+    temporary_paths: list[Path] = []
 
-    def mark_available(*args, **kwargs) -> bool:
-        source.write_text("# Edited after final graph freshness check\n", encoding="utf-8")
-        return real_mark_available(*args, **kwargs)
+    def race_before_replace(temporary: Path, live: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        assert live == index.path
+        assert temporary != live
+        temporary_paths.append(temporary)
+        source.write_text(
+            f"# Edited during availability publication attempt {attempts}\n",
+            encoding="utf-8",
+        )
+        freshness.mark_external_pending(vault)
 
-    monkeypatch.setattr(index, "_mark_available", mark_available)
+    monkeypatch.setattr(index, "_before_publish_replacement", race_before_replace)
 
     with pytest.raises(RuntimeError, match="did not stabilize"):
         index.rebuild_all()
 
+    assert attempts == 2
+    assert all(not temporary.exists() for temporary in temporary_paths)
+    with index._connect() as conn:
+        assert conn.execute(
+            "SELECT node_key, source_hash FROM graph_nodes ORDER BY node_key"
+        ).fetchall() == prior_rows
     assert index.available() is False
     assert index.nodes() == []
 
@@ -580,7 +595,9 @@ def test_full_rebuild_recovers_from_a_stale_live_registry(tmp_path: Path) -> Non
         ).fetchone()
     finally:
         conn.close()
-    assert checkpoint is None
+    assert checkpoint == (
+        epistemic_graph._checkpoint_value(freshness.recall_checkpoint(vault, "vault")),
+    )
 
 
 def test_checkpointless_refresh_rebuilds_unseen_direct_edits(tmp_path: Path) -> None:
@@ -653,7 +670,7 @@ def test_refresh_admitted_before_failed_rebuild_cannot_restore_availability(
 
     assert overlap_triggered is True
     assert report["indexed_files"] == 1
-    assert index.available() is False
+    assert index.available() is True
 
 
 def test_refresh_missing_sidecar_routes_to_full_rebuild(tmp_path: Path) -> None:
@@ -691,7 +708,7 @@ def test_full_rebuild_first_post_pass_freshness_failure_marks_unavailable(
         index.rebuild_all()
 
     assert freshness_checks == 2
-    assert index.available() is False
+    assert index.available() is True
 
 
 def test_full_rebuild_snapshot_isolated_from_shared_cache_patch(
@@ -908,6 +925,31 @@ def test_live_incremental_refresh_does_not_repeat_a_full_disk_walk(
     current = next(node for node in index.nodes(path=A) if node["kind"] == "file")
     assert current["source_hash"] == epistemic_graph.vault_module.content_hash(
         source.read_text(encoding="utf-8")
+    )
+
+
+def test_source_version_recheck_preserves_crlf_bytes(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    source = vault / A
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(
+        b"---\r\ntype: insight\r\nstatus: active\r\n---\r\n"
+        b"# A\r\n\r\n## Claim\r\n\r\nWindows line endings stay exact.\r\n"
+    )
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    disk_freshness = epistemic_graph._disk_vault_freshness(vault)
+    resolver = find_module.recall_resolver_snapshot(vault, freshness=disk_freshness)
+    membership = index._recall_membership()
+
+    assert membership == frozenset({A})
+    versions = index._resolver_source_versions(resolver, membership)
+    assert versions is not None
+    assert index._source_versions_current(versions)
+    index.rebuild_all()
+    assert index.available()
+    file_node = next(node for node in index.nodes(path=A) if node["kind"] == "file")
+    assert file_node["source_hash"] == vault_module.content_hash(
+        source.read_bytes().decode("utf-8")
     )
 
 

--- a/tests/test_epistemic_graph_neighbors.py
+++ b/tests/test_epistemic_graph_neighbors.py
@@ -151,46 +151,54 @@ def test_cache_token_none_when_unavailable(tmp_path: Path, monkeypatch) -> None:
     assert epistemic_graph.cache_token(vault) is None
 
 
-def test_generation_bumps_on_write(tmp_path: Path) -> None:
+def test_in_place_write_bumps_generation_without_changing_instance(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _seed(vault)
     idx = epistemic_graph.EpistemicGraphIndex(vault)
     idx.rebuild_all()
     before = epistemic_graph.cache_token(vault)
+    assert before is not None
 
     target = vault / TARGET
     target.write_text(target.read_text(encoding="utf-8") + "\nMore.\n", encoding="utf-8")
-    epistemic_graph.upsert_after_write(vault, [target])
+    index_sync.upsert_after_write(vault, [target])
 
     after = epistemic_graph.cache_token(vault)
+    assert after is not None
     assert after != before
     assert int(after[2]) > int(before[2])
+    assert after[3] == before[3]
 
 
-def test_generation_bumps_on_delete(tmp_path: Path) -> None:
+def test_cache_token_moves_on_delete(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _seed(vault)
     idx = epistemic_graph.EpistemicGraphIndex(vault)
     idx.rebuild_all()
     before = epistemic_graph.cache_token(vault)
+    assert before is not None
 
     (vault / LINKED).unlink()
     index_sync.delete_after_remove(vault, [LINKED])
 
     after = epistemic_graph.cache_token(vault)
-    assert int(after[2]) > int(before[2])
+    assert after is not None
+    assert after != before
 
 
-def test_generation_bumps_on_rebuild(tmp_path: Path) -> None:
+def test_cache_token_moves_on_rebuild(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _seed(vault)
     idx = epistemic_graph.EpistemicGraphIndex(vault)
     idx.rebuild_all()
     before = epistemic_graph.cache_token(vault)
+    assert before is not None
 
     idx.rebuild_all()
     after = epistemic_graph.cache_token(vault)
+    assert after is not None
     assert after != before
+    assert after[3] != before[3]
 
 
 def test_neighbors_for_resolves_semantic_block_relations(tmp_path: Path) -> None:
@@ -309,6 +317,7 @@ def test_content_edit_moves_token_like_a_rebuild(tmp_path: Path) -> None:
     idx = epistemic_graph.EpistemicGraphIndex(vault)
     idx.rebuild_all()
     before = epistemic_graph.cache_token(vault)
+    assert before is not None
 
     seed = vault / SEED
     seed.write_text(
@@ -318,13 +327,16 @@ def test_content_edit_moves_token_like_a_rebuild(tmp_path: Path) -> None:
     )
     epistemic_graph.upsert_after_write(vault, [seed])
     incremental = epistemic_graph.cache_token(vault)
+    assert incremental is not None
     assert incremental != before
 
     epistemic_graph.sidecar_path(vault).unlink()
     epistemic_graph.EpistemicGraphIndex(vault).rebuild_all()
     rebuilt = epistemic_graph.cache_token(vault)
-    # Both operations produce a live token (schema + registry identity match);
-    # the generation counter differs by history, which is expected.
+    # Both operations produce a live token with the same schema and registry.
+    # Recreating the sidecar gives the rebuild a fresh instance identity even
+    # when its local generation happens to equal an earlier sidecar's value.
     assert rebuilt is not None
     assert rebuilt[0] == incremental[0]
     assert rebuilt[1] == incremental[1]
+    assert rebuilt[3] != incremental[3]

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -413,6 +413,17 @@ def test_non_markdown_is_ignored(vault, monkeypatch: pytest.MonkeyPatch) -> None
     assert ups == [] and dels == []
 
 
+def test_observed_access_policy_edit_marks_external_pending(vault: Path) -> None:
+    watcher = file_watcher.FileWatcher(vault)
+    policy = vault / "Knowledge Base" / "_access.yaml"
+    policy.write_text("excluded: []\n", encoding="utf-8")
+
+    watcher._record(policy, deleted=False)
+
+    assert freshness.external_pending(vault) is True
+    assert watcher._pending_upsert == set()
+
+
 # ---- Automatic governed-media dispatch (OpenSpec: automatic-media-processing) ----
 
 

--- a/tests/test_find_graph_freshness.py
+++ b/tests/test_find_graph_freshness.py
@@ -8,6 +8,7 @@ file mtime (a WAL checkpoint moves mtime without a content change).
 from __future__ import annotations
 
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -84,3 +85,32 @@ def test_availability_flip_separates_cache_entries(vault: Path, monkeypatch) -> 
     monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_INDEX", "1")
     find_module.find(vault, query="metabolism")
     assert calls["n"] == 2
+
+
+def test_full_rebuild_replacement_invalidates_a_retained_relation_cache(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    notes = vault / "Knowledge Base" / "Notes" / "Insights"
+    notes.mkdir(parents=True)
+    (notes / "source.md").write_text(
+        "# Source\n\n## Relations\n\n- supports [[Knowledge Base/Notes/Insights/target]]\n",
+        encoding="utf-8",
+    )
+    (notes / "target.md").write_text("# Target\n", encoding="utf-8")
+
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    sidecar = epistemic_graph.sidecar_path(vault)
+    with sqlite3.connect(sidecar) as conn:
+        conn.execute("DELETE FROM graph_edges")
+
+    broken_token = epistemic_graph.cache_token(vault)
+    request = {"query": "", "mode": "keyword", "relations": ["supports"]}
+    assert find_module.find(vault, **request) == []
+
+    index.rebuild_all()
+
+    assert epistemic_graph.cache_token(vault) != broken_token
+    assert {hit.path for hit in find_module.find(vault, **request)} == {
+        "Knowledge Base/Notes/Insights/source.md",
+        "Knowledge Base/Notes/Insights/target.md",
+    }

--- a/tests/test_find_relation_filter.py
+++ b/tests/test_find_relation_filter.py
@@ -10,7 +10,9 @@ unavailable).
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -145,6 +147,38 @@ def test_missing_sidecar_raises_warming(tmp_path: Path) -> None:
     with pytest.raises(RetrievalIndexWarming) as excinfo:
         find_module.find(vault, query="", relations=["supports"], limit=15)
     assert excinfo.value.status == "warming"
+
+
+def test_custom_manager_read_binds_relation_warming_to_its_runtime_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    ambient_state = tmp_path / "ambient-state"
+    custom_state = tmp_path / "custom-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(ambient_state))
+    vault = _vault(tmp_path, build=False)
+    manager = LeaseManager(LeaseConfig(state_dir=custom_state))
+    observed: list[Path] = []
+    rebuilt = threading.Event()
+
+    def rebuild(self):  # noqa: ANN001
+        observed.append(self._canonical_mutation_coordinator().state_root)
+        rebuilt.set()
+        return {}
+
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "rebuild_all", rebuild)
+    command = SimpleNamespace(
+        name="relation-read",
+        read_only=True,
+        leaf=lambda root: find_module.find(root, query="", relations=["supports"], limit=15),
+    )
+
+    with pytest.raises(RetrievalIndexWarming):
+        manager.invoke(command, (vault,), {})
+
+    assert rebuilt.wait(1)
+    assert observed == [custom_state]
 
 
 def test_stale_sidecar_raises_warming(tmp_path: Path) -> None:

--- a/tests/test_find_scene_frames.py
+++ b/tests/test_find_scene_frames.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from exomem import find as find_mod
-from exomem import preserve, scene_frames
+from exomem import preserve, scene_frames, semantic_contract
 from exomem.embeddings import Scene
 from exomem.find import find
 
@@ -121,7 +121,8 @@ def test_plain_images_unaffected(vault: Path) -> None:
     _setup_video_with_frames(vault)
     photo = vault / "Knowledge Base/Evidence/Test/clips/whiteboard.jpg"
     photo.write_bytes(b"\xff\xd8x")
-    photo.with_name("whiteboard.jpg.md").write_text(
+    sidecar = photo.with_name("whiteboard.jpg.md")
+    sidecar.write_text(
         "---\ntype: source\nsource_type: other\ncaptured: 2026-07-01\n"
         "media_type: image\n"
         "evidence_file: Knowledge Base/Evidence/Test/clips/whiteboard.jpg\n"
@@ -130,6 +131,10 @@ def test_plain_images_unaffected(vault: Path) -> None:
         "architecture sketch for the ingestion pipeline\n",
         encoding="utf-8",
     )
+    # This test writes out of band while the suite watcher is disabled. Publish
+    # the same corpus event a real watcher/self-write path would emit so the
+    # warmed recall checkpoint admits the new sidecar.
+    semantic_contract.publish_corpus_files_changed(vault, changed=(sidecar,))
     hits = find(vault, query="architecture sketch ingestion", mode="hybrid")
     assert len(hits) == 1
     h = hits[0].as_dict()

--- a/tests/test_governance_receipts.py
+++ b/tests/test_governance_receipts.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from exomem import audit, delete_directory, delete_file, embeddings, recover_from_trash
+from exomem import audit, delete_directory, delete_file, embeddings, index_sync, recover_from_trash
 from exomem import reconcile as reconcile_module
 from exomem.governance import egress, receipts, store
 
@@ -2092,6 +2092,188 @@ def test_repeat_delete_recover_delete_cycles_have_distinct_persisted_identity(
     assert deletion_records[0]["causation_id"] != deletion_records[1]["causation_id"]
 
 
+def test_governed_delete_retains_tombstone_when_graph_failure_handle_is_returned(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.governance import lifecycle
+
+    rel = "Knowledge Base/Notes/Insights/failed-graph-delete.md"
+    target = vault / rel
+    target.write_text("---\ntype: insight\nstatus: draft\n---\n# Hold evidence\n", encoding="utf-8")
+    _write_restricting_policy(vault, "Notes/Insights/failed-graph-delete.md")
+    failed = index_sync.IndexSyncReport(
+        "delete",
+        (rel,),
+        (rel,),
+        (index_sync.IndexComponentOutcome("epistemic_graph", "failed", "graph_handle_failed"),),
+    )
+    monkeypatch.setattr(index_sync, "delete_after_remove", lambda *_args, **_kwargs: failed)
+
+    result = delete_file.delete_file(vault, path=rel, confirm=True)
+
+    assert any("remains tombstoned" in warning for warning in result.warnings)
+    markers = list((vault / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json"))
+    assert len(markers) == 1
+    assert json.loads(markers[0].read_text(encoding="utf-8"))["state"] == "pending"
+    assert not any(item["event_type"] == "deletion" for item in _receipt_records(vault))
+    assert lifecycle.is_tombstoned(vault, rel)
+
+
+def test_governed_recovery_retains_markers_when_graph_failure_handle_is_returned(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rel = "Knowledge Base/Notes/Insights/failed-graph-recovery.md"
+    target = vault / rel
+    target.write_text("---\ntype: insight\nstatus: draft\n---\n# Hold recovery evidence\n", encoding="utf-8")
+    _write_restricting_policy(vault, "Notes/Insights/failed-graph-recovery.md")
+    deleted = delete_file.delete_file(vault, path=rel, confirm=True)
+    failed = index_sync.IndexSyncReport(
+        "upsert",
+        (rel,),
+        (rel,),
+        (index_sync.IndexComponentOutcome("epistemic_graph", "failed", "graph_handle_failed"),),
+    )
+    monkeypatch.setattr(index_sync, "upsert_after_write", lambda *_args, **_kwargs: failed)
+
+    result = recover_from_trash.recover_from_trash(vault, trash_path=deleted.trash_path)
+
+    assert target.exists()
+    assert any("remains tombstoned" in warning for warning in result.warnings)
+    tombstones = list((vault / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json"))
+    recovery = list((vault / "Knowledge Base/_Governance/deletion-tombstones/recovery").glob("*.json"))
+    assert len(tombstones) == 1
+    assert len(recovery) == 1
+    assert not any(item["event_type"] == "recovery" for item in _receipt_records(vault))
+
+
+def _coerce_legacy_void_index_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the production fan-out's legacy void-callback adaptation."""
+    from exomem import claims, deferred_index, epistemic_graph, graph_sync, lexstore, memory_refs
+
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="a" * 24,
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    monkeypatch.setattr(index_sync, "publish_corpus_delta", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(lexstore, "delete_after_remove", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(lexstore, "upsert_after_write", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(memory_refs, "delete_after_remove", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(memory_refs, "upsert_after_write", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(claims, "delete_after_remove", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        deferred_index, "clear_semantic_receipts", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        epistemic_graph,
+        "upsert_after_write",
+        lambda *_args, **_kwargs: epistemic_graph.GraphDispatchResult(
+            "registered", "graph_rebuild_registered", checkpoint
+        ),
+    )
+
+
+def test_governed_delete_keeps_tombstone_for_legacy_void_index_callbacks(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.governance import lifecycle
+
+    rel = "Knowledge Base/Notes/Insights/unverified-legacy-delete.md"
+    target = vault / rel
+    target.write_text("---\ntype: insight\nstatus: draft\n---\n# Hold evidence\n", encoding="utf-8")
+    _write_restricting_policy(vault, "Notes/Insights/unverified-legacy-delete.md")
+    _coerce_legacy_void_index_callbacks(monkeypatch)
+
+    result = delete_file.delete_file(vault, path=rel, confirm=True)
+
+    assert any("remains tombstoned" in warning for warning in result.warnings)
+    assert result.index is not None
+    assert any(item["code"] == "accepted_unverified" for item in result.index["components"])
+    assert {
+        (item["outcome"], item["code"])
+        for item in result.index["components"]
+    } >= {("registered", "graph_rebuild_registered")}
+    assert not any(item["event_type"] == "deletion" for item in _receipt_records(vault))
+    assert lifecycle.is_tombstoned(vault, rel)
+
+
+def test_governed_recovery_keeps_markers_for_legacy_void_index_callbacks(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rel = "Knowledge Base/Notes/Insights/unverified-legacy-recovery.md"
+    target = vault / rel
+    target.write_text("---\ntype: insight\nstatus: draft\n---\n# Hold recovery\n", encoding="utf-8")
+    _write_restricting_policy(vault, "Notes/Insights/unverified-legacy-recovery.md")
+    monkeypatch.setattr(
+        index_sync,
+        "delete_after_remove",
+        lambda *_args, **_kwargs: index_sync.IndexSyncReport(
+            "delete",
+            (rel,),
+            (rel,),
+            (index_sync.IndexComponentOutcome("epistemic_graph", "registered", "graph_rebuild_registered"),),
+        ),
+    )
+    deleted = delete_file.delete_file(vault, path=rel, confirm=True)
+    assert any(item["event_type"] == "deletion" for item in _receipt_records(vault))
+    _coerce_legacy_void_index_callbacks(monkeypatch)
+
+    result = recover_from_trash.recover_from_trash(vault, trash_path=deleted.trash_path)
+
+    assert target.exists()
+    assert any("remains tombstoned" in warning for warning in result.warnings)
+    assert result.index is not None
+    assert any(item["code"] == "accepted_unverified" for item in result.index["components"])
+    assert {
+        (item["outcome"], item["code"])
+        for item in result.index["components"]
+    } >= {("registered", "graph_rebuild_registered")}
+    tombstones = list((vault / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json"))
+    recovery = list((vault / "Knowledge Base/_Governance/deletion-tombstones/recovery").glob("*.json"))
+    assert len(tombstones) == 1
+    assert len(recovery) == 1
+    assert not any(item["event_type"] == "recovery" for item in _receipt_records(vault))
+
+
+def test_index_report_exactness_requires_closed_accepted_codes() -> None:
+    from exomem.governance import lifecycle
+
+    assert lifecycle._index_report_is_exact(
+        {
+            "components": [
+                {"outcome": "registered", "code": "graph_rebuild_registered"},
+                {"outcome": "accepted", "code": "no_eligible_paths"},
+            ],
+            "paths_truncated": False,
+            "reconcile_required": False,
+        }
+    )
+    assert lifecycle._index_report_is_exact(
+        {
+            "components": [],
+            "derived_work": "not_required",
+            "paths_truncated": False,
+            "reconcile_required": False,
+        }
+    )
+    assert not lifecycle._index_report_is_exact(
+        {
+            "components": [{"outcome": "accepted", "code": "accepted_unverified"}],
+            "paths_truncated": False,
+            "reconcile_required": False,
+        }
+    )
+    assert not lifecycle._index_report_is_exact(
+        {
+            "components": [{"outcome": "accepted", "code": "opaque_acceptance"}],
+            "paths_truncated": False,
+            "reconcile_required": False,
+        }
+    )
+
+
 def test_same_cycle_retry_reuses_persisted_operation_identity(vault: Path) -> None:
     from exomem.governance import lifecycle
 
@@ -2396,6 +2578,12 @@ def test_media_recovery_can_activate_when_clip_is_explicitly_disabled(
     )
 
     assert not any("remains tombstoned" in warning for warning in recovered.warnings)
+    assert recovered.index == {
+        "components": [],
+        "derived_work": "not_required",
+        "paths_truncated": False,
+        "reconcile_required": False,
+    }
     assert any(item["event_type"] == "recovery" for item in _receipt_records(vault))
 
 

--- a/tests/test_graph_epoch_protocol.py
+++ b/tests/test_graph_epoch_protocol.py
@@ -1,0 +1,908 @@
+"""Red-first protocol tests for graph checkpoint publication primitives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from exomem import graph_sync, vault
+from exomem import hosted_portability as portability
+from exomem import writer_lease
+
+
+def _checkpoint_payload(**changes: object) -> str:
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=(("Knowledge Base/Notes/example.md", "a" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+    payload = checkpoint.as_dict()
+    payload.update(changes)
+    unsigned = {key: value for key, value in payload.items() if key != "checkpoint_sha256"}
+    payload["checkpoint_sha256"] = hashlib.sha256(
+        graph_sync._DOMAIN
+        + json.dumps(unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _valid_protocol_artifact(artifact: str) -> str:
+    if artifact == "floor":
+        return graph_sync.GraphSyncGenerationFloor.create(1).render()
+    if artifact == "checkpoint":
+        return graph_sync.GraphSyncCheckpoint.create(
+            generation=1,
+            mutation_id="0123456789abcdef01234567",
+            paths=(),
+            created_paths=(),
+            scope="full",
+        ).render()
+    return graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="0123456789abcdef01234567",
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=b"s" * 32,
+    ).render()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"paths": [["Knowledge Base/Notes/../example.md", "a" * 64]]},
+        {"paths": [["Knowledge Base//Notes/example.md", "a" * 64]]},
+        {"paths": [["Knowledge Base/Notes\\example.md", "a" * 64]]},
+        {"paths": [["/Knowledge Base/Notes/example.md", "a" * 64]]},
+        {"paths": [["C:/Example/example.md", "a" * 64]]},
+        {"paths": [["C:relative.md", "a" * 64]]},
+        {"paths": [["//server/share/example.md", "a" * 64]]},
+        {"paths": [["//?/C:/Example/example.md", "a" * 64]]},
+        {"paths": [["\\\\?\\" + "C:" + "\\Example\\example.md", "a" * 64]]},
+        {"paths": [["Knowledge Base/Notes/CON.md", "a" * 64]]},
+        {"paths": [["Knowledge Base/Notes/example. ", "a" * 64]]},
+        {"paths": [["Knowledge Base/Notes/example.md", "A" * 64]]},
+        {
+            "paths": [
+                ["Knowledge Base/Notes/example.md", "a" * 64],
+                ["Knowledge Base/Notes/example.md", "a" * 64],
+            ]
+        },
+        {"created_paths": ["Knowledge Base/Notes/missing.md"]},
+        {"scope": "full", "paths": [["Knowledge Base/Notes/example.md", "a" * 64]]},
+    ],
+)
+def test_checkpoint_parser_rejects_noncanonical_path_entries_before_admission(
+    changes: dict[str, object],
+) -> None:
+    assert graph_sync.GraphSyncCheckpoint.parse(_checkpoint_payload(**changes)) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "C:/Example/example.md",
+        "C:relative.md",
+        "//server/share/example.md",
+        "//?/C:/Example/example.md",
+        "\\\\?\\" + "C:" + "\\Example\\example.md",
+        "Knowledge Base/Notes/CON.md",
+        "Knowledge Base/Notes/CON .md",
+        "Knowledge Base/Notes/CONIN$.md",
+        "Knowledge Base/Notes/CONOUT$.md",
+        "Knowledge Base/Notes/COM¹.md",
+        "Knowledge Base/Notes/LPT².md",
+        "Knowledge Base/Notes/example. ",
+    ],
+)
+def test_checkpoint_parser_rejects_windows_qualified_or_reserved_paths(path: str) -> None:
+    assert graph_sync.GraphSyncCheckpoint.parse(
+        _checkpoint_payload(paths=[[path, "a" * 64]], created_paths=[path])
+    ) is None
+
+
+def test_checkpoint_parser_limits_path_entries_not_rendered_bytes() -> None:
+    paths = tuple(
+        (f"Knowledge Base/Notes/{index:04d}-" + "x" * 80 + ".md", "a" * 64)
+        for index in range(1_000)
+    )
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=paths,
+        created_paths=(),
+    )
+
+    assert len(checkpoint.render().encode("utf-8")) > 1_000
+    assert graph_sync.GraphSyncCheckpoint.parse(checkpoint.render()) == checkpoint
+
+    too_many = _checkpoint_payload(
+        paths=[[f"Knowledge Base/Notes/{index}.md", "a" * 64] for index in range(1_001)],
+        created_paths=[],
+    )
+    assert graph_sync.GraphSyncCheckpoint.parse(too_many) is None
+
+
+@pytest.mark.parametrize("field", ["paths", "created_paths"])
+def test_full_scope_parser_caps_raw_entries_before_item_validation(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = json.loads(_checkpoint_payload(scope="full", paths=[], created_paths=[]))
+    payload[field] = (
+        [["not-a-path", "a" * 64]] * 1_001
+        if field == "paths"
+        else ["not-a-path"] * 1_001
+    )
+    unsigned = {key: value for key, value in payload.items() if key != "checkpoint_sha256"}
+    payload["checkpoint_sha256"] = hashlib.sha256(
+        graph_sync._DOMAIN + graph_sync._canonical_json(unsigned)
+    ).hexdigest()
+    monkeypatch.setattr(
+        graph_sync,
+        "_is_canonical_relative_path",
+        lambda _value: pytest.fail("oversized full-scope entries were inspected"),
+    )
+    assert graph_sync.GraphSyncCheckpoint.parse(graph_sync._canonical_json(payload)) is None
+
+    empty = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    assert graph_sync.GraphSyncCheckpoint.parse(empty.render()) == empty
+
+
+def test_checkpoint_accepts_1000_exact_1024_byte_paths_in_file_and_sqlite_meta(
+    tmp_path: Path,
+) -> None:
+    paths = tuple(
+        (
+            f"Knowledge Base/Notes/{index:04d}-"
+            + "x" * (1_024 - len(f"Knowledge Base/Notes/{index:04d}-.md"))
+            + ".md",
+            "a" * 64,
+        )
+        for index in range(1_000)
+    )
+    assert {len(path.encode("utf-8")) for path, _digest in paths} == {1_024}
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=paths,
+        created_paths=tuple(path for path, _digest in paths),
+    )
+    assert graph_sync.GraphSyncCheckpoint.parse(checkpoint.render()) == checkpoint
+
+    graph_sync.floor_path(tmp_path).parent.mkdir(parents=True)
+    graph_sync.floor_path(tmp_path).write_text(
+        graph_sync.GraphSyncGenerationFloor.create(4).render(), encoding="utf-8"
+    )
+    graph_sync.checkpoint_path(tmp_path).write_text(checkpoint.render(), encoding="utf-8")
+    with sqlite3.connect(tmp_path / "Knowledge Base/.graph.sqlite") as conn:
+        conn.execute("CREATE TABLE graph_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        conn.executemany(
+            "INSERT INTO graph_meta(key, value) VALUES (?, ?)",
+            (
+                ("graph_sync_generation", "4"),
+                ("graph_sync_digest", checkpoint.checkpoint_sha256),
+                ("graph_sync_checkpoint", checkpoint.render()),
+            ),
+        )
+    assert graph_sync.acknowledgement_state(tmp_path) == (
+        "valid",
+        graph_sync.GraphBuildOutcome.covering(checkpoint),
+    )
+
+
+def test_checkpoint_create_rejects_over_limit_created_paths_before_normalization() -> None:
+    created_paths = tuple(f"Knowledge Base/Notes/{index:04d}.md" for index in range(1_001))
+    with pytest.raises(ValueError, match="created paths cannot exceed 1000 entries"):
+        graph_sync.GraphSyncCheckpoint.create(
+            generation=4,
+            mutation_id="0123456789abcdef01234567",
+            paths=(),
+            created_paths=created_paths,
+        )
+
+
+@pytest.mark.parametrize("artifact", ["checkpoint", "floor"])
+def test_graph_protocol_rejects_boolean_versions(artifact: str) -> None:
+    if artifact == "checkpoint":
+        assert graph_sync.GraphSyncCheckpoint.parse(_checkpoint_payload(version=True)) is None
+    else:
+        floor = graph_sync.GraphSyncGenerationFloor.create(4).as_dict()
+        floor["version"] = True
+        assert graph_sync.GraphSyncGenerationFloor.parse(json.dumps(floor)) is None
+
+
+def test_checkpoint_nfc_is_accepted_and_nfd_is_rejected() -> None:
+    nfc_path = "Knowledge Base/Notes/caf\N{LATIN SMALL LETTER E WITH ACUTE}.md"
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=((nfc_path, "a" * 64),),
+        created_paths=(nfc_path,),
+    )
+    assert graph_sync.GraphSyncCheckpoint.parse(checkpoint.render()) == checkpoint
+    nfd_path = "Knowledge Base/Notes/cafe\N{COMBINING ACUTE ACCENT}.md"
+    assert graph_sync.GraphSyncCheckpoint.parse(
+        _checkpoint_payload(paths=[[nfd_path, "a" * 64]], created_paths=[nfd_path])
+    ) is None
+
+
+def test_receipt_rejects_malformed_hmac_and_all_signed_tampering() -> None:
+    secret = b"s" * 32
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        checkpoint_generation=4,
+        checkpoint_sha256="c" * 64,
+        commit_secret=secret,
+    )
+    malformed = receipt.as_dict()
+    malformed["receipt_hmac_sha256"] = "not-a-digest"
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(malformed)) is None
+
+    def assert_tampered(**changes: object) -> None:
+        payload = receipt.as_dict()
+        payload.update(changes)
+        if "terminal_projection" in changes:
+            payload["terminal_projection_sha256"] = hashlib.sha256(
+                graph_sync._RECEIPT_TERMINAL_DOMAIN
+                + json.dumps(
+                    payload["terminal_projection"],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+        parsed = graph_sync.GraphCommitReceipt.parse(graph_sync._canonical_json(payload))
+        assert parsed is not None
+        assert parsed.verify(
+            secret,
+            idempotency_key_digest="a" * 64,
+            command_digest="b" * 64,
+            attempt_id="0123456789abcdef01234567",
+            commit_token="fedcba987654321001234567",
+        ) is False
+
+    assert_tampered(receipt_hmac_sha256="0" * 64)
+    assert_tampered(idempotency_key_digest="d" * 64)
+    assert_tampered(command_digest="e" * 64)
+    assert_tampered(attempt_id="111111111111111111111111")
+    assert_tampered(commit_token="222222222222222222222222")
+    invalid_projection = receipt.as_dict()
+    invalid_projection["terminal_projection"] = {"status": "failed", "mutated": True}
+    invalid_projection["terminal_projection_sha256"] = hashlib.sha256(
+        graph_sync._RECEIPT_TERMINAL_DOMAIN
+        + graph_sync._canonical_json(invalid_projection["terminal_projection"])
+    ).hexdigest()
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(invalid_projection)) is None
+    assert_tampered(checkpoint_generation=5, checkpoint_sha256="f" * 64)
+
+    assert receipt.verify(
+        secret,
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="111111111111111111111111",
+        commit_token="fedcba987654321001234567",
+    ) is False
+
+
+def test_v2_receipt_requires_an_authenticated_outer_canonical_disposition() -> None:
+    secret = b"s" * 32
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=secret,
+    )
+    assert receipt.canonical_disposition == "success"
+    assert receipt.verify(
+        secret,
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+    )
+
+    committed_failure = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+        canonical_disposition="committed_failure",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=secret,
+    )
+    assert graph_sync.GraphCommitReceipt.parse(committed_failure.render()) == committed_failure
+    assert committed_failure.verify(
+        secret,
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+    )
+
+    missing = receipt.as_dict()
+    missing.pop("canonical_disposition")
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(missing)) is None
+    invalid = receipt.as_dict()
+    invalid["canonical_disposition"] = "unknown"
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(invalid)) is None
+
+    tampered = receipt.as_dict()
+    tampered["canonical_disposition"] = "committed_failure"
+    parsed = graph_sync.GraphCommitReceipt.parse(graph_sync._canonical_json(tampered))
+    assert parsed is not None
+    assert parsed.verify(
+        secret,
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+    ) is False
+
+
+def test_v2_receipt_requires_exact_canonical_utf8_json_before_authentication() -> None:
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=b"s" * 32,
+    )
+    rendered = receipt.render()
+    assert graph_sync.GraphCommitReceipt.parse(rendered) == receipt
+
+    payload = receipt.as_dict()
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(payload, indent=2)) is None
+    assert graph_sync.GraphCommitReceipt.parse(
+        json.dumps(dict(reversed(tuple(payload.items()))), separators=(",", ":"))
+    ) is None
+    assert graph_sync.GraphCommitReceipt.parse(
+        rendered.replace('"status":"committed"', '"status":"committ\\u0065d"')
+    ) is None
+    assert graph_sync.GraphCommitReceipt.parse(rendered + "\n") is None
+
+    legacy = receipt.as_dict()
+    legacy.pop("canonical_disposition")
+    legacy.pop("receipt_hmac_sha256")
+    legacy["version"] = 1
+    legacy["commit_point"] = True
+    assert graph_sync.GraphCommitReceipt.parse(json.dumps(legacy, indent=2)) is not None
+
+
+def test_v2_receipt_rejects_noncanonical_terminal_projection_scalars_before_auth() -> None:
+    secret = b"s" * 32
+    projection = {
+        "_terminal": "exomem.mutation-terminal",
+        "version": 1,
+        "ok": True,
+        "state": "committed",
+        "status": "committed",
+        "committed": True,
+        "mutated": True,
+        "terminal": True,
+        "request_id": "123e4567-e89b-42d3-a456-426614174000",
+        "receipt_id": "0123456789abcdef",
+        "operation_id": "123e4567-e89b-42d3-a456-426614174001",
+        "warnings_count": 0,
+        "result_sha256": "a" * 64,
+    }
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba987654321001234567",
+        canonical_disposition="success",
+        terminal_projection=projection,
+        commit_secret=secret,
+    )
+    assert graph_sync.GraphCommitReceipt.parse(receipt.render()) == receipt
+
+    invalid_fields = (
+        ("_terminal", "wrong-marker"),
+        ("version", True),
+        ("ok", "yes"),
+        ("state", "unknown"),
+        ("status", "failed"),
+        ("committed", 1),
+        ("mutated", None),
+        ("terminal", 0),
+        ("request_id", "not-a-uuid"),
+        ("receipt_id", "not-a-receipt-tag"),
+        ("operation_id", ""),
+        ("warnings_count", -7),
+        ("warnings_count", True),
+        ("result_sha256", "not-a-digest"),
+    )
+    for field, value in invalid_fields:
+        malformed = dict(projection)
+        malformed[field] = value
+        payload = receipt.as_dict()
+        payload["terminal_projection"] = malformed
+        payload["terminal_projection_sha256"] = hashlib.sha256(
+            graph_sync._RECEIPT_TERMINAL_DOMAIN
+            + graph_sync._canonical_json(malformed)
+        ).hexdigest()
+        assert graph_sync.GraphCommitReceipt.parse(graph_sync._canonical_json(payload)) is None
+        with pytest.raises(ValueError, match="terminal projection"):
+            graph_sync.GraphCommitReceipt.create(
+                idempotency_key_digest="a" * 64,
+                command_digest="b" * 64,
+                attempt_id="0123456789abcdef01234567",
+                commit_token="fedcba987654321001234567",
+                canonical_disposition="success",
+                terminal_projection=malformed,
+                commit_secret=secret,
+            )
+
+    with pytest.raises(ValueError, match="content-free"):
+        graph_sync.GraphCommitReceipt.create(
+            idempotency_key_digest="a" * 64,
+            command_digest="b" * 64,
+            attempt_id="0123456789abcdef01234567",
+            commit_token="fedcba987654321001234567",
+            canonical_disposition="success",
+            terminal_projection={"committed_failure_code": "forbidden"},
+            commit_secret=secret,
+        )
+    assert receipt.verify(
+        secret,
+        idempotency_key_digest="a" * 64,
+        command_digest="b" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="222222222222222222222222",
+    ) is False
+
+
+def test_bounded_artifact_readers_reject_sparse_oversized_inputs(
+    tmp_path: Path,
+) -> None:
+    receipt_token = "0123456789abcdef01234567"
+    paths_and_limits = (
+        (graph_sync.graph_commit_receipt_path(tmp_path, receipt_token), graph_sync._RECEIPT_READ_LIMIT),
+        (graph_sync.floor_path(tmp_path), graph_sync._FLOOR_READ_LIMIT),
+        (graph_sync.checkpoint_path(tmp_path), graph_sync._CHECKPOINT_READ_LIMIT),
+    )
+    for path, limit in paths_and_limits:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as stream:
+            stream.truncate(limit + 1)
+
+    assert graph_sync.read_graph_commit_receipt(tmp_path, receipt_token) is None
+    assert graph_sync.floor_state(tmp_path) == ("malformed", None)
+    assert graph_sync.checkpoint_state(tmp_path) == ("malformed", None)
+    for path, _limit in paths_and_limits[1:]:
+        with pytest.raises(OSError, match="could not be safely read"):
+            graph_sync._prior_artifact_bytes(path)
+
+
+def test_bounded_artifact_reader_rejects_regular_oversized_input_without_large_allocation(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "regular-artifact.json"
+    artifact.write_bytes(b"x" * 129)
+    with pytest.raises(OSError, match="could not be safely read"):
+        graph_sync._read_bounded_bytes(artifact, limit=128)
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint", "receipt"])
+def test_protocol_artifact_reader_rejects_symlink_outside_vault(
+    tmp_path: Path, artifact: str
+) -> None:
+    outside = tmp_path / "outside.json"
+    outside.write_text(_valid_protocol_artifact(artifact), encoding="utf-8")
+    token = "0123456789abcdef01234567"
+    path = {
+        "floor": graph_sync.floor_path(tmp_path),
+        "checkpoint": graph_sync.checkpoint_path(tmp_path),
+        "receipt": graph_sync.graph_commit_receipt_path(tmp_path, token),
+    }[artifact]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(outside)
+
+    if artifact == "floor":
+        assert graph_sync.floor_state(tmp_path) == ("malformed", None)
+    elif artifact == "checkpoint":
+        assert graph_sync.checkpoint_state(tmp_path) == ("malformed", None)
+    else:
+        assert graph_sync.read_graph_commit_receipt(tmp_path, token) is None
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO contract is POSIX-only")
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint", "receipt"])
+def test_protocol_artifact_reader_rejects_fifo_without_blocking(
+    tmp_path: Path, artifact: str
+) -> None:
+    token = "0123456789abcdef01234567"
+    path = {
+        "floor": graph_sync.floor_path(tmp_path),
+        "checkpoint": graph_sync.checkpoint_path(tmp_path),
+        "receipt": graph_sync.graph_commit_receipt_path(tmp_path, token),
+    }[artifact]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.mkfifo(path)
+
+    if artifact == "floor":
+        assert graph_sync.floor_state(tmp_path) == ("malformed", None)
+    elif artifact == "checkpoint":
+        assert graph_sync.checkpoint_state(tmp_path) == ("malformed", None)
+    else:
+        assert graph_sync.read_graph_commit_receipt(tmp_path, token) is None
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint", "receipt"])
+def test_protocol_artifact_reader_rejects_replace_during_guarded_read(
+    tmp_path: Path, artifact: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import vault as vault_module
+
+    token = "0123456789abcdef01234567"
+    path = {
+        "floor": graph_sync.floor_path(tmp_path),
+        "checkpoint": graph_sync.checkpoint_path(tmp_path),
+        "receipt": graph_sync.graph_commit_receipt_path(tmp_path, token),
+    }[artifact]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_valid_protocol_artifact(artifact), encoding="utf-8")
+    replacement = path.with_suffix(".replacement")
+    replacement.write_text(_valid_protocol_artifact(artifact), encoding="utf-8")
+    original = vault_module._read_bounded_guarded_snapshot
+
+    def replace_after_snapshot(
+        root: Path, target: str, limit: int
+    ) -> tuple[bytes, vault_module.PathGuard]:
+        data, guard = original(root, target, limit)
+        replacement.replace(path)
+        return data, guard
+
+    monkeypatch.setattr(vault_module, "_read_bounded_guarded_snapshot", replace_after_snapshot)
+    if artifact == "floor":
+        assert graph_sync.floor_state(tmp_path) == ("malformed", None)
+    elif artifact == "checkpoint":
+        assert graph_sync.checkpoint_state(tmp_path) == ("malformed", None)
+    else:
+        assert graph_sync.read_graph_commit_receipt(tmp_path, token) is None
+
+
+def test_fresh_vault_missing_graph_artifacts_remain_absent_and_admit_first_write(
+    tmp_path: Path,
+) -> None:
+    assert graph_sync.floor_state(tmp_path) == ("absent", None)
+    assert graph_sync.checkpoint_state(tmp_path) == ("absent", None)
+    assert graph_sync.status(tmp_path) == {"state": "current", "generation": 0}
+
+    note = tmp_path / "Knowledge Base/Notes/first.md"
+    vault.batch_atomic_write(
+        [vault.PlannedWrite(note, "# First\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    assert graph_sync.checkpoint_state(tmp_path)[0] == "valid"
+
+
+def test_deeply_nested_protocol_json_fails_closed_through_file_backed_status(
+    tmp_path: Path,
+) -> None:
+    nested = ("[" * 2_000 + "0" + "]" * 2_000).encode("ascii")
+    graph_sync.floor_path(tmp_path).parent.mkdir(parents=True)
+    graph_sync.floor_path(tmp_path).write_bytes(nested)
+    graph_sync.checkpoint_path(tmp_path).write_bytes(nested)
+    receipt_path = graph_sync.graph_commit_receipt_path(
+        tmp_path, "0123456789abcdef01234567"
+    )
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_bytes(nested)
+
+    assert graph_sync.GraphSyncGenerationFloor.parse(nested) is None
+    assert graph_sync.GraphSyncCheckpoint.parse(nested) is None
+    assert graph_sync.GraphCommitReceipt.parse(nested) is None
+    assert graph_sync.floor_state(tmp_path) == ("malformed", None)
+    assert graph_sync.checkpoint_state(tmp_path) == ("malformed", None)
+    assert graph_sync.read_graph_commit_receipt(tmp_path, "0123456789abcdef01234567") is None
+    assert graph_sync.status(tmp_path)["state"] == "unavailable"
+
+
+@pytest.mark.parametrize(
+    "parser",
+    (
+        graph_sync.GraphSyncCheckpoint.parse,
+        graph_sync.GraphSyncGenerationFloor.parse,
+        graph_sync.GraphCommitReceipt.parse,
+    ),
+)
+def test_protocol_parsers_fail_closed_on_json_recursion(
+    parser: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        graph_sync.json,
+        "loads",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RecursionError("deep JSON")),
+    )
+    assert parser(b"{}") is None  # type: ignore[operator]
+
+
+def test_oversized_sqlite_checkpoint_meta_fails_closed_without_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sidecar = tmp_path / "Knowledge Base/.graph.sqlite"
+    sidecar.parent.mkdir(parents=True)
+    with sqlite3.connect(sidecar) as conn:
+        conn.execute("CREATE TABLE graph_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        conn.executemany(
+            "INSERT INTO graph_meta(key, value) VALUES (?, ?)",
+            (
+                ("graph_sync_generation", "1"),
+                ("graph_sync_digest", "a" * 64),
+                ("graph_sync_checkpoint", "x" * 129),
+            ),
+        )
+    monkeypatch.setattr(graph_sync, "_CHECKPOINT_READ_LIMIT", 128)
+    monkeypatch.setattr(
+        graph_sync.GraphSyncCheckpoint,
+        "parse",
+        classmethod(lambda _cls, _raw: pytest.fail("oversized meta reached checkpoint parser")),
+    )
+    assert graph_sync.acknowledgement_state(tmp_path) == ("malformed", None)
+
+
+def test_checkpoint_parser_rejects_duplicate_closed_json_fields() -> None:
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=4,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    raw = checkpoint.render().replace('"generation":4,', '"generation":4,"generation":4,')
+
+    assert graph_sync.GraphSyncCheckpoint.parse(raw) is None
+
+
+def test_acknowledgement_requires_the_full_checkpoint_meta_proof(tmp_path: Path) -> None:
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="0123456789abcdef01234567",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    graph_sync.floor_path(tmp_path).parent.mkdir(parents=True)
+    graph_sync.floor_path(tmp_path).write_text(
+        graph_sync.GraphSyncGenerationFloor.create(1).render(), encoding="utf-8"
+    )
+    graph_sync.checkpoint_path(tmp_path).write_text(checkpoint.render(), encoding="utf-8")
+    sidecar = tmp_path / "Knowledge Base/.graph.sqlite"
+    with sqlite3.connect(sidecar) as conn:
+        conn.execute("CREATE TABLE graph_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        conn.executemany(
+            "INSERT INTO graph_meta(key, value) VALUES (?, ?)",
+            (
+                ("graph_sync_generation", "1"),
+                ("graph_sync_digest", checkpoint.checkpoint_sha256),
+            ),
+        )
+
+    assert graph_sync.acknowledgement_state(tmp_path)[0] == "malformed"
+    assert graph_sync.status(tmp_path)["state"] == "unavailable"
+
+    with sqlite3.connect(sidecar) as conn:
+        conn.execute(
+            "INSERT INTO graph_meta(key, value) VALUES (?, ?)",
+            ("graph_sync_checkpoint", checkpoint.render()),
+        )
+    assert graph_sync.acknowledgement_state(tmp_path) == (
+        "valid",
+        graph_sync.GraphBuildOutcome.covering(checkpoint),
+    )
+    assert graph_sync.status(tmp_path)["state"] == "current"
+
+
+def test_status_and_public_graph_availability_agree_on_missing_checkpoint_meta(
+    tmp_path: Path,
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/proof.md"
+    vault.batch_atomic_write(
+        [vault.PlannedWrite(note, "# Proof\n")], vault_root=tmp_path, post_commit_fanout=False
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    assert graph_sync.status(tmp_path)["state"] == "current"
+    assert index.available() is True
+
+    with index._connect() as conn:
+        conn.execute("DELETE FROM graph_meta WHERE key = 'graph_sync_checkpoint'")
+
+    assert graph_sync.status(tmp_path)["state"] == "unavailable"
+    assert index.available() is False
+
+
+def test_graph_commit_receipt_is_closed_content_free_and_portable(tmp_path: Path) -> None:
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="1" * 64,
+        command_digest="2" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba9876543210fedcba98",
+        canonical_disposition="success",
+        terminal_projection={
+            "status": "committed",
+            "mutated": True,
+        },
+        checkpoint_generation=7,
+        checkpoint_sha256="3" * 64,
+        commit_secret=b"s" * 32,
+    )
+
+    assert "secret-command-argument" not in receipt.render()
+    assert "secret-payload-value" not in receipt.render()
+    assert graph_sync.GraphCommitReceipt.parse(receipt.render()) == receipt
+    assert receipt.receipt_hmac_sha256 is not None
+
+    stored = graph_sync.write_graph_commit_receipt(tmp_path, receipt)
+    assert stored == graph_sync.graph_commit_receipt_path(tmp_path, receipt.commit_token)
+    assert graph_sync.read_graph_commit_receipt(tmp_path, receipt.commit_token) == receipt
+    assert graph_sync.is_graph_input_path(
+        "Knowledge Base/.graph-commit-receipts/fedcba9876543210fedcba98.json"
+    ) is False
+    assert (
+        portability.classify_artifact(
+            "Knowledge Base/.graph-commit-receipts/fedcba9876543210fedcba98.json"
+        ).artifact_class
+        is portability.ArtifactClass.PORTABLE_DERIVED
+    )
+
+
+def test_v2_graph_commit_receipt_authenticates_every_closed_field() -> None:
+    """A copied or edited vault receipt is advisory without its local secret."""
+    secret = b"s" * 32
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="1" * 64,
+        command_digest="2" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba9876543210fedcba98",
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=secret,
+    )
+
+    assert receipt.version == 2
+    assert receipt.verify(
+        secret,
+        idempotency_key_digest="1" * 64,
+        command_digest="2" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba9876543210fedcba98",
+    )
+    tampered = receipt.as_dict()
+    tampered["terminal_projection"] = {"status": "committed", "mutated": False}
+    tampered["terminal_projection_sha256"] = __import__("hashlib").sha256(
+        graph_sync._RECEIPT_TERMINAL_DOMAIN
+        + graph_sync._canonical_json(tampered["terminal_projection"])
+    ).hexdigest()
+    parsed = graph_sync.GraphCommitReceipt.parse(graph_sync._canonical_json(tampered))
+    assert parsed is not None
+    assert not parsed.verify(
+        secret,
+        idempotency_key_digest="1" * 64,
+        command_digest="2" * 64,
+        attempt_id="0123456789abcdef01234567",
+        commit_token="fedcba9876543210fedcba98",
+    )
+
+
+def test_graph_receipt_rejects_non_nfc_checkpoint_paths() -> None:
+    with pytest.raises(ValueError, match="paths must be canonical"):
+        graph_sync.GraphSyncCheckpoint.create(
+            generation=1,
+            mutation_id="0123456789abcdef01234567",
+            paths=(("Knowledge Base/Notes/cafe\u0301.md", "1" * 64),),
+            created_paths=("Knowledge Base/Notes/cafe\u0301.md",),
+        )
+
+
+def test_receipt_leaf_projection_never_copies_collection_paths() -> None:
+    from exomem.mutation_terminal import receipt_leaf_projection
+
+    receipt = {
+        "_record_receipt": "exomem.records-mutation",
+        "receipt_version": 1,
+        "operation": "create",
+        "collection_id": "c",
+        "item_key": "i",
+        "before_item_hash": None,
+        "after_item_hash": "1" * 64,
+        "before_container_hash": "2" * 64,
+        "after_container_hash": "3" * 64,
+        "affected_paths": ["Knowledge Base/private-secret.md"],
+        "payload_hash": "4" * 64,
+        "outcome": "committed",
+        "audit_correlation": "a",
+    }
+
+    assert receipt_leaf_projection(receipt) == {}
+
+
+def test_namespaced_receipt_key_digest_does_not_cross_replay_namespaces() -> None:
+    first = graph_sync.namespaced_idempotency_key_digest("mcp:alice", "client-key")
+    second = graph_sync.namespaced_idempotency_key_digest("mcp:bob", "client-key")
+
+    assert first != second
+    assert len(first) == 64
+    assert "client-key" not in first
+
+
+def test_floor_checkpoint_and_receipt_writes_do_not_mark_active_mutation_committed(
+    tmp_path: Path,
+) -> None:
+    trace = writer_lease._ACTIVE_MUTATION_TRACE.set(("request", "command", "receipt"))
+    committed = writer_lease._ACTIVE_MUTATION_COMMITTED.set(False)
+    try:
+        floor = graph_sync.GraphSyncGenerationFloor.create(1)
+        checkpoint = graph_sync.GraphSyncCheckpoint.create(
+            generation=1,
+            mutation_id="0123456789abcdef01234567",
+            paths=(),
+            created_paths=(),
+            scope="full",
+        )
+        receipt = graph_sync.GraphCommitReceipt.create(
+            idempotency_key_digest="1" * 64,
+            command_digest="2" * 64,
+            attempt_id="0123456789abcdef01234567",
+            commit_token="fedcba9876543210fedcba98",
+            canonical_disposition="success",
+            terminal_projection={"status": "committed", "mutated": True},
+            commit_secret=b"s" * 32,
+        )
+
+        graph_sync._write_floor(tmp_path, floor)
+        graph_sync._write_checkpoint(tmp_path, checkpoint)
+        graph_sync.write_graph_commit_receipt(tmp_path, receipt)
+
+        assert writer_lease._ACTIVE_MUTATION_COMMITTED.get() is False
+
+        vault.batch_atomic_write(
+            [vault.PlannedWrite(tmp_path / "Knowledge Base/Notes/committed.md", "# committed\n")],
+            vault_root=tmp_path,
+            post_commit_fanout=False,
+        )
+        assert writer_lease._ACTIVE_MUTATION_COMMITTED.get() is True
+    finally:
+        writer_lease._ACTIVE_MUTATION_COMMITTED.reset(committed)
+        writer_lease._ACTIVE_MUTATION_TRACE.reset(trace)
+
+
+def test_active_mutation_claim_context_exposes_only_opaque_protocol_identity() -> None:
+    assert writer_lease.active_mutation_claim_token() is None
+    assert writer_lease.active_mutation_command_digest() is None
+
+    with writer_lease.active_mutation_claim_context(
+        claim_token="0123456789abcdef01234567",
+        command_digest="a" * 64,
+    ):
+        assert writer_lease.active_mutation_claim_token() == "0123456789abcdef01234567"
+        assert writer_lease.active_mutation_command_digest() == "a" * 64
+
+    assert writer_lease.active_mutation_claim_token() is None
+    assert writer_lease.active_mutation_command_digest() is None

--- a/tests/test_graph_fanout_totality.py
+++ b/tests/test_graph_fanout_totality.py
@@ -1,0 +1,168 @@
+"""Contract tests for exact post-commit graph fanout outcomes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import epistemic_graph, graph_sync, index_sync, vault
+
+
+def _checkpoint() -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/example.md", "a" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+
+
+def test_empty_graph_fanout_is_explicitly_not_required(tmp_path: Path) -> None:
+    result = epistemic_graph.upsert_after_write(tmp_path, [])
+
+    assert result == epistemic_graph.GraphDispatchResult.not_required()
+    assert graph_sync.registered_checkpoint(tmp_path) is None
+
+
+def test_registration_exception_installs_exact_failure_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/example.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Example\n", encoding="utf-8")
+    checkpoint = _checkpoint()
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, checkpoint)
+
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("registration failed")),
+    )
+
+    result = epistemic_graph.upsert_after_write(tmp_path, [note])
+
+    assert result.outcome == "failed"
+    assert result.checkpoint == checkpoint
+    assert result.code == "GRAPH_SYNC_REGISTRATION_FAILED"
+    assert graph_sync.registered_checkpoint(tmp_path) == checkpoint
+
+
+def test_scheduling_disabled_keeps_exact_deferred_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/example.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Example\n", encoding="utf-8")
+    checkpoint = _checkpoint()
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, checkpoint)
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+
+    result = epistemic_graph.upsert_after_write(tmp_path, [note])
+
+    assert result.outcome == "deferred"
+    assert result.checkpoint == checkpoint
+    assert graph_sync.registered_checkpoint(tmp_path) == checkpoint
+
+
+def test_canonical_batch_repairs_a_missing_graph_handoff_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/example.md"
+
+    def incomplete_report(_root: Path, _paths: list[Path], **_kwargs) -> index_sync.IndexSyncReport:
+        return index_sync.IndexSyncReport(
+            "upsert",
+            ("Knowledge Base/Notes/example.md",),
+            ("Knowledge Base/Notes/example.md",),
+            (
+                index_sync.IndexComponentOutcome(
+                    "epistemic_graph", "registered", "graph_rebuild_registered"
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", incomplete_report)
+    reports: list[index_sync.IndexSyncReport] = []
+
+    vault.batch_atomic_write(
+        [vault.PlannedWrite(note, "# Example\n")], vault_root=tmp_path, index_reports=reports
+    )
+
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert checkpoint is not None
+    assert graph_sync.registered_checkpoint(tmp_path) == checkpoint
+    graph = next(item for item in reports[0].components if item.component == "epistemic_graph")
+    assert (graph.outcome, graph.code) == ("failed", "GRAPH_SYNC_HANDOFF_MISSING")
+
+
+def test_records_only_batch_performs_no_graph_dispatch_or_handoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = tmp_path / "Knowledge Base/Records/Health/example.md"
+    calls = 0
+
+    def graph_dispatch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("Records-only fanout must not touch the graph")
+
+    monkeypatch.setattr(epistemic_graph, "upsert_after_write", graph_dispatch)
+
+    vault.batch_atomic_write([vault.PlannedWrite(record, "value: 1\n")], vault_root=tmp_path)
+
+    assert calls == 0
+    assert graph_sync.read_checkpoint(tmp_path) is None
+    assert graph_sync.registered_checkpoint(tmp_path) is None
+
+
+def test_constructor_failure_fallback_keeps_invoking_manager_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker must retain manager B rather than recover ambient manager A."""
+    from exomem import writer_lease
+
+    ambient_state = tmp_path / "ambient-state"
+    custom_state = tmp_path / "custom-state"
+    ambient = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=ambient_state))
+    manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=custom_state))
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: ambient)
+    vault_root = tmp_path / "vault"
+    note = vault_root / "Knowledge Base/Notes/example.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Example\n", encoding="utf-8")
+    checkpoint = _checkpoint()
+    graph_sync._write_floor(vault_root, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(vault_root, checkpoint)
+
+    real_init = epistemic_graph.EpistemicGraphIndex.__init__
+    initial_construction = True
+    observed_roots: list[Path] = []
+
+    def fail_initial_construction(self, root, **kwargs):  # noqa: ANN001
+        nonlocal initial_construction
+        if initial_construction:
+            initial_construction = False
+            raise RuntimeError("injected graph constructor failure")
+        real_init(self, root, **kwargs)
+
+    def capture_rebuild(self):  # noqa: ANN001
+        observed_roots.append(self._canonical_mutation_coordinator().state_root)
+        return {"indexed_files": 0, "nodes": 0, "edges": 0}
+
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "__init__", fail_initial_construction)
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "_rebuild_all_off_boundary", capture_rebuild
+    )
+    command = SimpleNamespace(
+        name="graph-fallback-boundary",
+        read_only=False,
+        leaf=lambda root: epistemic_graph.upsert_after_write(root, [note]),
+    )
+
+    manager.invoke(command, (vault_root,), {})
+
+    assert observed_roots == [custom_state]

--- a/tests/test_graph_idempotency_crash_matrix.py
+++ b/tests/test_graph_idempotency_crash_matrix.py
@@ -1,0 +1,231 @@
+"""Process-cut acceptance coverage for the graph receipt handoff.
+
+The child owns the first idempotency store and dies with ``os._exit`` at a
+real protocol boundary.  The parent then opens an independent store object
+against the same local runtime and performs the exact retry.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+_DIGEST = "d" * 64
+
+
+def _run_cut(tmp_path: Path, cut: str) -> tuple[Path, Path, Path, subprocess.CompletedProcess[str]]:
+    vault = tmp_path / "vault"
+    state = tmp_path / "state"
+    marker = tmp_path / "leaf-calls"
+    script = dedent(
+        """
+        import os
+        import sqlite3
+        import sys
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        from exomem import graph_sync
+        from exomem import vault as vault_module
+        from exomem import writer_lease as writer_lease_module
+        from exomem.vault import BatchTargetSummary, BatchWriteError, PlannedWrite, batch_atomic_write
+        from exomem.writer_lease import LeaseConfig, LeaseManager
+
+        vault, state, marker = map(Path, sys.argv[1:4])
+        cut = sys.argv[4]
+        note = vault / "Knowledge Base/Notes/cut.md"
+        original_replace = vault_module.os.replace
+        if cut == "after_caller_files":
+            def exit_after_caller(source, destination, *args, **kwargs):
+                result = original_replace(source, destination, *args, **kwargs)
+                if Path(destination) == note:
+                    os._exit(42)
+                return result
+            vault_module.os.replace = exit_after_caller
+        if cut == "after_checkpoint":
+            original_phase = writer_lease_module.log_active_mutation_phase
+            def exit_after_checkpoint(phase, **fields):
+                original_phase(phase, **fields)
+                if phase == "canonical_files_committed":
+                    os._exit(43)
+            writer_lease_module.log_active_mutation_phase = exit_after_checkpoint
+        if cut == "after_receipt":
+            original_receipt = graph_sync.write_graph_commit_receipt
+            def exit_after_receipt(*args, **kwargs):
+                original_receipt(*args, **kwargs)
+                os._exit(44)
+            graph_sync.write_graph_commit_receipt = exit_after_receipt
+
+        manager = LeaseManager(LeaseConfig(state_dir=state))
+        if cut == "committed_cleanup":
+            def lose_trusted_state(*_args, **_kwargs):
+                with sqlite3.connect(manager.idempotency.path) as connection:
+                    connection.execute(
+                        "UPDATE mutations SET result = NULL, commit_secret = NULL "
+                        "WHERE state = 'canonically_committed'"
+                    )
+                os._exit(45)
+            manager.idempotency._persist_committed_failure = lose_trusted_state
+
+        def leaf(root):
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            with marker.open("a", encoding="utf-8") as handle:
+                handle.write("leaf\\n")
+            batch_atomic_write([PlannedWrite(note, "# cut\\n")], vault_root=root)
+            if cut == "committed_cleanup":
+                raise BatchWriteError(
+                    "BATCH_CLEANUP_INCOMPLETE",
+                    BatchTargetSummary(1, ("Knowledge Base/Notes/cut.md",), 0),
+                    committed=True,
+                )
+            return {"path": "Knowledge Base/Notes/cut.md", "warnings": []}
+
+        command = SimpleNamespace(name="graph-crash-matrix", read_only=False, leaf=leaf)
+        manager.invoke(command, (vault,), {}, idempotency_key="graph-crash-matrix")
+        """
+    )
+    vault.joinpath("Knowledge Base").mkdir(parents=True)
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(vault), str(state), str(marker), cut],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
+        timeout=30,
+    )
+    return vault, state, marker, completed
+
+
+def _retry(vault: Path, state: Path, marker: Path) -> object:
+    from types import SimpleNamespace
+
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    def leaf(root: Path) -> dict[str, object]:
+        with marker.open("a", encoding="utf-8") as handle:
+            handle.write("replayed-leaf\n")
+        batch_atomic_write(
+            [PlannedWrite(root / "Knowledge Base/Notes/cut.md", "# replayed\n")],
+            vault_root=root,
+        )
+        return {"path": "Knowledge Base/Notes/cut.md", "warnings": []}
+
+    return LeaseManager(LeaseConfig(state_dir=state)).invoke(
+        SimpleNamespace(name="graph-crash-matrix", read_only=False, leaf=leaf),
+        (vault,),
+        {},
+        idempotency_key="graph-crash-matrix",
+    )
+
+
+def test_subprocess_crash_before_leaf_leaves_executing_claim_outcome_unknown(
+    tmp_path: Path,
+) -> None:
+    """The child dies at the real guard boundary after claim, before leaf entry."""
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    state = tmp_path / "state"
+    marker = tmp_path / "leaf-calls"
+    script = dedent(
+        """
+        import os
+        import sys
+        from pathlib import Path
+
+        from exomem.writer_lease import IdempotencyStore
+
+        class CrashBeforeLeaf:
+            def __enter__(self):
+                os._exit(41)
+
+            def __exit__(self, *_args):
+                raise AssertionError("process should have exited before leaf")
+
+        store = IdempotencyStore(Path(sys.argv[1]) / "idempotency.sqlite")
+        store.run(
+            "before-leaf",
+            "d" * 64,
+            lambda: Path(sys.argv[2]).write_text("leaf\\n", encoding="utf-8"),
+            operation_guard=CrashBeforeLeaf,
+        )
+        """
+    )
+    child = subprocess.run(
+        [sys.executable, "-c", script, str(state), str(marker)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
+        timeout=30,
+    )
+
+    assert child.returncode == 41, child.stderr
+    parent = IdempotencyStore(state / "idempotency.sqlite")
+
+    def leaf() -> dict[str, bool]:
+        with marker.open("a", encoding="utf-8") as handle:
+            handle.write("replayed-leaf\\n")
+        return {"executed": True}
+
+    with pytest.raises(OpError) as retry:
+        parent.run("before-leaf", _DIGEST, leaf)
+    assert retry.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    ("cut", "exit_code"),
+    [("after_caller_files", 42), ("after_checkpoint", 43)],
+)
+def test_ambiguous_subprocess_cuts_are_outcome_unknown_without_leaf_replay(
+    tmp_path: Path, cut: str, exit_code: int
+) -> None:
+    from exomem.writer_lease import OpError
+
+    vault, state, marker, child = _run_cut(tmp_path, cut)
+
+    assert child.returncode == exit_code, child.stderr
+    with pytest.raises(OpError) as retry:
+        _retry(vault, state, marker)
+    assert retry.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert marker.read_text(encoding="utf-8").splitlines() == ["leaf"]
+
+
+def test_subprocess_receipt_cut_heals_only_the_matching_local_executing_row(
+    tmp_path: Path,
+) -> None:
+    from exomem import graph_sync
+
+    vault, state, marker, child = _run_cut(tmp_path, "after_receipt")
+
+    assert child.returncode == 44, child.stderr
+    result = _retry(vault, state, marker)
+    assert isinstance(result, dict)
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "completed"
+    assert graph_sync.status(vault)["state"] == "current"
+    assert marker.read_text(encoding="utf-8").splitlines() == ["leaf"]
+    with sqlite3.connect(next(state.glob("idempotency-*.sqlite"))) as connection:
+        assert connection.execute("SELECT state FROM mutations").fetchone() == ("completed",)
+
+
+def test_committed_cleanup_cut_with_lost_trusted_state_is_never_success(
+    tmp_path: Path,
+) -> None:
+    from exomem.writer_lease import OpError
+
+    vault, state, marker, child = _run_cut(tmp_path, "committed_cleanup")
+
+    assert child.returncode == 45, child.stderr
+    with pytest.raises(OpError) as retry:
+        _retry(vault, state, marker)
+    assert retry.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert marker.read_text(encoding="utf-8").splitlines() == ["leaf"]

--- a/tests/test_graph_idempotency_handoff.py
+++ b/tests/test_graph_idempotency_handoff.py
@@ -1,0 +1,1320 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+
+def _receipt(root: Path, *, digest: str, attempt: object) -> None:
+    from exomem import graph_sync
+
+    receipt = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest=digest,
+        attempt_id=attempt.attempt_id,
+        commit_token=attempt.commit_token,
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=attempt.commit_secret,
+    )
+    graph_sync.write_graph_commit_receipt(root, receipt)
+
+
+def _exact_receipt(
+    root: Path, digest: str, attempt_id: str, token: str, secret: bytes | None = None
+) -> bool:
+    from exomem import graph_sync
+
+    receipt = graph_sync.read_graph_commit_receipt(root, token)
+    return bool(
+        receipt is not None
+        and (
+            receipt.verify(
+                secret,
+                idempotency_key_digest="a" * 64,
+                command_digest=digest,
+                attempt_id=attempt_id,
+                commit_token=token,
+            )
+            if secret is not None
+            else receipt.command_digest == digest
+            and receipt.attempt_id == attempt_id
+            and receipt.commit_token == token
+        )
+    )
+
+
+def _legacy_graph_pending_checkpoint(
+    vault: Path, *, generation: int = 1, mutation_id: str = "1" * 24
+):
+    from exomem import graph_sync
+
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=mutation_id,
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    graph_sync._write_floor(vault, graph_sync.GraphSyncGenerationFloor.create(generation))
+    graph_sync._write_checkpoint(vault, checkpoint)
+    return checkpoint
+
+
+def _legacy_graph_pending_proof(vault: Path):
+    from exomem import graph_sync
+
+    def proof(candidate):  # noqa: ANN001
+        return (
+            graph_sync.read_checkpoint(vault) == candidate
+            and graph_sync.classify_epoch(vault).kind == "coherent"
+        )
+
+    return proof
+
+
+def _assert_retained_outcome_unknown(store: object) -> None:
+    import pickle
+
+    with store._connect() as conn:
+        state, payload = conn.execute("SELECT state, result FROM mutations").fetchone()
+    assert state == "completed"
+    assert pickle.loads(payload) == ("exomem.outcome-unknown", 1)
+
+
+def test_canonical_result_is_handed_off_before_derived_wait(tmp_path: Path) -> None:
+    """The graph wait cannot retain execution ownership of the leaf."""
+    from exomem.writer_lease import IdempotencyStore
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    canonical_guard_released = threading.Event()
+    allow_graph_completion = threading.Event()
+    results: list[object] = []
+
+    class Guard:
+        def __enter__(self) -> Guard:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            canonical_guard_released.set()
+
+    def invoke() -> None:
+        results.append(
+            store.run(
+                "handoff",
+                "digest",
+                lambda: {"canonical": "committed"},
+                operation_guard=Guard,
+                after_canonical_persisted=lambda result: result,
+                after_operation_guard=lambda result: (
+                    allow_graph_completion.wait(2) and {**result, "graph_sync": "completed"}
+                ),
+            )
+        )
+
+    worker = threading.Thread(target=invoke)
+    worker.start()
+    assert canonical_guard_released.wait(1)
+    with store._connect() as conn:
+        assert conn.execute("SELECT state, owner FROM mutations").fetchone() == (
+            "canonically_committed",
+            None,
+        )
+    allow_graph_completion.set()
+    worker.join(2)
+    assert results == [{"canonical": "committed", "graph_sync": "completed"}]
+
+
+def test_exact_receipt_recovers_same_process_canonical_persistence_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The leaf ran once even when its canonical SQLite CAS failed."""
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    root = tmp_path / "vault"
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    digest = "d" * 64
+    calls = 0
+    original = store._persist_canonically_committed
+    failed = False
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise __import__("sqlite3").OperationalError("injected canonical CAS failure")
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(store, "_persist_canonically_committed", fail_once)
+
+    def leaf() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"canonical": "committed"}
+
+    def persist(result: dict[str, str], attempt: object) -> dict[str, str]:
+        _receipt(root, digest=digest, attempt=attempt)
+        return result
+
+    with pytest.raises(OpError, match="exact terminal result could not be persisted"):
+        store.run(
+            "exact-canonical-cas",
+            digest,
+            leaf,
+            after_canonical_persisted=persist,
+            commit_evidence=lambda expected, attempt_id, token: _exact_receipt(
+                root, expected, attempt_id, token
+            ),
+        )
+
+    recovered = store.run(
+        "exact-canonical-cas",
+        digest,
+        lambda: pytest.fail("canonical leaf replayed"),
+        resume_canonically_committed=lambda _stored: {"canonical": "resumed"},
+        commit_evidence=lambda expected, attempt_id, token: _exact_receipt(
+            root, expected, attempt_id, token
+        ),
+    )
+
+    assert recovered == {"canonical": "resumed"}
+    assert calls == 1
+
+
+def test_lease_manager_recovers_terminal_from_exact_receipt_after_canonical_cas_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exact retry rebuilds only graph work when SQLite lost the terminal handoff."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/recovered.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    original = manager.idempotency._persist_canonically_committed
+    failed = False
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("injected canonical CAS failure")
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(manager.idempotency, "_persist_canonically_committed", fail_once)
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# recovered\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/recovered.md", "warnings": []}
+
+    command = SimpleNamespace(name="receipt-cas-recovery", read_only=False, leaf=leaf)
+    with pytest.raises(OpError) as uncertain:
+        manager.invoke(command, (vault,), {}, idempotency_key="receipt-cas-recovery")
+    assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+
+    recovered = manager.invoke(command, (vault,), {}, idempotency_key="receipt-cas-recovery")
+
+    assert recovered["status"] == "committed"
+    assert recovered["mutated"] is True
+    assert recovered["terminal"] is True
+    assert recovered["graph_sync"] == "completed"
+    assert calls == 1
+
+
+def test_canonical_resume_rebuild_keeps_the_invoking_manager_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt recovery must not fall back to ambient runtime state after the leaf."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem import epistemic_graph
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    ambient_state = tmp_path / "ambient-state"
+    custom_state = tmp_path / "custom-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(ambient_state))
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/resume-boundary.md"
+    manager = LeaseManager(LeaseConfig(state_dir=custom_state))
+    original_persist = manager.idempotency._persist_canonically_committed
+    failed = False
+    observed_roots: list[Path] = []
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("injected canonical CAS failure")
+        original_persist(*args, **kwargs)
+
+    def capture_rebuild(self):  # noqa: ANN001
+        observed_roots.append(self._canonical_mutation_coordinator().state_root)
+        return {"indexed_files": 0, "nodes": 0, "edges": 0}
+
+    monkeypatch.setattr(manager.idempotency, "_persist_canonically_committed", fail_once)
+    monkeypatch.setattr(epistemic_graph.EpistemicGraphIndex, "rebuild_all", capture_rebuild)
+
+    def leaf(root: Path) -> dict[str, object]:
+        batch_atomic_write([PlannedWrite(note, "# resume boundary\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/resume-boundary.md", "warnings": []}
+
+    command = SimpleNamespace(name="resume-boundary", read_only=False, leaf=leaf)
+    with pytest.raises(OpError, match="exact terminal result"):
+        manager.invoke(command, (vault,), {}, idempotency_key="resume-boundary")
+
+    result = manager.invoke(command, (vault,), {}, idempotency_key="resume-boundary")
+
+    assert result["graph_sync"] == "failed"
+    assert observed_roots == [custom_state]
+
+
+def test_receipt_recovery_preserves_public_terminal_schemas_without_leaf_leakage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt recovery rebuilds a terminal envelope, not a bare projection."""
+    import json
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/schema-recovery.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    original = manager.idempotency._persist_canonically_committed
+    failed = False
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("injected canonical CAS failure")
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(manager.idempotency, "_persist_canonically_committed", fail_once)
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# schema recovery\n")], vault_root=root)
+        return {
+            "path": "Knowledge Base/Notes/schema-recovery.md",
+            "warnings": ["private warning"],
+            "private_leaf_value": "must not enter the graph receipt",
+        }
+
+    command = SimpleNamespace(name="receipt-schema-recovery", read_only=False, leaf=leaf)
+    with pytest.raises(OpError) as uncertain:
+        manager.invoke(
+            command,
+            (vault,),
+            {"response_detail": "compact"},
+            idempotency_key="receipt-schema-recovery",
+        )
+    assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+
+    compact = manager.invoke(
+        command,
+        (vault,),
+        {"response_detail": "compact"},
+        idempotency_key="receipt-schema-recovery",
+    )
+    full = manager.invoke(
+        command,
+        (vault,),
+        {"response_detail": "full"},
+        idempotency_key="receipt-schema-recovery",
+    )
+    legacy = manager.invoke(
+        command,
+        (vault,),
+        {"response_detail": "legacy"},
+        idempotency_key="receipt-schema-recovery",
+    )
+    compact_replay = manager.invoke(
+        command,
+        (vault,),
+        {"response_detail": "compact"},
+        idempotency_key="receipt-schema-recovery",
+    )
+
+    assert {
+        "ok",
+        "state",
+        "terminal",
+        "status",
+        "mutated",
+        "request_id",
+        "receipt_id",
+        "idempotency_key",
+        "warnings_count",
+    } <= compact.keys()
+    assert full == {**compact, "diagnostics": legacy}
+    assert isinstance(legacy, dict)
+    assert compact_replay == compact
+    assert "private_leaf_value" not in json.dumps(full)
+    assert "private warning" not in json.dumps(full)
+    assert calls == 1
+
+
+def test_receipt_result_digest_commits_non_retained_leaf_summary_without_leaking_it(
+    tmp_path: Path,
+) -> None:
+    """Receipt digests bind hidden leaf output without retaining its content."""
+    import json
+    from types import SimpleNamespace
+
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    def receipt_for(result: dict[str, object], name: str) -> tuple[dict[str, object], bytes]:
+        vault = tmp_path / name
+        note = vault / "Knowledge Base/Notes/receipt-digest.md"
+        manager = LeaseManager(
+            LeaseConfig(state_dir=tmp_path / f"{name}-state", vault_id="receipt-digest-test")
+        )
+
+        def leaf(root: Path) -> dict[str, object]:
+            batch_atomic_write([PlannedWrite(note, "# receipt digest\n")], vault_root=root)
+            return result
+
+        command = SimpleNamespace(name="receipt-result-digest", read_only=False, leaf=leaf)
+        manager.invoke(
+            command,
+            (vault,),
+            {},
+            idempotency_key="receipt-result-digest",
+            mutation_request_id="11111111-1111-4111-8111-111111111111",
+        )
+        raw = next((vault / "Knowledge Base/.graph-commit-receipts").glob("*.json")).read_bytes()
+        return json.loads(raw)["terminal_projection"], raw
+
+    first, first_bytes = receipt_for(
+        {
+            "path": "Knowledge Base/Notes/private-first.md",
+            "warnings": ["private first warning"],
+            "private_result": {"content": "first private content", "count": 1},
+        },
+        "first",
+    )
+    second, second_bytes = receipt_for(
+        {
+            "path": "Knowledge Base/Notes/private-second.md",
+            "warnings": ["private second warning"],
+            "private_result": {"content": "second private content", "count": 1},
+        },
+        "second",
+    )
+    reordered, reordered_bytes = receipt_for(
+        {
+            "private_result": {"count": 1, "content": "first private content"},
+            "warnings": ["private first warning"],
+            "path": "Knowledge Base/Notes/private-first.md",
+        },
+        "reordered",
+    )
+
+    def without_digest(projection: dict[str, object]) -> dict[str, object]:
+        return {key: value for key, value in projection.items() if key != "result_sha256"}
+
+    assert without_digest(first) == without_digest(second) == without_digest(reordered)
+    assert first["result_sha256"] != second["result_sha256"]
+    assert first["result_sha256"] == reordered["result_sha256"]
+    for receipt_bytes in (first_bytes, second_bytes, reordered_bytes):
+        assert b"private-first.md" not in receipt_bytes
+        assert b"private-second.md" not in receipt_bytes
+        assert b"private first warning" not in receipt_bytes
+        assert b"private second warning" not in receipt_bytes
+        assert b"first private content" not in receipt_bytes
+        assert b"second private content" not in receipt_bytes
+
+
+def test_receipt_result_digest_uses_closed_summary_for_unserializable_values() -> None:
+    """Opaque values must not leak through a fallback string representation."""
+    from exomem import writer_lease
+
+    class UnserializableLeafValue:
+        def __str__(self) -> str:
+            return "private __str__ output must not reach the receipt"
+
+    first_value = UnserializableLeafValue()
+    first = writer_lease._receipt_result_sha256({"opaque": first_value})
+    second = writer_lease._receipt_result_sha256({"opaque": UnserializableLeafValue()})
+    summary = writer_lease._receipt_result_summary({"opaque": first_value})
+
+    assert first == second
+    assert "private __str__ output" not in first
+    assert summary["items"][0][1] == {"type": "opaque"}
+
+
+def test_lease_manager_receipt_recovery_returns_graph_failure_after_rebuild_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt-backed recovery remains terminal when the derived rebuild itself fails."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem.epistemic_graph import EpistemicGraphIndex
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/rebuild-error.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    original = manager.idempotency._persist_canonically_committed
+    failed = False
+
+    def fail_canonical_cas(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("injected canonical CAS failure")
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        manager.idempotency, "_persist_canonically_committed", fail_canonical_cas
+    )
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# rebuild error\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/rebuild-error.md", "warnings": []}
+
+    command = SimpleNamespace(name="receipt-rebuild-error", read_only=False, leaf=leaf)
+    with pytest.raises(OpError) as uncertain:
+        manager.invoke(command, (vault,), {}, idempotency_key="receipt-rebuild-error")
+    assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+
+    def fail_rebuild(_self: EpistemicGraphIndex) -> dict[str, int]:
+        raise RuntimeError("injected graph rebuild failure")
+
+    monkeypatch.setattr(EpistemicGraphIndex, "rebuild_all", fail_rebuild)
+    recovered = manager.invoke(command, (vault,), {}, idempotency_key="receipt-rebuild-error")
+    replay = manager.invoke(command, (vault,), {}, idempotency_key="receipt-rebuild-error")
+
+    assert recovered["status"] == "committed"
+    assert recovered["graph_sync"] == "failed"
+    assert recovered["graph_sync_code"] == "GRAPH_SYNC_STABILIZATION_EXHAUSTED"
+    assert recovered == replay
+    assert calls == 1
+
+
+def test_pre_receipt_cut_is_retained_as_a_completed_outcome_unknown_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dead post-write attempt without a receipt remains fail-closed without a fifth state."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+    from exomem.vault import PlannedWrite, batch_atomic_write
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/unknown.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    original = graph_sync.write_graph_commit_receipt
+
+    def fail_receipt(*args: object, **kwargs: object) -> Path:
+        raise OSError("injected receipt failure after caller files")
+
+    monkeypatch.setattr(graph_sync, "write_graph_commit_receipt", fail_receipt)
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# unknown\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/unknown.md", "warnings": []}
+
+    command = SimpleNamespace(name="receipt-cut", read_only=False, leaf=leaf)
+    with pytest.raises(OpError) as first:
+        manager.invoke(command, (vault,), {}, idempotency_key="receipt-cut")
+    assert first.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+    monkeypatch.setattr(graph_sync, "write_graph_commit_receipt", original)
+
+    with pytest.raises(OpError) as retry:
+        manager.invoke(command, (vault,), {}, idempotency_key="receipt-cut")
+    assert retry.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert "will remain fail-closed" in retry.value.remediation
+    assert calls == 1
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        assert connection.execute("SELECT state FROM mutations").fetchone() == ("completed",)
+
+
+def test_committed_cleanup_failure_replays_from_completed_state_without_leaf_rerun(
+    tmp_path: Path,
+) -> None:
+    """New committed failures use the canonical terminal state, not a fifth lifecycle state."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem.vault import BatchTargetSummary, BatchWriteError, PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/cleanup.md"
+    calls = 0
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+
+    def leaf(root: Path) -> None:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# cleanup\n")], vault_root=root)
+        raise BatchWriteError(
+            "BATCH_CLEANUP_INCOMPLETE",
+            BatchTargetSummary(1, ("Knowledge Base/Notes/cleanup.md",), 0),
+            committed=True,
+        )
+
+    command = SimpleNamespace(name="committed-cleanup", read_only=False, leaf=leaf)
+    with pytest.raises(BatchWriteError) as first:
+        manager.invoke(command, (vault,), {}, idempotency_key="committed-cleanup")
+    with pytest.raises(ValueError) as replay:
+        manager.invoke(command, (vault,), {}, idempotency_key="committed-cleanup")
+
+    assert replay.value.as_public_dict() == first.value.as_public_dict()
+    assert calls == 1
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        assert connection.execute("SELECT state FROM mutations").fetchone() == ("completed",)
+
+
+def test_post_fanout_cleanup_failure_finishes_graph_before_exact_failure_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real post-fanout cleanup error cannot strand its registered graph work."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.vault import BatchWriteError, PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+    from exomem import vault as vault_module
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/cleanup-after-fanout.md"
+    calls = 0
+    original_cleanup = vault_module._cleanup_batch_workspaces
+    injected = False
+
+    def retain_first_cleanup(*args: object, **kwargs: object) -> bool:
+        nonlocal injected
+        cleaned = original_cleanup(*args, **kwargs)
+        if not injected:
+            injected = True
+            return True
+        return cleaned
+
+    monkeypatch.setattr(vault_module, "_cleanup_batch_workspaces", retain_first_cleanup)
+
+    def leaf(root: Path) -> None:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# cleanup after fanout\n")], vault_root=root)
+
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    command = SimpleNamespace(name="cleanup-after-fanout", read_only=False, leaf=leaf)
+    with pytest.raises(BatchWriteError) as first:
+        manager.invoke(command, (vault,), {}, idempotency_key="cleanup-after-fanout")
+    with pytest.raises(ValueError) as replay:
+        manager.invoke(command, (vault,), {}, idempotency_key="cleanup-after-fanout")
+
+    assert graph_sync.status(vault)["state"] == "current"
+    assert replay.value.as_public_dict() == first.value.as_public_dict()
+    assert calls == 1
+
+
+def test_cleanup_receipt_before_canonical_cas_never_recovers_as_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The signed receipt retains failure classification across the SQLite cut."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from exomem import vault as vault_module
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/cleanup-cas.md"
+    calls = 0
+    original_cleanup = vault_module._cleanup_batch_workspaces
+    cleanup_failed = False
+
+    def retain_first_cleanup(*args: object, **kwargs: object) -> bool:
+        nonlocal cleanup_failed
+        cleaned = original_cleanup(*args, **kwargs)
+        if not cleanup_failed:
+            cleanup_failed = True
+            return True
+        return cleaned
+
+    monkeypatch.setattr(vault_module, "_cleanup_batch_workspaces", retain_first_cleanup)
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    persist = manager.idempotency._persist_canonically_committed
+    failed = False
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("injected canonical CAS failure")
+        persist(*args, **kwargs)
+
+    monkeypatch.setattr(manager.idempotency, "_persist_canonically_committed", fail_once)
+
+    def leaf(root: Path) -> None:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# cleanup cas\n")], vault_root=root)
+
+    command = SimpleNamespace(name="cleanup-cas", read_only=False, leaf=leaf)
+    with pytest.raises(OpError) as first:
+        manager.invoke(command, (vault,), {}, idempotency_key="cleanup-cas")
+    assert first.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+    with pytest.raises(OpError) as replay:
+        manager.invoke(command, (vault,), {}, idempotency_key="cleanup-cas")
+    assert replay.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert calls == 1
+    receipts = list((vault / "Knowledge Base/.graph-commit-receipts").glob("*.json"))
+    assert len(receipts) == 1
+    from exomem import graph_sync
+
+    assert graph_sync.GraphCommitReceipt.parse(receipts[0].read_bytes()).canonical_disposition == (
+        "committed_failure"
+    )
+    with sqlite3.connect(manager.idempotency.path) as connection:
+        assert connection.execute("SELECT state FROM mutations").fetchone() == ("completed",)
+
+
+def test_compact_terminal_retains_deferred_graph_failure_from_real_lease_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deferred graph handoff remains visible through compact terminal projection."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/deferred.md"
+
+    def leaf(root: Path) -> dict[str, object]:
+        batch_atomic_write([PlannedWrite(note, "# deferred\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/deferred.md", "warnings": []}
+
+    result = LeaseManager(LeaseConfig(state_dir=tmp_path / "state")).invoke(
+        SimpleNamespace(name="deferred-graph", read_only=False, leaf=leaf),
+        (vault,),
+        {},
+        idempotency_key="deferred-graph",
+    )
+
+    assert graph_sync.status(vault)["state"] == "recovery_required"
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == "GRAPH_SYNC_SCHEDULING_DISABLED"
+    assert result["graph_sync_checkpoint"]
+    assert result["graph_sync_remediation"] == (
+        "Enable graph scheduling or run reconcile to recover the derived graph."
+    )
+
+
+def test_lease_manager_outer_upsert_failure_registers_graph_failure_before_guard_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caught batch fanout error keeps its exact graph epoch through replay."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync, index_sync
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/outer-upsert.md"
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    calls = 0
+    registered: list[graph_sync.GraphSyncCheckpoint | None] = []
+    original_register_failure = graph_sync.register_outer_fanout_failure
+
+    def fail_outer_upsert(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected outer upsert failure")
+
+    def register_failure_while_guarded(root: Path, **kwargs: object) -> graph_sync.GraphSyncCheckpoint | None:
+        assert manager.status(root)["mutation_boundary"]["state"] == "held"
+        checkpoint = original_register_failure(root, **kwargs)
+        registered.append(graph_sync.registered_checkpoint(root))
+        return checkpoint
+
+    monkeypatch.setattr(index_sync, "upsert_after_write", fail_outer_upsert)
+    monkeypatch.setattr(graph_sync, "register_outer_fanout_failure", register_failure_while_guarded)
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# outer upsert\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/outer-upsert.md", "warnings": []}
+
+    command = SimpleNamespace(name="outer-upsert", read_only=False, leaf=leaf)
+    result = manager.invoke(command, (vault,), {}, idempotency_key="outer-upsert")
+    replay = manager.invoke(command, (vault,), {}, idempotency_key="outer-upsert")
+
+    checkpoint = graph_sync.read_checkpoint(vault)
+    assert checkpoint is not None
+    assert registered == [checkpoint]
+    assert graph_sync.registered_checkpoint(vault, state_root=manager.config.state_dir) is None
+    assert graph_sync.status(vault)["state"] == "recovery_required"
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == "GRAPH_SYNC_FANOUT_FAILED"
+    assert result["graph_sync_checkpoint"] == checkpoint.checkpoint_sha256
+    assert replay == result
+    assert calls == 1
+
+
+def test_compact_terminal_retains_typed_platform_graph_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An immediate platform failure handle survives production terminal projection."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/platform.md"
+
+    def platform_failure(
+        root: Path, checkpoint: graph_sync.GraphSyncCheckpoint, **_kwargs: object
+    ):
+        return graph_sync.register_failure(
+            root,
+            checkpoint,
+            code="GRAPH_SYNC_PLATFORM_UNAVAILABLE",
+            remediation="Restore the graph platform, then run reconcile.",
+        )
+
+    monkeypatch.setattr(graph_sync, "register_deferred", platform_failure)
+
+    def leaf(root: Path) -> dict[str, object]:
+        batch_atomic_write([PlannedWrite(note, "# platform\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/platform.md", "warnings": []}
+
+    result = LeaseManager(LeaseConfig(state_dir=tmp_path / "state")).invoke(
+        SimpleNamespace(name="platform-graph", read_only=False, leaf=leaf),
+        (vault,),
+        {},
+        idempotency_key="platform-graph",
+    )
+
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == "GRAPH_SYNC_PLATFORM_UNAVAILABLE"
+    assert result["graph_sync_remediation"] == "Restore the graph platform, then run reconcile."
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_code", "expected_remediation"),
+    [
+        (
+            "GraphEpochIncoherent",
+            "GRAPH_SYNC_LINEAGE_CONFLICT",
+            "Reconcile the graph epoch before retrying this mutation.",
+        ),
+        (
+            "GraphRebuildLockUnavailable",
+            "GRAPH_SYNC_REBUILD_LOCK_UNAVAILABLE",
+            "Retry the same mutation identity after graph rebuild locking recovers, or run reconcile.",
+        ),
+        (
+            "GraphSidecarReplaceUnavailable",
+            "GRAPH_SYNC_PLATFORM_SHARING_REFUSED",
+            "Release graph sidecar readers, then run reconcile to recover the derived graph.",
+        ),
+        (
+            "RuntimeError",
+            "GRAPH_SYNC_REBUILD_STOPPED",
+            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+        ),
+    ],
+)
+def test_lease_manager_preserves_real_wait_path_graph_failure_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    expected_code: str,
+    expected_remediation: str,
+) -> None:
+    """A builder failure keeps its exact handle through terminal persistence and replay."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.epistemic_graph import EpistemicGraphIndex
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/wait-failure.md"
+    calls = 0
+    failure_type = RuntimeError if failure_kind == "RuntimeError" else getattr(graph_sync, failure_kind)
+    failure = failure_type("injected wait-path failure")
+
+    def fail_builder(_self: EpistemicGraphIndex) -> dict[str, int]:
+        raise failure
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_off_boundary", fail_builder)
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# wait failure\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/wait-failure.md", "warnings": []}
+
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    command = SimpleNamespace(name="wait-path-failure", read_only=False, leaf=leaf)
+    result = manager.invoke(command, (vault,), {}, idempotency_key=f"wait-{failure_kind}")
+    replay = manager.invoke(command, (vault,), {}, idempotency_key=f"wait-{failure_kind}")
+
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == expected_code
+    assert result["graph_sync_remediation"] == expected_remediation
+    assert replay == result
+    assert calls == 1
+
+
+def test_lease_manager_preserves_graph_thread_start_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scheduler-thread start failure is a stable terminal graph handle."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    class BrokenThread:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def start(self) -> None:
+            raise RuntimeError("thread start refused")
+
+    monkeypatch.setattr(graph_sync.threading, "Thread", BrokenThread)
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/thread-start.md"
+    calls = 0
+
+    def leaf(root: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        batch_atomic_write([PlannedWrite(note, "# thread start\n")], vault_root=root)
+        return {"path": "Knowledge Base/Notes/thread-start.md", "warnings": []}
+
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    command = SimpleNamespace(name="thread-start-failure", read_only=False, leaf=leaf)
+    result = manager.invoke(command, (vault,), {}, idempotency_key="thread-start-failure")
+    replay = manager.invoke(command, (vault,), {}, idempotency_key="thread-start-failure")
+
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == "GRAPH_SYNC_START_FAILED"
+    assert result["graph_sync_remediation"] == (
+        "Retry the same mutation identity or run reconcile to recover the derived graph."
+    )
+    assert replay == result
+    assert calls == 1
+
+
+def test_live_attempt_wins_over_exact_receipt_until_it_exits(tmp_path: Path) -> None:
+    """A receipt is evidence after liveness, never a way to steal a live leaf."""
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    root = tmp_path / "vault"
+    digest = "e" * 64
+    owner = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    observer = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=0)
+    assert owner._claim_or_inspect("live", digest, None) == ("owner", None)
+    attempt = owner._attempts["live"]
+    _receipt(root, digest=digest, attempt=attempt)
+
+    with pytest.raises(OpError) as pending:
+        observer.run(
+            "live",
+            digest,
+            lambda: pytest.fail("live canonical leaf was stolen"),
+            commit_evidence=lambda expected, attempt_id, token: _exact_receipt(
+                root, expected, attempt_id, token
+            ),
+        )
+    assert pending.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+    owner._release_attempt("live", attempt)
+
+
+def test_legacy_graph_pending_migrates_only_with_an_exact_coherent_checkpoint(
+    tmp_path: Path,
+) -> None:
+    import pickle
+
+    from exomem.writer_lease import IdempotencyStore
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    vault = tmp_path / "vault"
+    checkpoint = _legacy_graph_pending_checkpoint(vault)
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, 0, 'legacy-owner')",
+            (
+                "legacy",
+                "f" * 64,
+                pickle.dumps(
+                    {
+                        "canonical": "committed",
+                        "_graph_sync_checkpoint": checkpoint.as_dict(),
+                    }
+                ),
+            ),
+        )
+
+    assert store.run(
+        "legacy",
+        "f" * 64,
+        lambda: pytest.fail("legacy graph_pending replayed the leaf"),
+        resume_canonically_committed=lambda result: {
+            key: value
+            for key, value in {**result, "graph_sync": "completed"}.items()
+            if key != "_graph_sync_checkpoint"
+        },
+        legacy_graph_pending_proof=_legacy_graph_pending_proof(vault),
+    ) == {"canonical": "committed", "graph_sync": "completed"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "generation", "mutation_id"),
+    [
+        ({"canonical": "committed"}, 1, "1" * 24),
+        ({"canonical": "committed", "_graph_sync_checkpoint": {}}, 1, "1" * 24),
+        (
+            {
+                "canonical": "committed",
+                "_graph_sync_checkpoint": "stale-placeholder",
+            },
+            2,
+            "2" * 24,
+        ),
+    ],
+    ids=("missing-binding", "malformed-binding", "wrong-payload-type"),
+)
+def test_legacy_graph_pending_without_a_strict_checkpoint_binding_fails_closed(
+    tmp_path: Path, payload: dict[str, object], generation: int, mutation_id: str
+) -> None:
+    import pickle
+
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    vault = tmp_path / "vault"
+    _legacy_graph_pending_checkpoint(vault, generation=generation, mutation_id=mutation_id)
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, 0, 'legacy-owner')",
+            ("legacy", "f" * 64, pickle.dumps(payload)),
+        )
+
+    with pytest.raises(OpError) as error:
+        store.run(
+            "legacy",
+            "f" * 64,
+            lambda: pytest.fail("invalid legacy graph_pending replayed the leaf"),
+            resume_canonically_committed=lambda result: {**result, "graph_sync": "completed"},
+            legacy_graph_pending_proof=_legacy_graph_pending_proof(vault),
+        )
+
+    assert error.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    _assert_retained_outcome_unknown(store)
+
+
+@pytest.mark.parametrize("kind", ("stale", "same-generation-wrong-digest"))
+def test_legacy_graph_pending_checkpoint_mismatch_never_replays_the_leaf(
+    tmp_path: Path, kind: str
+) -> None:
+    import pickle
+
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    vault = tmp_path / "vault"
+    current = _legacy_graph_pending_checkpoint(vault, generation=2, mutation_id="2" * 24)
+    if kind == "stale":
+        stored = _legacy_graph_pending_checkpoint(
+            tmp_path / "stale", generation=1, mutation_id="1" * 24
+        )
+    else:
+        stored = _legacy_graph_pending_checkpoint(
+            tmp_path / "conflict", generation=current.generation, mutation_id="3" * 24
+        )
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, 0, 'legacy-owner')",
+            (
+                "legacy",
+                "f" * 64,
+                pickle.dumps(
+                    {
+                        "canonical": "committed",
+                        "_graph_sync_checkpoint": stored.as_dict(),
+                    }
+                ),
+            ),
+        )
+
+    with pytest.raises(OpError) as error:
+        store.run(
+            "legacy",
+            "f" * 64,
+            lambda: pytest.fail("mismatched legacy graph_pending replayed the leaf"),
+            resume_canonically_committed=lambda result: {**result, "graph_sync": "completed"},
+            legacy_graph_pending_proof=_legacy_graph_pending_proof(vault),
+        )
+
+    assert error.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    _assert_retained_outcome_unknown(store)
+
+
+def test_corrupt_legacy_graph_pending_pickle_fails_closed_before_resume(tmp_path: Path) -> None:
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    vault = tmp_path / "vault"
+    _legacy_graph_pending_checkpoint(vault)
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, 0, 'legacy-owner')",
+            ("legacy", "f" * 64, b"not a pickle"),
+        )
+
+    with pytest.raises(OpError) as error:
+        store.run(
+            "legacy",
+            "f" * 64,
+            lambda: pytest.fail("corrupt legacy graph_pending replayed the leaf"),
+            resume_canonically_committed=lambda result: {**result, "graph_sync": "completed"},
+            legacy_graph_pending_proof=_legacy_graph_pending_proof(vault),
+        )
+
+    assert error.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    _assert_retained_outcome_unknown(store)
+
+
+def test_lease_manager_never_completes_an_unbound_legacy_graph_pending_result(
+    tmp_path: Path,
+) -> None:
+    import pickle
+    from types import SimpleNamespace
+
+    from exomem import writer_lease
+    from exomem.writer_lease import LeaseConfig, LeaseManager, OpError
+
+    vault = tmp_path / "vault"
+    _legacy_graph_pending_checkpoint(vault)
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    command = SimpleNamespace(
+        name="legacy-graph-pending",
+        read_only=False,
+        leaf=lambda _root: pytest.fail("unbound legacy graph_pending replayed the leaf"),
+    )
+    digest = writer_lease._command_digest(command, {})
+    key, _expires_after, _on_replay = writer_lease._effective_idempotency_key(
+        manager,
+        command=command,
+        mutation_subject=vault,
+        digest=digest,
+        idempotency_key="legacy",
+        principal_scope=None,
+    )
+    assert key is not None
+    with manager.idempotency._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, 0, 'legacy-owner')",
+            (key, digest, pickle.dumps({"canonical": "committed"})),
+        )
+
+    with pytest.raises(OpError) as error:
+        manager.invoke(command, (vault,), {}, idempotency_key="legacy")
+
+    assert error.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    _assert_retained_outcome_unknown(manager.idempotency)
+
+
+def test_v1_receipt_is_advisory_and_a_copied_v2_receipt_cannot_authorize_without_local_secret(
+    tmp_path: Path,
+) -> None:
+    """Only the local attempt row can turn a v2 receipt into exact evidence."""
+    from exomem import graph_sync
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    root = tmp_path / "vault"
+    digest = "a" * 64
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    assert store._claim_or_inspect("copied", digest, None) == ("owner", None)
+    local_attempt = store._attempts["copied"]
+    copied = graph_sync.GraphCommitReceipt.create(
+        idempotency_key_digest="a" * 64,
+        command_digest=digest,
+        attempt_id=local_attempt.attempt_id,
+        commit_token=local_attempt.commit_token,
+        canonical_disposition="success",
+        terminal_projection={"status": "committed", "mutated": True},
+        commit_secret=b"c" * 32,
+    )
+    graph_sync.write_graph_commit_receipt(root, copied)
+    legacy = copied.as_dict()
+    legacy["version"] = 1
+    legacy.pop("receipt_hmac_sha256")
+    legacy.pop("canonical_disposition")
+    legacy["commit_point"] = True
+    parsed_legacy = graph_sync.GraphCommitReceipt.parse(__import__("json").dumps(legacy))
+    assert parsed_legacy is not None
+    assert parsed_legacy.verify(
+        local_attempt.commit_secret,
+        idempotency_key_digest="a" * 64,
+        command_digest=digest,
+        attempt_id=local_attempt.attempt_id,
+        commit_token=local_attempt.commit_token,
+    ) is False
+
+    store._release_attempt("copied", local_attempt)
+    observer = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=0)
+    with pytest.raises(OpError) as blocked:
+        observer.run(
+            "copied",
+            digest,
+            lambda: pytest.fail("copied receipt authorized a leaf replay"),
+            commit_evidence=lambda expected, attempt_id, token, secret: (
+                graph_sync.read_graph_commit_receipt(root, token).verify(
+                    secret,
+                    idempotency_key_digest="a" * 64,
+                    command_digest=expected,
+                    attempt_id=attempt_id,
+                    commit_token=token,
+                )
+            ),
+        )
+    assert blocked.value.code == "MUTATION_OUTCOME_UNKNOWN"
+
+    empty_store = IdempotencyStore(tmp_path / "fresh-idempotency.sqlite")
+    leaf_calls: list[str] = []
+    evidence_calls: list[str] = []
+    assert empty_store.run(
+        "copied",
+        digest,
+        lambda: leaf_calls.append("ran") or {"canonical": "new"},
+        commit_evidence=lambda *_args: evidence_calls.append("consulted") or True,
+    ) == {"canonical": "new"}
+    assert leaf_calls == ["ran"]
+    assert evidence_calls == []
+
+
+def test_opaque_mutation_subject_never_becomes_a_relative_receipt_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cell/role identity is not filesystem authority for a receipt."""
+    from types import SimpleNamespace
+
+    from exomem.writer_lease import (
+        LeaseConfig,
+        LeaseManager,
+        OpError,
+        mark_active_mutation_committed,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("EXOMEM_VAULT_PATH", raising=False)
+    opaque_cell = "opaque-cell-not-a-vault"
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state", vault_id=opaque_cell))
+    command = SimpleNamespace(
+        name="opaque-mutation",
+        read_only=False,
+        leaf=lambda _subject: mark_active_mutation_committed() or {"committed": True},
+    )
+
+    with pytest.raises(OpError) as error:
+        manager.invoke(command, (opaque_cell,), {}, idempotency_key="opaque-receipt")
+
+    assert error.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+    assert not (tmp_path / opaque_cell).exists()
+
+
+def test_standalone_path_subject_persists_exact_receipt_under_its_vault(tmp_path: Path) -> None:
+    """A real standalone vault, unlike a coordination identity, owns its receipt."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.vault import PlannedWrite, batch_atomic_write
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/receipt.md"
+
+    def leaf(root: Path) -> dict[str, bool]:
+        batch_atomic_write([PlannedWrite(note, "# receipt\n")], vault_root=root)
+        return {"committed": True}
+
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    manager.invoke(
+        SimpleNamespace(name="standalone-receipt", read_only=False, leaf=leaf),
+        (vault,),
+        {},
+        idempotency_key="standalone-receipt",
+    )
+
+    receipt_dir = vault / "Knowledge Base/.graph-commit-receipts"
+    receipts = list(receipt_dir.glob("*.json"))
+    assert len(receipts) == 1
+    assert graph_sync.GraphCommitReceipt.parse(receipts[0].read_bytes()).version == 2
+
+
+def test_hosted_cell_uses_its_configured_vault_for_exact_receipts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hosted cell identity resolves receipts through its configured mount."""
+    from types import SimpleNamespace
+
+    from exomem import graph_sync
+    from exomem.writer_lease import LeaseConfig, LeaseManager, mark_active_mutation_committed
+
+    vault = tmp_path / "hosted-vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(vault))
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state", vault_id="cell:rita"))
+    command = SimpleNamespace(
+        name="hosted-receipt",
+        read_only=False,
+        leaf=lambda _cell: mark_active_mutation_committed() or {"committed": True},
+    )
+
+    manager.invoke(command, ("cell:rita",), {}, idempotency_key="hosted-receipt")
+
+    receipts = list((vault / "Knowledge Base/.graph-commit-receipts").glob("*.json"))
+    assert len(receipts) == 1
+    assert graph_sync.GraphCommitReceipt.parse(receipts[0].read_bytes()).version == 2

--- a/tests/test_graph_lifecycle_transition.py
+++ b/tests/test_graph_lifecycle_transition.py
@@ -1,0 +1,593 @@
+"""Failure-window coverage for graph-aware lifecycle transitions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import (
+    delete_directory,
+    delete_file,
+    graph_sync,
+    index_sync,
+    recall_policy,
+    recover_from_trash,
+)
+from exomem import writer_lease
+from exomem.governance import lifecycle
+
+
+def _note(vault: Path, name: str = "transition.md") -> tuple[str, Path]:
+    relative = f"Knowledge Base/Notes/Insights/{name}"
+    path = vault / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# transition\n", encoding="utf-8")
+    return relative, path
+
+
+def test_lifecycle_epoch_staging_never_marks_an_active_mutation_committed(
+    tmp_path: Path,
+) -> None:
+    relative, source = _note(tmp_path)
+    trace = writer_lease._ACTIVE_MUTATION_TRACE.set(("request", "delete_file", "receipt"))
+    committed = writer_lease._ACTIVE_MUTATION_COMMITTED.set(False)
+    try:
+        transition = graph_sync.begin_deletion_transition(
+            tmp_path,
+            source_rel=relative,
+            trash_rel="Knowledge Base/_trash/transition.md",
+            removed_rel_paths=[relative],
+        )
+        assert transition.epoch is not None
+        assert writer_lease._ACTIVE_MUTATION_COMMITTED.get() is False
+        transition.abort()
+        assert source.exists()
+    finally:
+        writer_lease._ACTIVE_MUTATION_COMMITTED.reset(committed)
+        writer_lease._ACTIVE_MUTATION_TRACE.reset(trace)
+
+
+def test_lifecycle_checkpoints_bind_active_lease_claims_for_delete_and_recovery(
+    tmp_path: Path,
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    relative, source = _note(tmp_path, "lease-claim.md")
+    source.write_text(
+        "---\ntype: insight\nstatus: draft\n---\n# lease claim\n",
+        encoding="utf-8",
+    )
+    EpistemicGraphIndex(tmp_path).rebuild_all()
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    trash_paths: list[str] = []
+
+    def delete(root: Path) -> dict:
+        result = delete_file.delete_file(root, path=relative, confirm=True)
+        trash_paths.append(result.trash_path)
+        return result.as_dict()
+
+    manager.invoke(
+        SimpleNamespace(
+            name="delete_file",
+            read_only=False,
+            leaf=delete,
+        ),
+        (tmp_path,),
+        {},
+        idempotency_key="lease-claim-delete",
+    )
+    delete_checkpoint = graph_sync.read_checkpoint(tmp_path)
+    delete_receipts = list(
+        (tmp_path / "Knowledge Base/.graph-commit-receipts").glob("*.json")
+    )
+    assert delete_checkpoint is not None
+    assert len(delete_receipts) == 1
+    delete_receipt = graph_sync.GraphCommitReceipt.parse(delete_receipts[0].read_bytes())
+    assert delete_receipt is not None
+    assert delete_checkpoint.mutation_id == delete_receipt.commit_token
+    assert delete_receipt.checkpoint_generation == delete_checkpoint.generation
+    assert delete_receipt.checkpoint_sha256 == delete_checkpoint.checkpoint_sha256
+
+    manager.invoke(
+        SimpleNamespace(
+            name="recover_from_trash",
+            read_only=False,
+            leaf=lambda root: recover_from_trash.recover_from_trash(
+                root, trash_path=trash_paths[0]
+            ).as_dict(),
+        ),
+        (tmp_path,),
+        {},
+        idempotency_key="lease-claim-recovery",
+    )
+    recovery_checkpoint = graph_sync.read_checkpoint(tmp_path)
+    recovery_receipts = list(
+        (tmp_path / "Knowledge Base/.graph-commit-receipts").glob("*.json")
+    )
+    assert recovery_checkpoint is not None
+    assert len(recovery_receipts) == 2
+    recovery_receipt = max(
+        (graph_sync.GraphCommitReceipt.parse(path.read_bytes()) for path in recovery_receipts),
+        key=lambda receipt: receipt.checkpoint_generation if receipt is not None else -1,
+    )
+    assert recovery_receipt is not None
+    assert recovery_checkpoint.mutation_id == recovery_receipt.commit_token
+    assert recovery_receipt.checkpoint_generation == recovery_checkpoint.generation
+    assert recovery_receipt.checkpoint_sha256 == recovery_checkpoint.checkpoint_sha256
+
+
+def test_rename_failure_after_floor_restores_prior_epoch_and_aborts_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "rename-failure.md")
+
+    def fail_rename(*_args: object, **_kwargs: object) -> None:
+        raise lifecycle.LifecycleError("ATOMIC_MOVE_FAILED", "injected rename failure")
+
+    monkeypatch.setattr(lifecycle, "atomic_rename", fail_rename)
+
+    with pytest.raises(delete_file.DeleteFileError) as error:
+        delete_file.delete_file(tmp_path, path=relative, confirm=True)
+
+    assert error.value.code == "ATOMIC_MOVE_FAILED"
+    assert source.exists()
+    assert graph_sync.floor_path(tmp_path).exists() is False
+    assert graph_sync.checkpoint_path(tmp_path).exists() is False
+
+
+def test_checkpoint_failure_after_rename_restores_exact_prior_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "checkpoint-failure.md")
+    prior = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="a" * 24,
+        paths=((relative, "a" * 64),),
+        created_paths=(relative,),
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, prior)
+    prior_floor = graph_sync.floor_path(tmp_path).read_bytes()
+    prior_checkpoint = graph_sync.checkpoint_path(tmp_path).read_bytes()
+
+    real_write = graph_sync._write_checkpoint
+
+    def write_then_fail(root: Path, checkpoint: graph_sync.GraphSyncCheckpoint) -> None:
+        real_write(root, checkpoint)
+        raise PermissionError("injected checkpoint failure")
+
+    monkeypatch.setattr(graph_sync, "_write_checkpoint", write_then_fail)
+
+    with pytest.raises(delete_file.DeleteFileError) as error:
+        delete_file.delete_file(tmp_path, path=relative, confirm=True)
+
+    assert error.value.code == "GRAPH_SYNC_CHECKPOINT_FAILED"
+    assert source.exists()
+    assert graph_sync.floor_path(tmp_path).read_bytes() == prior_floor
+    assert graph_sync.checkpoint_path(tmp_path).read_bytes() == prior_checkpoint
+
+
+def test_recovery_epoch_setup_failure_aborts_the_staged_floor_and_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "recovery-setup.md")
+    source.write_text(
+        "---\ntype: insight\nstatus: draft\n---\n# transition\n",
+        encoding="utf-8",
+    )
+    deleted = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+    prior_floor = graph_sync.floor_path(tmp_path).read_bytes()
+    prior_checkpoint = graph_sync.checkpoint_path(tmp_path).read_bytes()
+    real_prepare = graph_sync.prepare_recovery_epoch
+
+    def stage_then_fail(
+        root: Path, restored: list[tuple[str, str]]
+    ) -> graph_sync.GraphDeletionEpoch | None:
+        real_prepare(root, restored)
+        raise RuntimeError("injected recovery epoch setup failure")
+
+    monkeypatch.setattr(graph_sync, "prepare_recovery_epoch", stage_then_fail)
+
+    with pytest.raises(recover_from_trash.RecoverError) as error:
+        recover_from_trash.recover_from_trash(tmp_path, trash_path=deleted.trash_path)
+
+    assert error.value.code == "GRAPH_SYNC_EPOCH_FAILED"
+    assert source.exists() is False
+    assert (tmp_path / deleted.trash_path).exists()
+    assert graph_sync.floor_path(tmp_path).read_bytes() == prior_floor
+    assert graph_sync.checkpoint_path(tmp_path).read_bytes() == prior_checkpoint
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint"])
+def test_oversized_prior_artifact_aborts_deletion_marker_before_epoch_staging(
+    tmp_path: Path, artifact: str
+) -> None:
+    relative, _source = _note(tmp_path, f"oversized-{artifact}.md")
+    _govern(tmp_path, relative)
+    path = graph_sync.floor_path(tmp_path) if artifact == "floor" else graph_sync.checkpoint_path(tmp_path)
+    limit = graph_sync._FLOOR_READ_LIMIT if artifact == "floor" else graph_sync._CHECKPOINT_READ_LIMIT
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as stream:
+        stream.truncate(limit + 1)
+
+    with pytest.raises(graph_sync.GraphLifecycleEpochSetupError):
+        graph_sync.begin_deletion_transition(
+            tmp_path,
+            source_rel=relative,
+            trash_rel="Knowledge Base/_trash/oversized.md",
+            removed_rel_paths=[relative],
+        )
+
+    assert not list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json")
+    )
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint"])
+def test_oversized_prior_artifact_aborts_recovery_marker_before_epoch_staging(
+    tmp_path: Path, artifact: str
+) -> None:
+    relative, source = _note(tmp_path, f"oversized-recovery-{artifact}.md")
+    source.write_text("---\ntype: insight\nstatus: draft\n---\n# transition\n", encoding="utf-8")
+    _govern(tmp_path, relative)
+    deleted = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+    path = graph_sync.floor_path(tmp_path) if artifact == "floor" else graph_sync.checkpoint_path(tmp_path)
+    limit = graph_sync._FLOOR_READ_LIMIT if artifact == "floor" else graph_sync._CHECKPOINT_READ_LIMIT
+    with path.open("wb") as stream:
+        stream.truncate(limit + 1)
+
+    with pytest.raises(graph_sync.GraphLifecycleEpochSetupError):
+        graph_sync.begin_recovery_transition(
+            tmp_path,
+            trash_rel=deleted.trash_path,
+            source_rel=relative,
+            restored_paths=[(relative, "a" * 64)],
+        )
+
+    assert not list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones/recovery").glob("*.json")
+    )
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint"])
+def test_malformed_non_utf8_prior_artifact_aborts_deletion_before_rename(
+    tmp_path: Path, artifact: str
+) -> None:
+    relative, source = _note(tmp_path, f"malformed-delete-{artifact}.md")
+    _govern(tmp_path, relative)
+    path = graph_sync.floor_path(tmp_path) if artifact == "floor" else graph_sync.checkpoint_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prior_bytes = b"\xffmalformed epoch artifact"
+    path.write_bytes(prior_bytes)
+
+    with pytest.raises(graph_sync.GraphLifecycleEpochSetupError):
+        graph_sync.begin_deletion_transition(
+            tmp_path,
+            source_rel=relative,
+            trash_rel="Knowledge Base/_trash/malformed-delete.md",
+            removed_rel_paths=[relative],
+        )
+
+    assert source.exists()
+    assert path.read_bytes() == prior_bytes
+    assert not list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json")
+    )
+
+
+@pytest.mark.parametrize("artifact", ["floor", "checkpoint"])
+def test_malformed_non_utf8_prior_artifact_aborts_recovery_before_rename(
+    tmp_path: Path, artifact: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, f"malformed-recovery-{artifact}.md")
+    source.write_text("---\ntype: insight\nstatus: draft\n---\n# transition\n", encoding="utf-8")
+    _govern(tmp_path, relative)
+    deleted = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+    path = graph_sync.floor_path(tmp_path) if artifact == "floor" else graph_sync.checkpoint_path(tmp_path)
+    prior_bytes = b"\xffmalformed epoch artifact"
+    path.write_bytes(prior_bytes)
+    if artifact == "checkpoint":
+        graph_sync.floor_path(tmp_path).unlink()
+    monkeypatch.setattr(recall_policy, "is_recall_candidate", lambda *_args: True)
+
+    with pytest.raises(graph_sync.GraphLifecycleEpochSetupError):
+        graph_sync.begin_recovery_transition(
+            tmp_path,
+            trash_rel=deleted.trash_path,
+            source_rel=relative,
+            restored_paths=[(relative, "a" * 64)],
+        )
+
+    assert source.exists() is False
+    assert (tmp_path / deleted.trash_path).exists()
+    assert path.read_bytes() == prior_bytes
+    assert not list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones/recovery").glob("*.json")
+    )
+
+
+def test_rollback_failure_preserves_durable_recovery_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "rollback-failure.md")
+    real_rename = lifecycle.atomic_rename
+
+    def fail_only_inverse(
+        operation: lifecycle.LifecycleOperation,
+        *,
+        source: Path,
+        destination: Path,
+        recovery: bool = False,
+    ) -> None:
+        if "_trash" in source.parts:
+            raise lifecycle.LifecycleError("ATOMIC_MOVE_FAILED", "injected rollback failure")
+        real_rename(operation, source=source, destination=destination, recovery=recovery)
+
+    monkeypatch.setattr(lifecycle, "atomic_rename", fail_only_inverse)
+    monkeypatch.setattr(
+        graph_sync,
+        "commit_deletion_epoch",
+        lambda _epoch: (_ for _ in ()).throw(PermissionError("injected checkpoint failure")),
+    )
+
+    with pytest.raises(delete_file.DeleteFileError) as error:
+        delete_file.delete_file(tmp_path, path=relative, confirm=True)
+
+    assert error.value.code == "GRAPH_SYNC_DELETION_ROLLBACK_FAILED"
+    assert source.exists() is False
+    assert graph_sync.floor_path(tmp_path).exists()
+    assert list((tmp_path / "Knowledge Base/_trash").rglob("*rollback-failure.md"))
+
+
+@pytest.mark.parametrize(
+    ("outcome", "code"),
+    [
+        ("failed", "graph_handle_failed"),
+        ("deferred", "deferred_durable"),
+        ("unverified", "graph_outcome_unverified"),
+    ],
+)
+def test_lifecycle_terminal_gate_rejects_nonexact_graph_outcomes(
+    outcome: str, code: str
+) -> None:
+    report = {
+        "paths_truncated": False,
+        "reconcile_required": outcome == "failed",
+        "components": [
+            {"component": "epistemic_graph", "outcome": outcome, "code": code}
+        ],
+    }
+
+    assert lifecycle._index_report_is_exact(report) is False
+
+
+def test_lifecycle_terminal_gate_allows_a_registered_graph_handle() -> None:
+    report = {
+        "paths_truncated": False,
+        "reconcile_required": False,
+        "components": [
+            {
+                "component": "epistemic_graph",
+                "outcome": "registered",
+                "code": "rebuild_registered",
+            }
+        ],
+    }
+
+    assert lifecycle._index_report_is_exact(report) is True
+
+
+def test_lifecycle_terminal_gate_requires_an_explicit_derived_report() -> None:
+    assert lifecycle._index_report_is_exact(None) is False
+
+
+def _govern(vault: Path, relative: str) -> None:
+    governance = vault / "Knowledge Base/_Governance"
+    scope = governance / "scopes/lifecycle.yaml"
+    rule = governance / "rules/lifecycle.yaml"
+    scope.parent.mkdir(parents=True, exist_ok=True)
+    rule.parent.mkdir(parents=True, exist_ok=True)
+    scope.write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n"
+        f'paths: ["{relative.removeprefix("Knowledge Base/")}"]\n',
+        encoding="utf-8",
+    )
+    rule.write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB0\n"
+        "scope_ids: [\"01ARZ3NDEKTSV4RRFFQ69G5FAV\"]\n"
+        "audience: external\nceiling: 4\n",
+        encoding="utf-8",
+    )
+    from exomem.governance import membership, policy
+
+    policy._CACHE.clear()
+    membership.clear_memo()
+
+
+def test_lease_graph_wait_does_not_finalize_a_degraded_governed_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, _source = _note(tmp_path, "mixed-component.md")
+    _govern(tmp_path, relative)
+    real_delete = index_sync.delete_after_remove
+
+    def mixed_delete(root: Path, paths: list[str]) -> index_sync.IndexSyncReport:
+        return index_sync.with_component(
+            real_delete(root, paths),
+            index_sync.IndexComponentOutcome("embeddings", "degraded", "injected_failure"),
+        )
+
+    monkeypatch.setattr(index_sync, "delete_after_remove", mixed_delete)
+    calls: list[int] = []
+
+    def leaf(root: Path) -> dict:
+        calls.append(1)
+        return delete_file.delete_file(root, path=relative, confirm=True).as_dict()
+
+    result = _lease_manager(tmp_path).invoke(
+        SimpleNamespace(name="delete_file", read_only=False, leaf=leaf),
+        (tmp_path,),
+        {"response_detail": "full"},
+        idempotency_key="mixed-component-delete",
+    )
+
+    tombstones = list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json")
+    )
+    assert calls == [1]
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "completed"
+    assert any("remains tombstoned until reconcile" in warning for warning in result["diagnostics"]["warnings"])
+    assert len(tombstones) == 1
+    assert lifecycle._read_json(tmp_path, tombstones[0])["state"] == "pending"
+
+
+def test_governed_delete_stays_pending_for_an_unverified_legacy_fanout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, _source = _note(tmp_path, "legacy-delete.md")
+    _govern(tmp_path, relative)
+    monkeypatch.setattr(index_sync, "delete_after_remove", lambda *_args: True)
+
+    result = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+
+    tombstones = list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones").glob("*.json")
+    )
+    assert any("remains tombstoned until reconcile" in warning for warning in result.warnings)
+    assert len(tombstones) == 1
+    assert lifecycle._read_json(tmp_path, tombstones[0])["state"] == "pending"
+
+
+def test_governed_recovery_stays_pending_for_an_unverified_legacy_fanout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "legacy-recovery.md")
+    source.write_text("---\ntype: insight\nstatus: draft\n---\n# transition\n", encoding="utf-8")
+    _govern(tmp_path, relative)
+    deleted = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+    monkeypatch.setattr(index_sync, "upsert_after_write", lambda *_args, **_kwargs: True)
+
+    result = recover_from_trash.recover_from_trash(tmp_path, trash_path=deleted.trash_path)
+
+    recovery = list(
+        (tmp_path / "Knowledge Base/_Governance/deletion-tombstones/recovery").glob("*.json")
+    )
+    assert any("remains tombstoned until reconcile" in warning for warning in result.warnings)
+    assert len(recovery) == 1
+    assert lifecycle._read_json(tmp_path, recovery[0])["state"] == "staged"
+
+
+def _raise_fanout(*_args: object, **_kwargs: object) -> None:
+    raise RuntimeError("injected outer fanout failure")
+
+
+def _lease_manager(tmp_path: Path) -> writer_lease.LeaseManager:
+    return writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=tmp_path / "state"))
+
+
+def _assert_outer_fanout_failure_terminal(
+    manager: writer_lease.LeaseManager,
+    command: SimpleNamespace,
+    vault: Path,
+    *,
+    key: str,
+    calls: list[int],
+    observed: list[graph_sync.GraphSyncCheckpoint | None],
+) -> None:
+    result = manager.invoke(command, (vault,), {}, idempotency_key=key)
+    replay = manager.invoke(command, (vault,), {}, idempotency_key=key)
+
+    assert calls == [1]
+    assert replay == result
+    assert observed == [graph_sync.read_checkpoint(vault)]
+    assert observed[0] is not None
+    assert result["status"] == "committed"
+    assert result["graph_sync"] == "failed"
+    assert result["graph_sync_code"] == "GRAPH_SYNC_FANOUT_FAILED"
+    assert result["graph_sync_checkpoint"] == observed[0].checkpoint_sha256
+
+
+def test_lease_delete_file_outer_fanout_failure_keeps_an_exact_graph_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, _source = _note(tmp_path, "outer-delete-file.md")
+    monkeypatch.setattr(index_sync, "delete_after_remove", _raise_fanout)
+    calls: list[int] = []
+    observed: list[graph_sync.GraphSyncCheckpoint | None] = []
+
+    def leaf(root: Path) -> dict:
+        calls.append(1)
+        result = delete_file.delete_file(root, path=relative, confirm=True)
+        observed.append(graph_sync.registered_checkpoint(root))
+        return result.as_dict()
+
+    _assert_outer_fanout_failure_terminal(
+        _lease_manager(tmp_path),
+        SimpleNamespace(name="delete_file", read_only=False, leaf=leaf),
+        tmp_path,
+        key="outer-delete-file",
+        calls=calls,
+        observed=observed,
+    )
+
+
+def test_lease_delete_directory_outer_fanout_failure_keeps_an_exact_graph_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative = "Knowledge Base/Notes/Insights/outer-delete-directory"
+    source = tmp_path / relative / "nested.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# transition\n", encoding="utf-8")
+    monkeypatch.setattr(index_sync, "delete_after_remove", _raise_fanout)
+    calls: list[int] = []
+    observed: list[graph_sync.GraphSyncCheckpoint | None] = []
+
+    def leaf(root: Path) -> dict:
+        calls.append(1)
+        result = delete_directory.delete_directory(
+            root, path=relative, confirm=True, recursive=True
+        )
+        observed.append(graph_sync.registered_checkpoint(root))
+        return result.as_dict()
+
+    _assert_outer_fanout_failure_terminal(
+        _lease_manager(tmp_path),
+        SimpleNamespace(name="delete_directory", read_only=False, leaf=leaf),
+        tmp_path,
+        key="outer-delete-directory",
+        calls=calls,
+        observed=observed,
+    )
+
+
+def test_lease_recovery_outer_fanout_failure_keeps_an_exact_graph_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    relative, source = _note(tmp_path, "outer-recovery.md")
+    source.write_text(
+        "---\ntype: insight\nstatus: draft\n---\n# transition\n",
+        encoding="utf-8",
+    )
+    deleted = delete_file.delete_file(tmp_path, path=relative, confirm=True)
+    monkeypatch.setattr(index_sync, "upsert_after_write", _raise_fanout)
+    calls: list[int] = []
+    observed: list[graph_sync.GraphSyncCheckpoint | None] = []
+
+    def leaf(root: Path) -> dict:
+        calls.append(1)
+        result = recover_from_trash.recover_from_trash(root, trash_path=deleted.trash_path)
+        observed.append(graph_sync.registered_checkpoint(root))
+        return result.as_dict()
+
+    _assert_outer_fanout_failure_terminal(
+        _lease_manager(tmp_path),
+        SimpleNamespace(name="recover_from_trash", read_only=False, leaf=leaf),
+        tmp_path,
+        key="outer-recovery",
+        calls=calls,
+        observed=observed,
+    )

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -845,7 +845,7 @@ def test_incremental_graph_ack_rollback_keeps_prior_rows_and_ack(
 
     with index._connect() as conn:
         row = conn.execute(
-            "SELECT source_hash FROM graph_nodes WHERE node_key = ?", 
+            "SELECT source_hash FROM graph_nodes WHERE node_key = ?",
             ("file:Knowledge Base/Notes/Insights/atomic.md",),
         ).fetchone()
         meta = dict(

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1,0 +1,2246 @@
+"""Contract coverage for durable graph rebuild handoff and publication."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from contextlib import closing, contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import freshness, graph_sync, runtime_readiness
+from exomem import reconcile as reconcile_module
+from exomem import vault as vault_module
+
+
+def _crash_after_canonical_terminal(database: str, marker: str) -> None:
+    from exomem.writer_lease import IdempotencyStore
+
+    def operation() -> dict[str, object]:
+        Path(marker).write_text("committed", encoding="utf-8")
+        return {"state": "committed", "graph_sync": "pending"}
+
+    def crash(_result: object) -> object:
+        os._exit(0)
+
+    IdempotencyStore(Path(database)).run(
+        "crash-window", "digest", operation, after_operation_guard=crash
+    )
+
+
+def _hold_cross_process_rebuild_lock(
+    vault_root: str, temporary: str, ready, release  # noqa: ANN001
+) -> None:
+    from exomem import graph_sync as graph_sync_module
+
+    assert graph_sync_module.claim_rebuild_owner(Path(vault_root), Path(temporary))
+    ready.set()
+    assert release.wait(10)
+    graph_sync_module.release_rebuild_owner(Path(vault_root), Path(temporary))
+
+
+def _attempt_cross_process_rebuild_lock(vault_root: str, temporary: str, result) -> None:  # noqa: ANN001
+    from exomem import graph_sync as graph_sync_module
+
+    claimed = graph_sync_module.claim_rebuild_owner(Path(vault_root), Path(temporary))
+    try:
+        result.put(claimed)
+    finally:
+        if claimed:
+            graph_sync_module.release_rebuild_owner(Path(vault_root), Path(temporary))
+
+
+def _forked_graph_lock_state(vault_root: str, temporary: str, result) -> None:  # noqa: ANN001
+    from exomem import graph_sync as graph_sync_module
+
+    inherited_registry = bool(graph_sync_module._REBUILD_LOCK_HANDLES)
+    claimed = graph_sync_module.claim_rebuild_owner(Path(vault_root), Path(temporary))
+    try:
+        result.put((inherited_registry, claimed))
+    finally:
+        if claimed:
+            graph_sync_module.release_rebuild_owner(Path(vault_root), Path(temporary))
+
+
+def _checkpoint(generation: int) -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=f"{generation:024x}",
+        paths=(("Knowledge Base/Notes/example.md", "d" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+
+
+def test_checkpoint_is_closed_domain_separated_and_projects_paths() -> None:
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="0123456789abcdef01234567",
+        paths=(("Knowledge Base/Notes/example.md", "d" * 64),),
+        created_paths=("Knowledge Base/Notes/example.md",),
+    )
+
+    assert checkpoint.as_dict() == {
+        "version": 1,
+        "generation": 1,
+        "mutation_id": "0123456789abcdef01234567",
+        "scope": "paths",
+        "paths": [["Knowledge Base/Notes/example.md", "d" * 64]],
+        "created_paths": ["Knowledge Base/Notes/example.md"],
+        "checkpoint_sha256": "941d8a67ae715b6795daade34607f445d4c5b5726b9dc5e4ac095c9946c6d877",
+    }
+    assert graph_sync.GraphSyncCheckpoint.parse(checkpoint.render()) == checkpoint
+    assert graph_sync.GraphSyncCheckpoint.parse('{"generation":1}') is None
+    projected = graph_sync.GraphSyncCheckpoint.create(
+        generation=2,
+        mutation_id="fedcba9876543210fedcba98",
+        paths=(
+            ("Knowledge Base/Notes/z.md", None),
+            ("Knowledge Base/Notes/a.md", "a" * 64),
+        ),
+        created_paths=("Knowledge Base/Notes/a.md",),
+    )
+    assert projected.paths == (
+        ("Knowledge Base/Notes/a.md", "a" * 64),
+        ("Knowledge Base/Notes/z.md", None),
+    )
+    assert projected.created_paths == (
+        "Knowledge Base/Notes/a.md",
+    )
+
+
+def test_generation_floor_is_closed_and_rejects_noncanonical_mutation_ids() -> None:
+    floor = graph_sync.GraphSyncGenerationFloor.create(1)
+
+    assert floor.as_dict() == {
+        "version": 1,
+        "generation": 1,
+        "floor_sha256": "a1d6d04d75a81af9abb1a6c8ea88214a520fdde62d2a03fb99eda5934d3ad829",
+    }
+    assert graph_sync.GraphSyncGenerationFloor.parse(floor.render()) == floor
+    assert graph_sync.GraphSyncGenerationFloor.parse('{"generation":1}') is None
+    with pytest.raises(ValueError, match="lowercase 24-hex"):
+        graph_sync.GraphSyncCheckpoint.create(
+            generation=1,
+            mutation_id="0123456789ABCDEF01234567",
+            paths=(),
+            created_paths=(),
+        )
+
+
+def test_checkpoint_generation_is_monotonic_and_full_scope_is_bounded() -> None:
+    prior = _checkpoint(4)
+    checkpoint = graph_sync.next_checkpoint(
+        current=prior,
+        acknowledged_generation=7,
+        mutation_id="f" * 24,
+        paths=[(f"Knowledge Base/Notes/{index}.md", "a" * 64) for index in range(1001)],
+        created_paths=[],
+    )
+
+    assert checkpoint.generation == 8
+    assert checkpoint.scope == "full"
+    assert checkpoint.paths == ()
+    assert checkpoint.created_paths == ()
+
+
+def test_graph_relevant_batch_stages_checkpoint_with_canonical_write(tmp_path: Path) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/example.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Example\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert checkpoint is not None
+    assert checkpoint.generation == 1
+    assert checkpoint.paths == (("Knowledge Base/Notes/Insights/example.md", vault_module.content_hash("# Example\n")),)
+    assert not graph_sync.is_graph_input_path("Knowledge Base/.graph-sync.json")
+
+
+def test_interrupted_floor_is_recovered_by_the_next_caller_batch_at_full_scope(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "Knowledge Base/Notes/Insights/first.md"
+    second = tmp_path / "Knowledge Base/Notes/Insights/second.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(first, "# First\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    graph_sync.checkpoint_path(tmp_path).unlink()
+
+    replaced = vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(second, "# Second\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert replaced == [second]
+    assert checkpoint is not None
+    assert checkpoint.generation == 2
+    assert checkpoint.scope == "full"
+    assert checkpoint.paths == ()
+    assert checkpoint.created_paths == ()
+    assert graph_sync.read_floor(tmp_path) == graph_sync.GraphSyncGenerationFloor.create(2)
+
+
+def test_malformed_checkpoint_after_a_valid_floor_is_recovered_by_the_next_batch(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "Knowledge Base/Notes/Insights/first.md"
+    second = tmp_path / "Knowledge Base/Notes/Insights/second.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(first, "# First\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    graph_sync.checkpoint_path(tmp_path).write_text("{broken", encoding="utf-8")
+
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(second, "# Second\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert checkpoint is not None
+    assert checkpoint.generation == 2
+    assert checkpoint.scope == "full"
+
+
+def test_recovery_epoch_preparation_admits_a_fresh_floor_without_checkpoint(
+    tmp_path: Path,
+) -> None:
+    restored = "Knowledge Base/Notes/Insights/restored.md"
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+
+    epoch = graph_sync.prepare_recovery_epoch(tmp_path, [(restored, "a" * 64)])
+
+    assert epoch is not None
+    assert epoch.checkpoint.generation == 2
+    assert epoch.checkpoint.scope == "full"
+    assert epoch.checkpoint.paths == ()
+    assert epoch.checkpoint.created_paths == ()
+    assert graph_sync.read_floor(tmp_path) == graph_sync.GraphSyncGenerationFloor.create(2)
+
+
+def test_records_write_does_not_issue_an_epoch_or_schedule_graph_work(tmp_path: Path) -> None:
+    record = tmp_path / "Knowledge Base/Records/private.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(record, "# Private record\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+
+    assert graph_sync.read_floor(tmp_path) is None
+    assert graph_sync.read_checkpoint(tmp_path) is None
+
+
+def test_caught_batch_failure_rolls_back_the_checkpoint_with_canonical_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/rollback.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    prior_checkpoint = graph_sync.checkpoint_path(tmp_path).read_bytes()
+    replace = vault_module._BatchWorkspace.replace_artifact
+
+    def fail_checkpoint(workspace, artifact, target):
+        if target == graph_sync.checkpoint_path(tmp_path):
+            raise PermissionError(13, "replacement denied", str(target))
+        return replace(workspace, artifact, target)
+
+    monkeypatch.setattr(vault_module._BatchWorkspace, "replace_artifact", fail_checkpoint)
+    with pytest.raises(PermissionError):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(note, "# After\n")],
+            vault_root=tmp_path,
+            post_commit_fanout=False,
+        )
+
+    assert note.read_text(encoding="utf-8") == "# Before\n"
+    assert graph_sync.checkpoint_path(tmp_path).read_bytes() == prior_checkpoint
+
+
+def test_valid_floor_with_malformed_checkpoint_recovers_at_a_higher_full_epoch(
+    tmp_path: Path,
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/recovery-floor.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Recovery\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    graph_sync.checkpoint_path(tmp_path).write_text("{broken", encoding="utf-8")
+
+    recovered = graph_sync.recover_checkpoint(tmp_path)
+
+    assert recovered is not None
+    assert recovered.generation == 2
+    assert recovered.scope == "full"
+    assert graph_sync.read_floor(tmp_path).generation == 2
+
+
+def test_full_rebuild_rejects_malformed_checkpoint_before_live_sidecar_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/publication-floor.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    with index._connect() as conn:
+        prior_rows = conn.execute("SELECT node_key, source_hash FROM graph_nodes").fetchall()
+    graph_sync.checkpoint_path(tmp_path).write_text("{broken", encoding="utf-8")
+    seam_reached = False
+
+    def seam(_temporary: Path, _live: Path) -> None:
+        nonlocal seam_reached
+        seam_reached = True
+
+    monkeypatch.setattr(index, "_before_publish_replacement", seam)
+
+    with pytest.raises(graph_sync.GraphEpochIncoherent, match="coherent"):
+        index.rebuild_all()
+
+    assert seam_reached is False
+    with index._connect() as conn:
+        assert conn.execute("SELECT node_key, source_hash FROM graph_nodes").fetchall() == prior_rows
+    assert graph_sync.status(tmp_path) == {"state": "recovery_required", "generation": 1}
+
+
+def test_publication_epoch_retries_a_floor_checkpoint_commit_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = _checkpoint(1)
+    second = graph_sync.GraphSyncCheckpoint.create(
+        generation=2,
+        mutation_id="2" * 24,
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(2))
+    graph_sync._write_checkpoint(tmp_path, first)
+    real_checkpoint_state = graph_sync.checkpoint_state
+    reads = 0
+
+    def complete_after_read(root: Path):
+        nonlocal reads
+        reads += 1
+        state = real_checkpoint_state(root)
+        if reads == 1:
+            graph_sync.checkpoint_path(root).write_text(second.render(), encoding="utf-8")
+        return state
+
+    monkeypatch.setattr(graph_sync, "checkpoint_state", complete_after_read)
+
+    assert graph_sync.publication_epoch(tmp_path) == graph_sync.GraphPublicationEpoch(
+        graph_sync.GraphSyncGenerationFloor.create(2), second, None
+    )
+    assert reads == 2
+
+
+def test_rebuild_retries_an_epoch_window_that_outlives_inner_resampling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/epoch-window.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Epoch window\n", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(note), freshness.stat_signature(note))])
+    first = _checkpoint(1)
+    second = graph_sync.GraphSyncCheckpoint.create(
+        generation=2,
+        mutation_id="2" * 24,
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(2))
+    graph_sync._write_checkpoint(tmp_path, first)
+    real_checkpoint_state = graph_sync.checkpoint_state
+    reads = 0
+
+    def finish_on_outer_retry(root: Path):
+        nonlocal reads
+        reads += 1
+        if reads == 3:
+            graph_sync.checkpoint_path(root).write_text(second.render(), encoding="utf-8")
+        return real_checkpoint_state(root)
+
+    monkeypatch.setattr(graph_sync, "checkpoint_state", finish_on_outer_retry)
+
+    EpistemicGraphIndex(tmp_path).rebuild_all()
+
+    assert reads >= 3
+    assert graph_sync.read_checkpoint(tmp_path) == second
+    assert EpistemicGraphIndex(tmp_path).available()
+
+
+def test_ahead_floor_never_accepts_or_reuses_an_old_checkpoint(tmp_path: Path) -> None:
+    old = _checkpoint(1)
+    graph_sync._write_checkpoint(tmp_path, old)
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(2))
+
+    assert graph_sync.status(tmp_path) == {"state": "unavailable", "generation": 2}
+
+    recovered = graph_sync.recover_checkpoint(tmp_path)
+
+    assert recovered is not None
+    assert recovered.scope == "full"
+    assert recovered.generation == 3
+    assert graph_sync.read_floor(tmp_path).generation == 3
+
+
+def test_nonlegacy_malformed_floor_cannot_be_overwritten_by_a_new_write(tmp_path: Path) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/malformed-floor.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    graph_sync.floor_path(tmp_path).write_text("{broken", encoding="utf-8")
+
+    with pytest.raises(graph_sync.GraphEpochIncoherent, match="floor"):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(note, "# After\n")],
+            vault_root=tmp_path,
+            post_commit_fanout=False,
+        )
+
+    assert note.read_text(encoding="utf-8") == "# Before\n"
+    assert graph_sync.floor_path(tmp_path).read_text(encoding="utf-8") == "{broken"
+
+
+def test_deletion_epoch_restores_the_prior_floor_when_checkpoint_commit_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = "Knowledge Base/Notes/Insights/deleted.md"
+    source = tmp_path / path
+    source.parent.mkdir(parents=True)
+    source.write_text("# Deleted\n", encoding="utf-8")
+    epoch = graph_sync.prepare_deletion_epoch(tmp_path, [path])
+    assert epoch is not None
+    assert graph_sync.read_floor(tmp_path).generation == 1
+
+    def fail(*_args, **_kwargs):
+        raise PermissionError("checkpoint denied")
+
+    monkeypatch.setattr(graph_sync, "_write_checkpoint", fail)
+    with pytest.raises(PermissionError, match="checkpoint denied"):
+        graph_sync.commit_deletion_epoch(epoch)
+
+    graph_sync.restore_deletion_epoch(epoch)
+    assert graph_sync.read_floor(tmp_path) is None
+
+
+def test_file_delete_checkpoint_failure_restores_the_source_and_epoch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import delete_file
+
+    rel = "Knowledge Base/Notes/Insights/rollback-file.md"
+    source = tmp_path / rel
+    source.parent.mkdir(parents=True)
+    source.write_text("# Rollback\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        graph_sync,
+        "commit_deletion_epoch",
+        lambda _epoch: (_ for _ in ()).throw(PermissionError("checkpoint denied")),
+    )
+    with pytest.raises(delete_file.DeleteFileError) as error:
+        delete_file.delete_file(tmp_path, path=rel, confirm=True)
+
+    assert error.value.code == "GRAPH_SYNC_CHECKPOINT_FAILED"
+    assert source.read_text(encoding="utf-8") == "# Rollback\n"
+    assert graph_sync.read_floor(tmp_path) is None
+    assert not any((tmp_path / "Knowledge Base/_trash").rglob("rollback-file.md"))
+
+
+def test_recursive_delete_checkpoint_failure_restores_the_tree_and_epoch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import delete_directory
+
+    rel = "Knowledge Base/Notes/Insights/rollback-directory"
+    source = tmp_path / rel / "nested.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# Rollback\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        graph_sync,
+        "commit_deletion_epoch",
+        lambda _epoch: (_ for _ in ()).throw(PermissionError("checkpoint denied")),
+    )
+    with pytest.raises(delete_directory.DeleteDirectoryError) as error:
+        delete_directory.delete_directory(tmp_path, path=rel, confirm=True, recursive=True)
+
+    assert error.value.code == "GRAPH_SYNC_CHECKPOINT_FAILED"
+    assert source.read_text(encoding="utf-8") == "# Rollback\n"
+    assert graph_sync.read_floor(tmp_path) is None
+    assert not any((tmp_path / "Knowledge Base/_trash").rglob("rollback-directory"))
+
+
+def test_second_writer_commits_while_first_waits_outside_the_graph_hold(tmp_path: Path) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def build(_checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(_checkpoint)
+
+    first = coordinator.start_or_join(_checkpoint(1), build)
+    assert entered.wait(1)
+    second = coordinator.start_or_join(_checkpoint(2), build)
+
+    assert first.builder_started is True
+    assert second.builder_started is False
+    assert coordinator.writer_hold_count == 0
+    release.set()
+    assert first.wait(2).covers(_checkpoint(1))
+    assert second.wait(2).covers(_checkpoint(2))
+
+
+def test_registered_rebuild_enters_only_after_post_guard_wait(tmp_path: Path) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    entered = threading.Event()
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/escaped.md", vault_module.content_hash("# Escaped\n")),),
+        created_paths=("Knowledge Base/Notes/escaped.md",),
+    )
+
+    def build(required: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        return graph_sync.GraphBuildOutcome.covering(required)
+
+    coordinator = EpistemicGraphIndex(tmp_path)._mutation_coordinator
+    with coordinator.hold(operation="canonical-write", holder_kind="command"):
+        graph_sync.register_rebuild(tmp_path, checkpoint, build)
+        assert entered.is_set() is False
+
+    assert entered.is_set() is False
+    assert graph_sync.wait_for_registered(tmp_path, timeout=1).covers(checkpoint)
+    assert entered.is_set() is True
+
+
+def test_standalone_upsert_joins_registered_rebuild_before_returning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/standalone-join.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Standalone join\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    original = EpistemicGraphIndex._rebuild_all_locked
+
+    def slow_rebuild(index: EpistemicGraphIndex) -> dict[str, int]:
+        assert index.path.name.startswith(".graph-rebuild-")
+        entered.set()
+        assert release.wait(1)
+        return original(index)
+
+    def release_build() -> None:
+        assert entered.wait(1)
+        time.sleep(0.1)
+        release.set()
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", slow_rebuild)
+    releaser = threading.Thread(target=release_build)
+    releaser.start()
+    try:
+        result = upsert_after_write(tmp_path, [note], created_paths=[note])
+    finally:
+        release.set()
+        releaser.join(timeout=1)
+
+    assert result.outcome == "completed"
+    assert not list(note.parent.glob(".graph-rebuild-*.sqlite"))
+
+
+@pytest.mark.parametrize("as_string", [False, True])
+def test_direct_mutation_guard_starts_registered_graph_work_after_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, as_string: bool
+) -> None:
+    """A direct leaf cannot wait for graph work while it owns the boundary."""
+    from exomem import mutation_lock
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/direct-guard.md"
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+    calls: list[str] = []
+
+    def start_registered(*_args, **_kwargs) -> None:
+        calls.append(f"start:{mutation_lock.active_mutation_snapshot()['state']}")
+
+    def wait_for_registered(*_args, **_kwargs) -> None:
+        calls.append(f"wait:{mutation_lock.active_mutation_snapshot()['state']}")
+
+    monkeypatch.setattr(graph_sync, "start_registered", start_registered)
+    monkeypatch.setattr(graph_sync, "wait_for_registered", wait_for_registered)
+
+    root = str(tmp_path) if as_string else tmp_path
+    with manager.mutation_guard(root, operation="direct_leaf"):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(note, "# Direct guard\n")],
+            vault_root=tmp_path,
+        )
+        assert calls == []
+
+    assert calls == ["start:free", "wait:free"]
+
+
+def test_direct_mutation_guard_keeps_a_durable_graph_failure_nonfatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Direct leaves retain a graph failure handle instead of raising after commit."""
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+    note = tmp_path / "Knowledge Base/Notes/Insights/direct-deferred.md"
+    manager = LeaseManager(LeaseConfig(state_dir=tmp_path / "state"))
+
+    with manager.mutation_guard(tmp_path, operation="direct_leaf"):
+        vault_module.batch_atomic_write(
+            [vault_module.PlannedWrite(note, "# Direct deferred\n")],
+            vault_root=tmp_path,
+        )
+
+    assert graph_sync.status(tmp_path)["state"] == "recovery_required"
+
+
+def test_immediate_checkpoint_successor_refreshes_without_full_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import file_watcher, freshness
+    from exomem import find as find_module
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/incremental.md"
+    companion = tmp_path / "Knowledge Base/Notes/Insights/companion.md"
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# Before\n"
+            ),
+            vault_module.PlannedWrite(
+                companion, "---\ntype: insight\nstatus: active\n---\n# Companion\n"
+            ),
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    freshness.seed(
+        tmp_path,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(tmp_path)),
+    )
+    freshness.seed(
+        tmp_path,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(tmp_path / "Knowledge Base")
+        ),
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    rebuild_calls = 0
+    real_rebuild = EpistemicGraphIndex._rebuild_all_locked
+
+    def count_rebuild(self, *args, **kwargs):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(self, *args, **kwargs)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", count_rebuild)
+
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# After\n"
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    file_watcher._publish_registry_change(tmp_path, [note], [])
+    upsert_after_write(tmp_path, [note])
+
+    assert rebuild_calls == 0
+    assert graph_sync.status(tmp_path)["state"] == "current"
+
+
+def test_failed_incremental_proof_registers_off_boundary_work_without_rebuilding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/deferred.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Deferred\n", encoding="utf-8")
+    index = EpistemicGraphIndex(tmp_path)
+    required = _checkpoint(1)
+    graph_sync._write_checkpoint(tmp_path, required)
+    rebuilds = 0
+    registrations: list[graph_sync.GraphSyncCheckpoint] = []
+
+    def rebuild(*_args, **_kwargs):
+        nonlocal rebuilds
+        rebuilds += 1
+        raise AssertionError("incremental proof fallback rebuilt under writer authority")
+
+    monkeypatch.setattr(index, "_rebuild_all_locked", rebuild)
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        lambda _root, checkpoint, _builder, **_kwargs: registrations.append(checkpoint),
+    )
+
+    report = index._refresh_paths_locked([note], graph_checkpoint=required)
+
+    assert report["deferred"] == 1
+    assert rebuilds == 0
+    assert registrations == [required]
+
+
+def test_no_checkpoint_or_paths_skips_graph_fanout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    calls = 0
+
+    def refresh(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("Records-only fanout must not touch the graph")
+
+    monkeypatch.setattr(EpistemicGraphIndex, "refresh_paths", refresh)
+
+    upsert_after_write(tmp_path, [])
+
+    assert calls == 0
+
+
+def test_rollback_compatibility_disables_new_scheduling_but_keeps_epoch_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex, upsert_after_write
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/compatibility.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Compatibility\n", encoding="utf-8")
+    checkpoint = _checkpoint(1)
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, checkpoint)
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+    calls = 0
+
+    def scheduled(*_args, **_kwargs) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(
+        EpistemicGraphIndex,
+        "refresh_paths",
+        scheduled,
+    )
+    monkeypatch.setattr(
+        graph_sync,
+        "register_rebuild",
+        scheduled,
+    )
+
+    upsert_after_write(tmp_path, [note])
+
+    assert calls == 0
+    assert graph_sync.read_checkpoint(tmp_path) == checkpoint
+    assert graph_sync.recover_checkpoint(tmp_path) == checkpoint
+
+
+def test_incremental_graph_ack_rollback_keeps_prior_rows_and_ack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import file_watcher, freshness
+    from exomem import find as find_module
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/atomic.md"
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# Before\n"
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    freshness.seed(
+        tmp_path,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(tmp_path)),
+    )
+    freshness.seed(
+        tmp_path,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(tmp_path / "Knowledge Base")
+        ),
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    prior_checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert prior_checkpoint is not None
+    prior_hash = vault_module.content_hash(note.read_text(encoding="utf-8"))
+
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# After\n"
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    current_checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert current_checkpoint is not None
+    assert current_checkpoint.generation == prior_checkpoint.generation + 1
+    file_watcher._publish_registry_change(tmp_path, [note], [])
+
+    def cut_publication(*_args, **_kwargs) -> None:
+        raise RuntimeError("cut before incremental commit")
+
+    monkeypatch.setattr(index, "_publish_available_marker_in_transaction", cut_publication)
+    with pytest.raises(RuntimeError, match="cut before incremental commit"):
+        index.refresh_paths([note], graph_checkpoint=current_checkpoint)
+
+    with index._connect() as conn:
+        row = conn.execute(
+            "SELECT source_hash FROM graph_nodes WHERE node_key = ?", 
+            ("file:Knowledge Base/Notes/Insights/atomic.md",),
+        ).fetchone()
+        meta = dict(
+            conn.execute(
+                "SELECT key, value FROM graph_meta WHERE key IN "
+                "('graph_sync_generation', 'graph_sync_digest')"
+            )
+        )
+    assert row == (prior_hash,)
+    assert meta == {
+        "graph_sync_generation": str(prior_checkpoint.generation),
+        "graph_sync_digest": prior_checkpoint.checkpoint_sha256,
+    }
+
+
+def test_incremental_predecessor_requires_a_valid_checkpoint_lineage(tmp_path: Path) -> None:
+    from exomem import file_watcher, freshness
+    from exomem import find as find_module
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/lineage.md"
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# Before\n"
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    freshness.seed(
+        tmp_path,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(tmp_path)),
+    )
+    freshness.seed(
+        tmp_path,
+        "kb",
+        (
+            (str(path), freshness.stat_signature(path))
+            for path in find_module._walk_md(tmp_path / "Knowledge Base")
+        ),
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                note, "---\ntype: insight\nstatus: active\n---\n# After\n"
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    current_checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert current_checkpoint is not None
+    file_watcher._publish_registry_change(tmp_path, [note], [])
+
+    with index._connect() as conn:
+        conn.execute(
+            "UPDATE graph_meta SET value = ? WHERE key = 'graph_sync_checkpoint'",
+            ("{malformed",),
+        )
+
+    assert index._graph_sync_predecessor_available(current_checkpoint) is False
+
+
+def test_single_flight_retries_for_new_checkpoint_and_never_releases_stale_waiter(
+    tmp_path: Path,
+) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    entered = threading.Event()
+    release = threading.Event()
+    observed: list[int] = []
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        observed.append(checkpoint.generation)
+        entered.set()
+        if checkpoint.generation == 1:
+            assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    first = coordinator.start_or_join(_checkpoint(1), build)
+    assert entered.wait(1)
+    second = coordinator.start_or_join(_checkpoint(2), build)
+    release.set()
+
+    assert first.wait(2).covers(_checkpoint(1))
+    assert second.wait(2).covers(_checkpoint(2))
+    assert observed == [1, 2]
+
+
+def test_same_generation_with_a_different_digest_does_not_cover_a_waiter() -> None:
+    first = _checkpoint(1)
+    replacement = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="f" * 24,
+        paths=first.paths,
+        created_paths=first.created_paths,
+    )
+
+    assert graph_sync.GraphBuildOutcome.covering(first).covers(replacement) is False
+
+
+def test_same_generation_split_flight_fails_original_waiter_promptly(tmp_path: Path) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    first_checkpoint = _checkpoint(1)
+    replacement = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="f" * 24,
+        paths=first_checkpoint.paths,
+        created_paths=first_checkpoint.created_paths,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    first = coordinator.start_or_join(first_checkpoint, build)
+    assert entered.wait(1)
+    second = coordinator.start_or_join(replacement, build)
+
+    with pytest.raises(graph_sync.GraphEpochIncoherent, match="same-generation"):
+        first.wait(1)
+    with pytest.raises(graph_sync.GraphEpochIncoherent, match="same-generation"):
+        second.wait(1)
+    release.set()
+
+
+def test_original_index_publication_seam_rechecks_freshness_before_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/publication-race.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Before\n", encoding="utf-8")
+    required = _checkpoint(1)
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, required)
+    index = EpistemicGraphIndex(tmp_path)
+    raced = False
+
+    def race(_temporary: Path, _live: Path) -> None:
+        nonlocal raced
+        if not raced:
+            raced = True
+            note.write_text("# After\n", encoding="utf-8")
+            freshness.mark_external_pending(tmp_path)
+
+    monkeypatch.setattr(index, "_before_publish_replacement", race)
+
+    index.rebuild_all()
+
+    with index._connect() as conn:
+        source_hash = conn.execute(
+            "SELECT source_hash FROM graph_nodes WHERE node_key = ?",
+            ("file:Knowledge Base/Notes/Insights/publication-race.md",),
+        ).fetchone()
+    assert raced is True
+    assert source_hash == (vault_module.content_hash("# After\n"),)
+
+
+def test_publication_hook_exception_discards_ticket_and_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/hook-retry.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Hook retry\n", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(note), freshness.stat_signature(note))])
+    index = EpistemicGraphIndex(tmp_path)
+    calls = 0
+
+    def fail_once(_temporary: Path, _live: Path) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("hook failed once")
+
+    monkeypatch.setattr(index, "_before_publish_replacement", fail_once)
+
+    index.rebuild_all()
+
+    assert calls == 2
+    assert index.available()
+
+
+def test_persistent_publication_hook_failure_is_exact_stabilization_exhaustion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    note = tmp_path / "Knowledge Base/Notes/hook-failure.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Before\n", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(note), freshness.stat_signature(note))])
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    old_live = index.path.read_bytes()
+
+    def fail(_temporary: Path, _live: Path) -> None:
+        raise RuntimeError("persistent hook failure")
+
+    monkeypatch.setattr(index, "_before_publish_replacement", fail)
+
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as raised:
+        index.rebuild_all()
+
+    assert raised.value.code == "GRAPH_SYNC_STABILIZATION_EXHAUSTED"
+    assert f"after {epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS} attempts" in str(raised.value)
+    assert index.path.read_bytes() == old_live
+
+
+def test_canonical_publication_epoch_uses_only_floor_and_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkpoint = _checkpoint(1)
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, checkpoint)
+    monkeypatch.setattr(
+        graph_sync,
+        "acknowledgement_state",
+        lambda *_args: pytest.fail("canonical publication epoch must not read SQLite acknowledgement"),
+    )
+
+    assert graph_sync.canonical_publication_epoch(tmp_path) == graph_sync.GraphPublicationEpoch(
+        graph_sync.GraphSyncGenerationFloor.create(1), checkpoint, None
+    )
+
+
+def test_rebuild_publication_hold_runs_no_disk_or_sqlite_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/availability.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Availability\n", encoding="utf-8")
+    freshness.seed(vault, "vault", [(str(note), freshness.stat_signature(note))])
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    holding = False
+
+    class Coordinator:
+        def __init__(self, root: Path) -> None:
+            self.state_root = root
+
+        @contextmanager
+        def hold(self, **_kwargs):
+            nonlocal holding
+            holding = True
+            try:
+                yield
+            finally:
+                holding = False
+
+    index._mutation_coordinator = Coordinator(state_root)
+    real_freshness = epistemic_graph._disk_vault_freshness
+    real_connect = epistemic_graph.sqlite3.connect
+
+    def no_disk_work(root: Path):
+        assert not holding, "vault walk ran under publication hold"
+        return real_freshness(root)
+
+    def no_sqlite_work(*args, **kwargs):
+        assert not holding, "SQLite opened under publication hold"
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(epistemic_graph, "_disk_vault_freshness", no_disk_work)
+    monkeypatch.setattr(epistemic_graph.sqlite3, "connect", no_sqlite_work)
+
+    index.rebuild_all()
+
+
+def test_rebuild_stops_after_bounded_cold_recall_preparation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    preparations = 0
+    reconciles = 0
+
+    def unavailable(*_args, **_kwargs):
+        nonlocal preparations
+        preparations += 1
+        return None
+
+    def reconcile() -> None:
+        nonlocal reconciles
+        reconciles += 1
+
+    monkeypatch.setattr(freshness, "prepare_recall_publication", unavailable)
+    monkeypatch.setattr(index, "_reconcile_recall_publication", reconcile)
+
+    with pytest.raises(graph_sync.GraphRebuildRegistrationError) as raised:
+        index.rebuild_all()
+
+    assert raised.value.code == "GRAPH_SYNC_STABILIZATION_EXHAUSTED"
+    assert f"after {epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS} attempts" in str(raised.value)
+    assert preparations == epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS
+    assert reconciles == epistemic_graph.REBUILD_PUBLICATION_ATTEMPTS
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink replacement contract")
+def test_publication_rejects_a_hook_swapped_temp_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/symlink-race.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Safe\n", encoding="utf-8")
+    freshness.seed(vault, "vault", [(str(note), freshness.stat_signature(note))])
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    old_live = index.path.read_bytes()
+    target = tmp_path / "attacker.sqlite"
+    target.write_bytes(b"attacker")
+
+    def swap(temporary: Path, _live: Path) -> None:
+        temporary.unlink()
+        temporary.symlink_to(target)
+
+    monkeypatch.setattr(index, "_before_publish_replacement", swap)
+
+    with pytest.raises(RuntimeError, match="did not stabilize"):
+        index.rebuild_all()
+
+    assert index.path.read_bytes() == old_live
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows reparse contract")
+def test_publication_rejects_a_hook_swapped_temp_reparse_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/reparse-race.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Safe\n", encoding="utf-8")
+    freshness.seed(vault, "vault", [(str(note), freshness.stat_signature(note))])
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+    old_live = index.path.read_bytes()
+    target = tmp_path / "attacker.sqlite"
+    target.write_bytes(b"attacker")
+    probe = tmp_path / "reparse-probe.sqlite"
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", str(probe), str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode:
+        pytest.skip("Windows file reparse creation is unavailable")
+    probe.unlink()
+
+    def swap(temporary: Path, _live: Path) -> None:
+        temporary.unlink()
+        linked = subprocess.run(
+            ["cmd", "/c", "mklink", str(temporary), str(target)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert linked.returncode == 0
+
+    monkeypatch.setattr(index, "_before_publish_replacement", swap)
+
+    with pytest.raises(RuntimeError, match="did not stabilize"):
+        index.rebuild_all()
+
+    assert index.path.read_bytes() == old_live
+
+
+def test_temporary_identity_rejects_a_windows_reparse_attribute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph, mutation_lock
+
+    temporary = tmp_path / "temporary.sqlite"
+    temporary.write_bytes(b"sqlite")
+    info = temporary.lstat()
+    monkeypatch.setattr(
+        mutation_lock.os,
+        "lstat",
+        lambda _path: SimpleNamespace(
+            st_dev=info.st_dev,
+            st_ino=info.st_ino,
+            st_mode=info.st_mode,
+            st_size=info.st_size,
+            st_mtime_ns=info.st_mtime_ns,
+            st_file_attributes=0x400,
+        ),
+    )
+
+    with pytest.raises(OSError, match="no-follow"):
+        epistemic_graph.EpistemicGraphIndex._temporary_identity(temporary)
+
+
+def test_private_ticket_handles_special_character_vault_paths(tmp_path: Path) -> None:
+    from exomem import epistemic_graph
+
+    vault = tmp_path / "vault?#"
+    note = vault / "Knowledge Base/Notes/escaped.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Escaped\n", encoding="utf-8")
+    freshness.seed(vault, "vault", [(str(note), freshness.stat_signature(note))])
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/escaped.md", vault_module.content_hash("# Escaped\n")),),
+        created_paths=("Knowledge Base/Notes/escaped.md",),
+    )
+    graph_sync._write_floor(vault, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(vault, checkpoint)
+
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    index.rebuild_all()
+
+    assert index.available()
+
+
+def test_publication_retries_when_access_policy_changes_at_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault = tmp_path / "vault"
+    note = vault / "Knowledge Base/Notes/controlled.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Controlled\n", encoding="utf-8")
+    freshness.seed(vault, "vault", [(str(note), freshness.stat_signature(note))])
+    index = epistemic_graph.EpistemicGraphIndex(vault)
+    changed = False
+
+    def change_policy(_temporary: Path, _live: Path) -> None:
+        nonlocal changed
+        if not changed:
+            changed = True
+            (vault / "Knowledge Base/_access.yaml").write_text(
+                "excluded:\n  - Notes\n", encoding="utf-8"
+            )
+
+    monkeypatch.setattr(index, "_before_publish_replacement", change_policy)
+
+    index.rebuild_all()
+
+    assert changed
+    assert index.available()
+    assert index.nodes(path="Knowledge Base/Notes/controlled.md") == []
+
+
+def test_rebuild_refuses_a_malformed_live_acknowledgement(tmp_path: Path) -> None:
+    from exomem import epistemic_graph
+
+    note = tmp_path / "Knowledge Base/Notes/ack.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Ack\n", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(note), freshness.stat_signature(note))])
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/ack.md", vault_module.content_hash("# Ack\n")),),
+        created_paths=("Knowledge Base/Notes/ack.md",),
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(tmp_path, checkpoint)
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    with index._connect() as conn:
+        conn.execute(
+            "UPDATE graph_meta SET value = ? WHERE key = 'graph_sync_digest'", ("f" * 64,)
+        )
+
+    with pytest.raises(graph_sync.GraphEpochIncoherent):
+        index.rebuild_all()
+
+
+def test_higher_full_recovery_replaces_an_older_malformed_acknowledgement(
+    tmp_path: Path,
+) -> None:
+    from exomem import epistemic_graph
+
+    note = tmp_path / "Knowledge Base/Notes/ack-recovery.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Ack recovery\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    with index._connect() as conn:
+        conn.execute(
+            "UPDATE graph_meta SET value = ? WHERE key = 'graph_sync_digest'", ("f" * 64,)
+        )
+    recovery = graph_sync.GraphSyncCheckpoint.create(
+        generation=2,
+        mutation_id="2" * 24,
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(2))
+    graph_sync._write_checkpoint(tmp_path, recovery)
+
+    index.rebuild_all()
+
+    assert graph_sync.acknowledged_checkpoint(tmp_path) == graph_sync.GraphBuildOutcome.covering(
+        recovery
+    )
+    assert index.available()
+
+
+def test_rebuild_replaces_an_exact_current_acknowledgement(tmp_path: Path) -> None:
+    from exomem import epistemic_graph
+
+    note = tmp_path / "Knowledge Base/Notes/current-ack.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Current acknowledgement\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    required = graph_sync.read_checkpoint(tmp_path)
+
+    index.rebuild_all()
+
+    assert required is not None
+    assert graph_sync.acknowledged_checkpoint(tmp_path) == graph_sync.GraphBuildOutcome.covering(
+        required
+    )
+    assert index.available()
+
+
+def test_single_flight_caps_waiter_registration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(graph_sync, "MAX_GRAPH_REBUILD_WAITERS", 1)
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    release = threading.Event()
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    first = coordinator.start_or_join(_checkpoint(1), build)
+    rejected = coordinator.start_or_join(_checkpoint(1), build)
+    with pytest.raises(graph_sync.GraphWaiterCapacityError):
+        rejected.wait()
+    release.set()
+    assert first.wait(2).covers(_checkpoint(1))
+
+
+def test_temp_sidecar_is_private_until_atomic_publication_and_reconcile_sweeps_abandoned(
+    tmp_path: Path,
+) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    live.write_bytes(b"old")
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"new")
+
+    assert graph_sync.readable_sidecar(live) == live
+    assert graph_sync.readable_sidecar(temporary) is None
+    assert graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths=set()) == [temporary]
+    assert live.read_bytes() == b"old"
+
+
+def test_temp_sweep_is_proof_scoped_to_well_formed_graph_rebuild_artifacts(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    abandoned = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    unrelated = live.with_name(".graph-rebuild-user-copy.sqlite")
+    abandoned.write_bytes(b"abandoned")
+    unrelated.write_bytes(b"user")
+
+    assert graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths=set()) == [abandoned]
+    assert unrelated.read_bytes() == b"user"
+
+
+def test_temp_sweep_preserves_a_live_owner_from_another_process(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"building")
+    assert graph_sync.claim_rebuild_owner(tmp_path, temporary) is True
+    try:
+        assert graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths=set()) == []
+        assert temporary.exists()
+    finally:
+        graph_sync.release_rebuild_owner(tmp_path, temporary)
+
+
+def test_cross_process_rebuild_lock_rejects_a_second_builder(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    first = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    second = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    owner = context.Process(
+        target=_hold_cross_process_rebuild_lock,
+        args=(str(tmp_path), str(first), ready, release),
+    )
+    owner.start()
+    try:
+        assert ready.wait(5)
+        assert graph_sync.claim_rebuild_owner(tmp_path, second) is False
+        assert not (tmp_path / "Knowledge Base/.graph-rebuild.owner").exists()
+    finally:
+        release.set()
+        owner.join(10)
+    assert owner.exitcode == 0
+
+
+def test_standalone_write_joins_rebuild_and_exits_without_live_temporary(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    started = tmp_path / "rebuild-started"
+    script = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+
+        from exomem import graph_sync, vault
+        from exomem.epistemic_graph import EpistemicGraphIndex
+
+        root = Path(sys.argv[1])
+        started = Path(sys.argv[2])
+        original = EpistemicGraphIndex._rebuild_all_locked
+
+        def rebuild(self):
+            started.write_text("started", encoding="utf-8")
+            return original(self)
+
+        EpistemicGraphIndex._rebuild_all_locked = rebuild
+        vault.batch_atomic_write(
+            [vault.PlannedWrite(root / "Knowledge Base/Notes/standalone.md", "# Standalone\\n")],
+            vault_root=root,
+        )
+        assert started.exists(), "direct rebuild never started"
+        assert graph_sync.read_checkpoint(root) is not None
+        assert graph_sync.status(root)["state"] == "current"
+        assert EpistemicGraphIndex(root).available()
+        assert not graph_sync._REBUILD_LOCK_HANDLES
+        assert not list((root / "Knowledge Base").glob(".graph-rebuild-*.sqlite"))
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(vault_root), str(started)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Exception ignored" not in completed.stderr
+    assert "PytestUnraisableExceptionWarning" not in completed.stderr
+    assert "ResourceWarning" not in completed.stderr
+    checkpoint = graph_sync.read_checkpoint(vault_root)
+    assert checkpoint is not None
+    assert graph_sync.recover_checkpoint(vault_root) == checkpoint
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork descriptor inheritance is POSIX-only")
+def test_fork_child_drops_inherited_graph_lock_without_unlocking_parent(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    parent_temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    child_temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    competitor_temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    fork_context = multiprocessing.get_context("fork")
+    result = fork_context.Queue()
+
+    assert graph_sync.claim_rebuild_owner(tmp_path, parent_temporary) is True
+    child = fork_context.Process(
+        target=_forked_graph_lock_state,
+        args=(str(tmp_path), str(child_temporary), result),
+    )
+    child.start()
+    child.join(10)
+    try:
+        assert child.exitcode == 0
+        assert result.get(timeout=2) == (False, False)
+
+        spawn_context = multiprocessing.get_context("spawn")
+        competitor_result = spawn_context.Queue()
+        competitor = spawn_context.Process(
+            target=_attempt_cross_process_rebuild_lock,
+            args=(str(tmp_path), str(competitor_temporary), competitor_result),
+        )
+        competitor.start()
+        competitor.join(10)
+        assert competitor.exitcode == 0
+        assert competitor_result.get(timeout=2) is False
+    finally:
+        graph_sync.release_rebuild_owner(tmp_path, parent_temporary)
+
+
+def test_rebuild_lock_release_is_idempotent(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+
+    assert graph_sync.claim_rebuild_owner(tmp_path, temporary) is True
+    graph_sync.release_rebuild_owner(tmp_path, temporary)
+    graph_sync.release_rebuild_owner(tmp_path, temporary)
+    assert graph_sync.claim_rebuild_owner(tmp_path, temporary) is True
+    graph_sync.release_rebuild_owner(tmp_path, temporary)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows lock contract")
+def test_windows_rebuild_lock_claims_persists_and_refuses_parent_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(tmp_path / "runtime-state"))
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    lock = graph_sync._rebuild_lock_path(tmp_path)
+
+    assert graph_sync.claim_rebuild_owner(tmp_path, temporary) is True
+    try:
+        assert lock.is_file()
+        with pytest.raises(PermissionError):
+            os.replace(lock.parent, lock.parent.with_name("moved-rebuild-locks"))
+    finally:
+        graph_sync.release_rebuild_owner(tmp_path, temporary)
+
+    assert graph_sync.claim_rebuild_owner(tmp_path, temporary) is True
+    graph_sync.release_rebuild_owner(tmp_path, temporary)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows lock contract")
+def test_windows_rebuild_lock_rejects_a_reparse_lock_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_root = tmp_path / "runtime-state"
+    target = tmp_path / "reparse-target"
+    target.mkdir()
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(state_root), str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode:
+        pytest.skip("junction creation is unavailable on this Windows host")
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
+
+    with pytest.raises(graph_sync.GraphRebuildLockUnavailable):
+        graph_sync.claim_rebuild_owner(tmp_path, tmp_path / "temporary.sqlite")
+
+
+def test_runtime_readiness_projects_checkpoint_health_without_vault_paths() -> None:
+    snapshot = runtime_readiness.build_runtime_readiness(
+        coordination={
+            "enabled": False,
+            "role": "standalone",
+            "replica_id": None,
+            "coordinator_healthy": True,
+            "graph_sync": {"state": "recovery_required", "generation": 2},
+        },
+        release="1.2.3",
+        mcp_tool_surface_sha256="a" * 64,
+    )
+
+    assert snapshot["coordination"]["graph_sync"] == {
+        "state": "recovery_required",
+        "generation": 2,
+    }
+    assert "Knowledge Base" not in repr(snapshot)
+
+
+def test_reconcile_recovers_an_unacknowledged_checkpoint_without_rewriting_markdown(
+    tmp_path: Path,
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/recovery.md"
+    body = "---\ntype: insight\nstatus: active\n---\n# Recovery\n"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, body)], vault_root=tmp_path, post_commit_fanout=False
+    )
+
+    report = reconcile_module.reconcile(tmp_path)
+
+    assert note.read_text(encoding="utf-8") == body
+    assert graph_sync.status(tmp_path)["state"] == "current"
+    assert report.graph_status == "refreshed"
+
+
+def test_manager_reconcile_releases_canonical_boundary_before_graph_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reconcile graph rebuild must not retain the command mutation boundary."""
+    from types import SimpleNamespace
+
+    from exomem.commands import commands_for
+    from exomem.epistemic_graph import EpistemicGraphIndex
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/reconcile-boundary.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Reconcile boundary\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    rebuild_started = threading.Event()
+    release_rebuild = threading.Event()
+    second_admitted = threading.Event()
+    original = EpistemicGraphIndex._rebuild_all_locked
+
+    def slow_rebuild(index: EpistemicGraphIndex) -> dict[str, int]:
+        rebuild_started.set()
+        assert release_rebuild.wait(2)
+        return original(index)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", slow_rebuild)
+    state_dir = tmp_path / "state"
+    reconcile_manager = LeaseManager(
+        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=1
+    )
+    mutation_manager = LeaseManager(
+        LeaseConfig(state_dir=state_dir), mutation_timeout_seconds=0.1
+    )
+    reconcile_command = next(
+        command
+        for command in commands_for("mcp")
+        if command.name == "reconcile"
+    )
+
+    def canonical_leaf(vault_root: Path) -> dict[str, str]:
+        vault_module.batch_atomic_write(
+            [
+                vault_module.PlannedWrite(
+                    vault_root / "Knowledge Base/Records/concurrent.md",
+                    "# Concurrent canonical mutation\n",
+                )
+            ],
+            vault_root=vault_root,
+            post_commit_fanout=False,
+        )
+        second_admitted.set()
+        return {"status": "committed"}
+
+    second_command = SimpleNamespace(
+        name="canonical_mutation", read_only=False, leaf=canonical_leaf
+    )
+    reconcile_result: list[object] = []
+
+    def run_reconcile() -> None:
+        reconcile_result.append(
+            reconcile_manager.invoke(
+                reconcile_command, (tmp_path,), {"response_detail": "legacy"}
+            )
+        )
+
+    reconcile_thread = threading.Thread(target=run_reconcile)
+    reconcile_thread.start()
+    assert rebuild_started.wait(1)
+    try:
+        mutation_manager.invoke(second_command, (tmp_path,), {})
+        assert second_admitted.is_set()
+    finally:
+        release_rebuild.set()
+        reconcile_thread.join(timeout=3)
+
+    assert not reconcile_thread.is_alive()
+    assert reconcile_result[0]["graph_status"] == "refreshed", reconcile_result
+    assert reconcile_result[0]["graph_refreshed"] == 1
+    assert graph_sync.status(tmp_path)["state"] == "current"
+
+
+def test_legacy_refresh_releases_canonical_boundary_before_missing_sidecar_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy refresh rebuilds privately after, not inside, graph authority."""
+    from types import SimpleNamespace
+
+    from exomem.epistemic_graph import EpistemicGraphIndex
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/legacy-refresh.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Legacy refresh\n", encoding="utf-8")
+    rebuild_started = threading.Event()
+    release_rebuild = threading.Event()
+    concurrent_writer_admitted = threading.Event()
+    original = EpistemicGraphIndex._rebuild_all_locked
+
+    def slow_rebuild(index: EpistemicGraphIndex) -> dict[str, int]:
+        assert index.path.name.startswith(".graph-rebuild-")
+        rebuild_started.set()
+        assert release_rebuild.wait(2)
+        return original(index)
+
+    monkeypatch.setattr(EpistemicGraphIndex, "_rebuild_all_locked", slow_rebuild)
+    state_dir = tmp_path / "state"
+    refresh_manager = LeaseManager(LeaseConfig(state_dir=state_dir, mutation_timeout_seconds=1))
+    writer_manager = LeaseManager(LeaseConfig(state_dir=state_dir, mutation_timeout_seconds=0.1))
+    index = EpistemicGraphIndex(
+        tmp_path,
+        mutation_coordinator=refresh_manager._mutation_coordinator_for(tmp_path),
+    )
+
+    def canonical_leaf(vault_root: Path) -> dict[str, str]:
+        record = vault_root / "Knowledge Base/Records/concurrent.md"
+        record.parent.mkdir(parents=True, exist_ok=True)
+        record.write_text("# Concurrent canonical mutation\n", encoding="utf-8")
+        concurrent_writer_admitted.set()
+        return {"status": "committed"}
+
+    writer_command = SimpleNamespace(
+        name="canonical_mutation", read_only=False, leaf=canonical_leaf
+    )
+    reports: list[dict[str, int]] = []
+
+    refresh_thread = threading.Thread(
+        target=lambda: reports.append(index.refresh_paths([note]))
+    )
+    refresh_thread.start()
+    assert rebuild_started.wait(1)
+    try:
+        writer_manager.invoke(writer_command, (tmp_path,), {})
+        assert concurrent_writer_admitted.is_set()
+    finally:
+        release_rebuild.set()
+        refresh_thread.join(timeout=3)
+
+    assert not refresh_thread.is_alive()
+    assert reports[0]["indexed_files"] == 1
+    assert index.available() is True
+
+
+def test_manager_maintain_memory_reconcile_projects_graph_repair_across_terminal_details(
+    tmp_path: Path,
+) -> None:
+    from exomem.commands import product_commands_for
+    from exomem.writer_lease import LeaseConfig, LeaseManager
+
+    command = next(
+        command
+        for command in product_commands_for("mcp")
+        if command.name == "maintain_memory"
+    )
+
+    def reconcile_detail(name: str, detail: str | None = None) -> object:
+        vault_root = tmp_path / name
+        vault_module.batch_atomic_write(
+            [
+                vault_module.PlannedWrite(
+                    vault_root / "Knowledge Base/Notes/Insights/reconcile-projection.md",
+                    "# Reconcile projection\n",
+                )
+            ],
+            vault_root=vault_root,
+            post_commit_fanout=False,
+        )
+        kwargs = {"mode": "reconcile"}
+        if detail is not None:
+            kwargs["response_detail"] = detail
+        return LeaseManager(LeaseConfig(state_dir=vault_root / "state")).invoke(
+            command, (vault_root,), kwargs
+        )
+
+    compact = reconcile_detail("compact")
+    assert compact["graph_sync"] == "completed"
+    assert "diagnostics" not in compact
+
+    full = reconcile_detail("full", "full")
+
+    assert full["graph_sync"] == "completed"
+    assert full["diagnostics"]["graph_status"] == "refreshed"
+    assert full["diagnostics"]["graph_refreshed"] == 1
+    assert "_graph_reconcile_registered" not in full["diagnostics"]
+
+    legacy = reconcile_detail("legacy", "legacy")
+    assert legacy["graph_status"] == "refreshed"
+    assert legacy["graph_refreshed"] == 1
+
+
+def test_malformed_checkpoint_refuses_an_acknowledged_graph_and_reconcile_keeps_markdown(
+    tmp_path: Path,
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/malformed.md"
+    body = "---\ntype: insight\nstatus: active\n---\n# Malformed\n"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, body)], vault_root=tmp_path, post_commit_fanout=False
+    )
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    EpistemicGraphIndex(tmp_path).rebuild_all()
+    graph_sync.checkpoint_path(tmp_path).write_text("{not-json", encoding="utf-8")
+
+    assert EpistemicGraphIndex(tmp_path).available() is False
+    report = reconcile_module.reconcile(tmp_path)
+
+    assert note.read_text(encoding="utf-8") == body
+    assert graph_sync.status(tmp_path)["state"] == "current"
+    assert EpistemicGraphIndex(tmp_path).available() is True
+    assert report.graph_status == "refreshed"
+
+
+def test_legacy_graph_without_a_checkpoint_remains_available(tmp_path: Path) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/legacy.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("---\ntype: insight\nstatus: active\n---\n# Legacy\n", encoding="utf-8")
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+
+    assert graph_sync.read_checkpoint(tmp_path) is None
+    assert index.available() is True
+
+
+def test_missing_checkpoint_after_acknowledgement_stays_recovery_required(tmp_path: Path) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/missing.md"
+    body = "---\ntype: insight\nstatus: active\n---\n# Missing\n"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, body)], vault_root=tmp_path, post_commit_fanout=False
+    )
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    graph_sync.checkpoint_path(tmp_path).unlink()
+
+    assert index.available() is False
+    reconcile_module.reconcile(tmp_path)
+    assert note.read_text(encoding="utf-8") == body
+    assert graph_sync.status(tmp_path)["state"] == "current"
+    assert EpistemicGraphIndex(tmp_path).available() is True
+
+
+def test_reconcile_does_not_claim_current_when_the_generation_floor_is_malformed(
+    tmp_path: Path,
+) -> None:
+    note = tmp_path / "Knowledge Base/Notes/Insights/malformed-floor.md"
+    body = "---\ntype: insight\nstatus: active\n---\n# Malformed floor\n"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, body)], vault_root=tmp_path, post_commit_fanout=False
+    )
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    EpistemicGraphIndex(tmp_path).rebuild_all()
+    graph_sync.floor_path(tmp_path).write_text("{not-json", encoding="utf-8")
+
+    report = reconcile_module.reconcile(tmp_path)
+
+    assert note.read_text(encoding="utf-8") == body
+    assert graph_sync.status(tmp_path)["state"] == "unavailable"
+    assert EpistemicGraphIndex(tmp_path).available() is False
+    assert report.graph_status == "unavailable"
+
+
+def test_reconcile_sweeps_only_abandoned_reserved_graph_temporaries(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    abandoned = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    abandoned.write_bytes(b"abandoned")
+
+    reconcile_module.reconcile(tmp_path)
+
+    assert not abandoned.exists()
+
+
+def test_unacknowledged_checkpoint_requires_recovery_and_preserves_committed_terminal() -> None:
+    required = _checkpoint(2)
+    availability = graph_sync.availability(required, acknowledged=None)
+    failure = graph_sync.committed_graph_failure(required)
+
+    assert availability.available is False
+    assert availability.reason == "checkpoint_unacknowledged"
+    assert failure == {
+        "graph_sync": "failed",
+        "graph_sync_code": "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+        "graph_sync_checkpoint": required.checkpoint_sha256,
+        "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+    }
+
+
+def test_committed_derived_failure_is_idempotently_replayed(tmp_path: Path) -> None:
+    from exomem.writer_lease import IdempotencyStore
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    required = _checkpoint(2)
+    calls = 0
+
+    def operation() -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {"mutated": True}
+
+    def derived_failure(result: dict[str, object]) -> dict[str, object]:
+        return {**result, **graph_sync.committed_graph_failure(required)}
+
+    first = store.run(
+        "same-request", "digest", operation, after_operation_guard=derived_failure
+    )
+    replay = store.run(
+        "same-request", "digest", operation, after_operation_guard=derived_failure
+    )
+
+    assert calls == 1
+    assert replay == first
+
+
+def test_canonical_handoff_is_non_owned_until_off_boundary_graph_work_completes(
+    tmp_path: Path,
+) -> None:
+    from exomem.writer_lease import IdempotencyStore
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", wait_seconds=1)
+    released_guard = threading.Event()
+    release_graph = threading.Event()
+    result: list[dict[str, object]] = []
+
+    class Guard:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            released_guard.set()
+
+    def run_owner() -> None:
+        result.append(
+            store.run(
+                "graph-pending",
+                "digest",
+                lambda: {"state": "committed"},
+                operation_guard=Guard,
+                after_canonical_persisted=lambda value: value,
+                after_operation_guard=lambda value: (
+                    release_graph.wait(2) and {**value, "graph_sync": "completed"}
+                ),
+            )
+        )
+
+    owner = threading.Thread(target=run_owner)
+    owner.start()
+    assert released_guard.wait(1)
+    with store._connect() as conn:
+        assert conn.execute("SELECT state, owner FROM mutations").fetchone() == (
+            "canonically_committed",
+            None,
+        )
+    replay = threading.Thread(
+        target=lambda: result.append(
+            store.run(
+                "graph-pending",
+                "digest",
+                lambda: (_ for _ in ()).throw(AssertionError("canonical leaf replayed")),
+                resume_canonically_committed=lambda value: {**value, "graph_sync": "completed"},
+            )
+        )
+    )
+    replay.start()
+    release_graph.set()
+    owner.join(2)
+    replay.join(2)
+
+    assert result == [
+        {"state": "committed", "graph_sync": "completed"},
+        {"state": "committed", "graph_sync": "completed"},
+    ]
+
+
+def test_dead_graph_pending_owner_resumes_only_derived_graph_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import pickle
+
+    from exomem.writer_lease import IdempotencyStore
+
+    monkeypatch.setenv("EXOMEM_DISABLE_GRAPH_SCHEDULING", "1")
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    vault = tmp_path / "vault"
+    checkpoint = _checkpoint(1)
+    graph_sync._write_floor(vault, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(vault, checkpoint)
+    canonical = {
+        "state": "committed",
+        "graph_sync": "pending",
+        "_graph_sync_checkpoint": checkpoint.as_dict(),
+    }
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, result, updated_at, owner) "
+            "VALUES (?, ?, 'graph_pending', ?, ?, ?)",
+            ("dead-graph", "digest", pickle.dumps(canonical), 0, "999999:deadowner00000002"),
+        )
+
+    resumed = store.run(
+        "dead-graph",
+        "digest",
+        lambda: (_ for _ in ()).throw(AssertionError("canonical leaf replayed")),
+        resume_canonically_committed=lambda result: {
+            key: value
+            for key, value in {**result, "graph_sync": "completed"}.items()
+            if key != "_graph_sync_checkpoint"
+        },
+        commit_evidence=lambda: True,
+        legacy_graph_pending_proof=lambda candidate: (
+            graph_sync.read_checkpoint(vault) == candidate
+            and graph_sync.classify_epoch(vault).kind == "coherent"
+        ),
+    )
+
+    assert resumed == {"state": "committed", "graph_sync": "completed"}
+
+
+def test_dead_pending_without_an_exact_receipt_is_outcome_unknown(tmp_path: Path) -> None:
+    from exomem.writer_lease import IdempotencyStore, OpError
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite")
+    with store._connect() as conn:
+        conn.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner) VALUES (?, ?, ?, ?, ?)",
+            ("uncertain-cut", "digest", "pending", 0, "999999:deadowner00000003"),
+        )
+
+    with pytest.raises(OpError) as outcome:
+        store.run(
+            "uncertain-cut",
+            "digest",
+            lambda: (_ for _ in ()).throw(AssertionError("canonical leaf replayed")),
+            commit_evidence=lambda: True,
+        )
+    assert outcome.value.code == "MUTATION_OUTCOME_UNKNOWN"
+
+
+def test_crash_after_canonical_terminal_persistence_never_replays_the_write(tmp_path: Path) -> None:
+    from exomem.writer_lease import IdempotencyStore
+
+    database = tmp_path / "idempotency.sqlite"
+    marker = tmp_path / "canonical-write"
+    child = multiprocessing.get_context("spawn").Process(
+        target=_crash_after_canonical_terminal, args=(str(database), str(marker))
+    )
+    child.start()
+    child.join(timeout=10)
+    assert child.exitcode == 0
+    assert marker.read_text(encoding="utf-8") == "committed"
+
+    replayed = IdempotencyStore(database).run(
+        "crash-window",
+        "digest",
+        lambda: (_ for _ in ()).throw(AssertionError("canonical write replayed")),
+        resume_canonically_committed=lambda result: {**result, "graph_sync": "completed"},
+    )
+    assert replayed == {"state": "committed", "graph_sync": "completed"}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows refuses replacement while a reader is open")
+def test_temporary_swap_keeps_an_open_reader_on_the_previous_sidecar(tmp_path: Path) -> None:
+    import sqlite3
+
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    with closing(sqlite3.connect(live)) as conn:
+        conn.execute("CREATE TABLE value (item TEXT)")
+        conn.execute("INSERT INTO value VALUES ('old')")
+        conn.commit()
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    with closing(sqlite3.connect(temporary)) as conn:
+        conn.execute("CREATE TABLE value (item TEXT)")
+        conn.execute("INSERT INTO value VALUES ('new')")
+        conn.commit()
+
+    reader = sqlite3.connect(live)
+    try:
+        assert reader.execute("SELECT item FROM value").fetchone() == ("old",)
+        graph_sync.replace_sidecar(temporary, live)
+        assert reader.execute("SELECT item FROM value").fetchone() == ("old",)
+        with closing(sqlite3.connect(live)) as current:
+            assert current.execute("SELECT item FROM value").fetchone() == ("new",)
+    finally:
+        reader.close()
+
+
+def test_windows_replacement_refusal_keeps_the_previous_complete_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    live.write_bytes(b"old")
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"new")
+    monkeypatch.setattr(graph_sync.os, "replace", lambda *_args: (_ for _ in ()).throw(PermissionError()))
+
+    with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable):
+        graph_sync.replace_sidecar(temporary, live)
+    assert live.read_bytes() == b"old"
+    assert temporary.read_bytes() == b"new"
+
+
+def test_full_rebuild_replacement_refusal_retains_complete_temp_for_later_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sqlite3
+
+    from exomem.epistemic_graph import EpistemicGraphIndex
+
+    note = tmp_path / "Knowledge Base/Notes/Insights/replacement-refusal.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Before\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    index = EpistemicGraphIndex(tmp_path)
+    index.rebuild_all()
+    old_live = index.path.read_bytes()
+    note.write_text("# After\n", encoding="utf-8")
+    retained: list[Path] = []
+    original_replace = graph_sync.replace_sidecar
+
+    def refuse_replacement(temporary: Path, _live: Path) -> None:
+        retained.append(temporary)
+        raise graph_sync.GraphSidecarReplaceUnavailable("live graph sidecar has an open reader")
+
+    monkeypatch.setattr(graph_sync, "replace_sidecar", refuse_replacement)
+    with pytest.raises(graph_sync.GraphSidecarReplaceUnavailable):
+        index.rebuild_all()
+
+    assert len(retained) == 1
+    temporary = retained[0]
+    assert index.path.read_bytes() == old_live
+    assert temporary.exists()
+    with closing(sqlite3.connect(temporary)) as conn:
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+
+    monkeypatch.setattr(graph_sync, "replace_sidecar", original_replace)
+    index.rebuild_all()
+    assert index.path.read_bytes() != old_live
+    assert temporary in graph_sync.sweep_abandoned_temporaries(
+        tmp_path, index.path, live_paths=set()
+    )
+    assert not temporary.exists()
+
+
+def test_temp_sweep_preserves_a_sharing_refused_abandoned_temporary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    temporary.write_bytes(b"complete")
+    original_unlink = Path.unlink
+
+    def sharing_refused(path: Path, *, missing_ok: bool = False) -> None:
+        if path == temporary:
+            raise PermissionError("reader still holds the temporary")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", sharing_refused)
+
+    assert graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths=set()) == []
+    assert temporary.read_bytes() == b"complete"
+
+
+def test_temp_sweep_removes_abandoned_sqlite_companions_but_keeps_active_set(
+    tmp_path: Path,
+) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    abandoned = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    active = graph_sync.temporary_sidecar_path(live, _checkpoint(1))
+    abandoned_set = (
+        abandoned,
+        *(
+            abandoned.with_name(f"{abandoned.name}{suffix}")
+            for suffix in ("-journal", "-wal", "-shm")
+        ),
+    )
+    active_set = (
+        active,
+        *(active.with_name(f"{active.name}{suffix}") for suffix in ("-journal", "-wal", "-shm")),
+    )
+    for path in (*abandoned_set, *active_set):
+        path.write_bytes(b"sqlite artifact")
+
+    removed = graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths={active})
+
+    assert set(removed) == set(abandoned_set)
+    assert all(not path.exists() for path in abandoned_set)
+    assert all(path.exists() for path in active_set)

--- a/tests/test_graph_rebuild_locking.py
+++ b/tests/test_graph_rebuild_locking.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+import stat
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from exomem import graph_sync
+from exomem.cli_ops import OpError
+from exomem.writer_lease import LeaseConfig, LeaseManager
+
+
+def _checkpoint(generation: int = 1) -> graph_sync.GraphSyncCheckpoint:
+    return graph_sync.GraphSyncCheckpoint.create(
+        generation=generation,
+        mutation_id=f"{generation:024x}",
+        paths=(),
+        created_paths=(),
+        scope="full",
+    )
+
+
+def _claim_in_child(vault_root: str, temporary: str, claimed) -> None:  # noqa: ANN001
+    from exomem import graph_sync as graph_sync_module
+
+    result = graph_sync_module.claim_rebuild_owner(Path(vault_root), Path(temporary))
+    claimed.put(result)
+    if result:
+        graph_sync_module.release_rebuild_owner(Path(vault_root), Path(temporary))
+
+
+def _claim_in_child_at_root(
+    vault_root: str, temporary: str, state_root: str, claimed  # noqa: ANN001
+) -> None:
+    from exomem import graph_sync as graph_sync_module
+
+    root = Path(state_root)
+    result = graph_sync_module.claim_rebuild_owner(
+        Path(vault_root), Path(temporary), state_root=root
+    )
+    claimed.put(result)
+    if result:
+        graph_sync_module.release_rebuild_owner(
+            Path(vault_root), Path(temporary), state_root=root
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and mode contract")
+def test_rebuild_lock_requires_a_trusted_runtime_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root = tmp_path / "runtime-state"
+    state_root.mkdir(mode=0o777)
+    state_root.chmod(0o777)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
+
+    with pytest.raises(graph_sync.GraphRebuildLockUnavailable):
+        graph_sync.claim_rebuild_owner(tmp_path / "vault", tmp_path / "temporary.sqlite")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and mode contract")
+def test_rebuild_lock_lives_directly_beneath_trusted_runtime_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root = tmp_path / "runtime-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
+    vault_root = tmp_path / "vault"
+    temporary = tmp_path / "temporary.sqlite"
+
+    assert graph_sync.claim_rebuild_owner(vault_root, temporary)
+    try:
+        lock = graph_sync._rebuild_lock_path(vault_root)
+        assert lock.parent == state_root
+        info = lock.stat()
+        assert stat.S_IMODE(info.st_mode) == 0o600
+        assert info.st_uid == os.getuid()
+        assert lock.is_file()
+    finally:
+        graph_sync.release_rebuild_owner(vault_root, temporary)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and mode contract")
+def test_rebuild_lock_rejects_an_existing_non_owner_only_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_root = tmp_path / "runtime-state"
+    state_root.mkdir(mode=0o700)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
+    vault_root = tmp_path / "vault"
+    lock = graph_sync._rebuild_lock_path(vault_root)
+    lock.write_bytes(b"\0")
+    lock.chmod(0o644)
+
+    with pytest.raises(graph_sync.GraphRebuildLockUnavailable):
+        graph_sync.claim_rebuild_owner(vault_root, tmp_path / "temporary.sqlite")
+
+
+def test_legacy_lock_child_has_no_authority_over_the_direct_runtime_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_root = tmp_path / "runtime-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_root))
+    vault_root = tmp_path / "vault"
+    first = tmp_path / "first.sqlite"
+    second = tmp_path / "second.sqlite"
+
+    assert graph_sync.claim_rebuild_owner(vault_root, first)
+    try:
+        legacy_child = state_root / "graph-rebuild-locks"
+        legacy_child.mkdir()
+        os.replace(legacy_child, state_root / "renamed-legacy-locks")
+        context = multiprocessing.get_context("spawn")
+        claimed = context.Queue()
+        contender = context.Process(
+            target=_claim_in_child,
+            args=(str(vault_root), str(second), claimed),
+        )
+        contender.start()
+        contender.join(10)
+        assert contender.exitcode == 0
+        assert claimed.get(timeout=2) is False
+    finally:
+        graph_sync.release_rebuild_owner(vault_root, first)
+
+
+def test_explicit_rebuild_runtime_root_overrides_ambient_environment_and_coalesces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ambient_root = tmp_path / "ambient-state"
+    manager_root = tmp_path / "manager-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(ambient_root))
+    vault_root = tmp_path / "vault"
+    first = tmp_path / "first.sqlite"
+    second = tmp_path / "second.sqlite"
+
+    assert graph_sync.claim_rebuild_owner(vault_root, first, state_root=manager_root)
+    try:
+        lock = graph_sync._rebuild_lock_path(vault_root, state_root=manager_root)
+        assert lock.parent == manager_root
+        assert lock.exists()
+        assert not graph_sync._rebuild_lock_path(vault_root).exists()
+        context = multiprocessing.get_context("spawn")
+        claimed = context.Queue()
+        contender = context.Process(
+            target=_claim_in_child_at_root,
+            args=(str(vault_root), str(second), str(manager_root), claimed),
+        )
+        contender.start()
+        contender.join(10)
+        assert contender.exitcode == 0
+        assert claimed.get(timeout=2) is False
+    finally:
+        graph_sync.release_rebuild_owner(vault_root, first, state_root=manager_root)
+
+
+def test_index_full_rebuild_claim_uses_its_bound_manager_runtime_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    ambient_root = tmp_path / "ambient-state"
+    manager_root = tmp_path / "manager-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(ambient_root))
+    vault_root = tmp_path / "vault"
+    note = vault_root / "Knowledge Base/Notes/bound-rebuild.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Bound rebuild\n", encoding="utf-8")
+    manager = LeaseManager(LeaseConfig(state_dir=manager_root))
+    captured: dict[str, epistemic_graph.EpistemicGraphIndex] = {}
+    command = SimpleNamespace(
+        name="bound-rebuild",
+        read_only=False,
+        leaf=lambda root: captured.setdefault("index", epistemic_graph.EpistemicGraphIndex(root)),
+    )
+
+    manager.invoke(command, (vault_root,), {})
+    captured["index"].rebuild_all()
+
+    assert graph_sync._rebuild_lock_path(vault_root, state_root=manager_root).exists()
+    assert not graph_sync._rebuild_lock_path(vault_root).exists()
+
+
+def test_explicit_temp_sweep_uses_the_bound_runtime_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ambient_root = tmp_path / "ambient-state"
+    manager_root = tmp_path / "manager-state"
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(ambient_root))
+    vault_root = tmp_path / "vault"
+    live = vault_root / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint())
+    temporary.write_bytes(b"private")
+
+    assert graph_sync.sweep_abandoned_temporaries(
+        vault_root, live, live_paths=set(), state_root=manager_root
+    ) == [temporary]
+    assert graph_sync._rebuild_lock_path(vault_root, state_root=manager_root).exists()
+    assert not graph_sync._rebuild_lock_path(vault_root).exists()
+
+
+def test_overlapping_custom_manager_registrations_do_not_cross_coalesce(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    state_a = tmp_path / "state-a"
+    state_b = tmp_path / "state-b"
+    first_started = threading.Event()
+    release_first = threading.Event()
+    observed: list[tuple[str, int]] = []
+
+    def build_a(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        observed.append(("a", checkpoint.generation))
+        first_started.set()
+        assert release_first.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    def build_b(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        observed.append(("b", checkpoint.generation))
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    first = graph_sync.register_rebuild(
+        vault_root, _checkpoint(1), build_a, state_root=state_a
+    )
+    first.start()
+    assert first_started.wait(1)
+    second = graph_sync.register_rebuild(
+        vault_root, _checkpoint(2), build_b, state_root=state_b
+    )
+    assert second.wait(1).covers(_checkpoint(2))
+    release_first.set()
+    assert first.wait(1).covers(_checkpoint(1))
+    assert observed == [("a", 1), ("b", 2)]
+
+
+def test_joined_builder_requires_reader_valid_sidecar_before_claiming_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    vault_root = tmp_path / "vault"
+    note = vault_root / "Knowledge Base/Notes/join-proof.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Join proof\n", encoding="utf-8")
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    index.rebuild_all()
+    checkpoint = graph_sync.GraphSyncCheckpoint.create(
+        generation=1,
+        mutation_id="1" * 24,
+        paths=(("Knowledge Base/Notes/join-proof.md", "a" * 64),),
+        created_paths=(),
+    )
+    graph_sync._write_floor(vault_root, graph_sync.GraphSyncGenerationFloor.create(1))
+    graph_sync._write_checkpoint(vault_root, checkpoint)
+    with index._connect() as connection:
+        index._write_graph_sync_acknowledgement(connection, checkpoint)
+        connection.execute("DELETE FROM graph_meta WHERE key = 'schema_version'")
+        connection.commit()
+    assert graph_sync.status(vault_root)["state"] == "current"
+    assert index.available() is False
+    original_wait = graph_sync.wait_for_current
+    monkeypatch.setattr(graph_sync, "claim_rebuild_owner", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        graph_sync,
+        "wait_for_current",
+        lambda root, required, **kwargs: original_wait(
+            root, required, timeout_seconds=0.01, **kwargs
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="did not publish a current sidecar"):
+        index._rebuild_all_off_boundary()
+
+
+def test_joined_builder_accepts_a_reader_valid_higher_generation_sidecar(tmp_path: Path) -> None:
+    from exomem import epistemic_graph
+
+    vault_root = tmp_path / "vault"
+    note = vault_root / "Knowledge Base/Notes/superseded.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Superseded\n", encoding="utf-8")
+    required = _checkpoint(1)
+    current = _checkpoint(2)
+    graph_sync._write_floor(vault_root, graph_sync.GraphSyncGenerationFloor.create(2))
+    graph_sync._write_checkpoint(vault_root, current)
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    index.rebuild_all()
+
+    assert graph_sync.status(vault_root)["state"] == "current"
+    assert index.available()
+    assert graph_sync.wait_for_current(
+        vault_root, required, availability=index.available, timeout_seconds=0.1
+    )
+
+
+def test_pending_registrations_are_isolated_by_runtime_root(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    state_a = tmp_path / "state-a"
+    state_b = tmp_path / "state-b"
+    first = graph_sync.register_rebuild(
+        vault_root,
+        _checkpoint(1),
+        lambda checkpoint: graph_sync.GraphBuildOutcome.covering(checkpoint),
+        state_root=state_a,
+    )
+    second = graph_sync.register_rebuild(
+        vault_root,
+        _checkpoint(2),
+        lambda checkpoint: graph_sync.GraphBuildOutcome.covering(checkpoint),
+        state_root=state_b,
+    )
+
+    assert graph_sync.registered_checkpoint(vault_root, state_root=state_a) == _checkpoint(1)
+    assert graph_sync.registered_checkpoint(vault_root, state_root=state_b) == _checkpoint(2)
+    assert graph_sync.start_registered(vault_root, state_root=state_a) is not None
+    assert graph_sync.start_registered(vault_root, state_root=state_b) is not None
+    assert graph_sync.wait_for_registered(vault_root, state_root=state_a).covers(_checkpoint(1))
+    assert graph_sync.wait_for_registered(vault_root, state_root=state_b).covers(_checkpoint(2))
+    assert first.wait(1).covers(_checkpoint(1))
+    assert second.wait(1).covers(_checkpoint(2))
+
+
+def test_registration_start_does_not_consume_waiter_capacity(tmp_path: Path) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        entered.set()
+        assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    registration = graph_sync.GraphRebuildRegistration(coordinator, _checkpoint(), build)
+    registration.start()
+    assert entered.wait(1)
+    for _ in range(255):
+        registration.start()
+    assert coordinator.waiter_count == 0
+    release.set()
+
+
+def test_join_releases_waiter_capacity_after_timeout(tmp_path: Path) -> None:
+    coordinator = graph_sync.GraphRebuildCoordinator(tmp_path)
+    release = threading.Event()
+
+    def build(checkpoint: graph_sync.GraphSyncCheckpoint) -> graph_sync.GraphBuildOutcome:
+        assert release.wait(2)
+        return graph_sync.GraphBuildOutcome.covering(checkpoint)
+
+    coordinator.ensure_started(_checkpoint(), build)
+    with pytest.raises(TimeoutError):
+        coordinator.join(_checkpoint()).wait(0.01)
+    assert coordinator.waiter_count == 0
+    release.set()
+
+
+def test_full_rebuild_constructor_failure_releases_owned_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    index = epistemic_graph.EpistemicGraphIndex(tmp_path)
+
+    class BrokenTemporaryIndex:
+        def __init__(self, _vault_root: Path, **_kwargs: object) -> None:
+            raise RuntimeError("temporary index construction failed")
+
+    monkeypatch.setattr(epistemic_graph, "EpistemicGraphIndex", BrokenTemporaryIndex)
+    with pytest.raises(RuntimeError, match="temporary index construction failed"):
+        index._rebuild_all_off_boundary()
+
+    assert not graph_sync._REBUILD_LOCK_HANDLES
+    assert not graph_sync.live_temporary_paths()
+    assert not list((tmp_path / "Knowledge Base").glob(".graph-rebuild-*.sqlite"))
+
+
+def test_temp_sweep_never_removes_an_in_process_registered_temp(tmp_path: Path) -> None:
+    live = tmp_path / "Knowledge Base/.graph.sqlite"
+    live.parent.mkdir(parents=True)
+    temporary = graph_sync.temporary_sidecar_path(live, _checkpoint())
+    temporary.write_bytes(b"private")
+    graph_sync.register_temporary(temporary)
+    try:
+        assert graph_sync.sweep_abandoned_temporaries(tmp_path, live, live_paths=set()) == []
+        assert temporary.exists()
+    finally:
+        graph_sync.unregister_temporary(temporary)
+
+
+def test_final_graph_publish_uses_the_lease_manager_mutation_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph, writer_lease
+
+    state_root = tmp_path / "configured-state"
+    vault_root = tmp_path / "vault"
+    manager = LeaseManager(
+        LeaseConfig(state_dir=state_root), mutation_timeout_seconds=0.01
+    )
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    publisher = index._canonical_mutation_coordinator()
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_final_publish() -> None:
+        with publisher.hold(operation="epistemic_graph_publish_rebuild", holder_kind="graph"):
+            entered.set()
+            assert release.wait(2)
+
+    thread = threading.Thread(target=hold_final_publish)
+    thread.start()
+    assert entered.wait(1)
+    try:
+        with pytest.raises(OpError, match="MUTATION_BUSY"):
+            with manager.mutation_guard(vault_root):
+                pytest.fail("writer entered during final graph publication")
+    finally:
+        release.set()
+        thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert publisher.state_root == state_root
+
+
+def test_registered_builder_retains_the_originating_custom_lease_boundary(
+    tmp_path: Path,
+) -> None:
+    from exomem import epistemic_graph
+
+    state_root = tmp_path / "custom-state"
+    vault_root = tmp_path / "vault"
+    manager = LeaseManager(LeaseConfig(state_dir=state_root))
+    captured: dict[str, epistemic_graph.EpistemicGraphIndex] = {}
+    command = SimpleNamespace(
+        name="graph-boundary-test",
+        read_only=False,
+        leaf=lambda root: captured.setdefault("index", epistemic_graph.EpistemicGraphIndex(root)),
+    )
+
+    manager.invoke(command, (vault_root,), {})
+    index = captured["index"]
+    observed_roots: list[Path] = []
+    registration = graph_sync.register_rebuild(
+        vault_root,
+        _checkpoint(),
+        lambda checkpoint: (
+            observed_roots.append(index._canonical_mutation_coordinator().state_root),
+            graph_sync.GraphBuildOutcome.covering(checkpoint),
+        )[1],
+    )
+
+    assert registration.wait(1).covers(_checkpoint())
+    assert observed_roots == [state_root]
+
+
+def test_graph_swap_waits_for_a_real_lease_manager_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph, writer_lease
+
+    state_root = tmp_path / "configured-state"
+    vault_root = tmp_path / "vault"
+    note = vault_root / "Knowledge Base/Notes/graph-race.md"
+    note.parent.mkdir(parents=True)
+    note.write_text("# Graph race\n", encoding="utf-8")
+    manager = LeaseManager(
+        LeaseConfig(state_dir=state_root), mutation_timeout_seconds=1
+    )
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
+    index = epistemic_graph.EpistemicGraphIndex(vault_root)
+    writer_entered = threading.Event()
+    release_writer = threading.Event()
+    private_build_finished = threading.Event()
+    publish_entered = threading.Event()
+    rebuilt: list[object] = []
+
+    def hold_writer() -> None:
+        with manager.mutation_guard(vault_root):
+            writer_entered.set()
+            assert release_writer.wait(2)
+
+    def publication_seam(_temporary: Path, _live: Path) -> None:
+        publish_entered.set()
+
+    original_rebuild = epistemic_graph.EpistemicGraphIndex._rebuild_all_locked
+
+    def private_rebuild_finished(self):  # noqa: ANN001
+        report = original_rebuild(self)
+        private_build_finished.set()
+        return report
+
+    index._before_publish_replacement = publication_seam  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        epistemic_graph.EpistemicGraphIndex, "_rebuild_all_locked", private_rebuild_finished
+    )
+    writer = threading.Thread(target=hold_writer)
+    writer.start()
+    assert writer_entered.wait(1)
+    rebuilder = threading.Thread(target=lambda: rebuilt.append(index.rebuild_all()))
+    rebuilder.start()
+    try:
+        assert private_build_finished.wait(2)
+        assert not publish_entered.is_set()
+    finally:
+        release_writer.set()
+        writer.join(timeout=2)
+        rebuilder.join(timeout=5)
+    assert not writer.is_alive()
+    assert not rebuilder.is_alive()
+    assert publish_entered.is_set()
+    assert rebuilt

--- a/tests/test_hosted_portability.py
+++ b/tests/test_hosted_portability.py
@@ -100,6 +100,15 @@ def _raw_zip(
         ("Knowledge Base/_Schema/project-keys.yaml", "canonical"),
         ("Knowledge Base/_trash/2026-07-12/note.md", "canonical"),
         ("Knowledge Base/.review-state.json", "portable-derived"),
+        (
+            "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json",
+            "portable-derived",
+        ),
+        ("Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json.bak", "disposable-runtime"),
+        ("Knowledge Base/.graph-commit-receipts/0123456789ABCDEF01234567.json", "disposable-runtime"),
+        ("Secrets/.graph-commit-receipts/.env", "disposable-runtime"),
+        (".graph-commit-receipts/private.pem", "disposable-runtime"),
+        ("Knowledge Base/Notes/.graph-commit-receipts/secret.txt", "disposable-runtime"),
         ("Knowledge Base/.embeddings.sqlite", "disposable-runtime"),
         ("Knowledge Base/.embeddings.sqlite-wal", "disposable-runtime"),
         ("Knowledge Base/.lexical.sqlite-shm", "disposable-runtime"),
@@ -135,6 +144,29 @@ def test_versioned_artifact_classification_registry(path: str, expected: str) ->
     assert classification.artifact_class.value == expected
     assert portability.classification_registry()["version"] == 1
     assert portability.classification_registry()["rules"]
+
+
+def test_graph_commit_receipt_classification_uses_configured_kb_dirname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXOMEM_KB_DIRNAME", "Brain")
+
+    assert (
+        portability.classify_artifact(
+            "Brain/.graph-commit-receipts/0123456789abcdef01234567.json"
+        ).artifact_class
+        is portability.ArtifactClass.PORTABLE_DERIVED
+    )
+    assert (
+        portability.classify_artifact(
+            "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json"
+        ).artifact_class
+        is portability.ArtifactClass.DISPOSABLE_RUNTIME
+    )
+    assert (
+        portability.classify_artifact("Brain/.graph-commit-receipts/private.pem").artifact_class
+        is portability.ArtifactClass.DISPOSABLE_RUNTIME
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_index_sync.py
+++ b/tests/test_index_sync.py
@@ -10,6 +10,7 @@ from exomem import (
     embeddings,
     epistemic_graph,
     freshness,
+    graph_sync,
     index_sync,
     readiness,
     semantic_contract,
@@ -224,10 +225,78 @@ def test_upsert_report_contains_failures_and_continues_single_fanout(
     assert _outcome(report, "lexstore").code == "dispatch_failed"
     assert _outcome(report, "memory_refs").code == "accepted_unverified"
     assert _outcome(report, "resolver").outcome == "completed"
-    assert _outcome(report, "epistemic_graph").code == "accepted_unverified"
+    assert _outcome(report, "epistemic_graph").outcome == "failed"
+    assert _outcome(report, "epistemic_graph").code == "graph_outcome_missing"
     assert _outcome(report, "embeddings").outcome == "completed"
     assert report.reconcile_required is True
     assert "private lexstore detail" not in repr(report)
+
+
+def test_upsert_report_marks_synchronous_legacy_callbacks_completed(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "Knowledge Base" / "Notes" / "item.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Item\n", encoding="utf-8")
+
+    report = index_sync.upsert_after_write(tmp_path, [target])
+
+    assert _outcome(report, "lexstore").outcome == "completed"
+    assert _outcome(report, "memory_refs").outcome == "completed"
+    assert all(item.code != "accepted_unverified" for item in report.components)
+
+
+def test_delete_report_marks_known_synchronous_callbacks_completed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import epistemic_graph
+
+    rel = "Knowledge Base/Notes/item.md"
+    monkeypatch.setattr(index_sync, "publish_corpus_delta", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        epistemic_graph,
+        "upsert_after_write",
+        lambda *_args, **_kwargs: epistemic_graph.GraphDispatchResult(
+            "completed", "incremental_completed"
+        ),
+    )
+
+    report = index_sync.delete_after_remove(tmp_path, [rel])
+
+    assert _outcome(report, "lexstore").outcome == "completed"
+    assert _outcome(report, "memory_refs").outcome == "completed"
+    assert _outcome(report, "claims").outcome == "completed"
+    assert _outcome(report, "clip").as_dict() == {
+        "component": "clip",
+        "outcome": "accepted",
+        "code": "clip_disabled",
+    }
+    assert all(item.code != "accepted_unverified" for item in report.components)
+
+
+def test_legacy_callback_internal_failures_report_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import lexstore, memory_refs
+
+    target = tmp_path / "Knowledge Base" / "Notes" / "item.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Item\n", encoding="utf-8")
+    lexstore.lexical_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    lexstore.lexical_path(tmp_path).touch()
+    monkeypatch.setattr(
+        lexstore,
+        "get_store",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("lexstore failure")),
+    )
+    monkeypatch.setattr(
+        memory_refs,
+        "ReferenceIndex",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("memory ref failure")),
+    )
+
+    assert lexstore.upsert_after_write(tmp_path, [target]) is False
+    assert memory_refs.upsert_after_write(tmp_path, [target]) is False
 
 
 def test_durable_defer_report_does_not_enter_embedding_warmup_queue(
@@ -238,8 +307,13 @@ def test_durable_defer_report_does_not_enter_embedding_warmup_queue(
     target = tmp_path / "Knowledge Base" / "Notes" / "item.md"
     target.parent.mkdir(parents=True)
     target.write_text("# Item\n", encoding="utf-8")
-    for module in (lexstore, memory_refs, epistemic_graph):
+    for module in (lexstore, memory_refs):
         monkeypatch.setattr(module, "upsert_after_write", lambda *_args: None)
+    monkeypatch.setattr(
+        epistemic_graph,
+        "upsert_after_write",
+        lambda *_args: epistemic_graph.GraphDispatchResult("completed", "incremental_completed"),
+    )
     monkeypatch.setattr(find, "on_resolver_files_changed", lambda *_args: None)
     monkeypatch.setattr(
         embeddings,
@@ -357,7 +431,17 @@ def test_batch_atomic_write_collector_observes_existing_fanout_once(
         index_reports=collected,
     )
 
+    # Epoch publication wraps the canonical write, but it is internal to the
+    # batch: callers only receive the paths they supplied.
     assert replaced == [target]
+    floor = graph_sync.read_floor(tmp_path)
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert floor is not None
+    assert checkpoint is not None
+    assert checkpoint.generation == floor.generation
+    assert checkpoint.paths == (
+        ("Knowledge Base/Notes/item.md", vault_module.content_hash("# Item\n")),
+    )
     assert calls == [[target]]
     assert kwargs_seen == [
         {
@@ -366,6 +450,20 @@ def test_batch_atomic_write_collector_observes_existing_fanout_once(
         }
     ]
     assert collected == [report]
+
+
+def test_batch_atomic_write_hides_internal_epoch_paths_without_fanout(tmp_path: Path) -> None:
+    target = tmp_path / "Knowledge Base" / "Notes" / "item.md"
+
+    replaced = vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(target, "# Item\n")],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+
+    assert replaced == [target]
+    assert graph_sync.read_floor(tmp_path) is not None
+    assert graph_sync.read_checkpoint(tmp_path) is not None
 
 
 def test_graph_lock_error_reaches_index_sync_as_degraded(
@@ -394,8 +492,8 @@ def test_graph_lock_error_reaches_index_sync_as_degraded(
     report = index_sync.upsert_after_write(tmp_path, [target])
 
     graph = _outcome(report, "epistemic_graph")
-    assert graph.outcome == "degraded"
-    assert graph.code == "dispatch_failed"
+    assert graph.outcome == "failed"
+    assert graph.code == "graph_dispatch_failed"
     assert report.reconcile_required is True
 
 
@@ -431,10 +529,7 @@ def test_publication_failure_withdraws_stale_graph_and_resolver(
     )
     assert warning is None
     assert resolved == "Knowledge Base/Notes/b"
-    assert graph.available() is True
-    assert graph.relation_participants(["links_to"]).paths == frozenset(
-        {"Knowledge Base/Notes/a.md", "Knowledge Base/Notes/b.md"}
-    )
+    assert graph.available() is False
 
 
 def test_delete_publication_failure_cannot_leave_graph_current_at_old_checkpoint(
@@ -460,9 +555,7 @@ def test_delete_publication_failure_cannot_leave_graph_current_at_old_checkpoint
     assert report.reconcile_required is True
     assert _outcome(report, "epistemic_graph").code == "publication_failed"
     assert freshness.recall_is_live(tmp_path, "vault") is False
-    assert graph.available() is True
-    assert graph.nodes(path="Knowledge Base/Notes/b.md") == []
-    assert graph.relation_participants(["links_to"]).paths == frozenset()
+    assert graph.available() is False
 
 
 def test_delete_report_continues_after_observable_component_failure(

--- a/tests/test_index_trash_exclusion.py
+++ b/tests/test_index_trash_exclusion.py
@@ -536,7 +536,13 @@ def test_full_index_drain_keeps_work_when_embeddings_report_incomplete(
     monkeypatch.setattr(lexstore, "upsert_after_write", lambda *_a, **_kw: None)
     monkeypatch.setattr(memory_refs, "upsert_after_write", lambda *_a, **_kw: None)
     monkeypatch.setattr(find, "on_resolver_files_changed", lambda *_a, **_kw: None)
-    monkeypatch.setattr(epistemic_graph, "upsert_after_write", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        epistemic_graph,
+        "upsert_after_write",
+        lambda *_a, **_kw: epistemic_graph.GraphDispatchResult(
+            "completed", "incremental_completed"
+        ),
+    )
     monkeypatch.setattr(
         embeddings,
         "upsert_after_write_status",

--- a/tests/test_media_deletion_propagation.py
+++ b/tests/test_media_deletion_propagation.py
@@ -80,7 +80,7 @@ def test_delete_after_remove_drops_clip_rows(
     assert gen_after > gen_before
     clip_outcome = _outcome(report, "clip")
     assert clip_outcome.outcome == "completed"
-    assert clip_outcome.code == "dispatch_completed"
+    assert clip_outcome.code == "clip_delete_completed"
 
 
 def test_delete_after_remove_clip_extra_absent_delete_still_succeeds(
@@ -95,8 +95,8 @@ def test_delete_after_remove_clip_extra_absent_delete_still_succeeds(
     report = index_sync.delete_after_remove(vault, [rel])
 
     clip_outcome = _outcome(report, "clip")
-    assert clip_outcome.outcome == "completed"  # never breaks the delete
-    assert clip_outcome.code == "dispatch_completed"
+    assert clip_outcome.outcome == "accepted"  # never breaks the delete
+    assert clip_outcome.code == "clip_disabled"
     assert report.reconcile_required is False
 
 
@@ -144,7 +144,11 @@ def test_delete_after_remove_scene_frames_noop_when_no_frames_dir(
 
     report = index_sync.delete_after_remove(vault, [video_rel])
 
-    assert _outcome(report, "clip").outcome == "completed"
+    assert _outcome(report, "clip").as_dict() == {
+        "component": "clip",
+        "outcome": "accepted",
+        "code": "clip_disabled",
+    }
 
 
 # ---- 3. Media-binary fan-out gate -------------------------------------------
@@ -238,7 +242,12 @@ def test_delete_file_non_media_non_md_keeps_current_behavior(
     )
 
     assert not target.exists()
-    assert result.index is None
+    assert result.index == {
+        "components": [],
+        "derived_work": "not_required",
+        "paths_truncated": False,
+        "reconcile_required": False,
+    }
 
 
 def test_delete_directory_media_binaries_enter_fanout(

--- a/tests/test_mutation_lock.py
+++ b/tests/test_mutation_lock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import multiprocessing
@@ -12,7 +13,30 @@ import pytest
 
 from exomem import mutation_lock as mutation_lock_module
 from exomem.cli_ops import OpError
-from exomem.mutation_lock import VaultMutationCoordinator, active_mutation_snapshot
+from exomem.mutation_lock import (
+    VaultMutationCoordinator,
+    active_mutation_snapshot,
+    last_mutation_timing,
+)
+
+
+def test_windows_path_inspection_access_has_dacl_read_right_without_mutation_rights() -> None:
+    access = inspect.signature(mutation_lock_module._windows_open_path).parameters["access"].default
+
+    assert isinstance(access, int)
+    assert access & 0x00000080  # FILE_READ_ATTRIBUTES
+    assert access & 0x00020000  # READ_CONTROL, required by GetSecurityInfo(DACL)
+    assert not access & 0x40000000  # GENERIC_WRITE
+    assert not access & 0x00010000  # DELETE
+
+
+def test_windows_private_dacl_deduplicates_local_system_principal() -> None:
+    sddl = mutation_lock_module._windows_private_dacl_sddl("S-1-5-18")
+
+    assert sddl == "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+    assert mutation_lock_module._windows_private_dacl_is_valid(
+        sddl, "S-1-5-18", directory=True
+    )
 
 
 def _process_hold(
@@ -651,6 +675,22 @@ def test_hold_emits_acquired_and_released_events_with_timing(
     assert acquired.fields["operation"] == "remember"
     assert isinstance(released.fields["hold_ms"], float)
     assert released.fields["operation"] == "remember"
+
+
+def test_last_mutation_timing_identifies_the_completed_operation(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    coordinator = VaultMutationCoordinator(tmp_path / "state", vault)
+
+    with coordinator.hold(operation="epistemic_graph_publish_rebuild", holder_kind="graph"):
+        pass
+
+    timing = last_mutation_timing()
+    assert timing is not None
+    assert timing["wait_ms"] >= 0.0
+    assert timing["hold_ms"] >= 0.0
+    assert timing["operation"] == "epistemic_graph_publish_rebuild"
+    assert timing["holder_kind"] == "graph"
 
 
 def test_long_hold_warning_is_guaranteed_on_release_without_any_probe(

--- a/tests/test_mutation_terminal.py
+++ b/tests/test_mutation_terminal.py
@@ -22,7 +22,6 @@ def test_compact_projection_leads_with_decisive_commit_fields() -> None:
         "warnings": ["review a link"],
         "semantic": {"transition": "verbose"},
     }
-
     terminal = mutation_terminal.committed_terminal(
         raw,
         request_id="11111111-1111-4111-8111-111111111111",
@@ -43,6 +42,27 @@ def test_compact_projection_leads_with_decisive_commit_fields() -> None:
         "warnings_count": 1,
     }
 
+
+def test_compact_terminal_retains_completed_graph_sync_fields() -> None:
+    mutation_terminal = _terminal_module()
+    terminal = mutation_terminal.committed_terminal(
+        {
+            "graph_sync": "failed",
+            "graph_sync_code": "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+            "graph_sync_checkpoint": "a" * 64,
+            "graph_sync_remediation": "Run reconcile to recover the derived graph.",
+        },
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    projected = mutation_terminal.project_terminal(terminal)
+
+    assert projected["graph_sync"] == "failed"
+    assert projected["graph_sync_code"] == "GRAPH_SYNC_STABILIZATION_EXHAUSTED"
+    assert projected["graph_sync_checkpoint"] == "a" * 64
+    assert projected["graph_sync_remediation"] == "Run reconcile to recover the derived graph."
 
 def test_full_projection_adds_the_complete_leaf_result_only_under_diagnostics() -> None:
     mutation_terminal = _terminal_module()
@@ -450,11 +470,13 @@ def test_one_committed_identity_projects_compact_full_and_legacy_without_rerun(
         return raw
 
     command = SimpleNamespace(name="remember", leaf=leaf, read_only=False)
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
     manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=tmp_path / "state"))
     first_request_id = "11111111-1111-4111-8111-111111111111"
     compact = manager.invoke(
         command,
-        (tmp_path / "vault",),
+        (vault,),
         {"value": 7, "response_detail": "compact"},
         idempotency_key="same-public-key",
         idempotency_principal_scope="principal:one",
@@ -462,7 +484,7 @@ def test_one_committed_identity_projects_compact_full_and_legacy_without_rerun(
     )
     full = manager.invoke(
         command,
-        (tmp_path / "vault",),
+        (vault,),
         {"value": 7, "response_detail": "full"},
         idempotency_key="same-public-key",
         idempotency_principal_scope="principal:one",
@@ -470,7 +492,7 @@ def test_one_committed_identity_projects_compact_full_and_legacy_without_rerun(
     )
     legacy = manager.invoke(
         command,
-        (tmp_path / "vault",),
+        (vault,),
         {"value": 7, "response_detail": "legacy"},
         idempotency_key="same-public-key",
         idempotency_principal_scope="principal:one",
@@ -502,12 +524,14 @@ def test_internal_replay_key_is_separate_from_public_terminal_identity(
         return {"path": "Knowledge Base/hosted.md", "warnings": []}
 
     command = SimpleNamespace(name="remember", leaf=leaf, read_only=False)
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
     manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=tmp_path / "state"))
     internal_key = "hosted:" + "a" * 64
 
     terminal = manager.invoke(
         command,
-        (tmp_path / "vault",),
+        (vault,),
         {},
         idempotency_key=internal_key,
         public_idempotency_key=public_key,
@@ -575,6 +599,8 @@ def test_acknowledgement_loss_replays_the_persisted_original_terminal(
             raise asyncio.CancelledError
 
     command = SimpleNamespace(name="remember", leaf=leaf, read_only=False)
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
     manager = writer_lease.LeaseManager(
         writer_lease.LeaseConfig(state_dir=tmp_path / "state"),
         after_terminal_persisted=after_terminal_persisted,
@@ -583,7 +609,7 @@ def test_acknowledgement_loss_replays_the_persisted_original_terminal(
     with pytest.raises(asyncio.CancelledError):
         manager.invoke(
             command,
-            (tmp_path / "vault",),
+            (vault,),
             {"response_detail": "compact"},
             idempotency_key="ack-lost",
             mutation_request_id=first_request_id,
@@ -591,7 +617,7 @@ def test_acknowledgement_loss_replays_the_persisted_original_terminal(
 
     replay = manager.invoke(
         command,
-        (tmp_path / "vault",),
+        (vault,),
         {"response_detail": "full"},
         idempotency_key="ack-lost",
         mutation_request_id="22222222-2222-4222-8222-222222222222",

--- a/tests/test_observe_memory.py
+++ b/tests/test_observe_memory.py
@@ -67,9 +67,10 @@ def test_add_compact_observation_is_canonical_addressable_and_indexed(
     assert state.document.resolve_unit(result["unit_ref"]).status == "found"
     assert result["semantic"]["index"]["requested_paths"][-1] == PAGE
     assert all(
-        component["outcome"] in {"accepted", "completed", "deferred", "degraded"}
+        component["outcome"]
+        in {"accepted", "completed", "registered", "deferred", "degraded"}
         for component in result["semantic"]["index"]["components"]
-    )
+    ), result["semantic"]["index"]
 
 
 def test_validate_assigns_anchor_from_canonical_rendered_fields(tmp_path: Path) -> None:

--- a/tests/test_product_e2e_helpers.py
+++ b/tests/test_product_e2e_helpers.py
@@ -259,6 +259,25 @@ def test_mutation_diagnostics_requires_and_unwraps_committed_full_envelope() -> 
     ) == diagnostics
 
 
+def test_mutation_diagnostics_rejects_explicit_graph_sync_failure() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="capture_source graph synchronization failed: GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+    ):
+        e2e_product_loop._mutation_diagnostics(
+            {
+                "ok": True,
+                "status": "committed",
+                "mutated": True,
+                "diagnostics": {
+                    "graph_sync": "failed",
+                    "graph_sync_code": "GRAPH_SYNC_STABILIZATION_EXHAUSTED",
+                },
+            },
+            operation="capture_source",
+        )
+
+
 @pytest.mark.parametrize(
     ("result", "expected"),
     [

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -20,6 +20,7 @@ from exomem import (
     activation_manifest,
     commands,
     freshness,
+    graph_sync,
     index_sync,
     relation_review,
     semantic_contract,
@@ -203,6 +204,33 @@ def test_reconcile_does_not_report_relation_disposition_for_inactive_external_dr
     payload = reconcile_module.reconcile(tmp_path, dry_run=True).as_dict()
 
     assert payload["semantic_contract_findings"] == []
+
+
+def test_reconcile_repairs_ahead_floor_and_older_checkpoint_with_full_recovery(
+    tmp_path: Path,
+) -> None:
+    page = tmp_path / "Knowledge Base/Notes/Insights/ahead-floor.md"
+    page.parent.mkdir(parents=True)
+    vault_module.batch_atomic_write(
+        [
+            vault_module.PlannedWrite(
+                page,
+                _semantic_page("00000000-0000-4000-8000-000000000299"),
+            )
+        ],
+        vault_root=tmp_path,
+        post_commit_fanout=False,
+    )
+    graph_sync._write_floor(tmp_path, graph_sync.GraphSyncGenerationFloor.create(2))
+
+    report = reconcile_module.reconcile(tmp_path)
+
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert checkpoint is not None
+    assert checkpoint.generation == 3
+    assert checkpoint.scope == "full"
+    assert graph_sync.status(tmp_path)["state"] == "current"
+    assert report.graph_status == "refreshed"
 
 
 def test_reconcile_recomputes_and_clears_repaired_semantic_finding(
@@ -654,6 +682,19 @@ def test_reconcile_reports_malformed_state_and_deletes_nothing(tmp_path: Path) -
     assert malformed.read_text(encoding="utf-8") == "not-json"
     assert stale.read_bytes() == stale_bytes
     assert stale_page.read_bytes() == page_bytes
+
+
+def test_reconcile_fails_closed_without_crashing_on_deep_graph_protocol_json(
+    tmp_path: Path,
+) -> None:
+    nested = ("[" * 2_000 + "0" + "]" * 2_000).encode("ascii")
+    graph_sync.floor_path(tmp_path).parent.mkdir(parents=True)
+    graph_sync.floor_path(tmp_path).write_bytes(nested)
+    graph_sync.checkpoint_path(tmp_path).write_bytes(nested)
+
+    report = reconcile_module.reconcile(tmp_path, dry_run=True)
+
+    assert report.graph_status == "unavailable"
 
 
 @pytest.mark.parametrize("limit_kind", ["single", "aggregate"])

--- a/tests/test_record_audit_protocol.py
+++ b/tests/test_record_audit_protocol.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from record_fixtures import copy_vehicle_maintenance_fixture, copy_x3_fixture
 
-from exomem import record_formats, vault, writer_lease
+from exomem import graph_sync, record_formats, vault, writer_lease
 from exomem import structured_collections as collections
 
 
@@ -17,6 +17,10 @@ def _activity_log(vault: Path) -> None:
     path = vault / "Knowledge Base/log.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("# Activity\n", encoding="utf-8")
+
+
+def _is_caller_target(root: Path, target: Path) -> bool:
+    return target not in {graph_sync.floor_path(root), graph_sync.checkpoint_path(root)}
 
 
 @pytest.fixture(autouse=True)
@@ -576,8 +580,9 @@ def test_caught_and_abrupt_publication_prefixes_leave_rollback_or_gap(
 
     def fail_first(workspace, artifact, target):
         nonlocal calls
-        calls += 1
-        if calls == 1:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == 1:
             raise PermissionError(13, "Access is denied", str(target))
         return real_replace(workspace, artifact, target)
 
@@ -603,8 +608,9 @@ def test_caught_and_abrupt_publication_prefixes_leave_rollback_or_gap(
     def interrupt_after_canonical(workspace, artifact, target):
         nonlocal calls
         result = real_replace(workspace, artifact, target)
-        calls += 1
-        if calls == 1:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == 1:
             raise KeyboardInterrupt("simulated abrupt publication")
         return result
 
@@ -656,8 +662,9 @@ def test_later_log_update_publication_prefixes_roll_back_or_report_gap(
 
     def fail(workspace, artifact, target):
         nonlocal calls
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise PermissionError(13, "Access is denied", str(target))
         return real_replace(workspace, artifact, target)
 
@@ -709,8 +716,9 @@ def test_later_log_update_abrupt_prefixes_are_not_normalized(
     def interrupt(workspace, artifact, target):
         nonlocal calls
         result = real_replace(workspace, artifact, target)
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise KeyboardInterrupt("later abrupt prefix")
         return result
 
@@ -748,8 +756,9 @@ def test_item_append_caught_prefixes_restore_exact_files(
 
     def deny(workspace, artifact, target):
         nonlocal calls
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise PermissionError(13, "Access is denied", str(target))
         return real_replace(workspace, artifact, target)
 
@@ -795,8 +804,9 @@ def test_item_append_abrupt_prefixes_remain_inspectable(
     def interrupt(workspace, artifact, target):
         nonlocal calls
         result = real_replace(workspace, artifact, target)
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise KeyboardInterrupt("item abrupt prefix")
         return result
 
@@ -856,8 +866,9 @@ item_schema:
 
     def fail_scaffold(workspace, artifact, target):
         nonlocal calls
-        calls += 1
-        if calls == 2:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == 2:
             raise PermissionError(13, "Access is denied", str(target))
         return real_replace(workspace, artifact, target)
 
@@ -868,13 +879,10 @@ item_schema:
     assert not (tmp_path / "Knowledge Base/Records/New/Events").exists()
 
     monkeypatch.setattr(vault._BatchWorkspace, "replace_artifact", real_replace)
-    calls = 0
 
     def interrupt_after_manifest(workspace, artifact, target):
-        nonlocal calls
         result = real_replace(workspace, artifact, target)
-        calls += 1
-        if calls == 1:
+        if Path(target) == tmp_path / manifest_path:
             raise KeyboardInterrupt("simulated abrupt create")
         return result
 

--- a/tests/test_record_mutation_matrix.py
+++ b/tests/test_record_mutation_matrix.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from record_fixtures import copy_vehicle_maintenance_fixture, copy_x3_fixture
 
-from exomem import mutation_lock, record_formats, vault, writer_lease
+from exomem import graph_sync, mutation_lock, record_formats, vault, writer_lease
 from exomem import structured_collections as collections
 
 
@@ -58,6 +58,10 @@ def _item_update_context(root: Path) -> tuple[Path, collections.CollectionManife
     return fixture, manifest, record, log
 
 
+def _is_caller_target(root: Path, target: Path) -> bool:
+    return target not in {graph_sync.floor_path(root), graph_sync.checkpoint_path(root)}
+
+
 @pytest.mark.parametrize("prefix", [1, 2, 3])
 def test_bom_crlf_item_update_caught_prefixes_restore_exact_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, prefix: int
@@ -76,8 +80,9 @@ def test_bom_crlf_item_update_caught_prefixes_restore_exact_bytes(
 
     def deny(workspace, artifact, target):  # noqa: ANN001
         nonlocal calls
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise PermissionError(13, "Access is denied", str(target))
         return real_replace(workspace, artifact, target)
 
@@ -117,8 +122,9 @@ def test_bom_crlf_item_update_abrupt_prefixes_report_audit_gap(
     def interrupt(workspace, artifact, target):  # noqa: ANN001
         nonlocal calls
         result = real_replace(workspace, artifact, target)
-        calls += 1
-        if calls == prefix:
+        if _is_caller_target(tmp_path, Path(target)):
+            calls += 1
+        if _is_caller_target(tmp_path, Path(target)) and calls == prefix:
             raise KeyboardInterrupt("abrupt markdown item publication")
         return result
 

--- a/tests/test_record_product_e2e.py
+++ b/tests/test_record_product_e2e.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 import pytest
@@ -42,7 +43,14 @@ def _source_hash(result: dict[str, object], suffix: str) -> str:
 
 
 def _files(vault: Path) -> set[str]:
-    return {path.relative_to(vault).as_posix() for path in vault.rglob("*") if path.is_file()}
+    reserved = re.compile(
+        r"^\.graph-rebuild-[0-9a-f]{64}-[0-9a-f]{24}\.sqlite(?:-(?:journal|wal|shm))?$"
+    )
+    return {
+        path.relative_to(vault).as_posix()
+        for path in vault.rglob("*")
+        if path.is_file() and reserved.fullmatch(path.name) is None
+    }
 
 
 def _write_l6_rule(vault: Path, *, paths: str) -> None:

--- a/tests/test_records_recall_freshness.py
+++ b/tests/test_records_recall_freshness.py
@@ -6,6 +6,115 @@ from exomem import find as find_module
 from exomem import freshness, recall_policy
 
 
+def test_peek_recall_publication_is_cold_and_never_reprojects(
+    tmp_path: Path, monkeypatch
+) -> None:
+    assert freshness.peek_recall_publication(tmp_path, "vault") is None
+
+    page = tmp_path / "Knowledge Base" / "Notes" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("page", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(page), freshness.stat_signature(page))])
+    prepared = freshness.prepare_recall_publication(tmp_path, "vault")
+    assert prepared is not None
+
+    monkeypatch.setattr(
+        recall_policy,
+        "recall_policy_identity",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("peek must not call policy")),
+    )
+    monkeypatch.setattr(
+        freshness,
+        "triple_from_entries",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("peek must not compute triple")),
+    )
+
+    assert freshness.peek_recall_publication(tmp_path, "vault") == prepared
+
+
+def test_prepare_recall_publication_requires_live_map_and_no_pending(tmp_path: Path) -> None:
+    assert freshness.prepare_recall_publication(tmp_path, "vault") is None
+
+    page = tmp_path / "Knowledge Base" / "Notes" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("page", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(page), freshness.stat_signature(page))])
+    assert freshness.prepare_recall_publication(tmp_path, "vault") is not None
+
+    freshness.mark_external_pending(tmp_path)
+    assert freshness.prepare_recall_publication(tmp_path, "vault") is None
+    assert freshness.peek_recall_publication(tmp_path, "vault") is None
+
+
+def test_prepare_recall_publication_refuses_policy_identity_race(
+    tmp_path: Path, monkeypatch
+) -> None:
+    page = tmp_path / "Knowledge Base" / "Notes" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("page", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(page), freshness.stat_signature(page))])
+    prepared = freshness.prepare_recall_publication(tmp_path, "vault")
+    assert prepared is not None
+
+    assert (
+        freshness.prepare_recall_publication(
+            tmp_path,
+            "vault",
+            expected_policy_identity=(prepared.policy_version, "not-current"),
+    )
+    is None
+    )
+
+
+def test_peek_recall_publication_uses_the_key_prepared_outside_the_lock(
+    tmp_path: Path, monkeypatch
+) -> None:
+    page = tmp_path / "Knowledge Base" / "Notes" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("page", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(page), freshness.stat_signature(page))])
+
+    monkeypatch.chdir(tmp_path.parent)
+    prepared = freshness.prepare_recall_publication(Path(tmp_path.name), "vault")
+
+    assert prepared is not None
+    assert freshness.peek_recall_publication(Path("not-the-vault"), "vault", ticket=prepared) == prepared
+
+
+def test_prepare_recall_publication_bounds_sustained_policy_churn(
+    tmp_path: Path, monkeypatch
+) -> None:
+    page = tmp_path / "Knowledge Base" / "Notes" / "page.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("page", encoding="utf-8")
+    freshness.seed(tmp_path, "vault", [(str(page), freshness.stat_signature(page))])
+    publication_calls = 0
+    checkpoint_calls = 0
+
+    def churning_publication_identity(_root: Path) -> tuple[str, str]:
+        nonlocal publication_calls
+        publication_calls += 1
+        return "test-policy", str(publication_calls)
+
+    def churning_checkpoint_identity(_root: Path) -> tuple[str, str]:
+        nonlocal checkpoint_calls
+        checkpoint_calls += 1
+        return "test-policy", str(checkpoint_calls)
+
+    monkeypatch.setattr(
+        recall_policy,
+        "recall_publication_policy_identity",
+        churning_publication_identity,
+    )
+    monkeypatch.setattr(recall_policy, "recall_policy_identity", churning_checkpoint_identity)
+
+    assert freshness.prepare_recall_publication(tmp_path, "vault") is None
+    assert publication_calls <= freshness.RECALL_PUBLICATION_PREPARE_ATTEMPTS
+    # One bounded checkpoint admission takes an initial and a stability policy
+    # observation; neither can restart the outer publication budget.
+    assert checkpoint_calls <= freshness.RECALL_PUBLICATION_PREPARE_ATTEMPTS * 2
+
+
 def test_cold_checkpoint_retries_when_access_policy_changes_during_projection(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_records_recall_index_sync.py
+++ b/tests/test_records_recall_index_sync.py
@@ -275,13 +275,21 @@ def test_delete_after_move_purges_claim_and_semantic_receipt_but_keeps_identity_
         lambda _root, _changed, paths: calls.append(("resolver", paths)),
     )
     monkeypatch.setattr(lexstore, "delete_after_remove", lambda *_args: None)
-    monkeypatch.setattr(epistemic_graph, "delete_after_remove", lambda *_args: None)
+    monkeypatch.setattr(
+        epistemic_graph,
+        "upsert_after_write",
+        lambda *_args: epistemic_graph.GraphDispatchResult("completed", "incremental_completed"),
+    )
     monkeypatch.setattr(
         embeddings,
         "delete_after_remove_status",
         lambda *_args: embeddings.EmbeddingSyncStatus("completed", "embedding_delete_completed", 1),
     )
-    monkeypatch.setattr(embeddings, "delete_clip_after_remove", lambda *_args: None)
+    monkeypatch.setattr(
+        embeddings,
+        "delete_clip_after_remove",
+        lambda *_args: embeddings.EmbeddingSyncStatus("completed", "clip_delete_completed", 1),
+    )
 
     report = index_sync.delete_after_remove(tmp_path, [old_rel])
 
@@ -290,7 +298,7 @@ def test_delete_after_move_purges_claim_and_semantic_receipt_but_keeps_identity_
     assert deferred_index.snapshot(tmp_path) == []
     assert calls == [("memory_refs", [old_rel]), ("resolver", [old_rel])]
     assert receipt.rel_path == old_rel
-    assert next(item for item in report.components if item.component == "claims").outcome == "accepted"
+    assert next(item for item in report.components if item.component == "claims").outcome == "completed"
     assert next(
         item for item in report.components if item.component == "semantic_purge"
     ).outcome == "completed"

--- a/tests/test_relation_review.py
+++ b/tests/test_relation_review.py
@@ -12,6 +12,7 @@ import pytest
 
 from exomem import (
     activation_manifest,
+    graph_sync,
     memory_refs,
     metrics,
     relation_review,
@@ -408,6 +409,11 @@ def test_reviewed_none_commit_writes_artifact_then_auxiliaries_then_primary(
         ]
     assert commit.resumed_prepared is False
     assert commit.written_paths == captured[0][0]
+    assert all(
+        path
+        not in {"Knowledge Base/.graph-sync-floor.json", "Knowledge Base/.graph-sync.json"}
+        for path in commit.written_paths
+    )
     committed_auxiliary = captured_writes[0][1]
     assert committed_auxiliary.create_only is True
     assert committed_auxiliary.expected_hash == vault.MISSING_CONTENT_HASH
@@ -735,6 +741,10 @@ def test_process_crash_before_primary_resumes_exact_prepared_commit(
     assert commit.resumed_prepared is True
     assert artifact.read_bytes() == artifact_bytes
     assert (tmp_path / _PAGE_B).exists()
+    checkpoint = graph_sync.read_checkpoint(tmp_path)
+    assert checkpoint is not None
+    assert checkpoint.generation >= 2
+    assert checkpoint.scope == "full"
 
 
 def test_successful_replay_and_same_identity_copy_have_exact_precedence(

--- a/tests/test_repro_graph_rebuild_hold.py
+++ b/tests/test_repro_graph_rebuild_hold.py
@@ -1,0 +1,96 @@
+"""Unit coverage for the graph rebuild publication-hold reproduction harness."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "repro_graph_rebuild_hold.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("repro_graph_rebuild_hold_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_summary_reports_request_and_canonical_publication_hold_percentiles() -> None:
+    summary = load_module().summarize([10.0, 30.0, 20.0])
+
+    assert summary == {"median_ms": 20.0, "p95_ms": 30.0}
+
+
+def test_format_result_identifies_the_publication_operation_and_scale_ratio() -> None:
+    output = load_module().format_result(
+        {
+            "pages": 2_000,
+            "trials": 5,
+            "request": {"median_ms": 32_000.0, "p95_ms": 33_000.0},
+            "publication_hold": {"median_ms": 12.0, "p95_ms": 15.0},
+        },
+        hold_ratio=1.25,
+    )
+
+    assert "FINAL canonical publication hold" in output
+    assert "operation=epistemic_graph_publish_rebuild" in output
+    assert "2000/500 hold median ratio=1.25x" in output
+
+
+def test_publication_hold_rejects_timing_from_any_other_operation() -> None:
+    module = load_module()
+
+    assert module.publication_hold_ms(
+        {"operation": "epistemic_graph_publish_rebuild", "hold_ms": 12.5}
+    ) == 12.5
+    with pytest.raises(RuntimeError, match="epistemic_graph_publish_rebuild"):
+        module.publication_hold_ms({"operation": "epistemic_graph_refresh_paths", "hold_ms": 12.5})
+
+
+def test_advance_checkpoint_uses_a_real_write_then_reseeds_live_freshness(
+    tmp_path: Path,
+) -> None:
+    module = load_module()
+    target = tmp_path / "Knowledge Base" / "Notes" / "target.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Target\n", encoding="utf-8")
+    batches = []
+    seeded = []
+
+    class FakeVault:
+        class PlannedWrite:
+            def __init__(self, path, source):
+                self.path = path
+                self.source = source
+
+        @staticmethod
+        def batch_atomic_write(writes, **kwargs):
+            batches.append((list(writes), kwargs))
+
+    class FakeFreshness:
+        @staticmethod
+        def stat_signature(path):
+            return str(path)
+
+        @staticmethod
+        def seed(vault_root, scope, entries):
+            seeded.append((vault_root, scope, list(entries)))
+
+    imports = {
+        "find": SimpleNamespace(_walk_md=lambda _path: []),
+        "freshness": FakeFreshness,
+        "kb_dirname": lambda: "Knowledge Base",
+        "vault": FakeVault,
+        "walk_vault_md": lambda _root: [target],
+    }
+
+    module.advance_checkpoint(tmp_path, target, imports)
+
+    writes, kwargs = batches[0]
+    assert [(write.path, write.source) for write in writes] == [(target, "# Target\n\n")]
+    assert kwargs == {"vault_root": tmp_path, "post_commit_fanout": False}
+    assert [scope for _root, scope, _entries in seeded] == ["vault", "kb"]

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -234,3 +234,43 @@ def test_runtime_readiness_uses_vault_path_identity_for_a_real_held_boundary(
     assert boundary["state"] == "held"
     assert boundary["verified"] is True
     assert boundary["request_id"] == "req-readiness-held"
+
+
+def test_coordination_graph_health_requires_a_readable_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Epoch state alone must not make readiness claim the graph is current."""
+    from exomem import epistemic_graph, vault as vault_module, writer_lease
+
+    manager = writer_lease.LeaseManager(writer_lease.LeaseConfig(state_dir=tmp_path / "state"))
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert manager.status(empty)["graph_sync"] == {"state": "unavailable", "generation": 0}
+    from exomem import runtime_readiness as readiness_module
+
+    monkeypatch.setenv("EXOMEM_VAULT_PATH", str(empty))
+    monkeypatch.setattr(writer_lease, "get_manager", lambda: manager)
+    readiness = readiness_module.runtime_readiness(mcp_tool_surface_sha256="a" * 64)
+    assert readiness["coordination"]["graph_sync"] == {
+        "state": "unavailable",
+        "generation": 0,
+    }
+    assert str(empty) not in repr(readiness)
+
+    missing = tmp_path / "missing"
+    note = missing / "Knowledge Base/Notes/health.md"
+    vault_module.batch_atomic_write(
+        [vault_module.PlannedWrite(note, "# Health\n")],
+        vault_root=missing,
+        post_commit_fanout=False,
+    )
+    assert manager.status(missing)["graph_sync"] == {"state": "recovery_required", "generation": 1}
+
+    index = epistemic_graph.EpistemicGraphIndex(missing)
+    index.rebuild_all()
+    assert manager.status(missing)["graph_sync"] == {"state": "current", "generation": 1}
+
+    epistemic_graph.sidecar_path(missing).write_bytes(b"not sqlite")
+    snapshot = manager.status(missing)
+    assert snapshot["graph_sync"] == {"state": "unavailable", "generation": 1}
+    assert str(missing) not in repr(snapshot)

--- a/tests/test_semantic_creation_writers.py
+++ b/tests/test_semantic_creation_writers.py
@@ -895,7 +895,7 @@ def test_note_partial_commit_after_registry_replacement_recovers_exactly(
     }
     real_batch = relation_review.vault.batch_atomic_write
     real_replace = vault_module.os.replace
-    replacements = 0
+    registry_path = vault / "Knowledge Base" / "_Schema" / "project-keys.yaml"
     captured: list[tuple[tuple[str, str], ...]] = []
 
     def capture_batch(writes: object, **batch_kwargs: object):
@@ -912,13 +912,10 @@ def test_note_partial_commit_after_registry_replacement_recovers_exactly(
         return real_batch(detached, **batch_kwargs)
 
     def die_after_registry(src: object, dst: object) -> None:
-        nonlocal replacements
         real_replace(src, dst)
         destination = Path(dst)  # type: ignore[arg-type]
-        if str(src).endswith(".tmp") and destination.is_relative_to(vault):
-            replacements += 1
-            if replacements == 2:  # receipt, then project registry
-                raise SimulatedProcessDeath
+        if str(src).endswith(".tmp") and destination == registry_path:
+            raise SimulatedProcessDeath
 
     monkeypatch.setattr(relation_review.vault, "batch_atomic_write", capture_batch)
     monkeypatch.setattr(vault_module.os, "replace", die_after_registry)

--- a/tests/test_semantic_lifecycle_writers.py
+++ b/tests/test_semantic_lifecycle_writers.py
@@ -976,7 +976,12 @@ def test_non_markdown_trash_does_not_register_markdown_self_delete(
 
     assert watcher_calls == []
     assert cleanup_calls == []
-    assert result.index is None
+    assert result.index == {
+        "components": [],
+        "derived_work": "not_required",
+        "paths_truncated": False,
+        "reconcile_required": False,
+    }
 
 
 def test_trash_legacy_none_is_accepted_unverified(

--- a/tests/test_windows_idempotency_trust.py
+++ b/tests/test_windows_idempotency_trust.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(os.name != "nt", reason="native Windows idempotency trust boundary")
+
+
+def test_dpapi_receipt_envelope_round_trips_with_exact_header(tmp_path: Path) -> None:
+    from exomem import writer_lease
+    from exomem.writer_lease import IdempotencyStore
+
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
+    digest = "a" * 64
+    assert store._claim_or_inspect("protected", digest, None) == ("owner", None)
+    attempt = store._attempts["protected"]
+    with sqlite3.connect(store.path) as connection:
+        stored = connection.execute(
+            "SELECT commit_secret FROM mutations WHERE key = 'protected'"
+        ).fetchone()[0]
+
+    assert len(stored) <= 4096
+    assert stored[:4] == b"EXID"
+    assert stored[4:6] == b"\x01\x01"
+    assert int.from_bytes(stored[6:10], "big") == len(stored[10:])
+    recovered = writer_lease._ExecutionAttempt(
+        attempt.attempt_id, attempt.commit_token, stored, None
+    )
+    assert store._unprotected_commit_secret(digest, recovered) == attempt.commit_secret
+
+
+def test_unsafe_database_ace_is_refused_before_sqlite_or_pickle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import mutation_lock, writer_lease
+    from exomem.writer_lease import IdempotencyStore
+
+    database = tmp_path / "state" / "idempotency.sqlite"
+    IdempotencyStore(database)
+    mutation_lock._windows_apply_dacl_sddl(database, "D:P(A;OICI;FA;;;WD)")
+    called = False
+
+    def sqlite_open(*_args: object, **_kwargs: object):
+        nonlocal called
+        called = True
+        raise AssertionError("unsafe runtime state reached sqlite")
+
+    monkeypatch.setattr(writer_lease.sqlite3, "connect", sqlite_open)
+    blocked = IdempotencyStore(database)
+
+    with pytest.raises(RuntimeError, match="unsafe Windows DACL"):
+        blocked._connect()
+    assert called is False
+
+
+def test_reparse_runtime_directory_is_refused_before_sqlite(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import writer_lease
+    from exomem.writer_lease import IdempotencyStore
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    runtime = tmp_path / "runtime"
+    try:
+        runtime.symlink_to(outside, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"Windows symlink creation is unavailable: {error}")
+    called = False
+
+    def sqlite_open(*_args: object, **_kwargs: object):
+        nonlocal called
+        called = True
+        raise AssertionError("reparse runtime state reached sqlite")
+
+    monkeypatch.setattr(writer_lease.sqlite3, "connect", sqlite_open)
+
+    with pytest.raises(OSError, match="reparse"):
+        IdempotencyStore(runtime / "idempotency.sqlite")
+    assert called is False
+
+
+def test_reparse_ancestor_is_refused_before_sqlite(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from exomem import writer_lease
+    from exomem.writer_lease import IdempotencyStore
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    ancestor = tmp_path / "runtime-parent"
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(ancestor), str(outside)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode:
+        pytest.skip("Windows junction creation is unavailable")
+    called = False
+
+    def sqlite_open(*_args: object, **_kwargs: object):
+        nonlocal called
+        called = True
+        raise AssertionError("reparse ancestor reached sqlite")
+
+    monkeypatch.setattr(writer_lease.sqlite3, "connect", sqlite_open)
+
+    with pytest.raises(OSError, match="reparse"):
+        IdempotencyStore(ancestor / "state" / "idempotency.sqlite")
+    assert called is False

--- a/tests/test_windows_path_alias_guard.py
+++ b/tests/test_windows_path_alias_guard.py
@@ -1,0 +1,171 @@
+"""Regression coverage for Windows aliases in graph and freshness paths."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from ctypes import wintypes
+from pathlib import Path
+
+import pytest
+
+from exomem import epistemic_graph, freshness, graph_sync, mutation_lock, writer_lease
+from exomem import vault as vault_module
+from exomem.vault import PlannedWrite
+
+
+def test_epoch_writes_preserve_the_caller_vault_spelling(
+    vault: Path,
+) -> None:
+    """Internal graph artifacts must share an alias caller's namespace spelling."""
+    alias = vault / ".." / vault.name
+    note = alias / "Knowledge Base" / "Notes" / "alias-planning.md"
+    writes = graph_sync.epoch_writes(alias, (PlannedWrite(note, "# Alias\n"),))
+
+    assert writes is not None
+    floor, checkpoint = writes
+    assert floor.path.parent == alias / "Knowledge Base"
+    assert checkpoint.path.parent == alias / "Knowledge Base"
+
+
+def test_census_accepts_epoch_artifacts_from_an_alias_root(vault: Path) -> None:
+    """A guarded first graph-admitted create retains one namespace for every write."""
+    alias = vault / ".." / vault.name
+    notes = alias / "Knowledge Base" / "Notes"
+    notes.mkdir(exist_ok=True)
+    census = vault_module.DirectoryCensusGuard.capture(alias, "Knowledge Base", max_entries=16)
+    first = notes / "first.md"
+
+    vault_module.batch_atomic_write(
+        (PlannedWrite(first, "# First Note\n"),),
+        vault_root=alias,
+        required_guards=(census,),
+        post_commit_fanout=False,
+    )
+
+    assert first.read_text(encoding="utf-8") == "# First Note\n"
+    assert graph_sync.floor_path(alias).is_file()
+    assert graph_sync.checkpoint_path(alias).is_file()
+
+
+def test_windows_digest_normalizes_resolved_alias_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The digest treats equivalent Windows aliases as one path spelling."""
+
+    class WindowsPath:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def resolve(self) -> WindowsPath:
+            return WindowsPath(
+                self.value.replace("EXAMPLE~1", "Example Vault").replace(
+                    "c" + ":" + "\\" + "users\\example", "C" + ":" + "\\" + "Users\\Example"
+                )
+            )
+
+        def __str__(self) -> str:
+            return self.value
+
+    monkeypatch.setattr(freshness.os, "name", "nt")
+    monkeypatch.setattr(freshness, "Path", WindowsPath)
+    signature = (1, 2, 3)
+    long = "C" + ":" + "\\" + "Users\\Example\\Example Vault\\Notes\\alias.md"
+    short = "c" + ":" + "\\" + "users\\example\\EXAMPLE~1\\Notes\\alias.md"
+
+    assert freshness.triple_from_entries(((long, signature),)) == freshness.triple_from_entries(
+        ((short, signature),)
+    )
+
+
+def _short_path_name(path: Path) -> Path | None:
+    if sys.platform != "win32":
+        return None
+    get_short = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
+    get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    result = ctypes.create_unicode_buffer(1024)
+    if get_short(str(path), result, len(result)) == 0:
+        return None
+    return Path(result.value)
+
+
+@pytest.fixture
+def isolated_windows_writer_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Prepare test-only runtime state with production's protected Windows DACL."""
+    state_dir = tmp_path / "writer-state"
+    owners_dir = state_dir / "idempotency-owners"
+    mutation_lock.prepare_windows_idempotency_runtime_paths(state_dir, owners_dir)
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state_dir))
+    writer_lease.reset_managers_for_tests()
+    try:
+        yield state_dir
+    finally:
+        writer_lease.reset_managers_for_tests()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires native Windows 8.3 aliases")
+def test_directory_census_allows_a_long_form_write_from_a_short_root_alias(
+    vault: Path,
+) -> None:
+    """The actual 8.3/case split must not reject a graph-admitted write."""
+    root = vault.with_name("Exomem Vault Alias Regression")
+    vault.rename(root)
+    notes = root / "Knowledge Base" / "Notes"
+    notes.mkdir(parents=True, exist_ok=True)
+    short_root = _short_path_name(root)
+    if short_root is None:
+        pytest.skip("8.3 short-name generation is disabled for this volume")
+    assert short_root is not None
+    if os.path.normcase(str(short_root)) == os.path.normcase(str(root)):
+        pytest.skip("8.3 short-name generation is disabled for this volume")
+
+    census = vault_module.DirectoryCensusGuard.capture(short_root, "Knowledge Base", max_entries=16)
+    first = short_root / "Knowledge Base" / "Notes" / "first.md"
+
+    vault_module.batch_atomic_write(
+        (PlannedWrite(first, "# First Note\n"),),
+        vault_root=short_root,
+        required_guards=(census,),
+        post_commit_fanout=False,
+    )
+
+    assert (notes / "first.md").read_text(encoding="utf-8") == "# First Note\n"
+    assert graph_sync.floor_path(short_root).is_file()
+    assert graph_sync.checkpoint_path(short_root).is_file()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires native Windows 8.3 aliases")
+def test_recall_projection_identity_survives_short_root_restart(
+    vault: Path, isolated_windows_writer_state: Path
+) -> None:
+    """A published long-root graph remains current after a short-root restart."""
+    root = vault.with_name("Exomem Vault Freshness Alias Regression")
+    vault.rename(root)
+    note = root / "Knowledge Base" / "Notes" / "alias.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# Alias\n", encoding="utf-8")
+    short_root = _short_path_name(root)
+    if short_root is None:
+        pytest.skip("8.3 short-name generation is disabled for this volume")
+    assert short_root is not None
+    if os.path.normcase(str(short_root)) == os.path.normcase(str(root)):
+        pytest.skip("8.3 short-name generation is disabled for this volume")
+
+    freshness.seed(
+        root,
+        "vault",
+        ((str(path), freshness.stat_signature(path)) for path in vault_module.walk_vault_md(root)),
+    )
+    long_index = epistemic_graph.EpistemicGraphIndex(root)
+    long_index.rebuild_all()
+    long_identity = epistemic_graph._incremental_projection_identity(root)
+    assert long_index.available() is True
+
+    freshness.invalidate(root)
+
+    short_index = epistemic_graph.EpistemicGraphIndex(short_root)
+    assert epistemic_graph._incremental_projection_identity(short_root) == long_identity
+    assert short_index.available() is True

--- a/tests/test_writer_lease.py
+++ b/tests/test_writer_lease.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import os
 import sqlite3
+import stat
 import threading
 import time
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, replace
@@ -22,12 +25,417 @@ from exomem.lease_coordinator import SQLiteLeaseStore
 from exomem.mutation_lock import VaultMutationCoordinator
 from exomem.vault import PlannedWrite, batch_atomic_write
 from exomem.writer_lease import (
+    IdempotencyStore,
     LeaseConfig,
     LeaseManager,
     LeaseRecord,
     invoke_command,
     reset_managers_for_tests,
 )
+
+
+class _UnknownLengthMapping(Mapping[str, str]):
+    def __init__(self, item_count: int) -> None:
+        self._values = {f"key-{index}": "private result content" for index in range(item_count)}
+        self.items_iterated = 0
+
+    def __getitem__(self, key: str) -> str:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        for key in self._values:
+            self.items_iterated += 1
+            if self.items_iterated > writer_lease_module._RECEIPT_RESULT_SUMMARY_MAX_ITEMS + 1:
+                raise AssertionError("receipt summary consumed too many mapping items")
+            yield key
+
+    def __len__(self) -> int:
+        raise TypeError("mapping length is unavailable")
+
+
+def test_receipt_summary_closes_large_dict_without_visiting_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = writer_lease_module._receipt_result_summary
+    visited = 0
+
+    def counted(value: object, *, depth: int = 0) -> dict[str, object]:
+        nonlocal visited
+        visited += 1
+        return original(value, depth=depth)
+
+    monkeypatch.setattr(writer_lease_module, "_receipt_result_summary", counted)
+    summary = original({f"key-{index}": "private result content" for index in range(200_000)})
+
+    assert summary == {"type": "mapping", "size": 200_000, "truncated": True}
+    assert visited == 0
+    assert "private result content" not in json.dumps(summary)
+
+
+def test_receipt_summary_closes_unknown_length_mapping_after_bounded_probe() -> None:
+    mapping = _UnknownLengthMapping(writer_lease_module._RECEIPT_RESULT_SUMMARY_MAX_ITEMS + 50)
+
+    summary = writer_lease_module._receipt_result_summary(mapping)
+
+    assert summary == {"type": "mapping", "truncated": True}
+    assert mapping.items_iterated == writer_lease_module._RECEIPT_RESULT_SUMMARY_MAX_ITEMS + 1
+    assert "private result content" not in json.dumps(summary)
+
+
+def test_receipt_result_digest_remains_stable_and_sensitive_for_small_mappings() -> None:
+    first = {"z": "private alpha", "a": {"hidden": "one"}}
+    same_values_different_order = {"a": {"hidden": "one"}, "z": "private alpha"}
+    changed = {"a": {"hidden": "two"}, "z": "private alpha"}
+
+    assert writer_lease_module._receipt_result_sha256(first) == writer_lease_module._receipt_result_sha256(
+        same_values_different_order
+    )
+    assert writer_lease_module._receipt_result_sha256(first) != writer_lease_module._receipt_result_sha256(
+        changed
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_idempotency_secret_runtime_artifacts_are_owner_only(tmp_path: Path) -> None:
+    store = IdempotencyStore(tmp_path / "state" / "idempotency.sqlite")
+    store.run("secret-modes", "digest", lambda: {"ok": True})
+
+    for path in (
+        store.state_dir,
+        store.state_dir / "idempotency-owners",
+        store.path,
+        store.path.with_name(f"{store.path.name}-wal"),
+        store.path.with_name(f"{store.path.name}-shm"),
+    ):
+        if path.exists():
+            assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_insecure_idempotency_database_is_rejected_before_unpickle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = tmp_path / "state"
+    state.mkdir(mode=0o700)
+    database = state / "idempotency.sqlite"
+    database.write_bytes(b"not sqlite")
+    database.chmod(0o666)
+    monkeypatch.setattr(
+        writer_lease_module.pickle,
+        "loads",
+        lambda _raw: pytest.fail("unsafe idempotency state reached pickle.loads"),
+    )
+
+    store = IdempotencyStore(database)
+    with pytest.raises(RuntimeError, match="cannot be upgraded safely"):
+        store.run("unsafe", "digest", lambda: pytest.fail("unsafe state ran a leaf"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_legacy_owner_owned_runtime_state_is_hardened_before_sqlite_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = tmp_path / "legacy-state"
+    state.mkdir(mode=0o755)
+    database = state / "idempotency.sqlite"
+    with sqlite3.connect(database) as conn:
+        conn.execute(
+            "CREATE TABLE mutations (key TEXT PRIMARY KEY, digest TEXT NOT NULL, "
+            "state TEXT NOT NULL, result BLOB, updated_at REAL NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO mutations VALUES (?, ?, 'completed', ?, 1.0)",
+            ("legacy", "digest", sqlite3.Binary(__import__("pickle").dumps({"kept": True}))),
+        )
+    state.chmod(0o755)
+    database.chmod(0o644)
+    real_connect = writer_lease_module.sqlite3.connect
+
+    def secure_connect(path: object, *args: object, **kwargs: object) -> sqlite3.Connection:
+        if Path(path) == database:
+            assert stat.S_IMODE(database.stat().st_mode) == 0o600
+        return real_connect(path, *args, **kwargs)
+
+    monkeypatch.setattr(writer_lease_module.sqlite3, "connect", secure_connect)
+    store = IdempotencyStore(database)
+
+    assert store.run("legacy", "digest", lambda: pytest.fail("legacy replay lost")) == {
+        "kept": True
+    }
+    assert stat.S_IMODE(state.stat().st_mode) == 0o700
+    assert stat.S_IMODE(database.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_legacy_owner_lock_is_hardened_with_runtime_state(tmp_path: Path) -> None:
+    state = tmp_path / "legacy-lock-state"
+    owners = state / "idempotency-owners"
+    owners.mkdir(parents=True, mode=0o755)
+    lock = owners / "legacy.lock"
+    lock.write_bytes(b"")
+    state.chmod(0o755)
+    owners.chmod(0o755)
+    lock.chmod(0o644)
+
+    IdempotencyStore(state / "idempotency.sqlite")
+
+    assert stat.S_IMODE(lock.stat().st_mode) == 0o600
+
+
+class _EnvelopeProtector:
+    """Portable stand-in for the Windows DPAPI boundary."""
+
+    provider = 1
+
+    def __init__(self) -> None:
+        self.protect_calls: list[tuple[bytes, bytes]] = []
+        self.unprotect_calls: list[tuple[bytes, bytes]] = []
+        self._values: dict[bytes, tuple[bytes, bytes]] = {}
+
+    def protect(self, secret: bytes, entropy: bytes) -> bytes:
+        self.protect_calls.append((secret, entropy))
+        ciphertext = b"protected:" + len(self._values).to_bytes(2, "big") + secret[::-1]
+        self._values[ciphertext] = (secret, entropy)
+        return ciphertext
+
+    def unprotect(self, ciphertext: bytes, entropy: bytes) -> bytes:
+        self.unprotect_calls.append((ciphertext, entropy))
+        return self._values[ciphertext][0] if self._values[ciphertext][1] == entropy else b""
+
+
+class _FixedCiphertextProtector:
+    provider = 1
+
+    def __init__(self, ciphertext: bytes) -> None:
+        self.ciphertext = ciphertext
+
+    def protect(self, _secret: bytes, _entropy: bytes) -> bytes:
+        return self.ciphertext
+
+
+def test_protected_attempt_secret_never_writes_plaintext_to_sqlite(tmp_path: Path) -> None:
+    protector = _EnvelopeProtector()
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    digest = "a" * 64
+
+    assert store._claim_or_inspect("protected", digest, None) == ("owner", None)
+    attempt = store._attempts["protected"]
+    with sqlite3.connect(store.path) as connection:
+        stored = connection.execute(
+            "SELECT commit_secret FROM mutations WHERE key = 'protected'"
+        ).fetchone()[0]
+
+    assert stored != attempt.commit_secret
+    assert stored.startswith(writer_lease_module._WINDOWS_SECRET_ENVELOPE_MAGIC)
+    assert store._read_exact_evidence(
+        lambda _digest, _attempt_id, _token, secret: secret == attempt.commit_secret,
+        digest,
+        writer_lease_module._ExecutionAttempt(
+            attempt.attempt_id, attempt.commit_token, stored, None
+        ),
+    ) is True
+    assert len(protector.protect_calls) == len(protector.unprotect_calls) == 1
+    assert protector.protect_calls[0][1] == (
+        b"exomem-graph-commit-receipt-dpapi:v1\0"
+        + attempt.attempt_id.encode("utf-8")
+        + b"\0"
+        + attempt.commit_token.encode("utf-8")
+    )
+    assert protector.unprotect_calls[0][1] == protector.protect_calls[0][1]
+
+
+def test_protected_attempt_secret_envelope_caps_total_blob_at_4096_bytes(tmp_path: Path) -> None:
+    attempt = writer_lease_module._ExecutionAttempt("a" * 24, "b" * 24, b"s" * 32, None)
+    digest = "d" * 64
+    accepted = IdempotencyStore(
+        tmp_path / "accepted.sqlite", secret_protector=_FixedCiphertextProtector(b"x" * 4086)
+    )
+
+    envelope = accepted._stored_commit_secret(digest, attempt)
+
+    assert len(envelope) == 4096
+    assert envelope[:4] == writer_lease_module._WINDOWS_SECRET_ENVELOPE_MAGIC
+    assert envelope[4:6] == b"\x01\x01"
+    assert int.from_bytes(envelope[6:10], "big") == 4086
+    assert envelope[10:] == b"x" * 4086
+
+    rejected = IdempotencyStore(
+        tmp_path / "rejected.sqlite", secret_protector=_FixedCiphertextProtector(b"x" * 4087)
+    )
+    with pytest.raises(RuntimeError, match="invalid ciphertext"):
+        rejected._stored_commit_secret(digest, attempt)
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        b"EXID\x02\x01" + (1).to_bytes(4, "big") + b"x",
+        b"EXID\x01\x02" + (1).to_bytes(4, "big") + b"x",
+        b"EXID\x01\x01" + (2).to_bytes(4, "big") + b"x",
+        b"EXID\x01\x01" + (1).to_bytes(4, "big") + b"xy",
+        b"EXID\x01\x01" + (4087).to_bytes(4, "big") + b"x" * 4087,
+    ],
+)
+def test_protected_attempt_secret_rejects_non_exact_envelopes(
+    tmp_path: Path, stored: bytes
+) -> None:
+    protector = _EnvelopeProtector()
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    attempt = writer_lease_module._ExecutionAttempt("a" * 24, "b" * 24, stored, None)
+
+    assert store._unprotected_commit_secret("e" * 64, attempt) is None
+    assert protector.unprotect_calls == []
+
+
+@pytest.mark.parametrize("replacement", [b"x" * 32, b"", b"EXID\x01\x01\x00\x00\x00\x20x"])
+def test_malformed_or_legacy_protected_attempt_secret_fails_closed(
+    tmp_path: Path, replacement: bytes
+) -> None:
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
+    digest = "b" * 64
+    assert store._claim_or_inspect("protected", digest, None) == ("owner", None)
+    attempt = store._attempts["protected"]
+
+    assert store._read_exact_evidence(
+        lambda *_args: pytest.fail("invalid secret reached receipt verification"),
+        digest,
+        writer_lease_module._ExecutionAttempt(
+            attempt.attempt_id, attempt.commit_token, replacement, None
+        ),
+    ) is None
+
+
+def test_protected_attempt_secret_binds_the_attempt_identity(tmp_path: Path) -> None:
+    protector = _EnvelopeProtector()
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=protector)
+    digest = "c" * 64
+    assert store._claim_or_inspect("one", digest, None) == ("owner", None)
+    assert store._claim_or_inspect("two", digest, None) == ("owner", None)
+    one = store._attempts["one"]
+    two = store._attempts["two"]
+    with sqlite3.connect(store.path) as connection:
+        stored_one = connection.execute("SELECT commit_secret FROM mutations WHERE key = 'one'").fetchone()[0]
+        stored_two = connection.execute("SELECT commit_secret FROM mutations WHERE key = 'two'").fetchone()[0]
+
+    assert protector.protect_calls[0][1] != protector.protect_calls[1][1]
+    assert store._read_exact_evidence(
+        lambda *_args: pytest.fail("swapped envelope reached receipt verification"),
+        digest,
+        writer_lease_module._ExecutionAttempt(two.attempt_id, two.commit_token, stored_one, None),
+    ) is None
+    assert store._read_exact_evidence(
+        lambda _digest, _attempt_id, _token, secret: secret == one.commit_secret,
+        digest,
+        writer_lease_module._ExecutionAttempt(one.attempt_id, one.commit_token, stored_one, None),
+    ) is True
+    assert stored_one != stored_two
+
+
+def test_protection_failure_refuses_before_creating_an_execution_row(tmp_path: Path) -> None:
+    class BrokenProtector:
+        provider = 1
+
+        def protect(self, _secret: bytes, _entropy: bytes) -> bytes:
+            raise OSError("DPAPI unavailable")
+
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=BrokenProtector())
+
+    with pytest.raises(OpError) as error:
+        store.run("unprotected", "d" * 64, lambda: pytest.fail("leaf ran"))
+    assert error.value.code == "IDEMPOTENCY_SECRET_PROTECTION_UNAVAILABLE"
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM mutations").fetchone() == (0,)
+
+
+def test_legacy_raw_attempt_secret_never_heals_a_dead_execution(tmp_path: Path) -> None:
+    store = IdempotencyStore(tmp_path / "idempotency.sqlite", secret_protector=_EnvelopeProtector())
+    digest = "e" * 64
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "INSERT INTO mutations(key, digest, state, updated_at, owner, attempt_id, commit_token, commit_secret) "
+            "VALUES (?, ?, 'executing', ?, ?, ?, ?, ?)",
+            (
+                "legacy-raw", digest, 0.0, "dead-owner", "a" * 24, "b" * 24, b"x" * 32,
+            ),
+        )
+
+    with pytest.raises(OpError) as error:
+        store.run(
+            "legacy-raw", digest, lambda: pytest.fail("legacy raw row replayed"),
+            commit_evidence=lambda *_args: pytest.fail("legacy raw row verified"),
+        )
+    assert error.value.code == "MUTATION_OUTCOME_UNKNOWN"
+
+
+def test_windows_runtime_dacl_parser_rejects_a_broadened_or_unprotected_namespace() -> None:
+    from exomem.mutation_lock import _windows_private_dacl_is_valid
+
+    sid = "S-1-5-21-1-2-3-4"
+    protected = f"D:P(A;OICI;FA;;;{sid})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+    inherited_file = f"D:(A;ID;FA;;;{sid})(A;ID;FA;;;SY)(A;ID;FA;;;BA)"
+
+    assert _windows_private_dacl_is_valid(protected, sid, directory=True)
+    assert _windows_private_dacl_is_valid(inherited_file, sid, directory=False)
+    assert not _windows_private_dacl_is_valid(
+        protected + "(A;OICI;FA;;;WD)", sid, directory=True
+    )
+    assert not _windows_private_dacl_is_valid(
+        protected.removeprefix("D:P").join(("D:", "")), sid, directory=True
+    )
+
+
+def test_windows_runtime_validation_closes_every_non_reparse_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem import mutation_lock
+
+    database = tmp_path / "idempotency.sqlite"
+    database.write_bytes(b"sqlite")
+    closed: list[int] = []
+    sid = "S-1-5-21-1-2-3-4"
+    monkeypatch.setattr(mutation_lock, "_windows_open_path", lambda _path, *, directory: 10)
+    monkeypatch.setattr(mutation_lock, "_windows_close_handle", closed.append)
+    monkeypatch.setattr(
+        mutation_lock,
+        "_windows_dacl_sddl",
+        lambda _path: f"D:P(A;OICI;FA;;;{sid})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)",
+    )
+
+    mutation_lock._validate_windows_runtime_entry(
+        database, directory=False, sid=sid
+    )
+
+    assert closed == [10]
+
+
+def test_windows_runtime_validation_walks_and_closes_every_ancestor_before_sqlite_leaf(
+    tmp_path: Path,
+) -> None:
+    """The Windows path walk is injectable, so this guards it off Windows too."""
+    from exomem import mutation_lock
+
+    opened: list[Path] = []
+    closed: list[int] = []
+    next_handle = iter(range(100, 200))
+
+    def open_path(path: Path, *, directory: bool) -> int:
+        del directory
+        opened.append(path)
+        if path.name == "runtime":
+            raise OSError("reparse points are not allowed")
+        return next(next_handle)
+
+    with pytest.raises(OSError, match="reparse"):
+        mutation_lock._acquire_windows_secure_directory(
+            tmp_path / "runtime" / "state",
+            create=False,
+            mode=0o700,
+            open_path=open_path,
+            close_handle=closed.append,
+        )
+
+    assert any(path.name == "runtime" for path in opened)
+    assert closed == list(reversed(range(100, 100 + len(closed))))
 
 
 def _committed_error(tmp_path: Path, *, targets: tuple[str, ...] = ("note.md",)):
@@ -141,6 +549,33 @@ def test_default_manager_uses_configured_mutation_timeout(
         manager = writer_lease_module.get_manager()
         assert manager.config.mutation_timeout_seconds == 8.0
         assert manager._mutation_timeout_seconds == 8.0
+    finally:
+        reset_managers_for_tests()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_default_manager_hardens_legacy_configured_state_database(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Released default-manager state upgrades before its idempotency DB is opened."""
+    state = tmp_path / "legacy-default-state"
+    state.mkdir(mode=0o755)
+    safe_name = __import__("hashlib").sha256(b"standalone\0standalone").hexdigest()[:20]
+    database = state / f"idempotency-{safe_name}.sqlite"
+    with sqlite3.connect(database) as conn:
+        conn.execute(
+            "CREATE TABLE mutations (key TEXT PRIMARY KEY, digest TEXT NOT NULL, "
+            "state TEXT NOT NULL, result BLOB, updated_at REAL NOT NULL)"
+        )
+    state.chmod(0o755)
+    database.chmod(0o644)
+    reset_managers_for_tests()
+    monkeypatch.setenv("EXOMEM_WRITER_LEASE_STATE_DIR", str(state))
+    try:
+        manager = writer_lease_module.get_manager()
+        assert manager.idempotency.path == database
+        assert stat.S_IMODE(state.stat().st_mode) == 0o700
+        assert stat.S_IMODE(database.stat().st_mode) == 0o600
     finally:
         reset_managers_for_tests()
 
@@ -1137,13 +1572,15 @@ def test_identical_inflight_retry_waits_for_original_terminal_result(
     pending_seen = threading.Event()
     calls: list[int] = []
     outcomes: dict[str, object] = {}
+    vault = tmp_path / "vault"
+    (vault / "Knowledge Base").mkdir(parents=True)
     manager = LeaseManager(
         LeaseConfig(state_dir=tmp_path),
         mutation_timeout_seconds=0,
         idempotency_wait_seconds=2,
     )
 
-    def leaf(value: int) -> dict[str, object]:
+    def leaf(_vault: Path, value: int) -> dict[str, object]:
         calls.append(value)
         leaf_started.set()
         assert release_leaf.wait(timeout=2)
@@ -1162,7 +1599,7 @@ def test_identical_inflight_retry_waits_for_original_terminal_result(
         try:
             outcomes[name] = manager.invoke(
                 command,
-                (),
+                (vault,),
                 {"value": 1},
                 implicit_idempotency_scope="principal:alice",
             )
@@ -1345,12 +1782,10 @@ def test_pending_row_with_dead_owner_becomes_abandoned(tmp_path: Path) -> None:
     assert outcome_unknown.value.code == "MUTATION_OUTCOME_UNKNOWN"
 
 
-def test_identical_retry_executes_fresh_after_abandonment_grace_period(
+def test_identical_retry_never_replays_an_outcome_unknown_execution(
     tmp_path: Path,
 ) -> None:
-    """After a `pending` row is abandoned, an identical retry made at least
-    `_IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS` later executes fresh rather
-    than replaying `MUTATION_OUTCOME_UNKNOWN` forever."""
+    """An unprovable execution stays fail-closed after its owner dies."""
     clock = Clock()
     manager = LeaseManager(
         LeaseConfig(state_dir=tmp_path),
@@ -1388,15 +1823,16 @@ def test_identical_retry_executes_fresh_after_abandonment_grace_period(
     assert calls == []
 
     clock.value += writer_lease_module._IDEMPOTENCY_ABANDONED_RETRY_AFTER_SECONDS + 1
-    result = manager.invoke(
-        command,
-        (),
-        {},
-        idempotency_key="pending",
-        idempotency_principal_scope="principal:alice",
-    )
-    assert result == "fresh-result"
-    assert calls == ["ran"]
+    with pytest.raises(OpError) as repeated:
+        manager.invoke(
+            command,
+            (),
+            {},
+            idempotency_key="pending",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert repeated.value.code == "MUTATION_OUTCOME_UNKNOWN"
+    assert calls == []
 
 
 def test_different_identity_busy_is_precommit(tmp_path: Path) -> None:
@@ -1506,7 +1942,10 @@ def test_postcommit_error_cannot_escape_as_precommit_retryable(tmp_path: Path) -
         raise OpError("MUTATION_BUSY", "misleading post-commit error")
 
     command = _command(writes=True, leaf=commits_then_misreports)
-    for _ in range(2):
+    for expected_code in (
+        "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN",
+        "MUTATION_OUTCOME_UNKNOWN",
+    ):
         with pytest.raises(OpError) as uncertain:
             manager.invoke(
                 command,
@@ -1515,10 +1954,10 @@ def test_postcommit_error_cannot_escape_as_precommit_retryable(tmp_path: Path) -
                 idempotency_key="postcommit-error",
                 idempotency_principal_scope="principal:alice",
             )
-        assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+        assert uncertain.value.code == expected_code
         payload = error_dict(uncertain.value)
-        assert payload["status"] == "committed"
-        assert payload["committed"] is True
+        assert payload["status"] == ("committed" if expected_code.startswith("MUTATION_COMMITTED") else "uncertain")
+        assert payload["committed"] is (True if expected_code.startswith("MUTATION_COMMITTED") else None)
 
     assert target.read_text(encoding="utf-8") == "committed\n"
     assert calls == 1
@@ -1557,29 +1996,45 @@ def test_completed_result_receipt_failure_is_committed_uncertain(
         batch_atomic_write([PlannedWrite(target, "committed\n")], vault_root=vault)
         return {"committed": True}
 
-    def fail_terminal_receipt(*_args, **_kwargs) -> None:
-        raise sqlite3.OperationalError("deterministic receipt write failure")
+    original_persist = manager.idempotency._persist_completed_from_canonical
+    failed = False
 
-    monkeypatch.setattr(manager.idempotency, "_persist_completed", fail_terminal_receipt)
+    def fail_terminal_receipt(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise sqlite3.OperationalError("deterministic receipt write failure")
+        return original_persist(*args, **kwargs)
+
+    monkeypatch.setattr(
+        manager.idempotency, "_persist_completed_from_canonical", fail_terminal_receipt
+    )
     command = _command(writes=True, leaf=commit)
 
-    for _ in range(2):
-        with pytest.raises(OpError) as uncertain:
-            manager.invoke(
-                command,
-                (tmp_path,),
-                {},
-                idempotency_key="receipt-failure",
-                idempotency_principal_scope="principal:alice",
-            )
-        assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
-        assert error_dict(uncertain.value)["committed"] is True
+    with pytest.raises(OpError) as uncertain:
+        manager.invoke(
+            command,
+            (tmp_path,),
+            {},
+            idempotency_key="receipt-failure",
+            idempotency_principal_scope="principal:alice",
+        )
+    assert uncertain.value.code == "MUTATION_COMMITTED_ACKNOWLEDGEMENT_UNCERTAIN"
+    assert error_dict(uncertain.value)["committed"] is True
+    replay = manager.invoke(
+        command,
+        (tmp_path,),
+        {},
+        idempotency_key="receipt-failure",
+        idempotency_principal_scope="principal:alice",
+    )
+    assert replay["status"] == "committed"
 
     assert target.read_text(encoding="utf-8") == "committed\n"
     assert calls == 1
 
 
-def test_uncommitted_result_receipt_failure_does_not_claim_commit(
+def test_uncommitted_result_is_completed_without_a_graph_receipt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls = 0
@@ -1590,22 +2045,14 @@ def test_uncommitted_result_receipt_failure_does_not_claim_commit(
         calls += 1
         return {"validate_only": True, "committed": False}
 
-    def fail_terminal_receipt(*_args, **_kwargs) -> None:
-        raise sqlite3.OperationalError("deterministic receipt write failure")
-
-    monkeypatch.setattr(manager.idempotency, "_persist_completed", fail_terminal_receipt)
     command = _command(writes=True, leaf=validate_only)
 
-    for _ in range(2):
-        with pytest.raises(OpError) as pending:
-            manager.invoke(
-                command,
-                (),
-                {},
-                idempotency_key="validate-receipt-failure",
-            )
-        assert pending.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
-        assert error_dict(pending.value)["committed"] is None
+    assert manager.invoke(
+        command, (), {}, idempotency_key="validate-receipt-failure"
+    ) == {"validate_only": True, "committed": False}
+    assert manager.invoke(
+        command, (), {}, idempotency_key="validate-receipt-failure"
+    ) == {"validate_only": True, "committed": False}
 
     assert calls == 1
 
@@ -1899,7 +2346,7 @@ def test_committed_failure_persists_only_sanitized_public_json(tmp_path: Path) -
         manager.invoke(command, (), {}, idempotency_key="sanitized")
 
     _digest, state, stored = _row(manager, "sanitized")
-    assert state == "committed_failure"
+    assert state == "completed"
     assert json.loads(stored.decode("utf-8")) == original.as_public_dict()
     for secret in (
         str(tmp_path).encode(),
@@ -2148,7 +2595,7 @@ def test_corrupt_implicit_committed_failure_timestamp_fails_closed_without_reinv
         manager.invoke(command, (), {}, **marker)
     with sqlite3.connect(manager.idempotency.path) as connection:
         connection.execute(
-            "UPDATE mutations SET updated_at = 'corrupt' WHERE state = 'committed_failure'"
+            "UPDATE mutations SET updated_at = 'corrupt' WHERE state = 'completed'"
         )
 
     with pytest.raises(OpError) as blocked:
@@ -2186,7 +2633,7 @@ def test_expired_corrupt_implicit_committed_failure_payload_fails_closed_without
         manager.invoke(command, (), {}, **marker)
     with sqlite3.connect(manager.idempotency.path) as connection:
         connection.execute(
-            "UPDATE mutations SET result = ? WHERE state = 'committed_failure'",
+            "UPDATE mutations SET result = ? WHERE state = 'completed'",
             (b"not-json",),
         )
 
@@ -2199,7 +2646,7 @@ def test_expired_corrupt_implicit_committed_failure_payload_fails_closed_without
 
 
 @pytest.mark.parametrize("failure_point", ["serialize", "update"])
-def test_committed_marker_storage_failure_keeps_pending_and_blocks_retry(
+def test_committed_marker_storage_failure_keeps_execution_fail_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     failure_point: str,
@@ -2224,7 +2671,7 @@ def test_committed_marker_storage_failure_keeps_pending_and_blocks_retry(
         with sqlite3.connect(manager.idempotency.path) as connection:
             connection.execute(
                 "CREATE TRIGGER fail_committed_update "
-                "BEFORE UPDATE ON mutations WHEN NEW.state = 'committed_failure' "
+                "BEFORE UPDATE ON mutations WHEN NEW.state = 'completed' "
                 "BEGIN SELECT RAISE(FAIL, 'private sqlite detail'); END"
             )
 
@@ -2234,12 +2681,12 @@ def test_committed_marker_storage_failure_keeps_pending_and_blocks_retry(
     assert first.value.__cause__ is not None
     assert "private" not in str(first.value)
     _digest, state, stored = _row(manager, "storage-failure")
-    assert state == "pending"
+    assert state == "executing"
     assert stored is None
 
     with pytest.raises(OpError) as blocked:
         manager.invoke(command, (), {}, idempotency_key="storage-failure")
-    assert blocked.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+    assert blocked.value.code == "MUTATION_OUTCOME_UNKNOWN"
     assert calls == 1
 
 
@@ -2267,7 +2714,7 @@ def test_explicit_idempotency_blocks_orphaned_pending_after_process_abort(
     )
     with pytest.raises(OpError) as blocked:
         manager.invoke(recovered, (), {}, idempotency_key="request-after-crash")
-    assert blocked.value.code == "MUTATION_ACKNOWLEDGEMENT_PENDING"
+    assert blocked.value.code == "MUTATION_OUTCOME_UNKNOWN"
     assert calls == ["aborted"]
 
 


### PR DESCRIPTION
## Why

A missing or unusable epistemic-graph sidecar made a full vault rebuild run while canonical mutation authority was held. The rebuild itself scaled with the vault, so one recovery, upgrade, or cache repair could block unrelated writes for seconds or minutes.

Earlier work made steady-state resolution and incremental indexing scale. This closes the remaining exceptional path: full rebuild, crash recovery, exact retry, and cross-process publication.

## What changed

- Builds full graph sidecars privately and publishes them under canonical authority using two bounded ticket checks plus atomic replacement.
- Adds strict floor/checkpoint epochs, exact graph acknowledgements, durable rebuild or failure handles, and fail-closed recovery.
- Replaces the old graph-pending ownership model with exact canonical lifecycle states and authenticated, content-free v2 commit receipts.
- Preserves exact retry semantics across real subprocess crash cuts without replaying the canonical leaf.
- Adds cooperative POSIX single-flight rebuilding and Windows DPAPI, DACL, reparse, sharing-refusal, and path-alias handling.
- Covers delete, recursive delete, restore, reconcile, readiness, watcher, and lifecycle fanout paths.

## Performance

Quiesced five-trial benchmark:

- 500 pages: request p95 666.6 ms; final canonical publication hold p95 1.6 ms
- 2,000 pages: request p95 2,479.1 ms; final canonical publication hold p95 0.7 ms
- 2,000/500 median hold ratio: 0.44x

Total private rebuild time still scales with corpus size. Canonical writer hold no longer does.

## Verification

- Full Linux suite: 8,489 passed, 143 expected skips, 0 failed
- Graph and invalidated-gate suite: 921 passed, 3 native-only skips
- Independent final review: 200 passed, 9 native-only skips; no findings
- Five-cut real subprocess crash matrix passes
- Ruff F clean
- Targeted Mypy clean on six graph/mutation modules
- Strict OpenSpec validation passes
- PR-range diff check clean
- Source distribution and wheel build successfully
- Fresh installed-wheel Windows interactive product loop passed, including stdio, HTTP, Studio/review, and two-replica lease phases
- Native Windows DPAPI/DACL/reparse, cross-process lock, 8.3 alias, and open-reader sharing-refusal cases passed

## Remaining platform evidence

OpenSpec tasks 4.3 and 5.4 intentionally remain unchecked only for the real LocalSystem/NSSM service loop. The available Windows identity is non-administrative; a unique disposable service preflight failed at OpenSCManager with access denied before any service was created. Existing services were not modified. This is an external elevation requirement, not a failing implementation test.
