### PR TITLE
fix(hosted): release maintenance leases with Kubernetes 35

### DIFF
--- a/docs/superpowers/specs/2026-08-14-hosted-maintenance-lease-release-design.md
+++ b/docs/superpowers/specs/2026-08-14-hosted-maintenance-lease-release-design.md
@@ -1,0 +1,37 @@
+# Hosted maintenance Lease release compatibility
+
+## Context
+
+The provisioner uses a Kubernetes `coordination.k8s.io/v1` Lease to serialize
+cell maintenance. Kubernetes Python client 35 makes the Lease deletion `body`
+argument keyword-only, but `KubernetesMaintenanceLeaseAdapter.release` passes
+it positionally. The worker therefore crashes after completing maintenance and
+before releasing the Lease.
+
+The existing unit fake accepted a positional body, so it did not reproduce the
+generated client's call contract.
+
+## Decision
+
+Pass the unchanged UID and resource-version precondition document as the
+keyword argument `body`. Change the test double to require the same
+keyword-only signature as Kubernetes 35.
+
+Do not change Lease ownership, expiry, acquisition, retry, checkpoint, or
+provider-operation semantics. Relaxing deletion preconditions, catching the
+`TypeError`, or replacing the Kubernetes client would widen the change without
+addressing the incompatible call shape.
+
+## Verification
+
+The focused test must fail against the old adapter with the production
+`TypeError`, then pass with the keyword call while proving the exact deletion
+preconditions are preserved. The full provider adapter and lifecycle suites,
+Ruff, package build, and repository validation must remain green before the
+patched provisioner image is published.
+
+## Success criteria
+
+Maintenance release calls the Kubernetes 35 client successfully, deletes only
+the owned Lease version, and leaves all existing maintenance serialization and
+provider recovery contracts unchanged.

--- a/infra/provisioner/src/exomem_provisioner/adapters.py
+++ b/infra/provisioner/src/exomem_provisioner/adapters.py
@@ -698,7 +698,7 @@ class KubernetesMaintenanceLeaseAdapter:
             self._coordination.delete_namespaced_lease,
             name,
             namespace,
-            {
+            body={
                 "preconditions": {
                     "uid": lease.metadata.uid,
                     "resourceVersion": lease.metadata.resource_version,

--- a/infra/provisioner/tests/test_provider_adapters.py
+++ b/infra/provisioner/tests/test_provider_adapters.py
@@ -345,7 +345,7 @@ async def test_maintenance_lease_rejects_concurrent_owner_and_releases_with_prec
             self.lease.spec.holder_identity = body["spec"]["holderIdentity"]
             self.lease.spec.renew_time = body["spec"]["renewTime"]
 
-        def delete_namespaced_lease(self, name, namespace, body):
+        def delete_namespaced_lease(self, name, namespace, *, body):
             self.deleted = body
             self.lease = None
 


### PR DESCRIPTION
## Why

Kubernetes Python client 35 makes the Lease deletion body keyword-only. The provisioner passed it positionally, so maintenance workers crashed after completing work and before releasing their per-cell Lease.

## What changed

- pass the unchanged UID/resource-version preconditions as `body=`
- make the unit fake mirror the generated client's keyword-only signature
- record the compatibility decision and intentionally unchanged semantics

## Verification

- red-first regression reproduced the production `TypeError`
- full provisioner suite passed
- provider adapter/lifecycle suites: 62 passed
- Ruff check passed
- provisioner wheel build passed
- independent review: approved, no findings