### PR TITLE
fix(hosted): scope deletion authority to destructive actions

### DIFF
--- a/docs/superpowers/specs/2026-08-14-hosted-deletion-authority-action-scope-design.md
+++ b/docs/superpowers/specs/2026-08-14-hosted-deletion-authority-action-scope-design.md
@@ -1,0 +1,37 @@
+# Hosted deletion authority action scope
+
+## Problem
+
+Lifecycle maintenance rows (`quiesce` and `seal`) and a deletion row can share a
+tenant and external operation ID. `DeletionClaimAuthority` previously loaded an
+operation using only that pair, so database row order could select a completed
+maintenance row before the active `destroy` claim. The deletion worker then
+treated its own claim as unavailable and retried with `deletion-lock-busy`.
+
+## Design
+
+Keep the existing authority data flow and locking order: read the database
+clock, lock the tenant fence, then lock the one candidate operation. The query
+itself requires the deletion worker's explicit action set (`discard` and
+`destroy`) plus the caller's fence, a live `claimed` state, a claim token, and
+an unexpired lease. `scalar_one_or_none()` makes an unexpected second live
+deletion claim fail closed rather than selecting an arbitrary row. The existing
+post-query guards remain as defence in depth.
+
+## Alternatives rejected
+
+Making external operation IDs globally unique across actions would change the
+durable contract and require a migration for valid lifecycle histories. Adding
+ordering to the ambiguous query would still make authority depend on an
+incidental row choice. Retrying after a maintenance-row match leaves the worker
+in the same permanent pending loop. Scoping only to destructive actions still
+permits a final `discard` to shadow a live `destroy`. The active-claim predicate
+is the smallest least-privilege boundary that selects the authoritative
+deletion claim.
+
+## Verification
+
+Repository-level authority tests create final `quiesce`, `seal`, and `discard`
+rows plus a claimed `destroy` row with one tenant/external operation pair, and
+require authority acquisition to accept the destroy claim. A companion test
+verifies that a non-deletion row alone is never accepted.

--- a/infra/provisioner/src/exomem_provisioner/durability_runtime.py
+++ b/infra/provisioner/src/exomem_provisioner/durability_runtime.py
@@ -228,14 +228,22 @@ class DeletionClaimAuthority:
             raise RuntimeError("database clock is unavailable")
         checked_at = _utc(checked_at)
         tenant_fence = await session.get(TenantFence, tenant_id, with_for_update=True)
-        operation = await session.scalar(
-            select(Operation)
-            .where(
-                Operation.external_operation_id == operation_id,
-                Operation.tenant_id == tenant_id,
+        operation = (
+            await session.execute(
+                select(Operation)
+                .where(
+                    Operation.external_operation_id == operation_id,
+                    Operation.tenant_id == tenant_id,
+                    Operation.action.in_(DELETION_OPERATION_ACTIONS),
+                    Operation.state == OperationState.CLAIMED,
+                    Operation.fence_generation == fence,
+                    Operation.claim_token.is_not(None),
+                    Operation.claim_expires_at.is_not(None),
+                    Operation.claim_expires_at > checked_at,
+                )
+                .with_for_update()
             )
-            .with_for_update()
-        )
+        ).scalar_one_or_none()
         if (
             tenant_fence is None
             or tenant_fence.fence_generation != fence

--- a/infra/provisioner/tests/test_durability_runtime.py
+++ b/infra/provisioner/tests/test_durability_runtime.py
@@ -126,6 +126,143 @@ async def test_deletion_authority_requires_the_live_claim_and_exact_current_fenc
         await database.dispose()
 
 
+@pytest.mark.asyncio
+async def test_deletion_authority_ignores_final_maintenance_rows_sharing_external_operation_id(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path / "shared-operation-id.sqlite")
+    database = ProvisionerDatabase(settings)
+    await database.create_for_tests()
+    repository = OperationRepository(
+        database.session_factory,
+        codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+    )
+    authority = DeletionClaimAuthority(database.session_factory)
+    tenant_id = "tenant-alpha"
+    operation_id = "provider-deletion-alpha"
+    try:
+        for action in ("quiesce", "seal"):
+            submitted = await repository.submit(
+                action,
+                f"{action}-shared-operation",
+                _request(operation_id=operation_id, tenant_id=tenant_id),
+            )
+            claimed = await repository.claim_next(
+                f"{action}-worker",
+                allowed_actions=frozenset({OperationAction(action)}),
+            )
+            assert (
+                claimed is not None
+                and claimed.id == submitted.id
+                and claimed.claim_token is not None
+            )
+            await repository.complete(
+                claimed.id,
+                {},
+                worker_id=f"{action}-worker",
+                claim_token=claimed.claim_token,
+                claim_generation=claimed.claim_generation,
+            )
+
+        destroy = await repository.submit(
+            "destroy",
+            "destroy-shared-operation",
+            _request(operation_id=operation_id, tenant_id=tenant_id),
+        )
+        claimed_destroy = await repository.claim_next(
+            "deletion-worker",
+            allowed_actions=frozenset({OperationAction.DESTROY}),
+        )
+        assert claimed_destroy is not None and claimed_destroy.id == destroy.id
+
+        assert await authority.acquire(tenant_id, operation_id, 8) is True
+    finally:
+        await database.dispose()
+
+
+@pytest.mark.asyncio
+async def test_deletion_authority_ignores_final_discard_sharing_external_operation_id(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path / "discard-shared-operation-id.sqlite")
+    database = ProvisionerDatabase(settings)
+    await database.create_for_tests()
+    repository = OperationRepository(
+        database.session_factory,
+        codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+    )
+    authority = DeletionClaimAuthority(database.session_factory)
+    tenant_id = "tenant-alpha"
+    operation_id = "provider-deletion-alpha"
+    try:
+        discard = await repository.submit(
+            "discard",
+            "discard-shared-operation",
+            _request(operation_id=operation_id, tenant_id=tenant_id),
+        )
+        claimed_discard = await repository.claim_next(
+            "deletion-worker",
+            allowed_actions=frozenset({OperationAction.DISCARD}),
+        )
+        assert (
+            claimed_discard is not None
+            and claimed_discard.id == discard.id
+            and claimed_discard.claim_token is not None
+        )
+        await repository.complete(
+            claimed_discard.id,
+            {},
+            worker_id="deletion-worker",
+            claim_token=claimed_discard.claim_token,
+            claim_generation=claimed_discard.claim_generation,
+        )
+        destroy = await repository.submit(
+            "destroy",
+            "destroy-shared-operation",
+            _request(operation_id=operation_id, tenant_id=tenant_id),
+        )
+        claimed_destroy = await repository.claim_next(
+            "deletion-worker",
+            allowed_actions=frozenset({OperationAction.DESTROY}),
+        )
+        assert claimed_destroy is not None and claimed_destroy.id == destroy.id
+
+        assert await authority.acquire(tenant_id, operation_id, 8) is True
+    finally:
+        await database.dispose()
+
+
+@pytest.mark.asyncio
+async def test_deletion_authority_rejects_non_deletion_rows_sharing_external_operation_id(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path / "maintenance-only.sqlite")
+    database = ProvisionerDatabase(settings)
+    await database.create_for_tests()
+    repository = OperationRepository(
+        database.session_factory,
+        codec=AesGcmEnvelopeCodec.from_secret(settings.envelope_key.get_secret_value()),
+    )
+    authority = DeletionClaimAuthority(database.session_factory)
+    tenant_id = "tenant-alpha"
+    operation_id = "provider-maintenance-alpha"
+    try:
+        await repository.submit(
+            "quiesce",
+            "quiesce-maintenance-only",
+            _request(operation_id=operation_id, tenant_id=tenant_id),
+        )
+        claimed = await repository.claim_next(
+            "quiesce-worker",
+            allowed_actions=frozenset({OperationAction.QUIESCE}),
+        )
+        assert claimed is not None and claimed.claim_token is not None
+
+        assert await authority.acquire(tenant_id, operation_id, 8) is False
+    finally:
+        await database.dispose()
+
+
 def test_deletion_settings_are_verifier_only_and_bind_exact_bucket_contract() -> None:
     from exomem_provisioner.provider_recovery import ProviderRecoveryIdentityCodec
 


### PR DESCRIPTION
## Why

Lifecycle QUIESCE, SEAL, DISCARD, and DESTROY rows can share a tenant and external operation ID. The deletion authority lookup was not unique, so it could select a completed maintenance/deletion row instead of the live DESTROY claim and return a false `deletion-lock-busy`.

## What

- select only a live, current-fence, unexpired DISCARD/DESTROY claim
- fail closed when more than one live claim matches
- cover shared QUIESCE/SEAL and final-DISCARD histories
- document the narrow authority boundary

## Verification

- 106 provisioner durability/repository tests passed
- focused collision regressions: 3 passed
- Ruff check and touched-file format checks passed
- provisioner sdist/wheel build passed
- independent review: approved