### PR TITLE
fix(hooks): stay silent until the client has loaded the MCP server

### DIFF
--- a/plugins/claude-code/hooks/exomem_capture_nudge.py
+++ b/plugins/claude-code/hooks/exomem_capture_nudge.py
@@ -355,6 +355,54 @@ def _successful_kb_write(tool: dict) -> bool:
     return True
 
 
+#: Written by `install-hook`, cleared once an exomem MCP tool is observed. The
+#: hooks take effect for the CURRENT session, but the MCP server they reference
+#: is not loaded until the client restarts — so on a fresh install the very
+#: first thing the product does is ask for `remember` / `edit_memory` /
+#: `connect_memory`, none of which exist yet, and there is no CLI fallback for
+#: the write side. The nudge's own escape hatch ("no Knowledge Base configured,
+#: do nothing") cannot detect this case.
+PENDING_RESTART_MARKER = "pending-restart"
+
+#: Upper bound on the silence. The marker normally clears the moment an exomem
+#: tool appears, but a user who installs and never calls one would otherwise be
+#: muted forever — and the nudge is what prompts the first capture. After this,
+#: assume the restart happened.
+_PENDING_RESTART_MAX_AGE_SEC = 24 * 3600
+
+
+def _pending_restart_marker() -> Path:
+    return _hook_home() / ".cache" / "exomem-nudge" / PENDING_RESTART_MARKER
+
+
+def _exomem_tool_seen(tools: list[dict]) -> bool:
+    """Whether any exomem MCP tool appears this turn — read-only counts.
+
+    A read proves the server is loaded just as well as a write does, and this is
+    only ever used to answer "did the client restart yet".
+    """
+    return any(
+        re.search(r"exomem|knowledge[_-]?base", str(tool.get("name") or ""), re.I)
+        for tool in tools
+    )
+
+
+def _restart_pending(tools: list[dict]) -> bool:
+    """True while the MCP write tools the reminder asks for cannot exist yet."""
+    marker = _pending_restart_marker()
+    try:
+        if not marker.exists():
+            return False
+        if _exomem_tool_seen(tools) or (
+            time.time() - marker.stat().st_mtime > _PENDING_RESTART_MAX_AGE_SEC
+        ):
+            marker.unlink(missing_ok=True)
+            return False
+    except OSError:
+        return False
+    return True
+
+
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based, so we never parse content)."""
     state_dir = _hook_home() / ".cache" / "exomem-nudge"
@@ -421,6 +469,8 @@ def main() -> int:
     transcript_text, tools = _latest_turn(tpath) if tpath else ("", [])
     assistant_text = event_assistant_text or transcript_text
     if any(_successful_kb_write(tool) for tool in tools):  # already captured this turn
+        return 0
+    if _restart_pending(tools):  # hooks are live but the MCP server is not loaded yet
         return 0
     if re.search(r"Saved\s*(?:->|→|:)", assistant_text):
         return 0

--- a/src/exomem/_hooks/exomem_capture_nudge.py
+++ b/src/exomem/_hooks/exomem_capture_nudge.py
@@ -355,6 +355,54 @@ def _successful_kb_write(tool: dict) -> bool:
     return True
 
 
+#: Written by `install-hook`, cleared once an exomem MCP tool is observed. The
+#: hooks take effect for the CURRENT session, but the MCP server they reference
+#: is not loaded until the client restarts — so on a fresh install the very
+#: first thing the product does is ask for `remember` / `edit_memory` /
+#: `connect_memory`, none of which exist yet, and there is no CLI fallback for
+#: the write side. The nudge's own escape hatch ("no Knowledge Base configured,
+#: do nothing") cannot detect this case.
+PENDING_RESTART_MARKER = "pending-restart"
+
+#: Upper bound on the silence. The marker normally clears the moment an exomem
+#: tool appears, but a user who installs and never calls one would otherwise be
+#: muted forever — and the nudge is what prompts the first capture. After this,
+#: assume the restart happened.
+_PENDING_RESTART_MAX_AGE_SEC = 24 * 3600
+
+
+def _pending_restart_marker() -> Path:
+    return _hook_home() / ".cache" / "exomem-nudge" / PENDING_RESTART_MARKER
+
+
+def _exomem_tool_seen(tools: list[dict]) -> bool:
+    """Whether any exomem MCP tool appears this turn — read-only counts.
+
+    A read proves the server is loaded just as well as a write does, and this is
+    only ever used to answer "did the client restart yet".
+    """
+    return any(
+        re.search(r"exomem|knowledge[_-]?base", str(tool.get("name") or ""), re.I)
+        for tool in tools
+    )
+
+
+def _restart_pending(tools: list[dict]) -> bool:
+    """True while the MCP write tools the reminder asks for cannot exist yet."""
+    marker = _pending_restart_marker()
+    try:
+        if not marker.exists():
+            return False
+        if _exomem_tool_seen(tools) or (
+            time.time() - marker.stat().st_mtime > _PENDING_RESTART_MAX_AGE_SEC
+        ):
+            marker.unlink(missing_ok=True)
+            return False
+    except OSError:
+        return False
+    return True
+
+
 def _cooldown_ok(session_id: str, cooldown: int) -> tuple[bool, Path]:
     """Per-session timestamp file (mtime-based, so we never parse content)."""
     state_dir = _hook_home() / ".cache" / "exomem-nudge"
@@ -421,6 +469,8 @@ def main() -> int:
     transcript_text, tools = _latest_turn(tpath) if tpath else ("", [])
     assistant_text = event_assistant_text or transcript_text
     if any(_successful_kb_write(tool) for tool in tools):  # already captured this turn
+        return 0
+    if _restart_pending(tools):  # hooks are live but the MCP server is not loaded yet
         return 0
     if re.search(r"Saved\s*(?:->|→|:)", assistant_text):
         return 0

--- a/src/exomem/install_hook.py
+++ b/src/exomem/install_hook.py
@@ -1252,6 +1252,27 @@ def _merge_hooks(path: Path, installed: list[dict], timeout: int) -> dict:
     raise RuntimeError(f"concurrent hook config changes persisted at {path}")
 
 
+def _mark_restart_pending(hook_dir: Path) -> None:
+    """Record that hooks are live but the MCP server is not loaded yet.
+
+    Installing hooks takes effect for the CURRENT session; the MCP server they
+    were just registered alongside does not, until the client restarts. So on a
+    fresh install the Stop nudge fires immediately and asks for `remember`,
+    `edit_memory` and `connect_memory` — all MCP-only, none of which exist yet,
+    and the write side has no CLI fallback. The nudge reads this marker and
+    stays silent until an exomem tool proves the server is loaded.
+
+    Best-effort: a marker that cannot be written costs a premature nudge, never
+    a failed install, so this must not raise into the install path.
+    """
+    marker = hook_dir.parent / ".cache" / "exomem-nudge" / "pending-restart"
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(str(time.time()), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def install_hook(
     *,
     hook_dir: Path | None = None,
@@ -1302,6 +1323,8 @@ def install_hook(
         _deploy_file(_HOOK_DIR_SRC / _CONTINUATION_SCRIPT, hook_dir / _CONTINUATION_SCRIPT)
         _deploy_file(_HOOK_DIR_SRC / _CONTINUATION_WRAPPER, hook_dir / _CONTINUATION_WRAPPER)
         installed.extend(_continuation_items(hook_dir, client))
+
+    _mark_restart_pending(hook_dir)
 
     result = {
         "installed": installed,

--- a/tests/test_install_hook.py
+++ b/tests/test_install_hook.py
@@ -2078,3 +2078,70 @@ def test_retrieve_codex_client_accepts_camel_case_and_uses_codex_state(tmp_path:
     assert (home / ".codex" / ".cache" / "exomem-nudge" / "retrieve_codex-ret").exists()
     assert (home / ".codex" / "exomem-retrieve-nudge.log").exists()
     assert not (home / ".claude" / "exomem-retrieve-nudge.log").exists()
+
+
+# --- #484: the nudge must not ask for MCP tools that cannot exist yet -----------
+
+
+def test_install_hook_marks_a_pending_restart(tmp_path: Path) -> None:
+    """Hooks take effect this session; the MCP server does not until a restart."""
+    hd, sp = tmp_path / "hooks", tmp_path / "settings.json"
+    hook_module.install_hook(hook_dir=hd, settings_path=sp)
+
+    marker = tmp_path / ".cache" / "exomem-nudge" / "pending-restart"
+    assert marker.is_file()
+
+
+def test_capture_nudge_is_silent_while_a_restart_is_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem._hooks import exomem_capture_nudge as capture_hook
+
+    monkeypatch.setenv("EXOMEM_HOOK_HOME", str(tmp_path))
+    marker = tmp_path / ".cache" / "exomem-nudge" / "pending-restart"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(str(time.time()), encoding="utf-8")
+
+    assert capture_hook._restart_pending([]) is True
+
+
+def test_an_observed_exomem_tool_clears_the_pending_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Any exomem tool — read or write — proves the server is loaded."""
+    from exomem._hooks import exomem_capture_nudge as capture_hook
+
+    monkeypatch.setenv("EXOMEM_HOOK_HOME", str(tmp_path))
+    marker = tmp_path / ".cache" / "exomem-nudge" / "pending-restart"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(str(time.time()), encoding="utf-8")
+
+    assert capture_hook._restart_pending([{"name": "mcp__exomem__ask_memory"}]) is False
+    assert not marker.exists(), "the marker must be cleared, not just ignored"
+
+
+def test_a_stale_pending_restart_stops_muting_the_nudge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The nudge is what prompts the first capture, so it cannot mute forever."""
+    from exomem._hooks import exomem_capture_nudge as capture_hook
+
+    monkeypatch.setenv("EXOMEM_HOOK_HOME", str(tmp_path))
+    marker = tmp_path / ".cache" / "exomem-nudge" / "pending-restart"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("old", encoding="utf-8")
+    stale = time.time() - capture_hook._PENDING_RESTART_MAX_AGE_SEC - 60
+    os.utime(marker, (stale, stale))
+
+    assert capture_hook._restart_pending([]) is False
+    assert not marker.exists()
+
+
+def test_no_marker_means_the_nudge_behaves_exactly_as_before(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from exomem._hooks import exomem_capture_nudge as capture_hook
+
+    monkeypatch.setenv("EXOMEM_HOOK_HOME", str(tmp_path))
+
+    assert capture_hook._restart_pending([]) is False


### PR DESCRIPTION
Closes #484.

## What changed

On a fresh install the first thing the product does is ask for something impossible.

`install-hook` wires the Stop nudge into `settings.json`, and hooks take effect for the **current** session. The MCP server registered alongside them does not — not until the client restarts. So the nudge fires at the end of the next substantial turn and asks the agent to call `connect_memory(operation="resolve-entity", ...)`, `edit_memory` and `remember`: all MCP-only, none of which exist yet, and the write side has no CLI fallback. The nudge's own escape hatch — *"or no Knowledge Base is configured, do nothing and stop"* — can't cover it, because a Knowledge Base **is** configured. It's a small thing, but it's the first thing a new user sees the product do.

`install_hook` now writes a `pending-restart` marker beside the nudge's existing cooldown state, and `_restart_pending()` keeps the nudge silent while it's there.

## Clearing it, in both directions

This is the part worth reviewing — the marker has to clear, and it has to not clear too early:

- **Any observed exomem tool clears it**, read or write. A read proves the server is loaded just as well as a write, and that's the only question being asked.
- **It also expires after 24h.** Without that, a user who installs and never calls a tool is muted permanently — and the nudge is precisely what prompts a first capture, so that failure mode is worse than the bug being fixed.

Writing the marker is best-effort and swallows `OSError`: a marker that can't be written costs one premature nudge, never a failed install.

## Verification

- `tests/test_install_hook.py`: **84 passed**, 9 skipped, 4 failed.
- Those same 4 failures reproduce identically on an unmodified baseline worktree (**79 passed**, same 4 failed) — they are the known native-Windows limitations, not this change. The delta is exactly my 5 new tests.
- `scripts/validate-public-artifacts.py --repository`: clean.
- `compileall`: clean.

New tests cover all four states: marker written on install; silent while pending; an observed exomem tool clears it (and asserts the file is *removed*, not merely ignored); a stale marker stops muting; and no marker means behaviour is unchanged.

Linux CI is the authoritative gate for the full suite.