### PR TITLE
fix(governance): update archived spec test paths

### DIFF
--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -71,7 +71,7 @@ def _policy(rules=(), grants=(), scopes=()):
 def _change_contract(name: str) -> str:
     return (
         Path(__file__).resolve().parents[1]
-        / "openspec/changes/add-default-deny-scope-cap"
+        / "openspec/changes/archive/2026-08-13-add-default-deny-scope-cap"
         / name
     ).read_text(encoding="utf-8")
 

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -3655,7 +3655,7 @@ _RANK_DERIVED_SIGNALS = ("bm25_rank", "keyword_rank", "vector_rank", "graph_in_d
 def test_spec_names_the_known_preexisting_relevance_ranking_channel() -> None:
     spec = (
         Path(__file__).resolve().parents[1]
-        / "openspec/changes/add-default-deny-scope-cap/specs/governance-kernel/spec.md"
+        / "openspec/changes/archive/2026-08-13-add-default-deny-scope-cap/specs/governance-kernel/spec.md"
     ).read_text(encoding="utf-8")
     scenario = spec.split(
         "#### Scenario: an audience no rule names receives nothing", 1


### PR DESCRIPTION
## What changed

Update three governance contract assertions to read the default-deny design/spec from its stable dated OpenSpec archive location.

## Root cause

PR #460 correctly archived `add-default-deny-scope-cap`, but two test modules still hard-coded its former active-change path. The Python 3.11/3.13 shards therefore failed with identical `FileNotFoundError`s after otherwise passing roughly 2,200 tests each.

## Verification

- red: the three affected tests reproduced 3 `FileNotFoundError` failures on merged `main`
- green: the same three tests passed
- `tests/test_governance_decisions.py tests/test_governance_egress.py` — 312 passed
- `git diff --check`

No production or OpenSpec content changes.
