### PR TITLE
fix(governance): lazy-load membership sidecars

### DIFF
--- a/src/exomem/governance/tool.py
+++ b/src/exomem/governance/tool.py
@@ -22,7 +22,6 @@ from typing import Any
 import yaml
 
 from .. import (
-    claims,
     deferred_index,
     epistemic_graph,
     find_corpus,
@@ -32,7 +31,6 @@ from .. import (
     media_jobs,
     memory_refs,
     review_state,
-    voice_profiles,
 )
 from ..kbdir import kb_dirname
 from . import decisions, membership, receipts, store
@@ -201,6 +199,8 @@ def _memberships_for_path(
 
 def _is_operational_membership_path(vault_root: Path, candidate: Path) -> bool:
     """Whether a current internal-state owner, rather than content, owns a path."""
+    from .. import claims, voice_profiles
+
     sidecars = (
         index_paths.sidecar_path(vault_root),
         index_paths.clip_sidecar_path(vault_root),

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -61,6 +60,18 @@ from exomem import extract
 assert extract.media_type_for("demo.pdf") == "pdf"
 assert "numpy" not in sys.modules
 assert "exomem.semantic_segments" not in sys.modules
+"""
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_governance_tool_import_does_not_load_membership_only_modules() -> None:
+    result = _run_import_probe(
+        """
+import sys
+from exomem.governance import tool
+assert "exomem.claims" not in sys.modules
+assert "exomem.voice_profiles" not in sys.modules
 """
     )
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- defer claims and voice-profile sidecar imports until operational membership classification needs them
- restore the documented lazy import boundary for commands, server, and governance tool entrypoints
- add a direct fresh-process regression probe

## Verification

- `uv run pytest tests/test_lazy_imports.py tests/test_govern_memory_tool.py tests/test_non_markdown_membership_propagation.py -q` (207 passed)
- `uvx ruff check src/exomem/governance/tool.py tests/test_lazy_imports.py`
- `uv build`
- independent review: approved, no findings