### PR TITLE
fix(governance): fail closed on unresolved binary membership

### DIFF
--- a/openspec/changes/harden-governance-for-consolidation/tasks.md
+++ b/openspec/changes/harden-governance-for-consolidation/tasks.md
@@ -59,7 +59,7 @@
 
 ## 2. Fail-Closed Non-Markdown Membership
 
-- [ ] 2.1 Add red tests in `tests/test_governance_membership.py` for a missing companion
+- [x] 2.1 Add red tests in `tests/test_governance_membership.py` for a missing companion
   under semantic-only project/tag/type/class scopes, proving the outcome is unresolved
   rather than the classified empty set.
 - [ ] 2.2 Add red tests for malformed, unreadable, stale, symlink-escaping, and

--- a/src/exomem/governance/egress.py
+++ b/src/exomem/governance/egress.py
@@ -1100,8 +1100,14 @@ def _decide_path(
         # enumerated in the walk; permitted media stopped downloading for
         # everyone, owner included) and logged a `utf-8 codec` warning per
         # decision on the way. Path/ref selectors decide a binary with no
-        # parse at all; a sidecar page supplies frontmatter when one exists.
-        scope_ids = membership_module.evaluate_path_only(vault_root, rel_path, policy)
+        # parse at all; semantic selectors remain explicitly unresolved until
+        # companion descriptors are implemented.
+        try:
+            scope_ids = membership_module.evaluate_path_only(
+                vault_root, rel_path, policy
+            ).require_classified()
+        except membership_module.MembershipUnresolved:
+            return None
     else:
         page = find_corpus.parse_page(full_path, mtime, vault_root, content=raw)
         if page is None:
@@ -2826,12 +2832,12 @@ def release_level_for_path_only(
     who = principal if principal is not None else effective_principal()
     if policy.blocked or not who.resolved:
         return DISCLOSURE_MIN
-    if any(
-        scope.projects or scope.tags or scope.types or scope.classes
-        for scope in policy.scopes.values()
-    ):
+    try:
+        scope_ids = membership_module.evaluate_path_only(
+            vault_root, rel_path, policy
+        ).require_classified()
+    except membership_module.MembershipUnresolved:
         return DISCLOSURE_MIN
-    scope_ids = membership_module.evaluate_path_only(vault_root, rel_path, policy)
     decision = decide(
         scope_ids,
         audience=who.audience_id,

--- a/src/exomem/governance/lifecycle.py
+++ b/src/exomem/governance/lifecycle.py
@@ -257,7 +257,9 @@ def _derived_residue_paths(vault_root: Path, source_rel: str) -> tuple[str, ...]
 def _scope_ids(vault_root: Path, item: ManifestItem, policy: policy_module.Policy) -> frozenset[str] | None:
     source = Path(vault_root) / item.source_path
     if not item.source_path.lower().endswith(".md"):
-        return membership.evaluate_path_only(vault_root, item.source_path, policy)
+        return membership.evaluate_path_only(
+            vault_root, item.source_path, policy
+        ).require_classified()
     try:
         raw = source.read_bytes()
         stat = source.stat()
@@ -1149,9 +1151,13 @@ def _is_governed_for_restore(vault_root: Path, manifest: tuple[ManifestItem, ...
     restricting = _restricting_scope_ids(policy)
     for item in manifest:
         if not item.source_path.lower().endswith(".md"):
-            if restricting.intersection(
-                membership.evaluate_path_only(vault_root, item.source_path, policy)
-            ):
+            try:
+                scope_ids = membership.evaluate_path_only(
+                    vault_root, item.source_path, policy
+                ).require_classified()
+            except membership.MembershipUnresolved:
+                return True
+            if restricting.intersection(scope_ids):
                 return True
             continue
         try:

--- a/src/exomem/governance/membership.py
+++ b/src/exomem/governance/membership.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import fnmatch
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from .. import find_corpus
 from ..find_types import ParsedPage
@@ -35,6 +37,20 @@ class MembershipUnresolved(Exception):
     which is the opposite of what an IO failure should cost. Callers must
     translate this into their own fail-closed signal.
     """
+
+
+@dataclass(frozen=True)
+class MembershipOutcome:
+    """Non-Markdown membership that is either proven or safely unresolved."""
+
+    state: Literal["classified", "unresolved"]
+    scope_ids: frozenset[str]
+    reason: Literal["companion_required"] | None = None
+
+    def require_classified(self) -> frozenset[str]:
+        if self.state == "classified":
+            return self.scope_ids
+        raise MembershipUnresolved("non-Markdown membership requires a companion")
 
 
 def clear_memo() -> None:
@@ -112,23 +128,16 @@ def _scope_matches(scope: Scope, page: ParsedPage) -> bool:
     return not excluded
 
 
-def _scope_matches_path_only(scope: Scope, rel_path: str) -> bool:
-    """The half of `_scope_matches` that needs no parsed page.
-
-    Only `paths` and `refs` select on the path itself; every other selector
-    reads frontmatter. An exclude that cannot be evaluated is treated as NOT
-    excluding — the fail-closed direction, since excluding would widen
-    disclosure.
-    """
-    positive = (bool(scope.paths) and _matches_paths(scope.paths, rel_path)) or (
-        bool(scope.refs) and _matches_refs(scope.refs, rel_path)
-    )
-    if not positive:
-        return False
-    excluded = (
+def _path_ref_excludes(scope: Scope, rel_path: str) -> bool:
+    return (
         bool(scope.exclude_paths) and _matches_paths(scope.exclude_paths, rel_path)
     ) or (bool(scope.exclude_refs) and _matches_refs(scope.exclude_refs, rel_path))
-    return not excluded
+
+
+def _path_ref_matches(scope: Scope, rel_path: str) -> bool:
+    return (bool(scope.paths) and _matches_paths(scope.paths, rel_path)) or (
+        bool(scope.refs) and _matches_refs(scope.refs, rel_path)
+    )
 
 
 def _needs_frontmatter(scope: Scope) -> bool:
@@ -137,8 +146,8 @@ def _needs_frontmatter(scope: Scope) -> bool:
 
 def evaluate_path_only(
     vault_root: Path, rel_path: str, policy: Policy
-) -> frozenset[str]:
-    """Scope membership for a NON-MARKDOWN item, decided without parsing it.
+) -> MembershipOutcome:
+    """Classify a non-Markdown item's path/ref membership without reading it.
 
     `find_corpus.parse_page` cannot decode a binary, and the caller used to
     read that failure as `None` — a value overloaded to mean both "unreadable"
@@ -149,45 +158,27 @@ def evaluate_path_only(
     value as deny (so creating `_Governance/` broke media for everyone,
     including the owner).
 
-    A binary has no frontmatter of its own, so `paths` and `refs` are the only
-    selectors that can name it directly — no parse is needed for those. When a
-    scope selects on tags/types/classes/projects, the item's SIDECAR page
-    (`<name>.md`, the media metadata convention) is the thing carrying that
-    frontmatter, so it is consulted when present.
-
-    Never returns `None`: an unmatched binary is genuinely a member of no
-    scope. `None` is reserved for a real IO failure, which the caller raises.
+    A path/ref exclusion proves exclusion and a path/ref positive proves
+    membership.  A selector requiring artifact semantics cannot be decided in
+    this compatibility slice: descriptor-like legacy companions deliberately
+    stay unresolved until the closed companion registry lands.
     """
     if policy.empty or not policy.scopes:
-        return frozenset()
-
-    sidecar_page: ParsedPage | None = None
-    sidecar_loaded = False
-
-    def _sidecar() -> ParsedPage | None:
-        nonlocal sidecar_page, sidecar_loaded
-        if not sidecar_loaded:
-            sidecar_loaded = True
-            candidate = Path(vault_root) / f"{rel_path}.md"
-            try:
-                if candidate.is_file():
-                    sidecar_page = find_corpus.parse_page(
-                        candidate, candidate.stat().st_mtime, Path(vault_root)
-                    )
-            except OSError:
-                sidecar_page = None
-        return sidecar_page
+        return MembershipOutcome("classified", frozenset())
 
     matched: set[str] = set()
+    unresolved = False
     for scope_id, scope in policy.scopes.items():
-        if _scope_matches_path_only(scope, rel_path):
+        if _path_ref_excludes(scope, rel_path):
+            continue
+        if _path_ref_matches(scope, rel_path):
             matched.add(scope_id)
             continue
         if _needs_frontmatter(scope):
-            page = _sidecar()
-            if page is not None and _scope_matches(scope, page):
-                matched.add(scope_id)
-    return frozenset(matched)
+            unresolved = True
+    if unresolved:
+        return MembershipOutcome("unresolved", frozenset(matched), "companion_required")
+    return MembershipOutcome("classified", frozenset(matched))
 
 
 def evaluate(page: ParsedPage, policy: Policy) -> frozenset[str]:

--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import time
 import uuid
@@ -20,7 +21,20 @@ from typing import Any
 
 import yaml
 
-from .. import find_corpus, memory_refs
+from .. import (
+    claims,
+    deferred_index,
+    epistemic_graph,
+    find_corpus,
+    graph_sync,
+    index_paths,
+    lexstore,
+    media_jobs,
+    memory_refs,
+    review_state,
+    voice_profiles,
+)
+from ..kbdir import kb_dirname
 from . import decisions, membership, receipts, store
 from . import policy as policy_module
 from . import tokens as tokens_module
@@ -43,6 +57,14 @@ from .transaction import GovernanceCrash, GovernanceError, authorization_row, po
 
 PENDING_MARKER = ".policy-mutation.pending.json"
 DEFAULT_PROPOSAL_TTL_SECONDS = 900
+_GRAPH_REBUILD_SIDECAR_RE = re.compile(
+    rf"^{re.escape(graph_sync._TEMP_PREFIX)}[0-9a-f]{{64}}-[0-9a-f]{{24}}\.sqlite"
+    r"(?:-(?:wal|shm|journal))?$"
+)
+_REVIEW_STATE_TEMP_RE = re.compile(r"^\.\.review-state\.json\.[a-z0-9_]{8}\.tmp$")
+_LEXICAL_REBUILD_TEMP_RE = re.compile(
+    r"^\.lexical\.sqlite\.rebuild-[0-9a-f]{32}\.tmp(?:-(?:wal|shm|journal))?$"
+)
 
 __all__ = [
     "GovernanceCrash",
@@ -160,7 +182,14 @@ def _memberships_for_path(
 ) -> frozenset[str]:
     rel = path.relative_to(vault_root).as_posix()
     if path.suffix.casefold() != ".md":
-        return membership.evaluate_path_only(vault_root, rel, candidate)
+        try:
+            return membership.evaluate_path_only(
+                vault_root, rel, candidate
+            ).require_classified()
+        except membership.MembershipUnresolved as exc:
+            raise GovernanceError(
+                "MEMBERSHIP_UNRESOLVED", "cannot resolve exact non-Markdown membership"
+            ) from exc
     try:
         page = find_corpus.parse_page(path, path.stat().st_mtime, vault_root)
         return membership.evaluate(page, candidate)
@@ -168,6 +197,56 @@ def _memberships_for_path(
         raise GovernanceError(
             "MEMBERSHIP_UNRESOLVED", f"cannot resolve exact membership for {rel!r}"
         ) from exc
+
+
+def _is_operational_membership_path(vault_root: Path, candidate: Path) -> bool:
+    """Whether a current internal-state owner, rather than content, owns a path."""
+    sidecars = (
+        index_paths.sidecar_path(vault_root),
+        index_paths.clip_sidecar_path(vault_root),
+        index_paths.governance_sidecar_path(vault_root),
+        claims.sidecar_path(vault_root),
+        memory_refs.sidecar_path(vault_root),
+        lexstore.lexical_path(vault_root),
+        epistemic_graph.sidecar_path(vault_root),
+        deferred_index.store_path(vault_root),
+        media_jobs.job_store_path(vault_root),
+    )
+    for sidecar in sidecars:
+        if candidate in (
+            sidecar,
+            sidecar.with_name(f"{sidecar.name}-wal"),
+            sidecar.with_name(f"{sidecar.name}-shm"),
+            sidecar.with_name(f"{sidecar.name}-journal"),
+        ):
+            return True
+
+    if candidate in (
+        media_jobs.worker_lock_path(vault_root),
+        voice_profiles.voice_profiles_path(vault_root),
+        review_state.state_path(vault_root),
+        graph_sync.checkpoint_path(vault_root),
+        graph_sync.floor_path(vault_root),
+    ):
+        return True
+    review_state_path = review_state.state_path(vault_root)
+    if (
+        candidate.parent == review_state_path.parent
+        and _REVIEW_STATE_TEMP_RE.fullmatch(candidate.name) is not None
+    ):
+        return True
+    lexical_path = lexstore.lexical_path(vault_root)
+    if (
+        candidate.parent == lexical_path.parent
+        and _LEXICAL_REBUILD_TEMP_RE.fullmatch(candidate.name) is not None
+    ):
+        return True
+    receipt_root = graph_sync.graph_commit_receipt_path(vault_root, "0" * 24).parent
+    graph_sidecar_parent = epistemic_graph.sidecar_path(vault_root).parent
+    return candidate.is_relative_to(receipt_root) or (
+        candidate.parent == graph_sidecar_parent
+        and _GRAPH_REBUILD_SIDECAR_RE.fullmatch(candidate.name) is not None
+    )
 
 
 def _membership_manifest(
@@ -179,11 +258,13 @@ def _membership_manifest(
     affected = _affected_scope_ids(current, prospective, document_paths)
     rows: dict[str, str] = {}
     if affected:
-        for candidate in sorted(vault_root.rglob("*")):
+        for candidate in sorted((vault_root / kb_dirname()).rglob("*")):
             if not candidate.is_file():
                 continue
             rel = candidate.relative_to(vault_root).as_posix()
             if policy_module.is_governance_path(rel):
+                continue
+            if _is_operational_membership_path(vault_root, candidate):
                 continue
             union = _memberships_for_path(
                 vault_root, candidate, current
@@ -371,11 +452,13 @@ def _purpose_direction(
     before: dict[str, int] = {}
     after: dict[str, int] = {}
     try:
-        for candidate in sorted(vault_root.rglob("*")):
+        for candidate in sorted((vault_root / kb_dirname()).rglob("*")):
             if not candidate.is_file():
                 continue
             rel = candidate.relative_to(vault_root).as_posix()
             if policy_module.is_governance_path(rel):
+                continue
+            if _is_operational_membership_path(vault_root, candidate):
                 continue
             scopes = _memberships_for_path(vault_root, candidate, policy)
             before[rel] = decisions.decide(

--- a/tests/test_governance_membership.py
+++ b/tests/test_governance_membership.py
@@ -10,6 +10,8 @@ import os
 import time
 from pathlib import Path
 
+import pytest
+
 from exomem import find_corpus
 from exomem.governance import membership, policy
 
@@ -250,3 +252,85 @@ def test_unresolvable_membership_makes_the_decision_fail_closed(
         grants_hash="",
     )
     assert decision is None
+
+
+@pytest.mark.parametrize(
+    ("selector", "value"),
+    [
+        ("projects", "acmeco"),
+        ("tags", "confidential"),
+        ("types", "source"),
+        ("classes", "pii"),
+    ],
+)
+def test_missing_non_markdown_companion_is_unresolved_for_semantic_selectors(
+    vault: Path, selector: str, value: str
+) -> None:
+    _write_scope(
+        vault,
+        selector,
+        f"governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n{selector}: [\"{value}\"]\n",
+    )
+    pol = policy.load(vault)
+    asset = vault / "Knowledge Base/Notes/asset.bin"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(b"\\x00binary")
+
+    outcome = membership.evaluate_path_only(vault, "Knowledge Base/Notes/asset.bin", pol)
+
+    # A bare empty set means "not in any scope", which fail-opens through
+    # decisions.decide.  Missing descriptor-like companions must instead be
+    # explicit, non-iterable unresolved membership.
+    assert type(outcome).__name__ == "MembershipOutcome"
+    assert outcome.state == "unresolved"
+    assert outcome.reason == "companion_required"
+
+
+def test_path_only_non_markdown_membership_is_classified_empty(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "paths",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths: ["Knowledge Base/Private/**"]\n',
+    )
+    pol = policy.load(vault)
+
+    outcome = membership.evaluate_path_only(vault, "Knowledge Base/Notes/asset.bin", pol)
+
+    assert type(outcome).__name__ == "MembershipOutcome"
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset()
+
+
+def test_path_exclusion_proves_non_markdown_scope_is_excluded(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "excluded",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\ntypes: ["source"]\nexclude:\n  paths: ["Knowledge Base/Notes/asset.bin"]\n',
+    )
+    pol = policy.load(vault)
+
+    outcome = membership.evaluate_path_only(vault, "Knowledge Base/Notes/asset.bin", pol)
+
+    assert type(outcome).__name__ == "MembershipOutcome"
+    assert outcome.state == "classified"
+    assert outcome.scope_ids == frozenset()
+
+
+def test_path_match_does_not_erase_an_unresolved_semantic_sibling(vault: Path) -> None:
+    _write_scope(
+        vault,
+        "path",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FAV\npaths: ["Knowledge Base/Notes/asset.bin"]\n',
+    )
+    _write_scope(
+        vault,
+        "semantic",
+        'governance_version: 1\nid: 01ARZ3NDEKTSV4RRFFQ69G5FB1\ntags: ["confidential"]\n',
+    )
+    pol = policy.load(vault)
+
+    outcome = membership.evaluate_path_only(vault, "Knowledge Base/Notes/asset.bin", pol)
+
+    assert type(outcome).__name__ == "MembershipOutcome"
+    assert outcome.state == "unresolved"
+    assert outcome.scope_ids == frozenset({"01ARZ3NDEKTSV4RRFFQ69G5FAV"})

--- a/tests/test_non_markdown_membership_propagation.py
+++ b/tests/test_non_markdown_membership_propagation.py
@@ -1,0 +1,317 @@
+"""Fail-closed propagation for unclassified non-Markdown artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from exomem.governance import egress, lifecycle, policy
+from exomem.governance.principal import RequestPrincipal, owner_principal
+from exomem.governance.tool import GovernanceError, op_govern_memory
+
+SCOPE_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+RULE_ID = "01ARZ3NDEKTSV4RRFFQ69G5FB0"
+ASSET = "Knowledge Base/Notes/asset.bin"
+
+
+def _write_semantic_scope(vault: Path, *, default_deny: bool = False) -> None:
+    root = vault / "Knowledge Base" / "_Governance"
+    scopes = root / "scopes"
+    scopes.mkdir(parents=True, exist_ok=True)
+    (scopes / "semantic.yaml").write_text(
+        "governance_version: 1\n"
+        f"id: {SCOPE_ID}\n"
+        "types: [\"source\"]\n"
+        + ("default_deny: true\n" if default_deny else ""),
+        encoding="utf-8",
+    )
+
+
+def _write_asset(vault: Path) -> bytes:
+    data = b"\x00opaque binary"
+    target = vault / ASSET
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+    return data
+
+
+def _semantic_documents() -> dict[str, str]:
+    return {
+        "scopes/semantic.yaml": (
+            "governance_version: 1\n"
+            f"id: {SCOPE_ID}\n"
+            "types: [\"source\"]\n"
+        ),
+        "rules/semantic.yaml": (
+            "governance_version: 1\n"
+            f"id: {RULE_ID}\n"
+            f"scope_ids: [\"{SCOPE_ID}\"]\n"
+            "audience: external\nceiling: 1\n"
+        ),
+    }
+
+
+def test_unresolved_non_markdown_direct_egress_has_no_decision(vault: Path) -> None:
+    _write_semantic_scope(vault, default_deny=True)
+    _write_asset(vault)
+    loaded = policy.load(vault)
+
+    assert egress._decide_path(
+        vault,
+        ASSET,
+        policy=loaded,
+        audience="external",
+        purpose=None,
+        grants_hash="",
+    ) is None
+    assert egress.release_level_for(
+        vault, ASSET, principal=RequestPrincipal(audience_id="external", surface="mcp")
+    ) is None
+    assert egress.release_level_for_path_only(
+        vault, ASSET, principal=RequestPrincipal(audience_id="external", surface="mcp")
+    ) == egress.LEVEL_NONE
+
+
+def test_proposal_refuses_unresolved_non_markdown_membership(vault: Path) -> None:
+    _write_asset(vault)
+
+    with pytest.raises(GovernanceError) as raised:
+        op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Restrict sources",
+            documents=_semantic_documents(),
+            selector_paths=[],
+            target_ceiling=1,
+            duration="standing",
+        )
+
+    assert raised.value.code == "MEMBERSHIP_UNRESOLVED"
+    assert ASSET not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "operational_rel",
+    [
+        "Knowledge Base/.embeddings.sqlite",
+        "Knowledge Base/.clip.sqlite-wal",
+        "Knowledge Base/.graph.sqlite-shm",
+        "Knowledge Base/.claims.sqlite",
+        "Knowledge Base/.refs.sqlite-wal",
+        "Knowledge Base/.lexical.sqlite",
+        "Knowledge Base/.deferred-index.sqlite",
+        "Knowledge Base/.media-jobs.sqlite",
+        "Knowledge Base/.media-worker.lock",
+        "Knowledge Base/.voice_profiles.json",
+        "Knowledge Base/.review-state.json",
+        "Knowledge Base/.graph-sync.json",
+        "Knowledge Base/.graph-sync-floor.json",
+        "Knowledge Base/.graph-commit-receipts/0123456789abcdef01234567.json",
+        "Knowledge Base/.graph-rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbb.sqlite",
+        "Knowledge Base/..review-state.json.abc123_4.tmp",
+        "Knowledge Base/.lexical.sqlite.rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tmp",
+        "Knowledge Base/.lexical.sqlite.rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tmp-wal",
+        "Knowledge Base/.lexical.sqlite.rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tmp-shm",
+        "Knowledge Base/.lexical.sqlite.rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tmp-journal",
+    ],
+)
+def test_proposal_skips_operational_state_but_refuses_a_genuine_binary(
+    vault: Path, operational_rel: str
+) -> None:
+    state = vault / operational_rel
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_bytes(b"runtime state")
+
+    proposal = op_govern_memory(
+        vault,
+        operation="propose",
+        principal=owner_principal(),
+        intent="Restrict sources",
+        documents=_semantic_documents(),
+        selector_paths=[],
+        target_ceiling=1,
+        duration="standing",
+    )
+
+    assert proposal["proposal_id"]
+    _write_asset(vault)
+    with pytest.raises(GovernanceError) as raised:
+        op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Restrict sources",
+            documents=_semantic_documents(),
+            selector_paths=[],
+            target_ceiling=1,
+            duration="standing",
+        )
+    assert raised.value.code == "MEMBERSHIP_UNRESOLVED"
+
+
+@pytest.mark.parametrize(
+    "artifact_rel",
+    [
+        "Knowledge Base/Notes/_attachments/nested.bin",
+        "Knowledge Base/Notes/_archive/nested.bin",
+        "Knowledge Base/Notes/_trash/nested.bin",
+        (
+            "Knowledge Base/Notes/"
+            ".graph-rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
+            "bbbbbbbbbbbbbbbbbbbbbbbb.sqlite"
+        ),
+        "Knowledge Base/.review-state.json.abc123_4.tmp",
+        "Knowledge Base/Notes/..review-state.json.abc123_4.tmp",
+        "Knowledge Base/.lexical.sqlite.rebuild-not-a-digest.tmp",
+        "Knowledge Base/Notes/.lexical.sqlite.rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.tmp",
+    ],
+)
+def test_proposal_refuses_governance_bearing_and_transactional_lookalikes(
+    vault: Path, artifact_rel: str
+) -> None:
+    artifact = vault / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"user artifact")
+
+    with pytest.raises(GovernanceError) as raised:
+        op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Restrict sources",
+            documents=_semantic_documents(),
+            selector_paths=[],
+            target_ceiling=1,
+            duration="standing",
+        )
+
+    assert raised.value.code == "MEMBERSHIP_UNRESOLVED"
+
+
+def test_proposal_refuses_a_graph_rebuild_lookalike(vault: Path) -> None:
+    lookalike = vault / "Knowledge Base/.graph-rebuild-user-copy.sqlite"
+    lookalike.write_bytes(b"user artifact")
+
+    with pytest.raises(GovernanceError) as raised:
+        op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Restrict sources",
+            documents=_semantic_documents(),
+            selector_paths=[],
+            target_ceiling=1,
+            duration="standing",
+        )
+
+    assert raised.value.code == "MEMBERSHIP_UNRESOLVED"
+
+
+def test_proposal_refuses_unresolved_scene_frames(vault: Path) -> None:
+    frame = vault / "Knowledge Base/Evidence/call.mp4.frames/scene-001.jpg"
+    frame.parent.mkdir(parents=True, exist_ok=True)
+    frame.write_bytes(b"frame pixels")
+
+    with pytest.raises(GovernanceError) as raised:
+        op_govern_memory(
+            vault,
+            operation="propose",
+            principal=owner_principal(),
+            intent="Restrict sources",
+            documents=_semantic_documents(),
+            selector_paths=[],
+            target_ceiling=1,
+            duration="standing",
+        )
+
+    assert raised.value.code == "MEMBERSHIP_UNRESOLVED"
+
+
+def test_purpose_direction_is_conservative_for_unresolved_scene_frames(tmp_path: Path) -> None:
+    from exomem.governance import tool
+
+    root = tmp_path / "vault"
+    frame = root / "Knowledge Base/Evidence/call.mp4.frames/scene-001.jpg"
+    frame.parent.mkdir(parents=True, exist_ok=True)
+    frame.write_bytes(b"frame pixels")
+    governance = root / "Knowledge Base/_Governance"
+    (governance / "scopes").mkdir(parents=True)
+    (governance / "scopes/semantic.yaml").write_text(
+        "governance_version: 1\n"
+        f"id: {SCOPE_ID}\n"
+        "types: [\"source\"]\n",
+        encoding="utf-8",
+    )
+    (governance / "rules").mkdir()
+    (governance / "rules/semantic.yaml").write_text(
+        "governance_version: 1\n"
+        f"id: {RULE_ID}\n"
+        f"scope_ids: [\"{SCOPE_ID}\"]\n"
+        "audience: external\npurpose: approved\nceiling: 1\n",
+        encoding="utf-8",
+    )
+
+    assert tool._purpose_direction(
+        root, audience="external", before_purpose=None, after_purpose="approved"
+    ) == "widening"
+
+
+@pytest.mark.parametrize(
+    "artifact_rel",
+    [
+        "Knowledge Base/Notes/_attachments/nested.bin",
+        "Knowledge Base/Notes/_archive/nested.bin",
+        (
+            "Knowledge Base/Notes/"
+            ".graph-rebuild-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
+            "bbbbbbbbbbbbbbbbbbbbbbbb.sqlite"
+        ),
+    ],
+)
+def test_purpose_direction_is_conservative_for_unresolved_internal_tree_artifacts(
+    tmp_path: Path, artifact_rel: str
+) -> None:
+    from exomem.governance import tool
+
+    root = tmp_path / "vault"
+    artifact = root / artifact_rel
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_bytes(b"user artifact")
+    governance = root / "Knowledge Base/_Governance"
+    (governance / "scopes").mkdir(parents=True)
+    (governance / "scopes/semantic.yaml").write_text(
+        "governance_version: 1\n"
+        f"id: {SCOPE_ID}\n"
+        "types: [\"source\"]\n",
+        encoding="utf-8",
+    )
+    (governance / "rules").mkdir()
+    (governance / "rules/semantic.yaml").write_text(
+        "governance_version: 1\n"
+        f"id: {RULE_ID}\n"
+        f"scope_ids: [\"{SCOPE_ID}\"]\n"
+        "audience: external\npurpose: approved\nceiling: 1\n",
+        encoding="utf-8",
+    )
+
+    assert tool._purpose_direction(
+        root, audience="external", before_purpose=None, after_purpose="approved"
+    ) == "widening"
+
+
+def test_lifecycle_treats_unresolved_non_markdown_as_governed(vault: Path) -> None:
+    _write_semantic_scope(vault, default_deny=True)
+    data = _write_asset(vault)
+    item = lifecycle.ManifestItem(
+        source_path=ASSET,
+        trash_path="Knowledge Base/_trash/asset.bin",
+        content_hash=hashlib.sha256(data).hexdigest(),
+        size=len(data),
+        kind="file",
+        affected_ref="",
+    )
+
+    assert lifecycle._is_governed(vault, (item,)) is True


### PR DESCRIPTION
## What changed

- Replace ambiguous non-Markdown scope membership with a typed `classified` / `unresolved` outcome.
- Treat missing semantic companion data as unresolved instead of an empty scope set.
- Propagate unresolved membership conservatively through direct egress, governance proposals, purpose analysis, deletion, and recovery.
- Preserve path/ref-only classification, including path exclusions, while preventing a path match from erasing an unresolved semantic sibling scope.
- Keep current Exomem operational state out of proposal membership scans using exact owner paths and owner-anchored transactional families; canonical attachments, archives, trash, scene frames, and lookalikes remain governed content.

## Why

A non-Markdown artifact under a tag/project/type/class scope could previously be treated as belonging to no scope when companion metadata was absent. That empty-set interpretation could flow into a permissive decision. The new outcome makes uncertainty explicit and content-safe until the full bound companion-descriptor work lands.

## Scope

This completes OpenSpec task 2.1 and intentionally lays conservative, unclaimed groundwork for later tasks 2.9/2.10. Those later tasks remain unchecked because immutable companion identities, memo keys, and complete surface propagation are not implemented here.

## Verification

- Independent code review: GO after three correction/recheck rounds
- Independent verifier: PASS
- Python 3.11 targeted packet: `793 passed, 3 skipped` (optional PIL/AV only)
- Python 3.13 focused packet: `56 passed`
- Touched-file Ruff: clean
- `git diff --check origin/main...HEAD`
- `openspec validate harden-governance-for-consolidation --strict`
- `python3 scripts/validate-public-artifacts.py --repository`
