### PR TITLE
fix(setup): name the failing ancestor and stop the hook step tracebacking

### DIFF
--- a/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
+++ b/plugins/claude-code/hooks/exomem_continuation_checkpoint.py
@@ -1347,36 +1347,83 @@ def _require_private_state_directory(directory: _SecureDirectory) -> None:
         raise OSError(f"state directory permissions are too broad: {mode:04o}")
 
 
-def _require_trusted_directory(directory: _SecureDirectory) -> None:
-    """Reject hook/config directories writable by another local principal."""
+def unsafe_trusted_directory_ancestors(path: Path) -> list[tuple[str, str]]:
+    """Every ancestor of `path` (and `path`) that fails the trusted-directory rule.
+
+    Returns `[(offending path, reason)]`, nearest-root first, empty when the whole
+    chain is trusted. Separated from the raise so a preflight can report the full
+    chain before anything is attempted: the guard rejects any ancestor, but the
+    caller only ever learns about one path per run, and on a `umask 0002` box
+    (the Debian/Ubuntu default) three separate directories fail in sequence.
+    Fixing them one failed run at a time is three installs to get one.
+    """
     if os.name == "nt":
-        return
+        return []
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     handles: list[int] = []
+    offenders: list[tuple[str, str]] = []
+    absolute = Path(path).absolute()
     try:
-        current = os.open(directory.path.anchor or "/", flags)
+        current = os.open(absolute.anchor or "/", flags)
         handles.append(current)
-        parts = directory.path.absolute().parts[1:]
+        parts = absolute.parts[1:]
+        walked = Path(absolute.anchor or "/")
         for index, part in enumerate(parts):
             child = os.open(part, flags, dir_fd=current)
             handles.append(child)
             current = child
+            walked = walked / part
             info = os.fstat(child)
             mode = stat.S_IMODE(info.st_mode)
-            final = index == len(parts) - 1
-            if final:
-                unsafe = info.st_uid != os.geteuid() or bool(mode & 0o022)
+            if index == len(parts) - 1:
+                if info.st_uid != os.geteuid():
+                    offenders.append((str(walked), "owned by another user"))
+                elif mode & 0o022:
+                    offenders.append((str(walked), f"group/other-writable ({mode:04o})"))
             else:
                 sticky_trusted = bool(mode & stat.S_ISVTX) and info.st_uid in {
                     0,
                     os.geteuid(),
                 }
-                unsafe = bool(mode & 0o022) and not sticky_trusted
-            if unsafe:
-                raise OSError(
-                    errno.EPERM,
-                    f"unsafe writable or foreign-owned directory: {directory.path}",
-                )
+                if mode & 0o022 and not sticky_trusted:
+                    offenders.append((str(walked), f"group/other-writable ({mode:04o})"))
+    finally:
+        while handles:
+            os.close(handles.pop())
+    return offenders
+
+
+def trusted_directory_remediation(offenders: list[tuple[str, str]]) -> str:
+    """A single command that clears every offending path in one go."""
+    return "chmod g-w,o-w " + " ".join(path for path, _reason in offenders)
+
+
+def _require_trusted_directory(directory: _SecureDirectory) -> None:
+    """Reject hook/config directories writable by another local principal."""
+    if os.name == "nt":
+        return
+    offenders = unsafe_trusted_directory_ancestors(directory.path)
+    if offenders:
+        detail = "; ".join(f"{path} ({reason})" for path, reason in offenders)
+        leaf = str(Path(directory.path).absolute())
+        # Name the path that actually failed. Interpolating the leaf sent users
+        # to chmod a directory that was already fine while the real offender —
+        # an ancestor — went unnamed.
+        scope = detail if offenders[-1][0] == leaf else f"{detail} (ancestor(s) of {leaf})"
+        raise OSError(
+            errno.EPERM,
+            f"unsafe writable or foreign-owned directory: {scope}; "
+            f"fix: {trusted_directory_remediation(offenders)}",
+        )
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    handles: list[int] = []
+    try:
+        current = os.open(directory.path.anchor or "/", flags)
+        handles.append(current)
+        for part in directory.path.absolute().parts[1:]:
+            child = os.open(part, flags, dir_fd=current)
+            handles.append(child)
+            current = child
         retained = os.fstat(directory.fd)
         reopened = os.fstat(current)
         if (retained.st_dev, retained.st_ino) != (reopened.st_dev, reopened.st_ino):

--- a/src/exomem/_hooks/exomem_continuation_checkpoint.py
+++ b/src/exomem/_hooks/exomem_continuation_checkpoint.py
@@ -1347,36 +1347,83 @@ def _require_private_state_directory(directory: _SecureDirectory) -> None:
         raise OSError(f"state directory permissions are too broad: {mode:04o}")
 
 
-def _require_trusted_directory(directory: _SecureDirectory) -> None:
-    """Reject hook/config directories writable by another local principal."""
+def unsafe_trusted_directory_ancestors(path: Path) -> list[tuple[str, str]]:
+    """Every ancestor of `path` (and `path`) that fails the trusted-directory rule.
+
+    Returns `[(offending path, reason)]`, nearest-root first, empty when the whole
+    chain is trusted. Separated from the raise so a preflight can report the full
+    chain before anything is attempted: the guard rejects any ancestor, but the
+    caller only ever learns about one path per run, and on a `umask 0002` box
+    (the Debian/Ubuntu default) three separate directories fail in sequence.
+    Fixing them one failed run at a time is three installs to get one.
+    """
     if os.name == "nt":
-        return
+        return []
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     handles: list[int] = []
+    offenders: list[tuple[str, str]] = []
+    absolute = Path(path).absolute()
     try:
-        current = os.open(directory.path.anchor or "/", flags)
+        current = os.open(absolute.anchor or "/", flags)
         handles.append(current)
-        parts = directory.path.absolute().parts[1:]
+        parts = absolute.parts[1:]
+        walked = Path(absolute.anchor or "/")
         for index, part in enumerate(parts):
             child = os.open(part, flags, dir_fd=current)
             handles.append(child)
             current = child
+            walked = walked / part
             info = os.fstat(child)
             mode = stat.S_IMODE(info.st_mode)
-            final = index == len(parts) - 1
-            if final:
-                unsafe = info.st_uid != os.geteuid() or bool(mode & 0o022)
+            if index == len(parts) - 1:
+                if info.st_uid != os.geteuid():
+                    offenders.append((str(walked), "owned by another user"))
+                elif mode & 0o022:
+                    offenders.append((str(walked), f"group/other-writable ({mode:04o})"))
             else:
                 sticky_trusted = bool(mode & stat.S_ISVTX) and info.st_uid in {
                     0,
                     os.geteuid(),
                 }
-                unsafe = bool(mode & 0o022) and not sticky_trusted
-            if unsafe:
-                raise OSError(
-                    errno.EPERM,
-                    f"unsafe writable or foreign-owned directory: {directory.path}",
-                )
+                if mode & 0o022 and not sticky_trusted:
+                    offenders.append((str(walked), f"group/other-writable ({mode:04o})"))
+    finally:
+        while handles:
+            os.close(handles.pop())
+    return offenders
+
+
+def trusted_directory_remediation(offenders: list[tuple[str, str]]) -> str:
+    """A single command that clears every offending path in one go."""
+    return "chmod g-w,o-w " + " ".join(path for path, _reason in offenders)
+
+
+def _require_trusted_directory(directory: _SecureDirectory) -> None:
+    """Reject hook/config directories writable by another local principal."""
+    if os.name == "nt":
+        return
+    offenders = unsafe_trusted_directory_ancestors(directory.path)
+    if offenders:
+        detail = "; ".join(f"{path} ({reason})" for path, reason in offenders)
+        leaf = str(Path(directory.path).absolute())
+        # Name the path that actually failed. Interpolating the leaf sent users
+        # to chmod a directory that was already fine while the real offender —
+        # an ancestor — went unnamed.
+        scope = detail if offenders[-1][0] == leaf else f"{detail} (ancestor(s) of {leaf})"
+        raise OSError(
+            errno.EPERM,
+            f"unsafe writable or foreign-owned directory: {scope}; "
+            f"fix: {trusted_directory_remediation(offenders)}",
+        )
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    handles: list[int] = []
+    try:
+        current = os.open(directory.path.anchor or "/", flags)
+        handles.append(current)
+        for part in directory.path.absolute().parts[1:]:
+            child = os.open(part, flags, dir_fd=current)
+            handles.append(child)
+            current = child
         retained = os.fstat(directory.fd)
         reopened = os.fstat(current)
         if (retained.st_dev, retained.st_ino) != (reopened.st_dev, reopened.st_ino):

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -931,6 +931,18 @@ def run_setup(
             report("hooks", "[done] installed + wired")
         except FileNotFoundError as e:
             report("hooks", f"[failed: {e}]")
+        except OSError as e:
+            # The trusted-directory guard raises PermissionError, which is an
+            # OSError — uncaught, it escaped as a raw traceback after register,
+            # register-codex and skill had already succeeded. scripts/install.sh
+            # holds the line that a user never sees a stack trace; the wizard
+            # has to hold it too, and say that the earlier steps stuck.
+            report("hooks", f"[failed: {e}]")
+            print_fn("")
+            print_fn(
+                "  Setup is idempotent — fix the above and re-run the same command; "
+                "the completed steps are skipped."
+            )
     else:
         report("hooks", "[skipped]")
 

--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -3802,3 +3802,57 @@ def test_nested_repository_dirty_paths_survive_the_validator_round_trip(
     ]
     assert rejected == [], f"writer emitted paths its validator rejects: {rejected}"
     assert checkpoint._valid_workspace(workspace)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_trusted_directory_error_names_the_failing_ancestor_not_the_leaf(
+    tmp_path: Path,
+) -> None:
+    """#477: the guard walks ancestors but the message always named the leaf.
+
+    On a `umask 0002` box — the Debian/Ubuntu default — `~/.claude` and
+    `~/.claude/hooks` are both 0775, so a first install fails naming
+    `.claude/hooks`. Chmod that, and it fails again with the same path, because
+    the real offender is the ancestor. The reporter needed three runs to install.
+    """
+    home = tmp_path / "home"
+    hooks = home / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    (home / ".claude").chmod(0o775)  # the real offender
+    hooks.chmod(0o700)  # already fine
+
+    offenders = checkpoint.unsafe_trusted_directory_ancestors(hooks)
+
+    named = [path for path, _reason in offenders]
+    assert str(home / ".claude") in named
+    assert str(hooks) not in named
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_trusted_directory_reports_every_offender_in_one_pass(tmp_path: Path) -> None:
+    """One run must surface the whole chain, so one chmod clears it."""
+    home = tmp_path / "home"
+    hooks = home / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    (home / ".claude").chmod(0o775)
+    hooks.chmod(0o775)
+
+    offenders = checkpoint.unsafe_trusted_directory_ancestors(hooks)
+    named = [path for path, _reason in offenders]
+
+    assert str(home / ".claude") in named
+    assert str(hooks) in named
+    remediation = checkpoint.trusted_directory_remediation(offenders)
+    assert remediation.startswith("chmod g-w,o-w ")
+    assert str(home / ".claude") in remediation and str(hooks) in remediation
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_trusted_directory_accepts_a_clean_chain(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    hooks = home / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    for path in (home, home / ".claude", hooks):
+        path.chmod(0o755)
+
+    assert checkpoint.unsafe_trusted_directory_ancestors(hooks) == []

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -213,8 +213,10 @@ def test_hook_step_permission_error_reports_a_step_not_a_traceback(
     """
     vault, home = _messy_vault(tmp_path), tmp_path / "home"
 
+    guarded = home / ".claude"
+
     def _guard_rejects(**_kwargs):
-        raise PermissionError(1, "unsafe writable or foreign-owned directory: /home/u/.claude")
+        raise PermissionError(1, f"unsafe writable or foreign-owned directory: {guarded}")
 
     monkeypatch.setattr(setup_wizard.hook_module, "install_hook", _guard_rejects)
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -200,6 +200,35 @@ def test_legacy_skill_is_migrated(tmp_path: Path) -> None:
     assert "removed stale" in out
 
 
+def test_hook_step_permission_error_reports_a_step_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#478: the trusted-directory guard raises PermissionError, an OSError.
+
+    Only FileNotFoundError was caught, so the guard's rejection escaped as a raw
+    stack trace — after register, register-codex and skill had already applied.
+    scripts/install.sh keeps failures in plain language precisely so users never
+    see a traceback; the wizard has to hold the same line, and has to say the
+    earlier steps stuck so a user does not assume nothing happened.
+    """
+    vault, home = _messy_vault(tmp_path), tmp_path / "home"
+
+    def _guard_rejects(**_kwargs):
+        raise PermissionError(1, "unsafe writable or foreign-owned directory: /home/u/.claude")
+
+    monkeypatch.setattr(setup_wizard.hook_module, "install_hook", _guard_rejects)
+
+    code, out = _setup(vault, home, Recorder(), with_hooks=True)
+
+    assert code == 1
+    assert "Traceback" not in out
+    assert "hooks: [failed:" in out
+    assert "unsafe writable" in out
+    # The steps that did apply are named, so the user knows the state they are in.
+    assert "skill" in out
+    assert "idempotent" in out
+
+
 def test_setup_generates_access_policy(tmp_path: Path) -> None:
     vault, home = _messy_vault(tmp_path), tmp_path / "home"
     code, out = _setup(vault, home, Recorder())


### PR DESCRIPTION
Closes #477, #478.

## What changed

Two defects that compound: on a stock Debian/Ubuntu box (`umask 0002` is the distro default, so `~/.claude` is 0775) a first install fails three times with a misleading path, then ends in a raw stack trace.

**#477 — the guard named the wrong path.** `_require_trusted_directory` walks every ancestor and rejects any that is group/other-writable, but the raise interpolated `directory.path` — always the leaf. So it fails naming `~/.claude/hooks`; you chmod that; it fails again with the *identical* message, because the real offender is the ancestor `~/.claude`. The guard itself is correct and unchanged in what it rejects — a group-writable hook directory is code Claude Code executes. Only its diagnosis changed.

The walk is now `unsafe_trusted_directory_ancestors()`, returning every offending path with its reason, plus `trusted_directory_remediation()` rendering one chmod that clears all of them. Three failed runs become one.

**#478 — the hook step tracebacked.** Only `FileNotFoundError` was caught around `install_hook`. The guard raises `PermissionError`, an `OSError`, which escaped uncaught after `register`, `register-codex` and `skill` had already applied — reading as a crash rather than "one step remains", with no indication of the partial state. Now reported in the same `[step] ...` style as every other step, which routes through the existing `finish()` (non-zero exit + per-step summary), and states that setup is idempotent.

## Verification

- `tests/test_setup_wizard.py`: **34 passed** on Windows, including the new #478 test (asserts no `Traceback`, exit 1, the completed steps named).
- The #477 tests are POSIX-only and skip on Windows, so rather than ship them unverified I exercised the real code path **on Linux (WSL, ext4 `/tmp`)**:

```
CASE1 offenders: ['/tmp/.../home/.claude']              <- ancestor named, already-fine leaf NOT named
CASE2 offenders: ['/tmp/.../.claude', '/tmp/.../.claude/hooks']
CASE2 remediation: chmod g-w,o-w /tmp/.../.claude /tmp/.../.claude/hooks
CASE3 offenders: []                                      <- clean chain accepted
ALL_GUARD_CASES_PASS
```

Case 1 is precisely the reported bug. Three regression tests encode all three cases for Linux CI.

Full-suite is CI's call — native Windows can't run it.