### PR TITLE
fix(governance): close disclosure crossover

### DIFF
--- a/src/exomem/governance/decisions.py
+++ b/src/exomem/governance/decisions.py
@@ -1,13 +1,11 @@
 """Pure, order-free disclosure-ceiling evaluator.
 
-`decide()` computes `min(org_cap, max(grants, min(standing_rules)))` — the
-kernel's only decision surface, and the only place a later enforcement change
-will call into. It is a pure function over already-compiled tables: no file
-IO, no clock, no randomness, and no rule-priority ordering — every matching
-rule participates, and min/max are commutative so the result never depends on
-authoring order (design decision D5). Purpose-absence is deterministic: a
-purpose-conditioned allowance does not fire when purpose is undeclared, while
-an "outside purpose" restriction does.
+`decide()` resolves standing rules, exact-scope grants, and organisation caps
+for every member scope independently before taking the conservative item meet.
+It is a pure function over already-compiled tables: no file IO, no clock, no
+randomness, and no rule-priority ordering. Purpose-absence is deterministic:
+a purpose-conditioned allowance does not fire when purpose is undeclared,
+while an "outside purpose" restriction does.
 
 The standing default is OPEN — an audience no rule names receives full
 disclosure — unless a scope the item belongs to sets `default_deny`, which
@@ -20,11 +18,32 @@ a rule authored on one declared scope never suppresses another's declaration.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal
 
 from .policy import DISCLOSURE_MAX, DISCLOSURE_MIN, Policy, Rule, StandingGrant
 from .principal import OWNER_AUDIENCE
+
+_PurposeBranch = Literal["neutral", "declared", "undeclared"]
+
+
+@dataclass(frozen=True)
+class _ScopeContribution:
+    """Immutable owner-inspection evidence for one scope-local evaluation."""
+
+    scope_id: str
+    purpose_branch: _PurposeBranch
+    standing_floor: int
+    default_deny_supplied_floor: bool
+    standing_rule_ids: tuple[str, ...]
+    grant_ids: tuple[str, ...]
+    grant_ceiling: int | None
+    grant_contribution: int
+    organization_cap_ids: tuple[str, ...]
+    organization_cap: int
+    option_values: tuple[tuple[str, Any], ...]
+    option_ambiguities: tuple[str, ...]
+    final_ceiling: int
 
 
 @dataclass(frozen=True)
@@ -44,6 +63,11 @@ class Decision:
     release_grant_id: str | None = None
     release_strip: tuple[Any, ...] = ()
     release_dependency_digest: str | None = None
+    option_values: dict[str, Any] = field(default_factory=dict, repr=False)
+    option_ambiguities: frozenset[str] = field(default_factory=frozenset, repr=False)
+    scope_contributions: tuple[_ScopeContribution, ...] = field(
+        default_factory=tuple, repr=False
+    )
 
 
 def _rule_matches(
@@ -66,8 +90,202 @@ def _rule_matches(
     return True
 
 
-def _grant_matches(grant: StandingGrant, scope_ids: frozenset[str], audience: str) -> bool:
-    return grant.audience == audience and bool(set(grant.scope_ids) & scope_ids)
+def _grant_matches(grant: StandingGrant, scope_id: str, audience: str) -> bool:
+    return grant.audience == audience and scope_id in grant.scope_ids
+
+
+_OPTION_KEYS = frozenset({"notice", "constraint", "abstract", "bridge"})
+_OPTION_LEVELS = {"notice": 1, "constraint": 2, "abstract": 3, "bridge": 4}
+_MISSING = object()
+
+
+def _release_strip_key(value: Any) -> tuple[str, ...]:
+    value_type = type(value)
+    type_key = (value_type.__module__, value_type.__qualname__)
+    path = getattr(value, "path", None)
+    ref = getattr(value, "ref", None)
+    title = getattr(value, "title", None)
+    if all(isinstance(item, str) for item in (path, ref, title)):
+        return (*type_key, "identity", path, ref, title)
+    if isinstance(value, str):
+        return (*type_key, "string", value)
+    return (*type_key, "repr", repr(value))
+
+
+def _normalize_release_strip(values: Iterable[Any]) -> tuple[Any, ...]:
+    by_key: dict[tuple[str, ...], Any] = {}
+    for value in values:
+        by_key.setdefault(_release_strip_key(value), value)
+    return tuple(by_key[key] for key in sorted(by_key))
+
+
+def _scope_contribution_key(contribution: _ScopeContribution) -> tuple[Any, ...]:
+    return (
+        contribution.scope_id,
+        contribution.purpose_branch,
+        contribution.standing_floor,
+        contribution.default_deny_supplied_floor,
+        contribution.standing_rule_ids,
+        contribution.grant_ids,
+        -1 if contribution.grant_ceiling is None else contribution.grant_ceiling,
+        contribution.grant_contribution,
+        contribution.organization_cap_ids,
+        contribution.organization_cap,
+        tuple((key, repr(value)) for key, value in contribution.option_values),
+        contribution.option_ambiguities,
+        contribution.final_ceiling,
+    )
+
+
+def _normalize_scope_contributions(
+    contributions: Iterable[_ScopeContribution],
+) -> tuple[_ScopeContribution, ...]:
+    by_key: dict[tuple[Any, ...], _ScopeContribution] = {}
+    for contribution in contributions:
+        by_key.setdefault(_scope_contribution_key(contribution), contribution)
+    return tuple(by_key[key] for key in sorted(by_key))
+
+
+def _meet_options(option_sets: Iterable[dict[str, Any]]) -> tuple[dict[str, Any], set[str]]:
+    """Meet closed policy options without allowing a sibling to fill absence."""
+    contributors = tuple(option_sets)
+    if not contributors:
+        return {}, set()
+    result: dict[str, Any] = {}
+    ambiguous: set[str] = set()
+    for key in _OPTION_KEYS:
+        values = tuple(options.get(key, _MISSING) for options in contributors)
+        if all(value is _MISSING for value in values):
+            continue
+        if any(value is _MISSING or value != values[0] for value in values[1:]):
+            ambiguous.add(key)
+            continue
+        result[key] = values[0]
+    return result, ambiguous
+
+
+def _decision(
+    level: int,
+    *,
+    scope_ids: Iterable[str],
+    rule_ids: Iterable[str],
+    default_deny_scope_ids: Iterable[str],
+    options: dict[str, Any],
+    option_ambiguities: Iterable[str] = (),
+    option_values: dict[str, Any] | None = None,
+    release_reason: str | None = None,
+    release_grant_id: str | None = None,
+    release_strip: Iterable[Any] = (),
+    release_dependency_digest: str | None = None,
+    scope_contributions: Iterable[_ScopeContribution] = (),
+) -> Decision:
+    values = {
+        key: value
+        for key, value in (option_values if option_values is not None else options).items()
+        if key in _OPTION_KEYS
+    }
+    ambiguities = frozenset(option_ambiguities)
+    projected_level = level
+    for key in ("bridge", "abstract", "constraint", "notice"):
+        if key in ambiguities and projected_level >= _OPTION_LEVELS[key]:
+            projected_level = _OPTION_LEVELS[key] - 1
+    projected_options = {
+        key: value
+        for key, value in values.items()
+        if _OPTION_LEVELS[key] <= projected_level and key not in ambiguities
+    }
+    if (
+        "constraint" in projected_options
+        and options.get("constraint_source") == "scope"
+    ):
+        projected_options["constraint_source"] = "scope"
+    if "constraint" in ambiguities and projected_level == 1:
+        projected_options["constraint_ambiguous"] = True
+    return Decision(
+        level=projected_level,
+        scope_ids=tuple(sorted(set(scope_ids))),
+        rule_ids=tuple(sorted(set(rule_ids))),
+        default_deny_scope_ids=tuple(sorted(set(default_deny_scope_ids))),
+        options=projected_options,
+        notice=projected_options.get("notice"),
+        bridge=projected_options.get("bridge"),
+        release_reason=release_reason,
+        release_grant_id=release_grant_id,
+        release_strip=_normalize_release_strip(release_strip),
+        release_dependency_digest=release_dependency_digest,
+        option_values=values,
+        option_ambiguities=ambiguities,
+        scope_contributions=_normalize_scope_contributions(scope_contributions),
+    )
+
+
+def _meet_decisions(decisions: Iterable[Decision]) -> Decision:
+    """Conservatively fold complete decisions at a shared disclosure level."""
+    contributors = tuple(decisions)
+    if not contributors:
+        return _decision(
+            DISCLOSURE_MAX,
+            scope_ids=(),
+            rule_ids=(),
+            default_deny_scope_ids=(),
+            options={},
+        )
+    level = min(decision.level for decision in contributors)
+    values: dict[str, Any] = {}
+    ambiguous: set[str] = set()
+    for key in _OPTION_KEYS:
+        states = []
+        for decision in contributors:
+            if key in decision.option_ambiguities:
+                states.append(_MISSING)
+                ambiguous.add(key)
+            else:
+                source = decision.option_values or decision.options
+                states.append(source.get(key, _MISSING))
+        if all(state is _MISSING for state in states):
+            if key not in ambiguous:
+                continue
+        elif any(state is _MISSING or state != states[0] for state in states[1:]):
+            ambiguous.add(key)
+        else:
+            values[key] = states[0]
+    options = dict(values)
+    if values.get("constraint") and all(
+        decision.options.get("constraint_source") == "scope"
+        for decision in contributors
+    ):
+        options["constraint_source"] = "scope"
+
+    def singleton(name: str) -> Any:
+        candidates = [getattr(decision, name) for decision in contributors]
+        return candidates[0] if candidates[0] is not None and all(
+            candidate == candidates[0] for candidate in candidates
+        ) else None
+
+    return _decision(
+        level,
+        scope_ids=(scope_id for decision in contributors for scope_id in decision.scope_ids),
+        rule_ids=(rule_id for decision in contributors for rule_id in decision.rule_ids),
+        default_deny_scope_ids=(
+            scope_id
+            for decision in contributors
+            for scope_id in decision.default_deny_scope_ids
+        ),
+        options=options,
+        option_ambiguities=ambiguous,
+        option_values=values,
+        release_reason=singleton("release_reason"),
+        release_grant_id=singleton("release_grant_id"),
+        release_strip=(
+            strip for decision in contributors for strip in decision.release_strip
+        ),
+        release_dependency_digest=singleton("release_dependency_digest"),
+        scope_contributions=(
+            contribution
+            for decision in contributors
+            for contribution in decision.scope_contributions
+        ),
+    )
 
 
 def decide(
@@ -107,19 +325,20 @@ def decide(
     if purpose is None:
         return _decide_at(
             scope_ids, audience=audience, purpose=None, policy=policy,
+            purpose_branch="neutral",
             active_grants=active_grants,
         )
     declared = _decide_at(
         scope_ids, audience=audience, purpose=purpose, policy=policy,
+        purpose_branch="declared",
         active_grants=active_grants,
     )
     undeclared = _decide_at(
         scope_ids, audience=audience, purpose=None, policy=policy,
+        purpose_branch="undeclared",
         active_grants=active_grants,
     )
-    # Ties go to the declared branch so its rule_ids/scope_ids explain the
-    # outcome when both branches agree on the level.
-    return declared if declared.level <= undeclared.level else undeclared
+    return _meet_decisions((declared, undeclared))
 
 
 def _decide_at(
@@ -127,88 +346,75 @@ def _decide_at(
     *,
     audience: str,
     purpose: str | None,
+    purpose_branch: _PurposeBranch,
     policy: Policy,
     active_grants: Iterable[StandingGrant] | None = None,
 ) -> Decision:
     """One evaluation of the lattice at a single purpose value."""
     scope_id_set = frozenset(scope_ids)
     grants = policy.grants if active_grants is None else tuple(active_grants)
-
-    matched_rules = [r for r in policy.rules if _rule_matches(r, scope_id_set, audience, purpose)]
-    matched_grants = [g for g in grants if _grant_matches(g, scope_id_set, audience)]
-
-    standing = [r for r in matched_rules if r.kind != "org_cap"]
-    org_caps = [r for r in matched_rules if r.kind == "org_cap"]
-
-    # The one default this change inverts, resolved PER DECLARING SCOPE. A
-    # declared scope keeps its default until a standing rule names this
-    # audience *for that scope* — resolving it against the item's global
-    # matched-rule set instead would let a rule authored on one compartment
-    # suppress a different compartment's declaration, so authorising a partner
-    # on S1 would hand them an item that is also in an untouched S2.
-    #
-    # It stays a default and not a synthetic ceiling-0 rule: the floor is
-    # folded into `standing_min` only for scopes NO rule named, so an authored
-    # `ceiling: 3` on a declared scope still reads 3 rather than
-    # `min(3, 0) = 0`.
-    default_deny_scope_ids: tuple[str, ...] = ()
-    if audience != OWNER_AUDIENCE:
-        # The owner is exempt where the default is CHOSEN, not by a post-hoc
-        # override, so a rule that deliberately restricts the owner still
-        # takes effect through the ceilings below.
-        named_scope_ids = {
-            scope_id for rule in standing for scope_id in rule.scope_ids
-        } & scope_id_set
-        # ANY declared member that named nobody closes the item: membership is
-        # a set, and a declaration that could be defeated by authoring a broad
-        # undeclared scope alongside it would be no control at all.
-        default_deny_scope_ids = tuple(
-            sorted(
-                scope_id
-                for scope_id in scope_id_set
-                if scope_id not in named_scope_ids
-                and (scope := policy.scopes.get(scope_id)) is not None
-                and scope.default_deny
-            )
+    scope_decisions: list[Decision] = []
+    for scope_id in sorted(scope_id_set):
+        matched_rules = [
+            rule
+            for rule in policy.rules
+            if _rule_matches(rule, frozenset((scope_id,)), audience, purpose)
+        ]
+        standing = [rule for rule in matched_rules if rule.kind != "org_cap"]
+        org_caps = [rule for rule in matched_rules if rule.kind == "org_cap"]
+        scope = policy.scopes.get(scope_id)
+        default_denied = (
+            audience != OWNER_AUDIENCE
+            and not standing
+            and scope is not None
+            and scope.default_deny
         )
-    ceilings = [rule.ceiling for rule in standing]
-    if default_deny_scope_ids:
-        ceilings.append(DISCLOSURE_MIN)
-    standing_min = min(ceilings, default=DISCLOSURE_MAX)
-    # Unchanged: a grant still raises off the floor, so "unless a grant names
-    # them" needs no special case.
-    grant_max = max([g.ceiling for g in matched_grants] + [standing_min])
-    org_cap_min = min((r.ceiling for r in org_caps), default=DISCLOSURE_MAX)
-    level = min(org_cap_min, grant_max)
-
-    options: dict[str, Any] = {}
-    for rule in sorted(matched_rules, key=lambda r: r.id):
-        options.update(rule.options)
-
-    # Scope-registered L2 constraints are governed micro-bridges.  Resolve
-    # them as a set, not by document/rule order: one distinct approved string
-    # is deterministic; two different strings are ambiguous and therefore
-    # cannot cross the boundary.  Legacy rule-option constraints remain the
-    # fallback when no scope record applies.
-    scope_constraints = {
-        scope.constraint
-        for scope_id in scope_id_set
-        if (scope := policy.scopes.get(scope_id)) is not None and scope.constraint
-    }
-    if level >= 2 and len(scope_constraints) == 1:
-        options["constraint"] = next(iter(scope_constraints))
-        options["constraint_source"] = "scope"
-    elif level >= 2 and len(scope_constraints) > 1:
-        level = min(level, 1)
-        options.pop("constraint", None)
-        options["constraint_ambiguous"] = True
-
-    return Decision(
-        level=level,
-        scope_ids=tuple(sorted(scope_id_set)),
-        rule_ids=tuple(sorted(r.id for r in matched_rules)),
-        default_deny_scope_ids=default_deny_scope_ids,
-        options=options,
-        notice=options.get("notice"),
-        bridge=options.get("bridge"),
-    )
+        standing_level = min(
+            (rule.ceiling for rule in standing),
+            default=DISCLOSURE_MIN if default_denied else DISCLOSURE_MAX,
+        )
+        matched_grants = [
+            grant for grant in grants if _grant_matches(grant, scope_id, audience)
+        ]
+        grant_ceiling = max(
+            (grant.ceiling for grant in matched_grants), default=None
+        )
+        grant_level = max(
+            standing_level,
+            grant_ceiling if grant_ceiling is not None else standing_level,
+        )
+        organization_cap = min(
+            (rule.ceiling for rule in org_caps), default=DISCLOSURE_MAX
+        )
+        level = min(grant_level, organization_cap)
+        options, ambiguous = _meet_options(rule.options for rule in matched_rules)
+        if level >= 2 and scope is not None and scope.constraint:
+            options["constraint"] = scope.constraint
+            options["constraint_source"] = "scope"
+        scope_decision = _decision(
+            level,
+            scope_ids=(scope_id,),
+            rule_ids=(rule.id for rule in matched_rules),
+            default_deny_scope_ids=(scope_id,) if default_denied else (),
+            options=options,
+            option_ambiguities=ambiguous,
+        )
+        contribution = _ScopeContribution(
+            scope_id=scope_id,
+            purpose_branch=purpose_branch,
+            standing_floor=standing_level,
+            default_deny_supplied_floor=default_denied,
+            standing_rule_ids=tuple(sorted(rule.id for rule in standing)),
+            grant_ids=tuple(sorted(grant.id for grant in matched_grants)),
+            grant_ceiling=grant_ceiling,
+            grant_contribution=grant_level,
+            organization_cap_ids=tuple(sorted(rule.id for rule in org_caps)),
+            organization_cap=organization_cap,
+            option_values=tuple(sorted(scope_decision.option_values.items())),
+            option_ambiguities=tuple(sorted(scope_decision.option_ambiguities)),
+            final_ceiling=scope_decision.level,
+        )
+        scope_decisions.append(
+            replace(scope_decision, scope_contributions=(contribution,))
+        )
+    return _meet_decisions(scope_decisions)

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -53,7 +53,7 @@ from . import bridges, lifecycle, receipts, scrubber, store, tokens
 from . import membership as membership_module
 from . import policy as policy_module
 from .decisions import Decision, decide
-from .policy import DISCLOSURE_MAX, DISCLOSURE_MIN, Policy, StandingGrant
+from .policy import DISCLOSURE_MAX, DISCLOSURE_MIN, Policy
 from .principal import OWNER_AUDIENCE, RequestPrincipal, effective_principal
 
 log = logging.getLogger(__name__)
@@ -1073,13 +1073,7 @@ def _decide_path(
         if expected_content_hash is not None and expected_content_hash != live_content_hash:
             return None
 
-    session_rows, session_identity = store.active_session_grants(
-        vault_root,
-        audience=audience,
-        authorization_session=authorization_session,
-        rel_path=rel_path,
-        purpose=purpose,
-    )
+    session_identity = "v3-session-grants-unscoped"
     key = (
         str(vault_root),
         policy.fingerprint,
@@ -1124,22 +1118,12 @@ def _decide_path(
             # was stattable one line ago and is not now — which is exactly
             # when guessing is least defensible.
             return None
-    session_grants = tuple(
-        StandingGrant(
-            id=str(row["grant_id"]),
-            source="session",
-            scope_ids=tuple(scope_ids),
-            audience=audience,
-            ceiling=int(row["ceiling"]),
-        )
-        for row in session_rows
-    )
     decision = decide(
         scope_ids,
         audience=audience,
         purpose=purpose,
         policy=policy,
-        active_grants=(*policy.grants, *session_grants),
+        active_grants=policy.grants,
     )
     if raw is not None:
         admission = bridges.admit(
@@ -1679,29 +1663,12 @@ def annotate_page(
         scope_ids = membership_module.evaluate_snapshot(
             parsed, policy, content_hash=snapshot_hash
         )
-        session_rows, _session_identity = store.active_session_grants(
-            vault_root,
-            audience=who.audience_id,
-            authorization_session=who.authorization_session_id,
-            rel_path=rel_path,
-            purpose=declared_purpose,
-        )
-        session_grants = tuple(
-            StandingGrant(
-                id=str(row["grant_id"]),
-                source="session",
-                scope_ids=tuple(scope_ids),
-                audience=who.audience_id,
-                ceiling=int(row["ceiling"]),
-            )
-            for row in session_rows
-        )
         decision = decide(
             scope_ids,
             audience=who.audience_id,
             purpose=declared_purpose,
             policy=policy,
-            active_grants=(*policy.grants, *session_grants),
+            active_grants=policy.grants,
         )
         admission = bridges.admit(
             vault_root,
@@ -2064,8 +2031,6 @@ def postfilter(command_name: str, result: Any, vault_root: Path) -> Any:
         scan_all=command_name
         in {"continue_adoption", "adoption_run", "adoption_runs", "adoption_studio"},
     )
-    if not scrubber.enabled(vault_root):
-        return result
     if hasattr(result, "content") and hasattr(result, "structured_content"):
         cleaned, blocked = _scrub_tool_result(result, vault_root)
         if blocked:
@@ -2211,15 +2176,13 @@ def postfilter_error(
         purpose=None,
         exempt=_caller_supplied_references(request_kwargs),
     )
-    scrub = scrubber.enabled(vault_root)
     blocked = False
 
     def _clean(value: Any) -> Any:
         nonlocal blocked
         cleaned = gate.gate_payload(value, scan_strings=True)
-        if scrub:
-            cleaned, hit = scrubber.scrub_value(cleaned)
-            blocked = blocked or hit
+        cleaned, hit = scrubber.scrub_value(cleaned)
+        blocked = blocked or hit
         return cleaned
 
     code = getattr(error, "code", None)

--- a/src/exomem/governance/inspection.py
+++ b/src/exomem/governance/inspection.py
@@ -120,6 +120,32 @@ def inspect_operation(
         # from a non-owner while disclosing rule ids — a default denial must
         # not become the one place a third party learns the scope structure.
         declaring_scopes = [] if decision is None else list(decision.default_deny_scope_ids)
+        scope_contributions = (
+            []
+            if decision is None
+            else [
+                {
+                    "scope_id": contribution.scope_id,
+                    "purpose_branch": contribution.purpose_branch,
+                    "standing_floor": contribution.standing_floor,
+                    "default_deny_supplied_floor": (
+                        contribution.default_deny_supplied_floor
+                    ),
+                    "standing_rule_ids": list(contribution.standing_rule_ids),
+                    "grant_ids": list(contribution.grant_ids),
+                    "grant_ceiling": contribution.grant_ceiling,
+                    "grant_contribution": contribution.grant_contribution,
+                    "organization_cap_ids": list(
+                        contribution.organization_cap_ids
+                    ),
+                    "organization_cap": contribution.organization_cap,
+                    "option_values": dict(contribution.option_values),
+                    "option_ambiguities": list(contribution.option_ambiguities),
+                    "final_ceiling": contribution.final_ceiling,
+                }
+                for contribution in decision.scope_contributions
+            ]
+        )
         return {
             "enabled": True,
             "effective_ceiling": level,
@@ -128,6 +154,11 @@ def inspect_operation(
             **(
                 {"default_deny_scope_ids": declaring_scopes}
                 if owner and declaring_scopes
+                else {}
+            ),
+            **(
+                {"scope_contributions": scope_contributions}
+                if owner
                 else {}
             ),
             **(

--- a/src/exomem/governance/policy.py
+++ b/src/exomem/governance/policy.py
@@ -149,10 +149,78 @@ _RELEASE_DEPENDENCY_FIELDS = frozenset(
     {"ref", "path", "content_hash", "restriction_signature"}
 )
 _RELEASE_OPTIONS_FIELDS = frozenset({"strip_provenance"})
+_RULE_OPTION_STRING_FIELDS = frozenset({"notice", "constraint", "abstract", "bridge"})
+_RULE_OPTION_CONTROL_FIELDS = frozenset({"suspended"})
+_RULE_OPTION_FIELDS = _RULE_OPTION_STRING_FIELDS | _RULE_OPTION_CONTROL_FIELDS
 _PURPOSE_CONDITIONS = frozenset({"matches", "outside"})
 _RULE_KINDS = frozenset({"standing", "org_cap"})
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _CONSTRAINT_MAX_CHARS = 500
+
+
+def _mapping_key_sort_key(value: Any) -> tuple[str, str, str]:
+    value_type = type(value)
+    return value_type.__module__, value_type.__qualname__, repr(value)
+
+
+def _check_mapping_keys(
+    mapping: dict[Any, Any],
+    allowed: frozenset[str],
+    location: str,
+    findings: list[dict[str, str]],
+    *,
+    separator: str,
+    noun: str,
+) -> None:
+    """Validate a strict YAML mapping without comparing heterogeneous keys."""
+    non_string = sorted(
+        (key for key in mapping if not isinstance(key, str)),
+        key=_mapping_key_sort_key,
+    )
+    for key in non_string:
+        findings.append(
+            _finding(
+                "invalid_field",
+                location,
+                f"{noun} keys must be strings; got {type(key).__name__}",
+            )
+        )
+    unknown = sorted(
+        key for key in mapping if isinstance(key, str) and key not in allowed
+    )
+    for key in sorted(unknown):
+        findings.append(
+            _finding(
+                "unknown_field",
+                f"{location}{separator}{key}",
+                f"unknown {noun} {key!r}",
+            )
+        )
+
+
+def _check_option_keys(
+    options: dict[Any, Any],
+    allowed: frozenset[str],
+    rel: str,
+    findings: list[dict[str, str]],
+) -> None:
+    """Reject YAML's non-string and unregistered option keys."""
+    _check_mapping_keys(
+        options,
+        allowed,
+        f"{rel}:options",
+        findings,
+        separator=".",
+        noun="option",
+    )
+    if "credential_scrubber" in options:
+        findings.append(
+            _finding(
+                "owner_migration_required",
+                f"{rel}:options.credential_scrubber",
+                "remove credential_scrubber through a reviewed owner migration",
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -705,11 +773,17 @@ def compile_prospective(
 
 
 def _check_common(
-    data: dict[str, Any], rel: str, allowed: frozenset[str]
+    data: dict[Any, Any], rel: str, allowed: frozenset[str]
 ) -> tuple[list[dict[str, str]], str | None]:
     findings: list[dict[str, str]] = []
-    for key in sorted(set(data) - allowed):
-        findings.append(_finding("unknown_field", f"{rel}:{key}", f"unknown field {key!r}"))
+    _check_mapping_keys(
+        data,
+        allowed,
+        rel,
+        findings,
+        separator=":",
+        noun="field",
+    )
     version = data.get("governance_version")
     if version != GOVERNANCE_VERSION:
         findings.append(
@@ -798,10 +872,14 @@ def _parse_scope(data: dict[str, Any], rel: str) -> tuple[Scope | None, list[dic
         findings.append(_finding("invalid_field", f"{rel}:exclude", "exclude must be a mapping"))
         exclude = {}
     else:
-        for key in sorted(set(exclude) - _SCOPE_EXCLUDE_ALLOWED_FIELDS):
-            findings.append(
-                _finding("unknown_field", f"{rel}:exclude.{key}", f"unknown exclude field {key!r}")
-            )
+        _check_mapping_keys(
+            exclude,
+            _SCOPE_EXCLUDE_ALLOWED_FIELDS,
+            f"{rel}:exclude",
+            findings,
+            separator=".",
+            noun="exclude field",
+        )
 
     name = data.get("name")
     if name is not None and not isinstance(name, str):
@@ -922,7 +1000,10 @@ def _parse_rule(data: dict[str, Any], rel: str) -> tuple[Rule | None, list[dict[
         purpose = None
 
     purpose_condition = data.get("purpose_condition", "matches")
-    if purpose_condition not in _PURPOSE_CONDITIONS:
+    if (
+        type(purpose_condition) is not str
+        or purpose_condition not in _PURPOSE_CONDITIONS
+    ):
         findings.append(
             _finding(
                 "invalid_field",
@@ -933,7 +1014,7 @@ def _parse_rule(data: dict[str, Any], rel: str) -> tuple[Rule | None, list[dict[
         purpose_condition = "matches"
 
     kind = data.get("kind", "standing")
-    if kind not in _RULE_KINDS:
+    if type(kind) is not str or kind not in _RULE_KINDS:
         findings.append(_finding("invalid_field", f"{rel}:kind", f"must be one of {sorted(_RULE_KINDS)}"))
         kind = "standing"
 
@@ -941,6 +1022,25 @@ def _parse_rule(data: dict[str, Any], rel: str) -> tuple[Rule | None, list[dict[
     if not isinstance(options, dict):
         findings.append(_finding("invalid_field", f"{rel}:options", "options must be a mapping"))
         options = {}
+    else:
+        _check_option_keys(options, _RULE_OPTION_FIELDS, rel, findings)
+        for key in _RULE_OPTION_STRING_FIELDS:
+            if key in options and not _valid_constraint(options[key]):
+                findings.append(
+                    _finding(
+                        "invalid_field",
+                        f"{rel}:options.{key}",
+                        f"{key} must be a bounded provenance-free string",
+                    )
+                )
+        if "suspended" in options and not isinstance(options["suspended"], bool):
+            findings.append(
+                _finding(
+                    "invalid_field",
+                    f"{rel}:options.suspended",
+                    "suspended must be a boolean",
+                )
+            )
 
     if doc_id is None or not scope_ids or audience is None or ceiling is None:
         return None, findings
@@ -1063,8 +1163,14 @@ def _parse_release_grant(
             if not isinstance(raw, dict):
                 findings.append(_finding("invalid_field", location, "dependency must be a mapping"))
                 continue
-            for key in sorted(set(raw) - _RELEASE_DEPENDENCY_FIELDS):
-                findings.append(_finding("unknown_field", f"{location}.{key}", f"unknown dependency field {key!r}"))
+            _check_mapping_keys(
+                raw,
+                _RELEASE_DEPENDENCY_FIELDS,
+                location,
+                findings,
+                separator=".",
+                noun="dependency field",
+            )
             dep_ref = raw.get("ref")
             dep_path = raw.get("path")
             dep_hash = raw.get("content_hash")
@@ -1101,15 +1207,21 @@ def _parse_release_grant(
     if not isinstance(options, dict):
         findings.append(_finding("missing_field", f"{rel}:options", "options must be a mapping"))
     else:
-        for key in sorted(set(options) - _RELEASE_OPTIONS_FIELDS):
-            findings.append(_finding("unknown_field", f"{rel}:options.{key}", f"unknown option {key!r}"))
+        _check_option_keys(options, _RELEASE_OPTIONS_FIELDS, rel, findings)
         values = options.get("strip_provenance")
         if not isinstance(values, list) or not values or not all(isinstance(item, str) and item.strip() for item in values):
             findings.append(_finding("missing_field", f"{rel}:options.strip_provenance", "strip_provenance must be a non-empty list of refs or paths"))
         else:
             strip = tuple(dict.fromkeys(item.strip() for item in values))
             identities = {item for dep in dependencies for item in (dep.ref, dep.path)}
-            if any(item not in identities for item in strip):
+            if any(
+                item not in identities
+                or (
+                    memory_refs.parse_memory_ref(item) is None
+                    and not _valid_relative_path(item)
+                )
+                for item in strip
+            ):
                 findings.append(_finding("invalid_field", f"{rel}:options.strip_provenance", "strip targets must name approved dependencies"))
             for dep in dependencies:
                 if dep.ref not in strip and dep.path not in strip:

--- a/src/exomem/governance/scrubber.py
+++ b/src/exomem/governance/scrubber.py
@@ -3,8 +3,8 @@
 Design decision D7 — and the one intentional behavior change this change ships
 for a vault with **no** `_Governance/` directory (owner-confirmed). Unlike
 every other consumer in this package, the scrubber is *policy-independent*: it
-is content-pattern-based, so it runs on the empty-policy fast path too. Only
-an explicit standing rule (`options: {credential_scrubber: off}`) turns it off.
+is content-pattern-based, so it runs on the empty-policy fast path too. It has
+no policy-controlled disable switch.
 
 Two properties make it safe to run on every result:
 
@@ -24,7 +24,11 @@ Two properties make it safe to run on every result:
 
 from __future__ import annotations
 
+import base64
+import binascii
+import datetime as dt
 import functools
+import hmac
 import math
 import re
 from collections import Counter
@@ -36,6 +40,100 @@ from typing import Any
 #: What replaces a blocked value. Deliberately fixed text: a per-credential
 #: description would itself carry information about what was found.
 NOTICE = "[credential blocked by exomem egress policy]"
+
+# The future authorization-session wire token is parsed here, rather than by
+# each future transport, so the terminal scanner and issuance validation share
+# one canonical spelling. This broad regex remains the fail-closed sweep for
+# malformed candidates in a rejected issuance. Canonical scanning cannot use
+# token boundaries: an adversary may place valid base64url characters directly
+# beside a bearer, so `_scrub_canonical_authorization_bearers` locates every
+# literal start and makes the parser the sole accept/reject authority.
+_AUTHORIZATION_BEARER_CANDIDATE_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])as1\.[A-Za-z0-9_-]{1,256}\.[A-Za-z0-9_-]{1,256}(?![A-Za-z0-9_-])"
+)
+_BASE64URL_ALPHABET = frozenset(
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+)
+_ISSUANCE_ACTIONS = frozenset({"open", "rotate"})
+_ISSUANCE_CONTEXT_SEAL = object()
+_RFC3339_RE = re.compile(
+    r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\Z",
+    re.ASCII,
+)
+
+
+def _parse_authorization_bearer(value: object) -> str | None:
+    """Return only the exact canonical 70-byte authorization bearer.
+
+    Decode and byte-identical re-encoding are load-bearing: alphabet/length
+    checks alone accept final characters whose unused base64 bits are non-zero.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError:
+        return None
+    if (
+        len(encoded) != 70
+        or encoded[:4] != b"as1."
+        or encoded[26:27] != b"."
+    ):
+        return None
+    locator = encoded[4:26]
+    secret = encoded[27:]
+    if not all(byte in _BASE64URL_ALPHABET for byte in (*locator, *secret)):
+        return None
+    try:
+        locator_bytes = base64.b64decode(
+            locator + b"==", altchars=b"-_", validate=True
+        )
+        secret_bytes = base64.b64decode(
+            secret + b"=", altchars=b"-_", validate=True
+        )
+    except (binascii.Error, ValueError):
+        return None
+    if len(locator_bytes) != 16 or len(secret_bytes) != 32:
+        return None
+    if (
+        base64.urlsafe_b64encode(locator_bytes).rstrip(b"=") != locator
+        or base64.urlsafe_b64encode(secret_bytes).rstrip(b"=") != secret
+    ):
+        return None
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class _IssuanceContext:
+    """Private, non-serializable authority for one just-issued bearer."""
+
+    action: str
+    bearer: str
+    _seal: object
+
+    def __reduce__(self) -> object:
+        raise TypeError("issuance context is process-local")
+
+
+def _new_issuance_context(action: object, bearer: object) -> _IssuanceContext:
+    if action not in _ISSUANCE_ACTIONS:
+        raise ValueError("issuance action must be open or rotate")
+    canonical = _parse_authorization_bearer(bearer)
+    if canonical is None:
+        raise ValueError("issued bearer is not canonical")
+    return _IssuanceContext(str(action), canonical, _ISSUANCE_CONTEXT_SEAL)
+
+
+def _valid_rfc3339(value: object) -> bool:
+    if not isinstance(value, str) or not (20 <= len(value) <= 64):
+        return False
+    if _RFC3339_RE.fullmatch(value) is None:
+        return False
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
 
 #: Field names whose value is a structural identifier, not prose. Checked
 #: BEFORE the entropy heuristic; the explicit credential patterns still apply.
@@ -180,6 +278,12 @@ class CredentialPattern:
 #: Trivy failed CI over the GitHub one — and the samples only need to match
 #: their own pattern and anchors, not look plausible. Keep new ones synthesised.
 CREDENTIAL_PATTERNS: tuple[CredentialPattern, ...] = (
+    CredentialPattern(
+        name="authorization_bearer",
+        pattern=_AUTHORIZATION_BEARER_CANDIDATE_RE.pattern,
+        anchors=("as1.",),
+        samples=("as1." + "A" * 22 + "." + "A" * 43,),
+    ),
     CredentialPattern(
         name="pem_private_key",
         pattern=r"-----BEGIN[ A-Z]*PRIVATE KEY-----.*?-----END[ A-Z]*PRIVATE KEY-----",
@@ -408,12 +512,62 @@ def _may_contain_credential(text: str) -> bool:
     return bool(_active_alternatives(text.lower()))
 
 
+def _scrub_canonical_authorization_bearers(text: str) -> tuple[str, int]:
+    """Replace canonical bearers at every literal start, without boundaries.
+
+    Each parser call receives one fixed 70-character window. Advancing past an
+    accepted window makes adjacent occurrences deterministic; rejected starts
+    advance by one character so a later start is never hidden by malformed
+    surrounding text. The fixed window keeps the work linear and bounded.
+    """
+    parts: list[str] = []
+    copied_through = 0
+    search_from = 0
+    replacements = 0
+    while True:
+        start = text.find("as1.", search_from)
+        if start < 0:
+            break
+        end = start + 70
+        candidate = text[start:end]
+        if _parse_authorization_bearer(candidate) is None:
+            search_from = start + 1
+            continue
+        parts.extend((text[copied_through:start], NOTICE))
+        copied_through = end
+        search_from = end
+        replacements += 1
+    if not replacements:
+        return text, 0
+    parts.append(text[copied_through:])
+    return "".join(parts), replacements
+
+
 def _scrub_explicit(text: str) -> tuple[str, int]:
     """Run only the alternatives this text can possibly match."""
     indices = _active_alternatives(text.lower())
     if not indices:
         return text, 0
-    return _union_for(indices).subn(NOTICE, text)
+    replacements = 0
+    authorization_indices = tuple(
+        index
+        for index in indices
+        if CREDENTIAL_PATTERNS[index].name == "authorization_bearer"
+    )
+    if authorization_indices:
+        text, authorization_replacements = _scrub_canonical_authorization_bearers(
+            text
+        )
+        replacements += authorization_replacements
+    ordinary_indices = tuple(
+        index
+        for index in indices
+        if CREDENTIAL_PATTERNS[index].name != "authorization_bearer"
+    )
+    if ordinary_indices:
+        text, ordinary_replacements = _union_for(ordinary_indices).subn(NOTICE, text)
+        replacements += ordinary_replacements
+    return text, replacements
 
 
 def scrub_text(text: str) -> tuple[str, bool]:
@@ -442,6 +596,42 @@ def _scrub_structural(value: str) -> tuple[str, bool]:
     return cleaned, replacements > 0
 
 
+def _stable_mapping_key(value: Any) -> tuple[str, str, str]:
+    """Order JSON-shaped mapping keys without comparing unlike Python types."""
+    value_type = type(value)
+    return value_type.__module__, value_type.__qualname__, repr(value)
+
+
+def _allocate_mapping_keys(
+    entries: list[tuple[Any, Any, bool]],
+) -> list[Any]:
+    """Allocate collision-free transformed keys independent of insertion order.
+
+    Unchanged authored keys reserve their spelling first. Transformed keys are
+    then assigned by their stable original identity, and a suffix counter loops
+    until it finds a genuinely unused key. This preserves every entry even when
+    an adversary pre-populates NOTICE and arbitrary NOTICE#N spellings.
+    """
+    assigned: list[Any] = [None] * len(entries)
+    used: set[Any] = set()
+    for index in sorted(
+        range(len(entries)),
+        key=lambda item: (
+            entries[item][2],
+            _stable_mapping_key(entries[item][0]),
+        ),
+    ):
+        _original, desired, _changed = entries[index]
+        candidate = desired
+        suffix = 1
+        while candidate in used:
+            candidate = f"{desired}#{suffix}"
+            suffix += 1
+        assigned[index] = candidate
+        used.add(candidate)
+    return assigned
+
+
 def scrub_value(value: Any, *, field_name: str | None = None) -> tuple[Any, bool]:
     """Walk any JSON-shaped result, scrubbing every string it contains.
 
@@ -454,11 +644,26 @@ def scrub_value(value: Any, *, field_name: str | None = None) -> tuple[Any, bool
         return scrub_text(value)
     if isinstance(value, Mapping):
         blocked = False
-        out: dict[Any, Any] = {}
+        entries: list[tuple[Any, Any, bool, Any, bool]] = []
         for key, item in value.items():
+            cleaned_key = key
+            key_hit = False
+            if isinstance(key, str):
+                cleaned_key, key_hit = scrub_text(key)
+                blocked = blocked or key_hit
             cleaned, hit = scrub_value(item, field_name=str(key))
-            out[key] = cleaned
+            entries.append((key, cleaned_key, key_hit, cleaned, hit))
             blocked = blocked or hit
+        allocated = _allocate_mapping_keys(
+            [
+                (original_key, cleaned_key, key_hit)
+                for original_key, cleaned_key, key_hit, _, _ in entries
+            ]
+        )
+        out = {
+            allocated[index]: cleaned
+            for index, (_, _, _, cleaned, _) in enumerate(entries)
+        }
         return out, blocked
     if isinstance(value, (list, tuple)):
         blocked = False
@@ -480,26 +685,84 @@ def scrub_value(value: Any, *, field_name: str | None = None) -> tuple[Any, bool
     return value, False
 
 
-def enabled(vault_root: Path) -> bool:
-    """False only when a standing rule explicitly turns the scrubber off.
+def _scrub_issuance_candidates(value: Any) -> tuple[Any, bool]:
+    """Fail closed over malformed `as1` candidates in a rejected issuance."""
+    if isinstance(value, str):
+        cleaned, exact_replacements = _scrub_canonical_authorization_bearers(value)
+        cleaned, broad_replacements = _AUTHORIZATION_BEARER_CANDIDATE_RE.subn(
+            NOTICE, cleaned
+        )
+        return cleaned, exact_replacements + broad_replacements > 0
+    if isinstance(value, Mapping):
+        blocked = False
+        entries: list[tuple[Any, Any, bool, Any, bool]] = []
+        for key, item in value.items():
+            cleaned_key, key_hit = _scrub_issuance_candidates(key)
+            cleaned, hit = _scrub_issuance_candidates(item)
+            entries.append((key, cleaned_key, key_hit, cleaned, hit))
+            blocked = blocked or key_hit or hit
+        allocated = _allocate_mapping_keys(
+            [
+                (original_key, cleaned_key, key_hit)
+                for original_key, cleaned_key, key_hit, _, _ in entries
+            ]
+        )
+        out = {
+            allocated[index]: cleaned
+            for index, (_, _, _, cleaned, _) in enumerate(entries)
+        }
+        return out, blocked
+    if isinstance(value, (list, tuple)):
+        items = []
+        blocked = False
+        for item in value:
+            cleaned, hit = _scrub_issuance_candidates(item)
+            items.append(cleaned)
+            blocked = blocked or hit
+        return (tuple(items) if isinstance(value, tuple) else items), blocked
+    return value, False
 
-    The three-state contract inverts here on purpose: `empty` means no rule
-    can have disabled it (ON — this is the always-on default), and `blocked`
-    means the policy cannot be trusted, so the safe reading is also ON. Only a
-    successfully compiled rule carrying `options: {credential_scrubber: off}`
-    disables it.
+
+def _scrub_issuance_response(
+    command_name: str, response: Any, context: _IssuanceContext | None
+) -> tuple[Any, bool]:
+    """Allow exactly one typed open/rotate bearer; scrub every other shape.
+
+    No public route wires this yet. The terminal postfilter supplies no
+    context, so the production default remains unconditional scrubbing.
     """
-    from . import policy as policy_module
+    context_valid = (
+        type(context) is _IssuanceContext
+        and context._seal is _ISSUANCE_CONTEXT_SEAL
+        and context.action == command_name
+        and context.action in _ISSUANCE_ACTIONS
+    )
+    response_valid = (
+        type(response) is dict
+        and set(response) == {"status", "issued_credential"}
+        and response.get("status") == "ok"
+    )
+    credential = response.get("issued_credential") if response_valid else None
+    credential_valid = (
+        type(credential) is dict
+        and set(credential) == {"kind", "bearer", "expires_at"}
+        and credential.get("kind") == "authorization-session-bearer"
+        and _parse_authorization_bearer(credential.get("bearer")) is not None
+        and _valid_rfc3339(credential.get("expires_at"))
+    )
+    valid = context_valid and credential_valid and hmac.compare_digest(
+        credential["bearer"], context.bearer
+    )
+    if valid:
+        return response, False
+    cleaned, blocked = _scrub_issuance_candidates(response)
+    fallback, fallback_blocked = scrub_value(cleaned)
+    return fallback, blocked or fallback_blocked
 
-    policy = policy_module.load(Path(vault_root))
-    if policy.empty or policy.blocked:
-        return True
-    for rule in policy.rules:
-        setting = rule.options.get("credential_scrubber")
-        if isinstance(setting, str) and setting.strip().lower() in ("off", "false", "no"):
-            return False
-        if setting is False:
-            return False
+
+def enabled(vault_root: Path) -> bool:
+    """The terminal credential scrubber is not a policy-controlled option."""
+    del vault_root
     return True
 
 

--- a/src/exomem/governance/store.py
+++ b/src/exomem/governance/store.py
@@ -408,94 +408,12 @@ def active_session_grants(
     """Return exact unchanged active grants and their decision identity."""
     if not authorization_session or not sidecar_path(vault_root).exists():
         return [], "no-session-grants"
-    moment = __import__("time").time() if now is None else float(now)
-    conn = open_readonly_connection(vault_root)
-    if conn is None:
-        return [], "unavailable-session-grants"
-    try:
-        rows = conn.execute(
-            "SELECT grant_id, purpose, ceiling, paths, fingerprints, expires_at, "
-            "membership_manifest, policy_fingerprint "
-            "FROM governance_session_grants WHERE authorization_session=? AND audience=? "
-            "AND status='active' AND expires_at>=? ORDER BY grant_id",
-            (authorization_session, audience, moment),
-        ).fetchall()
-        purpose_row = conn.execute(
-            "SELECT purpose, expires_at FROM governance_session_purpose "
-            "WHERE authorization_session=? AND principal_id=? AND status='active'",
-            (authorization_session, audience),
-        ).fetchone()
-    finally:
-        conn.close()
-    effective_purpose = purpose
-    if effective_purpose is None and purpose_row is not None and float(purpose_row[1]) >= moment:
-        effective_purpose = str(purpose_row[0])
-    from .. import find_corpus
-    from . import membership as membership_module
-    from . import policy as policy_module
-
-    current_policy = policy_module.load(vault_root)
-    active: list[dict[str, object]] = []
-    for (
-        grant_id,
-        grant_purpose,
-        ceiling,
-        raw_paths,
-        raw_fingerprints,
-        expires_at,
-        raw_membership,
-        policy_fingerprint,
-    ) in rows:
-        paths = tuple(__import__("json").loads(str(raw_paths)))
-        fingerprints = tuple(__import__("json").loads(str(raw_fingerprints)))
-        if rel_path not in paths or (grant_purpose is not None and grant_purpose != effective_purpose):
-            continue
-        current = []
-        for path_value in paths:
-            target = Path(vault_root) / str(path_value)
-            try:
-                current.append(__import__("hashlib").sha256(target.read_bytes()).hexdigest())
-            except OSError:
-                current.append("")
-        if tuple(current) != fingerprints:
-            continue
-        if current_policy.blocked:
-            continue
-        resolved_membership: list[dict[str, object]] = []
-        try:
-            for path_value in paths:
-                path_text = str(path_value)
-                target = Path(vault_root) / path_text
-                if target.suffix.casefold() == ".md":
-                    page = find_corpus.parse_page(
-                        target, target.stat().st_mtime, Path(vault_root)
-                    )
-                    if page is None:
-                        raise membership_module.MembershipUnresolved(path_text)
-                    scope_ids = membership_module.evaluate(page, current_policy)
-                else:
-                    scope_ids = membership_module.evaluate_path_only(
-                        Path(vault_root), path_text, current_policy
-                    )
-                resolved_membership.append(
-                    {"path": path_text, "scope_ids": sorted(scope_ids)}
-                )
-        except (OSError, UnicodeError, membership_module.MembershipUnresolved):
-            continue
-        if resolved_membership != __import__("json").loads(str(raw_membership)):
-            continue
-        active.append(
-            {
-                "grant_id": str(grant_id),
-                "ceiling": int(ceiling),
-                "expires_at": float(expires_at),
-                "policy_fingerprint": str(policy_fingerprint),
-            }
-        )
-    identity = __import__("hashlib").sha256(
-        repr((authorization_session, audience, effective_purpose, active)).encode("utf-8")
-    ).hexdigest()[:16]
-    return active, identity
+    # Schema-v3 rows bind paths and a membership snapshot, but do not persist
+    # the exact reviewed scope IDs. Re-evaluating current item membership and
+    # treating it as a grant binding would let a legacy row authorise sibling
+    # scopes it never reviewed. v4 will store that proof; v3 grants are inert.
+    del audience, rel_path, purpose, now
+    return [], "v3-session-grants-unscoped"
 
 
 def active_session_purpose(

--- a/tests/test_govern_memory_tool.py
+++ b/tests/test_govern_memory_tool.py
@@ -671,7 +671,9 @@ def _committed_policy(vault: Path) -> None:
     )
 
 
-def test_grant_compound_receipts_activate_exact_session_items_in_lattice(vault: Path) -> None:
+def test_grant_compound_receipts_leave_schema_v3_session_grant_inert_until_v4(
+    vault: Path,
+) -> None:
     from exomem.find_types import Hit
     from exomem.governance import egress, receipts, tokens
     from exomem.governance.tool import op_govern_memory
@@ -709,11 +711,22 @@ def test_grant_compound_receipts_activate_exact_session_items_in_lattice(vault: 
     }
     assert len({record["event_id"] for record in child_intents}) == 2
 
+    rel_path = "Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md"
+    active, identity = store.active_session_grants(
+        vault,
+        audience="external",
+        authorization_session="conversation-a",
+        rel_path=rel_path,
+        purpose=None,
+    )
+    assert active == []
+    assert identity == "v3-session-grants-unscoped"
+
     result = egress.annotate_hits(
         vault,
         [
             Hit(
-                path="Knowledge Base/Notes/Patterns/kill-switch-for-risky-releases.md",
+                path=rel_path,
                 type="pattern",
                 scope=None,
                 title="restricted",
@@ -724,7 +737,8 @@ def test_grant_compound_receipts_activate_exact_session_items_in_lattice(vault: 
         principal=_external(),
         limit=1,
     )
-    assert len(result.hits) == 1
+    assert result.hits == []
+    assert "allowed excerpt" not in repr(result)
     with pytest.raises(Exception, match="TOKEN_CONSUMED"):
         op_govern_memory(
             vault,

--- a/tests/test_governance_bridges.py
+++ b/tests/test_governance_bridges.py
@@ -1166,7 +1166,7 @@ def test_restriction_signature_preserves_container_types() -> None:
     assert signature({"value": b"binary"}) != signature({"value": "b'binary'"})
 
 
-def test_safe_loaded_rule_options_stale_without_get_find_or_attention_crash(
+def test_unsafe_loaded_rule_options_block_all_content_paths_without_leaking(
     vault: Path,
 ) -> None:
     _write_bridge_fixture(vault, approval=True)
@@ -1192,32 +1192,58 @@ def test_safe_loaded_rule_options_stale_without_get_find_or_attention_crash(
     policy._LAST_GOOD.clear()
 
     compiled = policy.load(vault)
-    values = compiled.rules[0].options
-    assert values["binary"] == b"\x01\x02"
-    assert isinstance(values["day"], dt.date)
-    assert isinstance(values["instant"], dt.datetime)
-    assert values["members"] == {"a", "b"}
+    assert compiled.blocked
+    assert compiled.rules == ()
+    assert compiled.release_grants == ()
+    assert {
+        "rules/private.yaml:options.binary",
+        "rules/private.yaml:options.day",
+        "rules/private.yaml:options.instant",
+        "rules/private.yaml:options.members",
+        "rules/private.yaml:options.not_a_number",
+        "rules/private.yaml:options.infinity",
+    } <= {
+        finding["path"]
+        for finding in compiled.findings
+        if finding["severity"] == "error"
+    }
 
     with request_scope(_external()):
-        with pytest.raises(ValueError, match="^NOT_FOUND"):
+        with pytest.raises(ValueError, match="^NOT_FOUND") as get_error:
             commands.op_get(vault, path=BRIDGE_PATH)
-        assert all(
-            hit.get("path") != BRIDGE_PATH
-            for hit in commands.op_find(
-                vault,
-                query="unlimited evening capacity",
-                mode="keyword",
-                graph=False,
-                limit=10,
-            )
+        found = commands.op_find(
+            vault,
+            query="unlimited evening capacity",
+            mode="keyword",
+            graph=False,
+            limit=10,
         )
-    item = next(
-        item
-        for item in attention.attention(vault, today=dt.date(2026, 7, 28), limit=0).items
-        if "bridge_review" in item.categories
+        attention_result = egress.postfilter(
+            "attention",
+            attention.attention(
+                vault, today=dt.date(2026, 7, 28), limit=0
+            ).as_dict(),
+            vault,
+        )
+
+    assert found == []
+    assert attention_result["items"] == []
+    assert str(get_error.value) == f"NOT_FOUND: file does not exist: {BRIDGE_PATH}"
+    assert BRIDGE_PATH not in repr({"find": found, "attention": attention_result})
+    projected = repr(
+        {
+            "get_error": str(get_error.value),
+            "find": found,
+            "attention": attention_result,
+        }
     )
-    reason = next(reason for reason in item.reasons if reason["category"] == "bridge_review")
-    assert reason["meta"]["cause"] == "SOURCE_CHANGED_OR_RESTRICTION_CHANGED"
+    for private_value in (
+        SOURCE_PATH,
+        "RESTRICTED-SENTINEL",
+        "Private source title",
+        "unlimited evening capacity",
+    ):
+        assert private_value not in projected
 
 
 def test_unsupported_rule_option_fails_closed_without_crashing_admission(

--- a/tests/test_governance_decisions.py
+++ b/tests/test_governance_decisions.py
@@ -13,7 +13,11 @@ import itertools
 import random
 from pathlib import Path
 
-from exomem.governance.decisions import decide
+import pytest
+
+from exomem.governance import decisions
+from exomem.governance.bridges import StripIdentity
+from exomem.governance.decisions import Decision, decide
 from exomem.governance.policy import (
     DISCLOSURE_MAX,
     DISCLOSURE_MIN,
@@ -290,26 +294,19 @@ def test_decision_carries_scope_and_rule_ids() -> None:
     assert decision.rule_ids == ("r1",)
 
 
-def test_options_merge_pins_lexical_rule_id_order() -> None:
-    """Pins the exact (documented) merge contract for overlapping option keys
-    across matching rules, so `add-release-gate` inherits a tested behavior
-    rather than an accidental one: rules merge in ascending `id` order, so
-    for a shared key the lexically GREATEST rule id wins."""
-    rule_a = _rule("aaa", 4, options={"notice": "from-aaa", "bridge": "bridge-a", "only_a": 1})
-    rule_b = _rule("bbb", 4, options={"notice": "from-bbb", "only_b": 2})
-    # Insertion order deliberately reversed — the merge must not depend on it.
-    pol = _policy(rules=[rule_b, rule_a])
+def test_options_meet_does_not_select_a_rule_id_winner() -> None:
+    """Equal contributors must agree; authoring order cannot select content."""
+    rule_a = _rule("aaa", 4, options={"notice": "from-aaa"})
+    rule_b = _rule("bbb", 4, options={"notice": "from-bbb"})
 
-    decision = decide([SCOPE], audience="ext", policy=pol)
+    first = decide([SCOPE], audience="ext", policy=_policy(rules=(rule_a, rule_b)))
+    decision = decide([SCOPE], audience="ext", policy=_policy(rules=(rule_b, rule_a)))
 
-    assert decision.options == {
-        "notice": "from-bbb",  # "bbb" > "aaa" lexically -> bbb wins the shared key
-        "bridge": "bridge-a",
-        "only_a": 1,
-        "only_b": 2,
-    }
-    assert decision.notice == "from-bbb"
-    assert decision.bridge == "bridge-a"
+    assert decision == first
+    assert decision.level == 0
+    assert decision.options == {}
+    assert decision.notice is None
+    assert decision.bridge is None
 
 
 # ---------------------------------------------------------------------------
@@ -555,20 +552,8 @@ def test_no_declaring_scope_is_recorded_for_the_owner() -> None:
     assert decide([SCOPE], audience=OWNER_AUDIENCE, policy=pol).default_deny_scope_ids == ()
 
 
-def test_a_grant_on_a_sibling_scope_still_raises_a_declared_scope_as_it_does_a_ceiling_0_rule() -> None:
-    """The declaration does NOT close the grant lane, and must not pretend to.
-
-    `grant_max = max(grant_ceilings + [standing_min])` and `_grant_matches` tests
-    scope INTERSECTION, so a grant naming an audience for S2 raises an item that
-    is also in a closed S1 — the compartment crossover, via grants rather than
-    rules. Measured L0 -> L6.
-
-    This is pinned as an EQUIVALENCE, not as an approval. The authored
-    `ceiling: 0` spelling behaves identically, so the behaviour is a pre-existing
-    property of the lattice and not something the declaration introduced. The
-    test exists so the two spellings cannot silently diverge while the real fix
-    (scoping a grant's raise to the scopes it names) is out of scope here.
-    """
+def test_a_grant_on_a_sibling_scope_cannot_raise_a_declared_scope() -> None:
+    """A scope grant raises only the explicitly named compartment."""
     s1 = "01ARZ3NDEKTSV4RRFFQ69G5FA1"
     s2 = "01ARZ3NDEKTSV4RRFFQ69G5FA2"
     both = [s1, s2]
@@ -587,31 +572,270 @@ def test_a_grant_on_a_sibling_scope_still_raises_a_declared_scope_as_it_does_a_c
             s2: Scope(id=s2, source="scopes/s2.yaml"),
         },
     )
-    authored = Policy(
+    assert decide(both, audience="partner-x", policy=declared).level == DISCLOSURE_MIN
+    declared_granted = dataclasses.replace(declared, grants=(grant,))
+    assert decide(both, audience="partner-x", policy=declared_granted).level == DISCLOSURE_MIN
+    assert decide(list(reversed(both)), audience="partner-x", policy=declared_granted).level == DISCLOSURE_MIN
+
+
+def test_a_grant_covering_each_scope_raises_each_scope_independently() -> None:
+    s1, s2 = "scope-a", "scope-b"
+    grant = StandingGrant(
+        id="g", source="grants/g.yaml", scope_ids=(s1, s2), audience="ext", ceiling=5
+    )
+    policy = Policy(
         fingerprint="p",
         scopes={
-            s1: Scope(id=s1, source="scopes/s1.yaml"),
-            s2: Scope(id=s2, source="scopes/s2.yaml"),
+            s1: Scope(id=s1, source="scopes/a.yaml", default_deny=True),
+            s2: Scope(id=s2, source="scopes/b.yaml", default_deny=True),
+        },
+        grants=(grant,),
+    )
+
+    assert decide((s1, s2), audience="ext", policy=policy).level == 5
+    assert decide((s2, s1), audience="ext", policy=policy).level == 5
+
+
+def test_item_minimum_keeps_a_sibling_organisation_cap_and_owner_rule() -> None:
+    s1, s2 = "scope-a", "scope-b"
+    policy = Policy(
+        fingerprint="p",
+        scopes={
+            s1: Scope(id=s1, source="scopes/a.yaml", default_deny=True),
+            s2: Scope(id=s2, source="scopes/b.yaml", default_deny=True),
         },
         rules=(
-            Rule(
-                id="01ARZ3NDEKTSV4RRFFQ69G5FB0",
-                source="rules/r.yaml",
-                scope_ids=(s1,),
-                audience="partner-x",
-                ceiling=0,
-            ),
+            Rule("owner", "rules/owner.yaml", (s1,), OWNER_AUDIENCE, 5),
+            Rule("cap", "rules/cap.yaml", (s2,), OWNER_AUDIENCE, 2, kind="org_cap"),
         ),
     )
 
-    # Closed identically without a grant.
-    assert decide(both, audience="partner-x", policy=declared).level == DISCLOSURE_MIN
-    assert decide(both, audience="partner-x", policy=authored).level == DISCLOSURE_MIN
+    assert decide((s1, s2), audience=OWNER_AUDIENCE, policy=policy).level == 2
 
-    # And raised identically by a grant that names only the sibling scope.
-    declared_granted = dataclasses.replace(declared, grants=(grant,))
-    authored_granted = dataclasses.replace(authored, grants=(grant,))
-    assert (
-        decide(both, audience="partner-x", policy=declared_granted).level
-        == decide(both, audience="partner-x", policy=authored_granted).level
-    ), "the declaration must not be weaker OR stronger than an authored ceiling-0 here"
+
+def test_equal_purpose_levels_meet_options_without_adding_declared_content() -> None:
+    policy = _policy(
+        rules=(
+            _rule("plain", 3, options={"abstract": "undeclared abstraction"}),
+            _rule(
+                "declared", 3, purpose="audit", options={"notice": "declared notice"}
+            ),
+        )
+    )
+
+    decision = decide((SCOPE,), audience="ext", purpose="audit", policy=policy)
+
+    assert decision.level == 0
+    assert decision.options == {}
+    assert decision.notice is None
+
+
+def test_decision_meet_is_associative_commutative_and_idempotent() -> None:
+    contributors = (
+        Decision(level=2, options={"constraint": "one"}),
+        Decision(level=2, options={"constraint": "two"}),
+        Decision(level=2, options={"constraint": "two"}),
+    )
+    expected = decisions._meet_decisions(contributors)
+
+    for permutation in itertools.permutations(contributors):
+        folded = decisions._meet_decisions(permutation)
+        left = decisions._meet_decisions(
+            (decisions._meet_decisions(permutation[:2]), permutation[2])
+        )
+        right = decisions._meet_decisions(
+            (permutation[0], decisions._meet_decisions(permutation[1:]))
+        )
+        assert folded == expected
+        assert left == expected
+        assert right == expected
+    assert decisions._meet_decisions((expected, expected)) == expected
+
+
+@pytest.mark.parametrize(
+    ("level", "key", "left", "right", "expected_level"),
+    [
+        (1, "notice", "one", "two", 0),
+        (2, "constraint", "one", "two", 1),
+        (3, "abstract", "one", "two", 2),
+        (4, "bridge", "one", "two", 3),
+    ],
+)
+def test_same_scope_option_conflicts_lower_before_cross_scope_meet(
+    level: int, key: str, left: str, right: str, expected_level: int
+) -> None:
+    rules = (
+        _rule("a", level, options={key: left}),
+        _rule("b", level, options={key: right}),
+    )
+
+    decision = decide((SCOPE,), audience="ext", policy=_policy(rules=rules))
+
+    assert decision.level == expected_level
+    assert key not in decision.options
+
+
+def test_decision_meet_is_aci_with_absence_and_mixed_levels() -> None:
+    contributors = (
+        Decision(level=2, options={"constraint": "one"}),
+        Decision(level=2, options={}),
+        Decision(level=3, options={"abstract": "abstract"}),
+    )
+    expected = decisions._meet_decisions(contributors)
+
+    assert expected.level == 1
+    assert expected.options["constraint_ambiguous"] is True
+    for permutation in itertools.permutations(contributors):
+        assert decisions._meet_decisions(permutation) == expected
+        assert decisions._meet_decisions(
+            (decisions._meet_decisions(permutation[:2]), permutation[2])
+        ) == expected
+        assert decisions._meet_decisions(
+            (permutation[0], decisions._meet_decisions(permutation[1:]))
+        ) == expected
+
+
+def test_decision_meet_preserves_equal_release_fields_and_unions_strip() -> None:
+    first = Decision(
+        level=4,
+        release_reason="approved",
+        release_grant_id="grant",
+        release_dependency_digest="digest",
+        release_strip=("a",),
+    )
+    second = dataclasses.replace(first, release_strip=("b", "a"))
+
+    decision = decisions._meet_decisions((first, second))
+
+    assert decision.release_reason == "approved"
+    assert decision.release_grant_id == "grant"
+    assert decision.release_dependency_digest == "digest"
+    assert decision.release_strip == ("a", "b")
+
+
+def test_decision_meet_drops_disagreed_or_absent_release_singletons() -> None:
+    first = Decision(level=4, release_reason="approved", release_grant_id="grant")
+    disagreed = Decision(level=4, release_reason="other", release_grant_id="other")
+    absent = Decision(level=4)
+
+    assert decisions._meet_decisions((first, disagreed)).release_reason is None
+    assert decisions._meet_decisions((first, disagreed)).release_grant_id is None
+    assert decisions._meet_decisions((first, absent)).release_reason is None
+    assert decisions._meet_decisions((first, absent)).release_grant_id is None
+
+
+def test_release_strip_unions_real_identities_across_orders_and_groupings() -> None:
+    identities = (
+        StripIdentity(path="Knowledge Base/Sources/a.md", ref="ref-a", title="A"),
+        StripIdentity(path="Knowledge Base/Sources/b.md", ref="ref-b", title="B"),
+        StripIdentity(path="Knowledge Base/Sources/c.md", ref="ref-c", title="C"),
+    )
+    contributors = (
+        Decision(level=4, release_strip=(identities[1], identities[0])),
+        Decision(level=4, release_strip=(identities[2], identities[0])),
+        Decision(level=4, release_strip=(identities[1],)),
+    )
+    expected = tuple(sorted(identities, key=lambda item: (item.path, item.ref, item.title)))
+
+    for permutation in itertools.permutations(contributors):
+        assert decisions._meet_decisions(permutation).release_strip == expected
+        assert decisions._meet_decisions(
+            (decisions._meet_decisions(permutation[:2]), permutation[2])
+        ).release_strip == expected
+        assert decisions._meet_decisions(
+            (permutation[0], decisions._meet_decisions(permutation[1:]))
+        ).release_strip == expected
+
+
+def test_decision_retains_deterministic_per_scope_contributions() -> None:
+    s1, s2 = "scope-a", "scope-b"
+    constraint = {"constraint": "reviewed constraint"}
+    standing = Rule(
+        "standing", "rules/standing.yaml", (s1,), "ext", 5, options=constraint
+    )
+    cap = Rule(
+        "cap", "rules/cap.yaml", (s1,), "ext", 4, kind="org_cap", options=constraint
+    )
+    grant = StandingGrant("grant", "grants/grant.yaml", (s2,), "ext", 3)
+    policy = Policy(
+        fingerprint="p",
+        scopes={
+            s1: Scope(id=s1, source="scopes/a.yaml", default_deny=True),
+            s2: Scope(id=s2, source="scopes/b.yaml", default_deny=True),
+        },
+        rules=(cap, standing),
+        grants=(grant,),
+    )
+
+    decision = decide((s2, s1), audience="ext", policy=policy)
+
+    # The scope-local constraint is absent from the sibling, so the complete
+    # item meet lowers below L2 even though the numeric scope ceilings are 4/3.
+    assert decision.level == 1
+    assert [item.scope_id for item in decision.scope_contributions] == [s1, s2]
+    first, second = decision.scope_contributions
+    assert first.purpose_branch == "neutral"
+    assert first.standing_floor == 5
+    assert first.default_deny_supplied_floor is False
+    assert first.standing_rule_ids == ("standing",)
+    assert first.grant_ids == ()
+    assert first.grant_ceiling is None
+    assert first.grant_contribution == 5
+    assert first.organization_cap_ids == ("cap",)
+    assert first.organization_cap == 4
+    assert first.option_values == (("constraint", "reviewed constraint"),)
+    assert first.option_ambiguities == ()
+    assert first.final_ceiling == 4
+    assert second.standing_floor == 0
+    assert second.default_deny_supplied_floor is True
+    assert second.standing_rule_ids == ()
+    assert second.grant_ids == ("grant",)
+    assert second.grant_ceiling == 3
+    assert second.grant_contribution == 3
+    assert second.organization_cap_ids == ()
+    assert second.organization_cap == DISCLOSURE_MAX
+    assert second.option_values == ()
+    assert second.option_ambiguities == ()
+    assert second.final_ceiling == 3
+
+
+def test_purpose_meet_labels_duplicate_scope_contributions_by_branch() -> None:
+    declared = _rule(
+        "declared",
+        3,
+        purpose="audit",
+        purpose_condition="matches",
+        options={"abstract": "declared abstract"},
+    )
+    undeclared = _rule(
+        "undeclared",
+        3,
+        purpose="audit",
+        purpose_condition="outside",
+    )
+
+    forward = decide(
+        (SCOPE,),
+        audience="ext",
+        purpose="audit",
+        policy=_policy(rules=(declared, undeclared)),
+    )
+    reverse = decide(
+        (SCOPE,),
+        audience="ext",
+        purpose="audit",
+        policy=_policy(rules=(undeclared, declared)),
+    )
+
+    assert forward == reverse
+    assert forward.level == 2
+    assert [item.scope_id for item in forward.scope_contributions] == [SCOPE, SCOPE]
+    assert [item.purpose_branch for item in forward.scope_contributions] == [
+        "declared",
+        "undeclared",
+    ]
+    assert [item.final_ceiling for item in forward.scope_contributions] == [3, 3]
+    assert forward.scope_contributions[0].option_values == (
+        ("abstract", "declared abstract"),
+    )
+    assert forward.scope_contributions[1].option_values == ()

--- a/tests/test_governance_egress.py
+++ b/tests/test_governance_egress.py
@@ -21,7 +21,7 @@ from exomem import commands
 from exomem import find as find_module
 from exomem.find_types import GraphProvenance, Hit
 from exomem.governance import egress, receipts
-from exomem.governance.principal import RequestPrincipal, request_scope
+from exomem.governance.principal import RequestPrincipal, owner_principal, request_scope
 
 # --------------------------------------------------------------------------
 # Governed-vault helpers
@@ -3834,3 +3834,136 @@ def test_a_broad_undeclared_scope_cannot_reopen_a_declared_one(vault: Path) -> N
     with request_scope(_external()):
         with pytest.raises(ValueError, match="NOT_FOUND"):
             commands.op_get(vault, path=RESTRICTED_PATH)
+
+
+def test_owner_explain_exposes_per_scope_contributions_only_to_owner(vault: Path) -> None:
+    from exomem.governance.inspection import inspect_operation
+
+    write_scope(vault, default_deny=True)
+    second_scope = "01ARZ3NDEKTSV4RRFFQ69G5FC2"
+    (_gov_dir(vault) / "scopes" / "second.yaml").write_text(
+        f"governance_version: 1\nid: {second_scope}\nname: Second\n"
+        f'paths: ["{PATTERNS_GLOB}"]\ndefault_deny: true\n',
+        encoding="utf-8",
+    )
+    write_rule(
+        vault,
+        ceiling=5,
+        extra="options:\n  constraint: reviewed constraint\n",
+    )
+    (_gov_dir(vault) / "rules" / "cap.yaml").write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FC3\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: {EXTERNAL}\nkind: org_cap\n'
+        "ceiling: 4\noptions:\n  constraint: reviewed constraint\n",
+        encoding="utf-8",
+    )
+    grants = _gov_dir(vault) / "grants"
+    grants.mkdir(parents=True, exist_ok=True)
+    (grants / "second.yaml").write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FC4\nkind: standing\n"
+        f'scope_ids: ["{second_scope}"]\naudience: {EXTERNAL}\nceiling: 3\n',
+        encoding="utf-8",
+    )
+    _reset_caches()
+
+    owner_result = inspect_operation(
+        vault,
+        "explain",
+        principal=owner_principal(),
+        audience=EXTERNAL,
+        path=RESTRICTED_PATH,
+    )
+    non_owner_result = inspect_operation(
+        vault,
+        "explain",
+        principal=_external(),
+        audience=EXTERNAL,
+        path=RESTRICTED_PATH,
+    )
+
+    assert owner_result["effective_ceiling"] == 1
+    assert owner_result["scope_contributions"] == [
+        {
+            "scope_id": SCOPE_ID,
+            "purpose_branch": "neutral",
+            "standing_floor": 5,
+            "default_deny_supplied_floor": False,
+            "standing_rule_ids": [RULE_ID],
+            "grant_ids": [],
+            "grant_ceiling": None,
+            "grant_contribution": 5,
+            "organization_cap_ids": ["01ARZ3NDEKTSV4RRFFQ69G5FC3"],
+            "organization_cap": 4,
+            "option_values": {"constraint": "reviewed constraint"},
+            "option_ambiguities": [],
+            "final_ceiling": 4,
+        },
+        {
+            "scope_id": second_scope,
+            "purpose_branch": "neutral",
+            "standing_floor": 0,
+            "default_deny_supplied_floor": True,
+            "standing_rule_ids": [],
+            "grant_ids": ["01ARZ3NDEKTSV4RRFFQ69G5FC4"],
+            "grant_ceiling": 3,
+            "grant_contribution": 3,
+            "organization_cap_ids": [],
+            "organization_cap": 6,
+            "option_values": {},
+            "option_ambiguities": [],
+            "final_ceiling": 3,
+        },
+    ]
+    assert set(non_owner_result) == {
+        "enabled",
+        "effective_ceiling",
+        "rule_ids",
+        "participating_chain",
+    }
+
+
+def test_owner_explain_labels_purpose_branches_before_conservative_meet(
+    vault: Path,
+) -> None:
+    from exomem.governance.inspection import inspect_operation
+
+    write_scope(vault)
+    rules = _gov_dir(vault) / "rules"
+    rules.mkdir(parents=True, exist_ok=True)
+    (rules / "declared.yaml").write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FC5\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: {EXTERNAL}\nceiling: 3\n'
+        "purpose: audit\npurpose_condition: matches\n"
+        "options:\n  abstract: declared abstract\n",
+        encoding="utf-8",
+    )
+    (rules / "undeclared.yaml").write_text(
+        "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FC6\n"
+        f'scope_ids: ["{SCOPE_ID}"]\naudience: {EXTERNAL}\nceiling: 3\n'
+        "purpose: audit\npurpose_condition: outside\n",
+        encoding="utf-8",
+    )
+    _reset_caches()
+
+    result = inspect_operation(
+        vault,
+        "explain",
+        principal=owner_principal(),
+        audience=EXTERNAL,
+        purpose="audit",
+        path=RESTRICTED_PATH,
+    )
+
+    assert result["effective_ceiling"] == 2
+    assert [row["purpose_branch"] for row in result["scope_contributions"]] == [
+        "declared",
+        "undeclared",
+    ]
+    assert [row["final_ceiling"] for row in result["scope_contributions"]] == [
+        3,
+        3,
+    ]
+    assert result["scope_contributions"][0]["option_values"] == {
+        "abstract": "declared abstract"
+    }
+    assert result["scope_contributions"][1]["option_values"] == {}

--- a/tests/test_governance_policy.py
+++ b/tests/test_governance_policy.py
@@ -40,6 +40,72 @@ _RULE_A = (
 )
 
 
+class _UnhashablePolicyValue:
+    __hash__ = None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("purpose_condition", ["matches"]),
+        ("purpose_condition", {"value": "matches"}),
+        ("purpose_condition", _UnhashablePolicyValue()),
+        ("kind", ["standing"]),
+        ("kind", {"value": "standing"}),
+        ("kind", _UnhashablePolicyValue()),
+    ],
+)
+def test_rule_enum_fields_reject_unhashable_containers_without_crashing(
+    field: str, value: object
+) -> None:
+    data = {
+        "governance_version": 1,
+        "id": "01ARZ3NDEKTSV4RRFFQ69G5FB0",
+        "scope_ids": ["01ARZ3NDEKTSV4RRFFQ69G5FAV"],
+        "audience": "external",
+        "ceiling": 2,
+        field: value,
+    }
+
+    _rule, findings = policy._parse_rule(data, "rules/invalid.yaml")
+
+    assert any(
+        finding["code"] == "invalid_field"
+        and finding["path"] == f"rules/invalid.yaml:{field}"
+        for finding in findings
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "yaml_value"),
+    [
+        ("purpose_condition", "[matches]"),
+        ("purpose_condition", "{value: matches}"),
+        ("kind", "[standing]"),
+        ("kind", "{value: standing}"),
+    ],
+)
+def test_rule_enum_container_values_block_a_cold_policy_compile(
+    vault: Path, field: str, yaml_value: str
+) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(
+        vault,
+        "rules",
+        "invalid",
+        _RULE_A + f"{field}: {yaml_value}\n",
+    )
+
+    compiled = policy.load(vault)
+
+    assert compiled.blocked
+    assert any(
+        finding["code"] == "invalid_field"
+        and finding["path"].endswith(f":{field}")
+        for finding in compiled.findings
+    )
+
+
 def test_empty_dir_yields_empty_singleton(vault: Path) -> None:
     (vault / "Knowledge Base" / "_Governance").mkdir(parents=True, exist_ok=True)
     pol = policy.load(vault)
@@ -884,6 +950,144 @@ def test_a_yaml_boolean_spelling_is_accepted(vault: Path) -> None:
     pol = policy.load(vault)
     assert pol.blocked is False
     assert pol.scopes[_SCOPE_A_ID].default_deny is True
+
+
+@pytest.mark.parametrize(
+    "option_yaml",
+    [
+        "credential_scrubber: off\n",
+        "credential_scrubber: true\n",
+        "unknown: value\n",
+        "notice: [not, a, string]\n",
+        'suspended: "no"\n',
+        "constraint_source: scope\n",
+    ],
+)
+def test_rule_options_are_a_closed_typed_registry(vault: Path, option_yaml: str) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(vault, "rules", "external", _RULE_A + "options:\n  " + option_yaml.replace("\n", "\n  "))
+
+    compiled = policy.load(vault)
+
+    assert compiled.blocked is True
+    assert any(finding["path"].startswith("rules/external.yaml:options") for finding in compiled.findings)
+
+
+@pytest.mark.parametrize(
+    "option_yaml",
+    [
+        "1: value\n",
+        "1: value\nunknown: value\n",
+        "[list]: value\n",
+        "notice: !!set {value: null}\n",
+        "notice: !!python/name:os.system ''\n",
+        "notice: .nan\n",
+        "notice: " + "x" * 501 + "\n",
+        "bridge: [wrong]\n",
+        "credential_scrubber: on\n",
+        "credential_scrubber: false\n",
+        "credential_scrubber: no\n",
+        'credential_scrubber: "disabled"\n',
+        "credential_scrubber: [off]\n",
+    ],
+)
+def test_rule_option_malformed_values_always_block_without_parser_crash(
+    vault: Path, option_yaml: str
+) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(vault, "rules", "external", _RULE_A + "options:\n  " + option_yaml.replace("\n", "\n  "))
+
+    compiled = policy.load(vault)
+
+    assert compiled.blocked is True
+    assert compiled.findings
+
+
+def _release_document(*, top_extra: str = "", dependency_extra: str = "", options_extra: str = "") -> str:
+    return (
+        "governance_version: 1\n"
+        "id: 01ARZ3NDEKTSV4RRFFQ69G5FB2\n"
+        "kind: release\n"
+        "path: Knowledge Base/Notes/Patterns/released.md\n"
+        "ref: exomem://memory/00000000-0000-0000-0000-000000000001\n"
+        f"content_hash: {'a' * 64}\n"
+        "to_audience: external\n"
+        "released_at: '2026-08-13T12:00:00Z'\n"
+        "why: Owner reviewed the exact release\n"
+        "bridge_scope: review\n"
+        "bridge_of:\n"
+        "  - ref: exomem://memory/00000000-0000-0000-0000-000000000002\n"
+        "    path: Knowledge Base/Sources/Other/source.md\n"
+        f"    content_hash: {'b' * 64}\n"
+        f"    restriction_signature: {'c' * 64}\n"
+        f"{dependency_extra}"
+        "options:\n"
+        "  strip_provenance:\n"
+        "    - exomem://memory/00000000-0000-0000-0000-000000000002\n"
+        f"{options_extra}"
+        f"{top_extra}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "document"),
+    [
+        ("scopes", _SCOPE_A + "unknown: mixed\n1: mixed\n"),
+        (
+            "scopes",
+            _SCOPE_A + "exclude:\n  paths: []\n  unknown: mixed\n  1: mixed\n",
+        ),
+        ("rules", _RULE_A + "unknown: mixed\n1: mixed\n"),
+        ("grants", _GRANT_A + "unknown: mixed\n1: mixed\n"),
+        ("grants", _release_document(top_extra="unknown: mixed\n1: mixed\n")),
+        (
+            "grants",
+            _release_document(
+                dependency_extra="    unknown: mixed\n    1: mixed\n"
+            ),
+        ),
+        (
+            "grants",
+            _release_document(options_extra="  unknown: mixed\n  1: mixed\n"),
+        ),
+    ],
+)
+def test_every_strict_policy_map_blocks_mixed_keys_without_type_error(
+    vault: Path, kind: str, document: str
+) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(vault, kind, "mixed-keys", document)
+
+    compiled = policy.load(vault)
+
+    assert compiled.blocked is True
+    assert any(
+        finding["code"] == "invalid_field"
+        and "keys must be strings" in finding["detail"]
+        for finding in compiled.findings
+    )
+
+
+def test_credential_scrubber_occurrence_emits_owner_migration_finding(vault: Path) -> None:
+    _write(vault, "scopes", "acmeco", _SCOPE_A)
+    _write(
+        vault,
+        "rules",
+        "legacy-scrubber",
+        _RULE_A + "options:\n  credential_scrubber: off\n",
+    )
+
+    compiled = policy.load(vault)
+
+    assert compiled.blocked is True
+    migration = [
+        finding
+        for finding in compiled.findings
+        if finding["code"] == "owner_migration_required"
+    ]
+    assert len(migration) == 1
+    assert migration[0]["path"].endswith(":options.credential_scrubber")
+    assert "remove" in migration[0]["detail"].lower()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_governance_postfilter.py
+++ b/tests/test_governance_postfilter.py
@@ -15,6 +15,7 @@ other consumer: empty -> open, blocked -> fail closed, else decide.
 from __future__ import annotations
 
 import json
+import pickle
 import re
 from pathlib import Path
 
@@ -49,6 +50,14 @@ JWT = (
 )
 BEARER = "Authorization: Bearer sk-proj-9dQm2XvKpLzR4wTnBcYeF8aHgJ1sVuNiO0rEyMdA"
 HIGH_ENTROPY = "s3cr3tK3yZ9qWmPvXtLnBdRfGhJkYuIoAeCxSvTgNbMh"
+AS1_BEARER = "as1." + "A" * 22 + "." + "A" * 43
+AS1_VECTOR_BEARER = (
+    "as1."
+    + "AAECAwQFBgcICQoLDA0ODw"
+    + "."
+    + "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+)
+ISSUANCE_EXPIRY = "2026-08-13T12:34:56Z"
 
 # Structural identifiers that MUST survive untouched.
 CONTENT_HASH = "9f2c4e1a7b8d3f0e6c5a9b2d4e7f1a3c8b6d0e2f4a7c9b1d3e5f7a9c0b2d4e6f"
@@ -355,7 +364,222 @@ def test_nested_structures_are_walked() -> None:
     assert cleaned["hits"][1]["excerpt"] == "fine"
 
 
-def test_scrubber_is_disabled_by_a_standing_rule(vault: Path) -> None:
+def test_canonical_as1_bearers_and_mapping_keys_are_scrubbed() -> None:
+    payload = {
+        AS1_BEARER: "value",
+        "nested": {AWS_KEY: AS1_BEARER},
+    }
+
+    cleaned, blocked = scrubber.scrub_value(payload)
+
+    encoded = json.dumps(cleaned)
+    assert blocked
+    assert AS1_BEARER not in encoded
+    assert AWS_KEY not in encoded
+    assert scrubber.NOTICE in encoded
+
+
+def test_as1_parser_accepts_fixed_canonical_vectors_and_rejects_unused_bits() -> None:
+    assert scrubber._parse_authorization_bearer(AS1_BEARER) == AS1_BEARER
+    assert scrubber._parse_authorization_bearer(AS1_VECTOR_BEARER) == AS1_VECTOR_BEARER
+
+    locator, secret = AS1_BEARER.removeprefix("as1.").split(".")
+    for malformed in (
+        AS1_BEARER[:-1],
+        AS1_BEARER + "x",
+        AS1_BEARER.replace("as1.", "AS1."),
+        AS1_BEARER.replace(".", "_", 1),
+        f"as1.{locator[:-1]}B.{secret}",
+        f"as1.{locator}.{secret[:-1]}B",
+    ):
+        assert scrubber._parse_authorization_bearer(malformed) is None
+
+
+def test_arbitrary_content_scanning_calls_the_canonical_as1_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+    real = scrubber._parse_authorization_bearer
+
+    def recording_parser(value: object) -> str | None:
+        calls.append(value)
+        return real(value)
+
+    monkeypatch.setattr(scrubber, "_parse_authorization_bearer", recording_parser)
+
+    cleaned, blocked = scrubber.scrub_text(f"prefix {AS1_VECTOR_BEARER} suffix")
+
+    assert blocked
+    assert AS1_VECTOR_BEARER not in cleaned
+    assert AS1_VECTOR_BEARER in calls
+
+
+def test_canonical_as1_scanning_ignores_adjacent_base64url_characters() -> None:
+    # The first `as1.` is a malformed start whose fixed 70-character window
+    # overlaps the canonical bearer that follows it. The scanner must advance
+    # to the later start, then continue through an adjacent second bearer.
+    payload = f"as1.x{AS1_VECTOR_BEARER}{AS1_BEARER}y"
+
+    cleaned, blocked = scrubber.scrub_text(payload)
+
+    assert blocked
+    assert AS1_VECTOR_BEARER not in cleaned
+    assert AS1_BEARER not in cleaned
+    assert cleaned == f"as1.x{scrubber.NOTICE}{scrubber.NOTICE}y"
+
+
+def test_canonical_as1_in_mapping_key_is_scrubbed_without_token_boundaries() -> None:
+    payload = {f"x{AS1_VECTOR_BEARER}y": "safe"}
+
+    cleaned, blocked = scrubber.scrub_value(payload)
+
+    assert blocked
+    assert cleaned == {f"x{scrubber.NOTICE}y": "safe"}
+
+
+def _issuance_response(bearer: str = AS1_BEARER) -> dict[str, object]:
+    return {
+        "status": "ok",
+        "issued_credential": {
+            "kind": "authorization-session-bearer",
+            "bearer": bearer,
+            "expires_at": ISSUANCE_EXPIRY,
+        },
+    }
+
+
+def test_exact_issuance_context_allows_only_one_matching_typed_response() -> None:
+    context = scrubber._new_issuance_context("open", AS1_BEARER)
+    response = _issuance_response()
+
+    cleaned, blocked = scrubber._scrub_issuance_response("open", response, context)
+
+    assert not blocked
+    assert cleaned == response
+
+
+def test_issuance_context_cannot_be_serialized() -> None:
+    with pytest.raises(TypeError, match="process-local"):
+        pickle.dumps(scrubber._new_issuance_context("rotate", AS1_BEARER))
+
+
+def test_issuance_context_validates_action_and_private_seal() -> None:
+    with pytest.raises(ValueError, match="action"):
+        scrubber._new_issuance_context("get", AS1_BEARER)
+
+    forged = scrubber._IssuanceContext(
+        action="open", bearer=AS1_BEARER, _seal=object()
+    )
+    cleaned, blocked = scrubber._scrub_issuance_response(
+        "open", _issuance_response(), forged
+    )
+
+    assert blocked
+    assert AS1_BEARER not in json.dumps(cleaned)
+
+
+@pytest.mark.parametrize(
+    ("command", "response"),
+    [
+        ("get", _issuance_response()),
+        ("rotate", _issuance_response()),
+        ("open", {**_issuance_response(), "copy": AS1_BEARER}),
+        ("open", {"status": "error", "issued_credential": _issuance_response()["issued_credential"]}),
+        ("open", {"issued_credential": _issuance_response()["issued_credential"]}),
+        ("open", {"status": "ok", "issued_credential": {**_issuance_response()["issued_credential"], "extra": 1}}),
+        ("open", {"status": "ok", "issued_credential": {**_issuance_response()["issued_credential"], "kind": "other"}}),
+        ("open", {"status": "ok", "issued_credential": {**_issuance_response()["issued_credential"], "expires_at": "tomorrow"}}),
+        ("open", _issuance_response(AS1_BEARER + "x")),
+    ],
+)
+def test_issuance_context_scrubs_wrong_or_duplicate_bearers(
+    command: str, response: dict[str, object]
+) -> None:
+    context = scrubber._new_issuance_context("open", AS1_BEARER)
+
+    cleaned, blocked = scrubber._scrub_issuance_response(command, response, context)
+
+    assert blocked
+    assert AS1_BEARER not in json.dumps(cleaned)
+
+
+def test_rejected_issuance_scrubs_embedded_duplicate_canonical_bearers() -> None:
+    context = scrubber._new_issuance_context("open", AS1_BEARER)
+    response = {
+        **_issuance_response(),
+        f"x{AS1_VECTOR_BEARER}y": f"x{AS1_BEARER}{AS1_VECTOR_BEARER}y",
+    }
+
+    cleaned, blocked = scrubber._scrub_issuance_response("open", response, context)
+
+    encoded = json.dumps(cleaned)
+    assert blocked
+    assert AS1_BEARER not in encoded
+    assert AS1_VECTOR_BEARER not in encoded
+    assert encoded.count(scrubber.NOTICE) == 4
+
+
+def test_issuance_without_process_local_context_is_refused() -> None:
+    cleaned, blocked = scrubber._scrub_issuance_response(
+        "open", _issuance_response(), None
+    )
+
+    assert blocked
+    assert AS1_BEARER not in json.dumps(cleaned)
+
+
+def test_live_success_and_control_envelopes_never_receive_issuance_exception(
+    vault: Path,
+) -> None:
+    response = _issuance_response()
+
+    cleaned = egress.postfilter("open", response, vault)
+
+    assert AS1_BEARER not in json.dumps(cleaned)
+    assert scrubber.NOTICE in json.dumps(cleaned)
+
+
+@pytest.mark.parametrize("rejected_issuance", [False, True])
+def test_mapping_key_scrubbing_is_collision_safe_and_order_independent(
+    rejected_issuance: bool,
+) -> None:
+    entries = [
+        (scrubber.NOTICE, "literal notice"),
+        (f"{scrubber.NOTICE}#1", "literal suffix one"),
+        (f"{scrubber.NOTICE}#3", "literal suffix three"),
+        (AS1_BEARER, "authorization bearer key"),
+        (AWS_KEY, "aws key"),
+    ]
+
+    outputs = []
+    for ordered in (entries, list(reversed(entries))):
+        payload = dict(ordered)
+        if rejected_issuance:
+            cleaned, blocked = scrubber._scrub_issuance_response("get", payload, None)
+        else:
+            cleaned, blocked = scrubber.scrub_value(payload)
+        assert blocked
+        assert len(cleaned) == len(payload)
+        assert sorted(cleaned.values()) == sorted(value for _, value in entries)
+        assert AS1_BEARER not in cleaned
+        assert AWS_KEY not in cleaned
+        outputs.append(cleaned)
+
+    assert outputs[0] == outputs[1]
+
+
+def test_error_details_scrub_bearers_and_credential_mapping_keys(vault: Path) -> None:
+    error = ValueError("upstream bearer " + AS1_BEARER)
+    error.details = {AWS_KEY: {AS1_BEARER: "value"}}
+
+    egress.postfilter_error("get", error, vault)
+
+    encoded = json.dumps({"args": error.args, "details": error.details})
+    assert AS1_BEARER not in encoded
+    assert AWS_KEY not in encoded
+
+
+def test_scrubber_cannot_be_disabled_by_a_standing_rule(vault: Path) -> None:
     assert scrubber.enabled(vault) is True
     disable = vault / "Knowledge Base" / "_Governance" / "rules" / "no-scrubber.yaml"
     disable.parent.mkdir(parents=True, exist_ok=True)
@@ -372,7 +596,7 @@ def test_scrubber_is_disabled_by_a_standing_rule(vault: Path) -> None:
         "governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths: [\"**\"]\n",
         encoding="utf-8",
     )
-    assert scrubber.enabled(vault) is False
+    assert scrubber.enabled(vault) is True
 
 
 def test_scrubber_stays_on_for_a_blocked_policy(vault: Path) -> None:

--- a/tests/test_governance_store.py
+++ b/tests/test_governance_store.py
@@ -52,6 +52,37 @@ def test_open_connection_is_idempotent(vault: Path) -> None:
         second.close()
 
 
+def test_v3_session_grant_rows_are_non_authoritative(vault: Path) -> None:
+    conn = store.open_connection(vault)
+    try:
+        conn.execute(
+            "INSERT INTO governance_session_grants "
+            "(grant_id, authorization_session, audience, purpose, ceiling, paths, "
+            "fingerprints, token_jti, status, created_at, expires_at, "
+            "membership_manifest, policy_fingerprint) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "grant-1", "session-1", "external", None, 6, '["Notes/a.md"]',
+                '["hash"]', "token-1", "active", 0.0, 4_000_000_000.0,
+                '[{"path":"Notes/a.md","scope_ids":["scope-a"]}]', "policy",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    active, identity = store.active_session_grants(
+        vault,
+        audience="external",
+        authorization_session="session-1",
+        rel_path="Notes/a.md",
+        purpose=None,
+    )
+
+    assert active == []
+    assert identity == "v3-session-grants-unscoped"
+
+
 def test_existing_v3_sidecar_gets_purpose_staging_table_idempotently(vault: Path) -> None:
     conn = store.open_connection(vault)
     conn.execute("DROP TABLE governance_session_purpose_staging")


### PR DESCRIPTION
## What changed

- evaluate disclosure independently per matched scope before taking the conservative cross-scope meet
- prevent a grant for one scope from lifting content protected by a sibling closed scope
- define a closed conservative policy-option registry and keep equal-ceiling purpose ties non-widening
- treat schema-v3 session grants as unscoped and therefore inert until the reviewed schema-v4 scope proof ships
- make terminal credential scrubbing non-disableable, including collision-safe mapping-key and canonical bearer scanning
- expose per-scope decision contributions only through owner inspection

## Why

The shipped lattice computed one standing minimum for an entire item and then applied any matching grant to that shared value. An item belonging to both an allowed scope and a closed scope could therefore move from L0 to L6 when a grant named only the allowed sibling. Consolidation would multiply those mixed-domain memberships, so this crossover has to close before managed vaults can share a destination.

## Compatibility and safety

- no schema migration or `user_version` change
- no public authorization-session lifecycle or new command surface
- no deployment, connector mutation, consolidation command, or live-vault access
- legacy schema-v3 session grants fail closed because they cannot prove reviewed scope identity

## Verification

- red-first implementation packet, same-reviewer recheck: GO with no findings
- independent verifier: 553 packet tests, 831 adjacent governance tests, 32 targeted security probes
- fresh after rebasing on current `main`: 553 packet tests passed
- changed-file Ruff passed
- `git diff --check origin/main...HEAD` passed

