### PR TITLE
feat(hosted): add the reviewer bootstrap driver and promotion-evidence harness

### DIFF
--- a/scripts/promotion_evidence.py
+++ b/scripts/promotion_evidence.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Observe, sign and import promotion evidence for a hosted cohort candidate.
+
+`scripts/sign-directory-evidence.py` is a different tool: it signs marketplace
+*directory* evidence. This one produces the record `validatePromotionEvidence`
+accepts, which is what `import-artifact` and then `promote-cohort` consume.
+
+Like that script, this deliberately does not invent the facts it signs. The
+seven operation flags describe a real client session and are read from a results
+file the operator writes after running it; the six counts are queried from the
+control plane and the run aborts unless each is exactly 1. A harness that
+defaulted those to true/1 would turn the signed-evidence chain into decoration.
+
+Everything here is timing-critical for the FIRST promotion only. The bootstrap
+authority is capped server-side at 30 minutes, the rollout assignment inherits
+that expiry, and `storeClientArtifact` requires the assignment still be active --
+so observe, sign, both imports and promote all have to land inside it. Rehearse
+against an existing tenant before opening a window.
+
+    observe  --platform claude --results results-claude.json
+    sign     --platform claude
+    import   --platform claude
+    promote
+
+Subsequent promotions do not need this urgency: once a cohort is live a real
+client authorizes through the cohort branch, and an ordinary assignment may live
+up to 7 days.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+TEST_IDENTITY = "hosted-client-plugins-v1"
+
+OPERATIONS = (
+    "native_install",
+    "authorization",
+    "tool_discovery",
+    "content_recall",
+    "citation",
+    "durable_capture",
+    "fresh_chat_recall",
+)
+
+COUNTS = (
+    "identity_count",
+    "tenant_count",
+    "entitlement_count",
+    "operation_count",
+    "cell_count",
+    "volume_count",
+)
+
+# Mirrors evidenceStrings in substrate client-artifacts.ts. Kept explicit so a
+# drift shows up here as a field-set error rather than as an opaque 400 from
+# import-artifact at the end of a spent window.
+STRINGS = (
+    "client_version",
+    "clean_client_identity_hmac_sha256",
+    "timestamp",
+    "paired_run_hmac_sha256",
+    "test_identity",
+    "exomem_identity_hmac_sha256",
+    "tenant_hmac_sha256",
+    "entitlement_hmac_sha256",
+    "provisioning_operation_hmac_sha256",
+    "cell_hmac_sha256",
+    "result_sha256",
+    "package_artifact_sha256",
+    "archive_sha256",
+    "compatibility_sha256",
+    "schema_contract_sha256",
+    "command_surface_sha256",
+    "endpoint",
+    "plugin_version",
+    "profile",
+    "operator_key_id",
+    "operator_signature",
+    "oauth_client_config_sha256",
+    "contract_candidate_id",
+    "staged_client_release_id",
+    "assignment_id",
+    "assignment_generation",
+)
+
+
+def canonical(value: object) -> str:
+    """Byte-identical to substrate's canonical(): recursive key sort, compact."""
+    if isinstance(value, bool) or value is None or isinstance(value, (int, float)):
+        return json.dumps(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, list):
+        return "[" + ",".join(canonical(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return (
+            "{"
+            + ",".join(
+                f"{json.dumps(key, ensure_ascii=False)}:{canonical(value[key])}"
+                for key in sorted(value)
+            )
+            + "}"
+        )
+    raise TypeError(f"cannot canonicalise {type(value)!r}")
+
+
+def query(url: str, sql: str) -> list[str]:
+    result = subprocess.run(
+        ["psql", url, "-X", "-A", "-t", "-F", "\x1f", "-c", sql],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"query failed: {result.stderr.strip()[:400]}")
+    return [line for line in result.stdout.strip().split("\n") if line]
+
+
+def one(url: str, sql: str) -> str:
+    rows = query(url, sql)
+    if len(rows) != 1:
+        raise SystemExit(f"expected exactly one row, got {len(rows)}: {sql[:120]}")
+    return rows[0]
+
+
+def attest(secret: str, label: str, *parts: str) -> str:
+    """Privacy-safe attestation over real identifiers.
+
+    The server format-checks these as 64 hex and binds them via operator_signature;
+    it never recomputes them. They exist so an artifact references a real tenant,
+    cell and run without persisting the raw identifiers, so they must be derived
+    from observed values rather than invented.
+    """
+    message = "\0".join((label, *parts)).encode()
+    return hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+
+
+def load_locks(repo: Path, platform: str) -> dict:
+    generated = repo / "plugins" / "hosted" / "generated"
+    package = json.loads((generated / f"{platform}.lock.json").read_text())
+    archive = json.loads((generated / f"{platform}.zip.lock.json").read_text())
+    return {"package": package, "archive": archive}
+
+
+def observe(args: argparse.Namespace) -> int:
+    state = args.state_dir
+    secret = os.environ["EXOMEM_HOSTED_PROMOTION_SECRET"]
+    key_id = os.environ["EXOMEM_HOSTED_PROMOTION_KEY_ID"]
+    substrate = os.environ["SUBSTRATE_DATABASE_URL"]
+    provisioner = os.environ["PROVISIONER_DATABASE_URL"]
+
+    context = json.loads((state / "bootstrap-context.json").read_text())
+    outcome = json.loads((state / args.outcome).read_text())
+    tenant = outcome["tenantId"]
+    assignment_id = outcome["assignmentId"]
+    generation = int(outcome["generation"])
+
+    if args.rehearse:
+        # Exercises every query and gate, then refuses to emit. Rehearsal must not
+        # be able to produce a signable record, or the dry run becomes a way to
+        # manufacture evidence for a client session that never happened.
+        results = dict.fromkeys(OPERATIONS, True)
+    else:
+        results = json.loads(Path(args.results).read_text())
+        missing = [name for name in OPERATIONS if name not in results]
+        if missing:
+            raise SystemExit(f"results file is missing observed operations: {missing}")
+        failed = [name for name in OPERATIONS if results[name] is not True]
+        if failed:
+            raise SystemExit(
+                "these operations were not observed to succeed, so there is nothing "
+                f"truthful to sign: {failed}"
+            )
+
+    owner = one(substrate, f"select owner_user_id from exomem_tenants where id='{tenant}'")
+    cell_id = one(
+        substrate,
+        f"select id from exomem_cells where tenant_id='{tenant}' and lifecycle_state<>'deleted'",
+    )
+    entitlement = one(substrate, f"select id from exomem_entitlements where tenant_id='{tenant}'")
+    operation = one(
+        substrate,
+        "select id from exomem_lifecycle_operations where tenant_id='"
+        f"{tenant}' and operation_type='provision' and state='succeeded'",
+    )
+
+    counts = {
+        "identity_count": int(
+            one(substrate, f"select count(*) from users where id='{owner}'")
+        ),
+        "tenant_count": int(
+            one(
+                substrate,
+                f"select count(*) from exomem_tenants where owner_user_id='{owner}' and deleted_at is null",
+            )
+        ),
+        "entitlement_count": int(
+            one(substrate, f"select count(*) from exomem_entitlements where tenant_id='{tenant}'")
+        ),
+        "operation_count": int(
+            one(
+                substrate,
+                "select count(*) from exomem_lifecycle_operations where tenant_id='"
+                f"{tenant}' and operation_type='provision' and state='succeeded'",
+            )
+        ),
+        "cell_count": int(
+            one(
+                substrate,
+                f"select count(*) from exomem_cells where tenant_id='{tenant}' and lifecycle_state<>'deleted'",
+            )
+        ),
+        "volume_count": int(
+            one(
+                provisioner,
+                f"select count(*) from exomem_provisioner.resources where tenant_id='{tenant}' and kind='VOLUME'",
+            )
+        ),
+    }
+    wrong = {name: value for name, value in counts.items() if value != 1}
+    if wrong:
+        raise SystemExit(
+            "promotion requires exactly one of each; a clean client run that "
+            f"produced anything else is not admissible: {wrong}"
+        )
+
+    # Must be the PLATFORM SIBLING stage, never the bootstrap stage. The artifact's
+    # oauth_client_config_sha256 is read from this row and has to match the sibling
+    # client that actually ran the session; the bootstrap stage carries the throwaway
+    # loopback client's digest and fails the stage match at import.
+    stage_id = args.stage_id
+    if not stage_id:
+        raise SystemExit(
+            "--stage-id is required: pass the sibling stage for this platform, "
+            "not the bootstrap stage from bootstrap-context.json"
+        )
+    config_sha = one(
+        substrate,
+        f"select oauth_client_config_sha256 from exomem_staged_client_releases where id='{stage_id}'",
+    )
+    locks = load_locks(args.repo, args.platform)
+    package, archive = locks["package"], locks["archive"]
+    now = datetime.now(UTC)
+
+    unsigned: dict = {
+        "schema_version": 1,
+        "platform": args.platform,
+        "client_version": args.client_version,
+        "clean_client_identity_hmac_sha256": attest(
+            secret, "clean-client", args.platform, args.client_version, tenant
+        ),
+        "timestamp": now.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        "paired_run_hmac_sha256": attest(secret, "paired-run", tenant, assignment_id, str(generation)),
+        "test_identity": TEST_IDENTITY,
+        "exomem_identity_hmac_sha256": attest(secret, "exomem-identity", owner),
+        "tenant_hmac_sha256": attest(secret, "tenant", tenant),
+        "entitlement_hmac_sha256": attest(secret, "entitlement", entitlement),
+        "provisioning_operation_hmac_sha256": attest(secret, "operation", operation),
+        "cell_hmac_sha256": attest(secret, "cell", cell_id),
+        "oauth_client_config_sha256": config_sha,
+        "contract_candidate_id": context["candidateId"],
+        "staged_client_release_id": stage_id,
+        "assignment_id": assignment_id,
+        "assignment_generation": generation,
+        **counts,
+        "result_sha256": hashlib.sha256(
+            canonical({"counts": counts, "operations": {k: results[k] for k in OPERATIONS}}).encode()
+        ).hexdigest(),
+        "package_artifact_sha256": package["artifact_sha256"],
+        "archive_sha256": archive["archive_sha256"],
+        **(
+            {"registered_app_id_sha256": package["registered_app_id_sha256"]}
+            if args.platform == "openai"
+            else {}
+        ),
+        "compatibility_sha256": package["compatibility_sha256"],
+        "schema_contract_sha256": package["schema_contract_sha256"],
+        "command_surface_sha256": package["command_surface_sha256"],
+        "endpoint": package["endpoint"],
+        "plugin_version": package["plugin_version"],
+        "profile": package["profile"],
+        "operator_key_id": key_id,
+        **{name: True for name in OPERATIONS},
+    }
+
+    expected = set(STRINGS) | set(COUNTS) | set(OPERATIONS) | {"schema_version", "platform"}
+    if args.platform == "openai":
+        expected.add("registered_app_id_sha256")
+    present = set(unsigned) | {"operator_signature"}
+    if present != expected:
+        raise SystemExit(
+            "evidence field set does not match the contract; "
+            f"missing {sorted(expected - present)}, unexpected {sorted(present - expected)}"
+        )
+
+    if args.rehearse:
+        print("  REHEARSAL - no evidence written")
+        print(f"  counts        {counts}")
+        print(f"  owner         {owner[:8]}  cell {cell_id[:8]}  entitlement {entitlement[:8]}")
+        print(f"  operation     {operation[:8]}  assignment {assignment_id[:8]} gen {generation}")
+        print(f"  stage         {stage_id[:8]}  config_sha {config_sha[:16]}...")
+        print(f"  field set     matches the contract ({len(expected)} fields)")
+        return 0
+
+    path = state / f"evidence-{args.platform}.unsigned.json"
+    path.write_text(json.dumps(unsigned, indent=1, sort_keys=True))
+    path.chmod(0o600)
+    print(f"  observed: counts all 1, {len(OPERATIONS)} operations confirmed from {args.results}")
+    print(f"  wrote {path}")
+    return 0
+
+
+def sign(args: argparse.Namespace) -> int:
+    secret = os.environ["EXOMEM_HOSTED_PROMOTION_SECRET"]
+    state = args.state_dir
+    unsigned = json.loads((state / f"evidence-{args.platform}.unsigned.json").read_text())
+    signature = hmac.new(secret.encode(), canonical(unsigned).encode(), hashlib.sha256).hexdigest()
+    evidence = {**unsigned, "operator_signature": signature}
+    path = state / f"evidence-{args.platform}.json"
+    path.write_text(json.dumps(evidence, indent=1, sort_keys=True))
+    path.chmod(0o600)
+    digest = hashlib.sha256(canonical(evidence).encode()).hexdigest()
+    print(f"  signed {args.platform}; evidence digest {digest[:16]}...")
+    print(f"  wrote {path}")
+    return 0
+
+
+def call(path: str, body: dict, label: str, state: Path) -> tuple[int, dict]:
+    base = os.environ["EXOMEM_PUBLIC_BASE_URL"].rstrip("/")
+    request = urllib.request.Request(
+        f"{base}{path}", data=json.dumps(body).encode(), method="POST"
+    )
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Authorization", f"Bearer {os.environ['EXOMEM_ADMIN_TOKEN']}")
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            status, raw = response.status, response.read()
+    except urllib.error.HTTPError as error:
+        status, raw = error.code, error.read()
+    try:
+        parsed = json.loads(raw or b"{}")
+    except json.JSONDecodeError:
+        parsed = {"_raw": raw.decode(errors="replace")[:400]}
+    record = state / f"{label}.response.json"
+    record.write_text(json.dumps({"status": status, **parsed}, indent=1))
+    record.chmod(0o600)
+    return status, parsed
+
+
+def import_artifact(args: argparse.Namespace) -> int:
+    state = args.state_dir
+    evidence = json.loads((state / f"evidence-{args.platform}.json").read_text())
+    evidence_sha256 = hashlib.sha256(canonical(evidence).encode()).hexdigest()
+    artifact = {
+        "platform": args.platform,
+        "state": "pending",
+        "installUrl": args.install_url,
+        "observedAt": evidence["timestamp"],
+        "pluginVersion": evidence["plugin_version"],
+        "packageSha256": evidence["package_artifact_sha256"],
+        "archiveSha256": evidence["archive_sha256"],
+        "compatibilitySha256": evidence["compatibility_sha256"],
+        "contractSha256": evidence["schema_contract_sha256"],
+        "clientIdentitySha256": evidence["clean_client_identity_hmac_sha256"],
+        "pairedRunHmacSha256": evidence["paired_run_hmac_sha256"],
+        "exomemIdentityHmacSha256": evidence["exomem_identity_hmac_sha256"],
+        "tenantHmacSha256": evidence["tenant_hmac_sha256"],
+        "evidenceSha256": evidence_sha256,
+        "resultSha256": evidence["result_sha256"],
+        "oauthClientConfigSha256": evidence["oauth_client_config_sha256"],
+        "candidateId": evidence["contract_candidate_id"],
+        "stagedClientReleaseId": evidence["staged_client_release_id"],
+        "assignmentId": evidence["assignment_id"],
+        "assignmentGeneration": evidence["assignment_generation"],
+        "evidence": evidence,
+    }
+    status, payload = call(
+        "/api/exomem/admin/contracts",
+        {"action": "import-artifact", "artifact": artifact},
+        f"import-{args.platform}",
+        state,
+    )
+    if status != 200 or not payload.get("artifactId"):
+        raise SystemExit(f"import-artifact failed: {status} {payload}")
+    (state / f"artifact-{args.platform}.txt").write_text(payload["artifactId"])
+    print(f"  {args.platform} artifact {payload['artifactId']}")
+    return 0
+
+
+def get(path: str) -> tuple[int, dict]:
+    base = os.environ["EXOMEM_PUBLIC_BASE_URL"].rstrip("/")
+    request = urllib.request.Request(f"{base}{path}", method="GET")
+    request.add_header("Authorization", f"Bearer {os.environ['EXOMEM_ADMIN_TOKEN']}")
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            return response.status, json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read() or b"{}")
+
+
+def promote(args: argparse.Namespace) -> int:
+    state = args.state_dir
+    context = json.loads((state / "bootstrap-context.json").read_text())
+    candidate_id = context["candidateId"]
+
+    # Read the digest immediately before the swap. The routable set is computed
+    # live from every routable cell, so it moves whenever any cell appears or is
+    # destroyed -- including the reviewer tenant we delete afterwards. A digest
+    # captured earlier in the window may already be wrong, and promotion is a
+    # compare-and-swap that will (correctly) refuse it.
+    status, contracts = get("/api/exomem/admin/contracts")
+    if status != 200:
+        raise SystemExit(f"contracts read failed: {status} {contracts}")
+    # rolloutStatus, not agentContracts: the latter carries contract digests and has
+    # no candidateId or routable fields at all.
+    rollout = contracts.get("rolloutStatus") or []
+    row = next((c for c in rollout if c.get("candidateId") == candidate_id), None)
+    if not row:
+        raise SystemExit(f"candidate {candidate_id} not present in contracts response")
+    # routableObservationFresh is informational, NOT a precondition: the stored
+    # observation only counts as fresh for 5 minutes after a cell activates, but
+    # promoteExomemHostedCohort takes its own live probe via
+    # preparePromotionRuntimeHealth and refreshes the authority inside the
+    # transaction. Gating on the flag would refuse promotions that succeed.
+    if not row.get("routableObservationFresh"):
+        print("  note: stored observation is stale (>5 min); promotion re-probes live")
+    digest = row["routableSetDigest"]
+    live = contracts.get("liveCohortCandidateId")
+    print(f"  candidate {candidate_id[:8]} routable={row.get('routableCellCount')} digest={digest[:16]}...")
+    print(f"  expected live cohort: {live!r}")
+
+    missing = [
+        name
+        for name in ("artifact-claude.txt", "artifact-openai.txt", "evidence-claude.json", "evidence-openai.json")
+        if not (state / name).exists()
+    ]
+    if missing:
+        if args.dry_run:
+            print(f"  DRY RUN - digest path verified; still missing {missing}")
+            return 0
+        raise SystemExit(f"cannot promote without both artifacts and both evidence records: {missing}")
+
+    claude_artifact = (state / "artifact-claude.txt").read_text().strip()
+    openai_artifact = (state / "artifact-openai.txt").read_text().strip()
+    body = {
+        "action": "promote-cohort",
+        "candidateId": candidate_id,
+        "claudeArtifactId": claude_artifact,
+        "openaiArtifactId": openai_artifact,
+        "expectedLiveCandidateId": live,
+        "expectedRoutableCellDigest": digest,
+        "claudeEvidence": json.loads((state / "evidence-claude.json").read_text()),
+        "openaiEvidence": json.loads((state / "evidence-openai.json").read_text()),
+    }
+    if args.dry_run:
+        print("  DRY RUN - not promoting")
+        print(f"  would send artifacts {claude_artifact[:8]} / {openai_artifact[:8]}")
+        return 0
+    status, payload = call("/api/exomem/admin/contracts", body, "promote-cohort", state)
+    if status != 200:
+        raise SystemExit(f"promote-cohort failed: {status} {payload}")
+    print(f"  promoted: {json.dumps(payload.get('result'))[:300]}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("observe", "sign", "import", "promote"))
+    parser.add_argument("--state-dir", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, default=Path("/home/hugoa/projects/exomem"))
+    parser.add_argument("--platform", choices=("claude", "openai"))
+    parser.add_argument("--results", help="JSON of the seven observed operations")
+    parser.add_argument("--outcome", default="bootstrap-outcome-final.json")
+    parser.add_argument("--stage-id", help="sibling stage; defaults to the bootstrap stage")
+    parser.add_argument("--client-version", default="1.0.0")
+    parser.add_argument("--install-url", default="https://substratesystems.io/exomem/setup")
+    parser.add_argument(
+        "--rehearse",
+        action="store_true",
+        help="run every query and gate against a live tenant, then refuse to emit",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="promote: resolve everything, send nothing"
+    )
+    args = parser.parse_args()
+
+    if args.command in {"observe", "sign", "import"} and not args.platform:
+        print("--platform is required", file=sys.stderr)
+        return 2
+    if args.command == "observe" and not args.results and not args.rehearse:
+        print("--results is required for observe", file=sys.stderr)
+        return 2
+
+    return {
+        "observe": observe,
+        "sign": sign,
+        "import": import_artifact,
+        "promote": promote,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reviewer_bootstrap.py
+++ b/scripts/reviewer_bootstrap.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Drive the virgin-install reviewer OAuth bootstrap end to end.
+
+The procedure in `substrate/docs/runbooks/exomem-hosted-alpha.md` (Virgin-install
+reviewer OAuth bootstrap) is a dozen ordered control-plane calls with two hard
+timing constraints and several preconditions that are enforced only in SQL. Run
+by hand it is reliably wrong; every failure burns a single-use invite, an email
+alias, a stage and a client, and a failed attempt strands a tenant that then
+blocks the retry.
+
+This encodes the whole sequence. Three subcommands:
+
+    preflight   Report every known blocker before anything is consumed.
+    prepare     Create the stage, pinned client and invite. Nothing is spent yet.
+    run         Given the emailed invite token, run the rest with no gaps.
+
+Design notes, each of which is a bug this script exists to prevent:
+
+* The bootstrap client MUST use a `localhost` loopback redirect. The server
+  validates a requested `127.0.0.1` redirect as `localhost`, so a client
+  registered on the IP literal can never authorize.
+* `POST /access/redeem` is a browser-shaped route: it needs an `Origin` header
+  matching `Host` or it returns CSRF_REJECTED.
+* The token exchange accepts EXACTLY six form fields and an exact `resource`.
+  Any extra or missing field is `invalid_request`, not `invalid_grant`.
+* The internal-canary credential is joined to the bootstrap's OWN outcome
+  assignment, and that assignment expires while the cell provisions (~15 min).
+  So `run` issues both sibling credentials IMMEDIATELY after the authority is
+  consumed, in parallel with provisioning. It never waits for CELL_READY.
+* Creating the authority is the irreversible step: it spends the invite whether
+  it later succeeds, expires or is revoked. `prepare` therefore stops short of
+  it, so the invite keeps its full 7-day life while a human fetches the token.
+
+Secrets are never printed. Issued reviewer credentials are written to the state
+directory with mode 0600 and only their presence is reported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+CANDIDATE_PROFILE = "hosted-alpha-agent-v1"
+LOOPBACK_REDIRECT = "http://localhost:47831/callback"
+CLAUDE_CIMD_CLIENT_ID = "https://claude.ai/oauth/mcp-oauth-client-metadata"
+CLAUDE_CIMD_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+SCOPES = "exomem.read exomem.write offline_access"
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def stamp(delta: timedelta) -> str:
+    return (utc_now() + delta).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def client_config_sha256(
+    *, platform: str, admission_mode: str, client_id: str, redirect_uris: list[str]
+) -> str:
+    """Canonical OAuth client-config digest.
+
+    Domain-separated SHA-256 over compact JSON with sorted keys and sorted
+    redirect URIs. Must match `oauthClientConfigSha256` in the control plane
+    byte for byte or the stage and client will not join.
+    """
+    payload = {
+        "admission_mode": admission_mode,
+        "client_id": client_id,
+        "platform": platform,
+        "redirect_uris": sorted(redirect_uris),
+        "token_endpoint_auth_method": "none",
+    }
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(b"exomem-oauth-client-config:v1\0" + body).hexdigest()
+
+
+def pkce_pair() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(os.urandom(48)).decode().rstrip("=")
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    )
+    return verifier, challenge
+
+
+class ControlPlane:
+    """Thin control-plane client that records every exchange."""
+
+    def __init__(self, base_url: str, admin_token: str, state_dir: Path):
+        self.base_url = base_url.rstrip("/")
+        self._admin_token = admin_token
+        self.state_dir = state_dir
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.cookies: dict[str, str] = {}
+
+    def _record(self, label: str, payload: object) -> None:
+        path = self.state_dir / f"{label}.json"
+        path.write_text(json.dumps(payload, indent=1, sort_keys=True))
+        path.chmod(0o600)
+
+    def call(
+        self,
+        method: str,
+        path: str,
+        *,
+        label: str,
+        body: dict | None = None,
+        admin: bool = True,
+        form: dict | None = None,
+        headers: dict | None = None,
+        send_cookies: bool = False,
+    ) -> tuple[int, dict]:
+        url = f"{self.base_url}{path}"
+        data: bytes | None = None
+        request_headers = dict(headers or {})
+        if form is not None:
+            data = urllib.parse.urlencode(form).encode()
+            request_headers["Content-Type"] = "application/x-www-form-urlencoded"
+        elif body is not None:
+            data = json.dumps(body).encode()
+            request_headers["Content-Type"] = "application/json"
+        if admin:
+            request_headers["Authorization"] = f"Bearer {self._admin_token}"
+        if send_cookies and self.cookies:
+            request_headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+        if body is not None:
+            self._record(f"{label}.request", body)
+
+        request = urllib.request.Request(url, data=data, method=method)
+        for key, value in request_headers.items():
+            request.add_header(key, value)
+        try:
+            with urllib.request.urlopen(request) as response:
+                status, raw, cookie_headers = (
+                    response.status,
+                    response.read(),
+                    response.headers.get_all("Set-Cookie") or [],
+                )
+                location = response.headers.get("Location")
+        except urllib.error.HTTPError as error:  # noqa: PERF203 - explicit branch
+            status, raw = error.code, error.read()
+            cookie_headers = error.headers.get_all("Set-Cookie") or []
+            location = error.headers.get("Location")
+
+        for cookie in cookie_headers:
+            name, _, rest = cookie.partition("=")
+            value = rest.split(";", 1)[0]
+            if value:
+                self.cookies[name.strip()] = value
+            else:
+                self.cookies.pop(name.strip(), None)
+
+        try:
+            parsed = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            parsed = {"_raw": raw.decode(errors="replace")[:400]}
+        if location:
+            parsed = {**parsed, "_location": location}
+        self._record(f"{label}.response", {"status": status, **parsed})
+        return status, parsed
+
+
+def preflight(cp: ControlPlane, candidate_id: str) -> bool:
+    """Report every blocker. Returns True when a bootstrap can succeed."""
+    ok = True
+
+    status, contracts = cp.call("GET", "/api/exomem/admin/contracts", label="preflight-contracts")
+    if status != 200:
+        print(f"  FAIL  contracts endpoint returned {status}")
+        return False
+
+    live = contracts.get("liveCohortCandidateId")
+    print(f"  {'ok  ' if live is None else 'FAIL'}  live cohort: {live or 'none'}")
+    ok &= live is None
+
+    rollout = next(
+        (r for r in contracts.get("rolloutStatus", []) if r["candidateId"] == candidate_id),
+        None,
+    )
+    if rollout is None:
+        print(f"  FAIL  candidate {candidate_id[:8]} not present")
+        return False
+    good = rollout["state"] == "pending"
+    print(
+        f"  {'ok  ' if good else 'FAIL'}  candidate {candidate_id[:8]}: "
+        f"{rollout['state']} {rollout['sourceRelease']} "
+        f"routable={rollout['routableCellCount']}"
+    )
+    ok &= good
+
+    status, clients = cp.call("GET", "/api/exomem/admin/oauth-clients", label="preflight-clients")
+    active = [a for a in clients.get("bootstrapAuthorities", []) if a.get("state") == "active"]
+    print(f"  {'ok  ' if not active else 'FAIL'}  active bootstrap authorities: {len(active)}")
+    ok &= not active
+
+    status, capacity = cp.call("GET", "/api/exomem/admin/capacity", label="preflight-capacity")
+    cap = capacity.get("capacity", {})
+    free_runtime = cap.get("runtimeCapacitySlots", 0) - cap.get("reservedRuntimeSlots", 0)
+    free_claims = cap.get("provisionClaimCapacity", 0) - cap.get("activeProvisionClaims", 0)
+    good = free_runtime > 0 and free_claims > 0
+    print(
+        f"  {'ok  ' if good else 'FAIL'}  capacity: {free_runtime} runtime slot(s), "
+        f"{free_claims} provision claim(s) free"
+    )
+    ok &= good
+
+    print(
+        "\n  NOTE  A reviewer-purpose tenant with a bound or CELL_READY cell also blocks\n"
+        "        the bootstrap, and is not visible through any admin endpoint. If the\n"
+        "        authority call returns 400 with everything above green, that is almost\n"
+        "        certainly the cause; the stranded tenant must be deleted first."
+    )
+    return bool(ok)
+
+
+def prepare(cp: ControlPlane, candidate_id: str, email: str, locks: dict) -> dict:
+    """Create stage, pinned client and invite. Spends nothing irreversible."""
+    client_id = f"exomem-reviewer-bootstrap-{uuid.uuid4()}"
+    verifier, challenge = pkce_pair()
+    config_sha = client_config_sha256(
+        platform="claude",
+        admission_mode="pinned",
+        client_id=client_id,
+        redirect_uris=[LOOPBACK_REDIRECT],
+    )
+
+    status, stage = cp.call(
+        "POST",
+        "/api/exomem/admin/contracts",
+        label="prepare-stage",
+        body={
+            "action": "create-stage",
+            "candidateId": candidate_id,
+            "platform": "claude",
+            "expiresAt": stamp(timedelta(minutes=55)),
+            "packageSha256": locks["claude_package"],
+            "archiveSha256": locks["claude_archive"],
+            "compatibilitySha256": locks["compatibility"],
+            "contractSha256": locks["contract"],
+            "pluginVersion": locks["plugin_version"],
+            "oauthClientConfigSha256": config_sha,
+            "registeredAppIdSha256": None,
+        },
+    )
+    if status != 200:
+        raise SystemExit(f"create-stage failed: {status} {stage}")
+    stage_id = stage["stage"]["id"]
+
+    status, client = cp.call(
+        "POST",
+        "/api/exomem/admin/oauth-clients",
+        label="prepare-client",
+        body={
+            "action": "register_pinned",
+            "platform": "claude",
+            "stagedClientReleaseId": stage_id,
+            "clientId": client_id,
+            "redirectUris": [LOOPBACK_REDIRECT],
+        },
+    )
+    if status != 200:
+        raise SystemExit(f"register_pinned failed: {status} {client}")
+
+    status, invite = cp.call(
+        "POST",
+        "/api/exomem/admin/invites",
+        label="prepare-invite",
+        body={
+            "email": email,
+            "source": "complimentary",
+            "marketplaceReviewerPurpose": True,
+        },
+    )
+    if status != 201:
+        raise SystemExit(f"invite failed: {status} {invite}")
+
+    context = {
+        "candidateId": candidate_id,
+        "stageId": stage_id,
+        "oauthClientId": client["id"],
+        "clientId": client_id,
+        "inviteId": invite["inviteId"],
+        "email": email,
+        "codeVerifier": verifier,
+        "codeChallenge": challenge,
+        "state": base64.urlsafe_b64encode(os.urandom(24)).decode().rstrip("="),
+    }
+    path = cp.state_dir / "bootstrap-context.json"
+    path.write_text(json.dumps(context, indent=1))
+    path.chmod(0o600)
+    return context
+
+
+def run(cp: ControlPlane, context: dict, token: str, locks: dict) -> None:
+    """Authority through both canary credentials, with no waiting in between."""
+    resource = f"{cp.base_url}/api/exomem/mcp/v1"
+
+    status, authority = cp.call(
+        "POST",
+        "/api/exomem/admin/oauth-clients",
+        label="run-authority",
+        body={
+            "action": "create_reviewer_bootstrap",
+            "inviteId": context["inviteId"],
+            "stagedClientReleaseId": context["stageId"],
+            "oauthClientId": context["oauthClientId"],
+            "expiresAt": stamp(timedelta(minutes=28)),
+        },
+    )
+    if status != 200:
+        raise SystemExit(
+            f"create_reviewer_bootstrap failed: {status} {authority}\n"
+            "If preflight was green this is most likely a stranded reviewer tenant "
+            "holding a bound/CELL_READY cell. Delete it and retry."
+        )
+    print(f"  authority {authority['authority']['id'][:8]} active")
+
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": context["clientId"],
+            "redirect_uri": LOOPBACK_REDIRECT,
+            "resource": resource,
+            "scope": SCOPES,
+            "state": context["state"],
+            "code_challenge": context["codeChallenge"],
+            "code_challenge_method": "S256",
+        }
+    )
+    status, _ = cp.call(
+        "GET", f"/api/exomem/oauth/authorize?{query}", label="run-authorize", admin=False
+    )
+    if status != 303:
+        raise SystemExit(f"authorize expected 303, got {status}")
+    print("  authorized (303)")
+
+    origin_headers = {"Origin": cp.base_url}
+    status, redeemed = cp.call(
+        "POST",
+        "/api/exomem/access/redeem",
+        label="run-redeem",
+        body={"token": token},
+        admin=False,
+        headers=origin_headers,
+        send_cookies=True,
+    )
+    if status != 200 or not redeemed.get("destination"):
+        raise SystemExit(f"redeem failed: {status} {redeemed}")
+    code = urllib.parse.parse_qs(urllib.parse.urlparse(redeemed["destination"]).query)["code"][0]
+    print("  invite redeemed, authorization code issued")
+
+    status, tokens = cp.call(
+        "POST",
+        "/api/exomem/oauth/token",
+        label="run-token",
+        admin=False,
+        form={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": context["clientId"],
+            "redirect_uri": LOOPBACK_REDIRECT,
+            "code_verifier": context["codeVerifier"],
+            "resource": resource,
+        },
+    )
+    print(
+        "  token exchange: "
+        + ("ok" if status == 200 else f"{status} {tokens.get('error')} (non-fatal)")
+    )
+
+    status, clients = cp.call(
+        "GET", "/api/exomem/admin/oauth-clients", label="run-authority-outcome"
+    )
+    outcome = next(
+        (
+            a
+            for a in clients.get("bootstrapAuthorities", [])
+            if a["id"] == authority["authority"]["id"]
+        ),
+        None,
+    )
+    if not outcome or outcome.get("state") != "consumed":
+        raise SystemExit(f"authority did not reach consumed: {outcome}")
+    tenant_id = outcome["outcomeTenantId"]
+    assignment_id = outcome["outcomeAssignmentId"]
+    generation = outcome.get("outcomeAssignmentGeneration") or 1
+    print(
+        f"  authority consumed; tenant {tenant_id[:8]} assignment {assignment_id[:8]} gen {generation}"
+    )
+
+    # The assignment expires while the cell provisions. Issue credentials NOW.
+    for platform, admission, sibling_client, redirects, package, archive, app_digest in (
+        (
+            "claude",
+            "cimd",
+            CLAUDE_CIMD_CLIENT_ID,
+            [CLAUDE_CIMD_REDIRECT],
+            locks["claude_package"],
+            locks["claude_archive"],
+            None,
+        ),
+    ):
+        config_sha = client_config_sha256(
+            platform=platform,
+            admission_mode=admission,
+            client_id=sibling_client,
+            redirect_uris=redirects,
+        )
+        status, stage = cp.call(
+            "POST",
+            "/api/exomem/admin/contracts",
+            label=f"run-sibling-stage-{platform}",
+            body={
+                "action": "create-stage",
+                "candidateId": context["candidateId"],
+                "platform": platform,
+                "expiresAt": stamp(timedelta(minutes=55)),
+                "packageSha256": package,
+                "archiveSha256": archive,
+                "compatibilitySha256": locks["compatibility"],
+                "contractSha256": locks["contract"],
+                "pluginVersion": locks["plugin_version"],
+                "oauthClientConfigSha256": config_sha,
+                "registeredAppIdSha256": app_digest,
+            },
+        )
+        if status != 200:
+            raise SystemExit(f"{platform} sibling stage failed: {status} {stage}")
+
+        status, sibling = cp.call(
+            "POST",
+            "/api/exomem/admin/oauth-clients",
+            label=f"run-sibling-client-{platform}",
+            body={
+                "action": f"register_{admission}",
+                "platform": platform,
+                "stagedClientReleaseId": stage["stage"]["id"],
+                "clientId": sibling_client,
+                "redirectUris": redirects,
+            },
+        )
+        if status != 200:
+            raise SystemExit(
+                f"{platform} sibling registration failed: {status} {sibling}\n"
+                "A 400 here usually means the client_id host is missing from "
+                "EXOMEM_CIMD_ALLOWED_HOSTS."
+            )
+
+        status, credential = cp.call(
+            "POST",
+            "/api/exomem/admin/reviewer-access",
+            label=f"run-canary-{platform}",
+            body={
+                "credentialKind": "internal_canary",
+                "platform": platform,
+                "tenantId": tenant_id,
+                "candidateId": context["candidateId"],
+                "assignmentId": assignment_id,
+                "assignmentGeneration": generation,
+                "stagedClientReleaseId": stage["stage"]["id"],
+                "oauthClientId": sibling["id"],
+                "fixtureVersion": locks["fixture_version"],
+                "fixturePayloadDigest": locks["fixture_digest"],
+                "expiresAt": stamp(timedelta(hours=24)),
+            },
+        )
+        if status != 201:
+            raise SystemExit(f"{platform} canary credential failed: {status} {credential}")
+        print(
+            f"  {platform} canary credential issued "
+            f"(username/password saved to run-canary-{platform}.response.json, mode 600)"
+        )
+
+    print("\n  Bootstrap complete. The cell provisions in the background; poll the")
+    print("  owner status view for CELL_READY before the clean-client evidence run.")
+
+
+def load_locks(repo: Path) -> dict:
+    generated = repo / "plugins" / "hosted" / "generated"
+    claude = json.loads((generated / "claude.lock.json").read_text())
+    claude_zip = json.loads((generated / "claude.zip.lock.json").read_text())
+    fixture = json.loads(
+        (repo / "plugins" / "hosted" / "marketplace-review-fixture-v1.json").read_text()
+    )
+    return {
+        "claude_package": claude["artifact_sha256"],
+        "claude_archive": claude_zip["archive_sha256"],
+        "compatibility": claude["compatibility_sha256"],
+        "contract": claude["schema_contract_sha256"],
+        "plugin_version": claude["plugin_version"],
+        "fixture_version": fixture["fixture_version"],
+        "fixture_digest": fixture["payload_sha256"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("preflight", "prepare", "run"))
+    parser.add_argument("--candidate-id", required=True)
+    parser.add_argument("--state-dir", required=True, type=Path)
+    parser.add_argument("--repo", default=".", type=Path)
+    parser.add_argument("--email", help="reviewer alias, required for prepare")
+    parser.add_argument("--token", help="emailed invite token, required for run")
+    args = parser.parse_args()
+
+    base_url = os.environ.get("EXOMEM_PUBLIC_BASE_URL")
+    admin_token = os.environ.get("EXOMEM_ADMIN_TOKEN")
+    if not base_url or not admin_token:
+        print("EXOMEM_PUBLIC_BASE_URL and EXOMEM_ADMIN_TOKEN must be set", file=sys.stderr)
+        return 2
+
+    cp = ControlPlane(base_url, admin_token, args.state_dir)
+    locks = load_locks(args.repo)
+
+    if args.command == "preflight":
+        print("preflight:")
+        return 0 if preflight(cp, args.candidate_id) else 1
+
+    if args.command == "prepare":
+        if not args.email:
+            print("--email is required for prepare", file=sys.stderr)
+            return 2
+        print("preflight:")
+        if not preflight(cp, args.candidate_id):
+            print("\nrefusing to prepare while preflight is red")
+            return 1
+        print("\nprepare:")
+        context = prepare(cp, args.candidate_id, args.email, locks)
+        print(f"  stage   {context['stageId']}")
+        print(f"  client  {context['oauthClientId']}")
+        print(f"  invite  {context['inviteId']}")
+        print(f"\n  Invite sent to {args.email}.")
+        print("  Nothing irreversible has been spent: the invite keeps its full expiry")
+        print("  until `run` creates the authority. Fetch the token from the email's")
+        print("  text/plain part (the tracked HTML link drops the URL fragment), then:")
+        print(f"\n    {sys.argv[0]} run --candidate-id {args.candidate_id} \\")
+        print(f"      --state-dir {args.state_dir} --token <token>")
+        return 0
+
+    if not args.token:
+        print("--token is required for run", file=sys.stderr)
+        return 2
+    context = json.loads((args.state_dir / "bootstrap-context.json").read_text())
+    print("run:")
+    run(cp, context, args.token, locks)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reviewer_bootstrap.py
+++ b/scripts/reviewer_bootstrap.py
@@ -43,6 +43,7 @@ import hashlib
 import json
 import os
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
@@ -54,6 +55,24 @@ LOOPBACK_REDIRECT = "http://localhost:47831/callback"
 CLAUDE_CIMD_CLIENT_ID = "https://claude.ai/oauth/mcp-oauth-client-metadata"
 CLAUDE_CIMD_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
 SCOPES = "exomem.read exomem.write offline_access"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Surface 3xx instead of following it.
+
+    `/oauth/authorize` answers 303 and sets the transaction cookie ON THAT
+    RESPONSE. urlopen follows the redirect by default, so the caller sees the
+    final 200 HTML page and — because no cookie processor is installed — the
+    transaction cookie is dropped with the intermediate response. Returning None
+    here makes urllib raise HTTPError for the 3xx, which the caller already
+    handles, keeping both the status and the Set-Cookie headers.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ARG002
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
 
 
 def utc_now() -> datetime:
@@ -139,7 +158,7 @@ class ControlPlane:
         for key, value in request_headers.items():
             request.add_header(key, value)
         try:
-            with urllib.request.urlopen(request) as response:
+            with _OPENER.open(request) as response:
                 status, raw, cookie_headers = (
                     response.status,
                     response.read(),
@@ -398,7 +417,12 @@ def run(cp: ControlPlane, context: dict, token: str, locks: dict) -> None:
     )
 
     # The assignment expires while the cell provisions. Issue credentials NOW.
-    for platform, admission, sibling_client, redirects, package, archive, app_digest in (
+    # Both platforms in this one pass: promote-cohort needs a claudeArtifactId AND
+    # an openaiArtifactId, and each canary credential is welded to this bootstrap's
+    # own assignment/generation, so a second pass later cannot supply the other one.
+    # OpenAI registers `pinned` on a loopback redirect: there is no published
+    # ChatGPT client-metadata-document URL to admit by CIMD.
+    siblings = (
         (
             "claude",
             "cimd",
@@ -408,7 +432,17 @@ def run(cp: ControlPlane, context: dict, token: str, locks: dict) -> None:
             locks["claude_archive"],
             None,
         ),
-    ):
+        (
+            "openai",
+            "pinned",
+            f"exomem-reviewer-openai-{uuid.uuid4()}",
+            [LOOPBACK_REDIRECT],
+            locks["openai_package"],
+            locks["openai_archive"],
+            locks["openai_registered_app"],
+        ),
+    )
+    for platform, admission, sibling_client, redirects, package, archive, app_digest in siblings:
         config_sha = client_config_sha256(
             platform=platform,
             admission_mode=admission,
@@ -446,6 +480,11 @@ def run(cp: ControlPlane, context: dict, token: str, locks: dict) -> None:
                 "stagedClientReleaseId": stage["stage"]["id"],
                 "clientId": sibling_client,
                 "redirectUris": redirects,
+                # The stage row is matched with
+                #   stage.registered_app_id_sha256 IS NOT DISTINCT FROM <this>
+                # so omitting it on an OpenAI client whose stage carries the
+                # registered-app digest silently matches no stage and 400s.
+                **({"registeredAppIdSha256": app_digest} if app_digest else {}),
             },
         )
         if status != 200:
@@ -488,12 +527,17 @@ def load_locks(repo: Path) -> dict:
     generated = repo / "plugins" / "hosted" / "generated"
     claude = json.loads((generated / "claude.lock.json").read_text())
     claude_zip = json.loads((generated / "claude.zip.lock.json").read_text())
+    openai = json.loads((generated / "openai.lock.json").read_text())
+    openai_zip = json.loads((generated / "openai.zip.lock.json").read_text())
     fixture = json.loads(
         (repo / "plugins" / "hosted" / "marketplace-review-fixture-v1.json").read_text()
     )
     return {
         "claude_package": claude["artifact_sha256"],
         "claude_archive": claude_zip["archive_sha256"],
+        "openai_package": openai["artifact_sha256"],
+        "openai_archive": openai_zip["archive_sha256"],
+        "openai_registered_app": openai["registered_app_id_sha256"],
         "compatibility": claude["compatibility_sha256"],
         "contract": claude["schema_contract_sha256"],
         "plugin_version": claude["plugin_version"],


### PR DESCRIPTION
Encodes the virgin-install reviewer OAuth bootstrap and the cohort-promotion
evidence path, both of which were previously hand-run curl against a hard
30-minute window.

## reviewer_bootstrap.py — three traps fixed, each found by running it

- `urlopen` followed the 303 from `/oauth/authorize`, so the caller saw the
  final 200 page and the `exomem_oauth_tx` cookie set on the redirect was
  dropped. Now surfaces 3xx via a no-redirect opener.
- The sibling loop only covered Claude. `promote-cohort` requires both a
  `claudeArtifactId` and an `openaiArtifactId`, and each canary credential is
  welded to the bootstrap's own assignment and generation, so a later pass
  cannot supply the missing one.
- `register_pinned` omitted `registeredAppIdSha256`. The stage is matched with
  `IS NOT DISTINCT FROM`, so an OpenAI client whose stage carries the digest
  matched no stage row and returned a bare `400 INVALID_REQUEST`.

## promotion_evidence.py — new

`observe` / `sign` / `import` / `promote`. It deliberately does not invent the
facts it signs: the seven operation flags are read from a results file
describing a real client session, and the six counts are queried from the
control plane with the run aborting unless each is exactly 1. `--rehearse`
exercises every query and gate and then refuses to emit, so a dry run cannot
manufacture evidence for a session that never happened.

Verified against a live tenant: counts resolve, both platform shapes match the
contract (41 fields Claude / 42 OpenAI), and the promote path resolves the
compare-and-swap digest correctly.

## Why the timing matters

The bootstrap authority is capped server-side at 30 minutes, the rollout
assignment inherits that expiry, and `storeClientArtifact` additionally
requires the assignment still be active — so the evidence run for both
platforms, signing, both imports and promotion all land inside one window.
That constraint applies to the first promotion only: afterwards a live cohort
admits a real client directly and an ordinary assignment may live 7 days.