### PR TITLE
fix(hosted): disable recovery pod service links

### DIFF
--- a/docs/runbooks/hosted/cell.md
+++ b/docs/runbooks/hosted/cell.md
@@ -161,6 +161,7 @@ metadata:
   labels:
     app.kubernetes.io/name: exomem-init-retry-recovery
 spec:
+  enableServiceLinks: false
   serviceAccountName: exomem-init-retry-recovery
   automountServiceAccountToken: true
   restartPolicy: Never

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -456,6 +456,7 @@ def test_platform_renders_a_read_only_recovery_operator_identity() -> None:
     )
     runbook = (ROOT / "docs/runbooks/hosted/cell.md").read_text(encoding="utf-8")
     assert "exomem-init-retry-recovery" in runbook
+    assert "spec:\n  enableServiceLinks: false\n  serviceAccountName: exomem-init-retry-recovery" in runbook
     assert 'exomem-provisioner-recover-init-retry "$mode" --stdin < "$recovery_identity"' in runbook
     assert 'kubectl -n exomem-platform exec -i "$operator_pod" --' in runbook
     assert "--identity-file" not in runbook


### PR DESCRIPTION
## Why

The manual init-retry recovery Pod inherited Kubernetes service-link variables for the provisioner Service. Those `EXOMEM_PROVISIONER_*` names were correctly rejected by the recovery helper's least-authority environment validator before database access, so recovery failed closed.

## What changed

- disable service-link injection on the short-lived recovery Pod
- lock the requirement into the hosted Helm/runbook contract test

The recovery settings validator remains unchanged and fail-closed.

## Verification

- red-first focused contract assertion: failed before the runbook change
- focused recovery operator contract: 1 passed
- hosted Helm contract suite: 38 passed
- operation recovery suite: 22 passed
- Ruff: passed
- package build: passed
- `git diff --check`: passed

Live state was restored before this change: the operator Pod was deleted, the routine worker and five database CronJobs returned to their captured baseline, and external reconcile remains suspended. No database mutation occurred.
