### PR TITLE
test(checkpoint): assert bounded cleanup over sweeps, not within one call

### DIFF
--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -3449,12 +3449,22 @@ def test_prune_recovers_authorized_crash_tombstone_only(tmp_path: Path) -> None:
     except OSError:
         symlink = None
 
-    removed = checkpoint.prune_expired(
-        home,
-        client,
-        current_session="other",
-        now_ns=100 + checkpoint.RETENTION_NS + 2,
-    )
+    # Bounded sweeps, not one: the 50 ms MAX_PRUNE_LOCK_SECONDS deadline can be
+    # exhausted by a contended runner before the authorized tombstone is
+    # reached, and the sweep resumes from its stored cursor on the next call.
+    # This test is about WHICH entries the sweep is allowed to remove, not about
+    # how many calls it takes — asserting on a single call made it fail on main
+    # (2026-08-14, py3.11 shard 2/4) with `assert 0 == 1`.
+    removed = 0
+    for _ in range(20):
+        removed += checkpoint.prune_expired(
+            home,
+            client,
+            current_session="other",
+            now_ns=100 + checkpoint.RETENTION_NS + 2,
+        )
+        if not (root_path / tombstone_name).exists():
+            break
 
     assert removed == 1
     assert not (root_path / tombstone_name).exists()
@@ -3597,14 +3607,24 @@ def test_true_kill_after_pending_temp_fsync_is_cleaned_boundedly(
     root = checkpoint.client_state_root(home, "codex")
     assert list(root.glob(".pending-*.tmp-*"))
 
-    if cleanup == "retry":
-        checkpoint.write_checkpoint(
-            _event(client="codex", session_id=session),
-            home,
-            observed_at_ns=200,
-        )
-    else:
-        for _ in range(20):
+    # "Cleaned boundedly" means within a bounded number of sweeps, not within
+    # one. Each sweep runs under MAX_PRUNE_LOCK_SECONDS (50 ms) and resumes from
+    # a stored cursor, so a contended runner can exhaust the deadline having done
+    # little work and leave the temp for the next call — the intended
+    # degradation, not a failure. Asserting after a SINGLE retry sweep is what
+    # made this runner-load-sensitive: #284 saw it fail four times consecutively
+    # on py3.11 while never reproducing locally. The prune variant already
+    # looped; both do now.
+    for _ in range(20):
+        if not list(root.glob(".pending-*.tmp-*")):
+            break
+        if cleanup == "retry":
+            checkpoint.write_checkpoint(
+                _event(client="codex", session_id=session),
+                home,
+                observed_at_ns=200,
+            )
+        else:
             checkpoint.prune_expired(
                 home,
                 "codex",


### PR DESCRIPTION
Closes #284. Test-only — no product change.

## The defect

Two continuation-checkpoint tests asserted that a **single** cleanup sweep finished the work. The sweep runs under `MAX_PRUNE_LOCK_SECONDS` — a 50 ms monotonic deadline — and resumes from a stored cursor (`_read_prune_sequence` / `next_cursor`), so a contended runner can exhaust the deadline having done very little and leave the work for the next call.

That is the *intended* degradation, and it's what #284 proposed as the ideal product-side behaviour — it turns out to already be implemented. "Cleaned boundedly" means within a bounded number of sweeps, not within one. Asserting after one call is what made these load-sensitive.

## It is live, not historical

`test_prune_recovers_authorized_crash_tombstone_only` failed **on `main` today** (2026-08-14, `tests (py3.11, shard 2/4)`) with exactly the reported mechanism:

```
>       assert removed == 1
E       assert 0 == 1
tests/test_continuation_checkpoint.py:3459: AssertionError
```

It red-flagged an unrelated commit — which is the cost #284 describes: either the merge blocks, or people learn to merge through red.

## The change

Both now loop, bounded at 20. The `[prune]` variant of the bounded-cleanup test **already looped 20×**; the `[retry]` variant simply never got the same treatment, and the tombstone test never got it at all. So this makes the file internally consistent rather than inventing a new pattern.

The loops are bounded and the final assertions are unchanged, so a genuine never-cleans regression still fails — only "not yet, ask again" stops being reported as a defect.

`test_many_busy_prune_candidates_do_not_starve_supported_writer` already carries the equivalent hardening (it monkeypatches the deadline to 2.0s, with a comment explaining exactly this) and is left alone.

## Verification — and its honest limit

Full `tests/test_continuation_checkpoint.py` on **Linux** (WSL, real ext4, uv 0.11.28 — the pinned writer version), baseline vs this branch:

```
baseline:    164 passed, 1 skipped in 17.82s
this branch: 164 passed, 1 skipped in 17.80s
```

So no regression. **I could not reproduce the flake locally**, which is consistent with #284's own observation that local runs never do: 10 runs of both tests under saturating 16-core load produced 0 failures. Native Windows is not a proxy either — these tests fail there for the unrelated platform reasons the repo already documents.

So this is hardening whose effect only CI-under-contention can demonstrate. I'm flagging that rather than claiming a measured improvement. The argument for merging it is structural: the assertion was testing something the implementation deliberately does not promise.

## Related

#382 tracks a different intermittent failure (`LIFECYCLE_TRANSITION_MISMATCH` in `test_command_surface_retry.py`). It has **not** reproduced in the last 60 CI runs, and the one concurrency failure that did appear today — `test_two_concurrent_edit_memory_writers_on_different_pages_both_succeed`, an identity census reading a vanishing `.graph-rebuild-*` journal — is fixed by #472. Worth watching a few runs before deciding whether #382 is still live.