### PR TITLE
feat(server): allow a loopback-only HTTP server without GitHub OAuth

### DIFF
--- a/env.example
+++ b/env.example
@@ -190,6 +190,16 @@ EXOMEM_JWT_SIGNING_KEY=
 
 # Bearer key for the personal REST facade (/api/<tool>). Generate:
 #   uv run --no-sync python scripts/set-rest-key.py
+#
+# Setting this ALSO unlocks a loopback-only HTTP server:
+#   exomem --transport http --host 127.0.0.1 --port 8765
+# GitHub OAuth is skipped for it, but ONLY when all three hold — the bind host
+# is literally 127.0.0.1 or ::1, EXOMEM_BASE_URL is unset, and this key is set.
+# /api/* still requires this bearer key; what the skip relaxes is the MCP
+# endpoints, which become reachable by any local process — the same boundary a
+# local stdio server already has. Set EXOMEM_BASE_URL plus the GitHub OAuth
+# block for a remote connector: the two are mutually exclusive by design, so a
+# misconfigured remote deployment cannot silently degrade into this mode.
 # EXOMEM_REST_API_KEY=
 
 # Secret that enables binary upload/download token minting. Generate:

--- a/src/exomem/server.py
+++ b/src/exomem/server.py
@@ -535,6 +535,41 @@ def _legacy_mcp_commands(
     )
 
 
+#: Hosts that cannot receive a packet from another machine. `localhost` is
+#: excluded on purpose: it is a NAME, and what it resolves to is decided by
+#: /etc/hosts, so it is not a property this gate can verify.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "[::1]"})
+
+
+def local_http_allowed(bind_host: str) -> bool:
+    """Whether HTTP may skip GitHub OAuth for a purely local server.
+
+    `EXOMEM_REST_API_KEY` documents `/api/*` as a personal loopback facade, and
+    the retrieve hook builds exactly that URL — but no HTTP transport would
+    start without the full remote OAuth block, so the local path was
+    unreachable (#482).
+
+    All three conditions are required, and the gate fails closed on anything it
+    cannot verify:
+
+    - the bind host is literally loopback, so no other machine can connect;
+    - `EXOMEM_BASE_URL` is unset — a public base URL is remote intent, and this
+      must never be what a misconfigured remote deployment silently falls into;
+    - `EXOMEM_REST_API_KEY` is set, which is the operator stating they want the
+      local facade. Nobody sets a bearer key by accident.
+
+    `/api/*` keeps its own independent bearer check (`server_rest._rest_gate`)
+    and is unaffected by this. What this actually relaxes is the MCP endpoints,
+    which become reachable by any local process — the boundary a local stdio
+    server already has.
+    """
+    if bind_host.strip() not in _LOOPBACK_HOSTS:
+        return False
+    if os.environ.get("EXOMEM_BASE_URL", "").strip():
+        return False
+    return bool(os.environ.get("EXOMEM_REST_API_KEY", "").strip())
+
+
 def run(
     *,
     transport: str = "stdio",
@@ -549,14 +584,26 @@ def run(
         log_dir if log_dir is not None else resolve_log_dir(), process="server"
     )
 
-    require_auth = transport != "stdio"
+    resolved_host = os.environ.get("EXOMEM_HOST") or host or "127.0.0.1"
+    require_auth = transport != "stdio" and not local_http_allowed(resolved_host)
+    if transport != "stdio" and not require_auth:
+        log.warning(
+            "exomem starting LOOPBACK-ONLY on %s: GitHub OAuth is skipped because "
+            "the bind host is loopback, EXOMEM_BASE_URL is unset, and "
+            "EXOMEM_REST_API_KEY is set. /api/* still requires that bearer key. "
+            "The MCP endpoints are reachable by any local process — the same "
+            "boundary a local stdio server already has, but wider than a "
+            "single-parent stdio pipe on a shared machine. Set EXOMEM_BASE_URL "
+            "and the GitHub OAuth block for a remote connector.",
+            resolved_host,
+        )
     mcp = build_server(require_auth=require_auth)
 
     if transport == "stdio":
         log.info("exomem starting on stdio")
         mcp.run(transport="stdio")
     else:
-        host = os.environ.get("EXOMEM_HOST") or host or "127.0.0.1"
+        host = resolved_host
         log.info("exomem starting on %s host=%s port=%s", transport, host, port)
         mcp.run(
             transport=transport,

--- a/tests/test_rest_registry.py
+++ b/tests/test_rest_registry.py
@@ -1061,3 +1061,49 @@ def test_process_media_rest_uses_shared_actionable_error_envelope(
     assert error["code"] == expected_code
     assert error["message"]
     assert "remediation" in error
+
+
+# --- #482: the documented loopback REST facade must be startable --------------
+
+
+def test_loopback_http_skips_oauth_only_with_all_three_conditions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EXOMEM_REST_API_KEY documents /api/* as a personal loopback facade, and the
+    retrieve hook builds that exact URL — but no HTTP transport would start
+    without a public base URL and a GitHub OAuth app, so it was unreachable."""
+    from exomem import server as server_module
+
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "local-key")
+
+    assert server_module.local_http_allowed("127.0.0.1") is True
+    assert server_module.local_http_allowed("::1") is True
+
+
+def test_loopback_gate_fails_closed_on_every_non_local_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from exomem import server as server_module
+
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "local-key")
+
+    # A routable bind host can receive packets from other machines.
+    assert server_module.local_http_allowed("0.0.0.0") is False
+    assert server_module.local_http_allowed("192.168.1.10") is False
+    # `localhost` is a NAME; /etc/hosts decides what it means, so the gate
+    # cannot verify it and must not accept it.
+    assert server_module.local_http_allowed("localhost") is False
+
+    # A public base URL is remote intent — a misconfigured remote deployment
+    # must never silently degrade into an unauthenticated server.
+    monkeypatch.setenv("EXOMEM_BASE_URL", "https://memory.example.test")
+    assert server_module.local_http_allowed("127.0.0.1") is False
+    monkeypatch.delenv("EXOMEM_BASE_URL", raising=False)
+
+    # Without the REST key there is no operator statement of local intent.
+    monkeypatch.delenv("EXOMEM_REST_API_KEY", raising=False)
+    assert server_module.local_http_allowed("127.0.0.1") is False
+    monkeypatch.setenv("EXOMEM_REST_API_KEY", "   ")
+    assert server_module.local_http_allowed("127.0.0.1") is False


### PR DESCRIPTION
Closes #482. **This relaxes an auth boundary — please review the gate specifically.**

## The gap

`EXOMEM_REST_API_KEY` is documented as the bearer key for a *personal* REST facade, README shows it as a `127.0.0.1` curl, and `exomem_retrieve_nudge` builds exactly that URL. But no HTTP transport would start without `EXOMEM_BASE_URL` plus a full GitHub OAuth app, so the local path was unreachable. A personal loopback facade shouldn't require a public OAuth application.

## The gate

HTTP skips OAuth when — and only when — **all three** hold:

1. bind host is literally `127.0.0.1` or `::1`;
2. `EXOMEM_BASE_URL` is unset;
3. `EXOMEM_REST_API_KEY` is set.

It fails closed on anything it can't verify. `localhost` is **rejected**: it's a name, and `/etc/hosts` decides what it means, so it isn't a property this gate can check. A set `EXOMEM_BASE_URL` always wins, so a misconfigured *remote* deployment can never silently degrade into an unauthenticated server.

### What is and isn't relaxed

- **`/api/*` is unaffected.** It has its own independent bearer check in `server_rest._rest_gate` that never depended on OAuth.
- **The MCP endpoints are what this opens**, to any local process. That's the boundary a local stdio server already has — though wider than a single-parent stdio pipe on a shared machine. So the mode logs a startup warning naming exactly what it did, and `env.example` documents it. It is never silent.

## A correction to the issue

#482 also argues that hook inject mode loses retrieval quality by falling back to the CLI ("injected routing stubs are lexical even when the install has a working vector lane"). **That isn't so.** Both rungs request `mode="keyword"` — `_fetch_via_rest` (line 337) as well as `_fetch_via_cli` (line 375) — deliberately, since the hook runs on every prompt submission under a 2s/5s timeout. Reaching REST would retrieve exactly the same thing. So nothing about the hook is changed here, and the quality argument shouldn't be used to justify this change; the "documented feature is unreachable" argument should.

## Verification

Unit: `tests/test_rest_registry.py` **38 passed**, including a gate test that asserts every non-local signal fails closed (`0.0.0.0`, a LAN address, `localhost`, a set base URL, an unset key, a whitespace-only key).

End-to-end on Linux (WSL), real server, real curl:

```
no REST key, loopback           -> exomem failed: EXOMEM_JWT_SIGNING_KEY is required   (still demands OAuth)
REST key, --host 0.0.0.0        -> exomem failed: EXOMEM_JWT_SIGNING_KEY is required   (still demands OAuth)
REST key, --host 127.0.0.1      -> Uvicorn running on http://127.0.0.1:8793            (starts)
  POST /api/ask_memory  correct key -> HTTP 200  {"success": true, "data": {"hits": [], ...}}
  POST /api/ask_memory  wrong key   -> HTTP 401
  POST /api/ask_memory  no key      -> HTTP 401
```

`validate-public-artifacts.py --repository`: clean.