### PR TITLE
fix(hosted): align provisioner namespace contract

### DIFF
--- a/infra/provisioner/src/exomem_provisioner/lifecycle.py
+++ b/infra/provisioner/src/exomem_provisioner/lifecycle.py
@@ -1548,6 +1548,8 @@ def _fixed_helm_values(
             "tenantDigest": metadata.kubernetes_annotations["exomem.io/tenant-digest"],
         },
         "resourceName": metadata.resource_name,
+        "recordsReaderVersion": 2,
+        "lifecycleActionsEnabled": False,
         "routes": {"controlHostname": config.control_hostname, "enabled": False},
         "runtimeGid": 10001,
         "runtimeUid": 10001,
@@ -1567,7 +1569,6 @@ def _fixed_helm_values(
         if records_reader_version < 2:
             raise MetadataConflict("Records reader compatibility is not admitted")
         values["recordsReaderVersion"] = records_reader_version
-        target = config.runtime_target_for(request, v2=has_runtime_target)
         values["lifecycleActionsEnabled"] = bool(
             getattr(config, "lifecycle_actions_enabled", False)
             and target.get("agentProfile") == "hosted-alpha-agent-v2"

--- a/infra/provisioner/src/exomem_provisioner/live.py
+++ b/infra/provisioner/src/exomem_provisioner/live.py
@@ -394,6 +394,12 @@ class KubernetesProviderRegistry:
                 "exomem.io/vault-id": helm_values["vaultId"],
                 "exomem.io/expected-release": helm_values["expectedRelease"],
                 "exomem.io/worker-policy-digest": helm_values["workerPolicyDigest"],
+                "exomem.io/records-reader-version": str(
+                    helm_values["recordsReaderVersion"]
+                ),
+                "exomem.io/lifecycle-actions-enabled": str(
+                    helm_values["lifecycleActionsEnabled"]
+                ).lower(),
                 "exomem.io/browser-origin": helm_values["browserOrigin"],
                 "exomem.io/transfer-hostname": helm_values["transferHostname"],
                 "helm.sh/resource-policy": "keep",

--- a/infra/provisioner/tests/test_live_provider.py
+++ b/infra/provisioner/tests/test_live_provider.py
@@ -318,6 +318,8 @@ async def test_registry_creates_exact_helm_adoptable_namespace_and_operation_fen
             "vaultId": metadata.tenant_id,
             "expectedRelease": "0.22.0",
             "workerPolicyDigest": "a" * 64,
+            "recordsReaderVersion": 2,
+            "lifecycleActionsEnabled": False,
             "browserOrigin": "https://substratesystems.io",
             "transferHostname": "transfer.example.invalid",
         },
@@ -422,6 +424,8 @@ async def test_live_plane_namespace_carries_the_fixed_helm_contract_annotations(
         "exomem.io/worker-policy-digest": hashlib.sha256(
             b'{"media":false,"semantic":true,"workerCount":2}'
         ).hexdigest(),
+        "exomem.io/records-reader-version": "2",
+        "exomem.io/lifecycle-actions-enabled": "false",
         "exomem.io/browser-origin": "https://substratesystems.io",
         "exomem.io/transfer-hostname": "transfer.example.invalid",
     }
@@ -689,6 +693,8 @@ async def test_registry_rejects_unowned_existing_namespace() -> None:
                 "vaultId": metadata.tenant_id,
                 "expectedRelease": "0.22.0",
                 "workerPolicyDigest": "a" * 64,
+                "recordsReaderVersion": 2,
+                "lifecycleActionsEnabled": False,
                 "browserOrigin": "https://substratesystems.io",
                 "transferHostname": "transfer.example.invalid",
             },

--- a/infra/provisioner/tests/test_provider_lifecycle.py
+++ b/infra/provisioner/tests/test_provider_lifecycle.py
@@ -179,6 +179,20 @@ def test_fixed_helm_values_use_one_selected_rollback_runtime_unit() -> None:
     assert values["lifecycleActionsEnabled"] is False
 
 
+def test_fixed_helm_values_keep_legacy_runtime_records_lifecycle_read_only() -> None:
+    config = replace(
+        _config(),
+        runtime_target=_runtime_target(agentProfile="hosted-alpha-agent-v2"),
+        records_reader_version=2,
+        lifecycle_actions_enabled=True,
+    )
+
+    values = _fixed_helm_values(_metadata(), _request(), config)
+
+    assert values["recordsReaderVersion"] == 2
+    assert values["lifecycleActionsEnabled"] is False
+
+
 @pytest.mark.asyncio
 async def test_release_unit_mismatch_is_terminal_before_any_provider_effect() -> None:
     plane = HighFidelityProviderPlane(location="fsn1")
@@ -799,6 +813,8 @@ async def test_provision_adopts_partial_attempt_and_waits_for_volume_health_and_
         },
         "providerRecoveryEnvelopes": request["_providerRecoveryEnvelopes"],
         "resourceName": _metadata().resource_name,
+        "recordsReaderVersion": 2,
+        "lifecycleActionsEnabled": False,
         "routes": {"controlHostname": "control.example.invalid", "enabled": False},
         "runtimeGid": 10001,
         "runtimeUid": 10001,


### PR DESCRIPTION
## Why

The live v0.49 provisioner pre-creates tenant Namespaces, but the active admission policy requires two Records annotations that the live registry omitted. Kubernetes rejected Namespace creation with HTTP 422, leaving the provisioner worker crash-looping and the reviewer cell unable to converge.

## What changed

- define the effective schema-v2/v1 Records defaults in the selected Helm values
- serialize the selected reader version and lifecycle-action flag onto pre-created Namespaces
- preserve schema-v3 active/rollback selection
- keep legacy v1 lifecycle writes disabled even when the active v3 target enables them
- add focused regression coverage for both the emitted Namespace contract and legacy selection

## Verification

- red-first regressions reproduced both omissions and the adjacent legacy-selection bug
- provisioner suite: 475 passed, 17 skipped
- Helm contract suite: 52 passed
- exact opt-in K3s admission test: passed
- full repository validator: passed (hosted 851 passed; provisioner 475 passed)
- Ruff, mypy, build, Helm lint/policy/kubeconform, SOPS validation, and Trivy secret scan: passed
- independent code review: approved with no remaining findings