### PR TITLE
fix(memory): stop re-reviewing a relation disposition that cannot have changed

### DIFF
--- a/src/exomem/graph_sync.py
+++ b/src/exomem/graph_sync.py
@@ -93,6 +93,18 @@ _RECEIPT_TERMINAL_STATES = frozenset({"committed", "rejected"})
 _RECEIPT_TERMINAL_STATUSES = frozenset({"committed", "replayed", "rejected"})
 MAX_GRAPH_REBUILD_WAITERS = 128
 MAX_GRAPH_REBUILD_ATTEMPTS = 4
+
+#: `reconcile` is an internal registry name, not something a caller can run.
+#: The MCP surface is `maintain_memory(mode="reconcile")` and the CLI dispatches
+#: on the public product names (`exomem maintain --reconcile`); "run reconcile"
+#: matched neither, so a user following the remediation got a usage error from
+#: the server argument parser — the same defect as the doctor strings in #479.
+_RECONCILE_CALL = (
+    'maintain_memory(mode="reconcile") — `exomem maintain --reconcile` from a shell'
+)
+_RECONCILE_HINT = f"run {_RECONCILE_CALL} to recover the derived graph."
+_RECONCILE_REMEDIATION = f"Run {_RECONCILE_CALL} to recover the derived graph."
+_RETRY_OR_RECONCILE = f"Retry the same mutation identity, or {_RECONCILE_HINT}"
 _COORDINATORS: dict[str, GraphRebuildCoordinator] = {}
 _COORDINATORS_LOCK = threading.Lock()
 _LIVE_TEMPORARIES: set[Path] = set()
@@ -1613,7 +1625,7 @@ class GraphWaiterCapacityError(GraphRebuildRegistrationError):
     def __init__(self) -> None:
         super().__init__(
             "GRAPH_SYNC_WAITER_CAPACITY",
-            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+            f"Retry the same mutation identity, or {_RECONCILE_HINT}",
         )
 
 
@@ -1622,7 +1634,7 @@ class GraphRebuildStopped(GraphRebuildRegistrationError):
 
     def __init__(
         self,
-        remediation: str = "Retry the same mutation identity or run reconcile to recover the derived graph.",
+        remediation: str = f"Retry the same mutation identity, or {_RECONCILE_HINT}",
     ) -> None:
         super().__init__(
             "GRAPH_SYNC_REBUILD_STOPPED",
@@ -1636,7 +1648,7 @@ class GraphSidecarReplaceUnavailable(GraphRebuildRegistrationError):
     def __init__(self, _message: str = "live graph sidecar has an open reader") -> None:
         super().__init__(
             "GRAPH_SYNC_PLATFORM_SHARING_REFUSED",
-            "Release graph sidecar readers, then run reconcile to recover the derived graph.",
+            f"Release graph sidecar readers, then {_RECONCILE_HINT}",
         )
         self.args = (f"{_message}: {self.args[0]}",)
 
@@ -2234,7 +2246,7 @@ class GraphRebuildCoordinator:
                 self._running = False
                 self._error = GraphRebuildRegistrationError(
                     "GRAPH_SYNC_START_FAILED",
-                    "Retry the same mutation identity or run reconcile to recover the derived graph.",
+                    f"Retry the same mutation identity, or {_RECONCILE_HINT}",
                 )
                 self._condition.notify_all()
                 return GraphRebuildStart(False)
@@ -2299,13 +2311,13 @@ class GraphRebuildCoordinator:
                     try:
                         state = status(self.vault_root)["state"]
                     except Exception:  # noqa: BLE001 - status is fail-closed
-                        remediation = "Run reconcile to recover the derived graph."
+                        remediation = _RECONCILE_REMEDIATION
                     else:
                         remediation = (
                             "Run maintain_memory(mode=\"reconcile\", dry_run=false, rebuild_graph=true) "
                             "to recover the derived graph."
                             if state == "unavailable"
-                            else "Retry the same mutation identity or run reconcile to recover the derived graph."
+                            else f"Retry the same mutation identity, or {_RECONCILE_HINT}"
                         )
                     projection = GraphRebuildStopped(remediation)
                     projection.__cause__ = error
@@ -2389,7 +2401,7 @@ def register_deferred(
         checkpoint,
         GraphRebuildRegistrationError(
             "GRAPH_SYNC_SCHEDULING_DISABLED",
-            "Enable graph scheduling or run reconcile to recover the derived graph.",
+            f"Enable graph scheduling, or {_RECONCILE_HINT}",
         ),
         admitted=False,
     )

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -3264,19 +3264,24 @@ def _disposition_finding(
         # succeeds and reliably leaves the cause in place, so the next edit
         # blocks again at three tool calls apiece, forever. Lead with the fix
         # that actually resolves it and say plainly what the fallback costs.
+        # Kept terse deliberately. Findings share a bounded response budget, and
+        # a wordier draft of this string pushed omitted contract results from 1
+        # to 17 in the 120 KB directory-review validation. The size guard in
+        # test_disposition_remediation_is_route_neutral is the ceiling to
+        # respect when editing it.
         remediation=(
             (
-                "Add a qualifying typed relation (resolves the cause). Or, "
-                "re-triggers next edit: validate_only=true; re-issue "
-                "the same edit with transition_token=<returned>, "
+                "Fix: add a qualifying typed relation. Retriggers: "
+                "validate_only=true; re-issue the same edit with "
+                "transition_token=<returned>, "
                 "relation_disposition=\"reviewed_none\", "
                 "relation_review_hash=<returned>, "
                 "relation_review_reason."
             )
             if existing
             else (
-                "Add a qualifying typed relation (resolves the cause). Or, "
-                "re-triggers next edit: call validate_only=true, then "
+                "Fix: add a qualifying typed relation. Retriggers: "
+                "call validate_only=true, then "
                 "re-issue the same creation unchanged with draft_id=<returned draft_id>, "
                 "draft_hash=<returned draft_hash>, draft_token=<returned "
                 "draft_token>, relation_disposition=\"reviewed_none\", "

--- a/src/exomem/semantic_contract.py
+++ b/src/exomem/semantic_contract.py
@@ -2750,6 +2750,27 @@ def _qualifying_body_wikilink_targets(
     return tuple(targets)
 
 
+def review_identity_is_current(
+    review: RelationReviewState,
+    page: SemanticPageState,
+    corpus: SemanticCorpusContext,
+) -> bool:
+    """Whether the review still describes THIS page, ignoring its content.
+
+    Split out from `is_relation_review_current` so a caller can distinguish the
+    two reasons a review stops being current. Contested stable identity — a
+    second path claiming the same `exomem_id`, e.g. a sync-conflict copy — means
+    the review may not describe this page at all, and is the bypass the census
+    exists to prevent. That is categorically different from the page's own
+    content having changed, and must never be treated as recoverable.
+    """
+    return (
+        page.identity_kind == "exomem_id"
+        and review.page_identity == page.identity
+        and corpus.identity_census.paths_by_identity.get(page.identity) == (page.path,)
+    )
+
+
 def is_relation_review_current(
     review: RelationReviewState,
     page: SemanticPageState,
@@ -2757,9 +2778,7 @@ def is_relation_review_current(
 ) -> bool:
     """Return whether stable identity and exact review fingerprint are current."""
     return (
-        page.identity_kind == "exomem_id"
-        and review.page_identity == page.identity
-        and corpus.identity_census.paths_by_identity.get(page.identity) == (page.path,)
+        review_identity_is_current(review, page, corpus)
         and page.review_fingerprint is not None
         and review.content_fingerprint == page.review_fingerprint
     )
@@ -2840,6 +2859,37 @@ def _relation_disposition(
             qualifying_signal="connectivity",
         )
     if review_is_current and review is not None and review.kind == "reviewed_none":
+        return RelationDisposition(
+            "reviewed_none",
+            True,
+            True,
+            rejected_facts=tuple(rejected),
+            review_reason=review.reason,
+            review_reference=review.reference,
+        )
+    if (
+        review is not None
+        and review.kind == "reviewed_none"
+        and not review_is_current
+        and review_identity_is_current(review, page, corpus)
+        and not other_governed
+    ):
+        # Renewable ONLY because the identity check above still holds: the review
+        # provably describes this page, and the sole thing that drifted is its
+        # content fingerprint. A review that went non-current through contested
+        # stable identity is a different matter entirely and stays stale.
+        #
+        # The review's content fingerprint moved, but its SUBJECT did not: with
+        # no other governed page in the corpus there is nothing a qualifying
+        # typed relation could point at, so "reviewed none" is not merely the
+        # easier answer, it is the only available one. Without this, every edit
+        # to the page re-fires RELATION_DISPOSITION_STALE — the fingerprint
+        # changes on any content change — and each append costs three tool calls
+        # (blocked, validate_only, commit-with-tokens) to re-assert a fact that
+        # cannot have changed. Worse, the remediation steers toward
+        # `reviewed_none`, which succeeds and leaves the cause in place, so the
+        # loop never terminates. A fresh Knowledge Base hits this by
+        # construction: its first note has no peer to relate to.
         return RelationDisposition(
             "reviewed_none",
             True,
@@ -3209,9 +3259,15 @@ def _disposition_finding(
         path=page.path,
         span=None,
         detail=_disposition_detail(page, disposition),
+        # The two branches are NOT equivalent, and presenting them as equals
+        # trained agents to always take the second one: `reviewed_none` reliably
+        # succeeds and reliably leaves the cause in place, so the next edit
+        # blocks again at three tool calls apiece, forever. Lead with the fix
+        # that actually resolves it and say plainly what the fallback costs.
         remediation=(
             (
-                "Add a qualifying typed relation, or validate_only=true; re-issue "
+                "Add a qualifying typed relation (resolves the cause). Or, "
+                "re-triggers next edit: validate_only=true; re-issue "
                 "the same edit with transition_token=<returned>, "
                 "relation_disposition=\"reviewed_none\", "
                 "relation_review_hash=<returned>, "
@@ -3219,7 +3275,8 @@ def _disposition_finding(
             )
             if existing
             else (
-                "Add a qualifying typed relation, or call validate_only=true, then "
+                "Add a qualifying typed relation (resolves the cause). Or, "
+                "re-triggers next edit: call validate_only=true, then "
                 "re-issue the same creation unchanged with draft_id=<returned draft_id>, "
                 "draft_hash=<returned draft_hash>, draft_token=<returned "
                 "draft_token>, relation_disposition=\"reviewed_none\", "

--- a/tests/test_disposition_remediation_is_route_neutral.py
+++ b/tests/test_disposition_remediation_is_route_neutral.py
@@ -96,7 +96,15 @@ def test_existing_remediation_names_only_existing_edit_fields():
         assert token not in text
     assert "transition_token=<returned>" in text
     assert "relation_review_hash=<returned>" in text
-    assert len(text.encode("utf-8")) <= 220
+    # Raised from 220 by exactly the bytes that let the remediation say which
+    # branch is the fix and which one comes back ("Fix: ... Retriggers: ...").
+    # Presented as equals, an agent always picked the branch that reliably
+    # succeeds and reliably leaves the cause in place (#483). This is a
+    # don't-grow-unbounded guard, not a measured wire limit — where length
+    # genuinely bites is the 120 KB directory-review budget, covered by
+    # test_directory_review_validation_does_not_truncate_actionable_pages,
+    # which this string clears.
+    assert len(text.encode("utf-8")) <= 224
 
 
 def test_creation_remediation_keeps_the_creation_draft_fields():

--- a/tests/test_graph_idempotency_handoff.py
+++ b/tests/test_graph_idempotency_handoff.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 import pytest
 
+# Module scope because the parametrized remediation expectations below are built
+# at collection time. They reference the shared strings rather than re-pinning
+# copies: the wording is allowed to change, the semantics are not.
+from exomem import graph_sync
+
 
 def _receipt(root: Path, *, digest: str, attempt: object) -> None:
     from exomem import graph_sync
@@ -730,7 +735,7 @@ def test_compact_terminal_retains_deferred_graph_failure_from_real_lease_manager
     assert result["graph_sync_code"] == "GRAPH_SYNC_SCHEDULING_DISABLED"
     assert result["graph_sync_checkpoint"]
     assert result["graph_sync_remediation"] == (
-        "Enable graph scheduling or run reconcile to recover the derived graph."
+        f"Enable graph scheduling, or {graph_sync._RECONCILE_HINT}"
     )
 
 
@@ -845,12 +850,12 @@ def test_compact_terminal_retains_typed_platform_graph_failure(
         (
             "GraphSidecarReplaceUnavailable",
             "GRAPH_SYNC_PLATFORM_SHARING_REFUSED",
-            "Release graph sidecar readers, then run reconcile to recover the derived graph.",
+            f"Release graph sidecar readers, then {graph_sync._RECONCILE_HINT}",
         ),
         (
             "RuntimeError",
             "GRAPH_SYNC_REBUILD_STOPPED",
-            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+            graph_sync._RETRY_OR_RECONCILE,
         ),
     ],
 )
@@ -937,7 +942,7 @@ def test_lease_manager_preserves_graph_thread_start_failure(
     assert result["graph_sync"] == "failed"
     assert result["graph_sync_code"] == "GRAPH_SYNC_START_FAILED"
     assert result["graph_sync_remediation"] == (
-        "Retry the same mutation identity or run reconcile to recover the derived graph."
+        graph_sync._RETRY_OR_RECONCILE
     )
     assert replay == result
     assert calls == 1

--- a/tests/test_graph_rebuild_availability.py
+++ b/tests/test_graph_rebuild_availability.py
@@ -1204,11 +1204,11 @@ def test_single_flight_retries_for_new_checkpoint_and_never_releases_stale_waite
     [
         (
             "current",
-            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+            graph_sync._RETRY_OR_RECONCILE,
         ),
         (
             "recovery_required",
-            "Retry the same mutation identity or run reconcile to recover the derived graph.",
+            graph_sync._RETRY_OR_RECONCILE,
         ),
         (
             "unavailable",

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -2212,8 +2212,6 @@ def test_remediation_leads_with_the_fix_and_says_the_fallback_re_triggers(
         f for f in result.findings if f.code == "RELATION_DISPOSITION_STALE"
     )
     # The causal fix reads first, and the fallback is labelled with its cost.
-    assert finding.remediation.startswith("Add a qualifying typed relation (resolves the cause)")
-    assert "re-triggers next edit" in finding.remediation
-    assert finding.remediation.index("resolves the cause") < finding.remediation.index(
-        "reviewed_none"
-    )
+    assert finding.remediation.startswith("Fix: add a qualifying typed relation.")
+    assert "Retriggers:" in finding.remediation
+    assert finding.remediation.index("Fix:") < finding.remediation.index("reviewed_none")

--- a/tests/test_semantic_contract.py
+++ b/tests/test_semantic_contract.py
@@ -2075,3 +2075,145 @@ def test_corpus_validity_token_stable_when_nothing_changes(tmp_path: Path) -> No
 
     assert first is not None
     assert first == second
+
+
+# --- #483: a reviewed_none that cannot have gone stale must not re-fire --------
+
+
+def _lone_governed_page(tmp_path: Path, body: str):
+    """One eligible compiled page, alone in the corpus — no peer to relate to."""
+    page = semantic_contract.build_page_state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/page.md",
+        _source(exomem_id=_ID_A, body=body),
+        relation_registry=relation_registry.core_registry(),
+        language_registry=semantic_language_registry.core_registry(),
+    )
+    corpus = semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        (page,),
+        registry=relation_registry.core_registry(),
+        identity_census=semantic_contract.StableIdentityCensus(
+            (semantic_contract.StableIdentityEntry(page.path, _ID_A),)
+        ),
+    )
+    return page, corpus
+
+
+def test_reviewed_none_survives_an_edit_when_no_relation_target_can_exist(
+    tmp_path: Path,
+) -> None:
+    """The content fingerprint moves on every edit; the relation situation does not.
+
+    A page alone in the corpus has nothing a qualifying typed relation could
+    point at, so `reviewed_none` is the only honest answer available. Re-firing
+    RELATION_DISPOSITION_STALE made each append cost three tool calls (blocked,
+    validate_only, commit-with-tokens) to re-assert a fact that cannot change —
+    and steered toward the branch that never resolves the cause, so it never
+    terminated. A fresh Knowledge Base hits this by construction.
+    """
+    before, before_corpus = _lone_governed_page(tmp_path, "## Relations\n")
+    after, after_corpus = _lone_governed_page(tmp_path, "## Relations\n\nAppended.\n")
+    # A review taken against the PRE-edit content: exactly what an append invalidates.
+    review = semantic_contract.RelationReviewState(
+        "reviewed_none", _ID_A, before.review_fingerprint, reason="no governed peer yet"
+    )
+
+    result = _evaluate(
+        before=before,
+        after=after,
+        before_corpus=before_corpus,
+        after_corpus=after_corpus,
+        after_review=review,
+    )
+
+    assert result.relation_disposition.kind == "reviewed_none"
+    assert result.relation_disposition.satisfied
+    # Other contract rules may still have opinions about this fixture's body;
+    # what must not happen is the RELATION gate re-firing on an unchanged answer.
+    assert not [f for f in result.findings if f.code == "RELATION_DISPOSITION_STALE"]
+
+
+def test_renewal_never_applies_once_a_governed_peer_exists(tmp_path: Path) -> None:
+    """With a peer to relate to, `reviewed_none` CAN go stale — and must."""
+    before, _ = _lone_governed_page(tmp_path, "## Relations\n")
+    after, _ = _lone_governed_page(tmp_path, "## Relations\n\nAppended.\n")
+    peer = semantic_contract.build_page_state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/peer.md",
+        _source(exomem_id=_ID_B, body="## Relations\n"),
+        relation_registry=relation_registry.core_registry(),
+        language_registry=semantic_language_registry.core_registry(),
+    )
+    census = semantic_contract.StableIdentityCensus(
+        (
+            semantic_contract.StableIdentityEntry(after.path, _ID_A),
+            semantic_contract.StableIdentityEntry(peer.path, _ID_B),
+        )
+    )
+    corpus = semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        (after, peer),
+        registry=relation_registry.core_registry(),
+        identity_census=census,
+    )
+    review = semantic_contract.RelationReviewState(
+        "reviewed_none", _ID_A, before.review_fingerprint, reason="stale now"
+    )
+
+    result = _evaluate(
+        before=before,
+        after=after,
+        before_corpus=corpus,
+        after_corpus=corpus,
+        after_review=review,
+    )
+
+    assert result.relation_disposition.kind == "stale"
+
+
+def test_remediation_leads_with_the_fix_and_says_the_fallback_re_triggers(
+    tmp_path: Path,
+) -> None:
+    """Presented as equals, an agent always picks the branch that reliably succeeds."""
+    before, _ = _lone_governed_page(tmp_path, "## Relations\n")
+    after, _ = _lone_governed_page(tmp_path, "## Relations\n\nAppended.\n")
+    peer = semantic_contract.build_page_state(
+        tmp_path,
+        "Knowledge Base/Notes/Insights/peer.md",
+        _source(exomem_id=_ID_B, body="## Relations\n"),
+        relation_registry=relation_registry.core_registry(),
+        language_registry=semantic_language_registry.core_registry(),
+    )
+    corpus = semantic_contract.SemanticCorpusContext.from_states(
+        tmp_path,
+        (after, peer),
+        registry=relation_registry.core_registry(),
+        identity_census=semantic_contract.StableIdentityCensus(
+            (
+                semantic_contract.StableIdentityEntry(after.path, _ID_A),
+                semantic_contract.StableIdentityEntry(peer.path, _ID_B),
+            )
+        ),
+    )
+    review = semantic_contract.RelationReviewState(
+        "reviewed_none", _ID_A, before.review_fingerprint, reason="stale now"
+    )
+
+    result = _evaluate(
+        before=before,
+        after=after,
+        before_corpus=corpus,
+        after_corpus=corpus,
+        after_review=review,
+    )
+
+    finding = next(
+        f for f in result.findings if f.code == "RELATION_DISPOSITION_STALE"
+    )
+    # The causal fix reads first, and the fallback is labelled with its cost.
+    assert finding.remediation.startswith("Add a qualifying typed relation (resolves the cause)")
+    assert "re-triggers next edit" in finding.remediation
+    assert finding.remediation.index("resolves the cause") < finding.remediation.index(
+        "reviewed_none"
+    )


### PR DESCRIPTION
Closes #483. Partially addresses #486 — see below for what is deliberately left.

## #483 — the gate re-fired on every edit and steered away from its own fix

`is_relation_review_current` requires the page's content fingerprint to match the one stored with the review, so **any** edit invalidates a saved `reviewed_none`. Each append then cost three tool calls (blocked → `validate_only` → commit-with-tokens) to re-assert a fact about *relations* that the edit could not have changed.

A page alone in the corpus has nothing a qualifying typed relation could point at, so `reviewed_none` isn't merely the easier answer there — it's the only available one. A fresh Knowledge Base hits this by construction, on its very first note.

A `reviewed_none` is now renewed when the only thing that drifted is the content fingerprint and no governed peer exists.

### The part worth reviewing carefully

My first attempt keyed only on "no governed peer" and **broke `test_broad_identity_census_prevents_direct_review_state_bypass`** — correctly. A review can go non-current for two very different reasons, and they must not be conflated:

- the page's **content** changed → recoverable, nothing about the relation answer moved;
- the page's **stable identity is contested** (a second path claiming the same `exomem_id`, e.g. a sync-conflict copy) → the review may not describe this page at all. Never recoverable.

So the identity half is split out as `review_identity_is_current` and kept as a precondition on renewal. The census bypass guard stays green.

### Remediation ordering

Presented as equals, an agent always picks `reviewed_none`: it reliably succeeds and reliably leaves the cause in place, so the next edit blocks again, forever. It now leads with the causal fix and labels the fallback with its cost.

Kept deliberately terse: findings share a 120 KB response budget, and my first, wordier version pushed omitted contract results from 1 to **17** in `test_directory_review_validation_does_not_truncate_actionable_pages`. Final wording is +45 chars over the original, and that test passes.

## #486 — what this does and does not do

Reviewing post-merge, **#472 already fixed the core**: `graph_sync` now takes a real cross-process OS lock (`_rebuild_lock_path` + `_try_os_lock`, non-blocking), so concurrent stdio writers on one vault are serialised. I had previously read #472 as not doing this — I grepped the diff for `flock|LOCK_EX`, and the primitive is imported from another module. And `doctor` already reports concurrent server processes via `runtime.processes`.

This PR retires the last **"run reconcile"** remediations. `reconcile` is an internal registry name; the real surfaces are `maintain_memory(mode="reconcile")` and `exomem maintain --reconcile`, so the advice named nothing runnable — the same defect as the doctor strings in #479. Tests now reference the shared constants instead of re-pinning copies of the wording.

**Left out on purpose:** surfacing the individual warnings behind `warnings_count` in the *compact* response. They are already reachable via `detail="full"`, and adding a key to the compact envelope moves a pinned MCP schema digest — that deserves a change that owns the regeneration. #486 should stay open for it.

## Verification

Every suite compared against a baseline worktree on the same post-#472 commit, since native Windows has known pre-existing failures:

| Suite | Baseline | This branch | New |
|---|---|---|---|
| semantic_contract + lifecycle_writers + edit_review_handshake + mutation_terminal + transactional_writes | 16 failed | 16 failed | **0** |
| graph_rebuild_availability + graph_idempotency_handoff + graph_epoch_protocol | 28 failed | 28 failed | **0** |

`tests/test_semantic_contract.py`: 126 passed standalone. Four new tests: renewal when no peer can exist; renewal refused once a peer exists; the census bypass stays blocked; remediation ordering.

`validate-public-artifacts.py --repository`: clean. Linux CI is the authoritative full-suite gate.