### PR TITLE
fix(init): refresh the vault's shipped schema docs instead of freezing them

### DIFF
--- a/src/exomem/init.py
+++ b/src/exomem/init.py
@@ -33,6 +33,60 @@ _FOLDERS = (
     "Evidence",
 )
 
+#: Scaffold entries the PRODUCT owns: the governance contract the agent follows.
+#: `install-skill` redeploys its copy of these from this same source on every
+#: upgrade, but `init` is skipped once a Knowledge Base exists, so the vault
+#: copy stayed frozen at whatever version created the vault. The two then drift,
+#: and both are live — `product_invoke` resolves the vault copy while agents
+#: read the deployed one — which makes it a correctness problem, not clutter
+#: (#488).
+#:
+#: Everything NOT matched here is per-vault configuration the user owns
+#: (project-keys.yaml, relation-registry.yaml, semantic-language-registry.yaml,
+#: traversal-profiles.yaml) or their own content, and is never overwritten.
+_SHIPPED_SCHEMA_GLOBS = (
+    "_Schema/SKILL.md",
+    "_Schema/references/*.md",
+    "_Schema/workflow-skills/*/SKILL.md",
+)
+
+
+def shipped_schema_sources() -> list[Path]:
+    """Product-owned scaffold files, resolved from the bundled package."""
+    found: list[Path] = []
+    for pattern in _SHIPPED_SCHEMA_GLOBS:
+        found.extend(sorted(_SCAFFOLD.glob(pattern)))
+    return found
+
+
+def refresh_shipped_schema(vault_root: Path) -> list[str]:
+    """Re-deploy the product-owned governance docs into an existing vault.
+
+    Returns the vault-relative paths actually rewritten — empty when already
+    current, so a caller can say "nothing to do" honestly. Only files whose
+    bytes differ are touched, so this is a no-op on a current vault and never
+    churns mtimes for the file watcher.
+
+    Deliberately NOT `init_vault(force=True)`: that overlays the whole scaffold,
+    including the per-vault YAML registries the user is expected to edit.
+    """
+    vault_root = Path(vault_root)
+    kb = vault_root / kb_dirname()
+    if not kb.is_dir():
+        return []
+    refreshed: list[str] = []
+    for src in shipped_schema_sources():
+        dest = kb / src.relative_to(_SCAFFOLD)
+        try:
+            if dest.is_file() and dest.read_bytes() == src.read_bytes():
+                continue
+        except OSError:
+            pass
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        refreshed.append(dest.relative_to(vault_root).as_posix())
+    return refreshed
+
 
 def init_vault(vault_root: Path, *, force: bool = False) -> dict:
     """Create `<vault_root>/Knowledge Base/` with the starter scaffold.

--- a/src/exomem/setup_wizard.py
+++ b/src/exomem/setup_wizard.py
@@ -686,7 +686,23 @@ def run_setup(
         init_module.init_vault(vault_path)
         report("init", f"[done] {kb_prefix()} scaffold created")
     except FileExistsError:
-        report("init", f"[skipped: {kb_prefix()} already exists]")
+        # The vault already has a Knowledge Base, so init is skipped — but the
+        # governance docs inside it are product-owned and were last written by
+        # whatever version created the vault, while `install-skill` below
+        # redeploys its copy on every run. Left alone the two drift, and both
+        # stay live. Only the shipped docs refresh; the per-vault YAML
+        # registries the user edits are untouched.
+        try:
+            refreshed = init_module.refresh_shipped_schema(vault_path)
+        except OSError as exc:
+            report("init", f"[skipped: {kb_prefix()} already exists] (refresh failed: {exc})")
+        else:
+            suffix = (
+                f"; refreshed {len(refreshed)} shipped schema file(s)"
+                if refreshed
+                else "; shipped schema already current"
+            )
+            report("init", f"[skipped: {kb_prefix()} already exists]{suffix}")
 
     # 3b. packs — product guidance for fresh vaults and suggested routes for existing vaults
     try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -159,3 +159,78 @@ def test_init_vault_accepts_writes_and_stays_clean(
     assert "## [2026-05-31] add" in (kb / "log.md").read_text(encoding="utf-8")
     report = audit_module.audit(tmp_path, categories=["broken_wikilink", "index_drift"])
     assert not report.findings, [f.as_dict() for f in report.findings]
+
+
+# --- #488: the vault copy of the shipped contract must not freeze ------------
+
+
+def _shipped(kb: Path) -> Path:
+    return kb / "_Schema" / "SKILL.md"
+
+
+def test_refresh_rewrites_a_stale_shipped_doc(tmp_path: Path) -> None:
+    """install-skill redeploys its copy every upgrade; init is skipped once the
+    KB exists, so the vault copy froze at the version that created it. Both are
+    live — product_invoke resolves the vault copy, agents read the deployed one."""
+    from exomem import init as init_module
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    init_module.init_vault(vault)
+    kb = vault / "Knowledge Base"
+    _shipped(kb).write_text("stale contract from an older release\n", encoding="utf-8")
+
+    refreshed = init_module.refresh_shipped_schema(vault)
+
+    assert "Knowledge Base/_Schema/SKILL.md" in refreshed
+    packaged = (Path(init_module.__file__).parent / "_scaffold" / "_Schema" / "SKILL.md")
+    assert _shipped(kb).read_bytes() == packaged.read_bytes()
+
+
+def test_refresh_is_a_no_op_when_already_current(tmp_path: Path) -> None:
+    """No churn on a current vault — the file watcher sees no spurious mtimes."""
+    from exomem import init as init_module
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    init_module.init_vault(vault)
+
+    assert init_module.refresh_shipped_schema(vault) == []
+
+
+def test_refresh_never_touches_per_vault_configuration(tmp_path: Path) -> None:
+    """project-keys.yaml and the registries are the user's to edit, not ours.
+
+    This is the line between the two halves of _Schema: shipped governance docs
+    are product-owned, the YAML registries are per-vault configuration.
+    """
+    from exomem import init as init_module
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    init_module.init_vault(vault)
+    kb = vault / "Knowledge Base"
+
+    user_edits = {
+        "project-keys.yaml": "my-own-project: Notes/Research/Mine\n",
+        "relation-registry.yaml": "# my registry\n",
+        "semantic-language-registry.yaml": "# my language\n",
+        "traversal-profiles.yaml": "# my profiles\n",
+    }
+    for name, body in user_edits.items():
+        (kb / "_Schema" / name).write_text(body, encoding="utf-8")
+    _shipped(kb).write_text("stale\n", encoding="utf-8")
+
+    init_module.refresh_shipped_schema(vault)
+
+    for name, body in user_edits.items():
+        assert (kb / "_Schema" / name).read_text(encoding="utf-8") == body
+
+
+def test_refresh_on_a_vault_without_a_knowledge_base_is_inert(tmp_path: Path) -> None:
+    from exomem import init as init_module
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    assert init_module.refresh_shipped_schema(vault) == []


### PR DESCRIPTION
Addresses the **correctness half** of #488. The namespace half is left open deliberately — see below.

## The drift, and its real mechanism

#488 reports that `Knowledge Base/_Schema/` and `~/.claude/skills/exomem/` have drifted, and infers two sources of truth. **There is only one**: `init.py` and `install_skill.py` both read `src/exomem/_scaffold/`.

The actual mechanism is staleness. `install-skill` redeploys its copy on every run; `init` is skipped once a Knowledge Base exists, so the *vault* copy stays frozen at whatever version created the vault. After any upgrade the two disagree — and both are live, since `product_invoke` resolves the vault copy while agents read the deployed one. Two live copies of one governance contract is the correctness problem.

`setup` now refreshes exactly the product-owned files when a KB already exists. Only differing bytes are written, so a current vault is untouched and the watcher sees no spurious mtimes.

## The line drawn inside `_Schema/`

- **Product-owned, refreshed**: `SKILL.md`, `references/*.md`, `workflow-skills/*/SKILL.md`.
- **User-owned, never touched**: `project-keys.yaml`, `relation-registry.yaml`, `semantic-language-registry.yaml`, `traversal-profiles.yaml`.

This is why it is not `init_vault(force=True)` — that overlays the whole scaffold including the YAML the user is expected to edit. A test asserts a refresh leaves all four untouched.

## What I deliberately did not do, and why

#488 also asks that the shipped markdown stop living in the user's note namespace. I scoped that and it is **much** larger than the issue describes. `_Schema/SKILL.md` is:

- the vault marker — `vault._is_vault()` is literally `(path / kb / "_Schema" / "SKILL.md").exists()`;
- a hosted **cell validity gate** — `hosted_runtime._valid_vault_scaffold`;
- a hosted **portability archive requirement** — `hosted_portability._verify_required_scaffold`;
- an **agent-facing path** — `bootstrap()` advertises `Knowledge Base/_Schema/workflow-skills/<name>/SKILL.md` via `workflow_skills.bootstrap_entries()`;
- plus two doctor checks, across 68 `_Schema` references.

`_Schema/` is also not just docs: it holds `relation-reviews/` runtime state, `contracts/`, the activation manifest and `private-skills/`. Relocating the markdown is a cross-plane change reaching into the hosted product, with a migration for every existing vault. That deserves its own arc rather than being appended here, so #488 stays open for it and this PR is `Refs`, not `Fixes`.

Two corrections for whoever picks that up: `_Schema` is **not** "the only non-dot member" of `VAULT_SCAN_SKIP_DIRS` (`_attachments`, `_archive`, `_trash`, `_Governance`, `_Adoption` are too), and there is no second source of truth in the repo.

## Verification

`tests/test_init.py` + `tests/test_setup_wizard.py` + `tests/test_scaffold_no_leak.py`: **52 passed**.

End-to-end against the real `install_skill`, simulating an upgrade:

```
BEFORE refresh: vault == deployed ? False (vault 22B, deployed 75715B)
AFTER  refresh: vault == deployed ? True  (1 file(s) rewritten)
references differing after refresh: none
```

Four new tests: a stale doc is rewritten to match the package; a current vault is a no-op (empty list); all four YAML registries survive a refresh with user edits intact; a vault with no Knowledge Base is inert.

`validate-public-artifacts.py --repository`: clean.