### PR TITLE
fix(doctor): resolve Tesseract the way the runtime does

### DIFF
--- a/src/exomem/doctor.py
+++ b/src/exomem/doctor.py
@@ -1047,11 +1047,23 @@ def _check_models_cache() -> DoctorCheck:
 
 
 def _check_tesseract(*, required: bool = True) -> DoctorCheck:
+    """Report what the RUNTIME will resolve, not a narrower guess.
+
+    Doctor checked only `EXOMEM_TESSERACT_CMD` and PATH, while
+    `extract._ensure_tesseract_cmd` also probes the standard install locations.
+    The UB-Mannheim Windows package installs to one of those and does not touch
+    PATH, so doctor reported FAIL on a host where OCR demonstrably worked — and
+    `scripts/upgrade.ps1 -Profile media` then refused a safe service restart
+    with the release already staged. Sharing one resolver is what stops the two
+    drifting again.
+    """
+    from . import extract
+
     configured = os.environ.get("EXOMEM_TESSERACT_CMD")
     if configured and Path(configured).exists():
         return _check("tool.tesseract", "pass", f"Tesseract configured at {configured}.")
-    found = shutil.which("tesseract")
-    if found:
+    found = extract.resolve_tesseract_cmd()
+    if found and Path(found).exists():
         return _check("tool.tesseract", "pass", f"Tesseract found at {found}.")
     return _check(
         "tool.tesseract",

--- a/src/exomem/extract.py
+++ b/src/exomem/extract.py
@@ -38,6 +38,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -916,28 +917,51 @@ def _has_audio_stream(path: Path) -> bool:
 _TESSERACT_READY = False
 
 
+#: Standard install locations for the UB-Mannheim Windows package, which does
+#: not put the binary on PATH.
+TESSERACT_INSTALL_CANDIDATES: tuple[str, ...] = (
+    "C:" + r"\Program Files\Tesseract-OCR\tesseract.exe",
+    "C:" + r"\Program Files (x86)\Tesseract-OCR\tesseract.exe",
+)
+
+
+def resolve_tesseract_cmd() -> str | None:
+    """The Tesseract binary this install will actually use, or None.
+
+    THE single discovery answer, shared with `doctor`. Doctor previously kept
+    its own narrower set — `EXOMEM_TESSERACT_CMD` plus PATH — so on a host with
+    the UB-Mannheim package at its documented location it reported
+    `tool.tesseract` FAIL while extraction would have found and used the binary.
+    That made `scripts/upgrade.ps1 -Profile media` refuse a safe restart with
+    the release already staged. A dependency the runtime will use must pass
+    doctor, so the two cannot hold separate candidate sets.
+    """
+    explicit = (os.environ.get("EXOMEM_TESSERACT_CMD") or "").strip()
+    if explicit:
+        return explicit
+    found = shutil.which("tesseract")
+    if found:
+        return found
+    return next((cand for cand in TESSERACT_INSTALL_CANDIDATES if Path(cand).is_file()), None)
+
+
 def _ensure_tesseract_cmd() -> None:
     """Point pytesseract at the Tesseract binary when it isn't on PATH.
 
     The UB-Mannheim Windows installer doesn't add Tesseract to PATH, and the
-    service process may not inherit a shell PATH that has it. Honor an explicit
-    `EXOMEM_TESSERACT_CMD`, else probe the standard install locations. Idempotent.
+    service process may not inherit a shell PATH that has it. Idempotent.
     """
     global _TESSERACT_READY
     if _TESSERACT_READY:
         return
-    import shutil
-
     import pytesseract
 
     explicit = os.environ.get("EXOMEM_TESSERACT_CMD")
     if explicit:
         pytesseract.pytesseract.tesseract_cmd = explicit
     elif not shutil.which("tesseract"):
-        for cand in (
-            "C:" + r"\Program Files\Tesseract-OCR\tesseract.exe",
-            "C:" + r"\Program Files (x86)\Tesseract-OCR\tesseract.exe",
-        ):
+        # Same candidate set doctor probes — that shared tuple is the point.
+        for cand in TESSERACT_INSTALL_CANDIDATES:
             if Path(cand).is_file():
                 pytesseract.pytesseract.tesseract_cmd = cand
                 break

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -662,14 +662,53 @@ def test_process_memory_mixed_rows_keep_physical_and_rss_totals_separate() -> No
 def test_standard_profile_accepts_missing_tesseract_as_degraded_warning(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from exomem import extract as extract_module
+
     monkeypatch.delenv("EXOMEM_TESSERACT_CMD", raising=False)
     monkeypatch.setattr(doctor_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(extract_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(extract_module, "TESSERACT_INSTALL_CANDIDATES", ())
 
     check = doctor_module._check_tesseract(required=False)
 
     assert check.status == "warn"
     assert "Tesseract" in check.message
 
+
+def test_doctor_finds_tesseract_at_a_standard_install_location_off_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#302: doctor FAILed on a host where extraction would have worked.
+
+    The UB-Mannheim Windows package installs to a documented location and does
+    not add it to PATH. Doctor checked only EXOMEM_TESSERACT_CMD and PATH, so
+    `scripts/upgrade.ps1 -Profile media` refused a safe restart on an install
+    whose runtime dependency was present and usable.
+    """
+    from exomem import extract as extract_module
+
+    installed = tmp_path / "Tesseract-OCR" / "tesseract.exe"
+    installed.parent.mkdir(parents=True)
+    installed.write_text("binary", encoding="utf-8")
+
+    monkeypatch.delenv("EXOMEM_TESSERACT_CMD", raising=False)
+    monkeypatch.setattr(extract_module.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(extract_module, "TESSERACT_INSTALL_CANDIDATES", (str(installed),))
+
+    check = doctor_module._check_tesseract(required=True)
+
+    assert check.status == "pass"
+    assert str(installed) in check.message
+
+
+def test_doctor_and_runtime_cannot_hold_separate_tesseract_candidate_sets() -> None:
+    """The drift guard #302 asks for: one discovery function, not two lists."""
+    from exomem import extract as extract_module
+
+    source = Path(doctor_module.__file__).read_text(encoding="utf-8")
+    assert "resolve_tesseract_cmd" in source, "doctor must use the shared resolver"
+    for candidate in extract_module.TESSERACT_INSTALL_CANDIDATES:
+        assert candidate not in source, "doctor must not re-declare install locations"
 
 
 def test_doctor_missing_vault_fails(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #302.

## What changed

`doctor --profile media` checked only `EXOMEM_TESSERACT_CMD` and `PATH`. `extract._ensure_tesseract_cmd` **also** probes the standard Windows install locations — and the UB-Mannheim package installs to one of those and deliberately does not touch `PATH`.

So on such a host doctor reported `tool.tesseract` **FAIL** while extraction would have found and used the binary, and `scripts/upgrade.ps1 -Profile media` refused a safe service restart with the release already staged. A dependency the runtime will use has to pass doctor.

The candidate set moves to `extract.TESSERACT_INSTALL_CANDIDATES` and the answer to `extract.resolve_tesseract_cmd()`, which doctor now calls. Doctor already imports `extract` lazily in three other checks, so this adds no new coupling.

**Runtime behaviour is unchanged.** `_ensure_tesseract_cmd` keeps its exact ordering — honour an explicit override verbatim; otherwise only override pytesseract's default when the binary is *off* PATH — and simply reads the shared tuple instead of an inline copy. (An earlier draft of mine routed it through the resolver and would have started rewriting `tesseract_cmd` to an absolute path in the on-PATH case; that's a behaviour change with no benefit, so it's not here.)

`shutil` moves to a module-level import in `extract` so the runtime and its tests share one patchable discovery seam.

## The drift guard

#302's acceptance asks that "doctor and extraction cannot drift on candidate discovery". `test_doctor_and_runtime_cannot_hold_separate_tesseract_candidate_sets` asserts doctor calls the shared resolver **and** never re-declares the install locations in its own source — re-introducing the second list fails the suite.

## Verification

`tests/test_doctor.py` + `tests/test_extract.py`: **134 passed**, 1 skipped (the skip needs `sentence_transformers`, absent here by design).

New coverage: doctor passes when the binary is at a standard install location and off PATH (the exact reported repro, using a temp file rather than a real install so it runs everywhere); the missing-binary warning still holds; plus the drift guard.

`validate-public-artifacts.py --repository`: clean.