### PR TITLE
test(checkpoint): drop wall-clock asserts from the directory-window cursor tests

### DIFF
--- a/tests/test_continuation_checkpoint.py
+++ b/tests/test_continuation_checkpoint.py
@@ -2902,16 +2902,17 @@ def test_directory_window_cursor_is_bounded_and_eventually_visits_every_entry(
 
     with checkpoint._open_secure_directory(root_path, create=False) as root:
         for _ in range(40):
-            started = time.monotonic()
             names, cursor, exhausted, inspected = checkpoint._directory_window(
                 root,
                 cursor=cursor,
                 limit=checkpoint.MAX_PRUNE_ENUM_ENTRIES,
                 deadline=time.monotonic() + checkpoint.MAX_PRUNE_LOCK_SECONDS,
             )
-            elapsed = time.monotonic() - started
+            # `inspected` is the bound this test is named for: the window
+            # enumerates at most MAX_PRUNE_ENUM_ENTRIES per call whatever the
+            # deadline does. The wall-clock assertion that used to sit here
+            # measured the runner instead — see the portable variant below.
             assert inspected <= checkpoint.MAX_PRUNE_ENUM_ENTRIES
-            assert elapsed < checkpoint.MAX_PRUNE_LOCK_SECONDS + 0.05
             seen.update(names)
             if exhausted:
                 break
@@ -2934,7 +2935,6 @@ def test_portable_directory_window_cursor_never_replays_a_growing_prefix(
 
     with checkpoint._open_secure_directory(root_path, create=False) as root:
         for _ in range(40):
-            started = time.monotonic()
             names, cursor, exhausted, inspected = checkpoint._directory_window(
                 root,
                 cursor=cursor,
@@ -2943,8 +2943,17 @@ def test_portable_directory_window_cursor_never_replays_a_growing_prefix(
                 force_portable=True,
             )
             inspected_windows.append(inspected)
+            # Cursor semantics, not timing. The former
+            # `elapsed < MAX_PRUNE_LOCK_SECONDS + 0.05` here was a 50 ms
+            # tolerance on a 50 ms budget, asserted 40 times: on a contended
+            # shared runner one iteration took 326 ms and failed CI on a PR that
+            # touches neither this file nor the prune path. Budget enforcement is
+            # covered on its own by
+            # `test_prune_respects_total_budget_when_root_lock_is_held`, which is
+            # the same reasoning
+            # `test_many_busy_prune_candidates_do_not_starve_supported_writer`
+            # already records for widening its budget.
             assert inspected <= checkpoint.MAX_PRUNE_ENUM_ENTRIES
-            assert time.monotonic() - started < checkpoint.MAX_PRUNE_LOCK_SECONDS + 0.05
             seen.update(names)
             if exhausted:
                 break


### PR DESCRIPTION
Unblocks **PR #497**. Test-only — no product change. `Refs #284`.

## What happened

PR #497 (relation disposition, `semantic_contract.py` + `graph_sync.py`) failed `tests (py3.11, shard 1/4)`:

```
>  assert time.monotonic() - started < checkpoint.MAX_PRUNE_LOCK_SECONDS + 0.05
E  assert (133.064830631 - 132.739068516) < (0.05 + 0.05)
FAILED tests/test_continuation_checkpoint.py::test_portable_directory_window_cursor_never_replays_a_growing_prefix
```

**#497 touches neither this file nor the prune path** — `git diff --stat origin/main...HEAD -- src/exomem/_hooks/ tests/test_continuation_checkpoint.py` is empty. This is #284's pattern exactly: a load-sensitive assertion presenting as a red required check on an unrelated PR, which either blocks the merge or teaches people to merge through red.

I hardened two tests in this family in #498 but missed these two — they fail in the opposite direction. #498's were "the work didn't finish in one sweep"; these are "the call took too long".

## The fix

Both tests assert `elapsed < MAX_PRUNE_LOCK_SECONDS + 0.05` on **every iteration of a 40-iteration loop** — a 50 ms tolerance on a 50 ms budget, on a shared runner. One iteration took 326 ms.

These tests are named for *cursor semantics* — the window never replays a growing prefix, and eventually visits every entry — and they still assert exactly that, plus `inspected <= MAX_PRUNE_ENUM_ENTRIES`, which is the real bound under test and a property of the **code** rather than of the machine. The wall-clock line measured the runner.

Budget enforcement keeps its own dedicated cover in `test_prune_respects_total_budget_when_root_lock_is_held`, **left untouched**. That is the same reasoning `test_many_busy_prune_candidates_do_not_starve_supported_writer` already records in this file for widening its own budget:

> *Budget enforcement is covered by test_prune_respects_total_budget_when_root_lock_is_held; widening it here leaves contention as the only thing under test.*

## Verification, and its honest limit

Full `tests/test_continuation_checkpoint.py` on Linux (WSL, real ext4, uv 0.11.28): **167 passed, 1 skipped**.

I could **not** reproduce the flake locally — 12 runs of both tests under saturating 16-core load failed **0/12 on baseline and 0/12 with the fix**. A 16-core box simply isn't as contended as a shared GitHub runner, which is the same limitation I hit on #284.

So the argument for this isn't a measured improvement; it's that the assertion was testing the wrong thing. The CI failure above is the evidence that it's load-sensitive, and the properties the tests exist to prove are all still asserted.

## After merge

Update PR #497's branch and it should go green.