### PR TITLE
fix(hosted): bound deletion dispatcher calls

### DIFF
--- a/infra/helm/platform/templates/durability-workloads.yaml
+++ b/infra/helm/platform/templates/durability-workloads.yaml
@@ -925,8 +925,8 @@ spec:
                 - name: HOME
                   value: /tmp
               resources:
-                requests: {cpu: 10m, memory: 64Mi}
-                limits: {cpu: 100m, memory: 128Mi}
+                requests: {cpu: 10m, memory: 128Mi}
+                limits: {cpu: 250m, memory: 256Mi}
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/infra/provisioner/src/exomem_provisioner/durability_jobs.py
+++ b/infra/provisioner/src/exomem_provisioner/durability_jobs.py
@@ -122,6 +122,7 @@ class KubernetesDeletionJobLauncher:
             self._batch.list_namespaced_job,  # type: ignore[attr-defined]
             self._namespace,
             label_selector="exomem.io/deletion-job=true",
+            _request_timeout=(2, 5),
         )
         for item in getattr(result, "items", ()) or ():
             status = getattr(item, "status", None)
@@ -155,6 +156,7 @@ class KubernetesDeletionJobLauncher:
             self._batch.create_namespaced_job,  # type: ignore[attr-defined]
             self._namespace,
             body,
+            _request_timeout=(2, 5),
         )
 
     @staticmethod
@@ -650,10 +652,13 @@ async def _run_deletion_dispatcher(settings: DeletionDispatcherSettings) -> None
     sessions = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     try:
         kubernetes_config.load_incluster_config()
+        kubernetes_configuration = kubernetes_client.Configuration.get_default_copy()
+        kubernetes_configuration.retries = 0
+        api_client = kubernetes_client.ApiClient(configuration=kubernetes_configuration)
         await dispatch_one_deletion_job(
             RepositoryDeletionDispatchSource(sessions),
             KubernetesDeletionJobLauncher(
-                batch_v1=kubernetes_client.BatchV1Api(),
+                batch_v1=kubernetes_client.BatchV1Api(api_client=api_client),
                 namespace=settings.namespace,
                 job_template=template,
             ),

--- a/infra/provisioner/tests/test_durability_jobs.py
+++ b/infra/provisioner/tests/test_durability_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import UTC, datetime
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -319,13 +320,28 @@ async def test_kubernetes_deletion_launcher_uses_scoped_template_and_content_fre
         def __init__(self) -> None:
             self.items: list[object] = []
             self.created: list[tuple[str, dict[str, object]]] = []
+            self.request_timeouts: list[tuple[int, int]] = []
 
-        def list_namespaced_job(self, namespace: str, *, label_selector: str):
+        def list_namespaced_job(
+            self,
+            namespace: str,
+            *,
+            label_selector: str,
+            _request_timeout: tuple[int, int],
+        ):
             assert namespace == "exomem-platform"
             assert label_selector == "exomem.io/deletion-job=true"
+            self.request_timeouts.append(_request_timeout)
             return SimpleNamespace(items=self.items)
 
-        def create_namespaced_job(self, namespace: str, body: dict[str, object]):
+        def create_namespaced_job(
+            self,
+            namespace: str,
+            body: dict[str, object],
+            *,
+            _request_timeout: tuple[int, int],
+        ):
+            self.request_timeouts.append(_request_timeout)
             self.created.append((namespace, body))
 
     template = {
@@ -372,6 +388,77 @@ async def test_kubernetes_deletion_launcher_uses_scoped_template_and_content_fre
     assert set(annotations) == {"exomem.io/deletion-operation-sha256"}
     assert annotations["exomem.io/deletion-operation-sha256"] != "operation-sensitive-opaque"
     assert "operation-sensitive-opaque" not in str(body)
+    assert batch.request_timeouts == [(2, 5), (2, 5)]
+
+
+@pytest.mark.asyncio
+async def test_deletion_dispatcher_uses_an_explicit_retry_free_kubernetes_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created_clients: list[object] = []
+
+    class Configuration:
+        def __init__(self) -> None:
+            self.retries: object | None = None
+
+        @classmethod
+        def get_default_copy(cls) -> Configuration:
+            return cls()
+
+    class ApiClient:
+        def __init__(self, configuration: Configuration) -> None:
+            self.configuration = configuration
+            created_clients.append(self)
+
+    class BatchV1Api:
+        def __init__(self, api_client: ApiClient) -> None:
+            self.api_client = api_client
+
+        def list_namespaced_job(
+            self,
+            namespace: str,
+            *,
+            label_selector: str,
+            _request_timeout: tuple[int, int],
+        ) -> SimpleNamespace:
+            return SimpleNamespace(
+                items=[SimpleNamespace(status=SimpleNamespace(completion_time=None, failed=0))]
+            )
+
+    client = SimpleNamespace(
+        Configuration=Configuration,
+        ApiClient=ApiClient,
+        BatchV1Api=BatchV1Api,
+    )
+    config = SimpleNamespace(load_incluster_config=lambda: None)
+    monkeypatch.setitem(sys.modules, "kubernetes", SimpleNamespace(client=client, config=config))
+    monkeypatch.setitem(sys.modules, "kubernetes.client", client)
+    monkeypatch.setitem(sys.modules, "kubernetes.config", config)
+
+    class Engine:
+        async def dispose(self) -> None:
+            return None
+
+    monkeypatch.setattr(durability_jobs, "create_async_engine", lambda *args, **kwargs: Engine())
+    monkeypatch.setattr(durability_jobs, "async_sessionmaker", lambda *args, **kwargs: object())
+    template = tmp_path / "deletion-job.json"
+    template.write_text(
+        '{"apiVersion":"batch/v1","kind":"Job","metadata":{"generateName":"exomem-deletion-","labels":{"exomem.io/deletion-job":"true"}},"spec":{"activeDeadlineSeconds":240,"backoffLimit":0,"ttlSecondsAfterFinished":300,"template":{"spec":{"serviceAccountName":"exomem-deletion-worker","restartPolicy":"Never","containers":[{"name":"deletion-worker","command":["exomem-deletion-worker"]}]}}}}',
+        encoding="utf-8",
+    )
+    settings = SimpleNamespace(
+        database_url=SimpleNamespace(get_secret_value=lambda: "postgresql+asyncpg://test"),
+        database_schema="exomem_provisioner",
+        database_role="exomem_provisioner_runtime",
+        namespace="exomem-platform",
+        job_template_path=template,
+    )
+
+    await durability_jobs._run_deletion_dispatcher(settings)
+
+    assert len(created_clients) == 1
+    assert created_clients[0].configuration.retries == 0  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hosted_helm_contract.py
+++ b/tests/test_hosted_helm_contract.py
@@ -1293,6 +1293,11 @@ def test_platform_deletion_dispatcher_is_credential_free_and_worker_is_job_only(
 
     assert dispatcher_pod["serviceAccountName"] == "exomem-deletion-dispatcher"
     assert dispatcher_container["command"] == ["exomem-deletion-dispatcher"]
+    assert dispatcher["spec"]["jobTemplate"]["spec"]["activeDeadlineSeconds"] == 30
+    assert dispatcher_container["resources"] == {
+        "requests": {"cpu": "10m", "memory": "128Mi"},
+        "limits": {"cpu": "250m", "memory": "256Mi"},
+    }
     assert dispatcher_secret_refs == {"exomem-provisioner-database/url"}
     assert not any(
         fragment in item["name"]


### PR DESCRIPTION
## What changed

- Bound Kubernetes list/create calls with explicit connect/read timeouts and disabled transport retries.
- Raised the deletion dispatcher to a 128Mi memory request, 256Mi memory limit, and 250m CPU limit while retaining its 30-second Job deadline.
- Added regression coverage for transport and rendered Helm resource contracts.

## Why

The generated Kubernetes client can otherwise wait without a socket deadline, and its eager import graph exceeded the previous 128Mi ceiling. Live dispatchers were being killed before they could launch deletion Jobs.

## Verification

- Provisioner durability: 13 passed
- Helm contract suite: 52 passed
- Ruff clean
- Provisioner package build succeeded
- Helm lint completed with no failures
- Independent review: approved with no findings