### PR TITLE
fix(mutation): show the warnings behind warnings_count in compact responses

### DIFF
--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -202,7 +202,13 @@ Agent behavior:
 
 Successful product mutations now return a compact decisive terminal by default:
 `ok`, `status="committed"`, `mutated`, `path` or `paths`, `request_id`,
-`receipt_id`, and `warnings_count`. Use `response_detail="full"` when an agent
+`receipt_id`, and `warnings_count`. When the write actually warned, the texts
+come back as `warnings` — at most 8 entries of at most 300 characters each.
+`warnings_count` stays authoritative, so fewer entries than the count means the
+rest were trimmed. Two cases return a count with no `warnings`: an upload
+receipt, whose warnings are already per-file rows under `files`, and a mutation
+recovered from a portable receipt, which deliberately retains no leaf content.
+Use `response_detail="full"` when an agent
 needs the previous leaf diagnostics nested under `diagnostics`.
 `response_detail="legacy"` returns the old raw result for temporary
 compatibility. Detail is presentation-only and does not change replay identity.

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exomem",
   "description": "Governed long-term memory over a markdown vault: raw sources stay immutable, conclusions are compiled with provenance, and nothing is deleted - it is superseded. Requires EXOMEM_VAULT_PATH to point at your vault; run `exomem setup` if you do not have one yet.",
-  "version": "0.48.0",
+  "version": "0.51.0",
   "author": {
     "name": "Substrate Systems O\u00dc",
     "url": "https://substratesystems.io"

--- a/plugins/claude-code/skills/exomem/SKILL.md
+++ b/plugins/claude-code/skills/exomem/SKILL.md
@@ -360,6 +360,12 @@ Successful product mutations return a compact decisive terminal by default:
 `request_id`, `receipt_id`, and `warnings_count` (plus a caller-supplied
 `idempotency_key` when the surface supports one). A null receipt means that the
 surface supplied no replay identity; it does not weaken the committed status.
+When the write warned, `warnings` carries the texts — at most 8 entries of at
+most 300 characters. `warnings_count` remains authoritative, so fewer entries
+than the count means the rest were trimmed; ask for `response_detail="full"` to
+see them all. An upload receipt reports its warnings as per-file rows under
+`files` instead, and a mutation recovered from a portable receipt reports the
+count alone because it retains no leaf content.
 Use `response_detail="full"` when existing leaf diagnostics are needed under
 `diagnostics`. Use `response_detail="legacy"` only for temporary compatibility
 with the former raw result. Response detail is presentation-only: changing it

--- a/plugins/claude-code/skills/exomem/references/operations.md
+++ b/plugins/claude-code/skills/exomem/references/operations.md
@@ -138,7 +138,12 @@ arbitrary page.
 Product mutations default to a compact committed terminal containing `ok`,
 `status`, `mutated`, `path` or `paths`, `request_id`, `receipt_id`, and
 `warnings_count`; a supported caller-supplied idempotency key is echoed as
-`idempotency_key`. `response_detail="full"` adds the existing leaf result under
+`idempotency_key`. A write that warned also returns `warnings`, bounded to 8
+entries of 300 characters each; `warnings_count` stays authoritative, so a
+shorter list means the remainder was trimmed. Upload receipts carry their
+warnings as per-file rows under `files`, and a terminal rebuilt from a portable
+receipt reports only the count, since that receipt retains no leaf content.
+`response_detail="full"` adds the existing leaf result under
 `diagnostics`. `response_detail="legacy"` returns that old raw leaf result and
 is retained for at least one compatibility release. The response-detail choice
 is removed before mutation identity is calculated, so it cannot create a second

--- a/scripts/records_live_acceptance.py
+++ b/scripts/records_live_acceptance.py
@@ -50,6 +50,9 @@ _COMPACT_MUTATION_OPTIONAL = frozenset(
         "graph_sync_code",
         "graph_sync_checkpoint",
         "graph_sync_remediation",
+        # Present only when the leaf actually warned; absent on receipt recovery,
+        # which reports a count with no retained texts.
+        "warnings",
     }
 )
 _COMPACT_V1_RECEIPT = frozenset(

--- a/src/exomem/_scaffold/_Schema/SKILL.md
+++ b/src/exomem/_scaffold/_Schema/SKILL.md
@@ -360,6 +360,12 @@ Successful product mutations return a compact decisive terminal by default:
 `request_id`, `receipt_id`, and `warnings_count` (plus a caller-supplied
 `idempotency_key` when the surface supports one). A null receipt means that the
 surface supplied no replay identity; it does not weaken the committed status.
+When the write warned, `warnings` carries the texts — at most 8 entries of at
+most 300 characters. `warnings_count` remains authoritative, so fewer entries
+than the count means the rest were trimmed; ask for `response_detail="full"` to
+see them all. An upload receipt reports its warnings as per-file rows under
+`files` instead, and a mutation recovered from a portable receipt reports the
+count alone because it retains no leaf content.
 Use `response_detail="full"` when existing leaf diagnostics are needed under
 `diagnostics`. Use `response_detail="legacy"` only for temporary compatibility
 with the former raw result. Response detail is presentation-only: changing it

--- a/src/exomem/_scaffold/_Schema/references/operations.md
+++ b/src/exomem/_scaffold/_Schema/references/operations.md
@@ -138,7 +138,12 @@ arbitrary page.
 Product mutations default to a compact committed terminal containing `ok`,
 `status`, `mutated`, `path` or `paths`, `request_id`, `receipt_id`, and
 `warnings_count`; a supported caller-supplied idempotency key is echoed as
-`idempotency_key`. `response_detail="full"` adds the existing leaf result under
+`idempotency_key`. A write that warned also returns `warnings`, bounded to 8
+entries of 300 characters each; `warnings_count` stays authoritative, so a
+shorter list means the remainder was trimmed. Upload receipts carry their
+warnings as per-file rows under `files`, and a terminal rebuilt from a portable
+receipt reports only the count, since that receipt retains no leaf content.
+`response_detail="full"` adds the existing leaf result under
 `diagnostics`. `response_detail="legacy"` returns that old raw leaf result and
 is retained for at least one compatibility release. The response-detail choice
 is removed before mutation identity is calculated, so it cannot create a second

--- a/src/exomem/mutation_terminal.py
+++ b/src/exomem/mutation_terminal.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
 ResponseDetail = Literal["compact", "full", "legacy"]
@@ -72,6 +72,13 @@ _ENVELOPE_KEYS = (
     "receipt_id",
 )
 
+#: Bounds on the free-text `warnings` compact carries beside `warnings_count`.
+#: Same shape the client-artifact rows already use (see `_artifact_receipt_projection`),
+#: because compact otherwise carries no unbounded strings at all and a bulk
+#: `delete_directory` emits one warning per path.
+_MAX_WARNINGS = 8
+_MAX_WARNING_CHARS = 300
+
 
 def _operation_id(result: Any) -> str | None:
     """Correlate a validate call with its later commit.
@@ -124,6 +131,45 @@ def _warning_count(result: Any) -> int:
             return len(source_warnings)
         return 1 if source_warnings else 0
     return 0
+
+
+def _warning_texts(result: Any, *, has_artifact_receipt: bool) -> list[str]:
+    """The warnings behind ``warnings_count``, bounded for the compact envelope.
+
+    A bare count is not actionable: the caller learns something was wrong but
+    not what, and the texts were only reachable by re-issuing the whole call
+    with ``detail="full"``.
+
+    Follows ``_warning_count``'s source order exactly so the list and the count
+    always describe the same warnings. Artifact receipts are skipped because
+    ``_artifact_receipt_projection`` already puts their per-file warnings in the
+    compact ``files`` rows; repeating them here would show each one twice.
+
+    Bounded deliberately. These are the only free-text strings compact carries,
+    and ``delete_directory``/``adopt`` emit one per path. ``warnings_count``
+    stays authoritative, so a caller seeing fewer entries than the count knows
+    the remainder was dropped and can ask for ``detail="full"``.
+    """
+    if not isinstance(result, Mapping) or has_artifact_receipt:
+        return []
+    warnings = result.get("warnings")
+    if isinstance(warnings, (list, tuple)):
+        candidates: Sequence[Any] = warnings
+    elif warnings:
+        candidates = [warnings]
+    else:
+        source = result.get("source")
+        source_warnings = source.get("warnings") if isinstance(source, Mapping) else None
+        if isinstance(source_warnings, (list, tuple)):
+            candidates = source_warnings
+        elif source_warnings:
+            candidates = [source_warnings]
+        else:
+            return []
+    return [
+        (warning if isinstance(warning, str) else str(warning))[:_MAX_WARNING_CHARS]
+        for warning in candidates[:_MAX_WARNINGS]
+    ]
 
 
 def _path_projection(result: Any) -> dict[str, Any]:
@@ -446,7 +492,8 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         compact.update({key: leaf[key] for key in _RECORD_RECEIPT_FIELDS if key in leaf})
     elif valid_planning_receipt(leaf):
         compact.update({key: leaf[key] for key in _PLAN_RECEIPT_FIELDS if key in leaf})
-    compact.update(_artifact_receipt_projection(leaf))
+    artifact_receipt = _artifact_receipt_projection(leaf)
+    compact.update(artifact_receipt)
     graph_result = result if result.get("graph_sync") in {"completed", "failed"} else leaf
     if isinstance(graph_result, Mapping) and graph_result.get("graph_sync") in {"completed", "failed"}:
         compact["graph_sync"] = graph_result["graph_sync"]
@@ -487,6 +534,13 @@ def project_terminal(result: Any, detail: ResponseDetail = "compact") -> Any:
         if isinstance(warning, str) and 0 < len(warning) <= 128:
             compact["graph_rebuild_warning"] = warning
     compact["warnings_count"] = result["warnings_count"]
+    # Projected from the leaf, never from the receipt. Receipt recovery replaces
+    # `leaf_result` with `{}` on purpose (the portable receipt must not retain
+    # leaf paths or content) while `warnings_count` survives in the receipt
+    # fields, so that path keeps reporting a count with no texts — by design.
+    warnings = _warning_texts(leaf, has_artifact_receipt=bool(artifact_receipt))
+    if warnings:
+        compact["warnings"] = warnings
     if detail == "full":
         compact["diagnostics"] = leaf
     return compact

--- a/tests/test_mutation_terminal.py
+++ b/tests/test_mutation_terminal.py
@@ -40,7 +40,78 @@ def test_compact_projection_leads_with_decisive_commit_fields() -> None:
         "receipt_id": "receipt-1",
         "idempotency_key": "public-key",
         "warnings_count": 1,
+        "warnings": ["review a link"],
     }
+
+
+def test_compact_warnings_are_bounded_in_count_and_length() -> None:
+    """`warnings_count` stays authoritative when the texts are trimmed.
+
+    A bulk `delete_directory` or `adopt` emits one warning per path, so this is
+    the only unbounded free text compact could carry. The count tells a caller
+    that entries were dropped; `detail="full"` returns the rest.
+    """
+    mutation_terminal = _terminal_module()
+    terminal = mutation_terminal.committed_terminal(
+        {"warnings": [f"warning {index} " + "x" * 400 for index in range(12)]},
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    compact = mutation_terminal.project_terminal(terminal, "compact")
+
+    assert compact["warnings_count"] == 12
+    assert len(compact["warnings"]) == 8
+    assert all(len(warning) <= 300 for warning in compact["warnings"])
+    assert compact["warnings"][0].startswith("warning 0 ")
+
+
+def test_compact_omits_warnings_when_the_leaf_did_not_warn() -> None:
+    mutation_terminal = _terminal_module()
+    terminal = mutation_terminal.committed_terminal(
+        {"path": "Knowledge Base/Notes/quiet.md"},
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    compact = mutation_terminal.project_terminal(terminal, "compact")
+
+    assert compact["warnings_count"] == 0
+    assert "warnings" not in compact
+
+
+def test_compact_does_not_repeat_artifact_receipt_warnings_at_the_top_level() -> None:
+    """Artifact warnings are already per-file rows; listing them twice is noise."""
+    mutation_terminal = _terminal_module()
+    terminal = mutation_terminal.committed_terminal(
+        {
+            "files": [
+                {
+                    "file_id": "f1",
+                    "outcome": "stored",
+                    "stored_path": "Knowledge Base/_attachments/a.pdf",
+                    "size": 10,
+                    "hash": "a" * 64,
+                    "hash_algorithm": "sha256",
+                    "content_type": "application/pdf",
+                    "media_id": None,
+                    "warnings": ["text layer missing"],
+                }
+            ],
+            "summary": {"stored": 1, "failed": 0},
+        },
+        request_id="11111111-1111-4111-8111-111111111111",
+        receipt_id=None,
+        idempotency_key=None,
+    )
+
+    compact = mutation_terminal.project_terminal(terminal, "compact")
+
+    assert compact["warnings_count"] == 1
+    assert compact["files"][0]["warnings"] == ["text layer missing"]
+    assert "warnings" not in compact
 
 
 def test_compact_terminal_retains_completed_graph_sync_fields() -> None:


### PR DESCRIPTION
Closes #486.

## The residual

#486's core was fixed by #472 — `graph_sync` takes a real cross-process OS lock, so concurrent stdio writers on one vault are serialised, and `doctor` reports concurrent processes via `runtime.processes`. #497 retired the last "run reconcile" remediations, which named nothing runnable.

What was left is what the issue actually shows you: a compact terminal that says `warnings_count: 2` and gives you no way to read the two warnings. They existed, but only via a second call with `response_detail="full"` — a round trip to read something the first response already had in hand.

## The change

`project_terminal` emits `warnings` beside the count when the leaf warned. `_warning_texts` follows `_warning_count`'s source order exactly, so the list and the count cannot describe different warnings.

**Bounded in the same change**, not deferred: 8 entries of 300 characters, reusing the shape the client-artifact rows at `_artifact_receipt_projection` already use. This is the first genuinely unbounded string field compact would carry — a bulk `delete_directory` or `adopt` emits one warning per path. `warnings_count` stays authoritative, so a shorter list is self-describing.

## The part worth reviewing

Two paths deliberately still report a count with no texts, and both are load-bearing:

**Artifact receipts.** Their warnings are already per-file rows under `files`. Emitting them again at the top level would show each one twice, and `_warning_count` counts them from the same place — so the skip keeps the two consistent.

**Receipt recovery.** `writer_lease` replaces `leaf_result` with `{}` on purpose, because a portable receipt must not retain leaf paths or content, while `warnings_count` survives via `_RECEIPT_TERMINAL_FIELDS`. Projecting `warnings` **from the leaf and never from the receipt** is what keeps that boundary intact — `test_receipt_recovery_preserves_public_terminal_schemas_without_leaf_leakage`, which asserts `"private warning" not in json.dumps(full)`, stays green **unmodified**. `warnings` is deliberately *not* added to `_RECEIPT_TERMINAL_FIELDS`; that would sync user content into a portable receipt, which `receipt_leaf_projection` exists to prevent.

## No connector re-attestation

`warnings` is a *response* key. The pinned digest fingerprints the discovery surface — `name`, `title`, `description`, `inputSchema`, `outputSchema`, `icons`, `annotations`, `meta`, `execution` — and `warnings_count` appears zero times in `tests/fixtures/mcp_tool_schemas.json`. No docstring and no `inputSchema` changed, so `test_mcp_schema_fidelity` and `test_connector_guardrails` pass with no regeneration. That was a constraint on the change rather than a happy accident: it keeps this out of the post-deploy Personal Plugin refresh path.

`scripts/records_live_acceptance.py` enforces a *closed* compact key set, so `warnings` is added to `_COMPACT_MUTATION_OPTIONAL` — otherwise live acceptance rejects the new key.

## Verification

| Suite | Baseline (same commit) | This branch | New |
|---|---|---|---|
| test_mutation_terminal + test_mutation_state_machine + test_client_artifacts + test_graph_idempotency_handoff | 11 failed | 11 failed | **0** |

All 11 are pre-existing `WindowsRuntimeDaclError` failures on native Windows, identical on both sides. Linux CI is the authoritative gate.

`test_mcp_schema_fidelity`, `test_connector_guardrails`, `test_plugin_sync`, `test_scaffold_no_leak`: 37 passed. `uvx ruff check . --select F`: clean.

Four new tests: warnings surface in compact; bounded to 8×300 with the count still authoritative; omitted entirely when nothing warned; not duplicated for artifact receipts.

Docs updated in `docs/ai-assistant-guide.md` and the `_Schema` scaffold, with the plugin mirror regenerated via `exomem package-skills` (which also brings `plugin.json` from its stale `0.48.0` to `0.51.0`).