### PR TITLE
fix(doctor): prove the ONNX vector lane instead of reporting it absent

### DIFF
--- a/src/exomem/__main__.py
+++ b/src/exomem/__main__.py
@@ -979,12 +979,24 @@ def _warm_main(argv: list[str]) -> int:
         )
         return 0
 
-    from . import embeddings
+    from . import embedding_backend, embeddings
+
+    # Which models this install can actually load. The reranker and CLIP are
+    # sentence-transformers models, so the `embeddings-onnx` lane withholds both
+    # by design. Reporting their absence as a warm failure means a correct ONNX
+    # install exits 1 on a successful run, and calls itself "lean" while holding
+    # a working embedder.
+    try:
+        backend = embedding_backend.resolve_backend()
+    except ValueError:
+        backend = embedding_backend.TORCH
+    lane_serves_torch_models = backend != embedding_backend.ONNX
 
     failed = False
     missing_extra = False
+    optional_unavailable: list[str] = []
 
-    def _step(label: str, fn) -> None:
+    def _step(label: str, fn, *, required: bool = True) -> None:
         nonlocal failed, missing_extra
         t0 = time.perf_counter()
         try:
@@ -992,7 +1004,13 @@ def _warm_main(argv: list[str]) -> int:
             print(f"  {label}: ready ({time.perf_counter() - t0:.1f}s)")
         except ImportError as e:
             # A lean install has no ML stack — that's a missing extra, not a
-            # download problem, and the remediation must say so.
+            # download problem, and the remediation must say so. On a lane that
+            # never carries this model, the same ImportError is the expected
+            # state and must not fail the run.
+            if not required:
+                optional_unavailable.append(label)
+                print(f"  {label}: unavailable on the {backend} lane (skipped)")
+                return
             failed = True
             missing_extra = True
             print(f"  {label}: FAILED ({e})", file=sys.stderr)
@@ -1002,9 +1020,17 @@ def _warm_main(argv: list[str]) -> int:
 
     print("exomem warm — downloading/loading search models (first run can take minutes)")
     _step(f"embedding model {embeddings.MODEL_NAME}", embeddings.get_model)
-    _step(f"reranker {embeddings.RERANKER_NAME}", embeddings.get_reranker)
+    _step(
+        f"reranker {embeddings.RERANKER_NAME}",
+        embeddings.get_reranker,
+        required=lane_serves_torch_models,
+    )
     if embeddings.clip_enabled():
-        _step(f"CLIP model {embeddings.CLIP_MODEL_NAME}", embeddings.get_clip_model)
+        _step(
+            f"CLIP model {embeddings.CLIP_MODEL_NAME}",
+            embeddings.get_clip_model,
+            required=lane_serves_torch_models,
+        )
     else:
         print("  CLIP: skipped (EXOMEM_DISABLE_CLIP)")
 
@@ -1026,6 +1052,14 @@ def _warm_main(argv: list[str]) -> int:
             return 1
         print("warm: one or more models failed — check network/proxy and retry.", file=sys.stderr)
         return 1
+    if optional_unavailable:
+        print(
+            f"warm: done on the {backend} lane. Not carried by this lane: "
+            f"{', '.join(optional_unavailable)} — that is the documented "
+            "`embeddings-onnx` trade-off, not a failure. Install the `embeddings` "
+            "extra if you need reranking or image search."
+        )
+        return 0
     print("warm: done. Server starts will now warm from disk in seconds.")
     return 0
 

--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -66,6 +66,13 @@ HA_AUTH_ENV_KEYS = (
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
+#: How a user actually rebuilds vectors from a shell. `reconcile` and `audit_fix`
+#: are internal registry names, not CLI surface — the CLI dispatches on the
+#: PRODUCT_PUBLIC_NAMES, where this operation is `maintain_memory --mode
+#: reconcile` (or the `maintain` alias). Remediation strings named the internal
+#: ops, so every one of them fell through to the server argument parser.
+_REBUILD_VECTORS_CMD = "exomem maintain --reconcile"
+
 
 @dataclass
 class DoctorCheck:
@@ -381,6 +388,45 @@ def _check_schema_files(vault_root: Path | None) -> list[DoctorCheck]:
     return checks
 
 
+def _resolved_embedding_backend() -> str:
+    """The runtime actually configured to serve the bi-encoder.
+
+    Every embedding-related finding must be phrased about *this* lane. Probing
+    for torch and reporting its absence as "the vector stack isn't installed"
+    tells an ONNX install that a working vector lane is missing, which is how a
+    correct deployment comes to be benchmarked as lexical-only.
+    """
+    from . import embedding_backend
+
+    try:
+        return embedding_backend.resolve_backend(is_available=_module_available)
+    except ValueError:
+        # A misconfigured backend is reported by its own check; fall back to the
+        # default lane rather than raising out of a diagnostic command.
+        return embedding_backend.TORCH
+
+
+def _vector_stack_available(backend: str) -> bool:
+    """Whether the resolved lane's serving modules are importable."""
+    from . import embedding_backend
+
+    if backend == embedding_backend.ONNX:
+        return _module_available("onnxruntime") and _module_available("tokenizers")
+    return _module_available("sentence_transformers") and _module_available("torch")
+
+
+def _serves_reranker_and_clip(backend: str) -> bool:
+    """Whether this lane can load the reranker and CLIP at all.
+
+    Both are sentence-transformers models, so the ONNX lane withholds them by
+    design. Listing them as cache misses there produces a WARN that no action
+    can ever clear.
+    """
+    from . import embedding_backend
+
+    return backend != embedding_backend.ONNX
+
+
 def _embedding_requirements() -> tuple[str, list[tuple[str, str]]]:
     """`(extra, [(distribution, import name)])` for the configured embedding backend.
 
@@ -392,12 +438,7 @@ def _embedding_requirements() -> tuple[str, list[tuple[str, str]]]:
     """
     from . import embedding_backend
 
-    try:
-        backend = embedding_backend.resolve_backend(is_available=_module_available)
-    except ValueError:
-        # A misconfigured backend is reported by its own check; fall back to the
-        # default lane rather than raising out of a diagnostic command.
-        backend = embedding_backend.TORCH
+    backend = _resolved_embedding_backend()
     if backend == embedding_backend.ONNX:
         return "embeddings-onnx", [
             ("onnxruntime", "onnxruntime"),
@@ -940,7 +981,7 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
             "embeddings.sidecar",
             "warn",
             "Embedding sidecar is missing; hybrid search will degrade until vectors are built.",
-            "After installing embeddings, run `kb reconcile` or `kb audit_fix --rebuild-embeddings true`.",
+            f"After installing embeddings, run `{_REBUILD_VECTORS_CMD}`.",
         )
     if os.environ.get("EXOMEM_DISABLE_EMBEDDINGS"):
         return _check(
@@ -950,13 +991,15 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
             "probe was skipped.",
             "Unset EXOMEM_DISABLE_EMBEDDINGS to run the embed+search probe against it.",
         )
-    if not (_module_available("sentence_transformers") and _module_available("torch")):
+    backend = _resolved_embedding_backend()
+    if not _vector_stack_available(backend):
+        extra, _ = _embedding_requirements()
         return _check(
             "embeddings.sidecar",
             "warn",
-            "Embedding sidecar exists but the vector stack isn't installed, so it can't "
-            "be probed.",
-            "Install it with `uv sync --extra embeddings` to enable hybrid search.",
+            f"Embedding sidecar exists but the {backend} serving stack isn't installed, "
+            "so it can't be probed.",
+            f"Install it with `uv sync --extra {extra}` to enable hybrid search.",
         )
     from . import embeddings
 
@@ -980,7 +1023,7 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
             "embeddings.sidecar",
             "fail",
             f"Embedding sidecar is present but a live embed+search probe failed: {e}",
-            "Rebuild vectors: `kb reconcile` or `kb audit_fix --rebuild-embeddings true`.",
+            f"Rebuild vectors: `{_REBUILD_VECTORS_CMD}`.",
         )
     if not hits:
         return _check(
@@ -988,12 +1031,33 @@ def _check_embedding_sidecar(vault_root: Path | None) -> DoctorCheck | None:
             "warn",
             "Embedding sidecar loads and the model embeds, but a probe query returned no "
             "vectors — the index is empty.",
-            "Build vectors: `kb reconcile` or `kb audit_fix --rebuild-embeddings true`.",
+            f"Build vectors: `{_REBUILD_VECTORS_CMD}`.",
         )
+    # Readiness must be provable, not merely un-refuted: report the serving
+    # backend, the vector count behind the hit, and the model fingerprint that
+    # identifies the vector space. A benchmark contender is disqualified when it
+    # cannot show it is serving semantically (docs/benchmark-fairness-contract.md),
+    # and until now an ONNX install had no way to show that from doctor.
+    from . import embedding_backend
+
+    fingerprint = embedding_backend.fingerprint(embeddings.MODEL_NAME)
+    try:
+        metadata, _matrix = index.all_vectors()
+        vector_count: int | None = len(metadata)
+    except Exception:  # noqa: BLE001 — the probe already proved the lane serves
+        vector_count = None
+    counted = f"{vector_count} vector(s)" if vector_count is not None else "vectors present"
     return _check(
         "embeddings.sidecar",
         "pass",
-        f"Embedding sidecar live: embed+search returned {len(hits)} hit(s).",
+        f"Embedding sidecar live via {backend}: embed+search over {counted} returned "
+        f"{len(hits)} hit(s) ({fingerprint}).",
+        details={
+            "backend": backend,
+            "vector_count": vector_count,
+            "fingerprint": fingerprint,
+            "model": embeddings.MODEL_NAME,
+        },
     )
 
 
@@ -1026,22 +1090,44 @@ def _check_models_cache() -> DoctorCheck:
     from . import embeddings
 
     hub = _hf_hub_dir()
+    backend = _resolved_embedding_backend()
 
     expected = {
         embeddings.MODEL_NAME: "models--" + embeddings.MODEL_NAME.replace("/", "--"),
-        embeddings.RERANKER_NAME: "models--" + embeddings.RERANKER_NAME.replace("/", "--"),
-        # sentence-transformers resolves bare names under its org.
-        embeddings.CLIP_MODEL_NAME: "models--sentence-transformers--" + embeddings.CLIP_MODEL_NAME,
     }
+    # The reranker and CLIP are sentence-transformers models. On a lane that
+    # withholds torch they can never be cached, so listing them as misses is a
+    # WARN no action can clear — and `exomem warm`, the remediation, cannot
+    # fetch them either.
+    if _serves_reranker_and_clip(backend):
+        expected[embeddings.RERANKER_NAME] = "models--" + embeddings.RERANKER_NAME.replace(
+            "/", "--"
+        )
+        # sentence-transformers resolves bare names under its org.
+        expected[embeddings.CLIP_MODEL_NAME] = (
+            "models--sentence-transformers--" + embeddings.CLIP_MODEL_NAME
+        )
 
     missing = [name for name, dirname in expected.items() if not _model_cached(hub, dirname)]
     if not missing:
-        return _check("models.cache", "pass", "Search models are present in the local HF cache.")
+        return _check(
+            "models.cache",
+            "pass",
+            f"Search models for the {backend} lane are present in the local HF cache.",
+        )
+    # Only claim degraded recall when the bi-encoder itself is absent — with it
+    # cached and serving, finds are semantic whatever else is still downloading.
+    bi_encoder_missing = embeddings.MODEL_NAME in missing
+    consequence = (
+        " The first server start downloads them in the background; hybrid finds are "
+        "lexical-only meanwhile."
+        if bi_encoder_missing
+        else " Hybrid finds already run semantically on the cached bi-encoder."
+    )
     return _check(
         "models.cache",
         "warn",
-        f"Not yet in the local HF cache: {', '.join(missing)}. The first server "
-        "start downloads them in the background; hybrid finds are lexical-only meanwhile.",
+        f"Not yet in the local HF cache: {', '.join(missing)}.{consequence}",
         "Run `exomem warm` to pre-download them now (~1-2 GB).",
     )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -798,7 +798,98 @@ def test_sidecar_present_but_stack_missing_skips_probe(
     check = doctor_module._check_embedding_sidecar(vault)
 
     assert check.status == "warn"
-    assert "vector stack" in check.message
+    # The finding names the lane actually configured to serve, so an ONNX
+    # install is never told the torch stack is the thing it is missing.
+    assert "serving stack isn't installed" in check.message
+
+
+def test_sidecar_probe_uses_the_onnx_lane_when_that_is_what_is_installed(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#487: gating the probe on torch reported a working ONNX lane as absent.
+
+    `embeddings-onnx` installs neither torch nor sentence_transformers by design,
+    so a torch-shaped probe concludes "no vector stack" on an install whose
+    vector search demonstrably works — and doctor then offers no way to prove
+    readiness, which `docs/benchmark-fairness-contract.md` requires.
+    """
+    _sidecar(vault)
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "onnx")
+    monkeypatch.setattr(
+        doctor_module,
+        "_module_available",
+        lambda m: m in {"onnxruntime", "tokenizers"},
+    )
+
+    check = doctor_module._check_embedding_sidecar(vault)
+
+    # It must get past the stack gate. Whatever it reports next is about the
+    # sidecar or the model cache — never "the stack isn't installed".
+    assert "serving stack isn't installed" not in check.message
+
+
+def test_rebuild_remediations_name_a_command_the_cli_actually_dispatches() -> None:
+    """#479: `kb reconcile` / `kb audit_fix` fall through to the server parser.
+
+    Both are internal registry names; the CLI dispatches on the public product
+    names, so the remediation has to name `maintain` / `maintain_memory`.
+    """
+    assert "reconcile" in doctor_module._REBUILD_VECTORS_CMD
+    assert "maintain" in doctor_module._REBUILD_VECTORS_CMD
+    source = Path(doctor_module.__file__).read_text(encoding="utf-8")
+    assert "kb reconcile" not in source
+    assert "kb audit_fix" not in source
+
+
+def test_warm_exits_zero_when_only_the_withheld_torch_models_are_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """#480: `warm` exited 1 on a successful `embeddings-onnx` run.
+
+    The bi-encoder — the only model that lane can serve — loads fine. The
+    reranker and CLIP raise ImportError because `embeddings-onnx` withholds
+    sentence-transformers by design, which is the documented trade-off, not a
+    failure. Reporting it as one also called the install "lean".
+    """
+    from exomem import embeddings as embeddings_module
+
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "onnx")
+    monkeypatch.delenv("EXOMEM_DISABLE_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("EXOMEM_DISABLE_CLIP", raising=False)
+
+    def _no_sentence_transformers():
+        raise ImportError("No module named 'sentence_transformers'")
+
+    monkeypatch.setattr(embeddings_module, "get_model", lambda: object())
+    monkeypatch.setattr(embeddings_module, "get_reranker", _no_sentence_transformers)
+    monkeypatch.setattr(embeddings_module, "get_clip_model", _no_sentence_transformers)
+    monkeypatch.setattr(embeddings_module, "clip_enabled", lambda: True)
+
+    code, out, _err = _run(["warm"], capsys)
+
+    assert code == 0
+    assert "lean install" not in out
+    assert "onnx" in out
+
+
+def test_models_cache_does_not_demand_torch_models_on_the_onnx_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#480/#487: the reranker and CLIP can never be cached on an ONNX install.
+
+    `exomem warm` — the stated remediation — cannot fetch them there either, so
+    the WARN is permanent noise that no action clears.
+    """
+    monkeypatch.setenv("EXOMEM_EMBED_BACKEND", "onnx")
+    monkeypatch.setattr(
+        doctor_module, "_model_cached", lambda _hub, dirname: "bge-base" in dirname
+    )
+
+    check = doctor_module._check_models_cache()
+
+    assert check.status == "pass"
+    assert "reranker" not in check.message.lower()
 
 
 def test_sidecar_present_but_model_not_cached_skips_probe(


### PR DESCRIPTION
Closes #487, #480, #479.

## What changed

An `embeddings-onnx` install — a GPU-less CPU host, which is most of them — was mistreated by three separate readiness surfaces. All three shared one cause: the code probed for **torch** and reported its absence as a finding about the *vector lane*, when torch is not the lane that install configured.

- **`doctor` sidecar probe (#487)** — gated on `sentence_transformers and torch`, so the check concluded "the vector stack isn't installed" on an install whose vector search demonstrably works. Now probes through `embedding_backend.resolve_backend()` (the seam `_embedding_requirements` already uses) and names the resolved lane when a stack genuinely is missing.
- **`doctor` positive report (#487)** — there was no way to *prove* the lane was live. Success now reports backend, vector count and model fingerprint. `docs/benchmark-fairness-contract.md` treats a silently lexical-only contender as disqualifying, so readiness has to be provable, not merely un-refuted.
- **`doctor` models.cache (#480/#487)** — listed the reranker and CLIP as cache misses on a lane that can never hold them, with `exomem warm` as the remediation, which cannot fetch them there either. A permanent WARN no action clears. Now lane-aware, and only claims lexical-only recall when the bi-encoder itself is absent.
- **`exomem warm` (#480)** — exited **1 on a successful run**, because the two withheld sentence-transformers models raised `ImportError`, and printed "this is a lean install" while the bi-encoder it actually needs had loaded in 23s. Optional models on a withholding lane are now reported as skipped; the run exits 0.
- **Rebuild remediations (#479)** — named `kb reconcile` and `kb audit_fix --rebuild-embeddings true`. Both are *internal registry names*; the CLI dispatches on the public product names, so both fell through to the server argument parser and errored. They now name `exomem maintain --reconcile`.

Note on #479: the reporter assumed `kb` was the wrong binary. It isn't — `kb` is a real console script (`pyproject.toml`). The op name was the wrong half.

## Not changed, deliberately

#480 also reports that `warm`'s failures print *before* the banner. That is stdout/stderr interleaving in the terminal, not a sequencing bug — nothing to fix.

## Verification

- `tests/test_doctor.py`: 61 passed, 1 skipped (the skip needs sentence_transformers, absent here by design).
- Wider set — `test_doctor{,_probe,_ha,_edge_ingress}.py`, `test_instant_start.py`, `test_cli_core_ops.py`: **198 passed, 1 skipped**.
- `python -m compileall`: clean.
- Four new regression tests, each failing before the change: ONNX lane gets past the stack gate; remediations name a dispatchable command (and assert the internal names cannot return); models.cache passes on ONNX with only the bi-encoder cached; `warm` exits 0 with only the withheld models unavailable.

Full-suite and latency gates are CI's call — native Windows can't run them.