### PR TITLE
fix(install): add a CPU-only ONNX profile; document the uv pin workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          # The single writer version. `required-version` in pyproject is a
-          # floor, so a contributor is not forced to downgrade a shared global
-          # uv to run `uv sync`; the exact version is enforced HERE, where
-          # lockfile marker normalization actually matters — this is the job
-          # that runs `uv lock --check`.
-          version: "0.11.28"
       - name: Verify lockfile is current
         run: uv lock --check
       - name: Run tests (lean — BM25/keyword, server media extraction off)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          # The single writer version. `required-version` in pyproject is a
+          # floor, so a contributor is not forced to downgrade a shared global
+          # uv to run `uv sync`; the exact version is enforced HERE, where
+          # lockfile marker normalization actually matters — this is the job
+          # that runs `uv lock --check`.
+          version: "0.11.28"
       - name: Verify lockfile is current
         run: uv lock --check
       - name: Run tests (lean — BM25/keyword, server media extraction off)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,31 @@ git worktree remove ../exomem-<topic>
 Commit and push from the worktree; leave the primary checkout on whatever branch
 the other session is using.
 
+## uv: a floor here, the exact version in CI
+
+`required-version` in `pyproject.toml` is `>=0.11.28`, not `==`. uv is normally
+one shared installation managing many unrelated tools, so an exact pin made a
+fresh-checkout `uv sync` fail outright and tell you to run
+`uv self update 0.11.28` — a global downgrade to satisfy one repo.
+
+The pin still exists where it matters. Lockfile marker normalization can only
+diverge when something *writes* the lock, so CI pins uv to the exact writer
+version (`0.11.28`) on the job that runs `uv lock --check`. If you regenerate
+`uv.lock` and CI disagrees with your local result, match that version without
+touching your global install:
+
+```
+UV_INSTALL_DIR=.uvbin curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
+```
+
+## Installing the service on a CPU-only host
+
+`scripts/install-service.sh --profile hybrid` pulls `torch`, which is pinned to
+the CUDA index on Linux and Windows — multi-GB, and unusable without a GPU. Use
+`--profile onnx` instead: the same bi-encoder served through ONNX Runtime, with
+`EXOMEM_EMBED_BACKEND=onnx` written into the service environment. It is the
+right default for any host without a GPU.
+
 ## The skill scaffold is hand-authored — keep it generic
 
 `src/exomem/_scaffold/_Schema/` (the skill shipped to new users via `init` /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,22 +16,32 @@ git worktree remove ../exomem-<topic>
 Commit and push from the worktree; leave the primary checkout on whatever branch
 the other session is using.
 
-## uv: a floor here, the exact version in CI
+## uv is pinned — install it project-locally, don't downgrade your global one
 
-`required-version` in `pyproject.toml` is `>=0.11.28`, not `==`. uv is normally
-one shared installation managing many unrelated tools, so an exact pin made a
-fresh-checkout `uv sync` fail outright and tell you to run
-`uv self update 0.11.28` — a global downgrade to satisfy one repo.
+`uv sync` in a fresh checkout fails on any uv other than the pinned writer
+version:
 
-The pin still exists where it matters. Lockfile marker normalization can only
-diverge when something *writes* the lock, so CI pins uv to the exact writer
-version (`0.11.28`) on the job that runs `uv lock --check`. If you regenerate
-`uv.lock` and CI disagrees with your local result, match that version without
-touching your global install:
+```
+error: Required uv version `==0.11.28` does not match the running version `0.11.31`.
+Update `uv` by running `uv self update 0.11.28`.
+```
+
+**Do not run that suggestion.** uv is normally one shared installation managing
+many unrelated tools, and `uv self update` downgrades all of them to satisfy this
+repo. Install the pinned version project-locally instead:
 
 ```
 UV_INSTALL_DIR=.uvbin curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
+PATH="$PWD/.uvbin:$PATH" uv sync
 ```
+
+The pin is deliberate and is not just about this file. A single writer version
+keeps lockfile marker normalization identical across Windows, WSL, Docker and
+CI, and `required-version` is what makes that bind — `Dockerfile`,
+`infra/tool-versions.env` and `.github/workflows/hosted-infrastructure.yml` all
+declare the same version, and
+`tests/test_uv_lock_policy.py::test_uv_writer_version_is_pinned_across_repository_surfaces`
+fails if any of the four drifts. Bumping uv means bumping all four together.
 
 ## Installing the service on a CPU-only host
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,8 +235,14 @@ markers = [
 # index out of general resolution. Multi-host GPU bring-up is documented in README.
 [tool.uv]
 # A single writer version prevents harmless-but-noisy marker normalization
-# differences between Windows, WSL, Docker, and CI.
-required-version = "==0.11.28"
+# differences between Windows, WSL, Docker, and CI. This is a FLOOR, not a pin:
+# uv is usually one shared installation managing many unrelated tools, so `==`
+# made `uv sync` in a fresh checkout fail with "Update `uv` by running `uv self
+# update 0.11.28`" — a global downgrade to satisfy one repo, which is a real
+# cost to a first-time contributor and not obviously safe. The exact writer
+# version is enforced in CI (.github/workflows/ci.yml, the `uv lock --check`
+# job), which is the only place lockfile normalization can actually diverge.
+required-version = ">=0.11.28"
 
 [tool.uv.sources]
 torch = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,14 +235,18 @@ markers = [
 # index out of general resolution. Multi-host GPU bring-up is documented in README.
 [tool.uv]
 # A single writer version prevents harmless-but-noisy marker normalization
-# differences between Windows, WSL, Docker, and CI. This is a FLOOR, not a pin:
-# uv is usually one shared installation managing many unrelated tools, so `==`
-# made `uv sync` in a fresh checkout fail with "Update `uv` by running `uv self
-# update 0.11.28`" — a global downgrade to satisfy one repo, which is a real
-# cost to a first-time contributor and not obviously safe. The exact writer
-# version is enforced in CI (.github/workflows/ci.yml, the `uv lock --check`
-# job), which is the only place lockfile normalization can actually diverge.
-required-version = ">=0.11.28"
+# differences between Windows, WSL, Docker, and CI. Deliberately `==`, and one
+# leg of a four-surface invariant enforced by
+# tests/test_uv_lock_policy.py::test_uv_writer_version_is_pinned_across_repository_surfaces
+# alongside the Dockerfile, infra/tool-versions.env and the hosted-infrastructure
+# workflow — this is the leg that makes the other three bind, so loosening it
+# would leave them declaring a version nothing enforces.
+#
+# The cost lands on contributors: uv is usually one shared installation managing
+# many unrelated tools, and uv's own error suggests `uv self update 0.11.28`, a
+# global downgrade to satisfy one repo. Do not do that — CONTRIBUTING.md
+# documents a project-local install instead.
+required-version = "==0.11.28"
 
 [tool.uv.sources]
 torch = [

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -36,7 +36,9 @@ Modes:
   --repo-dev                Use the checkout .venv (default for compatibility)
 
 Options:
-  --profile lean|hybrid|standard|media
+  --profile lean|onnx|hybrid|standard|media
+                            onnx is the CPU-only vector lane: same model as
+                            hybrid, served by ONNX Runtime, no CUDA torch wheel
   --service-root PATH       Override release state/venv location
   --package-version VERSION Pin the PyPI release version
   --env-file PATH           Dotenv file (default: <repo>/.env)
@@ -115,9 +117,19 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$PROFILE" in
-    lean|hybrid|standard|media) ;;
-    *) die "--profile must be lean, hybrid, standard, or media" ;;
+    lean|onnx|hybrid|standard|media) ;;
+    *) die "--profile must be lean, onnx, hybrid, standard, or media" ;;
 esac
+
+# `onnx` is an install lane, not a doctor profile. It expects exactly the vector
+# lane `hybrid` expects — same model, same sidecar — and only the serving runtime
+# differs, which doctor already resolves from EXOMEM_EMBED_BACKEND.
+DOCTOR_PROFILE="$PROFILE"
+EMBED_BACKEND=""
+if [[ "$PROFILE" == "onnx" ]]; then
+    DOCTOR_PROFILE="hybrid"
+    EMBED_BACKEND="onnx"
+fi
 if [[ ! "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); then
     die "--port must be an integer from 1 to 65535"
 fi
@@ -170,6 +182,13 @@ if [[ "$MODE" == "release" ]]; then
         lean)
             EXTRAS=""
             ;;
+        onnx)
+            # `torch` is pinned to the CUDA index for Linux and Windows, so on a
+            # GPU-less host `hybrid` downloads a multi-GB wheel that can never be
+            # used. This lane serves the identical model through ONNX Runtime —
+            # the right default for a CPU-only host, which is most of them.
+            EXTRAS="embeddings-onnx"
+            ;;
         hybrid)
             EXTRAS="embeddings"
             ;;
@@ -218,7 +237,8 @@ trap cleanup EXIT
     "$PROCESS_ENV_FILE" \
     "$LAUNCHD_ENV_FILE" \
     "$LOG_DIR" \
-    "$LEGACY_MCP_COMPAT" <<'PY'
+    "$LEGACY_MCP_COMPAT" \
+    "$EMBED_BACKEND" <<'PY'
 from __future__ import annotations
 
 import os
@@ -230,7 +250,7 @@ from xml.sax.saxutils import escape
 
 from dotenv import dotenv_values
 
-env_path, systemd_path, process_path, xml_path, log_dir, legacy = sys.argv[1:]
+env_path, systemd_path, process_path, xml_path, log_dir, legacy, embed_backend = sys.argv[1:]
 values = {
     key: str(value)
     for key, value in dotenv_values(env_path).items()
@@ -245,6 +265,10 @@ for key, value in values.items():
 if not values.get("EXOMEM_VAULT_PATH", "").strip():
     raise SystemExit(f"EXOMEM_VAULT_PATH is required in {env_path}")
 values.setdefault("EXOMEM_LOG_DIR", log_dir)
+# setdefault, not assignment: an explicit choice in the dotenv outranks the
+# profile's default, so `--profile onnx` never silently overrides it.
+if embed_backend:
+    values.setdefault("EXOMEM_EMBED_BACKEND", embed_backend)
 if os.environ.get("PATH"):
     values.setdefault("PATH", os.environ["PATH"])
 if legacy == "1":
@@ -278,9 +302,9 @@ PY
 source "$PROCESS_ENV_FILE"
 rm -f "$PROCESS_ENV_FILE"
 
-echo "Preflight: exomem doctor --profile $PROFILE..."
+echo "Preflight: exomem doctor --profile $DOCTOR_PROFILE..."
 "$VENV_PYTHON" -m exomem doctor \
-    --profile "$PROFILE" \
+    --profile "$DOCTOR_PROFILE" \
     --vault "$EXOMEM_VAULT_PATH"
 echo "Preflight: exomem doctor --profile remote..."
 "$VENV_PYTHON" -m exomem doctor \

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -231,14 +231,14 @@ trap cleanup EXIT
 
 # Parse dotenv with the package's own dependency, render systemd/launchd-safe
 # forms, and create a shell-quoted temporary export file for doctor.
+EXOMEM_PROFILE_EMBED_BACKEND="$EMBED_BACKEND" \
 "$VENV_PYTHON" - \
     "$ENV_FILE" \
     "$SERVICE_ENV_FILE" \
     "$PROCESS_ENV_FILE" \
     "$LAUNCHD_ENV_FILE" \
     "$LOG_DIR" \
-    "$LEGACY_MCP_COMPAT" \
-    "$EMBED_BACKEND" <<'PY'
+    "$LEGACY_MCP_COMPAT" <<'PY'
 from __future__ import annotations
 
 import os
@@ -250,7 +250,11 @@ from xml.sax.saxutils import escape
 
 from dotenv import dotenv_values
 
-env_path, systemd_path, process_path, xml_path, log_dir, legacy, embed_backend = sys.argv[1:]
+env_path, systemd_path, process_path, xml_path, log_dir, legacy = sys.argv[1:]
+# Passed through the environment rather than as an eighth positional: the
+# renderer invocations here are told apart by argv length, so a new positional
+# would silently alias this call onto a different renderer.
+embed_backend = os.environ.get("EXOMEM_PROFILE_EMBED_BACKEND", "")
 values = {
     key: str(value)
     for key, value in dotenv_values(env_path).items()

--- a/tests/test_service_installers.py
+++ b/tests/test_service_installers.py
@@ -369,7 +369,41 @@ def test_help_and_invalid_profile_are_non_mutating() -> None:
     assert "--repo-dev" in help_result.stdout
     assert 'MODE="repo-dev"' in INSTALL_SH.read_text(encoding="utf-8")
     assert invalid_result.returncode != 0
-    assert "lean, hybrid, standard, or media" in invalid_result.stderr
+    assert "lean, onnx, hybrid, standard, or media" in invalid_result.stderr
+
+
+def test_onnx_profile_installs_the_cpu_lane_and_preflights_as_hybrid(tmp_path: Path) -> None:
+    """#481: a GPU-less host had no way to get vectors without a CUDA torch wheel.
+
+    `torch` is pinned to the CUDA index for Linux, so `--profile hybrid` pulled
+    multi-GB of wheel that can never be used, and `lean` gave no vectors at all.
+    `onnx` is an install lane rather than a doctor profile — it expects exactly
+    the vector lane `hybrid` expects, so the preflight maps onto that.
+    """
+    env, service_root, env_file = _fixture(tmp_path)
+    subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--release",
+            "--profile",
+            "onnx",
+            "--service-root",
+            str(service_root),
+            "--env-file",
+            str(env_file),
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    trace = Path(env["TRACE_FILE"]).read_text(encoding="utf-8")
+    assert "exomem[embeddings-onnx]" in trace
+    assert "exomem[embeddings]\n" not in trace, "must not pull the CUDA torch lane"
+    assert "doctor hybrid" in trace
 
 
 def test_windows_installer_gates_remote_and_verifies_before_success() -> None:


### PR DESCRIPTION
Closes #481. Closes #485 — but not the way the issue proposed; see below.

## #481 — no ONNX profile in the service installer

`torch` is pinned to the CUDA index for Linux and Windows (`[tool.uv.sources]`), so on a GPU-less host `--profile hybrid` downloads a multi-GB wheel that can never be used, and the only alternative was `lean` — no vectors at all. The `embeddings-onnx` extra already existed and is the documented substitute; nothing selected it.

`--profile onnx` now maps to `exomem[embeddings-onnx]` and writes `EXOMEM_EMBED_BACKEND=onnx` into the rendered service env via `setdefault`, so an explicit dotenv value still wins. `onnx` is an *install* lane rather than a doctor profile, so the preflight maps it to `hybrid` — same vector lane expected, only the serving runtime differs.

One trap worth noting for reviewers: the renderer invocations in `install-service.sh` are told apart by **argv length** (8 / 10 / 9). My first attempt passed the backend as an eighth positional, which silently aliased the environment renderer onto the systemd-unit branch — the process env file was never written and the preflight died on an unbound `EXOMEM_VAULT_PATH`. It goes through the environment instead.

## #485 — I did not loosen the pin, and I think that's right

The issue's preferred option was relaxing `required-version` to `>=0.11.28`. I tried that, and `tests/test_uv_lock_policy.py::test_uv_writer_version_is_pinned_across_repository_surfaces` failed — correctly.

`0.11.28` is pinned across **four** surfaces: `pyproject.toml`, `Dockerfile`, `infra/tool-versions.env`, and `.github/workflows/hosted-infrastructure.yml`. `required-version` is the leg that makes the other three actually bind. Loosening it alone leaves three surfaces declaring an exact version that nothing enforces — worse than either extreme.

The complaint underneath is still real, and it's the one the issue lists as its second option: uv is normally one shared installation managing many unrelated tools, and uv's own error suggests `uv self update 0.11.28`, a **global** downgrade to satisfy one repo. `CONTRIBUTING.md` now documents the project-local install and says plainly not to follow that suggestion:

```
UV_INSTALL_DIR=.uvbin curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
PATH="$PWD/.uvbin:$PATH" uv sync
```

...along with what bumping the pin actually requires (all four surfaces together). If you'd rather still loosen the pin, that's a change that should update the policy test and all four surfaces deliberately — say the word and I'll do it separately.

## Verification

`tests/test_uv_lock_policy.py`: **3 passed**.

`test_service_installers.py` is bash-driven and can't run on native Windows (baseline there is 7 failed / 1 passed), so I exercised the installer for real on Linux (WSL) with a stub python:

```
uv pip install --upgrade --python .../python exomem[embeddings-onnx]   <- ONNX extra, no CUDA torch
argv_len=8                                                              <- env renderer selected
render environment backend=onnx                                         <- backend reaches the renderer
doctor hybrid                                                           <- preflight maps correctly
doctor remote
```

Profile validation and extras derivation, all five profiles — only `onnx` changes:

```
lean      pkg=exomem                                       doctor=lean     backend=<unset>
onnx      pkg=exomem[embeddings-onnx]                      doctor=hybrid   backend=onnx
hybrid    pkg=exomem[embeddings]                           doctor=hybrid   backend=<unset>
standard  pkg=exomem[embeddings,media]                     doctor=standard backend=<unset>
media     pkg=exomem[embeddings,media,vision,diarization]  doctor=media    backend=<unset>
```

Linux CI is the authoritative gate for the bash suite.